### PR TITLE
fix(desktop): transport federated transcript images

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type {
+  AppServerReadThreadResponse,
   FederationProtocolEnvelope,
   TrustCodexProjectRequest,
 } from "@pwragent/shared";
@@ -459,9 +460,28 @@ describe("federation backend bridge", () => {
       sendEnvelope: (envelope) => sent.push(envelope),
       now: () => 1_000,
     });
-    const client = new FederationRemoteBackendClient(rpc);
     const ownerUrl =
       `pwragent-image://file/${encodeURIComponent("file:///Users/owner/.pwragent/profiles/default/state/image-inputs/image.png")}`;
+    const transformedUrl =
+      `pwragent-image://federation/owner_one/${encodeURIComponent(ownerUrl)}`;
+    const transformReadThreadResponse = vi.fn((
+      response: AppServerReadThreadResponse,
+    ): AppServerReadThreadResponse => ({
+      ...response,
+      replay: {
+        ...response.replay,
+        messages: response.replay.messages.map((message) => ({
+          ...message,
+          parts: message.parts?.map((part) =>
+            part.type === "image" ? { ...part, url: transformedUrl } : part,
+          ),
+        })),
+      },
+    }));
+    const client = new FederationRemoteBackendClient(
+      rpc,
+      transformReadThreadResponse,
+    );
     const readPending = client.readThread({
       backend: "codex",
       threadId: "thread-1",
@@ -500,11 +520,12 @@ describe("federation backend bridge", () => {
         messages: [{
           parts: [{
             type: "image",
-            url: `pwragent-image://federation/owner_one/${encodeURIComponent(ownerUrl)}`,
+            url: transformedUrl,
           }],
         }],
       },
     });
+    expect(transformReadThreadResponse).toHaveBeenCalledTimes(1);
 
     const imagePending = client.readTranscriptImage({ url: ownerUrl });
     const imageRequest = sent.at(-1)!;

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -451,6 +451,92 @@ describe("federation backend bridge", () => {
     });
   });
 
