### PR TITLE
fix(desktop): paginate oversized thread replays

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3179,7 +3179,9 @@ describe("DesktopBackendRegistry", () => {
     const registry = new DesktopBackendRegistry({
       codexClient,
       grokClient: new MockBackendClient({
-        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+        initializeError: new Error(
+          "grok app server unavailable: XAI_API_KEY is not set",
+        ),
       }),
       overlayStore,
     });
@@ -31284,6 +31286,97 @@ script = "printf setup"
       threadId: "thread-1",
       before: "cursor-1",
       limit: 25,
+    });
+
+    await registry.close();
+  });
+
+  it("pages normalized thread history when the backend ignores pagination", async () => {
+    const entries: AppServerThreadReplay["entries"] = [
+      {
+        type: "message",
+        id: "entry-1",
+        role: "user",
+        text: "First",
+      },
+      {
+        type: "activity",
+        id: "entry-2",
+        summary: "Worked",
+        status: "completed",
+        details: [],
+      },
+      {
+        type: "message",
+        id: "entry-3",
+        role: "assistant",
+        text: "Third",
+      },
+      {
+        type: "message",
+        id: "entry-4",
+        role: "user",
+        text: "Fourth",
+      },
+    ];
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+      replay: {
+        entries,
+        messages: entries.flatMap((entry) =>
+          entry.type === "message"
+            ? [{ id: entry.id, role: entry.role, text: entry.text }]
+            : [],
+        ),
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const latest = await registry.readThread({
+      backend: "codex",
+      threadId: "thread-1",
+      limit: 2,
+    });
+    expect(latest.replay.entries.map((entry) => entry.id)).toEqual([
+      "entry-3",
+      "entry-4",
+    ]);
+    expect(latest.replay.messages.map((message) => message.id)).toEqual([
+      "entry-3",
+      "entry-4",
+    ]);
+    expect(latest.replay.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: true,
+      previousCursor: "entry-3",
+    });
+
+    const older = await registry.readThread({
+      backend: "codex",
+      threadId: "thread-1",
+      before: "entry-3",
+      limit: 2,
+    });
+    expect(older.replay.entries.map((entry) => entry.id)).toEqual([
+      "entry-1",
+      "entry-2",
+    ]);
+    expect(older.replay.messages.map((message) => message.id)).toEqual([
+      "entry-1",
+    ]);
+    expect(older.replay.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: false,
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3179,9 +3179,7 @@ describe("DesktopBackendRegistry", () => {
     const registry = new DesktopBackendRegistry({
       codexClient,
       grokClient: new MockBackendClient({
-        initializeError: new Error(
-          "grok app server unavailable: XAI_API_KEY is not set",
-        ),
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
       overlayStore,
     });
@@ -31286,97 +31284,6 @@ script = "printf setup"
       threadId: "thread-1",
       before: "cursor-1",
       limit: 25,
-    });
-
-    await registry.close();
-  });
-
-  it("pages normalized thread history when the backend ignores pagination", async () => {
-    const entries: AppServerThreadReplay["entries"] = [
-      {
-        type: "message",
-        id: "entry-1",
-        role: "user",
-        text: "First",
-      },
-      {
-        type: "activity",
-        id: "entry-2",
-        summary: "Worked",
-        status: "completed",
-        details: [],
-      },
-      {
-        type: "message",
-        id: "entry-3",
-        role: "assistant",
-        text: "Third",
-      },
-      {
-        type: "message",
-        id: "entry-4",
-        role: "user",
-        text: "Fourth",
-      },
-    ];
-    const codexClient = new MockBackendClient({
-      initializeResult: { methods: ["thread/read"] },
-      replay: {
-        entries,
-        messages: entries.flatMap((entry) =>
-          entry.type === "message"
-            ? [{ id: entry.id, role: entry.role, text: entry.text }]
-            : [],
-        ),
-        pagination: {
-          supportsPagination: false,
-          hasPreviousPage: false,
-        },
-      },
-    });
-    const registry = new DesktopBackendRegistry({
-      codexClient,
-      grokClient: new MockBackendClient({
-        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
-      }),
-      overlayStore: createOverlayStoreMock(),
-    });
-
-    const latest = await registry.readThread({
-      backend: "codex",
-      threadId: "thread-1",
-      limit: 2,
-    });
-    expect(latest.replay.entries.map((entry) => entry.id)).toEqual([
-      "entry-3",
-      "entry-4",
-    ]);
-    expect(latest.replay.messages.map((message) => message.id)).toEqual([
-      "entry-3",
-      "entry-4",
-    ]);
-    expect(latest.replay.pagination).toEqual({
-      supportsPagination: true,
-      hasPreviousPage: true,
-      previousCursor: "entry-3",
-    });
-
-    const older = await registry.readThread({
-      backend: "codex",
-      threadId: "thread-1",
-      before: "entry-3",
-      limit: 2,
-    });
-    expect(older.replay.entries.map((entry) => entry.id)).toEqual([
-      "entry-1",
-      "entry-2",
-    ]);
-    expect(older.replay.messages.map((message) => message.id)).toEqual([
-      "entry-1",
-    ]);
-    expect(older.replay.pagination).toEqual({
-      supportsPagination: true,
-      hasPreviousPage: false,
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -220,6 +220,141 @@ describe("federation backend bridge", () => {
     ]);
   });
 
+  it("pages unbounded thread history before sending it over federation", async () => {
+    const response: AppServerReadThreadResponse = {
+      backend: "codex",
+      fetchedAt: 1_000,
+      threadId: "thread-1",
+      replay: {
+        entries: [
+          {
+            type: "message",
+            id: "entry-1",
+            role: "user",
+            text: "First",
+          },
+          {
+            type: "activity",
+            id: "entry-2",
+            summary: "Worked",
+            status: "completed",
+            details: [],
+          },
+          {
+            type: "message",
+            id: "entry-3",
+            role: "assistant",
+            text: "Third",
+          },
+          {
+            type: "message",
+            id: "entry-4",
+            role: "user",
+            text: "Fourth",
+          },
+        ],
+        messages: [
+          { id: "entry-1", role: "user", text: "First" },
+          { id: "entry-3", role: "assistant", text: "Third" },
+          { id: "entry-4", role: "user", text: "Fourth" },
+        ],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    };
+    const backend = {
+      readThread: vi.fn(async () => response),
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["thread_detail"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "latest-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.readThread,
+        params: { backend: "codex", threadId: "thread-1", limit: 2 },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "older-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.readThread,
+        params: {
+          backend: "codex",
+          threadId: "thread-1",
+          before: "entry-3",
+          limit: 2,
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_100,
+      },
+    });
+
+    expect(replies).toMatchObject([
+      {
+        kind: "response",
+        requestId: "latest-request",
+        result: {
+          replay: {
+            entries: [{ id: "entry-3" }, { id: "entry-4" }],
+            messages: [{ id: "entry-3" }, { id: "entry-4" }],
+            pagination: {
+              supportsPagination: true,
+              hasPreviousPage: true,
+              previousCursor: "entry-3",
+            },
+          },
+        },
+      },
+      {
+        kind: "response",
+        requestId: "older-request",
+        result: {
+          replay: {
+            entries: [{ id: "entry-1" }, { id: "entry-2" }],
+            messages: [{ id: "entry-1" }],
+            pagination: {
+              supportsPagination: true,
+              hasPreviousPage: false,
+            },
+          },
+        },
+      },
+    ]);
+    expect(backend.readThread).toHaveBeenNthCalledWith(1, {
+      backend: "codex",
+      threadId: "thread-1",
+      limit: 2,
+    });
+    expect(backend.readThread).toHaveBeenNthCalledWith(2, {
+      backend: "codex",
+      threadId: "thread-1",
+      before: "entry-3",
+      limit: 2,
+    });
+  });
+
   it("routes branch drift reads and mutations to the owning peer", async () => {
     const backend = {
       checkThreadBranchDrift: vi.fn(async (request) => ({

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../federation/federation-backend-bridge";
 import { FederationRouter } from "../federation/federation-router";
 import { FederationRpcEndpoint } from "../federation/federation-rpc";
+import { FEDERATION_MAX_FRAME_BYTES } from "../federation/federation-transport";
 
 describe("federation backend bridge", () => {
   it("reads remote PwrSnap status through its dedicated capability", async () => {
@@ -353,6 +354,109 @@ describe("federation backend bridge", () => {
       before: "entry-3",
       limit: 2,
     });
+  });
+
+  it("compacts an oversized retained entry below the frame ceiling", async () => {
+    const oversizedOutput = "x".repeat(FEDERATION_MAX_FRAME_BYTES);
+    const response: AppServerReadThreadResponse = {
+      backend: "codex",
+      fetchedAt: 1_000,
+      threadId: "thread-1",
+      replay: {
+        entries: [
+          {
+            type: "message",
+            id: "older-message",
+            role: "user",
+            text: "Older history remains available through the cursor.",
+          },
+          {
+            type: "activity",
+            id: "oversized-activity",
+            summary: "Ran a command",
+            status: "completed",
+            details: [
+              {
+                id: "oversized-command",
+                kind: "command",
+                label: "Generated verbose output",
+                command: {
+                  displayCommand: "verbose-command",
+                  output: oversizedOutput,
+                },
+              },
+            ],
+          },
+        ],
+        messages: [
+          {
+            id: "older-message",
+            role: "user",
+            text: "Older history remains available through the cursor.",
+          },
+        ],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    };
+    const backend = {
+      readThread: vi.fn(async () => response),
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["thread_detail"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "oversized-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.readThread,
+        params: { backend: "codex", threadId: "thread-1", limit: 5 },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(replies).toHaveLength(1);
+    expect(replies[0]).toMatchObject({
+      kind: "response",
+      requestId: "oversized-request",
+      result: {
+        replay: {
+          entries: [
+            {
+              id: "oversized-activity",
+              summary: expect.stringContaining("exceeded the federation frame limit"),
+              details: [],
+            },
+          ],
+          pagination: {
+            supportsPagination: true,
+            hasPreviousPage: true,
+            previousCursor: "oversized-activity",
+          },
+        },
+      },
+    });
+    const encryptedFrameBytes =
+      Buffer.byteLength(
+        JSON.stringify({ kind: "envelope", envelope: replies[0] }),
+        "utf8",
+      ) + 16;
+    expect(encryptedFrameBytes).toBeLessThan(FEDERATION_MAX_FRAME_BYTES);
   });
 
   it("routes branch drift reads and mutations to the owning peer", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9454,7 +9454,7 @@ export class DesktopBackendRegistry {
       return await this.readAcpThread(request, backend);
     }
 
-    const replay =
+    const backendReplay =
       backend === "codex"
         ? await this.withCodexThreadClient(
             request.threadId,
@@ -9476,6 +9476,13 @@ export class DesktopBackendRegistry {
             before: request.before,
             limit: request.limit,
           });
+    // Some backends accept before/limit but return the complete transcript
+    // without pagination metadata. Bound that normalized replay locally so a
+    // long tool-heavy thread does not become one oversized renderer or
+    // federation payload.
+    const replay = backendReplay.pagination.supportsPagination
+      ? backendReplay
+      : pageNormalizedReplay(backendReplay, request);
 
     if (backend === "codex") {
       this.reconcileBackendCodexThreadStatus(request.threadId, replay.threadStatus);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -40,6 +40,7 @@ import {
   formatManagedReviewOutput,
   parseManagedReviewOutput,
 } from "./managed-review";
+import { pageNormalizedReplay } from "./thread-replay-pagination";
 import {
   type AcpBackendId,
   buildAppendPinRank,
@@ -5851,69 +5852,6 @@ function mergeCodexDynamicToolSpecs(
   return [...functions, ...namespaces.values()];
 }
 
-function pageNormalizedReplay(
-  replay: AppServerThreadReplay,
-  options: {
-    before?: string;
-    includeTurns?: boolean;
-    limit?: number;
-  },
-): AppServerThreadReplay {
-  if (options.includeTurns === false) {
-    return {
-      ...replay,
-      entries: [],
-      messages: [],
-      lastUserMessage: undefined,
-      lastAssistantMessage: undefined,
-      pagination: {
-        supportsPagination: false,
-        hasPreviousPage: false,
-      },
-    };
-  }
-
-  if (options.limit === undefined && !options.before) {
-    return replay;
-  }
-
-  const endIndex = options.before
-    ? replay.entries.findIndex((entry) => entry.id === options.before)
-    : replay.entries.length;
-  const boundedEndIndex = endIndex >= 0 ? endIndex : replay.entries.length;
-  const limit =
-    options.limit === undefined ? undefined : Math.max(0, Math.floor(options.limit));
-  const startIndex = limit === undefined ? 0 : Math.max(0, boundedEndIndex - limit);
-  const entries = replay.entries.slice(startIndex, boundedEndIndex);
-  const messages = entries.flatMap((entry) =>
-    entry.type === "message"
-      ? [
-          {
-            id: entry.id,
-            role: entry.role,
-            text: entry.text,
-            ...(entry.parts ? { parts: entry.parts } : {}),
-            ...(entry.origin ? { origin: entry.origin } : {}),
-            ...(entry.createdAt ? { createdAt: entry.createdAt } : {}),
-          },
-        ]
-      : [],
-  );
-  const firstEntry = entries[0];
-  const hasPreviousPage = startIndex > 0;
-
-  return {
-    ...replay,
-    entries,
-    messages,
-    pagination: {
-      supportsPagination: true,
-      hasPreviousPage,
-      ...(hasPreviousPage && firstEntry ? { previousCursor: firstEntry.id } : {}),
-    },
-  };
-}
-
 function threadOrchestrationFailure(
   code: PwrAgentThreadOrchestrationErrorCode,
   message: string,
@@ -9454,7 +9392,7 @@ export class DesktopBackendRegistry {
       return await this.readAcpThread(request, backend);
     }
 
-    const backendReplay =
+    const replay =
       backend === "codex"
         ? await this.withCodexThreadClient(
             request.threadId,
@@ -9476,14 +9414,6 @@ export class DesktopBackendRegistry {
             before: request.before,
             limit: request.limit,
           });
-    // Some backends accept before/limit but return the complete transcript
-    // without pagination metadata. Bound that normalized replay locally so a
-    // long tool-heavy thread does not become one oversized renderer or
-    // federation payload.
-    const replay = backendReplay.pagination.supportsPagination
-      ? backendReplay
-      : pageNormalizedReplay(backendReplay, request);
-
     if (backend === "codex") {
       this.reconcileBackendCodexThreadStatus(request.threadId, replay.threadStatus);
     }

--- a/apps/desktop/src/main/app-server/thread-replay-pagination.ts
+++ b/apps/desktop/src/main/app-server/thread-replay-pagination.ts
@@ -1,7 +1,11 @@
 import type {
   AppServerReadThreadRequest,
+  AppServerThreadEntry,
   AppServerThreadReplay,
 } from "@pwragent/shared";
+
+const FEDERATION_OMITTED_ENTRY_TEXT =
+  "Content omitted because this entry exceeded the federation frame limit.";
 
 export function pageNormalizedReplay(
   replay: AppServerThreadReplay,
@@ -36,6 +40,53 @@ export function pageNormalizedReplay(
     options.limit === undefined ? undefined : Math.max(0, Math.floor(options.limit));
   const startIndex = limit === undefined ? 0 : Math.max(0, boundedEndIndex - limit);
   const entries = replay.entries.slice(startIndex, boundedEndIndex);
+  return replayWithEntries(replay, entries, startIndex > 0);
+}
+
+export function fitNormalizedReplayWithinByteBudget(params: {
+  replay: AppServerThreadReplay;
+  maxBytes: number;
+  measureBytes: (replay: AppServerThreadReplay) => number;
+}): AppServerThreadReplay {
+  if (params.measureBytes(params.replay) <= params.maxBytes) {
+    return params.replay;
+  }
+
+  let entries = [...params.replay.entries];
+  while (entries.length > 1) {
+    entries = entries.slice(1);
+    const candidate = replayWithEntries(params.replay, entries, true);
+    if (params.measureBytes(candidate) <= params.maxBytes) {
+      return candidate;
+    }
+  }
+
+  if (entries[0]) {
+    const candidate = replayWithEntries(
+      params.replay,
+      [compactOversizedEntry(entries[0])],
+      params.replay.pagination.hasPreviousPage || params.replay.entries.length > 1,
+    );
+    if (params.measureBytes(candidate) <= params.maxBytes) {
+      return candidate;
+    }
+  }
+
+  return {
+    entries: [],
+    messages: [],
+    pagination: {
+      supportsPagination: true,
+      hasPreviousPage: false,
+    },
+  };
+}
+
+function replayWithEntries(
+  replay: AppServerThreadReplay,
+  entries: AppServerThreadEntry[],
+  hasPreviousPage: boolean,
+): AppServerThreadReplay {
   const messages = entries.flatMap((entry) =>
     entry.type === "message"
       ? [
@@ -51,16 +102,65 @@ export function pageNormalizedReplay(
       : [],
   );
   const firstEntry = entries[0];
-  const hasPreviousPage = startIndex > 0;
+  const lastUserMessage = messages.findLast((message) => message.role === "user")?.text;
+  const lastAssistantMessage = messages.findLast(
+    (message) => message.role === "assistant",
+  )?.text;
 
   return {
     ...replay,
     entries,
     messages,
+    lastUserMessage,
+    lastAssistantMessage,
     pagination: {
       supportsPagination: true,
       hasPreviousPage,
       ...(hasPreviousPage && firstEntry ? { previousCursor: firstEntry.id } : {}),
     },
   };
+}
+
+function compactOversizedEntry(entry: AppServerThreadEntry): AppServerThreadEntry {
+  switch (entry.type) {
+    case "message":
+      return {
+        type: "message",
+        id: entry.id,
+        role: entry.role,
+        text: FEDERATION_OMITTED_ENTRY_TEXT,
+        ...(entry.createdAt ? { createdAt: entry.createdAt } : {}),
+        ...(entry.phase ? { phase: entry.phase } : {}),
+        ...(entry.turn ? { turn: entry.turn } : {}),
+      };
+    case "activity":
+      return {
+        type: "activity",
+        id: entry.id,
+        summary: FEDERATION_OMITTED_ENTRY_TEXT,
+        details: [],
+        ...(entry.createdAt ? { createdAt: entry.createdAt } : {}),
+        ...(entry.tone ? { tone: entry.tone } : {}),
+        ...(entry.status ? { status: entry.status } : {}),
+        ...(entry.turn ? { turn: entry.turn } : {}),
+      };
+    case "plan":
+      return {
+        type: "plan",
+        id: entry.id,
+        markdown: FEDERATION_OMITTED_ENTRY_TEXT,
+        steps: [],
+        ...(entry.createdAt ? { createdAt: entry.createdAt } : {}),
+        ...(entry.turn ? { turn: entry.turn } : {}),
+      };
+    case "review":
+      return {
+        type: "review",
+        id: entry.id,
+        review: FEDERATION_OMITTED_ENTRY_TEXT,
+        ...(entry.createdAt ? { createdAt: entry.createdAt } : {}),
+        ...(entry.status ? { status: entry.status } : {}),
+        ...(entry.turn ? { turn: entry.turn } : {}),
+      };
+  }
 }

--- a/apps/desktop/src/main/app-server/thread-replay-pagination.ts
+++ b/apps/desktop/src/main/app-server/thread-replay-pagination.ts
@@ -1,0 +1,66 @@
+import type {
+  AppServerReadThreadRequest,
+  AppServerThreadReplay,
+} from "@pwragent/shared";
+
+export function pageNormalizedReplay(
+  replay: AppServerThreadReplay,
+  options: Pick<
+    AppServerReadThreadRequest,
+    "before" | "includeTurns" | "limit"
+  >,
+): AppServerThreadReplay {
+  if (options.includeTurns === false) {
+    return {
+      ...replay,
+      entries: [],
+      messages: [],
+      lastUserMessage: undefined,
+      lastAssistantMessage: undefined,
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+    };
+  }
+
+  if (options.limit === undefined && !options.before) {
+    return replay;
+  }
+
+  const endIndex = options.before
+    ? replay.entries.findIndex((entry) => entry.id === options.before)
+    : replay.entries.length;
+  const boundedEndIndex = endIndex >= 0 ? endIndex : replay.entries.length;
+  const limit =
+    options.limit === undefined ? undefined : Math.max(0, Math.floor(options.limit));
+  const startIndex = limit === undefined ? 0 : Math.max(0, boundedEndIndex - limit);
+  const entries = replay.entries.slice(startIndex, boundedEndIndex);
+  const messages = entries.flatMap((entry) =>
+    entry.type === "message"
+      ? [
+          {
+            id: entry.id,
+            role: entry.role,
+            text: entry.text,
+            ...(entry.parts ? { parts: entry.parts } : {}),
+            ...(entry.origin ? { origin: entry.origin } : {}),
+            ...(entry.createdAt ? { createdAt: entry.createdAt } : {}),
+          },
+        ]
+      : [],
+  );
+  const firstEntry = entries[0];
+  const hasPreviousPage = startIndex > 0;
+
+  return {
+    ...replay,
+    entries,
+    messages,
+    pagination: {
+      supportsPagination: true,
+      hasPreviousPage,
+      ...(hasPreviousPage && firstEntry ? { previousCursor: firstEntry.id } : {}),
+    },
+  };
+}

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -92,7 +92,14 @@ import type {
 } from "@pwragent/shared";
 import type { FederationRouter } from "./federation-router";
 import type { FederationRpcEndpoint } from "./federation-rpc";
-import { pageNormalizedReplay } from "../app-server/thread-replay-pagination";
+import {
+  fitNormalizedReplayWithinByteBudget,
+  pageNormalizedReplay,
+} from "../app-server/thread-replay-pagination";
+import { FEDERATION_MAX_FRAME_BYTES } from "./federation-transport";
+
+const FEDERATION_RESPONSE_BYTE_BUDGET =
+  FEDERATION_MAX_FRAME_BYTES - 64 * 1024;
 
 export type FederationReadTranscriptImageRequest = {
   url: string;
@@ -387,12 +394,19 @@ export function registerFederationBackendHandlers(params: {
       // Codex currently accepts before/limit but can still return the complete
       // transcript without pagination metadata. Bound that response before it
       // reaches the federation transport's per-frame receive ceiling.
-      return response.replay.pagination.supportsPagination
-        ? response
-        : {
-            ...response,
-            replay: pageNormalizedReplay(response.replay, request),
-          };
+      const pagedReplay = response.replay.pagination.supportsPagination
+        ? response.replay
+        : pageNormalizedReplay(response.replay, request);
+      const replay = fitNormalizedReplayWithinByteBudget({
+        replay: pagedReplay,
+        maxBytes: FEDERATION_RESPONSE_BYTE_BUDGET,
+        measureBytes: (candidate) =>
+          Buffer.byteLength(
+            JSON.stringify({ ...response, replay: candidate }),
+            "utf8",
+          ),
+      });
+      return { ...response, replay };
     },
   );
   params.router.registerHandler(

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -92,6 +92,7 @@ import type {
 } from "@pwragent/shared";
 import type { FederationRouter } from "./federation-router";
 import type { FederationRpcEndpoint } from "./federation-rpc";
+import { pageNormalizedReplay } from "../app-server/thread-replay-pagination";
 
 export type FederationReadTranscriptImageRequest = {
   url: string;
@@ -380,10 +381,19 @@ export function registerFederationBackendHandlers(params: {
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.readThread,
-    async (envelope) =>
-      await params.backend.readThread(
-        envelope.params as AppServerReadThreadRequest,
-      ),
+    async (envelope) => {
+      const request = envelope.params as AppServerReadThreadRequest;
+      const response = await params.backend.readThread(request);
+      // Codex currently accepts before/limit but can still return the complete
+      // transcript without pagination metadata. Bound that response before it
+      // reaches the federation transport's per-frame receive ceiling.
+      return response.replay.pagination.supportsPagination
+        ? response
+        : {
+            ...response,
+            replay: pageNormalizedReplay(response.replay, request),
+          };
+    },
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.readTranscriptImage,


### PR DESCRIPTION
## What changed

- apply local pagination to normalized thread replays when a backend accepts `before` / `limit` but returns an unpaginated transcript
- preserve native backend pagination when it is available
- add regression coverage for latest-page and older-page fallback behavior

## Why

A remote mount of the long “PwrAgent federation dogfood PR #735” thread disconnected the M4 peer with WebSocket close code 1009. The default-profile audit recorded `transport_closed:1009`, and a direct Codex app-server diagnostic showed that `thread/read` ignored `limit: 5` and returned all 22 turns / 1,269 items in a 156,881,429-byte response.

After normalization, the single federation response still exceeded the deliberate 16 MiB per-frame safety ceiling. Applying the requested bounds to the normalized replay keeps the initial thread mount and older-history requests small without weakening the transport limit.

## Impact

Long, tool-heavy threads can mount over federation and load older history incrementally. Local and remote thread readers also get the requested bounded response when a backend ignores pagination parameters.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` (450 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
