### PR TITLE
feat(messaging): add branded Slack App Home

### DIFF
--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { SlackAdapter, type SlackApi, type SlackSocketClient } from "../slack-adapter.ts";
+import type { SlackHomeView } from "../slack-home.ts";
 import type {
   MessagingChannelRef,
   MessagingCallbackHandleRecord,
@@ -61,6 +62,7 @@ function fakeApi(spies: {
   permalinks?: Record<string, string>;
   deleted?: Array<{ channel: string; ts: string }>;
   deleteErrors?: Error[];
+  publishedHomes?: Array<{ userId: string; view: SlackHomeView }>;
   posted?: unknown[];
   replies?: Record<string, string>;
   updated?: unknown[];
@@ -103,6 +105,9 @@ function fakeApi(spies: {
     postMessage: async (params) => {
       spies.posted?.push(params);
       return { channel: params.channel, ts: "1712023032.123456" };
+    },
+    publishHomeView: async (params) => {
+      spies.publishedHomes?.push(params);
     },
     updateMessage: async (params) => {
       spies.updated?.push(params);
@@ -158,6 +163,85 @@ describe("SlackAdapter", () => {
     expect(adapter.capabilityProfile.actions?.maxActions).toBe(25);
     expect(adapter.capabilityProfile.actions?.supportsLayoutHints).toBe(true);
     expect(adapter.capabilityProfile.text.markdownDialect).toBe("markdown");
+  });
+
+  it("publishes App Home for authorized users during startup", async () => {
+    const publishedHomes: Array<{ userId: string; view: SlackHomeView }> = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ publishedHomes }),
+      socketClient: fakeSocket(),
+    });
+
+    await adapter.start(async () => undefined);
+
+    expect(publishedHomes).toHaveLength(1);
+    expect(publishedHomes[0]).toMatchObject({
+      userId: "U012ABCDEF0",
+      view: { type: "home" },
+    });
+    expect(JSON.stringify(publishedHomes[0]?.view)).toContain(
+      "https://pwragent.ai/assets/logo.png",
+    );
+  });
+
+  it("acknowledges App Home opens and refreshes the user's Home tab", async () => {
+    const publishedHomes: Array<{ userId: string; view: SlackHomeView }> = [];
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ publishedHomes }),
+      socketClient: socket,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+    publishedHomes.length = 0;
+    let acknowledged = false;
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => {
+        acknowledged = true;
+      },
+      event: {
+        type: "app_home_opened",
+        tab: "home",
+        user: "U012ABCDEF0",
+      },
+    });
+
+    expect(acknowledged).toBe(true);
+    expect(events).toEqual([]);
+    expect(publishedHomes).toHaveLength(1);
+    expect(publishedHomes[0]?.userId).toBe("U012ABCDEF0");
+  });
+
+  it("keeps Slack messaging available when App Home publishing fails", async () => {
+    const warnings: Array<{ message: string; data?: Record<string, unknown> }> = [];
+    const api = fakeApi({});
+    api.publishHomeView = async () => {
+      throw new Error("not_enabled");
+    };
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api,
+      logger: {
+        warn: (message, data) => {
+          warnings.push({ message, data });
+        },
+      },
+      socketClient: fakeSocket(),
+    });
+
+    await expect(adapter.start(async () => undefined)).resolves.toBeUndefined();
+    expect(warnings).toContainEqual({
+      message: "slack App Home publish failed",
+      data: { reason: "not_enabled" },
+    });
   });
 
   it("posts assistant Markdown tables through Slack's native Markdown block", async () => {

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -186,6 +186,35 @@ describe("SlackAdapter", () => {
     );
   });
 
+  it("skips authorized bot actors when publishing App Homes", async () => {
+    const publishedHomes: Array<{ userId: string; view: SlackHomeView }> = [];
+    const warnings: Array<{ message: string; data?: Record<string, unknown> }> = [];
+    const adapter = new SlackAdapter({
+      config: {
+        ...baseConfig,
+        authorizedActorIds: [
+          ...baseConfig.authorizedActorIds,
+          { id: "B012DATADOG", displayName: "Datadog" },
+        ],
+      },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ publishedHomes }),
+      logger: {
+        warn: (message, data) => {
+          warnings.push({ message, data });
+        },
+      },
+      socketClient: fakeSocket(),
+    });
+
+    await adapter.start(async () => undefined);
+
+    expect(publishedHomes.map((home) => home.userId)).toEqual([
+      "U012ABCDEF0",
+    ]);
+    expect(warnings).toEqual([]);
+  });
+
   it("acknowledges App Home opens and refreshes the user's Home tab", async () => {
     const publishedHomes: Array<{ userId: string; view: SlackHomeView }> = [];
     const socket = fakeSocket();

--- a/packages/messaging/providers/slack/src/__tests__/slack-home.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-home.test.ts
@@ -17,6 +17,7 @@ const lockedDownConfig: SlackMessagingConfig = {
     { id: "C012ABCDEF0", displayName: "engineering" },
     { id: "C012ABCDEF1", displayName: "product" },
   ],
+  slashCommandPrefix: "pwragent_",
 };
 
 describe("buildSlackHomeView", () => {
@@ -35,6 +36,11 @@ describe("buildSlackHomeView", () => {
     expect(payload).toContain("1 approved workspace");
     expect(payload).toContain("2 approved conversations");
     expect(payload).toContain("2 configured users");
+    expect(payload).toContain("/pwragent_new");
+    expect(payload).toContain("/pwragent_resume");
+    expect(payload).toContain("/pwragent_help");
+    expect(payload).toContain("/pwragent_status");
+    expect(payload).not.toContain("Use `/new`");
     expect(payload).not.toContain("T012ABCDEF0");
     expect(payload).not.toContain("C012ABCDEF0");
     expect(payload).not.toContain("engineering");

--- a/packages/messaging/providers/slack/src/__tests__/slack-home.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-home.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { buildSlackHomeView } from "../slack-home.ts";
+import type { SlackMessagingConfig } from "../slack-config.ts";
+
+const lockedDownConfig: SlackMessagingConfig = {
+  channel: "slack",
+  botToken: "xoxb-test",
+  appToken: "xapp-test",
+  authorizedActorIds: [
+    { id: "U012ABCDEF0", displayName: "Alice" },
+    { id: "U012ABCDEF1", displayName: "Bob" },
+  ],
+  authorizedTeamIds: [
+    { id: "T012ABCDEF0", displayName: "PwrDrvr" },
+  ],
+  authorizedConversationIds: [
+    { id: "C012ABCDEF0", displayName: "engineering" },
+    { id: "C012ABCDEF1", displayName: "product" },
+  ],
+};
+
+describe("buildSlackHomeView", () => {
+  it("builds a branded, useful Home tab without exposing allowlisted IDs", () => {
+    const view = buildSlackHomeView({
+      config: lockedDownConfig,
+      userId: "U012ABCDEF0",
+    });
+    const payload = JSON.stringify(view);
+
+    expect(view.type).toBe("home");
+    expect(view.blocks).toHaveLength(14);
+    expect(payload).toContain("https://pwragent.ai/assets/logo.png");
+    expect(payload).toContain("Welcome, <@U012ABCDEF0>");
+    expect(payload).toContain("Permission controls, by design");
+    expect(payload).toContain("1 approved workspace");
+    expect(payload).toContain("2 approved conversations");
+    expect(payload).toContain("2 configured users");
+    expect(payload).not.toContain("T012ABCDEF0");
+    expect(payload).not.toContain("C012ABCDEF0");
+    expect(payload).not.toContain("engineering");
+  });
+
+  it("describes open Slack gates without implying an allowlist", () => {
+    const view = buildSlackHomeView({
+      config: {
+        ...lockedDownConfig,
+        teamAuthorizationMode: "allow_all",
+        channelAuthorizationMode: "allow_all",
+        channelUserAccessMode: "any_channel_user",
+        dmAccessMode: "any_workspace_user",
+        groupDmAccessMode: "authorized_users",
+      },
+      userId: "U012ABCDEF0",
+    });
+    const payload = JSON.stringify(view);
+
+    expect(payload).toContain("Any workspace reaching this installation");
+    expect(payload).toContain("Any channel the bot can access");
+    expect(payload).toContain("Any member of an approved channel");
+    expect(payload).toContain("Any workspace user");
+    expect(payload).toContain("Authorized users, when they mention the bot");
+  });
+});

--- a/packages/messaging/providers/slack/src/index.ts
+++ b/packages/messaging/providers/slack/src/index.ts
@@ -1,6 +1,7 @@
 export type { SlackMessagingConfig, SlackInboundMode } from "./slack-config.ts";
 export { validateCredentials } from "./validate-credentials.ts";
 export { resolveContact } from "./resolve-contact.ts";
+export { buildSlackHomeView, type SlackHomeView } from "./slack-home.ts";
 export type {
   SlackAdapterOptions,
   SlackApi,

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -48,6 +48,7 @@ import type {
   SlackAuthorizedContact,
   SlackMessagingConfig,
 } from "./slack-config.ts";
+import { buildSlackHomeView, type SlackHomeView } from "./slack-home.ts";
 import {
   actionsForSlackIntent,
   buildSlackActionBlocks,
@@ -108,6 +109,10 @@ export type SlackApi = {
   downloadFile(params: { url: string; maxBytes: number }): Promise<Uint8Array>;
   filesInfo(params: { file: string }): Promise<SlackFileInfo | undefined>;
   postMessage(params: SlackPostBody): Promise<SlackMessageResult>;
+  publishHomeView?(params: {
+    userId: string;
+    view: SlackHomeView;
+  }): Promise<void>;
   updateMessage(params: SlackPostBody & { ts: string }): Promise<SlackMessageResult>;
   uploadFile?(params: {
     channel: string;
@@ -257,6 +262,12 @@ type SlackMessageEvent = {
   thread_ts?: string;
   ts?: string;
   type: "app_mention" | "message";
+  user?: string;
+};
+
+type SlackAppHomeOpenedEvent = {
+  tab?: "home" | "messages";
+  type: "app_home_opened";
   user?: string;
 };
 
@@ -415,6 +426,10 @@ export class SlackAdapter implements SlackProviderAdapter {
   }
 
   async updateAuthorization(update: MessagingAdapterAuthorizationUpdate): Promise<void> {
+    const homeUserIds = new Set([
+      ...this.authorizedActorIdsValue,
+      ...update.authorizedActorIds,
+    ]);
     this.authorizedActorIdsValue = [...update.authorizedActorIds];
     if (update.responseMode !== undefined) {
       this.config.responseMode = update.responseMode;
@@ -461,6 +476,9 @@ export class SlackAdapter implements SlackProviderAdapter {
       update.authorizedWorkspaceIds ?? [],
       this.config.authorizedTeamIds,
     );
+    if (this.started) {
+      await this.publishAppHomes([...homeUserIds]);
+    }
   }
 
   async updateRenderingPreferences(
@@ -511,6 +529,11 @@ export class SlackAdapter implements SlackProviderAdapter {
     this.socketClient.on("slash_commands", this.handleSlashCommand);
     await this.socketClient.start();
     this.started = true;
+    // Existing PwrAgent Slack apps may have the Home tab enabled without an
+    // `app_home_opened` subscription. Pre-publishing for configured users
+    // replaces Slack's indefinite loading state as soon as the adapter starts;
+    // the event handler below keeps the view fresh for apps that do subscribe.
+    await this.publishAppHomes(this.authorizedActorIdsValue);
   }
 
   async stop(): Promise<void> {
@@ -788,12 +811,54 @@ export class SlackAdapter implements SlackProviderAdapter {
     const body = envelope.body as SlackEventsApiBody | undefined;
     const event = (envelope.event ?? body?.event) as
       | SlackMessageEvent
+      | SlackAppHomeOpenedEvent
       | undefined;
+    if (event?.type === "app_home_opened") {
+      if (!event.tab || event.tab === "home") {
+        await this.publishAppHome(event.user);
+      }
+      return;
+    }
     if (!event || (event.type !== "message" && event.type !== "app_mention")) {
       return;
     }
     await this.handleMessageEvent(event, body?.team_id ?? event.team);
   };
+
+  private async publishAppHomes(userIds: readonly string[]): Promise<void> {
+    await Promise.all(
+      [...new Set(userIds)].map(
+        async (userId) => await this.publishAppHome(userId),
+      ),
+    );
+  }
+
+  private async publishAppHome(userId: unknown): Promise<void> {
+    if (!this.api.publishHomeView) return;
+    const validation = validateSlackUserId(userId);
+    if (!validation.ok) {
+      logSlackInvalidIdentifier({
+        field: "user_id",
+        logger: this.logger,
+        reason: validation.reason,
+        value: userId,
+      });
+      return;
+    }
+    try {
+      await this.api.publishHomeView({
+        userId: userId as string,
+        view: buildSlackHomeView({
+          config: this.config,
+          userId: userId as string,
+        }),
+      });
+    } catch (error) {
+      this.logger.warn?.("slack App Home publish failed", {
+        reason: slackErrorReason(error),
+      });
+    }
+  }
 
   private readonly handleInteractive = async (payload: unknown): Promise<void> => {
     const envelope = payload as SlackSocketEnvelope;
@@ -2313,6 +2378,12 @@ export function createSlackApi(botToken: string): SlackApi {
       return (await client.chat.postMessage(
         params as unknown as Parameters<typeof client.chat.postMessage>[0],
       )) as SlackMessageResult;
+    },
+    async publishHomeView(params) {
+      await client.views.publish({
+        user_id: params.userId,
+        view: params.view as unknown as Parameters<typeof client.views.publish>[0]["view"],
+      });
     },
     async updateMessage(params) {
       return (await client.chat.update(

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -826,8 +826,11 @@ export class SlackAdapter implements SlackProviderAdapter {
   };
 
   private async publishAppHomes(userIds: readonly string[]): Promise<void> {
+    const homeUserIds = [...new Set(userIds)].filter(
+      (userId) => !validateSlackBotId(userId).ok,
+    );
     await Promise.all(
-      [...new Set(userIds)].map(
+      homeUserIds.map(
         async (userId) => await this.publishAppHome(userId),
       ),
     );

--- a/packages/messaging/providers/slack/src/slack-home.ts
+++ b/packages/messaging/providers/slack/src/slack-home.ts
@@ -1,0 +1,252 @@
+import {
+  SLACK_CHANNEL_AUTHORIZATION_MODE_DEFAULT,
+  SLACK_CHANNEL_USER_ACCESS_MODE_DEFAULT,
+  SLACK_DM_ACCESS_MODE_DEFAULT,
+  SLACK_GROUP_DM_ACCESS_MODE_DEFAULT,
+  SLACK_TEAM_AUTHORIZATION_MODE_DEFAULT,
+} from "@pwragent/messaging-interface";
+import type { SlackMessagingConfig } from "./slack-config.ts";
+
+const PWRAGENT_LOGO_URL = "https://pwragent.ai/assets/logo.png";
+
+type SlackHomeTextObject = {
+  type: "mrkdwn" | "plain_text";
+  text: string;
+  emoji?: boolean;
+};
+
+type SlackHomeImageElement = {
+  type: "image";
+  image_url: string;
+  alt_text: string;
+};
+
+type SlackHomeBlock =
+  | {
+      type: "header";
+      text: SlackHomeTextObject & { type: "plain_text" };
+    }
+  | { type: "divider" }
+  | {
+      type: "section";
+      text?: SlackHomeTextObject;
+      fields?: SlackHomeTextObject[];
+      accessory?: SlackHomeImageElement;
+    }
+  | {
+      type: "context";
+      elements: SlackHomeTextObject[];
+    };
+
+export type SlackHomeView = {
+  type: "home";
+  blocks: SlackHomeBlock[];
+};
+
+/**
+ * Build the private, per-user landing page Slack renders in the app's Home tab.
+ * The copy is intentionally useful without exposing allowlisted Slack IDs or
+ * desktop-only state across the provider boundary.
+ */
+export function buildSlackHomeView(params: {
+  config: SlackMessagingConfig;
+  userId: string;
+}): SlackHomeView {
+  const config = params.config;
+  return {
+    type: "home",
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: [
+            `*Welcome, <@${params.userId}>*`,
+            "*Your coding agent runs on your computer. You drive it from Slack.*",
+            "Start work, resume a thread, steer the agent, answer questions, and approve protected actions without returning to your desk.",
+          ].join("\n"),
+        },
+        accessory: {
+          type: "image",
+          image_url: PWRAGENT_LOGO_URL,
+          alt_text: "PwrAgent logo",
+        },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "PwrAgent is open source, MIT-licensed, and local-first.",
+          },
+        ],
+      },
+      { type: "divider" },
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: "What you can do",
+          emoji: true,
+        },
+      },
+      {
+        type: "section",
+        fields: [
+          homeField(
+            ":rocket: Start or resume",
+            "Use `/new` for fresh work or `/resume` to pick up an existing thread.",
+          ),
+          homeField(
+            ":control_knobs: Steer from Slack",
+            "Send prompts, queue follow-ups, stop work, or continue the same thread from desktop.",
+          ),
+          homeField(
+            ":mag: Review and decide",
+            "Read results, inspect tool activity, answer questions, and approve protected commands.",
+          ),
+          homeField(
+            ":card_file_box: Keep context attached",
+            "Share files and images, choose projects and worktrees, and keep each Slack thread bound to the right coding thread.",
+          ),
+          homeField(
+            ":satellite_antenna: Monitor and schedule",
+            "Watch active work, schedule a future prompt, and get the result back in the conversation where it belongs.",
+          ),
+          homeField(
+            ":information_source: See every command",
+            "Send `/help` or mention the bot with `help` for the live command menu.",
+          ),
+        ],
+      },
+      { type: "divider" },
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: "Permission controls, by design",
+          emoji: true,
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: [
+            "*Slack access gates run before a message reaches the agent.* The operator controls which workspaces, channels, direct messages, group DMs, and people may invoke PwrAgent.",
+            "",
+            "*Execution access is separate and per thread.* Default Access asks before protected actions. Full Access can be disabled for messaging entirely and, when enabled, is an explicit operator-controlled escalation.",
+            "",
+            "Use `/status` in a bound conversation to inspect and control that thread's model, reasoning, speed, and access mode.",
+          ].join("\n"),
+        },
+      },
+      {
+        type: "section",
+        fields: slackAccessFields(config),
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "This access snapshot comes from *PwrAgent → Settings → Messaging → Slack*. Allowlisted IDs stay private.",
+          },
+        ],
+      },
+      { type: "divider" },
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: "Local-first, without a PwrAgent cloud relay",
+          emoji: true,
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "PwrAgent runs on your computer and connects directly to Slack. PwrAgent adds no hosted account, relay, or telemetry service between this workspace and your local agent. Slack and your configured model provider still handle the data sent to their services.",
+        },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "<https://docs.pwragent.ai/using-codex/|Usage guide>  •  <https://docs.pwragent.ai/providers/slack/|Slack setup>  •  <https://github.com/pwrdrvr/PwrAgent|Source on GitHub>",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function slackAccessFields(config: SlackMessagingConfig): SlackHomeTextObject[] {
+  const teamMode =
+    config.teamAuthorizationMode ?? SLACK_TEAM_AUTHORIZATION_MODE_DEFAULT;
+  const channelMode =
+    config.channelAuthorizationMode ?? SLACK_CHANNEL_AUTHORIZATION_MODE_DEFAULT;
+  const channelUserMode =
+    config.channelUserAccessMode ?? SLACK_CHANNEL_USER_ACCESS_MODE_DEFAULT;
+  const dmMode = config.dmAccessMode ?? SLACK_DM_ACCESS_MODE_DEFAULT;
+  const groupDmMode =
+    config.groupDmAccessMode ?? SLACK_GROUP_DM_ACCESS_MODE_DEFAULT;
+
+  return [
+    homeField(
+      ":office: Workspaces",
+      teamMode === "allow_all"
+        ? "Any workspace reaching this installation"
+        : countLabel(config.authorizedTeamIds?.length ?? 0, "approved workspace"),
+    ),
+    homeField(
+      ":speech_balloon: Channels",
+      channelMode === "allow_all"
+        ? "Any channel the bot can access"
+        : countLabel(
+            config.authorizedConversationIds?.length ?? 0,
+            "approved conversation",
+          ),
+    ),
+    homeField(
+      ":busts_in_silhouette: Channel senders",
+      channelUserMode === "any_channel_user"
+        ? "Any member of an approved channel"
+        : channelUserMode === "authorized_users"
+          ? "Authorized users only"
+          : "Channel messages disabled",
+    ),
+    homeField(
+      ":incoming_envelope: Direct messages",
+      dmMode === "any_workspace_user"
+        ? "Any workspace user"
+        : dmMode === "authorized_users"
+          ? "Authorized users only"
+          : "Direct messages disabled",
+    ),
+    homeField(
+      ":people_holding_hands: Group DMs",
+      groupDmMode === "authorized_users"
+        ? "Authorized users, when they mention the bot"
+        : "Closed",
+    ),
+    homeField(
+      ":key: Authorized users",
+      countLabel(config.authorizedActorIds.length, "configured user"),
+    ),
+  ];
+}
+
+function homeField(title: string, body: string): SlackHomeTextObject {
+  return {
+    type: "mrkdwn",
+    text: `*${title}*\n${body}`,
+  };
+}
+
+function countLabel(count: number, singular: string): string {
+  if (count === 0) return `No ${singular}s configured`;
+  return `${count} ${singular}${count === 1 ? "" : "s"}`;
+}

--- a/packages/messaging/providers/slack/src/slack-home.ts
+++ b/packages/messaging/providers/slack/src/slack-home.ts
@@ -53,6 +53,8 @@ export function buildSlackHomeView(params: {
   userId: string;
 }): SlackHomeView {
   const config = params.config;
+  const slashCommand = (command: string) =>
+    `/${config.slashCommandPrefix?.trim() ?? ""}${command}`;
   return {
     type: "home",
     blocks: [
@@ -95,7 +97,7 @@ export function buildSlackHomeView(params: {
         fields: [
           homeField(
             ":rocket: Start or resume",
-            "Use `/new` for fresh work or `/resume` to pick up an existing thread.",
+            `Use \`${slashCommand("new")}\` for fresh work or \`${slashCommand("resume")}\` to pick up an existing thread.`,
           ),
           homeField(
             ":control_knobs: Steer from Slack",
@@ -115,7 +117,7 @@ export function buildSlackHomeView(params: {
           ),
           homeField(
             ":information_source: See every command",
-            "Send `/help` or mention the bot with `help` for the live command menu.",
+            `Send \`${slashCommand("help")}\` or mention the bot with \`help\` for the live command menu.`,
           ),
         ],
       },
@@ -137,7 +139,7 @@ export function buildSlackHomeView(params: {
             "",
             "*Execution access is separate and per thread.* Default Access asks before protected actions. Full Access can be disabled for messaging entirely and, when enabled, is an explicit operator-controlled escalation.",
             "",
-            "Use `/status` in a bound conversation to inspect and control that thread's model, reasoning, speed, and access mode.",
+            `Use \`${slashCommand("status")}\` in a bound conversation to inspect and control that thread's model, reasoning, speed, and access mode.`,
           ].join("\n"),
         },
       },


### PR DESCRIPTION
## Summary

- publish a branded, per-user Slack App Home with the PwrAgent logo
- explain the core messaging workflows, permission controls, and local-first architecture
- show a live access-policy summary without exposing allowlisted Slack IDs
- pre-publish Home views for configured authorized users at adapter startup
- refresh the view when Slack sends `app_home_opened`, and keep messaging healthy if Home publishing fails

## Root cause

The Slack app had its Home tab enabled, but the provider adapter discarded every event other than messages and mentions and never called `views.publish`. Slack therefore had no Home view to render and left the tab on its loading spinner.

## User impact

Authorized users get a useful Home page as soon as the Slack adapter starts, including installations that do not yet subscribe to `app_home_opened`. Apps that do subscribe refresh the view whenever a user opens Home. The page covers start/resume/steer/review/monitor workflows, separates Slack ingress gates from per-thread execution access, and links to the operator docs and source.

The small app icon in Slack chrome remains Slack app-level display information; operators can upload the existing 512px PwrAgent icon under Basic Information → Display Information. For per-open refreshes, add `app_home_opened` under Event Subscriptions → Bot Events.

## Validation

- `pnpm test packages/messaging/providers/slack/src/__tests__/slack-home.test.ts packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts` (67 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`
