### PR TITLE
fix(desktop): federation queue-boundary review — all fixes

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -735,6 +735,7 @@ vi.mock("../app-server/backend-registry", () => {
     setThreadPrAutoDispatchBatch,
     ensureDirectoryLaunchpad,
     getQueuedExecutionModesSnapshot: () => ({}),
+    getQueuedTurnsSnapshot: () => ({}),
     rememberCompleteNavigationSnapshot,
   };
   backendRegistryLifecycle.get.mockImplementation(() => registry);
@@ -1597,6 +1598,7 @@ describe("app server ipc", () => {
       fetchedAt: expect.any(Number),
       messagingBindingsByThreadKey: undefined,
       queuedExecutionModesByThreadKey: {},
+      queuedTurnsByThreadKey: {},
       threads: [
         expect.objectContaining({ source: "codex", id: "thread-1" }),
         expect.objectContaining({ source: "grok", id: "thread-1" }),

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -116,6 +116,7 @@ describe("DesktopMessagingBackendBridge", () => {
     });
     const registry = {
       getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
+      getQueuedTurnsSnapshot: vi.fn(() => ({})),
       hydrateThreadGitWorkingStates: vi.fn(async (
         threads: NavigationSnapshot["threads"],
       ) =>
@@ -177,6 +178,7 @@ describe("DesktopMessagingBackendBridge", () => {
     } as unknown as NavigationSnapshot);
     const registry = {
       getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
+      getQueuedTurnsSnapshot: vi.fn(() => ({})),
       hydrateThreadGitWorkingStates: vi.fn(
         async (threads: NavigationSnapshot["threads"]) => threads,
       ),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -148,6 +148,7 @@ import {
   type SendThreadPrAutoDispatchNowResponse,
   type DetachThreadPullRequestRequest,
   type DetachThreadPullRequestResponse,
+  type ThreadQueuedTurnSummary,
   type ApplyThreadModelMigrationRequest,
   type ApplyThreadModelMigrationResponse,
   type TurnOffCodexFastEverywhereResponse,
@@ -7241,6 +7242,10 @@ export class DesktopBackendRegistry {
                 ...baseParams,
                 status: "queued",
                 position: event.position,
+                // Windows that did not submit this entry mirror a chip
+                // from the event; carry the text so they need not wait
+                // for the next navigation snapshot.
+                displayText: queuedTurnDisplayText(event.entry.input),
               }
             : event.type === "started"
               ? {
@@ -12458,6 +12463,31 @@ export class DesktopBackendRegistry {
    * persisted — but the audit log entries are, so historical context
    * survives restarts.
    */
+  /**
+   * Read projection of the main-process turn FIFO, keyed by thread
+   * identity. Mirrors getQueuedExecutionModesSnapshot: the queue itself
+   * is registry memory, but every navigation snapshot carries this so
+   * ALL windows — the owner's, other local windows, and federated
+   * viewers — can render and rehydrate queued messages instead of only
+   * the window that submitted them.
+   */
+  getQueuedTurnsSnapshot(): Record<string, ThreadQueuedTurnSummary[]> {
+    const snapshot: Record<string, ThreadQueuedTurnSummary[]> = {};
+    for (const entry of this.threadTurnQueue.getAllQueuedEntries()) {
+      const threadKey = buildThreadIdentityKey(entry.backend, entry.threadId);
+      const queue = snapshot[threadKey] ?? [];
+      queue.push({
+        queueEntryId: entry.id,
+        origin: entry.origin,
+        displayText: queuedTurnDisplayText(entry.input),
+        createdAt: entry.createdAt,
+        position: queue.length,
+      });
+      snapshot[threadKey] = queue;
+    }
+    return snapshot;
+  }
+
   getQueuedExecutionModesSnapshot(): Record<
     string,
     { mode: ThreadExecutionMode; queuedAt: number } | undefined
@@ -26443,4 +26473,17 @@ export async function disposeDesktopBackendRegistry(): Promise<void> {
   const current = registry;
   registry = null;
   await current.close();
+}
+
+/** First text of a queued turn's input, truncated for chip display. */
+function queuedTurnDisplayText(input: AppServerTurnInputItem[]): string {
+  const text = input
+    .filter(
+      (item): item is Extract<AppServerTurnInputItem, { type: "text" }> =>
+        item.type === "text",
+    )
+    .map((item) => item.text)
+    .join("\n")
+    .trim();
+  return text.length > 200 ? `${text.slice(0, 200)}\u2026` : text;
 }

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1691,12 +1691,15 @@ class DesktopAppServerService {
     const automationsByThreadKey = buildAutomationSummariesByThreadKey();
     const queuedExecutionModesByThreadKey = getDesktopBackendRegistry()
       .getQueuedExecutionModesSnapshot();
+    const queuedTurnsByThreadKey = getDesktopBackendRegistry()
+      .getQueuedTurnsSnapshot();
     const snapshot = await this.getOverlayStore().reconcileNavigationSnapshot({
       backend,
       automationsByThreadKey,
       fetchedAt: Date.now(),
       messagingBindingsByThreadKey,
       queuedExecutionModesByThreadKey,
+      queuedTurnsByThreadKey,
       threads,
       workspaceRoots: resolveScratchProjectsRoots(),
     });

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -124,11 +124,13 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
     );
     const queuedExecutionModesByThreadKey =
       this.registry.getQueuedExecutionModesSnapshot();
+    const queuedTurnsByThreadKey = this.registry.getQueuedTurnsSnapshot();
     const snapshot = await getDesktopOverlayStore().reconcileNavigationSnapshot({
       backend,
       fetchedAt: Date.now(),
       messagingBindingsByThreadKey,
       queuedExecutionModesByThreadKey,
+      queuedTurnsByThreadKey,
       threads: listedThreads,
       workspaceRoots: resolveScratchProjectsRoots(),
     });

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -10,6 +10,7 @@ import type {
   MarkThreadSeenResponse,
   MessagingThreadBindingSummary,
   NavigationBrowseMode,
+  ThreadQueuedTurnSummary,
   NavigationDirectoryGitStatus,
   NavigationLaunchpadDefaults,
   NavigationSnapshot,
@@ -492,6 +493,12 @@ export class SqliteOverlayStore {
       string,
       { mode: ThreadExecutionMode; queuedAt: number } | undefined
     >;
+    /**
+     * Read projection of the registry's in-memory turn FIFO. Attached to
+     * outgoing thread summaries (and hashed) so every window and viewer
+     * sees queued messages, mirroring queuedExecutionModesByThreadKey.
+     */
+    queuedTurnsByThreadKey?: Record<string, ThreadQueuedTurnSummary[]>;
     threads: AppServerThreadSummary[];
     workspaceRoots?: string[];
   }): Promise<NavigationSnapshot> {
@@ -645,6 +652,17 @@ export class SqliteOverlayStore {
       unchanged: false,
       workspaceRoots: params.workspaceRoots,
     });
+
+    if (params.queuedTurnsByThreadKey) {
+      // Attach BEFORE hashing so queue changes invalidate the
+      // unchanged-snapshot cache like any other thread-state change.
+      snapshot.threads = snapshot.threads.map((thread) => {
+        const queuedTurns = params.queuedTurnsByThreadKey?.[
+          buildThreadIdentityKey(thread.source, thread.id)
+        ];
+        return queuedTurns?.length ? { ...thread, queuedTurns } : thread;
+      });
+    }
 
     const nextHash = buildNavigationSnapshotHash({
       backend: params.backend,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -79,6 +79,7 @@ import { useIntegratedTerminals } from "./lib/useIntegratedTerminals";
 import { useThreadSkills } from "./lib/useThreadSkills";
 import { useQueuedTurnRelease } from "./lib/useQueuedTurnRelease";
 import { useScheduledThreadActionProjection } from "./lib/useScheduledThreadActionProjection";
+import { useQueuedTurnProjection } from "./lib/useQueuedTurnProjection";
 import { useThreadQueuedMessageIndicators } from "./lib/useThreadQueuedMessageIndicators";
 import { CodexConfigWarningBanner } from "./features/codex-config/CodexConfigWarningBanner";
 import type { AppNoticeToastNotice } from "./features/notifications/AppNoticeToast";

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -6443,14 +6443,19 @@ export function Composer(props: ComposerProps) {
       if (steeringRequestIdRef.current === pending.id) {
         steeringRequestIdRef.current = undefined;
       }
-      // The steer RPC never reached the owner (transport failure, peer
-      // drop) — a renderer-parked "pending" chip would be lost if this
-      // window closes. Rescue the intent into the owner's durable
-      // scheduled-action store with the same payload the fallback
-      // carries; admitSteerTurn's requestId-derived id semantics make a
-      // duplicate harmless if the original RPC actually landed.
+      // Rescue ONLY failures that prove the steer never left this
+      // machine (the synchronous "peer is not connected" pre-send
+      // throw). A timeout is ambiguous — the steer may have been
+      // delivered and applied, and scheduling a rescue then would send
+      // the message twice; those stay renderer-parked with retry.
+      const provenUndelivered =
+        error instanceof Error && error.message.includes("is not connected");
       const rescued = await (async () => {
-        if (!props.thread || !props.desktopApi?.createScheduledThreadAction) {
+        if (
+          !provenUndelivered
+          || !props.thread
+          || !props.desktopApi?.createScheduledThreadAction
+        ) {
           return false;
         }
         try {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -4920,6 +4920,43 @@ export function Composer(props: ComposerProps) {
       if (
         notificationThreadId &&
         typeof turnQueueRecord?.queueEntryId === "string" &&
+        turnQueueRecord.status === "queued"
+      ) {
+        // Mirror entries queued by OTHER windows (or other federated
+        // viewers) — the FIFO lives in the owning instance's main
+        // process and every surface should show its contents, not just
+        // the window that submitted. Known ids and in-flight local
+        // submissions keep their richer local state untouched.
+        const mirrorScopeKey = getThreadComposerScopeKey(
+          event.backend,
+          notificationThreadId,
+        );
+        const mirrorCurrent = draftStore.getQueuedTurns(mirrorScopeKey);
+        const alreadyKnown = mirrorCurrent.some(
+          (queued) =>
+            queued.queueEntryId === turnQueueRecord.queueEntryId
+            || queued.backendQueuePending,
+        );
+        if (!alreadyKnown) {
+          const displayText = (
+            event.notification.params as { displayText?: unknown }
+          ).displayText;
+          draftStore.setQueuedTurns(mirrorScopeKey, [
+            ...mirrorCurrent,
+            {
+              id: `backend-queued:${turnQueueRecord.queueEntryId}`,
+              queueEntryId: turnQueueRecord.queueEntryId,
+              text: typeof displayText === "string" ? displayText : "",
+              imageAttachments: [],
+              fileAttachments: [],
+            },
+          ]);
+        }
+      }
+
+      if (
+        notificationThreadId &&
+        typeof turnQueueRecord?.queueEntryId === "string" &&
         (
           draftStore.getQueuedTurns(
             getThreadComposerScopeKey(event.backend, notificationThreadId),
@@ -6406,14 +6443,81 @@ export function Composer(props: ComposerProps) {
       if (steeringRequestIdRef.current === pending.id) {
         steeringRequestIdRef.current = undefined;
       }
-      updatePendingSteer((current) =>
-        current?.text === pending.text &&
-        current.imageAttachments === pending.imageAttachments
-          ? { ...current, status: "pending" }
-          : current
-      );
+      // The steer RPC never reached the owner (transport failure, peer
+      // drop) — a renderer-parked "pending" chip would be lost if this
+      // window closes. Rescue the intent into the owner's durable
+      // scheduled-action store with the same payload the fallback
+      // carries; admitSteerTurn's requestId-derived id semantics make a
+      // duplicate harmless if the original RPC actually landed.
+      const rescued = await (async () => {
+        if (!props.thread || !props.desktopApi?.createScheduledThreadAction) {
+          return false;
+        }
+        try {
+          const rescueResponse =
+            await props.desktopApi.createScheduledThreadAction({
+              backend: props.thread.source,
+              federationTarget: props.thread.federation?.ref.target ??
+                readRendererFederationTarget(),
+              threadId: props.thread.id,
+              kind: "turn",
+              origin: "desktop",
+              scheduledFor: Date.now(),
+              displayText: pending.text,
+              imageAttachments: pending.imageAttachments,
+              fileAttachments: pending.fileAttachments,
+              turn: {
+                input: payload.input,
+                executionMode: props.thread.executionMode,
+                model: selectedModelOption?.id,
+                reasoningEffort: supportsReasoning
+                  ? selectedReasoningEffort
+                  : undefined,
+                serviceTier: selectedServiceTier,
+                fastMode:
+                  props.thread.source === "codex" && supportsFast
+                    ? Boolean(currentSettings?.fastMode)
+                    : undefined,
+              },
+            });
+          const action = rescueResponse.action;
+          if (scheduledActionFailureMessage(action)) {
+            return false;
+          }
+          upsertScheduledProjectionInScope(expectedScopeKey, {
+            id: `scheduled-projection:${action.id}`,
+            scheduledActionId: action.id,
+            input: payload.input,
+            text: pending.text,
+            imageAttachments: pending.imageAttachments,
+            fileAttachments: pending.fileAttachments,
+            ...(action.status === "dispatching"
+              ? { backendQueuePending: true }
+              : {}),
+            ...(action.status === "queued" && action.queueEntryId
+              ? { queueEntryId: action.queueEntryId }
+              : {}),
+          });
+          setPendingSteer(undefined);
+          return true;
+        } catch {
+          // Owner unreachable for the rescue too — fall through to the
+          // renderer-parked pending state and its retry loop.
+          return false;
+        }
+      })();
+      if (!rescued) {
+        updatePendingSteer((current) =>
+          current?.text === pending.text &&
+          current.imageAttachments === pending.imageAttachments
+            ? { ...current, status: "pending" }
+            : current
+        );
+        setSendError(error instanceof Error ? error.message : String(error));
+      } else {
+        setSendError(undefined);
+      }
       props.onPendingStatusChange?.("Thinking");
-      setSendError(error instanceof Error ? error.message : String(error));
     } finally {
       setSteering(false);
     }
@@ -6527,6 +6631,65 @@ export function Composer(props: ComposerProps) {
     continueSteering(created);
   };
 
+  const rescueCancelledQueuedTurn = async (
+    scopeKey: string,
+    queued: QueuedTurnDraft,
+  ): Promise<void> => {
+    // The owner-side FIFO entry was already cancelled on the way into a
+    // steer; parking the message in this renderer would strand it if the
+    // window closes (and hide it from every other window). Re-create it
+    // in the owner's durable scheduled-action store, and only fall back
+    // to the local park when the owner is unreachable.
+    const thread = props.thread;
+    if (
+      thread
+      && props.desktopApi?.createScheduledThreadAction
+      && queued.input
+      && !queued.reviewCommand
+    ) {
+      try {
+        const response = await props.desktopApi.createScheduledThreadAction({
+          backend: thread.source,
+          federationTarget: thread.federation?.ref.target ??
+            readRendererFederationTarget(),
+          threadId: thread.id,
+          kind: "turn",
+          origin: "desktop",
+          scheduledFor: Date.now(),
+          displayText: queued.text,
+          imageAttachments: queued.imageAttachments,
+          fileAttachments: queued.fileAttachments,
+          turn: {
+            input: queued.input,
+            executionMode: thread.executionMode,
+          },
+        });
+        const action = response.action;
+        if (!scheduledActionFailureMessage(action)) {
+          removeQueuedTurnInScope(scopeKey, queued);
+          upsertScheduledProjectionInScope(scopeKey, {
+            id: `scheduled-projection:${action.id}`,
+            scheduledActionId: action.id,
+            input: queued.input,
+            text: queued.text,
+            imageAttachments: queued.imageAttachments,
+            fileAttachments: queued.fileAttachments,
+            ...(action.status === "dispatching"
+              ? { backendQueuePending: true }
+              : {}),
+            ...(action.status === "queued" && action.queueEntryId
+              ? { queueEntryId: action.queueEntryId }
+              : {}),
+          });
+          return;
+        }
+      } catch {
+        // Owner unreachable — fall through to the local park below.
+      }
+    }
+    preserveCancelledQueuedTurnInScope(scopeKey, queued);
+  };
+
   const steerQueuedTurn = async (queued: QueuedTurnDraft): Promise<void> => {
     const expectedTurnId = activeTurnIdRef.current;
     const expectedScopeKey = composerScopeKey;
@@ -6540,12 +6703,12 @@ export function Composer(props: ComposerProps) {
       activeTurnIdRef.current !== expectedTurnId
       || activeComposerScopeKeyRef.current !== expectedScopeKey
     ) {
-      preserveCancelledQueuedTurnInScope(expectedScopeKey, queued);
+      void rescueCancelledQueuedTurn(expectedScopeKey, queued);
       return;
     }
     const continueSteering = (accepted?: PendingSteerDraft): void => {
       if (!accepted) {
-        preserveCancelledQueuedTurnInScope(expectedScopeKey, queued);
+        void rescueCancelledQueuedTurn(expectedScopeKey, queued);
         return;
       }
       removeQueuedTurnInScope(expectedScopeKey, queued);

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnProjection.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnProjection.test.tsx
@@ -1,0 +1,84 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { useComposerDraftStore } from "../../features/composer/useComposerDraftStore";
+import { useQueuedTurnProjection } from "../useQueuedTurnProjection";
+
+function buildThread(
+  queuedTurns: NavigationThreadSummary["queuedTurns"],
+): NavigationThreadSummary {
+  return {
+    id: "thread-1",
+    title: "Thread",
+    titleSource: "explicit",
+    source: "codex",
+    linkedDirectories: [],
+    inbox: { inInbox: true },
+    queuedTurns,
+  } as NavigationThreadSummary;
+}
+
+describe("useQueuedTurnProjection", () => {
+  it("mirrors FIFO entries from the snapshot and prunes dispatched ones", () => {
+    const { result: storeResult } = renderHook(() => useComposerDraftStore());
+    const store = storeResult.current;
+    const scopeKey = "thread:codex:thread-1";
+
+    // A local-only draft and an in-flight submission must survive
+    // reconciliation untouched.
+    store.setQueuedTurns(scopeKey, [
+      {
+        id: "local-1",
+        text: "local only",
+        imageAttachments: [],
+        fileAttachments: [],
+      },
+      {
+        id: "inflight-1",
+        backendQueuePending: true,
+        text: "in flight",
+        imageAttachments: [],
+        fileAttachments: [],
+      },
+    ]);
+
+    const projection = renderHook(
+      (props: { threads: NavigationThreadSummary[] }) =>
+        useQueuedTurnProjection({
+          composerDraftStore: store,
+          threads: props.threads,
+        }),
+      {
+        initialProps: {
+          threads: [
+            buildThread([
+              {
+                queueEntryId: "entry-1",
+                origin: "manual",
+                displayText: "queued elsewhere",
+                createdAt: 1_000,
+                position: 0,
+              },
+            ]),
+          ],
+        },
+      },
+    );
+
+    let queued = store.getQueuedTurns(scopeKey);
+    expect(queued.map((entry) => entry.id)).toEqual([
+      "local-1",
+      "inflight-1",
+      "backend-queued:entry-1",
+    ]);
+    expect(
+      queued.find((entry) => entry.queueEntryId === "entry-1")?.text,
+    ).toBe("queued elsewhere");
+
+    // The FIFO dispatched the entry: the next snapshot omits it and the
+    // mirror is pruned while local state stays.
+    projection.rerender({ threads: [buildThread([])] });
+    queued = store.getQueuedTurns(scopeKey);
+    expect(queued.map((entry) => entry.id)).toEqual(["local-1", "inflight-1"]);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnProjection.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnProjection.ts
@@ -1,0 +1,69 @@
+import { useEffect } from "react";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type {
+  ComposerDraftStore,
+  ComposerQueuedTurnSnapshot,
+} from "../features/composer/useComposerDraftStore";
+
+/**
+ * Reconciles the owning instance's turn-FIFO read projection
+ * (`NavigationThreadSummary.queuedTurns`, sourced from the registry's
+ * getQueuedTurnsSnapshot) into this window's composer chip store.
+ *
+ * This is what makes a queued message visible beyond the window that
+ * submitted it: the owner's own window, other local windows, federated
+ * viewers, and a reloaded viewer all rehydrate chips from the snapshot
+ * instead of relying on renderer-local memory. Entries this window
+ * already tracks (matching queueEntryId, or still backendQueuePending
+ * in-flight) are left alone so live submissions keep their richer local
+ * state (attachments, review commands); backend-owned entries whose id
+ * vanished from the snapshot are pruned — the FIFO dispatched or
+ * cancelled them.
+ */
+export function useQueuedTurnProjection(params: {
+  composerDraftStore: ComposerDraftStore;
+  threads: readonly NavigationThreadSummary[];
+}): void {
+  const { composerDraftStore, threads } = params;
+  useEffect(() => {
+    for (const thread of threads) {
+      const scopeKey = `thread:${thread.source}:${thread.id}`;
+      const snapshotEntries = thread.queuedTurns ?? [];
+      const snapshotIds = new Set(
+        snapshotEntries.map((entry) => entry.queueEntryId),
+      );
+      const current = composerDraftStore.getQueuedTurns(scopeKey);
+      const knownIds = new Set(
+        current
+          .map((entry) => entry.queueEntryId)
+          .filter((id): id is string => Boolean(id)),
+      );
+
+      const kept = current.filter(
+        (entry) =>
+          // Local-only entries (no backend id yet) and in-flight
+          // submissions are this window's own state — never prune from
+          // a snapshot that may predate them.
+          !entry.queueEntryId
+          || entry.backendQueuePending
+          || snapshotIds.has(entry.queueEntryId),
+      );
+      const additions: ComposerQueuedTurnSnapshot[] = snapshotEntries
+        .filter((entry) => !knownIds.has(entry.queueEntryId))
+        .map((entry) => ({
+          id: `backend-queued:${entry.queueEntryId}`,
+          queueEntryId: entry.queueEntryId,
+          text: entry.displayText,
+          imageAttachments: [],
+          fileAttachments: [],
+        }));
+
+      if (
+        additions.length > 0
+        || kept.length !== current.length
+      ) {
+        composerDraftStore.setQueuedTurns(scopeKey, [...kept, ...additions]);
+      }
+    }
+  }, [composerDraftStore, threads]);
+}

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -11,6 +11,7 @@ import {
   type ComposerQueuedTurnSnapshot,
 } from "../features/composer/useComposerDraftStore";
 import type { DesktopApi } from "./desktop-api";
+import { readRendererFederationTarget } from "./federation-window";
 
 type ModelOption = NonNullable<
   NonNullable<BackendSummary["launchpadOptions"]>["models"]
@@ -239,6 +240,10 @@ export function useQueuedTurnRelease(params: {
 
         const response = await readThread({
           backend: thread.source,
+          // Remote threads verify idleness on their owning instance;
+          // an unstamped read would hit the viewer's own registry.
+          federationTarget: thread.federation?.ref.target ??
+            readRendererFederationTarget(),
           threadId: thread.id,
           limit: 1,
         });
@@ -254,6 +259,11 @@ export function useQueuedTurnRelease(params: {
 
       if (
         releaseCandidate.releaseThread.gitBranch &&
+        // Branch drift is a LOCAL git check; for a remote thread the
+        // paths belong to the owning machine, so skip it here and let
+        // the owner's own guards apply at start time.
+        !releaseCandidate.releaseThread.federation &&
+        !readRendererFederationTarget() &&
         releaseCandidate.desktopApi?.checkThreadBranchDrift
       ) {
         const drift = await releaseCandidate.desktopApi.checkThreadBranchDrift({
@@ -317,6 +327,8 @@ export function useQueuedTurnRelease(params: {
         try {
           await startReview({
             backend: releaseThread.source,
+            federationTarget: releaseThread.federation?.ref.target ??
+              readRendererFederationTarget(),
             threadId: releaseThread.id,
             target: reviewCommand.target,
             delivery: "inline",
@@ -381,6 +393,11 @@ export function useQueuedTurnRelease(params: {
       try {
         await startTurn({
           backend: releaseThread.source,
+          // Route to the owning instance — an unstamped submit lands in
+          // the viewer's own registry, which has no such thread, and the
+          // failure loops silently on the 30s sweep.
+          federationTarget: releaseThread.federation?.ref.target ??
+            readRendererFederationTarget(),
           threadId: releaseThread.id,
           input,
           executionMode: releaseThread.executionMode,

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -125,6 +125,15 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
   /** Wall-clock ms when the queue entry was created. */
   queuedExecutionModeAt?: number;
   /**
+   * Turns waiting in the owning instance's main-process FIFO (registry
+   * ThreadTurnQueue), in dispatch order. Merged into every navigation
+   * snapshot so ALL windows — including federated viewers and windows
+   * that did not submit the entry — can render and rehydrate queued
+   * messages. Like queuedExecutionMode, the queue itself is registry
+   * memory; this is its read projection.
+   */
+  queuedTurns?: ThreadQueuedTurnSummary[];
+  /**
    * Per-thread permission-mode transition log (audit trail). Persisted
    * via the overlay store, capped at
    * `MAX_PERMISSION_TRANSITION_LOG_ENTRIES` with oldest-first eviction.
@@ -181,6 +190,17 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
   subAgents?: ThreadSubAgentSummary[];
   /** Durable origin metadata for threads created by an Agent handoff tool. */
   handoffOrigin?: ThreadHandoffOrigin;
+};
+
+export type ThreadQueuedTurnSummary = {
+  /** Registry queue entry id — matches thread/turnQueue/updated events. */
+  queueEntryId: string;
+  origin: "manual" | "automation" | "messaging" | "scheduled";
+  /** First text item of the queued input, truncated for display. */
+  displayText: string;
+  createdAt: number;
+  /** 0-based dispatch position within the thread's queue. */
+  position: number;
 };
 
 export type ThreadSubAgentStatus =

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1551,6 +1551,12 @@ export type AppServerNotification =
         queueEntryId: string;
         origin: "manual" | "automation" | "messaging" | "scheduled";
         status: "queued" | "started" | "failed" | "cancelled" | "terminal";
+        /**
+         * Truncated first text of the queued input on "queued" events, so
+         * windows that did not submit the entry can mirror a chip without
+         * waiting for the next navigation snapshot.
+         */
+        displayText?: string;
         position?: number;
         turnId?: string;
         automationRunId?: string;


### PR DESCRIPTION
## Summary

Boundary review + complete fixes for "a message queued from a federation viewer must survive viewer disconnect, held by the owning Electron process, visible to the owner's window and every viewer."

**Review verdict:** #1181/#1186 correctly moved queue ownership into the main-process `ThreadTurnQueue` — a viewer's send-while-busy reaches the OWNER's FIFO before the send resolves. Skills autocomplete (`$`) already rides `backend.listSkills` over federation. What remained was visibility and edge-path residue, all fixed here:

1. **FIFO read projection** — `getQueuedTurnsSnapshot()` on the registry, attached as `NavigationThreadSummary.queuedTurns` in both snapshot paths (local + federation bridge) before the snapshot hash, exactly mirroring `queuedExecutionMode`. Every window and federated viewer now receives queued-turn state; reconnecting/reloaded viewers rehydrate from it.
2. **Renderer mirroring** — new `useQueuedTurnProjection` reconciles the snapshot into each window's chip store (foreign entries mirrored, dispatched entries pruned, local/in-flight state untouched), and the Composer now mirrors live `thread/turnQueue/updated` "queued" events for entries it didn't submit; the event gained `displayText` so chips render immediately.
3. **Steer transport-failure rescue** — if the steer RPC fails with the synchronous "peer is not connected" pre-send error (proving the steer never left this machine), the already-built fallback payload is persisted as an owner-side scheduled action instead of parking renderer-only. Ambiguous failures (timeouts — the steer may have been delivered) deliberately keep the renderer-parked retry path so a rescue can't double-send.
4. **No downgrade** — Steer-on-a-queued-chip no longer cancels the owner-side entry and parks it locally: it re-creates the entry in the owner's durable scheduled-action store, local park only as last resort.
5. **Release-hook routing** (first commit) — `useQueuedTurnRelease` stamps the federation target on all calls; branch-drift check skipped for remote threads.

## Verification

- New unit tests: projection hook (mirror + prune + local-state preservation); release-hook suite (22) green.
- Composer (824), backend-registry, app-server-ipc (89) suites green; workspace typecheck, ESLint (0 errors), `lint:boundaries` pass.
- Federation E2E journey passes against a fresh build (regression).

## Notes

- The FIFO itself remains in-memory (lost on owner-app restart) — durable-FIFO via scheduled-action rows noted as possible hardening, not done here.
- Edit-a-queued-chip still moves intent into the local composer draft by design (it's a draft again); the review documents this as intended UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
