### PR TITLE
fix(desktop): route branch drift through federation

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -4,6 +4,7 @@ import type {
   ApplyThreadModelMigrationRequest,
   CancelQueuedTurnRequest,
   CancelThreadExecutionModeQueueRequest,
+  CheckThreadBranchDriftRequest,
   CompactThreadRequest,
   ForkThreadRequest,
   InterruptTurnRequest,
@@ -11,6 +12,7 @@ import type {
   MaterializeDirectoryLaunchpadRequest,
   QueueThreadExecutionModeRequest,
   RunCodexEnvironmentActionRequest,
+  RetainThreadBranchDriftRequest,
   StopCodexEnvironmentActionRequest,
   SetAcpSessionRuntimeOptionRequest,
   SetCodexThreadEnvironmentRequest,
@@ -23,6 +25,7 @@ import type {
   SteerTurnRequest,
   SubmitServerRequestRequest,
   TrustCodexProjectRequest,
+  UpdateThreadExpectedBranchRequest,
 } from "@pwragent/shared";
 
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
@@ -183,6 +186,26 @@ const federationMock = vi.hoisted(() => {
         status: "acknowledged-new-thread" as const,
       }),
     ),
+    checkThreadBranchDrift: vi.fn(
+      async (request: CheckThreadBranchDriftRequest) => ({
+        ...request,
+        checkedAt: 1_000,
+        drifted: true,
+        observedBranch: "main",
+      }),
+    ),
+    updateThreadExpectedBranch: vi.fn(
+      async (request: UpdateThreadExpectedBranchRequest) => ({
+        ...request,
+        updatedAt: 1_000,
+      }),
+    ),
+    retainThreadBranchDrift: vi.fn(
+      async (request: RetainThreadBranchDriftRequest) => ({
+        ...request,
+        retainedAt: 1_000,
+      }),
+    ),
     runCodexEnvironmentAction: vi.fn(
       async (request: RunCodexEnvironmentActionRequest) => ({
         backend: request.backend,
@@ -324,12 +347,14 @@ describe("agent ipc", () => {
       AGENT_CANCEL_QUEUED_TURN_CHANNEL,
       AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
       AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL,
+      AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
       AGENT_COMPACT_THREAD_CHANNEL,
       AGENT_FORK_THREAD_CHANNEL,
       AGENT_INTERRUPT_TURN_CHANNEL,
       AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
       AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL,
       AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL,
+      AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL,
       AGENT_STOP_CODEX_ENVIRONMENT_ACTION_CHANNEL,
       AGENT_SET_ACP_SESSION_RUNTIME_OPTION_CHANNEL,
       AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL,
@@ -341,6 +366,7 @@ describe("agent ipc", () => {
       AGENT_STEER_TURN_CHANNEL,
       AGENT_SUBMIT_SERVER_REQUEST_CHANNEL,
       AGENT_TRUST_CODEX_PROJECT_CHANNEL,
+      AGENT_UPDATE_THREAD_EXPECTED_BRANCH_CHANNEL,
     } = await import("../../shared/ipc");
     const federationTarget = {
       scope: "remote" as const,
@@ -435,6 +461,25 @@ describe("agent ipc", () => {
       threadId: "thread-1",
       threadCreatedAt: 1_000,
       threadModel: "gpt-5-codex",
+    });
+    await handlers.get(AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL)?.({}, {
+      backend: "codex",
+      expectedBranch: "feature/expected",
+      federationTarget,
+      threadId: "thread-1",
+    });
+    await handlers.get(AGENT_UPDATE_THREAD_EXPECTED_BRANCH_CHANNEL)?.({}, {
+      backend: "codex",
+      branch: "main",
+      federationTarget,
+      threadId: "thread-1",
+    });
+    await handlers.get(AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL)?.({}, {
+      backend: "codex",
+      expectedBranch: "feature/expected",
+      federationTarget,
+      observedBranch: "main",
+      threadId: "thread-1",
     });
     await handlers.get(AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL)?.({}, {
       backend: "codex",
@@ -543,6 +588,22 @@ describe("agent ipc", () => {
       threadId: "thread-1",
       threadCreatedAt: 1_000,
       threadModel: "gpt-5-codex",
+    });
+    expect(federationMock.remoteBackend.checkThreadBranchDrift).toHaveBeenCalledWith({
+      backend: "codex",
+      expectedBranch: "feature/expected",
+      threadId: "thread-1",
+    });
+    expect(federationMock.remoteBackend.updateThreadExpectedBranch).toHaveBeenCalledWith({
+      backend: "codex",
+      branch: "main",
+      threadId: "thread-1",
+    });
+    expect(federationMock.remoteBackend.retainThreadBranchDrift).toHaveBeenCalledWith({
+      backend: "codex",
+      expectedBranch: "feature/expected",
+      observedBranch: "main",
+      threadId: "thread-1",
     });
     expect(federationMock.remoteBackend.runCodexEnvironmentAction).toHaveBeenCalledWith({
       backend: "codex",

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -175,6 +175,106 @@ describe("federation backend bridge", () => {
     ]);
   });
 
+  it("routes branch drift reads and mutations to the owning peer", async () => {
+    const backend = {
+      checkThreadBranchDrift: vi.fn(async (request) => ({
+        ...request,
+        checkedAt: 1_100,
+        drifted: true,
+        observedBranch: "main",
+      })),
+      updateThreadExpectedBranch: vi.fn(async (request) => ({
+        ...request,
+        updatedAt: 1_200,
+      })),
+      retainThreadBranchDrift: vi.fn(async (request) => ({
+        ...request,
+        retainedAt: 1_300,
+      })),
+    } as unknown as FederationBackendOperations;
+    const ownerRouter = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    ownerRouter.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["thread_navigation", "turn_control"],
+      sendEnvelope: (envelope) => {
+        rpc.receiveEnvelope(envelope);
+      },
+    });
+    registerFederationBackendHandlers({ router: ownerRouter, backend });
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "viewer_one",
+      remoteInstanceId: "owner_one",
+      sendEnvelope: (envelope) => {
+        void ownerRouter.routeEnvelope({
+          envelope,
+          sourcePeerId: "viewer_one",
+        });
+      },
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+
+    await expect(client.checkThreadBranchDrift({
+      backend: "codex",
+      expectedBranch: "feature/expected",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      checkedAt: 1_100,
+      drifted: true,
+      observedBranch: "main",
+    });
+    await expect(client.updateThreadExpectedBranch({
+      backend: "codex",
+      branch: "main",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      branch: "main",
+      updatedAt: 1_200,
+    });
+    await expect(client.retainThreadBranchDrift({
+      backend: "codex",
+      expectedBranch: "feature/expected",
+      observedBranch: "main",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      retainedAt: 1_300,
+    });
+
+    expect(backend.checkThreadBranchDrift).toHaveBeenCalledExactlyOnceWith({
+      backend: "codex",
+      expectedBranch: "feature/expected",
+      threadId: "thread-1",
+    });
+    expect(backend.updateThreadExpectedBranch).toHaveBeenCalledExactlyOnceWith({
+      backend: "codex",
+      branch: "main",
+      threadId: "thread-1",
+    });
+    expect(backend.retainThreadBranchDrift).toHaveBeenCalledExactlyOnceWith({
+      backend: "codex",
+      expectedBranch: "feature/expected",
+      observedBranch: "main",
+      threadId: "thread-1",
+    });
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.checkThreadBranchDrift
+      ],
+    ).toBe("thread_navigation");
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.updateThreadExpectedBranch
+      ],
+    ).toBe("turn_control");
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.retainThreadBranchDrift
+      ],
+    ).toBe("turn_control");
+  });
+
   it("routes pin reorder over RPC with thread_navigation authorization", async () => {
     const sent: FederationProtocolEnvelope[] = [];
     const rpc = new FederationRpcEndpoint({
@@ -891,6 +991,9 @@ describe("federation backend bridge", () => {
         ...request,
         status: "acknowledged-new-thread" as const,
       })),
+      checkThreadBranchDrift: vi.fn(),
+      updateThreadExpectedBranch: vi.fn(),
+      retainThreadBranchDrift: vi.fn(),
       submitServerRequest: vi.fn(async () => ({
         backend: "codex" as const,
         threadId: "thread-1",
@@ -1093,6 +1196,9 @@ describe("federation backend bridge", () => {
         setAcpSessionRuntimeOption: vi.fn(),
         setThreadModelSettings: vi.fn(),
         applyThreadModelMigration: vi.fn(),
+        checkThreadBranchDrift: vi.fn(),
+        updateThreadExpectedBranch: vi.fn(),
+        retainThreadBranchDrift: vi.fn(),
         submitServerRequest: vi.fn(),
         runCodexEnvironmentAction: vi.fn(),
         stopCodexEnvironmentAction: vi.fn(),

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -14,6 +14,8 @@ import type {
   CancelQueuedTurnResponse,
   CancelThreadExecutionModeQueueRequest,
   CancelThreadExecutionModeQueueResponse,
+  CheckThreadBranchDriftRequest,
+  CheckThreadBranchDriftResponse,
   CompactThreadRequest,
   CompactThreadResponse,
   CreateScheduledThreadActionRequest,
@@ -53,6 +55,8 @@ import type {
   QueueThreadExecutionModeResponse,
   RefreshDirectoryGitStatusesRequest,
   RefreshDirectoryGitStatusesResponse,
+  RetainThreadBranchDriftRequest,
+  RetainThreadBranchDriftResponse,
   RenameThreadRequest,
   RenameThreadResponse,
   RunCodexEnvironmentActionRequest,
@@ -82,6 +86,8 @@ import type {
   TrustCodexProjectRequest,
   TrustCodexProjectResponse,
   UpdateScheduledThreadActionRequest,
+  UpdateThreadExpectedBranchRequest,
+  UpdateThreadExpectedBranchResponse,
 } from "@pwragent/shared";
 import type { FederationRouter } from "./federation-router";
 import type { FederationRpcEndpoint } from "./federation-rpc";
@@ -117,6 +123,9 @@ export const FEDERATION_BACKEND_METHODS = {
   setAcpSessionRuntimeOption: "backend.setAcpSessionRuntimeOption",
   setThreadModelSettings: "backend.setThreadModelSettings",
   applyThreadModelMigration: "backend.applyThreadModelMigration",
+  checkThreadBranchDrift: "backend.checkThreadBranchDrift",
+  updateThreadExpectedBranch: "backend.updateThreadExpectedBranch",
+  retainThreadBranchDrift: "backend.retainThreadBranchDrift",
   submitServerRequest: "backend.submitServerRequest",
   runCodexEnvironmentAction: "backend.runCodexEnvironmentAction",
   stopCodexEnvironmentAction: "backend.stopCodexEnvironmentAction",
@@ -185,6 +194,9 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.setAcpSessionRuntimeOption]: "turn_control",
   [FEDERATION_BACKEND_METHODS.setThreadModelSettings]: "turn_control",
   [FEDERATION_BACKEND_METHODS.applyThreadModelMigration]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.checkThreadBranchDrift]: "thread_navigation",
+  [FEDERATION_BACKEND_METHODS.updateThreadExpectedBranch]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.retainThreadBranchDrift]: "turn_control",
   [FEDERATION_BACKEND_METHODS.submitServerRequest]: "pending_request_control",
   [FEDERATION_BACKEND_METHODS.runCodexEnvironmentAction]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.stopCodexEnvironmentAction]: "environment_actions",
@@ -284,6 +296,15 @@ export type FederationBackendOperations = {
   applyThreadModelMigration(
     request: ApplyThreadModelMigrationRequest,
   ): Promise<ApplyThreadModelMigrationResponse>;
+  checkThreadBranchDrift(
+    request: CheckThreadBranchDriftRequest,
+  ): Promise<CheckThreadBranchDriftResponse>;
+  updateThreadExpectedBranch(
+    request: UpdateThreadExpectedBranchRequest,
+  ): Promise<UpdateThreadExpectedBranchResponse>;
+  retainThreadBranchDrift(
+    request: RetainThreadBranchDriftRequest,
+  ): Promise<RetainThreadBranchDriftResponse>;
   submitServerRequest(
     request: SubmitServerRequestRequest,
   ): Promise<SubmitServerRequestResponse>;
@@ -541,6 +562,27 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.applyThreadModelMigration(
         envelope.params as ApplyThreadModelMigrationRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.checkThreadBranchDrift,
+    async (envelope) =>
+      await params.backend.checkThreadBranchDrift(
+        envelope.params as CheckThreadBranchDriftRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.updateThreadExpectedBranch,
+    async (envelope) =>
+      await params.backend.updateThreadExpectedBranch(
+        envelope.params as UpdateThreadExpectedBranchRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.retainThreadBranchDrift,
+    async (envelope) =>
+      await params.backend.retainThreadBranchDrift(
+        envelope.params as RetainThreadBranchDriftRequest,
       ),
   );
   params.router.registerHandler(
@@ -890,6 +932,33 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<ApplyThreadModelMigrationResponse> {
     return await this.rpc.request<ApplyThreadModelMigrationResponse>({
       method: FEDERATION_BACKEND_METHODS.applyThreadModelMigration,
+      params: request,
+    });
+  }
+
+  async checkThreadBranchDrift(
+    request: CheckThreadBranchDriftRequest,
+  ): Promise<CheckThreadBranchDriftResponse> {
+    return await this.rpc.request<CheckThreadBranchDriftResponse>({
+      method: FEDERATION_BACKEND_METHODS.checkThreadBranchDrift,
+      params: request,
+    });
+  }
+
+  async updateThreadExpectedBranch(
+    request: UpdateThreadExpectedBranchRequest,
+  ): Promise<UpdateThreadExpectedBranchResponse> {
+    return await this.rpc.request<UpdateThreadExpectedBranchResponse>({
+      method: FEDERATION_BACKEND_METHODS.updateThreadExpectedBranch,
+      params: request,
+    });
+  }
+
+  async retainThreadBranchDrift(
+    request: RetainThreadBranchDriftRequest,
+  ): Promise<RetainThreadBranchDriftResponse> {
+    return await this.rpc.request<RetainThreadBranchDriftResponse>({
+      method: FEDERATION_BACKEND_METHODS.retainThreadBranchDrift,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -8,6 +8,7 @@ import type {
   AppServerReadThreadResponse,
   CancelQueuedTurnResponse,
   CancelThreadExecutionModeQueueResponse,
+  CheckThreadBranchDriftResponse,
   CompactThreadResponse,
   CreateScheduledThreadActionRequest,
   CodexEnvironmentSetupProgressEvent,
@@ -34,6 +35,7 @@ import type {
   OpenDesktopApplicationResponse,
   QueueThreadExecutionModeResponse,
   RefreshDirectoryGitStatusesResponse,
+  RetainThreadBranchDriftResponse,
   RenameThreadResponse,
   RunCodexEnvironmentActionResponse,
   ScheduledThreadActionIdRequest,
@@ -48,6 +50,7 @@ import type {
   StopCodexEnvironmentActionResponse,
   SubmitServerRequestResponse,
   TrustCodexProjectResponse,
+  UpdateThreadExpectedBranchResponse,
   UpdateScheduledThreadActionRequest,
 } from "@pwragent/shared";
 import {
@@ -65,6 +68,7 @@ import {
   type ApplyThreadModelMigrationRequest,
   type CancelQueuedTurnRequest,
   type CancelThreadExecutionModeQueueRequest,
+  type CheckThreadBranchDriftRequest,
   type CompactThreadRequest,
   type ForkThreadRequest,
   type FederationRemoteTarget,
@@ -86,6 +90,7 @@ import {
   type OpenDesktopApplicationRequest,
   type QueueThreadExecutionModeRequest,
   type RefreshDirectoryGitStatusesRequest,
+  type RetainThreadBranchDriftRequest,
   type RenameThreadRequest,
   type RunCodexEnvironmentActionRequest,
   type SetAcpSessionRuntimeOptionRequest,
@@ -100,6 +105,7 @@ import {
   type SubmitServerRequestRequest,
   type StopCodexEnvironmentActionRequest,
   type TrustCodexProjectRequest,
+  type UpdateThreadExpectedBranchRequest,
 } from "@pwragent/shared";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
@@ -2177,6 +2183,21 @@ function localBackendOperations(): FederationBackendOperations {
       request: ApplyThreadModelMigrationRequest,
     ): Promise<ApplyThreadModelMigrationResponse> {
       return await getDesktopBackendRegistry().applyThreadModelMigration(request);
+    },
+    async checkThreadBranchDrift(
+      request: CheckThreadBranchDriftRequest,
+    ): Promise<CheckThreadBranchDriftResponse> {
+      return await getDesktopBackendRegistry().checkThreadBranchDrift(request);
+    },
+    async updateThreadExpectedBranch(
+      request: UpdateThreadExpectedBranchRequest,
+    ): Promise<UpdateThreadExpectedBranchResponse> {
+      return await getDesktopBackendRegistry().updateThreadExpectedBranch(request);
+    },
+    async retainThreadBranchDrift(
+      request: RetainThreadBranchDriftRequest,
+    ): Promise<RetainThreadBranchDriftResponse> {
+      return await getDesktopBackendRegistry().retainThreadBranchDrift(request);
     },
     async submitServerRequest(
       request: SubmitServerRequestRequest,

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -875,6 +875,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: CheckThreadBranchDriftRequest,
     ): Promise<CheckThreadBranchDriftResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .checkThreadBranchDrift(stripFederationTarget(request));
+      }
       return await registry.checkThreadBranchDrift(request);
     },
   );
@@ -886,6 +894,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: UpdateThreadExpectedBranchRequest,
     ): Promise<UpdateThreadExpectedBranchResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .updateThreadExpectedBranch(stripFederationTarget(request));
+      }
       return await registry.updateThreadExpectedBranch(request);
     },
   );
@@ -897,6 +913,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: RetainThreadBranchDriftRequest,
     ): Promise<RetainThreadBranchDriftResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .retainThreadBranchDrift(stripFederationTarget(request));
+      }
       return await registry.retainThreadBranchDrift(request);
     },
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1799,6 +1799,9 @@ export function ThreadView(props: ThreadViewProps) {
       const result = await props.desktopApi.checkThreadBranchDrift({
         backend: thread.source,
         expectedBranch: thread.gitBranch,
+        federationTarget:
+          thread.federation?.ref.target
+          ?? readRendererFederationTarget(),
         threadId: thread.id,
       });
       // Stale-closure guard: user navigated away mid-IPC.
@@ -3456,6 +3459,9 @@ export function ThreadView(props: ThreadViewProps) {
                     try {
                       await props.desktopApi.retainThreadBranchDrift({
                         backend: selectedThread.source,
+                        federationTarget:
+                          selectedThread.federation?.ref.target
+                          ?? readRendererFederationTarget(),
                         threadId: selectedThread.id,
                         expectedBranch: branchDriftDialog.expectedBranch,
                         observedBranch: branchDriftDialog.observedBranch,
@@ -3501,6 +3507,9 @@ export function ThreadView(props: ThreadViewProps) {
                     try {
                       await props.desktopApi.updateThreadExpectedBranch({
                         backend: selectedThread.source,
+                        federationTarget:
+                          selectedThread.federation?.ref.target
+                          ?? readRendererFederationTarget(),
                         threadId: selectedThread.id,
                         branch: branchDriftDialog.observedBranch,
                       });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -4733,6 +4733,16 @@ describe("ThreadView", () => {
           source: "codex",
           gitBranch: "feature/old",
           observedGitBranch: "main",
+          federation: {
+            ref: {
+              backend: "codex",
+              target: { scope: "remote", instanceId: "owner-one" },
+              threadId: "thread-branch",
+            },
+            instanceLabel: "Owner Mac",
+            peerStatus: "connected",
+            capabilities: ["thread_navigation", "turn_control"],
+          },
           updatedAt: Date.now(),
           linkedDirectories: [],
           inbox: {
@@ -4770,6 +4780,7 @@ describe("ThreadView", () => {
     await waitFor(() => {
       expect(updateThreadExpectedBranch).toHaveBeenCalledWith({
         backend: "codex",
+        federationTarget: { scope: "remote", instanceId: "owner-one" },
         threadId: "thread-branch",
         branch: "main",
       });
@@ -4841,6 +4852,71 @@ describe("ThreadView", () => {
     );
   });
 
+  it("retains branch drift on the remote thread owner", async () => {
+    const retainThreadBranchDrift = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-branch",
+      expectedBranch: "feature/old",
+      observedBranch: "main",
+      retainedAt: Date.now(),
+    }));
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        composerDisabled={false}
+        desktopApi={{ retainThreadBranchDrift }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={{
+          id: "thread-branch",
+          title: "Branch drift",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "feature/old",
+          observedGitBranch: "main",
+          federation: {
+            ref: {
+              backend: "codex",
+              target: { scope: "remote", instanceId: "owner-one" },
+              threadId: "thread-branch",
+            },
+            instanceLabel: "Owner Mac",
+            peerStatus: "connected",
+            capabilities: ["thread_navigation", "turn_control"],
+          },
+          updatedAt: Date.now(),
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+        skills={[]}
+        transcriptEntries={[]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />,
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Thread branch changed",
+    });
+    fireEvent.click(within(dialog).getByRole("button", {
+      name: "Keep warning. I'll switch back to feature/old",
+    }));
+
+    await waitFor(() => {
+      expect(retainThreadBranchDrift).toHaveBeenCalledWith({
+        backend: "codex",
+        expectedBranch: "feature/old",
+        federationTarget: { scope: "remote", instanceId: "owner-one" },
+        observedBranch: "main",
+        threadId: "thread-branch",
+      });
+    });
+  });
+
   it("checks branch drift on selection and focus without background polling", async () => {
     const setIntervalSpy = vi.spyOn(window, "setInterval");
     const checkThreadBranchDrift = vi.fn(async () => ({
@@ -4878,6 +4954,16 @@ describe("ThreadView", () => {
             source: "codex",
             gitBranch: "feature/old",
             observedGitBranch: "feature/old",
+            federation: {
+              ref: {
+                backend: "codex",
+                target: { scope: "remote", instanceId: "owner-one" },
+                threadId: "thread-branch",
+              },
+              instanceLabel: "Owner Mac",
+              peerStatus: "connected",
+              capabilities: ["thread_navigation", "turn_control"],
+            },
             updatedAt: Date.now(),
             linkedDirectories: [],
             inbox: {
@@ -4898,6 +4984,7 @@ describe("ThreadView", () => {
       expect(checkThreadBranchDrift).toHaveBeenLastCalledWith({
         backend: "codex",
         expectedBranch: "feature/old",
+        federationTarget: { scope: "remote", instanceId: "owner-one" },
         threadId: "thread-branch",
       });
       expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 30_000);
@@ -4912,11 +4999,81 @@ describe("ThreadView", () => {
       expect(checkThreadBranchDrift).toHaveBeenLastCalledWith({
         backend: "codex",
         expectedBranch: "feature/old",
+        federationTarget: { scope: "remote", instanceId: "owner-one" },
         threadId: "thread-branch",
       });
     } finally {
       setIntervalSpy.mockRestore();
     }
+  });
+
+  it("allows a remote send when an older owner lacks branch drift RPC", async () => {
+    const checkThreadBranchDrift = vi.fn(async () => {
+      throw Object.assign(new Error(
+        "method_not_found: No federation handler registered for backend.checkThreadBranchDrift",
+      ), { code: "method_not_found" });
+    });
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-branch",
+      turnId: "turn-1",
+    }));
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        composerDisabled={false}
+        desktopApi={{ checkThreadBranchDrift, startTurn }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={{
+          id: "thread-branch",
+          title: "Remote branch",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          gitBranch: "feature/current",
+          observedGitBranch: "feature/current",
+          federation: {
+            ref: {
+              backend: "codex",
+              target: { scope: "remote", instanceId: "owner-one" },
+              threadId: "thread-branch",
+            },
+            instanceLabel: "Owner Mac",
+            peerStatus: "connected",
+            capabilities: ["thread_navigation", "turn_control"],
+          },
+          updatedAt: Date.now(),
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+        skills={[]}
+        transcriptEntries={[]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Send despite the older peer" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(expect.objectContaining({
+        backend: "codex",
+        federationTarget: { scope: "remote", instanceId: "owner-one" },
+        threadId: "thread-branch",
+        input: [{ type: "text", text: "Send despite the older peer" }],
+      }));
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Thread branch changed" }),
+    ).not.toBeInTheDocument();
   });
 
   it("suppresses the branch drift dialog while a turn is active", async () => {

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -510,6 +510,7 @@ export type SetAcpSessionRuntimeOptionResponse = {
 export type CheckThreadBranchDriftRequest = {
   backend: AppServerBackendKind;
   expectedBranch?: string;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
 };
 
@@ -524,6 +525,7 @@ export type CheckThreadBranchDriftResponse = {
 
 export type UpdateThreadExpectedBranchRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   branch: string;
 };
@@ -537,6 +539,7 @@ export type UpdateThreadExpectedBranchResponse = {
 
 export type RetainThreadBranchDriftRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   expectedBranch: string;
   observedBranch: string;


### PR DESCRIPTION
## Summary

- route branch-drift checks, expected-branch updates, and retained-warning mutations to the owning federated instance
- carry the federation target from the selected remote thread through renderer and IPC contracts
- add owner-side RPC handlers with thread-navigation/turn-control authorization
- preserve compatibility with older peers: an unsupported branch-check RPC fails open for sending and never falls back to viewer-local state

## Root cause

Remote turn submission already carried a federation target, but the three branch-drift operations were local-only. A remote send could therefore compare against stale viewer-side overlay state, block Enter, and offer mutations that would update the wrong instance.

## Validation

- 3 focused Vitest files, 80 tests
- desktop TypeScript
- production Electron build
- ESLint: 0 errors
- dependency boundaries: 1,276 modules / 4,048 dependencies
- Codex-storage boundary lint
- `git diff --check`
