### PR TITLE
fix(desktop): reconcile missed remote completions

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -10432,6 +10432,68 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("cancels missed-completion reconciliation when navigation becomes active again", async () => {
+    const activeTurn = {
+      id: "turn-1",
+      status: "in_progress" as const,
+      startedAt: 5_000,
+    };
+    const readThread = vi.fn(async () => readThreadResponse({
+      entries: [
+        {
+          type: "message",
+          id: "commentary-1",
+          role: "assistant",
+          phase: "commentary",
+          text: "Still working.",
+          turn: activeTurn,
+        },
+      ],
+      hasPreviousPage: false,
+      threadStatus: "active",
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ threadStatus }: { threadStatus: "active" | "idle" }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: {
+            ...buildThread({ id: "thread-1", updatedAt: 1_000 }),
+            threadStatus,
+          },
+        }),
+      {
+        initialProps: {
+          threadStatus: "active" as "active" | "idle",
+        },
+      }
+    );
+
+    await waitForThreadHydration(result);
+    expect(result.current.activeTurnId).toBe("turn-1");
+    expect(readThread).toHaveBeenCalledTimes(1);
+
+    vi.useFakeTimers();
+    try {
+      rerender({ threadStatus: "idle" });
+      rerender({ threadStatus: "active" });
+
+      act(() => {
+        vi.advanceTimersByTime(2_000);
+      });
+
+      expect(readThread).toHaveBeenCalledTimes(1);
+      expect(result.current.activeTurnId).toBe("turn-1");
+      expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBe(true);
+      expect(result.current.threadBusy).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("restores thinking from active backend status after renderer HMR", async () => {
     let agentEventHandler:
       | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -10351,6 +10351,87 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("rehydrates stale thinking when navigation reports a missed remote completion", async () => {
+    const activeTurn = {
+      id: "turn-1",
+      status: "in_progress" as const,
+      startedAt: 5_000,
+    };
+    const completedTurn = {
+      ...activeTurn,
+      status: "completed" as const,
+      completedAt: 6_000,
+    };
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [
+          {
+            type: "message",
+            id: "commentary-1",
+            role: "assistant",
+            phase: "commentary",
+            text: "Working remotely.",
+            turn: activeTurn,
+          },
+        ],
+        hasPreviousPage: false,
+        threadStatus: "active",
+      }))
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [
+          {
+            type: "message",
+            id: "final-1",
+            role: "assistant",
+            phase: "final",
+            text: "Done.",
+            turn: completedTurn,
+          },
+        ],
+        hasPreviousPage: false,
+        threadStatus: "idle",
+      }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+
+    const { result, rerender } = renderHook(
+      ({ threadStatus }: { threadStatus: "active" | "idle" }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: {
+            ...buildThread({ id: "thread-1", updatedAt: 1_000 }),
+            threadStatus,
+          },
+        }),
+      {
+        initialProps: {
+          threadStatus: "active" as "active" | "idle",
+        },
+      }
+    );
+
+    await waitForThreadHydration(result);
+    expect(result.current.activeTurnId).toBe("turn-1");
+    expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBe(true);
+
+    // Simulate a federation viewer that missed both terminal events. Its
+    // later navigation snapshot changes only the status; updatedAt is the
+    // same as the already-hydrated active snapshot.
+    rerender({ threadStatus: "idle" });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    }, { timeout: 3_000 });
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBeUndefined();
+      expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
+      expect(result.current.threadBusy).toBe(false);
+    });
+  });
+
   it("restores thinking from active backend status after renderer HMR", async () => {
     let agentEventHandler:
       | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3976,15 +3976,32 @@ export function useThreadSessionState(params: {
       if (threadStatusSummarySeedRef.current[threadKey] !== summarySeed) {
         threadStatusSummarySeedRef.current[threadKey] = summarySeed;
         const backendReportedActive = thread.threadStatus === "active";
-        updateSession(threadKey, (current) =>
-          current.backendReportedActive === backendReportedActive
-            ? current
-            : {
-                ...current,
-                backendReportedActive,
-                lastTouchedAt: Date.now(),
-              }
-        );
+        updateSession(threadKey, (current) => {
+          const shouldRecheckStaleThinking =
+            !backendReportedActive && hasThinkingState(current);
+          if (
+            current.backendReportedActive === backendReportedActive
+            && !shouldRecheckStaleThinking
+          ) {
+            return current;
+          }
+
+          const now = Date.now();
+          return {
+            ...current,
+            backendReportedActive,
+            lastTouchedAt: now,
+            // Federation backend events are live-only. If a remote viewer
+            // misses the terminal notifications during a transport gap, its
+            // next navigation snapshot still carries the authoritative idle
+            // status. Re-read after the normal completion grace so that the
+            // transcript snapshot can clear the stale active turn without
+            // racing an idle-before-turn/completed notification pair.
+            staleThinkingRecheckAt: shouldRecheckStaleThinking
+              ? now + OWN_UPDATE_IDLE_GRACE_MS
+              : current.staleThinkingRecheckAt,
+          };
+        });
       }
     }
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3997,9 +3997,11 @@ export function useThreadSessionState(params: {
             // status. Re-read after the normal completion grace so that the
             // transcript snapshot can clear the stale active turn without
             // racing an idle-before-turn/completed notification pair.
-            staleThinkingRecheckAt: shouldRecheckStaleThinking
-              ? now + OWN_UPDATE_IDLE_GRACE_MS
-              : current.staleThinkingRecheckAt,
+            staleThinkingRecheckAt: backendReportedActive
+              ? undefined
+              : shouldRecheckStaleThinking
+                ? now + OWN_UPDATE_IDLE_GRACE_MS
+                : current.staleThinkingRecheckAt,
           };
         });
       }


### PR DESCRIPTION
## What changed

- Reconcile stale renderer thinking state when an authoritative navigation snapshot changes a thread from active to idle.
- Re-read the thread after the existing completion grace period so the transcript snapshot can clear a stale active turn.
- Cancel the pending reconciliation if navigation becomes active again before the grace period expires.
- Add a regression test for a federation viewer that misses both terminal events and later receives an idle navigation snapshot with an unchanged `updatedAt`.

## Root cause

The owning PwrAgent instance correctly received `thread/status/changed → idle` and `turn/completed`. Federation backend events are live-only, so a transport gap can make a remote viewer miss those terminal notifications.

The navigation snapshot later reports the durable idle state, but `useThreadSessionState` previously refused to hydrate while its stale client-side `activeTurnId` was set. That prevented the authoritative thread read from ever clearing the thinking indicator.

The recent federation keepalive and disconnected-state changes improve transport visibility and recovery, but do not resolve this renderer hydration deadlock.

## User impact

Remote federation viewers recover from a missed terminal event instead of showing a completed thread as working indefinitely.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx` — 103 passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — 0 errors (existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`
