### PR TITLE
fix(desktop): preserve federated live images

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -12,7 +12,7 @@ import {
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
@@ -17175,6 +17175,84 @@ command = "pnpm dev"
       );
       expect(path.basename(imagePath)).toBe("workspace setup.png");
       await expect(readFile(imagePath)).resolves.toEqual(Buffer.from([1, 2, 3]));
+    } finally {
+      await registry.close();
+      await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      if (previousHome === undefined) {
+        delete process.env.PWRAGENT_HOME;
+      } else {
+        process.env.PWRAGENT_HOME = previousHome;
+      }
+    }
+  });
+
+  it("restores materialized images onto text-only Codex user item events", async () => {
+    const tempHome = await mkdtemp(path.join(os.tmpdir(), "pwragent-image-event-"));
+    const previousHome = process.env.PWRAGENT_HOME;
+    process.env.PWRAGENT_HOME = tempHome;
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    try {
+      await registry.startTurn({
+        backend: "codex",
+        threadId: "thread-image",
+        input: [
+          { type: "text", text: "Describe it" },
+          {
+            type: "image",
+            name: "remote-paste.png",
+            url: "data:image/png;base64,AQID",
+          },
+        ],
+      });
+      const imageInput = codexClient.lastStartTurnParams?.input[1];
+      const imagePath = imageInput?.type === "localImage" ? imageInput.path : "";
+
+      await codexClient.emit({
+        method: "item/completed",
+        params: {
+          threadId: "thread-image",
+          turnId: "turn-1",
+          item: {
+            id: "user-message-1",
+            type: "userMessage",
+            content: [{ type: "text", text: "Describe it" }],
+          },
+        },
+      });
+
+      expect(events.at(-1)).toMatchObject({
+        notification: {
+          method: "item/completed",
+          params: {
+            item: {
+              content: [
+                { type: "text", text: "Describe it" },
+                {
+                  alt: "remote-paste.png",
+                  type: "image",
+                  url: `pwragent-image://file/${encodeURIComponent(
+                    pathToFileURL(imagePath).toString(),
+                  )}`,
+                },
+              ],
+            },
+          },
+        },
+      });
     } finally {
       await registry.close();
       await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -17128,7 +17128,7 @@ command = "pnpm dev"
     await registry.startTurn({
       backend: "codex",
       threadId: "thread-title",
-      input: [{ type: "image", url: "file:///tmp/image.png" }],
+      input: [{ type: "image", url: "https://example.test/image.png" }],
     });
     await flushAsync();
 
@@ -17186,8 +17186,11 @@ command = "pnpm dev"
     }
   });
 
