### PR TITLE
fix(desktop): preserve copied PR chip references

### DIFF
--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -111,6 +111,8 @@ export function PrChip(props: PrChipProps) {
         aria-label={`Open ${pr.org}/${pr.repo}#${pr.number} (${status}) in browser`}
         className={className}
         data-pr-chip=""
+        data-pr-label={label}
+        data-pr-url={pr.url}
         draggable={false}
         onBlur={tooltipController.hide}
         onClick={handleActivate}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -15,6 +15,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ClipboardEvent,
   type MouseEvent,
   type ReactNode,
 } from "react";
@@ -84,6 +85,41 @@ type EditorApplication = DesktopApplicationsSnapshot["editors"][number];
  */
 const CodeBlockContext = createContext(false);
 const MarkdownLinkContext = createContext(false);
+
+function copySelectedPullRequestLinks(
+  event: ClipboardEvent<HTMLDivElement>,
+): void {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return;
+  }
+
+  const fragment = selection.getRangeAt(0).cloneContents();
+  const pullRequestChips = fragment.querySelectorAll<HTMLElement>(
+    "[data-pr-chip][data-pr-url]",
+  );
+  if (pullRequestChips.length === 0) {
+    return;
+  }
+
+  pullRequestChips.forEach((chip) => {
+    const href = chip.dataset.prUrl;
+    if (!href) {
+      return;
+    }
+
+    const link = document.createElement("a");
+    link.href = href;
+    link.textContent = chip.dataset.prLabel || chip.textContent || href;
+    chip.replaceWith(link);
+  });
+
+  const html = document.createElement("div");
+  html.append(fragment);
+  event.clipboardData.setData("text/plain", selection.toString());
+  event.clipboardData.setData("text/html", html.innerHTML);
+  event.preventDefault();
+}
 
 function TranscriptCode(props: {
   children: ReactNode;
@@ -603,6 +639,7 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
       ]
         .filter(Boolean)
         .join(" ")}
+      onCopy={copySelectedPullRequestLinks}
     >
       <ReactMarkdown
         components={components}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
@@ -99,6 +99,39 @@ describe("pull request links in transcript markdown", () => {
     expect(open).toHaveBeenCalledWith(PR_URL, "_blank", "noopener,noreferrer");
   });
 
+  it("preserves a selected PR chip as text and a link on the clipboard", () => {
+    const { container } = renderWithPullRequests(
+      `> Deploy merged PR [Giphy/giphy-services#13290](${PR_URL}) now.`,
+      [prSummary()],
+    );
+    const quote = container.querySelector("blockquote");
+    const markdown = container.querySelector(".thread-markdown");
+    expect(quote).not.toBeNull();
+    expect(markdown).not.toBeNull();
+
+    const range = document.createRange();
+    range.selectNodeContents(quote!);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    const setData = vi.fn();
+    fireEvent.copy(markdown!, {
+      clipboardData: { setData },
+    });
+
+    expect(setData).toHaveBeenCalledWith(
+      "text/plain",
+      expect.stringContaining("Giphy/giphy-services#13290"),
+    );
+    expect(setData).toHaveBeenCalledWith(
+      "text/html",
+      expect.stringContaining(
+        `<a href="${PR_URL}">Giphy/giphy-services#13290</a>`,
+      ),
+    );
+  });
+
   it("hydrates the exact draft-PR link shape emitted by a completed thread", () => {
     renderWithPullRequests(
       `Draft PR: [#13290 — Document JDK 17 for EMR jobs](${PR_URL})`,

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -465,13 +465,16 @@ describe("Tangerine Terminal theme contract", () => {
     expect(pricingRunningTotalRule).toContain("user-select: text;");
   });
 
-  it("keeps transcript link chips atomic instead of text-selectable", () => {
+  it("keeps transcript link chips atomic during selection", () => {
     const prChipRule = extractRuleBody(css, ".pr-chip");
+    const transcriptPrChipRule = extractRuleBody(css, ".thread-markdown .pr-chip");
     const skillChipRule = extractRuleBody(css, ".skill-chip--transcript");
     const threadChipRule = extractRuleBody(css, ".thread-chip");
 
     expect(prChipRule).toContain("-webkit-user-select: none;");
     expect(prChipRule).toContain("user-select: none;");
+    expect(transcriptPrChipRule).toContain("-webkit-user-select: all;");
+    expect(transcriptPrChipRule).toContain("user-select: all;");
     expect(skillChipRule).toContain("-webkit-user-select: none;");
     expect(skillChipRule).toContain("user-select: none;");
     expect(threadChipRule).toContain("-webkit-user-select: none;");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4071,6 +4071,15 @@ textarea,
   line-height: normal;
 }
 
+/* A PR chip inside rendered markdown is part of the message's copyable prose.
+   Select it atomically so Chromium includes the full label in text/plain;
+   ThreadMarkdown upgrades the matching text/html fragment to a real link.
+   Chips in sidebar rows and context chrome remain non-selectable controls. */
+.thread-markdown .pr-chip {
+  -webkit-user-select: all;
+  user-select: all;
+}
+
 /* Draft affordance: a short, round-ended gray bar centered beneath the dot +
    number. Orthogonal to the dot color (which still shows check/merge status),
    it reads as an extra marker, not an underline — there's a deliberate gap


### PR DESCRIPTION
## What changed

- Make PR chips inside rendered transcript markdown atomically selectable while leaving sidebar and context-chrome chips non-selectable.
- Preserve the visible `org/repo#number` label in the clipboard's plain-text flavor.
- Replace selected PR-chip markup with a real anchor in the clipboard's HTML flavor so rich paste targets can retain the PR URL.
- Add regression coverage for quoted transcript selections and the selection-style contract.

## Root cause

The shared `.pr-chip` primitive uses `user-select: none` because it is normally an atomic control. Transcript PR chips inherited that rule, so Chromium omitted the chip and all of its text from a copied selection.

## User impact

Selecting and copying prose that includes a PR chip now preserves at least the PR label/number everywhere, and preserves the link in rich clipboard targets instead of silently dropping the reference.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`
