### PR TITLE
fix(desktop): invalidate stale squash-merge badges

### DIFF
--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -1,11 +1,15 @@
+import { execFile } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { promisify } from "node:util";
 import { describe, expect, it, vi } from "vitest";
 import {
   GitWorkingStateService,
   probeWorktreeWorkingState,
 } from "../app-server/git-working-state-service";
+
+const execFileAsync = promisify(execFile);
 
 type GitCall = { cwd: string; args: string[]; input?: string };
 
@@ -15,6 +19,11 @@ function makeTempPrefix(): string {
 
 function normalizeTestPath(value: string): string {
   return path.resolve(value).replace(/\\/g, "/");
+}
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd });
+  return stdout;
 }
 
 function fakeGit(
@@ -138,6 +147,56 @@ describe("probeWorktreeWorkingState", () => {
     expect(calls.find((call) => call.args.includes("rev-list"))?.input)
       .toBe(`^${mergedPrHeadSha}\n`);
   });
+
+  it("does not count a deleted multi-commit PR worktree after a squash merge", async () => {
+    const root = await mkdtemp(makeTempPrefix());
+    const primary = path.join(root, "primary");
+    const remote = path.join(root, "remote.git");
+    const worktree = path.join(root, "feature-worktree");
+
+    try {
+      await mkdir(primary);
+      await git(root, "init", "--bare", remote);
+      await git(primary, "init", "-b", "main");
+      await git(primary, "config", "user.email", "test@example.com");
+      await git(primary, "config", "user.name", "PwrAgent Test");
+      await writeFile(path.join(primary, "base.txt"), "base\n");
+      await git(primary, "add", "base.txt");
+      await git(primary, "commit", "-m", "base");
+      await git(primary, "remote", "add", "origin", remote);
+      await git(primary, "push", "-u", "origin", "main");
+
+      await git(primary, "worktree", "add", "-b", "feature", worktree, "main");
+      for (let index = 1; index <= 3; index += 1) {
+        const file = `feature-${index}.txt`;
+        await writeFile(path.join(worktree, file), `feature ${index}\n`);
+        await git(worktree, "add", file);
+        await git(worktree, "commit", "-m", `feature ${index}`);
+      }
+      await git(worktree, "push", "-u", "origin", "feature");
+      const mergedPrHeadSha = (await git(worktree, "rev-parse", "HEAD")).trim();
+
+      await git(primary, "merge", "--squash", "feature");
+      await git(primary, "commit", "-m", "squash feature");
+      await git(primary, "push", "origin", "main");
+      await git(primary, "push", "origin", "--delete", "feature");
+
+      const beforePrMetadata = await probeWorktreeWorkingState(worktree);
+      const afterPrMetadata = await probeWorktreeWorkingState(worktree, {
+        acceptedPushedCommitShas: [mergedPrHeadSha],
+      });
+
+      expect(beforePrMetadata?.unpushedCommits).toBe(3);
+      expect(afterPrMetadata?.unpushedCommits).toBe(0);
+    } finally {
+      await rm(root, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 100,
+      });
+    }
+  }, 20_000);
 
   it("falls back to the raw local count when PR exclusion input fails", async () => {
     const mergedPrHeadSha = "a".repeat(40);

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -125,6 +125,36 @@ describe("StateDb", () => {
     );
   });
 
+  it("invalidates working-state counts computed before squash-merge support", () => {
+    const dbPath = path.join(tempDir, "state.db");
+    stateDb.raw.prepare(
+      `INSERT INTO thread_git_working_state(worktree_path, fetched_at, payload)
+       VALUES (?, ?, ?)`,
+    ).run(
+      "/repo/stale-worktree",
+      Date.now(),
+      JSON.stringify({
+        dirtyFiles: 0,
+        dirtyAdditions: 0,
+        dirtyDeletions: 0,
+        untrackedFiles: 0,
+        unpushedCommits: 3,
+      }),
+    );
+    stateDb.raw.pragma("user_version = 40");
+    stateDb.close();
+
+    stateDb = StateDb.open(dbPath);
+
+    const cachedRows = stateDb.raw
+      .prepare("SELECT worktree_path FROM thread_git_working_state")
+      .all();
+    expect(cachedRows).toEqual([]);
+    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(
+      CURRENT_STATE_DB_USER_VERSION,
+    );
+  });
+
   it("creates durable pull request status watch storage", () => {
     const table = stateDb.raw
       .prepare(

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 40;
+export const CURRENT_STATE_DB_USER_VERSION = 41;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -1229,12 +1229,22 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 39) {
       db.transaction(() => {
         db.exec(SCHEDULED_THREAD_ACTION_SCHEMA);
-        db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
+        db.pragma("user_version = 39");
       })();
     }
     if ((db.pragma("user_version", { simple: true }) as number) < 40) {
       db.transaction(() => {
         ensureScheduledThreadActionMetadataColumns(db);
+        db.pragma("user_version = 40");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 41) {
+      db.transaction(() => {
+        // Working-state semantics now account for deleted squash-merged PR
+        // heads. Cached pre-v41 counts can therefore show false unpushed
+        // badges indefinitely for worktrees outside the startup probe budget.
+        // This table is derived state and is safe to repopulate lazily.
+        db.prepare("DELETE FROM thread_git_working_state").run();
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }


### PR DESCRIPTION
Follow-up to #1220.

## What changed

- invalidate the derived per-worktree Git working-state cache once when upgrading to state DB v41
- add a real Git/worktree regression test covering a deleted multi-commit PR branch after a squash merge
- preserve sequential state DB migration versions while introducing v41

## Root cause

The ancestry-aware probe from #1220 works when recomputed, but existing durable cache rows were created before that behavior. Worktrees outside the bounded startup refresh set kept hydrating those stale unpushed counts indefinitely, even after GitHub PR metadata refreshed.

The working-state table is derived data, so clearing it once removes the false badges and lets normal probes repopulate current values without affecting thread or repository data.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/git-working-state-service.test.ts apps/desktop/src/main/__tests__/state-db.test.ts` (58 tests passed)
- `pnpm lint:eslint` (0 errors; baseline warnings only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:sql`

The real Git regression test observes 3 unpushed commits before supplying the merged PR head SHA and 0 afterward.