### PR TITLE
fix(messaging): clarify Slack origin labels

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1075,6 +1075,49 @@ describe("DesktopSettingsService", () => {
     ]);
   });
 
+  it("round-trips normalized authorized contact usernames", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      [
+        "[[messaging.slack.authorized_users]]",
+        'id = "U079K80HTGS"',
+        'display_name = "Harold Hunt"',
+        'username = "@hhunt"',
+      ].join("\n"),
+      "utf8",
+    );
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const before = await service.readSettings();
+    expect(before.messaging.slack.authorizedUserIds.value).toEqual([{
+      id: "U079K80HTGS",
+      displayName: "Harold Hunt",
+      username: "hhunt",
+    }]);
+
+    await service.writeConfigPatch({
+      messaging: {
+        slack: {
+          authorizedUserIds: before.messaging.slack.authorizedUserIds.value,
+        },
+      },
+    });
+
+    expect(fs.readFileSync(configPath, "utf8")).toContain('username = "hhunt"');
+    const after = await service.readSettings();
+    expect(after.messaging.slack.authorizedUserIds.value).toEqual([{
+      id: "U079K80HTGS",
+      displayName: "Harold Hunt",
+      username: "hhunt",
+    }]);
+  });
+
   it("sanitizes authorized contact display names read from config", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -2749,6 +2749,55 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
+  it("hot-applies Slack actor metadata without restarting the running adapter", async () => {
+    await prepareRuntimeStore();
+    const updateAuthorization = vi.fn(async () => undefined);
+    const slackAdapter = createAdapter("slack", { updateAuthorization });
+    const factory = vi.fn<DesktopMessagingAdapterFactory>(({ config }) =>
+      config.slack ? [slackAdapter] : [],
+    );
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: factory,
+      backendBridge: createBackendBridge(),
+      config: {
+        inputDebounceMs: 0,
+        slack: {
+          channel: "slack",
+          botToken: "slack-bot-token",
+          authorizedActorIds: [{ id: "U012ABCDEF0", displayName: "Harold" }],
+        },
+      },
+    });
+
+    await runtime.start();
+    await runtime.applyConfig({
+      inputDebounceMs: 0,
+      slack: {
+        channel: "slack",
+        botToken: "slack-bot-token",
+        authorizedActorIds: [{
+          id: "U012ABCDEF0",
+          displayName: "Harold Hunt",
+          username: "hhunt",
+        }],
+      },
+    });
+
+    expect(slackAdapter.start).toHaveBeenCalledTimes(1);
+    expect(slackAdapter.stop).not.toHaveBeenCalled();
+    expect(updateAuthorization).toHaveBeenCalledWith(expect.objectContaining({
+      authorizedActorIds: ["U012ABCDEF0"],
+      authorizedActors: [{
+        platformUserId: "U012ABCDEF0",
+        displayName: "Harold Hunt",
+        username: "hhunt",
+      }],
+    }));
+  });
+
   it("restarts on authorization changes when the adapter has no hot-update hook", async () => {
     await prepareRuntimeStore();
     const firstTelegramAdapter = createAdapter("telegram");

--- a/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
@@ -402,7 +402,11 @@ describe("messaging status ipc", () => {
       status: "observed",
       generatedAt: 1_000,
       expiresAt: 2_000,
-      observedActor: { id: "U012ABCDEF0", displayName: "Harold" },
+      observedActor: {
+        id: "U012ABCDEF0",
+        displayName: "Harold",
+        username: "hhunt",
+      },
       observedChat: {
         id: "C012ABCDEF0",
         kind: "channel",
@@ -449,7 +453,7 @@ describe("messaging status ipc", () => {
       messaging: {
         slack: {
           authorizedUserIds: [
-            { id: "U012ABCDEF0", displayName: "Harold" },
+            { id: "U012ABCDEF0", displayName: "Harold", username: "hhunt" },
           ],
         },
       },

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -151,8 +151,20 @@ function buildPairingApprovalPatch(
   const merge = (
     current: DesktopAuthorizedContact[],
   ): { added: boolean; contacts: DesktopAuthorizedContact[] } => {
-    if (current.some((existing) => existing.id === contact.id)) {
-      return { added: false, contacts: current };
+    const existingIndex = current.findIndex((existing) => existing.id === contact.id);
+    if (existingIndex >= 0) {
+      return {
+        added: false,
+        contacts: current.map((existing, index) =>
+          index === existingIndex
+            ? {
+                ...existing,
+                displayName: existing.displayName || contact.displayName,
+                ...(contact.username ? { username: contact.username } : {}),
+              }
+            : existing,
+        ),
+      };
     }
     return { added: true, contacts: [...current, contact] };
   };
@@ -350,6 +362,9 @@ function contactForPairing(
     displayName:
       entry.observedActor.displayName
       ?? (entry.observedActor.username ? `@${entry.observedActor.username}` : ""),
+    ...(entry.observedActor.username
+      ? { username: entry.observedActor.username }
+      : {}),
   };
 }
 

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -13,6 +13,7 @@ import type {
   MessagingChannelKind,
 } from "@pwragent/shared";
 import type {
+  MessagingActorIdentity,
   MessagingAdapterAuthorizationUpdate,
   MessagingAdapterRenderingPreferencesUpdate,
   MessagingConversationResponseMode,
@@ -1460,6 +1461,7 @@ function authorizationUpdateForChannelConfig(
     case "slack":
       return {
         authorizedActorIds: contactIds(config.slack?.authorizedActorIds),
+        authorizedActors: slackAuthorizedActors(config.slack?.authorizedActorIds),
         authorizedConversationIds: contactIds(config.slack?.authorizedConversationIds),
         conversationAuthorizationMode: config.slack?.channelAuthorizationMode,
         conversationResponseModes: conversationResponseModes(
@@ -1491,6 +1493,16 @@ function authorizationUpdateForChannelConfig(
       throw new Error(`unknown messaging channel: ${exhaustive}`);
     }
   }
+}
+
+function slackAuthorizedActors(
+  contacts: readonly DesktopAuthorizedContact[] | undefined,
+): MessagingActorIdentity[] {
+  return (contacts ?? []).map((contact) => ({
+    platformUserId: contact.id,
+    displayName: contact.displayName,
+    ...(contact.username ? { username: contact.username } : {}),
+  }));
 }
 
 function renderingPreferencesForChannelConfig(

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -46,6 +46,7 @@ import {
   isDesktopOnboardingCompletedSource,
   isDesktopWorktreeStorageLocation,
   isDesktopUpdateChannel,
+  sanitizeMessagingContactHandle,
   sanitizeMessagingContactLabel,
 } from "@pwragent/shared";
 import { DEFAULT_PASTED_IMAGE_MAX_PATCHES } from "../../shared/image-normalization";
@@ -609,6 +610,7 @@ export function desktopSettingsPatchToEdits(
       value: normalizedContacts.map((contact) => ({
         id: contact.id,
         display_name: contact.displayName,
+        ...(contact.username ? { username: contact.username } : {}),
         ...(contact.fullAccessWarningOverride
           ? { full_access_warning: contact.fullAccessWarningOverride }
           : {}),
@@ -2651,6 +2653,12 @@ function readAuthorizedContactArray(
           : typeof entry.displayName === "string"
             ? entry.displayName
             : "",
+      username:
+        typeof entry.username === "string"
+          ? entry.username
+          : typeof entry.handle === "string"
+            ? entry.handle
+            : undefined,
       fullAccessWarningOverride: isFullAccessWarningUserPolicy(
         entry.full_access_warning,
       )
@@ -2674,20 +2682,24 @@ function normalizeAuthorizedContacts(
   contacts: readonly DesktopAuthorizedContact[],
 ): DesktopAuthorizedContact[] {
   return contacts
-    .map((contact) => ({
-      id: contact.id.trim(),
-      displayName: sanitizeMessagingContactLabel(contact.displayName),
-      ...(isFullAccessWarningUserPolicy(contact.fullAccessWarningOverride) &&
-      contact.fullAccessWarningOverride !== "default"
-        ? { fullAccessWarningOverride: contact.fullAccessWarningOverride }
-        : {}),
-      ...(contact.fullAccessWarningDismissed === true
-        ? { fullAccessWarningDismissed: true }
-        : {}),
-      ...(isMessagingResponseMode(contact.responseMode)
-        ? { responseMode: contact.responseMode }
-        : {}),
-    }))
+    .map((contact) => {
+      const username = sanitizeMessagingContactHandle(contact.username);
+      return {
+        id: contact.id.trim(),
+        displayName: sanitizeMessagingContactLabel(contact.displayName),
+        ...(username ? { username } : {}),
+        ...(isFullAccessWarningUserPolicy(contact.fullAccessWarningOverride) &&
+        contact.fullAccessWarningOverride !== "default"
+          ? { fullAccessWarningOverride: contact.fullAccessWarningOverride }
+          : {}),
+        ...(contact.fullAccessWarningDismissed === true
+          ? { fullAccessWarningDismissed: true }
+          : {}),
+        ...(isMessagingResponseMode(contact.responseMode)
+          ? { responseMode: contact.responseMode }
+          : {}),
+      };
+    })
     .filter((contact) => contact.id.length > 0);
 }
 

--- a/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
@@ -6,9 +6,10 @@ import {
   type CSSProperties,
   type PointerEvent as ReactPointerEvent,
 } from "react";
-import type {
-  MessagingActivityEntry,
-  MessagingActivityKind,
+import {
+  sanitizeMessagingContactHandle,
+  type MessagingActivityEntry,
+  type MessagingActivityKind,
 } from "@pwragent/shared";
 import { copyText } from "../../lib/copy-text";
 import type { DesktopApi } from "../../lib/desktop-api";
@@ -249,6 +250,7 @@ function ActivitySection(props: {
 function ActivityRow(props: { entry: MessagingActivityEntry }) {
   const { entry } = props;
   const tone = KIND_TONE[entry.kind];
+  const actorUsername = activityActorUsername(entry);
   const [copiedKey, setCopiedKey] = useState<string | undefined>(undefined);
   const copyFields = copyFieldsForEntry(entry);
   const Icon = MESSAGING_PLATFORM_ICONS[entry.platform];
@@ -266,7 +268,10 @@ function ActivityRow(props: { entry: MessagingActivityEntry }) {
           <span className={`settings-pill settings-pill--${tone === "ok" ? "ok" : tone === "warning" ? "warn" : tone === "error" ? "bad" : "neutral"}`}>
             {KIND_LABEL[entry.kind]}
           </span>
-          <span className="messaging-activity-row__summary">{entry.summary}</span>
+          <span className="messaging-activity-row__summary">
+            {entry.summary}
+            {actorUsername ? ` (@${actorUsername})` : ""}
+          </span>
         </div>
         <div className="messaging-activity-row__meta">
           {entry.conversationTitle ?? entry.conversationId ?? "—"}
@@ -358,6 +363,14 @@ function copyFieldsForEntry(
       value: entry.actorId,
     });
   }
+  const actorUsername = activityActorUsername(entry);
+  if (actorUsername) {
+    fields.push({
+      key: "actor-username",
+      label: "Username",
+      value: `@${actorUsername}`,
+    });
+  }
   if (entry.kind === "diagnostic") {
     if (entry.bindingId) {
       fields.push({
@@ -398,6 +411,11 @@ function copyFieldsForEntry(
   }
 
   return fields;
+}
+
+function activityActorUsername(entry: MessagingActivityEntry): string | undefined {
+  const username = sanitizeMessagingContactHandle(entry.payload?.actorUsername);
+  return username || undefined;
 }
 
 function userIdLabel(platform: MessagingActivityEntry["platform"]): string {

--- a/apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx
@@ -141,6 +141,7 @@ describe("MessagingActivityScreen", () => {
             payload: {
               conversationKind: "channel",
               conversationBucketId: "T079K80HTGS",
+              actorUsername: "hhunt",
             },
           },
         ],
@@ -154,11 +155,15 @@ describe("MessagingActivityScreen", () => {
     });
     expect((await screen.findByText("U079K80HTGS")).closest("button"))
       .toHaveTextContent("User ID");
+    expect(screen.getByText("@hhunt").closest("button"))
+      .toHaveTextContent("Username");
+    expect(screen.getByText("Observed pairing token (@hhunt)"))
+      .toBeInTheDocument();
     expect(screen.getByText("T079K80HTGS").closest("button"))
       .toHaveTextContent("Workspace ID");
     expect(screen.getByText("C079K80HTGS").closest("button"))
       .toHaveTextContent("Channel ID");
-    const row = screen.getByText("Observed pairing token").closest("li");
+    const row = screen.getByText("Observed pairing token (@hhunt)").closest("li");
     expect(row).not.toHaveTextContent("sl");
     expect(row?.querySelector("img")).toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -721,6 +721,9 @@ function formatBindingLabel(binding: MessagingThreadBindingSummary): string {
         // (super)group name — that's the breadcrumb itself.
         return title ? elide(title, 28) : "Group";
       }
+      if (platform === "slack") {
+        return title ? `#${elide(title, 28)}` : "Channel";
+      }
       // Discord. Thread messages are still kind="channel" (kind drives
       // binding lookup, can't change), so we distinguish by data
       // shape: ancestorTitle populated → it's a thread (3-level).

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -138,6 +138,28 @@ describe("ThreadRow chip flow", () => {
     expect(bindingChip?.textContent).not.toContain("sl");
   });
 
+  it("labels a Slack channel with its known channel name", () => {
+    const slackBinding: MessagingThreadBindingSummary = {
+      bindingId: "binding-slack-channel",
+      platform: "slack",
+      conversationKind: "channel",
+      conversationTitle: "p-pwragent-testing",
+    };
+    const { container } = renderRow({
+      thread: {
+        ...baseThread,
+        messagingBindings: [slackBinding],
+        reactions: [],
+      },
+    });
+    const bindingChip = container.querySelector(".thread-row__chip--binding");
+    expect(bindingChip).toHaveTextContent("#p-pwragent-testing");
+    expect(bindingChip).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("Channel: #p-pwragent-testing"),
+    );
+  });
+
   it("labels a Slack group DM (mpim) as a Group DM, not a channel", () => {
     const groupDmBinding: MessagingThreadBindingSummary = {
       ...telegramBinding,

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -2357,7 +2357,7 @@ function PairingTokenField(props: {
         if (result?.entry.id === messageEntryId) {
           setGeneratedMessage(undefined, undefined);
         }
-        if (result?.added) {
+        if (result) {
           await props.onSettingsChanged?.();
         }
       } else {
@@ -2381,15 +2381,17 @@ function PairingTokenField(props: {
     setBusyId(entry.id);
     setError(undefined);
     try {
+      let approved = false;
       for (const step of steps) {
         const result = await props.desktopApi?.approveMessagingPairing?.({
           entryId: entry.id,
           target: step.target,
           ...(step.consume ? {} : { consume: false }),
         });
-        if (result?.added) {
-          await props.onSettingsChanged?.();
-        }
+        approved = approved || Boolean(result);
+      }
+      if (approved) {
+        await props.onSettingsChanged?.();
       }
       if (entry.id === messageEntryId) {
         setGeneratedMessage(undefined, undefined);
@@ -2962,13 +2964,20 @@ function AuthorizedListField(props: {
                         );
                         setRows(nextRows);
                         saveIfValid(nextRows);
-                        if (normalized.displayName.length === 0) {
+                        if (
+                          normalized.displayName.length === 0
+                          || (props.showUsername && !normalized.username)
+                        ) {
                           void lookupRow(index, nextRows);
                         }
                       }}
-                      onChange={(event) =>
-                        updateRow(index, { id: event.currentTarget.value })
-                      }
+                      onChange={(event) => {
+                        const id = event.currentTarget.value;
+                        updateRow(index, {
+                          id,
+                          ...(id !== row.id ? { username: undefined } : {}),
+                        });
+                      }}
                     />
                   </div>
                   <div className="settings-authorized-list__field">

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -19,6 +19,7 @@ import {
   validateMattermostId,
   validateSlackTeamId,
   validateSlackUserId,
+  sanitizeMessagingContactHandle,
   sanitizeMessagingContactLabel,
   validateTelegramGroupChatId,
   validateTelegramPositiveId,
@@ -1126,6 +1127,7 @@ export function MessagingSettings(props: {
             validateEntry={validateSlackUserIdEntry}
             value={slack.authorizedUserIds.value}
             fullAccessWarningPolicy
+            showUsername
             onSave={(authorizedUserIds) => {
               void props.onSaveSlack({
                 ...slack,
@@ -2716,6 +2718,7 @@ function AuthorizedListField(props: {
   label: string;
   lookup?: (id: string) => Promise<DesktopMessagingContactLookupResponse>;
   responseModePolicy?: boolean;
+  showUsername?: boolean;
   sub?: ReactNode;
   source: string;
   validateEntry?: (value: string) => string | undefined;
@@ -2724,11 +2727,13 @@ function AuthorizedListField(props: {
 }) {
   const inputId = useId();
   const descriptionId = `${inputId}-validation`;
-  // When a row carries a labeled policy column (Full Access warning /
-  // Response mode), give the ID and Display name columns matching headers
+  // When a row carries a labeled policy or resolved Username column, give
+  // the identity columns matching headers
   // so every input shares a baseline instead of floating.
   const showColumnHeaders = Boolean(
-    props.fullAccessWarningPolicy || props.responseModePolicy,
+    props.fullAccessWarningPolicy
+    || props.responseModePolicy
+    || props.showUsername,
   );
   const [rows, setRowsState] = useState<DesktopAuthorizedContact[]>(props.value);
   const rowsRef = useRef<DesktopAuthorizedContact[]>(props.value);
@@ -2749,8 +2754,8 @@ function AuthorizedListField(props: {
           message:
             row.id.length > 0
               ? props.validateEntry?.(row.id)
-              : row.displayName.length > 0
-                ? "ID cannot be blank when a display name is set."
+              : row.displayName.length > 0 || Boolean(row.username)
+                ? "ID cannot be blank when a display name or username is set."
                 : undefined,
         }))
         .filter(
@@ -2777,7 +2782,8 @@ function AuthorizedListField(props: {
       normalized.some(
         (row) =>
           (row.id.length > 0 && props.validateEntry?.(row.id))
-          || (row.id.length === 0 && row.displayName.length > 0),
+          || (row.id.length === 0
+            && (row.displayName.length > 0 || Boolean(row.username))),
       )
     ) {
       return;
@@ -2832,7 +2838,13 @@ function AuthorizedListField(props: {
         errorMessage: error instanceof Error ? error.message : String(error),
       };
     }
-    if (result.status === "ok" && result.displayName) {
+    const resolvedUsername = props.showUsername
+      ? sanitizeMessagingContactHandle(result.handle)
+      : "";
+    if (
+      result.status === "ok"
+      && (result.displayName || resolvedUsername)
+    ) {
       const latestRows = rowsRef.current;
       const latestRow = normalizeAuthorizedContactRow(
         latestRows[indexToLookup] ?? { id: "", displayName: "" },
@@ -2850,7 +2862,15 @@ function AuthorizedListField(props: {
           ? {
               ...current,
               id: row.id,
-              displayName: result.displayName ?? "",
+              displayName: result.displayName ?? current.displayName,
+              ...(props.showUsername
+                ? {
+                    username:
+                      resolvedUsername
+                      || sanitizeMessagingContactHandle(current.username)
+                      || undefined,
+                  }
+                : {}),
             }
           : current,
       );
@@ -2910,6 +2930,10 @@ function AuthorizedListField(props: {
                         ? " settings-authorized-list__row--with-warning"
                         : props.responseModePolicy
                           ? " settings-authorized-list__row--with-response-mode"
+                        : ""
+                    }${
+                      props.showUsername
+                        ? " settings-authorized-list__row--with-username"
                         : ""
                     }`}
                   >
@@ -2977,6 +3001,26 @@ function AuthorizedListField(props: {
                       }
                     />
                   </div>
+                  {props.showUsername ? (
+                    <div className="settings-authorized-list__field">
+                      {showColumnHeaders ? (
+                        <span
+                          aria-hidden="true"
+                          className="settings-authorized-list__policy-label"
+                        >
+                          Username
+                        </span>
+                      ) : null}
+                      <input
+                        aria-label={`${props.label} username ${index + 1}`}
+                        className="settings-input settings-authorized-list__username"
+                        placeholder="Not resolved"
+                        readOnly
+                        title="Resolved from Slack and stored for identity labels."
+                        value={normalized.username ? `@${normalized.username}` : ""}
+                      />
+                    </div>
+                  ) : null}
                   {props.fullAccessWarningPolicy ? (
                     <div className="settings-authorized-list__policy">
                       <label
@@ -3204,9 +3248,11 @@ function lookupFailureMessage(
 function normalizeAuthorizedContactRow(
   contact: DesktopAuthorizedContact,
 ): DesktopAuthorizedContact {
+  const username = sanitizeMessagingContactHandle(contact.username);
   return {
     id: contact.id.trim(),
     displayName: sanitizeMessagingContactLabel(contact.displayName),
+    ...(username ? { username } : {}),
     ...(contact.fullAccessWarningOverride &&
     contact.fullAccessWarningOverride !== "default"
       ? { fullAccessWarningOverride: contact.fullAccessWarningOverride }

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -3004,7 +3004,7 @@ describe("SettingsScreen", () => {
     );
   });
 
-  it("shows observed pairing IDs and refreshes authorized IDs after approval", async () => {
+  it("refreshes authorized contacts after metadata-only pairing approval", async () => {
     const snapshot = createSnapshot();
     const initialSnapshot: DesktopSettingsSnapshot = {
       ...snapshot,
@@ -3013,6 +3013,10 @@ describe("SettingsScreen", () => {
         telegram: {
           ...snapshot.messaging.telegram,
           enabled: { value: true, source: "config" },
+          authorizedUserIds: {
+            value: [{ id: "8460800771", displayName: "" }],
+            source: "config" as const,
+          },
         },
       },
     };
@@ -3055,7 +3059,7 @@ describe("SettingsScreen", () => {
     const approveMessagingPairing = vi.fn(async () => {
       approved = true;
       return {
-        added: true,
+        added: false,
         entry: {
           ...observedEntry,
           status: "consumed" as const,
@@ -3353,6 +3357,75 @@ describe("SettingsScreen", () => {
     const username = screen.getByLabelText("Authorized User IDs username 1");
     expect(username).toHaveValue("@hhunt");
     expect(username).toHaveAttribute("readonly");
+  });
+
+  it("clears and re-resolves a Slack username when its user ID changes", async () => {
+    const snapshot = createSnapshot();
+    const settings = createSettingsState({
+      ...snapshot,
+      messaging: {
+        ...snapshot.messaging,
+        slack: {
+          ...snapshot.messaging.slack,
+          authorizedUserIds: {
+            value: [{
+              id: "U079K80HTGS",
+              displayName: "Harold Hunt",
+              username: "hhunt",
+            }],
+            source: "config",
+          },
+        },
+      },
+    });
+    const resolveMessagingContact = vi.fn(async () => ({
+      status: "ok" as const,
+      id: "U012ABCDEF1",
+      displayName: "New User",
+      handle: "@newuser",
+    }));
+    const desktopApi = {
+      resolveMessagingContact,
+    } as unknown as Parameters<typeof SettingsScreen>[0]["desktopApi"];
+
+    render(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        settings={settings}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+
+    const idInput = screen.getByLabelText("Authorized User IDs ID 1");
+    const usernameInput = screen.getByLabelText("Authorized User IDs username 1");
+    expect(usernameInput).toHaveValue("@hhunt");
+
+    fireEvent.change(idInput, { target: { value: "U012ABCDEF1" } });
+    expect(usernameInput).toHaveValue("");
+    fireEvent.blur(idInput);
+
+    await waitFor(() => {
+      expect(resolveMessagingContact).toHaveBeenCalledWith({
+        platform: "slack",
+        kind: "user",
+        id: "U012ABCDEF1",
+      });
+    });
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenLastCalledWith({
+        messaging: {
+          slack: {
+            authorizedUserIds: [{
+              id: "U012ABCDEF1",
+              displayName: "New User",
+              username: "newuser",
+            }],
+          },
+        },
+      });
+    });
+    expect(usernameInput).toHaveValue("@newuser");
   });
 
   it("places Slack channel pairing and defaults with channel authorization", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -3341,11 +3341,18 @@ describe("SettingsScreen", () => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         messaging: {
           slack: {
-            authorizedUserIds: [{ id: "U079K80HTGS", displayName: "Harold Hunt" }],
+            authorizedUserIds: [{
+              id: "U079K80HTGS",
+              displayName: "Harold Hunt",
+              username: "hhunt",
+            }],
           },
         },
       });
     });
+    const username = screen.getByLabelText("Authorized User IDs username 1");
+    expect(username).toHaveValue("@hhunt");
+    expect(username).toHaveAttribute("readonly");
   });
 
   it("places Slack channel pairing and defaults with channel authorization", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/settings-patch-delta.ts
+++ b/apps/desktop/src/renderer/src/features/settings/settings-patch-delta.ts
@@ -356,6 +356,7 @@ function authorizedContactArrayEqual(
     if (
       a[i]?.id !== b[i]?.id ||
       a[i]?.displayName !== b[i]?.displayName ||
+      a[i]?.username !== b[i]?.username ||
       a[i]?.fullAccessWarningOverride !== b[i]?.fullAccessWarningOverride ||
       a[i]?.fullAccessWarningDismissed !== b[i]?.fullAccessWarningDismissed ||
       a[i]?.responseMode !== b[i]?.responseMode

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -792,17 +792,18 @@ function MessagingOriginChip(props: {
   const surface = surfaceParts.join(" / ");
   const actor = formatMessagingOriginActor(props.origin.actor);
   const directMessage = props.origin.surface.kind === "dm";
-  const surfaceDetail = directMessage ? `DM with ${surface}` : surface;
-  const actorDetail = directMessage ? `From ${actor.detail}` : actor.detail;
-  const actorLabel = directMessage && actor.usernameLabel
-    ? actor.usernameLabel
-    : actor.label;
-  const description = `${platform}: ${surfaceDetail} · ${actorDetail}`;
+  const chipSurfaceParts = directMessage
+    ? [`DM with ${actor.label}`]
+    : surfaceParts;
+  const surfaceDetail = directMessage ? `DM with ${actor.detail}` : surface;
+  const description = directMessage
+    ? `${platform}: ${surfaceDetail}`
+    : `${platform}: ${surfaceDetail} · ${actor.detail}`;
   const sourceUrl = safeMessagingSourceUrl(props.origin.sourceUrl);
   const tooltipText = [
     platform,
     surfaceDetail,
-    actorDetail,
+    directMessage ? undefined : actor.detail,
     sourceUrl ? `Open in ${platform}` : undefined,
   ].filter(Boolean).join("\n");
   const content = (
@@ -820,7 +821,7 @@ function MessagingOriginChip(props: {
         )}
       </span>
       <span className="transcript-message__messaging-surface">
-        {surfaceParts.map((part, index) => (
+        {chipSurfaceParts.map((part, index) => (
           <span
             className="transcript-message__messaging-surface-segment"
             key={`${index}:${part}`}
@@ -839,13 +840,17 @@ function MessagingOriginChip(props: {
           </span>
         ))}
       </span>
-      <span
-        aria-hidden="true"
-        className="transcript-message__messaging-separator"
-      >
-        ·
-      </span>
-      <span className="transcript-message__messaging-actor">{actorLabel}</span>
+      {!directMessage ? (
+        <>
+          <span
+            aria-hidden="true"
+            className="transcript-message__messaging-separator"
+          >
+            ·
+          </span>
+          <span className="transcript-message__messaging-actor">{actor.label}</span>
+        </>
+      ) : null}
     </>
   );
   const sharedProps = {
@@ -938,7 +943,7 @@ function messagingSurfaceParts(
 
 function formatMessagingOriginActor(
   actor: NonNullable<AppServerThreadMessageOrigin["messaging"]>["actor"],
-): { detail: string; label: string; usernameLabel?: string } {
+): { detail: string; label: string } {
   const displayName = actor.displayName?.trim();
   const username = actor.username?.trim().replace(/^@/, "");
   const usernameLabel = username ? `@${username}` : undefined;
@@ -949,7 +954,6 @@ function formatMessagingOriginActor(
     || actor.platformUserId;
   return {
     label,
-    usernameLabel,
     detail: displayName && usernameLabel
       ? `${displayName} (${usernameLabel})`
       : label,

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -791,12 +791,18 @@ function MessagingOriginChip(props: {
   const surfaceParts = messagingOriginSurfaceParts(props.origin);
   const surface = surfaceParts.join(" / ");
   const actor = formatMessagingOriginActor(props.origin.actor);
-  const description = `${platform}: ${surface} · ${actor.detail}`;
+  const directMessage = props.origin.surface.kind === "dm";
+  const surfaceDetail = directMessage ? `DM with ${surface}` : surface;
+  const actorDetail = directMessage ? `From ${actor.detail}` : actor.detail;
+  const actorLabel = directMessage && actor.usernameLabel
+    ? actor.usernameLabel
+    : actor.label;
+  const description = `${platform}: ${surfaceDetail} · ${actorDetail}`;
   const sourceUrl = safeMessagingSourceUrl(props.origin.sourceUrl);
   const tooltipText = [
     platform,
-    surface,
-    actor.detail,
+    surfaceDetail,
+    actorDetail,
     sourceUrl ? `Open in ${platform}` : undefined,
   ].filter(Boolean).join("\n");
   const content = (
@@ -839,7 +845,7 @@ function MessagingOriginChip(props: {
       >
         ·
       </span>
-      <span className="transcript-message__messaging-actor">{actor.label}</span>
+      <span className="transcript-message__messaging-actor">{actorLabel}</span>
     </>
   );
   const sharedProps = {
@@ -932,7 +938,7 @@ function messagingSurfaceParts(
 
 function formatMessagingOriginActor(
   actor: NonNullable<AppServerThreadMessageOrigin["messaging"]>["actor"],
-): { detail: string; label: string } {
+): { detail: string; label: string; usernameLabel?: string } {
   const displayName = actor.displayName?.trim();
   const username = actor.username?.trim().replace(/^@/, "");
   const usernameLabel = username ? `@${username}` : undefined;
@@ -943,6 +949,7 @@ function formatMessagingOriginActor(
     || actor.platformUserId;
   return {
     label,
+    usernameLabel,
     detail: displayName && usernameLabel
       ? `${displayName} (${usernameLabel})`
       : label,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -453,7 +453,7 @@ describe("TranscriptList", () => {
     expect(container.querySelector(".transcript-message--injected")).toBeInTheDocument();
   });
 
-  it("distinguishes a DM peer from its sender by full name and handle", async () => {
+  it("collapses a single-user DM to its peer's full name and handle", async () => {
     const { container } = render(
       <TranscriptList
         entries={[
@@ -489,24 +489,66 @@ describe("TranscriptList", () => {
     );
 
     const origin = screen.getByLabelText(
-      "Slack: DM with Harold Hunt · From Harold Hunt (@hhunt)",
+      "Slack: DM with Harold Hunt (@hhunt)",
     );
     expect(
       origin.querySelector(".transcript-message__messaging-surface"),
-    ).toHaveTextContent("Harold Hunt");
-    expect(
-      origin.querySelector(".transcript-message__messaging-actor"),
-    ).toHaveTextContent("@hhunt");
+    ).toHaveTextContent("DM with Harold Hunt");
+    expect(origin.querySelector(".transcript-message__messaging-actor")).toBeNull();
+    expect(origin.querySelector(".transcript-message__messaging-separator")).toBeNull();
     fireEvent.mouseEnter(origin);
     expect((await screen.findByRole("tooltip")).textContent).toBe(
       [
         "Slack",
-        "DM with Harold Hunt",
-        "From Harold Hunt (@hhunt)",
+        "DM with Harold Hunt (@hhunt)",
         "Open in Slack",
       ].join("\n"),
     );
     expect(container.querySelector(".transcript-message--injected")).toBeInTheDocument();
+  });
+
+  it("does not duplicate a historical DM origin without a saved handle", async () => {
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "historical-message-from-slack-dm",
+            role: "user",
+            text: "Bro this is literally a DM",
+            origin: {
+              kind: "messaging",
+              messaging: {
+                platform: "slack",
+                surface: {
+                  id: "D012ABCDEF0",
+                  kind: "dm",
+                  title: "Harold",
+                },
+                actor: {
+                  platformUserId: "U079K80HTGS",
+                  displayName: "Harold",
+                },
+              },
+            },
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />,
+    );
+
+    const origin = screen.getByLabelText("Slack: DM with Harold");
+    expect(
+      origin.querySelector(".transcript-message__messaging-surface"),
+    ).toHaveTextContent("DM with Harold");
+    expect(origin.querySelector(".transcript-message__messaging-actor")).toBeNull();
+    expect(origin.querySelector(".transcript-message__messaging-separator")).toBeNull();
+    fireEvent.mouseEnter(origin);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      ["Slack", "DM with Harold"].join("\n"),
+    );
   });
 
   it("renders transcript history without a persistent older-history button", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -453,6 +453,62 @@ describe("TranscriptList", () => {
     expect(container.querySelector(".transcript-message--injected")).toBeInTheDocument();
   });
 
+  it("distinguishes a DM peer from its sender by full name and handle", async () => {
+    const { container } = render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-from-slack-dm",
+            role: "user",
+            text: "Bro this is literally a DM",
+            origin: {
+              kind: "messaging",
+              messaging: {
+                platform: "slack",
+                sourceUrl:
+                  "https://giphy.slack.com/archives/D012ABCDEF0/p1785945048967109",
+                surface: {
+                  id: "D012ABCDEF0",
+                  kind: "dm",
+                  title: "Harold Hunt",
+                },
+                actor: {
+                  platformUserId: "U079K80HTGS",
+                  displayName: "Harold Hunt",
+                  username: "hhunt",
+                },
+              },
+            },
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />,
+    );
+
+    const origin = screen.getByLabelText(
+      "Slack: DM with Harold Hunt · From Harold Hunt (@hhunt)",
+    );
+    expect(
+      origin.querySelector(".transcript-message__messaging-surface"),
+    ).toHaveTextContent("Harold Hunt");
+    expect(
+      origin.querySelector(".transcript-message__messaging-actor"),
+    ).toHaveTextContent("@hhunt");
+    fireEvent.mouseEnter(origin);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      [
+        "Slack",
+        "DM with Harold Hunt",
+        "From Harold Hunt (@hhunt)",
+        "Open in Slack",
+      ].join("\n"),
+    );
+    expect(container.querySelector(".transcript-message--injected")).toBeInTheDocument();
+  });
+
   it("renders transcript history without a persistent older-history button", () => {
     const loadOlder = vi.fn(async () => undefined);
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6970,8 +6970,28 @@ textarea,
     auto;
 }
 
+.settings-authorized-list__row--with-username {
+  grid-template-columns:
+    minmax(130px, 1fr)
+    minmax(130px, 1fr)
+    minmax(110px, 0.7fr)
+    auto
+    auto;
+}
+
+.settings-authorized-list__row--with-warning.settings-authorized-list__row--with-username {
+  grid-template-columns:
+    minmax(130px, 1fr)
+    minmax(130px, 1fr)
+    minmax(110px, 0.7fr)
+    minmax(128px, 0.7fr)
+    auto
+    auto;
+}
+
 .settings-authorized-list__id,
 .settings-authorized-list__name,
+.settings-authorized-list__username,
 .settings-authorized-list__policy,
 .settings-authorized-list__warning,
 .settings-authorized-list__response-mode {

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -339,6 +339,8 @@ export type MessagingActorIdentity = {
 
 export type MessagingAdapterAuthorizationUpdate = {
   authorizedActorIds: readonly string[];
+  /** Current metadata for authorized actors, when the host has it available. */
+  authorizedActors?: readonly MessagingActorIdentity[];
   authorizedConversationIds?: readonly string[];
   conversationAuthorizationMode?: MessagingAuthorizationMode;
   conversationResponseModes?: readonly MessagingConversationResponseMode[];

--- a/packages/messaging/providers/slack/src/__tests__/resolve-contact.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/resolve-contact.test.ts
@@ -38,8 +38,8 @@ describe("Slack resolveContact", () => {
         id: "U079K80HTGS",
         name: "hhunt",
         profile: {
-          display_name: "Harold Hunt",
-          real_name: "Harold",
+          display_name: "Harold",
+          real_name: "Harold Hunt",
         },
       },
     });

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -1702,6 +1702,57 @@ describe("SlackAdapter", () => {
     ]);
   });
 
+  it("uses a persisted username when users.info is unavailable", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: {
+        ...baseConfig,
+        authorizedActorIds: [{
+          id: "U012ABCDEF0",
+          displayName: "Harold Hunt",
+          username: "hhunt",
+        }],
+      },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "message",
+        channel: "D012ABCDEF0",
+        channel_type: "im",
+        team: "T012ABCDEF0",
+        ts: "1712023032.123456",
+        user: "U012ABCDEF0",
+        text: "hello",
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        actor: expect.objectContaining({
+          displayName: "Harold Hunt",
+          platformUserId: "U012ABCDEF0",
+          username: "hhunt",
+        }),
+        channel: expect.objectContaining({
+          conversation: expect.objectContaining({
+            kind: "dm",
+            title: "Harold Hunt",
+          }),
+        }),
+      }),
+    ]);
+  });
+
   it("emits rejected activity for unauthorized actors", async () => {
     const socket = fakeSocket();
     const adapter = new SlackAdapter({

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -1648,6 +1648,60 @@ describe("SlackAdapter", () => {
     ]);
   });
 
+  it("preserves a configured name when users.info only resolves a handle", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: {
+        ...baseConfig,
+        authorizedActorIds: [{
+          id: "U012ABCDEF0",
+          displayName: "Harold Hunt",
+        }],
+      },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({
+        users: {
+          U012ABCDEF0: { username: "hhunt" },
+        },
+      }),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "message",
+        channel: "D012ABCDEF0",
+        channel_type: "im",
+        team: "T012ABCDEF0",
+        ts: "1712023032.123456",
+        user: "U012ABCDEF0",
+        text: "hello",
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        actor: expect.objectContaining({
+          displayName: "Harold Hunt",
+          platformUserId: "U012ABCDEF0",
+          username: "hhunt",
+        }),
+        channel: expect.objectContaining({
+          conversation: expect.objectContaining({
+            kind: "dm",
+            title: "Harold Hunt",
+          }),
+        }),
+      }),
+    ]);
+  });
+
   it("emits rejected activity for unauthorized actors", async () => {
     const socket = fakeSocket();
     const adapter = new SlackAdapter({

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -1753,6 +1753,58 @@ describe("SlackAdapter", () => {
     ]);
   });
 
+  it("uses contact metadata received through a hot authorization update", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: {
+        ...baseConfig,
+        authorizedActorIds: [{
+          id: "U012ABCDEF0",
+          displayName: "Harold",
+        }],
+      },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+    await adapter.updateAuthorization({
+      authorizedActorIds: ["U012ABCDEF0"],
+      authorizedActors: [{
+        platformUserId: "U012ABCDEF0",
+        displayName: "Harold Hunt",
+        username: "hhunt",
+      }],
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "message",
+        channel: "D012ABCDEF0",
+        channel_type: "im",
+        team: "T012ABCDEF0",
+        ts: "1712023032.123456",
+        user: "U012ABCDEF0",
+        text: "hello",
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        actor: expect.objectContaining({
+          displayName: "Harold Hunt",
+          platformUserId: "U012ABCDEF0",
+          username: "hhunt",
+        }),
+      }),
+    ]);
+  });
+
   it("emits rejected activity for unauthorized actors", async () => {
     const socket = fakeSocket();
     const adapter = new SlackAdapter({

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -1592,17 +1592,21 @@ describe("SlackAdapter", () => {
     ]);
   });
 
-  it("uses users.info display names for DM labels when users:read is granted", async () => {
+  it("uses users.info full names and handles for DM origins", async () => {
     const socket = fakeSocket();
     const adapter = new SlackAdapter({
       config: {
         ...baseConfig,
-        authorizedActorIds: [{ id: "U012ABCDEF0", displayName: "" }],
+        authorizedActorIds: [{ id: "U012ABCDEF0", displayName: "Harold" }],
       },
       callbackHandleStore: fakeStore(),
       api: fakeApi({
         users: {
-          U012ABCDEF0: { displayName: "Harold Hunt", username: "hhunt" },
+          U012ABCDEF0: {
+            displayName: "Harold",
+            realName: "Harold Hunt",
+            username: "hhunt",
+          },
         },
       }),
       socketClient: socket,
@@ -1631,6 +1635,7 @@ describe("SlackAdapter", () => {
         actor: expect.objectContaining({
           displayName: "Harold Hunt",
           platformUserId: "U012ABCDEF0",
+          username: "hhunt",
         }),
         channel: expect.objectContaining({
           conversation: expect.objectContaining({

--- a/packages/messaging/providers/slack/src/resolve-contact.ts
+++ b/packages/messaging/providers/slack/src/resolve-contact.ts
@@ -79,9 +79,9 @@ export async function resolveContact(
       status: "ok",
       id: request.id,
       displayName:
-        sanitizeOptionalContactLabel(user.profile?.display_name)
-        ?? sanitizeOptionalContactLabel(user.profile?.real_name)
+        sanitizeOptionalContactLabel(user.profile?.real_name)
         ?? sanitizeOptionalContactLabel(user.real_name)
+        ?? sanitizeOptionalContactLabel(user.profile?.display_name)
         ?? sanitizeOptionalContactLabel(user.name)
         ?? request.id,
       handle,

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -181,6 +181,11 @@ export type SlackUserInfo = {
   real_name?: string;
 };
 
+type SlackUserProfile = {
+  displayName?: string;
+  username?: string;
+};
+
 export type SlackProviderAdapter = {
   authorizedActorIds: readonly string[];
   capabilityProfile: MessagingCapabilityProfile;
@@ -344,7 +349,7 @@ export class SlackAdapter implements SlackProviderAdapter {
   private readonly conversationGroupDmCache = new Map<string, boolean>();
   private readonly recentInboundMessageEvents = new Map<string, number>();
   private readonly threadTitleCache = new Map<string, string | undefined>();
-  private readonly userDisplayNameCache = new Map<string, string | undefined>();
+  private readonly userProfileCache = new Map<string, SlackUserProfile | undefined>();
   // Per-stream posted surfaces, keyed by `intent.stream.key`. Slack has no
   // "create-or-edit" primitive, so the first chunk posts a new message and
   // records its `ts` here; later chunks (and the final) edit it in place — the
@@ -1802,14 +1807,16 @@ export class SlackAdapter implements SlackProviderAdapter {
     username?: string,
   ): Promise<MessagingActorIdentity> {
     const contact = this.config.authorizedActorIds.find((item) => item.id === userId);
+    const profile = await this.lookupSlackUserProfile(userId);
+    const resolvedUsername = profile?.username || username?.trim().replace(/^@/, "");
     const displayName =
-      contact?.displayName
-      || (await this.lookupSlackUserDisplayName(userId))
-      || username;
+      profile?.displayName
+      || contact?.displayName
+      || resolvedUsername;
     return {
       platformUserId: userId,
       ...(displayName ? { displayName } : {}),
-      ...(username ? { username } : {}),
+      ...(resolvedUsername ? { username: resolvedUsername } : {}),
     };
   }
 
@@ -1822,27 +1829,31 @@ export class SlackAdapter implements SlackProviderAdapter {
     };
   }
 
-  private async lookupSlackUserDisplayName(
+  private async lookupSlackUserProfile(
     userId: string,
-  ): Promise<string | undefined> {
-    if (this.userDisplayNameCache.has(userId)) {
-      return this.userDisplayNameCache.get(userId);
+  ): Promise<SlackUserProfile | undefined> {
+    if (this.userProfileCache.has(userId)) {
+      return this.userProfileCache.get(userId);
     }
     if (this.userInfoLookupDisabled || !this.api.usersInfo) {
-      this.userDisplayNameCache.set(userId, undefined);
+      this.userProfileCache.set(userId, undefined);
       return undefined;
     }
 
     try {
       const user = await this.api.usersInfo({ user: userId });
       const displayName =
-        user?.profile?.display_name?.trim()
-        || user?.profile?.real_name?.trim()
+        user?.profile?.real_name?.trim()
         || user?.real_name?.trim()
+        || user?.profile?.display_name?.trim()
         || user?.name?.trim()
         || undefined;
-      this.userDisplayNameCache.set(userId, displayName);
-      return displayName;
+      const username = user?.name?.trim().replace(/^@/, "") || undefined;
+      const profile = displayName || username
+        ? { displayName, username }
+        : undefined;
+      this.userProfileCache.set(userId, profile);
+      return profile;
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       if (reason.includes("missing_scope")) {
@@ -1857,7 +1868,7 @@ export class SlackAdapter implements SlackProviderAdapter {
           userHash: createHash("sha256").update(userId).digest("hex").slice(0, 8),
         });
       }
-      this.userDisplayNameCache.set(userId, undefined);
+      this.userProfileCache.set(userId, undefined);
       return undefined;
     }
   }

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -1846,7 +1846,6 @@ export class SlackAdapter implements SlackProviderAdapter {
         user?.profile?.real_name?.trim()
         || user?.real_name?.trim()
         || user?.profile?.display_name?.trim()
-        || user?.name?.trim()
         || undefined;
       const username = user?.name?.trim().replace(/^@/, "") || undefined;
       const profile = displayName || username

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -1808,7 +1808,10 @@ export class SlackAdapter implements SlackProviderAdapter {
   ): Promise<MessagingActorIdentity> {
     const contact = this.config.authorizedActorIds.find((item) => item.id === userId);
     const profile = await this.lookupSlackUserProfile(userId);
-    const resolvedUsername = profile?.username || username?.trim().replace(/^@/, "");
+    const resolvedUsername =
+      profile?.username
+      || contact?.username
+      || username?.trim().replace(/^@/, "");
     const displayName =
       profile?.displayName
       || contact?.displayName

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -31,7 +31,6 @@ import type {
   MessagingManagedConversationRightsResult,
   MessagingRateLimitInfo,
   MessagingRejectedInboundEvent,
-  MessagingResponseMode,
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
   MessagingSurfaceRef,
@@ -45,7 +44,10 @@ import {
   SLACK_GROUP_DM_ACCESS_MODE_DEFAULT,
   SLACK_TEAM_AUTHORIZATION_MODE_DEFAULT,
 } from "@pwragent/messaging-interface";
-import type { SlackMessagingConfig } from "./slack-config.ts";
+import type {
+  SlackAuthorizedContact,
+  SlackMessagingConfig,
+} from "./slack-config.ts";
 import {
   actionsForSlackIntent,
   buildSlackActionBlocks,
@@ -435,6 +437,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     this.config.authorizedActorIds = slackContactsFromIds(
       update.authorizedActorIds,
       this.config.authorizedActorIds,
+      update.authorizedActors,
     );
     this.config.authorizedConversationIds = slackContactsFromIds(
       update.authorizedConversationIds ?? [],
@@ -2457,16 +2460,29 @@ function callbackAllowedActorIds(
 
 function slackContactsFromIds(
   ids: readonly string[],
-  previous:
-    | readonly {
-        id: string;
-        displayName: string;
-        responseMode?: MessagingResponseMode;
-      }[]
-    | undefined,
-): { id: string; displayName: string; responseMode?: MessagingResponseMode }[] {
+  previous: readonly SlackAuthorizedContact[] | undefined,
+  actors?: readonly MessagingActorIdentity[],
+): SlackAuthorizedContact[] {
   const previousById = new Map((previous ?? []).map((contact) => [contact.id, contact]));
-  return ids.map((id) => previousById.get(id) ?? { id, displayName: "" });
+  if (!actors) {
+    return ids.map((id) => previousById.get(id) ?? { id, displayName: "" });
+  }
+  const actorById = new Map(
+    actors.map((actor) => [actor.platformUserId, actor]),
+  );
+  return ids.map((id) => {
+    const previousContact = previousById.get(id);
+    const actor = actorById.get(id);
+    if (!actor) return previousContact ?? { id, displayName: "" };
+    return {
+      id,
+      displayName: actor.displayName ?? "",
+      ...(actor.username ? { username: actor.username } : {}),
+      ...(previousContact?.responseMode
+        ? { responseMode: previousContact.responseMode }
+        : {}),
+    };
+  });
 }
 
 // All four fall back to the shared locked-down defaults so the adapter's gate

--- a/packages/messaging/providers/slack/src/slack-config.ts
+++ b/packages/messaging/providers/slack/src/slack-config.ts
@@ -9,6 +9,7 @@ import type {
 export type SlackAuthorizedContact = {
   id: string;
   displayName: string;
+  username?: string;
   responseMode?: MessagingResponseMode;
 };
 

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -187,6 +187,8 @@ export type DesktopProviderThreadModelMigration = {
 export type DesktopAuthorizedContact = {
   id: string;
   displayName: string;
+  /** Provider username without presentation punctuation such as a leading `@`. */
+  username?: string;
   fullAccessWarningDismissed?: boolean;
   fullAccessWarningOverride?: DesktopMessagingFullAccessWarningUserPolicy;
   responseMode?: DesktopMessagingResponseMode;


### PR DESCRIPTION
## What changed

- Resolve inbound Slack users through `users.info` even when an authorized-user label is already cached.
- Prefer the Slack full name, retain the `@handle`, and preserve configured names when Slack only resolves a handle.
- Persist resolved Slack usernames on authorized contacts and show them as a read-only `Username` field in Settings.
- Carry persisted usernames through pairing approval, adapter fallback, message origins, and Messaging Activity summaries/copy fields.
- Refresh Settings after metadata-only pairing enrichment and hot-apply contact metadata to the running Slack adapter.
- Clear and re-resolve the read-only username whenever an operator edits its Slack user ID.
- Collapse single-user DM origins to one `DM with …` label, with the full name and handle available in the tooltip.
- Render known Slack channel bindings as `#channel-name` instead of the generic `Channel` fallback.
- Add adapter, config round-trip, pairing, Settings, Activity, runtime hot-update, thread-row, and origin regression coverage.

## Root cause

Authorized Slack contacts persisted only a user ID and editable display label. Although Slack lookup could return the account username, Settings discarded it, so subsequent adapter instances and UI surfaces had no stable `@handle` fallback. Authorized-contact labels also short-circuited live profile lookup, preventing inbound origins from capturing richer profile data. Hot authorization updates originally carried only IDs, and Settings refreshed pairing approvals only when a new allowlist row was added, so metadata enrichment could remain stale until restart or another refresh. Separately, Slack channel bindings fell through to the Discord channel breadcrumb formatter, whose missing server parent caused it to return `Channel` even though the Slack conversation title was present.

## User impact

Looking up a Slack authorized user now saves the normalized username (for example, `hhunt`) and displays `@hhunt` read-only beside the configured display name. Pairing approval enriches existing contacts immediately in both Settings and the running adapter. Editing a user ID clears the previous handle before resolving the replacement, preventing stale attribution when lookup is unavailable. New Slack activity and message origins use the persisted handle when live profile lookup is unavailable, while a configured human-readable name continues to win over a handle-only Slack profile. Single-user DM chips render once as `DM with Harold Hunt`, and Slack channel chips show their known name, such as `#p-pwragent-testing`.

## Validation

- Original focused Vitest suite across Slack adapter/contact resolution, config persistence, pairing IPC, Settings, Messaging Activity, thread chips, and transcript origins: 349 tests passed.
- Review-fix Vitest suite across Settings, runtime hot updates, config classification, and the Slack adapter: 216 tests passed.
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`
