### PR TITLE
fix(desktop): isolate PwrSnap MCP bridge config

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7771,21 +7771,28 @@ script = "echo setup"
 
     expect(registerBridge).toHaveBeenCalledWith("pwrsnap", undefined);
     expect(bindThread).toHaveBeenCalledWith("thread-1");
-    expect(codexClient.lastStartThreadParams?.config).toEqual({
-      mcp_servers: {
-        pwrsnap: { enabled: false },
-        pwragent_pwrsnap: {
-          enabled: true,
-          command: "/Applications/PwrAgent.app/Contents/MacOS/PwrAgent",
-          args: ["/app/mcp-connection-bridge.js"],
-          env: {
-            ELECTRON_RUN_AS_NODE: "1",
-            PWRAGENT_MCP_CONNECTION_SOCKET: "/tmp/pwragent.sock",
-            PWRAGENT_MCP_CONNECTION_TOKEN: "local-grant",
-          },
-          tool_timeout_sec: 720,
-        },
+    const mcpServers = (
+      codexClient.lastStartThreadParams?.config as {
+        mcp_servers?: Record<string, unknown>;
+      }
+    )?.mcp_servers;
+    expect(mcpServers?.pwrsnap).toEqual({ enabled: false });
+    expect(mcpServers?.pwragent_pwrsnap).toEqual({ enabled: false });
+    const bridgeNames = Object.keys(mcpServers ?? {}).filter((name) =>
+      name.startsWith("pwragent_pwrsnap_"),
+    );
+    expect(bridgeNames).toHaveLength(1);
+    expect(bridgeNames[0]).toMatch(/^pwragent_pwrsnap_[0-9a-f]{32}$/);
+    expect(mcpServers?.[bridgeNames[0]!]).toEqual({
+      enabled: true,
+      command: "/Applications/PwrAgent.app/Contents/MacOS/PwrAgent",
+      args: ["/app/mcp-connection-bridge.js"],
+      env: {
+        ELECTRON_RUN_AS_NODE: "1",
+        PWRAGENT_MCP_CONNECTION_SOCKET: "/tmp/pwragent.sock",
+        PWRAGENT_MCP_CONNECTION_TOKEN: "local-grant",
       },
+      tool_timeout_sec: 720,
     });
     await expect(overlayStore.getThreadOverlayState({
       backend: "codex",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7738,7 +7738,7 @@ script = "echo setup"
     expect(pdfMcp.close).toHaveBeenCalledTimes(1);
   });
 
-  it("injects a selected PwrSnap stdio bridge and persists the thread selection", async () => {
+  it("isolates a selected PwrSnap stdio bridge from global Codex MCP config", async () => {
     const codexClient = new MockBackendClient({ threads: [] });
     const overlayStore = createOverlayStoreMock();
     const bindThread = vi.fn();
@@ -7773,7 +7773,8 @@ script = "echo setup"
     expect(bindThread).toHaveBeenCalledWith("thread-1");
     expect(codexClient.lastStartThreadParams?.config).toEqual({
       mcp_servers: {
-        pwrsnap: {
+        pwrsnap: { enabled: false },
+        pwragent_pwrsnap: {
           enabled: true,
           command: "/Applications/PwrAgent.app/Contents/MacOS/PwrAgent",
           args: ["/app/mcp-connection-bridge.js"],

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5620,6 +5620,7 @@ function buildCodexParentDynamicToolSpecs(
 
 const PWRAGENT_PDF_MCP_SERVER_NAME = "pwragent_pdf";
 const PWRAGENT_CONNECTION_MCP_SERVER_PREFIX = "pwragent_";
+const PWRAGENT_CONNECTION_MCP_SERVER_HASH_LENGTH = 32;
 
 function buildCodexPdfMcpConfig(
   registration: AgentToolMcpRegistration,
@@ -5647,6 +5648,25 @@ function buildCodexPdfMcpDisabledConfig(): CodexThreadStartParams["config"] {
   } as CodexThreadStartParams["config"];
 }
 
+function buildCodexConnectionMcpServerName(
+  server: McpConnectionBridgeRegistration["server"],
+): string {
+  const identity = createHash("sha256")
+    .update(server.command)
+    .update("\0")
+    .update(server.args.join("\0"))
+    .update("\0")
+    .update(
+      Object.entries(server.env)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([name, value]) => `${name}\0${value}`)
+        .join("\0"),
+    )
+    .digest("hex")
+    .slice(0, PWRAGENT_CONNECTION_MCP_SERVER_HASH_LENGTH);
+  return `${PWRAGENT_CONNECTION_MCP_SERVER_PREFIX}${server.name}_${identity}`;
+}
+
 function buildCodexConnectionMcpConfig(
   registrations: McpConnectionBridgeRegistration[],
 ): CodexThreadStartParams["config"] | undefined {
@@ -5655,12 +5675,16 @@ function buildCodexConnectionMcpConfig(
     mcp_servers: Object.fromEntries(
       registrations.flatMap(({ server }) => [
         // Codex recursively merges thread config over the operator's global
-        // config. Disable a same-named global server, then give PwrAgent's
-        // stdio bridge a reserved key so an inherited HTTP `url` cannot turn
-        // the combined entry into an invalid mixed transport.
+        // config. Disable both the original name and our former fixed alias,
+        // then give this grant a stable hashed key so inherited HTTP fields
+        // cannot turn the stdio bridge into an invalid mixed transport.
         [server.name, { enabled: false }],
         [
           `${PWRAGENT_CONNECTION_MCP_SERVER_PREFIX}${server.name}`,
+          { enabled: false },
+        ],
+        [
+          buildCodexConnectionMcpServerName(server),
           {
             enabled: true,
             command: server.command,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5619,6 +5619,7 @@ function buildCodexParentDynamicToolSpecs(
 }
 
 const PWRAGENT_PDF_MCP_SERVER_NAME = "pwragent_pdf";
+const PWRAGENT_CONNECTION_MCP_SERVER_PREFIX = "pwragent_";
 
 function buildCodexPdfMcpConfig(
   registration: AgentToolMcpRegistration,
@@ -5652,15 +5653,22 @@ function buildCodexConnectionMcpConfig(
   if (registrations.length === 0) return undefined;
   return {
     mcp_servers: Object.fromEntries(
-      registrations.map(({ server }) => [
-        server.name,
-        {
-          enabled: true,
-          command: server.command,
-          args: server.args,
-          env: server.env,
-          tool_timeout_sec: MCP_CONNECTION_TOOL_TIMEOUT_SECONDS,
-        },
+      registrations.flatMap(({ server }) => [
+        // Codex recursively merges thread config over the operator's global
+        // config. Disable a same-named global server, then give PwrAgent's
+        // stdio bridge a reserved key so an inherited HTTP `url` cannot turn
+        // the combined entry into an invalid mixed transport.
+        [server.name, { enabled: false }],
+        [
+          `${PWRAGENT_CONNECTION_MCP_SERVER_PREFIX}${server.name}`,
+          {
+            enabled: true,
+            command: server.command,
+            args: server.args,
+            env: server.env,
+            tool_timeout_sec: MCP_CONNECTION_TOOL_TIMEOUT_SECONDS,
+          },
+        ],
       ]),
     ),
   } as CodexThreadStartParams["config"];


### PR DESCRIPTION
## Summary

- I isolate PwrAgent's thread-scoped PwrSnap stdio bridge under a stable per-registration Codex MCP key derived from the opaque bridge launch configuration.
- I disable both the same-named global `pwrsnap` entry and the former fixed `pwragent_pwrsnap` alias for threads that explicitly enable the PwrAgent-managed connection.
- I added regression coverage for the collision-proof configuration shape.

## Verification

- I reproduced the production failure against Codex 0.145.0 through the public app-server protocol with a global HTTP `mcp_servers.pwrsnap` and a thread-scoped stdio override.
- I verified that `url: null` does not clear Codex's recursively merged HTTP transport.
- I verified through the same protocol that disabling `pwrsnap` and starting an isolated PwrAgent bridge key allows ephemeral thread creation under the colliding global configuration.
- I added regression coverage requiring a 128-bit hashed bridge-key suffix and neutralization of the former fixed alias.
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` (447 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (zero errors; existing warning baseline only)
- `pnpm lint:boundaries`

## Notes

- The root cause is Codex recursively merging per-thread MCP configuration over global MCP configuration. Reusing the `pwrsnap` key retained the global HTTP `url` beside PwrAgent's stdio `command`, which Codex rejects as a mixed transport.
- ACP continues to use the existing `pwrsnap` server name; this namespace isolation is Codex-specific.
