### PR TITLE
feat(desktop): compress federation protocol frames

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-config-federation.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-config-federation.test.ts
@@ -6,6 +6,23 @@ import {
 import { applyTomlEdits, parseTomlTables } from "../settings/toml-editor";
 
 describe("desktop config [federation] section", () => {
+  it.each([true, false])("round-trips compression %s without changing unrelated TOML", (compressionEnabled) => {
+    const original = '# Keep this comment\n[federation]\nmode = "client"\n';
+    const written = applyTomlEdits(original, desktopSettingsPatchToEdits({
+      federation: { compressionEnabled },
+    }));
+    expect(written).toContain("# Keep this comment");
+    expect(written).toContain('mode = "client"');
+    expect(parseDesktopSettingsToml(written, "test.toml").federation?.compressionEnabled)
+      .toBe(compressionEnabled);
+  });
+
+  it("leaves missing or malformed compression settings unspecified", () => {
+    for (const src of ["[federation]", '[federation]\ncompression_enabled = "false"']) {
+      expect(parseDesktopSettingsToml(src, "test.toml").federation?.compressionEnabled)
+        .toBeUndefined();
+    }
+  });
   it("reads federation settings from TOML", () => {
     const src = [
       "[federation]",

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -43,6 +43,19 @@ function existsOrEmpty(filePath: string): boolean {
 }
 
 describe("DesktopSettingsService", () => {
+  it("persists an explicit federation compression opt-out in the settings snapshot", async () => {
+    const service = new DesktopSettingsService({
+      configPath: path.join(createTempRoot(), "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+    await service.writeConfigPatchTargeted({ federation: { compressionEnabled: false } });
+    expect((await service.readSettingsProjection()).federation.compressionEnabled)
+      .toEqual({ value: false, source: "config" });
+    await service.writeConfigPatchTargeted({ federation: { compressionEnabled: true } });
+    expect((await service.readSettingsProjection()).federation.compressionEnabled)
+      .toEqual({ value: true, source: "config" });
+  });
   it("resolves routine runtime settings from narrow store domains", () => {
     const root = createTempRoot();
     const configPath = path.join(root, "missing-config.toml");
@@ -297,6 +310,7 @@ describe("DesktopSettingsService", () => {
       mode: { value: "gateway", source: "config" },
       listenHost: { value: "127.0.0.1", source: "config" },
       listenPort: { value: 47830, source: "config" },
+      compressionEnabled: { value: true, source: "default" },
       publicUrl: {
         value: "https://pwragent.example.com",
         source: "config",
@@ -755,6 +769,7 @@ describe("DesktopSettingsService", () => {
       mode: { value: "disabled", source: "default" },
       listenHost: { value: "127.0.0.1", source: "default" },
       listenPort: { value: 47830, source: "default" },
+      compressionEnabled: { value: true, source: "default" },
       publicUrl: { value: "", source: "default" },
       gatewayUrl: { value: "", source: "default" },
       cloudflareMtlsEnabled: { value: false, source: "default" },

--- a/apps/desktop/src/main/__tests__/federation-frame-codec.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-frame-codec.test.ts
@@ -1,0 +1,91 @@
+import { randomBytes } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  decodeFederationFramePayload,
+  encodeFederationFramePayload,
+} from "../federation/federation-frame-codec";
+
+describe("federation frame codec", () => {
+  it("compresses repetitive protocol JSON and restores it exactly", () => {
+    const json = Buffer.from(JSON.stringify({
+      kind: "envelope",
+      envelope: {
+        kind: "response",
+        result: {
+          items: Array.from({ length: 4_000 }, (_, index) => ({
+            id: `command-${index}`,
+            output: "repeated command output\n".repeat(12),
+            type: "commandExecution",
+          })),
+        },
+      },
+    }));
+
+    const frame = encodeFederationFramePayload({
+      json,
+      compressionEnabled: true,
+    });
+
+    expect(frame.length).toBeLessThan(json.length);
+    expect(frame.subarray(0, 4).toString("ascii")).toBe("PWB1");
+    expect(decodeFederationFramePayload({
+      frame,
+      compressionEnabled: true,
+    })).toEqual(json);
+  });
+
+  it("leaves small and incompressible frames unwrapped", () => {
+    const small = Buffer.from('{"kind":"envelope"}');
+    const incompressible = randomBytes(16 * 1024);
+
+    expect(encodeFederationFramePayload({
+      json: small,
+      compressionEnabled: true,
+    })).toBe(small);
+    expect(encodeFederationFramePayload({
+      json: incompressible,
+      compressionEnabled: true,
+    })).toBe(incompressible);
+  });
+
+  it("rejects compressed frames unless the signed capability negotiated them", () => {
+    const frame = encodeFederationFramePayload({
+      json: Buffer.from("compressible payload ".repeat(1_000)),
+      compressionEnabled: true,
+      compressionThresholdBytes: 1,
+    });
+
+    expect(() => decodeFederationFramePayload({
+      frame,
+      compressionEnabled: false,
+    })).toThrow("Federation frame compression was not negotiated");
+  });
+
+  it("enforces the logical limit before decompressing", () => {
+    const frame = encodeFederationFramePayload({
+      json: Buffer.from("bounded payload ".repeat(1_000)),
+      compressionEnabled: true,
+      compressionThresholdBytes: 1,
+    });
+
+    expect(() => decodeFederationFramePayload({
+      frame,
+      compressionEnabled: true,
+      maxDecodedBytes: 1_024,
+    })).toThrow("Federation decoded frame exceeds the configured limit");
+  });
+
+  it("rejects a forged declared length", () => {
+    const frame = encodeFederationFramePayload({
+      json: Buffer.from("length checked payload ".repeat(1_000)),
+      compressionEnabled: true,
+      compressionThresholdBytes: 1,
+    });
+    frame.writeUInt32BE(frame.readUInt32BE(4) - 1, 4);
+
+    expect(() => decodeFederationFramePayload({
+      frame,
+      compressionEnabled: true,
+    })).toThrow("Compressed federation frame length mismatch");
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-frame-codec.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-frame-codec.test.ts
@@ -12,7 +12,7 @@ describe("federation frame codec", () => {
       envelope: {
         kind: "response",
         result: {
-          items: Array.from({ length: 4_000 }, (_, index) => ({
+          items: Array.from({ length: 100 }, (_, index) => ({
             id: `command-${index}`,
             output: "repeated command output\n".repeat(12),
             type: "commandExecution",
@@ -28,10 +28,11 @@ describe("federation frame codec", () => {
 
     expect(frame.length).toBeLessThan(json.length);
     expect(frame.subarray(0, 4).toString("ascii")).toBe("PWB1");
-    expect(decodeFederationFramePayload({
+    const decoded = decodeFederationFramePayload({
       frame,
       compressionEnabled: true,
-    })).toEqual(json);
+    });
+    expect(decoded.equals(json)).toBe(true);
   });
 
   it("leaves small and incompressible frames unwrapped", () => {

--- a/apps/desktop/src/main/__tests__/federation-runtime-config.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime-config.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import { resolveFederationRuntimeConfig } from "../federation/federation-runtime-config";
 
 describe("resolveFederationRuntimeConfig", () => {
+  it("preserves an explicit compression opt-out", () => {
+    expect(resolveFederationRuntimeConfig({ compressionEnabled: false }).compressionEnabled).toBe(false);
+  });
   it("normalizes the credential-free runtime projection", () => {
     const config = resolveFederationRuntimeConfig({
       advertisedEndpoints: [" ", " wss://public.example/federation "],
@@ -22,6 +25,7 @@ describe("resolveFederationRuntimeConfig", () => {
       cloudflareAccessServiceAuthEnabled: true,
       cloudflareEndpoint: "wss://edge.example/federation",
       cloudflareMtlsEnabled: false,
+      compressionEnabled: true,
       gatewayEndpoints: ["wss://gateway.example/federation"],
       instanceLabel: "Studio",
       instanceNotes: "Primary",
@@ -40,6 +44,7 @@ describe("resolveFederationRuntimeConfig", () => {
       cloudflareAccessServiceAuthEnabled: false,
       cloudflareEndpoint: "",
       cloudflareMtlsEnabled: false,
+      compressionEnabled: true,
       gatewayEndpoints: [],
       instanceLabel: "",
       instanceNotes: "",

--- a/apps/desktop/src/main/__tests__/federation-runtime-startup.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime-startup.test.ts
@@ -93,6 +93,7 @@ const fakeSettings = {
   instanceNotes: "",
   listenHost: "127.0.0.1",
   listenPort: 4321,
+  compressionEnabled: true,
   mode: "gateway",
   publicUrl: "",
 } as const satisfies FederationRuntimeConfig;

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -704,10 +704,15 @@ describe("federation transport", () => {
     });
   });
 
-  it("carries a compressed logical envelope larger than ws maxPayload through Noise", async () => {
-    const maxFrameBytes = 16 * 1024;
+  it.each([
+    { gatewayCompression: true, clientCompression: true },
+    { gatewayCompression: false, clientCompression: true },
+    { gatewayCompression: true, clientCompression: false },
+  ])("negotiates compression through Noise: %j", async ({ gatewayCompression, clientCompression }) => {
+    const compressionEnabled = gatewayCompression && clientCompression;
+    const maxFrameBytes = compressionEnabled ? 16 * 1024 : 1024 * 1024;
     const transcript = "repetitive tool output line\n".repeat(12_000);
-    expect(Buffer.byteLength(transcript)).toBeGreaterThan(maxFrameBytes);
+    expect(Buffer.byteLength(transcript)).toBeGreaterThan(16 * 1024);
     const gatewayTransfers: Array<{
       peerId: string;
       direction: "sent" | "received";
@@ -741,6 +746,7 @@ describe("federation transport", () => {
       store,
       noiseStatic: gatewayNoise,
       maxFrameBytes,
+      compressionEnabled: gatewayCompression,
       onEnvelopeTransfer: (info) => gatewayTransfers.push(info),
       onEnvelope: (envelope, connection) => {
         resolveReceived?.(envelope);
@@ -767,7 +773,9 @@ describe("federation transport", () => {
         peerInstanceId: "client_one",
         privateKeyPem: clientKeyPair.privateKeyPem,
         publicKeyPem: clientKeyPair.publicKeyPem,
-        capabilities: ["remote_window", "transport_brotli"],
+        capabilities: clientCompression
+          ? ["remote_window", "transport_brotli"]
+          : ["remote_window"],
         inviteToken: invite.token,
         label: "Client",
         role: "client",
@@ -777,6 +785,7 @@ describe("federation transport", () => {
         onEnvelope: resolve,
         onEnvelopeTransfer: (info) => clientTransfers.push(info),
       }).then((client) => {
+        expect(client.capabilities.includes("transport_brotli")).toBe(compressionEnabled);
         client.sendEnvelope({
           id: "large-request",
           kind: "request",
@@ -805,6 +814,10 @@ describe("federation transport", () => {
     expect(clientReceived.byteCount).toBe(gatewaySent.byteCount);
     expect(clientSent.byteCount).toBeLessThan(maxFrameBytes);
     expect(gatewaySent.byteCount).toBeLessThan(maxFrameBytes);
+    if (!compressionEnabled) {
+      expect(clientSent.byteCount).toBeGreaterThan(Buffer.byteLength(transcript));
+      expect(gatewaySent.byteCount).toBeGreaterThan(Buffer.byteLength(transcript));
+    }
   });
 
   it("carries the encrypted channel over an externally created outer socket", async () => {

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -1533,7 +1533,7 @@ describe("federation transport liveness", () => {
     expect(received).toHaveLength(1);
   });
 
-  it("rejects an oversized client envelope before sending it", async () => {
+  it.each([false, true])("rejects oversized client envelopes locally (compression: %s)", async (compressionEnabled) => {
     const gatewayNoise = generateNoiseStaticKeyPair();
     const clientNoise = generateNoiseStaticKeyPair();
     const clientKeyPair = generateFederationIdentityKeyPair();
@@ -1564,11 +1564,12 @@ describe("federation transport liveness", () => {
       peerInstanceId: "client_one",
       privateKeyPem: clientKeyPair.privateKeyPem,
       publicKeyPem: clientKeyPair.publicKeyPem,
-      capabilities: ["remote_window"],
+      capabilities: compressionEnabled ? ["remote_window", "transport_brotli"] : ["remote_window"],
       inviteToken: invite.token,
       label: "Client",
       role: "client",
       maxFrameBytes: 64 * 1024,
+      maxDecodedFrameBytes: compressionEnabled ? 64 * 1024 : undefined,
       noiseStatic: clientNoise,
       gatewayNoisePublicKey: gatewayNoise.publicKeyRaw,
     });
@@ -1586,12 +1587,15 @@ describe("federation transport liveness", () => {
     expect(() => client.sendEnvelope(
       envelope("request-too-large", { blob: "x".repeat(128 * 1024) }),
     )).toThrow(/exceeds.*frame.*limit/i);
+    await expect(client.sendEnvelopeWithBackpressure!(
+      envelope("request-too-large-async", { blob: "x".repeat(128 * 1024) }),
+    )).rejects.toThrow(/exceeds.*frame.*limit/i);
     client.sendEnvelope(envelope("request-small", { note: "small" }));
     await expect.poll(() => received.length, { timeout: 5_000 }).toBe(1);
     expect(received[0]?.id).toBe("request-small");
   });
 
-  it("rejects an oversized gateway envelope before sending it", async () => {
+  it.each([false, true])("rejects oversized gateway envelopes locally (compression: %s)", async (compressionEnabled) => {
     const gatewayNoise = generateNoiseStaticKeyPair();
     const clientNoise = generateNoiseStaticKeyPair();
     const clientKeyPair = generateFederationIdentityKeyPair();
@@ -1612,6 +1616,7 @@ describe("federation transport liveness", () => {
       port: 0,
       store,
       maxFrameBytes: 64 * 1024,
+      maxDecodedFrameBytes: compressionEnabled ? 64 * 1024 : undefined,
       noiseStatic: gatewayNoise,
       onConnection: (connection) => {
         gatewayConnection = connection;
@@ -1626,7 +1631,7 @@ describe("federation transport liveness", () => {
       peerInstanceId: "client_one",
       privateKeyPem: clientKeyPair.privateKeyPem,
       publicKeyPem: clientKeyPair.publicKeyPem,
-      capabilities: ["remote_window"],
+      capabilities: compressionEnabled ? ["remote_window", "transport_brotli"] : ["remote_window"],
       inviteToken: invite.token,
       label: "Client",
       role: "client",
@@ -1649,6 +1654,9 @@ describe("federation transport liveness", () => {
     expect(() => gatewayConnection?.sendEnvelope(
       envelope("request-too-large", { blob: "x".repeat(128 * 1024) }),
     )).toThrow(/exceeds.*frame.*limit/i);
+    await expect(gatewayConnection!.sendEnvelopeWithBackpressure!(
+      envelope("request-too-large-async", { blob: "x".repeat(128 * 1024) }),
+    )).rejects.toThrow(/exceeds.*frame.*limit/i);
     gatewayConnection?.sendEnvelope(
       envelope("request-small", { note: "small" }),
     );

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -704,6 +704,109 @@ describe("federation transport", () => {
     });
   });
 
+  it("carries a compressed logical envelope larger than ws maxPayload through Noise", async () => {
+    const maxFrameBytes = 16 * 1024;
+    const transcript = "repetitive tool output line\n".repeat(12_000);
+    expect(Buffer.byteLength(transcript)).toBeGreaterThan(maxFrameBytes);
+    const gatewayTransfers: Array<{
+      peerId: string;
+      direction: "sent" | "received";
+      byteCount: number;
+    }> = [];
+    const clientTransfers: Array<{
+      direction: "sent" | "received";
+      byteCount: number;
+    }> = [];
+
+    const gatewayNoise = generateNoiseStaticKeyPair();
+    const clientNoise = generateNoiseStaticKeyPair();
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    let resolveReceived: ((envelope: FederationProtocolEnvelope) => void) | undefined;
+    const received = new Promise<FederationProtocolEnvelope>((resolve) => {
+      resolveReceived = resolve;
+    });
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-compressed",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      noiseStatic: gatewayNoise,
+      maxFrameBytes,
+      onEnvelopeTransfer: (info) => gatewayTransfers.push(info),
+      onEnvelope: (envelope, connection) => {
+        resolveReceived?.(envelope);
+        connection.sendEnvelope({
+          id: "large-response",
+          kind: "response",
+          requestId: envelope.id,
+          protocolVersion: FEDERATION_PROTOCOL_VERSION,
+          sourceInstanceId: "gateway_one",
+          targetInstanceId: connection.peerId,
+          createdAt: 2_000,
+          result: { transcript },
+        });
+      },
+    });
+    const { url } = await server.start();
+
+    const reply = new Promise<FederationProtocolEnvelope>((resolve) => {
+      void connectFederationClient({
+        url,
+        mode: "enroll",
+        gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+        peerInstanceId: "client_one",
+        privateKeyPem: clientKeyPair.privateKeyPem,
+        publicKeyPem: clientKeyPair.publicKeyPem,
+        capabilities: ["remote_window", "transport_brotli"],
+        inviteToken: invite.token,
+        label: "Client",
+        role: "client",
+        noiseStatic: clientNoise,
+        gatewayNoisePublicKey: gatewayNoise.publicKeyRaw,
+        maxFrameBytes,
+        onEnvelope: resolve,
+        onEnvelopeTransfer: (info) => clientTransfers.push(info),
+      }).then((client) => {
+        client.sendEnvelope({
+          id: "large-request",
+          kind: "request",
+          method: "thread.read",
+          params: { transcript },
+          protocolVersion: FEDERATION_PROTOCOL_VERSION,
+          sourceInstanceId: "client_one",
+          targetInstanceId: "gateway_one",
+          createdAt: 1_000,
+        });
+      });
+    });
+
+    await expect(received).resolves.toMatchObject({
+      kind: "request",
+      params: { transcript },
+    });
+    await expect(reply).resolves.toMatchObject({
+      kind: "response",
+      requestId: "large-request",
+      result: { transcript },
+    });
+    const [gatewayReceived, gatewaySent] = gatewayTransfers;
+    const [clientSent, clientReceived] = clientTransfers;
+    expect(gatewayReceived.byteCount).toBe(clientSent.byteCount);
+    expect(clientReceived.byteCount).toBe(gatewaySent.byteCount);
+    expect(clientSent.byteCount).toBeLessThan(maxFrameBytes);
+    expect(gatewaySent.byteCount).toBeLessThan(maxFrameBytes);
+  });
+
   it("carries the encrypted channel over an externally created outer socket", async () => {
     const gatewayNoise = generateNoiseStaticKeyPair();
     const clientNoise = generateNoiseStaticKeyPair();

--- a/apps/desktop/src/main/federation/federation-frame-codec.ts
+++ b/apps/desktop/src/main/federation/federation-frame-codec.ts
@@ -1,0 +1,119 @@
+import {
+  brotliCompressSync,
+  brotliDecompressSync,
+  constants as zlibConstants,
+} from "node:zlib";
+
+/**
+ * Signed session capability for application-layer Brotli frames. Compression
+ * must happen before optional Noise encryption; WebSocket compression sees
+ * only the resulting AES-GCM ciphertext in Noise mode.
+ */
+export const FEDERATION_BROTLI_CAPABILITY = "transport_brotli" as const;
+
+/** Small streamed notifications cost more CPU than bandwidth when compressed. */
+export const FEDERATION_COMPRESSION_THRESHOLD_BYTES = 4 * 1024;
+
+/**
+ * Logical-message ceiling after decompression. This is deliberately separate
+ * from ws maxPayload, which limits the compressed/encrypted wire message.
+ */
+export const FEDERATION_MAX_DECODED_FRAME_BYTES = 64 * 1024 * 1024;
+
+// "PWB1" identifies PwrAgent's first Brotli application-frame encoding. The
+// following uint32 is the authenticated plaintext length, allowing rejection
+// before decompression allocates attacker-controlled output.
+const FEDERATION_BROTLI_HEADER = Buffer.from("PWB1", "ascii");
+const FEDERATION_BROTLI_HEADER_BYTES = 8;
+
+export function encodeFederationFramePayload(params: {
+  json: Buffer;
+  compressionEnabled: boolean;
+  compressionThresholdBytes?: number;
+}): Buffer {
+  if (
+    !params.compressionEnabled
+    || params.json.length <
+      (params.compressionThresholdBytes
+        ?? FEDERATION_COMPRESSION_THRESHOLD_BYTES)
+  ) {
+    return params.json;
+  }
+
+  const compressed = brotliCompressSync(params.json, {
+    params: {
+      // Quality 1 is the low-latency mode. Federation compresses discrete
+      // messages, not one context-carrying stream, so every frame remains
+      // independently decodable and small notifications stay uncompressed.
+      [zlibConstants.BROTLI_PARAM_QUALITY]: 1,
+    },
+  });
+  if (compressed.length + FEDERATION_BROTLI_HEADER_BYTES >= params.json.length) {
+    return params.json;
+  }
+
+  const header = Buffer.allocUnsafe(FEDERATION_BROTLI_HEADER_BYTES);
+  FEDERATION_BROTLI_HEADER.copy(header);
+  header.writeUInt32BE(params.json.length, FEDERATION_BROTLI_HEADER.length);
+  return Buffer.concat([header, compressed]);
+}
+
+export function decodeFederationFramePayload(params: {
+  frame: Buffer;
+  compressionEnabled: boolean;
+  maxDecodedBytes?: number;
+}): Buffer {
+  const maxDecodedBytes =
+    params.maxDecodedBytes ?? FEDERATION_MAX_DECODED_FRAME_BYTES;
+  const compressed =
+    params.frame.length >= FEDERATION_BROTLI_HEADER_BYTES
+    && params.frame.subarray(0, FEDERATION_BROTLI_HEADER.length).equals(
+      FEDERATION_BROTLI_HEADER,
+    );
+  if (!compressed) {
+    assertDecodedSize(params.frame.length, maxDecodedBytes);
+    return params.frame;
+  }
+  if (!params.compressionEnabled) {
+    throw new FederationFrameCompressionError(
+      "Federation frame compression was not negotiated",
+    );
+  }
+
+  const declaredBytes = params.frame.readUInt32BE(
+    FEDERATION_BROTLI_HEADER.length,
+  );
+  assertDecodedSize(declaredBytes, maxDecodedBytes);
+  let decoded: Buffer;
+  try {
+    decoded = brotliDecompressSync(
+      params.frame.subarray(FEDERATION_BROTLI_HEADER_BYTES),
+      { maxOutputLength: maxDecodedBytes },
+    );
+  } catch {
+    throw new FederationFrameCompressionError(
+      "Invalid compressed federation frame",
+    );
+  }
+  if (decoded.length !== declaredBytes) {
+    throw new FederationFrameCompressionError(
+      "Compressed federation frame length mismatch",
+    );
+  }
+  return decoded;
+}
+
+function assertDecodedSize(size: number, maxDecodedBytes: number): void {
+  if (size > maxDecodedBytes) {
+    throw new FederationFrameCompressionError(
+      "Federation decoded frame exceeds the configured limit",
+    );
+  }
+}
+
+export class FederationFrameCompressionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FederationFrameCompressionError";
+  }
+}

--- a/apps/desktop/src/main/federation/federation-runtime-config.ts
+++ b/apps/desktop/src/main/federation/federation-runtime-config.ts
@@ -14,6 +14,7 @@ export type FederationRuntimeConfig = Readonly<{
   instanceNotes: string;
   listenHost: string;
   listenPort: number;
+  compressionEnabled: boolean;
   mode: DesktopFederationMode;
   publicUrl: string;
 }>;
@@ -37,6 +38,7 @@ export function resolveFederationRuntimeConfig(
     instanceNotes: config.instanceNotes?.trim() ?? "",
     listenHost: config.listenHost ?? "127.0.0.1",
     listenPort: config.listenPort ?? 47_830,
+    compressionEnabled: config.compressionEnabled ?? true,
     mode: config.mode ?? DESKTOP_FEDERATION_MODE_DEFAULT,
     publicUrl: config.publicUrl?.trim() ?? "",
   });

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -487,6 +487,8 @@ const DEFAULT_CAPABILITIES: FederationCapability[] = [
   "remote_pty",
   "event_subscriptions",
   "turn_input_blobs",
+  // Signed transport negotiation; not a user-authorized remote action.
+  "transport_brotli",
 ];
 
 const REMOTE_THREAD_SUMMARY_EVENT_CONSUMER_ID =

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -2789,6 +2789,7 @@ export class DesktopFederationRuntime {
         gatewayPublicKeyPem: gatewayIdentity.publicKeyPem,
         host: config.listenHost,
         port: config.listenPort,
+        compressionEnabled: config.compressionEnabled,
         store: this.store(),
         noiseStatic,
         onConnection: (connection) => this.registerGatewayConnection(connection),
@@ -3036,7 +3037,9 @@ export class DesktopFederationRuntime {
       peerInstanceId: this.ensureLocalInstanceId(),
       privateKeyPem: keyPair.privateKeyPem,
       publicKeyPem: keyPair.publicKeyPem,
-      capabilities: DEFAULT_CAPABILITIES,
+      capabilities: DEFAULT_CAPABILITIES.filter(
+        (capability) => config.compressionEnabled || capability !== "transport_brotli",
+      ),
       inviteToken: pendingInviteToken || undefined,
       label:
         this.instanceLabel ||
@@ -3757,13 +3760,16 @@ export class DesktopFederationRuntime {
   ): FederationPeerSummary[] {
     const localInstanceId = this.ensureLocalInstanceId();
     const localProfileName = getAppStateDb().getMeta("profile_name") || undefined;
+    const compressionEnabled = this.readRuntimeConfig().compressionEnabled;
     const peers: FederationPeerSummary[] = [
       {
         id: localInstanceId,
         label: this.instanceLabel || localProfileName || "Gateway",
         role: "gateway",
         status: "connected",
-        capabilities: DEFAULT_CAPABILITIES,
+        capabilities: DEFAULT_CAPABILITIES.filter(
+          (capability) => compressionEnabled || capability !== "transport_brotli",
+        ),
         protocolVersion: FEDERATION_PROTOCOL_VERSION,
         navigationQueryProtocol: 2,
         profileName: localProfileName,

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -336,7 +336,7 @@ export type FederationGatewayWebSocketServerOptions = {
   keepaliveIntervalMs?: number;
   /** Per-WebSocket-message send and receive ceiling. */
   maxFrameBytes?: number;
-  /** Logical receive ceiling after application-layer decompression. */
+  /** Logical send/receive ceiling, independent of compressed wire size. */
   maxDecodedFrameBytes?: number;
   /** Deadline for a connected socket to finish Noise + identity auth. */
   authTimeoutMs?: number;
@@ -687,6 +687,7 @@ export class FederationGatewayWebSocketServer {
           transport,
           {
             maxFrameBytes: this.options.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES,
+            maxDecodedFrameBytes: this.options.maxDecodedFrameBytes,
             compressionEnabled: decision.capabilities.includes(
               FEDERATION_BROTLI_CAPABILITY,
             ),
@@ -710,6 +711,7 @@ export class FederationGatewayWebSocketServer {
           transport,
           {
             maxFrameBytes: this.options.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES,
+            maxDecodedFrameBytes: this.options.maxDecodedFrameBytes,
             compressionEnabled: decision.capabilities.includes(
               FEDERATION_BROTLI_CAPABILITY,
             ),
@@ -986,7 +988,7 @@ export async function connectFederationClient(params: {
   keepaliveIntervalMs?: number;
   /** Per-WebSocket-message send and receive ceiling. */
   maxFrameBytes?: number;
-  /** Logical receive ceiling after application-layer decompression. */
+  /** Logical send/receive ceiling, independent of compressed wire size. */
   maxDecodedFrameBytes?: number;
   /** Client's Noise static keypair. Enables encryption (initiator role). */
   noiseStatic?: NoiseKeyPair;
@@ -1324,7 +1326,7 @@ async function establishFederationClient(
         socket,
         { kind: "envelope", envelope },
         transport,
-        { compressionEnabled, maxFrameBytes },
+        { compressionEnabled, maxFrameBytes, maxDecodedFrameBytes: params.maxDecodedFrameBytes },
         diagnosticsContext,
       );
       if (byteCount > 0) {
@@ -1339,7 +1341,7 @@ async function establishFederationClient(
         socket,
         { kind: "envelope", envelope },
         transport,
-        { compressionEnabled, maxFrameBytes },
+        { compressionEnabled, maxFrameBytes, maxDecodedFrameBytes: params.maxDecodedFrameBytes },
         diagnosticsContext,
       );
       if (byteCount > 0) {
@@ -1448,7 +1450,7 @@ function sendFrame(
   socket: WebSocket,
   message: FederationSocketMessage,
   transport?: NoiseTransport,
-  options?: { compressionEnabled?: boolean; maxFrameBytes?: number },
+  options?: { compressionEnabled?: boolean; maxFrameBytes?: number; maxDecodedFrameBytes?: number },
   context?: EnvelopeDiagnosticsContext,
 ): number {
   if (socket.readyState !== WebSocket.OPEN) return 0;
@@ -1459,6 +1461,13 @@ function sendFrame(
     log.info("federation search request queued for send", envelopeLogFields(message.envelope, context));
   }
   const socketPayload = encodeFederationSocketPayload(message);
+  const maxDecodedFrameBytes =
+    options?.maxDecodedFrameBytes ?? FEDERATION_MAX_DECODED_FRAME_BYTES;
+  // Reject locally before compression or advancing the Noise nonce. A small
+  // wire frame can still exceed the receiver's logical-message ceiling.
+  if (socketPayload.byteLength > maxDecodedFrameBytes) {
+    throw new FederationFrameTooLargeError(socketPayload.byteLength, maxDecodedFrameBytes);
+  }
   const payload = encodeFederationFramePayload({
     json: socketPayload,
     compressionEnabled: options?.compressionEnabled ?? false,
@@ -1500,7 +1509,7 @@ async function sendFrameWithBackpressure(
   socket: WebSocket,
   message: FederationSocketMessage,
   transport?: NoiseTransport,
-  options?: { compressionEnabled?: boolean; maxFrameBytes?: number },
+  options?: { compressionEnabled?: boolean; maxFrameBytes?: number; maxDecodedFrameBytes?: number },
   context?: EnvelopeDiagnosticsContext,
 ): Promise<number> {
   await waitForFederationSendCapacity(socket);

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -36,6 +36,13 @@ import {
   type NoiseTransport,
 } from "./federation-noise";
 import {
+  decodeFederationFramePayload,
+  encodeFederationFramePayload,
+  FEDERATION_BROTLI_CAPABILITY,
+  FEDERATION_MAX_DECODED_FRAME_BYTES,
+  FederationFrameCompressionError,
+} from "./federation-frame-codec";
+import {
   federationFailure,
   type FederationRedactedFailure,
 } from "./federation-redaction";
@@ -98,11 +105,13 @@ const REPLACEMENT_FLAP_THRESHOLD = 3;
 export const FEDERATION_KEEPALIVE_INTERVAL_MS = 15_000;
 
 /**
- * Hard ceiling on a single WebSocket frame, both directions. Legitimate
- * frames are JSON envelopes (RPC payloads, ≤ ~43 KiB base64 PTY chunks);
- * transcript-bearing responses can reach megabytes, so the ceiling is
- * generous — but without one, ws defaults to 100 MiB and a hostile enrolled
- * peer can force that allocation per frame.
+ * Hard ceiling on a single WebSocket message, both directions. Legitimate
+ * messages are framed protocol payloads; transcript-bearing responses can
+ * reach megabytes, so the ceiling is generous — but without one, ws defaults
+ * to 100 MiB and a hostile enrolled peer can force that allocation per
+ * message. WebSocket compression stays disabled, so this limits the
+ * compressed application frame plus Noise tag;
+ * FEDERATION_MAX_DECODED_FRAME_BYTES separately limits expanded plaintext.
  */
 export const FEDERATION_MAX_FRAME_BYTES = 16 * 1024 * 1024;
 // Match the decimal KB units shown by Federation Activity.
@@ -323,8 +332,10 @@ export type FederationGatewayWebSocketServerOptions = {
   noiseStatic?: NoiseKeyPair;
   /** Ping cadence; a peer missing one interval's pong is terminated. */
   keepaliveIntervalMs?: number;
-  /** Per-frame send and receive ceiling. */
+  /** Per-WebSocket-message send and receive ceiling. */
   maxFrameBytes?: number;
+  /** Logical receive ceiling after application-layer decompression. */
+  maxDecodedFrameBytes?: number;
   /** Deadline for a connected socket to finish Noise + identity auth. */
   authTimeoutMs?: number;
   onConnection?: (connection: FederationGatewayConnection) => void;
@@ -388,6 +399,10 @@ export class FederationGatewayWebSocketServer {
     this.wsServer = new WebSocketServer({
       server: this.httpServer,
       maxPayload: this.options.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES,
+      // In Noise mode ws sees incompressible ciphertext. Tunnel mode uses the
+      // same negotiated inner codec so maxPayload continues to protect wire
+      // bytes while the codec separately limits decompressed bytes.
+      perMessageDeflate: false,
     });
     this.wsServer.on("connection", (socket, request) => void this.handleSocket(socket, request));
     // Belt-and-suspenders behind the per-socket keepalive: sweep sessions
@@ -560,9 +575,13 @@ export class FederationGatewayWebSocketServer {
     }
     let message: FederationSocketMessage | undefined;
     try {
-      message = decodeFrame(authFrame, transport);
-    } catch {
-      closeAfterFrameAuthenticationFailure(socket);
+      message = decodeFrame(authFrame, transport, {
+        maxDecodedBytes:
+          this.options.maxDecodedFrameBytes
+          ?? FEDERATION_MAX_DECODED_FRAME_BYTES,
+      });
+    } catch (error) {
+      closeAfterFrameDecodeFailure(socket, error);
       return;
     }
     if (!message || message.kind !== "auth") {
@@ -657,7 +676,12 @@ export class FederationGatewayWebSocketServer {
           socket,
           { kind: "envelope", envelope },
           transport,
-          this.options.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES,
+          {
+            maxFrameBytes: this.options.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES,
+            compressionEnabled: decision.capabilities.includes(
+              FEDERATION_BROTLI_CAPABILITY,
+            ),
+          },
           diagnosticsContext,
         );
         if (byteCount > 0) {
@@ -675,7 +699,12 @@ export class FederationGatewayWebSocketServer {
           socket,
           { kind: "envelope", envelope },
           transport,
-          this.options.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES,
+          {
+            maxFrameBytes: this.options.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES,
+            compressionEnabled: decision.capabilities.includes(
+              FEDERATION_BROTLI_CAPABILITY,
+            ),
+          },
           diagnosticsContext,
         );
         if (byteCount > 0) {
@@ -813,9 +842,16 @@ export class FederationGatewayWebSocketServer {
       }
       let next: FederationSocketMessage | undefined;
       try {
-        next = decodeFrame(frame, transport);
-      } catch {
-        closeAfterFrameAuthenticationFailure(socket);
+        next = decodeFrame(frame, transport, {
+          compressionEnabled: decision.capabilities.includes(
+            FEDERATION_BROTLI_CAPABILITY,
+          ),
+          maxDecodedBytes:
+            this.options.maxDecodedFrameBytes
+            ?? FEDERATION_MAX_DECODED_FRAME_BYTES,
+        });
+      } catch (error) {
+        closeAfterFrameDecodeFailure(socket, error);
         return;
       }
       if (!next || next.kind !== "envelope") continue;
@@ -939,8 +975,10 @@ export async function connectFederationClient(params: {
   connectTimeoutMs?: number;
   /** Ping cadence; a gateway missing one interval's pong is terminated. */
   keepaliveIntervalMs?: number;
-  /** Per-frame send and receive ceiling. */
+  /** Per-WebSocket-message send and receive ceiling. */
   maxFrameBytes?: number;
+  /** Logical receive ceiling after application-layer decompression. */
+  maxDecodedFrameBytes?: number;
   /** Client's Noise static keypair. Enables encryption (initiator role). */
   noiseStatic?: NoiseKeyPair;
   /** Pinned gateway Noise static public key (raw 32 bytes), from the invite. */
@@ -974,12 +1012,14 @@ export async function connectFederationClient(params: {
           headers: params.headers,
           handshakeTimeout: connectTimeoutMs,
           maxPayload,
+          perMessageDeflate: false,
           agent: outerSocketAgent(params.createSocket),
         }
       : {
           headers: params.headers,
           handshakeTimeout: connectTimeoutMs,
           maxPayload,
+          perMessageDeflate: false,
           cert: params.clientCertificate,
           key: params.clientPrivateKey,
         },
@@ -1075,9 +1115,12 @@ async function establishFederationClient(
   // Phase 2: identity auth.
   let challenge: FederationSocketMessage | undefined;
   try {
-    challenge = decodeFrame(await reader.next(), transport);
+    challenge = decodeFrame(await reader.next(), transport, {
+      maxDecodedBytes:
+        params.maxDecodedFrameBytes ?? FEDERATION_MAX_DECODED_FRAME_BYTES,
+    });
   } catch (error) {
-    closeAfterFrameAuthenticationFailure(socket);
+    closeAfterFrameDecodeFailure(socket, error);
     throw error;
   }
   if (challenge?.kind === "auth.rejected") {
@@ -1145,9 +1188,12 @@ async function establishFederationClient(
 
   let accepted: FederationSocketMessage | undefined;
   try {
-    accepted = decodeFrame(await reader.next(), transport);
+    accepted = decodeFrame(await reader.next(), transport, {
+      maxDecodedBytes:
+        params.maxDecodedFrameBytes ?? FEDERATION_MAX_DECODED_FRAME_BYTES,
+    });
   } catch (error) {
-    closeAfterFrameAuthenticationFailure(socket);
+    closeAfterFrameDecodeFailure(socket, error);
     throw error;
   }
   if (accepted?.kind === "auth.rejected") {
@@ -1178,6 +1224,10 @@ async function establishFederationClient(
     socket.close();
     throw new Error("Invalid federation auth acceptance signature");
   }
+  const acceptedCapabilities = knownCapabilities(accepted.capabilities);
+  const compressionEnabled = acceptedCapabilities.includes(
+    FEDERATION_BROTLI_CAPABILITY,
+  );
   // Carry the close code/reason to the runtime — dropping them made a
   // deliberate "replaced_by_new_session" eviction indistinguishable
   // from a network blip in every log and health surface. (An error is
@@ -1227,9 +1277,13 @@ async function establishFederationClient(
       }
       let message: FederationSocketMessage | undefined;
       try {
-        message = decodeFrame(frame, transport);
-      } catch {
-        closeAfterFrameAuthenticationFailure(socket);
+        message = decodeFrame(frame, transport, {
+          compressionEnabled,
+          maxDecodedBytes:
+            params.maxDecodedFrameBytes ?? FEDERATION_MAX_DECODED_FRAME_BYTES,
+        });
+      } catch (error) {
+        closeAfterFrameDecodeFailure(socket, error);
         return;
       }
       if (message?.kind === "envelope") {
@@ -1255,13 +1309,13 @@ async function establishFederationClient(
     // The signature above covered the raw list; narrow to capabilities
     // THIS build understands only after it verified, so a newer gateway
     // granting a capability we predate is ignored, not fatal.
-    capabilities: knownCapabilities(accepted.capabilities),
+    capabilities: acceptedCapabilities,
     sendEnvelope: (envelope) => {
       const byteCount = sendFrame(
         socket,
         { kind: "envelope", envelope },
         transport,
-        maxFrameBytes,
+        { compressionEnabled, maxFrameBytes },
         diagnosticsContext,
       );
       if (byteCount > 0) {
@@ -1276,7 +1330,7 @@ async function establishFederationClient(
         socket,
         { kind: "envelope", envelope },
         transport,
-        maxFrameBytes,
+        { compressionEnabled, maxFrameBytes },
         diagnosticsContext,
       );
       if (byteCount > 0) {
@@ -1385,7 +1439,7 @@ function sendFrame(
   socket: WebSocket,
   message: FederationSocketMessage,
   transport?: NoiseTransport,
-  maxFrameBytes = FEDERATION_MAX_FRAME_BYTES,
+  options?: { compressionEnabled?: boolean; maxFrameBytes?: number },
   context?: EnvelopeDiagnosticsContext,
 ): number {
   if (socket.readyState !== WebSocket.OPEN) return 0;
@@ -1395,7 +1449,12 @@ function sendFrame(
       || message.envelope.method === "backend.searchFederatedThreads")) {
     log.info("federation search request queued for send", envelopeLogFields(message.envelope, context));
   }
-  const payload = encodeFederationSocketPayload(message);
+  const socketPayload = encodeFederationSocketPayload(message);
+  const payload = encodeFederationFramePayload({
+    json: socketPayload,
+    compressionEnabled: options?.compressionEnabled ?? false,
+  });
+  const maxFrameBytes = options?.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES;
   const wireByteLength = transport
     ? transport.encryptedByteLength(payload.byteLength)
     : payload.byteLength;
@@ -1422,7 +1481,9 @@ function sendFrame(
     });
   }
   const wire = transport ? transport.encrypt(payload) : payload;
-  socket.send(wire);
+  socket.send(wire, {
+    compress: false,
+  });
   return wire.byteLength;
 }
 
@@ -1430,14 +1491,14 @@ async function sendFrameWithBackpressure(
   socket: WebSocket,
   message: FederationSocketMessage,
   transport?: NoiseTransport,
-  maxFrameBytes = FEDERATION_MAX_FRAME_BYTES,
+  options?: { compressionEnabled?: boolean; maxFrameBytes?: number },
   context?: EnvelopeDiagnosticsContext,
 ): Promise<number> {
   await waitForFederationSendCapacity(socket);
   if (socket.readyState !== WebSocket.OPEN) {
     throw new Error("Federation connection closed while sending an attachment.");
   }
-  return sendFrame(socket, message, transport, maxFrameBytes, context);
+  return sendFrame(socket, message, transport, options, context);
 }
 
 export async function waitForFederationSendCapacity(
@@ -1459,9 +1520,30 @@ function closeAfterFrameAuthenticationFailure(socket: WebSocket): void {
   socket.close(1008, "Encrypted federation frame authentication failed");
 }
 
+function closeAfterFrameDecodeFailure(socket: WebSocket, error: unknown): void {
+  if (!(error instanceof FederationFrameCompressionError)) {
+    closeAfterFrameAuthenticationFailure(socket);
+    return;
+  }
+  const oversized = error.message.includes("exceeds the configured limit");
+  log.warn("compressed federation frame rejected", {
+    reason: error.message,
+  });
+  socket.close(
+    oversized ? 1009 : 1008,
+    oversized
+      ? "Federation decoded frame exceeds the configured limit"
+      : "Invalid compressed federation frame",
+  );
+}
+
 function decodeFrame(
   frame: Buffer,
   transport?: NoiseTransport,
+  options?: {
+    compressionEnabled?: boolean;
+    maxDecodedBytes?: number;
+  },
 ): FederationSocketMessage | undefined {
   let payload = frame;
   if (transport) {
@@ -1471,7 +1553,12 @@ function decodeFrame(
       throw new FederationFrameAuthenticationError();
     }
   }
-  return decodeFederationSocketPayload(payload);
+  const socketPayload = decodeFederationFramePayload({
+    frame: payload,
+    compressionEnabled: options?.compressionEnabled ?? false,
+    maxDecodedBytes: options?.maxDecodedBytes,
+  });
+  return decodeFederationSocketPayload(socketPayload);
 }
 
 // Weak keys never extend envelope lifetime. Capture the serialization length at

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -323,6 +323,8 @@ export type FederationGatewayWebSocketServerOptions = {
   port: number;
   store: FederationStore;
   sessions?: FederationSessionRegistry;
+  /** Allow negotiated compression. Changing this requires a new session. */
+  compressionEnabled?: boolean;
   /**
    * Gateway's Noise static keypair. When set, every connection runs a Noise_IK
    * handshake (responder role) before auth, and all frames are encrypted. When
@@ -648,6 +650,13 @@ export class FederationGatewayWebSocketServer {
       return;
     }
 
+    // Verify the signed request unchanged, then narrow the granted session
+    // capabilities before signing the acceptance. Either endpoint can opt out.
+    if (this.options.compressionEnabled === false) {
+      decision.capabilities = decision.capabilities.filter(
+        (capability) => capability !== FEDERATION_BROTLI_CAPABILITY,
+      );
+    }
     const sessionId = `federation-session:${randomUUID()}`;
     this.sessions.openSession({
       sessionId,

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -165,6 +165,7 @@ export type DesktopSettingsConfig = {
     instanceNotes?: string;
     listenHost?: string;
     listenPort?: number;
+    compressionEnabled?: boolean;
     publicUrl?: string;
     gatewayUrl?: string;
     gatewayEndpoints?: string[];
@@ -1000,6 +1001,9 @@ export function desktopSettingsPatchToEdits(
       set(["federation", "listen_host"], patch.federation.listenHost);
     }
   }
+  if (patch.federation?.compressionEnabled !== undefined) {
+    set(["federation", "compression_enabled"], patch.federation.compressionEnabled);
+  }
   if (patch.federation?.listenPort !== undefined) {
     if (patch.federation.listenPort === 0) {
       edits.push({ op: "delete", path: ["federation", "listen_port"] });
@@ -1818,6 +1822,7 @@ function normalizeDesktopConfig(
       instanceNotes: readString(federation?.instance_notes),
       listenHost: readString(federation?.listen_host),
       listenPort: readNumber(federation?.listen_port),
+      compressionEnabled: readBoolean(federation?.compression_enabled),
       publicUrl: readString(federation?.public_url),
       gatewayUrl: readString(federation?.gateway_url),
       gatewayEndpoints: readEndpointList(federation?.gateway_endpoints),

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -1033,6 +1033,10 @@ export class DesktopSettingsService {
           "127.0.0.1",
         ),
         listenPort: this.resolveConfigNumber(config.federation?.listenPort, 47830),
+        compressionEnabled: this.resolveConfigBoolean(
+          config.federation?.compressionEnabled,
+          true,
+        ),
         publicUrl: this.resolveConfigString(config.federation?.publicUrl),
         gatewayUrl: this.resolveConfigString(config.federation?.gatewayUrl),
         gatewayEndpoints: this.resolveFederationEndpointList(

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1692,6 +1692,7 @@ describe("App", () => {
         instanceNotes: { value: "", source: "default" },
         listenHost: { value: "127.0.0.1", source: "default" },
         listenPort: { value: 47830, source: "default" },
+        compressionEnabled: { value: true, source: "default" },
         publicUrl: { value: "", source: "default" },
         gatewayUrl: { value: "", source: "default" },
         gatewayEndpoints: { value: [], source: "default" },

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -1701,15 +1701,18 @@ const FEDERATION_CAPABILITY_LABELS: Record<FederationCapability, string> = {
   remote_pty: "open a remote terminal",
   event_subscriptions: "stream explicitly subscribed events",
   turn_input_blobs: "transfer turn attachments",
+  // Transport negotiation is informational, not a remote action.
+  transport_brotli: "",
 };
 
 function formatFederationCapabilities(
   capabilities: FederationCapability[],
 ): string {
-  if (capabilities.length === 0) return "no remote actions advertised";
-  return capabilities
+  const labels = capabilities
     .map((capability) => FEDERATION_CAPABILITY_LABELS[capability])
-    .join(" · ");
+    .filter(Boolean);
+  if (labels.length === 0) return "no remote actions advertised";
+  return labels.join(" · ");
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -97,6 +97,9 @@ export function FederationSettings(props: FederationSettingsProps) {
   const [instanceLabel, setInstanceLabel] = useState(
     props.snapshot.federation.instanceLabel.value,
   );
+  const [compressionEnabled, setCompressionEnabled] = useState(
+    props.snapshot.federation.compressionEnabled.value,
+  );
   const [instanceNotes, setInstanceNotes] = useState(
     props.snapshot.federation.instanceNotes.value,
   );
@@ -137,6 +140,7 @@ export function FederationSettings(props: FederationSettingsProps) {
 
   useEffect(() => {
     setMode(props.snapshot.federation.mode.value);
+    setCompressionEnabled(props.snapshot.federation.compressionEnabled.value);
     setInstanceLabel(props.snapshot.federation.instanceLabel.value);
     setInstanceNotes(props.snapshot.federation.instanceNotes.value);
     setListenHost(props.snapshot.federation.listenHost.value);
@@ -637,6 +641,19 @@ export function FederationSettings(props: FederationSettingsProps) {
               />
             }
           />
+          <SettingsField
+            label="Protocol compression"
+            sub="Use Brotli for larger messages when both peers allow it. Small messages stay uncompressed. Saving reconnects federation sessions."
+            control={
+              <input
+                type="checkbox"
+                aria-label="Protocol compression"
+                checked={compressionEnabled}
+                disabled={props.saving}
+                onChange={(event) => setCompressionEnabled(event.target.checked)}
+              />
+            }
+          />
           <div className="settings-button-row">
             <button
               className="button button--primary"
@@ -663,6 +680,7 @@ export function FederationSettings(props: FederationSettingsProps) {
                 void props.onWriteConfig({
                   federation: {
                     mode,
+                    compressionEnabled,
                     instanceLabel,
                     instanceNotes,
                     listenHost,

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -24,6 +24,29 @@ afterEach(() => {
 });
 
 describe("FederationSettings", () => {
+  it("saves the compression toggle with federation settings", async () => {
+    const onWriteConfig = vi.fn(async () => true);
+    render(
+      <FederationSettings
+        desktopApi={{ readFederationHealth: vi.fn(async () => ({
+          health: { enabled: false, role: "client", status: "disabled", peers: [] } satisfies FederationHealthStatus,
+        })) }}
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={onWriteConfig}
+      />,
+    );
+    const toggle = screen.getByRole("checkbox", { name: "Protocol compression" });
+    expect(toggle).toBeChecked();
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByRole("button", { name: "Save federation settings" }));
+    await waitFor(() => expect(onWriteConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ federation: expect.objectContaining({ compressionEnabled: false }) }),
+    ));
+  });
   it("renders configured endpoints and sanitized peer health", async () => {
     const health: FederationHealthStatus = {
       enabled: true,
@@ -1148,6 +1171,7 @@ function settingsSnapshot(): DesktopSettingsSnapshot {
       instanceNotes: { value: "", source: "default" },
       listenHost: { value: "127.0.0.1", source: "config" },
       listenPort: { value: 8765, source: "config" },
+      compressionEnabled: { value: true, source: "default" },
       publicUrl: {
         value: "wss://pwragent.example.com/federation",
         source: "config",

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -235,6 +235,7 @@ function createSnapshot(
       instanceNotes: { value: "", source: "default" },
       listenHost: { value: "127.0.0.1", source: "default" },
       listenPort: { value: 47830, source: "default" },
+      compressionEnabled: { value: true, source: "default" },
       publicUrl: { value: "", source: "default" },
       gatewayUrl: { value: "", source: "default" },
       gatewayEndpoints: { value: [], source: "default" },

--- a/packages/shared/src/contracts/__tests__/federation.test.ts
+++ b/packages/shared/src/contracts/__tests__/federation.test.ts
@@ -60,6 +60,7 @@ describe("federation contracts", () => {
     expect(isFederationCapability("launchpad_metadata")).toBe(true);
     expect(isFederationCapability("event_subscriptions")).toBe(true);
     expect(isFederationCapability("navigation_snapshot_deltas")).toBe(true);
+    expect(isFederationCapability("transport_brotli")).toBe(true);
     expect(isFederationCapability("unknown")).toBe(false);
     expect(isFederationEventClass("navigation")).toBe(true);
     expect(isFederationEventClass("pending_requests")).toBe(true);

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -169,6 +169,7 @@ describe("desktop settings contracts", () => {
         instanceNotes: { value: "", source: "default" },
         listenHost: { value: "127.0.0.1", source: "default" },
         listenPort: { value: 8765, source: "default" },
+        compressionEnabled: { value: true, source: "default" },
         publicUrl: { value: "", source: "default" },
         gatewayUrl: { value: "", source: "default" },
         gatewayEndpoints: { value: [], source: "default" },

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -28,6 +28,7 @@ export const FEDERATION_CAPABILITIES = [
   "remote_pty",
   "event_subscriptions",
   "turn_input_blobs",
+  "transport_brotli",
 ] as const;
 
 export type FederationCapability = (typeof FEDERATION_CAPABILITIES)[number];

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -893,6 +893,7 @@ export type DesktopFederationSettingsSnapshot = {
   instanceNotes: DesktopSettingsValue<string>;
   listenHost: DesktopSettingsValue<string>;
   listenPort: DesktopSettingsValue<number>;
+  compressionEnabled: DesktopSettingsValue<boolean>;
   publicUrl: DesktopSettingsValue<string>;
   gatewayUrl: DesktopSettingsValue<string>;
   /**
@@ -1337,6 +1338,7 @@ export type DesktopSettingsConfigPatch = {
     instanceNotes?: string;
     listenHost?: string;
     listenPort?: number;
+    compressionEnabled?: boolean;
     publicUrl?: string;
     gatewayUrl?: string;
     gatewayEndpoints?: string[];


### PR DESCRIPTION
## What changed

- negotiate inner-frame compression through the signed, forward-compatible `transport_brotli` federation capability
- compress JSON envelopes with Brotli quality 1 before optional Noise encryption, while leaving messages below 4 KiB and incompressible messages raw
- disable WebSocket permessage-deflate explicitly on both endpoints
- retain the 16 MiB `ws` wire-message ceiling and add a separate 64 MiB post-decompression ceiling with a declared-length check
- keep transport capabilities out of the Settings list of user-authorized remote actions

## Why compression belongs inside the federation frame

PwrAgent uses `ws@8.21.0`. Its `Receiver` passes `maxPayload` into `PerMessageDeflate`, and `inflateOnData` rejects once inflated output exceeds that limit. A loopback experiment with a 1 KiB `maxPayload` and permessage-deflate enabled rejected a 16 KiB repeated message with `WS_ERR_UNSUPPORTED_MESSAGE_LENGTH` / close code 1009 even though its compressed wire representation was below the limit.

In Noise mode, PwrAgent serializes JSON and AES-GCM encrypts it before calling `socket.send()`. WebSocket compression therefore sees ciphertext, which is intentionally incompressible. The useful ordering is JSON -> application compression -> Noise encryption -> WebSocket. Tunnel mode uses the same inner framing and safety limits, avoiding two transport behaviors.

The capability is signed in both the peer proof and gateway acceptance. Auth frames remain raw, and compression starts only after `auth.accepted`, so old/new peers safely fall back to existing raw frames without a protocol-version break.

## Codec choice

Representative local benchmarks compared low-latency settings:

- varied 38.6 MiB protocol-like JSON: gzip level 1 183.5 ms / 32.4%, raw deflate level 1 165.4 ms / 32.4%, Brotli quality 1 100.2 ms / 32.7%
- 21.0 MiB base64-heavy JSON: gzip level 1 270.9 ms / 75.3%, raw deflate level 1 249.6 ms / 75.3%, Brotli quality 1 43.5 ms / 75.0%
- Zstd was fastest, but Node 24 still marks its Zstd API experimental; Brotli is the stable built-in low-latency choice for the Electron 41 / Node 24 runtime

Frames are independent (no context takeover), auth material is never compressed, and small streamed notifications skip compression.

## Relationship to #1244

This is independent from #1244's byte-safe replay pagination. Compression does not make a 156 MiB replay an acceptable single logical message: this PR deliberately caps expanded frames at 64 MiB. #1244 remains the immediate fix that keeps thread replay responses bounded; this PR improves bandwidth and allows safely bounded compressible envelopes to exceed the 16 MiB wire ceiling.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/federation-*.test.ts packages/shared/src/contracts/__tests__/federation.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx` (25 files, 267 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (warnings only, no errors)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:sql`
- `pnpm --filter @pwragent/desktop build`
