### PR TITLE
fix(desktop): isolate Codex fork workspace roots

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1,5 +1,15 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { copyFile, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13025,6 +13035,62 @@ script = "printf setup-output"
     ).resolves.toMatchObject({ extraLinkedDirectories: [] });
 
     await registry.close();
+  });
+
+  it("preserves an equivalent requested repository path as the worktree identity", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-repo-alias-"));
+    const repositoryPath = path.join(root, "repository");
+    const requestedRepositoryPath = path.join(root, "requested-repository");
+    const worktreePath = path.join(root, "worktree");
+    await mkdir(repositoryPath, { recursive: true });
+    await symlink(
+      repositoryPath,
+      requestedRepositoryPath,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: worktreePath,
+          repositoryPath,
+          workMode: "worktree" as const,
+        })),
+        recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+      } as never,
+    });
+
+    try {
+      const response = await registry.materializeDirectoryLaunchpad({
+        directoryKey: `directory:${requestedRepositoryPath}`,
+        launchpad: {
+          directoryKey: `directory:${requestedRepositoryPath}`,
+          directoryKind: "directory",
+          directoryLabel: "repository",
+          directoryPath: requestedRepositoryPath,
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "worktree",
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+      });
+
+      expect(response.linkedDirectory).toMatchObject({
+        kind: "worktree",
+        path: expectedDir(requestedRepositoryPath),
+        worktreePath: expectedDir(worktreePath),
+      });
+    } finally {
+      await registry.close();
+      await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
   });
 
   it("passes launchpad-selected Agent metadata through materialized starts", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13502,6 +13502,107 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("keeps the prepared fork worktree authoritative while Codex metadata catches up", async () => {
+    const repoPath = "/repo/app";
+    const parentWorktreePath = "/repo/app/.worktrees/thread-parent/app";
+    const forkWorktreePath = "/repo/app/.worktrees/thread-fork/app";
+    const staleForkThread: AppServerThreadSummary = {
+      id: "thread-fork",
+      title: "Forked thread",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: parentWorktreePath,
+      createdAt: 1_000,
+      updatedAt: 2_000,
+      linkedDirectories: [
+        {
+          id: repoPath,
+          label: "app",
+          path: repoPath,
+          worktreePath: parentWorktreePath,
+          kind: "worktree",
+        },
+      ],
+      gitBranch: "feature/parent",
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/fork"] },
+      threads: [staleForkThread],
+    });
+    Object.assign(codexClient, {
+      enrichThreadDirectories: vi.fn(
+        async (threads: AppServerThreadSummary[]) => threads,
+      ),
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: forkWorktreePath,
+          repositoryPath: repoPath,
+          workMode: "worktree" as const,
+        })),
+        recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+      } as never,
+    });
+
+    await registry.forkThread({
+      backend: "codex",
+      sourceThreadId: "thread-parent",
+      parentThreadId: "thread-parent",
+      executionMode: "default",
+      directoryKind: "directory",
+      directoryLabel: "app",
+      directoryPath: repoPath,
+      workMode: "worktree",
+    });
+
+    const expectForkWorkspace = async () => {
+      await expect(
+        overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-fork",
+        }),
+      ).resolves.toMatchObject({
+        extraLinkedDirectories: [
+          {
+            label: "app",
+            path: expectedDir(repoPath),
+            worktreePath: expectedDir(forkWorktreePath),
+            kind: "worktree",
+          },
+        ],
+      });
+    };
+
+    await expectForkWorkspace();
+    await registry.readThread({ backend: "codex", threadId: "thread-fork" });
+    await expectForkWorkspace();
+
+    const [listedThread] = await registry.listThreads({
+      backend: "codex",
+      callerReason: "navigation-snapshot",
+      forceRefresh: true,
+    });
+    expect(listedThread).toMatchObject({
+      id: "thread-fork",
+      projectKey: forkWorktreePath,
+      linkedDirectories: [
+        expect.objectContaining({
+          path: expectedDir(repoPath),
+          worktreePath: expectedDir(forkWorktreePath),
+          kind: "worktree",
+        }),
+      ],
+    });
+    await expectForkWorkspace();
+
+    await registry.close();
+  });
+
   it("reports detached HEAD as the expected branch for new worktree forks", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-fork-branch-"));
     const repoPath = path.join(root, "repo");

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13032,38 +13032,71 @@ script = "printf setup-output"
         backend: "codex",
         threadId: "thread-1",
       }),
