### PR TITLE
fix(desktop): reconcile stale Codex thread status

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1460,6 +1460,7 @@ class MockBackendClient {
       nativeSubAgentThreads?: AppServerThreadSummary[];
       replay?: AppServerThreadReplay;
       readThreadReplays?: AppServerThreadReplay[];
+      readThreadDelay?: Promise<unknown>;
       skills?: Array<{
         commands?: AppServerAvailableCommandSummary[];
         cwd?: string;
@@ -1634,6 +1635,9 @@ class MockBackendClient {
       this.readThreadCalls.push(_params);
     }
     const replay = this.options.readThreadReplays?.shift();
+    if (this.options.readThreadDelay) {
+      await this.options.readThreadDelay;
+    }
     if (replay) {
       return replay;
     }
@@ -15135,6 +15139,100 @@ command = "pnpm dev"
     expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
       count: 1,
       threadIds: ["codex:thread-stale-active"],
+    });
+
+    await registry.close();
+  });
+
+  it("ignores an active Codex thread read that started before completion", async () => {
+    const readThreadDelay = createDeferred<void>();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/read"] },
+      readThreadDelay: readThreadDelay.promise,
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "active",
+      },
+      threads: [
+        {
+          id: "thread-stale-read",
+          title: "Finished while reading",
+          titleSource: "explicit",
+          threadStatus: "active",
+          linkedDirectories: [],
+          source: "codex",
+          updatedAt: 1_000,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.listThreads({ backend: "codex" });
+    const readPromise = registry.readThread({
+      backend: "codex",
+      threadId: "thread-stale-read",
+    });
+    await waitForCondition(() => codexClient.readThreadCalls.length === 1);
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-stale-read",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          output: [],
+        },
+      },
+    });
+    codexClient.setThreads([
+      {
+        id: "thread-stale-read",
+        title: "Finished while reading",
+        titleSource: "explicit",
+        threadStatus: "idle",
+        linkedDirectories: [],
+        source: "codex",
+        updatedAt: 2_000,
+      },
+    ]);
+    await expect(
+      registry.listThreads({ backend: "codex" }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-stale-read",
+        threadStatus: "idle",
+      }),
+    ]);
+
+    readThreadDelay.resolve();
+    await expect(readPromise).resolves.toMatchObject({
+      threadStatus: "active",
+    });
+
+    await expect(
+      registry.listThreads({ backend: "codex", forceRefresh: true }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-stale-read",
+        threadStatus: "idle",
+      }),
+    ]);
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 0,
+      threadIds: [],
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -15038,6 +15038,108 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("preserves a newer idle observation over a stale active Codex thread list", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/read"] },
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      },
+      threads: [
+        {
+          id: "thread-stale-active",
+          title: "Finished remotely",
+          titleSource: "explicit",
+          threadStatus: "active",
+          linkedDirectories: [],
+          source: "codex",
+          updatedAt: 1_000,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await expect(
+      registry.listThreads({ backend: "codex" }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-stale-active",
+        threadStatus: "active",
+      }),
+    ]);
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-stale-active",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          output: [],
+        },
+      },
+    });
+    await expect(
+      registry.readThread({
+        backend: "codex",
+        threadId: "thread-stale-active",
+      }),
+    ).resolves.toMatchObject({
+      threadStatus: "idle",
+    });
+
+    await expect(
+      registry.listThreads({ backend: "codex" }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-stale-active",
+        threadStatus: "idle",
+      }),
+    ]);
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 0,
+      threadIds: [],
+    });
+
+    await codexClient.emit({
+      method: "turn/started",
+      params: {
+        threadId: "thread-stale-active",
+        turn: {
+          id: "turn-2",
+          status: "inProgress",
+          items: [],
+        },
+      },
+    });
+    await expect(
+      registry.listThreads({ backend: "codex", forceRefresh: true }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-stale-active",
+        threadStatus: "active",
+      }),
+    ]);
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: ["codex:thread-stale-active"],
+    });
+
+    await registry.close();
+  });
+
   it("reserves Codex turn starts before awaited pre-start work", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6323,11 +6323,21 @@ export class DesktopBackendRegistry {
    * Live lifecycle notifications and thread reads can be newer than Codex's
    * cached thread/list status. Preserve that observation until thread/list
    * returns the same value, then hand authority back to the list snapshot.
+   * Read sequences are reserved before awaiting the backend; the per-thread
+   * high-water mark survives that handoff so a delayed older read stays stale.
    */
   private readonly observedCodexThreadStatuses = new Map<
     string,
-    AppServerThreadStatus
+    {
+      sequence: number;
+      status: AppServerThreadStatus;
+    }
   >();
+  private readonly latestCodexThreadStatusObservationSequences = new Map<
+    string,
+    number
+  >();
+  private codexThreadStatusObservationSequence = 0;
   private readonly liveThreadUsageBaselines = new Map<
     string,
     TaskMonitorTokenUsageBreakdown
@@ -9479,6 +9489,11 @@ export class DesktopBackendRegistry {
       return await this.readAcpThread(request, backend);
     }
 
+    const codexStatusObservationSequence =
+      backend === "codex"
+        ? this.reserveCodexThreadStatusObservationSequence()
+        : undefined;
+
     const replay =
       backend === "codex"
         ? await this.withCodexThreadClient(
@@ -9503,7 +9518,11 @@ export class DesktopBackendRegistry {
           });
 
     if (backend === "codex") {
-      this.reconcileBackendCodexThreadStatus(request.threadId, replay.threadStatus);
+      this.reconcileBackendCodexThreadStatus(
+        request.threadId,
+        replay.threadStatus,
+        codexStatusObservationSequence,
+      );
     }
 
     if (
@@ -13162,12 +13181,27 @@ export class DesktopBackendRegistry {
   private reconcileBackendCodexThreadStatus(
     threadId: string,
     status: string | undefined,
+    sequence = this.reserveCodexThreadStatusObservationSequence(),
   ): void {
     if (!isAppServerThreadStatus(status)) {
       return;
     }
-    this.observedCodexThreadStatuses.set(threadId, status);
+    const latestSequence =
+      this.latestCodexThreadStatusObservationSequences.get(threadId);
+    if (latestSequence !== undefined && latestSequence > sequence) {
+      return;
+    }
+    this.latestCodexThreadStatusObservationSequences.set(threadId, sequence);
+    this.observedCodexThreadStatuses.set(threadId, {
+      sequence,
+      status,
+    });
     this.seedBackendCodexThreadStatus(threadId, status);
+  }
+
+  private reserveCodexThreadStatusObservationSequence(): number {
+    this.codexThreadStatusObservationSequence += 1;
+    return this.codexThreadStatusObservationSequence;
   }
 
   private seedBackendCodexThreadStatus(
@@ -13186,11 +13220,12 @@ export class DesktopBackendRegistry {
   private reconcileCodexThreadListStatus(
     thread: AppServerThreadSummary,
   ): AppServerThreadSummary {
-    const observedStatus = this.observedCodexThreadStatuses.get(thread.id);
-    if (!observedStatus) {
+    const observation = this.observedCodexThreadStatuses.get(thread.id);
+    if (!observation) {
       this.seedBackendCodexThreadStatus(thread.id, thread.threadStatus);
       return thread;
     }
+    const observedStatus = observation.status;
 
     // Codex review flows can emit an idle boundary for one turn while another
     // tracked turn remains active. In-memory turn ownership wins in that case;
@@ -13201,7 +13236,10 @@ export class DesktopBackendRegistry {
         : observedStatus;
     this.seedBackendCodexThreadStatus(thread.id, reconciledStatus);
     if (thread.threadStatus === reconciledStatus) {
-      if (reconciledStatus === observedStatus) {
+      if (
+        reconciledStatus === observedStatus
+        && this.observedCodexThreadStatuses.get(thread.id) === observation
+      ) {
         this.observedCodexThreadStatuses.delete(thread.id);
       }
       return thread;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2503,6 +2503,17 @@ function readStatusType(value: unknown): string | undefined {
   return typeof type === "string" ? type : undefined;
 }
 
+function isAppServerThreadStatus(
+  value: string | undefined,
+): value is AppServerThreadStatus {
+  return (
+    value === "active"
+    || value === "idle"
+    || value === "notLoaded"
+    || value === "unknown"
+  );
+}
+
 function readNotificationItemType(notification: AppServerNotification): string | undefined {
   if (
     notification.method !== "item/started" &&
@@ -6308,6 +6319,15 @@ export class DesktopBackendRegistry {
    * original `turn/started` notification.
    */
   private readonly backendActiveCodexThreadIds = new Set<string>();
+  /**
+   * Live lifecycle notifications and thread reads can be newer than Codex's
+   * cached thread/list status. Preserve that observation until thread/list
+   * returns the same value, then hand authority back to the list snapshot.
+   */
+  private readonly observedCodexThreadStatuses = new Map<
+    string,
+    AppServerThreadStatus
+  >();
   private readonly liveThreadUsageBaselines = new Map<
     string,
     TaskMonitorTokenUsageBreakdown
@@ -13143,6 +13163,17 @@ export class DesktopBackendRegistry {
     threadId: string,
     status: string | undefined,
   ): void {
+    if (!isAppServerThreadStatus(status)) {
+      return;
+    }
+    this.observedCodexThreadStatuses.set(threadId, status);
+    this.seedBackendCodexThreadStatus(threadId, status);
+  }
+
+  private seedBackendCodexThreadStatus(
+    threadId: string,
+    status: AppServerThreadStatus | undefined,
+  ): void {
     if (status === "active") {
       this.backendActiveCodexThreadIds.add(threadId);
       return;
@@ -13150,6 +13181,36 @@ export class DesktopBackendRegistry {
     if (status) {
       this.backendActiveCodexThreadIds.delete(threadId);
     }
+  }
+
+  private reconcileCodexThreadListStatus(
+    thread: AppServerThreadSummary,
+  ): AppServerThreadSummary {
+    const observedStatus = this.observedCodexThreadStatuses.get(thread.id);
+    if (!observedStatus) {
+      this.seedBackendCodexThreadStatus(thread.id, thread.threadStatus);
+      return thread;
+    }
+
+    // Codex review flows can emit an idle boundary for one turn while another
+    // tracked turn remains active. In-memory turn ownership wins in that case;
+    // retain the observation so the next genuine terminal event can settle it.
+    const reconciledStatus =
+      observedStatus !== "active" && this.threadHasActiveTurn(thread.id)
+        ? "active"
+        : observedStatus;
+    this.seedBackendCodexThreadStatus(thread.id, reconciledStatus);
+    if (thread.threadStatus === reconciledStatus) {
+      if (reconciledStatus === observedStatus) {
+        this.observedCodexThreadStatuses.delete(thread.id);
+      }
+      return thread;
+    }
+
+    return {
+      ...thread,
+      threadStatus: reconciledStatus,
+    };
   }
 
   private threadHasActiveTurn(
@@ -17085,11 +17146,11 @@ export class DesktopBackendRegistry {
       }),
     );
 
-    for (const thread of enrichedThreads) {
-      this.reconcileBackendCodexThreadStatus(thread.id, thread.threadStatus);
-    }
+    const statusReconciledThreads = enrichedThreads.map((thread) =>
+      this.reconcileCodexThreadListStatus(thread)
+    );
 
-    return enrichedThreads.sort(
+    return statusReconciledThreads.sort(
       (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
     );
   }
@@ -25538,7 +25599,10 @@ export class DesktopBackendRegistry {
       };
       const turnId = turnIdFromStartedNotification(notification);
       if (event.backend === "codex") {
-        this.backendActiveCodexThreadIds.add(notification.params.threadId);
+        this.reconcileBackendCodexThreadStatus(
+          notification.params.threadId,
+          "active",
+        );
       }
       if (!isAcpBackendId(event.backend)) {
         this.schedulePendingThreadTitleGenerationFromLifecycle({
@@ -25594,7 +25658,10 @@ export class DesktopBackendRegistry {
         });
       }
       if (event.backend === "codex") {
-        this.backendActiveCodexThreadIds.delete(notification.params.threadId);
+        this.reconcileBackendCodexThreadStatus(
+          notification.params.threadId,
+          "idle",
+        );
       }
       const managedReview = turnId
         ? this.findActiveReviewSubAgentForTerminal({


### PR DESCRIPTION
## Summary

- I preserve newer Codex lifecycle and `thread/read` status observations when a cached `thread/list` response still reports the previous state.
- I order asynchronous status observations from the start of each read so a delayed stale response cannot replace a later lifecycle event, even after `thread/list` catches up.
- I keep in-memory active-turn ownership authoritative for overlapping/review turns, and I hand status authority back to `thread/list` once it catches up.
- I added a regression test for the observed remote-viewer split: the transcript reads idle after `turn/completed`, but the stale thread list continues to report active.

## Verification

- I confirmed the new regression test fails on `origin/main` with the listed thread still active after the idle read.
- I confirmed the delayed-read regression fails before the ordering fix when an active read starts before `turn/completed` and resolves afterward.
- I ran all 451 tests in `apps/desktop/src/main/__tests__/backend-registry.test.ts`.
- I ran `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:boundaries`, `pnpm lint:codex-storage`, `pnpm lint:sql`, `pnpm lint:colors`, `pnpm lint:electron-version`, and `pnpm licenses:check`.

## Notes

- The source log recorded `turn/completed` for thread `019fd408-7e28-7ca0-a8a8-3296f5fb71c8` at 2026-08-05 18:52:16.685. The missing composer Stop button and transcript thinking indicator were consistent with `thread/read` already being idle; only the thread-list status remained stale.
