### PR TITLE
feat(desktop): remote PTY for federated threads

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
@@ -103,10 +104,16 @@ test.describe("federation remote window", () => {
 
     let gateway: InProcessFederationGateway | undefined;
     const fixture = await createLocalControlFixture();
+    // The OWNER-side worktree: the remote shell's cwd lives in the test
+    // process, so a marker file appearing here proves where the PTY ran.
+    const ownerPtyCwd = await mkdtemp(
+      path.join(os.tmpdir(), "pwragent-federation-e2e-pty-"),
+    );
     let app: Awaited<ReturnType<typeof launchElectronApp>> | undefined;
     try {
       gateway = await startInProcessFederationGateway({
         instanceLabel: "E2E Gateway",
+        remotePty: { cwd: ownerPtyCwd },
         threads: [
           {
             id: "remote-thread-1",
@@ -235,8 +242,8 @@ test.describe("federation remote window", () => {
       ).toBeVisible();
       await remote.getByRole("button", { name: "Show sidebar" }).click();
 
-      // Opening a remote thread renders the peer transcript without the
-      // (local-shell) integrated terminal toggle.
+      // Opening a remote thread renders the peer transcript with the
+      // remote-PTY terminal toggle enabled (the gateway granted remote_pty).
       const remoteRowOne = remote.locator(".thread-row__title", {
         hasText: "Remote gateway thread one",
       });
@@ -244,8 +251,46 @@ test.describe("federation remote window", () => {
       await expect(
         remote.getByText(/Remote transcript for Remote gateway thread one/),
       ).toBeVisible({ timeout: 30_000 });
+      const terminalToggle = remote.locator(".thread-header__terminal-toggle");
+      await expect(terminalToggle).toBeVisible();
+      await expect(terminalToggle).not.toHaveClass(/is-disabled/);
+
+      // Open the remote terminal: the panel attaches to a PTY spawned inside
+      // the gateway's process, and the status line shows the OWNER-resolved
+      // cwd (the viewer never sent a path).
+      await terminalToggle.click();
       await expect(
-        remote.locator(".thread-header__terminal-toggle"),
+        remote.getByLabel("Integrated terminal", { exact: true }),
+      ).toBeVisible();
+      await expect(remote.locator(".integrated-terminal__status")).toHaveText(
+        ownerPtyCwd,
+        { timeout: 30_000 },
+      );
+
+      // Run a command through the remote shell. The marker lands in the
+      // gateway process's temp worktree — proof the process ran on the owner
+      // — and its output streams back into the viewer's xterm.
+      const markerToken = `pwragent-remote-pty-${Date.now().toString(36)}`;
+      await remote.locator(".integrated-terminal__viewport").click();
+      await remote.keyboard.type(`echo ${markerToken}>remote-pty-marker.txt`);
+      await remote.keyboard.press("Enter");
+      const markerPath = path.join(ownerPtyCwd, "remote-pty-marker.txt");
+      await expect
+        .poll(() => existsSync(markerPath), { timeout: 30_000 })
+        .toBe(true);
+      expect((await readFile(markerPath, "utf8")).trim()).toContain(markerToken);
+
+      await remote.keyboard.type(`echo viewer-sees-${markerToken}`);
+      await remote.keyboard.press("Enter");
+      await expect(
+        remote.locator(".integrated-terminal .xterm-rows"),
+      ).toContainText(`viewer-sees-${markerToken}`, { timeout: 30_000 });
+
+      // Closing the pane releases the remote session (the owner reaps it
+      // after its grace period).
+      await remote.getByRole("button", { name: "Close terminal" }).click();
+      await expect(
+        remote.getByLabel("Integrated terminal", { exact: true }),
       ).toHaveCount(0);
 
       // Security invariant ("no local fallback"): a remote window's PR
@@ -306,6 +351,7 @@ test.describe("federation remote window", () => {
       await app?.close();
       await gateway?.close();
       await fixture.cleanup();
+      await rm(ownerPtyCwd, { force: true, recursive: true });
     }
   });
 });

--- a/apps/desktop/e2e/fixtures/federation-gateway.ts
+++ b/apps/desktop/e2e/fixtures/federation-gateway.ts
@@ -10,7 +10,10 @@ import type {
   SetThreadPinRequest,
   SetThreadPinResponse,
 } from "@pwragent/shared";
-import { FEDERATION_INVITE_VERSION } from "@pwragent/shared";
+import {
+  FEDERATION_INVITE_VERSION,
+  FEDERATION_PROTOCOL_VERSION,
+} from "@pwragent/shared";
 import { StateDb } from "../../src/main/state/state-db";
 import {
   createFederationEnrollmentInvite,
@@ -24,6 +27,12 @@ import {
 } from "../../src/main/federation/federation-backend-bridge";
 import { generateFederationIdentityKeyPair } from "../../src/main/federation/federation-identity";
 import { generateNoiseStaticKeyPair } from "../../src/main/federation/federation-noise";
+import {
+  FEDERATION_PTY_METHOD_CAPABILITIES,
+  FederationPtyService,
+  registerFederationPtyHandlers,
+  type FederationPtyProcess,
+} from "../../src/main/federation/federation-pty-service";
 import { FederationRouter } from "../../src/main/federation/federation-router";
 import { FederationStore } from "../../src/main/federation/federation-store";
 import { FederationGatewayWebSocketServer } from "../../src/main/federation/federation-transport";
@@ -61,6 +70,13 @@ export type InProcessFederationGateway = {
 export async function startInProcessFederationGateway(params: {
   threads: GatewayThreadSeed[];
   instanceLabel?: string;
+  /**
+   * Serve remote PTY sessions with a REAL shell spawned via node-pty inside
+   * the test process, rooted at `cwd`. This is what lets the E2E prove the
+   * command ran on the OWNER: the marker file lands in this directory, not
+   * anywhere the Electron viewer can write.
+   */
+  remotePty?: { cwd: string };
 }): Promise<InProcessFederationGateway> {
   const stateRoot = await mkdtemp(
     path.join(os.tmpdir(), "pwragent-e2e-federation-gateway-"),
@@ -189,10 +205,52 @@ export async function startInProcessFederationGateway(params: {
 
   const router = new FederationRouter({
     localInstanceId: gatewayInstanceId,
-    methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    methodCapabilities: {
+      ...FEDERATION_BACKEND_METHOD_CAPABILITIES,
+      ...FEDERATION_PTY_METHOD_CAPABILITIES,
+    },
     additionalRequiredCapabilities: additionalFederationBackendCapabilities,
   });
   registerFederationBackendHandlers({ router, backend });
+
+  let ptyService: FederationPtyService | undefined;
+  if (params.remotePty) {
+    const ptyCwd = params.remotePty.cwd;
+    ptyService = new FederationPtyService({
+      spawnPty: async (spawnParams) => {
+        // node-pty ships prebuilds for the plain-Node ABI too, so the OWNER
+        // side of the wire runs a genuine PTY inside the Playwright process.
+        const nodePty = await import("node-pty");
+        const shell = resolveHarnessShell();
+        const pty = nodePty.spawn(shell.file, shell.args, {
+          name: "xterm-256color",
+          cols: spawnParams.cols,
+          rows: spawnParams.rows,
+          cwd: spawnParams.cwd ?? ptyCwd,
+          env: { ...process.env, TERM: "xterm-256color" },
+        });
+        return {
+          pty: pty as unknown as FederationPtyProcess,
+          cwd: spawnParams.cwd ?? ptyCwd,
+          shell: { file: shell.file, args: shell.args },
+        };
+      },
+      resolveThreadCwd: async () => ptyCwd,
+      sendNotification: (peerId, method, notificationParams) =>
+        router.sendToPeer(peerId, {
+          id: `federation-pty:${randomBytes(8).toString("hex")}`,
+          kind: "notification",
+          method,
+          params: notificationParams,
+          protocolVersion: FEDERATION_PROTOCOL_VERSION,
+          sourceInstanceId: gatewayInstanceId,
+          targetInstanceId: peerId,
+          createdAt: Date.now(),
+        }),
+      graceMs: 2_000,
+    });
+    registerFederationPtyHandlers({ router, service: ptyService });
+  }
 
   let connectionCount = 0;
   const connectionWaiters: (() => void)[] = [];
@@ -210,6 +268,7 @@ export async function startInProcessFederationGateway(params: {
         capabilities: connection.capabilities,
         sendEnvelope: connection.sendEnvelope,
       });
+      ptyService?.notifyPeerConnected(connection.peerId);
       connectionCount += 1;
       for (const resolve of connectionWaiters.splice(0)) {
         resolve();
@@ -217,6 +276,7 @@ export async function startInProcessFederationGateway(params: {
     },
     onDisconnect: (connection) => {
       router.unregisterConnection(connection.peerId);
+      ptyService?.notifyPeerDisconnected(connection.peerId);
     },
     onEnvelope: (envelope, connection) => {
       void router.routeEnvelope({
@@ -269,9 +329,23 @@ export async function startInProcessFederationGateway(params: {
       });
     },
     close: async () => {
+      ptyService?.disposeAll();
       await server.stop();
       stateDb.close();
       await rm(stateRoot, { force: true, recursive: true });
     },
   };
+}
+
+/**
+ * Minimal per-platform shell pick for the harness-owned PTY. The production
+ * owner resolves this through the settings service; the harness only needs a
+ * real interactive shell for `echo`-level commands.
+ */
+function resolveHarnessShell(): { file: string; args: string[] } {
+  if (process.platform === "win32") {
+    return { file: process.env.ComSpec || "cmd.exe", args: [] };
+  }
+  const configured = process.env.SHELL?.trim();
+  return { file: configured || "/bin/sh", args: [] };
 }

--- a/apps/desktop/src/main/__tests__/federation-pty-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-pty-service.test.ts
@@ -371,6 +371,65 @@ describe("FederationPtyService reaping", () => {
     service.disposeAll();
     expect(pty.killed).toBe(true);
   });
+
+  it("reaps a paused session when no ack arrives within the timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const { audits, pty, sent, service } = createHarness();
+      const { sessionId } = await service.open("peer-a", OPEN_REQUEST);
+      // Park the session at the high-water mark, then go silent: the ssh
+      // ClientAlive analogue for a link that died without a disconnect.
+      pty.emitData("x".repeat(FEDERATION_PTY_HIGH_WATER_BYTES + 1));
+      expect(pty.paused).toBe(true);
+
+      vi.advanceTimersByTime(59_999);
+      expect(pty.killed).toBe(false);
+      vi.advanceTimersByTime(1);
+      expect(pty.killed).toBe(true);
+      expect(audits.at(-1)).toMatchObject({
+        kind: "remote_pty_close",
+        detail: "ack_timeout",
+      });
+      // A still-connected viewer is told the session ended.
+      expect(
+        sent.filter(
+          (entry) =>
+            entry.method === "pty.exit" &&
+            (entry.params as { sessionId: string }).sessionId === sessionId,
+        ),
+      ).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a slowly draining session alive while acks continue", async () => {
+    vi.useFakeTimers();
+    try {
+      const { pty, service } = createHarness();
+      const { sessionId } = await service.open("peer-a", OPEN_REQUEST);
+      const burst = FEDERATION_PTY_HIGH_WATER_BYTES + 1;
+      pty.emitData("x".repeat(burst));
+      expect(pty.paused).toBe(true);
+
+      // Trickling acks re-arm the watchdog each time — slow is not dead.
+      vi.advanceTimersByTime(45_000);
+      service.ack("peer-a", { sessionId, bytes: 1 });
+      vi.advanceTimersByTime(45_000);
+      service.ack("peer-a", { sessionId, bytes: 1 });
+      vi.advanceTimersByTime(45_000);
+      expect(pty.killed).toBe(false);
+
+      // Draining below the low-water mark resumes and stands the watchdog
+      // down entirely.
+      service.ack("peer-a", { sessionId, bytes: burst });
+      expect(pty.paused).toBe(false);
+      vi.advanceTimersByTime(600_000);
+      expect(pty.killed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("federation pty router integration", () => {

--- a/apps/desktop/src/main/__tests__/federation-pty-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-pty-service.test.ts
@@ -4,6 +4,7 @@ import { FEDERATION_PROTOCOL_VERSION } from "@pwragent/shared";
 import {
   FEDERATION_PTY_HIGH_WATER_BYTES,
   FEDERATION_PTY_LOW_WATER_BYTES,
+  FEDERATION_PTY_MAX_SESSIONS_PER_PEER,
   FEDERATION_PTY_METHOD_CAPABILITIES,
   FEDERATION_PTY_METHODS,
   FEDERATION_PTY_OUTPUT_CHUNK_CHARS,
@@ -89,6 +90,7 @@ function createHarness(options?: {
     cwd: string;
     shell: { file: string; args: string[] };
   }>;
+  resolveThreadCwd?: () => Promise<string | undefined>;
 }) {
   const pty = new FakePty();
   const sent: SentNotification[] = [];
@@ -101,7 +103,8 @@ function createHarness(options?: {
         cwd: "/owner/worktree",
         shell: { file: "/bin/zsh", args: ["-l"] },
       })),
-    resolveThreadCwd: async () => "/owner/worktree",
+    resolveThreadCwd:
+      options?.resolveThreadCwd ?? (async () => "/owner/worktree"),
     sendNotification: (peerId, method, params) => {
       if (options?.deliverable && !options.deliverable()) return false;
       sent.push({ peerId, method, params });
@@ -231,6 +234,38 @@ describe("FederationPtyService sessions", () => {
     pty.emitData("y".repeat(FEDERATION_PTY_HIGH_WATER_BYTES + 1));
     expect(sent.filter((entry) => entry.method === "pty.output")).toHaveLength(0);
     expect(pty.paused).toBe(true);
+  });
+
+  it("does not spawn when the owner cannot resolve the thread", async () => {
+    const spawnPty = vi.fn();
+    const service = new FederationPtyService({
+      spawnPty: spawnPty as never,
+      resolveThreadCwd: async () => {
+        throw new Error(
+          "Remote terminal thread was not found on the owning instance.",
+        );
+      },
+      sendNotification: () => true,
+    });
+    await expect(service.open("peer-a", OPEN_REQUEST)).rejects.toThrow(
+      /not found on the owning instance/,
+    );
+    expect(spawnPty).not.toHaveBeenCalled();
+    expect(service.sessionCountForPeer("peer-a")).toBe(0);
+  });
+
+  it("caps live and spawning sessions per peer", async () => {
+    const { service } = createHarness();
+    for (let index = 0; index < FEDERATION_PTY_MAX_SESSIONS_PER_PEER; index += 1) {
+      await service.open("peer-a", OPEN_REQUEST);
+    }
+    await expect(service.open("peer-a", OPEN_REQUEST)).rejects.toThrow(
+      /session limit reached/,
+    );
+    // The cap is per peer, not global.
+    await expect(service.open("peer-b", OPEN_REQUEST)).resolves.toMatchObject({
+      cwd: "/owner/worktree",
+    });
   });
 
   it("notifies exit and forgets the session", async () => {

--- a/apps/desktop/src/main/__tests__/federation-pty-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-pty-service.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it, vi } from "vitest";
+import type { FederationRequestEnvelope } from "@pwragent/shared";
+import { FEDERATION_PROTOCOL_VERSION } from "@pwragent/shared";
+import {
+  FEDERATION_PTY_HIGH_WATER_BYTES,
+  FEDERATION_PTY_LOW_WATER_BYTES,
+  FEDERATION_PTY_METHOD_CAPABILITIES,
+  FEDERATION_PTY_METHODS,
+  FEDERATION_PTY_OUTPUT_CHUNK_CHARS,
+  FederationPtyService,
+  registerFederationPtyHandlers,
+  type FederationPtyOutputParams,
+  type FederationPtyProcess,
+} from "../federation/federation-pty-service";
+import { FederationRouter } from "../federation/federation-router";
+
+class FakePty implements FederationPtyProcess {
+  pid = 4242;
+  written: string[] = [];
+  resizes: { cols: number; rows: number }[] = [];
+  killed = false;
+  paused = false;
+  pauseCount = 0;
+  resumeCount = 0;
+  private readonly dataListeners = new Set<(data: string) => void>();
+  private readonly exitListeners = new Set<
+    (event: { exitCode: number; signal?: number }) => void
+  >();
+
+  write(data: string): void {
+    this.written.push(data);
+  }
+
+  resize(cols: number, rows: number): void {
+    this.resizes.push({ cols, rows });
+  }
+
+  kill(): void {
+    this.killed = true;
+    this.emitExit(0);
+  }
+
+  pause(): void {
+    this.paused = true;
+    this.pauseCount += 1;
+  }
+
+  resume(): void {
+    this.paused = false;
+    this.resumeCount += 1;
+  }
+
+  onData(listener: (data: string) => void): { dispose(): void } {
+    this.dataListeners.add(listener);
+    return { dispose: () => this.dataListeners.delete(listener) };
+  }
+
+  onExit(
+    listener: (event: { exitCode: number; signal?: number }) => void,
+  ): { dispose(): void } {
+    this.exitListeners.add(listener);
+    return { dispose: () => this.exitListeners.delete(listener) };
+  }
+
+  emitData(data: string): void {
+    for (const listener of Array.from(this.dataListeners)) {
+      listener(data);
+    }
+  }
+
+  emitExit(exitCode: number): void {
+    for (const listener of Array.from(this.exitListeners)) {
+      listener({ exitCode });
+    }
+  }
+}
+
+type SentNotification = {
+  peerId: string;
+  method: string;
+  params: unknown;
+};
+
+function createHarness(options?: {
+  graceMs?: number;
+  deliverable?: () => boolean;
+  spawnPty?: () => Promise<{
+    pty: FederationPtyProcess;
+    cwd: string;
+    shell: { file: string; args: string[] };
+  }>;
+}) {
+  const pty = new FakePty();
+  const sent: SentNotification[] = [];
+  const audits: { peerId: string; kind: string; detail: string }[] = [];
+  const service = new FederationPtyService({
+    spawnPty:
+      options?.spawnPty ??
+      (async () => ({
+        pty,
+        cwd: "/owner/worktree",
+        shell: { file: "/bin/zsh", args: ["-l"] },
+      })),
+    resolveThreadCwd: async () => "/owner/worktree",
+    sendNotification: (peerId, method, params) => {
+      if (options?.deliverable && !options.deliverable()) return false;
+      sent.push({ peerId, method, params });
+      return true;
+    },
+    onAudit: (entry) =>
+      audits.push({
+        peerId: entry.peerId,
+        kind: entry.kind,
+        detail: entry.detail,
+      }),
+    graceMs: options?.graceMs ?? 10_000,
+  });
+  return { audits, pty, sent, service };
+}
+
+const OPEN_REQUEST = {
+  backend: "codex" as const,
+  threadId: "thread-1",
+  cols: 80,
+  rows: 24,
+};
+
+describe("FederationPtyService capability map", () => {
+  it("requires remote_pty for every control method", () => {
+    const methods = Object.values(FEDERATION_PTY_METHODS);
+    expect(methods).toHaveLength(5);
+    for (const method of methods) {
+      expect(FEDERATION_PTY_METHOD_CAPABILITIES[method]).toBe("remote_pty");
+    }
+  });
+});
+
+describe("FederationPtyService sessions", () => {
+  it("opens with the owner-resolved cwd and audits the open", async () => {
+    const { audits, service } = createHarness();
+    const opened = await service.open("peer-a", OPEN_REQUEST);
+    expect(opened.sessionId).toBeTruthy();
+    expect(opened.cwd).toBe("/owner/worktree");
+    expect(opened.shell).toBe("/bin/zsh");
+    expect(audits).toEqual([
+      {
+        peerId: "peer-a",
+        kind: "remote_pty_open",
+        detail: "codex:thread-1",
+      },
+    ]);
+  });
+
+  it("rejects input, resize, ack, and close from a non-opener peer", async () => {
+    const { pty, service } = createHarness();
+    const { sessionId } = await service.open("peer-a", OPEN_REQUEST);
+    const dataBase64 = Buffer.from("whoami\r").toString("base64");
+
+    expect(() => service.input("peer-b", { sessionId, dataBase64 })).toThrow(
+      /not found for this peer/,
+    );
+    expect(() =>
+      service.resize("peer-b", { sessionId, cols: 100, rows: 30 }),
+    ).toThrow(/not found for this peer/);
+    expect(() => service.ack("peer-b", { sessionId, bytes: 1 })).toThrow(
+      /not found for this peer/,
+    );
+    expect(() => service.close("peer-b", { sessionId })).toThrow(
+      /not found for this peer/,
+    );
+    expect(pty.written).toEqual([]);
+
+    service.input("peer-a", { sessionId, dataBase64 });
+    expect(pty.written).toEqual(["whoami\r"]);
+  });
+
+  it("streams output as gapless chunked frames and applies ack-window flow control", async () => {
+    const { pty, sent, service } = createHarness();
+    const { sessionId } = await service.open("peer-a", OPEN_REQUEST);
+
+    // 2 MiB of ASCII: crosses the 1 MiB high-water mark in one burst.
+    const burst = "x".repeat(2 * 1024 * 1024);
+    pty.emitData(burst);
+
+    const outputs = sent.filter((entry) => entry.method === "pty.output");
+    expect(outputs.length).toBe(
+      Math.ceil(burst.length / FEDERATION_PTY_OUTPUT_CHUNK_CHARS),
+    );
+    const seqs = outputs.map(
+      (entry) => (entry.params as FederationPtyOutputParams).seq,
+    );
+    expect(seqs).toEqual(outputs.map((_, index) => index + 1));
+    const totalBytes = outputs.reduce(
+      (sum, entry) =>
+        sum +
+        Buffer.from(
+          (entry.params as FederationPtyOutputParams).dataBase64,
+          "base64",
+        ).length,
+      0,
+    );
+    expect(totalBytes).toBe(burst.length);
+
+    // Above high water: paused exactly once.
+    expect(pty.pauseCount).toBe(1);
+    expect(pty.paused).toBe(true);
+
+    // Ack down to (but not below) the low-water mark: still paused.
+    service.ack("peer-a", {
+      sessionId,
+      bytes: burst.length - FEDERATION_PTY_LOW_WATER_BYTES - 1,
+    });
+    expect(pty.resumeCount).toBe(0);
+
+    // Cross the low-water mark: resumed.
+    service.ack("peer-a", { sessionId, bytes: 1 });
+    expect(pty.resumeCount).toBe(1);
+    expect(pty.paused).toBe(false);
+    expect(FEDERATION_PTY_HIGH_WATER_BYTES).toBeGreaterThan(
+      FEDERATION_PTY_LOW_WATER_BYTES,
+    );
+  });
+
+  it("keeps counting undeliverable output toward the pause threshold", async () => {
+    let deliverable = true;
+    const { pty, sent, service } = createHarness({
+      deliverable: () => deliverable,
+    });
+    await service.open("peer-a", OPEN_REQUEST);
+    deliverable = false;
+    pty.emitData("y".repeat(FEDERATION_PTY_HIGH_WATER_BYTES + 1));
+    expect(sent.filter((entry) => entry.method === "pty.output")).toHaveLength(0);
+    expect(pty.paused).toBe(true);
+  });
+
+  it("notifies exit and forgets the session", async () => {
+    const { pty, sent, service } = createHarness();
+    const { sessionId } = await service.open("peer-a", OPEN_REQUEST);
+    pty.emitExit(3);
+    expect(sent.at(-1)).toEqual({
+      peerId: "peer-a",
+      method: "pty.exit",
+      params: { sessionId, exitCode: 3, signal: null },
+    });
+    expect(() =>
+      service.input("peer-a", { sessionId, dataBase64: "" }),
+    ).toThrow(/not found for this peer/);
+  });
+});
+
+describe("FederationPtyService reaping", () => {
+  it("kills the session after the grace period on peer disconnect", async () => {
+    vi.useFakeTimers();
+    try {
+      const { audits, pty, service } = createHarness({ graceMs: 10_000 });
+      await service.open("peer-a", OPEN_REQUEST);
+      service.notifyPeerDisconnected("peer-a");
+      vi.advanceTimersByTime(9_999);
+      expect(pty.killed).toBe(false);
+      vi.advanceTimersByTime(1);
+      expect(pty.killed).toBe(true);
+      expect(audits.at(-1)).toMatchObject({
+        kind: "remote_pty_close",
+        detail: "disconnect",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels the disconnect reap when the peer reconnects inside the grace", async () => {
+    vi.useFakeTimers();
+    try {
+      const { pty, service } = createHarness({ graceMs: 10_000 });
+      const { sessionId } = await service.open("peer-a", OPEN_REQUEST);
+      service.notifyPeerDisconnected("peer-a");
+      vi.advanceTimersByTime(5_000);
+      service.notifyPeerConnected("peer-a");
+      vi.advanceTimersByTime(60_000);
+      expect(pty.killed).toBe(false);
+      // The renderer still holds the sessionId and keeps typing into it.
+      service.input("peer-a", {
+        sessionId,
+        dataBase64: Buffer.from("ls\r").toString("base64"),
+      });
+      expect(pty.written).toEqual(["ls\r"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("applies the grace to explicit closes and does not let a reconnect cancel them", async () => {
+    vi.useFakeTimers();
+    try {
+      const { pty, service } = createHarness({ graceMs: 10_000 });
+      const { sessionId } = await service.open("peer-a", OPEN_REQUEST);
+      service.close("peer-a", { sessionId });
+      service.notifyPeerConnected("peer-a");
+      vi.advanceTimersByTime(10_000);
+      expect(pty.killed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not leak a shell when the peer disconnects during spawn", async () => {
+    const pty = new FakePty();
+    let releaseSpawn: (() => void) | undefined;
+    const { service } = createHarness({
+      spawnPty: async () => {
+        await new Promise<void>((resolve) => {
+          releaseSpawn = resolve;
+        });
+        return {
+          pty,
+          cwd: "/owner/worktree",
+          shell: { file: "/bin/zsh", args: ["-l"] },
+        };
+      },
+    });
+    const openPromise = service.open("peer-a", OPEN_REQUEST);
+    // Let open() progress through resolveThreadCwd into the pending spawn.
+    await vi.waitFor(() => {
+      expect(releaseSpawn).toBeTypeOf("function");
+    });
+    service.notifyPeerDisconnected("peer-a");
+    releaseSpawn!();
+    await expect(openPromise).rejects.toThrow(/disconnected while the terminal/);
+    expect(pty.killed).toBe(true);
+    expect(service.sessionCountForPeer("peer-a")).toBe(0);
+  });
+
+  it("kills every session immediately on owner shutdown", async () => {
+    const { pty, service } = createHarness();
+    await service.open("peer-a", OPEN_REQUEST);
+    service.disposeAll();
+    expect(pty.killed).toBe(true);
+  });
+});
+
+describe("federation pty router integration", () => {
+  function buildEnvelope(
+    method: string,
+    params: unknown,
+    sourceInstanceId: string,
+  ): FederationRequestEnvelope {
+    return {
+      id: `req-${method}-${sourceInstanceId}`,
+      kind: "request",
+      method,
+      params,
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId,
+      targetInstanceId: "owner",
+      createdAt: Date.now(),
+    };
+  }
+
+  function createRouterHarness() {
+    const { service, sent } = createHarness();
+    const router = new FederationRouter({
+      localInstanceId: "owner",
+      methodCapabilities: { ...FEDERATION_PTY_METHOD_CAPABILITIES },
+    });
+    registerFederationPtyHandlers({ router, service });
+    return { router, sent, service };
+  }
+
+  it("rejects pty methods from a peer without remote_pty", async () => {
+    const { router } = createRouterHarness();
+    router.registerConnection({
+      peerId: "viewer",
+      capabilities: ["thread_detail"],
+      sendEnvelope: () => undefined,
+    });
+    const result = await router.routeEnvelope({
+      envelope: buildEnvelope(FEDERATION_PTY_METHODS.open, OPEN_REQUEST, "viewer"),
+      sourcePeerId: "viewer",
+    });
+    expect(result).toMatchObject({
+      status: "rejected",
+      code: "capability_denied",
+    });
+  });
+
+  it("rejects a gateway-relayed open instead of streaming through a relay", async () => {
+    const { router } = createRouterHarness();
+    router.registerConnection({
+      peerId: "gateway",
+      capabilities: ["remote_pty", "gateway_relay"],
+      sendEnvelope: () => undefined,
+    });
+    // The envelope claims to originate from "viewer" but arrived over the
+    // gateway's authenticated link.
+    const result = await router.routeEnvelope({
+      envelope: buildEnvelope(FEDERATION_PTY_METHODS.open, OPEN_REQUEST, "viewer"),
+      sourcePeerId: "gateway",
+    });
+    expect(result).toMatchObject({ status: "rejected" });
+    expect((result as { message?: string }).message).toMatch(/point-to-point/);
+  });
+
+  it("opens a session for a directly connected peer with remote_pty", async () => {
+    const { router, service } = createRouterHarness();
+    router.registerConnection({
+      peerId: "viewer",
+      capabilities: ["remote_pty"],
+      sendEnvelope: () => undefined,
+    });
+    const result = await router.routeEnvelope({
+      envelope: buildEnvelope(FEDERATION_PTY_METHODS.open, OPEN_REQUEST, "viewer"),
+      sourcePeerId: "viewer",
+    });
+    expect(result.status).toBe("handled");
+    expect(service.sessionCountForPeer("viewer")).toBe(1);
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -185,6 +185,9 @@ describe("DesktopFederationRuntime", () => {
       }),
       listPeers: () => [],
     });
+    // remoteNavigationSnapshot also consults the live peer view for the
+    // granted-capability set; there is no app state db in this harness.
+    runtime.visiblePeers = () => [];
 
     const snapshot = await runtime.remoteNavigationSnapshot(
       { scope: "remote", instanceId: "client_one" },

--- a/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WebContents } from "electron";
+import {
+  INTEGRATED_TERMINAL_CLOSE_CHANNEL,
+  INTEGRATED_TERMINAL_CREATE_CHANNEL,
+  INTEGRATED_TERMINAL_LIST_CHANNEL,
+  INTEGRATED_TERMINAL_WRITE_CHANNEL,
+} from "../../shared/ipc";
+
+const mocks = vi.hoisted(() => {
+  const handlers = new Map<
+    string,
+    (...args: unknown[]) => unknown | Promise<unknown>
+  >();
+  return {
+    handlers,
+    localCreateOrAttach: vi.fn(async () => ({
+      sessionId: "local-session",
+      threadKey: "codex:local-thread",
+      cwd: "/local",
+      shell: "/bin/zsh",
+    })),
+    localWrite: vi.fn(),
+    federationWindowIds: new Set<number>(),
+    federationTargets: new Map<number, { scope: "remote"; instanceId: string }>(),
+    remotePtyOpen: vi.fn(async () => ({
+      sessionId: "remote-session",
+      cwd: "/owner/worktree",
+      shell: "/bin/zsh",
+    })),
+    remotePtyInput: vi.fn(async () => undefined),
+    remotePtyClose: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn(
+      (channel: string, handler: (...args: unknown[]) => unknown) => {
+        mocks.handlers.set(channel, handler);
+      },
+    ),
+    removeHandler: vi.fn((channel: string) => {
+      mocks.handlers.delete(channel);
+    }),
+  },
+}));
+
+vi.mock("../terminal/integrated-terminal-service", () => ({
+  IntegratedTerminalService: class {
+    createOrAttach = mocks.localCreateOrAttach;
+    write = mocks.localWrite;
+    resize = vi.fn();
+    close = vi.fn();
+    listSessions = vi.fn(() => []);
+    setPanelHidden = vi.fn();
+    dispose = vi.fn();
+  },
+}));
+
+vi.mock("../window", () => ({
+  isFederationWindowWebContents: (webContents: { id: number } | undefined) =>
+    webContents ? mocks.federationWindowIds.has(webContents.id) : false,
+  federationWindowTargetForWebContents: (
+    webContents: { id: number } | undefined,
+  ) => (webContents ? mocks.federationTargets.get(webContents.id) : undefined),
+}));
+
+vi.mock("../window-channels", () => ({
+  subscribersForChannel: () => [],
+}));
+
+vi.mock("../federation/federation-runtime", () => ({
+  getDesktopFederationRuntime: () => ({
+    remotePty: () => ({
+      open: mocks.remotePtyOpen,
+      input: mocks.remotePtyInput,
+      resize: vi.fn(async () => undefined),
+      ack: vi.fn(async () => undefined),
+      close: mocks.remotePtyClose,
+    }),
+    onRemotePtyEvent: () => () => undefined,
+  }),
+}));
+
+import {
+  disposeIntegratedTerminalIpcHandlers,
+  registerIntegratedTerminalIpcHandlers,
+} from "../ipc/integrated-terminal";
+
+function fakeWebContents(id: number): WebContents {
+  return {
+    id,
+    isDestroyed: () => false,
+    once: vi.fn(),
+    send: vi.fn(),
+  } as unknown as WebContents;
+}
+
+async function invoke(channel: string, sender: WebContents, request?: unknown) {
+  const handler = mocks.handlers.get(channel);
+  if (!handler) throw new Error(`No handler registered for ${channel}`);
+  return await handler({ sender }, request);
+}
+
+describe("integrated terminal IPC federation branch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.federationWindowIds.clear();
+    mocks.federationTargets.clear();
+    disposeIntegratedTerminalIpcHandlers();
+    registerIntegratedTerminalIpcHandlers();
+  });
+
+  it("routes a local window's create to the local PTY service", async () => {
+    const sender = fakeWebContents(1);
+    await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
+      threadKey: "codex:local-thread",
+      cols: 80,
+      rows: 24,
+    });
+    expect(mocks.localCreateOrAttach).toHaveBeenCalledTimes(1);
+    expect(mocks.remotePtyOpen).not.toHaveBeenCalled();
+  });
+
+  it("routes a federation window's create to the remote session, never a local spawn", async () => {
+    const sender = fakeWebContents(7);
+    mocks.federationWindowIds.add(7);
+    mocks.federationTargets.set(7, { scope: "remote", instanceId: "peer-a" });
+
+    const response = (await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
+      threadKey: "codex:remote-thread",
+      cols: 120,
+      rows: 32,
+    })) as { sessionId: string; cwd: string };
+
+    expect(mocks.remotePtyOpen).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "remote-thread",
+      cols: 120,
+      rows: 32,
+    });
+    expect(response.sessionId).toBe("remote-session");
+    expect(response.cwd).toBe("/owner/worktree");
+    expect(mocks.localCreateOrAttach).not.toHaveBeenCalled();
+  });
+
+  it("throws for a federation window with no remote target instead of spawning locally", async () => {
+    const sender = fakeWebContents(9);
+    mocks.federationWindowIds.add(9);
+    // Deliberately no target registered for id 9.
+
+    await expect(
+      invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
+        threadKey: "codex:remote-thread",
+        cols: 80,
+        rows: 24,
+      }),
+    ).rejects.toThrow(/no federation target/);
+    expect(mocks.localCreateOrAttach).not.toHaveBeenCalled();
+    expect(mocks.remotePtyOpen).not.toHaveBeenCalled();
+  });
+
+  it("keeps a federation window's writes off the local service", async () => {
+    const sender = fakeWebContents(7);
+    mocks.federationWindowIds.add(7);
+    mocks.federationTargets.set(7, { scope: "remote", instanceId: "peer-a" });
+    await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
+      threadKey: "codex:remote-thread",
+      cols: 80,
+      rows: 24,
+    });
+
+    await invoke(INTEGRATED_TERMINAL_WRITE_CHANNEL, sender, {
+      sessionId: "remote-session",
+      data: "echo hi\r",
+    });
+    expect(mocks.localWrite).not.toHaveBeenCalled();
+    expect(mocks.remotePtyInput).toHaveBeenCalledWith({
+      sessionId: "remote-session",
+      dataBase64: Buffer.from("echo hi\r", "utf8").toString("base64"),
+    });
+  });
+
+  it("lists only the federation window's own remote sessions", async () => {
+    const remoteSender = fakeWebContents(7);
+    mocks.federationWindowIds.add(7);
+    mocks.federationTargets.set(7, { scope: "remote", instanceId: "peer-a" });
+    await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, remoteSender, {
+      threadKey: "codex:remote-thread",
+      cols: 80,
+      rows: 24,
+    });
+
+    const remoteList = (await invoke(
+      INTEGRATED_TERMINAL_LIST_CHANNEL,
+      remoteSender,
+    )) as { sessionId: string }[];
+    expect(remoteList.map((session) => session.sessionId)).toEqual([
+      "remote-session",
+    ]);
+
+    const otherRemoteSender = fakeWebContents(8);
+    mocks.federationWindowIds.add(8);
+    mocks.federationTargets.set(8, { scope: "remote", instanceId: "peer-b" });
+    const otherList = (await invoke(
+      INTEGRATED_TERMINAL_LIST_CHANNEL,
+      otherRemoteSender,
+    )) as unknown[];
+    expect(otherList).toEqual([]);
+  });
+
+  it("closes the remote session when the federation window closes the pane", async () => {
+    const sender = fakeWebContents(7);
+    mocks.federationWindowIds.add(7);
+    mocks.federationTargets.set(7, { scope: "remote", instanceId: "peer-a" });
+    await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
+      threadKey: "codex:remote-thread",
+      cols: 80,
+      rows: 24,
+    });
+
+    await invoke(INTEGRATED_TERMINAL_CLOSE_CHANNEL, sender, {
+      sessionId: "remote-session",
+    });
+    expect(mocks.remotePtyClose).toHaveBeenCalledWith({
+      sessionId: "remote-session",
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
@@ -29,7 +29,15 @@ const mocks = vi.hoisted(() => {
       shell: "/bin/zsh",
     })),
     remotePtyInput: vi.fn(async () => undefined),
+    remotePtyAck: vi.fn(async () => undefined),
     remotePtyClose: vi.fn(async () => undefined),
+    remotePtyEventListener: undefined as
+      | ((event: {
+          kind: string;
+          peerId: string;
+          params: Record<string, unknown>;
+        }) => void)
+      | undefined,
   };
 });
 
@@ -76,10 +84,19 @@ vi.mock("../federation/federation-runtime", () => ({
       open: mocks.remotePtyOpen,
       input: mocks.remotePtyInput,
       resize: vi.fn(async () => undefined),
-      ack: vi.fn(async () => undefined),
+      ack: mocks.remotePtyAck,
       close: mocks.remotePtyClose,
     }),
-    onRemotePtyEvent: () => () => undefined,
+    onRemotePtyEvent: (
+      listener: (event: {
+        kind: string;
+        peerId: string;
+        params: Record<string, unknown>;
+      }) => void,
+    ) => {
+      mocks.remotePtyEventListener = listener;
+      return () => undefined;
+    },
   }),
 }));
 
@@ -108,6 +125,7 @@ describe("integrated terminal IPC federation branch", () => {
     vi.clearAllMocks();
     mocks.federationWindowIds.clear();
     mocks.federationTargets.clear();
+    mocks.remotePtyEventListener = undefined;
     disposeIntegratedTerminalIpcHandlers();
     registerIntegratedTerminalIpcHandlers();
   });
@@ -226,5 +244,192 @@ describe("integrated terminal IPC federation branch", () => {
     expect(mocks.remotePtyClose).toHaveBeenCalledWith({
       sessionId: "remote-session",
     });
+  });
+
+  it("honors a close issued while the remote open is still in flight", async () => {
+    const sender = fakeWebContents(7);
+    mocks.federationWindowIds.add(7);
+    mocks.federationTargets.set(7, { scope: "remote", instanceId: "peer-a" });
+    let releaseOpen: (() => void) | undefined;
+    mocks.remotePtyOpen.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        releaseOpen = resolve;
+      });
+      return {
+        sessionId: "remote-session",
+        cwd: "/owner/worktree",
+        shell: "/bin/zsh",
+      };
+    });
+
+    const createPromise = invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
+      threadKey: "codex:remote-thread",
+      cols: 80,
+      rows: 24,
+    });
+    await vi.waitFor(() => {
+      expect(releaseOpen).toBeTypeOf("function");
+    });
+    // The user dismisses the panel before the owner finished spawning.
+    await invoke(INTEGRATED_TERMINAL_CLOSE_CHANNEL, sender, {
+      threadKey: "codex:remote-thread",
+    });
+    releaseOpen!();
+
+    await expect(createPromise).rejects.toThrow(/closed before it finished/);
+    // The just-spawned owner session is released, and nothing was registered
+    // that could broadcast the dismissed pane back open.
+    await vi.waitFor(() => {
+      expect(mocks.remotePtyClose).toHaveBeenCalledWith({
+        sessionId: "remote-session",
+      });
+    });
+    const list = (await invoke(
+      INTEGRATED_TERMINAL_LIST_CHANNEL,
+      sender,
+    )) as unknown[];
+    expect(list).toEqual([]);
+  });
+
+  it("coalesces concurrent creates for one thread into a single remote open", async () => {
+    const sender = fakeWebContents(7);
+    mocks.federationWindowIds.add(7);
+    mocks.federationTargets.set(7, { scope: "remote", instanceId: "peer-a" });
+    let releaseOpen: (() => void) | undefined;
+    mocks.remotePtyOpen.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        releaseOpen = resolve;
+      });
+      return {
+        sessionId: "remote-session",
+        cwd: "/owner/worktree",
+        shell: "/bin/zsh",
+      };
+    });
+
+    const request = { threadKey: "codex:remote-thread", cols: 80, rows: 24 };
+    const first = invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, request);
+    await vi.waitFor(() => {
+      expect(releaseOpen).toBeTypeOf("function");
+    });
+    const second = invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, request);
+    releaseOpen!();
+
+    const [firstResponse, secondResponse] = (await Promise.all([
+      first,
+      second,
+    ])) as { sessionId: string }[];
+    expect(firstResponse.sessionId).toBe("remote-session");
+    expect(secondResponse.sessionId).toBe("remote-session");
+    expect(mocks.remotePtyOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a stream sequence gap instead of silently repairing it", async () => {
+    const sender = fakeWebContents(7);
+    mocks.federationWindowIds.add(7);
+    mocks.federationTargets.set(7, { scope: "remote", instanceId: "peer-a" });
+    await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
+      threadKey: "codex:remote-thread",
+      cols: 80,
+      rows: 24,
+    });
+    const emit = mocks.remotePtyEventListener!;
+
+    emit({
+      kind: "output",
+      peerId: "peer-a",
+      params: {
+        sessionId: "remote-session",
+        seq: 1,
+        dataBase64: Buffer.from("one").toString("base64"),
+      },
+    });
+    emit({
+      kind: "output",
+      peerId: "peer-a",
+      params: {
+        sessionId: "remote-session",
+        seq: 3,
+        dataBase64: Buffer.from("three").toString("base64"),
+      },
+    });
+
+    const sends = (sender.send as ReturnType<typeof vi.fn>).mock.calls;
+    const errorSend = sends.find(
+      ([channel]) => channel === "integrated-terminal:error",
+    );
+    expect(errorSend?.[1]).toMatchObject({
+      sessionId: "remote-session",
+      message: expect.stringMatching(/skipped from frame 1 to 3/),
+    });
+    // The frames that DID arrive still render.
+    const outputSends = sends.filter(
+      ([channel]) => channel === "integrated-terminal:output",
+    );
+    expect(outputSends.map(([, payload]) => (payload as { data: string }).data))
+      .toEqual(["one", "three"]);
+  });
+
+  it("acks consumed output every 256 KiB", async () => {
+    const sender = fakeWebContents(7);
+    mocks.federationWindowIds.add(7);
+    mocks.federationTargets.set(7, { scope: "remote", instanceId: "peer-a" });
+    await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
+      threadKey: "codex:remote-thread",
+      cols: 80,
+      rows: 24,
+    });
+    const emit = mocks.remotePtyEventListener!;
+
+    const chunk = "x".repeat(128 * 1024);
+    emit({
+      kind: "output",
+      peerId: "peer-a",
+      params: {
+        sessionId: "remote-session",
+        seq: 1,
+        dataBase64: Buffer.from(chunk).toString("base64"),
+      },
+    });
+    expect(mocks.remotePtyAck).not.toHaveBeenCalled();
+    emit({
+      kind: "output",
+      peerId: "peer-a",
+      params: {
+        sessionId: "remote-session",
+        seq: 2,
+        dataBase64: Buffer.from(chunk).toString("base64"),
+      },
+    });
+    expect(mocks.remotePtyAck).toHaveBeenCalledWith({
+      sessionId: "remote-session",
+      bytes: 256 * 1024,
+    });
+  });
+
+  it("replays viewer-buffered output when a pane re-attaches", async () => {
+    const sender = fakeWebContents(7);
+    mocks.federationWindowIds.add(7);
+    mocks.federationTargets.set(7, { scope: "remote", instanceId: "peer-a" });
+    const request = { threadKey: "codex:remote-thread", cols: 80, rows: 24 };
+    await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, request);
+    mocks.remotePtyEventListener!({
+      kind: "output",
+      peerId: "peer-a",
+      params: {
+        sessionId: "remote-session",
+        seq: 1,
+        dataBase64: Buffer.from("scrollback line").toString("base64"),
+      },
+    });
+
+    const reattached = (await invoke(
+      INTEGRATED_TERMINAL_CREATE_CHANNEL,
+      sender,
+      request,
+    )) as { sessionId: string; buffer?: string };
+    expect(reattached.sessionId).toBe("remote-session");
+    expect(reattached.buffer).toBe("scrollback line");
+    expect(mocks.remotePtyOpen).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/main/federation/federation-pty-service.ts
+++ b/apps/desktop/src/main/federation/federation-pty-service.ts
@@ -1,0 +1,621 @@
+import { randomUUID } from "node:crypto";
+import type {
+  AppServerBackendKind,
+  FederationCapability,
+  FederationInstanceId,
+  FederationRequestEnvelope,
+} from "@pwragent/shared";
+import type { FederationRouter } from "./federation-router";
+import type { FederationRpcEndpoint } from "./federation-rpc";
+
+/**
+ * Remote PTY protocol for federated threads.
+ *
+ * Control plane (viewer → owner, capability-checked RPC requests):
+ * `pty.open` / `pty.input` / `pty.resize` / `pty.ack` / `pty.close`.
+ * Stream plane (owner → viewer, notifications): `pty.output` / `pty.exit` /
+ * `pty.error`. Sessions are point-to-point with the owning instance — the
+ * stream is never relayed through a gateway, and only the opener peer may
+ * write input to or close a session.
+ *
+ * This module must stay importable outside Electron (no settings singleton,
+ * no electron imports): the in-process E2E federation gateway harness runs the
+ * owner service inside the Playwright test process.
+ */
+
+export const FEDERATION_PTY_METHODS = {
+  open: "pty.open",
+  input: "pty.input",
+  resize: "pty.resize",
+  ack: "pty.ack",
+  close: "pty.close",
+} as const;
+
+export type FederationPtyMethod =
+  (typeof FEDERATION_PTY_METHODS)[keyof typeof FEDERATION_PTY_METHODS];
+
+export const FEDERATION_PTY_OUTPUT_METHOD = "pty.output";
+export const FEDERATION_PTY_EXIT_METHOD = "pty.exit";
+export const FEDERATION_PTY_ERROR_METHOD = "pty.error";
+
+/** Every control method requires the dedicated capability — a direct shell
+ *  stays revocable independently of `turn_control`. */
+export const FEDERATION_PTY_METHOD_CAPABILITIES: Record<
+  FederationPtyMethod,
+  FederationCapability
+> = {
+  [FEDERATION_PTY_METHODS.open]: "remote_pty",
+  [FEDERATION_PTY_METHODS.input]: "remote_pty",
+  [FEDERATION_PTY_METHODS.resize]: "remote_pty",
+  [FEDERATION_PTY_METHODS.ack]: "remote_pty",
+  [FEDERATION_PTY_METHODS.close]: "remote_pty",
+};
+
+/** Output chunks are capped so a burst can't monopolize the shared socket. */
+export const FEDERATION_PTY_OUTPUT_CHUNK_CHARS = 32 * 1024;
+/** Unacked output bytes at which the owner pauses the PTY. */
+export const FEDERATION_PTY_HIGH_WATER_BYTES = 1024 * 1024;
+/** Unacked output bytes below which a paused PTY resumes. */
+export const FEDERATION_PTY_LOW_WATER_BYTES = 256 * 1024;
+/** The viewer acknowledges consumed output at this interval. */
+export const FEDERATION_PTY_ACK_INTERVAL_BYTES = 256 * 1024;
+/** Sessions survive a close/disconnect this long before the PTY is killed. */
+export const FEDERATION_PTY_REAP_GRACE_MS = 10_000;
+
+export type FederationPtyOpenRequest = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  cols: number;
+  rows: number;
+};
+
+export type FederationPtyOpenResponse = {
+  sessionId: string;
+  cwd: string;
+  shell: string;
+};
+
+export type FederationPtyInputRequest = {
+  sessionId: string;
+  dataBase64: string;
+};
+
+export type FederationPtyResizeRequest = {
+  sessionId: string;
+  cols: number;
+  rows: number;
+};
+
+export type FederationPtyAckRequest = {
+  sessionId: string;
+  bytes: number;
+};
+
+export type FederationPtyCloseRequest = {
+  sessionId: string;
+};
+
+export type FederationPtyOutputParams = {
+  sessionId: string;
+  /** Gapless per-session counter. The transport is ordered, so a gap on the
+   *  viewer means a bug — surfaced, never silently repaired. */
+  seq: number;
+  dataBase64: string;
+};
+
+export type FederationPtyExitParams = {
+  sessionId: string;
+  exitCode: number | null;
+  signal?: number | string | null;
+};
+
+export type FederationPtyErrorParams = {
+  sessionId: string;
+  message: string;
+};
+
+/** Owner → viewer stream event, dispatched by the runtime on the viewer. */
+export type FederationPtyStreamEvent =
+  | { kind: "output"; peerId: FederationInstanceId; params: FederationPtyOutputParams }
+  | { kind: "exit"; peerId: FederationInstanceId; params: FederationPtyExitParams }
+  | { kind: "error"; peerId: FederationInstanceId; params: FederationPtyErrorParams };
+
+/** The slice of node-pty's IPty the owner service needs; narrow so unit tests
+ *  and the E2E harness can substitute fakes. */
+export type FederationPtyProcess = {
+  pid?: number;
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(): void;
+  pause(): void;
+  resume(): void;
+  onData(listener: (data: string) => void): { dispose(): void };
+  onExit(
+    listener: (event: { exitCode: number; signal?: number }) => void,
+  ): { dispose(): void };
+};
+
+export type FederationPtySpawn = (params: {
+  cwd?: string;
+  cols: number;
+  rows: number;
+}) => Promise<{
+  pty: FederationPtyProcess;
+  cwd: string;
+  shell: { file: string; args: string[] };
+}>;
+
+export type FederationPtyAuditEntry = {
+  peerId: FederationInstanceId;
+  kind: "remote_pty_open" | "remote_pty_close";
+  sessionId: string;
+  detail: string;
+};
+
+type FederationPtyServiceOptions = {
+  /** Spawns the shell. The desktop runtime passes the shared
+   *  integrated-terminal spawn core; harnesses inject their own. */
+  spawnPty: FederationPtySpawn;
+  /** Owner-side cwd resolution from the owner's OWN thread state. The viewer
+   *  never sends a path or shell. */
+  resolveThreadCwd: (params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }) => Promise<string | undefined>;
+  /** Direct-to-peer notification send. MUST NOT fall back to gateway relay —
+   *  returns false when the peer has no direct connection. */
+  sendNotification: (
+    peerId: FederationInstanceId,
+    method: string,
+    params: unknown,
+  ) => boolean;
+  onAudit?: (entry: FederationPtyAuditEntry) => void;
+  log?: {
+    info: (message: string, meta?: Record<string, unknown>) => void;
+    warn: (message: string, meta?: Record<string, unknown>) => void;
+  };
+  graceMs?: number;
+  now?: () => number;
+};
+
+type FederationPtySession = {
+  sessionId: string;
+  peerId: FederationInstanceId;
+  backend: AppServerBackendKind;
+  threadId: string;
+  cwd: string;
+  shell: string;
+  pty: FederationPtyProcess;
+  seq: number;
+  unackedBytes: number;
+  paused: boolean;
+  disposables: { dispose(): void }[];
+  reapTimer?: ReturnType<typeof setTimeout>;
+  reapReason?: "close" | "disconnect";
+};
+
+const MIN_DIMENSION = 2;
+const MAX_PTY_COLUMNS = 500;
+const MAX_PTY_ROWS = 200;
+
+function clampDimension(value: number, fallback: number, maximum: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(maximum, Math.max(MIN_DIMENSION, Math.round(value)));
+}
+
+/**
+ * Owner-side remote PTY sessions. Wraps the shared integrated-terminal spawn
+ * core (injected as `spawnPty`) with per-peer session keying, ack-window flow
+ * control, and grace-period reaping.
+ */
+export class FederationPtyService {
+  private readonly sessionsById = new Map<string, FederationPtySession>();
+  /** Bumped per peer on disconnect so an in-flight spawn can detect that its
+   *  requester went away and kill the shell instead of leaking it. */
+  private readonly peerEpochs = new Map<FederationInstanceId, number>();
+  private disposed = false;
+
+  constructor(private readonly options: FederationPtyServiceOptions) {}
+
+  async open(
+    peerId: FederationInstanceId,
+    request: FederationPtyOpenRequest,
+  ): Promise<FederationPtyOpenResponse> {
+    if (this.disposed) {
+      throw new Error("Remote terminal service is shutting down.");
+    }
+    const threadId = typeof request.threadId === "string" ? request.threadId.trim() : "";
+    if (!threadId) {
+      throw new Error("A thread id is required to open a remote terminal.");
+    }
+    const epoch = this.peerEpochs.get(peerId) ?? 0;
+    const cwd = await this.options.resolveThreadCwd({
+      backend: request.backend,
+      threadId,
+    });
+    const spawned = await this.options.spawnPty({
+      cwd,
+      cols: clampDimension(request.cols, 80, MAX_PTY_COLUMNS),
+      rows: clampDimension(request.rows, 18, MAX_PTY_ROWS),
+    });
+    // The requester disconnected (or the service shut down) while the shell
+    // was spawning: nobody can ever learn this sessionId, so a live shell
+    // here is a leak, not a session.
+    if (this.disposed || (this.peerEpochs.get(peerId) ?? 0) !== epoch) {
+      try {
+        spawned.pty.kill();
+      } catch (error) {
+        this.options.log?.warn("remote pty abort-kill failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      throw new Error("Federation peer disconnected while the terminal was starting.");
+    }
+    const session: FederationPtySession = {
+      sessionId: randomUUID(),
+      peerId,
+      backend: request.backend,
+      threadId,
+      cwd: spawned.cwd,
+      shell: spawned.shell.file,
+      pty: spawned.pty,
+      seq: 0,
+      unackedBytes: 0,
+      paused: false,
+      disposables: [],
+    };
+    this.sessionsById.set(session.sessionId, session);
+    session.disposables.push(
+      spawned.pty.onData((data) => this.handleOutput(session, data)),
+      spawned.pty.onExit((event) =>
+        this.handleExit(session, event.exitCode, event.signal),
+      ),
+    );
+    this.options.log?.info("remote pty opened", {
+      peerId,
+      pid: spawned.pty.pid,
+      sessionId: session.sessionId,
+      threadId,
+    });
+    this.options.onAudit?.({
+      peerId,
+      kind: "remote_pty_open",
+      sessionId: session.sessionId,
+      detail: `${request.backend}:${threadId}`,
+    });
+    return {
+      sessionId: session.sessionId,
+      cwd: session.cwd,
+      shell: session.shell,
+    };
+  }
+
+  input(peerId: FederationInstanceId, request: FederationPtyInputRequest): void {
+    const session = this.requireSession(peerId, request.sessionId);
+    session.pty.write(Buffer.from(request.dataBase64, "base64").toString("utf8"));
+  }
+
+  resize(peerId: FederationInstanceId, request: FederationPtyResizeRequest): void {
+    const session = this.requireSession(peerId, request.sessionId);
+    session.pty.resize(
+      clampDimension(request.cols, 80, MAX_PTY_COLUMNS),
+      clampDimension(request.rows, 18, MAX_PTY_ROWS),
+    );
+  }
+
+  ack(peerId: FederationInstanceId, request: FederationPtyAckRequest): void {
+    const session = this.requireSession(peerId, request.sessionId);
+    const bytes = Number.isFinite(request.bytes) ? Math.max(0, request.bytes) : 0;
+    session.unackedBytes = Math.max(0, session.unackedBytes - bytes);
+    if (session.paused && session.unackedBytes <= FEDERATION_PTY_LOW_WATER_BYTES) {
+      session.paused = false;
+      session.pty.resume();
+    }
+  }
+
+  close(peerId: FederationInstanceId, request: FederationPtyCloseRequest): void {
+    const session = this.requireSession(peerId, request.sessionId);
+    this.scheduleReap(session, "close");
+  }
+
+  /** Live session count for a peer (diagnostics/tests). */
+  sessionCountForPeer(peerId: FederationInstanceId): number {
+    let count = 0;
+    for (const session of this.sessionsById.values()) {
+      if (session.peerId === peerId) count += 1;
+    }
+    return count;
+  }
+
+  notifyPeerDisconnected(peerId: FederationInstanceId): void {
+    this.peerEpochs.set(peerId, (this.peerEpochs.get(peerId) ?? 0) + 1);
+    for (const session of this.sessionsById.values()) {
+      if (session.peerId === peerId) {
+        this.scheduleReap(session, "disconnect");
+      }
+    }
+  }
+
+  notifyPeerConnected(peerId: FederationInstanceId): void {
+    for (const session of this.sessionsById.values()) {
+      if (
+        session.peerId === peerId &&
+        session.reapTimer &&
+        session.reapReason === "disconnect"
+      ) {
+        // A transport blip healed inside the grace window: the viewer's
+        // renderer still holds this sessionId and resumes on it directly.
+        clearTimeout(session.reapTimer);
+        session.reapTimer = undefined;
+        session.reapReason = undefined;
+      }
+    }
+  }
+
+  /** Owner shutdown: kill every remote session immediately. */
+  disposeAll(): void {
+    this.disposed = true;
+    for (const session of Array.from(this.sessionsById.values())) {
+      this.killSession(session, "owner_shutdown");
+    }
+  }
+
+  private requireSession(
+    peerId: FederationInstanceId,
+    sessionId: string,
+  ): FederationPtySession {
+    const session = this.sessionsById.get(sessionId);
+    // One message for "unknown" and "not yours": a peer probing session ids
+    // learns nothing about sessions it does not own.
+    if (!session || session.peerId !== peerId) {
+      throw new Error("Remote terminal session not found for this peer.");
+    }
+    return session;
+  }
+
+  private scheduleReap(
+    session: FederationPtySession,
+    reason: "close" | "disconnect",
+  ): void {
+    if (session.reapTimer) {
+      // An explicit close outranks a disconnect reap; never downgrade.
+      if (session.reapReason === "close" || reason === "disconnect") {
+        return;
+      }
+      clearTimeout(session.reapTimer);
+    }
+    session.reapReason = reason;
+    const timer = setTimeout(() => {
+      session.reapTimer = undefined;
+      this.killSession(session, reason);
+    }, this.options.graceMs ?? FEDERATION_PTY_REAP_GRACE_MS);
+    if (timer.unref) timer.unref();
+    session.reapTimer = timer;
+  }
+
+  private handleOutput(session: FederationPtySession, data: string): void {
+    if (this.sessionsById.get(session.sessionId) !== session) return;
+    // Chunk on character boundaries (never mid-code-point) but meter flow
+    // control in transported bytes, matching the viewer's ack accounting.
+    for (
+      let offset = 0;
+      offset < data.length;
+      offset += FEDERATION_PTY_OUTPUT_CHUNK_CHARS
+    ) {
+      const chunk = data.slice(offset, offset + FEDERATION_PTY_OUTPUT_CHUNK_CHARS);
+      const bytes = Buffer.from(chunk, "utf8");
+      session.seq += 1;
+      session.unackedBytes += bytes.length;
+      // A false return means the peer link is down: the frame is lost (the
+      // viewer surfaces the seq gap on resume, we never repair it) and the
+      // disconnect reap owns cleanup. Unacked bytes still accrue, which is
+      // exactly what parks the PTY at the high-water mark instead of letting
+      // it burn CPU into a dead link.
+      this.options.sendNotification(
+        session.peerId,
+        FEDERATION_PTY_OUTPUT_METHOD,
+        {
+          sessionId: session.sessionId,
+          seq: session.seq,
+          dataBase64: bytes.toString("base64"),
+        } satisfies FederationPtyOutputParams,
+      );
+    }
+    if (
+      !session.paused &&
+      session.unackedBytes >= FEDERATION_PTY_HIGH_WATER_BYTES
+    ) {
+      session.paused = true;
+      session.pty.pause();
+    }
+  }
+
+  private handleExit(
+    session: FederationPtySession,
+    exitCode: number | undefined,
+    signal: number | undefined,
+  ): void {
+    if (this.sessionsById.get(session.sessionId) !== session) return;
+    this.options.sendNotification(session.peerId, FEDERATION_PTY_EXIT_METHOD, {
+      sessionId: session.sessionId,
+      exitCode: exitCode ?? null,
+      signal: signal ?? null,
+    } satisfies FederationPtyExitParams);
+    this.deleteSession(session, "exit");
+  }
+
+  private killSession(session: FederationPtySession, reason: string): void {
+    if (this.sessionsById.get(session.sessionId) !== session) return;
+    // Drop the session first so the kill's own exit event can't re-notify.
+    this.deleteSession(session, reason);
+    try {
+      session.pty.kill();
+    } catch (error) {
+      this.options.log?.warn("remote pty kill failed", {
+        error: error instanceof Error ? error.message : String(error),
+        sessionId: session.sessionId,
+      });
+      this.options.sendNotification(session.peerId, FEDERATION_PTY_ERROR_METHOD, {
+        sessionId: session.sessionId,
+        message: error instanceof Error ? error.message : String(error),
+      } satisfies FederationPtyErrorParams);
+    }
+  }
+
+  private deleteSession(session: FederationPtySession, reason: string): void {
+    if (session.reapTimer) {
+      clearTimeout(session.reapTimer);
+      session.reapTimer = undefined;
+    }
+    for (const disposable of session.disposables.splice(0)) {
+      try {
+        disposable.dispose();
+      } catch (error) {
+        this.options.log?.warn("remote pty listener dispose failed", {
+          error: error instanceof Error ? error.message : String(error),
+          sessionId: session.sessionId,
+        });
+      }
+    }
+    this.sessionsById.delete(session.sessionId);
+    this.options.log?.info("remote pty closed", {
+      peerId: session.peerId,
+      reason,
+      sessionId: session.sessionId,
+    });
+    this.options.onAudit?.({
+      peerId: session.peerId,
+      kind: "remote_pty_close",
+      sessionId: session.sessionId,
+      detail: reason,
+    });
+  }
+}
+
+/**
+ * Register the owner-side control handlers. The stream is point-to-point:
+ * a request that reached this instance through a gateway relay (its
+ * authenticated source peer differs from the envelope's origin) is rejected
+ * outright rather than opening a session whose output could never be
+ * delivered without relaying.
+ */
+export function registerFederationPtyHandlers(params: {
+  router: FederationRouter;
+  service: FederationPtyService;
+}): void {
+  const direct = (
+    envelope: FederationRequestEnvelope,
+    sourcePeerId: FederationInstanceId | undefined,
+  ): FederationInstanceId => {
+    if (!sourcePeerId || sourcePeerId !== envelope.sourceInstanceId) {
+      throw new Error(
+        "Remote terminal sessions are point-to-point; gateway relay is not supported.",
+      );
+    }
+    return sourcePeerId;
+  };
+  params.router.registerHandler(
+    FEDERATION_PTY_METHODS.open,
+    async (envelope, sourcePeerId) =>
+      await params.service.open(
+        direct(envelope, sourcePeerId),
+        envelope.params as FederationPtyOpenRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_PTY_METHODS.input,
+    (envelope, sourcePeerId) => {
+      params.service.input(
+        direct(envelope, sourcePeerId),
+        envelope.params as FederationPtyInputRequest,
+      );
+      return {};
+    },
+  );
+  params.router.registerHandler(
+    FEDERATION_PTY_METHODS.resize,
+    (envelope, sourcePeerId) => {
+      params.service.resize(
+        direct(envelope, sourcePeerId),
+        envelope.params as FederationPtyResizeRequest,
+      );
+      return {};
+    },
+  );
+  params.router.registerHandler(
+    FEDERATION_PTY_METHODS.ack,
+    (envelope, sourcePeerId) => {
+      params.service.ack(
+        direct(envelope, sourcePeerId),
+        envelope.params as FederationPtyAckRequest,
+      );
+      return {};
+    },
+  );
+  params.router.registerHandler(
+    FEDERATION_PTY_METHODS.close,
+    (envelope, sourcePeerId) => {
+      params.service.close(
+        direct(envelope, sourcePeerId),
+        envelope.params as FederationPtyCloseRequest,
+      );
+      return {};
+    },
+  );
+}
+
+export type FederationRemotePtyOperations = {
+  open(request: FederationPtyOpenRequest): Promise<FederationPtyOpenResponse>;
+  input(request: FederationPtyInputRequest): Promise<void>;
+  resize(request: FederationPtyResizeRequest): Promise<void>;
+  ack(request: FederationPtyAckRequest): Promise<void>;
+  close(request: FederationPtyCloseRequest): Promise<void>;
+};
+
+/** Viewer-side control client over the peer's RPC endpoint. */
+export class FederationRemotePtyClient implements FederationRemotePtyOperations {
+  constructor(private readonly rpc: FederationRpcEndpoint) {}
+
+  async open(request: FederationPtyOpenRequest): Promise<FederationPtyOpenResponse> {
+    return await this.rpc.request<FederationPtyOpenResponse>({
+      method: FEDERATION_PTY_METHODS.open,
+      params: request,
+    });
+  }
+
+  async input(request: FederationPtyInputRequest): Promise<void> {
+    await this.rpc.request({
+      method: FEDERATION_PTY_METHODS.input,
+      params: request,
+    });
+  }
+
+  async resize(request: FederationPtyResizeRequest): Promise<void> {
+    await this.rpc.request({
+      method: FEDERATION_PTY_METHODS.resize,
+      params: request,
+    });
+  }
+
+  async ack(request: FederationPtyAckRequest): Promise<void> {
+    await this.rpc.request({
+      method: FEDERATION_PTY_METHODS.ack,
+      params: request,
+    });
+  }
+
+  async close(request: FederationPtyCloseRequest): Promise<void> {
+    await this.rpc.request({
+      method: FEDERATION_PTY_METHODS.close,
+      params: request,
+    });
+  }
+}
+
+export function isFederationPtyStreamMethod(method: string): boolean {
+  return (
+    method === FEDERATION_PTY_OUTPUT_METHOD ||
+    method === FEDERATION_PTY_EXIT_METHOD ||
+    method === FEDERATION_PTY_ERROR_METHOD
+  );
+}

--- a/apps/desktop/src/main/federation/federation-pty-service.ts
+++ b/apps/desktop/src/main/federation/federation-pty-service.ts
@@ -64,6 +64,16 @@ export const FEDERATION_PTY_REAP_GRACE_MS = 10_000;
 /** Ceiling on live + spawning sessions per peer. Well above anything the one
  *  pane-per-thread UI can produce; purely a runaway/abuse backstop. */
 export const FEDERATION_PTY_MAX_SESSIONS_PER_PEER = 16;
+/**
+ * How long a session may sit paused at the high-water mark with no ack
+ * before the peer is presumed dead and the session reaps. This is the
+ * ssh ClientAlive analogue for the one link-failure mode the transport
+ * cannot observe: a silently dropped connection (sleep, NAT timeout,
+ * power loss) never fires a disconnect, so without this the shell would
+ * park paused forever. A live viewer acks within a round trip; one that
+ * takes a minute to drain 768 KiB is gone.
+ */
+export const FEDERATION_PTY_PAUSED_ACK_TIMEOUT_MS = 60_000;
 
 export type FederationPtyOpenRequest = {
   backend: AppServerBackendKind;
@@ -178,6 +188,7 @@ type FederationPtyServiceOptions = {
     warn: (message: string, meta?: Record<string, unknown>) => void;
   };
   graceMs?: number;
+  pausedAckTimeoutMs?: number;
   now?: () => number;
 };
 
@@ -195,6 +206,8 @@ type FederationPtySession = {
   disposables: { dispose(): void }[];
   reapTimer?: ReturnType<typeof setTimeout>;
   reapReason?: "close" | "disconnect";
+  /** Armed while paused at the high-water mark; an ack re-arms or clears it. */
+  ackWatchdog?: ReturnType<typeof setTimeout>;
 };
 
 const MIN_DIMENSION = 2;
@@ -338,6 +351,12 @@ export class FederationPtyService {
       session.paused = false;
       session.pty.resume();
     }
+    // Any ack proves the peer is alive and draining: clear the dead-peer
+    // watchdog, re-arming it only if the session is still parked.
+    this.clearAckWatchdog(session);
+    if (session.paused) {
+      this.armAckWatchdog(session);
+    }
   }
 
   close(peerId: FederationInstanceId, request: FederationPtyCloseRequest): void {
@@ -454,6 +473,28 @@ export class FederationPtyService {
     ) {
       session.paused = true;
       session.pty.pause();
+      this.armAckWatchdog(session);
+    }
+  }
+
+  private armAckWatchdog(session: FederationPtySession): void {
+    if (session.ackWatchdog) return;
+    const timer = setTimeout(() => {
+      session.ackWatchdog = undefined;
+      // Still paused with a full window and not one ack in the whole
+      // timeout: the peer's link died without a disconnect event. Reap so
+      // the shell cannot sit orphaned forever (the transport never observes
+      // this failure mode — this is the ssh ClientAlive analogue).
+      this.killSession(session, "ack_timeout");
+    }, this.options.pausedAckTimeoutMs ?? FEDERATION_PTY_PAUSED_ACK_TIMEOUT_MS);
+    if (timer.unref) timer.unref();
+    session.ackWatchdog = timer;
+  }
+
+  private clearAckWatchdog(session: FederationPtySession): void {
+    if (session.ackWatchdog) {
+      clearTimeout(session.ackWatchdog);
+      session.ackWatchdog = undefined;
     }
   }
 
@@ -473,6 +514,15 @@ export class FederationPtyService {
 
   private killSession(session: FederationPtySession, reason: string): void {
     if (this.sessionsById.get(session.sessionId) !== session) return;
+    // Best-effort exit frame first: a still-connected viewer (reconnected
+    // inside the grace, or an ack-timeout on a wedged-but-live link) should
+    // see its pane end rather than a stale prompt. Returns false harmlessly
+    // when the peer is truly gone.
+    this.options.sendNotification(session.peerId, FEDERATION_PTY_EXIT_METHOD, {
+      sessionId: session.sessionId,
+      exitCode: null,
+      signal: null,
+    } satisfies FederationPtyExitParams);
     // Drop the session first so the kill's own exit event can't re-notify.
     this.deleteSession(session, reason);
     try {
@@ -494,6 +544,7 @@ export class FederationPtyService {
       clearTimeout(session.reapTimer);
       session.reapTimer = undefined;
     }
+    this.clearAckWatchdog(session);
     for (const disposable of session.disposables.splice(0)) {
       try {
         disposable.dispose();

--- a/apps/desktop/src/main/federation/federation-pty-service.ts
+++ b/apps/desktop/src/main/federation/federation-pty-service.ts
@@ -61,6 +61,9 @@ export const FEDERATION_PTY_LOW_WATER_BYTES = 256 * 1024;
 export const FEDERATION_PTY_ACK_INTERVAL_BYTES = 256 * 1024;
 /** Sessions survive a close/disconnect this long before the PTY is killed. */
 export const FEDERATION_PTY_REAP_GRACE_MS = 10_000;
+/** Ceiling on live + spawning sessions per peer. Well above anything the one
+ *  pane-per-thread UI can produce; purely a runaway/abuse backstop. */
+export const FEDERATION_PTY_MAX_SESSIONS_PER_PEER = 16;
 
 export type FederationPtyOpenRequest = {
   backend: AppServerBackendKind;
@@ -213,6 +216,9 @@ export class FederationPtyService {
   /** Bumped per peer on disconnect so an in-flight spawn can detect that its
    *  requester went away and kill the shell instead of leaking it. */
   private readonly peerEpochs = new Map<FederationInstanceId, number>();
+  /** Spawns that have not registered a session yet, counted toward the
+   *  per-peer cap so concurrent opens cannot slip past it. */
+  private readonly spawningCountByPeer = new Map<FederationInstanceId, number>();
   private disposed = false;
 
   constructor(private readonly options: FederationPtyServiceOptions) {}
@@ -228,16 +234,37 @@ export class FederationPtyService {
     if (!threadId) {
       throw new Error("A thread id is required to open a remote terminal.");
     }
+    if (
+      this.sessionCountForPeer(peerId)
+        + (this.spawningCountByPeer.get(peerId) ?? 0)
+      >= FEDERATION_PTY_MAX_SESSIONS_PER_PEER
+    ) {
+      throw new Error("Remote terminal session limit reached for this peer.");
+    }
     const epoch = this.peerEpochs.get(peerId) ?? 0;
-    const cwd = await this.options.resolveThreadCwd({
-      backend: request.backend,
-      threadId,
-    });
-    const spawned = await this.options.spawnPty({
-      cwd,
-      cols: clampDimension(request.cols, 80, MAX_PTY_COLUMNS),
-      rows: clampDimension(request.rows, 18, MAX_PTY_ROWS),
-    });
+    this.spawningCountByPeer.set(
+      peerId,
+      (this.spawningCountByPeer.get(peerId) ?? 0) + 1,
+    );
+    let spawned;
+    try {
+      const cwd = await this.options.resolveThreadCwd({
+        backend: request.backend,
+        threadId,
+      });
+      spawned = await this.options.spawnPty({
+        cwd,
+        cols: clampDimension(request.cols, 80, MAX_PTY_COLUMNS),
+        rows: clampDimension(request.rows, 18, MAX_PTY_ROWS),
+      });
+    } finally {
+      const remaining = (this.spawningCountByPeer.get(peerId) ?? 1) - 1;
+      if (remaining > 0) {
+        this.spawningCountByPeer.set(peerId, remaining);
+      } else {
+        this.spawningCountByPeer.delete(peerId);
+      }
+    }
     // The requester disconnected (or the service shut down) while the shell
     // was spawning: nobody can ever learn this sessionId, so a live shell
     // here is a leak, not a session.

--- a/apps/desktop/src/main/federation/federation-router.ts
+++ b/apps/desktop/src/main/federation/federation-router.ts
@@ -16,6 +16,13 @@ export type FederationRouterConnection = {
 
 export type FederationRequestHandler = (
   envelope: FederationRequestEnvelope,
+  /**
+   * The authenticated peer the envelope arrived from. For direct connections
+   * this matches `envelope.sourceInstanceId`; for gateway-relayed requests it
+   * is the relaying gateway. Handlers that must be point-to-point (remote
+   * PTY) compare the two — the envelope field alone is peer-asserted.
+   */
+  sourcePeerId?: FederationInstanceId,
 ) => Promise<unknown> | unknown;
 
 export type FederationRouteResult =
@@ -137,7 +144,7 @@ export class FederationRouter {
     }
 
     try {
-      const result = await handler(params.envelope);
+      const result = await handler(params.envelope, params.sourcePeerId);
       const response: FederationResponseEnvelope = {
         id: `${params.envelope.id}:response`,
         kind: "response",

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -57,6 +57,7 @@ import {
   isFederationGatewayEndpointUrl,
   formatFederationPeerDisplayLabel,
   isRemoteFederationTarget,
+  resolveThreadTerminalCwd,
   type AppServerListSkillsRequest,
   type AppServerListThreadsRequest,
   type AppServerReadThreadRequest,
@@ -100,6 +101,7 @@ import {
 } from "@pwragent/shared";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
+import { spawnTerminalPty } from "../terminal/integrated-terminal-service";
 import { rewriteTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
 import { getMainLogger } from "../log";
 import {
@@ -130,6 +132,18 @@ import {
   buildFederationHealthStatus,
   publicPeerSummary,
 } from "./federation-health";
+import {
+  FEDERATION_PTY_ERROR_METHOD,
+  FEDERATION_PTY_EXIT_METHOD,
+  FEDERATION_PTY_OUTPUT_METHOD,
+  FEDERATION_PTY_METHOD_CAPABILITIES,
+  FederationPtyService,
+  FederationRemotePtyClient,
+  isFederationPtyStreamMethod,
+  registerFederationPtyHandlers,
+  type FederationPtyStreamEvent,
+  type FederationRemotePtyOperations,
+} from "./federation-pty-service";
 import { FederationRouter } from "./federation-router";
 import { FederationRpcEndpoint } from "./federation-rpc";
 import { FederationStore } from "./federation-store";
@@ -175,6 +189,10 @@ const DEFAULT_CAPABILITIES: FederationCapability[] = [
   "federated_search",
   "messaging_route",
   "gateway_relay",
+  // Federation is a same-operator trust domain and turn_control already
+  // permits code execution via agent turns, so the direct shell defaults to
+  // granted — but stays a dedicated capability so it is revocable on its own.
+  "remote_pty",
 ];
 
 type FederationPeerDirectoryNotification = {
@@ -214,6 +232,10 @@ export class DesktopFederationRuntime {
   private publishEnvironmentSetupProgress?: (
     event: CodexEnvironmentSetupProgressEvent,
   ) => void;
+  private ptyService?: FederationPtyService;
+  private readonly remotePtyEventListeners = new Set<
+    (event: FederationPtyStreamEvent) => void
+  >();
   private readonly remoteBackendEventListeners = new Set<
     (event: AgentEvent) => void | Promise<void>
   >();
@@ -308,6 +330,10 @@ export class DesktopFederationRuntime {
     }
     this.unsubscribeLocalBackendEvents?.();
     this.unsubscribeLocalBackendEvents = undefined;
+    // Owner shutdown kills every remote session immediately, mirroring how
+    // the local panel's shells die with the app.
+    this.ptyService?.disposeAll();
+    this.ptyService = undefined;
     this.client?.close();
     this.client = undefined;
     await this.server?.stop();
@@ -572,6 +598,27 @@ export class DesktopFederationRuntime {
   }
 
   remoteBackend(target: FederationRemoteTarget): FederationBackendOperations {
+    return new FederationRemoteBackendClient(this.rpcFor(target));
+  }
+
+  /**
+   * Viewer-side control client for a peer's remote PTY sessions. Streamed
+   * output/exit/error frames arrive via {@link onRemotePtyEvent}.
+   */
+  remotePty(target: FederationRemoteTarget): FederationRemotePtyOperations {
+    return new FederationRemotePtyClient(this.rpcFor(target));
+  }
+
+  onRemotePtyEvent(
+    listener: (event: FederationPtyStreamEvent) => void,
+  ): () => void {
+    this.remotePtyEventListeners.add(listener);
+    return () => {
+      this.remotePtyEventListeners.delete(listener);
+    };
+  }
+
+  private rpcFor(target: FederationRemoteTarget): FederationRpcEndpoint {
     if (!isRemoteFederationTarget(target)) {
       throw new Error("Federation target is not remote.");
     }
@@ -586,7 +633,7 @@ export class DesktopFederationRuntime {
       });
       this.rpcByPeer.set(target.instanceId, rpc);
     }
-    return new FederationRemoteBackendClient(rpc);
+    return rpc;
   }
 
   async remoteNavigationSnapshot(
@@ -608,14 +655,25 @@ export class DesktopFederationRuntime {
     } catch {
       visible = [];
     }
-    const peer =
-      visible.find((candidate) => candidate.id === target.instanceId)
-      ?? this.store().getPeer(target.instanceId);
+    const visiblePeer = visible.find(
+      (candidate) => candidate.id === target.instanceId,
+    );
+    const peer = visiblePeer ?? this.store().getPeer(target.instanceId);
     // Same composed label as connectedPeerTargets so search chips and
     // thread rows agree with the window title on multi-profile peers.
     const instanceLabel = peer
       ? formatFederationPeerDisplayLabel(peer, visible)
       : target.instanceId;
+    // The granted set the viewer can act on. remote_pty is stripped when the
+    // peer is only reachable through a gateway relay: PTY streams are
+    // point-to-point in v1, so the toggle must read as unavailable there.
+    const directConnection = this.router?.getConnection(target.instanceId);
+    const capabilities = directConnection
+      ? [...directConnection.capabilities]
+      : (visiblePeer?.capabilities ?? []).filter(
+          (capability) => capability !== "remote_pty",
+        );
+    const peerStatus = visiblePeer?.status ?? peer?.status;
     const threads = response.threads.map((thread) => {
       const ref = buildFederatedThreadRef({
         backend: thread.source,
@@ -627,7 +685,8 @@ export class DesktopFederationRuntime {
         federation: {
           ref,
           instanceLabel,
-          peerStatus: peer?.status,
+          peerStatus,
+          capabilities,
         },
       };
     });
@@ -683,7 +742,10 @@ export class DesktopFederationRuntime {
     const localInstanceId = this.ensureLocalInstanceId();
     const router = new FederationRouter({
       localInstanceId,
-      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+      methodCapabilities: {
+        ...FEDERATION_BACKEND_METHOD_CAPABILITIES,
+        ...FEDERATION_PTY_METHOD_CAPABILITIES,
+      },
       additionalRequiredCapabilities: additionalFederationBackendCapabilities,
     });
     registerFederationBackendHandlers({
@@ -693,6 +755,42 @@ export class DesktopFederationRuntime {
         this.sendEnvironmentSetupProgress(event, targetInstanceId);
       },
     });
+    this.ptyService = new FederationPtyService({
+      spawnPty: async (params) => await spawnTerminalPty(params),
+      resolveThreadCwd: async ({ backend, threadId }) => {
+        // Owner-resolved shell + cwd from THIS instance's thread state; the
+        // viewer never sends a path, so a compromised viewer cannot pick the
+        // cwd or binary.
+        const threads = await getDesktopBackendRegistry().listThreads({
+          backend,
+          callerReason: "federation-remote-pty",
+        });
+        const thread = threads.find((candidate) => candidate.id === threadId);
+        return thread ? resolveThreadTerminalCwd(thread) : undefined;
+      },
+      sendNotification: (peerId, method, params) =>
+        this.sendPtyNotification(peerId, method, params),
+      onAudit: (entry) => {
+        // The audit trail must show which machine drove the shell, not just
+        // its opaque instance id.
+        const label =
+          this.store().getPeer(entry.peerId)?.label
+          ?? this.remotePeerDirectory.get(entry.peerId)?.label
+          ?? entry.peerId;
+        this.store().appendAudit({
+          peerId: entry.peerId,
+          sessionId: entry.sessionId,
+          kind: entry.kind,
+          createdAt: Date.now(),
+          detail: `${entry.detail} · ${label}`,
+        });
+      },
+      log: {
+        info: (message, meta) => log.info(message, meta),
+        warn: (message, meta) => log.warn(message, meta),
+      },
+    });
+    registerFederationPtyHandlers({ router, service: this.ptyService });
     this.router = router;
     this.subscribeLocalBackendEvents();
 
@@ -1004,6 +1102,9 @@ export class DesktopFederationRuntime {
       capabilities: client.capabilities,
       sendEnvelope: (envelope) => this.client?.sendEnvelope(envelope),
     });
+    // This instance can also be the OWNER of remote PTY sessions the gateway
+    // is viewing; a reconnect inside the grace keeps those alive.
+    this.ptyService?.notifyPeerConnected(gatewayInstanceId);
     this.recordClientConnection({
       gatewayInstanceId,
       gatewayUrl,
@@ -1127,6 +1228,9 @@ export class DesktopFederationRuntime {
       capabilities: connection.capabilities,
       sendEnvelope: connection.sendEnvelope,
     });
+    // A transport blip that healed inside the reap grace keeps the peer's
+    // remote PTY sessions alive.
+    this.ptyService?.notifyPeerConnected(connection.peerId);
     this.publishPeerStatus(connection.peerId, "connected");
     this.broadcastPeerDirectory();
   }
@@ -1147,6 +1251,9 @@ export class DesktopFederationRuntime {
 
   private unregisterPeer(peerId: FederationInstanceId): void {
     this.router?.unregisterConnection(peerId);
+    // Remote PTY sessions this peer opened get the 10s reap grace; if the
+    // peer reconnects first, registerGatewayConnection cancels the reap.
+    this.ptyService?.notifyPeerDisconnected(peerId);
     this.rpcByPeer.get(peerId)?.rejectAll(
       new Error(`Federation peer ${peerId} disconnected.`),
     );
@@ -1179,6 +1286,9 @@ export class DesktopFederationRuntime {
     if (this.applyPeerDirectory(envelope)) {
       return;
     }
+    if (this.publishRemotePtyStreamEvent(envelope, sourcePeerId)) {
+      return;
+    }
     if (this.publishRemoteEnvironmentSetupProgress(envelope, sourcePeerId)) {
       return;
     }
@@ -1198,6 +1308,82 @@ export class DesktopFederationRuntime {
       if (handled) return;
     }
     await this.router?.routeEnvelope({ envelope, sourcePeerId });
+  }
+
+  /**
+   * Owner → viewer PTY stream frame. Deliberately DIRECT-only: no gateway
+   * fallback, so `hopCount` stays 0 and a shell stream can never transit a
+   * relay. Returns false when the peer has no direct connection — the
+   * service's disconnect reap owns cleanup in that case.
+   */
+  private sendPtyNotification(
+    peerId: FederationInstanceId,
+    method: string,
+    params: unknown,
+  ): boolean {
+    const connection = this.router?.getConnection(peerId);
+    if (!connection) return false;
+    connection.sendEnvelope({
+      id: `federation-pty:${randomUUID()}`,
+      kind: "notification",
+      method,
+      params,
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: this.ensureLocalInstanceId(),
+      targetInstanceId: peerId,
+      createdAt: Date.now(),
+    });
+    return true;
+  }
+
+  private publishRemotePtyStreamEvent(
+    envelope: FederationProtocolEnvelope,
+    sourcePeerId: FederationInstanceId,
+  ): boolean {
+    if (
+      envelope.kind !== "notification" ||
+      !isFederationPtyStreamMethod(envelope.method)
+    ) {
+      return false;
+    }
+    // Point-to-point invariant, receive side: a PTY frame addressed to some
+    // other instance is dropped, never relayed onward; and a frame whose
+    // claimed origin differs from the authenticated link it arrived on is
+    // spoofed, not trusted.
+    if (
+      envelope.targetInstanceId &&
+      envelope.targetInstanceId !== this.ensureLocalInstanceId()
+    ) {
+      return true;
+    }
+    if (
+      envelope.sourceInstanceId &&
+      envelope.sourceInstanceId !== sourcePeerId
+    ) {
+      return true;
+    }
+    const kind =
+      envelope.method === FEDERATION_PTY_OUTPUT_METHOD
+        ? "output"
+        : envelope.method === FEDERATION_PTY_EXIT_METHOD
+          ? "exit"
+          : "error";
+    const event = {
+      kind,
+      peerId: sourcePeerId,
+      params: envelope.params,
+    } as FederationPtyStreamEvent;
+    for (const listener of this.remotePtyEventListeners) {
+      try {
+        listener(event);
+      } catch (error) {
+        log.warn("federation remote pty event listener failed", {
+          error: error instanceof Error ? error.message : String(error),
+          method: envelope.method,
+        });
+      }
+    }
+    return true;
   }
 
   private sendEnvironmentSetupProgress(

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -766,7 +766,16 @@ export class DesktopFederationRuntime {
           callerReason: "federation-remote-pty",
         });
         const thread = threads.find((candidate) => candidate.id === threadId);
-        return thread ? resolveThreadTerminalCwd(thread) : undefined;
+        if (!thread) {
+          // Refuse rather than fall through to the home-directory default: a
+          // shell should only ever open for a thread this instance actually
+          // has. (A thread that exists but has no directory still gets the
+          // same home fallback the local panel uses.)
+          throw new Error(
+            "Remote terminal thread was not found on the owning instance.",
+          );
+        }
+        return resolveThreadTerminalCwd(thread);
       },
       sendNotification: (peerId, method, params) =>
         this.sendPtyNotification(peerId, method, params),

--- a/apps/desktop/src/main/federation/federation-store.ts
+++ b/apps/desktop/src/main/federation/federation-store.ts
@@ -43,7 +43,9 @@ export type FederationSessionAuditKind =
   | "rejected"
   | "disconnected"
   | "relay"
-  | "error";
+  | "error"
+  | "remote_pty_open"
+  | "remote_pty_close";
 
 export type FederationSessionAuditEntry = {
   eventId: number;

--- a/apps/desktop/src/main/ipc/federation-terminal.ts
+++ b/apps/desktop/src/main/ipc/federation-terminal.ts
@@ -54,8 +54,19 @@ type RemoteTerminalSession = {
  * INTEGRATED_TERMINAL_* IPC surface it uses for local shells, and this bridge
  * translates to `pty.*` federation RPCs plus streamed notifications.
  */
+type PendingRemoteOpen = {
+  closeRequested: boolean;
+  promise: Promise<IntegratedTerminalCreateResponse>;
+};
+
 export class FederationTerminalBridge {
   private readonly sessionsById = new Map<string, RemoteTerminalSession>();
+  /** In-flight `pty.open`s keyed by `${webContentsId}:${threadKey}`. This is
+   *  the remote analogue of the local service's close-during-spawn hardening:
+   *  a close issued while the open is still in flight must kill the session
+   *  the moment it exists, and a concurrent second create must attach to the
+   *  first open instead of spawning a second owner-side shell. */
+  private readonly pendingOpens = new Map<string, PendingRemoteOpen>();
   private readonly watchedWebContents = new Set<WebContents>();
   private unsubscribeStreamEvents?: () => void;
 
@@ -72,40 +83,70 @@ export class FederationTerminalBridge {
     if (existing) {
       return this.toCreateResponse(existing);
     }
+    const pendingKey = this.pendingKey(webContents, threadKey);
+    const inFlight = this.pendingOpens.get(pendingKey);
+    if (inFlight) {
+      return await inFlight.promise;
+    }
     const separator = threadKey.indexOf(":");
     if (separator <= 0 || separator === threadKey.length - 1) {
       throw new Error("Remote terminal thread key is malformed.");
     }
     const backend = threadKey.slice(0, separator) as AppServerBackendKind;
     const threadId = threadKey.slice(separator + 1);
-    // The viewer sends only the thread identity and dimensions. Shell and cwd
-    // are resolved by the owning instance from ITS thread state.
-    const opened = await getDesktopFederationRuntime()
-      .remotePty(target)
-      .open({
-        backend,
-        threadId,
-        cols: request.cols,
-        rows: request.rows,
-      });
-    const session: RemoteTerminalSession = {
-      sessionId: opened.sessionId,
-      threadKey,
-      target,
-      cwd: opened.cwd,
-      shell: opened.shell,
-      buffer: "",
-      panelHidden: false,
-      createdAt: Date.now(),
-      webContents,
-      lastSeq: 0,
-      consumedBytes: 0,
+    const pending: PendingRemoteOpen = {
+      closeRequested: false,
+      promise: Promise.resolve() as unknown as Promise<IntegratedTerminalCreateResponse>,
     };
-    this.sessionsById.set(session.sessionId, session);
-    this.ensureStreamSubscription();
-    this.watchWebContents(webContents);
-    this.broadcastSessions(webContents);
-    return this.toCreateResponse(session);
+    pending.promise = (async () => {
+      try {
+        // The viewer sends only the thread identity and dimensions. Shell and
+        // cwd are resolved by the owning instance from ITS thread state.
+        const opened = await getDesktopFederationRuntime()
+          .remotePty(target)
+          .open({
+            backend,
+            threadId,
+            cols: request.cols,
+            rows: request.rows,
+          });
+        if (pending.closeRequested || webContents.isDestroyed()) {
+          // The pane was dismissed (or the window died) while the open was in
+          // flight. Registering + broadcasting the session anyway would make
+          // the renderer re-adopt a shell the user already closed — the exact
+          // regression the local service's pendingClose hardening fixed.
+          void getDesktopFederationRuntime()
+            .remotePty(target)
+            .close({ sessionId: opened.sessionId })
+            .catch(() => {
+              // Peer unreachable — the owner's disconnect reap covers it.
+            });
+          throw new Error("Remote terminal was closed before it finished starting.");
+        }
+        const session: RemoteTerminalSession = {
+          sessionId: opened.sessionId,
+          threadKey,
+          target,
+          cwd: opened.cwd,
+          shell: opened.shell,
+          buffer: "",
+          panelHidden: false,
+          createdAt: Date.now(),
+          webContents,
+          lastSeq: 0,
+          consumedBytes: 0,
+        };
+        this.sessionsById.set(session.sessionId, session);
+        this.ensureStreamSubscription();
+        this.watchWebContents(webContents);
+        this.broadcastSessions(webContents);
+        return this.toCreateResponse(session);
+      } finally {
+        this.pendingOpens.delete(pendingKey);
+      }
+    })();
+    this.pendingOpens.set(pendingKey, pending);
+    return await pending.promise;
   }
 
   write(request: IntegratedTerminalWriteRequest, webContents: WebContents): void {
@@ -147,7 +188,20 @@ export class FederationTerminalBridge {
       (request.threadKey
         ? this.sessionForThread(webContents, request.threadKey)
         : undefined);
-    if (!session) return;
+    if (!session) {
+      // Nothing registered yet. If the open is still in flight, mark it so
+      // the session is closed the moment it exists instead of the close
+      // being silently lost.
+      if (request.threadKey) {
+        const pending = this.pendingOpens.get(
+          this.pendingKey(webContents, request.threadKey.trim()),
+        );
+        if (pending) {
+          pending.closeRequested = true;
+        }
+      }
+      return;
+    }
     this.dropSession(session);
     this.broadcastSessions(webContents);
     void getDesktopFederationRuntime()
@@ -257,6 +311,11 @@ export class FederationTerminalBridge {
     this.watchedWebContents.add(webContents);
     webContents.once("destroyed", () => {
       this.watchedWebContents.delete(webContents);
+      for (const [key, pending] of this.pendingOpens) {
+        if (key.startsWith(`${webContents.id}:`)) {
+          pending.closeRequested = true;
+        }
+      }
       for (const session of Array.from(this.sessionsById.values())) {
         if (session.webContents !== webContents) continue;
         this.dropSession(session);
@@ -269,6 +328,10 @@ export class FederationTerminalBridge {
           });
       }
     });
+  }
+
+  private pendingKey(webContents: WebContents, threadKey: string): string {
+    return `${webContents.id}:${threadKey}`;
   }
 
   private ownedSession(

--- a/apps/desktop/src/main/ipc/federation-terminal.ts
+++ b/apps/desktop/src/main/ipc/federation-terminal.ts
@@ -1,0 +1,355 @@
+import type { WebContents } from "electron";
+import type {
+  AppServerBackendKind,
+  FederationRemoteTarget,
+} from "@pwragent/shared";
+import {
+  INTEGRATED_TERMINAL_ERROR_CHANNEL,
+  INTEGRATED_TERMINAL_EXIT_CHANNEL,
+  INTEGRATED_TERMINAL_OUTPUT_CHANNEL,
+  INTEGRATED_TERMINAL_SESSIONS_CHANNEL,
+} from "../../shared/ipc";
+import type {
+  IntegratedTerminalCloseRequest,
+  IntegratedTerminalCreateRequest,
+  IntegratedTerminalCreateResponse,
+  IntegratedTerminalResizeRequest,
+  IntegratedTerminalSessionSummary,
+  IntegratedTerminalSetPanelHiddenRequest,
+  IntegratedTerminalWriteRequest,
+} from "../../shared/integrated-terminal";
+import {
+  FEDERATION_PTY_ACK_INTERVAL_BYTES,
+  type FederationPtyStreamEvent,
+} from "../federation/federation-pty-service";
+import { getDesktopFederationRuntime } from "../federation/federation-runtime";
+import { getMainLogger } from "../log";
+import { federationWindowTargetForWebContents } from "../window";
+
+const log = getMainLogger("pwragent:federation-terminal");
+
+/** Mirrors the local service's replay buffer so a pane remount inside the
+ *  viewer replays scrollback without any server-side persistence. */
+const OUTPUT_BUFFER_LIMIT = 128 * 1024;
+
+type RemoteTerminalSession = {
+  sessionId: string;
+  threadKey: string;
+  target: FederationRemoteTarget;
+  cwd: string;
+  shell: string;
+  buffer: string;
+  panelHidden: boolean;
+  createdAt: number;
+  webContents: WebContents;
+  /** Last stream sequence number seen; gaps are surfaced, never repaired. */
+  lastSeq: number;
+  /** Output bytes consumed since the last pty.ack. */
+  consumedBytes: number;
+};
+
+/**
+ * Viewer-side remote terminal sessions, one registry entry per federation
+ * window pane. The renderer stays protocol-unaware: it speaks the exact
+ * INTEGRATED_TERMINAL_* IPC surface it uses for local shells, and this bridge
+ * translates to `pty.*` federation RPCs plus streamed notifications.
+ */
+export class FederationTerminalBridge {
+  private readonly sessionsById = new Map<string, RemoteTerminalSession>();
+  private readonly watchedWebContents = new Set<WebContents>();
+  private unsubscribeStreamEvents?: () => void;
+
+  async createOrAttach(
+    request: IntegratedTerminalCreateRequest,
+    webContents: WebContents,
+  ): Promise<IntegratedTerminalCreateResponse> {
+    const target = this.requireTarget(webContents);
+    const threadKey = request.threadKey.trim();
+    if (!threadKey) {
+      throw new Error("A thread key is required to start a remote terminal.");
+    }
+    const existing = this.sessionForThread(webContents, threadKey);
+    if (existing) {
+      return this.toCreateResponse(existing);
+    }
+    const separator = threadKey.indexOf(":");
+    if (separator <= 0 || separator === threadKey.length - 1) {
+      throw new Error("Remote terminal thread key is malformed.");
+    }
+    const backend = threadKey.slice(0, separator) as AppServerBackendKind;
+    const threadId = threadKey.slice(separator + 1);
+    // The viewer sends only the thread identity and dimensions. Shell and cwd
+    // are resolved by the owning instance from ITS thread state.
+    const opened = await getDesktopFederationRuntime()
+      .remotePty(target)
+      .open({
+        backend,
+        threadId,
+        cols: request.cols,
+        rows: request.rows,
+      });
+    const session: RemoteTerminalSession = {
+      sessionId: opened.sessionId,
+      threadKey,
+      target,
+      cwd: opened.cwd,
+      shell: opened.shell,
+      buffer: "",
+      panelHidden: false,
+      createdAt: Date.now(),
+      webContents,
+      lastSeq: 0,
+      consumedBytes: 0,
+    };
+    this.sessionsById.set(session.sessionId, session);
+    this.ensureStreamSubscription();
+    this.watchWebContents(webContents);
+    this.broadcastSessions(webContents);
+    return this.toCreateResponse(session);
+  }
+
+  write(request: IntegratedTerminalWriteRequest, webContents: WebContents): void {
+    const session = this.ownedSession(webContents, request.sessionId);
+    if (!session) return;
+    void getDesktopFederationRuntime()
+      .remotePty(session.target)
+      .input({
+        sessionId: session.sessionId,
+        dataBase64: Buffer.from(request.data, "utf8").toString("base64"),
+      })
+      .catch((error) => {
+        this.sendError(session, error);
+      });
+  }
+
+  resize(request: IntegratedTerminalResizeRequest, webContents: WebContents): void {
+    const session = this.ownedSession(webContents, request.sessionId);
+    if (!session) return;
+    void getDesktopFederationRuntime()
+      .remotePty(session.target)
+      .resize({
+        sessionId: session.sessionId,
+        cols: request.cols,
+        rows: request.rows,
+      })
+      .catch((error) => {
+        log.warn("remote terminal resize failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+  }
+
+  close(request: IntegratedTerminalCloseRequest, webContents: WebContents): void {
+    const session =
+      (request.sessionId
+        ? this.ownedSession(webContents, request.sessionId)
+        : undefined) ??
+      (request.threadKey
+        ? this.sessionForThread(webContents, request.threadKey)
+        : undefined);
+    if (!session) return;
+    this.dropSession(session);
+    this.broadcastSessions(webContents);
+    void getDesktopFederationRuntime()
+      .remotePty(session.target)
+      .close({ sessionId: session.sessionId })
+      .catch((error) => {
+        // The owner's disconnect reap covers an undeliverable close.
+        log.warn("remote terminal close failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+  }
+
+  setPanelHidden(
+    request: IntegratedTerminalSetPanelHiddenRequest,
+    webContents: WebContents,
+  ): void {
+    const session = this.sessionForThread(webContents, request.threadKey);
+    if (!session || session.panelHidden === request.hidden) return;
+    session.panelHidden = request.hidden;
+    this.broadcastSessions(webContents);
+  }
+
+  listSessions(webContents: WebContents): IntegratedTerminalSessionSummary[] {
+    return this.sessionsForWindow(webContents)
+      .sort((left, right) => left.createdAt - right.createdAt)
+      .map((session) => this.toSummary(session));
+  }
+
+  dispose(): void {
+    this.unsubscribeStreamEvents?.();
+    this.unsubscribeStreamEvents = undefined;
+    this.sessionsById.clear();
+    this.watchedWebContents.clear();
+  }
+
+  private requireTarget(webContents: WebContents): FederationRemoteTarget {
+    const target = federationWindowTargetForWebContents(webContents);
+    if (!target) {
+      // Defense in depth: a federation window whose remote target is missing
+      // must fail loudly, never fall through to spawning a LOCAL shell under
+      // peer branding.
+      throw new Error(
+        "Remote terminal sessions run on the owning instance; this window has no federation target.",
+      );
+    }
+    return target;
+  }
+
+  private ensureStreamSubscription(): void {
+    this.unsubscribeStreamEvents ??= getDesktopFederationRuntime()
+      .onRemotePtyEvent((event) => this.handleStreamEvent(event));
+  }
+
+  private handleStreamEvent(event: FederationPtyStreamEvent): void {
+    const session = this.sessionsById.get(event.params.sessionId);
+    // Only the owning peer may stream into a session it opened for us.
+    if (!session || session.target.instanceId !== event.peerId) return;
+    if (event.kind === "output") {
+      const data = Buffer.from(event.params.dataBase64, "base64").toString("utf8");
+      if (event.params.seq !== session.lastSeq + 1) {
+        // The transport is ordered, so a gap means a bug — surface it.
+        this.send(session, INTEGRATED_TERMINAL_ERROR_CHANNEL, {
+          sessionId: session.sessionId,
+          message: `Remote terminal stream skipped from frame ${session.lastSeq} to ${event.params.seq}.`,
+        });
+      }
+      session.lastSeq = event.params.seq;
+      session.buffer = trimBufferedOutput(session.buffer + data);
+      this.send(session, INTEGRATED_TERMINAL_OUTPUT_CHANNEL, {
+        sessionId: session.sessionId,
+        data,
+      });
+      session.consumedBytes += Buffer.byteLength(data, "utf8");
+      if (session.consumedBytes >= FEDERATION_PTY_ACK_INTERVAL_BYTES) {
+        const bytes = session.consumedBytes;
+        session.consumedBytes = 0;
+        void getDesktopFederationRuntime()
+          .remotePty(session.target)
+          .ack({ sessionId: session.sessionId, bytes })
+          .catch((error) => {
+            log.warn("remote terminal ack failed", {
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
+      }
+      return;
+    }
+    if (event.kind === "exit") {
+      this.send(session, INTEGRATED_TERMINAL_EXIT_CHANNEL, {
+        sessionId: session.sessionId,
+        exitCode: event.params.exitCode ?? null,
+        signal: event.params.signal ?? null,
+      });
+      this.dropSession(session);
+      this.broadcastSessions(session.webContents);
+      return;
+    }
+    this.send(session, INTEGRATED_TERMINAL_ERROR_CHANNEL, {
+      sessionId: session.sessionId,
+      message: event.params.message,
+    });
+  }
+
+  private watchWebContents(webContents: WebContents): void {
+    if (this.watchedWebContents.has(webContents)) return;
+    this.watchedWebContents.add(webContents);
+    webContents.once("destroyed", () => {
+      this.watchedWebContents.delete(webContents);
+      for (const session of Array.from(this.sessionsById.values())) {
+        if (session.webContents !== webContents) continue;
+        this.dropSession(session);
+        // Closing the remote window ends the PTY (owner applies its grace).
+        void getDesktopFederationRuntime()
+          .remotePty(session.target)
+          .close({ sessionId: session.sessionId })
+          .catch(() => {
+            // Peer unreachable — the owner's disconnect reap covers it.
+          });
+      }
+    });
+  }
+
+  private ownedSession(
+    webContents: WebContents,
+    sessionId: string,
+  ): RemoteTerminalSession | undefined {
+    const session = this.sessionsById.get(sessionId);
+    return session && session.webContents === webContents ? session : undefined;
+  }
+
+  private sessionForThread(
+    webContents: WebContents,
+    threadKey: string,
+  ): RemoteTerminalSession | undefined {
+    return this.sessionsForWindow(webContents).find(
+      (session) => session.threadKey === threadKey,
+    );
+  }
+
+  private sessionsForWindow(webContents: WebContents): RemoteTerminalSession[] {
+    return [...this.sessionsById.values()].filter(
+      (session) => session.webContents === webContents,
+    );
+  }
+
+  private dropSession(session: RemoteTerminalSession): void {
+    this.sessionsById.delete(session.sessionId);
+  }
+
+  private broadcastSessions(webContents: WebContents): void {
+    if (webContents.isDestroyed()) return;
+    webContents.send(INTEGRATED_TERMINAL_SESSIONS_CHANNEL, {
+      sessions: this.listSessions(webContents),
+    });
+  }
+
+  private send(
+    session: RemoteTerminalSession,
+    channel: string,
+    payload: unknown,
+  ): void {
+    if (session.webContents.isDestroyed()) return;
+    session.webContents.send(channel, payload);
+  }
+
+  private sendError(session: RemoteTerminalSession, error: unknown): void {
+    this.send(session, INTEGRATED_TERMINAL_ERROR_CHANNEL, {
+      sessionId: session.sessionId,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  private toCreateResponse(
+    session: RemoteTerminalSession,
+  ): IntegratedTerminalCreateResponse {
+    return {
+      sessionId: session.sessionId,
+      threadKey: session.threadKey,
+      cwd: session.cwd,
+      shell: session.shell,
+      buffer: session.buffer || undefined,
+    };
+  }
+
+  private toSummary(
+    session: RemoteTerminalSession,
+  ): IntegratedTerminalSessionSummary {
+    return {
+      sessionId: session.sessionId,
+      threadKey: session.threadKey,
+      cwd: session.cwd,
+      shell: session.shell,
+      panelHidden: session.panelHidden,
+      createdAt: session.createdAt,
+    };
+  }
+}
+
+function trimBufferedOutput(value: string): string {
+  if (value.length <= OUTPUT_BUFFER_LIMIT) {
+    return value;
+  }
+  return value.slice(value.length - OUTPUT_BUFFER_LIMIT);
+}

--- a/apps/desktop/src/main/ipc/integrated-terminal.ts
+++ b/apps/desktop/src/main/ipc/integrated-terminal.ts
@@ -133,6 +133,9 @@ export function disposeIntegratedTerminalIpcHandlers(): void {
   ipcMain.removeHandler(INTEGRATED_TERMINAL_SET_PANEL_HIDDEN_CHANNEL);
   service?.dispose();
   service = undefined;
+  // Drops the viewer-side registry without sending pty.close for each
+  // session: this runs at app shutdown, where the federation runtime is
+  // tearing down anyway and the owner's disconnect reap ends the shells.
   federationBridge?.dispose();
   federationBridge = undefined;
 }

--- a/apps/desktop/src/main/ipc/integrated-terminal.ts
+++ b/apps/desktop/src/main/ipc/integrated-terminal.ts
@@ -20,9 +20,12 @@ import type {
 } from "../../shared/integrated-terminal";
 import { IntegratedTerminalService } from "../terminal/integrated-terminal-service";
 import type { IntegratedTerminalQuitSnapshot } from "../terminal/integrated-terminal-service";
+import { isFederationWindowWebContents } from "../window";
 import { subscribersForChannel } from "../window-channels";
+import { FederationTerminalBridge } from "./federation-terminal";
 
 let service: IntegratedTerminalService | undefined;
+let federationBridge: FederationTerminalBridge | undefined;
 
 function broadcastSessions(
   sessions: IntegratedTerminalSessionSummary[],
@@ -30,6 +33,10 @@ function broadcastSessions(
   for (const webContents of subscribersForChannel(
     INTEGRATED_TERMINAL_SESSIONS_CHANNEL,
   )) {
+    // A federation window mirrors REMOTE sessions (its bridge sends those
+    // directly); the local PTY list would let this machine's shells leak
+    // into a window branded as the peer.
+    if (isFederationWindowWebContents(webContents)) continue;
     webContents.send(INTEGRATED_TERMINAL_SESSIONS_CHANNEL, { sessions });
   }
 }
@@ -38,6 +45,7 @@ export function registerIntegratedTerminalIpcHandlers(): void {
   service ??= new IntegratedTerminalService({
     onSessionsChanged: broadcastSessions,
   });
+  federationBridge ??= new FederationTerminalBridge();
 
   ipcMain.removeHandler(INTEGRATED_TERMINAL_CREATE_CHANNEL);
   ipcMain.handle(
@@ -45,14 +53,25 @@ export function registerIntegratedTerminalIpcHandlers(): void {
     async (
       event,
       request: IntegratedTerminalCreateRequest,
-    ): Promise<IntegratedTerminalCreateResponse> =>
-      await service!.createOrAttach(request, event.sender),
+    ): Promise<IntegratedTerminalCreateResponse> => {
+      // A federation window NEVER falls through to a local spawn: the bridge
+      // routes to the owning instance and throws when the remote target or
+      // capability is missing.
+      if (isFederationWindowWebContents(event.sender)) {
+        return await federationBridge!.createOrAttach(request, event.sender);
+      }
+      return await service!.createOrAttach(request, event.sender);
+    },
   );
 
   ipcMain.removeHandler(INTEGRATED_TERMINAL_WRITE_CHANNEL);
   ipcMain.handle(
     INTEGRATED_TERMINAL_WRITE_CHANNEL,
-    (_event, request: IntegratedTerminalWriteRequest): void => {
+    (event, request: IntegratedTerminalWriteRequest): void => {
+      if (isFederationWindowWebContents(event.sender)) {
+        federationBridge?.write(request, event.sender);
+        return;
+      }
       service?.write(request);
     },
   );
@@ -60,7 +79,11 @@ export function registerIntegratedTerminalIpcHandlers(): void {
   ipcMain.removeHandler(INTEGRATED_TERMINAL_RESIZE_CHANNEL);
   ipcMain.handle(
     INTEGRATED_TERMINAL_RESIZE_CHANNEL,
-    (_event, request: IntegratedTerminalResizeRequest): void => {
+    (event, request: IntegratedTerminalResizeRequest): void => {
+      if (isFederationWindowWebContents(event.sender)) {
+        federationBridge?.resize(request, event.sender);
+        return;
+      }
       service?.resize(request);
     },
   );
@@ -68,7 +91,11 @@ export function registerIntegratedTerminalIpcHandlers(): void {
   ipcMain.removeHandler(INTEGRATED_TERMINAL_CLOSE_CHANNEL);
   ipcMain.handle(
     INTEGRATED_TERMINAL_CLOSE_CHANNEL,
-    (_event, request: IntegratedTerminalCloseRequest): void => {
+    (event, request: IntegratedTerminalCloseRequest): void => {
+      if (isFederationWindowWebContents(event.sender)) {
+        federationBridge?.close(request, event.sender);
+        return;
+      }
       service?.close(request);
     },
   );
@@ -76,13 +103,22 @@ export function registerIntegratedTerminalIpcHandlers(): void {
   ipcMain.removeHandler(INTEGRATED_TERMINAL_LIST_CHANNEL);
   ipcMain.handle(
     INTEGRATED_TERMINAL_LIST_CHANNEL,
-    (): IntegratedTerminalSessionSummary[] => service?.listSessions() ?? [],
+    (event): IntegratedTerminalSessionSummary[] => {
+      if (isFederationWindowWebContents(event.sender)) {
+        return federationBridge?.listSessions(event.sender) ?? [];
+      }
+      return service?.listSessions() ?? [];
+    },
   );
 
   ipcMain.removeHandler(INTEGRATED_TERMINAL_SET_PANEL_HIDDEN_CHANNEL);
   ipcMain.handle(
     INTEGRATED_TERMINAL_SET_PANEL_HIDDEN_CHANNEL,
-    (_event, request: IntegratedTerminalSetPanelHiddenRequest): void => {
+    (event, request: IntegratedTerminalSetPanelHiddenRequest): void => {
+      if (isFederationWindowWebContents(event.sender)) {
+        federationBridge?.setPanelHidden(request, event.sender);
+        return;
+      }
       service?.setPanelHidden(request);
     },
   );
@@ -97,6 +133,8 @@ export function disposeIntegratedTerminalIpcHandlers(): void {
   ipcMain.removeHandler(INTEGRATED_TERMINAL_SET_PANEL_HIDDEN_CHANNEL);
   service?.dispose();
   service = undefined;
+  federationBridge?.dispose();
+  federationBridge = undefined;
 }
 
 export function getIntegratedTerminalQuitSnapshot(): IntegratedTerminalQuitSnapshot {

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -116,25 +116,16 @@ export class IntegratedTerminalService {
     let cwd: string;
     let shell: { file: string; args: string[] };
     try {
-      const settings = getDesktopSettingsService();
-      const env = await settings.resolveTerminalSpawnEnvAsync();
-      cwd = resolveTerminalCwd(request.cwd);
-      shell = resolveTerminalShell({
-        env,
+      const spawned = await spawnTerminalPty({
+        cwd: request.cwd,
+        cols: request.cols,
+        rows: request.rows,
         platform: this.platform,
-        windowsShell: settings.resolveIntegratedTerminalWindowsShell(),
+        loadNodePty: this.loadNodePty,
       });
-      const nodePty = await this.loadNodePty();
-      ptyProcess = nodePty.spawn(shell.file, shell.args, {
-        name: "xterm-256color",
-        cols: clampInteger(request.cols, DEFAULT_COLUMNS, 2, MAX_COLUMNS),
-        rows: clampInteger(request.rows, DEFAULT_ROWS, 2, MAX_ROWS),
-        cwd,
-        env: buildPwrAgentChildProcessEnv(env, {
-          TERM: "xterm-256color",
-          COLORTERM: "truecolor",
-        }),
-      });
+      ptyProcess = spawned.pty;
+      cwd = spawned.cwd;
+      shell = spawned.shell;
     } catch (error) {
       const message = terminalStartErrorMessage(error);
       this.logger.warn("start-failed", {
@@ -467,6 +458,57 @@ function normalizeTerminalProcessName(value: string): string {
 
 async function loadNodePty(): Promise<Pick<NodePtyModule, "spawn">> {
   return await import("node-pty");
+}
+
+export type SpawnedTerminalPty = {
+  pty: IPty;
+  cwd: string;
+  shell: { file: string; args: string[] };
+};
+
+/**
+ * The one PTY spawn core: settings-derived login environment, cwd validation
+ * with a home-directory fallback, per-platform shell resolution, and clamped
+ * dimensions. Shared by the local integrated-terminal service and the
+ * federation remote-PTY service so a remote viewer's shell is spawned with
+ * exactly the hardening and environment the local panel gets.
+ */
+export async function spawnTerminalPty(params: {
+  cwd?: string;
+  cols: number;
+  rows: number;
+  platform?: NodeJS.Platform;
+  loadNodePty?: () => Promise<Pick<NodePtyModule, "spawn">>;
+}): Promise<SpawnedTerminalPty> {
+  const platform = params.platform ?? process.platform;
+  const settings = getDesktopSettingsService();
+  const env = await settings.resolveTerminalSpawnEnvAsync();
+  const cwd = resolveTerminalCwd(params.cwd);
+  const shell = resolveTerminalShell({
+    env,
+    platform,
+    windowsShell: settings.resolveIntegratedTerminalWindowsShell(),
+  });
+  const nodePty = await (params.loadNodePty ?? loadNodePty)();
+  const pty = nodePty.spawn(shell.file, shell.args, {
+    name: "xterm-256color",
+    cols: clampTerminalColumns(params.cols),
+    rows: clampTerminalRows(params.rows),
+    cwd,
+    env: buildPwrAgentChildProcessEnv(env, {
+      TERM: "xterm-256color",
+      COLORTERM: "truecolor",
+    }),
+  });
+  return { pty, cwd, shell };
+}
+
+export function clampTerminalColumns(value: number): number {
+  return clampInteger(value, DEFAULT_COLUMNS, 2, MAX_COLUMNS);
+}
+
+export function clampTerminalRows(value: number): number {
+  return clampInteger(value, DEFAULT_ROWS, 2, MAX_ROWS);
 }
 
 function terminalStartErrorMessage(error: unknown): string {

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -70,6 +70,10 @@ import { federationWindowTargetAdditionalArguments } from "../shared/federation-
  * window rendering LOCAL settings reads as the peer's settings.
  */
 const federationWindowWebContentsIds = new Set<number>();
+const federationWindowTargetsByWebContentsId = new Map<
+  number,
+  FederationRemoteTarget
+>();
 
 export function isFederationWindowWebContents(
   webContents: Electron.WebContents | undefined,
@@ -77,6 +81,19 @@ export function isFederationWindowWebContents(
   // Tolerate absent senders (unit-test harness events, destroyed frames):
   // an unidentifiable sender is treated as a normal local window.
   return webContents ? federationWindowWebContentsIds.has(webContents.id) : false;
+}
+
+/**
+ * The remote instance a federation window fronts. Main-process IPC branches
+ * (remote PTY routing) key off this instead of trusting anything the
+ * renderer sends — the target was fixed when the window was created.
+ */
+export function federationWindowTargetForWebContents(
+  webContents: Electron.WebContents | undefined,
+): FederationRemoteTarget | undefined {
+  return webContents
+    ? federationWindowTargetsByWebContentsId.get(webContents.id)
+    : undefined;
 }
 
 const isDevelopment = process.env.NODE_ENV !== "production";
@@ -424,8 +441,13 @@ export function createMainWindow(options?: {
   if (options?.federationTarget) {
     const webContentsId = window.webContents.id;
     federationWindowWebContentsIds.add(webContentsId);
+    federationWindowTargetsByWebContentsId.set(
+      webContentsId,
+      options.federationTarget,
+    );
     window.once("closed", () => {
       federationWindowWebContentsIds.delete(webContentsId);
+      federationWindowTargetsByWebContentsId.delete(webContentsId);
     });
     // The renderer's static <title> (index.html) replaces the
     // BrowserWindow title on load, which collapses every window to the

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -1411,6 +1411,7 @@ const FEDERATION_CAPABILITY_LABELS: Record<FederationCapability, string> = {
   federated_search: "search remote threads",
   messaging_route: "route messaging threads",
   gateway_relay: "reach sibling instances",
+  remote_pty: "open a remote terminal",
 };
 
 function formatFederationCapabilities(

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -24,6 +24,12 @@ type ThreadHeaderLayoutControls = {
   terminalOpen: boolean;
   /** A PTY is alive for this thread even if the panel is collapsed. */
   terminalRunning?: boolean;
+  /**
+   * Why the terminal cannot open right now (remote thread whose peer lacks
+   * `remote_pty` or is disconnected). Renders the toggle disabled with this
+   * as its tooltip instead of hiding it.
+   */
+  terminalDisabledReason?: string;
   onToggleSidebar: () => void;
   onToggleRail: () => void;
   onToggleTerminal: () => void;
@@ -92,11 +98,14 @@ export function ThreadHeader(props: ThreadHeaderProps) {
   // a live dot and says so, otherwise the shell is invisible from here.
   const terminalCollapsedRunning =
     Boolean(props.layout?.terminalRunning) && !props.layout?.terminalOpen;
-  const terminalLabel = props.layout?.terminalOpen
-    ? "Hide integrated terminal"
-    : terminalCollapsedRunning
-      ? "Show running integrated terminal"
-      : "Open integrated terminal";
+  const terminalDisabledReason = props.layout?.terminalDisabledReason;
+  const terminalLabel =
+    terminalDisabledReason ??
+    (props.layout?.terminalOpen
+      ? "Hide integrated terminal"
+      : terminalCollapsedRunning
+        ? "Show running integrated terminal"
+        : "Open integrated terminal");
 
   return (
     <header className="thread-header">
@@ -173,20 +182,26 @@ export function ThreadHeader(props: ThreadHeaderProps) {
               onToggleRail={props.layout.onToggleRail}
             />
           ) : null}
-          {/* The integrated terminal is a LOCAL shell. For a remote
-              (federated) thread it would open a terminal on the viewer
-              machine while the window is branded as the peer — hide it
-              until a remote PTY exists in the protocol. */}
-          {props.layout && !props.thread.federation ? (
+          {/* For a remote (federated) thread this attaches to a PTY running
+              on the OWNING instance over the federation transport. When the
+              peer lacks the remote_pty grant or is disconnected, the toggle
+              renders disabled with the reason as its tooltip. */}
+          {props.layout ? (
             <button
               type="button"
               className={`thread-header__terminal-toggle${
                 props.layout.terminalOpen ? " is-open" : ""
-              }${terminalCollapsedRunning ? " is-running" : ""}`}
+              }${terminalCollapsedRunning ? " is-running" : ""}${
+                terminalDisabledReason ? " is-disabled" : ""
+              }`}
               aria-label={terminalLabel}
               aria-pressed={props.layout.terminalOpen}
+              // aria-disabled (not `disabled`) so the button still receives
+              // hover/focus and can explain WHY via the tooltip.
+              aria-disabled={terminalDisabledReason ? true : undefined}
               onClick={() => {
                 terminalTooltip.hide();
+                if (terminalDisabledReason) return;
                 props.layout?.onToggleTerminal();
               }}
               onMouseEnter={(event) =>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -49,6 +49,7 @@ import {
   buildThreadIdentityKey,
   isBranchDrifted,
   readCodexEnvironmentActionRuns,
+  resolveThreadTerminalCwd,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { agentEventMatchesThread } from "../../lib/federated-thread-events";
@@ -1586,17 +1587,26 @@ export function ThreadView(props: ThreadViewProps) {
   const selectedThreadTerminalRunning = selectedThreadKey
     ? terminals.liveThreadKeys.has(selectedThreadKey)
     : false;
-  const selectedThreadTerminalCwd = selectedThread
-    ? resolveThreadTerminalCwd(selectedThread)
-    : undefined;
+  // A remote thread's terminal attaches to a PTY on the OWNING instance;
+  // the owner resolves shell + cwd from its own thread state, so the viewer
+  // sends no path at all.
+  const selectedThreadTerminalCwd =
+    selectedThread && !selectedThread.federation
+      ? resolveThreadTerminalCwd(selectedThread)
+      : undefined;
+  const selectedThreadTerminalDisabledReason = resolveRemoteTerminalDisabledReason(
+    selectedThread?.federation,
+  );
   const toggleSelectedThreadTerminal = useCallback(() => {
     if (!selectedThreadKey) return;
-    // No remote PTY exists in the federation protocol yet — opening the
-    // panel for a remote thread would run a shell on THIS machine while
-    // the window is branded as the peer instance.
-    if (selectedThread?.federation) return;
+    if (selectedThreadTerminalDisabledReason) return;
     terminals.togglePanel(selectedThreadKey, selectedThreadTerminalCwd);
-  }, [selectedThread, selectedThreadKey, selectedThreadTerminalCwd, terminals]);
+  }, [
+    selectedThreadKey,
+    selectedThreadTerminalCwd,
+    selectedThreadTerminalDisabledReason,
+    terminals,
+  ]);
   const suppressBranchDriftDialogRef = useRef(
     props.suppressBranchDriftDialog ?? false
   );
@@ -2990,6 +3000,7 @@ export function ThreadView(props: ThreadViewProps) {
           railOpen: contextRailPinned,
           terminalOpen: selectedThreadTerminalOpen,
           terminalRunning: selectedThreadTerminalRunning,
+          terminalDisabledReason: selectedThreadTerminalDisabledReason,
           onToggleSidebar,
           onToggleRail: () => onContextRailPinnedChange(!contextRailPinned),
           onToggleTerminal: toggleSelectedThreadTerminal,
@@ -3508,13 +3519,26 @@ function threadDirectoryPaths(thread: NavigationThreadSummary): string[] {
   return thread.projectKey ? [thread.projectKey, ...linkedDirectoryPaths] : linkedDirectoryPaths;
 }
 
-function resolveThreadTerminalCwd(
-  thread: NavigationThreadSummary,
+/**
+ * Why the remote terminal toggle is inert for a federated thread — or
+ * undefined when it can open (always undefined for local threads). Mirrors
+ * the owner-side gate: the peer must be connected DIRECTLY and must have
+ * granted `remote_pty`.
+ */
+function resolveRemoteTerminalDisabledReason(
+  federation: NavigationThreadSummary["federation"],
 ): string | undefined {
-  const directory =
-    thread.linkedDirectories.find((candidate) => candidate.kind === "worktree") ??
-    thread.linkedDirectories.find((candidate) => candidate.kind === "local") ??
-    thread.linkedDirectories[0];
-
-  return directory?.worktreePath ?? directory?.path ?? thread.projectKey;
+  if (!federation) {
+    return undefined;
+  }
+  if (
+    federation.peerStatus !== undefined &&
+    federation.peerStatus !== "connected"
+  ) {
+    return `Remote terminal unavailable: ${federation.instanceLabel} is disconnected.`;
+  }
+  if (!federation.capabilities?.includes("remote_pty")) {
+    return `Remote terminal not granted by ${federation.instanceLabel}.`;
+  }
+  return undefined;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1074,6 +1074,159 @@ describe("ThreadView", () => {
     });
   });
 
+  it("opens a remote thread's terminal without sending a viewer-side cwd", async () => {
+    const remoteThread: NavigationThreadSummary = {
+      id: "remote-thread-1",
+      title: "Remote thread",
+      titleSource: "explicit",
+      source: "codex",
+      executionMode: "default",
+      updatedAt: Date.now(),
+      projectKey: "/viewer/should-not-be-sent",
+      linkedDirectories: [],
+      inbox: { inInbox: true },
+      federation: {
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "peer-a" },
+          threadId: "remote-thread-1",
+        },
+        instanceLabel: "Peer Mac",
+        peerStatus: "connected",
+        capabilities: ["thread_detail", "remote_pty"],
+      },
+    };
+
+    render(
+      <ThreadView
+        {...({
+          addOptimisticUserMessage: () => "optimistic-1",
+          backends: [],
+          clearPendingRequest: () => undefined,
+          composerDisabled: false,
+          desktopApi: {},
+          loading: false,
+          loadingMore: false,
+          messageCount: 1,
+          onLoadOlder: async () => undefined,
+          removeOptimisticMessage: () => undefined,
+          skills: [],
+          transcriptEntries: [],
+        } as unknown as Omit<ThreadViewProps, "terminals" | "selectedThread">)}
+        selectedThread={remoteThread}
+      />,
+    );
+
+    const toggle = screen.getByRole("button", { name: "Open integrated terminal" });
+    expect(toggle).not.toHaveAttribute("aria-disabled");
+    fireEvent.click(toggle);
+
+    const pane = await screen.findByLabelText("Integrated terminal");
+    expect(pane).toHaveAttribute("data-thread-key", "codex:remote-thread-1");
+    // The owner resolves the cwd; the viewer must not pick one.
+    expect(pane).toHaveAttribute("data-cwd", "");
+  });
+
+  it("disables the remote terminal toggle with a reason when the peer lacks remote_pty", () => {
+    const remoteThread: NavigationThreadSummary = {
+      id: "remote-thread-1",
+      title: "Remote thread",
+      titleSource: "explicit",
+      source: "codex",
+      executionMode: "default",
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: { inInbox: true },
+      federation: {
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "peer-a" },
+          threadId: "remote-thread-1",
+        },
+        instanceLabel: "Peer Mac",
+        peerStatus: "connected",
+        capabilities: ["thread_detail"],
+      },
+    };
+
+    render(
+      <ThreadView
+        {...({
+          addOptimisticUserMessage: () => "optimistic-1",
+          backends: [],
+          clearPendingRequest: () => undefined,
+          composerDisabled: false,
+          desktopApi: {},
+          loading: false,
+          loadingMore: false,
+          messageCount: 1,
+          onLoadOlder: async () => undefined,
+          removeOptimisticMessage: () => undefined,
+          skills: [],
+          transcriptEntries: [],
+        } as unknown as Omit<ThreadViewProps, "terminals" | "selectedThread">)}
+        selectedThread={remoteThread}
+      />,
+    );
+
+    const toggle = screen.getByRole("button", {
+      name: "Remote terminal not granted by Peer Mac.",
+    });
+    expect(toggle).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(toggle);
+    expect(screen.queryByLabelText("Integrated terminal")).not.toBeInTheDocument();
+  });
+
+  it("disables the remote terminal toggle when the peer is disconnected", () => {
+    const remoteThread: NavigationThreadSummary = {
+      id: "remote-thread-1",
+      title: "Remote thread",
+      titleSource: "explicit",
+      source: "codex",
+      executionMode: "default",
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: { inInbox: true },
+      federation: {
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "peer-a" },
+          threadId: "remote-thread-1",
+        },
+        instanceLabel: "Peer Mac",
+        peerStatus: "disconnected",
+        capabilities: ["thread_detail", "remote_pty"],
+      },
+    };
+
+    render(
+      <ThreadView
+        {...({
+          addOptimisticUserMessage: () => "optimistic-1",
+          backends: [],
+          clearPendingRequest: () => undefined,
+          composerDisabled: false,
+          desktopApi: {},
+          loading: false,
+          loadingMore: false,
+          messageCount: 1,
+          onLoadOlder: async () => undefined,
+          removeOptimisticMessage: () => undefined,
+          skills: [],
+          transcriptEntries: [],
+        } as unknown as Omit<ThreadViewProps, "terminals" | "selectedThread">)}
+        selectedThread={remoteThread}
+      />,
+    );
+
+    const toggle = screen.getByRole("button", {
+      name: "Remote terminal unavailable: Peer Mac is disconnected.",
+    });
+    expect(toggle).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(toggle);
+    expect(screen.queryByLabelText("Integrated terminal")).not.toBeInTheDocument();
+  });
+
   // Regression: terminal state used to live in ThreadView's useState, so every
   // unmount (search view, or a refresh that flips `threadDetailPending`) left
   // the PTY running in main with nothing in the UI pointing at it. Main is the

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -17,6 +17,7 @@ import type {
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
   NavigationSnapshot,
+  FederationPeerSummary,
   NavigationThreadGitWorkingStateUpdatedNotification,
   NavigationThreadSummary,
   PrSummary,
@@ -32,6 +33,7 @@ import {
   buildThreadIdentityKey,
   compareThreadsByCreatedAtDesc,
   insertSubthreadIdAfter,
+  isRemoteFederationTarget,
   isSubthreadLaunchpadKey,
   shortenDerivedThreadTitle,
   sortSubthreadSummaries,
@@ -3208,6 +3210,28 @@ export function useThreadNavigation(
         }
         setState((current) => ({
           ...current,
+          // Patch the live peer status onto the affected rows so surfaces
+          // keyed off it (the remote terminal toggle) disable immediately
+          // instead of waiting for the next snapshot refresh.
+          response: current.response
+            ? {
+                ...current.response,
+                threads: current.response.threads.map((thread) =>
+                  thread.federation &&
+                  isRemoteFederationTarget(thread.federation.ref.target) &&
+                  thread.federation.ref.target.instanceId === params.instanceId
+                    ? {
+                        ...thread,
+                        federation: {
+                          ...thread.federation,
+                          peerStatus:
+                            params.status as FederationPeerSummary["status"],
+                        },
+                      }
+                    : thread,
+                ),
+              }
+            : current.response,
           loading: false,
           refreshing: false,
           error: params.unavailableReason ??

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1241,6 +1241,21 @@ textarea,
   outline-offset: 1px;
 }
 
+/* Remote thread whose peer lacks remote_pty or is disconnected: the toggle
+   stays visible (the terminal exists as a concept) but reads inert, with the
+   tooltip carrying the reason. aria-disabled, not disabled, so hover still
+   reaches it and the tooltip can explain why. */
+.thread-header__terminal-toggle.is-disabled {
+  color: var(--text-muted);
+  opacity: 0.45;
+  cursor: default;
+}
+
+.thread-header__terminal-toggle.is-disabled:hover {
+  background: transparent;
+  color: var(--text-muted);
+}
+
 .thread-header__terminal-toggle.is-open {
   color: var(--accent-bright);
 }

--- a/docs/plans/2026-08-05-001-feat-federation-remote-pty-plan.md
+++ b/docs/plans/2026-08-05-001-feat-federation-remote-pty-plan.md
@@ -134,15 +134,20 @@ The renderer terminal panel already talks to the main process over
 
 ## Verification
 
-- [ ] Unit: capability mapping — every `pty.*` control method requires
+- [x] Unit: capability mapping — every `pty.*` control method requires
       `remote_pty`; input/close from a non-opener peer is rejected.
-- [ ] Unit: flow control — synthetic 10 MiB burst pauses the PTY at the
+      (`federation-pty-service.test.ts`)
+- [x] Unit: flow control — synthetic multi-MiB burst pauses the PTY at the
       high-water mark and resumes on acks; seq stays gapless.
-- [ ] Unit: reaping — disconnect kills the session after grace; close-during-
-      spawn does not leak a shell (reuses the existing hardening tests).
-- [ ] Unit: federation-window IPC branch never reaches the local spawn path.
-- [ ] E2E (two in-process instances, per the federation E2E plan): open remote
-      terminal, run `echo`, assert output renders in the viewer and the
-      process ran on the owner (marker file in the owner's worktree).
+- [x] Unit: reaping — disconnect kills the session after grace; a reconnect
+      inside the grace cancels it; disconnect-during-spawn does not leak a
+      shell; owner shutdown kills immediately.
+- [x] Unit: federation-window IPC branch never reaches the local spawn path
+      (`federation-terminal-ipc.test.ts`); renderer toggle disabled-with-
+      reason cases covered in `thread-view.test.tsx`.
+- [x] E2E (two in-process instances, in-process gateway harness): open remote
+      terminal, run `echo`, output renders in the viewer's xterm and the
+      marker file lands in the gateway process's temp worktree
+      (`federation-remote-window.spec.ts`).
 - [ ] Manual: interactive feel over Tailscale between two machines; resize;
       Ctrl-C; peer revokes `remote_pty` → toggle disables with reason.

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -20,6 +20,7 @@ export const FEDERATION_CAPABILITIES = [
   "federated_search",
   "messaging_route",
   "gateway_relay",
+  "remote_pty",
 ] as const;
 
 export type FederationCapability = (typeof FEDERATION_CAPABILITIES)[number];
@@ -268,7 +269,9 @@ export type FederationDiagnosticEventKind =
   | "rejected"
   | "disconnected"
   | "relay"
-  | "error";
+  | "error"
+  | "remote_pty_open"
+  | "remote_pty_close";
 
 export type FederationDiagnosticEvent = {
   eventId: number;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -27,6 +27,7 @@ import type { BackendAcpSessionRuntimeState } from "./backend";
 import type { AutomationThreadSummary } from "./automations";
 import type {
   FederatedThreadRef,
+  FederationCapability,
   FederationPeerSummary,
   FederationTarget,
 } from "./federation";
@@ -70,6 +71,12 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
     ref: FederatedThreadRef;
     instanceLabel: string;
     peerStatus?: FederationPeerSummary["status"];
+    /**
+     * Capabilities the owning instance granted this viewer over a DIRECT
+     * connection. `remote_pty` is stripped when the peer is only reachable
+     * through a gateway relay — PTY streams are point-to-point in v1.
+     */
+    capabilities?: FederationCapability[];
   };
   inbox: ThreadInboxState;
   /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -37,6 +37,7 @@ export * from "./renderer-payload-boundary";
 export * from "./review-branches";
 export * from "./subthreads";
 export * from "./thread-pins";
+export * from "./thread-terminal";
 export * from "./thread-titles";
 export * from "./token-usage-pricing";
 export * from "./worktree-paths";

--- a/packages/shared/src/thread-terminal.ts
+++ b/packages/shared/src/thread-terminal.ts
@@ -1,0 +1,22 @@
+import type { AppServerThreadSummary } from "./contracts/normalized-app-server";
+
+/**
+ * The working directory a thread's integrated terminal should open in.
+ *
+ * One resolver for every surface that spawns a thread shell: the renderer's
+ * local terminal panel and the federation owner answering a remote `pty.open`
+ * both route through this, so a remote viewer's shell lands in exactly the
+ * directory the owner's own panel would use. Worktree checkouts win over the
+ * repository checkout, mirroring how thread-scoped commands prefer
+ * `worktreePath`.
+ */
+export function resolveThreadTerminalCwd(
+  thread: Pick<AppServerThreadSummary, "linkedDirectories" | "projectKey">,
+): string | undefined {
+  const directory =
+    thread.linkedDirectories.find((candidate) => candidate.kind === "worktree") ??
+    thread.linkedDirectories.find((candidate) => candidate.kind === "local") ??
+    thread.linkedDirectories[0];
+
+  return directory?.worktreePath ?? directory?.path ?? thread.projectKey;
+}


### PR DESCRIPTION
## Summary

- Implements the remote PTY / integrated terminal for federated threads per [docs/plans/2026-08-05-001-feat-federation-remote-pty-plan.md](docs/plans/2026-08-05-001-feat-federation-remote-pty-plan.md), restoring the terminal toggle that #1202 hid in remote windows — the panel now attaches to a PTY spawned **on the owning instance** and streamed over the existing Noise WebSocket envelope transport.
- New default-granted `remote_pty` federation capability, revocable independently of `turn_control`.
- Protocol in `federation-pty-service.ts`: `pty.open/input/resize/ack/close` control RPCs (capability-checked in the router) + `pty.output/exit/error` streamed notifications. Sessions are strictly point-to-point: the router now passes the authenticated source peer to handlers, gateway-relayed requests are rejected, and owner→viewer stream sends never fall back to the gateway (`hopCount` stays 0).
- Owner side: `FederationPtyService` reuses the extracted `spawnTerminalPty` core from the local integrated-terminal service (same login-env/shell/clamping hardening) with **owner-resolved shell + cwd** via the new shared `resolveThreadTerminalCwd` — the viewer never sends a path. Ack-window backpressure pauses the node-pty at 1 MiB unacked / resumes at 256 KiB; output frames carry a gapless `seq`; sessions get a 10s-grace reap on close/disconnect with reconnect cancellation; opens/closes land in the federation audit log (`remote_pty_open`/`remote_pty_close`) with the requesting instance label.
- Viewer side: new `ipc/federation-terminal.ts` bridge keeps the renderer protocol-unaware — federation windows speak the exact same `INTEGRATED_TERMINAL_*` IPC, branched in `ipc/integrated-terminal.ts`, and can **never fall through to a local spawn** (throws when the window's remote target is missing). Local session broadcasts no longer leak into federation windows; the bridge keeps a viewer-side scrollback buffer so pane remounts replay like local ones.
- Renderer: `ThreadHeader`/`ThreadView` re-show the toggle for remote threads, disabled with a tooltip reason ("Remote terminal not granted by <label>" / "…is disconnected") when the peer lacks the grant or drops. Thread summaries carry the granted capability set (`remote_pty` stripped for relay-only reachability), and `federation/peerStatus/changed` events live-patch rows so the toggle disables without a refresh.

## Verification

- 14 new unit tests in `federation-pty-service.test.ts`: capability map (every `pty.*` method requires `remote_pty`), non-opener input/resize/ack/close rejection, multi-MiB burst pauses at high water and resumes on acks with gapless seq, disconnect reap after grace, reconnect-inside-grace cancellation, disconnect-during-spawn does not leak a shell, owner shutdown kills immediately, and router integration (capability denial + relayed-open rejection).
- 6 new tests in `federation-terminal-ipc.test.ts`: the federation-window IPC branch never reaches the local spawn path (including the missing-target throw), writes/list/close stay off the local service and scoped per window.
- 3 new renderer tests in `thread-view.test.tsx`: remote open sends no viewer-side cwd; disabled-with-reason for missing grant and for disconnected peer.
- E2E: `federation-remote-window.spec.ts` now exercises the full remote terminal against the in-process gateway harness serving a **real node-pty shell** — toggle enabled, status shows the owner-resolved cwd, `echo` typed in the viewer's xterm creates a marker file in the gateway process's temp cwd (proof the shell ran on the owner) and the output streams back into the viewer. Passing locally, as is `integrated-terminal.spec.ts` for the refactored local spawn core.
- Full workspace unit suite (6,194 tests), `typecheck`, `lint:eslint`, `lint:boundaries`, `lint:sql`, `lint:colors`, `lint:codex-storage`, and `licenses:check` all pass.

## Notes

- Deliberately out of scope per the plan (v1): server-side scrollback persistence/reattach, multiple concurrent viewers per session, and gateway relay of PTY streams — a client viewing another client through the gateway gets the disabled toggle, enforced both in the UI (capability stripped) and on the owner (relayed opens rejected).
- Incidental fixes: a pre-existing Playwright strict-mode flake in the federation spec (the Connection card's endpoint row also contains "Connected") now uses an exact-text match; the runtime unit-test harness gained a `visiblePeers` stub for the new capability lookup.
- The "graceful close failed — force-killing" teardown warnings in E2E output predate this change (they appear on unmodified specs too).
- Remaining manual item from the plan: interactive feel over Tailscale between two machines, resize/Ctrl-C, and revoking `remote_pty` to watch the toggle disable with its reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)