### PR TITLE
fix(desktop): scope remote PwrSnap controls

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -14,6 +14,50 @@ import { FederationRouter } from "../federation/federation-router";
 import { FederationRpcEndpoint } from "../federation/federation-rpc";
 
 describe("federation backend bridge", () => {
+  it("reads remote PwrSnap status through its dedicated capability", async () => {
+    const sent: FederationProtocolEnvelope[] = [];
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "viewer_one",
+      remoteInstanceId: "owner_one",
+      sendEnvelope: (envelope) => sent.push(envelope),
+      now: () => 1_000,
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+
+    const pending = client.readPwrSnapConnectionStatus();
+    const request = sent.at(-1)!;
+    expect(request).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.readPwrSnapConnectionStatus,
+      params: {},
+    });
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.readPwrSnapConnectionStatus
+      ],
+    ).toBe("pwrsnap_connection");
+
+    rpc.receiveEnvelope({
+      id: "response-pwrsnap",
+      kind: "response",
+      requestId: request.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_100,
+      result: {
+        connectionId: "pwrsnap",
+        displayName: "PwrSnap",
+        availability: "running",
+        configured: true,
+      },
+    });
+    await expect(pending).resolves.toMatchObject({
+      availability: "running",
+      configured: true,
+    });
+  });
+
   it("maps federation backend methods to local app-server operations", async () => {
     const backend: FederationBackendOperations = {
       listThreads: vi.fn(async () => ({
@@ -856,6 +900,7 @@ describe("federation backend bridge", () => {
       readApplications: vi.fn(),
       openApplication: vi.fn(),
       readMessagingPlatformStatuses: vi.fn(),
+      readPwrSnapConnectionStatus: vi.fn(),
       trustCodexProject: vi.fn(),
     };
     const replies: FederationProtocolEnvelope[] = [];
@@ -1016,6 +1061,7 @@ describe("federation backend bridge", () => {
         readApplications: vi.fn(),
         openApplication: vi.fn(),
         readMessagingPlatformStatuses: vi.fn(),
+        readPwrSnapConnectionStatus: vi.fn(),
         trustCodexProject: vi.fn(),
       } as FederationBackendOperations,
     });

--- a/apps/desktop/src/main/__tests__/mcp-connections-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-connections-ipc.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  PwrSnapConnectionStatus,
+  ReadPwrSnapConnectionStatusRequest,
+} from "@pwragent/shared";
+
+const federationTarget = {
+  scope: "remote" as const,
+  instanceId: "remote-owner",
+};
+const remoteSender = { id: 17 };
+
+const mocks = vi.hoisted(() => {
+  const handlers = new Map<
+    string,
+    (...args: unknown[]) => Promise<unknown>
+  >();
+  const remoteStatus: PwrSnapConnectionStatus = {
+    connectionId: "pwrsnap",
+    displayName: "PwrSnap",
+    availability: "running",
+    configured: true,
+  };
+  return {
+    handlers,
+    readRemoteStatus: vi.fn(async () => remoteStatus),
+    remoteBackend: vi.fn(() => ({
+      readPwrSnapConnectionStatus: mocks.readRemoteStatus,
+    })),
+  };
+});
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn(
+      (channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+        mocks.handlers.set(channel, handler);
+      },
+    ),
+    removeHandler: vi.fn((channel: string) => {
+      mocks.handlers.delete(channel);
+    }),
+  },
+}));
+
+vi.mock("../federation/federation-runtime", () => ({
+  getDesktopFederationRuntime: () => ({ remoteBackend: mocks.remoteBackend }),
+}));
+
+vi.mock("../window", () => ({
+  federationWindowTargetForWebContents: (sender: unknown) =>
+    sender === remoteSender ? federationTarget : undefined,
+}));
+
+describe("MCP connection IPC", () => {
+  const localStatus: PwrSnapConnectionStatus = {
+    connectionId: "pwrsnap",
+    displayName: "PwrSnap",
+    availability: "not_installed",
+    configured: false,
+  };
+  const service = {
+    readStatus: vi.fn(async () => localStatus),
+    connect: vi.fn(),
+    openApplication: vi.fn(),
+    openDownload: vi.fn(),
+  };
+
+  beforeEach(() => {
+    mocks.handlers.clear();
+    mocks.readRemoteStatus.mockClear();
+    mocks.remoteBackend.mockClear();
+    service.readStatus.mockClear();
+    service.connect.mockClear();
+    service.openApplication.mockClear();
+    service.openDownload.mockClear();
+  });
+
+  it("reads status from the remote owner without consulting local PwrSnap", async () => {
+    const { registerMcpConnectionIpcHandlers } = await import(
+      "../ipc/mcp-connections"
+    );
+    const { MCP_CONNECTION_PWRSNAP_STATUS_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    registerMcpConnectionIpcHandlers(service as never);
+
+    const response = await mocks.handlers.get(
+      MCP_CONNECTION_PWRSNAP_STATUS_CHANNEL,
+    )?.(
+      { sender: remoteSender },
+      {} satisfies ReadPwrSnapConnectionStatusRequest,
+    );
+
+    expect(mocks.remoteBackend).toHaveBeenCalledWith(federationTarget);
+    expect(mocks.readRemoteStatus).toHaveBeenCalledOnce();
+    expect(service.readStatus).not.toHaveBeenCalled();
+    expect(response).toMatchObject({ configured: true, availability: "running" });
+  });
+
+  it("preserves local PwrSnap status and pairing behavior", async () => {
+    const { registerMcpConnectionIpcHandlers } = await import(
+      "../ipc/mcp-connections"
+    );
+    const {
+      MCP_CONNECTION_PWRSNAP_CONNECT_CHANNEL,
+      MCP_CONNECTION_PWRSNAP_STATUS_CHANNEL,
+    } = await import("../../shared/ipc");
+    service.connect.mockResolvedValue({
+      outcome: "connected",
+      status: { ...localStatus, availability: "running", configured: true },
+    });
+    registerMcpConnectionIpcHandlers(service as never);
+
+    await expect(mocks.handlers.get(MCP_CONNECTION_PWRSNAP_STATUS_CHANNEL)?.(
+      { sender: { id: 18 } },
+      {},
+    )).resolves.toEqual(localStatus);
+    await mocks.handlers.get(MCP_CONNECTION_PWRSNAP_CONNECT_CHANNEL)?.({
+      sender: { id: 18 },
+    });
+
+    expect(service.readStatus).toHaveBeenCalledOnce();
+    expect(service.connect).toHaveBeenCalledOnce();
+    expect(mocks.remoteBackend).not.toHaveBeenCalled();
+  });
+
+  it("blocks every local PwrSnap pairing or launch action in a remote window", async () => {
+    const { registerMcpConnectionIpcHandlers } = await import(
+      "../ipc/mcp-connections"
+    );
+    const {
+      MCP_CONNECTION_PWRSNAP_CONNECT_CHANNEL,
+      MCP_CONNECTION_PWRSNAP_DOWNLOAD_CHANNEL,
+      MCP_CONNECTION_PWRSNAP_OPEN_CHANNEL,
+    } = await import("../../shared/ipc");
+    registerMcpConnectionIpcHandlers(service as never);
+    const event = { sender: remoteSender };
+
+    await expect(
+      mocks.handlers.get(MCP_CONNECTION_PWRSNAP_CONNECT_CHANNEL)?.(event),
+    ).rejects.toThrow(/only available on the machine that owns/i);
+    await expect(
+      mocks.handlers.get(MCP_CONNECTION_PWRSNAP_OPEN_CHANNEL)?.(event),
+    ).resolves.toMatchObject({ opened: false });
+    await expect(
+      mocks.handlers.get(MCP_CONNECTION_PWRSNAP_DOWNLOAD_CHANNEL)?.(event),
+    ).resolves.toMatchObject({ opened: false });
+
+    expect(service.connect).not.toHaveBeenCalled();
+    expect(service.openApplication).not.toHaveBeenCalled();
+    expect(service.openDownload).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -37,6 +37,7 @@ import type {
   MarkThreadSeenRequest,
   MarkThreadSeenResponse,
   MessagingPlatformStatus,
+  PwrSnapConnectionStatus,
   SetThreadPinRequest,
   SetThreadPinResponse,
   SetThreadPrAutoDispatchRequest,
@@ -125,6 +126,7 @@ export const FEDERATION_BACKEND_METHODS = {
   readApplications: "backend.readApplications",
   openApplication: "backend.openApplication",
   readMessagingPlatformStatuses: "backend.readMessagingPlatformStatuses",
+  readPwrSnapConnectionStatus: "backend.readPwrSnapConnectionStatus",
   trustCodexProject: "backend.trustCodexProject",
 } as const;
 
@@ -194,6 +196,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   // Read-only peer messaging health for the remote window's MSG chip.
   // messaging_route stays reserved for messaging-originated remote control.
   [FEDERATION_BACKEND_METHODS.readMessagingPlatformStatuses]: "remote_window",
+  [FEDERATION_BACKEND_METHODS.readPwrSnapConnectionStatus]: "pwrsnap_connection",
   [FEDERATION_BACKEND_METHODS.trustCodexProject]: "environment_actions",
 };
 
@@ -305,6 +308,7 @@ export type FederationBackendOperations = {
     request: OpenDesktopApplicationRequest,
   ): Promise<OpenDesktopApplicationResponse>;
   readMessagingPlatformStatuses(): Promise<MessagingPlatformStatus[]>;
+  readPwrSnapConnectionStatus(): Promise<PwrSnapConnectionStatus>;
   trustCodexProject(
     request: TrustCodexProjectRequest,
   ): Promise<TrustCodexProjectResponse>;
@@ -600,6 +604,10 @@ export function registerFederationBackendHandlers(params: {
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.readMessagingPlatformStatuses,
     async () => await params.backend.readMessagingPlatformStatuses(),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.readPwrSnapConnectionStatus,
+    async () => await params.backend.readPwrSnapConnectionStatus(),
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.openApplication,
@@ -962,6 +970,13 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   async readMessagingPlatformStatuses(): Promise<MessagingPlatformStatus[]> {
     return await this.rpc.request<MessagingPlatformStatus[]>({
       method: FEDERATION_BACKEND_METHODS.readMessagingPlatformStatuses,
+      params: {},
+    });
+  }
+
+  async readPwrSnapConnectionStatus(): Promise<PwrSnapConnectionStatus> {
+    return await this.rpc.request<PwrSnapConnectionStatus>({
+      method: FEDERATION_BACKEND_METHODS.readPwrSnapConnectionStatus,
       params: {},
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -30,6 +30,7 @@ import type {
   MaterializeDirectoryLaunchpadResponse,
   MarkThreadSeenResponse,
   MessagingPlatformStatus,
+  PwrSnapConnectionStatus,
   OpenDesktopApplicationResponse,
   QueueThreadExecutionModeResponse,
   RefreshDirectoryGitStatusesResponse,
@@ -108,6 +109,7 @@ import {
   discoverDesktopApplications,
   openDesktopApplication,
 } from "../settings/application-discovery";
+import { getPwrSnapConnectionService } from "../mcp-connections/pwrsnap-connection-service";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { getAppStateDb, isAppStateInitialized } from "../state/app-state";
 import { DesktopMessagingBackendBridge } from "../messaging/desktop-backend-bridge";
@@ -191,6 +193,7 @@ const DEFAULT_CAPABILITIES: FederationCapability[] = [
   "environment_actions",
   "federated_search",
   "messaging_route",
+  "pwrsnap_connection",
   "gateway_relay",
   // Federation is a same-operator trust domain and turn_control already
   // permits code execution via agent turns, so the direct shell defaults to
@@ -2220,6 +2223,9 @@ function localBackendOperations(): FederationBackendOperations {
       request: OpenDesktopApplicationRequest,
     ): Promise<OpenDesktopApplicationResponse> {
       return await openDesktopApplication(request);
+    },
+    async readPwrSnapConnectionStatus(): Promise<PwrSnapConnectionStatus> {
+      return await getPwrSnapConnectionService().readStatus();
     },
     async trustCodexProject(
       request: TrustCodexProjectRequest,

--- a/apps/desktop/src/main/ipc/mcp-connections.ts
+++ b/apps/desktop/src/main/ipc/mcp-connections.ts
@@ -1,8 +1,10 @@
 import { ipcMain } from "electron";
-import type {
-  ConnectPwrSnapResponse,
-  OpenPwrSnapResponse,
-  PwrSnapConnectionStatus,
+import {
+  isRemoteFederationTarget,
+  type ConnectPwrSnapResponse,
+  type OpenPwrSnapResponse,
+  type PwrSnapConnectionStatus,
+  type ReadPwrSnapConnectionStatusRequest,
 } from "@pwragent/shared";
 import {
   MCP_CONNECTION_PWRSNAP_CONNECT_CHANNEL,
@@ -14,6 +16,8 @@ import {
   getPwrSnapConnectionService,
   type PwrSnapConnectionService,
 } from "../mcp-connections/pwrsnap-connection-service";
+import { getDesktopFederationRuntime } from "../federation/federation-runtime";
+import { federationWindowTargetForWebContents } from "../window";
 
 export function registerMcpConnectionIpcHandlers(
   service: PwrSnapConnectionService = getPwrSnapConnectionService(),
@@ -21,22 +25,58 @@ export function registerMcpConnectionIpcHandlers(
   ipcMain.removeHandler(MCP_CONNECTION_PWRSNAP_STATUS_CHANNEL);
   ipcMain.handle(
     MCP_CONNECTION_PWRSNAP_STATUS_CHANNEL,
-    async (): Promise<PwrSnapConnectionStatus> => await service.readStatus(),
+    async (
+      event,
+      request: ReadPwrSnapConnectionStatusRequest = {},
+    ): Promise<PwrSnapConnectionStatus> => {
+      const federationTarget =
+        federationWindowTargetForWebContents(event.sender)
+        ?? request.federationTarget;
+      if (federationTarget && isRemoteFederationTarget(federationTarget)) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(federationTarget)
+          .readPwrSnapConnectionStatus();
+      }
+      return await service.readStatus();
+    },
   );
   ipcMain.removeHandler(MCP_CONNECTION_PWRSNAP_CONNECT_CHANNEL);
   ipcMain.handle(
     MCP_CONNECTION_PWRSNAP_CONNECT_CHANNEL,
-    async (): Promise<ConnectPwrSnapResponse> => await service.connect(),
+    async (event): Promise<ConnectPwrSnapResponse> => {
+      if (federationWindowTargetForWebContents(event.sender)) {
+        throw new Error(
+          "PwrSnap pairing is only available on the machine that owns this window.",
+        );
+      }
+      return await service.connect();
+    },
   );
   ipcMain.removeHandler(MCP_CONNECTION_PWRSNAP_OPEN_CHANNEL);
   ipcMain.handle(
     MCP_CONNECTION_PWRSNAP_OPEN_CHANNEL,
-    async (): Promise<OpenPwrSnapResponse> => await service.openApplication(),
+    async (event): Promise<OpenPwrSnapResponse> => {
+      if (federationWindowTargetForWebContents(event.sender)) {
+        return {
+          opened: false,
+          error: "This thread uses PwrSnap on its remote owner.",
+        };
+      }
+      return await service.openApplication();
+    },
   );
   ipcMain.removeHandler(MCP_CONNECTION_PWRSNAP_DOWNLOAD_CHANNEL);
   ipcMain.handle(
     MCP_CONNECTION_PWRSNAP_DOWNLOAD_CHANNEL,
-    async (): Promise<OpenPwrSnapResponse> => await service.openDownload(),
+    async (event): Promise<OpenPwrSnapResponse> => {
+      if (federationWindowTargetForWebContents(event.sender)) {
+        return {
+          opened: false,
+          error: "Install PwrSnap on the machine that owns this thread.",
+        };
+      }
+      return await service.openDownload();
+    },
   );
 }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -154,6 +154,7 @@ import type {
   ConnectPwrSnapResponse,
   OpenPwrSnapResponse,
   PwrSnapConnectionStatus,
+  ReadPwrSnapConnectionStatusRequest,
   InspectPdfReferencePathsRequest,
   InspectPdfReferencePathsResponse,
   RenderComposerPdfPreviewRequest,
@@ -672,8 +673,10 @@ const desktopApi = Object.freeze({
   copyRichText: async (payload: { text: string; html: string }): Promise<void> => {
     await ipcRenderer.invoke(CLIPBOARD_WRITE_RICH_TEXT_CHANNEL, payload);
   },
-  readPwrSnapConnectionStatus: async (): Promise<PwrSnapConnectionStatus> =>
-    await ipcRenderer.invoke(MCP_CONNECTION_PWRSNAP_STATUS_CHANNEL),
+  readPwrSnapConnectionStatus: async (
+    request: ReadPwrSnapConnectionStatusRequest = {},
+  ): Promise<PwrSnapConnectionStatus> =>
+    await ipcRenderer.invoke(MCP_CONNECTION_PWRSNAP_STATUS_CHANNEL, request),
   connectPwrSnap: async (): Promise<ConnectPwrSnapResponse> =>
     await ipcRenderer.invoke(MCP_CONNECTION_PWRSNAP_CONNECT_CHANNEL),
   openPwrSnap: async (): Promise<OpenPwrSnapResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -736,17 +736,32 @@ function DesktopAppShell(props: {
   });
   const selectedThreadFederationTarget =
     navigation.selectedThread?.federation?.ref.target;
+  const navigationFederationTarget = navigation.federationTarget;
   const remoteApplicationInstanceId =
     selectedThreadFederationTarget
     && isRemoteFederationTarget(selectedThreadFederationTarget)
       ? selectedThreadFederationTarget.instanceId
-      : readRendererFederationTarget()?.instanceId;
+      : navigationFederationTarget
+        && isRemoteFederationTarget(navigationFederationTarget)
+        ? navigationFederationTarget.instanceId
+        : readRendererFederationTarget()?.instanceId;
   const activeFederationTarget = useMemo(
     () => remoteApplicationInstanceId
       ? { scope: "remote" as const, instanceId: remoteApplicationInstanceId }
       : undefined,
     [remoteApplicationInstanceId],
   );
+  const activeFederationOwnerLabel = activeFederationTarget
+    ? navigation.selectedThread?.federation?.instanceLabel
+      ?? navigation.threads.find((thread) => {
+        const target = thread.federation?.ref.target;
+        return target
+          && isRemoteFederationTarget(target)
+          && target.instanceId === activeFederationTarget.instanceId;
+      })?.federation?.instanceLabel
+      ?? readRendererFederationLabel()
+      ?? "the remote machine"
+    : undefined;
   const threadDesktopApi = useMemo(
     () => scopeDesktopApiToFederationTarget(desktopApi, activeFederationTarget),
     [activeFederationTarget, desktopApi],
@@ -1179,6 +1194,8 @@ function DesktopAppShell(props: {
     },
   };
   const threadViewProps = {
+    activeFederationOwnerLabel,
+    activeFederationTarget,
     activeTurnId: session.activeTurnId,
     activeTurnStartedAt: session.activeTurnStartedAt,
     terminals,

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -1410,6 +1410,7 @@ const FEDERATION_CAPABILITY_LABELS: Record<FederationCapability, string> = {
   environment_actions: "run environments and scripts",
   federated_search: "search remote threads",
   messaging_route: "route messaging threads",
+  pwrsnap_connection: "read PwrSnap availability",
   gateway_relay: "reach sibling instances",
   remote_pty: "open a remote terminal",
 };

--- a/apps/desktop/src/renderer/src/features/thread-detail/PwrSnapConnectionPrompt.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/PwrSnapConnectionPrompt.test.tsx
@@ -3,6 +3,60 @@ import { describe, expect, it, vi } from "vitest";
 import { PwrSnapConnectionPrompt } from "./PwrSnapConnectionPrompt";
 
 describe("PwrSnapConnectionPrompt", () => {
+  it("renders nothing when a remote owner does not report PwrSnap available", async () => {
+    const readPwrSnapConnectionStatus = vi.fn(async () => ({
+      connectionId: "pwrsnap" as const,
+      displayName: "PwrSnap" as const,
+      availability: "running" as const,
+      configured: false,
+    }));
+    render(
+      <PwrSnapConnectionPrompt
+        backend="codex"
+        desktopApi={{ readPwrSnapConnectionStatus }}
+        enabled={false}
+        remoteOwnerLabel="Studio Mac"
+        onEnabledChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(readPwrSnapConnectionStatus).toHaveBeenCalledOnce());
+    expect(screen.queryByLabelText(/PwrSnap connection/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: /PwrSnap/i })).toBeNull();
+  });
+
+  it("offers only per-thread enablement for PwrSnap on an available remote owner", async () => {
+    const onEnabledChange = vi.fn(async () => undefined);
+    render(
+      <PwrSnapConnectionPrompt
+        backend="codex"
+        desktopApi={{
+          readPwrSnapConnectionStatus: async () => ({
+            connectionId: "pwrsnap",
+            displayName: "PwrSnap",
+            availability: "running",
+            configured: true,
+          }),
+        }}
+        enabled={false}
+        remoteOwnerLabel="Studio Mac"
+        onEnabledChange={onEnabledChange}
+      />,
+    );
+
+    expect(await screen.findByText("PwrSnap is available on Studio Mac"))
+      .toBeTruthy();
+    expect(screen.getByText(/where the thread runs/)).toBeTruthy();
+    expect(screen.queryByText("Connect to PwrSnap")).toBeNull();
+    expect(screen.queryByText("Get PwrSnap")).toBeNull();
+    expect(screen.queryByText("Open PwrSnap")).toBeNull();
+
+    fireEvent.click(screen.getByRole("switch", {
+      name: "Enable PwrSnap on Studio Mac in this thread",
+    }));
+    await waitFor(() => expect(onEnabledChange).toHaveBeenCalledWith(true));
+  });
+
   it("offers the PwrSnap download when the app is not installed", async () => {
     const openPwrSnapDownload = vi.fn(async () => ({ opened: true }));
     render(

--- a/apps/desktop/src/renderer/src/features/thread-detail/PwrSnapConnectionPrompt.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/PwrSnapConnectionPrompt.tsx
@@ -13,6 +13,7 @@ export function PwrSnapConnectionPrompt(props: {
   backend: AppServerBackendKind;
   desktopApi?: DesktopApi;
   enabled: boolean;
+  remoteOwnerLabel?: string;
   onEnabledChange: (enabled: boolean) => Promise<void>;
 }) {
   const [status, setStatus] = useState<PwrSnapConnectionStatus>();
@@ -80,6 +81,57 @@ export function PwrSnapConnectionPrompt(props: {
   const configured = status?.configured === true;
   const running = status?.availability === "running";
   const installed = status?.availability === "installed" || running;
+  const remoteOwnerLabel = props.remoteOwnerLabel?.trim();
+
+  // A remote launchpad may only expose PwrSnap after its owner explicitly
+  // reports a configured, running connection. Never turn the viewer's local
+  // install state into a remote pairing or download affordance.
+  if (remoteOwnerLabel && (!configured || !running)) {
+    return null;
+  }
+
+  if (remoteOwnerLabel) {
+    const switchLabel = `Enable PwrSnap on ${remoteOwnerLabel} in this thread`;
+    const description =
+      `Enable it to let this thread use PwrSnap on ${remoteOwnerLabel}, `
+      + "where the thread runs. This does not connect to PwrSnap on this device.";
+    return (
+      <aside className="pwrsnap-connection" aria-label="Remote PwrSnap connection">
+        <img
+          alt=""
+          aria-hidden="true"
+          className="pwrsnap-connection__icon"
+          src={pwrSnapIcon}
+        />
+        <div className="pwrsnap-connection__copy">
+          <p className="eyebrow">Remote PwrSuite connection</p>
+          <h2>{`PwrSnap is available on ${remoteOwnerLabel}`}</h2>
+          <p>{description}</p>
+          {!backendSupported ? (
+            <p className="pwrsnap-connection__detail">
+              Choose Codex or an ACP agent to use MCP connections in this thread.
+            </p>
+          ) : null}
+          {error ? (
+            <p className="pwrsnap-connection__error" role="status">{error}</p>
+          ) : null}
+        </div>
+        <div className="pwrsnap-connection__action">
+          <div className="pwrsnap-connection__toggle">
+            <span>Enable PwrSnap in this thread</span>
+            <SettingsSwitch
+              checked={props.enabled}
+              disabled={busy || !backendSupported}
+              label={switchLabel}
+              onChange={(enabled) => {
+                void runAction(async () => await props.onEnabledChange(enabled));
+              }}
+            />
+          </div>
+        </div>
+      </aside>
+    );
+  }
 
   return (
     <aside className="pwrsnap-connection" aria-label="PwrSnap connection">

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -54,7 +54,10 @@ import {
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { agentEventMatchesThread } from "../../lib/federated-thread-events";
-import { readRendererFederationTarget } from "../../lib/federation-window";
+import {
+  readRendererFederationLabel,
+  readRendererFederationTarget,
+} from "../../lib/federation-window";
 import type { IntegratedTerminalsController } from "../../lib/useIntegratedTerminals";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import type { PendingForkEnvironmentSetup } from "../../lib/useThreadNavigation";
@@ -2887,6 +2890,11 @@ export function ThreadView(props: ThreadViewProps) {
                   selectedLaunchpad.mcpConnectionIds?.includes(
                     PWRSNAP_MCP_CONNECTION_ID,
                   ) === true
+                }
+                remoteOwnerLabel={
+                  readRendererFederationTarget()
+                    ? readRendererFederationLabel() ?? "the remote machine"
+                    : undefined
                 }
                 onEnabledChange={async (enabled) => {
                   await props.onUpdateLaunchpad?.(

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -32,6 +32,7 @@ import type {
   DesktopChatReplyComposer,
   DesktopProviderModelDefaults,
   DesktopProviderThreadModelMigration,
+  FederationRemoteTarget,
   HandoffThreadWorkspaceRequest,
   MarkdownFileViewerContext,
   MessagingChannelKind,
@@ -54,10 +55,7 @@ import {
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { agentEventMatchesThread } from "../../lib/federated-thread-events";
-import {
-  readRendererFederationLabel,
-  readRendererFederationTarget,
-} from "../../lib/federation-window";
+import { readRendererFederationTarget } from "../../lib/federation-window";
 import type { IntegratedTerminalsController } from "../../lib/useIntegratedTerminals";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import type { PendingForkEnvironmentSetup } from "../../lib/useThreadNavigation";
@@ -851,6 +849,8 @@ function activityHasFileDiff(entry: AppServerThreadActivityEntry | undefined): b
 }
 
 export type ThreadViewProps = {
+  activeFederationOwnerLabel?: string;
+  activeFederationTarget?: FederationRemoteTarget;
   activeTurnId?: string;
   activeTurnStartedAt?: number;
   /**
@@ -2892,8 +2892,8 @@ export function ThreadView(props: ThreadViewProps) {
                   ) === true
                 }
                 remoteOwnerLabel={
-                  readRendererFederationTarget()
-                    ? readRendererFederationLabel() ?? "the remote machine"
+                  props.activeFederationTarget
+                    ? props.activeFederationOwnerLabel ?? "the remote machine"
                     : undefined
                 }
                 onEnabledChange={async (enabled) => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1602,6 +1602,67 @@ describe("ThreadView", () => {
     expect(screen.getByRole("group", { name: "Messaging platform status" })).toBeInTheDocument();
   });
 
+  it("treats a main-window launchpad as remote from the active federation target", async () => {
+    const selectedDirectory = {
+      key: "directory:/remote/repo",
+      kind: "directory",
+      label: "Remote Repo",
+      path: "/remote/repo",
+      threadKeys: [],
+      needsAttentionCount: 0,
+    } satisfies NavigationDirectorySummary;
+    const selectedLaunchpad = {
+      backend: "codex",
+      createdAt: 1_000,
+      directoryKey: selectedDirectory.key,
+      directoryKind: selectedDirectory.kind,
+      directoryLabel: selectedDirectory.label,
+      directoryPath: selectedDirectory.path,
+      executionMode: "default",
+      prompt: "",
+      updatedAt: 1_000,
+      workMode: "local",
+    } satisfies NavigationLaunchpadDraft;
+    const readPwrSnapConnectionStatus = vi.fn(async () => ({
+      connectionId: "pwrsnap" as const,
+      displayName: "PwrSnap" as const,
+      availability: "running" as const,
+      configured: false,
+    }));
+
+    render(
+      <ThreadView
+        activeFederationOwnerLabel="Studio Mac"
+        activeFederationTarget={{
+          scope: "remote",
+          instanceId: "studio-mac",
+        }}
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        desktopApi={{ readPwrSnapConnectionStatus }}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        selectedDirectory={selectedDirectory}
+        selectedLaunchpad={selectedLaunchpad}
+        skills={[]}
+        transcriptEntries={[]}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(readPwrSnapConnectionStatus).toHaveBeenCalledOnce();
+    });
+    expect(screen.queryByLabelText("PwrSnap connection")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Connect to PwrSnap" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows environment setup details from config even when the deprecated setup flag is false", async () => {
     const selectedDirectory = {
       key: "directory:/repo",

--- a/apps/desktop/src/renderer/src/lib/__tests__/federation-desktop-api.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/federation-desktop-api.test.ts
@@ -8,9 +8,19 @@ describe("scopeDesktopApiToFederationTarget", () => {
     const refreshDirectoryGitStatuses = vi.fn(async () => ({
       scheduledCount: 1,
     }));
+    const readPwrSnapConnectionStatus = vi.fn(async () => ({
+      connectionId: "pwrsnap" as const,
+      displayName: "PwrSnap" as const,
+      availability: "running" as const,
+      configured: true,
+    }));
     const desktopApi = {
       openApplication,
       refreshDirectoryGitStatuses,
+      readPwrSnapConnectionStatus,
+      connectPwrSnap: vi.fn(),
+      openPwrSnap: vi.fn(),
+      openPwrSnapDownload: vi.fn(),
       openPath: vi.fn(),
       revealPath: vi.fn(),
       readMarkdownFile: vi.fn(),
@@ -36,6 +46,7 @@ describe("scopeDesktopApiToFederationTarget", () => {
       directoryKeys: ["directory:/remote/repo"],
       force: true,
     });
+    await scopedApi?.readPwrSnapConnectionStatus?.();
 
     expect(openApplication).toHaveBeenCalledWith({
       applicationId: "vscode",
@@ -48,6 +59,12 @@ describe("scopeDesktopApiToFederationTarget", () => {
       force: true,
       federationTarget,
     });
+    expect(readPwrSnapConnectionStatus).toHaveBeenCalledWith({
+      federationTarget,
+    });
+    expect(scopedApi?.connectPwrSnap).toBeUndefined();
+    expect(scopedApi?.openPwrSnap).toBeUndefined();
+    expect(scopedApi?.openPwrSnapDownload).toBeUndefined();
     expect(scopedApi?.openPath).toBeUndefined();
     expect(scopedApi?.revealPath).toBeUndefined();
     expect(scopedApi?.readMarkdownFile).toBeUndefined();

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2121,6 +2121,7 @@ describe("useThreadNavigation", () => {
     let title = "Before disconnect";
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,
+      federationTarget,
       fetchedAt: Date.now(),
       unchanged: false,
       inboxThreadKeys: ["codex:thread-remote"],
@@ -2154,6 +2155,7 @@ describe("useThreadNavigation", () => {
     await waitFor(() => {
       expect(result.current.selectedThread?.title).toBe("Before disconnect");
     });
+    expect(result.current.federationTarget).toEqual(federationTarget);
 
     act(() => {
       for (const listener of listeners) {

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -172,6 +172,7 @@ import type {
   ConnectPwrSnapResponse,
   OpenPwrSnapResponse,
   PwrSnapConnectionStatus,
+  ReadPwrSnapConnectionStatusRequest,
   InspectPdfReferencePathsRequest,
   InspectPdfReferencePathsResponse,
   RenderComposerPdfPreviewRequest,
@@ -345,7 +346,9 @@ import type {
 export type DesktopApi = {
   copyText?: (text: string) => Promise<void>;
   copyRichText?: (payload: { text: string; html: string }) => Promise<void>;
-  readPwrSnapConnectionStatus?: () => Promise<PwrSnapConnectionStatus>;
+  readPwrSnapConnectionStatus?: (
+    request?: ReadPwrSnapConnectionStatusRequest,
+  ) => Promise<PwrSnapConnectionStatus>;
   connectPwrSnap?: () => Promise<ConnectPwrSnapResponse>;
   openPwrSnap?: () => Promise<OpenPwrSnapResponse>;
   openPwrSnapDownload?: () => Promise<OpenPwrSnapResponse>;

--- a/apps/desktop/src/renderer/src/lib/federation-desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/federation-desktop-api.ts
@@ -10,6 +10,7 @@ export function scopeDesktopApiToFederationTarget(
   }
   const openApplication = desktopApi.openApplication;
   const refreshDirectoryGitStatuses = desktopApi.refreshDirectoryGitStatuses;
+  const readPwrSnapConnectionStatus = desktopApi.readPwrSnapConnectionStatus;
 
   return {
     ...desktopApi,
@@ -25,6 +26,12 @@ export function scopeDesktopApiToFederationTarget(
           federationTarget,
         })
       : undefined,
+    readPwrSnapConnectionStatus: readPwrSnapConnectionStatus
+      ? async () => await readPwrSnapConnectionStatus({ federationTarget })
+      : undefined,
+    connectPwrSnap: undefined,
+    openPwrSnap: undefined,
+    openPwrSnapDownload: undefined,
     openPath: undefined,
     revealPath: undefined,
     readMarkdownFile: undefined,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -8,6 +8,7 @@ import type {
   AppServerTurnInputItem,
   ArchiveThreadCleanupResult,
   CodexThreadEnvironmentRuntime,
+  FederationTarget,
   HandoffThreadWorkspaceRequest,
   LinkedDirectorySummary,
   NavigationBrowseMode,
@@ -2375,6 +2376,8 @@ export function useThreadNavigation(
   creatingThread?: CreatingThreadState;
   directories: NavigationDirectorySummary[];
   error?: string;
+  /** Instance that owns the active navigation snapshot. */
+  federationTarget?: FederationTarget;
   inboxThreads: NavigationThreadSummary[];
   recentThreads: NavigationThreadSummary[];
   launchpadError?: string;
@@ -6521,6 +6524,7 @@ export function useThreadNavigation(
     creatingThread,
     directories,
     error: state.error,
+    federationTarget: state.response?.federationTarget,
     inboxThreads,
     recentThreads,
     launchpadError,

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -19,6 +19,7 @@ export const FEDERATION_CAPABILITIES = [
   "environment_actions",
   "federated_search",
   "messaging_route",
+  "pwrsnap_connection",
   "gateway_relay",
   "remote_pty",
 ] as const;

--- a/packages/shared/src/contracts/mcp-connections.ts
+++ b/packages/shared/src/contracts/mcp-connections.ts
@@ -1,3 +1,5 @@
+import type { FederationRemoteTarget } from "./federation";
+
 export const PWRSNAP_MCP_CONNECTION_ID = "pwrsnap" as const;
 
 export type McpConnectionId = typeof PWRSNAP_MCP_CONNECTION_ID;
@@ -13,6 +15,10 @@ export type PwrSnapConnectionStatus = {
   availability: PwrSnapConnectionAvailability;
   configured: boolean;
   detail?: string;
+};
+
+export type ReadPwrSnapConnectionStatusRequest = {
+  federationTarget?: FederationRemoteTarget;
 };
 
 export type ConnectPwrSnapResponse = {


### PR DESCRIPTION
## Summary

- I route PwrSnap availability checks through the remote Federation owner instead of reading the viewer's local PwrSnap state.
- I hide PwrSnap controls for remote launchpads unless the owner reports PwrSnap as configured and running, then show only an owner-labeled per-thread enablement switch.
- I block local PwrSnap pairing, launch, and download actions from Federation windows and preserve the existing local New Thread workflow.
- I added a dedicated `pwrsnap_connection` Federation capability plus focused RPC, IPC, API-scoping, and renderer coverage.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/federation-*.test.ts apps/desktop/src/main/__tests__/mcp-connections-ipc.test.ts apps/desktop/src/renderer/src/features/thread-detail/PwrSnapConnectionPrompt.test.tsx apps/desktop/src/renderer/src/lib/__tests__/federation-desktop-api.test.ts packages/shared/src/contracts/__tests__/federation.test.ts` (26 files, 197 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`

## Notes

- The remote UI does not infer availability from the viewer's machine. If the owner is unavailable, unconfigured, not running PwrSnap, or does not advertise the new capability, no PwrSnap control is shown.
