### PR TITLE
feat(desktop): federation agent-tool layer

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-config-federation.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-config-federation.test.ts
@@ -11,6 +11,7 @@ describe("desktop config [federation] section", () => {
       "[federation]",
       'mode = "gateway"',
       'instance_label = "Studio Mac"',
+      'instance_notes = "PwrSnap dev + screen recording"',
       'listen_host = "127.0.0.1"',
       "listen_port = 47830",
       'public_url = "https://pwragent.example.com"',
@@ -25,6 +26,7 @@ describe("desktop config [federation] section", () => {
     expect(config.federation).toEqual({
       mode: "gateway",
       instanceLabel: "Studio Mac",
+      instanceNotes: "PwrSnap dev + screen recording",
       listenHost: "127.0.0.1",
       listenPort: 47830,
       publicUrl: "https://pwragent.example.com",
@@ -39,6 +41,7 @@ describe("desktop config [federation] section", () => {
       federation: {
         mode: "dual",
         instanceLabel: "Studio Mac",
+        instanceNotes: "PwrSnap dev + screen recording",
         listenHost: "0.0.0.0",
         listenPort: 47831,
         publicUrl: "https://gateway.example.com",
@@ -53,6 +56,7 @@ describe("desktop config [federation] section", () => {
     expect(config.federation).toEqual({
       mode: "dual",
       instanceLabel: "Studio Mac",
+      instanceNotes: "PwrSnap dev + screen recording",
       listenHost: "0.0.0.0",
       listenPort: 47831,
       publicUrl: "https://gateway.example.com",
@@ -67,6 +71,7 @@ describe("desktop config [federation] section", () => {
       "[federation]",
       'mode = "gateway"',
       'instance_label = "Studio Mac"',
+      'instance_notes = "PwrSnap dev + screen recording"',
       'listen_host = "127.0.0.1"',
       "listen_port = 47830",
       'public_url = "https://gateway.example.com"',
@@ -80,6 +85,7 @@ describe("desktop config [federation] section", () => {
         federation: {
           mode: "disabled",
           instanceLabel: "",
+          instanceNotes: "",
           listenHost: "",
           listenPort: 0,
           publicUrl: "",

--- a/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
@@ -132,7 +132,7 @@ describe("federation agent tools service", () => {
                 status: "connected",
                 capabilities: ["thread_navigation", "federated_search"],
                 notes: "PwrSnap dev + screen recording",
-                icon: "nebula",
+                celestialIcon: "ringed-planet",
               },
               {
                 id: "pwr_rack",
@@ -160,7 +160,7 @@ describe("federation agent tools service", () => {
       isLocal: false,
       status: "connected",
       notes: "PwrSnap dev + screen recording",
-      icon: "nebula",
+      icon: "ringed-planet",
     });
     expect(data.instances[2]).toMatchObject({
       instanceId: "pwr_rack",

--- a/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
@@ -1,0 +1,468 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  CreateInstanceThreadResult,
+  FederationHealthStatus,
+  ListFederationInstancesResult,
+  ListInstanceProjectsResult,
+  MaterializeDirectoryLaunchpadRequest,
+  NavigationSnapshot,
+  SearchFederationThreadsResult,
+} from "@pwragent/shared";
+import { createFederationAgentToolsHandler } from "../federation/federation-agent-tools-service";
+import type { DesktopFederationRuntime } from "../federation/federation-runtime";
+
+vi.mock("../settings/desktop-settings-singleton", () => ({
+  getDesktopSettingsService: () => ({
+    readSettings: async () => ({
+      federation: {
+        instanceLabel: { value: "Local Mac", source: "config" },
+        instanceNotes: { value: "Primary dev machine", source: "config" },
+      },
+    }),
+  }),
+}));
+
+const context = {
+  backend: "codex" as const,
+  threadId: "thread-1",
+  turnId: "turn-1",
+  callId: "call-1",
+};
+
+function buildHealth(
+  overrides: Partial<FederationHealthStatus> = {},
+): FederationHealthStatus {
+  return {
+    enabled: true,
+    role: "gateway",
+    status: "listening",
+    instanceId: "pwr_local",
+    peers: [],
+    ...overrides,
+  };
+}
+
+function buildSnapshot(
+  overrides: Partial<NavigationSnapshot> = {},
+): NavigationSnapshot {
+  return {
+    backend: "all",
+    fetchedAt: 100,
+    unchanged: false,
+    threads: [],
+    inboxThreadKeys: [],
+    directories: [],
+    launchpadDefaults: {
+      backend: "codex",
+      executionMode: "default",
+      workMode: "worktree",
+      model: "gpt-5.5-codex",
+    },
+    ...overrides,
+  } as NavigationSnapshot;
+}
+
+function buildRuntime(overrides: Partial<DesktopFederationRuntime>): () =>
+  DesktopFederationRuntime {
+  return () => overrides as DesktopFederationRuntime;
+}
+
+describe("federation agent tools service", () => {
+  it("lists just the local instance when federation is disabled", async () => {
+    const handler = createFederationAgentToolsHandler({
+      runtime: buildRuntime({
+        health: async () => buildHealth({ enabled: false, status: "disabled" }),
+      }),
+    });
+
+    const response = await handler({
+      operation: "list_federation_instances",
+      context,
+      args: {},
+    });
+
+    expect(response.ok).toBe(true);
+    const data = (response as { ok: true; data: ListFederationInstancesResult })
+      .data;
+    expect(data.federationEnabled).toBe(false);
+    expect(data.instances).toHaveLength(1);
+    expect(data.instances[0]).toMatchObject({
+      instanceId: "pwr_local",
+      label: "Local Mac",
+      isLocal: true,
+      status: "connected",
+      notes: "Primary dev machine",
+    });
+  });
+
+  it("lists peers with purpose notes, icons, and status", async () => {
+    const handler = createFederationAgentToolsHandler({
+      runtime: buildRuntime({
+        health: async () =>
+          buildHealth({
+            peers: [
+              {
+                id: "pwr_studio",
+                label: "Studio Mac",
+                role: "client",
+                status: "connected",
+                capabilities: ["thread_navigation", "federated_search"],
+                notes: "PwrSnap dev + screen recording",
+                icon: "nebula",
+              },
+              {
+                id: "pwr_rack",
+                label: "Rack Mini",
+                role: "client",
+                status: "disconnected",
+                capabilities: [],
+              },
+            ],
+          }),
+      }),
+    });
+
+    const response = await handler({
+      operation: "list_federation_instances",
+      context,
+      args: {},
+    });
+
+    const data = (response as { ok: true; data: ListFederationInstancesResult })
+      .data;
+    expect(data.instances).toHaveLength(3);
+    expect(data.instances[1]).toMatchObject({
+      instanceId: "pwr_studio",
+      isLocal: false,
+      status: "connected",
+      notes: "PwrSnap dev + screen recording",
+      icon: "nebula",
+    });
+    expect(data.instances[2]).toMatchObject({
+      instanceId: "pwr_rack",
+      status: "disconnected",
+    });
+  });
+
+  it("routes list_instance_projects to the remote backend and filters unlinked", async () => {
+    const getNavigationSnapshot = vi.fn(async () =>
+      buildSnapshot({
+        directories: [
+          {
+            key: "dir:/Users/op/pwrsnap",
+            kind: "directory",
+            label: "PwrSnap",
+            path: "/Users/op/pwrsnap",
+            threadKeys: [],
+            needsAttentionCount: 0,
+            launchpad: {
+              backend: "codex",
+              executionMode: "default",
+              workMode: "worktree",
+              model: "gpt-5.5-codex",
+              directoryKey: "dir:/Users/op/pwrsnap",
+              directoryKind: "directory",
+              directoryLabel: "PwrSnap",
+              prompt: "",
+              createdAt: 1,
+              updatedAt: 2,
+            },
+          },
+          {
+            key: "unlinked",
+            kind: "unlinked",
+            label: "Unlinked",
+            threadKeys: [],
+            needsAttentionCount: 0,
+          },
+        ] as NavigationSnapshot["directories"],
+      }),
+    );
+    const handler = createFederationAgentToolsHandler({
+      runtime: buildRuntime({
+        health: async () =>
+          buildHealth({
+            peers: [
+              {
+                id: "pwr_studio",
+                label: "Studio Mac",
+                role: "client",
+                status: "connected",
+                capabilities: ["thread_navigation"],
+              },
+            ],
+          }),
+        remoteBackend: (() => ({ getNavigationSnapshot })) as never,
+      }),
+    });
+
+    const response = await handler({
+      operation: "list_instance_projects",
+      context,
+      args: { instanceId: "pwr_studio" },
+    });
+
+    expect(getNavigationSnapshot).toHaveBeenCalled();
+    const data = (response as { ok: true; data: ListInstanceProjectsResult })
+      .data;
+    expect(data).toMatchObject({
+      instanceId: "pwr_studio",
+      isLocal: false,
+    });
+    expect(data.projects).toEqual([
+      {
+        key: "dir:/Users/op/pwrsnap",
+        label: "PwrSnap",
+        kind: "directory",
+        path: "/Users/op/pwrsnap",
+        hasLaunchpad: true,
+        backend: "codex",
+        workMode: "worktree",
+        model: "gpt-5.5-codex",
+        executionMode: "default",
+      },
+    ]);
+  });
+
+  it("returns not_found for an unknown instance", async () => {
+    const handler = createFederationAgentToolsHandler({
+      runtime: buildRuntime({
+        health: async () => buildHealth(),
+      }),
+    });
+
+    const response = await handler({
+      operation: "list_instance_projects",
+      context,
+      args: { instanceId: "pwr_ghost" },
+    });
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: { code: "not_found" },
+    });
+  });
+
+  it("returns peer_unavailable for a disconnected instance", async () => {
+    const handler = createFederationAgentToolsHandler({
+      runtime: buildRuntime({
+        health: async () =>
+          buildHealth({
+            peers: [
+              {
+                id: "pwr_rack",
+                label: "Rack Mini",
+                role: "client",
+                status: "disconnected",
+                capabilities: [],
+              },
+            ],
+          }),
+      }),
+    });
+
+    const response = await handler({
+      operation: "create_instance_thread",
+      context,
+      args: { instanceId: "pwr_rack", projectKey: "dir:/repo" },
+    });
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: { code: "peer_unavailable" },
+    });
+  });
+
+  it("creates a local thread with merged launchpad settings and an initial input", async () => {
+    const materializeDirectoryLaunchpad = vi.fn(
+      async (request: MaterializeDirectoryLaunchpadRequest) => ({
+        backend: "codex" as const,
+        threadId: "thread-9",
+        executionMode:
+          request.launchpad?.executionMode ?? ("default" as const),
+        workMode: request.launchpad?.workMode ?? ("worktree" as const),
+        turnId: "turn-9",
+      }),
+    );
+    const getNavigationSnapshot = vi.fn(async () =>
+      buildSnapshot({
+        directories: [
+          {
+            key: "dir:/Users/op/pwragent",
+            kind: "directory",
+            label: "PwrAgent",
+            path: "/Users/op/pwragent",
+            threadKeys: [],
+            needsAttentionCount: 0,
+          },
+        ] as NavigationSnapshot["directories"],
+      }),
+    );
+    const handler = createFederationAgentToolsHandler({
+      runtime: buildRuntime({
+        health: async () => buildHealth(),
+        localBackend: (() => ({
+          getNavigationSnapshot,
+          materializeDirectoryLaunchpad,
+        })) as never,
+      }),
+    });
+
+    const response = await handler({
+      operation: "create_instance_thread",
+      context,
+      args: {
+        instanceId: "pwr_local",
+        projectKey: "dir:/Users/op/pwragent",
+        input: "Fix the recorder crash",
+        model: "gpt-5.5-codex-max",
+        executionMode: "full-access",
+      },
+    });
+
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "dir:/Users/op/pwragent",
+      launchpad: expect.objectContaining({
+        backend: "codex",
+        executionMode: "full-access",
+        workMode: "worktree",
+        model: "gpt-5.5-codex-max",
+        directoryKey: "dir:/Users/op/pwragent",
+        directoryLabel: "PwrAgent",
+        prompt: "",
+      }),
+      input: [{ type: "text", text: "Fix the recorder crash" }],
+    });
+    const data = (response as { ok: true; data: CreateInstanceThreadResult })
+      .data;
+    expect(data).toMatchObject({
+      instanceId: "pwr_local",
+      isLocal: true,
+      threadId: "thread-9",
+      executionMode: "full-access",
+      turnId: "turn-9",
+    });
+    expect(data.threadLink).toContain("pwragent://thread/thread-9");
+  });
+
+  it("merges local and peer results in search_federation_threads", async () => {
+    const localThread = {
+      id: "thread-local",
+      title: "Recorder crash on stop",
+      source: "codex" as const,
+      linkedDirectories: [],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const remoteThread = {
+      id: "thread-remote",
+      title: "Recorder crash investigation",
+      source: "codex" as const,
+      linkedDirectories: [],
+      createdAt: 1,
+      updatedAt: 3,
+    };
+    const handler = createFederationAgentToolsHandler({
+      runtime: buildRuntime({
+        health: async () => buildHealth(),
+        localBackend: (() => ({
+          listThreads: async () => ({
+            backend: "all",
+            fetchedAt: 10,
+            threads: [localThread],
+          }),
+        })) as never,
+        connectedPeerTargets: () => [
+          {
+            target: { scope: "remote", instanceId: "pwr_studio" },
+            label: "Studio Mac",
+            capabilities: ["federated_search"],
+          },
+        ],
+        remoteBackend: (() => ({
+          listThreads: async () => ({
+            backend: "all",
+            fetchedAt: 10,
+            threads: [remoteThread],
+          }),
+        })) as never,
+      }),
+    });
+
+    const response = await handler({
+      operation: "search_federation_threads",
+      context,
+      args: { query: "recorder crash" },
+    });
+
+    const data = (response as { ok: true; data: SearchFederationThreadsResult })
+      .data;
+    expect(data.results).toHaveLength(2);
+    const local = data.results.find((entry) => entry.isLocal);
+    const remote = data.results.find((entry) => !entry.isLocal);
+    expect(local).toMatchObject({
+      instanceId: "pwr_local",
+      instanceLabel: "Local Mac",
+      threadId: "thread-local",
+    });
+    expect(local?.threadLink).toContain("pwragent://thread/thread-local");
+    expect(remote).toMatchObject({
+      instanceId: "pwr_studio",
+      instanceLabel: "Studio Mac",
+      threadId: "thread-remote",
+    });
+    expect(remote?.threadLink).toBeUndefined();
+    expect(data.searchedInstances).toEqual([
+      { instanceId: "pwr_local", instanceLabel: "Local Mac", resultCount: 1 },
+      { instanceId: "pwr_studio", instanceLabel: "Studio Mac", resultCount: 1 },
+    ]);
+  });
+
+  it("scopes search_federation_threads to one peer and skips local", async () => {
+    const localListThreads = vi.fn();
+    const handler = createFederationAgentToolsHandler({
+      runtime: buildRuntime({
+        health: async () =>
+          buildHealth({
+            peers: [
+              {
+                id: "pwr_studio",
+                label: "Studio Mac",
+                role: "client",
+                status: "connected",
+                capabilities: ["federated_search"],
+              },
+            ],
+          }),
+        localBackend: (() => ({ listThreads: localListThreads })) as never,
+        connectedPeerTargets: () => [
+          {
+            target: { scope: "remote", instanceId: "pwr_studio" },
+            label: "Studio Mac",
+            capabilities: ["federated_search"],
+          },
+        ],
+        remoteBackend: (() => ({
+          listThreads: async () => ({
+            backend: "all",
+            fetchedAt: 10,
+            threads: [],
+          }),
+        })) as never,
+      }),
+    });
+
+    const response = await handler({
+      operation: "search_federation_threads",
+      context,
+      args: { query: "recorder crash", instanceId: "pwr_studio" },
+    });
+
+    expect(localListThreads).not.toHaveBeenCalled();
+    const data = (response as { ok: true; data: SearchFederationThreadsResult })
+      .data;
+    expect(data.searchedInstances).toEqual([
+      { instanceId: "pwr_studio", instanceLabel: "Studio Mac", resultCount: 0 },
+    ]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type {
   CreateInstanceThreadResult,
   FederationHealthStatus,
+  FederationHostInfo,
   ListFederationInstancesResult,
   ListInstanceProjectsResult,
   MaterializeDirectoryLaunchpadRequest,
@@ -10,6 +11,18 @@ import type {
 } from "@pwragent/shared";
 import { createFederationAgentToolsHandler } from "../federation/federation-agent-tools-service";
 import type { DesktopFederationRuntime } from "../federation/federation-runtime";
+
+const localHostInfo: FederationHostInfo = {
+  platform: "darwin",
+  osVersion: "25.5.0",
+  hostname: "local-mac",
+  arch: "arm64",
+  cpuCount: 16,
+  memoryBytes: 68_719_476_736,
+  diskFreeBytes: 512_000_000_000,
+  machineId: "mach_local",
+};
+
 
 vi.mock("../settings/desktop-settings-singleton", () => ({
   getDesktopSettingsService: () => ({
@@ -70,6 +83,8 @@ function buildRuntime(overrides: Partial<DesktopFederationRuntime>): () =>
 describe("federation agent tools service", () => {
   it("lists just the local instance when federation is disabled", async () => {
     const handler = createFederationAgentToolsHandler({
+      // Never let unit tests mint a machine-id in the real PwrAgent root.
+      collectHostInfo: async () => localHostInfo,
       runtime: buildRuntime({
         health: async () => buildHealth({ enabled: false, status: "disabled" }),
       }),
@@ -86,17 +101,26 @@ describe("federation agent tools service", () => {
       .data;
     expect(data.federationEnabled).toBe(false);
     expect(data.instances).toHaveLength(1);
+    expect(data.totalCount).toBe(1);
+    expect(data.nextCursor).toBeUndefined();
     expect(data.instances[0]).toMatchObject({
       instanceId: "pwr_local",
       label: "Local Mac",
       isLocal: true,
       status: "connected",
       notes: "Primary dev machine",
+      host: {
+        platform: "darwin",
+        cpuCount: 16,
+        machineId: "mach_local",
+      },
     });
   });
 
   it("lists peers with purpose notes, icons, and status", async () => {
     const handler = createFederationAgentToolsHandler({
+      // Never let unit tests mint a machine-id in the real PwrAgent root.
+      collectHostInfo: async () => localHostInfo,
       runtime: buildRuntime({
         health: async () =>
           buildHealth({
@@ -144,6 +168,135 @@ describe("federation agent tools service", () => {
     });
   });
 
+  it("pages the instance list with single-use continuation tokens", async () => {
+    const peers = Array.from({ length: 30 }, (_, index) => ({
+      id: `pwr_peer_${index}`,
+      label: `Peer ${index}`,
+      role: "client" as const,
+      status: "connected" as const,
+      capabilities: [],
+    }));
+    const handler = createFederationAgentToolsHandler({
+      // Never let unit tests mint a machine-id in the real PwrAgent root.
+      collectHostInfo: async () => localHostInfo,
+      runtime: buildRuntime({
+        health: async () => buildHealth({ peers }),
+      }),
+    });
+
+    const first = await handler({
+      operation: "list_federation_instances",
+      context,
+      args: {},
+    });
+    const firstData = (first as { ok: true; data: ListFederationInstancesResult })
+      .data;
+    expect(firstData.instances).toHaveLength(25);
+    expect(firstData.totalCount).toBe(31);
+    expect(firstData.nextCursor).toBeDefined();
+
+    const second = await handler({
+      operation: "list_federation_instances",
+      context,
+      args: { cursor: firstData.nextCursor! },
+    });
+    const secondData = (second as { ok: true; data: ListFederationInstancesResult })
+      .data;
+    expect(secondData.instances).toHaveLength(6);
+    expect(secondData.totalCount).toBe(31);
+    expect(secondData.nextCursor).toBeUndefined();
+    expect([
+      ...firstData.instances.map((instance) => instance.instanceId),
+      ...secondData.instances.map((instance) => instance.instanceId),
+    ]).toHaveLength(31);
+
+    // Tokens are single-use: replaying the consumed cursor fails.
+    const replay = await handler({
+      operation: "list_federation_instances",
+      context,
+      args: { cursor: firstData.nextCursor! },
+    });
+    expect(replay).toMatchObject({
+      ok: false,
+      error: { code: "invalid_arguments" },
+    });
+  });
+
+  it("rejects an unknown instance-list cursor", async () => {
+    const handler = createFederationAgentToolsHandler({
+      // Never let unit tests mint a machine-id in the real PwrAgent root.
+      collectHostInfo: async () => localHostInfo,
+      runtime: buildRuntime({
+        health: async () => buildHealth(),
+      }),
+    });
+
+    const response = await handler({
+      operation: "list_federation_instances",
+      context,
+      args: { cursor: "cursor-from-another-life" },
+    });
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: { code: "invalid_arguments" },
+    });
+  });
+
+  it("filters the instance list by query across labels, notes, and host facts", async () => {
+    const handler = createFederationAgentToolsHandler({
+      // Never let unit tests mint a machine-id in the real PwrAgent root.
+      collectHostInfo: async () => localHostInfo,
+      runtime: buildRuntime({
+        health: async () =>
+          buildHealth({
+            peers: [
+              {
+                id: "pwr_studio",
+                label: "Studio Mac",
+                role: "client",
+                status: "connected",
+                capabilities: [],
+                host: { platform: "darwin", hostname: "studio" },
+              },
+              {
+                id: "pwr_rack",
+                label: "Rack Mini",
+                role: "client",
+                status: "connected",
+                capabilities: [],
+                notes: "long-running agents",
+                host: { platform: "linux", hostname: "rack-01" },
+              },
+            ],
+          }),
+      }),
+    });
+
+    const byPlatform = await handler({
+      operation: "list_federation_instances",
+      context,
+      args: { query: "linux" },
+    });
+    const platformData = (
+      byPlatform as { ok: true; data: ListFederationInstancesResult }
+    ).data;
+    expect(platformData.totalCount).toBe(1);
+    expect(platformData.instances[0]).toMatchObject({ instanceId: "pwr_rack" });
+
+    const byNotes = await handler({
+      operation: "list_federation_instances",
+      context,
+      args: { query: "long-running" },
+    });
+    const notesData = (
+      byNotes as { ok: true; data: ListFederationInstancesResult }
+    ).data;
+    expect(notesData.instances.map((instance) => instance.instanceId)).toEqual([
+      "pwr_rack",
+    ]);
+  });
+
   it("routes list_instance_projects to the remote backend and filters unlinked", async () => {
     const getNavigationSnapshot = vi.fn(async () =>
       buildSnapshot({
@@ -179,6 +332,8 @@ describe("federation agent tools service", () => {
       }),
     );
     const handler = createFederationAgentToolsHandler({
+      // Never let unit tests mint a machine-id in the real PwrAgent root.
+      collectHostInfo: async () => localHostInfo,
       runtime: buildRuntime({
         health: async () =>
           buildHealth({
@@ -226,6 +381,8 @@ describe("federation agent tools service", () => {
 
   it("returns not_found for an unknown instance", async () => {
     const handler = createFederationAgentToolsHandler({
+      // Never let unit tests mint a machine-id in the real PwrAgent root.
+      collectHostInfo: async () => localHostInfo,
       runtime: buildRuntime({
         health: async () => buildHealth(),
       }),
@@ -245,6 +402,8 @@ describe("federation agent tools service", () => {
 
   it("returns peer_unavailable for a disconnected instance", async () => {
     const handler = createFederationAgentToolsHandler({
+      // Never let unit tests mint a machine-id in the real PwrAgent root.
+      collectHostInfo: async () => localHostInfo,
       runtime: buildRuntime({
         health: async () =>
           buildHealth({
@@ -299,6 +458,8 @@ describe("federation agent tools service", () => {
       }),
     );
     const handler = createFederationAgentToolsHandler({
+      // Never let unit tests mint a machine-id in the real PwrAgent root.
+      collectHostInfo: async () => localHostInfo,
       runtime: buildRuntime({
         health: async () => buildHealth(),
         localBackend: (() => ({
@@ -363,6 +524,8 @@ describe("federation agent tools service", () => {
       updatedAt: 3,
     };
     const handler = createFederationAgentToolsHandler({
+      // Never let unit tests mint a machine-id in the real PwrAgent root.
+      collectHostInfo: async () => localHostInfo,
       runtime: buildRuntime({
         health: async () => buildHealth(),
         localBackend: (() => ({
@@ -418,9 +581,90 @@ describe("federation agent tools service", () => {
     ]);
   });
 
+  it("excludes local results for scope remote and peers for scope local", async () => {
+    const localListThreads = vi.fn(async () => ({
+      backend: "all",
+      fetchedAt: 10,
+      threads: [
+        {
+          id: "thread-local",
+          title: "Recorder crash on stop",
+          source: "codex" as const,
+          linkedDirectories: [],
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+    }));
+    const remoteListThreads = vi.fn(async () => ({
+      backend: "all",
+      fetchedAt: 10,
+      threads: [
+        {
+          id: "thread-remote",
+          title: "Recorder crash investigation",
+          source: "codex" as const,
+          linkedDirectories: [],
+          createdAt: 1,
+          updatedAt: 3,
+        },
+      ],
+    }));
+    const handler = createFederationAgentToolsHandler({
+      // Never let unit tests mint a machine-id in the real PwrAgent root.
+      collectHostInfo: async () => localHostInfo,
+      runtime: buildRuntime({
+        health: async () => buildHealth(),
+        localBackend: (() => ({ listThreads: localListThreads })) as never,
+        connectedPeerTargets: () => [
+          {
+            target: { scope: "remote", instanceId: "pwr_studio" },
+            label: "Studio Mac",
+            capabilities: ["federated_search"],
+          },
+        ],
+        remoteBackend: (() => ({ listThreads: remoteListThreads })) as never,
+      }),
+    });
+
+    const remoteOnly = await handler({
+      operation: "search_federation_threads",
+      context,
+      args: { query: "recorder crash", scope: "remote" },
+    });
+    const remoteData = (
+      remoteOnly as { ok: true; data: SearchFederationThreadsResult }
+    ).data;
+    expect(localListThreads).not.toHaveBeenCalled();
+    expect(remoteData.results.map((entry) => entry.threadId)).toEqual([
+      "thread-remote",
+    ]);
+    expect(remoteData.searchedInstances).toEqual([
+      { instanceId: "pwr_studio", instanceLabel: "Studio Mac", resultCount: 1 },
+    ]);
+
+    const localOnly = await handler({
+      operation: "search_federation_threads",
+      context,
+      args: { query: "recorder crash", scope: "local" },
+    });
+    const localData = (
+      localOnly as { ok: true; data: SearchFederationThreadsResult }
+    ).data;
+    expect(remoteListThreads).toHaveBeenCalledTimes(1);
+    expect(localData.results.map((entry) => entry.threadId)).toEqual([
+      "thread-local",
+    ]);
+    expect(localData.searchedInstances).toEqual([
+      { instanceId: "pwr_local", instanceLabel: "Local Mac", resultCount: 1 },
+    ]);
+  });
+
   it("scopes search_federation_threads to one peer and skips local", async () => {
     const localListThreads = vi.fn();
     const handler = createFederationAgentToolsHandler({
+      // Never let unit tests mint a machine-id in the real PwrAgent root.
+      collectHostInfo: async () => localHostInfo,
       runtime: buildRuntime({
         health: async () =>
           buildHealth({

--- a/apps/desktop/src/main/__tests__/federation-endpoint-credential-scoping.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-endpoint-credential-scoping.test.ts
@@ -44,6 +44,7 @@ vi.mock("../settings/desktop-settings-singleton", () => {
       readSettings: async () => ({
         federation: {
           instanceLabel: { value: "" },
+          instanceNotes: { value: "" },
           cloudflareEndpoint: { value: cloudflareEndpoint.value },
           cloudflareMtlsEnabled: { value: true },
           cloudflareAccessServiceAuthEnabled: { value: true },

--- a/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
@@ -537,6 +537,112 @@ describe("federation enrollment", () => {
     expect(store.getPeer("client_one")?.profileName).toBe("dev");
   });
 
+  it("stores advertised purpose notes on enrollment", () => {
+    const keyPair = generateFederationIdentityKeyPair();
+    const capabilities = ["remote_window"] as const;
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "notes-invite-token-1234567890",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: 1_000,
+      expiresAt: 2_000,
+    });
+    const message = buildFederationProofMessage({
+      purpose: "enroll",
+      gatewayInstanceId: "gateway_one",
+      peerInstanceId: "client_one",
+      publicKeyPem: keyPair.publicKeyPem,
+      protocolVersion: 1,
+      nonce: "nonce-notes",
+      capabilities,
+    });
+
+    const decision = completeFederationEnrollment({
+      store,
+      gatewayInstanceId: "gateway_one",
+      inviteToken: invite.token,
+      now: 1_500,
+      peer: {
+        instanceId: "client_one",
+        label: "Studio Mac",
+        role: "client",
+        publicKeyPem: keyPair.publicKeyPem,
+        capabilities,
+        protocolVersion: 1,
+        nonce: "nonce-notes",
+        signatureBase64: signFederationMessage({
+          privateKeyPem: keyPair.privateKeyPem,
+          message,
+        }),
+        notes: " PwrSnap dev + screen recording ",
+      },
+    });
+
+    expect(decision).toMatchObject({
+      accepted: true,
+      peer: { notes: "PwrSnap dev + screen recording" },
+    });
+    expect(store.getPeer("client_one")).toMatchObject({
+      notes: "PwrSnap dev + screen recording",
+    });
+  });
+
+  it("refreshes purpose notes on reconnect and clears them when advertised empty", () => {
+    const keyPair = generateFederationIdentityKeyPair();
+    store.upsertPeer({
+      updatedAt: 1_000,
+      peer: {
+        id: "client_one",
+        label: "Studio Mac",
+        role: "client",
+        status: "disconnected",
+        capabilities: ["remote_window"],
+        protocolVersion: 1,
+        pinnedPublicKeyPem: keyPair.publicKeyPem,
+        notes: "old notes",
+      },
+    });
+    const reconnect = (nonce: string, fields: { notes?: string }) => {
+      const message = buildFederationProofMessage({
+        purpose: "reconnect",
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "client_one",
+        publicKeyPem: keyPair.publicKeyPem,
+        protocolVersion: 1,
+        nonce,
+        capabilities: ["remote_window"],
+      });
+      return authenticateFederationReconnect({
+        store,
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "client_one",
+        protocolVersion: 1,
+        nonce,
+        requestedCapabilities: ["remote_window"],
+        signatureBase64: signFederationMessage({
+          privateKeyPem: keyPair.privateKeyPem,
+          message,
+        }),
+        now: 2_000,
+        label: "Studio Mac",
+        ...fields,
+      });
+    };
+
+    // Updated notes replace the stored value.
+    expect(reconnect("nonce-notes-1", { notes: "fresh notes" })).toMatchObject({
+      accepted: true,
+      peer: { notes: "fresh notes" },
+    });
+    expect(store.getPeer("client_one")?.notes).toBe("fresh notes");
+
+    // Present-but-empty clears — the operator erased their notes.
+    expect(reconnect("nonce-notes-2", { notes: "" })).toMatchObject({
+      accepted: true,
+    });
+    expect(store.getPeer("client_one")?.notes).toBeUndefined();
+  });
+
   it("refreshes stored capabilities to the peer's current advertisement", () => {
     const keyPair = generateFederationIdentityKeyPair();
     store.upsertPeer({

--- a/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
@@ -575,6 +575,12 @@ describe("federation enrollment", () => {
           message,
         }),
         notes: " PwrSnap dev + screen recording ",
+        host: {
+          platform: "darwin",
+          hostname: "studio",
+          cpuCount: 16,
+          machineId: "mach_studio",
+        },
       },
     });
 
@@ -584,6 +590,12 @@ describe("federation enrollment", () => {
     });
     expect(store.getPeer("client_one")).toMatchObject({
       notes: "PwrSnap dev + screen recording",
+      host: {
+        platform: "darwin",
+        hostname: "studio",
+        cpuCount: 16,
+        machineId: "mach_studio",
+      },
     });
   });
 
@@ -641,6 +653,64 @@ describe("federation enrollment", () => {
       accepted: true,
     });
     expect(store.getPeer("client_one")?.notes).toBeUndefined();
+  });
+
+  it("replaces stored host facts on reconnect and keeps them when absent", async () => {
+    const keyPair = generateFederationIdentityKeyPair();
+    store.upsertPeer({
+      updatedAt: 1_000,
+      peer: {
+        id: "client_one",
+        label: "Studio Mac",
+        role: "client",
+        status: "disconnected",
+        capabilities: ["remote_window"],
+        protocolVersion: 1,
+        pinnedPublicKeyPem: keyPair.publicKeyPem,
+        host: { platform: "darwin", cpuCount: 8, machineId: "mach_studio" },
+      },
+    });
+    const reconnect = (
+      nonce: string,
+      fields: { host?: { platform?: string; cpuCount?: number; machineId?: string } },
+    ) => {
+      const message = buildFederationProofMessage({
+        purpose: "reconnect",
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "client_one",
+        publicKeyPem: keyPair.publicKeyPem,
+        protocolVersion: 1,
+        nonce,
+        capabilities: ["remote_window"],
+      });
+      return authenticateFederationReconnect({
+        store,
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "client_one",
+        protocolVersion: 1,
+        nonce,
+        requestedCapabilities: ["remote_window"],
+        signatureBase64: signFederationMessage({
+          privateKeyPem: keyPair.privateKeyPem,
+          message,
+        }),
+        now: 2_000,
+        label: "Studio Mac",
+        ...fields,
+      });
+    };
+
+    // A hardware upgrade replaces the stored block wholesale.
+    expect(
+      reconnect("nonce-host-1", {
+        host: { platform: "darwin", cpuCount: 16, machineId: "mach_studio" },
+      }),
+    ).toMatchObject({ accepted: true });
+    expect(store.getPeer("client_one")?.host?.cpuCount).toBe(16);
+
+    // An older client that never advertises host facts keeps the last block.
+    expect(reconnect("nonce-host-2", {})).toMatchObject({ accepted: true });
+    expect(store.getPeer("client_one")?.host?.cpuCount).toBe(16);
   });
 
   it("refreshes stored capabilities to the peer's current advertisement", () => {

--- a/apps/desktop/src/main/__tests__/federation-host-info.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-host-info.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  collectFederationHostInfo,
+  readOrCreateFederationMachineId,
+} from "../federation/federation-host-info";
+
+describe("federation host info", () => {
+  const tempRoots: string[] = [];
+
+  function makeRoot(): string {
+    const root = mkdtempSync(path.join(os.tmpdir(), "pwragent-host-info-"));
+    tempRoots.push(root);
+    return root;
+  }
+
+  afterEach(() => {
+    for (const root of tempRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("mints a machine id once and returns the same id afterwards", async () => {
+    const rootDir = makeRoot();
+
+    const first = await readOrCreateFederationMachineId({ rootDir });
+    const second = await readOrCreateFederationMachineId({ rootDir });
+
+    expect(first).toMatch(/^mach_/);
+    expect(second).toBe(first);
+    expect(readFileSync(path.join(rootDir, "machine-id"), "utf8").trim()).toBe(
+      first,
+    );
+  });
+
+  it("creates the root directory when it does not exist yet", async () => {
+    const rootDir = path.join(makeRoot(), "nested", "root");
+
+    const minted = await readOrCreateFederationMachineId({ rootDir });
+
+    expect(minted).toMatch(/^mach_/);
+  });
+
+  it("collects host facts with the shared machine id", async () => {
+    const rootDir = makeRoot();
+
+    const host = await collectFederationHostInfo({ rootDir });
+
+    expect(host.platform).toBe(process.platform);
+    expect(host.hostname).toBeTruthy();
+    expect(host.arch).toBeTruthy();
+    expect(host.osVersion).toBeTruthy();
+    expect(host.cpuCount).toBeGreaterThan(0);
+    expect(host.memoryBytes).toBeGreaterThan(0);
+    expect(host.diskFreeBytes).toBeGreaterThan(0);
+    expect(host.machineId).toMatch(/^mach_/);
+    // Two profiles sharing one root — the shared-hardware signal — agree.
+    expect((await collectFederationHostInfo({ rootDir })).machineId).toBe(
+      host.machineId,
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -93,6 +93,7 @@ const requestBindingRevokeAllForThreadMock = vi.fn();
 const setMessagingArchiveCleanerMock = vi.fn();
 const setMessagingAgentToolServiceMock = vi.fn();
 const setPwrAgentAppManagementHandlerMock = vi.fn();
+const setPwrAgentFederationHandlerMock = vi.fn();
 const listThreadsMock = vi.fn<(request?: unknown) => Promise<unknown[]>>();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
 const registerMessagingStatusIpcHandlersMock = vi.fn();
@@ -422,6 +423,7 @@ vi.mock("../app-server/backend-registry", () => ({
     listThreads: listThreadsMock,
     setMessagingAgentToolService: setMessagingAgentToolServiceMock,
     setPwrAgentAppManagementHandler: setPwrAgentAppManagementHandlerMock,
+    setPwrAgentFederationHandler: setPwrAgentFederationHandlerMock,
     setMessagingArchiveCleaner: setMessagingArchiveCleanerMock,
   })),
 }));
@@ -597,6 +599,7 @@ describe("bootstrapApp", () => {
     setMessagingArchiveCleanerMock.mockReset();
     setMessagingAgentToolServiceMock.mockReset();
     setPwrAgentAppManagementHandlerMock.mockReset();
+    setPwrAgentFederationHandlerMock.mockReset();
     listThreadsMock.mockReset();
     listThreadsMock.mockResolvedValue([]);
     disposeDesktopMessagingRuntimeMock.mockReset();

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts
@@ -18,10 +18,15 @@ describe("pwragent federation agent tools", () => {
             type: "function",
             name: "list_federation_instances",
             deferLoading: false,
-            description: expect.stringContaining("purpose notes"),
+            description: expect.stringContaining("machineId"),
             inputSchema: expect.objectContaining({
               type: "object",
               additionalProperties: false,
+              properties: expect.objectContaining({
+                query: expect.objectContaining({ type: "string" }),
+                limit: expect.objectContaining({ minimum: 1, maximum: 100 }),
+                cursor: expect.objectContaining({ type: "string" }),
+              }),
             }),
           }),
           expect.objectContaining({
@@ -54,6 +59,11 @@ describe("pwragent federation agent tools", () => {
             description: expect.stringContaining("every reachable PwrAgent instance"),
             inputSchema: expect.objectContaining({
               required: ["query"],
+              properties: expect.objectContaining({
+                scope: expect.objectContaining({
+                  enum: ["all", "local", "remote"],
+                }),
+              }),
             }),
           }),
         ]),
@@ -136,6 +146,81 @@ describe("pwragent federation agent tools", () => {
 
     expect(response).toMatchObject({ success: false });
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown scope before dispatching search_federation_threads", async () => {
+    const handler = vi.fn();
+    const router = buildPwrAgentFederationToolRouter(handler);
+
+    const response = await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "search_federation_threads",
+        arguments: { query: "recorder crash", scope: "nearby" },
+      },
+    });
+
+    expect(response).toMatchObject({ success: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("rejects an out-of-range list limit before dispatching list_federation_instances", async () => {
+    const handler = vi.fn();
+    const router = buildPwrAgentFederationToolRouter(handler);
+
+    const response = await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "list_federation_instances",
+        arguments: { limit: 500 },
+      },
+    });
+
+    expect(response).toMatchObject({ success: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("normalizes list_federation_instances filter args before dispatch", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        federationEnabled: true,
+        instances: [],
+        totalCount: 0,
+      },
+    }));
+    const router = buildPwrAgentFederationToolRouter(handler);
+
+    await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "list_federation_instances",
+        arguments: { query: " linux ", limit: 10 },
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith({
+      operation: "list_federation_instances",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        callId: "call-1",
+        turnId: "turn-1",
+      },
+      args: { query: "linux", limit: 10 },
+    });
   });
 
   it("rejects an out-of-range limit before dispatching search_federation_threads", async () => {

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  PWRAGENT_FEDERATION_UNAVAILABLE_MESSAGE,
+  buildPwrAgentFederationToolRouter,
+} from "../pwragent-federation-agent-tools";
+
+describe("pwragent federation agent tools", () => {
+  it("projects the federation tools under the unified pwragent namespace", () => {
+    const router = buildPwrAgentFederationToolRouter(undefined);
+
+    expect(router.buildDynamicToolSpecs()).toEqual([
+      {
+        type: "namespace",
+        name: "pwragent",
+        description: expect.stringContaining("PwrAgent"),
+        tools: expect.arrayContaining([
+          expect.objectContaining({
+            type: "function",
+            name: "list_federation_instances",
+            deferLoading: false,
+            description: expect.stringContaining("purpose notes"),
+            inputSchema: expect.objectContaining({
+              type: "object",
+              additionalProperties: false,
+            }),
+          }),
+          expect.objectContaining({
+            type: "function",
+            name: "list_instance_projects",
+            deferLoading: false,
+            description: expect.stringContaining("list_federation_instances"),
+            inputSchema: expect.objectContaining({
+              required: ["instanceId"],
+            }),
+          }),
+          expect.objectContaining({
+            type: "function",
+            name: "create_instance_thread",
+            deferLoading: false,
+            description: expect.stringContaining("~/.pwragent/AGENTS.md"),
+            inputSchema: expect.objectContaining({
+              required: ["instanceId", "projectKey"],
+              properties: expect.objectContaining({
+                workMode: expect.objectContaining({
+                  enum: ["local", "worktree"],
+                }),
+              }),
+            }),
+          }),
+          expect.objectContaining({
+            type: "function",
+            name: "search_federation_threads",
+            deferLoading: false,
+            description: expect.stringContaining("every reachable PwrAgent instance"),
+            inputSchema: expect.objectContaining({
+              required: ["query"],
+            }),
+          }),
+        ]),
+      },
+    ]);
+  });
+
+  it("reports the unavailable message when no handler is wired", async () => {
+    const router = buildPwrAgentFederationToolRouter(undefined);
+
+    await expect(
+      router.handleDynamicToolCall({
+        backend: "codex",
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: "pwragent",
+          tool: "list_federation_instances",
+          arguments: {},
+        },
+      }),
+    ).resolves.toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: JSON.stringify(
+            {
+              code: "internal_error",
+              message: PWRAGENT_FEDERATION_UNAVAILABLE_MESSAGE,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("rejects a blank instanceId before dispatching list_instance_projects", async () => {
+    const handler = vi.fn();
+    const router = buildPwrAgentFederationToolRouter(handler);
+
+    const response = await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "list_instance_projects",
+        arguments: { instanceId: "   " },
+      },
+    });
+
+    expect(response).toMatchObject({ success: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown workMode before dispatching create_instance_thread", async () => {
+    const handler = vi.fn();
+    const router = buildPwrAgentFederationToolRouter(handler);
+
+    const response = await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "create_instance_thread",
+        arguments: {
+          instanceId: "pwr_studio",
+          projectKey: "dir:/repo",
+          workMode: "container",
+        },
+      },
+    });
+
+    expect(response).toMatchObject({ success: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("rejects an out-of-range limit before dispatching search_federation_threads", async () => {
+    const handler = vi.fn();
+    const router = buildPwrAgentFederationToolRouter(handler);
+
+    const response = await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "search_federation_threads",
+        arguments: { query: "recorder crash", limit: 500 },
+      },
+    });
+
+    expect(response).toMatchObject({ success: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("normalizes create_instance_thread args before dispatch", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        instanceId: "pwr_studio",
+        instanceLabel: "Studio Mac",
+        isLocal: false,
+        backend: "codex" as const,
+        threadId: "thread-2",
+        executionMode: "default" as const,
+        workMode: "worktree" as const,
+        message: "Created thread in PwrSnap on Studio Mac.",
+      },
+    }));
+    const router = buildPwrAgentFederationToolRouter(handler);
+
+    const response = await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "create_instance_thread",
+        arguments: {
+          instanceId: " pwr_studio ",
+          projectKey: " dir:/Users/op/pwrsnap ",
+          input: " Fix the recorder crash ",
+          workMode: "worktree",
+          branchName: " origin/main ",
+          fastMode: true,
+        },
+      },
+    });
+
+    expect(response).toMatchObject({ success: true });
+    expect(handler).toHaveBeenCalledWith({
+      operation: "create_instance_thread",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        callId: "call-1",
+        turnId: "turn-1",
+      },
+      args: {
+        instanceId: "pwr_studio",
+        projectKey: "dir:/Users/op/pwrsnap",
+        input: "Fix the recorder crash",
+        workMode: "worktree",
+        branchName: "origin/main",
+        fastMode: true,
+      },
+    });
+  });
+
+  it("normalizes search_federation_threads args before dispatch", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        query: "recorder crash",
+        results: [],
+        searchedInstances: [],
+        failures: [],
+      },
+    }));
+    const router = buildPwrAgentFederationToolRouter(handler);
+
+    await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "search_federation_threads",
+        arguments: { query: " recorder crash ", instanceId: " pwr_studio ", limit: 5 },
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith({
+      operation: "search_federation_threads",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        callId: "call-1",
+        turnId: "turn-1",
+      },
+      args: {
+        query: "recorder crash",
+        instanceId: "pwr_studio",
+        limit: 5,
+      },
+    });
+  });
+});

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-task-monitor-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-task-monitor-agent-tools.test.ts
@@ -30,7 +30,7 @@ describe("PwrAgent task monitor agent tools", () => {
       "render_messaging_pdf_pages",
       "search_messaging_pdf_text",
     ]);
-    expect(dynamicTools).toHaveLength(26);
+    expect(dynamicTools).toHaveLength(30);
     expect(mcpTools).toEqual(
       dynamicTools.filter((tool) => !dynamicOnlyToolNames.has(tool.name)),
     );

--- a/apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts
+++ b/apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts
@@ -28,6 +28,10 @@ import {
   buildPwrAgentTaskMonitorToolDefinitions,
   type PwrAgentTaskMonitorHandler,
 } from "./pwragent-task-monitor-agent-tools.js";
+import {
+  buildPwrAgentFederationToolRouter,
+  type PwrAgentFederationHandler,
+} from "./pwragent-federation-agent-tools.js";
 import { AgentToolRouter } from "./agent-tool-router.js";
 
 export type ResolvedAgentToolCatalog = {
@@ -40,6 +44,7 @@ export type ResolvedAgentToolCatalog = {
 export function resolveAgentToolCatalogs(params: {
   appManagementHandler?: PwrAgentAppManagementHandler;
   automationInspectionHandler?: AutomationInspectionHandler;
+  federationHandler?: PwrAgentFederationHandler;
   messagingHandler?: PwrAgentMessagingHandler;
   taskMonitorHandler?: PwrAgentTaskMonitorHandler;
   threadInspectionHandler?: PwrAgentThreadInspectionHandler;
@@ -65,6 +70,10 @@ export function resolveAgentToolCatalogs(params: {
   );
   const threadOrchestrationDynamicTools =
     threadOrchestrationRouter.buildDynamicToolSpecs();
+  const federationRouter = buildPwrAgentFederationToolRouter(
+    params.federationHandler,
+  );
+  const federationDynamicTools = federationRouter.buildDynamicToolSpecs();
   return [
     {
       id: "automation_inspection",
@@ -143,6 +152,22 @@ export function resolveAgentToolCatalogs(params: {
           id: "thread_orchestration",
           namespace: PWRAGENT_TOOL_NAMESPACE,
           tools: threadOrchestrationDynamicTools,
+        }),
+      },
+    },
+    {
+      id: "federation",
+      dynamicTools: federationDynamicTools,
+      router: federationRouter,
+      summary: {
+        id: "federation",
+        namespace: PWRAGENT_TOOL_NAMESPACE,
+        enabled: true,
+        toolCount: countDynamicTools(federationDynamicTools),
+        fingerprint: buildCatalogFingerprint({
+          id: "federation",
+          namespace: PWRAGENT_TOOL_NAMESPACE,
+          tools: federationDynamicTools,
         }),
       },
     },

--- a/apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts
@@ -1,5 +1,6 @@
 import type {
   CreateInstanceThreadToolArgs,
+  FederationSearchScope,
   ListFederationInstancesToolArgs,
   ListInstanceProjectsToolArgs,
   PwrAgentFederationOperationName,
@@ -9,6 +10,7 @@ import type {
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import {
+  FEDERATION_SEARCH_SCOPES,
   PWRAGENT_FEDERATION_OPERATION_NAMES,
   PWRAGENT_TOOL_NAMESPACE,
 } from "@pwragent/shared";
@@ -90,13 +92,13 @@ function descriptionForOperation(
 ): string {
   switch (operation) {
     case "list_federation_instances":
-      return "List every PwrAgent instance this app can reach: the local instance plus any federated peers, each with its id, display label, celestial icon, operator-written purpose notes, connection status, capabilities, and an isLocal flag. Use this first when the user wants work routed to a particular machine ('on the studio Mac', 'on the rack mini') or when deciding where a task should run — the purpose notes describe what each machine is for. Works with federation disabled too: the result is then just the local instance, so there is no need to check whether federation is configured before calling. Only instances with status connected (or the local instance) can accept new work.";
+      return "List the PwrAgent instances this app can reach: the local instance plus any federated peers, each with its id, display label, celestial icon, operator-written purpose notes, connection status, capabilities, an isLocal flag, and host facts (OS platform/version, hostname, CPU architecture and count, total RAM, free disk, machineId). Use this first when the user wants work routed to a particular machine ('on the studio Mac', 'on the rack mini') or for 'find me a place to run this' requests — purpose notes describe intent, host facts describe capability. Instances sharing the same host.machineId are profiles on one physical machine and compete for the same CPUs/RAM — never sum their capacity. Disk/host figures are snapshots from the last handshake, not live readings. Results are paged: at most `limit` rows (default 25) per call, with nextCursor and totalCount when more remain; pass nextCursor back promptly (tokens expire after about a minute), or better, use `query` to filter by label, notes, profile, hostname, platform, or architecture instead of paging through a large fleet. Works with federation disabled too: the result is then just the local instance, so there is no need to check whether federation is configured before calling. Only instances with status connected (or the local instance) can accept new work.";
     case "list_instance_projects":
       return "List the projects/directories available on one PwrAgent instance, local or remote. Pass an instanceId from list_federation_instances. Each project row carries the key to pass to create_instance_thread as projectKey, plus its label, filesystem path, and whether a launchpad (per-project environment, model, and execution-mode presets) is configured. Use this to find the project the user is talking about on the chosen instance before creating a thread there.";
     case "create_instance_thread":
       return "Create and start a new PwrAgent thread in a project on a chosen instance, local or remote. Pass instanceId from list_federation_instances and projectKey from list_instance_projects; input becomes the first prompt of the created thread. Omitted settings inherit the project's launchpad presets, then the instance defaults — only pass model/executionMode/workMode overrides the user asked for. Consult ~/.pwragent/AGENTS.md (when it exists) for the operator's thread-startup preferences such as default projects and settings before choosing values. For delegating work on the local instance from an ordinary thread, prefer handoff_task, which offers richer workspace and grouping options; use create_instance_thread when targeting another instance or when routing intake work by instance. Thread startup can take minutes while a worktree or environment is prepared; if this call is slow, do not call it again — use search_federation_threads to check whether the thread appeared. When the result includes threadLink, include it verbatim when telling the user about the thread so it renders as a clickable chip; a bare threadId is a dead end for the user. Remote-instance results carry no threadLink yet — name the instance label instead.";
     case "search_federation_threads":
-      return "Search threads across every reachable PwrAgent instance, including the local one, in a single call — use it to find 'the PwrSnap thread about X' wherever it lives. Pass instanceId to scope the search to one instance. Results carry the owning instanceId, its display label, and an isLocal flag; failures lists peers that could not be searched. This is a metadata search (titles, summaries, project paths). For deeper local-only search with transcript content modes, use search_threads instead. When mentioning a local result to the user, include its threadLink verbatim so it renders as a clickable chip.";
+      return "Search threads across every reachable PwrAgent instance, including the local one, in a single call — use it to find 'the PwrSnap thread about X' wherever it lives. Use scope to pick the search surface: `all` (default) is local plus every connected peer, `local` is this instance only, and `remote` is every connected peer excluding local — the right choice when the user knows the thread is not on this machine. Pass instanceId to target one specific instance; scope and instanceId intersect when both are given. Results carry the owning instanceId, its display label, and an isLocal flag; failures lists peers that could not be searched. This is a metadata search (titles, summaries, project paths). For deeper local-only search with transcript content modes, use search_threads instead. When mentioning a local result to the user, include its threadLink verbatim so it renders as a clickable chip.";
   }
 }
 
@@ -108,7 +110,24 @@ function inputSchemaForOperation(
       return {
         type: "object",
         additionalProperties: false,
-        properties: {},
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "Optional case-insensitive substring filter matched against label, purpose notes, profile name, instance id, hostname, OS platform/version, and CPU architecture. Prefer filtering over paging through a large fleet. Ignored when cursor is set.",
+          },
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 100,
+            description: "Page size. Defaults to 25.",
+          },
+          cursor: {
+            type: "string",
+            description:
+              "Continuation token from a previous truncated result. Tokens expire after about a minute; on an expired-cursor error, call again without a cursor.",
+          },
+        },
       };
     case "list_instance_projects":
       return {
@@ -170,16 +189,22 @@ function inputSchemaForOperation(
             type: "string",
             description: "Search text matched against thread titles, summaries, and project paths.",
           },
+          scope: {
+            type: "string",
+            enum: FEDERATION_SEARCH_SCOPES,
+            description:
+              "`all` (default) searches the local instance plus every connected peer. `local` searches only this instance. `remote` searches every connected peer and excludes local — use it when the thread is known to live on another machine.",
+          },
           instanceId: {
             type: "string",
             description:
-              "Optional instance id to search only that instance. Omitted searches the local instance and every connected peer.",
+              "Optional instance id to search only that instance. Intersects with scope when both are given.",
           },
           limit: {
             type: "integer",
             minimum: 1,
             maximum: 200,
-            description: "Maximum results across all instances. Defaults to 20.",
+            description: "Maximum results across all instances. Defaults to 50.",
           },
         },
       };
@@ -197,7 +222,7 @@ function normalizeArgsForOperation(
   | undefined {
   switch (operation) {
     case "list_federation_instances":
-      return {};
+      return normalizeListFederationInstancesArgs(args);
     case "list_instance_projects":
       return normalizeListInstanceProjectsArgs(args);
     case "create_instance_thread":
@@ -212,14 +237,43 @@ function invalidArgumentsMessageForOperation(
 ): string {
   switch (operation) {
     case "list_federation_instances":
-      return "list_federation_instances accepts no arguments.";
+      return "list_federation_instances accepts an optional non-empty query, an integer limit between 1 and 100, and an optional non-empty cursor.";
     case "list_instance_projects":
       return "list_instance_projects requires a non-empty instanceId string.";
     case "create_instance_thread":
       return "create_instance_thread requires non-empty instanceId and projectKey strings, and accepts only known workMode values.";
     case "search_federation_threads":
-      return "search_federation_threads requires a non-empty query string; limit must be an integer between 1 and 200.";
+      return "search_federation_threads requires a non-empty query string; scope must be all, local, or remote; limit must be an integer between 1 and 200.";
   }
+}
+
+function normalizeListFederationInstancesArgs(
+  args: Record<string, unknown>,
+): ListFederationInstancesToolArgs | undefined {
+  for (const field of ["query", "cursor"] as const) {
+    if (Object.hasOwn(args, field) && !readTrimmedString(args[field])) {
+      return undefined;
+    }
+  }
+  let limit: number | undefined;
+  if (args.limit !== undefined) {
+    if (
+      typeof args.limit !== "number"
+      || !Number.isInteger(args.limit)
+      || args.limit < 1
+      || args.limit > 100
+    ) {
+      return undefined;
+    }
+    limit = args.limit;
+  }
+  const query = readTrimmedString(args.query);
+  const cursor = readTrimmedString(args.cursor);
+  return {
+    ...(query ? { query } : {}),
+    ...(limit !== undefined ? { limit } : {}),
+    ...(cursor ? { cursor } : {}),
+  };
 }
 
 function normalizeListInstanceProjectsArgs(
@@ -289,6 +343,13 @@ function normalizeSearchFederationThreadsArgs(
   if (Object.hasOwn(args, "instanceId") && !readTrimmedString(args.instanceId)) {
     return undefined;
   }
+  const scope =
+    args.scope === undefined
+      ? undefined
+      : readChoice(args.scope, FEDERATION_SEARCH_SCOPES);
+  if (args.scope !== undefined && !scope) {
+    return undefined;
+  }
   let limit: number | undefined;
   if (args.limit !== undefined) {
     if (
@@ -304,6 +365,7 @@ function normalizeSearchFederationThreadsArgs(
   const instanceId = readTrimmedString(args.instanceId);
   return {
     query,
+    ...(scope ? { scope: scope as FederationSearchScope } : {}),
     ...(instanceId ? { instanceId } : {}),
     ...(limit !== undefined ? { limit } : {}),
   };

--- a/apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts
@@ -1,0 +1,336 @@
+import type {
+  CreateInstanceThreadToolArgs,
+  ListFederationInstancesToolArgs,
+  ListInstanceProjectsToolArgs,
+  PwrAgentFederationOperationName,
+  PwrAgentFederationRequest,
+  PwrAgentFederationResponse,
+  SearchFederationThreadsToolArgs,
+  ThreadExecutionMode,
+} from "@pwragent/shared";
+import {
+  PWRAGENT_FEDERATION_OPERATION_NAMES,
+  PWRAGENT_TOOL_NAMESPACE,
+} from "@pwragent/shared";
+import type {
+  AgentToolDefinition,
+  AgentToolDispatchResult,
+} from "./agent-tool-definition.js";
+import {
+  agentToolFailure,
+  agentToolSuccess,
+} from "./agent-tool-definition.js";
+import { AgentToolRouter } from "./agent-tool-router.js";
+
+export const PWRAGENT_FEDERATION_UNAVAILABLE_MESSAGE =
+  "PwrAgent federation tools are not available.";
+
+const LAUNCHPAD_WORK_MODES = ["local", "worktree"] as const;
+
+export type PwrAgentFederationHandler = (
+  request: PwrAgentFederationRequest,
+) => PwrAgentFederationResponse | Promise<PwrAgentFederationResponse>;
+
+export function buildPwrAgentFederationToolRouter(
+  handler: PwrAgentFederationHandler | undefined,
+  options: { namespace?: string; unsupportedMessage?: string } = {},
+): AgentToolRouter {
+  return new AgentToolRouter(
+    buildPwrAgentFederationToolDefinitions(handler, {
+      namespace: options.namespace,
+    }),
+    {
+      unsupportedMessage:
+        options.unsupportedMessage ?? "Unsupported PwrAgent federation tool.",
+    },
+  );
+}
+
+export function buildPwrAgentFederationToolDefinitions(
+  handler: PwrAgentFederationHandler | undefined,
+  options: { namespace?: string } = {},
+): AgentToolDefinition<PwrAgentFederationOperationName>[] {
+  return PWRAGENT_FEDERATION_OPERATION_NAMES.map((operation) => ({
+    namespace: options.namespace ?? PWRAGENT_TOOL_NAMESPACE,
+    name: operation,
+    description: descriptionForOperation(operation),
+    inputSchema: inputSchemaForOperation(operation),
+    deferLoading: false,
+    dispatch: async (args, context): Promise<AgentToolDispatchResult> => {
+      if (!handler) {
+        return agentToolFailure({
+          code: "internal_error",
+          message: PWRAGENT_FEDERATION_UNAVAILABLE_MESSAGE,
+        });
+      }
+      const normalizedArgs = normalizeArgsForOperation(operation, args);
+      if (!normalizedArgs) {
+        return agentToolFailure({
+          code: "invalid_arguments",
+          message: invalidArgumentsMessageForOperation(operation),
+        });
+      }
+      const response = await handler({
+        operation,
+        context: {
+          backend: context.backend,
+          threadId: context.threadId,
+          callId: context.callId,
+          turnId: context.turnId,
+        },
+        args: normalizedArgs,
+      } as PwrAgentFederationRequest);
+      return federationResponseToAgentToolResult(response);
+    },
+  }));
+}
+
+function descriptionForOperation(
+  operation: PwrAgentFederationOperationName,
+): string {
+  switch (operation) {
+    case "list_federation_instances":
+      return "List every PwrAgent instance this app can reach: the local instance plus any federated peers, each with its id, display label, celestial icon, operator-written purpose notes, connection status, capabilities, and an isLocal flag. Use this first when the user wants work routed to a particular machine ('on the studio Mac', 'on the rack mini') or when deciding where a task should run — the purpose notes describe what each machine is for. Works with federation disabled too: the result is then just the local instance, so there is no need to check whether federation is configured before calling. Only instances with status connected (or the local instance) can accept new work.";
+    case "list_instance_projects":
+      return "List the projects/directories available on one PwrAgent instance, local or remote. Pass an instanceId from list_federation_instances. Each project row carries the key to pass to create_instance_thread as projectKey, plus its label, filesystem path, and whether a launchpad (per-project environment, model, and execution-mode presets) is configured. Use this to find the project the user is talking about on the chosen instance before creating a thread there.";
+    case "create_instance_thread":
+      return "Create and start a new PwrAgent thread in a project on a chosen instance, local or remote. Pass instanceId from list_federation_instances and projectKey from list_instance_projects; input becomes the first prompt of the created thread. Omitted settings inherit the project's launchpad presets, then the instance defaults — only pass model/executionMode/workMode overrides the user asked for. Consult ~/.pwragent/AGENTS.md (when it exists) for the operator's thread-startup preferences such as default projects and settings before choosing values. For delegating work on the local instance from an ordinary thread, prefer handoff_task, which offers richer workspace and grouping options; use create_instance_thread when targeting another instance or when routing intake work by instance. Thread startup can take minutes while a worktree or environment is prepared; if this call is slow, do not call it again — use search_federation_threads to check whether the thread appeared. When the result includes threadLink, include it verbatim when telling the user about the thread so it renders as a clickable chip; a bare threadId is a dead end for the user. Remote-instance results carry no threadLink yet — name the instance label instead.";
+    case "search_federation_threads":
+      return "Search threads across every reachable PwrAgent instance, including the local one, in a single call — use it to find 'the PwrSnap thread about X' wherever it lives. Pass instanceId to scope the search to one instance. Results carry the owning instanceId, its display label, and an isLocal flag; failures lists peers that could not be searched. This is a metadata search (titles, summaries, project paths). For deeper local-only search with transcript content modes, use search_threads instead. When mentioning a local result to the user, include its threadLink verbatim so it renders as a clickable chip.";
+  }
+}
+
+function inputSchemaForOperation(
+  operation: PwrAgentFederationOperationName,
+): Record<string, unknown> {
+  switch (operation) {
+    case "list_federation_instances":
+      return {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      };
+    case "list_instance_projects":
+      return {
+        type: "object",
+        additionalProperties: false,
+        required: ["instanceId"],
+        properties: {
+          instanceId: {
+            type: "string",
+            description:
+              "Instance id from list_federation_instances. The local instance id is accepted too.",
+          },
+        },
+      };
+    case "create_instance_thread":
+      return {
+        type: "object",
+        additionalProperties: false,
+        required: ["instanceId", "projectKey"],
+        properties: {
+          instanceId: {
+            type: "string",
+            description: "Target instance id from list_federation_instances.",
+          },
+          projectKey: {
+            type: "string",
+            description:
+              "Project directory key from list_instance_projects on the same instance.",
+          },
+          input: {
+            type: "string",
+            description:
+              "Initial prompt for the created thread's first turn. Include the concrete task, not the parent transcript.",
+          },
+          model: { type: "string" },
+          reasoningEffort: { type: "string" },
+          executionMode: { type: "string" },
+          fastMode: { type: "boolean" },
+          workMode: {
+            type: "string",
+            enum: LAUNCHPAD_WORK_MODES,
+            description:
+              "`worktree` runs the thread in an isolated Git worktree; `local` uses the project checkout directly. Omitted inherits the project's launchpad preset.",
+          },
+          branchName: {
+            type: "string",
+            description:
+              "Optional existing base branch/ref for workMode=worktree, for example `origin/main`. This is not a new feature branch name.",
+          },
+        },
+      };
+    case "search_federation_threads":
+      return {
+        type: "object",
+        additionalProperties: false,
+        required: ["query"],
+        properties: {
+          query: {
+            type: "string",
+            description: "Search text matched against thread titles, summaries, and project paths.",
+          },
+          instanceId: {
+            type: "string",
+            description:
+              "Optional instance id to search only that instance. Omitted searches the local instance and every connected peer.",
+          },
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 200,
+            description: "Maximum results across all instances. Defaults to 20.",
+          },
+        },
+      };
+  }
+}
+
+function normalizeArgsForOperation(
+  operation: PwrAgentFederationOperationName,
+  args: Record<string, unknown>,
+):
+  | ListFederationInstancesToolArgs
+  | ListInstanceProjectsToolArgs
+  | CreateInstanceThreadToolArgs
+  | SearchFederationThreadsToolArgs
+  | undefined {
+  switch (operation) {
+    case "list_federation_instances":
+      return {};
+    case "list_instance_projects":
+      return normalizeListInstanceProjectsArgs(args);
+    case "create_instance_thread":
+      return normalizeCreateInstanceThreadArgs(args);
+    case "search_federation_threads":
+      return normalizeSearchFederationThreadsArgs(args);
+  }
+}
+
+function invalidArgumentsMessageForOperation(
+  operation: PwrAgentFederationOperationName,
+): string {
+  switch (operation) {
+    case "list_federation_instances":
+      return "list_federation_instances accepts no arguments.";
+    case "list_instance_projects":
+      return "list_instance_projects requires a non-empty instanceId string.";
+    case "create_instance_thread":
+      return "create_instance_thread requires non-empty instanceId and projectKey strings, and accepts only known workMode values.";
+    case "search_federation_threads":
+      return "search_federation_threads requires a non-empty query string; limit must be an integer between 1 and 200.";
+  }
+}
+
+function normalizeListInstanceProjectsArgs(
+  args: Record<string, unknown>,
+): ListInstanceProjectsToolArgs | undefined {
+  const instanceId = readTrimmedString(args.instanceId);
+  if (!instanceId) {
+    return undefined;
+  }
+  return { instanceId };
+}
+
+function normalizeCreateInstanceThreadArgs(
+  args: Record<string, unknown>,
+): CreateInstanceThreadToolArgs | undefined {
+  const instanceId = readTrimmedString(args.instanceId);
+  const projectKey = readTrimmedString(args.projectKey);
+  if (!instanceId || !projectKey) {
+    return undefined;
+  }
+  const workMode =
+    args.workMode === undefined
+      ? undefined
+      : readChoice(args.workMode, LAUNCHPAD_WORK_MODES);
+  if (args.workMode !== undefined && !workMode) {
+    return undefined;
+  }
+  const optionalStringFields = [
+    "input",
+    "model",
+    "reasoningEffort",
+    "executionMode",
+    "branchName",
+  ] as const;
+  for (const field of optionalStringFields) {
+    if (Object.hasOwn(args, field) && !readTrimmedString(args[field])) {
+      return undefined;
+    }
+  }
+  const input = readTrimmedString(args.input);
+  const model = readTrimmedString(args.model);
+  const reasoningEffort = readTrimmedString(args.reasoningEffort);
+  const executionMode = readTrimmedString(args.executionMode);
+  const branchName = readTrimmedString(args.branchName);
+  return {
+    instanceId,
+    projectKey,
+    ...(input ? { input } : {}),
+    ...(model ? { model } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+    ...(executionMode
+      ? { executionMode: executionMode as ThreadExecutionMode }
+      : {}),
+    ...(typeof args.fastMode === "boolean" ? { fastMode: args.fastMode } : {}),
+    ...(workMode ? { workMode } : {}),
+    ...(branchName ? { branchName } : {}),
+  };
+}
+
+function normalizeSearchFederationThreadsArgs(
+  args: Record<string, unknown>,
+): SearchFederationThreadsToolArgs | undefined {
+  const query = readTrimmedString(args.query);
+  if (!query) {
+    return undefined;
+  }
+  if (Object.hasOwn(args, "instanceId") && !readTrimmedString(args.instanceId)) {
+    return undefined;
+  }
+  let limit: number | undefined;
+  if (args.limit !== undefined) {
+    if (
+      typeof args.limit !== "number"
+      || !Number.isInteger(args.limit)
+      || args.limit < 1
+      || args.limit > 200
+    ) {
+      return undefined;
+    }
+    limit = args.limit;
+  }
+  const instanceId = readTrimmedString(args.instanceId);
+  return {
+    query,
+    ...(instanceId ? { instanceId } : {}),
+    ...(limit !== undefined ? { limit } : {}),
+  };
+}
+
+function readTrimmedString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readChoice<TValue extends string>(
+  value: unknown,
+  choices: readonly TValue[],
+): TValue | undefined {
+  return typeof value === "string" && choices.includes(value as TValue)
+    ? (value as TValue)
+    : undefined;
+}
+
+function federationResponseToAgentToolResult(
+  response: PwrAgentFederationResponse,
+): AgentToolDispatchResult {
+  if (response.ok) {
+    return agentToolSuccess(response.data);
+  }
+  return agentToolFailure({
+    code: response.error.code,
+    message: response.error.message,
+    data: response.error.data,
+  });
+}

--- a/apps/desktop/src/main/agent-tools/pwragent-federation-codex-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-federation-codex-tools.ts
@@ -1,0 +1,65 @@
+import type {
+  AppServerBackendKind,
+  PwrAgentFederationOperationName,
+} from "@pwragent/shared";
+import {
+  PWRAGENT_FEDERATION_OPERATION_NAMES,
+  PWRAGENT_TOOL_NAMESPACE,
+} from "@pwragent/shared";
+import type {
+  DynamicToolCallParams,
+  DynamicToolCallResponse,
+} from "@pwrdrvr/codex-app-server-protocol/v2";
+import {
+  readAgentDynamicToolCall,
+  toDynamicToolResponse,
+} from "./agent-tool-router.js";
+import {
+  buildPwrAgentFederationToolRouter,
+  type PwrAgentFederationHandler,
+} from "./pwragent-federation-agent-tools.js";
+
+export function isPwrAgentFederationDynamicToolCall(
+  call: Pick<DynamicToolCallParams, "namespace" | "tool">,
+): call is DynamicToolCallParams & {
+  namespace: typeof PWRAGENT_TOOL_NAMESPACE;
+  tool: PwrAgentFederationOperationName;
+} {
+  return (
+    call.namespace === PWRAGENT_TOOL_NAMESPACE &&
+    PWRAGENT_FEDERATION_OPERATION_NAMES.includes(
+      call.tool as PwrAgentFederationOperationName,
+    )
+  );
+}
+
+export async function handlePwrAgentFederationDynamicToolCall(params: {
+  backend: AppServerBackendKind;
+  call: DynamicToolCallParams;
+  handler: PwrAgentFederationHandler | undefined;
+}): Promise<DynamicToolCallResponse> {
+  return await buildPwrAgentFederationToolRouter(
+    params.handler,
+  ).handleDynamicToolCall({
+    backend: params.backend,
+    call: params.call,
+  });
+}
+
+export function buildPwrAgentFederationDynamicToolErrorResponse(params: {
+  code: "forbidden" | "internal_error";
+  message: string;
+}): DynamicToolCallResponse {
+  return toDynamicToolResponse({
+    ok: false,
+    code: params.code,
+    message: params.message,
+  });
+}
+
+export function readPwrAgentFederationDynamicToolCall(request: {
+  method: string;
+  params: Record<string, unknown>;
+}): DynamicToolCallParams | undefined {
+  return readAgentDynamicToolCall(request);
+}

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -344,6 +344,13 @@ import {
   readPwrAgentThreadOrchestrationDynamicToolCall,
 } from "../agent-tools/pwragent-thread-orchestration-codex-tools";
 import type { PwrAgentThreadOrchestrationHandler } from "../agent-tools/pwragent-thread-orchestration-agent-tools";
+import {
+  buildPwrAgentFederationDynamicToolErrorResponse,
+  handlePwrAgentFederationDynamicToolCall,
+  isPwrAgentFederationDynamicToolCall,
+  readPwrAgentFederationDynamicToolCall,
+} from "../agent-tools/pwragent-federation-codex-tools";
+import type { PwrAgentFederationHandler } from "../agent-tools/pwragent-federation-agent-tools";
 import type { MessagingAgentToolService } from "../messaging/messaging-agent-tool-service";
 import { resolveAutomationInspectionMcpCommand } from "../automations/automation-inspection-cli";
 import { resolveAgentToolCatalogs } from "../agent-tools/agent-tool-catalog-registry";
@@ -6403,6 +6410,7 @@ export class DesktopBackendRegistry {
     async (request) => await this.handleThreadInspectionRequest(request);
   private readonly threadOrchestrationHandler: PwrAgentThreadOrchestrationHandler =
     async (request) => await this.handleThreadOrchestrationRequest(request);
+  private federationHandler: PwrAgentFederationHandler | undefined;
   private threadPullRequestStatusToolHandler:
     | ThreadPullRequestStatusToolHandler
     | undefined;
@@ -6776,6 +6784,7 @@ export class DesktopBackendRegistry {
               resolveAgentToolCatalogs({
                 appManagementHandler: this.appManagementHandler,
                 automationInspectionHandler: this.automationInspectionHandler,
+                federationHandler: this.federationHandler,
                 messagingHandler: this.messagingHandler,
                 taskMonitorHandler: async (request) =>
                   await this.handleAgentTaskMonitorRequest(request),
@@ -7107,6 +7116,12 @@ export class DesktopBackendRegistry {
     handler: PwrAgentAppManagementHandler | null | undefined,
   ): void {
     this.appManagementHandler = handler ?? undefined;
+  }
+
+  setPwrAgentFederationHandler(
+    handler: PwrAgentFederationHandler | null | undefined,
+  ): void {
+    this.federationHandler = handler ?? undefined;
   }
 
   setThreadPullRequestStatusToolHandler(
@@ -10002,6 +10017,7 @@ export class DesktopBackendRegistry {
     const agentToolCatalogs = resolveAgentToolCatalogs({
       appManagementHandler: this.appManagementHandler,
       automationInspectionHandler: this.automationInspectionHandler,
+      federationHandler: this.federationHandler,
       messagingHandler: this.messagingHandler,
       taskMonitorHandler: async (request) =>
         await this.handleAgentTaskMonitorRequest(request),
@@ -20776,6 +20792,41 @@ export class DesktopBackendRegistry {
         backend,
         call: threadOrchestrationToolCall,
         handler: this.threadOrchestrationHandler,
+      });
+    }
+
+    const federationToolCall = readPwrAgentFederationDynamicToolCall({
+      method: request.method,
+      params: request.params,
+    });
+    if (federationToolCall && isPwrAgentFederationDynamicToolCall(federationToolCall)) {
+      if (!this.isLiveDynamicToolCall(backend, federationToolCall)) {
+        backendRegistryLog.warn("rejecting federation dynamic tool call", {
+          backend,
+          callId: federationToolCall.callId,
+          namespace: federationToolCall.namespace,
+          threadId: federationToolCall.threadId,
+          tool: federationToolCall.tool,
+          turnId: federationToolCall.turnId,
+        });
+        return buildPwrAgentFederationDynamicToolErrorResponse({
+          code: "forbidden",
+          message:
+            "Federation tool calls must originate from an active turn on the same thread.",
+        });
+      }
+      backendRegistryLog.info("handling federation dynamic tool call", {
+        backend,
+        callId: federationToolCall.callId,
+        namespace: federationToolCall.namespace,
+        threadId: federationToolCall.threadId,
+        tool: federationToolCall.tool,
+        turnId: federationToolCall.turnId,
+      });
+      return await handlePwrAgentFederationDynamicToolCall({
+        backend,
+        call: federationToolCall,
+        handler: this.federationHandler,
       });
     }
 

--- a/apps/desktop/src/main/federation/federation-agent-tools-service.ts
+++ b/apps/desktop/src/main/federation/federation-agent-tools-service.ts
@@ -1,0 +1,431 @@
+import type {
+  CreateInstanceThreadResult,
+  CreateInstanceThreadToolArgs,
+  FederationHealthStatus,
+  FederationInstanceDescriptor,
+  FederationInstanceId,
+  FederationRemoteTarget,
+  FederationThreadSearchResultSummary,
+  ListFederationInstancesResult,
+  ListInstanceProjectsResult,
+  ListInstanceProjectsToolArgs,
+  NavigationLaunchpadDraft,
+  NavigationSnapshot,
+  PwrAgentFederationErrorCode,
+  PwrAgentFederationResponse,
+  SearchFederationThreadsResult,
+  SearchFederationThreadsToolArgs,
+} from "@pwragent/shared";
+import {
+  FEDERATION_CAPABILITIES,
+  buildThreadMarkdownLink,
+  buildThreadUrl,
+  formatFederationPeerDisplayLabel,
+  isRemoteFederationTarget,
+} from "@pwragent/shared";
+import type { PwrAgentFederationHandler } from "../agent-tools/pwragent-federation-agent-tools";
+import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
+import { FederatedSearchService } from "./federated-search-service";
+import type { FederationBackendOperations } from "./federation-backend-bridge";
+import {
+  defaultInstanceLabel,
+  getDesktopFederationRuntime,
+  type DesktopFederationRuntime,
+} from "./federation-runtime";
+
+type ResolvedInstance = {
+  instanceId: FederationInstanceId;
+  label: string;
+  isLocal: boolean;
+  target?: FederationRemoteTarget;
+};
+
+/**
+ * Dispatches the `federation` agent-tool catalog. Lives in federation-land
+ * (not `BackendRegistry`) because the runtime already imports the registry —
+ * the registry only ever sees the injected handler, wired from
+ * `main/index.ts`.
+ *
+ * Everything remote rides the existing capability-gated federation RPCs
+ * (`thread_navigation`, `environment_actions`, `federated_search`), so
+ * agent-originated control is authorized exactly like operator-originated
+ * control: enrollment is the trust boundary, per the PR #1202 capability
+ * model. No agent-specific capability or allowlist exists by design — see
+ * docs/plans/2026-08-05-003-feat-federation-agent-tools-plan.md.
+ */
+export function createFederationAgentToolsHandler(
+  options: {
+    runtime?: () => DesktopFederationRuntime;
+  } = {},
+): PwrAgentFederationHandler {
+  const runtime = options.runtime ?? getDesktopFederationRuntime;
+  return async (request) => {
+    try {
+      if (request.operation === "list_federation_instances") {
+        return ok(await listFederationInstances(runtime()));
+      }
+      if (request.operation === "list_instance_projects") {
+        return await listInstanceProjects(runtime(), request.args);
+      }
+      if (request.operation === "create_instance_thread") {
+        return await createInstanceThread(runtime(), request.args);
+      }
+      return await searchFederationThreads(runtime(), request.args);
+    } catch (error) {
+      return failure(
+        classifyFederationToolError(error),
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  };
+}
+
+async function listFederationInstances(
+  runtime: DesktopFederationRuntime,
+): Promise<ListFederationInstancesResult> {
+  const health = await runtime.health();
+  const local = await localInstanceDescriptor(health);
+  const peers = health.peers.map((peer): FederationInstanceDescriptor => ({
+    instanceId: peer.id,
+    label: formatFederationPeerDisplayLabel(peer, health.peers),
+    isLocal: false,
+    status: peer.status,
+    capabilities: [...peer.capabilities],
+    role: peer.role,
+    notes: peer.notes,
+    icon: peer.icon,
+    profileName: peer.profileName,
+    unavailableReason: peer.unavailableReason,
+  }));
+  return {
+    federationEnabled: health.enabled,
+    instances: [local, ...peers],
+  };
+}
+
+async function listInstanceProjects(
+  runtime: DesktopFederationRuntime,
+  args: ListInstanceProjectsToolArgs,
+): Promise<PwrAgentFederationResponse> {
+  const resolved = await resolveInstance(runtime, args.instanceId);
+  if (!resolved.ok) {
+    return resolved.response;
+  }
+  const instance = resolved.instance;
+  const snapshot = await backendFor(runtime, instance).getNavigationSnapshot({});
+  const result: ListInstanceProjectsResult = {
+    instanceId: instance.instanceId,
+    instanceLabel: instance.label,
+    isLocal: instance.isLocal,
+    projects: snapshot.directories
+      .filter((directory) => directory.kind !== "unlinked")
+      .map((directory) => ({
+        key: directory.key,
+        label: directory.label,
+        kind: directory.kind,
+        path: directory.path,
+        hasLaunchpad: Boolean(directory.launchpad),
+        backend: directory.launchpad?.backend,
+        workMode: directory.launchpad?.workMode,
+        model: directory.launchpad?.model,
+        executionMode: directory.launchpad?.executionMode,
+      })),
+  };
+  return ok(result);
+}
+
+async function createInstanceThread(
+  runtime: DesktopFederationRuntime,
+  args: CreateInstanceThreadToolArgs,
+): Promise<PwrAgentFederationResponse> {
+  const resolved = await resolveInstance(runtime, args.instanceId);
+  if (!resolved.ok) {
+    return resolved.response;
+  }
+  const instance = resolved.instance;
+  const backend = backendFor(runtime, instance);
+  const snapshot = await backend.getNavigationSnapshot({});
+  const directory = snapshot.directories.find(
+    (candidate) => candidate.key === args.projectKey,
+  );
+  if (!directory) {
+    return failure(
+      "not_found",
+      `No project with key ${args.projectKey} on ${instance.label}. Use list_instance_projects for the current project list.`,
+    );
+  }
+  const draft = buildLaunchpadDraft({ snapshot, directory, args });
+  const response = await backend.materializeDirectoryLaunchpad({
+    directoryKey: args.projectKey,
+    launchpad: draft,
+    ...(args.input ? { input: [{ type: "text", text: args.input }] } : {}),
+  });
+  const result: CreateInstanceThreadResult = {
+    instanceId: instance.instanceId,
+    instanceLabel: instance.label,
+    isLocal: instance.isLocal,
+    backend: response.backend,
+    threadId: response.threadId,
+    executionMode: response.executionMode,
+    workMode: response.workMode,
+    turnId: response.turnId,
+    ...(instance.isLocal
+      ? {
+          threadUrl: buildThreadUrl({
+            threadId: response.threadId,
+            backend: response.backend,
+          }),
+          threadLink: buildThreadMarkdownLink({
+            threadId: response.threadId,
+            backend: response.backend,
+            title: directory.label,
+          }),
+        }
+      : {}),
+    message: instance.isLocal
+      ? `Created thread in ${directory.label}.`
+      : `Created thread in ${directory.label} on ${instance.label}.`,
+    turnStartFailure: response.turnStartFailure,
+    codexEnvironmentStartupFailure: response.codexEnvironmentStartupFailure,
+  };
+  return ok(result);
+}
+
+async function searchFederationThreads(
+  runtime: DesktopFederationRuntime,
+  args: SearchFederationThreadsToolArgs,
+): Promise<PwrAgentFederationResponse> {
+  const health = await runtime.health();
+  const localId = health.instanceId;
+  const local = await localInstanceDescriptor(health);
+  if (args.instanceId && args.instanceId !== localId) {
+    const resolved = await resolveInstance(runtime, args.instanceId);
+    if (!resolved.ok) {
+      return resolved.response;
+    }
+  }
+  const includeLocal = !args.instanceId || args.instanceId === localId;
+  const service = new FederatedSearchService({
+    includeLocal,
+    local: runtime.localBackend(),
+    peers: () =>
+      runtime
+        .connectedPeerTargets()
+        .filter((peer) => peer.capabilities.includes("federated_search"))
+        .filter(
+          (peer) =>
+            !args.instanceId || peer.target.instanceId === args.instanceId,
+        )
+        .map((peer) => ({
+          instanceId: peer.target.instanceId,
+          label: peer.label,
+          status: "connected" as const,
+          backend: runtime.remoteBackend(peer.target),
+        })),
+  });
+  const response = await service.search({
+    query: args.query,
+    limit: args.limit,
+  });
+  const results = response.results.map(
+    (entry): FederationThreadSearchResultSummary => {
+      const target = entry.ref.target;
+      const isLocal = !isRemoteFederationTarget(target);
+      return {
+        instanceId: isRemoteFederationTarget(target)
+          ? target.instanceId
+          : localId ?? "local",
+        instanceLabel: isLocal ? local.label : entry.instanceLabel,
+        isLocal,
+        backend: entry.thread.source,
+        threadId: entry.thread.id,
+        title: entry.thread.title,
+        updatedAt: entry.thread.updatedAt,
+        projectKey: entry.thread.projectKey,
+        gitBranch: entry.thread.gitBranch,
+        score: entry.score,
+        ...(isLocal
+          ? {
+              threadLink: buildThreadMarkdownLink({
+                threadId: entry.thread.id,
+                backend: entry.thread.source,
+                title: entry.thread.title,
+              }),
+            }
+          : {}),
+      };
+    },
+  );
+  const localResultCount = results.filter((entry) => entry.isLocal).length;
+  const result: SearchFederationThreadsResult = {
+    query: response.query,
+    results,
+    searchedInstances: [
+      ...(includeLocal && localId
+        ? [
+            {
+              instanceId: localId,
+              instanceLabel: local.label,
+              resultCount: localResultCount,
+            },
+          ]
+        : []),
+      ...response.searchedInstances ?? [],
+    ],
+    failures: response.failures,
+  };
+  return ok(result);
+}
+
+async function localInstanceDescriptor(
+  health: FederationHealthStatus,
+): Promise<FederationInstanceDescriptor> {
+  const settings = await getDesktopSettingsService().readSettings();
+  return {
+    instanceId: health.instanceId ?? "local",
+    label:
+      settings.federation.instanceLabel.value.trim() || defaultInstanceLabel(),
+    isLocal: true,
+    // Reachable by definition; health.status describes the federation
+    // listener, not this instance's ability to take work.
+    status: "connected",
+    capabilities: [...FEDERATION_CAPABILITIES],
+    role: health.role,
+    notes: settings.federation.instanceNotes.value.trim() || undefined,
+    profileName: undefined,
+  };
+}
+
+type ResolveInstanceOutcome =
+  | { ok: true; instance: ResolvedInstance }
+  | { ok: false; response: PwrAgentFederationResponse };
+
+async function resolveInstance(
+  runtime: DesktopFederationRuntime,
+  instanceId: FederationInstanceId,
+): Promise<ResolveInstanceOutcome> {
+  const health = await runtime.health();
+  if (instanceId === health.instanceId) {
+    const local = await localInstanceDescriptor(health);
+    return {
+      ok: true,
+      instance: {
+        instanceId,
+        label: local.label,
+        isLocal: true,
+      },
+    };
+  }
+  const peer = health.peers.find((candidate) => candidate.id === instanceId);
+  if (!peer) {
+    return {
+      ok: false,
+      response: failure(
+        "not_found",
+        `No federation instance with id ${instanceId}. Use list_federation_instances for the current instance list.`,
+      ),
+    };
+  }
+  if (peer.status !== "connected") {
+    return {
+      ok: false,
+      response: failure(
+        "peer_unavailable",
+        `Federation instance ${formatFederationPeerDisplayLabel(peer, health.peers)} is ${peer.status}.`,
+      ),
+    };
+  }
+  return {
+    ok: true,
+    instance: {
+      instanceId,
+      label: formatFederationPeerDisplayLabel(peer, health.peers),
+      isLocal: false,
+      target: { scope: "remote", instanceId },
+    },
+  };
+}
+
+function backendFor(
+  runtime: DesktopFederationRuntime,
+  instance: ResolvedInstance,
+): FederationBackendOperations {
+  return instance.isLocal || !instance.target
+    ? runtime.localBackend()
+    : runtime.remoteBackend(instance.target);
+}
+
+function buildLaunchpadDraft(params: {
+  snapshot: NavigationSnapshot;
+  directory: NavigationSnapshot["directories"][number];
+  args: CreateInstanceThreadToolArgs;
+}): NavigationLaunchpadDraft {
+  const { snapshot, directory, args } = params;
+  const defaults = snapshot.launchpadDefaults;
+  const stored = directory.launchpad;
+  // Inherit only the project's *settings* presets from a stored launchpad.
+  // The stored prompt/editor document/attachments are the operator's unsent
+  // draft — sending them from an agent tool would fire composer text the
+  // operator never submitted.
+  const model = args.model ?? stored?.model ?? defaults.model;
+  const reasoningEffort =
+    args.reasoningEffort ?? stored?.reasoningEffort ?? defaults.reasoningEffort;
+  const serviceTier = stored?.serviceTier ?? defaults.serviceTier;
+  const fastMode = args.fastMode ?? stored?.fastMode ?? defaults.fastMode;
+  const acpRuntime = stored?.acpRuntime ?? defaults.acpRuntime;
+  const providerSettings = stored?.providerSettings ?? defaults.providerSettings;
+  const branchName = args.branchName ?? stored?.branchName;
+  const now = Date.now();
+  return {
+    createdAt: stored?.createdAt ?? now,
+    updatedAt: now,
+    backend: stored?.backend ?? defaults.backend,
+    executionMode:
+      args.executionMode ?? stored?.executionMode ?? defaults.executionMode,
+    workMode: args.workMode ?? stored?.workMode ?? defaults.workMode ?? "worktree",
+    ...(model !== undefined ? { model } : {}),
+    ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
+    ...(serviceTier !== undefined ? { serviceTier } : {}),
+    ...(fastMode !== undefined ? { fastMode } : {}),
+    ...(acpRuntime !== undefined ? { acpRuntime } : {}),
+    ...(providerSettings !== undefined ? { providerSettings } : {}),
+    ...(stored?.mcpConnectionIds
+      ? { mcpConnectionIds: stored.mcpConnectionIds }
+      : {}),
+    directoryKey: directory.key,
+    directoryKind: directory.kind,
+    directoryLabel: directory.label,
+    ...(directory.path ? { directoryPath: directory.path } : {}),
+    prompt: "",
+    ...(branchName !== undefined ? { branchName } : {}),
+  };
+}
+
+function ok(
+  data: Extract<PwrAgentFederationResponse, { ok: true }>["data"],
+): PwrAgentFederationResponse {
+  return { ok: true, data };
+}
+
+function failure(
+  code: PwrAgentFederationErrorCode,
+  message: string,
+): PwrAgentFederationResponse {
+  return { ok: false, error: { code, message } };
+}
+
+function classifyFederationToolError(error: unknown): PwrAgentFederationErrorCode {
+  const message =
+    error instanceof Error ? error.message.toLowerCase() : String(error);
+  if (message.includes("capability_denied") || message.includes("forbidden")) {
+    return "forbidden";
+  }
+  if (
+    message.includes("not connected")
+    || message.includes("timed out")
+    || message.includes("timeout")
+  ) {
+    return "peer_unavailable";
+  }
+  return "internal_error";
+}

--- a/apps/desktop/src/main/federation/federation-agent-tools-service.ts
+++ b/apps/desktop/src/main/federation/federation-agent-tools-service.ts
@@ -1,12 +1,15 @@
+import { randomUUID } from "node:crypto";
 import type {
   CreateInstanceThreadResult,
   CreateInstanceThreadToolArgs,
   FederationHealthStatus,
+  FederationHostInfo,
   FederationInstanceDescriptor,
   FederationInstanceId,
   FederationRemoteTarget,
   FederationThreadSearchResultSummary,
   ListFederationInstancesResult,
+  ListFederationInstancesToolArgs,
   ListInstanceProjectsResult,
   ListInstanceProjectsToolArgs,
   NavigationLaunchpadDraft,
@@ -27,11 +30,28 @@ import type { PwrAgentFederationHandler } from "../agent-tools/pwragent-federati
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { FederatedSearchService } from "./federated-search-service";
 import type { FederationBackendOperations } from "./federation-backend-bridge";
+import { collectFederationHostInfo } from "./federation-host-info";
 import {
   defaultInstanceLabel,
   getDesktopFederationRuntime,
   type DesktopFederationRuntime,
 } from "./federation-runtime";
+
+const DEFAULT_INSTANCE_PAGE_SIZE = 25;
+
+/**
+ * Continuation tokens deliberately live for about a minute: they exist so an
+ * agent can page through one oversized listing in a single reasoning step,
+ * not to serve as a durable snapshot of the fleet.
+ */
+const INSTANCE_CURSOR_TTL_MS = 60_000;
+
+type InstanceListCursorEntry = {
+  expiresAt: number;
+  offset: number;
+  federationEnabled: boolean;
+  instances: FederationInstanceDescriptor[];
+};
 
 type ResolvedInstance = {
   instanceId: FederationInstanceId;
@@ -56,21 +76,33 @@ type ResolvedInstance = {
 export function createFederationAgentToolsHandler(
   options: {
     runtime?: () => DesktopFederationRuntime;
+    collectHostInfo?: () => Promise<FederationHostInfo>;
   } = {},
 ): PwrAgentFederationHandler {
   const runtime = options.runtime ?? getDesktopFederationRuntime;
+  const collectHostInfo = options.collectHostInfo ?? collectFederationHostInfo;
+  const cursors = new Map<string, InstanceListCursorEntry>();
   return async (request) => {
     try {
       if (request.operation === "list_federation_instances") {
-        return ok(await listFederationInstances(runtime()));
+        return listFederationInstances(
+          runtime(),
+          request.args,
+          cursors,
+          collectHostInfo,
+        );
       }
       if (request.operation === "list_instance_projects") {
-        return await listInstanceProjects(runtime(), request.args);
+        return await listInstanceProjects(runtime(), request.args, collectHostInfo);
       }
       if (request.operation === "create_instance_thread") {
-        return await createInstanceThread(runtime(), request.args);
+        return await createInstanceThread(runtime(), request.args, collectHostInfo);
       }
-      return await searchFederationThreads(runtime(), request.args);
+      return await searchFederationThreads(
+        runtime(),
+        request.args,
+        collectHostInfo,
+      );
     } catch (error) {
       return failure(
         classifyFederationToolError(error),
@@ -82,9 +114,33 @@ export function createFederationAgentToolsHandler(
 
 async function listFederationInstances(
   runtime: DesktopFederationRuntime,
-): Promise<ListFederationInstancesResult> {
+  args: ListFederationInstancesToolArgs,
+  cursors: Map<string, InstanceListCursorEntry>,
+  collectHostInfo: () => Promise<FederationHostInfo>,
+): Promise<PwrAgentFederationResponse> {
+  const limit = args.limit ?? DEFAULT_INSTANCE_PAGE_SIZE;
+  pruneExpiredCursors(cursors);
+
+  if (args.cursor) {
+    const entry = cursors.get(args.cursor);
+    if (!entry) {
+      return failure(
+        "invalid_arguments",
+        "The cursor is unknown or expired. Call list_federation_instances again without a cursor (tokens last about a minute).",
+      );
+    }
+    return ok(
+      pageInstances({
+        cursors,
+        entry,
+        cursorId: args.cursor,
+        limit,
+      }),
+    );
+  }
+
   const health = await runtime.health();
-  const local = await localInstanceDescriptor(health);
+  const local = await localInstanceDescriptor(health, collectHostInfo);
   const peers = health.peers.map((peer): FederationInstanceDescriptor => ({
     instanceId: peer.id,
     label: formatFederationPeerDisplayLabel(peer, health.peers),
@@ -95,19 +151,93 @@ async function listFederationInstances(
     notes: peer.notes,
     icon: peer.icon,
     profileName: peer.profileName,
+    host: peer.host,
     unavailableReason: peer.unavailableReason,
   }));
+  const instances = [local, ...peers].filter((instance) =>
+    matchesInstanceQuery(instance, args.query),
+  );
+  return ok(
+    pageInstances({
+      cursors,
+      entry: {
+        expiresAt: Date.now() + INSTANCE_CURSOR_TTL_MS,
+        offset: 0,
+        federationEnabled: health.enabled,
+        instances,
+      },
+      limit,
+    }),
+  );
+}
+
+function pageInstances(params: {
+  cursors: Map<string, InstanceListCursorEntry>;
+  entry: InstanceListCursorEntry;
+  cursorId?: string;
+  limit: number;
+}): ListFederationInstancesResult {
+  const { cursors, entry, limit } = params;
+  const page = entry.instances.slice(entry.offset, entry.offset + limit);
+  const nextOffset = entry.offset + page.length;
+  const exhausted = nextOffset >= entry.instances.length;
+  if (params.cursorId) {
+    cursors.delete(params.cursorId);
+  }
+  let nextCursor: string | undefined;
+  if (!exhausted) {
+    nextCursor = randomUUID();
+    cursors.set(nextCursor, { ...entry, offset: nextOffset });
+  }
   return {
-    federationEnabled: health.enabled,
-    instances: [local, ...peers],
+    federationEnabled: entry.federationEnabled,
+    instances: page,
+    totalCount: entry.instances.length,
+    ...(nextCursor ? { nextCursor } : {}),
   };
+}
+
+function pruneExpiredCursors(
+  cursors: Map<string, InstanceListCursorEntry>,
+): void {
+  const now = Date.now();
+  for (const [id, entry] of cursors) {
+    if (entry.expiresAt <= now) {
+      cursors.delete(id);
+    }
+  }
+}
+
+function matchesInstanceQuery(
+  instance: FederationInstanceDescriptor,
+  query: string | undefined,
+): boolean {
+  if (!query) {
+    return true;
+  }
+  const needle = query.toLowerCase();
+  const haystack = [
+    instance.label,
+    instance.notes,
+    instance.profileName,
+    instance.instanceId,
+    instance.host?.hostname,
+    instance.host?.platform,
+    instance.host?.osVersion,
+    instance.host?.arch,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(needle);
 }
 
 async function listInstanceProjects(
   runtime: DesktopFederationRuntime,
   args: ListInstanceProjectsToolArgs,
+  collectHostInfo: () => Promise<FederationHostInfo>,
 ): Promise<PwrAgentFederationResponse> {
-  const resolved = await resolveInstance(runtime, args.instanceId);
+  const resolved = await resolveInstance(runtime, args.instanceId, collectHostInfo);
   if (!resolved.ok) {
     return resolved.response;
   }
@@ -137,8 +267,9 @@ async function listInstanceProjects(
 async function createInstanceThread(
   runtime: DesktopFederationRuntime,
   args: CreateInstanceThreadToolArgs,
+  collectHostInfo: () => Promise<FederationHostInfo>,
 ): Promise<PwrAgentFederationResponse> {
-  const resolved = await resolveInstance(runtime, args.instanceId);
+  const resolved = await resolveInstance(runtime, args.instanceId, collectHostInfo);
   if (!resolved.ok) {
     return resolved.response;
   }
@@ -194,23 +325,27 @@ async function createInstanceThread(
 async function searchFederationThreads(
   runtime: DesktopFederationRuntime,
   args: SearchFederationThreadsToolArgs,
+  collectHostInfo: () => Promise<FederationHostInfo>,
 ): Promise<PwrAgentFederationResponse> {
+  const scope = args.scope ?? "all";
   const health = await runtime.health();
   const localId = health.instanceId;
-  const local = await localInstanceDescriptor(health);
+  const local = await localInstanceDescriptor(health, collectHostInfo);
   if (args.instanceId && args.instanceId !== localId) {
-    const resolved = await resolveInstance(runtime, args.instanceId);
+    const resolved = await resolveInstance(runtime, args.instanceId, collectHostInfo);
     if (!resolved.ok) {
       return resolved.response;
     }
   }
-  const includeLocal = !args.instanceId || args.instanceId === localId;
+  // scope and instanceId intersect: each masks the surface independently.
+  const includeLocal =
+    scope !== "remote" && (!args.instanceId || args.instanceId === localId);
+  const includePeers = scope !== "local";
   const service = new FederatedSearchService({
     includeLocal,
     local: runtime.localBackend(),
     peers: () =>
-      runtime
-        .connectedPeerTargets()
+      (includePeers ? runtime.connectedPeerTargets() : [])
         .filter((peer) => peer.capabilities.includes("federated_search"))
         .filter(
           (peer) =>
@@ -279,8 +414,15 @@ async function searchFederationThreads(
 
 async function localInstanceDescriptor(
   health: FederationHealthStatus,
+  collectHostInfo: () => Promise<FederationHostInfo>,
 ): Promise<FederationInstanceDescriptor> {
   const settings = await getDesktopSettingsService().readSettings();
+  let host: FederationHostInfo | undefined;
+  try {
+    host = await collectHostInfo();
+  } catch {
+    host = undefined;
+  }
   return {
     instanceId: health.instanceId ?? "local",
     label:
@@ -292,7 +434,7 @@ async function localInstanceDescriptor(
     capabilities: [...FEDERATION_CAPABILITIES],
     role: health.role,
     notes: settings.federation.instanceNotes.value.trim() || undefined,
-    profileName: undefined,
+    ...(host ? { host } : {}),
   };
 }
 
@@ -303,10 +445,11 @@ type ResolveInstanceOutcome =
 async function resolveInstance(
   runtime: DesktopFederationRuntime,
   instanceId: FederationInstanceId,
+  collectHostInfo: () => Promise<FederationHostInfo>,
 ): Promise<ResolveInstanceOutcome> {
   const health = await runtime.health();
   if (instanceId === health.instanceId) {
-    const local = await localInstanceDescriptor(health);
+    const local = await localInstanceDescriptor(health, collectHostInfo);
     return {
       ok: true,
       instance: {

--- a/apps/desktop/src/main/federation/federation-agent-tools-service.ts
+++ b/apps/desktop/src/main/federation/federation-agent-tools-service.ts
@@ -149,7 +149,7 @@ async function listFederationInstances(
     capabilities: [...peer.capabilities],
     role: peer.role,
     notes: peer.notes,
-    icon: peer.icon,
+    icon: peer.celestialIcon,
     profileName: peer.profileName,
     host: peer.host,
     unavailableReason: peer.unavailableReason,
@@ -434,6 +434,7 @@ async function localInstanceDescriptor(
     capabilities: [...FEDERATION_CAPABILITIES],
     role: health.role,
     notes: settings.federation.instanceNotes.value.trim() || undefined,
+    icon: health.localCelestialIcon,
     ...(host ? { host } : {}),
   };
 }

--- a/apps/desktop/src/main/federation/federation-enrollment.ts
+++ b/apps/desktop/src/main/federation/federation-enrollment.ts
@@ -154,6 +154,7 @@ export function completeFederationEnrollment(params: {
     signatureBase64: string;
     endpoint?: string;
     profileName?: string;
+    notes?: string;
   };
 }): FederationAuthDecision {
   if (!isFederationInstanceId(params.peer.instanceId)) {
@@ -222,6 +223,7 @@ export function completeFederationEnrollment(params: {
     protocolVersion: params.peer.protocolVersion,
     endpoint: params.peer.endpoint ?? enrollment.endpoint,
     profileName: params.peer.profileName,
+    notes: params.peer.notes?.trim() || undefined,
     lastConnectedAt: params.now,
     lastActivityAt: params.now,
     pinnedPublicKeyPem: params.peer.publicKeyPem,
@@ -263,6 +265,12 @@ export function authenticateFederationReconnect(params: {
    * the next reconnect instead of needing a re-enrollment.
    */
   profileName?: string;
+  /**
+   * Purpose notes advertised by the peer. Present-but-empty clears the
+   * stored value (an operator can genuinely erase their notes), while
+   * absent keeps it (older clients never advertise the field).
+   */
+  notes?: string;
 }): FederationAuthDecision {
   if (!isFederationInstanceId(params.peerInstanceId)) {
     return {
@@ -324,6 +332,8 @@ export function authenticateFederationReconnect(params: {
     ...peer,
     label: params.label?.trim() || peer.label,
     profileName: params.profileName?.trim() || peer.profileName,
+    notes:
+      params.notes === undefined ? peer.notes : params.notes.trim() || undefined,
     // Stored capabilities are informational, not an allowlist: refresh
     // them to what the peer's current build advertises so peer cards and
     // capability-gated surfaces (messaging fan-out, event forwarding)

--- a/apps/desktop/src/main/federation/federation-enrollment.ts
+++ b/apps/desktop/src/main/federation/federation-enrollment.ts
@@ -1,5 +1,6 @@
 import type {
   FederationCapability,
+  FederationHostInfo,
   FederationInstanceId,
   FederationInstanceRole,
   FederationPeerSummary,
@@ -155,6 +156,7 @@ export function completeFederationEnrollment(params: {
     endpoint?: string;
     profileName?: string;
     notes?: string;
+    host?: FederationHostInfo;
   };
 }): FederationAuthDecision {
   if (!isFederationInstanceId(params.peer.instanceId)) {
@@ -224,6 +226,7 @@ export function completeFederationEnrollment(params: {
     endpoint: params.peer.endpoint ?? enrollment.endpoint,
     profileName: params.peer.profileName,
     notes: params.peer.notes?.trim() || undefined,
+    host: params.peer.host,
     lastConnectedAt: params.now,
     lastActivityAt: params.now,
     pinnedPublicKeyPem: params.peer.publicKeyPem,
@@ -271,6 +274,11 @@ export function authenticateFederationReconnect(params: {
    * absent keeps it (older clients never advertise the field).
    */
   notes?: string;
+  /**
+   * Host facts advertised by the peer. Present replaces the stored block
+   * wholesale; absent keeps it (older clients never advertise host facts).
+   */
+  host?: FederationHostInfo;
 }): FederationAuthDecision {
   if (!isFederationInstanceId(params.peerInstanceId)) {
     return {
@@ -334,6 +342,7 @@ export function authenticateFederationReconnect(params: {
     profileName: params.profileName?.trim() || peer.profileName,
     notes:
       params.notes === undefined ? peer.notes : params.notes.trim() || undefined,
+    host: params.host ?? peer.host,
     // Stored capabilities are informational, not an allowlist: refresh
     // them to what the peer's current build advertises so peer cards and
     // capability-gated surfaces (messaging fan-out, event forwarding)

--- a/apps/desktop/src/main/federation/federation-health.ts
+++ b/apps/desktop/src/main/federation/federation-health.ts
@@ -45,6 +45,7 @@ export function publicPeerSummary(peer: FederationPeerSummary): FederationPeerSu
     profileName: peer.profileName,
     celestialIcon: peer.celestialIcon,
     notes: peer.notes,
+    host: peer.host,
     lastConnectedAt: peer.lastConnectedAt,
     lastActivityAt: peer.lastActivityAt,
     revokedAt: peer.revokedAt,

--- a/apps/desktop/src/main/federation/federation-health.ts
+++ b/apps/desktop/src/main/federation/federation-health.ts
@@ -44,6 +44,7 @@ export function publicPeerSummary(peer: FederationPeerSummary): FederationPeerSu
     endpoint: peer.endpoint,
     profileName: peer.profileName,
     celestialIcon: peer.celestialIcon,
+    notes: peer.notes,
     lastConnectedAt: peer.lastConnectedAt,
     lastActivityAt: peer.lastActivityAt,
     revokedAt: peer.revokedAt,

--- a/apps/desktop/src/main/federation/federation-host-info.ts
+++ b/apps/desktop/src/main/federation/federation-host-info.ts
@@ -1,0 +1,76 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { FederationHostInfo } from "@pwragent/shared";
+import { resolvePwragentRoot } from "../profile";
+
+const MACHINE_ID_FILENAME = "machine-id";
+
+/**
+ * Machine-scoped identity for shared-hardware detection. Minted once at
+ * `<pwragent root>/machine-id` and read by every profile on the machine, so
+ * two enrolled profiles of one box advertise the same id and agents can tell
+ * they compete for the same CPUs/RAM. A custom `PWRAGENT_HOME` gets its own
+ * id — an isolated E2E root is deliberately not "the same machine" as the
+ * operator's real profiles.
+ */
+export async function readOrCreateFederationMachineId(options?: {
+  rootDir?: string;
+}): Promise<string | undefined> {
+  const rootDir = options?.rootDir ?? resolvePwragentRoot();
+  const filePath = path.join(rootDir, MACHINE_ID_FILENAME);
+  try {
+    const existing = (await fs.readFile(filePath, "utf8")).trim();
+    if (existing) {
+      return existing;
+    }
+  } catch {
+    // Missing or unreadable — fall through to mint.
+  }
+  const minted = `mach_${randomUUID()}`;
+  try {
+    await fs.mkdir(rootDir, { recursive: true });
+    await fs.writeFile(filePath, `${minted}\n`, { flag: "wx" });
+    return minted;
+  } catch {
+    // Lost a mint race or the root is read-only. Re-read; a concurrent
+    // writer's id is as good as ours, and no id at all is survivable.
+    try {
+      const raced = (await fs.readFile(filePath, "utf8")).trim();
+      return raced || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+/**
+ * Static host facts advertised to enrolled federation peers.
+ * `diskFreeBytes` measures the volume holding the PwrAgent root and is a
+ * point-in-time snapshot — callers re-collect on reconnect/broadcast rather
+ * than treating it as live.
+ */
+export async function collectFederationHostInfo(options?: {
+  rootDir?: string;
+}): Promise<FederationHostInfo> {
+  const rootDir = options?.rootDir ?? resolvePwragentRoot();
+  const machineId = await readOrCreateFederationMachineId({ rootDir });
+  let diskFreeBytes: number | undefined;
+  try {
+    const stats = await fs.statfs(rootDir);
+    diskFreeBytes = stats.bavail * stats.bsize;
+  } catch {
+    diskFreeBytes = undefined;
+  }
+  return {
+    platform: process.platform,
+    osVersion: os.release(),
+    hostname: os.hostname(),
+    arch: os.arch(),
+    cpuCount: os.cpus().length,
+    memoryBytes: os.totalmem(),
+    ...(diskFreeBytes !== undefined ? { diskFreeBytes } : {}),
+    ...(machineId ? { machineId } : {}),
+  };
+}

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -19,6 +19,7 @@ import type {
   FederatedSearchRequest,
   FederatedSearchResponse,
   FederationHealthStatus,
+  FederationHostInfo,
   FederationInstanceId,
   FederationInstanceRole,
   FederationPeerSummary,
@@ -139,6 +140,7 @@ import {
   encodeFederationInvite,
 } from "./federation-enrollment";
 import { FederatedSearchService } from "./federated-search-service";
+import { collectFederationHostInfo } from "./federation-host-info";
 import {
   FEDERATION_BACKEND_EVENT_METHOD,
   FEDERATION_BACKEND_METHOD_CAPABILITIES,
@@ -245,6 +247,7 @@ export class DesktopFederationRuntime {
   private localInstanceId?: FederationInstanceId;
   private instanceLabel?: string;
   private instanceNotes?: string;
+  private localHostInfo?: FederationHostInfo;
   private listenUrl?: string;
   private gatewayUrl?: string;
   private gatewayInstanceId?: FederationInstanceId;
@@ -804,6 +807,11 @@ export class DesktopFederationRuntime {
     this.instanceLabel =
       settings.federation.instanceLabel.value.trim() || defaultInstanceLabel();
     this.instanceNotes = settings.federation.instanceNotes.value.trim();
+    try {
+      this.localHostInfo = await collectFederationHostInfo();
+    } catch {
+      this.localHostInfo = undefined;
+    }
     const mode = settings.federation.mode.value;
     if (mode === "disabled") {
       return;
@@ -1117,6 +1125,7 @@ export class DesktopFederationRuntime {
       // Always a string: present-but-empty clears the gateway's stored
       // notes when the operator erases theirs (absent means "old client").
       notes: this.instanceNotes ?? settings.federation.instanceNotes.value.trim(),
+      host: this.localHostInfo,
       role: "client",
       headers: cloudflareAccessEnabled
         ? {
@@ -1290,6 +1299,7 @@ export class DesktopFederationRuntime {
       endpoint: existing?.endpoint ?? params.gatewayUrl,
       profileName: existing?.profileName,
       notes: existing?.notes,
+      host: existing?.host,
       lastConnectedAt: params.connectedAt,
       lastActivityAt: params.connectedAt,
       canRevoke: false,
@@ -1646,6 +1656,7 @@ export class DesktopFederationRuntime {
         endpoint: existing?.endpoint,
         profileName: existing?.profileName,
         notes: existing?.notes,
+        host: existing?.host,
         lastConnectedAt: existing?.lastConnectedAt,
         lastActivityAt: existing?.lastActivityAt,
         revokedAt: existing?.revokedAt,
@@ -1722,6 +1733,7 @@ export class DesktopFederationRuntime {
         profileName: localProfileName,
         celestialIcon: this.celestialAssignmentMap().get(localInstanceId)?.icon,
         notes: this.instanceNotes || undefined,
+        host: this.localHostInfo,
       },
     ];
 

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -244,6 +244,7 @@ export class DesktopFederationRuntime {
   private client?: FederationClientWebSocketClient;
   private localInstanceId?: FederationInstanceId;
   private instanceLabel?: string;
+  private instanceNotes?: string;
   private listenUrl?: string;
   private gatewayUrl?: string;
   private gatewayInstanceId?: FederationInstanceId;
@@ -793,6 +794,7 @@ export class DesktopFederationRuntime {
     const settings = await getDesktopSettingsService().readSettings();
     this.instanceLabel =
       settings.federation.instanceLabel.value.trim() || defaultInstanceLabel();
+    this.instanceNotes = settings.federation.instanceNotes.value.trim();
     const mode = settings.federation.mode.value;
     if (mode === "disabled") {
       return;
@@ -1103,6 +1105,9 @@ export class DesktopFederationRuntime {
       // Advertise which profile this instance runs so peers can tell
       // several enrollments of the same machine apart in their UI.
       profileName: getAppStateDb().getMeta("profile_name") || undefined,
+      // Always a string: present-but-empty clears the gateway's stored
+      // notes when the operator erases theirs (absent means "old client").
+      notes: this.instanceNotes ?? settings.federation.instanceNotes.value.trim(),
       role: "client",
       headers: cloudflareAccessEnabled
         ? {
@@ -1275,6 +1280,7 @@ export class DesktopFederationRuntime {
         existing?.protocolVersion ?? FEDERATION_PROTOCOL_VERSION,
       endpoint: existing?.endpoint ?? params.gatewayUrl,
       profileName: existing?.profileName,
+      notes: existing?.notes,
       lastConnectedAt: params.connectedAt,
       lastActivityAt: params.connectedAt,
       canRevoke: false,
@@ -1630,6 +1636,7 @@ export class DesktopFederationRuntime {
         protocolVersion: existing?.protocolVersion,
         endpoint: existing?.endpoint,
         profileName: existing?.profileName,
+        notes: existing?.notes,
         lastConnectedAt: existing?.lastConnectedAt,
         lastActivityAt: existing?.lastActivityAt,
         revokedAt: existing?.revokedAt,
@@ -1705,6 +1712,7 @@ export class DesktopFederationRuntime {
         protocolVersion: FEDERATION_PROTOCOL_VERSION,
         profileName: localProfileName,
         celestialIcon: this.celestialAssignmentMap().get(localInstanceId)?.icon,
+        notes: this.instanceNotes || undefined,
       },
     ];
 

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -663,6 +663,15 @@ export class DesktopFederationRuntime {
   }
 
   /**
+   * The same backend-operations surface {@link remoteBackend} exposes for a
+   * peer, served by this instance. Lets callers (the federation agent tools)
+   * treat local and remote targets uniformly.
+   */
+  localBackend(): FederationBackendOperations {
+    return localBackendOperations();
+  }
+
+  /**
    * Viewer-side control client for a peer's remote PTY sessions. Streamed
    * output/exit/error frames arrive via {@link onRemotePtyEvent}.
    */
@@ -2225,7 +2234,7 @@ export class DesktopFederationRuntime {
  * hostname (minus the mDNS suffix) beats both the profile name (almost
  * always "default") and the raw instance GUID for recognizing a peer.
  */
-function defaultInstanceLabel(): string {
+export function defaultInstanceLabel(): string {
   const host = hostname().trim().replace(/\.local$/i, "");
   return host || "PwrAgent";
 }

--- a/apps/desktop/src/main/federation/federation-store.ts
+++ b/apps/desktop/src/main/federation/federation-store.ts
@@ -7,6 +7,7 @@ import {
 import type {
   FederationCapability,
   FederationConnectionState,
+  FederationHostInfo,
   FederationInstanceRole,
   FederationPeerId,
   FederationPeerSummary,
@@ -72,6 +73,7 @@ type FederationPeerPayload = {
   endpoint?: string;
   profileName?: string;
   notes?: string;
+  host?: FederationHostInfo;
   pinnedPublicKeyPem?: string;
   lastConnectedAt?: number;
   lastActivityAt?: number;
@@ -150,6 +152,7 @@ export class FederationStore {
       endpoint: params.peer.endpoint,
       profileName: params.peer.profileName,
       notes: params.peer.notes,
+      host: params.peer.host,
       pinnedPublicKeyPem: params.peer.pinnedPublicKeyPem,
       lastConnectedAt: params.peer.lastConnectedAt,
       lastActivityAt: params.peer.lastActivityAt,
@@ -521,6 +524,7 @@ function rowToPeer(row: FederationPeerRow): FederationPeerSummary & {
     endpoint: payload.endpoint,
     profileName: payload.profileName,
     notes: payload.notes,
+    host: payload.host,
     pinnedPublicKeyPem: payload.pinnedPublicKeyPem,
     lastConnectedAt: payload.lastConnectedAt,
     lastActivityAt: payload.lastActivityAt,

--- a/apps/desktop/src/main/federation/federation-store.ts
+++ b/apps/desktop/src/main/federation/federation-store.ts
@@ -71,6 +71,7 @@ type FederationPeerPayload = {
   protocolVersion?: number;
   endpoint?: string;
   profileName?: string;
+  notes?: string;
   pinnedPublicKeyPem?: string;
   lastConnectedAt?: number;
   lastActivityAt?: number;
@@ -148,6 +149,7 @@ export class FederationStore {
       protocolVersion: params.peer.protocolVersion,
       endpoint: params.peer.endpoint,
       profileName: params.peer.profileName,
+      notes: params.peer.notes,
       pinnedPublicKeyPem: params.peer.pinnedPublicKeyPem,
       lastConnectedAt: params.peer.lastConnectedAt,
       lastActivityAt: params.peer.lastActivityAt,
@@ -518,6 +520,7 @@ function rowToPeer(row: FederationPeerRow): FederationPeerSummary & {
     protocolVersion: payload.protocolVersion,
     endpoint: payload.endpoint,
     profileName: payload.profileName,
+    notes: payload.notes,
     pinnedPublicKeyPem: payload.pinnedPublicKeyPem,
     lastConnectedAt: payload.lastConnectedAt,
     lastActivityAt: payload.lastActivityAt,

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -186,6 +186,7 @@ type FederationSocketAuthMessage = {
   role?: FederationInstanceRole;
   endpoint?: string;
   profileName?: string;
+  notes?: string;
 };
 
 type FederationSocketChallengeMessage = {
@@ -714,6 +715,7 @@ export class FederationGatewayWebSocketServer {
           signatureBase64: message.signatureBase64,
           endpoint: message.endpoint,
           profileName: message.profileName,
+          notes: message.notes,
         },
       });
     }
@@ -729,6 +731,7 @@ export class FederationGatewayWebSocketServer {
       now: Date.now(),
       label: message.label,
       profileName: message.profileName,
+      notes: message.notes,
     });
   }
 }
@@ -754,6 +757,7 @@ export async function connectFederationClient(params: {
   role?: FederationInstanceRole;
   endpoint?: string;
   profileName?: string;
+  notes?: string;
   headers?: Record<string, string>;
   clientCertificate?: string;
   clientPrivateKey?: string;
@@ -954,6 +958,7 @@ async function establishFederationClient(
     role: params.role,
     endpoint: params.endpoint,
     profileName: params.profileName,
+    notes: params.notes,
   };
   sendFrame(socket, authMessage, transport);
 

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -4,6 +4,7 @@ import type { Duplex } from "node:stream";
 import WebSocket, { WebSocketServer } from "ws";
 import type {
   FederationCapability,
+  FederationHostInfo,
   FederationInstanceId,
   FederationInstanceRole,
   FederationProtocolEnvelope,
@@ -187,6 +188,7 @@ type FederationSocketAuthMessage = {
   endpoint?: string;
   profileName?: string;
   notes?: string;
+  host?: FederationHostInfo;
 };
 
 type FederationSocketChallengeMessage = {
@@ -716,6 +718,7 @@ export class FederationGatewayWebSocketServer {
           endpoint: message.endpoint,
           profileName: message.profileName,
           notes: message.notes,
+          host: message.host,
         },
       });
     }
@@ -732,6 +735,7 @@ export class FederationGatewayWebSocketServer {
       label: message.label,
       profileName: message.profileName,
       notes: message.notes,
+      host: message.host,
     });
   }
 }
@@ -758,6 +762,7 @@ export async function connectFederationClient(params: {
   endpoint?: string;
   profileName?: string;
   notes?: string;
+  host?: FederationHostInfo;
   headers?: Record<string, string>;
   clientCertificate?: string;
   clientPrivateKey?: string;
@@ -959,6 +964,7 @@ async function establishFederationClient(
     endpoint: params.endpoint,
     profileName: params.profileName,
     notes: params.notes,
+    host: params.host,
   };
   sendFrame(socket, authMessage, transport);
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, dialog, Menu, nativeImage, shell } from "electron";
 import { join } from "node:path";
 import { getDesktopBackendRegistry } from "./app-server/backend-registry";
 import { createPwrAgentAppManagementHandler } from "./agent-tools/pwragent-app-management-service";
+import { createFederationAgentToolsHandler } from "./federation/federation-agent-tools-service";
 import { disposeAgentIpcHandlers, registerAgentIpcHandlers } from "./ipc/agent-ipc";
 import {
   disposeScheduledActionIpcHandlers,
@@ -897,6 +898,11 @@ export function bootstrapApp(): void {
         startedAt: mainProcessStartedAt,
         version: () => app.getVersion(),
       }),
+    );
+    // Injected rather than owned by the registry: the federation runtime
+    // already imports the registry, so the reverse import would be a cycle.
+    getDesktopBackendRegistry().setPwrAgentFederationHandler(
+      createFederationAgentToolsHandler(),
     );
     // Windows: serve the painted title-bar menu bar from the live application
     // menu (idempotent; the renderer mounts the bar only on win32).

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -143,6 +143,7 @@ export type DesktopSettingsConfig = {
   federation?: {
     mode?: DesktopFederationMode;
     instanceLabel?: string;
+    instanceNotes?: string;
     listenHost?: string;
     listenPort?: number;
     publicUrl?: string;
@@ -931,6 +932,13 @@ export function desktopSettingsPatchToEdits(
       set(["federation", "instance_label"], patch.federation.instanceLabel);
     }
   }
+  if (patch.federation?.instanceNotes !== undefined) {
+    if (patch.federation.instanceNotes.trim() === "") {
+      edits.push({ op: "delete", path: ["federation", "instance_notes"] });
+    } else {
+      set(["federation", "instance_notes"], patch.federation.instanceNotes);
+    }
+  }
   if (patch.federation?.listenHost !== undefined) {
     if (patch.federation.listenHost.trim() === "") {
       edits.push({ op: "delete", path: ["federation", "listen_host"] });
@@ -1676,6 +1684,7 @@ function normalizeDesktopConfig(
     federation: {
       mode: readFederationMode(federation?.mode),
       instanceLabel: readString(federation?.instance_label),
+      instanceNotes: readString(federation?.instance_notes),
       listenHost: readString(federation?.listen_host),
       listenPort: readNumber(federation?.listen_port),
       publicUrl: readString(federation?.public_url),

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -754,6 +754,7 @@ export class DesktopSettingsService {
       federation: {
         mode: this.resolveFederationMode(config.federation?.mode),
         instanceLabel: this.resolveConfigString(config.federation?.instanceLabel),
+        instanceNotes: this.resolveConfigString(config.federation?.instanceNotes),
         listenHost: this.resolveConfigStringWithDefault(
           config.federation?.listenHost,
           "127.0.0.1",

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -649,6 +649,7 @@ describe("App", () => {
       federation: {
         mode: { value: "disabled", source: "default" },
         instanceLabel: { value: "", source: "default" },
+        instanceNotes: { value: "", source: "default" },
         listenHost: { value: "127.0.0.1", source: "default" },
         listenPort: { value: 47830, source: "default" },
         publicUrl: { value: "", source: "default" },

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -77,6 +77,9 @@ export function FederationSettings(props: FederationSettingsProps) {
   const [instanceLabel, setInstanceLabel] = useState(
     props.snapshot.federation.instanceLabel.value,
   );
+  const [instanceNotes, setInstanceNotes] = useState(
+    props.snapshot.federation.instanceNotes.value,
+  );
   const [listenHost, setListenHost] = useState(
     props.snapshot.federation.listenHost.value,
   );
@@ -115,6 +118,7 @@ export function FederationSettings(props: FederationSettingsProps) {
   useEffect(() => {
     setMode(props.snapshot.federation.mode.value);
     setInstanceLabel(props.snapshot.federation.instanceLabel.value);
+    setInstanceNotes(props.snapshot.federation.instanceNotes.value);
     setListenHost(props.snapshot.federation.listenHost.value);
     setListenPort(String(props.snapshot.federation.listenPort.value));
     setPublicUrl(props.snapshot.federation.publicUrl.value);
@@ -428,6 +432,19 @@ export function FederationSettings(props: FederationSettingsProps) {
             }
           />
           <SettingsField
+            label="Purpose notes"
+            sub="What this machine is for, e.g. 'Studio Mac — PwrSnap dev + screen recording'. Shown to peers and read by agents when routing work to an instance."
+            control={
+              <input
+                aria-label="Purpose notes"
+                value={instanceNotes}
+                placeholder="What is this machine for?"
+                disabled={props.saving}
+                onChange={(event) => setInstanceNotes(event.target.value)}
+              />
+            }
+          />
+          <SettingsField
             label="Listen host"
             sub={
               listensForPeers
@@ -535,6 +552,7 @@ export function FederationSettings(props: FederationSettingsProps) {
                   federation: {
                     mode,
                     instanceLabel,
+                    instanceNotes,
                     listenHost,
                     listenPort: Number.parseInt(listenPort, 10) || 0,
                     publicUrl,

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -189,6 +189,42 @@ describe("FederationSettings", () => {
     ]);
   });
 
+  it("saves the instance purpose notes", async () => {
+    const onWriteConfig = vi.fn(async (_patch: DesktopSettingsConfigPatch) => true);
+    render(
+      <FederationSettings
+        desktopApi={{
+          readFederationHealth: vi.fn(async () => ({
+            health: {
+              enabled: true,
+              role: "client",
+              status: "disconnected",
+              peers: [],
+            } satisfies FederationHealthStatus,
+          })),
+        }}
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={onWriteConfig}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Purpose notes"), {
+      target: { value: "Studio Mac — PwrSnap dev + screen recording" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save federation settings" }),
+    );
+
+    await waitFor(() => expect(onWriteConfig).toHaveBeenCalled());
+    expect(onWriteConfig.mock.calls[0][0].federation?.instanceNotes).toBe(
+      "Studio Mac — PwrSnap dev + screen recording",
+    );
+  });
+
   it("rejects an invalid gateway endpoint before saving", async () => {
     const onWriteConfig = vi.fn(async () => true);
     render(
@@ -799,6 +835,7 @@ function settingsSnapshot(): DesktopSettingsSnapshot {
     federation: {
       mode: { value: "gateway", source: "config" },
       instanceLabel: { value: "", source: "default" },
+      instanceNotes: { value: "", source: "default" },
       listenHost: { value: "127.0.0.1", source: "config" },
       listenPort: { value: 8765, source: "config" },
       publicUrl: {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -200,6 +200,7 @@ function createSnapshot(
     federation: {
       mode: { value: "disabled", source: "default" },
       instanceLabel: { value: "", source: "default" },
+      instanceNotes: { value: "", source: "default" },
       listenHost: { value: "127.0.0.1", source: "default" },
       listenPort: { value: 47830, source: "default" },
       publicUrl: { value: "", source: "default" },

--- a/docs/agent-operator-preferences.md
+++ b/docs/agent-operator-preferences.md
@@ -1,0 +1,66 @@
+# Operator Preferences for Orchestration Agents (`~/.pwragent/AGENTS.md`)
+
+PwrAgent's orchestration and intake agents — the Star Map `[+]` intake
+sub-agent, in-thread agents using the `federation` and `thread_orchestration`
+tool catalogs — consult an operator-authored preferences file before choosing
+where and how to start threads:
+
+```
+~/.pwragent/AGENTS.md
+```
+
+The path honors `PWRAGENT_HOME`, so an overridden PwrAgent root moves the
+file with it (`$PWRAGENT_HOME/AGENTS.md`). The file is per-machine and is not
+synced across federated instances: each instance's agents read the local
+file, which is also where per-instance routing hints belong.
+
+## What it is
+
+A plain Markdown file the operator writes for agents, in the same spirit as a
+repository `AGENTS.md` — but scoped to the operator's PwrAgent workflow
+rather than any one repo. Agents read it as guidance, not configuration:
+there is no schema, no parser, and no enforcement. If the file is missing,
+agents proceed with instance and launchpad defaults.
+
+## What belongs in it
+
+- **Default projects and routing**: "PwrSnap work goes to the Studio Mac";
+  "anything long-running belongs on the rack mini"; "default to the
+  PwrAgent repo when I say 'the app'."
+- **Thread-startup preferences**: preferred models or execution modes for
+  particular kinds of work, when to use a worktree versus the local
+  checkout, base branches to start from.
+- **Naming conventions**: how the operator likes threads titled or grouped.
+- **Anything else an intake agent should know** before creating work on the
+  operator's behalf.
+
+## What does NOT belong in it
+
+- **Secrets** — tokens, API keys, passwords. The file is read into agent
+  context; treat it as visible to every model the operator runs.
+- **Per-repository instructions** — those live in the repository's own
+  `AGENTS.md`, which the coding agent reads once it is working in that repo.
+- **Machine-readable configuration** — settings with real switches belong in
+  `config.toml`, not prose.
+
+## How agents discover it
+
+The `federation` agent-tool catalog's `create_instance_thread` description
+tells agents to consult `~/.pwragent/AGENTS.md` (when it exists) before
+choosing thread settings. Agents with filesystem access read the file
+directly; there is deliberately no dedicated tool for it — the convention is
+a file, not an API, so operators can edit it with anything and agents can
+read it like any other context.
+
+## Example
+
+```markdown
+# My PwrAgent preferences
+
+- PwrSnap work runs on "Studio Mac" (it has the capture hardware).
+- Long-running agents (soak tests, batch refactors) go to "rack mini".
+- Default new threads to worktrees; only use the local checkout when I
+  explicitly say so.
+- Title threads as `<area>: <task>` — e.g. "recorder: fix crash on stop".
+- When I say "the app" with no repo context, I mean ~/github/PwrAgent.
+```

--- a/docs/brainstorms/2026-08-05-federation-agent-tools-requirements.md
+++ b/docs/brainstorms/2026-08-05-federation-agent-tools-requirements.md
@@ -1,0 +1,119 @@
+# Federation Agent-Tool Layer — Requirements
+
+Date: 2026-08-05
+Status: brainstorm feeding `docs/plans/2026-08-05-003-feat-federation-agent-tools-plan.md`
+
+## Problem
+
+Two mission-control surfaces are being built in sibling sessions — the Star
+Map (whose `[+]` intake dispatches a sub-agent that must "find the project the
+user was talking about and create a new thread with the specified settings" on
+a chosen instance) and Cmd+K unification. Both assume an agent can *see* and
+*reach* other federated PwrAgent instances.
+
+Today the agent-tools layer (`apps/desktop/src/main/agent-tools/`) has zero
+federation references. The operator-facing UI already routes `startThread`,
+`materializeDirectoryLaunchpad`, navigation snapshots, and search across
+federation (`isRemoteFederationTarget` branches in `ipc/agent-ipc.ts` /
+`ipc/app-server.ts`), but none of that reach is exposed to agents. An
+in-thread agent or intake sub-agent cannot enumerate instances, browse a
+remote instance's projects, create a thread on another machine, or find "the
+PwrSnap thread about X" wherever it lives.
+
+## Desired outcome
+
+"I want to do this thing" mode can route work to the right machine: an agent
+consults the instance directory (labels + operator-written purpose notes +
+celestial icon), picks a target, browses its projects, and creates a properly
+configured thread there — all through the existing capability-gated federation
+RPCs, with no new authorization surface.
+
+## Requirements
+
+### 1. Instance purpose metadata
+
+- New `[federation] instance_notes` TOML key beside `instance_label`: a short
+  operator-written description of what the machine is for ("Studio Mac —
+  PwrSnap dev + screen recording", "rack mini — long-running agents").
+- Wired end-to-end exactly like `instance_label`: shared settings contract
+  (snapshot + patch), desktop-config TOML read/write, settings snapshot
+  resolution, Settings → Federation field.
+- Additive scalar key — older clients ignore it; no legacy-shape machinery
+  from `docs/config-file-evolution.md` is required (that doc governs shape
+  *changes*, not additions).
+- Advertised to peers: auth/reconnect handshake, peer store payload, peer
+  directory gossip, health snapshot. Every instance can describe every peer.
+- A shared optional `icon` field rides the same wire surfaces. Icon
+  *assignment/sync* is being built on the Star Map branch — this layer only
+  carries the field so both branches converge on one name instead of two.
+
+### 2. Agent tools (core deliverable)
+
+A new `federation` agent-tool catalog in the unified `pwragent` namespace,
+following the `pwragent-thread-orchestration-*` dual-variant pattern
+(definitions module + thin Codex dynamic-tool adapter), advertised through
+both Codex dynamic tools and the loopback MCP server:
+
+- `list_federation_instances` — id, display label, celestial icon, purpose
+  notes, connection status, capabilities, local-vs-remote. Must work
+  non-federated: returns just the local instance so tool-calling code paths
+  don't fork on federation availability.
+- `list_instance_projects` (instanceId) — directories/projects available on
+  that instance, served from the already-federation-routed navigation
+  snapshot (`remoteNavigationSnapshot` → `directories`), including launchpad
+  availability so agents know which projects support configured environments.
+- `create_instance_thread` (instanceId, project, settings, initial input) —
+  creates a thread on the target instance through the federation-routed
+  `materializeDirectoryLaunchpad` / `startThread` paths, honoring launchpad
+  settings (environment, model, execution mode) when specified.
+- `search_federation_threads` (query, instanceId?) — thread search across the
+  fleet using the existing `searchConnectedPeers` fan-out, merged with local
+  results, so an agent can find a thread wherever it lives.
+- Read-status tool: **deferred.** `search_federation_threads` results carry
+  enough thread state for intake routing; remote `readThread` is already
+  federation-routed if a later need appears. Keeping v1 to four tools keeps
+  the catalog reviewable.
+
+### 3. Authorization
+
+- Everything routes through the existing capability-gated federation RPCs.
+  Per PR #1202's redesign, enrollment is the trust boundary
+  (trusted-operator model); stored capability lists are informational, and
+  per-peer narrowing is future RBAC.
+- **Decision needed in plan:** does agent-originated cross-instance control
+  need its own capability analog to `messaging_route`? (Leaning no — see
+  plan for rationale; `messaging_route` exists because messaging is an
+  external input surface, whereas in-thread agents already run under the
+  operator's execution-mode approvals on an enrolled instance.)
+- No new allowlists, no per-tool peer filtering.
+
+### 4. Operator preferences convention
+
+- Document `~/.pwragent/AGENTS.md`: orchestration/intake agents read it for
+  the operator's thread-startup preferences (default projects, naming,
+  settings). Contributor-facing doc under `docs/`; the tool descriptions
+  tell agents to consult the file so the convention is discoverable at the
+  point of use.
+
+## Constraints
+
+- Dependency boundaries: `BackendRegistry` must not import
+  `federation-runtime` (the runtime already imports the registry). The
+  federation tool handler therefore gets injected from `main/index.ts`
+  wiring, mirroring the `setPwrAgentAppManagementHandler` pattern.
+- MCP tool names are globally unique across catalogs
+  (`agent-tool-mcp-server.ts` throws on duplicates) — the four names above
+  do not collide with existing tools (`search_threads` ≠
+  `search_federation_threads`).
+- Agent-tool contract rules (`agent-tools/AGENTS.md`): additive-only schema
+  evolution; new threads get the unified `pwragent` namespace.
+- Repo style: ESLint only, hand-formatted, leading binary operators.
+
+## Non-goals
+
+- Star Map UI, icon assignment/sync UX (sibling branch).
+- Cmd+K unification (independent; benefits from `search_federation_threads`).
+- Per-peer capability narrowing / RBAC.
+- Remote thread transcript reading, remote PTY, or any new federation RPC —
+  the tool layer only composes RPCs that already exist.
+- Cross-instance `~/.pwragent/AGENTS.md` sync; the convention is per-machine.

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -209,6 +209,13 @@ approved on a remote coding-agent thread. Treat every enrolled peer as able to
 exercise the capabilities shown in Settings and revoke peers that are lost or
 retired.
 
+Peer-authored metadata — instance labels, purpose notes, thread titles, and
+host facts (OS, hostname, CPU/RAM/disk figures) — flows into local agent
+context through the federation tool catalog and federated search. An enrolled
+peer can therefore place text in front of your agents; this is accepted under
+the same trusted-operator boundary, and host facts are self-reported hints,
+not verified measurements.
+
 ## Agent Access to Federation
 
 In-thread agents get a `federation` tool catalog (`list_federation_instances`,

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -208,3 +208,15 @@ use that profile's unlocked desktop secret storage, or commands explicitly
 approved on a remote coding-agent thread. Treat every enrolled peer as able to
 exercise the capabilities shown in Settings and revoke peers that are lost or
 retired.
+
+## Agent Access to Federation
+
+In-thread agents get a `federation` tool catalog (`list_federation_instances`,
+`list_instance_projects`, `create_instance_thread`,
+`search_federation_threads`) that composes the same capability-gated RPCs the
+UI uses; agent-originated cross-instance control is authorized exactly like
+operator-originated control, with enrollment as the trust boundary. Instances
+describe themselves to peers with the Settings → Federation "Instance name"
+and "Purpose notes" fields, so agents can route work by what each machine is
+for. Operators can steer routing and thread-startup defaults with
+[`~/.pwragent/AGENTS.md`](agent-operator-preferences.md).

--- a/docs/plans/2026-08-05-003-feat-federation-agent-tools-plan.md
+++ b/docs/plans/2026-08-05-003-feat-federation-agent-tools-plan.md
@@ -1,0 +1,273 @@
+---
+title: "feat: Federation agent-tool layer"
+type: feat
+date: 2026-08-05
+---
+
+# Federation agent-tool layer
+
+Brainstorm: [2026-08-05-federation-agent-tools-requirements.md](../brainstorms/2026-08-05-federation-agent-tools-requirements.md)
+
+## Summary
+
+Give agents (in-thread agents, and the Star Map `[+]` intake sub-agent) eyes
+and hands across federated instances: a new `federation` agent-tool catalog
+with four tools — `list_federation_instances`, `list_instance_projects`,
+`create_instance_thread`, `search_federation_threads` — plus operator-written
+per-instance purpose notes (`[federation] instance_notes`) advertised through
+the peer directory so every instance can describe every peer. All
+cross-instance calls compose the *existing* capability-gated federation RPCs;
+no new authorization surface.
+
+## Product Contract
+
+- An agent can enumerate the fleet: every instance's id, label, celestial
+  icon (field carried now, assignment synced by the Star Map branch), purpose
+  notes, connection status, capabilities, and whether it is the local
+  instance. With federation disabled the same tool returns exactly one row
+  (local), so agent flows do not fork on federation availability.
+- An agent can list a chosen instance's projects/directories (with launchpad
+  availability) and create a thread there — honoring launchpad settings
+  (environment, model, execution mode) and an initial prompt — via the same
+  routed paths the UI uses.
+- An agent can search threads across all connected instances (plus local) in
+  one call, optionally scoped to one instance.
+- Operators describe each machine's purpose in Settings → Federation
+  ("Studio Mac — PwrSnap dev + screen recording"); peers see the notes in
+  their instance directories after the next handshake/gossip.
+- Orchestration/intake agents are pointed (in tool descriptions) at
+  `~/.pwragent/AGENTS.md` for the operator's thread-startup preferences.
+
+## Authorization decision — no new capability
+
+**Agent-originated cross-instance control does NOT get its own capability
+analog to `messaging_route`.** Rationale, recorded per the capability
+redesign in PR #1202's final round:
+
+- Enrollment is the trust boundary (trusted-operator model). Stored
+  capability lists are informational; per-peer narrowing is future RBAC and
+  building a new allowlist now was explicitly ruled out.
+- `messaging_route` exists because messaging is an *external input surface*
+  (Telegram/Discord traffic) that can originate control without a local
+  operator action, so it is separable at the call site. An in-thread agent,
+  by contrast, already runs under the operator's chosen execution mode and
+  approval policy on an enrolled instance; its federation reach is the same
+  reach the operator's own UI has.
+- The four tools only compose RPCs that are already per-method
+  capability-gated in the router: `thread_navigation`
+  (getNavigationSnapshot), `turn_control` (startThread),
+  `environment_actions` (materializeDirectoryLaunchpad), `federated_search`
+  (listThreads fan-out). A peer that revokes those capabilities is equally
+  protected from agents and operators — which is the correct symmetry.
+
+If future RBAC narrows per-peer grants, agent traffic inherits the narrowing
+for free because it flows through the same router checks.
+
+## Architecture
+
+### Unit A — `instance_notes` config key (mirror `instance_label`)
+
+Additive scalar key; `docs/config-file-evolution.md` legacy machinery is not
+needed (it governs shape changes, not additions). Seven touch points, in
+dependency order:
+
+1. `packages/shared/src/contracts/settings.ts` —
+   `DesktopFederationSettingsSnapshot.instanceNotes:
+   DesktopSettingsValue<string>` (beside `instanceLabel`, ~line 549) and
+   `DesktopSettingsConfigPatch.federation.instanceNotes?: string` (~line 957).
+2. `apps/desktop/src/main/settings/desktop-config.ts` —
+   `DesktopSettingsConfig.federation.instanceNotes?: string` (~line 145);
+   reader `readString(federation?.instance_notes)` in
+   `normalizeDesktopConfig` (~line 1678); writer branch in
+   `desktopSettingsPatchToEdits` (~line 927): empty string ⇒ delete
+   `["federation", "instance_notes"]`, else set — same convention as
+   `instance_label`.
+3. `apps/desktop/src/main/settings/desktop-settings-service.ts` — snapshot
+   builder `instanceNotes: this.resolveConfigString(config.federation?.instanceNotes)`
+   (~line 756).
+4. `apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx` —
+   state + snapshot-resync + a "Purpose notes" `SettingsField` under
+   "Instance name" (multiline-friendly input; sub copy explains it is shown
+   to peers and read by agents when routing work), included in the save
+   patch (~line 478).
+5. Test fixtures that construct federation settings snapshots gain the new
+   key: `desktop-config-federation.test.ts`, shared `settings.test.ts`,
+   `FederationSettings.test.tsx`, `settings-screen.test.tsx`,
+   `app-shell.test.tsx`, `federation-endpoint-credential-scoping.test.ts`.
+
+### Unit B — advertise notes + icon through handshake and directory
+
+Mirror the existing `label` / `profileName` plumbing. All optional fields —
+older peers drop unknown keys harmlessly (JSON payload store; gossip rebuild
+is wholesale).
+
+1. `packages/shared/src/contracts/federation.ts` —
+   `FederationPeerSummary.notes?: string; icon?: string`. `icon` is the
+   **shared field the Star Map branch populates** (assignment/sync lives
+   there; this layer carries and re-advertises whatever is set). Coordinate:
+   field name `icon`, free-form string token.
+2. `apps/desktop/src/main/federation/federation-transport.ts` —
+   `FederationSocketAuthMessage.notes?: string; icon?: string` (beside
+   `label`, ~line 185).
+3. `apps/desktop/src/main/federation/federation-enrollment.ts` — carry
+   notes/icon through `completeFederationEnrollment` (peer built ~line 216)
+   and refresh on reconnect in `authenticateFederationReconnect`
+   (~lines 325-326), same trim-or-keep pattern as `label`.
+4. `apps/desktop/src/main/federation/federation-store.ts` —
+   `FederationPeerPayload.notes?/icon?` (~line 69; JSON payload — no
+   migration).
+5. `apps/desktop/src/main/federation/federation-runtime.ts` — resolve
+   `this.instanceNotes` from settings in `restartNow()` (beside
+   `instanceLabel`, ~line 768); send in client auth (~line 1073); include in
+   the local row of `buildPeerDirectory` (~line 1657); preserved through
+   `applyPeerDirectory` since the directory rows are `FederationPeerSummary`.
+6. `apps/desktop/src/main/federation/federation-health.ts` —
+   `publicPeerSummary` copies `notes`/`icon` so `health()` (the renderer's
+   and tools' read path) exposes them.
+
+Icon *source* on the local instance: none in this branch. The field is
+threaded (auth message, payload, summary, directory row) with the local value
+left `undefined` until the Star Map branch lands its assignment store; that
+branch then has a single line to set (`this.instanceIcon` in `restartNow()` /
+directory row) rather than a parallel wire design.
+
+### Unit C — the `federation` agent-tool catalog
+
+Shared contract (`packages/shared/src/contracts/federation-tools.ts`, new;
+exported from `packages/shared/src/index.ts`):
+
+- `PWRAGENT_FEDERATION_OPERATION_NAMES = ["list_federation_instances",
+  "list_instance_projects", "create_instance_thread",
+  "search_federation_threads"] as const` + error codes
+  (`invalid_arguments`, `not_found`, `federation_unavailable`,
+  `peer_unavailable`, `capability_denied`, `forbidden`, `turn_start_failed`,
+  `internal_error`).
+- Args/result types:
+  - `ListFederationInstancesToolArgs = {}` →
+    `{ instances: FederationInstanceDescriptor[] }` where the descriptor is
+    `{ instanceId, label, icon?, notes?, status, capabilities, isLocal,
+    profileName?, role? }`.
+  - `ListInstanceProjectsToolArgs = { instanceId }` →
+    `{ instanceId, isLocal, projects: [{ key, label, kind, path?,
+    hasLaunchpad, launchpadEnvironmentReady? }] }` (projection of
+    `NavigationDirectorySummary` + `launchpad` presence).
+  - `CreateInstanceThreadToolArgs = { instanceId, projectKey, input?,
+    title?, model?, reasoningEffort?, executionMode?, fastMode?,
+    launchpadOverrides? }` → `{ instanceId, backend, threadId, turnId?,
+    threadUrl?, threadLink?, instanceLabel, turnStartFailure?,
+    codexEnvironmentStartupFailure? }`.
+  - `SearchFederationThreadsToolArgs = { query, instanceId?, limit? }` →
+    `{ query, results: [{ instanceId, instanceLabel, isLocal, backend,
+    threadId, title?, updatedAt?, status?, score }], failures: [{
+    instanceId, message }], searchedInstances }`.
+- `PwrAgentFederationRequest/Response` envelope + handler type, mirroring
+  `thread-orchestration-tools.ts`.
+
+Catalog id: add `"federation"` to `AGENT_TOOL_CATALOG_IDS`
+(`packages/shared/src/contracts/agent-tools.ts:3`) and to the exact-list
+assertion in `packages/shared/src/contracts/__tests__/agent-tools.test.ts`.
+
+Desktop side (`apps/desktop/src/main/agent-tools/`):
+
+- `pwragent-federation-agent-tools.ts` — definitions module: handler type,
+  `buildPwrAgentFederationToolRouter`, `buildPwrAgentFederationToolDefinitions`,
+  `descriptionForOperation`, `inputSchemaForOperation` (plain JSON Schema,
+  `additionalProperties: false`), `normalizeArgsForOperation` with per-op
+  trim/choice validators, `PWRAGENT_FEDERATION_UNAVAILABLE_MESSAGE`.
+  Descriptions follow house style (defaults, when-to-prefer, what NOT to do,
+  sibling-tool cross-references by bare name) and tell orchestration agents
+  to consult `~/.pwragent/AGENTS.md` for the operator's thread-startup
+  preferences before choosing settings.
+- `pwragent-federation-codex-tools.ts` — thin Codex adapter mirroring
+  `pwragent-thread-orchestration-codex-tools.ts` (no legacy namespace).
+- `agent-tool-catalog-registry.ts` — `federationHandler?` param; new catalog
+  entry with summary + fingerprint.
+- MCP: nothing extra — the MCP server flattens catalogs automatically. The
+  four names are globally unique (checked against every existing `pwragent`
+  tool; note `search_threads` already exists, hence
+  `search_federation_threads`).
+
+### Unit D — handler service + wiring
+
+`BackendRegistry` must not import `federation-runtime` (the runtime already
+imports the registry — boundary would go circular). So the handler lives in
+federation-land and is injected:
+
+- New `apps/desktop/src/main/federation/federation-agent-tools-service.ts`:
+  `createFederationAgentToolsHandler(...)` closing over
+  `getDesktopFederationRuntime()` + `getDesktopBackendRegistry()`:
+  - `list_federation_instances` — local row from `health()` (instanceId,
+    settings label/notes, mode) marked `isLocal: true`, plus
+    `health().peers` (already the reconciled `visiblePeers()` view with
+    status + capabilities + notes/icon after Unit B).
+  - `list_instance_projects` — local: registry `getNavigationSnapshot`;
+    remote: `runtime.remoteNavigationSnapshot({ instanceId })`; project rows
+    from `snapshot.directories` (`hasLaunchpad` = `launchpad` present).
+  - `create_instance_thread` — resolve project by `directoryKey`; prefer
+    `materializeDirectoryLaunchpad({ directoryKey, launchpad?, input?, agent? })`
+    (local registry or `remoteBackend(target)` client), which honors
+    launchpad environment/model/execution settings and starts the initial
+    turn; map result to threadUrl/threadLink like `handoff_task` does.
+  - `search_federation_threads` — remote fan-out via
+    `runtime.searchConnectedPeers` (optionally filtered to `instanceId`);
+    local results merged from the registry's thread search (same merge shape
+    as `ipc/app-server.ts` `searchThreads`); local rows tagged
+    `isLocal: true`.
+- `BackendRegistry` gains `setPwrAgentFederationHandler(...)` (mirror
+  `setPwrAgentAppManagementHandler`, `backend-registry.ts:7075`), passes the
+  handler at both `resolveAgentToolCatalogs` call sites (~6745 MCP, ~9958
+  Codex startThread), and adds a dynamic-tool dispatch branch beside the
+  thread-orchestration one (~20612-20648) including the
+  `isLiveDynamicToolCall` forbidden gate.
+- `apps/desktop/src/main/index.ts` wires the handler at startup (beside the
+  app-management handler wiring, ~line 895).
+
+### Unit E — `~/.pwragent/AGENTS.md` convention doc
+
+New `docs/agent-operator-preferences.md` (contributor-facing): what the file
+is (operator-authored, per-machine, plain Markdown under the PwrAgent root —
+honors `PWRAGENT_HOME`), what belongs in it (default projects, thread naming,
+preferred models/execution modes, per-instance routing hints), which agents
+read it (orchestration/intake — the federation catalog's tool descriptions
+reference it), and what does NOT belong (secrets, per-repo instructions that
+live in the repo's own AGENTS.md). Cross-link from `docs/federation.md`'s
+doc list and mention in the tool descriptions ("consult ~/.pwragent/AGENTS.md
+… if present").
+
+## Testing
+
+- `packages/shared/src/contracts/__tests__/agent-tools.test.ts` — catalog id
+  list gains `federation`.
+- New `packages/shared/src/contracts/__tests__/federation-tools.test.ts` —
+  operation-name/error-code exact lists (mirror thread-orchestration test).
+- New `apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts`
+  mirroring the four thread-orchestration test shapes: (1) schema/description
+  snapshot under the `pwragent` namespace, (2) missing-handler envelope,
+  (3) validation-before-dispatch (`expect(handler).not.toHaveBeenCalled()`),
+  (4) happy-path normalization (trimmed args, full request envelope).
+- `apps/desktop/src/main/__tests__/desktop-config-federation.test.ts` —
+  `instance_notes` read/round-trip/delete-on-empty.
+- Federation handshake tests (wherever label refresh is covered —
+  enrollment/reconnect specs) extended for notes/icon passthrough.
+- Handler service unit test with stubbed runtime/registry: instance list
+  merge (local + peers, non-federated single row), remote-vs-local project
+  routing, search merge + instanceId filter.
+
+## Sequencing / coordination
+
+Land order: A → B → C → D → E (each a reviewable commit; C and D may merge
+as one PR with separate commits). The Star Map `[+]` intake unit consumes
+these tools — coordinate so it does not invent its own; the shared icon
+field name is `icon` on `FederationPeerSummary`. Cmd+K unification is
+independent but can adopt `search_federation_threads`.
+
+## Progress
+
+- [x] Brainstorm doc
+- [x] Plan doc
+- [ ] Unit A — `instance_notes` config + settings UI
+- [ ] Unit B — handshake/directory advertisement (notes + icon)
+- [ ] Unit C — shared contract + federation catalog + dual-variant tools
+- [ ] Unit D — handler service + BackendRegistry/index wiring
+- [ ] Unit E — operator preferences convention doc
+- [ ] Tests green (lint:eslint, typecheck, lint:boundaries, focused vitest)

--- a/docs/plans/2026-08-05-003-feat-federation-agent-tools-plan.md
+++ b/docs/plans/2026-08-05-003-feat-federation-agent-tools-plan.md
@@ -261,6 +261,30 @@ these tools — coordinate so it does not invent its own; the shared icon
 field name is `icon` on `FederationPeerSummary`. Cmd+K unification is
 independent but can adopt `search_federation_threads`.
 
+## Follow-up round (same branch, post-review)
+
+Decided with the operator after the first review pass:
+
+- `search_federation_threads` gains `scope?: all | local | remote` — the
+  "remote only" intent ("I know it's not on this machine") was not
+  expressible in one call. scope and `instanceId` intersect.
+- `FederationPeerSummary.host` block: platform, osVersion, hostname, arch,
+  cpuCount, memoryBytes, diskFreeBytes (snapshot, not live), and
+  `machineId` — minted once at `<pwragent root>/machine-id` and shared by
+  every profile on the machine, so agents can tell that "work" and
+  "default" on one box compete for the same CPUs/RAM instead of summing
+  their capacity. Advertised like notes/icon (auth handshake, reconnect
+  replace-wholesale/absent-keeps, store payload, gossip, health).
+- `list_federation_instances` pages at 25 rows (limit 1-100) with
+  single-use ~60s continuation tokens, plus a `query` substring filter
+  over label/notes/profile/id/host facts — so a 75-instance fleet nudges
+  the agent toward filtering instead of eating tokens.
+- Live load signals (CPU load average, available RAM, free disk deltas)
+  are deliberately NOT in this round: they are a query-on-demand concern
+  (Star Map indicators + an opt-in flag on the instance list), not a
+  handshake field. Tracked as a spun-off task card; the `host` block is
+  shaped so a `load` sibling can join later.
+
 ## Progress
 
 - [x] Brainstorm doc

--- a/docs/plans/2026-08-05-003-feat-federation-agent-tools-plan.md
+++ b/docs/plans/2026-08-05-003-feat-federation-agent-tools-plan.md
@@ -261,6 +261,18 @@ these tools — coordinate so it does not invent its own; the shared icon
 field name is `icon` on `FederationPeerSummary`. Cmd+K unification is
 independent but can adopt `search_federation_threads`.
 
+## Rebase reconciliation (post-#1249)
+
+The Star Map branch's celestial-icon unit (#1249) merged to main before
+this branch. It shipped the icon as a typed
+`FederationPeerSummary.celestialIcon?: CelestialIconId` with a
+gateway-coordinated LWW assignment protocol — superseding Unit B's
+free-form `icon?: string` carry field, which was dropped during the
+rebase (contract, auth message, enrollment, store, gossip, health). The
+agent-tool descriptor's `icon` field remains and is now fed from the
+assignment map (`peer.celestialIcon` / `health.localCelestialIcon`).
+References to a carry-only `icon` field below are pre-rebase history.
+
 ## Follow-up round (same branch, post-review)
 
 Decided with the operator after the first review pass:

--- a/docs/plans/2026-08-05-003-feat-federation-agent-tools-plan.md
+++ b/docs/plans/2026-08-05-003-feat-federation-agent-tools-plan.md
@@ -265,9 +265,9 @@ independent but can adopt `search_federation_threads`.
 
 - [x] Brainstorm doc
 - [x] Plan doc
-- [ ] Unit A — `instance_notes` config + settings UI
-- [ ] Unit B — handshake/directory advertisement (notes + icon)
-- [ ] Unit C — shared contract + federation catalog + dual-variant tools
-- [ ] Unit D — handler service + BackendRegistry/index wiring
-- [ ] Unit E — operator preferences convention doc
+- [x] Unit A — `instance_notes` config + settings UI
+- [x] Unit B — handshake/directory advertisement (notes + icon)
+- [x] Unit C — shared contract + federation catalog + dual-variant tools
+- [x] Unit D — handler service + BackendRegistry/index wiring
+- [x] Unit E — operator preferences convention doc
 - [ ] Tests green (lint:eslint, typecheck, lint:boundaries, focused vitest)

--- a/packages/shared/src/contracts/__tests__/agent-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/agent-tools.test.ts
@@ -19,12 +19,14 @@ describe("agent tool contracts", () => {
       "thread_inspection",
       "messaging_context",
       "thread_orchestration",
+      "federation",
     ]);
     expect(isAgentToolCatalogId("automation_inspection")).toBe(true);
     expect(isAgentToolCatalogId("app_management")).toBe(true);
     expect(isAgentToolCatalogId("thread_inspection")).toBe(true);
     expect(isAgentToolCatalogId("messaging_context")).toBe(true);
     expect(isAgentToolCatalogId("thread_orchestration")).toBe(true);
+    expect(isAgentToolCatalogId("federation")).toBe(true);
     expect(isAgentToolCatalogId("shell")).toBe(false);
   });
 

--- a/packages/shared/src/contracts/__tests__/federation-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/federation-tools.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PWRAGENT_FEDERATION_ERROR_CODES,
+  PWRAGENT_FEDERATION_OPERATION_NAMES,
+  type CreateInstanceThreadToolArgs,
+  type FederationInstanceDescriptor,
+  type SearchFederationThreadsResult,
+} from "../federation-tools";
+
+describe("federation tool contracts", () => {
+  it("defines the federation tool operations", () => {
+    expect(PWRAGENT_FEDERATION_OPERATION_NAMES).toEqual([
+      "list_federation_instances",
+      "list_instance_projects",
+      "create_instance_thread",
+      "search_federation_threads",
+    ]);
+  });
+
+  it("defines structured federation error codes", () => {
+    expect(PWRAGENT_FEDERATION_ERROR_CODES).toEqual([
+      "invalid_arguments",
+      "not_found",
+      "peer_unavailable",
+      "forbidden",
+      "turn_start_failed",
+      "internal_error",
+    ]);
+  });
+
+  it("models instance descriptors with purpose notes and icons", () => {
+    const descriptor: FederationInstanceDescriptor = {
+      instanceId: "pwr_studio",
+      label: "Studio Mac",
+      isLocal: false,
+      status: "connected",
+      capabilities: ["thread_navigation", "federated_search"],
+      notes: "PwrSnap dev + screen recording",
+      icon: "nebula",
+    };
+    expect(descriptor.notes).toContain("PwrSnap");
+  });
+
+  it("models create-thread args and instance-scoped search results", () => {
+    const args: CreateInstanceThreadToolArgs = {
+      instanceId: "pwr_studio",
+      projectKey: "dir:/Users/op/pwrsnap",
+      input: "Fix the recorder crash on stop",
+      executionMode: "full-access",
+      workMode: "worktree",
+      branchName: "origin/main",
+    };
+    expect(args.projectKey).toContain("pwrsnap");
+
+    const result: SearchFederationThreadsResult = {
+      query: "recorder crash",
+      results: [
+        {
+          instanceId: "pwr_studio",
+          instanceLabel: "Studio Mac",
+          isLocal: false,
+          backend: "codex",
+          threadId: "thread-1",
+          title: "Recorder crash on stop",
+          score: 1250,
+        },
+      ],
+      searchedInstances: [
+        {
+          instanceId: "pwr_studio",
+          instanceLabel: "Studio Mac",
+          resultCount: 1,
+        },
+      ],
+      failures: [],
+    };
+    expect(result.results[0]?.isLocal).toBe(false);
+  });
+});

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -135,6 +135,7 @@ describe("desktop settings contracts", () => {
       federation: {
         mode: { value: "disabled", source: "default" },
         instanceLabel: { value: "", source: "default" },
+        instanceNotes: { value: "", source: "default" },
         listenHost: { value: "127.0.0.1", source: "default" },
         listenPort: { value: 8765, source: "default" },
         publicUrl: { value: "", source: "default" },

--- a/packages/shared/src/contracts/agent-tools.ts
+++ b/packages/shared/src/contracts/agent-tools.ts
@@ -6,6 +6,7 @@ export const AGENT_TOOL_CATALOG_IDS = [
   "thread_inspection",
   "messaging_context",
   "thread_orchestration",
+  "federation",
 ] as const;
 
 export type AgentToolCatalogId = (typeof AGENT_TOOL_CATALOG_IDS)[number];

--- a/packages/shared/src/contracts/federation-tools.ts
+++ b/packages/shared/src/contracts/federation-tools.ts
@@ -3,6 +3,7 @@ import type {
   FederatedSearchPeerFailure,
   FederationCapability,
   FederationConnectionState,
+  FederationHostInfo,
   FederationInstanceId,
   FederationInstanceRole,
 } from "./federation";
@@ -63,14 +64,38 @@ export type FederationInstanceDescriptor = {
   /** Celestial icon token assigned by the Star Map surface. */
   icon?: string;
   profileName?: string;
+  /**
+   * Static host facts (OS, arch, CPU count, RAM, disk free, machineId).
+   * Instances sharing a machineId run on the same hardware — their CPU/RAM
+   * capacity must not be summed.
+   */
+  host?: FederationHostInfo;
   unavailableReason?: string;
 };
 
-export type ListFederationInstancesToolArgs = Record<string, never>;
+export type ListFederationInstancesToolArgs = {
+  /**
+   * Case-insensitive substring filter matched against label, notes,
+   * profile name, instance id, and host facts (hostname, platform, arch,
+   * OS version). Ignored when continuing from a cursor.
+   */
+  query?: string;
+  /** Page size, 1-100. Defaults to 25. */
+  limit?: number;
+  /** Continuation token from a previous truncated result. Short-lived. */
+  cursor?: string;
+};
 
 export type ListFederationInstancesResult = {
   federationEnabled: boolean;
   instances: FederationInstanceDescriptor[];
+  /** Total instances matching the query across all pages. */
+  totalCount: number;
+  /**
+   * Present when more instances remain. Pass back as `cursor` promptly —
+   * tokens expire after about a minute.
+   */
+  nextCursor?: string;
 };
 
 export type ListInstanceProjectsToolArgs = {
@@ -141,9 +166,20 @@ export type CreateInstanceThreadResult = {
   codexEnvironmentStartupFailure?: CodexEnvironmentStartupFailure;
 };
 
+export const FEDERATION_SEARCH_SCOPES = ["all", "local", "remote"] as const;
+
+export type FederationSearchScope = (typeof FEDERATION_SEARCH_SCOPES)[number];
+
 export type SearchFederationThreadsToolArgs = {
   query: string;
-  /** Restrict the search to one instance; omitted searches the whole fleet. */
+  /**
+   * Which instances to search: `all` (default) is local plus every
+   * connected peer, `local` is this instance only, `remote` is every
+   * connected peer excluding local. Intersects with `instanceId` when both
+   * are given.
+   */
+  scope?: FederationSearchScope;
+  /** Restrict the search to one instance; omitted searches the whole scope. */
   instanceId?: FederationInstanceId;
   limit?: number;
 };

--- a/packages/shared/src/contracts/federation-tools.ts
+++ b/packages/shared/src/contracts/federation-tools.ts
@@ -1,0 +1,209 @@
+import type {
+  FederatedSearchInstanceSummary,
+  FederatedSearchPeerFailure,
+  FederationCapability,
+  FederationConnectionState,
+  FederationInstanceId,
+  FederationInstanceRole,
+} from "./federation";
+import type {
+  DirectorySummaryKind,
+  LaunchpadWorkMode,
+} from "./navigation";
+import type {
+  AppServerBackendKind,
+  ThreadExecutionMode,
+  ThreadIdentifier,
+} from "./normalized-app-server";
+import type { CodexEnvironmentStartupFailure } from "./agent";
+
+export const PWRAGENT_FEDERATION_OPERATION_NAMES = [
+  "list_federation_instances",
+  "list_instance_projects",
+  "create_instance_thread",
+  "search_federation_threads",
+] as const;
+
+export type PwrAgentFederationOperationName =
+  (typeof PWRAGENT_FEDERATION_OPERATION_NAMES)[number];
+
+export const PWRAGENT_FEDERATION_ERROR_CODES = [
+  "invalid_arguments",
+  "not_found",
+  "peer_unavailable",
+  "forbidden",
+  "turn_start_failed",
+  "internal_error",
+] as const;
+
+export type PwrAgentFederationErrorCode =
+  (typeof PWRAGENT_FEDERATION_ERROR_CODES)[number];
+
+export type PwrAgentFederationContext = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  callId?: string;
+  turnId?: string;
+};
+
+/**
+ * One row of the fleet directory an agent can route work across. The local
+ * instance is always present (even with federation disabled) so agent flows
+ * never fork on federation availability.
+ */
+export type FederationInstanceDescriptor = {
+  instanceId: FederationInstanceId;
+  label: string;
+  isLocal: boolean;
+  status: FederationConnectionState;
+  capabilities: FederationCapability[];
+  role?: FederationInstanceRole;
+  /** Operator-written purpose notes ("Studio Mac — PwrSnap dev"). */
+  notes?: string;
+  /** Celestial icon token assigned by the Star Map surface. */
+  icon?: string;
+  profileName?: string;
+  unavailableReason?: string;
+};
+
+export type ListFederationInstancesToolArgs = Record<string, never>;
+
+export type ListFederationInstancesResult = {
+  federationEnabled: boolean;
+  instances: FederationInstanceDescriptor[];
+};
+
+export type ListInstanceProjectsToolArgs = {
+  instanceId: FederationInstanceId;
+};
+
+export type FederationInstanceProjectSummary = {
+  /** Directory key to pass to create_instance_thread as projectKey. */
+  key: string;
+  label: string;
+  kind: DirectorySummaryKind;
+  path?: string;
+  /**
+   * Whether the project has a configured launchpad draft (environment,
+   * model, execution-mode presets). Threads can be created either way;
+   * without one, instance-level defaults apply.
+   */
+  hasLaunchpad: boolean;
+  backend?: AppServerBackendKind;
+  workMode?: LaunchpadWorkMode;
+  model?: string;
+  executionMode?: ThreadExecutionMode;
+};
+
+export type ListInstanceProjectsResult = {
+  instanceId: FederationInstanceId;
+  instanceLabel: string;
+  isLocal: boolean;
+  projects: FederationInstanceProjectSummary[];
+};
+
+export type CreateInstanceThreadToolArgs = {
+  instanceId: FederationInstanceId;
+  /** Directory key from list_instance_projects. */
+  projectKey: string;
+  /** Initial prompt for the created thread's first turn. */
+  input?: string;
+  model?: string;
+  reasoningEffort?: string;
+  executionMode?: ThreadExecutionMode;
+  fastMode?: boolean;
+  workMode?: LaunchpadWorkMode;
+  /** Existing base branch/ref for workMode=worktree, e.g. `origin/main`. */
+  branchName?: string;
+};
+
+export type CreateInstanceThreadResult = {
+  instanceId: FederationInstanceId;
+  instanceLabel: string;
+  isLocal: boolean;
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  executionMode: ThreadExecutionMode;
+  workMode: LaunchpadWorkMode;
+  turnId?: string;
+  /**
+   * Present for local-instance threads only: the pwragent:// link scheme
+   * has no cross-instance addressing yet, so a link to a remote thread
+   * would resolve against the wrong instance.
+   */
+  threadUrl?: string;
+  threadLink?: string;
+  message: string;
+  turnStartFailure?: {
+    message: string;
+    phase: "turn" | "review";
+  };
+  codexEnvironmentStartupFailure?: CodexEnvironmentStartupFailure;
+};
+
+export type SearchFederationThreadsToolArgs = {
+  query: string;
+  /** Restrict the search to one instance; omitted searches the whole fleet. */
+  instanceId?: FederationInstanceId;
+  limit?: number;
+};
+
+export type FederationThreadSearchResultSummary = {
+  instanceId: FederationInstanceId;
+  instanceLabel: string;
+  isLocal: boolean;
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  title: string;
+  updatedAt?: number;
+  projectKey?: string;
+  gitBranch?: string;
+  score: number;
+  /** Local-instance results only; see CreateInstanceThreadResult.threadLink. */
+  threadLink?: string;
+};
+
+export type SearchFederationThreadsResult = {
+  query: string;
+  results: FederationThreadSearchResultSummary[];
+  searchedInstances: FederatedSearchInstanceSummary[];
+  failures: FederatedSearchPeerFailure[];
+};
+
+export type PwrAgentFederationToolArgs<
+  TOperation extends PwrAgentFederationOperationName,
+> = {
+  list_federation_instances: ListFederationInstancesToolArgs;
+  list_instance_projects: ListInstanceProjectsToolArgs;
+  create_instance_thread: CreateInstanceThreadToolArgs;
+  search_federation_threads: SearchFederationThreadsToolArgs;
+}[TOperation];
+
+export type PwrAgentFederationRequest<
+  TOperation extends PwrAgentFederationOperationName =
+    PwrAgentFederationOperationName,
+> = {
+  [TOperationKey in TOperation]: {
+    operation: TOperationKey;
+    context: PwrAgentFederationContext;
+    args: PwrAgentFederationToolArgs<TOperationKey>;
+  };
+}[TOperation];
+
+export type PwrAgentFederationResponse =
+  | {
+      ok: true;
+      data:
+        | ListFederationInstancesResult
+        | ListInstanceProjectsResult
+        | CreateInstanceThreadResult
+        | SearchFederationThreadsResult;
+    }
+  | {
+      ok: false;
+      error: {
+        code: PwrAgentFederationErrorCode;
+        message: string;
+        data?: unknown;
+      };
+    };

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -74,6 +74,25 @@ export type FederationCapabilitySet = {
   capabilities: FederationCapability[];
 };
 
+/**
+ * Static host facts an instance advertises to enrolled peers. Refreshed on
+ * every reconnect; `diskFreeBytes` is a snapshot from the last handshake or
+ * directory broadcast, not a live reading. `machineId` is minted once per
+ * PwrAgent root (`<root>/machine-id`) and shared by every profile on the
+ * machine — instances with the same machineId run on the same hardware and
+ * compete for its CPUs/RAM.
+ */
+export type FederationHostInfo = {
+  platform?: string;
+  osVersion?: string;
+  hostname?: string;
+  arch?: string;
+  cpuCount?: number;
+  memoryBytes?: number;
+  diskFreeBytes?: number;
+  machineId?: string;
+};
+
 export type FederationPeerSummary = {
   id: FederationPeerId;
   label: string;
@@ -92,6 +111,7 @@ export type FederationPeerSummary = {
    * gossip; read by orchestration agents when routing work.
    */
   notes?: string;
+  host?: FederationHostInfo;
   lastConnectedAt?: number;
   lastActivityAt?: number;
   revokedAt?: number;

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -86,6 +86,12 @@ export type FederationPeerSummary = {
   profileName?: string;
   /** Assigned celestial identity icon, when the assignment map knows one. */
   celestialIcon?: CelestialIconId;
+  /**
+   * Operator-written purpose notes for the instance ("Studio Mac — PwrSnap
+   * dev + screen recording"). Advertised on handshake and peer-directory
+   * gossip; read by orchestration agents when routing work.
+   */
+  notes?: string;
   lastConnectedAt?: number;
   lastActivityAt?: number;
   revokedAt?: number;

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -547,6 +547,13 @@ export type DesktopFederationSettingsSnapshot = {
    * recognize a raw instance GUID.
    */
   instanceLabel: DesktopSettingsValue<string>;
+  /**
+   * Operator-written purpose notes for this instance ("Studio Mac — PwrSnap
+   * dev + screen recording"). Advertised to federation peers and read by
+   * orchestration agents when routing work to an instance. Empty means no
+   * notes.
+   */
+  instanceNotes: DesktopSettingsValue<string>;
   listenHost: DesktopSettingsValue<string>;
   listenPort: DesktopSettingsValue<number>;
   publicUrl: DesktopSettingsValue<string>;
@@ -955,6 +962,7 @@ export type DesktopSettingsConfigPatch = {
   federation?: {
     mode?: DesktopFederationMode;
     instanceLabel?: string;
+    instanceNotes?: string;
     listenHost?: string;
     listenPort?: number;
     publicUrl?: string;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,6 +16,7 @@ export * from "./contracts/celestial";
 export * from "./contracts/composer-drafts";
 export * from "./contracts/diff-focus";
 export * from "./contracts/federation";
+export * from "./contracts/federation-tools";
 export * from "./contracts/messaging";
 export * from "./contracts/messaging-tools";
 export * from "./contracts/mcp-connections";


### PR DESCRIPTION
## Summary

Gives agents (in-thread agents, and the Star Map `[+]` intake sub-agent) eyes and hands across federated instances. Brainstorm + plan docs are the first commit; the decision record for authorization is in the plan.

- **New `federation` agent-tool catalog** in the unified `pwragent` namespace, advertised through both Codex dynamic tools and the loopback MCP server:
  - `list_federation_instances` — fleet directory (label, purpose notes, celestial icon, status, capabilities, `isLocal`); returns just the local instance when federation is disabled.
  - `list_instance_projects` — an instance's directories with launchpad availability, via the federation-routed navigation snapshot.
  - `create_instance_thread` — thread creation on any instance through `materializeDirectoryLaunchpad`, inheriting the project's launchpad **settings** presets (never its unsent draft prompt/attachments).
  - `search_federation_threads` — fleet-wide search merging local results with the `searchConnectedPeers` fan-out.
- **`[federation] instance_notes`** — operator-written purpose field ("Studio Mac — PwrSnap dev + screen recording"), wired end-to-end like `instance_label` and advertised to peers via handshake + peer-directory gossip. A shared optional `icon` field rides the same wire surfaces for the Star Map branch to populate (assignment/sync stays there — coordinate on `FederationPeerSummary.icon`).
- **Authorization decision (recorded in the plan):** no new capability analog to `messaging_route`. Agent-originated cross-instance control rides the same per-method capability gates as operator control (`thread_navigation`, `turn_control`, `environment_actions`, `federated_search`); enrollment stays the trust boundary per the #1202 trusted-operator model, and future per-peer RBAC narrows agent traffic for free.
- **`~/.pwragent/AGENTS.md` convention** documented in `docs/agent-operator-preferences.md` and referenced from the tool descriptions so intake agents consult the operator's thread-startup preferences.

The handler lives in federation-land and is injected from `main/index.ts` (the federation runtime already imports the registry, so the reverse import would cycle).

## Sequencing

The Star Map session's `[+]` intake unit should consume these tools instead of inventing its own; its map/icons/topology units are independent. Cmd+K unification can adopt `search_federation_threads`.

## Testing

- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries`, `lint:sql`, `lint:codex-storage`, `lint:colors` all pass.
- Full workspace suite: 6330 passed / 3 skipped.
- New coverage: shared contract tests, tool schema/validation/normalization tests (mirroring the thread-orchestration patterns), handler-service tests (instance listing incl. non-federated, remote-vs-local routing, launchpad settings merge, search merge + instance scoping), enrollment/reconnect notes+icon passthrough (present-but-empty clears, absent keeps), and `instance_notes` TOML read/round-trip/delete-on-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)