### PR TITLE
fix(desktop): federation transport keepalive, stale-session sweep, and frame ceiling

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -880,6 +880,30 @@ describe("federation transport liveness", () => {
     socket.terminate();
   });
 
+  it("terminates a socket that upgrades but never completes auth", async () => {
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      authTimeoutMs: 100,
+      // Keepalive alone cannot catch this: a live-but-stalled peer answers
+      // pings from the ws protocol layer forever. Park it out of the way so
+      // this test isolates the auth deadline.
+      keepaliveIntervalMs: 60_000,
+    });
+    const { url } = await server.start();
+    const socket = new WebSocket(url);
+    await waitForSocketOpen(socket);
+    // Upgrade succeeded, challenge received; now say nothing.
+    const closed = new Promise<boolean>((resolve) => {
+      socket.once("close", () => resolve(true));
+    });
+    await expect(closed).resolves.toBe(true);
+  });
+
   it("keeps an idle authenticated peer connected and counts pongs as heartbeats", async () => {
     const clientKeyPair = generateFederationIdentityKeyPair();
     const invite = createFederationEnrollmentInvite({

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -23,6 +23,7 @@ import {
   generateNoiseStaticKeyPair,
   NoiseIKHandshake,
 } from "../federation/federation-noise";
+import { FederationSessionRegistry } from "../federation/federation-session-state";
 import { FederationStore } from "../federation/federation-store";
 import {
   connectFederationClient,
@@ -799,6 +800,307 @@ describe("federation transport", () => {
       publicKeyPem: clientKeyPair.publicKeyPem,
       capabilities: ["remote_window"],
     })).rejects.toThrow("Invalid federation auth acceptance signature");
+  });
+});
+
+describe("federation transport liveness", () => {
+  it("terminates an authenticated peer whose link stops answering keepalive probes", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-keepalive",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const registry = new FederationSessionRegistry();
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      sessions: registry,
+      keepaliveIntervalMs: 50,
+      // Keep the auth deadline out of the way: this test is about the
+      // post-auth keepalive, not the pre-auth deadline.
+      authTimeoutMs: 60_000,
+    });
+    const { url } = await server.start();
+    const socket = new WebSocket(url);
+    const challengePromise = nextSocketMessage(socket);
+    await waitForSocketOpen(socket);
+    const challenge = (await challengePromise) as { nonce: string };
+    socket.send(
+      JSON.stringify({
+        kind: "auth",
+        mode: "enroll",
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "client_one",
+        protocolVersion: 1,
+        nonce: challenge.nonce,
+        capabilities: ["remote_window"],
+        signatureBase64: signFederationMessage({
+          privateKeyPem: clientKeyPair.privateKeyPem,
+          message: buildFederationProofMessage({
+            purpose: "enroll",
+            gatewayInstanceId: "gateway_one",
+            peerInstanceId: "client_one",
+            publicKeyPem: clientKeyPair.publicKeyPem,
+            protocolVersion: 1,
+            nonce: challenge.nonce,
+            capabilities: ["remote_window"],
+          }),
+        }),
+        inviteToken: invite.token,
+        publicKeyPem: clientKeyPair.publicKeyPem,
+        label: "Client",
+        role: "client",
+      }),
+    );
+    await expect(nextSocketMessage(socket)).resolves.toMatchObject({
+      kind: "auth.accepted",
+    });
+    const session = registry.listActiveSessions()[0];
+    expect(session).toBeDefined();
+
+    // Simulate a silently dead link: stop reading, so the gateway's pings
+    // are never processed and no pong ever goes back. No FIN, no RST —
+    // exactly the failure mode keepalive exists for.
+    (socket as unknown as { _socket: net.Socket })._socket.pause();
+
+    await expect
+      .poll(() => registry.listActiveSessions().length, { timeout: 5_000 })
+      .toBe(0);
+    expect(registry.getSession(session.sessionId)).toMatchObject({
+      status: "closed",
+      closeReason: "transport_closed",
+    });
+    socket.terminate();
+  });
+
+  it("keeps an idle authenticated peer connected and counts pongs as heartbeats", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-idle",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const registry = new FederationSessionRegistry();
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      sessions: registry,
+      keepaliveIntervalMs: 40,
+    });
+    const { url } = await server.start();
+    let closeCount = 0;
+    const client = await connectFederationClient({
+      url,
+      mode: "enroll",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["remote_window"],
+      inviteToken: invite.token,
+      label: "Client",
+      role: "client",
+      keepaliveIntervalMs: 40,
+      onClose: () => {
+        closeCount += 1;
+      },
+    });
+    const session = registry.listActiveSessions()[0];
+    expect(session).toBeDefined();
+
+    // Several keepalive cycles with zero envelopes: the session must stay
+    // active and its heartbeat must advance on pongs alone, or the stale
+    // sweep would reap every idle-but-healthy peer.
+    await expect
+      .poll(
+        () =>
+          registry.getSession(session.sessionId)?.lastHeartbeatAt ??
+          session.connectedAt,
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThan(session.connectedAt);
+    expect(registry.listActiveSessions()).toHaveLength(1);
+    expect(closeCount).toBe(0);
+    client.close();
+  });
+
+  it("closes the connection when a frame exceeds the payload ceiling", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-max-frame",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const received: FederationProtocolEnvelope[] = [];
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      maxFrameBytes: 64 * 1024,
+      onEnvelope: (envelope) => {
+        received.push(envelope);
+      },
+    });
+    const { url } = await server.start();
+    let closeCount = 0;
+    const client = await connectFederationClient({
+      url,
+      mode: "enroll",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["remote_window"],
+      inviteToken: invite.token,
+      label: "Client",
+      role: "client",
+      onClose: () => {
+        closeCount += 1;
+      },
+    });
+    const envelope = (payload: unknown): FederationProtocolEnvelope => ({
+      id: "request-max-frame",
+      kind: "request",
+      method: "backend.listThreads",
+      params: payload,
+      protocolVersion: 1,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "gateway_one",
+      createdAt: 1_000,
+    });
+
+    // Within the ceiling: delivered.
+    client.sendEnvelope(envelope({ note: "small" }));
+    await expect.poll(() => received.length, { timeout: 5_000 }).toBe(1);
+
+    // Over the ceiling: the gateway drops the connection instead of
+    // buffering a frame of the peer's choosing.
+    client.sendEnvelope(envelope({ blob: "x".repeat(128 * 1024) }));
+    await expect.poll(() => closeCount, { timeout: 5_000 }).toBe(1);
+    expect(received).toHaveLength(1);
+  });
+
+  it("terminates the client side when a gateway stops answering keepalive probes", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const nonce = "challenge:keepalive";
+    // A protocol-correct but frozen gateway: it completes auth with real
+    // signatures, then never answers pings (autoPong off) and never speaks
+    // again — the client's own probes must detect the dead direction.
+    rawServer = new WebSocketServer({
+      host: "127.0.0.1",
+      port: 0,
+      autoPong: false,
+    });
+    rawServer.on("connection", (socket) => {
+      socket.send(JSON.stringify({
+        kind: "auth.challenge",
+        gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+        protocolVersion: 1,
+        nonce,
+        signatureBase64: signFederationMessage({
+          privateKeyPem: gatewayKeyPair.privateKeyPem,
+          message: buildFederationGatewayChallengeMessage({
+            gatewayInstanceId: "gateway_one",
+            gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+            protocolVersion: 1,
+            nonce,
+          }),
+        }),
+      }));
+      socket.once("message", () => {
+        const sessionId = "federation-session:frozen";
+        const capabilities = ["remote_window"] as const;
+        socket.send(JSON.stringify({
+          kind: "auth.accepted",
+          gatewayInstanceId: "gateway_one",
+          sessionId,
+          protocolVersion: 1,
+          nonce,
+          capabilities,
+          signatureBase64: signFederationMessage({
+            privateKeyPem: gatewayKeyPair.privateKeyPem,
+            message: buildFederationGatewayAcceptedMessage({
+              gatewayInstanceId: "gateway_one",
+              peerInstanceId: "client_one",
+              sessionId,
+              protocolVersion: 1,
+              nonce,
+              capabilities,
+            }),
+          }),
+        }));
+      });
+    });
+    const url = await websocketServerUrl(rawServer);
+
+    let closeCount = 0;
+    await connectFederationClient({
+      url,
+      mode: "reconnect",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["remote_window"],
+      keepaliveIntervalMs: 50,
+      onClose: () => {
+        closeCount += 1;
+      },
+    });
+    await expect.poll(() => closeCount, { timeout: 5_000 }).toBe(1);
+  });
+
+  it("expires only stale active sessions from the registry", () => {
+    const registry = new FederationSessionRegistry();
+    registry.openSession({
+      sessionId: "session-stale",
+      peerId: "peer_stale",
+      connectedAt: 1_000,
+      capabilities: [],
+    });
+    registry.openSession({
+      sessionId: "session-live",
+      peerId: "peer_live",
+      connectedAt: 1_000,
+      capabilities: [],
+    });
+    registry.heartbeat("session-live", 10_000);
+
+    const expired = registry.expireStaleSessions({
+      now: 10_500,
+      heartbeatTimeoutMs: 5_000,
+    });
+
+    expect(expired.map((session) => session.sessionId)).toEqual([
+      "session-stale",
+    ]);
+    expect(registry.getSession("session-stale")).toMatchObject({
+      status: "closed",
+      closeReason: "timeout",
+    });
+    expect(registry.getSession("session-live")?.status).toBe("active");
   });
 });
 

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -42,6 +42,74 @@ import type { FederationStore } from "./federation-store";
 const log = getMainLogger("pwragent:federation-transport");
 const FEDERATION_NOISE_TRANSPORT = "noise_ik_25519_aesgcm_sha256";
 
