### PR TITLE
fix(desktop): hide remote messaging divider

### DIFF
--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
@@ -168,12 +168,20 @@ describe("MessagingStatusBar", () => {
       setMessagingEnabled,
     };
 
-    render(<MessagingStatusBar desktopApi={desktopApi} />);
+    render(
+      <MessagingStatusBar
+        desktopApi={desktopApi}
+        onOpenActivity={vi.fn()}
+      />,
+    );
 
     fireEvent.click(await screen.findByRole("button", { name: /1 online/ }));
+    const popover = await screen.findByRole("dialog", {
+      name: "Messaging platforms",
+    });
     expect(
-      await screen.findByRole("dialog", { name: "Messaging platforms" }),
-    ).toBeInTheDocument();
+      popover.querySelector(".messaging-status-popover__rows"),
+    ).not.toHaveClass("messaging-status-popover__rows--without-footer");
 
     fireEvent.click(screen.getByRole("button", { name: "On" }));
 
@@ -558,6 +566,9 @@ describe("MessagingStatusBar", () => {
       expect(
         screen.queryByRole("button", { name: "Open Messaging Activity" }),
       ).not.toBeInTheDocument();
+      expect(
+        popover.querySelector(".messaging-status-popover__rows"),
+      ).toHaveClass("messaging-status-popover__rows--without-footer");
     } finally {
       delete federationWindow.__pwragentFederationTarget;
     }

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -135,6 +135,9 @@ export function MessagingStatusBar(props: {
         `${formatMessagingPlatformName(status.platform)}: ${HEALTH_LABEL[status.health]}`,
     )
     .join("; ");
+  const showActivityFooter =
+    !isFederationWindow
+    && Boolean(props.onOpenActivity);
 
   useEffect(() => {
     if (!open) return;
@@ -418,7 +421,13 @@ export function MessagingStatusBar(props: {
                 ) : null}
               </div>
             </div>
-            <div className="messaging-status-popover__rows">
+            <div
+              className={`messaging-status-popover__rows${
+                showActivityFooter
+                  ? ""
+                  : " messaging-status-popover__rows--without-footer"
+              }`}
+            >
               {displayStatuses.map((status) => (
                 <PlatformStatusRow
                   key={status.platform}
@@ -447,7 +456,7 @@ export function MessagingStatusBar(props: {
                 {toggleError ?? platformToggleError}
               </p>
             ) : null}
-            {!isFederationWindow && props.onOpenActivity ? (
+            {showActivityFooter ? (
               <button
                 type="button"
                 className="messaging-status-popover__activity"

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1554,6 +1554,11 @@ textarea,
   border-bottom: 1px solid var(--border-subtle);
 }
 
+.messaging-status-popover__rows--without-footer
+  .messaging-status-popover__row:last-child {
+  border-bottom: none;
+}
+
 .messaging-status-popover__row-main {
   flex: 1 1 auto;
   min-width: 0;


### PR DESCRIPTION
## Summary

- I hide the final messaging-platform divider when the popover has no Messaging Activity footer.
- I keep the divider on local popovers where the activity footer remains available.
- I added focused coverage for both local and remote/read-only popover rendering.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx` (13 tests passed).
- I ran `pnpm lint:eslint` (0 errors; existing warning baseline only).
- I ran `pnpm typecheck`.
- I ran `pnpm lint:boundaries`.
- I ran `git diff --check`.

## Notes

- The change is scoped to the messaging status popover component, its styling, and its focused unit test.