-    ).resolves.toMatchObject({ extraLinkedDirectories: [] });
+    ).resolves.toMatchObject({
+      extraLinkedDirectories: [
+        {
+          id: repoPath,
+          kind: "worktree",
+          label: "app",
+          path: repoPath,
+          worktreePath,
+        },
+      ],
+    });
 
     await registry.close();
   });
 
-  it("preserves an equivalent requested repository path as the worktree identity", async () => {
+  it("acknowledges and persists an equivalent requested repository identity", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-repo-alias-"));
     const repositoryPath = path.join(root, "repository");
     const requestedRepositoryPath = path.join(root, "requested-repository");
     const worktreePath = path.join(root, "worktree");
+    const movedWorktreePath = path.join(root, "moved-worktree");
     await mkdir(repositoryPath, { recursive: true });
+    await mkdir(worktreePath, { recursive: true });
+    await mkdir(movedWorktreePath, { recursive: true });
     await symlink(
       repositoryPath,
       requestedRepositoryPath,
       process.platform === "win32" ? "junction" : "dir",
     );
 
-    const registry = new DesktopBackendRegistry({
-      codexClient: new MockBackendClient({
-        initializeResult: { methods: ["thread/start"] },
-      }),
-      grokClient: new MockBackendClient({}),
-      overlayStore: createOverlayStoreMock(),
-      gitDirectoryService: {
-        prepareLaunchpadWorkspace: vi.fn(async () => ({
-          cwd: worktreePath,
-          repositoryPath,
-          workMode: "worktree" as const,
-        })),
-        recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
-      } as never,
+    const providerThread = (providerWorktreePath: string): AppServerThreadSummary => ({
+      id: "thread-1",
+      source: "codex",
+      title: "Repository thread",
+      titleSource: "derived",
+      projectKey: providerWorktreePath,
+      linkedDirectories: [
+        {
+          id: expectedDir(repositoryPath),
+          kind: "worktree",
+          label: "repository",
+          path: expectedDir(repositoryPath),
+          worktreePath: expectedDir(providerWorktreePath),
+        },
+      ],
     });
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start"] },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const gitDirectoryService = {
+      prepareLaunchpadWorkspace: vi.fn(async () => ({
+        cwd: worktreePath,
+        repositoryPath,
+        workMode: "worktree" as const,
+      })),
+      recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+    } as never;
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+      gitDirectoryService,
+    });
+    let restartedRegistry: DesktopBackendRegistry | undefined;
 
     try {
       const response = await registry.materializeDirectoryLaunchpad({
@@ -13087,7 +13120,66 @@ script = "printf setup-output"
         path: expectedDir(requestedRepositoryPath),
         worktreePath: expectedDir(worktreePath),
       });
+
+      codexClient.setThreads([providerThread(worktreePath)]);
+      await registry.listThreads({
+        backend: "codex",
+        callerReason: "navigation-snapshot",
+        forceRefresh: true,
+      });
+      await expect(
+        overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        }),
+      ).resolves.toMatchObject({
+        extraLinkedDirectories: [
+          expect.objectContaining({
+            path: expectedDir(requestedRepositoryPath),
+            worktreePath: expectedDir(worktreePath),
+          }),
+        ],
+      });
+
+      restartedRegistry = new DesktopBackendRegistry({
+        codexClient: new MockBackendClient({
+          initializeResult: { methods: ["thread/start"] },
+          threads: [providerThread(worktreePath)],
+        }),
+        grokClient: new MockBackendClient({}),
+        overlayStore,
+        gitDirectoryService,
+      });
+      await restartedRegistry.listThreads({
+        backend: "codex",
+        callerReason: "navigation-snapshot",
+        forceRefresh: true,
+      });
+      await expect(
+        overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        }),
+      ).resolves.toMatchObject({
+        extraLinkedDirectories: [
+          expect.objectContaining({
+            path: expectedDir(requestedRepositoryPath),
+            worktreePath: expectedDir(worktreePath),
+          }),
+        ],
+      });
+
+      codexClient.setThreads([providerThread(movedWorktreePath)]);
+      const [movedThread] = await registry.listThreads({
+        backend: "codex",
+        callerReason: "navigation-snapshot",
+        forceRefresh: true,
+      });
+      expect(movedThread.linkedDirectories[0]?.worktreePath).toBe(
+        expectedDir(movedWorktreePath),
+      );
     } finally {
+      await restartedRegistry?.close();
       await registry.close();
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13600,6 +13600,39 @@ command = "pnpm dev"
     });
     await expectForkWorkspace();
 
