### PR TITLE
feat(desktop): star map AI intake

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1458,6 +1458,7 @@ describe("federation backend bridge", () => {
       readPwrSnapConnectionStatus: vi.fn(),
       trustCodexProject: vi.fn(),
       setCelestialIcon: vi.fn(),
+      starMapIntake: vi.fn(),
     };
     const replies: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({
@@ -1654,6 +1655,7 @@ describe("federation backend bridge", () => {
         readPwrSnapConnectionStatus: vi.fn(),
         trustCodexProject: vi.fn(),
         setCelestialIcon: vi.fn(),
+        starMapIntake: vi.fn(),
       } as FederationBackendOperations,
     });
 

--- a/apps/desktop/src/main/__tests__/star-map-intake.test.ts
+++ b/apps/desktop/src/main/__tests__/star-map-intake.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NavigationDirectorySummary } from "@pwragent/shared";
+
+const generateGrokObject = vi.fn();
+const materializeDirectoryLaunchpad = vi.fn();
+const publishLocalEvent = vi.fn(async () => undefined);
+const getNavigationSnapshot = vi.fn();
+
+vi.mock("../app-server/backend-registry", () => ({
+  getDesktopBackendRegistry: () => ({
+    generateGrokObject,
+    materializeDirectoryLaunchpad,
+    publishLocalEvent,
+  }),
+}));
+
+vi.mock("../messaging/desktop-backend-bridge", () => ({
+  DesktopMessagingBackendBridge: class {
+    getNavigationSnapshot = getNavigationSnapshot;
+  },
+}));
+
+vi.mock("../profile", () => ({
+  resolveActiveProfileDir: () => "/nonexistent/profile",
+  resolvePwragentRoot: () => "/nonexistent/root",
+}));
+
+import { dispatchStarMapIntake } from "../app-server/star-map-intake";
+
+function directory(
+  key: string,
+  label: string,
+): NavigationDirectorySummary {
+  return {
+    key,
+    kind: "directory",
+    label,
+    path: `/repos/${label}`,
+    threadKeys: [],
+    needsAttentionCount: 0,
+  } as unknown as NavigationDirectorySummary;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getNavigationSnapshot.mockResolvedValue({
+    directories: [
+      directory("dir-snap", "PwrSnap"),
+      directory("dir-agent", "PwrAgent"),
+    ],
+  });
+  materializeDirectoryLaunchpad.mockResolvedValue({
+    backend: "codex",
+    threadId: "thread-9",
+  });
+});
+
+describe("dispatchStarMapIntake", () => {
+  it("creates a thread in the Grok-resolved directory with the request as first turn", async () => {
+    generateGrokObject.mockResolvedValue({
+      object: {
+        title: "Investigate PwrSnap issue",
+        directoryKey: "dir-snap",
+        confidence: 0.9,
+      },
+    });
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-1",
+      request: "Look into the screenshot issue in PwrSnap",
+    });
+
+    expect(response).toMatchObject({
+      status: "created",
+      backend: "codex",
+      threadId: "thread-9",
+      title: "Investigate PwrSnap issue",
+    });
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      {
+        directoryKey: "dir-snap",
+        input: [
+          { type: "text", text: "Look into the screenshot issue in PwrSnap" },
+        ],
+      },
+      { messageOrigin: { kind: "pwragent" } },
+    );
+    const phases = publishLocalEvent.mock.calls.map(
+      (call) =>
+        (call as unknown as [{ notification: { params: { phase: string } } }])[0]
+          .notification.params.phase,
+    );
+    expect(phases).toEqual(["resolving", "creating", "done"]);
+  });
+
+  it("falls back to a deterministic label match when Grok is unavailable", async () => {
+    generateGrokObject.mockRejectedValue(new Error("grok unavailable"));
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-2",
+      request: "Fix the flaky test in pwragent",
+    });
+
+    expect(response.status).toBe("created");
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({ directoryKey: "dir-agent" }),
+      expect.anything(),
+    );
+  });
+
+  it("asks for disambiguation when no directory clearly matches", async () => {
+    generateGrokObject.mockResolvedValue({
+      object: { title: "Do a thing", directoryKey: null, confidence: 0.1 },
+    });
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-3",
+      request: "Do a thing somewhere",
+    });
+
+    expect(response.status).toBe("needs_disambiguation");
+    if (response.status === "needs_disambiguation") {
+      expect(response.candidates.map((entry) => entry.directoryKey)).toEqual([
+        "dir-snap",
+        "dir-agent",
+      ]);
+    }
+    expect(materializeDirectoryLaunchpad).not.toHaveBeenCalled();
+  });
+
+  it("honors a disambiguation resubmit without re-resolving", async () => {
+    const response = await dispatchStarMapIntake({
+      requestId: "req-4",
+      request: "Do a thing somewhere",
+      directoryKey: "dir-agent",
+    });
+
+    expect(response.status).toBe("created");
+    expect(generateGrokObject).not.toHaveBeenCalled();
+  });
+
+  it("reports creation failures with a failed status event", async () => {
+    generateGrokObject.mockResolvedValue({
+      object: { title: "T", directoryKey: "dir-snap", confidence: 0.9 },
+    });
+    materializeDirectoryLaunchpad.mockRejectedValue(
+      new Error("launchpad exploded"),
+    );
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-5",
+      request: "Break things in PwrSnap",
+    });
+
+    expect(response).toMatchObject({
+      status: "failed",
+      error: "launchpad exploded",
+    });
+  });
+
+  it("rejects empty requests without touching the registry", async () => {
+    const response = await dispatchStarMapIntake({
+      requestId: "req-6",
+      request: "   ",
+    });
+    expect(response.status).toBe("failed");
+    expect(getNavigationSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/app-server/star-map-intake.ts
+++ b/apps/desktop/src/main/app-server/star-map-intake.ts
@@ -1,0 +1,270 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type {
+  NavigationDirectorySummary,
+  StarMapIntakeCandidate,
+  StarMapIntakePhase,
+  StarMapIntakeRequest,
+  StarMapIntakeResponse,
+} from "@pwragent/shared";
+import { getMainLogger } from "../log";
+import { resolveActiveProfileDir, resolvePwragentRoot } from "../profile";
+import { DesktopMessagingBackendBridge } from "../messaging/desktop-backend-bridge";
+import { getDesktopBackendRegistry } from "./backend-registry";
+
+const log = getMainLogger("pwragent:star-map-intake");
+
+const INTAKE_MODEL = "grok-4-1-fast-non-reasoning";
+const INTAKE_TIMEOUT_MS = 20_000;
+const INTAKE_PREFERENCES_MAX_CHARS = 8_000;
+const INTAKE_PROMPT_VERSION = "star-map-intake-v1";
+const MAX_DISAMBIGUATION_CANDIDATES = 8;
+
+const INTAKE_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    directoryKey: { type: ["string", "null"] },
+    confidence: { type: "number" },
+    notes: { type: ["string", "null"] },
+  },
+  required: ["title", "directoryKey", "confidence"],
+  additionalProperties: false,
+};
+
+type IntakeResolution = {
+  title?: string;
+  directoryKey?: string;
+  confidence: number;
+};
+
+function publishIntakeStatus(params: {
+  requestId: string;
+  phase: StarMapIntakePhase;
+  message?: string;
+  backend?: string;
+  threadId?: string;
+}): void {
+  // publishLocalEvent fans out to this instance's windows AND to remote
+  // viewers over the federation backend-event channel, so the requesting
+  // dialog streams progress no matter which machine it runs on.
+  void getDesktopBackendRegistry()
+    .publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "starMap/intake/status",
+        params,
+      },
+    })
+    .catch(() => {
+      // Progress is best-effort; the RPC response carries the outcome.
+    });
+}
+
+/**
+ * Operator thread-startup preferences: profile-scoped AGENTS.md first
+ * (~/.pwragent/profiles/<p>/AGENTS.md), then the root ~/.pwragent/AGENTS.md.
+ */
+async function readIntakePreferences(): Promise<string | undefined> {
+  const candidates = [
+    path.join(resolveActiveProfileDir(), "AGENTS.md"),
+    path.join(resolvePwragentRoot(), "AGENTS.md"),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const text = await readFile(candidate, "utf8");
+      if (text.trim().length > 0) {
+        return text.slice(0, INTAKE_PREFERENCES_MAX_CHARS);
+      }
+    } catch {
+      // Missing file — preferences are optional.
+    }
+  }
+  return undefined;
+}
+
+function describeDirectory(directory: NavigationDirectorySummary): string {
+  const parts = [
+    `key=${directory.key}`,
+    `label=${directory.label}`,
+  ];
+  if (directory.path) parts.push(`path=${directory.path}`);
+  parts.push(`threads=${directory.threadKeys.length}`);
+  return parts.join(" | ");
+}
+
+async function resolveViaGrok(params: {
+  text: string;
+  preferences?: string;
+  directories: NavigationDirectorySummary[];
+}): Promise<IntakeResolution | undefined> {
+  try {
+    const result = await getDesktopBackendRegistry().generateGrokObject({
+      model: INTAKE_MODEL,
+      promptCacheKey: INTAKE_PROMPT_VERSION,
+      timeoutMs: INTAKE_TIMEOUT_MS,
+      schema: INTAKE_SCHEMA,
+      schemaName: "star_map_intake_resolution",
+      system: [
+        "You resolve a natural-language task request to one of the",
+        "operator's registered project directories and give the task a",
+        "short thread title.",
+        "Pick directoryKey ONLY from the provided list; null when no",
+        "directory clearly matches.",
+        "confidence is 0..1 for the directory pick.",
+        "Return JSON matching the schema exactly.",
+      ].join("\n"),
+      prompt: [
+        params.preferences
+          ? `Operator thread-startup preferences (AGENTS.md):\n${params.preferences}\n`
+          : "",
+        "Registered project directories:",
+        ...params.directories.map((directory) => `- ${describeDirectory(directory)}`),
+        "",
+        `Task request: ${params.text}`,
+      ].join("\n"),
+    });
+    const object = result.object as {
+      title?: unknown;
+      directoryKey?: unknown;
+      confidence?: unknown;
+    };
+    const directoryKey =
+      typeof object.directoryKey === "string"
+      && params.directories.some((directory) => directory.key === object.directoryKey)
+        ? object.directoryKey
+        : undefined;
+    return {
+      title: typeof object.title === "string" ? object.title.trim() : undefined,
+      directoryKey,
+      confidence:
+        typeof object.confidence === "number" && Number.isFinite(object.confidence)
+          ? object.confidence
+          : 0,
+    };
+  } catch (error) {
+    log.warn("star map intake grok resolution unavailable", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}
+
+/** Deterministic fallback: rank directories by label-token hits. */
+function fuzzyMatchDirectories(
+  text: string,
+  directories: NavigationDirectorySummary[],
+): NavigationDirectorySummary[] {
+  const haystack = text.toLowerCase();
+  return directories
+    .map((directory) => {
+      const label = directory.label.toLowerCase();
+      const score = haystack.includes(label)
+        ? label.length
+        : 0;
+      return { directory, score };
+    })
+    .filter((entry) => entry.score > 0)
+    .sort((left, right) => right.score - left.score)
+    .map((entry) => entry.directory);
+}
+
+function candidateOf(
+  directory: NavigationDirectorySummary,
+): StarMapIntakeCandidate {
+  return {
+    directoryKey: directory.key,
+    label: directory.label,
+    path: directory.path,
+  };
+}
+
+/**
+ * The Star Map [+] intake: resolve the operator's natural-language request
+ * to a project (Grok structured call over the directory registry +
+ * AGENTS.md preferences, deterministic label match as fallback), then
+ * materialize the directory's launchpad with the request as the first
+ * turn. Runs on the instance that owns the [+] card.
+ */
+export async function dispatchStarMapIntake(
+  request: StarMapIntakeRequest,
+): Promise<StarMapIntakeResponse> {
+  const requestId = request.requestId;
+  const text = request.request.trim();
+  if (!requestId || !text) {
+    return {
+      status: "failed",
+      requestId,
+      error: "Describe the task to start a thread.",
+    };
+  }
+  try {
+    publishIntakeStatus({ requestId, phase: "resolving" });
+    const snapshot = await new DesktopMessagingBackendBridge()
+      .getNavigationSnapshot({});
+    const directories = snapshot.directories.filter(
+      (directory) => directory.kind !== "unlinked",
+    );
+
+    let directoryKey = request.directoryKey;
+    let title: string | undefined;
+    if (
+      directoryKey
+      && !directories.some((directory) => directory.key === directoryKey)
+    ) {
+      directoryKey = undefined;
+    }
+    if (!directoryKey) {
+      const preferences = await readIntakePreferences();
+      const resolved = await resolveViaGrok({ text, preferences, directories });
+      if (resolved && resolved.directoryKey && resolved.confidence >= 0.5) {
+        directoryKey = resolved.directoryKey;
+        title = resolved.title;
+      } else {
+        const fuzzy = fuzzyMatchDirectories(text, directories);
+        if (fuzzy.length === 1) {
+          directoryKey = fuzzy[0].key;
+          title = resolved?.title;
+        } else {
+          const ranked = fuzzy.length > 0 ? fuzzy : directories;
+          publishIntakeStatus({ requestId, phase: "needs_disambiguation" });
+          return {
+            status: "needs_disambiguation",
+            requestId,
+            candidates: ranked
+              .slice(0, MAX_DISAMBIGUATION_CANDIDATES)
+              .map(candidateOf),
+          };
+        }
+      }
+    }
+
+    publishIntakeStatus({ requestId, phase: "creating" });
+    const materialized = await getDesktopBackendRegistry()
+      .materializeDirectoryLaunchpad(
+        {
+          directoryKey,
+          input: [{ type: "text", text }],
+        },
+        { messageOrigin: { kind: "pwragent" } },
+      );
+    publishIntakeStatus({
+      requestId,
+      phase: "done",
+      backend: materialized.backend,
+      threadId: materialized.threadId,
+    });
+    return {
+      status: "created",
+      requestId,
+      backend: materialized.backend,
+      threadId: materialized.threadId,
+      title,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.warn("star map intake failed", { error: message });
+    publishIntakeStatus({ requestId, phase: "failed", message });
+    return { status: "failed", requestId, error: message };
+  }
+}

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -68,6 +68,8 @@ import type {
   SetAcpSessionRuntimeOptionResponse,
   SetCelestialIconRequest,
   SetCelestialIconResponse,
+  StarMapIntakeRequest,
+  StarMapIntakeResponse,
   SetCodexThreadEnvironmentRequest,
   SetCodexThreadEnvironmentResponse,
   SetThreadExecutionModeRequest,
@@ -161,6 +163,7 @@ export const FEDERATION_BACKEND_METHODS = {
   readPwrSnapConnectionStatus: "backend.readPwrSnapConnectionStatus",
   trustCodexProject: "backend.trustCodexProject",
   setCelestialIcon: "backend.setCelestialIcon",
+  starMapIntake: "backend.starMapIntake",
 } as const;
 
 export const FEDERATION_BACKEND_EVENT_METHOD = "backend.event";
@@ -241,6 +244,9 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   // cosmetic state; thread_navigation is the least-privileged grant every
   // browsing peer already holds.
   [FEDERATION_BACKEND_METHODS.setCelestialIcon]: "thread_navigation",
+  // Intake creates a thread and starts its first turn on the owning
+  // instance — the same trust the materialize-launchpad path carries.
+  [FEDERATION_BACKEND_METHODS.starMapIntake]: "environment_actions",
 };
 
 export function additionalFederationBackendCapabilities(
@@ -373,6 +379,7 @@ export type FederationBackendOperations = {
   setCelestialIcon(
     request: SetCelestialIconRequest,
   ): Promise<SetCelestialIconResponse>;
+  starMapIntake(request: StarMapIntakeRequest): Promise<StarMapIntakeResponse>;
 };
 
 export function registerFederationBackendHandlers(params: {
@@ -740,6 +747,13 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.setCelestialIcon(
         envelope.params as SetCelestialIconRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.starMapIntake,
+    async (envelope) =>
+      await params.backend.starMapIntake(
+        envelope.params as StarMapIntakeRequest,
       ),
   );
 }
@@ -1166,6 +1180,18 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
     return await this.rpc.request<SetCelestialIconResponse>({
       method: FEDERATION_BACKEND_METHODS.setCelestialIcon,
       params: request,
+    });
+  }
+
+  async starMapIntake(
+    request: StarMapIntakeRequest,
+  ): Promise<StarMapIntakeResponse> {
+    return await this.rpc.request<StarMapIntakeResponse>({
+      method: FEDERATION_BACKEND_METHODS.starMapIntake,
+      params: request,
+      // Resolution + thread materialization can outlive the default 30s
+      // (Grok call + worktree preparation), so give intake a longer leash.
+      timeoutMs: 120_000,
     });
   }
 }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -106,6 +106,8 @@ import {
   type SetCelestialIconRequest,
   type SetCelestialIconResponse,
   type StarMapArrangementEntry,
+  type StarMapIntakeRequest,
+  type StarMapIntakeResponse,
   type SetCodexThreadEnvironmentRequest,
   type SetThreadExecutionModeRequest,
   type SetThreadModelSettingsRequest,
@@ -121,6 +123,7 @@ import {
 } from "@pwragent/shared";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
+import { dispatchStarMapIntake } from "../app-server/star-map-intake";
 import { spawnTerminalPty } from "../terminal/integrated-terminal-service";
 import {
   readTranscriptImageProtocolRequest,
@@ -2849,6 +2852,11 @@ function localBackendOperations(): FederationBackendOperations {
       request: SetCelestialIconRequest,
     ): Promise<SetCelestialIconResponse> {
       return await getDesktopFederationRuntime().setCelestialIcon(request);
+    },
+    async starMapIntake(
+      request: StarMapIntakeRequest,
+    ): Promise<StarMapIntakeResponse> {
+      return await dispatchStarMapIntake(request);
     },
   };
 }

--- a/apps/desktop/src/main/ipc/star-map.ts
+++ b/apps/desktop/src/main/ipc/star-map.ts
@@ -1,20 +1,46 @@
 import { ipcMain } from "electron";
 import type {
+  FederationTarget,
   ReadStarMapArrangementResponse,
   SetStarMapCardPositionRequest,
   StarMapArrangementEntry,
+  StarMapIntakeRequest,
+  StarMapIntakeResponse,
 } from "@pwragent/shared";
-import { isStarMapArrangementEntry } from "@pwragent/shared";
 import {
+  isRemoteFederationTarget,
+  isStarMapArrangementEntry,
+} from "@pwragent/shared";
+import {
+  STAR_MAP_INTAKE_CHANNEL,
   STAR_MAP_READ_ARRANGEMENT_CHANNEL,
   STAR_MAP_SET_CARD_POSITION_CHANNEL,
 } from "../../shared/ipc";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
+import { dispatchStarMapIntake } from "../app-server/star-map-intake";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 
 export function registerStarMapIpcHandlers(): void {
   ipcMain.removeHandler(STAR_MAP_READ_ARRANGEMENT_CHANNEL);
   ipcMain.removeHandler(STAR_MAP_SET_CARD_POSITION_CHANNEL);
+  ipcMain.removeHandler(STAR_MAP_INTAKE_CHANNEL);
+  ipcMain.handle(
+    STAR_MAP_INTAKE_CHANNEL,
+    async (
+      _event,
+      request: StarMapIntakeRequest & { federationTarget?: FederationTarget },
+    ): Promise<StarMapIntakeResponse> => {
+      const { federationTarget, ...intake } = request;
+      if (federationTarget && isRemoteFederationTarget(federationTarget)) {
+        // Execute on the owning instance: its directory registry, defaults,
+        // and AGENTS.md preferences are the ones the intake must consult.
+        return await getDesktopFederationRuntime()
+          .remoteBackend(federationTarget)
+          .starMapIntake(intake);
+      }
+      return await dispatchStarMapIntake(intake);
+    },
+  );
   ipcMain.handle(
     STAR_MAP_READ_ARRANGEMENT_CHANNEL,
     async (): Promise<ReadStarMapArrangementResponse> => ({
@@ -57,4 +83,5 @@ export function registerStarMapIpcHandlers(): void {
 export function disposeStarMapIpcHandlers(): void {
   ipcMain.removeHandler(STAR_MAP_READ_ARRANGEMENT_CHANNEL);
   ipcMain.removeHandler(STAR_MAP_SET_CARD_POSITION_CHANNEL);
+  ipcMain.removeHandler(STAR_MAP_INTAKE_CHANNEL);
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -279,6 +279,9 @@ import type {
   SetCelestialIconResponse,
   ReadStarMapArrangementResponse,
   SetStarMapCardPositionRequest,
+  StarMapIntakeRequest,
+  StarMapIntakeResponse,
+  FederationTarget,
   ReadDesktopSettingsRequest,
   ReadDesktopSettingsResponse,
   RefreshDesktopCodexDiscoveryRequest,
@@ -457,6 +460,7 @@ import {
   FEDERATION_RESET_ENROLLMENT_CHANNEL,
   FEDERATION_REVOKE_PEER_CHANNEL,
   FEDERATION_SET_CELESTIAL_ICON_CHANNEL,
+  STAR_MAP_INTAKE_CHANNEL,
   STAR_MAP_READ_ARRANGEMENT_CHANNEL,
   STAR_MAP_SET_CARD_POSITION_CHANNEL,
   FEDERATION_TAILSCALE_CONFIGURE_CHANNEL,
@@ -897,6 +901,10 @@ const desktopApi = Object.freeze({
     request: SetStarMapCardPositionRequest,
   ): Promise<ReadStarMapArrangementResponse> =>
     await ipcRenderer.invoke(STAR_MAP_SET_CARD_POSITION_CHANNEL, request),
+  dispatchStarMapIntake: async (
+    request: StarMapIntakeRequest & { federationTarget?: FederationTarget },
+  ): Promise<StarMapIntakeResponse> =>
+    await ipcRenderer.invoke(STAR_MAP_INTAKE_CHANNEL, request),
   ...(isDevelopment
     ? {
         getRuntimeIdentity: async (): Promise<RuntimeIdentity> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -2009,6 +2009,9 @@ function DesktopAppShell(props: {
                   setStarMapFloatOpen(true);
                 }}
                 onFocusLocalInstance={closeStarMap}
+                onRefreshLocalThreads={() => {
+                  void navigation.refresh?.();
+                }}
               />
             </Suspense>
           </div>

--- a/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type {
+  CelestialIconId,
+  FederationTarget,
+  StarMapIntakeCandidate,
+  StarMapIntakePhase,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { CelestialIcon } from "../../icons";
+
+export type IntakeDialogTarget = {
+  instanceId: string;
+  label: string;
+  icon?: CelestialIconId;
+  /** Remote target when the [+] belongs to another instance. */
+  federationTarget?: FederationTarget;
+};
+
+const PHASE_COPY: Partial<Record<StarMapIntakePhase, string>> = {
+  resolving: "Finding the right project…",
+  creating: "Creating the thread…",
+};
+
+/**
+ * The Star Map [+] intake chat: describe a task in natural language and the
+ * owning instance resolves the project (its registry + AGENTS.md
+ * preferences), creates the thread, and the new card bubbles into the map.
+ */
+export function IntakeDialog(props: {
+  desktopApi?: DesktopApi;
+  target: IntakeDialogTarget;
+  onClose: () => void;
+  onCreated: (created: {
+    instanceId: string;
+    backend: string;
+    threadId: string;
+  }) => void;
+}) {
+  const [text, setText] = useState("");
+  const [phase, setPhase] = useState<StarMapIntakePhase | "idle">("idle");
+  const [error, setError] = useState<string>();
+  const [candidates, setCandidates] = useState<StarMapIntakeCandidate[]>();
+  const requestIdRef = useRef<string | undefined>(undefined);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const busy = phase === "resolving" || phase === "creating";
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  // Stream progress: the owning instance publishes starMap/intake/status
+  // for our requestId (fanned over federation for remote targets).
+  useEffect(() => {
+    const unsubscribe = props.desktopApi?.onAgentEvent?.((event) => {
+      if (event.notification.method !== "starMap/intake/status") return;
+      const params = event.notification.params as {
+        requestId: string;
+        phase: StarMapIntakePhase;
+        message?: string;
+      };
+      if (params.requestId !== requestIdRef.current) return;
+      setPhase(params.phase);
+      if (params.phase === "failed" && params.message) {
+        setError(params.message);
+      }
+    });
+    return () => unsubscribe?.();
+  }, [props.desktopApi]);
+
+  const submit = (directoryKey?: string) => {
+    const request = text.trim();
+    if (!request || busy || !props.desktopApi?.dispatchStarMapIntake) return;
+    const requestId =
+      requestIdRef.current ?? `intake-${Math.random().toString(36).slice(2)}`;
+    requestIdRef.current = requestId;
+    setError(undefined);
+    setCandidates(undefined);
+    setPhase("resolving");
+    void props.desktopApi
+      .dispatchStarMapIntake({
+        requestId,
+        request,
+        directoryKey,
+        federationTarget: props.target.federationTarget,
+      })
+      .then((response) => {
+        if (response.requestId !== requestIdRef.current) return;
+        if (response.status === "created") {
+          setPhase("done");
+          props.onCreated({
+            instanceId: props.target.instanceId,
+            backend: response.backend,
+            threadId: response.threadId,
+          });
+          props.onClose();
+          return;
+        }
+        if (response.status === "needs_disambiguation") {
+          setPhase("needs_disambiguation");
+          setCandidates(response.candidates);
+          return;
+        }
+        setPhase("failed");
+        setError(response.error);
+      })
+      .catch((err: unknown) => {
+        setPhase("failed");
+        setError(err instanceof Error ? err.message : String(err));
+      });
+  };
+
+  return createPortal(
+    <div
+      className="star-map-intake"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`New thread on ${props.target.label}`}
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && !busy) {
+          event.stopPropagation();
+          props.onClose();
+        }
+      }}
+    >
+      <button
+        type="button"
+        className="star-map-intake__backdrop"
+        aria-label="Close intake"
+        tabIndex={-1}
+        onClick={() => {
+          if (!busy) props.onClose();
+        }}
+      />
+      <div className="star-map-intake__panel">
+        <div className="star-map-intake__header">
+          {props.target.icon ? (
+            <CelestialIcon icon={props.target.icon} size={20} />
+          ) : null}
+          <span className="star-map-intake__target">{props.target.label}</span>
+          <button
+            type="button"
+            className="star-map-intake__close"
+            aria-label="Close"
+            disabled={busy}
+            onClick={props.onClose}
+          >
+            ✕
+          </button>
+        </div>
+        <textarea
+          ref={textareaRef}
+          className="star-map-intake__input"
+          placeholder="Give me a task, tell me the project, and any specifics that don't match your defaults."
+          value={text}
+          disabled={busy}
+          rows={4}
+          onChange={(event) => setText(event.target.value)}
+          onKeyDown={(event) => {
+            if (
+              event.key === "Enter"
+              && (event.metaKey || event.ctrlKey)
+            ) {
+              event.preventDefault();
+              submit();
+            }
+          }}
+        />
+        {candidates ? (
+          <div className="star-map-intake__candidates">
+            <p className="star-map-intake__hint">Which project?</p>
+            {candidates.map((candidate) => (
+              <button
+                key={candidate.directoryKey}
+                type="button"
+                className="star-map-intake__candidate"
+                onClick={() => submit(candidate.directoryKey)}
+              >
+                <span className="star-map-intake__candidate-label">
+                  {candidate.label}
+                </span>
+                {candidate.path ? (
+                  <span className="star-map-intake__candidate-path">
+                    {candidate.path}
+                  </span>
+                ) : null}
+              </button>
+            ))}
+          </div>
+        ) : null}
+        <div className="star-map-intake__footer">
+          <span
+            className={`star-map-intake__status${
+              busy ? " is-busy" : ""
+            }${phase === "failed" ? " is-failed" : ""}`}
+            role="status"
+          >
+            {phase === "failed" ? error : PHASE_COPY[phase as StarMapIntakePhase] ?? ""}
+          </span>
+          <button
+            type="button"
+            className="button button--secondary"
+            disabled={busy || text.trim().length === 0}
+            onClick={() => submit()}
+          >
+            {busy ? "Working…" : "Start thread"}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapInstanceCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapInstanceCard.tsx
@@ -32,6 +32,8 @@ export function StarMapInstanceCard(props: {
   isHub: boolean;
   unreachable?: boolean;
   onOpen: () => void;
+  /** Present when AI intake can target this instance. */
+  onIntake?: () => void;
 }) {
   return (
     <div
@@ -65,8 +67,20 @@ export function StarMapInstanceCard(props: {
           aria-hidden="true"
         />
       </button>
-      <span className="star-map-instance__label" title={props.label}>
-        {props.label}
+      <span className="star-map-instance__row">
+        <span className="star-map-instance__label" title={props.label}>
+          {props.label}
+        </span>
+        {props.onIntake ? (
+          <button
+            type="button"
+            className="star-map-instance__intake"
+            aria-label={`New thread on ${props.label}`}
+            onClick={props.onIntake}
+          >
+            +
+          </button>
+        ) : null}
       </span>
       {props.unreachable ? (
         <span className="star-map-instance__unreachable">Unreachable</span>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -28,6 +28,7 @@ import {
   starMapCardSlot,
   type StarMapInstancePosition,
 } from "./star-map-layout";
+import { IntakeDialog, type IntakeDialogTarget } from "./IntakeDialog";
 import { StarMapInstanceCard } from "./StarMapInstanceCard";
 import { StarMapThreadCard } from "./StarMapThreadCard";
 import { useStarMapArrangement } from "./useStarMapArrangement";
@@ -71,6 +72,8 @@ type StarMapScreenProps = {
   onOpenLocalThread: (thread: NavigationThreadSummary) => void;
   /** The local instance card's open action: back to the thread shell. */
   onFocusLocalInstance: () => void;
+  /** Refresh the App's navigation snapshot (after intake creates locally). */
+  onRefreshLocalThreads?: () => void;
 };
 
 /**
@@ -93,6 +96,13 @@ export function StarMapScreen(props: StarMapScreenProps) {
     height: number;
   }>({ width: 1280, height: 800 });
   const stars = useMemo(() => generateStarField(STAR_COUNT), []);
+  const [intakeTarget, setIntakeTarget] = useState<IntakeDialogTarget>();
+  // Thread keys that just bubbled in via intake — they wear the entrance
+  // animation until the timer clears them.
+  const [enteringThreadKeys, setEnteringThreadKeys] = useState<Set<string>>(
+    new Set(),
+  );
+  const [remoteRefreshNonce, setRemoteRefreshNonce] = useState(0);
 
   // Focus the layer on open AND whenever the floating thread closes -
   // "Back to map" leaves focus inside <main>, and without a refocus the
@@ -156,6 +166,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     desktopApi: props.desktopApi,
     peers,
     enabled: true,
+    refreshNonce: remoteRefreshNonce,
   });
   const arrangement = useStarMapArrangement({ desktopApi: props.desktopApi });
 
@@ -290,6 +301,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
                   : undefined
               }
               riseDelayMs={index * 45}
+              entering={enteringThreadKeys.has(threadKey)}
               baseSlot={slot}
               offset={arrangement.offsetFor(position.instanceId, threadKey)}
               width={layout.cardWidth}
@@ -432,12 +444,61 @@ export function StarMapScreen(props: StarMapScreenProps) {
                   position.instanceId,
                 )}
                 onOpen={() => openInstance(position.instanceId)}
+                onIntake={
+                  props.desktopApi?.dispatchStarMapIntake
+                  && (position.instanceId === localInstanceId
+                    || entry.peer?.status === "connected")
+                    ? () =>
+                        setIntakeTarget({
+                          instanceId: position.instanceId,
+                          label: entry.label,
+                          icon: celestialIcons.iconFor(
+                            position.instanceId === localInstanceId
+                              ? undefined
+                              : position.instanceId,
+                          ),
+                          federationTarget:
+                            position.instanceId === localInstanceId
+                              ? undefined
+                              : {
+                                  scope: "remote",
+                                  instanceId: position.instanceId,
+                                },
+                        })
+                    : undefined
+                }
               />
             </div>
           );
         })}
         {layout.positions.map((position) => renderCloud(position))}
       </div>
+      {intakeTarget ? (
+        <IntakeDialog
+          desktopApi={props.desktopApi}
+          target={intakeTarget}
+          onClose={() => setIntakeTarget(undefined)}
+          onCreated={(created) => {
+            const threadKey = buildThreadIdentityKey(
+              created.backend as NavigationThreadSummary["source"],
+              created.threadId,
+            );
+            setEnteringThreadKeys((current) => new Set(current).add(threadKey));
+            window.setTimeout(() => {
+              setEnteringThreadKeys((current) => {
+                const next = new Set(current);
+                next.delete(threadKey);
+                return next;
+              });
+            }, 2_000);
+            if (created.instanceId === localInstanceId) {
+              props.onRefreshLocalThreads?.();
+            } else {
+              setRemoteRefreshNonce((nonce) => nonce + 1);
+            }
+          }}
+        />
+      ) : null}
       <div className="star-map__filters" role="group" aria-label="Attention filters">
         {STAR_MAP_ATTENTION_CATEGORIES.map((category) => (
           <button

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { IntakeDialog } from "../IntakeDialog";
+
+const target = {
+  instanceId: "pwr_local",
+  label: "Mac-Mini-M4",
+  icon: "sun" as const,
+};
+
+function setup(dispatchResult: unknown) {
+  const dispatchStarMapIntake = vi.fn(
+    async (_request: { requestId: string; directoryKey?: string }) =>
+      dispatchResult as never,
+  );
+  const desktopApi: DesktopApi = {
+    dispatchStarMapIntake,
+    onAgentEvent: vi.fn(() => () => undefined),
+  };
+  const onClose = vi.fn();
+  const onCreated = vi.fn();
+  render(
+    <IntakeDialog
+      desktopApi={desktopApi}
+      target={target}
+      onClose={onClose}
+      onCreated={onCreated}
+    />,
+  );
+  return { dispatchStarMapIntake, onClose, onCreated };
+}
+
+function submitText(text: string) {
+  fireEvent.change(screen.getByPlaceholderText(/Give me a task/), {
+    target: { value: text },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Start thread" }));
+}
+
+describe("IntakeDialog", () => {
+  it("dispatches the request and reports the created thread", async () => {
+    const { dispatchStarMapIntake, onClose, onCreated } = setup({
+      status: "created",
+      requestId: expect.anything(),
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    // The stubbed response echoes whatever requestId the dialog generated.
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) =>
+        ({
+          status: "created",
+          requestId: request.requestId,
+          backend: "codex",
+          threadId: "thread-1",
+        }) as never,
+    );
+
+    submitText("Make a PwrAgent thread for the screenshot issue");
+
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith({
+        instanceId: "pwr_local",
+        backend: "codex",
+        threadId: "thread-1",
+      });
+    });
+    expect(onClose).toHaveBeenCalled();
+    expect(dispatchStarMapIntake).toHaveBeenCalledWith(
+      expect.objectContaining({
+        request: "Make a PwrAgent thread for the screenshot issue",
+      }),
+    );
+  });
+
+  it("shows disambiguation candidates and resubmits with the pick", async () => {
+    const { dispatchStarMapIntake } = setup(undefined);
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string; directoryKey?: string }) =>
+        (request.directoryKey
+          ? {
+              status: "created",
+              requestId: request.requestId,
+              backend: "codex",
+              threadId: "thread-2",
+            }
+          : {
+              status: "needs_disambiguation",
+              requestId: request.requestId,
+              candidates: [
+                { directoryKey: "dir-a", label: "PwrSnap", path: "/r/PwrSnap" },
+                { directoryKey: "dir-b", label: "PwrAgent" },
+              ],
+            }) as never,
+    );
+
+    submitText("Do a thing");
+    await waitFor(() => {
+      expect(screen.getByText("Which project?")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /PwrSnap/ }));
+    await waitFor(() => {
+      expect(dispatchStarMapIntake).toHaveBeenCalledWith(
+        expect.objectContaining({ directoryKey: "dir-a" }),
+      );
+    });
+  });
+
+  it("surfaces failures in the status line", async () => {
+    const { dispatchStarMapIntake } = setup(undefined);
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) =>
+        ({
+          status: "failed",
+          requestId: request.requestId,
+          error: "No backends available",
+        }) as never,
+    );
+
+    submitText("Anything");
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toContain(
+        "No backends available",
+      );
+    });
+  });
+
+  it("keeps the submit disabled while empty", () => {
+    setup(undefined);
+    const submit = screen.getByRole("button", { name: "Start thread" });
+    expect((submit as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapThreads.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapThreads.ts
@@ -23,6 +23,8 @@ export function useStarMapThreads(params: {
   desktopApi?: DesktopApi;
   peers: readonly FederationPeerSummary[];
   enabled: boolean;
+  /** Bump to force an immediate refetch (e.g. after intake creates a thread). */
+  refreshNonce?: number;
 }): StarMapRemoteThreads {
   const desktopApi = params.desktopApi;
   const [state, setState] = useState<StarMapRemoteThreads>({
@@ -111,7 +113,7 @@ export function useStarMapThreads(params: {
       generationRef.current += 1;
       clearInterval(timer);
     };
-  }, [desktopApi, connectedIds, params.enabled]);
+  }, [desktopApi, connectedIds, params.enabled, params.refreshNonce]);
 
   return state;
 }

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -118,6 +118,9 @@ import type {
   SetCelestialIconResponse,
   ReadStarMapArrangementResponse,
   SetStarMapCardPositionRequest,
+  StarMapIntakeRequest,
+  StarMapIntakeResponse,
+  FederationTarget,
   ReorderDirectoryPinsRequest,
   ReorderDirectoryPinsResponse,
   ReorderThreadPinsRequest,
@@ -505,6 +508,9 @@ export type DesktopApi = {
   setStarMapCardPosition?: (
     request: SetStarMapCardPositionRequest,
   ) => Promise<ReadStarMapArrangementResponse>;
+  dispatchStarMapIntake?: (
+    request: StarMapIntakeRequest & { federationTarget?: FederationTarget },
+  ) => Promise<StarMapIntakeResponse>;
   ping?: () => string;
   listSkills?: (
     request?: AppServerListSkillsRequest

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8996,6 +8996,191 @@ textarea,
   font-size: 11px;
 }
 
+/* Label pill + [+] intake side by side under the body. */
+.star-map-instance__row {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.star-map-instance__intake {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--accent-border);
+  border-radius: 6px;
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.star-map-instance__intake:hover {
+  background: var(--accent-bg-medium);
+}
+
+.star-map-instance__intake:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* AI intake dialog: a small centered chat panel over the map. */
+.star-map-intake {
+  position: fixed;
+  inset: 0;
+  z-index: 140;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.star-map-intake__backdrop {
+  position: absolute;
+  inset: 0;
+  border: none;
+  background: var(--scrim-medium);
+  cursor: default;
+}
+
+.star-map-intake__panel {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  gap: 10px;
+  width: min(520px, calc(100vw - 48px));
+  padding: 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+}
+
+.star-map-intake__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-primary);
+}
+
+.star-map-intake__target {
+  flex: 1;
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.star-map-intake__close {
+  border: none;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.star-map-intake__close:hover {
+  background: var(--bg-row-active);
+  color: var(--text-primary);
+}
+
+.star-map-intake__input {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 13px;
+  resize: vertical;
+}
+
+.star-map-intake__input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.star-map-intake__hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.star-map-intake__candidates {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.star-map-intake__candidate {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 6px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.star-map-intake__candidate:hover {
+  border-color: var(--accent-border);
+}
+
+.star-map-intake__candidate-label {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.star-map-intake__candidate-path {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.star-map-intake__footer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.star-map-intake__status {
+  flex: 1;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.star-map-intake__status.is-failed {
+  color: var(--danger-text);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .star-map-intake__status.is-busy {
+    animation: star-map-intake-pulse 1.2s ease-in-out infinite;
+  }
+}
+
+@keyframes star-map-intake-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
 .star-map__cloud {
   position: absolute;
   z-index: 1;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -15,6 +15,7 @@ export const FEDERATION_SET_CELESTIAL_ICON_CHANNEL =
   "federation:set-celestial-icon";
 export const STAR_MAP_READ_ARRANGEMENT_CHANNEL = "star-map:read-arrangement";
 export const STAR_MAP_SET_CARD_POSITION_CHANNEL = "star-map:set-card-position";
+export const STAR_MAP_INTAKE_CHANNEL = "star-map:intake";
 export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";
 export const APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL =
   "app-server:get-thread-file-diff";

--- a/docs/plans/2026-08-05-003-feat-star-map-mission-control-plan.md
+++ b/docs/plans/2026-08-05-003-feat-star-map-mission-control-plan.md
@@ -486,8 +486,18 @@ route; a `list_projects` orchestration tool is deliberately **not** added now
     (remote threads in the local snapshot), which this surface will adopt
     for free; (c) the [+] intake button ships with Unit 4 rather than as a
     disabled placeholder (no scaffold controls in shipped UI).
-- [ ] Unit 3: arrangement sync
-- [ ] Unit 4: AI intake
+- [x] Unit 3: arrangement sync
+  - Tombstone GC (30-day sweep) deferred: tombstones are one small row per
+    reset card and the table is bounded by cards ever dragged; a sweep can
+    ride a later cleanup pass if it ever matters.
+- [x] Unit 4: AI intake
+  - Implemented as designed (two-stage resolve → materialize, not a
+    headless tool-agent). Additional decisions: disambiguation reuses the
+    same requestId so the status stream stays continuous; a no-match
+    result offers ALL registered directories as candidates rather than a
+    directory-less thread (that flow arrives with launchpad-defaults
+    support later); the intake RPC gets a 120s timeout because worktree
+    preparation can exceed the 30s default.
 
 ## Open questions resolved during planning
 

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -5,7 +5,7 @@ import type {
   MessagingConversationKind,
 } from "./messaging";
 import type { CelestialIconAssignment } from "./celestial";
-import type { StarMapArrangementEntry } from "./star-map";
+import type { StarMapArrangementEntry, StarMapIntakePhase } from "./star-map";
 import type {
   FederationConnectionState,
   FederationTarget,
@@ -1053,6 +1053,17 @@ export type StarMapArrangementChangedNotification = {
   };
 };
 
+export type StarMapIntakeStatusNotification = {
+  method: "starMap/intake/status";
+  params: {
+    requestId: string;
+    phase: StarMapIntakePhase;
+    message?: string;
+    backend?: string;
+    threadId?: string;
+  };
+};
+
 export type AppServerMcpElicitationAction = "accept" | "decline" | "cancel";
 
 export type AppServerMcpElicitationSchema = {
@@ -1696,4 +1707,5 @@ export type AppServerNotification =
   | FederationPeerStatusChangedNotification
   | FederationCelestialIconsChangedNotification
   | StarMapArrangementChangedNotification
+  | StarMapIntakeStatusNotification
   | AppServerPendingRequestNotification;

--- a/packages/shared/src/contracts/star-map.ts
+++ b/packages/shared/src/contracts/star-map.ts
@@ -118,3 +118,52 @@ export type SetStarMapCardPositionRequest = {
   dx: number | null;
   dy: number | null;
 };
+
+/* ==== AI intake ==== */
+
+export type StarMapIntakeCandidate = {
+  directoryKey: string;
+  label: string;
+  path?: string;
+};
+
+/**
+ * Intake dispatch, executed ON the owning instance so its directory
+ * registry, launchpad defaults, and ~/.pwragent/AGENTS.md preferences are
+ * the ones consulted. `directoryKey` is set on a disambiguation resubmit.
+ *
+ * Backend/thread ids are plain strings here (not the normalized app-server
+ * types) so this contract stays leaf-importable without a type cycle.
+ */
+export type StarMapIntakeRequest = {
+  requestId: string;
+  request: string;
+  directoryKey?: string;
+};
+
+export type StarMapIntakeResponse =
+  | {
+      status: "created";
+      requestId: string;
+      backend: string;
+      threadId: string;
+      title?: string;
+    }
+  | {
+      status: "needs_disambiguation";
+      requestId: string;
+      /** Ranked candidate projects for the operator to pick from. */
+      candidates: StarMapIntakeCandidate[];
+    }
+  | {
+      status: "failed";
+      requestId: string;
+      error: string;
+    };
+
+export type StarMapIntakePhase =
+  | "resolving"
+  | "creating"
+  | "needs_disambiguation"
+  | "done"
+  | "failed";


### PR DESCRIPTION
Unit 4 of 4 of the Star Map plan — stacked on the arrangement-sync PR. The showcase moment.

- The [+] on each instance card opens an intake chat: "give me a task, tell me the project, and any specifics that don't match your defaults."
- The request executes ON the owning instance (new `backend.starMapIntake` RPC, `environment_actions`): a Grok structured call resolves the project over that instance's directory registry plus its `~/.pwragent/AGENTS.md` (profile-scoped first) thread-startup preferences, with a deterministic label match and a project chooser as fallbacks, then `materializeDirectoryLaunchpad` creates the thread with the request as the first turn.
- `starMap/intake/status` events stream resolve/create progress to the dialog through the existing backend-event fan-out (works across the federation).
- On success the new card bubbles into the map with an entrance animation and the owning instance's cloud refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)