### PR TITLE
fix(desktop): copy PR chips as full URLs

### DIFF
--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -111,7 +111,6 @@ export function PrChip(props: PrChipProps) {
         aria-label={`Open ${pr.org}/${pr.repo}#${pr.number} (${status}) in browser`}
         className={className}
         data-pr-chip=""
-        data-pr-label={label}
         data-pr-url={pr.url}
         draggable={false}
         onBlur={tooltipController.hide}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -86,6 +86,21 @@ type EditorApplication = DesktopApplicationsSnapshot["editors"][number];
 const CodeBlockContext = createContext(false);
 const MarkdownLinkContext = createContext(false);
 
+function clipboardTextFromFragment(fragment: DocumentFragment): string {
+  const container = document.createElement("div");
+  container.setAttribute("aria-hidden", "true");
+  container.style.position = "fixed";
+  container.style.left = "-100000px";
+  container.style.top = "0";
+  container.style.pointerEvents = "none";
+  container.style.whiteSpace = "pre-wrap";
+  container.append(fragment.cloneNode(true));
+  document.body.append(container);
+  const text = container.innerText || container.textContent || "";
+  container.remove();
+  return text;
+}
+
 function copySelectedPullRequestLinks(
   event: ClipboardEvent<HTMLDivElement>,
 ): void {
@@ -110,13 +125,14 @@ function copySelectedPullRequestLinks(
 
     const link = document.createElement("a");
     link.href = href;
-    link.textContent = chip.dataset.prLabel || chip.textContent || href;
+    link.textContent = href;
     chip.replaceWith(link);
   });
 
+  const plainText = clipboardTextFromFragment(fragment);
   const html = document.createElement("div");
   html.append(fragment);
-  event.clipboardData.setData("text/plain", selection.toString());
+  event.clipboardData.setData("text/plain", plainText);
   event.clipboardData.setData("text/html", html.innerHTML);
   event.preventDefault();
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
@@ -99,7 +99,7 @@ describe("pull request links in transcript markdown", () => {
     expect(open).toHaveBeenCalledWith(PR_URL, "_blank", "noopener,noreferrer");
   });
 
-  it("preserves a selected PR chip as text and a link on the clipboard", () => {
+  it("copies a selected PR chip as a full URL that can hydrate in any project", () => {
     const { container } = renderWithPullRequests(
       `> Deploy merged PR [Giphy/giphy-services#13290](${PR_URL}) now.`,
       [prSummary()],
@@ -122,12 +122,12 @@ describe("pull request links in transcript markdown", () => {
 
     expect(setData).toHaveBeenCalledWith(
       "text/plain",
-      expect.stringContaining("Giphy/giphy-services#13290"),
+      expect.stringContaining(PR_URL),
     );
     expect(setData).toHaveBeenCalledWith(
       "text/html",
       expect.stringContaining(
-        `<a href="${PR_URL}">Giphy/giphy-services#13290</a>`,
+        `<a href="${PR_URL}">${PR_URL}</a>`,
       ),
     );
   });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4137,8 +4137,8 @@ textarea,
 }
 
 /* A PR chip inside rendered markdown is part of the message's copyable prose.
-   Select it atomically so Chromium includes the full label in text/plain;
-   ThreadMarkdown upgrades the matching text/html fragment to a real link.
+   Select it atomically so Chromium includes the full chip in the range;
+   ThreadMarkdown serializes it as a full PR URL for cross-project hydration.
    Chips in sidebar rows and context chrome remain non-selectable controls. */
 .thread-markdown .pr-chip {
   -webkit-user-select: all;


### PR DESCRIPTION
## What changed

- Serialize selected transcript PR chips as their full pull-request URL in `text/plain`.
- Use the same full URL as the copied HTML anchor text and target.
- Preserve surrounding selected prose and block structure while substituting the chip.
- Update the regression test to require the cross-project-safe URL form.

## Why

The merged copy fix preserved `org/repo#number`, but that shorthand is not self-describing when pasted into a composer for another project. A full URL carries the provider, repository, and PR number, so PwrAgent's existing bare-PR-URL renderer can hydrate it back into a chip anywhere.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- Targeted ESLint: 0 errors (existing hook warnings only)
- `git diff --check`

Follow-up to #1238.
