### PR TITLE
fix(desktop): wait for complete CI failure before auto-fix

### DIFF
--- a/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
@@ -327,6 +327,45 @@ describe("PrAutoDispatchCoordinator", () => {
     );
   });
 
+  it("waits for all checks to finish before scheduling a CI repair", async () => {
+    const harness = createHarness();
+    const partiallyFailed = pr({ checksStillRunning: true });
+    harness.setCurrentPr(partiallyFailed);
+
+    expect((await observe(harness.coordinator, partiallyFailed))[0]?.status).toBe(
+      "not-actionable",
+    );
+    expect(await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    })).toBeUndefined();
+
+    const finishedFailing = pr({ checksStillRunning: false });
+    harness.setCurrentPr(finishedFailing);
+    expect((await observe(harness.coordinator, finishedFailing))[0]?.status).toBe(
+      "scheduled",
+    );
+  });
+
+  it("still schedules merge-conflict repair while checks are running", async () => {
+    const harness = createHarness();
+    const conflicting = pr({
+      checkState: "pending",
+      checksStillRunning: true,
+      mergeState: "conflicting",
+      state: "pending",
+    });
+    harness.setCurrentPr(conflicting);
+
+    expect((await observe(harness.coordinator, conflicting))[0]?.status).toBe(
+      "scheduled",
+    );
+    expect((await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    }))?.pending.eventKinds).toEqual(["merge-conflict"]);
+  });
+
   it("does not schedule terminal PRs and cancels a pending repair when one closes", async () => {
     const harness = createHarness();
     expect((await observe(
@@ -897,5 +936,19 @@ describe("PrAutoDispatchCoordinator", () => {
     attached = false;
     await runCountdown();
     expect(submitTurnIfIdle).not.toHaveBeenCalled();
+  });
+
+  it("drops a scheduled CI repair when checks are running again before send", async () => {
+    const harness = createHarness();
+    await observe(harness.coordinator);
+    harness.setCurrentPr(pr({ checksStillRunning: true }));
+
+    await runCountdown();
+
+    expect(harness.submitTurnIfIdle).not.toHaveBeenCalled();
+    expect(await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    })).toBeUndefined();
   });
 });

--- a/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
@@ -938,7 +938,33 @@ describe("PrAutoDispatchCoordinator", () => {
     expect(submitTurnIfIdle).not.toHaveBeenCalled();
   });
 
-  it("drops a scheduled CI repair when checks are running again before send", async () => {
+  it("re-arms a deferred CI repair after restarted checks finish failing", async () => {
+    const harness = createHarness();
+    await observe(harness.coordinator);
+    const restarted = pr({ checksStillRunning: true });
+    harness.setCurrentPr(restarted);
+
+    expect((await observe(harness.coordinator, restarted))[0]?.status).toBe(
+      "deferred",
+    );
+    expect(await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    })).toBeUndefined();
+
+    await runCountdown();
+    expect(harness.submitTurnIfIdle).not.toHaveBeenCalled();
+
+    const completed = pr({ checksStillRunning: false });
+    harness.setCurrentPr(completed);
+    expect((await observe(harness.coordinator, completed))[0]?.status).toBe(
+      "scheduled",
+    );
+    await runCountdown();
+    expect(harness.submitTurnIfIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it("defers a restarted-check race discovered at dispatch time", async () => {
     const harness = createHarness();
     await observe(harness.coordinator);
     harness.setCurrentPr(pr({ checksStillRunning: true }));
@@ -946,9 +972,10 @@ describe("PrAutoDispatchCoordinator", () => {
     await runCountdown();
 
     expect(harness.submitTurnIfIdle).not.toHaveBeenCalled();
-    expect(await store.getThreadPrAutoDispatchPending({
-      backend: "codex",
-      threadId: "thread-1",
-    })).toBeUndefined();
+    const completed = pr({ checksStillRunning: false });
+    harness.setCurrentPr(completed);
+    expect((await observe(harness.coordinator, completed))[0]?.status).toBe(
+      "scheduled",
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/pr-status-watch.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-status-watch.test.ts
@@ -143,7 +143,7 @@ describe("PrStatusWatchCoordinator", () => {
     });
   });
 
-  it("wakes on the first failing snapshot without waiting for other jobs", async () => {
+  it("waits for remaining checks before waking on a failed suite", async () => {
     await registerWatch();
     const harness = createHarness();
 
@@ -153,6 +153,15 @@ describe("PrStatusWatchCoordinator", () => {
     await expect(harness.coordinator.handleStatusSnapshot(pr({
       state: "failing",
       checkState: "failing",
+      checksStillRunning: true,
+    }), now)).resolves.toBe(0);
+    expect(harness.submitTurnIfIdle).not.toHaveBeenCalled();
+
+    now += 1;
+    await expect(harness.coordinator.handleStatusSnapshot(pr({
+      state: "failing",
+      checkState: "failing",
+      checksStillRunning: false,
     }), now)).resolves.toBe(1);
 
     expect(harness.submitTurnIfIdle).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
+++ b/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
@@ -39,6 +39,7 @@ export type PrAutoDispatchOutcome = {
     | "dispatched"
     | "gate-off"
     | "not-actionable"
+    | "deferred"
     | "missing-head"
     | "disabled"
     | "busy"
@@ -128,7 +129,7 @@ type PrAutoDispatchStore = {
     threadId: string;
     fingerprint: string;
     now?: number;
-    status?: "cancelled" | "resolved" | "superseded";
+    status?: "cancelled" | "deferred" | "resolved" | "superseded";
   }): Promise<boolean>;
   cancelPendingThreadPrAutoDispatchForPr(params: {
     backend: AppServerBackendKind;
@@ -249,19 +250,33 @@ export class PrAutoDispatchCoordinator {
       });
 
       if (!event) {
-        const cancelled = await this.options.store
-          .cancelPendingThreadPrAutoDispatchForPr({
-            ...identity,
-            prKey,
-            now: params.observedAt,
-          });
+        const record = await this.options.store
+          .getThreadPrAutoDispatchPending(identity);
+        const deferred = Boolean(
+          record
+          && shouldDeferPendingCiFailure(record.pending, params.pr),
+        );
+        const cancelled = deferred && record
+          ? await this.options.store.cancelThreadPrAutoDispatch({
+              ...identity,
+              fingerprint: record.pending.fingerprint,
+              now: params.observedAt,
+              status: "deferred",
+            })
+          : await this.options.store.cancelPendingThreadPrAutoDispatchForPr({
+              ...identity,
+              prKey,
+              now: params.observedAt,
+            });
         if (cancelled) {
           this.clearTimer(threadKey);
           await this.notifyPending(identity, null);
         }
         outcomes.push({
           threadKey,
-          status: eventKinds.length > 0 ? "missing-head" : "not-actionable",
+          status: deferred
+            ? "deferred"
+            : eventKinds.length > 0 ? "missing-head" : "not-actionable",
         });
         continue;
       }
@@ -425,6 +440,20 @@ export class PrAutoDispatchCoordinator {
       ...identity,
       prKey: record.pending.prKey,
     }) ?? true;
+    if (
+      attached
+      && currentPr
+      && shouldDeferPendingCiFailure(record.pending, currentPr)
+    ) {
+      await this.options.store.cancelThreadPrAutoDispatch({
+        ...identity,
+        fingerprint,
+        now: this.now(),
+        status: "deferred",
+      });
+      await this.notifyPending(identity, null);
+      return;
+    }
     if (
       !attached
       || !currentEvent
@@ -740,6 +769,19 @@ export function buildPrAutoDispatchEvent(
       .update(JSON.stringify(fingerprintPayload))
       .digest("hex"),
   };
+}
+
+function shouldDeferPendingCiFailure(
+  pending: ThreadPrAutoDispatchPending,
+  pr: PrSummary,
+): boolean {
+  return (
+    !isTerminalPullRequest(pr)
+    && pr.checksStillRunning === true
+    && pending.prKey === buildPullRequestStatusKey(pr)
+    && pending.headSha === pr.headSha
+    && pending.eventKinds.includes("ci-failure")
+  );
 }
 
 function getDefinitivelyResolvedEventKinds(

--- a/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
+++ b/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
@@ -691,7 +691,9 @@ export function getPrAutoDispatchEventKinds(
 ): ThreadPrAutoDispatchEventKind[] {
   if (isTerminalPullRequest(pr)) return [];
   const eventKinds: ThreadPrAutoDispatchEventKind[] = [];
-  if (pr.checkState === "failing") eventKinds.push("ci-failure");
+  if (pr.checkState === "failing" && !pr.checksStillRunning) {
+    eventKinds.push("ci-failure");
+  }
   if (pr.mergeState === "conflicting") eventKinds.push("merge-conflict");
   return eventKinds;
 }

--- a/apps/desktop/src/main/pr-status/pr-status-watch.ts
+++ b/apps/desktop/src/main/pr-status/pr-status-watch.ts
@@ -206,6 +206,7 @@ export function getPrStatusWatchOutcome(
   if (pr.lifecycleState === "merged") return "success";
   if (pr.lifecycleState === "closed") return "failure";
   if (pr.mergeState === "conflicting") return "failure";
+  if (pr.checksStillRunning) return undefined;
   const checkState = pr.checkState ?? pr.state;
   if (checkState === "failing") return "failure";
   if (checkState === "passing") return "success";

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2640,8 +2640,11 @@ export class SqliteOverlayStore {
         }) | undefined;
       if (duplicate) {
         if (
-          params.allowCancelledRearm
-          && ["cancelled", "resolved", "superseded"].includes(duplicate.status)
+          duplicate.status === "deferred"
+          || (
+            params.allowCancelledRearm
+            && ["cancelled", "resolved", "superseded"].includes(duplicate.status)
+          )
         ) {
           this.stateDb.raw
             .prepare(
@@ -3293,7 +3296,7 @@ export class SqliteOverlayStore {
     threadId: string;
     fingerprint: string;
     now?: number;
-    status?: "cancelled" | "resolved" | "superseded";
+    status?: "cancelled" | "deferred" | "resolved" | "superseded";
   }): Promise<boolean> {
     const result = this.stateDb.raw
       .prepare(


### PR DESCRIPTION
## Summary

- defer CI Auto-Fix scheduling while any checks are still running
- keep one-shot failure watches pending through partial failures
- keep merge-conflict repair independent from CI completion
- durably defer and re-arm a countdown when checks restart on the same head

## Root cause

The PR status model correctly represented a mixed rollup as `checkState: failing` with `checksStillRunning: true`, but Auto-Fix treated every failing rollup as actionable. That scheduled a repair as soon as the first check failed instead of waiting for the check suite to reach a terminal result.

The original fix made the initial scheduling predicate terminal-aware, but the one-shot watch predicate still treated partial failures as complete. It also marked interrupted countdowns as superseded, whose unchanged fingerprint could not be scheduled again by an ordinary poll.

## Impact

Auto-Fix and one-shot watches no longer start from the intermediate “some failures, still running” state. If checks restart during the countdown, the claim becomes deferred without spending an attempt or budget token and is automatically re-armed if the completed suite still fails. Existing merge-conflict automation is unchanged.

## Validation

- 143 focused and integration tests
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:sql`
- `pnpm lint:boundaries`
- `git diff --check`