+/**
+ * Liveness probe cadence (ssh ClientAliveInterval / ServerAliveInterval
+ * analogue, both directions). A peer that misses one full interval's pong is
+ * terminated, so a silently dropped link (sleep, NAT timeout, power loss) is
+ * detected within one to two intervals instead of never — the close then
+ * drives every existing onDisconnect/onClose consumer (peer status, remote
+ * PTY reaping, reconnect backoff).
+ */
+export const FEDERATION_KEEPALIVE_INTERVAL_MS = 15_000;
+
+/**
+ * Hard ceiling on a single WebSocket frame, both directions. Legitimate
+ * frames are JSON envelopes (RPC payloads, ≤ ~43 KiB base64 PTY chunks);
+ * transcript-bearing responses can reach megabytes, so the ceiling is
+ * generous — but without one, ws defaults to 100 MiB and a hostile enrolled
+ * peer can force that allocation per frame.
+ */
+export const FEDERATION_MAX_FRAME_BYTES = 16 * 1024 * 1024;
+
+/**
+ * WebSocket-level ping/pong watchdog. The counterpart answers pongs from the
+ * protocol layer (ws auto-pong), so this needs no cooperation from the remote
+ * application code — only a live link and an unwedged event loop.
+ */
+class FederationSocketKeepalive {
+  private alive = true;
+  private timer?: ReturnType<typeof setInterval>;
+
+  constructor(
+    socket: WebSocket,
+    options: {
+      intervalMs: number;
+      /** Fired on every pong — the liveness signal for session heartbeats. */
+      onLive?: () => void;
+      onDead: () => void;
+    },
+  ) {
+    socket.on("pong", () => {
+      this.alive = true;
+      options.onLive?.();
+    });
+    this.timer = setInterval(() => {
+      if (socket.readyState !== WebSocket.OPEN) return;
+      if (!this.alive) {
+        this.dispose();
+        options.onDead();
+        return;
+      }
+      this.alive = false;
+      try {
+        socket.ping();
+      } catch {
+        // The socket died between the readyState check and the ping; the
+        // close event owns cleanup.
+      }
+    }, options.intervalMs);
+    this.timer.unref?.();
+    socket.once("close", () => this.dispose());
+  }
+
+  dispose(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+}
+
 type FederationSocketTransportHelloMessage = {
   kind: "transport.hello";
   transportVersion: number;
@@ -126,6 +194,12 @@ export type FederationGatewayWebSocketServerOptions = {
    * expected from an outer TLS tunnel, e.g. Cloudflare).
    */
   noiseStatic?: NoiseKeyPair;
+  /** Ping cadence; a peer missing one interval's pong is terminated. */
+  keepaliveIntervalMs?: number;
+  /** Per-frame receive ceiling (ws maxPayload). */
+  maxFrameBytes?: number;
+  /** Deadline for a connected socket to finish Noise + identity auth. */
+  authTimeoutMs?: number;
   onConnection?: (connection: FederationGatewayConnection) => void;
   onDisconnect?: (connection: FederationGatewayConnection) => void;
   onEnvelope?: (
@@ -137,6 +211,7 @@ export type FederationGatewayWebSocketServerOptions = {
 export class FederationGatewayWebSocketServer {
   private httpServer?: http.Server;
   private wsServer?: WebSocketServer;
+  private sweepTimer?: ReturnType<typeof setInterval>;
   private readonly sessions: FederationSessionRegistry;
   private stopping = false;
   private readonly connections = new Map<
@@ -156,8 +231,33 @@ export class FederationGatewayWebSocketServer {
     }
     this.stopping = false;
     this.httpServer = http.createServer();
-    this.wsServer = new WebSocketServer({ server: this.httpServer });
+    this.wsServer = new WebSocketServer({
+      server: this.httpServer,
+      maxPayload: this.options.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES,
+    });
     this.wsServer.on("connection", (socket) => void this.handleSocket(socket));
+    // Belt-and-suspenders behind the per-socket keepalive: sweep sessions
+    // whose heartbeat (envelopes or pongs) stopped without the socket's
+    // close event ever firing, so the registry can never wedge "active".
+    const keepaliveIntervalMs =
+      this.options.keepaliveIntervalMs ?? FEDERATION_KEEPALIVE_INTERVAL_MS;
+    this.sweepTimer = setInterval(() => {
+      const expired = this.sessions.expireStaleSessions({
+        now: Date.now(),
+        heartbeatTimeoutMs: keepaliveIntervalMs * 4,
+      });
+      for (const session of expired) {
+        log.warn("federation session expired without heartbeat", {
+          peerId: session.peerId,
+          sessionId: session.sessionId,
+        });
+        const connection = [...this.connections.values()].find(
+          (candidate) => candidate.sessionId === session.sessionId,
+        );
+        connection?.close();
+      }
+    }, keepaliveIntervalMs);
+    this.sweepTimer.unref?.();
 
     await new Promise<void>((resolve, reject) => {
       const server = this.httpServer;
@@ -181,6 +281,10 @@ export class FederationGatewayWebSocketServer {
 
   async stop(): Promise<void> {
     this.stopping = true;
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = undefined;
+    }
     const wsServer = this.wsServer;
     const httpServer = this.httpServer;
     this.wsServer = undefined;
@@ -208,6 +312,28 @@ export class FederationGatewayWebSocketServer {
 
   private async handleSocket(socket: WebSocket): Promise<void> {
     const reader = new FederationFrameReader(socket);
+
+    // Armed for the socket's whole life, pre-auth included: a link that dies
+    // silently is terminated after one missed pong instead of parking a
+    // half-open connection forever.
+    new FederationSocketKeepalive(socket, {
+      intervalMs:
+        this.options.keepaliveIntervalMs ?? FEDERATION_KEEPALIVE_INTERVAL_MS,
+      onDead: () => {
+        log.warn("federation peer failed keepalive; terminating socket");
+        socket.terminate();
+      },
+    });
+    // A live socket that upgrades and then never finishes auth would pass
+    // keepalive forever (ws auto-pong needs no cooperation), so the auth
+    // exchange gets its own deadline — the gateway-side mirror of the
+    // client's FederationConnectDeadline.
+    const authDeadline = setTimeout(() => {
+      log.warn("federation auth deadline exceeded; terminating socket");
+      socket.terminate();
+    }, this.options.authTimeoutMs ?? FEDERATION_CONNECT_TIMEOUT_MS);
+    authDeadline.unref?.();
+    socket.once("close", () => clearTimeout(authDeadline));
 
     // Phase 1: Noise_IK handshake (responder). Skipped in tunnel mode.
     let transport: NoiseTransport | undefined;
@@ -387,6 +513,12 @@ export class FederationGatewayWebSocketServer {
       },
       transport,
     );
+    clearTimeout(authDeadline);
+    // Pongs count as session liveness alongside envelopes, so an idle but
+    // healthy peer never trips the stale-session sweep.
+    socket.on("pong", () => {
+      this.sessions.heartbeat(sessionId, Date.now());
+    });
     this.options.onConnection?.(connection);
     socket.once("close", () => {
       this.sessions.closeSession({
@@ -519,6 +651,10 @@ export async function connectFederationClient(params: {
    * forever, which stalls the caller's endpoint walk and reconnect loop.
    */
   connectTimeoutMs?: number;
+  /** Ping cadence; a gateway missing one interval's pong is terminated. */
+  keepaliveIntervalMs?: number;
+  /** Per-frame receive ceiling (ws maxPayload). */
+  maxFrameBytes?: number;
   /** Client's Noise static keypair. Enables encryption (initiator role). */
   noiseStatic?: NoiseKeyPair;
   /** Pinned gateway Noise static public key (raw 32 bytes), from the invite. */
@@ -528,17 +664,20 @@ export async function connectFederationClient(params: {
 }): Promise<FederationClientWebSocketClient> {
   const connectTimeoutMs =
     params.connectTimeoutMs ?? FEDERATION_CONNECT_TIMEOUT_MS;
+  const maxPayload = params.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES;
   const socket = new WebSocket(
     params.url,
     params.createSocket
       ? {
           headers: params.headers,
           handshakeTimeout: connectTimeoutMs,
+          maxPayload,
           agent: outerSocketAgent(params.createSocket),
         }
       : {
           headers: params.headers,
           handshakeTimeout: connectTimeoutMs,
+          maxPayload,
           cert: params.clientCertificate,
           key: params.clientPrivateKey,
         },
@@ -737,6 +876,17 @@ async function establishFederationClient(
   };
   socket.once("close", notifyTransportEnded);
   socket.once("error", notifyTransportEnded);
+
+  // Client-side liveness probes (the ssh ServerAliveInterval direction):
+  // a gateway whose link died silently is terminated, which fires onClose
+  // and hands control to the caller's reconnect loop.
+  new FederationSocketKeepalive(socket, {
+    intervalMs: params.keepaliveIntervalMs ?? FEDERATION_KEEPALIVE_INTERVAL_MS,
+    onDead: () => {
+      log.warn("federation gateway failed keepalive; terminating socket");
+      socket.terminate();
+    },
+  });
 
   // Phase 3: stream envelopes.
   void (async () => {

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -67,6 +67,12 @@ export const FEDERATION_MAX_FRAME_BYTES = 16 * 1024 * 1024;
  * application code — only a live link and an unwedged event loop.
  */
 class FederationSocketKeepalive {
+  /**
+   * Fired on every pong. The gateway assigns this once a session exists so
+   * pongs count as session heartbeats — assignable after construction
+   * because the watchdog is armed pre-auth, before there is a sessionId.
+   */
+  onLive?: () => void;
   private alive = true;
   private timer?: ReturnType<typeof setInterval>;
 
@@ -74,14 +80,12 @@ class FederationSocketKeepalive {
     socket: WebSocket,
     options: {
       intervalMs: number;
-      /** Fired on every pong — the liveness signal for session heartbeats. */
-      onLive?: () => void;
       onDead: () => void;
     },
   ) {
     socket.on("pong", () => {
       this.alive = true;
-      options.onLive?.();
+      this.onLive?.();
     });
     this.timer = setInterval(() => {
       if (socket.readyState !== WebSocket.OPEN) return;
@@ -177,6 +181,9 @@ export type FederationGatewayConnection = {
   capabilities: FederationCapability[];
   sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
   close: () => void;
+  /** Hard socket teardown for peers already presumed dead (stale sweep):
+   *  a graceful close queues a frame a wedged socket may never deliver. */
+  terminate?: () => void;
 };
 
 export type FederationGatewayWebSocketServerOptions = {
@@ -254,7 +261,9 @@ export class FederationGatewayWebSocketServer {
         const connection = [...this.connections.values()].find(
           (candidate) => candidate.sessionId === session.sessionId,
         );
-        connection?.close();
+        // The heartbeat already stopped, so the socket is presumed wedged:
+        // terminate rather than queue a close frame it may never deliver.
+        (connection?.terminate ?? connection?.close)?.();
       }
     }, keepaliveIntervalMs);
     this.sweepTimer.unref?.();
@@ -316,7 +325,7 @@ export class FederationGatewayWebSocketServer {
     // Armed for the socket's whole life, pre-auth included: a link that dies
     // silently is terminated after one missed pong instead of parking a
     // half-open connection forever.
-    new FederationSocketKeepalive(socket, {
+    const keepalive = new FederationSocketKeepalive(socket, {
       intervalMs:
         this.options.keepaliveIntervalMs ?? FEDERATION_KEEPALIVE_INTERVAL_MS,
       onDead: () => {
@@ -477,6 +486,7 @@ export class FederationGatewayWebSocketServer {
         sendFrame(socket, { kind: "envelope", envelope }, transport);
       },
       close: () => socket.close(),
+      terminate: () => socket.terminate(),
     };
     const previous = this.connections.get(connection.peerId);
     if (previous && previous.sessionId !== connection.sessionId) {
@@ -516,9 +526,9 @@ export class FederationGatewayWebSocketServer {
     clearTimeout(authDeadline);
     // Pongs count as session liveness alongside envelopes, so an idle but
     // healthy peer never trips the stale-session sweep.
-    socket.on("pong", () => {
+    keepalive.onLive = () => {
       this.sessions.heartbeat(sessionId, Date.now());
-    });
+    };
     this.options.onConnection?.(connection);
     socket.once("close", () => {
       this.sessions.closeSession({


### PR DESCRIPTION
## Summary

- Adds SSH-style liveness to the federation WebSocket transport, closing the gaps found while auditing the remote PTY feature (#1221) against SSH/tmux/VS Code practice: without probes, a silently dropped link (sleep, NAT timeout, power loss) never fired a disconnect on either side, so peers appeared connected indefinitely.
- **Keepalive both directions** (`FEDERATION_KEEPALIVE_INTERVAL_MS`, 15s): ws-level ping/pong watchdog on the gateway per-socket and on the client after auth. One missed pong terminates the socket; the resulting close drives the existing `onDisconnect`/`onClose` consumers (peer-status publishing, reconnect backoff, and remote PTY reaping once #1221 lands). The remote counterpart answers from the ws protocol layer (auto-pong), so no protocol change and no cooperation needed from the peer's application code.
- **Gateway auth deadline**: a socket that upgrades and then never completes Noise + identity auth is terminated after 20s — the gateway-side mirror of the client's `FederationConnectDeadline`. (Keepalive alone can't catch this: a live-but-stalled peer auto-pongs forever.)
- **`expireStaleSessions` wired**: it existed with zero call sites. Now a periodic sweep (4× keepalive interval) behind the per-socket watchdog, so the session registry can never wedge "active" even if a socket's close event is lost. Pongs count as session heartbeats alongside envelopes so idle-but-healthy peers never trip it.
- **Explicit frame ceiling** (`FEDERATION_MAX_FRAME_BYTES`, 16 MiB) on both the gateway `WebSocketServer` and the client socket. ws defaults to 100 MiB `maxPayload`, which let any enrolled peer force 100 MiB frame allocations; 16 MiB stays generous for transcript-bearing responses while bounding the abuse.

## Verification

- Five new tests in `federation-transport.test.ts` (18 total, all passing): gateway terminates an authenticated peer whose link goes silent (socket paused — no FIN/RST, the exact keepalive failure mode); an idle peer stays connected across several probe cycles with pong-driven heartbeat advancement; an over-ceiling frame drops the connection while in-ceiling frames round-trip; the client terminates a protocol-correct but frozen gateway (real signatures, `autoPong: false`); the registry sweep expires only stale active sessions.
- Full main-process suite (3,340 tests), `typecheck`, and `lint:eslint` (0 errors) pass; the federation remote-window E2E passes against a fresh build with the keepalive, sweep, and ceiling live in-process.

## Notes

- Interval/ceiling/deadline are options on both endpoints (`keepaliveIntervalMs`, `maxFrameBytes`, `authTimeoutMs`) — defaulted in production, tightened in tests.
- Independent of #1221 (branched from main); no conflicts expected either merge order. Once both land, the remote PTY's paused-ack watchdog (`FEDERATION_PTY_PAUSED_ACK_TIMEOUT_MS`) could arguably shorten, but it should stay: it also reaps sessions wedged by frames lost across a reconnect, which link-level keepalive cannot see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)