### PR TITLE
fix(desktop): route model migrations to federated owner

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentEvent,
+  ApplyThreadModelMigrationRequest,
   CancelQueuedTurnRequest,
   CancelThreadExecutionModeQueueRequest,
   CompactThreadRequest,
@@ -176,6 +177,12 @@ const federationMock = vi.hoisted(() => {
     setThreadModelSettings: vi.fn(
       async (request: SetThreadModelSettingsRequest) => request,
     ),
+    applyThreadModelMigration: vi.fn(
+      async (request: ApplyThreadModelMigrationRequest) => ({
+        ...request,
+        status: "acknowledged-new-thread" as const,
+      }),
+    ),
     runCodexEnvironmentAction: vi.fn(
       async (request: RunCodexEnvironmentActionRequest) => ({
         backend: request.backend,
@@ -316,6 +323,7 @@ describe("agent ipc", () => {
     const {
       AGENT_CANCEL_QUEUED_TURN_CHANNEL,
       AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
+      AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL,
       AGENT_COMPACT_THREAD_CHANNEL,
       AGENT_FORK_THREAD_CHANNEL,
       AGENT_INTERRUPT_TURN_CHANNEL,
@@ -421,6 +429,13 @@ describe("agent ipc", () => {
       threadId: "thread-1",
       model: "gpt-5-codex",
     });
+    await handlers.get(AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      threadCreatedAt: 1_000,
+      threadModel: "gpt-5-codex",
+    });
     await handlers.get(AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL)?.({}, {
       backend: "codex",
       federationTarget,
@@ -520,6 +535,14 @@ describe("agent ipc", () => {
       backend: "codex",
       threadId: "thread-1",
       model: "gpt-5-codex",
+    });
+    expect(
+      federationMock.remoteBackend.applyThreadModelMigration,
+    ).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      threadCreatedAt: 1_000,
+      threadModel: "gpt-5-codex",
     });
     expect(federationMock.remoteBackend.runCodexEnvironmentAction).toHaveBeenCalledWith({
       backend: "codex",

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -223,6 +223,60 @@ describe("federation backend bridge", () => {
     });
   });
 
+  it("routes thread model migrations over RPC with turn_control authorization", async () => {
+    const sent: FederationProtocolEnvelope[] = [];
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "viewer_one",
+      remoteInstanceId: "owner_one",
+      sendEnvelope: (envelope) => sent.push(envelope),
+      now: () => 1_000,
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+
+    const pending = client.applyThreadModelMigration({
+      backend: "codex",
+      threadId: "thread-1",
+      threadCreatedAt: 900,
+      threadModel: "gpt-5.5",
+    });
+    const request = sent.at(-1)!;
+    expect(request).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.applyThreadModelMigration,
+      params: {
+        backend: "codex",
+        threadId: "thread-1",
+        threadCreatedAt: 900,
+        threadModel: "gpt-5.5",
+      },
+    });
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.applyThreadModelMigration
+      ],
+    ).toBe("turn_control");
+
+    rpc.receiveEnvelope({
+      id: "response-migration",
+      kind: "response",
+      requestId: request.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_100,
+      result: {
+        backend: "codex",
+        threadId: "thread-1",
+        status: "applied",
+      },
+    });
+    await expect(pending).resolves.toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      status: "applied",
+    });
+  });
+
   it("routes PR detach over RPC with turn_control authorization", async () => {
     const sent: FederationProtocolEnvelope[] = [];
     const rpc = new FederationRpcEndpoint({
@@ -833,6 +887,10 @@ describe("federation backend bridge", () => {
       cancelThreadExecutionModeQueue: vi.fn(),
       setAcpSessionRuntimeOption: vi.fn(),
       setThreadModelSettings: vi.fn(),
+      applyThreadModelMigration: vi.fn(async (request) => ({
+        ...request,
+        status: "acknowledged-new-thread" as const,
+      })),
       submitServerRequest: vi.fn(async () => ({
         backend: "codex" as const,
         threadId: "thread-1",
@@ -909,6 +967,24 @@ describe("federation backend bridge", () => {
     await router.routeEnvelope({
       sourcePeerId: "gateway_one",
       envelope: {
+        id: "migration-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.applyThreadModelMigration,
+        params: {
+          backend: "codex",
+          threadId: "thread-1",
+          threadCreatedAt: 1_000,
+          threadModel: "gpt-5.6-sol",
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "client_one",
+        createdAt: 1_150,
+      },
+    });
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
         id: "env-request",
         kind: "request",
         method: FEDERATION_BACKEND_METHODS.runCodexEnvironmentAction,
@@ -934,6 +1010,12 @@ describe("federation backend bridge", () => {
       requestId: "approval-1",
       response: { decision: "approve" },
     });
+    expect(backend.applyThreadModelMigration).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      threadCreatedAt: 1_000,
+      threadModel: "gpt-5.6-sol",
+    });
     expect(backend.runCodexEnvironmentAction).toHaveBeenCalledWith({
       actionId: "start",
       backend: "codex",
@@ -949,6 +1031,11 @@ describe("federation backend bridge", () => {
         kind: "response",
         requestId: "approval-request",
         result: { requestId: "approval-1" },
+      },
+      {
+        kind: "response",
+        requestId: "migration-request",
+        result: { status: "acknowledged-new-thread" },
       },
       {
         kind: "response",
@@ -1005,6 +1092,7 @@ describe("federation backend bridge", () => {
         cancelThreadExecutionModeQueue: vi.fn(),
         setAcpSessionRuntimeOption: vi.fn(),
         setThreadModelSettings: vi.fn(),
+        applyThreadModelMigration: vi.fn(),
         submitServerRequest: vi.fn(),
         runCodexEnvironmentAction: vi.fn(),
         stopCodexEnvironmentAction: vi.fn(),

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -6,6 +6,8 @@ import type {
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
   AgentEvent,
+  ApplyThreadModelMigrationRequest,
+  ApplyThreadModelMigrationResponse,
   ArchiveThreadRequest,
   ArchiveThreadResponse,
   CancelQueuedTurnRequest,
@@ -114,6 +116,7 @@ export const FEDERATION_BACKEND_METHODS = {
   cancelThreadExecutionModeQueue: "backend.cancelThreadExecutionModeQueue",
   setAcpSessionRuntimeOption: "backend.setAcpSessionRuntimeOption",
   setThreadModelSettings: "backend.setThreadModelSettings",
+  applyThreadModelMigration: "backend.applyThreadModelMigration",
   submitServerRequest: "backend.submitServerRequest",
   runCodexEnvironmentAction: "backend.runCodexEnvironmentAction",
   stopCodexEnvironmentAction: "backend.stopCodexEnvironmentAction",
@@ -181,6 +184,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.cancelThreadExecutionModeQueue]: "turn_control",
   [FEDERATION_BACKEND_METHODS.setAcpSessionRuntimeOption]: "turn_control",
   [FEDERATION_BACKEND_METHODS.setThreadModelSettings]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.applyThreadModelMigration]: "turn_control",
   [FEDERATION_BACKEND_METHODS.submitServerRequest]: "pending_request_control",
   [FEDERATION_BACKEND_METHODS.runCodexEnvironmentAction]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.stopCodexEnvironmentAction]: "environment_actions",
@@ -277,6 +281,9 @@ export type FederationBackendOperations = {
   setThreadModelSettings(
     request: SetThreadModelSettingsRequest,
   ): Promise<SetThreadModelSettingsResponse>;
+  applyThreadModelMigration(
+    request: ApplyThreadModelMigrationRequest,
+  ): Promise<ApplyThreadModelMigrationResponse>;
   submitServerRequest(
     request: SubmitServerRequestRequest,
   ): Promise<SubmitServerRequestResponse>;
@@ -527,6 +534,13 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.setThreadModelSettings(
         envelope.params as SetThreadModelSettingsRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.applyThreadModelMigration,
+    async (envelope) =>
+      await params.backend.applyThreadModelMigration(
+        envelope.params as ApplyThreadModelMigrationRequest,
       ),
   );
   params.router.registerHandler(
@@ -867,6 +881,15 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<SetThreadModelSettingsResponse> {
     return await this.rpc.request<SetThreadModelSettingsResponse>({
       method: FEDERATION_BACKEND_METHODS.setThreadModelSettings,
+      params: request,
+    });
+  }
+
+  async applyThreadModelMigration(
+    request: ApplyThreadModelMigrationRequest,
+  ): Promise<ApplyThreadModelMigrationResponse> {
+    return await this.rpc.request<ApplyThreadModelMigrationResponse>({
+      method: FEDERATION_BACKEND_METHODS.applyThreadModelMigration,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -2,6 +2,7 @@ import { randomBytes, randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import type {
   AgentEvent,
+  ApplyThreadModelMigrationResponse,
   AppServerListSkillsResponse,
   AppServerListThreadsResponse,
   AppServerReadThreadResponse,
@@ -59,6 +60,7 @@ import {
   type AppServerListSkillsRequest,
   type AppServerListThreadsRequest,
   type AppServerReadThreadRequest,
+  type ApplyThreadModelMigrationRequest,
   type CancelQueuedTurnRequest,
   type CancelThreadExecutionModeQueueRequest,
   type CompactThreadRequest,
@@ -1852,6 +1854,11 @@ function localBackendOperations(): FederationBackendOperations {
       request: SetThreadModelSettingsRequest,
     ): Promise<SetThreadModelSettingsResponse> {
       return await getDesktopBackendRegistry().setThreadModelSettings(request);
+    },
+    async applyThreadModelMigration(
+      request: ApplyThreadModelMigrationRequest,
+    ): Promise<ApplyThreadModelMigrationResponse> {
+      return await getDesktopBackendRegistry().applyThreadModelMigration(request);
     },
     async submitServerRequest(
       request: SubmitServerRequestRequest,

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -848,6 +848,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: ApplyThreadModelMigrationRequest,
     ): Promise<ApplyThreadModelMigrationResponse> => {
+      if (
+        request.federationTarget
+        && isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .applyThreadModelMigration(stripFederationTarget(request));
+      }
       return await registry.applyThreadModelMigration(request);
     },
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1858,6 +1858,8 @@ export function ThreadView(props: ThreadViewProps) {
     void migrationDesktopApi
       .applyThreadModelMigration({
         backend: thread.source,
+        federationTarget: thread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: thread.id,
         threadCreatedAt: thread.createdAt,
         threadModel: thread.model,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -243,7 +243,7 @@ describe("ThreadView", () => {
     });
   });
 
-  it("applies a pending provider migration when an existing thread opens", async () => {
+  it("applies a pending provider migration on the federated owner", async () => {
     const applyThreadModelMigration = vi.fn(async () => ({
       backend: "codex" as const,
       threadId: "thread-old",
@@ -280,6 +280,14 @@ describe("ThreadView", () => {
           title: "Old model",
           titleSource: "explicit",
           source: "codex",
+          federation: {
+            ref: {
+              backend: "codex",
+              target: { scope: "remote", instanceId: "remote-instance" },
+              threadId: "thread-old",
+            },
+            instanceLabel: "Remote Mac",
+          },
           model: "gpt-5.5",
           createdAt: 1_000,
           updatedAt: 1_500,
@@ -294,6 +302,10 @@ describe("ThreadView", () => {
     await waitFor(() => {
       expect(applyThreadModelMigration).toHaveBeenCalledWith({
         backend: "codex",
+        federationTarget: {
+          scope: "remote",
+          instanceId: "remote-instance",
+        },
         threadId: "thread-old",
         threadCreatedAt: 1_000,
         threadModel: "gpt-5.5",

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -461,6 +461,7 @@ export type SendThreadPrAutoDispatchNowResponse =
 
 export type ApplyThreadModelMigrationRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   /** Creation time from the provider summary, used to exclude newer threads. */
   threadCreatedAt?: number;


### PR DESCRIPTION
## What changed

- Tag thread-model migration requests with the selected thread's federation target.
- Route migration evaluation and persistence through the owning PwrAgent instance.
- Add the migration operation to the capability-guarded federation backend bridge.
- Cover renderer tagging, IPC target stripping/routing, RPC serialization, authorization, and owner-side dispatch.

## Why

A federated viewer evaluated a remote thread's model migration against its local backend registry. The local registry could not resolve the remote thread's creation metadata, so the UI showed a misleading “Thread model migration pending” warning even when the owner had already started the thread with the intended model.

## Impact

Remote threads now use the owning instance's migration policy and metadata. New remote threads that already use the intended model no longer produce a false local metadata warning, and eligible existing remote threads are migrated on the instance that owns their runtime and overlay state.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/main/__tests__/agent-ipc.test.ts apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts` (75 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
