### PR TITLE
fix(messaging): route selected Slack channels exactly

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
@@ -496,6 +496,49 @@ describe("SqliteMessagingStore", () => {
     });
   });
 
+  it("routes a Settings-selected Slack channel ahead of the provider default", async () => {
+    const store = await createStore();
+    const channel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C0BN6UXFREE",
+        kind: "channel" as const,
+        title: "p-pwragent-testing",
+        workspaceId: "T1",
+      },
+    };
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "slack-provider-default",
+        scope: { kind: "provider", channel: "slack" },
+        target: {
+          kind: "agent",
+          backend: "codex",
+          threadId: "provider-agent",
+        },
+      }),
+    );
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "slack-channel-default",
+        scope: { kind: "conversation", channel },
+        target: {
+          kind: "agent",
+          backend: "codex",
+          threadId: "channel-agent",
+        },
+        createdAt: 1100,
+        updatedAt: 1100,
+      }),
+    );
+
+    await expect(store.findActiveDefaultAgentAssignmentForChannel(channel))
+      .resolves.toMatchObject({
+        id: "slack-channel-default",
+        target: { threadId: "channel-agent" },
+      });
+  });
+
   it("replaces active default Agent assignments within the same scope", async () => {
     const store = await createStore();
     await store.upsertDefaultAgentAssignment(buildDefaultAgentAssignment());

--- a/apps/desktop/src/renderer/src/features/settings/MessagingRoutesSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingRoutesSettings.tsx
@@ -659,7 +659,7 @@ function DefaultAgentEditor(props: {
                 Conversation
               </option>
               <option disabled={props.platforms.length === 0} value="parent">
-                Parent channel or group
+                Threads/topics in a channel or group
               </option>
               <option disabled={props.platforms.length === 0} value="workspace">
                 Workspace or server
@@ -735,8 +735,7 @@ function DefaultAgentEditor(props: {
               </select>
               {surfaceCandidates.length === 0 && !hasConfiguredSurface ? (
                 <small>
-                  No matching surfaces observed yet. Send the bot a message there,
-                  or enter the ID manually.
+                  {emptySurfaceMessage(form.scopeKind)}
                 </small>
               ) : null}
             </label>
@@ -910,27 +909,21 @@ function observedSurfaceCandidates(
       };
       label = formatConversationLabel(surface.platform, conversation);
     } else if (form.scopeKind === "parent") {
-      const parentConversationId = conversation.parentConversationId
-        ?? (conversation.kind === "channel" ? conversation.id : undefined);
+      const parentConversationId = conversation.parentConversationId;
       if (!parentConversationId) continue;
       candidateForm = {
         ...EMPTY_FORM,
         scopeKind: "parent",
         platform: surface.platform,
         parentConversationId,
-        title:
-          conversation.parentConversationId
-            ? conversation.parentTitle ?? ""
-            : conversation.title ?? "",
+        title: conversation.parentTitle ?? "",
       };
       label = formatObservedContainerLabel({
         platform: surface.platform,
         id: parentConversationId,
         names: [
           conversation.ancestorTitle,
-          conversation.parentConversationId
-            ? conversation.parentTitle
-            : conversation.title,
+          conversation.parentTitle,
         ],
       });
     } else {
@@ -1194,9 +1187,22 @@ function formatScopeKind(kind: DefaultScopeKind): string {
     case "profile": return "Profile default";
     case "provider": return "Provider default";
     case "workspace": return "Workspace default";
-    case "parent": return "Parent default";
+    case "parent": return "Child thread/topic default";
     case "conversation": return "Conversation default";
   }
+}
+
+function emptySurfaceMessage(kind: DefaultScopeKind): string {
+  if (kind === "parent") {
+    return (
+      "No child threads or topics observed yet. Send the bot a message in one, "
+      + "or enter the containing channel or group ID manually."
+    );
+  }
+  return (
+    "No matching surfaces observed yet. Send the bot a message there, "
+    + "or enter the ID manually."
+  );
 }
 
 function formatConversationKind(kind: MessagingConversationKind): string {
@@ -1216,8 +1222,8 @@ function workspaceIdLabel(platform: MessagingChannelKind): string {
 }
 
 function parentIdLabel(platform: MessagingChannelKind): string {
-  if (platform === "telegram") return "Group ID";
-  return "Parent channel ID";
+  if (platform === "telegram") return "Containing group ID";
+  return "Containing channel ID";
 }
 
 function identityParentIdLabel(

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/messaging-routes-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/messaging-routes-settings.test.tsx
@@ -410,6 +410,101 @@ describe("MessagingRoutesSettings", () => {
     });
   });
 
+  it("routes a selected Slack channel as an exact conversation, not a parent fallback", async () => {
+    const routes = buildRoutes();
+    routes.defaultAgents = [];
+    routes.bindings = [];
+    routes.observedSurfaces = [
+      {
+        platform: "slack",
+        conversation: {
+          id: "C0BN6UXFREE",
+          kind: "channel",
+          title: "p-pwragent-testing",
+          workspaceId: "T1",
+        },
+        firstSeenAt: 1000,
+        lastSeenAt: 2000,
+      },
+    ];
+    const api = buildDesktopApi(routes);
+    renderRoutes(api.desktopApi);
+    await screen.findByText("No default Agents configured.");
+
+    fireEvent.click(screen.getByRole("button", { name: "Add default" }));
+    expect(
+      screen.getByRole("option", {
+        name: "Threads/topics in a channel or group",
+      }),
+    ).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Default scope"), {
+      target: { value: "parent" },
+    });
+    expect(
+      [...screen.getByLabelText("Messaging surface").querySelectorAll("option")]
+        .map((option) => option.textContent),
+    ).toEqual([
+      "Choose a recently seen surface...",
+      "Enter an ID manually...",
+    ]);
+
+    fireEvent.change(screen.getByLabelText("Default scope"), {
+      target: { value: "conversation" },
+    });
+    fireEvent.change(screen.getByLabelText("Messaging surface"), {
+      target: {
+        value: JSON.stringify([
+          "conversation",
+          "slack",
+          "channel",
+          "",
+          "C0BN6UXFREE",
+        ]),
+      },
+    });
+    fireEvent.change(screen.getByLabelText("Default Agent"), {
+      target: { value: JSON.stringify(["codex", "agent-1"]) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save default" }));
+
+    await waitFor(() => {
+      expect(api.setMessagingDefaultAgent).toHaveBeenCalledWith({
+        scope: {
+          kind: "conversation",
+          platform: "slack",
+          conversation: {
+            id: "C0BN6UXFREE",
+            kind: "channel",
+            title: "p-pwragent-testing",
+            workspaceId: "T1",
+          },
+        },
+        target: { backend: "codex", threadId: "agent-1" },
+      });
+    });
+  });
+
+  it("labels an existing parent route as a child thread or topic default", async () => {
+    const routes = buildRoutes();
+    routes.defaultAgents = [{
+      ...routes.defaultAgents[0]!,
+      scope: {
+        kind: "parent",
+        platform: "slack",
+        conversationId: "C13056",
+      },
+    }];
+    routes.bindings = [];
+    const { desktopApi } = buildDesktopApi(routes);
+
+    renderRoutes(desktopApi);
+
+    expect(
+      await screen.findByText(/Child thread\/topic default/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Parent default/)).not.toBeInTheDocument();
+  });
+
   it("offers only messaging platforms configured for this instance", async () => {
     const api = buildDesktopApi();
     renderRoutes(
@@ -448,7 +543,22 @@ describe("MessagingRoutesSettings", () => {
   });
 
   it("orders observed surfaces by recency and derives parent and workspace choices", async () => {
-    const api = buildDesktopApi();
+    const routes = buildRoutes();
+    routes.observedSurfaces.push({
+      platform: "slack",
+      conversation: {
+        id: "C13056",
+        kind: "thread",
+        parentId: "1700000000.000100",
+        parentConversationId: "C13056",
+        parentTitle: "p-search-signals-project",
+        title: "13056 investigation",
+        workspaceId: "T1",
+      },
+      firstSeenAt: 2500,
+      lastSeenAt: 3000,
+    });
+    const api = buildDesktopApi(routes);
     renderRoutes(api.desktopApi);
     await screen.findByText("Search Signals Agent");
 
@@ -458,6 +568,7 @@ describe("MessagingRoutesSettings", () => {
       [...surfaceSelect.querySelectorAll("option")].map((option) => option.textContent),
     ).toEqual([
       "Choose a recently seen surface...",
+      expect.stringContaining("13056 investigation"),
       expect.stringContaining("p-search-signals-project"),
       expect.stringContaining("archived-project"),
       "Enter an ID manually...",
@@ -466,9 +577,14 @@ describe("MessagingRoutesSettings", () => {
     fireEvent.change(screen.getByLabelText("Default scope"), {
       target: { value: "parent" },
     });
-    expect(screen.getByLabelText("Messaging surface")).toHaveTextContent(
-      "Slack / p-search-signals-project",
-    );
+    expect(
+      [...screen.getByLabelText("Messaging surface").querySelectorAll("option")]
+        .map((option) => option.textContent),
+    ).toEqual([
+      "Choose a recently seen surface...",
+      expect.stringContaining("Slack / p-search-signals-project"),
+      "Enter an ID manually...",
+    ]);
 
     fireEvent.change(screen.getByLabelText("Default scope"), {
       target: { value: "workspace" },


### PR DESCRIPTION
## Summary

- route a selected root Slack channel through an exact conversation assignment
- only offer parent-scope surfaces when an observed child exposes parentConversationId
- relabel parent routing as a child thread/topic default and clarify manual containing-ID copy

## Root cause

Settings synthesized a parent conversation ID from a top-level channel own ID. The router intentionally evaluates parent assignments only for inbound child conversations that expose parentConversationId, so top-level Slack channel messages skipped that assignment and fell through to provider:slack.

## Behavior

Root Slack channels remain exact conversation routes, matching the original routing contract. Parent assignments remain descendant-only for threads/topics and are not broadened or migrated; existing parent routes are now labeled by their actual behavior.

## Validation

- regression test first reproduced the Settings picker bug
- 61 focused renderer, JSON-store, and SQLite-store tests pass
- pnpm typecheck
- pnpm lint:eslint (0 errors; existing warning baseline only)
- pnpm lint:boundaries
- git diff --check