### PR TITLE
fix(desktop): graceful disconnected state for remote windows + observable federation evictions

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -100,7 +100,7 @@ async function createLocalControlFixture(): Promise<{
 
 test.describe("federation remote window", () => {
   test("enrolls, browses remote threads, pins on the owner, and hides local-only chrome", async () => {
-    test.setTimeout(180_000);
+    test.setTimeout(300_000);
 
     let gateway: InProcessFederationGateway | undefined;
     const fixture = await createLocalControlFixture();
@@ -347,6 +347,31 @@ test.describe("federation remote window", () => {
       expect(
         gateway.calls.map((call) => call.method),
       ).not.toContain("refreshThreadPullRequests");
+
+      // Peer death: the window flips to an explicit read-only state —
+      // disconnected banner, composer disabled — instead of a half-dead
+      // surface hammering the peer with failing RPCs.
+      await gateway.stop();
+      await expect(
+        remote.locator(".federation-disconnected-banner"),
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(
+        remote.locator(".composer-tiptap-input__editor"),
+      ).toHaveAttribute("contenteditable", "false", { timeout: 15_000 });
+
+      // Recovery: the same identity returns on the same port; the client
+      // reconnects on its own backoff and the window heals without a
+      // reload — banner gone, remote threads back.
+      await gateway.restart();
+      await gateway.waitForNextConnection(90_000);
+      await expect(
+        remote.locator(".federation-disconnected-banner"),
+      ).toHaveCount(0, { timeout: 60_000 });
+      await expect(
+        remote.locator(".thread-row__title", {
+          hasText: "Remote gateway thread one",
+        }),
+      ).toBeVisible({ timeout: 30_000 });
     } finally {
       await app?.close();
       await gateway?.close();

--- a/apps/desktop/e2e/fixtures/federation-gateway.ts
+++ b/apps/desktop/e2e/fixtures/federation-gateway.ts
@@ -56,6 +56,12 @@ export type InProcessFederationGateway = {
   pinnedRankByThreadId: Map<string, string | undefined>;
   /** Resolves when a client connection has completed enrollment/auth. */
   waitForConnection: (timeoutMs?: number) => Promise<void>;
+  /** Resolves when a connection completes AFTER this call (reconnects). */
+  waitForNextConnection: (timeoutMs?: number) => Promise<void>;
+  /** Stop listening and drop live connections (simulates the peer dying). */
+  stop: () => Promise<void>;
+  /** Come back up on the SAME port + identity so clients can reconnect. */
+  restart: () => Promise<void>;
   close: () => Promise<void>;
 };
 
@@ -254,38 +260,63 @@ export async function startInProcessFederationGateway(params: {
 
   let connectionCount = 0;
   const connectionWaiters: (() => void)[] = [];
-  const server = new FederationGatewayWebSocketServer({
-    gatewayInstanceId,
-    gatewayPrivateKeyPem: identity.privateKeyPem,
-    gatewayPublicKeyPem: identity.publicKeyPem,
-    host: "127.0.0.1",
-    port: 0,
-    store,
-    noiseStatic,
-    onConnection: (connection) => {
-      router.registerConnection({
-        peerId: connection.peerId,
-        capabilities: connection.capabilities,
-        sendEnvelope: connection.sendEnvelope,
-      });
-      ptyService?.notifyPeerConnected(connection.peerId);
-      connectionCount += 1;
-      for (const resolve of connectionWaiters.splice(0)) {
-        resolve();
-      }
-    },
-    onDisconnect: (connection) => {
-      router.unregisterConnection(connection.peerId);
-      ptyService?.notifyPeerDisconnected(connection.peerId);
-    },
-    onEnvelope: (envelope, connection) => {
-      void router.routeEnvelope({
-        envelope,
-        sourcePeerId: connection.peerId,
-      });
-    },
-  });
-  const { url } = await server.start();
+  const buildServer = (port: number) =>
+    new FederationGatewayWebSocketServer({
+      gatewayInstanceId,
+      gatewayPrivateKeyPem: identity.privateKeyPem,
+      gatewayPublicKeyPem: identity.publicKeyPem,
+      host: "127.0.0.1",
+      port,
+      store,
+      noiseStatic,
+      onConnection: (connection) => {
+        router.registerConnection({
+          peerId: connection.peerId,
+          capabilities: connection.capabilities,
+          sendEnvelope: connection.sendEnvelope,
+        });
+        ptyService?.notifyPeerConnected(connection.peerId);
+        connectionCount += 1;
+        for (const resolve of connectionWaiters.splice(0)) {
+          resolve();
+        }
+      },
+      onDisconnect: (connection) => {
+        router.unregisterConnection(connection.peerId);
+        ptyService?.notifyPeerDisconnected(connection.peerId);
+      },
+      onEnvelope: (envelope, connection) => {
+        void router.routeEnvelope({
+          envelope,
+          sourcePeerId: connection.peerId,
+        });
+      },
+    });
+  let server = buildServer(0);
+  const { url, port } = await server.start();
+
+  const waitForConnectionCount = async (
+    minimumCount: number,
+    timeoutMs: number,
+  ): Promise<void> => {
+    if (connectionCount >= minimumCount) return;
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(
+          new Error("Timed out waiting for a federation client connection"),
+        );
+      }, timeoutMs);
+      const waiter = () => {
+        if (connectionCount >= minimumCount) {
+          clearTimeout(timer);
+          resolve();
+          return;
+        }
+        connectionWaiters.push(waiter);
+      };
+      connectionWaiters.push(waiter);
+    });
+  };
 
   const token = randomBytes(24).toString("base64url");
   const now = Date.now();
@@ -317,16 +348,19 @@ export async function startInProcessFederationGateway(params: {
     calls,
     pinnedRankByThreadId,
     waitForConnection: async (timeoutMs = 15_000) => {
-      if (connectionCount > 0) return;
-      await new Promise<void>((resolve, reject) => {
-        const timer = setTimeout(() => {
-          reject(new Error("Timed out waiting for a federation client connection"));
-        }, timeoutMs);
-        connectionWaiters.push(() => {
-          clearTimeout(timer);
-          resolve();
-        });
-      });
+      await waitForConnectionCount(1, timeoutMs);
+    },
+    waitForNextConnection: async (timeoutMs = 60_000) => {
+      await waitForConnectionCount(connectionCount + 1, timeoutMs);
+    },
+    stop: async () => {
+      await server.stop();
+    },
+    restart: async () => {
+      // Same port, identity, and sqlite store: the returning "machine"
+      // is the one the client pinned, so reconnect auth must succeed.
+      server = buildServer(port);
+      await server.start();
     },
     close: async () => {
       ptyService?.disposeAll();

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -159,6 +159,83 @@ describe("federation transport", () => {
     expect(server?.closePeer("client_one")).toBe(false);
   });
 
+  it("evicts a duplicated peer id with close code 4001 and audits the replacement", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    let firstClose: { code: number; reason: string } | undefined;
+    let resolveFirstClosed: (() => void) | undefined;
+    const firstClosed = new Promise<void>((resolve) => {
+      resolveFirstClosed = resolve;
+    });
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-replace",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+    });
+    const { url } = await server.start();
+
+    await connectFederationClient({
+      url,
+      mode: "enroll",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["remote_window"],
+      inviteToken: invite.token,
+      label: "Clone A",
+      role: "client",
+      onClose: (info) => {
+        firstClose = info;
+        resolveFirstClosed?.();
+      },
+    });
+
+    // A second process presenting the same instance id + pinned key (a
+    // cloned profile state.db) authenticates and evicts the first.
+    const second = await connectFederationClient({
+      url,
+      mode: "reconnect",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["remote_window"],
+      label: "Clone B",
+      role: "client",
+    });
+
+    await firstClosed;
+    // The evicted side can tell this apart from a network drop.
+    expect(firstClose).toMatchObject({
+      code: 4001,
+      reason: "replaced_by_new_session",
+    });
+
+    // Newest-first audit trail: the old session's "replaced" eviction is
+    // recorded before (i.e. listed after) the new session's "connected",
+    // and the evicted socket's close adds no duplicate disconnected row.
+    expect(store.listAudit({ peerId: "client_one" })).toMatchObject([
+      { kind: "connected", detail: "reconnect" },
+      { kind: "disconnected", detail: "replaced" },
+      { kind: "connect_attempt", detail: "reconnect" },
+      { kind: "connected", detail: "enroll" },
+      { kind: "connect_attempt", detail: "enroll" },
+    ]);
+    second.close();
+  });
+
   it("ignores capability names from newer builds instead of failing the handshake", async () => {
     const clientKeyPair = generateFederationIdentityKeyPair();
     const invite = createFederationEnrollmentInvite({

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -880,6 +880,30 @@ describe("federation transport liveness", () => {
     socket.terminate();
   });
 
+  it("terminates a socket that upgrades but never completes auth", async () => {
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      authTimeoutMs: 100,
+      // Keepalive alone cannot catch this: a live-but-stalled peer answers
+      // pings from the ws protocol layer forever. Park it out of the way so
+      // this test isolates the auth deadline.
+      keepaliveIntervalMs: 60_000,
+    });
+    const { url } = await server.start();
+    const socket = new WebSocket(url);
+    await waitForSocketOpen(socket);
+    // Upgrade succeeded, challenge received; now say nothing.
+    const closed = new Promise<boolean>((resolve) => {
+      socket.once("close", () => resolve(true));
+    });
+    await expect(closed).resolves.toBe(true);
+  });
+
   it("keeps an idle authenticated peer connected and counts pongs as heartbeats", async () => {
     const clientKeyPair = generateFederationIdentityKeyPair();
     const invite = createFederationEnrollmentInvite({

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -23,6 +23,7 @@ import {
   generateNoiseStaticKeyPair,
   NoiseIKHandshake,
 } from "../federation/federation-noise";
+import { FederationSessionRegistry } from "../federation/federation-session-state";
 import { FederationStore } from "../federation/federation-store";
 import {
   connectFederationClient,
@@ -799,6 +800,307 @@ describe("federation transport", () => {
       publicKeyPem: clientKeyPair.publicKeyPem,
       capabilities: ["remote_window"],
     })).rejects.toThrow("Invalid federation auth acceptance signature");
+  });
+});
+
+describe("federation transport liveness", () => {
+  it("terminates an authenticated peer whose link stops answering keepalive probes", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-keepalive",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const registry = new FederationSessionRegistry();
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      sessions: registry,
+      keepaliveIntervalMs: 50,
+      // Keep the auth deadline out of the way: this test is about the
+      // post-auth keepalive, not the pre-auth deadline.
+      authTimeoutMs: 60_000,
+    });
+    const { url } = await server.start();
+    const socket = new WebSocket(url);
+    const challengePromise = nextSocketMessage(socket);
+    await waitForSocketOpen(socket);
+    const challenge = (await challengePromise) as { nonce: string };
+    socket.send(
+      JSON.stringify({
+        kind: "auth",
+        mode: "enroll",
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "client_one",
+        protocolVersion: 1,
+        nonce: challenge.nonce,
+        capabilities: ["remote_window"],
+        signatureBase64: signFederationMessage({
+          privateKeyPem: clientKeyPair.privateKeyPem,
+          message: buildFederationProofMessage({
+            purpose: "enroll",
+            gatewayInstanceId: "gateway_one",
+            peerInstanceId: "client_one",
+            publicKeyPem: clientKeyPair.publicKeyPem,
+            protocolVersion: 1,
+            nonce: challenge.nonce,
+            capabilities: ["remote_window"],
+          }),
+        }),
+        inviteToken: invite.token,
+        publicKeyPem: clientKeyPair.publicKeyPem,
+        label: "Client",
+        role: "client",
+      }),
+    );
+    await expect(nextSocketMessage(socket)).resolves.toMatchObject({
+      kind: "auth.accepted",
+    });
+    const session = registry.listActiveSessions()[0];
+    expect(session).toBeDefined();
+
+    // Simulate a silently dead link: stop reading, so the gateway's pings
+    // are never processed and no pong ever goes back. No FIN, no RST —
+    // exactly the failure mode keepalive exists for.
+    (socket as unknown as { _socket: net.Socket })._socket.pause();
+
+    await expect
+      .poll(() => registry.listActiveSessions().length, { timeout: 5_000 })
+      .toBe(0);
+    expect(registry.getSession(session.sessionId)).toMatchObject({
+      status: "closed",
+      closeReason: "transport_closed",
+    });
+    socket.terminate();
+  });
+
+  it("keeps an idle authenticated peer connected and counts pongs as heartbeats", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-idle",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const registry = new FederationSessionRegistry();
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      sessions: registry,
+      keepaliveIntervalMs: 40,
+    });
+    const { url } = await server.start();
+    let closeCount = 0;
+    const client = await connectFederationClient({
+      url,
+      mode: "enroll",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["remote_window"],
+      inviteToken: invite.token,
+      label: "Client",
+      role: "client",
+      keepaliveIntervalMs: 40,
+      onClose: () => {
+        closeCount += 1;
+      },
+    });
+    const session = registry.listActiveSessions()[0];
+    expect(session).toBeDefined();
+
+    // Several keepalive cycles with zero envelopes: the session must stay
+    // active and its heartbeat must advance on pongs alone, or the stale
+    // sweep would reap every idle-but-healthy peer.
+    await expect
+      .poll(
+        () =>
+          registry.getSession(session.sessionId)?.lastHeartbeatAt ??
+          session.connectedAt,
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThan(session.connectedAt);
+    expect(registry.listActiveSessions()).toHaveLength(1);
+    expect(closeCount).toBe(0);
+    client.close();
+  });
+
+  it("closes the connection when a frame exceeds the payload ceiling", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-max-frame",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const received: FederationProtocolEnvelope[] = [];
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      maxFrameBytes: 64 * 1024,
+      onEnvelope: (envelope) => {
+        received.push(envelope);
+      },
+    });
+    const { url } = await server.start();
+    let closeCount = 0;
+    const client = await connectFederationClient({
+      url,
+      mode: "enroll",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["remote_window"],
+      inviteToken: invite.token,
+      label: "Client",
+      role: "client",
+      onClose: () => {
+        closeCount += 1;
+      },
+    });
+    const envelope = (payload: unknown): FederationProtocolEnvelope => ({
+      id: "request-max-frame",
+      kind: "request",
+      method: "backend.listThreads",
+      params: payload,
+      protocolVersion: 1,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "gateway_one",
+      createdAt: 1_000,
+    });
+
+    // Within the ceiling: delivered.
+    client.sendEnvelope(envelope({ note: "small" }));
+    await expect.poll(() => received.length, { timeout: 5_000 }).toBe(1);
+
+    // Over the ceiling: the gateway drops the connection instead of
+    // buffering a frame of the peer's choosing.
+    client.sendEnvelope(envelope({ blob: "x".repeat(128 * 1024) }));
+    await expect.poll(() => closeCount, { timeout: 5_000 }).toBe(1);
+    expect(received).toHaveLength(1);
+  });
+
+  it("terminates the client side when a gateway stops answering keepalive probes", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const nonce = "challenge:keepalive";
+    // A protocol-correct but frozen gateway: it completes auth with real
+    // signatures, then never answers pings (autoPong off) and never speaks
+    // again — the client's own probes must detect the dead direction.
+    rawServer = new WebSocketServer({
+      host: "127.0.0.1",
+      port: 0,
+      autoPong: false,
+    });
+    rawServer.on("connection", (socket) => {
+      socket.send(JSON.stringify({
+        kind: "auth.challenge",
+        gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+        protocolVersion: 1,
+        nonce,
+        signatureBase64: signFederationMessage({
+          privateKeyPem: gatewayKeyPair.privateKeyPem,
+          message: buildFederationGatewayChallengeMessage({
+            gatewayInstanceId: "gateway_one",
+            gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+            protocolVersion: 1,
+            nonce,
+          }),
+        }),
+      }));
+      socket.once("message", () => {
+        const sessionId = "federation-session:frozen";
+        const capabilities = ["remote_window"] as const;
+        socket.send(JSON.stringify({
+          kind: "auth.accepted",
+          gatewayInstanceId: "gateway_one",
+          sessionId,
+          protocolVersion: 1,
+          nonce,
+          capabilities,
+          signatureBase64: signFederationMessage({
+            privateKeyPem: gatewayKeyPair.privateKeyPem,
+            message: buildFederationGatewayAcceptedMessage({
+              gatewayInstanceId: "gateway_one",
+              peerInstanceId: "client_one",
+              sessionId,
+              protocolVersion: 1,
+              nonce,
+              capabilities,
+            }),
+          }),
+        }));
+      });
+    });
+    const url = await websocketServerUrl(rawServer);
+
+    let closeCount = 0;
+    await connectFederationClient({
+      url,
+      mode: "reconnect",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["remote_window"],
+      keepaliveIntervalMs: 50,
+      onClose: () => {
+        closeCount += 1;
+      },
+    });
+    await expect.poll(() => closeCount, { timeout: 5_000 }).toBe(1);
+  });
+
+  it("expires only stale active sessions from the registry", () => {
+    const registry = new FederationSessionRegistry();
+    registry.openSession({
+      sessionId: "session-stale",
+      peerId: "peer_stale",
+      connectedAt: 1_000,
+      capabilities: [],
+    });
+    registry.openSession({
+      sessionId: "session-live",
+      peerId: "peer_live",
+      connectedAt: 1_000,
+      capabilities: [],
+    });
+    registry.heartbeat("session-live", 10_000);
+
+    const expired = registry.expireStaleSessions({
+      now: 10_500,
+      heartbeatTimeoutMs: 5_000,
+    });
+
+    expect(expired.map((session) => session.sessionId)).toEqual([
+      "session-stale",
+    ]);
+    expect(registry.getSession("session-stale")).toMatchObject({
+      status: "closed",
+      closeReason: "timeout",
+    });
+    expect(registry.getSession("session-live")?.status).toBe("active");
   });
 });
 

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -61,6 +61,7 @@ describe("federation transport", () => {
   it("authenticates a client and carries protocol envelopes", async () => {
     const clientKeyPair = generateFederationIdentityKeyPair();
     let closeCount = 0;
+    let lastCloseInfo: { code: number; reason: string } | undefined;
     let resolveClosed: (() => void) | undefined;
     const closed = new Promise<void>((resolve) => {
       resolveClosed = resolve;
@@ -111,8 +112,9 @@ describe("federation transport", () => {
         label: "Client",
         role: "client",
         onEnvelope: resolve,
-        onClose: () => {
+        onClose: (info) => {
           closeCount += 1;
+          lastCloseInfo = info;
           resolveClosed?.();
         },
       }).then((client) => {
@@ -156,6 +158,9 @@ describe("federation transport", () => {
     expect(server?.closePeer("client_one")).toBe(true);
     await closed;
     expect(closeCount).toBe(1);
+    // Revocation closes with its own application code so the client can
+    // report "re-pair needed" instead of a generic connection loss.
+    expect(lastCloseInfo).toMatchObject({ code: 4002, reason: "revoked" });
     expect(server?.closePeer("client_one")).toBe(false);
   });
 

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -153,6 +153,7 @@ import {
 } from "./federation-redaction";
 import {
   connectFederationClient,
+  FEDERATION_CLOSE_REPLACED_CODE,
   FederationGatewayWebSocketServer,
   type FederationClientWebSocketClient,
   type FederationGatewayConnection,
@@ -250,7 +251,7 @@ export class DesktopFederationRuntime {
   private lastConnectedAt?: number;
   private stopping = true;
   private lastConnectionError?: string;
-  private lastConnectionFailureKind?: "auth" | "transport";
+  private lastConnectionFailureKind?: "auth" | "replaced" | "transport";
   private gatewayListenerError?: string;
 
   setAgentEventPublisher(publisher: (event: AgentEvent) => void): void {
@@ -373,9 +374,14 @@ export class DesktopFederationRuntime {
         ? "connected"
         : this.lastConnectionFailureKind === "auth"
           ? "rejected"
-          : this.reconnectTimer
-            ? "connecting"
-            : "disconnected";
+          // A "replaced" eviction will reconnect (and evict the sibling
+          // back) — degraded, not a clean connecting/disconnected, so
+          // the panel surfaces the duplicate-identity explanation.
+          : this.lastConnectionFailureKind === "replaced"
+            ? "degraded"
+            : this.reconnectTimer
+              ? "connecting"
+              : "disconnected";
       health.unavailableReason = this.lastConnectionError;
       const endpoints =
         this.configuredEndpoints.length > 0
@@ -1059,7 +1065,7 @@ export class DesktopFederationRuntime {
         gatewayNoisePublicKeyBase64,
         "base64",
       ),
-      onClose: () => {
+      onClose: (info) => {
         if (
           this.stopping ||
           connectionGeneration !== this.connectionGeneration
@@ -1067,14 +1073,43 @@ export class DesktopFederationRuntime {
           return;
         }
         this.client = undefined;
-        this.lastConnectionError = "Federation gateway connection closed.";
-        this.lastConnectionFailureKind = "transport";
+        // 4001 is the gateway's "another connection authenticated with
+        // your instance id" eviction — the signature of a cloned profile
+        // state.db. Say so instead of the generic transport message, or
+        // the operator sees an unexplained 30s connect/drop loop.
+        const replaced = info?.code === FEDERATION_CLOSE_REPLACED_CODE;
+        this.lastConnectionError = replaced
+          ? "Another instance connected with this federation identity "
+            + "(a cloned profile state.db shares the instance id and key). "
+            + "Reset federation on one of the profiles to stop the loop."
+          : info
+            ? `Federation gateway connection closed (${info.code}${
+                info.reason ? ` ${info.reason}` : ""
+              }).`
+            : "Federation gateway connection closed.";
+        this.lastConnectionFailureKind = replaced ? "replaced" : "transport";
+        const sessionAgeMs = this.lastConnectedAt
+          ? Date.now() - this.lastConnectedAt
+          : undefined;
+        // Post-auth drops previously logged nothing at all; a repeating
+        // short session age makes a kick loop obvious at a glance.
+        log.warn("federation client session closed", {
+          gatewayInstanceId,
+          code: info?.code,
+          reason: info?.reason,
+          replaced,
+          sessionAgeMs,
+        });
         this.store().appendAudit({
           peerId: gatewayInstanceId,
           sessionId: clientSession.id,
           kind: "disconnected",
           createdAt: Date.now(),
-          detail: "transport_closed",
+          detail: replaced
+            ? "replaced_by_new_session"
+            : info
+              ? `transport_closed:${info.code}`
+              : "transport_closed",
         });
         this.unregisterPeer(gatewayInstanceId);
         this.publishPeerStatus(
@@ -1271,6 +1306,12 @@ export class DesktopFederationRuntime {
 
   private disconnectAdvertisedPeers(reason: string): void {
     for (const [peerId, peer] of this.remotePeerDirectory) {
+      // Dual mode: a peer directly connected to THIS instance's own
+      // gateway is still reachable when the upstream client link drops —
+      // publishing "disconnected" for it would be false.
+      if (this.router?.getConnection(peerId)) {
+        continue;
+      }
       this.remotePeerDirectory.set(peerId, {
         ...peer,
         status: peer.status === "revoked" ? "revoked" : "disconnected",

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -154,6 +154,7 @@ import {
 import {
   connectFederationClient,
   FEDERATION_CLOSE_REPLACED_CODE,
+  FEDERATION_CLOSE_REVOKED_CODE,
   FederationGatewayWebSocketServer,
   type FederationClientWebSocketClient,
   type FederationGatewayConnection,
@@ -176,6 +177,7 @@ const PENDING_INVITE_TOKEN_META_KEY = "federation_pending_invite_token";
 const GATEWAY_ENROLLED_AT_META_KEY = "federation_gateway_enrolled_at";
 const FEDERATION_PEER_DIRECTORY_METHOD = "federation.peerDirectory";
 const FEDERATION_RECONNECT_MAX_DELAY_MS = 30_000;
+const DUPLICATE_IDENTITY_NOTE_TTL_MS = 5 * 60_000;
 /** A session must last this long before it counts as stable enough to reset backoff. */
 const FEDERATION_STABLE_SESSION_MS = 60_000;
 
@@ -252,6 +254,11 @@ export class DesktopFederationRuntime {
   private stopping = true;
   private lastConnectionError?: string;
   private lastConnectionFailureKind?: "auth" | "replaced" | "transport";
+  /** Peer ids the gateway recently flagged for duplicate-identity churn. */
+  private readonly duplicateIdentitySuspectedAt = new Map<
+    FederationInstanceId,
+    number
+  >();
   private gatewayListenerError?: string;
 
   setAgentEventPublisher(publisher: (event: AgentEvent) => void): void {
@@ -828,6 +835,11 @@ export class DesktopFederationRuntime {
         noiseStatic,
         onConnection: (connection) => this.registerGatewayConnection(connection),
         onDisconnect: (connection) => this.unregisterGatewayConnection(connection),
+        onPeerReplaced: (info) => {
+          if (info.duplicateInstanceIdSuspected) {
+            this.duplicateIdentitySuspectedAt.set(info.peerId, Date.now());
+          }
+        },
         onEnvelope: (envelope, connection) =>
           void this.receiveEnvelope(envelope, connection.peerId),
       });
@@ -1078,16 +1090,27 @@ export class DesktopFederationRuntime {
         // state.db. Say so instead of the generic transport message, or
         // the operator sees an unexplained 30s connect/drop loop.
         const replaced = info?.code === FEDERATION_CLOSE_REPLACED_CODE;
+        const revoked = info?.code === FEDERATION_CLOSE_REVOKED_CODE;
         this.lastConnectionError = replaced
           ? "Another instance connected with this federation identity "
             + "(a cloned profile state.db shares the instance id and key). "
             + "Reset federation on one of the profiles to stop the loop."
-          : info
-            ? `Federation gateway connection closed (${info.code}${
-                info.reason ? ` ${info.reason}` : ""
-              }).`
-            : "Federation gateway connection closed.";
-        this.lastConnectionFailureKind = replaced ? "replaced" : "transport";
+          : revoked
+            ? "This instance's enrollment was revoked by the gateway. "
+              + "Import a fresh invite to re-pair."
+            : info
+              ? `Federation gateway connection closed (${info.code}${
+                  info.reason ? ` ${info.reason}` : ""
+                }).`
+              : "Federation gateway connection closed.";
+        this.lastConnectionFailureKind = replaced
+          ? "replaced"
+          // Revocation is terminal until the operator re-pairs — the
+          // auth kind makes health read "rejected" instead of hiding it
+          // behind an endless "connecting".
+          : revoked
+            ? "auth"
+            : "transport";
         const sessionAgeMs = this.lastConnectedAt
           ? Date.now() - this.lastConnectedAt
           : undefined;
@@ -1556,16 +1579,38 @@ export class DesktopFederationRuntime {
       });
     }
 
-    return [...visible.values()].map((peer) =>
-      this.router?.getConnection(peer.id)
-        ? { ...peer, status: "connected" }
-        : this.remotePeerDirectory.has(peer.id)
-          ? peer
-        : {
-            ...peer,
-            status: peer.status === "connected" ? "disconnected" : peer.status,
-          },
-    );
+    return [...visible.values()]
+      .map((peer) =>
+        this.router?.getConnection(peer.id)
+          ? { ...peer, status: "connected" as const }
+          : this.remotePeerDirectory.has(peer.id)
+            ? peer
+          : {
+              ...peer,
+              status:
+                peer.status === "connected"
+                  ? ("disconnected" as const)
+                  : peer.status,
+            },
+      )
+      .map((peer) => {
+        // Surface a recent duplicate-identity eviction storm to everyone
+        // observing this peer (Settings rows here, and remote viewers via
+        // the peer directory) — the flapping peer itself only ever sees
+        // its own 4001 close.
+        const suspectedAt = this.duplicateIdentitySuspectedAt.get(peer.id);
+        return suspectedAt !== undefined
+          && Date.now() - suspectedAt < DUPLICATE_IDENTITY_NOTE_TTL_MS
+          && !peer.unavailableReason
+          ? {
+              ...peer,
+              unavailableReason:
+                "Multiple instances are presenting this federation identity "
+                + "(likely a cloned profile state.db); its connection is "
+                + "unstable until one is reset.",
+            }
+          : peer;
+      });
   }
 
   private defaultPeerLabel(peerId: FederationInstanceId): string {

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -42,6 +42,74 @@ import type { FederationStore } from "./federation-store";
 const log = getMainLogger("pwragent:federation-transport");
 const FEDERATION_NOISE_TRANSPORT = "noise_ik_25519_aesgcm_sha256";
 
+/**
+ * Liveness probe cadence (ssh ClientAliveInterval / ServerAliveInterval
+ * analogue, both directions). A peer that misses one full interval's pong is
+ * terminated, so a silently dropped link (sleep, NAT timeout, power loss) is
+ * detected within one to two intervals instead of never — the close then
+ * drives every existing onDisconnect/onClose consumer (peer status, remote
+ * PTY reaping, reconnect backoff).
+ */
+export const FEDERATION_KEEPALIVE_INTERVAL_MS = 15_000;
+
+/**
+ * Hard ceiling on a single WebSocket frame, both directions. Legitimate
+ * frames are JSON envelopes (RPC payloads, ≤ ~43 KiB base64 PTY chunks);
+ * transcript-bearing responses can reach megabytes, so the ceiling is
+ * generous — but without one, ws defaults to 100 MiB and a hostile enrolled
+ * peer can force that allocation per frame.
+ */
+export const FEDERATION_MAX_FRAME_BYTES = 16 * 1024 * 1024;
+
+/**
+ * WebSocket-level ping/pong watchdog. The counterpart answers pongs from the
+ * protocol layer (ws auto-pong), so this needs no cooperation from the remote
+ * application code — only a live link and an unwedged event loop.
+ */
+class FederationSocketKeepalive {
+  private alive = true;
+  private timer?: ReturnType<typeof setInterval>;
+
+  constructor(
+    socket: WebSocket,
+    options: {
+      intervalMs: number;
+      /** Fired on every pong — the liveness signal for session heartbeats. */
+      onLive?: () => void;
+      onDead: () => void;
+    },
+  ) {
+    socket.on("pong", () => {
+      this.alive = true;
+      options.onLive?.();
+    });
+    this.timer = setInterval(() => {
+      if (socket.readyState !== WebSocket.OPEN) return;
+      if (!this.alive) {
+        this.dispose();
+        options.onDead();
+        return;
+      }
+      this.alive = false;
+      try {
+        socket.ping();
+      } catch {
+        // The socket died between the readyState check and the ping; the
+        // close event owns cleanup.
+      }
+    }, options.intervalMs);
+    this.timer.unref?.();
+    socket.once("close", () => this.dispose());
+  }
+
+  dispose(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+}
+
 type FederationSocketTransportHelloMessage = {
   kind: "transport.hello";
   transportVersion: number;
@@ -126,6 +194,12 @@ export type FederationGatewayWebSocketServerOptions = {
    * expected from an outer TLS tunnel, e.g. Cloudflare).
    */
   noiseStatic?: NoiseKeyPair;
+  /** Ping cadence; a peer missing one interval's pong is terminated. */
+  keepaliveIntervalMs?: number;
+  /** Per-frame receive ceiling (ws maxPayload). */
+  maxFrameBytes?: number;
+  /** Deadline for a connected socket to finish Noise + identity auth. */
+  authTimeoutMs?: number;
   onConnection?: (connection: FederationGatewayConnection) => void;
   onDisconnect?: (connection: FederationGatewayConnection) => void;
   onEnvelope?: (
@@ -137,6 +211,7 @@ export type FederationGatewayWebSocketServerOptions = {
 export class FederationGatewayWebSocketServer {
   private httpServer?: http.Server;
   private wsServer?: WebSocketServer;
+  private sweepTimer?: ReturnType<typeof setInterval>;
   private readonly sessions: FederationSessionRegistry;
   private stopping = false;
   private readonly connections = new Map<
@@ -156,8 +231,33 @@ export class FederationGatewayWebSocketServer {
     }
     this.stopping = false;
     this.httpServer = http.createServer();
-    this.wsServer = new WebSocketServer({ server: this.httpServer });
+    this.wsServer = new WebSocketServer({
+      server: this.httpServer,
+      maxPayload: this.options.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES,
+    });
     this.wsServer.on("connection", (socket) => void this.handleSocket(socket));
+    // Belt-and-suspenders behind the per-socket keepalive: sweep sessions
+    // whose heartbeat (envelopes or pongs) stopped without the socket's
+    // close event ever firing, so the registry can never wedge "active".
+    const keepaliveIntervalMs =
+      this.options.keepaliveIntervalMs ?? FEDERATION_KEEPALIVE_INTERVAL_MS;
+    this.sweepTimer = setInterval(() => {
+      const expired = this.sessions.expireStaleSessions({
+        now: Date.now(),
+        heartbeatTimeoutMs: keepaliveIntervalMs * 4,
+      });
+      for (const session of expired) {
+        log.warn("federation session expired without heartbeat", {
+          peerId: session.peerId,
+          sessionId: session.sessionId,
+        });
+        const connection = [...this.connections.values()].find(
+          (candidate) => candidate.sessionId === session.sessionId,
+        );
+        connection?.close();
+      }
+    }, keepaliveIntervalMs);
+    this.sweepTimer.unref?.();
 
     await new Promise<void>((resolve, reject) => {
       const server = this.httpServer;
@@ -181,6 +281,10 @@ export class FederationGatewayWebSocketServer {
 
   async stop(): Promise<void> {
     this.stopping = true;
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = undefined;
+    }
     const wsServer = this.wsServer;
     const httpServer = this.httpServer;
     this.wsServer = undefined;
@@ -208,6 +312,28 @@ export class FederationGatewayWebSocketServer {
 
   private async handleSocket(socket: WebSocket): Promise<void> {
     const reader = new FederationFrameReader(socket);
+
+    // Armed for the socket's whole life, pre-auth included: a link that dies
+    // silently is terminated after one missed pong instead of parking a
+    // half-open connection forever.
+    new FederationSocketKeepalive(socket, {
+      intervalMs:
+        this.options.keepaliveIntervalMs ?? FEDERATION_KEEPALIVE_INTERVAL_MS,
+      onDead: () => {
+        log.warn("federation peer failed keepalive; terminating socket");
+        socket.terminate();
+      },
+    });
+    // A live socket that upgrades and then never finishes auth would pass
+    // keepalive forever (ws auto-pong needs no cooperation), so the auth
+    // exchange gets its own deadline — the gateway-side mirror of the
+    // client's FederationConnectDeadline.
+    const authDeadline = setTimeout(() => {
+      log.warn("federation auth deadline exceeded; terminating socket");
+      socket.terminate();
+    }, this.options.authTimeoutMs ?? FEDERATION_CONNECT_TIMEOUT_MS);
+    authDeadline.unref?.();
+    socket.once("close", () => clearTimeout(authDeadline));
 
     // Phase 1: Noise_IK handshake (responder). Skipped in tunnel mode.
     let transport: NoiseTransport | undefined;
@@ -387,6 +513,12 @@ export class FederationGatewayWebSocketServer {
       },
       transport,
     );
+    clearTimeout(authDeadline);
+    // Pongs count as session liveness alongside envelopes, so an idle but
+    // healthy peer never trips the stale-session sweep.
+    socket.on("pong", () => {
+      this.sessions.heartbeat(sessionId, Date.now());
+    });
     this.options.onConnection?.(connection);
     socket.once("close", () => {
       this.sessions.closeSession({
@@ -519,6 +651,10 @@ export async function connectFederationClient(params: {
    * forever, which stalls the caller's endpoint walk and reconnect loop.
    */
   connectTimeoutMs?: number;
+  /** Ping cadence; a gateway missing one interval's pong is terminated. */
+  keepaliveIntervalMs?: number;
+  /** Per-frame receive ceiling (ws maxPayload). */
+  maxFrameBytes?: number;
   /** Client's Noise static keypair. Enables encryption (initiator role). */
   noiseStatic?: NoiseKeyPair;
   /** Pinned gateway Noise static public key (raw 32 bytes), from the invite. */
@@ -528,17 +664,20 @@ export async function connectFederationClient(params: {
 }): Promise<FederationClientWebSocketClient> {
   const connectTimeoutMs =
     params.connectTimeoutMs ?? FEDERATION_CONNECT_TIMEOUT_MS;
+  const maxPayload = params.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES;
   const socket = new WebSocket(
     params.url,
     params.createSocket
       ? {
           headers: params.headers,
           handshakeTimeout: connectTimeoutMs,
+          maxPayload,
           agent: outerSocketAgent(params.createSocket),
         }
       : {
           headers: params.headers,
           handshakeTimeout: connectTimeoutMs,
+          maxPayload,
           cert: params.clientCertificate,
           key: params.clientPrivateKey,
         },
@@ -737,6 +876,17 @@ async function establishFederationClient(
   };
   socket.once("close", notifyTransportEnded);
   socket.once("error", notifyTransportEnded);
+
+  // Client-side liveness probes (the ssh ServerAliveInterval direction):
+  // a gateway whose link died silently is terminated, which fires onClose
+  // and hands control to the caller's reconnect loop.
+  new FederationSocketKeepalive(socket, {
+    intervalMs: params.keepaliveIntervalMs ?? FEDERATION_KEEPALIVE_INTERVAL_MS,
+    onDead: () => {
+      log.warn("federation gateway failed keepalive; terminating socket");
+      socket.terminate();
+    },
+  });
 
   // Phase 3: stream envelopes.
   void (async () => {

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -50,6 +50,8 @@ const FEDERATION_NOISE_TRANSPORT = "noise_ik_25519_aesgcm_sha256";
  * kicking its sibling in a loop.
  */
 export const FEDERATION_CLOSE_REPLACED_CODE = 4001;
+/** Close code for a peer whose enrollment the gateway revoked. */
+export const FEDERATION_CLOSE_REVOKED_CODE = 4002;
 const REPLACEMENT_FLAP_WINDOW_MS = 5 * 60_000;
 const REPLACEMENT_FLAP_THRESHOLD = 3;
 
@@ -220,6 +222,16 @@ export type FederationGatewayWebSocketServerOptions = {
   authTimeoutMs?: number;
   onConnection?: (connection: FederationGatewayConnection) => void;
   onDisconnect?: (connection: FederationGatewayConnection) => void;
+  /**
+   * A new connection for a peer id evicted an existing one.
+   * `duplicateInstanceIdSuspected` flags repeated evictions inside the
+   * detection window — the cloned-profile signature — so the runtime can
+   * surface it to peers observing this instance in the peer directory.
+   */
+  onPeerReplaced?: (info: {
+    peerId: FederationInstanceId;
+    duplicateInstanceIdSuspected: boolean;
+  }) => void;
   onEnvelope?: (
     envelope: FederationProtocolEnvelope,
     connection: FederationGatewayConnection,
@@ -329,7 +341,9 @@ export class FederationGatewayWebSocketServer {
       closedAt: Date.now(),
       reason: "revoked",
     });
-    connection.close();
+    // Application close code so the revoked client can report "re-pair
+    // needed" instead of a generic connection loss.
+    connection.close(FEDERATION_CLOSE_REVOKED_CODE, "revoked");
     return true;
   }
 
@@ -542,6 +556,10 @@ export class FederationGatewayWebSocketServer {
           ? "replaced_by_new_session duplicate_instance_id_suspected"
           : "replaced_by_new_session",
       );
+      this.options.onPeerReplaced?.({
+        peerId: connection.peerId,
+        duplicateInstanceIdSuspected: duplicateSuspected,
+      });
     }
     this.connections.set(connection.peerId, connection);
     this.options.store.appendAudit({
@@ -937,21 +955,23 @@ async function establishFederationClient(
     socket.close();
     throw new Error("Invalid federation auth acceptance signature");
   }
+  // Carry the close code/reason to the runtime — dropping them made a
+  // deliberate "replaced_by_new_session" eviction indistinguishable
+  // from a network blip in every log and health surface. (An error is
+  // usually followed by a close; the ended flag keeps onClose single-
+  // fire, with the error path reporting no close info.)
   let transportEnded = false;
-  const notifyTransportEnded = (info?: { code: number; reason: string }) => {
+  const onSocketClose = (code: number, reason: Buffer) => {
+    notifyTransportEnded({ code, reason: reason.toString("utf8") });
+  };
+  const onSocketError = () => notifyTransportEnded();
+  function notifyTransportEnded(info?: { code: number; reason: string }): void {
     if (transportEnded) return;
     transportEnded = true;
     socket.off("close", onSocketClose);
     socket.off("error", onSocketError);
     params.onClose?.(info);
-  };
-  // Carry the close code/reason to the runtime — dropping them made a
-  // deliberate "replaced_by_new_session" eviction indistinguishable
-  // from a network blip in every log and health surface.
-  const onSocketClose = (code: number, reason: Buffer) => {
-    notifyTransportEnded({ code, reason: reason.toString("utf8") });
-  };
-  const onSocketError = () => notifyTransportEnded();
+  }
   socket.once("close", onSocketClose);
   socket.once("error", onSocketError);
 

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -67,6 +67,12 @@ export const FEDERATION_MAX_FRAME_BYTES = 16 * 1024 * 1024;
  * application code — only a live link and an unwedged event loop.
  */
 class FederationSocketKeepalive {
+  /**
+   * Fired on every pong. The gateway assigns this once a session exists so
+   * pongs count as session heartbeats — assignable after construction
+   * because the watchdog is armed pre-auth, before there is a sessionId.
+   */
+  onLive?: () => void;
   private alive = true;
   private timer?: ReturnType<typeof setInterval>;
 
@@ -74,14 +80,12 @@ class FederationSocketKeepalive {
     socket: WebSocket,
     options: {
       intervalMs: number;
-      /** Fired on every pong — the liveness signal for session heartbeats. */
-      onLive?: () => void;
       onDead: () => void;
     },
   ) {
     socket.on("pong", () => {
       this.alive = true;
-      options.onLive?.();
+      this.onLive?.();
     });
     this.timer = setInterval(() => {
       if (socket.readyState !== WebSocket.OPEN) return;
@@ -177,6 +181,9 @@ export type FederationGatewayConnection = {
   capabilities: FederationCapability[];
   sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
   close: () => void;
+  /** Hard socket teardown for peers already presumed dead (stale sweep):
+   *  a graceful close queues a frame a wedged socket may never deliver. */
+  terminate?: () => void;
 };
 
 export type FederationGatewayWebSocketServerOptions = {
@@ -254,7 +261,9 @@ export class FederationGatewayWebSocketServer {
         const connection = [...this.connections.values()].find(
           (candidate) => candidate.sessionId === session.sessionId,
         );
-        connection?.close();
+        // The heartbeat already stopped, so the socket is presumed wedged:
+        // terminate rather than queue a close frame it may never deliver.
+        (connection?.terminate ?? connection?.close)?.();
       }
     }, keepaliveIntervalMs);
     this.sweepTimer.unref?.();
@@ -316,7 +325,7 @@ export class FederationGatewayWebSocketServer {
     // Armed for the socket's whole life, pre-auth included: a link that dies
     // silently is terminated after one missed pong instead of parking a
     // half-open connection forever.
-    new FederationSocketKeepalive(socket, {
+    const keepalive = new FederationSocketKeepalive(socket, {
       intervalMs:
         this.options.keepaliveIntervalMs ?? FEDERATION_KEEPALIVE_INTERVAL_MS,
       onDead: () => {
@@ -477,6 +486,7 @@ export class FederationGatewayWebSocketServer {
         sendFrame(socket, { kind: "envelope", envelope }, transport);
       },
       close: () => socket.close(),
+      terminate: () => socket.terminate(),
     };
     const previous = this.connections.get(connection.peerId);
     if (previous && previous.sessionId !== connection.sessionId) {
@@ -516,9 +526,9 @@ export class FederationGatewayWebSocketServer {
     clearTimeout(authDeadline);
     // Pongs count as session liveness alongside envelopes, so an idle but
     // healthy peer never trips the stale-session sweep.
-    socket.on("pong", () => {
+    keepalive.onLive = () => {
       this.sessions.heartbeat(sessionId, Date.now());
-    });
+    };
     this.options.onConnection?.(connection);
     socket.once("close", () => {
       this.sessions.closeSession({

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -43,6 +43,17 @@ const log = getMainLogger("pwragent:federation-transport");
 const FEDERATION_NOISE_TRANSPORT = "noise_ik_25519_aesgcm_sha256";
 
 /**
+ * Application close code sent to a connection evicted because the same
+ * peer instance id authenticated again. Clients use it to distinguish
+ * "another process is using my identity" from a network drop — the
+ * signature of a cloned profile state.db (duplicate instance id + key)
+ * kicking its sibling in a loop.
+ */
+export const FEDERATION_CLOSE_REPLACED_CODE = 4001;
+const REPLACEMENT_FLAP_WINDOW_MS = 5 * 60_000;
+const REPLACEMENT_FLAP_THRESHOLD = 3;
+
+/**
  * Liveness probe cadence (ssh ClientAliveInterval / ServerAliveInterval
  * analogue, both directions). A peer that misses one full interval's pong is
  * terminated, so a silently dropped link (sleep, NAT timeout, power loss) is
@@ -180,7 +191,7 @@ export type FederationGatewayConnection = {
   sessionId: FederationSessionId;
   capabilities: FederationCapability[];
   sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
-  close: () => void;
+  close: (code?: number, reason?: string) => void;
   /** Hard socket teardown for peers already presumed dead (stale sweep):
    *  a graceful close queues a frame a wedged socket may never deliver. */
   terminate?: () => void;
@@ -225,6 +236,9 @@ export class FederationGatewayWebSocketServer {
     FederationInstanceId,
     FederationGatewayConnection
   >();
+
+  /** Recent eviction timestamps per peer id, for duplicate-id detection. */
+  private readonly replacementsByPeerId = new Map<FederationInstanceId, number[]>();
 
   constructor(private readonly options: FederationGatewayWebSocketServerOptions) {
     this.sessions = options.sessions ?? new FederationSessionRegistry();
@@ -485,12 +499,49 @@ export class FederationGatewayWebSocketServer {
       sendEnvelope: (envelope) => {
         sendFrame(socket, { kind: "envelope", envelope }, transport);
       },
-      close: () => socket.close(),
+      close: (code?: number, reason?: string) => socket.close(code, reason),
       terminate: () => socket.terminate(),
     };
     const previous = this.connections.get(connection.peerId);
     if (previous && previous.sessionId !== connection.sessionId) {
-      previous.close();
+      // Evictions were previously silent (bare close, no log, no audit),
+      // which made a duplicate-identity kick loop invisible. Audit the
+      // eviction BEFORE the new session's "connected" row so the trail
+      // reads in causal order, and close with an application code the
+      // client can distinguish from a network drop. Repeated evictions
+      // inside the window are the cloned-profile signature — flag them.
+      const now = Date.now();
+      const replacements = [
+        ...(this.replacementsByPeerId.get(connection.peerId) ?? []).filter(
+          (at) => now - at < REPLACEMENT_FLAP_WINDOW_MS,
+        ),
+        now,
+      ];
+      this.replacementsByPeerId.set(connection.peerId, replacements);
+      const duplicateSuspected =
+        replacements.length >= REPLACEMENT_FLAP_THRESHOLD;
+      this.options.store.appendAudit({
+        peerId: connection.peerId,
+        sessionId: previous.sessionId,
+        kind: "disconnected",
+        createdAt: now,
+        detail: duplicateSuspected
+          ? "replaced:duplicate_instance_id_suspected"
+          : "replaced",
+      });
+      log.warn("federation peer session replaced", {
+        peerId: connection.peerId,
+        previousSessionId: previous.sessionId,
+        sessionId,
+        replacementsInWindow: replacements.length,
+        duplicateInstanceIdSuspected: duplicateSuspected,
+      });
+      previous.close(
+        FEDERATION_CLOSE_REPLACED_CODE,
+        duplicateSuspected
+          ? "replaced_by_new_session duplicate_instance_id_suspected"
+          : "replaced_by_new_session",
+      );
     }
     this.connections.set(connection.peerId, connection);
     this.options.store.appendAudit({
@@ -536,10 +587,15 @@ export class FederationGatewayWebSocketServer {
         closedAt: Date.now(),
         reason: "transport_closed",
       });
-      if (this.connections.get(connection.peerId)?.sessionId === sessionId) {
+      // A replaced session no longer owns the peer entry; its eviction
+      // was already audited on the replace path — don't add a second,
+      // later "disconnected" row for the same session.
+      const stillOwner =
+        this.connections.get(connection.peerId)?.sessionId === sessionId;
+      if (stillOwner) {
         this.connections.delete(connection.peerId);
       }
-      if (!this.stopping) {
+      if (!this.stopping && stillOwner) {
         this.options.store.appendAudit({
           peerId: connection.peerId,
           sessionId,
@@ -670,7 +726,12 @@ export async function connectFederationClient(params: {
   /** Pinned gateway Noise static public key (raw 32 bytes), from the invite. */
   gatewayNoisePublicKey?: Buffer;
   onEnvelope?: (envelope: FederationProtocolEnvelope) => void;
-  onClose?: () => void;
+  /**
+   * Called once when the transport ends. `info` carries the WebSocket
+   * close code/reason when the peer closed cleanly (e.g. 4001
+   * "replaced_by_new_session"); undefined for socket errors.
+   */
+  onClose?: (info?: { code: number; reason: string }) => void;
 }): Promise<FederationClientWebSocketClient> {
   const connectTimeoutMs =
     params.connectTimeoutMs ?? FEDERATION_CONNECT_TIMEOUT_MS;
@@ -877,15 +938,22 @@ async function establishFederationClient(
     throw new Error("Invalid federation auth acceptance signature");
   }
   let transportEnded = false;
-  const notifyTransportEnded = () => {
+  const notifyTransportEnded = (info?: { code: number; reason: string }) => {
     if (transportEnded) return;
     transportEnded = true;
-    socket.off("close", notifyTransportEnded);
-    socket.off("error", notifyTransportEnded);
-    params.onClose?.();
+    socket.off("close", onSocketClose);
+    socket.off("error", onSocketError);
+    params.onClose?.(info);
   };
-  socket.once("close", notifyTransportEnded);
-  socket.once("error", notifyTransportEnded);
+  // Carry the close code/reason to the runtime — dropping them made a
+  // deliberate "replaced_by_new_session" eviction indistinguishable
+  // from a network blip in every log and health surface.
+  const onSocketClose = (code: number, reason: Buffer) => {
+    notifyTransportEnded({ code, reason: reason.toString("utf8") });
+  };
+  const onSocketError = () => notifyTransportEnded();
+  socket.once("close", onSocketClose);
+  socket.once("error", onSocketError);
 
   // Client-side liveness probes (the ssh ServerAliveInterval direction):
   // a gateway whose link died silently is terminated, which fires onClose

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -54,7 +54,11 @@ import { useAppearance, type AppearanceController } from "./lib/useAppearance";
 import { useBackendSummaries } from "./lib/useBackendSummaries";
 import { useDesktopApi, type DesktopApi } from "./lib/desktop-api";
 import { useDesktopApplications } from "./lib/useDesktopApplications";
-import { readRendererFederationTarget } from "./lib/federation-window";
+import {
+  readRendererFederationLabel,
+  readRendererFederationTarget,
+} from "./lib/federation-window";
+import { useFederationPeerConnectivity } from "./lib/useFederationPeerConnectivity";
 import { scopeDesktopApiToFederationTarget } from "./lib/federation-desktop-api";
 import { useRuntimeIdentity } from "./lib/runtime-identity";
 import {
@@ -725,6 +729,10 @@ function DesktopAppShell(props: {
     () => scopeDesktopApiToFederationTarget(desktopApi, activeFederationTarget),
     [activeFederationTarget, desktopApi],
   );
+  const peerConnectivity = useFederationPeerConnectivity({
+    desktopApi,
+    target: activeFederationTarget,
+  });
   const applications = useDesktopApplications({
     desktopApi,
     localApplications: settings.snapshot?.applications,
@@ -917,6 +925,9 @@ function DesktopAppShell(props: {
     composerDraftStore,
     desktopApi,
     federationTarget: activeFederationTarget,
+    // A disconnected peer fails every reconciliation tick — stop polling
+    // until the runtime reports the peer connected again.
+    suspended: !peerConnectivity.connected,
   });
   const replayCodexProfileSetup = settings.snapshot
     ? inferReplayCodexProfileSetup(
@@ -1163,6 +1174,9 @@ function DesktopAppShell(props: {
     clearPendingRequest: session.clearPendingRequest,
     composerDisabled:
       !navigation.selectedThread ||
+      // A remote thread cannot accept input while its owning instance is
+      // unreachable — typing would only queue into a dead RPC.
+      !peerConnectivity.connected ||
       !backendSummaries.backends.some(
         (backend) =>
           backend.kind === navigation.selectedThread?.source &&
@@ -1652,6 +1666,16 @@ function DesktopAppShell(props: {
             threadDetailPending ? " app-main--thread-detail-pending" : ""
           }`}
         >
+          {!peerConnectivity.connected ? (
+            // The runtime keeps reconnecting on its own; this banner
+            // explains why the window went read-only (composer disabled,
+            // remote polling suspended) instead of leaving a half-dead
+            // surface that fails silently.
+            <div className="federation-disconnected-banner" role="alert">
+              <span className="federation-disconnected-banner__dot" aria-hidden="true" />
+              {`${readRendererFederationLabel() ?? "Remote instance"} is unreachable — reconnecting. Threads shown may be stale.`}
+            </div>
+          ) : null}
           {mainView === "search" ? (
             <ThreadSearchPanel
               desktopApi={desktopApi}

--- a/apps/desktop/src/renderer/src/lib/__tests__/useFederationPeerConnectivity.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useFederationPeerConnectivity.test.tsx
@@ -1,0 +1,119 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentEvent } from "@pwragent/shared";
+import type { DesktopApi } from "../desktop-api";
+import { useFederationPeerConnectivity } from "../useFederationPeerConnectivity";
+
+function buildDesktopApi(params: {
+  seededStatus?: "connected" | "disconnected";
+}): {
+  desktopApi: DesktopApi;
+  emit: (event: AgentEvent) => void;
+} {
+  let listener: ((event: AgentEvent) => void) | undefined;
+  const desktopApi: DesktopApi = {
+    readFederationHealth: vi.fn(async () => ({
+      health: {
+        enabled: true,
+        role: "client" as const,
+        status: "connected" as const,
+        peers: params.seededStatus
+          ? [
+              {
+                id: "peer_one",
+                label: "Mac-Mini-M4",
+                role: "gateway" as const,
+                status: params.seededStatus,
+                capabilities: [],
+              },
+            ]
+          : [],
+      },
+    })),
+    onAgentEvent: vi.fn((callback: (event: AgentEvent) => void) => {
+      listener = callback;
+      return () => {
+        listener = undefined;
+      };
+    }),
+  };
+  return {
+    desktopApi,
+    emit: (event) => listener?.(event),
+  };
+}
+
+function peerStatusEvent(
+  instanceId: string,
+  status: string,
+  unavailableReason?: string,
+): AgentEvent {
+  return {
+    backend: "codex",
+    federationTarget: { scope: "remote", instanceId },
+    notification: {
+      method: "federation/peerStatus/changed",
+      params: { instanceId, status, ...(unavailableReason ? { unavailableReason } : {}) },
+    },
+  } as AgentEvent;
+}
+
+describe("useFederationPeerConnectivity", () => {
+  it("stays connected without a target (local windows)", () => {
+    const { desktopApi } = buildDesktopApi({});
+    const { result } = renderHook(() =>
+      useFederationPeerConnectivity({ desktopApi }),
+    );
+    expect(result.current.connected).toBe(true);
+    expect(desktopApi.readFederationHealth).not.toHaveBeenCalled();
+  });
+
+  it("seeds from health and follows peerStatus transitions", async () => {
+    const { desktopApi, emit } = buildDesktopApi({
+      seededStatus: "disconnected",
+    });
+    const { result } = renderHook(() =>
+      useFederationPeerConnectivity({
+        desktopApi,
+        target: { scope: "remote", instanceId: "peer_one" },
+      }),
+    );
+
+    // Before the health read resolves the hook reports connected so
+    // surfaces don't flash a disconnected state during boot.
+    expect(result.current.connected).toBe(true);
+    await waitFor(() => {
+      expect(result.current.connected).toBe(false);
+    });
+    expect(result.current.status).toBe("disconnected");
+
+    act(() => {
+      emit(peerStatusEvent("peer_one", "connected"));
+    });
+    expect(result.current.connected).toBe(true);
+
+    act(() => {
+      emit(peerStatusEvent("peer_one", "disconnected", "Peer went away."));
+    });
+    expect(result.current.connected).toBe(false);
+    expect(result.current.unavailableReason).toBe("Peer went away.");
+  });
+
+  it("ignores status events for other peers", async () => {
+    const { desktopApi, emit } = buildDesktopApi({ seededStatus: "connected" });
+    const { result } = renderHook(() =>
+      useFederationPeerConnectivity({
+        desktopApi,
+        target: { scope: "remote", instanceId: "peer_one" },
+      }),
+    );
+    await waitFor(() => {
+      expect(result.current.status).toBe("connected");
+    });
+
+    act(() => {
+      emit(peerStatusEvent("peer_other", "disconnected"));
+    });
+    expect(result.current.connected).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/useFederationPeerConnectivity.ts
+++ b/apps/desktop/src/renderer/src/lib/useFederationPeerConnectivity.ts
@@ -1,0 +1,99 @@
+import { useEffect, useMemo, useState } from "react";
+import type {
+  FederationConnectionState,
+  FederationRemoteTarget,
+} from "@pwragent/shared";
+import type { DesktopApi } from "./desktop-api";
+
+export type FederationPeerConnectivity = {
+  /**
+   * True while the target peer is reachable — and also before the first
+   * health read resolves, so surfaces never flash "disconnected" during
+   * boot. Local windows (no target) are always connected.
+   */
+  connected: boolean;
+  status?: FederationConnectionState;
+  unavailableReason?: string;
+};
+
+/**
+ * Live connectivity of the federation peer this window targets. Seeds
+ * from readFederationHealth, then follows the
+ * `federation/peerStatus/changed` agent events the runtime publishes on
+ * every transition — the same signal useThreadNavigation uses for its
+ * error state. Consumers use it to suspend remote polling and disable
+ * write surfaces instead of hammering a dead peer with RPCs.
+ */
+export function useFederationPeerConnectivity(params: {
+  desktopApi?: DesktopApi;
+  target?: FederationRemoteTarget;
+}): FederationPeerConnectivity {
+  const desktopApi = params.desktopApi;
+  const instanceId = params.target?.instanceId;
+  const [state, setState] = useState<{
+    status?: FederationConnectionState;
+    unavailableReason?: string;
+  }>({});
+
+  useEffect(() => {
+    if (!instanceId) {
+      setState({});
+      return;
+    }
+    let cancelled = false;
+    void desktopApi
+      ?.readFederationHealth?.({})
+      .then((response) => {
+        if (cancelled) return;
+        const peer = response.health.peers.find(
+          (candidate) => candidate.id === instanceId,
+        );
+        if (peer) {
+          // Functional update: a peerStatus event that raced the health
+          // read is newer — do not clobber it with the snapshot.
+          setState((current) =>
+            current.status === undefined
+              ? {
+                  status: peer.status,
+                  unavailableReason: peer.unavailableReason,
+                }
+              : current,
+          );
+        }
+      })
+      .catch(() => {
+        // Health is a seed; the event stream below is the live source.
+      });
+    const unsubscribe = desktopApi?.onAgentEvent?.((event) => {
+      if (event.notification.method !== "federation/peerStatus/changed") {
+        return;
+      }
+      const status = event.notification.params as {
+        instanceId: string;
+        status: FederationConnectionState;
+        unavailableReason?: string;
+      };
+      if (status.instanceId !== instanceId) return;
+      setState({
+        status: status.status,
+        unavailableReason: status.unavailableReason,
+      });
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [desktopApi, instanceId]);
+
+  return useMemo(
+    () => ({
+      connected:
+        !instanceId
+        || state.status === undefined
+        || state.status === "connected",
+      status: state.status,
+      unavailableReason: state.unavailableReason,
+    }),
+    [instanceId, state],
+  );
+}

--- a/apps/desktop/src/renderer/src/lib/useScheduledThreadActionProjection.ts
+++ b/apps/desktop/src/renderer/src/lib/useScheduledThreadActionProjection.ts
@@ -10,16 +10,26 @@ export function useScheduledThreadActionProjection(params: {
   composerDraftStore: ComposerDraftStore;
   desktopApi?: DesktopApi;
   federationTarget?: FederationTarget;
+  /**
+   * True while the federation peer behind `federationTarget` is
+   * unreachable. Suspends the reconciliation poll so a disconnected
+   * remote window doesn't hammer the dead peer with a failing RPC (and
+   * a console warning) every five seconds; resuming re-runs the effect
+   * and refreshes immediately.
+   */
+  suspended?: boolean;
 }): void {
   const refreshSequenceRef = useRef(0);
   const projectedScopeKeysRef = useRef<Set<string>>(new Set());
   const projectedFailuresRef = useRef<Map<string, ScheduledThreadAction>>(new Map());
   const dismissedFailuresRef = useRef<Set<string>>(new Set());
   const terminalUpdatedAfterRef = useRef<number | undefined>(undefined);
+  const lastWarnedFailureRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     const desktopApi = params.desktopApi;
     if (!desktopApi?.listScheduledThreadActions) return;
+    if (params.suspended) return;
     let cancelled = false;
 
     const refresh = async (): Promise<void> => {
@@ -61,8 +71,16 @@ export function useScheduledThreadActionProjection(params: {
           visibleActions,
           projectedScopeKeysRef.current,
         );
+        lastWarnedFailureRef.current = undefined;
       } catch (error) {
-        console.warn("Failed to load scheduled thread actions", error);
+        // A persistent failure (peer offline, backend down) repeats on
+        // every 5s reconciliation tick — warn once per distinct failure
+        // instead of spamming the console/log for the same condition.
+        const message = error instanceof Error ? error.message : String(error);
+        if (lastWarnedFailureRef.current !== message) {
+          lastWarnedFailureRef.current = message;
+          console.warn("Failed to load scheduled thread actions", error);
+        }
       }
     };
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9045,6 +9045,33 @@ textarea,
   max-width: min(26ch, 28%);
 }
 
+/* Window-level notice for a remote federation window whose peer is
+   unreachable: the composer disables and remote polling suspends, so
+   the banner is the one place that says why. Warning tones (not danger)
+   — the runtime is auto-reconnecting and the state is expected to heal. */
+.federation-disconnected-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 10px 16px 0;
+  padding: 8px 12px;
+  border: 1px solid var(--accent-border);
+  border-radius: 8px;
+  background: var(--warning-surface);
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.federation-disconnected-banner__dot {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--status-warning);
+}
+
 .thread-header__warning {
   max-width: min(72vw, 760px);
   margin: 10px 0 0;


### PR DESCRIPTION
## Summary

Fixes the dogfood report: a remote window whose peer went down spewed `scheduled-actions:list … peer not connected` every 5s over a blank thread list with a live composer, and after the peer came back the window flashed connected/disconnected on an exact 30s cycle indefinitely.

**Root cause of the 30s flap** (found by code investigation): the M5 was running two profiles whose `state.db` shares a lineage — the federation **instance id and identity key both live in `state.db`**, so a cloned profile presents the *same identity*. The gateway evicts the previous connection whenever the same peer id authenticates (`federation-transport.ts` replace path), so the two processes evict each other forever; because no session survives the 60s stability window, reconnect backoff pins at the 30s ceiling (`min(1000·2^n, 30000)` never resets). The eviction was completely unobservable: bare `socket.close()` (code 1000, no reason), zero logging, and the client's close handler dropped the code/reason and logged nothing.

### Renderer — graceful disable (option 1 from the report)
- `useFederationPeerConnectivity`: seeds from federation health, follows `federation/peerStatus/changed` (the signal `useThreadNavigation` already uses).
- Scheduled-actions projection **suspends its 5s poll** while the peer is down (resume refreshes immediately) and warns **once per distinct failure** — kills the log spam.
- Remote windows go explicitly read-only on disconnect: **composer disabled** + a warning banner naming the machine ("… is unreachable — reconnecting. Threads shown may be stale."). The runtime keeps reconnecting on its own.

### Main — observable evictions + correctness
- Gateway eviction now audits `replaced` for the old session *before* the new `connected` row (causal order), logs with replacement counts, closes with application code **4001 `replaced_by_new_session`**, and appends `duplicate_instance_id_suspected` when evictions repeat ≥3× in 5 minutes. No more duplicate `transport_closed` audit row for the evicted socket.
- Client close path now carries the WebSocket code/reason: logs `federation client session closed` with code/reason/**session age** (a repeating sub-minute age makes a kick loop obvious), audits `transport_closed:<code>`, and maps 4001 to a new `replaced` failure kind — health reads **degraded** with an actionable message: duplicate identity from a cloned profile; reset federation on one of them.
- `disconnectAdvertisedPeers` no longer false-publishes "disconnected" for peers holding a live connection to this instance's own gateway (dual-mode bug).

## Verification

- Transport unit test: same-id reconnect evicts with 4001 + correct audit ordering, no duplicate rows.
- Connectivity hook unit tests (3): local windows always connected, seed + transitions, other-peer isolation.
- Federation E2E extended: **kills the in-process gateway** → banner + disabled composer appear; **restarts it on the same port/identity** → window heals with no reload. Passes locally.
- Workspace typecheck, ESLint (0 errors), `lint:boundaries`, renderer lib + main federation suites green.

## Notes / follow-ups (not in this PR)
- No heartbeat/keepalive exists — an abruptly dead peer stays "connected" until TCP gives up (RPCs die at the 30s deadline). `expireStaleSessions` exists but has no caller; wiring it to a ping/pong is the natural next PR.
- Enrollment currently re-pins an existing peer id to a new key without objection; rejecting that unless the operator re-pairs would close the H2 variant of the duplicate-identity case.
- Operator remediation for the observed loop: one of the two same-machine profiles has a cloned `state.db` — reset federation on one of them (Forget gateway + re-enroll); it will mint a fresh identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)