### PR TITLE
fix(desktop): hydrate launchpad environment options for remote viewers

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -41,6 +41,26 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
   getDesktopOverlayStore: () => ({ reconcileNavigationSnapshot }),
 }));
 
+const { hydrateLaunchpadCodexEnvironmentOptions } = vi.hoisted(() => ({
+  hydrateLaunchpadCodexEnvironmentOptions: vi.fn(
+    async (launchpad: { directoryPath: string }) => ({
+      ...launchpad,
+      codexEnvironmentOptions: [
+        {
+          id: "env-default",
+          name: "Default",
+          sourcePath: "/repos/PwrAgnt/.codex/environments.toml",
+          actions: [],
+        },
+      ],
+    }),
+  ),
+}));
+
+vi.mock("../app-server/codex-environment-config", () => ({
+  hydrateLaunchpadCodexEnvironmentOptions,
+}));
+
 describe("DesktopMessagingBackendBridge", () => {
   it("hydrates review working state before the messenger chooses a project", async () => {
     const pwrAgentWorktree = "/worktrees/PwrAgnt";
@@ -116,6 +136,65 @@ describe("DesktopMessagingBackendBridge", () => {
     expect(findPreferredReviewWorkspaceCwd(snapshot.threads[0])).toBe(
       pwrAgentWorktree,
     );
+  });
+
+  it("hydrates launchpad Codex environment options for served snapshots", async () => {
+    // Federation remote viewers get their navigation snapshot through
+    // this bridge; without hydration here their launchpad has no
+    // Environment picker even though the local window's does.
+    reconcileNavigationSnapshot.mockResolvedValueOnce({
+      backend: "all",
+      fetchedAt: 1_000,
+      unchanged: false,
+      threads: [],
+      inboxThreadKeys: [],
+      directories: [
+        {
+          key: "directory:/repos/PwrAgnt",
+          kind: "directory",
+          label: "PwrAgnt",
+          path: "/repos/PwrAgnt",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad: {
+            directoryPath: "/repos/PwrAgnt",
+            backend: "codex",
+          },
+        },
+        {
+          key: "directory:/repos/PwrSnap",
+          kind: "directory",
+          label: "PwrSnap",
+          path: "/repos/PwrSnap",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    } as unknown as NavigationSnapshot);
+    const registry = {
+      getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
+      hydrateThreadGitWorkingStates: vi.fn(
+        async (threads: NavigationSnapshot["threads"]) => threads,
+      ),
+      listThreads: vi.fn(async () => []),
+      readDirectoryStatuses: vi.fn(async () => ({})),
+      rememberCompleteNavigationSnapshot: vi.fn(),
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry);
+
+    const snapshot = await bridge.getNavigationSnapshot({});
+
+    expect(hydrateLaunchpadCodexEnvironmentOptions).toHaveBeenCalledTimes(1);
+    expect(snapshot.directories[0]?.launchpad).toMatchObject({
+      directoryPath: "/repos/PwrAgnt",
+      codexEnvironmentOptions: [{ id: "env-default", name: "Default" }],
+    });
+    // Directories without a launchpad pass through untouched.
+    expect(snapshot.directories[1]?.launchpad).toBeUndefined();
   });
 
   it("preserves enriched messaging provenance when starting a turn", async () => {

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -64,6 +64,7 @@ import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
 import { resolveScratchProjectsRoots } from "../app-server/scratch-projects";
 import { buildMessagingBindingsByThreadKey } from "./messaging-bindings-snapshot";
+import { hydrateLaunchpadCodexEnvironmentOptions } from "../app-server/codex-environment-config";
 import { materializeTranscriptMessageImagesForMessaging } from "../transcript-image-protocol";
 import type { FederationBackendOperations } from "../federation/federation-backend-bridge";
 import { getScheduledThreadActionService } from "../scheduled-actions/scheduled-thread-action-service";
@@ -150,12 +151,39 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       hydratedSnapshot.directories,
     );
 
+    // The renderer's local snapshot path (ipc/app-server.ts) hydrates
+    // each directory launchpad's Codex environment options. This bridge
+    // is the serving path for federation remote viewers (and messaging
+    // browse) — without the same hydration, a remote window's launchpad
+    // renders with no Environment picker even though thread creation and
+    // post-birth environment control are fully federation-routed.
+    const directoriesWithLaunchpads = await Promise.all(
+      hydratedSnapshot.directories.map(async (directory) => {
+        const withStatus = {
+          ...directory,
+          gitStatus: directoryStatuses[directory.key],
+        };
+        if (!withStatus.launchpad) {
+          return withStatus;
+        }
+        try {
+          return {
+            ...withStatus,
+            launchpad: await hydrateLaunchpadCodexEnvironmentOptions(
+              withStatus.launchpad,
+            ),
+          };
+        } catch {
+          // Options are an enhancement; a hydration failure must not
+          // block the snapshot.
+          return withStatus;
+        }
+      }),
+    );
+
     const localSnapshot: NavigationSnapshot = {
       ...hydratedSnapshot,
-      directories: hydratedSnapshot.directories.map((directory) => ({
-        ...directory,
-        gitStatus: directoryStatuses[directory.key],
-      })),
+      directories: directoriesWithLaunchpads,
     };
     if (!this.federation) {
       return localSnapshot;


### PR DESCRIPTION
## Summary

Dogfood finding: creating a new thread from a federation remote viewer shows **no Codex Environment control in the launchpad**, even though the environment picker appears and works correctly once the thread exists.

### Root cause

Not a stale build — this was never wired. Two different serving paths hydrate navigation snapshots:

- **Local windows**: `ipc/app-server.ts` `readNavigationSnapshot` runs `hydrateDirectoryLaunchpads`, which attaches `codexEnvironmentOptions` to every directory launchpad before the renderer sees it.
- **Remote viewers**: the owning instance serves `getNavigationSnapshot` through `DesktopMessagingBackendBridge` (`localBackendOperations` → bridge), which built the snapshot without ever hydrating launchpads.

The Composer's launchpad picker renders purely on `launchpad.codexEnvironmentOptions.length > 0` — no federation gating — so the remote launchpad silently rendered without the Environment section. Post-birth environment display/control worked because thread summaries carry their own `codexEnvironmentOptions` through the thread path, and `setCodexThreadEnvironment` / `runCodexEnvironmentAction` are federation-routed.

### Fix

Hydrate launchpad environment options in `DesktopMessagingBackendBridge.getNavigationSnapshot` (the serving path for both federation viewers and messaging browse), matching the local path's semantics:

- Hydration runs on the **owning machine**, so the environment config comes from the peer-local directory paths in the launchpad — the same data the peer's own window would show.
- A per-directory hydration failure degrades to the unhydrated launchpad instead of failing the snapshot (mirrors the local path's try/catch).

The rest of the flow needed no changes: `materializeDirectoryLaunchpad` already ships the full launchpad draft (with the chosen `codexEnvironmentId`/action/execution target) stamped with `federationTarget`, and remote environment-setup progress events were already plumbed.

### Tests

- New bridge test: served snapshots hydrate launchpad options; directories without launchpads pass through untouched.
- Full workspace suite: **6258 passed**; typecheck, eslint (0 errors), and dependency boundaries green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)