### PR TITLE
fix(desktop): restore revoked peers after reinvite

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
@@ -209,6 +209,95 @@ describe("federation enrollment", () => {
     });
   });
 
+  it("restores a revoked peer through a fresh one-time enrollment", () => {
+    const keyPair = generateFederationIdentityKeyPair();
+    store.upsertPeer({
+      updatedAt: 1_000,
+      peer: {
+        id: "client_one",
+        label: "Client",
+        role: "client",
+        status: "connected",
+        capabilities: ["remote_window"],
+        protocolVersion: 1,
+        pinnedPublicKeyPem: keyPair.publicKeyPem,
+      },
+    });
+    store.revokePeer("client_one", 1_100);
+
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "fresh-invite-token-1234567890",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: 1_200,
+      expiresAt: 2_000,
+    });
+    const capabilities = ["remote_window"] as const;
+    const enrollMessage = buildFederationProofMessage({
+      purpose: "enroll",
+      gatewayInstanceId: "gateway_one",
+      peerInstanceId: "client_one",
+      publicKeyPem: keyPair.publicKeyPem,
+      protocolVersion: 1,
+      nonce: "nonce-reenroll",
+      capabilities,
+    });
+
+    expect(
+      completeFederationEnrollment({
+        store,
+        gatewayInstanceId: "gateway_one",
+        inviteToken: invite.token,
+        now: 1_500,
+        peer: {
+          instanceId: "client_one",
+          label: "Client",
+          role: "client",
+          publicKeyPem: keyPair.publicKeyPem,
+          capabilities,
+          protocolVersion: 1,
+          nonce: "nonce-reenroll",
+          signatureBase64: signFederationMessage({
+            privateKeyPem: keyPair.privateKeyPem,
+            message: enrollMessage,
+          }),
+        },
+      }),
+    ).toMatchObject({
+      accepted: true,
+      peer: { id: "client_one", status: "connected" },
+    });
+    expect(store.getPeer("client_one")?.revokedAt).toBeUndefined();
+
+    const reconnectMessage = buildFederationProofMessage({
+      purpose: "reconnect",
+      gatewayInstanceId: "gateway_one",
+      peerInstanceId: "client_one",
+      publicKeyPem: keyPair.publicKeyPem,
+      protocolVersion: 1,
+      nonce: "nonce-after-restart",
+      capabilities,
+    });
+    expect(
+      authenticateFederationReconnect({
+        store,
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "client_one",
+        protocolVersion: 1,
+        nonce: "nonce-after-restart",
+        requestedCapabilities: capabilities,
+        signatureBase64: signFederationMessage({
+          privateKeyPem: keyPair.privateKeyPem,
+          message: reconnectMessage,
+        }),
+        now: 1_600,
+      }),
+    ).toMatchObject({
+      accepted: true,
+      peer: { id: "client_one", status: "connected" },
+    });
+  });
+
   it("rejects bad signatures, wrong gateway invites, and reused invites", () => {
     const keyPair = generateFederationIdentityKeyPair();
     const invite = createFederationEnrollmentInvite({

--- a/apps/desktop/src/main/__tests__/federation-store.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-store.test.ts
@@ -61,6 +61,55 @@ describe("FederationStore", () => {
         revokedAt: 2_000,
       },
     ]);
+
+    store.upsertPeer({
+      updatedAt: 3_000,
+      peer: {
+        id: "laptop_one",
+        label: "Laptop",
+        role: "client",
+        status: "connected",
+        capabilities: ["remote_window"],
+      },
+    });
+
+    expect(store.getPeer("laptop_one")).toMatchObject({
+      status: "revoked",
+      revokedAt: 2_000,
+    });
+  });
+
+  it("clears revocation only for an explicitly reauthorized peer", () => {
+    store.upsertPeer({
+      updatedAt: 1_000,
+      peer: {
+        id: "laptop_one",
+        label: "Laptop",
+        role: "client",
+        status: "connected",
+        capabilities: ["remote_window"],
+      },
+    });
+    store.revokePeer("laptop_one", 2_000);
+
+    store.upsertPeer({
+      updatedAt: 3_000,
+      clearRevocation: true,
+      peer: {
+        id: "laptop_one",
+        label: "Laptop",
+        role: "client",
+        status: "connected",
+        capabilities: ["remote_window"],
+      },
+    });
+
+    expect(store.getPeer("laptop_one")).toMatchObject({
+      status: "connected",
+      updatedAt: 3_000,
+    });
+    expect(store.getPeer("laptop_one")?.revokedAt).toBeUndefined();
+    expect(store.listPeers()).toHaveLength(1);
   });
 
   it("matches pending enrollments without storing the raw token", () => {

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -61,6 +61,80 @@ describe("StateDb", () => {
     );
   });
 
+  it("repairs revocation state after a later verified federation enrollment", () => {
+    const dbPath = path.join(tempDir, "state.db");
+    const insertPeer = stateDb.raw.prepare(
+      `INSERT INTO federation_peers(
+         peer_id, label, role, status, created_at, updated_at, last_seen_at,
+         revoked_at, payload
+       ) VALUES (?, ?, 'client', ?, 1000, 3000, 3000, 2000, '{}')`,
+    );
+    insertPeer.run("reenrolled_peer", "Re-enrolled", "connected");
+    insertPeer.run("still_revoked_peer", "Still revoked", "revoked");
+    insertPeer.run("unproven_peer", "Unproven", "connected");
+
+    const insertEnrollment = stateDb.raw.prepare(
+      `INSERT INTO federation_enrollment_tokens(
+         enrollment_id, token_hmac, status, generated_at, expires_at, used_at,
+         peer_id, payload
+       ) VALUES (?, ?, 'used', 1000, 4000, ?, ?, '{}')`,
+    );
+    insertEnrollment.run(
+      "federation-enrollment:reenrolled",
+      "reenrolled-token-hmac",
+      3_000,
+      "reenrolled_peer",
+    );
+    insertEnrollment.run(
+      "federation-enrollment:still-revoked",
+      "still-revoked-token-hmac",
+      3_000,
+      "still_revoked_peer",
+    );
+    insertEnrollment.run(
+      "federation-enrollment:unproven",
+      "unproven-token-hmac",
+      1_500,
+      "unproven_peer",
+    );
+
+    stateDb.raw.pragma("user_version = 41");
+    stateDb.close();
+    stateDb = StateDb.open(dbPath);
+
+    const peers = stateDb.raw
+      .prepare(
+        `SELECT peer_id, status, revoked_at
+         FROM federation_peers
+         ORDER BY peer_id`,
+      )
+      .all() as Array<{
+        peer_id: string;
+        status: string;
+        revoked_at: number | null;
+      }>;
+    expect(peers).toEqual([
+      {
+        peer_id: "reenrolled_peer",
+        status: "connected",
+        revoked_at: null,
+      },
+      {
+        peer_id: "still_revoked_peer",
+        status: "revoked",
+        revoked_at: 2_000,
+      },
+      {
+        peer_id: "unproven_peer",
+        status: "connected",
+        revoked_at: 2_000,
+      },
+    ]);
+    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(
+      CURRENT_STATE_DB_USER_VERSION,
+    );
+  });
+
   it("creates provider-aware pull request cache columns", () => {
     const prStatusColumns = stateDb.raw
       .prepare("PRAGMA table_info(pr_status_cache)")

--- a/apps/desktop/src/main/federation/federation-enrollment.ts
+++ b/apps/desktop/src/main/federation/federation-enrollment.ts
@@ -226,7 +226,11 @@ export function completeFederationEnrollment(params: {
     lastActivityAt: params.now,
     pinnedPublicKeyPem: params.peer.publicKeyPem,
   };
-  params.store.upsertPeer({ peer, updatedAt: params.now });
+  params.store.upsertPeer({
+    peer,
+    updatedAt: params.now,
+    clearRevocation: true,
+  });
   params.store.markEnrollmentUsed({
     enrollmentId: enrollment.id,
     peerId: params.peer.instanceId,

--- a/apps/desktop/src/main/federation/federation-store.ts
+++ b/apps/desktop/src/main/federation/federation-store.ts
@@ -129,11 +129,20 @@ export class FederationStore {
     peer: FederationPeerSummary & { pinnedPublicKeyPem?: string };
     createdAt?: number;
     updatedAt: number;
+    /**
+     * A successfully verified one-time enrollment explicitly restores trust
+     * in an instance that was previously revoked. Ordinary peer refreshes
+     * must never clear revocation state implicitly.
+     */
+    clearRevocation?: boolean;
   }): void {
     assertPeerId(params.peer.id);
     const existing = this.getPeer(params.peer.id);
     const createdAt = params.createdAt ?? existing?.createdAt ?? params.updatedAt;
-    const revokedAt = params.peer.revokedAt ?? existing?.revokedAt;
+    const revokedAt = params.clearRevocation
+      ? undefined
+      : params.peer.revokedAt ?? existing?.revokedAt;
+    const status = revokedAt === undefined ? params.peer.status : "revoked";
     const payload: FederationPeerPayload = {
       capabilities: params.peer.capabilities,
       protocolVersion: params.peer.protocolVersion,
@@ -163,7 +172,7 @@ export class FederationStore {
         params.peer.id,
         params.peer.label,
         params.peer.role,
-        params.peer.status,
+        status,
         createdAt,
         params.updatedAt,
         params.peer.lastActivityAt ?? null,

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 41;
+export const CURRENT_STATE_DB_USER_VERSION = 42;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -1245,6 +1245,12 @@ export class StateDb {
         // badges indefinitely for worktrees outside the startup probe budget.
         // This table is derived state and is safe to repopulate lazily.
         db.prepare("DELETE FROM thread_git_working_state").run();
+        db.pragma("user_version = 41");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 42) {
+      db.transaction(() => {
+        repairReenrolledFederationPeerRevocations(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -2421,6 +2427,28 @@ SET
   db.exec(`
 UPDATE pr_lookup_cache
 SET provider = COALESCE(NULLIF(provider, ''), 'github.com')
+`);
+}
+
+function repairReenrolledFederationPeerRevocations(
+  db: BetterSqlite3.Database,
+): void {
+  // The original federation upsert preserved revoked_at even after a fresh,
+  // verified enrollment changed the peer back to connected. Only clear rows
+  // with durable proof that a one-time invite was consumed after revocation;
+  // genuinely revoked peers and unrelated inconsistent rows stay revoked.
+  db.exec(`
+UPDATE federation_peers
+SET revoked_at = NULL
+WHERE status != 'revoked'
+  AND revoked_at IS NOT NULL
+  AND EXISTS (
+    SELECT 1
+    FROM federation_enrollment_tokens
+    WHERE federation_enrollment_tokens.peer_id = federation_peers.peer_id
+      AND federation_enrollment_tokens.status = 'used'
+      AND federation_enrollment_tokens.used_at > federation_peers.revoked_at
+  )
 `);
 }
 


### PR DESCRIPTION
## Summary

- I clear a peer's prior revocation only after a fresh, signed one-time federation enrollment succeeds.
- I keep ordinary peer refreshes from creating contradictory `connected` + `revoked_at` rows.
- I add a v42 state migration that repairs affected rows only when a consumed enrollment token proves the peer was re-enrolled after it was revoked.
- I cover revoke → reinvite → restart/reconnect, store invariants, and migration selectivity with regression tests.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/federation-store.test.ts apps/desktop/src/main/__tests__/federation-enrollment.test.ts apps/desktop/src/main/__tests__/federation-policy.test.ts apps/desktop/src/main/__tests__/state-db.test.ts` (52 tests passed).
- I ran `pnpm typecheck`.
- I ran `pnpm lint:eslint` (0 errors; existing warning baseline only).
- I ran `pnpm lint:boundaries`.
- I ran `pnpm lint:sql`.
- I verified the repair against the affected local default-profile database: one evidence-backed row was repaired, `PRAGMA quick_check` passed, and the M5 default peer reconnected through the normal reconnect path.

## Notes

- Root cause: `FederationStore.upsertPeer` preserved an existing `revoked_at` value during successful re-enrollment while writing `status = 'connected'`. The live enrolled session worked until disconnect, then reconnect policy correctly rejected the contradictory row as `revoked_peer`.
- The migration does not un-revoke a peer merely because its status is inconsistent. It requires a durable `used` enrollment whose `used_at` is later than `revoked_at`, and it leaves rows whose status is still `revoked` untouched.