+    codexClient.setThreads([
+      {
+        ...staleForkThread,
+        projectKey: forkWorktreePath,
+        linkedDirectories: [
+          {
+            id: forkWorktreePath,
+            label: "app",
+            path: forkWorktreePath,
+            kind: "local",
+          },
+        ],
+        gitBranch: "HEAD",
+      },
+    ]);
+    const [cwdOnlyThread] = await registry.listThreads({
+      backend: "codex",
+      callerReason: "navigation-snapshot",
+      forceRefresh: true,
+    });
+    expect(cwdOnlyThread).toMatchObject({
+      id: "thread-fork",
+      projectKey: forkWorktreePath,
+      linkedDirectories: [
+        expect.objectContaining({
+          path: expectedDir(repoPath),
+          worktreePath: expectedDir(forkWorktreePath),
+          kind: "worktree",
+        }),
+      ],
+    });
+    await expectForkWorkspace();
+
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13035,11 +13035,11 @@ script = "printf setup-output"
     ).resolves.toMatchObject({
       extraLinkedDirectories: [
         {
-          id: repoPath,
+          id: expectedDir(repoPath),
           kind: "worktree",
           label: "app",
-          path: repoPath,
-          worktreePath,
+          path: expectedDir(repoPath),
+          worktreePath: expectedDir(worktreePath),
         },
       ],
     });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -12932,19 +12932,40 @@ script = "printf setup-output"
   });
 
   it("records Codex owner metadata when materializing a worktree launchpad", async () => {
+    const repoPath = "/repo/app";
+    const worktreePath = "/repo/app/.worktrees/thread-1/app";
     const recordCodexWorktreeOwnerThread = vi.fn(async () => {});
+    const overlayStore = createOverlayStoreMock();
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start"] },
+      threads: [
+        {
+          id: "thread-1",
+          title: "Worktree thread",
+          titleSource: "derived",
+          source: "codex",
+          linkedDirectories: [
+            {
+              id: repoPath,
+              kind: "worktree",
+              label: "app",
+              path: repoPath,
+              worktreePath,
+            },
+          ],
+        },
+      ],
     });
     const registry = new DesktopBackendRegistry({
       codexClient,
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore,
       gitDirectoryService: {
         prepareLaunchpadWorkspace: vi.fn(async () => ({
-          cwd: "/repo/app/.worktrees/thread-1/app",
+          cwd: worktreePath,
+          repositoryPath: repoPath,
           workMode: "worktree" as const,
         })),
         recordCodexWorktreeOwnerThread,
@@ -12970,16 +12991,38 @@ script = "printf setup-output"
     });
 
     expect(recordCodexWorktreeOwnerThread).toHaveBeenCalledWith({
-      worktreePath: "/repo/app/.worktrees/thread-1/app",
+      worktreePath,
       threadId: "thread-1",
     });
     expect(response.linkedDirectory).toEqual({
-      id: expectedDir("/repo/app"),
+      id: expectedDir(repoPath),
       kind: "worktree",
       label: "app",
-      path: expectedDir("/repo/app"),
-      worktreePath: expectedDir("/repo/app/.worktrees/thread-1/app"),
+      path: expectedDir(repoPath),
+      worktreePath: expectedDir(worktreePath),
     });
+
+    await registry.readThread({ backend: "codex", threadId: "thread-1" });
+    const [listedThread] = await registry.listThreads({
+      backend: "codex",
+      callerReason: "navigation-snapshot",
+      forceRefresh: true,
+    });
+    expect(listedThread.linkedDirectories).toEqual([
+      {
+        id: repoPath,
+        kind: "worktree",
+        label: "app",
+        path: repoPath,
+        worktreePath,
+      },
+    ]);
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({ extraLinkedDirectories: [] });
 
     await registry.close();
   });