+  it("routes transcript images back to their owning instance", async () => {
+    const sent: FederationProtocolEnvelope[] = [];
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "viewer_one",
+      remoteInstanceId: "owner_one",
+      sendEnvelope: (envelope) => sent.push(envelope),
+      now: () => 1_000,
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+    const ownerUrl =
+      `pwragent-image://file/${encodeURIComponent("file:///Users/owner/.pwragent/profiles/default/state/image-inputs/image.png")}`;
+    const readPending = client.readThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const readRequest = sent.at(-1)!;
+    rpc.receiveEnvelope({
+      id: "response-read-thread",
+      kind: "response",
+      requestId: readRequest.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_100,
+      result: {
+        backend: "codex",
+        fetchedAt: 1_100,
+        threadId: "thread-1",
+        replay: {
+          entries: [],
+          messages: [{
+            id: "message-1",
+            role: "user",
+            text: "image",
+            parts: [{ type: "image", url: ownerUrl }],
+          }],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+    });
+
+    await expect(readPending).resolves.toMatchObject({
+      replay: {
+        messages: [{
+          parts: [{
+            type: "image",
+            url: `pwragent-image://federation/owner_one/${encodeURIComponent(ownerUrl)}`,
+          }],
+        }],
+      },
+    });
+
+    const imagePending = client.readTranscriptImage({ url: ownerUrl });
+    const imageRequest = sent.at(-1)!;
+    expect(imageRequest).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.readTranscriptImage,
+      params: { url: ownerUrl },
+    });
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.readTranscriptImage
+      ],
+    ).toBe("thread_detail");
+    rpc.receiveEnvelope({
+      id: "response-image",
+      kind: "response",
+      requestId: imageRequest.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_200,
+      result: {
+        dataBase64: "AQID",
+        mimeType: "image/png",
+      },
+    });
+    await expect(imagePending).resolves.toEqual({
+      dataBase64: "AQID",
+      mimeType: "image/png",
+    });
+  });
+
   it("executes directory Git status refreshes on the target instance", async () => {
     const backend = {
       refreshDirectoryGitStatuses: vi.fn(async () => ({ scheduledCount: 1 })),
@@ -738,6 +824,53 @@ describe("federation backend bridge", () => {
     });
   });
 
+  it("serves transcript image bytes through a thread-detail handler", async () => {
+    const backend = {
+      readTranscriptImage: vi.fn(async () => ({
+        dataBase64: "AQID",
+        mimeType: "image/png",
+      })),
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+      now: () => 2_000,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["thread_detail"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+    const url =
+      "pwragent-image://file/file%3A%2F%2F%2FUsers%2Fowner%2Fimage.png";
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "request-image",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.readTranscriptImage,
+        params: { url },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(backend.readTranscriptImage).toHaveBeenCalledWith({ url });
+    expect(replies).toMatchObject([{
+      kind: "response",
+      requestId: "request-image",
+      result: {
+        dataBase64: "AQID",
+        mimeType: "image/png",
+      },
+    }]);
+  });
+
   it("maps remote turn submission to a turn-control guarded handler", async () => {
     const backend: FederationBackendOperations = {
       listThreads: vi.fn(),
@@ -803,6 +936,7 @@ describe("federation backend bridge", () => {
       getNavigationSnapshot: vi.fn(),
       listThreads: vi.fn(),
       readThread: vi.fn(),
+      readTranscriptImage: vi.fn(),
       listSkills: vi.fn(),
       listBackends: vi.fn(),
       markThreadSeen: vi.fn(),
@@ -979,6 +1113,7 @@ describe("federation backend bridge", () => {
         getNavigationSnapshot: vi.fn(),
         listThreads: vi.fn(),
         readThread: vi.fn(),
+        readTranscriptImage: vi.fn(),
         listSkills: vi.fn(),
         listBackends: vi.fn(),
         markThreadSeen: vi.fn(),

--- a/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
+++ b/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
@@ -148,6 +148,8 @@ describe("transcript image protocol", () => {
     const ownerUrl = toProtocolUrl(
       "/Users/owner/.pwragent/profiles/default/state/image-inputs/image.png",
     );
+    const signedPwrSnapUrl =
+      "http://127.0.0.1:51729/media?grant=read-once-grant&signature=valid-signature";
 
     const response = rewriteFederatedTranscriptImageUrlsForRenderer({
       backend: "codex",
@@ -160,7 +162,10 @@ describe("transcript image protocol", () => {
             id: "entry-1",
             role: "user",
             text: "what's in this?",
-            parts: [{ type: "image", url: ownerUrl }],
+            parts: [
+              { type: "image", url: ownerUrl },
+              { type: "image", url: signedPwrSnapUrl },
+            ],
           },
         ],
         messages: [
@@ -168,7 +173,10 @@ describe("transcript image protocol", () => {
             id: "message-1",
             role: "user",
             text: "what's in this?",
-            parts: [{ type: "image", url: ownerUrl }],
+            parts: [
+              { type: "image", url: ownerUrl },
+              { type: "image", url: signedPwrSnapUrl },
+            ],
           },
         ],
         pagination: {
@@ -182,11 +190,21 @@ describe("transcript image protocol", () => {
       "owner_one",
       ownerUrl,
     );
+    const expectedPwrSnapUrl = toFederatedTranscriptImageProtocolUrl(
+      "owner_one",
+      signedPwrSnapUrl,
+    );
     expect(response.replay.entries[0]).toMatchObject({
-      parts: [{ type: "image", url: expectedUrl }],
+      parts: [
+        { type: "image", url: expectedUrl },
+        { type: "image", url: expectedPwrSnapUrl },
+      ],
     });
     expect(response.replay.messages[0]).toMatchObject({
-      parts: [{ type: "image", url: expectedUrl }],
+      parts: [
+        { type: "image", url: expectedUrl },
+        { type: "image", url: expectedPwrSnapUrl },
+      ],
     });
   });
 
@@ -220,6 +238,20 @@ describe("transcript image protocol", () => {
     expect(new Uint8Array(await response.arrayBuffer())).toEqual(
       new Uint8Array([1, 2, 3]),
     );
+
+    const signedPwrSnapUrl =
+      "http://127.0.0.1:51729/media?grant=read-once-grant&signature=valid-signature";
+    resolveFederatedImage.mockClear();
+    await handler({
+      url: toFederatedTranscriptImageProtocolUrl(
+        "owner_one",
+        signedPwrSnapUrl,
+      ),
+    });
+    expect(resolveFederatedImage).toHaveBeenCalledWith({
+      instanceId: "owner_one",
+      url: signedPwrSnapUrl,
+    });
   });
 
   it("materializes data image URLs into thread-scoped files before renderer IPC", async () => {
@@ -377,6 +409,45 @@ describe("transcript image protocol", () => {
       entryPart?.type === "image" ? filePathFromProtocolUrl(entryPart.url) : "";
     expect(path.basename(materializedPath)).toMatch(/^[a-f0-9]{64}\.jpg$/);
     await expect(readFile(materializedPath)).resolves.toEqual(Buffer.from([4, 5, 6]));
+  });
+
+  it("reads signed PwrSnap loopback images for federation transport", async () => {
+    const { readTranscriptImageProtocolRequest } = await import(
+      "../transcript-image-protocol"
+    );
+    const signedUrl =
+      "http://127.0.0.1:51729/media?grant=read-once-grant&signature=valid-signature";
+    const bytes = new Uint8Array([7, 8, 9]);
+    const fetch = vi.fn(async () => ({
+      ok: true,
+      headers: {
+        get: (name: string) => {
+          if (name === "content-type") {
+            return "image/png";
+          }
+          if (name === "content-length") {
+            return String(bytes.byteLength);
+          }
+          return null;
+        },
+      },
+      arrayBuffer: async () => bytes.buffer,
+    }));
+
+    await expect(
+      readTranscriptImageProtocolRequest(
+        signedUrl,
+        undefined,
+        { fetch },
+      ),
+    ).resolves.toEqual({
+      dataBase64: Buffer.from(bytes).toString("base64"),
+      mimeType: "image/png",
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      signedUrl,
+      expect.objectContaining({ redirect: "error" }),
+    );
   });
 
   it("does not fetch arbitrary HTTP image URLs", async () => {

--- a/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
+++ b/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
@@ -140,6 +140,88 @@ describe("transcript image protocol", () => {
     });
   });
 
+  it("rewrites owner-local image URLs into lazy federation protocol URLs", async () => {
+    const {
+      rewriteFederatedTranscriptImageUrlsForRenderer,
+      toFederatedTranscriptImageProtocolUrl,
+    } = await import("../transcript-image-protocol");
+    const ownerUrl = toProtocolUrl(
+      "/Users/owner/.pwragent/profiles/default/state/image-inputs/image.png",
+    );
+
+    const response = rewriteFederatedTranscriptImageUrlsForRenderer({
+      backend: "codex",
+      fetchedAt: 1,
+      threadId: "thread-images",
+      replay: {
+        entries: [
+          {
+            type: "message",
+            id: "entry-1",
+            role: "user",
+            text: "what's in this?",
+            parts: [{ type: "image", url: ownerUrl }],
+          },
+        ],
+        messages: [
+          {
+            id: "message-1",
+            role: "user",
+            text: "what's in this?",
+            parts: [{ type: "image", url: ownerUrl }],
+          },
+        ],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    }, "owner_one");
+
+    const expectedUrl = toFederatedTranscriptImageProtocolUrl(
+      "owner_one",
+      ownerUrl,
+    );
+    expect(response.replay.entries[0]).toMatchObject({
+      parts: [{ type: "image", url: expectedUrl }],
+    });
+    expect(response.replay.messages[0]).toMatchObject({
+      parts: [{ type: "image", url: expectedUrl }],
+    });
+  });
+
+  it("serves federation protocol URLs through the remote image resolver", async () => {
+    const {
+      installTranscriptImageProtocol,
+      toFederatedTranscriptImageProtocolUrl,
+    } = await import("../transcript-image-protocol");
+    const ownerUrl = toProtocolUrl(
+      "/Users/owner/.pwragent/profiles/default/state/image-inputs/image.png",
+    );
+    const resolveFederatedImage = vi.fn(async () => ({
+      dataBase64: Buffer.from([1, 2, 3]).toString("base64"),
+      mimeType: "image/png",
+    }));
+
+    installTranscriptImageProtocol({ resolveFederatedImage });
+    const handler = protocolHandleMock.mock.calls[0]?.[1] as (
+      request: { url: string },
+    ) => Promise<Response>;
+    const response = await handler({
+      url: toFederatedTranscriptImageProtocolUrl("owner_one", ownerUrl),
+    });
+
+    expect(resolveFederatedImage).toHaveBeenCalledWith({
+      instanceId: "owner_one",
+      url: ownerUrl,
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+      new Uint8Array([1, 2, 3]),
+    );
+  });
+
   it("materializes data image URLs into thread-scoped files before renderer IPC", async () => {
     const { materializeTranscriptImageUrlsForRenderer } = await import(
       "../transcript-image-protocol"

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -83,13 +83,14 @@ import type {
 } from "@pwragent/shared";
 import type { FederationRouter } from "./federation-router";
 import type { FederationRpcEndpoint } from "./federation-rpc";
-import {
-  rewriteFederatedTranscriptImageUrlsForRenderer,
-  type FederatedTranscriptImageResponse,
-} from "../transcript-image-protocol";
 
 export type FederationReadTranscriptImageRequest = {
   url: string;
+};
+
+export type FederatedTranscriptImageResponse = {
+  dataBase64: string;
+  mimeType: string;
 };
 
 export const FEDERATION_BACKEND_METHODS = {
@@ -638,7 +639,12 @@ export function registerFederationBackendHandlers(params: {
 }
 
 export class FederationRemoteBackendClient implements FederationBackendOperations {
-  constructor(private readonly rpc: FederationRpcEndpoint) {}
+  constructor(
+    private readonly rpc: FederationRpcEndpoint,
+    private readonly transformReadThreadResponse: (
+      response: AppServerReadThreadResponse,
+    ) => AppServerReadThreadResponse = (response) => response,
+  ) {}
 
   async getNavigationSnapshot(
     request: GetNavigationSnapshotRequest = {},
@@ -665,10 +671,7 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
       method: FEDERATION_BACKEND_METHODS.readThread,
       params: request,
     });
-    return rewriteFederatedTranscriptImageUrlsForRenderer(
-      response,
-      this.rpc.remoteInstanceId,
-    );
+    return this.transformReadThreadResponse(response);
   }
 
   async readTranscriptImage(

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -83,11 +83,20 @@ import type {
 } from "@pwragent/shared";
 import type { FederationRouter } from "./federation-router";
 import type { FederationRpcEndpoint } from "./federation-rpc";
+import {
+  rewriteFederatedTranscriptImageUrlsForRenderer,
+  type FederatedTranscriptImageResponse,
+} from "../transcript-image-protocol";
+
+export type FederationReadTranscriptImageRequest = {
+  url: string;
+};
 
 export const FEDERATION_BACKEND_METHODS = {
   getNavigationSnapshot: "backend.getNavigationSnapshot",
   listThreads: "backend.listThreads",
   readThread: "backend.readThread",
+  readTranscriptImage: "backend.readTranscriptImage",
   listSkills: "backend.listSkills",
   listBackends: "backend.listBackends",
   markThreadSeen: "backend.markThreadSeen",
@@ -152,6 +161,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.getNavigationSnapshot]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.listThreads]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.readThread]: "thread_detail",
+  [FEDERATION_BACKEND_METHODS.readTranscriptImage]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.listSkills]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.listBackends]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.markThreadSeen]: "thread_navigation",
@@ -215,6 +225,9 @@ export type FederationBackendOperations = {
   readThread(
     request: AppServerReadThreadRequest,
   ): Promise<AppServerReadThreadResponse>;
+  readTranscriptImage(
+    request: FederationReadTranscriptImageRequest,
+  ): Promise<FederatedTranscriptImageResponse>;
   listSkills(
     request?: AppServerListSkillsRequest,
   ): Promise<AppServerListSkillsResponse>;
@@ -337,6 +350,13 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.readThread(
         envelope.params as AppServerReadThreadRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.readTranscriptImage,
+    async (envelope) =>
+      await params.backend.readTranscriptImage(
+        envelope.params as FederationReadTranscriptImageRequest,
       ),
   );
   params.router.registerHandler(
@@ -641,8 +661,21 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   async readThread(
     request: AppServerReadThreadRequest,
   ): Promise<AppServerReadThreadResponse> {
-    return await this.rpc.request<AppServerReadThreadResponse>({
+    const response = await this.rpc.request<AppServerReadThreadResponse>({
       method: FEDERATION_BACKEND_METHODS.readThread,
+      params: request,
+    });
+    return rewriteFederatedTranscriptImageUrlsForRenderer(
+      response,
+      this.rpc.remoteInstanceId,
+    );
+  }
+
+  async readTranscriptImage(
+    request: FederationReadTranscriptImageRequest,
+  ): Promise<FederatedTranscriptImageResponse> {
+    return await this.rpc.request<FederatedTranscriptImageResponse>({
+      method: FEDERATION_BACKEND_METHODS.readTranscriptImage,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-rpc.ts
+++ b/apps/desktop/src/main/federation/federation-rpc.ts
@@ -27,10 +27,6 @@ export class FederationRpcEndpoint {
     },
   ) {}
 
-  get remoteInstanceId(): FederationInstanceId {
-    return this.options.remoteInstanceId;
-  }
-
   request<Result = unknown>(params: {
     method: string;
     params: unknown;

--- a/apps/desktop/src/main/federation/federation-rpc.ts
+++ b/apps/desktop/src/main/federation/federation-rpc.ts
@@ -27,6 +27,10 @@ export class FederationRpcEndpoint {
     },
   ) {}
 
+  get remoteInstanceId(): FederationInstanceId {
+    return this.options.remoteInstanceId;
+  }
+
   request<Result = unknown>(params: {
     method: string;
     params: unknown;

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -102,7 +102,10 @@ import {
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
 import { spawnTerminalPty } from "../terminal/integrated-terminal-service";
-import { rewriteTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
+import {
+  readTranscriptImageProtocolRequest,
+  rewriteTranscriptImageUrlsForRenderer,
+} from "../transcript-image-protocol";
 import { getMainLogger } from "../log";
 import {
   discoverDesktopApplications,
@@ -1836,7 +1839,10 @@ function localBackendOperations(): FederationBackendOperations {
       });
       return rewriteTranscriptImageUrlsForRenderer(response);
     },
-  async listSkills(
+    async readTranscriptImage(request) {
+      return await readTranscriptImageProtocolRequest(request.url);
+    },
+    async listSkills(
       request: AppServerListSkillsRequest = {},
     ): Promise<AppServerListSkillsResponse> {
       const backend = request.backend ?? "codex";

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -104,6 +104,7 @@ import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
 import { spawnTerminalPty } from "../terminal/integrated-terminal-service";
 import {
   readTranscriptImageProtocolRequest,
+  rewriteFederatedTranscriptImageUrlsForRenderer,
   rewriteTranscriptImageUrlsForRenderer,
 } from "../transcript-image-protocol";
 import { getMainLogger } from "../log";
@@ -601,7 +602,13 @@ export class DesktopFederationRuntime {
   }
 
   remoteBackend(target: FederationRemoteTarget): FederationBackendOperations {
-    return new FederationRemoteBackendClient(this.rpcFor(target));
+    return new FederationRemoteBackendClient(
+      this.rpcFor(target),
+      (response) => rewriteFederatedTranscriptImageUrlsForRenderer(
+        response,
+        target.instanceId,
+      ),
+    );
   }
 
   /**

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -919,7 +919,12 @@ export function bootstrapApp(): void {
     registerImageNormalizationIpcHandlers();
     registerIntegratedTerminalIpcHandlers();
     registerMcpConnectionIpcHandlers();
-    installTranscriptImageProtocol();
+    installTranscriptImageProtocol({
+      resolveFederatedImage: async ({ instanceId, url }) =>
+        await getDesktopFederationRuntime()
+          .remoteBackend({ scope: "remote", instanceId })
+          .readTranscriptImage({ url }),
+    });
     registerPreloadLogIpcHandlers();
     registerProfilesIpcHandlers({ onProfilesChanged: installApplicationMenu });
     registerRendererErrorIpcHandlers();

--- a/apps/desktop/src/main/transcript-image-protocol.ts
+++ b/apps/desktop/src/main/transcript-image-protocol.ts
@@ -108,6 +108,7 @@ export type TranscriptImageFileResolution =
 type MaterializedTranscriptImage = {
   buffer: Buffer;
   extension: string;
+  mimeType: string;
   sha256: string;
 };
 
@@ -185,7 +186,7 @@ export function rewriteFederatedTranscriptImageUrlsForRenderer(
   instanceId: FederationInstanceId,
 ): AppServerReadThreadResponse {
   return rewriteTranscriptImageUrls(response, (url) =>
-    isLocalTranscriptImageUrl(url)
+    isFederationOwnerImageUrl(url)
       ? toFederatedTranscriptImageProtocolUrl(instanceId, url)
       : undefined,
   );
@@ -531,7 +532,7 @@ async function fetchLoopbackSignedImage(
 
 async function fetchLoopbackSignedImageOnce(
   url: string,
-  deps: TranscriptImageMaterializerDependencies,
+  deps: Pick<TranscriptImageMaterializerDependencies, "fetch">,
 ): Promise<MaterializedTranscriptImage | undefined> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCHED_TRANSCRIPT_IMAGE_TIMEOUT_MS);
@@ -558,7 +559,7 @@ async function fetchLoopbackSignedImageOnce(
       ?.trim()
       .toLowerCase();
     const extension = mimeType ? DATA_IMAGE_EXTENSIONS.get(mimeType) : undefined;
-    if (!extension) {
+    if (!mimeType || !extension) {
       return undefined;
     }
 
@@ -570,6 +571,7 @@ async function fetchLoopbackSignedImageOnce(
     return {
       buffer,
       extension,
+      mimeType,
       sha256: createHash("sha256").update(buffer).digest("hex"),
     };
   } catch {
@@ -886,6 +888,7 @@ async function readMarkdownLinkedTranscriptImage(
   return {
     buffer,
     extension,
+    mimeType: resolution.mimeType,
     sha256: createHash("sha256").update(buffer).digest("hex"),
   };
 }
@@ -1062,6 +1065,10 @@ function isLocalTranscriptImageUrl(url: string): boolean {
   return url.startsWith(`${TRANSCRIPT_IMAGE_PROTOCOL_SCHEME}://file/`);
 }
 
+function isFederationOwnerImageUrl(url: string): boolean {
+  return isLocalTranscriptImageUrl(url) || isPwrSnapSignedMediaUrl(url);
+}
+
 function isFileImageUrl(url: string): boolean {
   return url.startsWith("file://");
 }
@@ -1166,7 +1173,7 @@ function decodeFederatedTranscriptImageProtocolRequest(
   try {
     const instanceId = decodeURIComponent(encodedInstanceId);
     const url = decodeURIComponent(encodedUrl);
-    if (!instanceId || !isLocalTranscriptImageUrl(url)) {
+    if (!instanceId || !isFederationOwnerImageUrl(url)) {
       return undefined;
     }
     return { instanceId, url };
@@ -1190,7 +1197,20 @@ export async function resolveTranscriptImageProtocolRequest(
 export async function readTranscriptImageProtocolRequest(
   requestUrl: string,
   options?: TranscriptImageProtocolOptions,
+  dependencies: Pick<TranscriptImageMaterializerDependencies, "fetch"> =
+    defaultMaterializerDependencies,
 ): Promise<FederatedTranscriptImageResponse> {
+  if (isPwrSnapSignedMediaUrl(requestUrl)) {
+    const image = await fetchLoopbackSignedImageOnce(requestUrl, dependencies);
+    if (!image) {
+      throw new Error("PwrSnap transcript image could not be fetched");
+    }
+    return {
+      dataBase64: image.buffer.toString("base64"),
+      mimeType: image.mimeType,
+    };
+  }
+
   const resolution = await resolveTranscriptImageProtocolRequest(
     requestUrl,
     options,
@@ -1338,7 +1358,7 @@ function mimeTypeForImagePath(filePath: string): string | undefined {
 
 function parseSupportedImageDataUrl(
   url: string,
-): { buffer: Buffer; extension: string; sha256: string } | undefined {
+): MaterializedTranscriptImage | undefined {
   const match = /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/]+={0,2})$/iu.exec(
     url,
   );
@@ -1349,7 +1369,7 @@ function parseSupportedImageDataUrl(
   const mimeType = match[1]?.toLowerCase();
   const extension = mimeType ? DATA_IMAGE_EXTENSIONS.get(mimeType) : undefined;
   const payload = match[2] ?? "";
-  if (!extension || payload.length % 4 === 1) {
+  if (!mimeType || !extension || payload.length % 4 === 1) {
     return undefined;
   }
 
@@ -1361,6 +1381,7 @@ function parseSupportedImageDataUrl(
   return {
     buffer,
     extension,
+    mimeType,
     sha256: createHash("sha256").update(buffer).digest("hex"),
   };
 }

--- a/apps/desktop/src/main/transcript-image-protocol.ts
+++ b/apps/desktop/src/main/transcript-image-protocol.ts
@@ -7,6 +7,7 @@ import type {
   AppServerThreadMessage,
   AppServerThreadMessageEntry,
   AppServerThreadMessagePart,
+  FederationInstanceId,
 } from "@pwragent/shared";
 import { createHash } from "node:crypto";
 import { mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
@@ -49,6 +50,22 @@ export type TranscriptImageProtocolOptions = {
   additionalAllowedRoots?: readonly string[];
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
+};
+
+export type FederatedTranscriptImageRequest = {
+  instanceId: FederationInstanceId;
+  url: string;
+};
+
+export type FederatedTranscriptImageResponse = {
+  dataBase64: string;
+  mimeType: string;
+};
+
+export type TranscriptImageProtocolInstallOptions = {
+  resolveFederatedImage?: (
+    request: FederatedTranscriptImageRequest,
+  ) => Promise<FederatedTranscriptImageResponse>;
 };
 
 export type TranscriptImageMaterializationOptions = {
@@ -148,17 +165,30 @@ export function toTranscriptImageProtocolUrl(src: string): string {
   return `pwragent-image://file/${encodeURIComponent(src)}`;
 }
 
+export function toFederatedTranscriptImageProtocolUrl(
+  instanceId: FederationInstanceId,
+  src: string,
+): string {
+  return `pwragent-image://federation/${encodeURIComponent(instanceId)}/${encodeURIComponent(src)}`;
+}
+
 export function rewriteTranscriptImageUrlsForRenderer(
   response: AppServerReadThreadResponse,
 ): AppServerReadThreadResponse {
-  return {
-    ...response,
-    replay: {
-      ...response.replay,
-      entries: response.replay.entries.map(rewriteTranscriptEntryImageUrls),
-      messages: response.replay.messages.map(rewriteTranscriptMessageImageUrls),
-    },
-  };
+  return rewriteTranscriptImageUrls(response, (url) =>
+    isFileImageUrl(url) ? toTranscriptImageProtocolUrl(url) : undefined,
+  );
+}
+
+export function rewriteFederatedTranscriptImageUrlsForRenderer(
+  response: AppServerReadThreadResponse,
+  instanceId: FederationInstanceId,
+): AppServerReadThreadResponse {
+  return rewriteTranscriptImageUrls(response, (url) =>
+    isLocalTranscriptImageUrl(url)
+      ? toFederatedTranscriptImageProtocolUrl(instanceId, url)
+      : undefined,
+  );
 }
 
 export async function materializeTranscriptImageUrlsForRenderer(
@@ -974,38 +1004,62 @@ function isInsideInlineCode(line: string, offset: number): boolean {
   return markerLength > 0;
 }
 
-function rewriteTranscriptEntryImageUrls(entry: AppServerThreadEntry): AppServerThreadEntry {
+type TranscriptImageUrlRewriter = (url: string) => string | undefined;
+
+function rewriteTranscriptImageUrls(
+  response: AppServerReadThreadResponse,
+  rewriteUrl: TranscriptImageUrlRewriter,
+): AppServerReadThreadResponse {
+  return {
+    ...response,
+    replay: {
+      ...response.replay,
+      entries: response.replay.entries.map((entry) =>
+        rewriteTranscriptEntryImageUrls(entry, rewriteUrl),
+      ),
+      messages: response.replay.messages.map((message) =>
+        rewriteTranscriptMessageImageUrls(message, rewriteUrl),
+      ),
+    },
+  };
+}
+
+function rewriteTranscriptEntryImageUrls(
+  entry: AppServerThreadEntry,
+  rewriteUrl: TranscriptImageUrlRewriter,
+): AppServerThreadEntry {
   if (entry.type !== "message") {
     return entry;
   }
 
-  return rewriteTranscriptMessageImageUrls(entry) as AppServerThreadMessageEntry;
+  return rewriteTranscriptMessageImageUrls(
+    entry,
+    rewriteUrl,
+  ) as AppServerThreadMessageEntry;
 }
 
 function rewriteTranscriptMessageImageUrls<T extends AppServerThreadMessage>(
   message: T,
+  rewriteUrl: TranscriptImageUrlRewriter,
 ): T {
-  if (!message.parts?.some((part) => part.type === "image" && isFileImageUrl(part.url))) {
-    return message;
-  }
+  let changed = false;
+  const parts = message.parts?.map((part) => {
+    if (part.type !== "image") {
+      return part;
+    }
+    const url = rewriteUrl(part.url);
+    if (!url) {
+      return part;
+    }
+    changed = true;
+    return { ...part, url };
+  });
 
-  return {
-    ...message,
-    parts: message.parts.map(rewriteTranscriptMessagePartImageUrl),
-  };
+  return changed ? { ...message, parts } : message;
 }
 
-function rewriteTranscriptMessagePartImageUrl(
-  part: AppServerThreadMessagePart,
-): AppServerThreadMessagePart {
-  if (part.type !== "image" || !isFileImageUrl(part.url)) {
-    return part;
-  }
-
-  return {
-    ...part,
-    url: toTranscriptImageProtocolUrl(part.url),
-  };
+function isLocalTranscriptImageUrl(url: string): boolean {
+  return url.startsWith(`${TRANSCRIPT_IMAGE_PROTOCOL_SCHEME}://file/`);
 }
 
 function isFileImageUrl(url: string): boolean {
@@ -1020,8 +1074,46 @@ function isMaterializableImageUrl(url: string): boolean {
   );
 }
 
-export function installTranscriptImageProtocol(): void {
+export function installTranscriptImageProtocol(
+  options: TranscriptImageProtocolInstallOptions = {},
+): void {
   protocol.handle(TRANSCRIPT_IMAGE_PROTOCOL_SCHEME, async (request) => {
+    const federatedRequest = decodeFederatedTranscriptImageProtocolRequest(
+      request.url,
+    );
+    if (federatedRequest) {
+      if (!options.resolveFederatedImage) {
+        return new Response("federated transcript image transport unavailable", {
+          status: 503,
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        });
+      }
+
+      try {
+        const remote = await options.resolveFederatedImage(federatedRequest);
+        const bytes = Buffer.from(remote.dataBase64, "base64");
+        if (
+          !remote.mimeType.startsWith("image/")
+          || bytes.byteLength === 0
+          || bytes.byteLength > MAX_FETCHED_TRANSCRIPT_IMAGE_BYTES
+        ) {
+          return new Response("invalid federated transcript image response", {
+            status: 502,
+            headers: { "content-type": "text/plain; charset=utf-8" },
+          });
+        }
+        return transcriptImageResponse(bytes, remote.mimeType);
+      } catch (error) {
+        return new Response(
+          error instanceof Error ? error.message : String(error),
+          {
+            status: 502,
+            headers: { "content-type": "text/plain; charset=utf-8" },
+          },
+        );
+      }
+    }
+
     const resolution = await resolveTranscriptImageProtocolRequest(request.url);
     if (!resolution.ok) {
       return new Response(resolution.message, {
@@ -1031,13 +1123,56 @@ export function installTranscriptImageProtocol(): void {
     }
 
     const bytes = await readFile(resolution.path);
-    return new Response(new Uint8Array(bytes), {
-      headers: {
-        "cache-control": "public, max-age=31536000, immutable",
-        "content-type": resolution.mimeType,
-      },
-    });
+    return transcriptImageResponse(bytes, resolution.mimeType);
   });
+}
+
+function transcriptImageResponse(
+  bytes: Uint8Array,
+  mimeType: string,
+): Response {
+  return new Response(new Uint8Array(bytes), {
+    headers: {
+      "cache-control": "public, max-age=31536000, immutable",
+      "content-type": mimeType,
+    },
+  });
+}
+
+function decodeFederatedTranscriptImageProtocolRequest(
+  requestUrl: string,
+): FederatedTranscriptImageRequest | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(requestUrl);
+  } catch {
+    return undefined;
+  }
+
+  if (
+    parsed.protocol !== `${TRANSCRIPT_IMAGE_PROTOCOL_SCHEME}:`
+    || parsed.hostname !== "federation"
+  ) {
+    return undefined;
+  }
+
+  const [encodedInstanceId, encodedUrl, ...unexpected] = parsed.pathname
+    .replace(/^\//, "")
+    .split("/");
+  if (!encodedInstanceId || !encodedUrl || unexpected.length > 0) {
+    return undefined;
+  }
+
+  try {
+    const instanceId = decodeURIComponent(encodedInstanceId);
+    const url = decodeURIComponent(encodedUrl);
+    if (!instanceId || !isLocalTranscriptImageUrl(url)) {
+      return undefined;
+    }
+    return { instanceId, url };
+  } catch {
+    return undefined;
+  }
 }
 
 export async function resolveTranscriptImageProtocolRequest(
@@ -1050,6 +1185,29 @@ export async function resolveTranscriptImageProtocolRequest(
   }
 
   return await resolveTranscriptImageFile(sourcePath, options);
+}
+
+export async function readTranscriptImageProtocolRequest(
+  requestUrl: string,
+  options?: TranscriptImageProtocolOptions,
+): Promise<FederatedTranscriptImageResponse> {
+  const resolution = await resolveTranscriptImageProtocolRequest(
+    requestUrl,
+    options,
+  );
+  if (!resolution.ok) {
+    throw new Error(resolution.message);
+  }
+
+  const fileStat = await stat(resolution.path);
+  if (fileStat.size === 0 || fileStat.size > MAX_FETCHED_TRANSCRIPT_IMAGE_BYTES) {
+    throw new Error("transcript image size is not supported");
+  }
+  const bytes = await readFile(resolution.path);
+  return {
+    dataBase64: bytes.toString("base64"),
+    mimeType: resolution.mimeType,
+  };
 }
 
 function decodeTranscriptImageProtocolRequest(requestUrl: string): string | undefined {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -676,12 +676,20 @@ function formatTranscriptImageSourceLabel(url: string): string {
 }
 
 function decodeTranscriptImageProtocolUrl(url: string): string | undefined {
-  if (!url.startsWith("pwragent-image://file/")) {
+  if (!url.startsWith("pwragent-image://")) {
     return undefined;
   }
 
   try {
-    return decodeURIComponent(new URL(url).pathname.replace(/^\//, ""));
+    const parsed = new URL(url);
+    const segments = parsed.pathname.replace(/^\//, "").split("/");
+    if (parsed.hostname === "file" && segments.length === 1) {
+      return decodeURIComponent(segments[0] ?? "");
+    }
+    if (parsed.hostname === "federation" && segments.length === 2) {
+      return decodeURIComponent(segments[1] ?? "");
+    }
+    return undefined;
   } catch {
     return undefined;
   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1423,6 +1423,44 @@ describe("TranscriptList", () => {
     });
   });
 
+  it("shows the owner path when a federated inline image fails to load", async () => {
+    const fileUrl =
+      "file:///Users/owner/.pwragent/profiles/default/state/image-inputs/missing.png";
+    const ownerUrl = `pwragent-image://file/${encodeURIComponent(fileUrl)}`;
+    const renderUrl =
+      `pwragent-image://federation/owner_one/${encodeURIComponent(ownerUrl)}`;
+
+    render(
+      <TranscriptList
+        entries={[{
+          type: "message",
+          id: "message-1",
+          role: "user",
+          text: "What's in this?",
+          parts: [{
+            type: "image",
+            url: renderUrl,
+            alt: "Missing federated transcript image",
+          }],
+        }]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    fireEvent.error(screen.getByAltText("Missing federated transcript image"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "/Users/owner/.pwragent/profiles/default/state/image-inputs/missing.png"
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
   it("renders pending status inside the transcript list", () => {
     render(
       <TranscriptList

--- a/docs/federation-architecture.md
+++ b/docs/federation-architecture.md
@@ -62,6 +62,12 @@ the dedicated `scheduled_actions` capability rather than inheriting broad turn
 control. Capability checks remain attached to every method, so an older or
 restricted peer fails closed instead of silently executing locally.
 
+Transcript images stay behind the renderer-safe `pwragent-image://` protocol.
+For a remote thread, the viewer rewrites owner-local image URLs to identify the
+owning instance and lazily fetches the validated bytes with
+`backend.readTranscriptImage`. That RPC requires `thread_detail`; the owner
+applies the same allowed-root and image-type checks as a local protocol fetch.
+
 The scheduled-action RPC surface is part of federation protocol v1 while the
 protocol remains under development. Peers must authorize `scheduled_actions`
 explicitly; `turn_control` does not imply scheduler access.

--- a/docs/federation-architecture.md
+++ b/docs/federation-architecture.md
@@ -66,7 +66,9 @@ Transcript images stay behind the renderer-safe `pwragent-image://` protocol.
 For a remote thread, the viewer rewrites owner-local image URLs to identify the
 owning instance and lazily fetches the validated bytes with
 `backend.readTranscriptImage`. That RPC requires `thread_detail`; the owner
-applies the same allowed-root and image-type checks as a local protocol fetch.
+applies the same allowed-root checks as a local file fetch, accepts only signed
+PwrSnap media from its fixed loopback origin, and enforces image type and size
+limits before returning bytes.
 
 The scheduled-action RPC surface is part of federation protocol v1 while the
 protocol remains under development. Peers must authorize `scheduled_actions`


### PR DESCRIPTION
## Summary

- preserve the renderer-safe `pwragent-image://` scheme for remote transcripts while encoding the owning Federation instance in the URL
- lazily fetch image bytes from that owner through a new `backend.readTranscriptImage` RPC guarded by `thread_detail`
- reuse the local protocol's allowed-root, image-type, and size validation before returning bytes
- keep failed remote image fallbacks readable by showing the original owner path

## Root cause

The Federation owner rewrote local `file://` image parts to `pwragent-image://file/...` before returning `backend.readThread`. The viewer received that URL unchanged, so its custom protocol handler attempted to resolve the owner's absolute path on the viewer filesystem. Federation transported the transcript metadata but had no image-byte path.

## Impact

Remote Federation windows can now render transcript images without embedding large base64 payloads in every thread read. Images are fetched only when Electron requests them, and local transcript image behavior is unchanged.

## Validation

- focused Vitest coverage: 5 files, 155 tests
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- SQL, Codex-storage, renderer-color, Electron-version, and license checks