-  it("restores materialized images onto text-only Codex user item events", async () => {
+  it("copies external local images before restoring text-only Codex user item events", async () => {
     const tempHome = await mkdtemp(path.join(os.tmpdir(), "pwragent-image-event-"));
+    const sourceRoot = await mkdtemp(path.join(os.tmpdir(), "pwragent-image-source-"));
+    const sourcePath = path.join(sourceRoot, "remote-paste.png");
+    await writeFile(sourcePath, Buffer.from([1, 2, 3]));
     const previousHome = process.env.PWRAGENT_HOME;
     process.env.PWRAGENT_HOME = tempHome;
     const codexClient = new MockBackendClient({
@@ -17212,14 +17215,16 @@ command = "pnpm dev"
         input: [
           { type: "text", text: "Describe it" },
           {
-            type: "image",
+            type: "localImage",
             name: "remote-paste.png",
-            url: "data:image/png;base64,AQID",
+            path: sourcePath,
           },
         ],
       });
       const imageInput = codexClient.lastStartTurnParams?.input[1];
       const imagePath = imageInput?.type === "localImage" ? imageInput.path : "";
+      expect(imagePath).toContain(path.join("state", "image-inputs"));
+      expect(imagePath).not.toBe(sourcePath);
 
       await codexClient.emit({
         method: "item/completed",
@@ -17256,6 +17261,7 @@ command = "pnpm dev"
     } finally {
       await registry.close();
       await rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      await rm(sourceRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       if (previousHome === undefined) {
         delete process.env.PWRAGENT_HOME;
       } else {

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -647,6 +647,64 @@ describe("DesktopFederationRuntime", () => {
     ]);
   });
 
+  it("routes live transcript images back through their owning instance", () => {
+    const forwarded: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({ localInstanceId: "gateway_one" });
+    router.registerConnection(
+      createConnection({
+        peerId: "client_one",
+        capabilities: ["remote_window"],
+        sendEnvelope: (envelope) => forwarded.push(envelope),
+      }),
+    );
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "gateway_one";
+    runtime.router = router;
+    const ownerUrl =
+      `pwragent-image://file/${encodeURIComponent("file:///Users/owner/.pwragent/profiles/default/state/image-inputs/image.png")}`;
+
+    runtime.forwardLocalBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "user-message-1",
+            type: "userMessage",
+            content: [
+              { type: "text", text: "Describe it" },
+              { type: "image", url: ownerUrl },
+            ],
+          },
+        },
+      },
+    } as AgentEvent);
+
+    expect(forwarded).toMatchObject([{
+      params: {
+        notification: {
+          method: "item/completed",
+          params: {
+            item: {
+              content: [
+                { type: "text", text: "Describe it" },
+                {
+                  type: "image",
+                  url:
+                    `pwragent-image://federation/gateway_one/${encodeURIComponent(ownerUrl)}`,
+                },
+              ],
+            },
+          },
+        },
+      },
+      sourceInstanceId: "gateway_one",
+      targetInstanceId: "client_one",
+    }]);
+  });
+
   it("forwards scheduler lifecycle events to scheduler-capable peers", () => {
     const forwarded: FederationProtocolEnvelope[] = [];
     const unauthorized: FederationProtocolEnvelope[] = [];

--- a/apps/desktop/src/main/__tests__/image-input-files.test.ts
+++ b/apps/desktop/src/main/__tests__/image-input-files.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, rm, writeFile as writeFileFs } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { materializeLocalImageInputs } from "../app-server/image-input-files";
 
@@ -60,13 +61,60 @@ describe("image input files", () => {
   });
 
   it("converts file URLs for supported local image paths", async () => {
-    const result = await materializeLocalImageInputs([
-      { type: "image", name: "friendly screenshot.jpg", url: "file:///tmp/screenshot%20one.jpg" },
-    ]);
+    const sourceRoot = await mkdtemp(path.join(os.tmpdir(), "pwragent-image-source-"));
+    const materializedRoot = await mkdtemp(path.join(os.tmpdir(), "pwragent-image-inputs-"));
+    const sourcePath = path.join(sourceRoot, "screenshot one.jpg");
+    await writeFileFs(sourcePath, Buffer.from([1, 2, 3]));
+    try {
+      const result = await materializeLocalImageInputs(
+        [{
+          type: "image",
+          name: "friendly screenshot.jpg",
+          url: pathToFileURL(sourcePath).toString(),
+        }],
+        { resolveRoot: () => materializedRoot },
+      );
 
-    expect(result).toEqual([
-      { type: "localImage", name: "friendly screenshot.jpg", path: "/tmp/screenshot one.jpg" },
-    ]);
+      expect(result).toEqual([{
+        type: "localImage",
+        name: "friendly screenshot.jpg",
+        path: path.join(
+          materializedRoot,
+          "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+          "friendly screenshot.jpg",
+        ),
+      }]);
+      const imagePath = result[0]?.type === "localImage" ? result[0].path : "";
+      await expect(readFile(imagePath)).resolves.toEqual(Buffer.from([1, 2, 3]));
+    } finally {
+      await rm(sourceRoot, { recursive: true, force: true });
+      await rm(materializedRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("copies external local images into the approved image-input root", async () => {
+    const sourceRoot = await mkdtemp(path.join(os.tmpdir(), "pwragent-image-source-"));
+    const materializedRoot = await mkdtemp(path.join(os.tmpdir(), "pwragent-image-inputs-"));
+    const sourcePath = path.join(sourceRoot, "external.png");
+    await writeFileFs(sourcePath, Buffer.from([4, 5, 6]));
+    try {
+      const [result] = await materializeLocalImageInputs(
+        [{ type: "localImage", name: "external.png", path: sourcePath }],
+        { resolveRoot: () => materializedRoot },
+      );
+
+      expect(result).toMatchObject({
+        type: "localImage",
+        name: "external.png",
+      });
+      const imagePath = result?.type === "localImage" ? result.path : "";
+      expect(imagePath.startsWith(`${materializedRoot}${path.sep}`)).toBe(true);
+      expect(imagePath).not.toBe(sourcePath);
+      await expect(readFile(imagePath)).resolves.toEqual(Buffer.from([4, 5, 6]));
+    } finally {
+      await rm(sourceRoot, { recursive: true, force: true });
+      await rm(materializedRoot, { recursive: true, force: true });
+    }
   });
 
   it("does not delete a reused stale cached image while materializing it", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6084,10 +6084,11 @@ type PendingThreadMessageContext = {
   turnId?: string;
 };
 
-function pendingThreadMessageImageParts(
+async function pendingThreadMessageImageParts(
   input: AppServerTurnInputItem[] | undefined,
-): AppServerThreadImagePart[] {
-  return (input ?? []).flatMap((item): AppServerThreadImagePart[] => {
+): Promise<AppServerThreadImagePart[]> {
+  const materializedInput = await materializeLocalImageInputs(input ?? []);
+  return materializedInput.flatMap((item): AppServerThreadImagePart[] => {
     if (item.type === "localImage") {
       return [{
         type: "image",
@@ -10983,7 +10984,7 @@ export class DesktopBackendRegistry {
           params.backend,
           params.threadId,
         );
-        pendingMessageContextId = this.registerPendingThreadMessageContext({
+        pendingMessageContextId = await this.registerPendingThreadMessageContext({
           backend: params.backend,
           input,
           threadId: params.threadId,
@@ -11156,7 +11157,7 @@ export class DesktopBackendRegistry {
     // turn/start call resolves. It must receive the same prepared input that
     // goes to the agent, not raw local PDF references from the composer.
     this.pendingTitleGenerationInputs.set(titleGenerationKey, input);
-    const pendingMessageContextId = this.registerPendingThreadMessageContext({
+    const pendingMessageContextId = await this.registerPendingThreadMessageContext({
       backend: params.backend,
       input,
       threadId: params.threadId,
@@ -11370,15 +11371,15 @@ export class DesktopBackendRegistry {
     return response;
   }
 
-  private registerPendingThreadMessageContext(params: {
+  private async registerPendingThreadMessageContext(params: {
     backend: AppServerBackendKind;
     input?: AppServerTurnInputItem[];
     threadId: string;
     origin?: AppServerThreadMessageOrigin;
     text?: string;
     turnId?: string;
-  }): string | undefined {
-    const imageParts = pendingThreadMessageImageParts(params.input);
+  }): Promise<string | undefined> {
+    const imageParts = await pendingThreadMessageImageParts(params.input);
     if (!params.origin && imageParts.length === 0) {
       return undefined;
     }
@@ -12444,7 +12445,7 @@ export class DesktopBackendRegistry {
     const input = await enrichLocalFileInputs(params.input, {
       privateStorageRoots: this.localFilePrivateStorageRoots,
     });
-    const pendingMessageContextId = this.registerPendingThreadMessageContext({
+    const pendingMessageContextId = await this.registerPendingThreadMessageContext({
       backend: params.backend,
       input,
       threadId: params.threadId,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4,6 +4,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { realpath, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import type {
   DynamicToolSpec as CodexDynamicToolSpec,
@@ -27,6 +28,7 @@ import type {
   WorktreeGitWorkingStateCacheEntry,
 } from "../state/overlay-store-sqlite";
 import { requestShowThread } from "../window-show-thread";
+import { toTranscriptImageProtocolUrl } from "../transcript-image-protocol";
 import { PerKeyAsyncLock } from "../util/per-key-async-lock";
 import type { AcpMcpServerRegistration } from "../acp/acp-client";
 import { MCP_CONNECTION_TOOL_TIMEOUT_SECONDS } from "../mcp-connections/mcp-connection-timeouts";
@@ -63,6 +65,7 @@ import {
   type AppServerReadThreadResponse,
   type AppServerThreadActivityEntry,
   type AppServerThreadEntry,
+  type AppServerThreadImagePart,
   type AppServerThreadMessage,
   type AppServerThreadMessageOrigin,
   type AppServerThreadReviewEntry,
@@ -6070,15 +6073,53 @@ function buildWorkspaceMoveFailurePrompt(params: {
   ].join("\n");
 }
 
-type PendingThreadMessageOrigin = {
+type PendingThreadMessageContext = {
   backend: AppServerBackendKind;
   createdAt: number;
   id: string;
-  origin: AppServerThreadMessageOrigin;
+  imageParts?: AppServerThreadImagePart[];
+  origin?: AppServerThreadMessageOrigin;
   text?: string;
   threadId: string;
   turnId?: string;
 };
+
+function pendingThreadMessageImageParts(
+  input: AppServerTurnInputItem[] | undefined,
+): AppServerThreadImagePart[] {
+  return (input ?? []).flatMap((item): AppServerThreadImagePart[] => {
+    if (item.type === "localImage") {
+      return [{
+        type: "image",
+        ...(item.name ? { alt: item.name } : {}),
+        url: toTranscriptImageProtocolUrl(pathToFileURL(item.path).toString()),
+      }];
+    }
+    if (item.type === "image") {
+      return [{
+        type: "image",
+        ...(item.name ? { alt: item.name } : {}),
+        url: item.url,
+      }];
+    }
+    return [];
+  });
+}
+
+function contentHasRenderableImage(content: unknown[]): boolean {
+  return content.some((value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return false;
+    }
+    const item = value as Record<string, unknown>;
+    return (
+      (item.type === "image"
+        || item.type === "input_image"
+        || item.type === "image_url")
+      && (typeof item.url === "string" || typeof item.image_url === "string")
+    );
+  });
+}
 
 type AcceptedSteerRequest = {
   promise: Promise<SteerTurnResponse>;
@@ -6263,9 +6304,9 @@ export class DesktopBackendRegistry {
     string,
     AppServerTurnInputItem[]
   >();
-  private readonly pendingThreadMessageOrigins = new Map<
+  private readonly pendingThreadMessageContexts = new Map<
     string,
-    PendingThreadMessageOrigin
+    PendingThreadMessageContext
   >();
   // Keep accepted requests through the active turn, not just while the RPC is
   // in flight. The backend can acknowledge a steer before its user item is
@@ -10918,7 +10959,7 @@ export class DesktopBackendRegistry {
         throw new Error("A turn is already active for this thread.");
       }
       this.reservedAcpStartThreadKeys.add(reservationKey);
-      let pendingMessageOriginId: string | undefined;
+      let pendingMessageContextId: string | undefined;
       try {
         const preparedPdfInput = await preparePdfTurnInput({
           handling: this.resolvePdfTurnInputHandling({
@@ -10942,8 +10983,9 @@ export class DesktopBackendRegistry {
           params.backend,
           params.threadId,
         );
-        pendingMessageOriginId = this.registerPendingThreadMessageOrigin({
+        pendingMessageContextId = this.registerPendingThreadMessageContext({
           backend: params.backend,
+          input,
           threadId: params.threadId,
           origin: resolveThreadMessageOrigin(params),
           text: extractFirstMeaningfulTextInput(params.input),
@@ -10968,8 +11010,8 @@ export class DesktopBackendRegistry {
           threadId: result.threadId,
           input,
         });
-        this.bindPendingThreadMessageOrigin(
-          pendingMessageOriginId,
+        this.bindPendingThreadMessageContext(
+          pendingMessageContextId,
           result.turnId,
         );
         await this.persistThreadMessageOrigin({
@@ -10978,10 +11020,10 @@ export class DesktopBackendRegistry {
           messageId: buildTurnUserMessageOriginId(result.turnId),
           origin: resolveThreadMessageOrigin(params),
         });
-        this.forgetPendingThreadMessageOrigin(pendingMessageOriginId);
+        this.forgetPendingThreadMessageContext(pendingMessageContextId);
         return result;
       } catch (error) {
-        this.forgetPendingThreadMessageOrigin(pendingMessageOriginId);
+        this.forgetPendingThreadMessageContext(pendingMessageContextId);
         throw error;
       } finally {
         this.reservedAcpStartThreadKeys.delete(reservationKey);
@@ -11114,8 +11156,9 @@ export class DesktopBackendRegistry {
     // turn/start call resolves. It must receive the same prepared input that
     // goes to the agent, not raw local PDF references from the composer.
     this.pendingTitleGenerationInputs.set(titleGenerationKey, input);
-    const pendingMessageOriginId = this.registerPendingThreadMessageOrigin({
+    const pendingMessageContextId = this.registerPendingThreadMessageContext({
       backend: params.backend,
+      input,
       threadId: params.threadId,
       origin: resolveThreadMessageOrigin(params),
       text: extractFirstMeaningfulTextInput(input),
@@ -11208,7 +11251,7 @@ export class DesktopBackendRegistry {
         this.reservedCodexStartThreadIds.delete(params.threadId);
       }
       this.pendingTitleGenerationInputs.delete(titleGenerationKey);
-      this.forgetPendingThreadMessageOrigin(pendingMessageOriginId);
+      this.forgetPendingThreadMessageContext(pendingMessageContextId);
       if (
         retryableCodexTurnStart
         && this.codexClient.recoverInvalidPersistedResponseMessageIds
@@ -11250,7 +11293,7 @@ export class DesktopBackendRegistry {
       },
       pdfAttachments,
     );
-    this.bindPendingThreadMessageOrigin(pendingMessageOriginId, result.turnId);
+    this.bindPendingThreadMessageContext(pendingMessageContextId, result.turnId);
     await this.persistThreadMessageOrigin({
       backend: params.backend,
       threadId: result.threadId,
@@ -11327,28 +11370,31 @@ export class DesktopBackendRegistry {
     return response;
   }
 
-  private registerPendingThreadMessageOrigin(params: {
+  private registerPendingThreadMessageContext(params: {
     backend: AppServerBackendKind;
+    input?: AppServerTurnInputItem[];
     threadId: string;
     origin?: AppServerThreadMessageOrigin;
     text?: string;
     turnId?: string;
   }): string | undefined {
-    if (!params.origin) {
+    const imageParts = pendingThreadMessageImageParts(params.input);
+    if (!params.origin && imageParts.length === 0) {
       return undefined;
     }
     const oldestAllowed = Date.now() - 10 * 60 * 1000;
-    for (const [id, pending] of this.pendingThreadMessageOrigins) {
+    for (const [id, pending] of this.pendingThreadMessageContexts) {
       if (pending.createdAt < oldestAllowed) {
-        this.pendingThreadMessageOrigins.delete(id);
+        this.pendingThreadMessageContexts.delete(id);
       }
     }
     const id = randomUUID();
-    this.pendingThreadMessageOrigins.set(id, {
+    this.pendingThreadMessageContexts.set(id, {
       backend: params.backend,
       createdAt: Date.now(),
       id,
-      origin: params.origin,
+      ...(imageParts.length > 0 ? { imageParts } : {}),
+      ...(params.origin ? { origin: params.origin } : {}),
       ...(params.text ? { text: params.text } : {}),
       threadId: params.threadId,
       ...(params.turnId ? { turnId: params.turnId } : {}),
@@ -11356,32 +11402,32 @@ export class DesktopBackendRegistry {
     return id;
   }
 
-  private bindPendingThreadMessageOrigin(
+  private bindPendingThreadMessageContext(
     id: string | undefined,
     turnId: string,
   ): void {
     if (!id) {
       return;
     }
-    const pending = this.pendingThreadMessageOrigins.get(id);
+    const pending = this.pendingThreadMessageContexts.get(id);
     if (pending) {
       pending.turnId = turnId;
     }
   }
 
-  private forgetPendingThreadMessageOrigin(id: string | undefined): void {
+  private forgetPendingThreadMessageContext(id: string | undefined): void {
     if (id) {
-      this.pendingThreadMessageOrigins.delete(id);
+      this.pendingThreadMessageContexts.delete(id);
     }
   }
 
-  private findPendingThreadMessageOrigin(params: {
+  private findPendingThreadMessageContext(params: {
     backend: AppServerBackendKind;
     threadId: string;
     text?: string;
     turnId?: string;
-  }): PendingThreadMessageOrigin | undefined {
-    const candidates = [...this.pendingThreadMessageOrigins.values()]
+  }): PendingThreadMessageContext | undefined {
+    const candidates = [...this.pendingThreadMessageContexts.values()]
       .filter(
         (pending) =>
           pending.backend === params.backend
@@ -11407,7 +11453,7 @@ export class DesktopBackendRegistry {
     );
   }
 
-  private async withThreadMessageOrigin(event: AgentEvent): Promise<AgentEvent> {
+  private async withThreadMessageContext(event: AgentEvent): Promise<AgentEvent> {
     if (event.notification.method === "turn/started") {
       const notification = event.notification as {
         method: "turn/started";
@@ -11417,7 +11463,7 @@ export class DesktopBackendRegistry {
           turn: { id: string };
         };
       };
-      const pending = this.findPendingThreadMessageOrigin({
+      const pending = this.findPendingThreadMessageContext({
         backend: event.backend,
         threadId: notification.params.threadId,
         turnId:
@@ -11443,6 +11489,7 @@ export class DesktopBackendRegistry {
         threadId: string;
         turnId?: string;
         item: {
+          content?: unknown;
           id: string;
           type: string;
           origin?: AppServerThreadMessageOrigin;
@@ -11453,7 +11500,7 @@ export class DesktopBackendRegistry {
     if (notification.params.item.type !== "userMessage") {
       return event;
     }
-    const pending = this.findPendingThreadMessageOrigin({
+    const pending = this.findPendingThreadMessageContext({
       backend: event.backend,
       threadId: notification.params.threadId,
       text: notification.params.item.text,
@@ -11469,8 +11516,15 @@ export class DesktopBackendRegistry {
       origin: pending.origin,
     });
     if (event.notification.method === "item/completed") {
-      this.pendingThreadMessageOrigins.delete(pending.id);
+      this.pendingThreadMessageContexts.delete(pending.id);
     }
+    const content = Array.isArray(notification.params.item.content)
+      ? notification.params.item.content
+      : [];
+    const imageParts =
+      pending.imageParts?.length && !contentHasRenderableImage(content)
+        ? pending.imageParts
+        : [];
     return {
       ...event,
       notification: {
@@ -11479,7 +11533,10 @@ export class DesktopBackendRegistry {
           ...notification.params,
           item: {
             ...notification.params.item,
-            origin: pending.origin,
+            ...(imageParts.length > 0
+              ? { content: [...content, ...imageParts] }
+              : {}),
+            ...(pending.origin ? { origin: pending.origin } : {}),
           },
         },
       } as AppServerNotification,
@@ -12387,8 +12444,9 @@ export class DesktopBackendRegistry {
     const input = await enrichLocalFileInputs(params.input, {
       privateStorageRoots: this.localFilePrivateStorageRoots,
     });
-    const pendingMessageOriginId = this.registerPendingThreadMessageOrigin({
+    const pendingMessageContextId = this.registerPendingThreadMessageContext({
       backend: params.backend,
+      input,
       threadId: params.threadId,
       turnId: params.expectedTurnId,
       origin: messageOrigin,
@@ -12414,7 +12472,7 @@ export class DesktopBackendRegistry {
           ? await this.withActiveCodexThreadClient(params.threadId, steerWithClient)
           : await steerWithClient(this.grokClient);
     } catch (error) {
-      this.forgetPendingThreadMessageOrigin(pendingMessageOriginId);
+      this.forgetPendingThreadMessageContext(pendingMessageContextId);
       throw error;
     }
 
@@ -25486,7 +25544,7 @@ export class DesktopBackendRegistry {
   }
 
   private async emit(event: AgentEvent): Promise<void> {
-    event = await this.withThreadMessageOrigin(event);
+    event = await this.withThreadMessageContext(event);
     this.rememberFileChangeApprovalContext(event);
     event = this.withEmbeddedFileChangeApprovalContext(event);
 

--- a/apps/desktop/src/main/app-server/image-input-files.ts
+++ b/apps/desktop/src/main/app-server/image-input-files.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
-import { mkdir, readdir, rm, stat, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rm, stat, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { AppServerTurnInputItem } from "@pwragent/shared";
 import { resolveActiveProfilePath } from "../profile";
 
@@ -8,6 +9,7 @@ const LOCAL_IMAGE_INPUT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 export type ImageInputFileDependencies = {
   now: () => number;
+  readFile: (filePath: string) => Promise<Buffer>;
   resolveRoot: () => string;
   writeFile: (filePath: string, data: Buffer) => Promise<unknown>;
   mkdir: (dirPath: string, options: { recursive: true }) => Promise<unknown>;
@@ -26,6 +28,7 @@ export type ImageInputFileDependencies = {
 
 const defaultDependencies: ImageInputFileDependencies = {
   now: () => Date.now(),
+  readFile,
   resolveRoot: () => resolveActiveProfilePath(path.join("state", "image-inputs")),
   writeFile,
   mkdir,
@@ -45,17 +48,22 @@ export async function materializeLocalImageInputs(
   let materializedRoot: string | undefined;
 
   for (const item of input) {
-    if (item.type !== "image") {
+    if (item.type !== "image" && item.type !== "localImage") {
       materialized.push(item);
       continue;
     }
 
-    const dataImage = parseSupportedImageDataUrl(item.url);
+    const dataImage = item.type === "image"
+      ? parseSupportedImageDataUrl(item.url)
+      : undefined;
     if (dataImage) {
       const root = deps.resolveRoot();
       materializedRoot = root;
       await deps.mkdir(root, { recursive: true });
-      const filePath = materializedImageFilePath(root, item.name, dataImage);
+      const filePath = materializedImageFilePath(root, item.name, {
+        extension: extensionForMimeType(dataImage.mimeType),
+        sha256: dataImage.sha256,
+      });
       await deps.mkdir(path.dirname(filePath), { recursive: true });
       await deps.writeFile(filePath, dataImage.buffer);
       materializedFilePaths.add(filePath);
@@ -67,12 +75,25 @@ export async function materializeLocalImageInputs(
       continue;
     }
 
-    const filePath = filePathFromFileUrl(item.url);
+    const filePath = item.type === "localImage"
+      ? item.path
+      : filePathFromFileUrl(item.url);
     if (filePath && isSupportedImagePath(filePath)) {
+      const root = deps.resolveRoot();
+      materializedRoot = root;
+      const buffer = await deps.readFile(filePath);
+      const extension = normalizedImageExtension(filePath);
+      const materializedPath = materializedImageFilePath(root, item.name, {
+        extension,
+        sha256: createHash("sha256").update(buffer).digest("hex"),
+      });
+      await deps.mkdir(path.dirname(materializedPath), { recursive: true });
+      await deps.writeFile(materializedPath, buffer);
+      materializedFilePaths.add(materializedPath);
       materialized.push({
         type: "localImage",
         ...(item.name ? { name: item.name } : {}),
-        path: filePath,
+        path: materializedPath,
       });
       continue;
     }
@@ -116,7 +137,7 @@ function parseSupportedImageDataUrl(
 function filePathFromFileUrl(url: string): string | undefined {
   try {
     const parsed = new URL(url);
-    return parsed.protocol === "file:" ? decodeURIComponent(parsed.pathname) : undefined;
+    return parsed.protocol === "file:" ? fileURLToPath(parsed) : undefined;
   } catch {
     return undefined;
   }
@@ -125,21 +146,20 @@ function filePathFromFileUrl(url: string): string | undefined {
 function materializedImageFilePath(
   root: string,
   name: string | undefined,
-  dataImage: { mimeType: "image/jpeg" | "image/png"; sha256: string },
+  image: { extension: string; sha256: string },
 ): string {
-  const extension = extensionForMimeType(dataImage.mimeType);
-  const fallback = path.join(root, `${dataImage.sha256}.${extension}`);
-  const basename = sanitizeImageBasename(name, extension);
+  const fallback = path.join(root, `${image.sha256}.${image.extension}`);
+  const basename = sanitizeImageBasename(name, image.extension);
   if (!basename) {
     return fallback;
   }
 
-  return path.join(root, dataImage.sha256, basename);
+  return path.join(root, image.sha256, basename);
 }
 
 function sanitizeImageBasename(
   name: string | undefined,
-  extension: "jpg" | "png",
+  extension: string,
 ): string | undefined {
   const normalized = name
     ?.trim()
@@ -169,8 +189,22 @@ function extensionForMimeType(mimeType: "image/jpeg" | "image/png"): "jpg" | "pn
 }
 
 function isSupportedImagePath(filePath: string): boolean {
-  const extension = path.extname(filePath).toLowerCase();
-  return extension === ".jpg" || extension === ".jpeg" || extension === ".png";
+  return SUPPORTED_LOCAL_IMAGE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+const SUPPORTED_LOCAL_IMAGE_EXTENSIONS = new Set([
+  ".avif",
+  ".bmp",
+  ".gif",
+  ".jpeg",
+  ".jpg",
+  ".png",
+  ".webp",
+]);
+
+function normalizedImageExtension(filePath: string): string {
+  const extension = path.extname(filePath).toLowerCase().slice(1);
+  return extension === "jpeg" ? "jpg" : extension;
 }
 
 async function cleanupOldImageInputs(

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -115,6 +115,7 @@ import {
   readTranscriptImageProtocolRequest,
   rewriteFederatedTranscriptImageUrlsForRenderer,
   rewriteTranscriptImageUrlsForRenderer,
+  toFederatedTranscriptImageProtocolUrl,
 } from "../transcript-image-protocol";
 import { getMainLogger } from "../log";
 import {
@@ -194,6 +195,67 @@ const FEDERATION_RECONNECT_MAX_DELAY_MS = 30_000;
 const DUPLICATE_IDENTITY_NOTE_TTL_MS = 5 * 60_000;
 /** A session must last this long before it counts as stable enough to reset backoff. */
 const FEDERATION_STABLE_SESSION_MS = 60_000;
+
+function rewriteLiveTranscriptImagesForFederation(
+  event: AgentEvent,
+  ownerInstanceId: FederationInstanceId,
+): AgentEvent {
+  if (
+    event.notification.method !== "item/started"
+    && event.notification.method !== "item/completed"
+  ) {
+    return event;
+  }
+  const params = event.notification.params as Record<string, unknown>;
+  const itemValue = params.item;
+  if (
+    !itemValue
+    || typeof itemValue !== "object"
+    || Array.isArray(itemValue)
+  ) {
+    return event;
+  }
+  const item = itemValue as Record<string, unknown>;
+  if (item.type !== "userMessage" || !Array.isArray(item.content)) {
+    return event;
+  }
+  let changed = false;
+  const content = item.content.map((part) => {
+    if (
+      !part
+      || typeof part !== "object"
+      || Array.isArray(part)
+      || !("type" in part)
+      || !("url" in part)
+      || part.type !== "image"
+      || typeof part.url !== "string"
+      || !part.url.startsWith("pwragent-image://file/")
+    ) {
+      return part;
+    }
+    changed = true;
+    return {
+      ...part,
+      url: toFederatedTranscriptImageProtocolUrl(ownerInstanceId, part.url),
+    };
+  });
+  if (!changed) {
+    return event;
+  }
+  return {
+    ...event,
+    notification: {
+      ...event.notification,
+      params: {
+        ...params,
+        item: {
+          ...item,
+          content,
+        },
+      },
+    },
+  } as AgentEvent;
+}
 
 const DEFAULT_CAPABILITIES: FederationCapability[] = [
   "remote_window",
@@ -1784,10 +1846,15 @@ export class DesktopFederationRuntime {
   private forwardLocalBackendEvent(event: AgentEvent): void {
     const router = this.router;
     if (!router) return;
+    const ownerInstanceId = this.ensureLocalInstanceId();
+    const federatedEvent = rewriteLiveTranscriptImagesForFederation(
+      event,
+      ownerInstanceId,
+    );
 
     for (const connection of router.listConnections()) {
       const scheduledActionEvent =
-        event.notification.method === "thread/scheduledAction/updated";
+        federatedEvent.notification.method === "thread/scheduledAction/updated";
       if (
         scheduledActionEvent
           ? !connection.capabilities.includes("scheduled_actions")
@@ -1802,11 +1869,11 @@ export class DesktopFederationRuntime {
         kind: "notification",
         method: FEDERATION_BACKEND_EVENT_METHOD,
         params: {
-          backend: event.backend,
-          notification: event.notification,
+          backend: federatedEvent.backend,
+          notification: federatedEvent.notification,
         },
         protocolVersion: FEDERATION_PROTOCOL_VERSION,
-        sourceInstanceId: this.ensureLocalInstanceId(),
+        sourceInstanceId: ownerInstanceId,
         targetInstanceId: connection.peerId,
         createdAt: Date.now(),
       });


### PR DESCRIPTION
## What changed

- retain prepared image parts while an owner-side turn is starting
- restore those parts when Codex emits a text-only live user-message item
- expose owner-local image files through the existing lazy `pwragent-image://` protocol
- rewrite live image URLs to federation-owned URLs before forwarding events to remote viewers

## Root cause

For a turn started from a remote federation window, the owning instance successfully received and materialized the pasted image. Codex then emitted a live `userMessage` item containing the prompt text but no image content. The remote sender still had its renderer-local optimistic image, but the owning renderer did not, so its transcript rendered only the text until durable replay became available.

The prior transcript-image transport fix covered owner-to-remote hydrated reads. This adds the missing remote-to-owner live-event path while preserving lazy owner-to-remote image transport.

## Impact

Images pasted while creating or replying to a federated thread now appear immediately in the owning instance transcript. Other remote viewers receive a lazy federation URL instead of owner-local paths or duplicated base64 payloads.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/federation-runtime.test.ts` — 467 passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — zero errors (existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