@@ -13569,6 +13612,7 @@ command = "pnpm dev"
       ).resolves.toMatchObject({
         extraLinkedDirectories: [
           {
+            id: expectedDir(repoPath),
             label: "app",
             path: expectedDir(repoPath),
             worktreePath: expectedDir(forkWorktreePath),

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -6463,6 +6463,7 @@ describe("CodexAppServerClient", () => {
     expect(request?.params).toMatchObject({
       threadId: "thread-2",
       cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+      runtimeWorkspaceRoots: ["/Users/huntharo/pwrdrvr/PwrAgent"],
       model: "gpt-5.5",
       approvalPolicy: "on-request",
       sandbox: "workspace-write",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1144,6 +1144,35 @@ function pendingStartedThreadMatchesFilter(
     .some((value) => value!.toLowerCase().includes(normalized));
 }
 
+function pendingStartedThreadWorkspaceMatches(
+  thread: AppServerThreadSummary,
+  pendingThread: AppServerThreadSummary,
+): boolean {
+  const workspaceCwd = resolveThreadWorkspaceCwd(thread)?.trim();
+  const pendingWorkspaceCwd = resolveThreadWorkspaceCwd(pendingThread)?.trim();
+  if (!pendingWorkspaceCwd) {
+    return true;
+  }
+  if (!workspaceCwd) {
+    return false;
+  }
+  return path.resolve(workspaceCwd) === path.resolve(pendingWorkspaceCwd);
+}
+
+function retainPendingStartedThreadWorkspace(
+  thread: AppServerThreadSummary,
+  pendingThread: AppServerThreadSummary,
+): AppServerThreadSummary {
+  return {
+    ...thread,
+    projectKey: pendingThread.projectKey,
+    linkedDirectories: pendingThread.linkedDirectories,
+    gitBranch: pendingThread.gitBranch,
+    codexEnvironmentRuntime:
+      pendingThread.codexEnvironmentRuntime ?? thread.codexEnvironmentRuntime,
+  };
+}
+
 function resolveExpectedThreadBranch(params: {
   overlay?: ThreadOverlayState;
   thread?: Pick<AppServerThreadSummary, "gitBranch">;
@@ -10146,6 +10175,20 @@ export class DesktopBackendRegistry {
         });
       }
 
+      const linkedDirectory = linkedDirectories[0];
+      if (linkedDirectory) {
+        // The fork response can become visible through thread/list before Codex
+        // has replaced the copied parent cwd. Persist the prepared workspace now
+        // so that transient provider metadata cannot become the child's source
+        // of truth.
+        await this.overlayStore.replaceWorkspaceLinkedDirectory({
+          backend,
+          threadId: result.threadId,
+          directory: linkedDirectory,
+          gitBranch,
+        });
+      }
+
       await this.overlayStore.setThreadExecutionMode({
         backend,
         threadId: result.threadId,
@@ -16074,6 +16117,13 @@ export class DesktopBackendRegistry {
   private async readCheapCodexThreadForRepair(
     threadId: string,
   ): Promise<AppServerThreadSummary | undefined> {
+    const pending = this.pendingStartedThreads.get(
+      buildThreadIdentityKey("codex", threadId),
+    );
+    if (pending) {
+      return pending;
+    }
+
     const cached = this.findCachedCodexThread(threadId);
     if (cached) {
       return cached;
@@ -16812,12 +16862,24 @@ export class DesktopBackendRegistry {
     threads: AppServerThreadSummary[],
     params: { archived?: boolean; filter?: string } = {},
   ): AppServerThreadSummary[] {
-    const threadIds = new Set(threads.map((thread) => thread.id));
-    for (const threadId of threadIds) {
-      this.pendingStartedThreads.delete(buildThreadIdentityKey(backend, threadId));
-    }
+    const resolvedThreads = threads.map((thread) => {
+      const pendingThreadKey = buildThreadIdentityKey(backend, thread.id);
+      const pendingThread = this.pendingStartedThreads.get(pendingThreadKey);
+      if (!pendingThread) {
+        return thread;
+      }
+      if (pendingStartedThreadWorkspaceMatches(thread, pendingThread)) {
+        this.pendingStartedThreads.delete(pendingThreadKey);
+        return thread;
+      }
+      // Codex can briefly surface a fork with the copied parent cwd. Keep the
+      // workspace PwrAgent just prepared until thread/list reports that same
+      // cwd, while still accepting fresh provider title and status metadata.
+      return retainPendingStartedThreadWorkspace(thread, pendingThread);
+    });
+    const threadIds = new Set(resolvedThreads.map((thread) => thread.id));
     if (params.archived === true) {
-      return threads;
+      return resolvedThreads;
     }
 
     const pendingThreads = [...this.pendingStartedThreads.values()].filter(
@@ -16827,10 +16889,10 @@ export class DesktopBackendRegistry {
         pendingStartedThreadMatchesFilter(thread, params.filter),
     );
     if (pendingThreads.length === 0) {
-      return threads;
+      return resolvedThreads;
     }
 
-    return [...pendingThreads, ...threads].sort(
+    return [...pendingThreads, ...resolvedThreads].sort(
       (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
     );
   }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -884,6 +884,30 @@ function buildWorktreeLinkedDirectory(params: {
   ];
 }
 
+async function resolvePreparedRepositoryIdentityPath(params: {
+  preparedPath?: string;
+  requestedPath?: string;
+}): Promise<string | undefined> {
+  const preparedPath = params.preparedPath?.trim();
+  const requestedPath = params.requestedPath?.trim();
+  if (!preparedPath || !requestedPath) {
+    return preparedPath || requestedPath || undefined;
+  }
+
+  const [preparedRealPath, requestedRealPath] = await Promise.all([
+    realpath(preparedPath).catch(() => undefined),
+    realpath(requestedPath).catch(() => undefined),
+  ]);
+  if (
+    preparedRealPath
+    && requestedRealPath
+    && path.resolve(preparedRealPath) === path.resolve(requestedRealPath)
+  ) {
+    return requestedPath;
+  }
+  return preparedPath;
+}
+
 function normalizeLinkedDirectoryPathForMatch(
   value: string | undefined,
 ): string | undefined {
@@ -14710,11 +14734,15 @@ export class DesktopBackendRegistry {
             cwd: await this.createScratchProjectDirectory(),
           }
         : preparedWorkspace;
+    const repositoryPath = await resolvePreparedRepositoryIdentityPath({
+      preparedPath: workspace.repositoryPath,
+      requestedPath: launchpad.directoryPath,
+    });
     const linkedDirectories =
       workspace.workMode === "worktree"
         ? buildWorktreeLinkedDirectory({
             label: launchpad.directoryLabel,
-            repositoryPath: workspace.repositoryPath ?? launchpad.directoryPath,
+            repositoryPath,
             worktreePath: workspace.cwd,
           })
         : undefined;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -16129,13 +16129,6 @@ export class DesktopBackendRegistry {
   private async readCheapCodexThreadForRepair(
     threadId: string,
   ): Promise<AppServerThreadSummary | undefined> {
-    const pending = this.pendingStartedThreads.get(
-      buildThreadIdentityKey("codex", threadId),
-    );
-    if (pending) {
-      return pending;
-    }
-
     const cached = this.findCachedCodexThread(threadId);
     if (cached) {
       return cached;
@@ -16160,6 +16153,15 @@ export class DesktopBackendRegistry {
     threadId: string;
   }): Promise<void> {
     if (!this.codexClient.enrichThreadDirectories) {
+      return;
+    }
+    // Pending threads already carry the workspace PwrAgent just prepared.
+    // Repairing them can persist a second identity for that same worktree.
+    if (
+      this.pendingStartedThreads.has(
+        buildThreadIdentityKey("codex", params.threadId),
+      )
+    ) {
       return;
     }
 
@@ -16749,6 +16751,15 @@ export class DesktopBackendRegistry {
     > = {};
 
     for (const thread of params.threads) {
+      // Wait for the provider to acknowledge the prepared workspace before
+      // deriving a persisted directory identity from its thread summary.
+      if (
+        this.pendingStartedThreads.has(
+          buildThreadIdentityKey("codex", thread.id),
+        )
+      ) {
+        continue;
+      }
       const directory = buildCachedDirectoryRelationship(thread);
       if (!directory) {
         continue;
@@ -16791,6 +16802,14 @@ export class DesktopBackendRegistry {
     }
 
     const candidates = params.threads.filter((thread) => {
+      // The pending summary is already enriched from workspace preparation.
+      if (
+        this.pendingStartedThreads.has(
+          buildThreadIdentityKey("codex", thread.id),
+        )
+      ) {
+        return false;
+      }
       if (overlayHasHandoffWorkspace(params.overlaysByThreadId[thread.id])) {
         return false;
       }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -915,6 +915,29 @@ function normalizeLinkedDirectoryPathForMatch(
   return normalized ? toDirectoryId(path.resolve(normalized)) : undefined;
 }
 
+function linkedDirectoriesShareWorktreeWorkspace(
+  left: LinkedDirectorySummary,
+  right: LinkedDirectorySummary,
+): boolean {
+  const normalizedLeft = normalizeLinkedDirectoryKind(left);
+  const normalizedRight = normalizeLinkedDirectoryKind(right);
+  if (normalizedLeft.kind !== "worktree" || normalizedRight.kind !== "worktree") {
+    return false;
+  }
+
+  const leftWorktreePath = normalizeLinkedDirectoryPathForMatch(
+    normalizedLeft.worktreePath,
+  );
+  const rightWorktreePath = normalizeLinkedDirectoryPathForMatch(
+    normalizedRight.worktreePath,
+  );
+  return Boolean(
+    leftWorktreePath
+    && rightWorktreePath
+    && leftWorktreePath === rightWorktreePath,
+  );
+}
+
 function linkedDirectoryMatchesDetachArgs(
   directory: LinkedDirectorySummary,
   args: DetachThreadDirectoryToolArgs,
@@ -969,6 +992,9 @@ function hasEquivalentLinkedDirectory(
 ): boolean {
   return Boolean(
     overlay?.extraLinkedDirectories.some((candidate) => {
+      if (linkedDirectoriesShareWorktreeWorkspace(candidate, directory)) {
+        return true;
+      }
       if (candidate.id !== directory.id || candidate.kind !== directory.kind) {
         return false;
       }
@@ -1191,7 +1217,10 @@ function pendingStartedThreadWorkspaceMatches(
     pendingThread.linkedDirectories.map(linkedDirectoryIdentityKey),
   );
   return thread.linkedDirectories.some((directory) =>
-    pendingDirectoryKeys.has(linkedDirectoryIdentityKey(directory)),
+    pendingDirectoryKeys.has(linkedDirectoryIdentityKey(directory))
+    || pendingThread.linkedDirectories.some((pendingDirectory) =>
+      linkedDirectoriesShareWorktreeWorkspace(directory, pendingDirectory),
+    ),
   );
 }
 
@@ -14848,6 +14877,18 @@ export class DesktopBackendRegistry {
       directoryKey: launchpad.directoryKey,
       parentThreadId: request.parentThreadId,
     });
+    const linkedDirectory = linkedDirectories?.[0];
+    if (linkedDirectory) {
+      // Preserve the launchpad's requested repository identity durably. Codex
+      // can report the same repository through a physical path alias (for
+      // example macOS /private/var for a requested /var path), but the
+      // worktree path still proves these describe one prepared workspace.
+      await this.overlayStore.replaceWorkspaceLinkedDirectory({
+        backend: launchpad.backend,
+        threadId: startThreadResponse.threadId,
+        directory: linkedDirectory,
+      });
+    }
     pendingActionThreadId = startThreadResponse.threadId;
     // The auto-started environment action spawned before this thread existed;
     // give its detached-process record an owner now so the quit dialog can name

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1156,7 +1156,19 @@ function pendingStartedThreadWorkspaceMatches(
   if (!workspaceCwd) {
     return false;
   }
-  return path.resolve(workspaceCwd) === path.resolve(pendingWorkspaceCwd);
+  if (path.resolve(workspaceCwd) !== path.resolve(pendingWorkspaceCwd)) {
+    return false;
+  }
+
+  if (pendingThread.linkedDirectories.length === 0) {
+    return true;
+  }
+  const pendingDirectoryKeys = new Set(
+    pendingThread.linkedDirectories.map(linkedDirectoryIdentityKey),
+  );
+  return thread.linkedDirectories.some((directory) =>
+    pendingDirectoryKeys.has(linkedDirectoryIdentityKey(directory)),
+  );
 }
 
 function retainPendingStartedThreadWorkspace(
@@ -16874,7 +16886,8 @@ export class DesktopBackendRegistry {
       }
       // Codex can briefly surface a fork with the copied parent cwd. Keep the
       // workspace PwrAgent just prepared until thread/list reports that same
-      // cwd, while still accepting fresh provider title and status metadata.
+      // repository/worktree relationship, while still accepting fresh
+      // provider title and status metadata.
       return retainPendingStartedThreadWorkspace(thread, pendingThread);
     });
     const threadIds = new Set(resolvedThreads.map((thread) => thread.id));

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -6209,7 +6209,9 @@ function buildThreadForkPayload(params: {
     base.path = params.path.trim();
   }
   if (params.cwd?.trim()) {
-    base.cwd = params.cwd.trim();
+    const cwd = params.cwd.trim();
+    base.cwd = cwd;
+    base.runtimeWorkspaceRoots = [cwd];
   }
   if (params.model?.trim()) {
     base.model = params.model.trim();

--- a/packages/agent-core/src/__tests__/navigation-state.test.ts
+++ b/packages/agent-core/src/__tests__/navigation-state.test.ts
@@ -115,6 +115,55 @@ describe("navigation execution mode authority", () => {
   });
 });
 
+describe("navigation worktree identity", () => {
+  it("prefers a persisted repository alias for the same provider worktree", () => {
+    const worktreePath = "/tmp/worktrees/thread-1/repository";
+    const [thread] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [
+            {
+              id: "/var/folders/repository",
+              kind: "worktree",
+              label: "repository",
+              path: "/var/folders/repository",
+              worktreePath,
+            },
+          ],
+        },
+      },
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [
+        buildThread({
+          linkedDirectories: [
+            {
+              id: "/private/var/folders/repository",
+              kind: "worktree",
+              label: "repository",
+              path: "/private/var/folders/repository",
+              worktreePath,
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(thread?.linkedDirectories).toEqual([
+      {
+        id: "/var/folders/repository",
+        kind: "worktree",
+        label: "repository",
+        path: "/var/folders/repository",
+        worktreePath,
+      },
+    ]);
+  });
+});
+
 describe("navigation primary repository", () => {
   it("includes the primary workspace repository in the snapshot hash", () => {
     const threadWithoutPrimaryRepository: NavigationThreadSummary = {

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -54,13 +54,21 @@ function dedupeLinkedDirectories(
           (directory.kind !== "local" && directory.kind !== "worktree"),
       )
     : normalizedDirectories;
-  const byId = new Map<string, LinkedDirectorySummary>();
+  const byWorkspaceIdentity = new Map<string, LinkedDirectorySummary>();
 
   for (const directory of filteredDirectories) {
-    byId.set(directory.id, directory);
+    const worktreePath = directory.kind === "worktree"
+      ? directory.worktreePath?.trim()
+      : undefined;
+    const identity = worktreePath
+      ? `worktree:${worktreePath.replace(/\\/g, "/").replace(/\/+$/, "")}`
+      : `directory:${directory.id}`;
+    // Overlay directories are appended after provider directories. Prefer
+    // their persisted repository spelling when both describe one worktree.
+    byWorkspaceIdentity.set(identity, directory);
   }
 
-  return [...byId.values()];
+  return [...byWorkspaceIdentity.values()];
 }
 
 function normalizeLinkedDirectoryKind(


### PR DESCRIPTION
## What changed

- send `runtimeWorkspaceRoots: [cwd]` alongside `cwd` for Codex `thread/fork` requests
- persist the prepared child workspace as soon as the fork succeeds
- keep that prepared workspace authoritative while Codex thread metadata still reflects the copied parent, then release it once Codex reports the child cwd
- cover immediate thread reads and navigation refreshes with stale-provider regression tests

## Root cause

The failure had two layers. PwrAgent originally omitted the thread-scoped runtime workspace-root override from the Codex fork request. After that was fixed, Codex did create the rollout in the new worktree, but `thread/list` could briefly expose the fork with copied parent workspace metadata. PwrAgent treated the first appearance of the child ID as authoritative, discarded its prepared-workspace record, and persisted the stale parent directory during reconciliation.

The child workspace now remains authoritative through that eventual-consistency window. Once Codex reports the same cwd, normal provider reconciliation resumes.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` (446 passed)
- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts` (136 passed)
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
