### PR TITLE
fix(desktop): run title helper for Agent threads

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11515,7 +11515,7 @@ command = "pnpm grok"
     await registry.close();
   });
 
-  it("seeds an idle newly started Agent thread with the Agent name", async () => {
+  it("seeds an idle newly started Agent thread with the Agent name as a fallback", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list", "thread/start"] },
       threads: [],
@@ -11538,7 +11538,7 @@ command = "pnpm grok"
       expect.objectContaining({
         id: "thread-1",
         title: "Summy Dummy",
-        titleSource: "explicit",
+        titleSource: "fallback",
       }),
     ]);
 
@@ -15471,6 +15471,73 @@ command = "pnpm dev"
           threadName: "Leopard tea button",
         },
       },
+    });
+
+    await registry.close();
+  });
+
+  it("generates a title for a desktop composer Agent thread", async () => {
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Testing manager agent",
+      })),
+    };
+    const overlayStore = createOverlayStoreMock();
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["thread/start", "turn/start", "thread/name/set"],
+      },
+      threads: [],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore,
+      threadTitleGenerationService: titleService,
+    });
+    const prompt =
+      "Testing testing is this thing on, I need to test the manager agent.";
+
+    await registry.startThread({
+      agent: {
+        name: "PwrAgent Agent",
+        instructions: "Manage PwrAgent threads.",
+      },
+      backend: "codex",
+      cwd: "/repo-a",
+    });
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: prompt }],
+    });
+    await waitForCondition(() => codexClient.lastRenameThreadParams !== undefined);
+
+    expect(titleService.generateTitle).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      userPrompt: prompt,
+    });
+    expect(codexClient.lastRenameThreadParams).toEqual({
+      threadId: "thread-1",
+      name: "Testing manager agent",
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          monitorId: "system:title-helper:codex:thread-1",
+          status: "success",
+          task: "Name this thread",
+        }),
+      ],
     });
 
     await registry.close();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10129,7 +10129,7 @@ export class DesktopBackendRegistry {
         id: result.threadId,
         source: backend,
         title: agentName || "Untitled thread",
-        titleSource: agentName ? "explicit" : "fallback",
+        titleSource: "fallback",
         projectKey: cwd,
         createdAt: startedAt,
         updatedAt: startedAt,


### PR DESCRIPTION
## Summary

- classify the initial Agent persona-name seed as a fallback thread title
- allow first-turn title generation to run for desktop composer Agent threads
- verify the generated name is applied and the title helper is persisted in the Sub-agents panel state

## Root cause

`startThread` seeded composer-created Agent threads with `request.agent.name` and marked that seed as an explicit thread title. The first-turn title eligibility check therefore treated the persona label as a user rename and exited before invoking or persisting the title-helper sub-agent.

The persona label remains the initial visible title, but its source is now correctly classified as fallback metadata.

## Test-first evidence

Before the production change, the new focused regression test failed on `origin/main`:

```
pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "generates a title for a desktop composer Agent thread"
```

Failure: `titleService.generateTitle` had 0 calls.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` (453 passed)
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm typecheck`
- `pnpm lint:boundaries`

## Issue

No matching existing GitHub issue was found after searching titles and bodies for the exact Agent-thread, composer, generated-title, and Sub-agents-panel symptoms.
