### PR TITLE
fix(desktop): clear submitted remote launchpad drafts

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -114,6 +114,13 @@ test.describe("federation remote window", () => {
       gateway = await startInProcessFederationGateway({
         instanceLabel: "E2E Gateway",
         remotePty: { cwd: ownerPtyCwd },
+        directories: [
+          {
+            key: "directory:/remote/FixtureRepo",
+            label: "FixtureRepo",
+            path: "/remote/FixtureRepo",
+          },
+        ],
         threads: [
           {
             id: "remote-thread-1",
@@ -341,6 +348,61 @@ test.describe("federation remote window", () => {
           timeout: 15_000,
         })
         .toBeNull();
+
+      // Remote launchpad drafts live in the viewer's overlay store while the
+      // user composes. After a successful remote materialization, reopening
+      // the same launchpad must start empty instead of rehydrating the message
+      // that was already submitted.
+      await remote.getByRole("tab", { name: "directories" }).click();
+      const openRemoteLaunchpad = remote.getByRole("button", {
+        name: "Open new thread launchpad for FixtureRepo",
+      });
+      await openRemoteLaunchpad.click();
+      const submittedPrompt = "Create a remote thread exactly once";
+      await remote.getByRole("textbox", { name: "New thread" }).fill(submittedPrompt);
+      await expect
+        .poll(
+          async () => await remote.evaluate(async (directoryKey) => {
+            const api = (window as typeof window & {
+              pwragent?: {
+                ensureDirectoryLaunchpad?: (request: unknown) => Promise<{
+                  launchpad: { prompt: string };
+                }>;
+              };
+            }).pwragent;
+            if (!api?.ensureDirectoryLaunchpad) return "missing-api";
+            const response = await api.ensureDirectoryLaunchpad({
+              directoryKey,
+              directoryKind: "directory",
+              directoryLabel: "FixtureRepo",
+              directoryPath: "/remote/FixtureRepo",
+            });
+            return response.launchpad.prompt;
+          }, "directory:/remote/FixtureRepo"),
+          { timeout: 15_000 },
+        )
+        .toBe(submittedPrompt);
+      await remote.getByRole("button", { name: "Start thread" }).click();
+      await expect
+        .poll(
+          () => gateway!.calls.filter(
+            (call) => call.method === "materializeDirectoryLaunchpad",
+          ).length,
+          { timeout: 30_000 },
+        )
+        .toBe(1);
+      await expect(
+        remote.getByRole("heading", { level: 2, name: submittedPrompt }),
+      ).toBeVisible({ timeout: 30_000 });
+
+      await openRemoteLaunchpad.click();
+      await expect(
+        remote.getByTestId("composer-tiptap-input"),
+      ).toHaveAttribute("data-value", "");
+      await remoteRowOne.click();
+      await expect(
+        remote.getByRole("textbox", { name: "Reply" }),
+      ).toBeVisible();
 
       // The gateway only ever served federation RPCs — no local PR
       // refresh or other local-only method leaked across the wire.

--- a/apps/desktop/e2e/fixtures/federation-gateway.ts
+++ b/apps/desktop/e2e/fixtures/federation-gateway.ts
@@ -6,6 +6,8 @@ import type {
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
   AppServerThreadSummary,
+  MaterializeDirectoryLaunchpadRequest,
+  MaterializeDirectoryLaunchpadResponse,
   NavigationSnapshot,
   SetThreadPinRequest,
   SetThreadPinResponse,
@@ -44,6 +46,12 @@ export type GatewayThreadSeed = {
   pinnedRank?: string;
 };
 
+export type GatewayDirectorySeed = {
+  key: string;
+  label: string;
+  path: string;
+};
+
 export type InProcessFederationGateway = {
   /** `pwragent-federation:<base64url>` invite for the Electron client. */
   invite: string;
@@ -75,6 +83,7 @@ export type InProcessFederationGateway = {
  */
 export async function startInProcessFederationGateway(params: {
   threads: GatewayThreadSeed[];
+  directories?: GatewayDirectorySeed[];
   instanceLabel?: string;
   /**
    * Serve remote PTY sessions with a REAL shell spawned via node-pty inside
@@ -93,19 +102,28 @@ export async function startInProcessFederationGateway(params: {
   const noiseStatic = generateNoiseStaticKeyPair();
   const gatewayInstanceId = `e2e_gateway_${randomBytes(4).toString("hex")}`;
   const instanceLabel = params.instanceLabel ?? "E2E Gateway";
+  const directories = params.directories ?? [];
+  const threads = [...params.threads];
 
   const calls: { method: string; params: unknown }[] = [];
   const pinnedRankByThreadId = new Map<string, string | undefined>(
-    params.threads.map((thread) => [thread.id, thread.pinnedRank]),
+    threads.map((thread) => [thread.id, thread.pinnedRank]),
   );
 
   const threadSummaries = (): AppServerThreadSummary[] =>
-    params.threads.map((thread) => ({
+    threads.map((thread) => ({
       id: thread.id,
       title: thread.title,
       titleSource: "explicit" as const,
       source: "codex" as const,
-      linkedDirectories: [],
+      linkedDirectories: directories[0]
+        ? [{
+            id: directories[0].path,
+            label: directories[0].label,
+            path: directories[0].path,
+            kind: "local" as const,
+          }]
+        : [],
       updatedAt: thread.updatedAt,
       createdAt: thread.updatedAt,
       ...(pinnedRankByThreadId.get(thread.id) !== undefined
@@ -121,8 +139,15 @@ export async function startInProcessFederationGateway(params: {
       ...thread,
       inbox: { inInbox: true },
     })),
-    inboxThreadKeys: params.threads.map((thread) => `codex:${thread.id}`),
-    directories: [],
+    inboxThreadKeys: threads.map((thread) => `codex:${thread.id}`),
+    directories: directories.map((directory) => ({
+      key: directory.key,
+      kind: "directory" as const,
+      label: directory.label,
+      path: directory.path,
+      threadKeys: threads.map((thread) => `codex:${thread.id}`),
+      needsAttentionCount: 0,
+    })),
     launchpadDefaults: {
       backend: "codex",
       executionMode: "default",
@@ -146,7 +171,7 @@ export async function startInProcessFederationGateway(params: {
       request: AppServerReadThreadRequest,
     ): Promise<AppServerReadThreadResponse> {
       calls.push({ method: "readThread", params: request });
-      const thread = params.threads.find((entry) => entry.id === request.threadId);
+      const thread = threads.find((entry) => entry.id === request.threadId);
       const text = `Remote transcript for ${thread?.title ?? request.threadId}.`;
       return {
         backend: "codex",
@@ -206,6 +231,28 @@ export async function startInProcessFederationGateway(params: {
     async listScheduledThreadActions() {
       calls.push({ method: "listScheduledThreadActions", params: {} });
       return { actions: [] };
+    },
+    async materializeDirectoryLaunchpad(
+      request: MaterializeDirectoryLaunchpadRequest,
+    ): Promise<MaterializeDirectoryLaunchpadResponse> {
+      calls.push({ method: "materializeDirectoryLaunchpad", params: request });
+      const threadId = `remote-created-${threads.length + 1}`;
+      const prompt =
+        request.input?.find((item) => item.type === "text")?.text.trim()
+        ?? request.launchpad?.prompt.trim()
+        ?? "";
+      threads.unshift({
+        id: threadId,
+        title: prompt || "Remote created thread",
+        updatedAt: Date.now(),
+      });
+      return {
+        backend: request.launchpad?.backend ?? "codex",
+        threadId,
+        executionMode: request.launchpad?.executionMode ?? "default",
+        workMode: request.launchpad?.workMode ?? "local",
+        turnId: `turn-${threadId}`,
+      };
     },
   } as unknown as FederationBackendOperations;
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2811,6 +2811,109 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("clears the viewer-persisted launchpad after remote materialization", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = federationTarget;
+    const directoryKey = "directory:/remote/PwrAgent";
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey,
+      directoryKind: "directory",
+      directoryLabel: "PwrAgent",
+      directoryPath: "/remote/PwrAgent",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "Submitted remotely",
+      workMode: "local",
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const defaults = {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    };
+    const initialSnapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/remote/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad,
+        },
+      ],
+      launchpadDefaults: defaults,
+    };
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce(initialSnapshot)
+      .mockResolvedValue({
+        ...initialSnapshot,
+        inboxThreadKeys: ["codex:remote-thread-new"],
+        threads: [
+          {
+            id: "remote-thread-new",
+            title: "Submitted remotely",
+            titleSource: "derived" as const,
+            source: "codex" as const,
+            linkedDirectories: [],
+            inbox: { inInbox: true, reason: "new-thread" as const },
+            updatedAt: 3,
+          },
+        ],
+        directories: [
+          {
+            ...initialSnapshot.directories[0]!,
+            threadKeys: ["codex:remote-thread-new"],
+            launchpad: undefined,
+          },
+        ],
+      });
+    const materializeDirectoryLaunchpad = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "remote-thread-new",
+      executionMode: "default" as const,
+      workMode: "local" as const,
+    }));
+    const resetDirectoryLaunchpad = vi.fn(async () => ({
+      directoryKey,
+      defaults,
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      resetDirectoryLaunchpad,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedLaunchpad?.prompt).toBe("Submitted remotely");
+    });
+
+    await act(async () => {
+      await result.current.materializeDirectoryLaunchpad(directoryKey);
+    });
+
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({ federationTarget }),
+    );
+    expect(resetDirectoryLaunchpad).toHaveBeenCalledWith({ directoryKey });
+    expect(result.current.selectedLaunchpad).toBeUndefined();
+  });
+
   it("shows a newly materialized detached worktree thread as HEAD before the backend snapshot catches up", async () => {
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -5350,11 +5350,12 @@ export function useThreadNavigation(
         parentThreadId ??
         launchpad.parentThreadId ??
         getParentThreadIdFromSubthreadLaunchpadKey(directoryKey);
+      const federationTarget = readRendererFederationTarget();
       let response: Awaited<ReturnType<NonNullable<DesktopApi["materializeDirectoryLaunchpad"]>>>;
       try {
         response = await desktopApi.materializeDirectoryLaunchpad({
           directoryKey,
-          federationTarget: readRendererFederationTarget(),
+          federationTarget,
           launchpad,
           input,
           collaborationMode,
@@ -5366,6 +5367,20 @@ export function useThreadNavigation(
       } catch (error) {
         setLaunchpadError(error instanceof Error ? error.message : String(error));
         throw error;
+      }
+      let localDraftResetFailure: string | undefined;
+      if (federationTarget && desktopApi.resetDirectoryLaunchpad) {
+        try {
+          // Remote launchpads are composed and persisted on the viewer, then
+          // sent in full to the owning instance for materialization. The owner
+          // clears its overlay row as part of that operation, but it cannot
+          // clear the viewer's local copy. Remove that copy after success so
+          // reopening the launchpad cannot resurrect the submitted message.
+          await desktopApi.resetDirectoryLaunchpad({ directoryKey });
+        } catch (error) {
+          localDraftResetFailure =
+            error instanceof Error ? error.message : String(error);
+        }
       }
       const optimisticMaterializedThread = buildOptimisticThreadFromLaunchpad({
         directory,
@@ -5433,6 +5448,10 @@ export function useThreadNavigation(
         setLaunchpadError(response.turnStartFailure.message);
       } else if (response.autoPinFailure) {
         setLaunchpadError(response.autoPinFailure.message);
+      } else if (localDraftResetFailure) {
+        setLaunchpadError(
+          `Thread started, but the saved launchpad draft could not be cleared: ${localDraftResetFailure}`,
+        );
       }
       // Link composer `@`-referenced directories to the just-created
       // thread before the refresh below so the snapshot comes back with


### PR DESCRIPTION
## What changed

- Clear the Federation viewer's persisted launchpad overlay after remote materialization succeeds.
- Preserve the successful thread transition if local draft cleanup fails, while surfacing the cleanup error.
- Extend the real Federation gateway fixture to support directory launchpads and remote materialization.
- Add focused hook coverage and an Electron E2E submit/reopen regression.

## Root cause

Remote launchpad drafts are composed and persisted in the viewer's local overlay store, then sent in full to the owning instance. The owner cleared its own launchpad row after materializing the thread, while the viewer only cleared in-memory React state. Reopening the launchpad therefore rehydrated the already-submitted viewer-local draft.

## Impact

After a remotely created thread is born, reopening that directory's launchpad now starts with an empty composer instead of the submitted text and attachments.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (100 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts federation-remote-window.spec.ts` (1 passed)
