### PR TITLE
fix(desktop): harden Windows test process isolation

### DIFF
--- a/apps/desktop/e2e/windows-vitest-stress.inspect.spec.ts
+++ b/apps/desktop/e2e/windows-vitest-stress.inspect.spec.ts
@@ -1,0 +1,202 @@
+import { spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "@playwright/test";
+
+const STRESS_ARG = "--pwragent-vitest-stress";
+const TARGET_ARG_PREFIX = "--pwragent-vitest-target=";
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(specDir, "../../..");
+
+type ProcessSnapshotEntry = {
+  commandLine: string;
+  executablePath: string;
+  id: number;
+  name: string;
+  parentId: number;
+};
+
+type CommandResult = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stderr: string;
+  stdout: string;
+};
+
+async function runCommand(
+  command: string,
+  args: string[],
+): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      resolve({ code, signal, stderr, stdout });
+    });
+  });
+}
+
+async function captureRelevantProcesses(): Promise<ProcessSnapshotEntry[]> {
+  const powershell = [
+    "$names = @('bash.exe', 'cmd.exe', 'git.exe', 'git-lfs.exe', 'node.exe', 'powershell.exe', 'pwsh.exe')",
+    "$rows = @(Get-CimInstance Win32_Process | Where-Object { $names -contains $_.Name -and $_.ProcessId -ne $PID } | ForEach-Object { [pscustomobject]@{ commandLine = [string]$_.CommandLine; executablePath = [string]$_.ExecutablePath; id = [int]$_.ProcessId; name = [System.IO.Path]::GetFileNameWithoutExtension($_.Name); parentId = [int]$_.ParentProcessId } })",
+    "$rows | Sort-Object name, id | ConvertTo-Json -Compress",
+  ].join("; ");
+  const result = await runCommand("powershell.exe", [
+    "-NoLogo",
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    powershell,
+  ]);
+  if (result.code !== 0) {
+    throw new Error(
+      `Process snapshot failed with exit ${result.code}: ${result.stderr.trim()}`,
+    );
+  }
+  const output = result.stdout.trim();
+  if (!output) {
+    return [];
+  }
+  const parsed = JSON.parse(output) as ProcessSnapshotEntry | ProcessSnapshotEntry[];
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+function processKey(entry: ProcessSnapshotEntry): string {
+  return `${entry.name}:${entry.id}`;
+}
+
+function newlyRunningProcesses(
+  before: ProcessSnapshotEntry[],
+  after: ProcessSnapshotEntry[],
+): ProcessSnapshotEntry[] {
+  const beforeKeys = new Set(before.map(processKey));
+  return after.filter((entry) => !beforeKeys.has(processKey(entry)));
+}
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+test.skip(
+  process.platform !== "win32",
+  "This diagnostic exercises the native Windows Vitest shutdown path.",
+);
+
+test(
+  "runs one complete Windows Vitest workspace iteration @windows-vitest-stress",
+  async ({ browserName }, testInfo) => {
+    test.setTimeout(20 * 60 * 1_000);
+    test.skip(
+      !testInfo.config.argv.includes(STRESS_ARG),
+      `Pass ${STRESS_ARG} after Playwright's -- separator to run this diagnostic.`,
+    );
+
+    const targetArgument = testInfo.config.argv.find((argument) =>
+      argument.startsWith(TARGET_ARG_PREFIX),
+    );
+    const vitestTarget = targetArgument?.slice(TARGET_ARG_PREFIX.length);
+    if (vitestTarget && !/^[A-Za-z0-9_./-]+$/.test(vitestTarget)) {
+      throw new Error(`Unsafe Vitest target: ${JSON.stringify(vitestTarget)}`);
+    }
+
+    const iteration = testInfo.repeatEachIndex + 1;
+    const logPath = testInfo.outputPath("vitest.log");
+    const log = createWriteStream(logPath, { encoding: "utf8" });
+    const before = await captureRelevantProcesses();
+    log.write(`iteration=${iteration}\n`);
+    log.write(`startedAt=${new Date().toISOString()}\n`);
+    log.write(`playwrightBrowserName=${browserName}\n`);
+    log.write(`availableParallelism=${os.availableParallelism()}\n`);
+    log.write(`totalMemoryBytes=${os.totalmem()}\n`);
+    log.write(`vitestTarget=${vitestTarget ?? "(full workspace)"}\n`);
+    log.write(`processesBefore=${JSON.stringify(before)}\n`);
+    log.write("\n===== pnpm test =====\n");
+
+    const startedAt = Date.now();
+    const vitestCommand = vitestTarget
+      ? `pnpm test ${vitestTarget}`
+      : "pnpm test";
+    const child = spawn(vitestCommand, {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        CI: "1",
+        NO_COLOR: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      // Windows resolves pnpm through its .cmd shim. The target is validated
+      // above before it is added to this constant shell command.
+      shell: true,
+      windowsHide: true,
+    });
+    child.stdout.pipe(log, { end: false });
+    child.stderr.pipe(log, { end: false });
+    const result = await new Promise<{
+      code: number | null;
+      signal: NodeJS.Signals | null;
+    }>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (code, signal) => resolve({ code, signal }));
+    });
+
+    const immediate = await captureRelevantProcesses();
+    await wait(2_000);
+    const settled = await captureRelevantProcesses();
+    const leakedImmediately = newlyRunningProcesses(before, immediate);
+    const leakedAfterTwoSeconds = newlyRunningProcesses(before, settled);
+    const durationMs = Date.now() - startedAt;
+
+    log.write("\n===== diagnostic summary =====\n");
+    log.write(`finishedAt=${new Date().toISOString()}\n`);
+    log.write(`durationMs=${durationMs}\n`);
+    log.write(`exitCode=${String(result.code)}\n`);
+    log.write(`signal=${String(result.signal)}\n`);
+    log.write(`newProcessesImmediate=${JSON.stringify(leakedImmediately)}\n`);
+    log.write(`newProcessesAfterTwoSeconds=${JSON.stringify(leakedAfterTwoSeconds)}\n`);
+    await new Promise<void>((resolve, reject) => {
+      log.once("error", reject);
+      log.end(resolve);
+    });
+    await testInfo.attach("vitest log", {
+      path: logPath,
+      contentType: "text/plain",
+    });
+
+    console.log(
+      [
+        `Windows Vitest stress iteration ${iteration}:`,
+        `exit=${String(result.code)}`,
+        `durationMs=${durationMs}`,
+        `persistentNewProcesses=${JSON.stringify(leakedAfterTwoSeconds)}`,
+      ].join(" "),
+    );
+
+    if (result.code !== 0) {
+      throw new Error(
+        `Windows Vitest stress iteration ${iteration} exited ${String(result.code)}.`,
+      );
+    }
+    if (leakedAfterTwoSeconds.length > 0) {
+      throw new Error(
+        `Windows Vitest stress iteration ${iteration} left processes running: ${JSON.stringify(leakedAfterTwoSeconds)}`,
+      );
+    }
+  },
+);

--- a/apps/desktop/e2e/windows-vitest-stress.inspect.spec.ts
+++ b/apps/desktop/e2e/windows-vitest-stress.inspect.spec.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { test } from "@playwright/test";
 
 const STRESS_ARG = "--pwragent-vitest-stress";
+const PROCESS_SAMPLES_ARG = "--pwragent-vitest-process-samples";
 const TARGET_ARG_PREFIX = "--pwragent-vitest-target=";
 const specDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(specDir, "../../..");
@@ -54,7 +55,9 @@ async function runCommand(
 
 async function captureRelevantProcesses(): Promise<ProcessSnapshotEntry[]> {
   const powershell = [
-    "$names = @('bash.exe', 'cmd.exe', 'git.exe', 'git-lfs.exe', 'node.exe', 'powershell.exe', 'pwsh.exe')",
+    // Exclude cmd/PowerShell because the lab controller's status probes run
+    // concurrently on the guest and are not descendants of the test process.
+    "$names = @('bash.exe', 'git.exe', 'git-lfs.exe', 'node.exe', 'sh.exe', 'sleep.exe')",
     "$rows = @(Get-CimInstance Win32_Process | Where-Object { $names -contains $_.Name -and $_.ProcessId -ne $PID } | ForEach-Object { [pscustomobject]@{ commandLine = [string]$_.CommandLine; executablePath = [string]$_.ExecutablePath; id = [int]$_.ProcessId; name = [System.IO.Path]::GetFileNameWithoutExtension($_.Name); parentId = [int]$_.ParentProcessId } })",
     "$rows | Sort-Object name, id | ConvertTo-Json -Compress",
   ].join("; ");
@@ -117,6 +120,9 @@ test(
     }
 
     const iteration = testInfo.repeatEachIndex + 1;
+    const captureProcessSamples = testInfo.config.argv.includes(
+      PROCESS_SAMPLES_ARG,
+    );
     const logPath = testInfo.outputPath("vitest.log");
     const log = createWriteStream(logPath, { encoding: "utf8" });
     const before = await captureRelevantProcesses();
@@ -148,6 +154,27 @@ test(
     });
     child.stdout.pipe(log, { end: false });
     child.stderr.pipe(log, { end: false });
+    let processSampling = captureProcessSamples;
+    const processSampler = (async () => {
+      let previousSample = "";
+      while (processSampling) {
+        const sample = newlyRunningProcesses(
+          before,
+          await captureRelevantProcesses(),
+        );
+        const serialized = JSON.stringify(sample);
+        if (serialized !== previousSample) {
+          log.write(
+            `processSample=${JSON.stringify({
+              atMs: Date.now() - startedAt,
+              processes: sample,
+            })}\n`,
+          );
+          previousSample = serialized;
+        }
+        await wait(250);
+      }
+    })();
     const result = await new Promise<{
       code: number | null;
       signal: NodeJS.Signals | null;
@@ -155,6 +182,8 @@ test(
       child.once("error", reject);
       child.once("close", (code, signal) => resolve({ code, signal }));
     });
+    processSampling = false;
+    await processSampler;
 
     const immediate = await captureRelevantProcesses();
     await wait(2_000);

--- a/apps/desktop/src/main/__tests__/automation-gate-runner.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-gate-runner.test.ts
@@ -63,9 +63,13 @@ describe("ShellAutomationGateRunner", () => {
 
   it("kills a runaway command on timeout and never hangs the caller", async () => {
     const startedAt = Date.now();
+    // Leave enough time on Windows for the native Job wrapper to compile and
+    // prove that it kills a running Git Bash descendant, rather than timing
+    // out before the shell starts.
+    const timeoutMs = process.platform === "win32" ? 3_000 : 200;
     const result = await new ShellAutomationGateRunner().runGate({
       command: "sleep 5",
-      timeoutMs: 200,
+      timeoutMs,
     });
 
     expect(result.status).toBe("failed");
@@ -73,6 +77,8 @@ describe("ShellAutomationGateRunner", () => {
     // Must settle shortly after the timeout (tree-kill → close, or the
     // force-settle net), well before `sleep 5` would have finished on its own.
     // A regression that leaves the child's tree alive would blow past this.
-    expect(Date.now() - startedAt).toBeLessThan(4_000);
+    expect(Date.now() - startedAt).toBeLessThan(
+      process.platform === "win32" ? 4_500 : 4_000,
+    );
   }, 10_000);
 });

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -212,9 +212,10 @@ describe("codex environment runtime", () => {
       });
 
       if (isWindows) {
-        await expect(detachedExit).resolves.toMatchObject({
-          exitCode: expect.any(Number),
-          exitSignal: null,
+        const exit = await detachedExit;
+        expect(exit, JSON.stringify(mainLogEntries)).toMatchObject({
+          exitCode: null,
+          exitSignal: "SIGTERM",
         });
       } else {
         await expect(detachedExit).resolves.toMatchObject({
@@ -237,6 +238,8 @@ describe("codex environment runtime", () => {
   it("counts an auto-started environment action as a quit blocker", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-auto-"));
     const runId = "test-run-auto";
+    let detachedExited = false;
+    let registeredPid: number | undefined;
     try {
       await applyLocalCodexEnvironmentSelection({
         cwd: root,
@@ -245,6 +248,9 @@ describe("codex environment runtime", () => {
         // owner arrives without a thread id.
         owner: { backend: "codex" },
         env: { ...process.env, SHELL: spawnableShell("/bin/sh") },
+        onActionDetachedExit: () => {
+          detachedExited = true;
+        },
         selection: {
           executionTarget: "local",
           runSetup: false,
@@ -285,12 +291,22 @@ describe("codex environment runtime", () => {
           threadId: "",
         }),
       ]);
+      registeredPid = running[0]?.pid;
 
       // The thread now exists; the run gets its owner and becomes linkable.
       attachDetachedCommandThreadId(runId, "thread-1");
       expect(listRunningDetachedCommands()[0]?.threadId).toBe("thread-1");
     } finally {
-      stopCodexEnvironmentDetachedCommand(runId, "terminate");
+      const stopResult = stopCodexEnvironmentDetachedCommand(runId, "terminate");
+      if (stopResult.found && !stopResult.alreadyClosed) {
+        await expectEventually(async () => {
+          if (!detachedExited) {
+            throw new Error(
+              `Detached action ${String(registeredPid)} did not exit within 5000ms: ${JSON.stringify(mainLogEntries)}`,
+            );
+          }
+        }, 5_000);
+      }
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   }, 15_000);

--- a/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
+++ b/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
@@ -1,0 +1,164 @@
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { wrapCommandInWindowsJob } from "../windows-job-wrapper";
+import { resolveWindowsBashShell } from "../windows-shell";
+
+function decodeBase64(value: string): string {
+  return Buffer.from(value, "base64").toString("utf8");
+}
+
+async function runWrappedCommand(params: {
+  args: [string, string];
+  command: string;
+  cwd: string;
+}): Promise<{
+  code: number | null;
+  stderr: string;
+  stdout: string;
+}> {
+  const wrapped = wrapCommandInWindowsJob({
+    ...params,
+    env: process.env,
+  });
+  try {
+    return await new Promise((resolve, reject) => {
+      const child = spawn(wrapped.command, wrapped.args, {
+        cwd: params.cwd,
+        env: wrapped.env,
+        windowsHide: true,
+      });
+      let stderr = "";
+      let stdout = "";
+      child.stderr.setEncoding("utf8");
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.once("error", reject);
+      child.once("close", (code) => {
+        resolve({ code, stderr, stdout });
+      });
+    });
+  } finally {
+    wrapped.cleanup();
+  }
+}
+
+describe("wrapCommandInWindowsJob", () => {
+  it("launches the shell through an atomic kill-on-close Job wrapper", () => {
+    const originalEnv = {
+      PATH: "C:\\tools",
+      SystemRoot: "C:\\Windows",
+    };
+    const command = [
+      "set -e",
+      'printf "quoted value"',
+      "while true; do sleep 1; done",
+    ].join("\n");
+
+    const wrapped = wrapCommandInWindowsJob({
+      args: ["-lc", command],
+      command: "C:\\Program Files\\Git\\usr\\bin\\bash.exe",
+      cwd: "C:\\work tree",
+      env: originalEnv,
+    });
+
+    expect(wrapped.command).toBe(
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
+    expect(wrapped.args.slice(0, -1)).toEqual([
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+    ]);
+    const wrapperScript = readFileSync(wrapped.args.at(-1)!, "utf8");
+    expect(wrapperScript).toContain("JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE");
+    expect(wrapperScript).toContain("CREATE_SUSPENDED | CREATE_NO_WINDOW");
+    expect(wrapperScript).toContain("AssignProcessToJobObject");
+    expect(wrapped.env.PWRAGENT_JOB_WRAPPER_EXECUTABLE).toBe(
+      "C:\\Program Files\\Git\\usr\\bin\\bash.exe",
+    );
+    expect(
+      decodeBase64(wrapped.env.PWRAGENT_JOB_WRAPPER_ARGUMENT_0!),
+    ).toBe("-lc");
+    expect(
+      decodeBase64(wrapped.env.PWRAGENT_JOB_WRAPPER_ARGUMENT_1!),
+    ).toBe(
+      [
+        "trap 'pwragent_exit=$?; trap - EXIT; printf \"%s\" \"$pwragent_exit\" > \"$PWRAGENT_JOB_WRAPPER_EXIT_FILE\"; exit \"$pwragent_exit\"' EXIT",
+        command,
+      ].join("\n"),
+    );
+    expect(wrapped.env.PWRAGENT_JOB_WRAPPER_CWD).toBe("C:\\work tree");
+    expect(wrapped.env.PWRAGENT_JOB_WRAPPER_READY_FILE).toBe(
+      wrapped.readyFilePath,
+    );
+    expect(wrapped.env.PWRAGENT_JOB_WRAPPER_EXIT_FILE).toMatch(
+      /pwragent-windows-job-.*[\\/]exit$/,
+    );
+    expect(originalEnv).toEqual({
+      PATH: "C:\\tools",
+      SystemRoot: "C:\\Windows",
+    });
+    wrapped.cleanup();
+  });
+
+  it.skipIf(process.platform !== "win32")(
+    "executes both native and Git Bash commands inside the Job",
+    async () => {
+      const root = await mkdtemp(
+        path.join(os.tmpdir(), "pwragent-windows-job-test-"),
+      );
+      try {
+        const nativeResult = await runWrappedCommand({
+          args: ["/c", "echo job-native"],
+          command: path.join(
+            process.env.SystemRoot ?? "C:\\Windows",
+            "System32",
+            "cmd.exe",
+          ),
+          cwd: root,
+        });
+        expect(nativeResult, nativeResult.stderr).toMatchObject({
+          code: 0,
+          stderr: "",
+        });
+        expect(nativeResult.stdout).toContain("job-native");
+
+        const bashResult = await runWrappedCommand({
+          args: [
+            "-lc",
+            [
+              '[ -s "$HOME/.bashrc" ] && . "$HOME/.bashrc"',
+              '[ -n "${NVM_DIR:-}" ] && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"',
+              '[ -z "${NVM_DIR:-}" ] && [ -s "$HOME/.nvm/nvm.sh" ] && . "$HOME/.nvm/nvm.sh"',
+              "set -e",
+              ": pwragent-env-integration-test",
+              'printf "job-bash"',
+            ].join("\n"),
+          ],
+          command: resolveWindowsBashShell(),
+          cwd: root,
+        });
+        expect(bashResult, bashResult.stderr).toMatchObject({
+          code: 0,
+          stderr: "",
+          stdout: "job-bash",
+        });
+      } finally {
+        await rm(root, { force: true, recursive: true });
+      }
+    },
+    30_000,
+  );
+});

--- a/apps/desktop/src/main/__tests__/windows-shell.test.ts
+++ b/apps/desktop/src/main/__tests__/windows-shell.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  preferStableWindowsBashPath,
+  windowsBashCandidates,
+} from "../windows-shell";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("Windows bash resolution", () => {
+  it("prefers the stable Git bash executable over its launcher", () => {
+    vi.stubEnv("ProgramFiles", "C:\\Program Files");
+    vi.stubEnv("ProgramFiles(x86)", "C:\\Program Files (x86)");
+    vi.stubEnv("LOCALAPPDATA", "C:\\Users\\operator\\AppData\\Local");
+
+    expect(windowsBashCandidates()).toEqual([
+      "C:\\Program Files\\Git\\usr\\bin\\bash.exe",
+      "C:\\Program Files\\Git\\bin\\bash.exe",
+      "C:\\Program Files (x86)\\Git\\usr\\bin\\bash.exe",
+      "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+      "C:\\Users\\operator\\AppData\\Local\\Programs\\Git\\usr\\bin\\bash.exe",
+      "C:\\Users\\operator\\AppData\\Local\\Programs\\Git\\bin\\bash.exe",
+      "bash.exe",
+    ]);
+  });
+
+  it("normalizes an explicit Git bash launcher when the stable sibling exists", () => {
+    const existingPaths: string[] = [];
+    expect(
+      preferStableWindowsBashPath(
+        "C:\\Program Files\\Git\\bin\\bash.exe",
+        (candidate) => {
+          existingPaths.push(candidate);
+          return true;
+        },
+      ),
+    ).toBe("C:\\Program Files\\Git\\usr\\bin\\bash.exe");
+    expect(existingPaths).toEqual([
+      "C:\\Program Files\\Git\\usr\\bin\\bash.exe",
+    ]);
+  });
+
+  it("preserves a launcher when its stable sibling is unavailable", () => {
+    expect(
+      preferStableWindowsBashPath(
+        "C:\\PortableGit\\bin\\bash.exe",
+        () => false,
+      ),
+    ).toBe("C:\\PortableGit\\bin\\bash.exe");
+  });
+});

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import {
   accessSync,
   constants,
+  existsSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -22,7 +23,11 @@ import {
 } from "@pwragent/shared";
 import { getMainLogger } from "../log";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
-import { windowsBashCandidates } from "../windows-shell";
+import { wrapCommandInWindowsJob } from "../windows-job-wrapper";
+import {
+  preferStableWindowsBashPath,
+  windowsBashCandidates,
+} from "../windows-shell";
 import type { CodexEnvironmentHydrationStoreLike } from "./codex-environment-hydration-store";
 
 const environmentRuntimeLog = getMainLogger("pwragent:codex-environment-runtime");
@@ -162,6 +167,7 @@ export type CodexEnvironmentDetachedOutput = {
 
 export const DETACHED_OUTPUT_SNAPSHOT_MS = 500;
 const DETACHED_STOP_SIGKILL_GRACE_MS = 2_000;
+const WINDOWS_JOB_READY_TIMEOUT_MS = 10_000;
 
 export type CodexEnvironmentCommandResult = {
   durationMs?: number;
@@ -660,20 +666,52 @@ function runShellCommand(
   const capture = params.captureShellEnvironment
     ? createShellEnvironmentCaptureTarget()
     : undefined;
+  const useWindowsJob =
+    process.platform === "win32"
+    && (params.mode === "detach" || Boolean(params.timeoutMs));
+  const shellArgs: [string, string] = [
+    "-lc",
+    wrapShellCommand(
+      shell,
+      params.command,
+      capture?.filePath,
+      processId,
+    ),
+  ];
+  const windowsJobLaunch = useWindowsJob
+    ? wrapCommandInWindowsJob({
+        args: shellArgs,
+        command: shell,
+        cwd: params.cwd,
+        env: commandEnv,
+      })
+    : undefined;
+  const launch = windowsJobLaunch ?? {
+    args: shellArgs,
+    command: shell,
+    env: commandEnv,
+  };
 
   return new Promise((resolve, reject) => {
     const child = spawn(
-      shell,
-      ["-lc", wrapShellCommand(shell, params.command, capture?.filePath)],
+      launch.command,
+      launch.args,
       {
         cwd: params.cwd,
-        detached: params.mode === "detach" || Boolean(params.timeoutMs),
-        env: commandEnv,
+        // Windows' detached-process flag breaks inherited stdio for the
+        // PowerShell-hosted Job launcher: commands can report exit 0 without
+        // ever running. The Job already owns the complete process tree, so a
+        // second detached process group is both unnecessary and harmful.
+        detached:
+          !windowsJobLaunch
+          && (params.mode === "detach" || Boolean(params.timeoutMs)),
+        env: launch.env,
         // Pipe output even in detach mode so we can drain to a ring buffer,
         // stream to the renderer's anchored output UI, and log non-zero exits.
         // Caller still resolves on spawn for detach mode; we keep listening so
         // long-running children (e.g., `pnpm dev`) report failures.
         stdio: "pipe",
+        windowsHide: true,
       },
     );
 
@@ -684,6 +722,7 @@ function runShellCommand(
     let timeoutHandle: NodeJS.Timeout | undefined;
     let killHandle: NodeJS.Timeout | undefined;
     let forceSettleHandle: NodeJS.Timeout | undefined;
+    let windowsJobReadyTimer: NodeJS.Timeout | undefined;
 
     const appendOutput = (text: string) => {
       combinedOutput = `${combinedOutput}${text}`.slice(-32_000);
@@ -694,15 +733,14 @@ function runShellCommand(
         return;
       }
       try {
-        if (process.platform !== "win32") {
+        if (windowsJobLaunch) {
+          // The launcher is the only process outside its Job. Terminating it
+          // closes the KILL_ON_JOB_CLOSE handle and atomically terminates the
+          // shell plus every descendant, so no taskkill tree walk is needed.
+          child.kill(signal);
+        } else if (process.platform !== "win32") {
           process.kill(-child.pid, signal);
         } else {
-          // child.kill only terminates the immediate bash.exe; its children
-          // (the actual command, e.g. `sleep`) linger, which keeps the `close`
-          // event from firing (timeouts hang) and holds handles on the
-          // workspace temp dir (EBUSY on cleanup). Kill the whole process tree.
-          // Match POSIX stop semantics: SIGTERM gets a non-forced taskkill,
-          // while SIGKILL is the immediate/fallback forced termination.
           const taskkillArgs = ["/pid", String(child.pid), "/t"];
           if (signal === "SIGKILL") {
             taskkillArgs.push("/f");
@@ -711,15 +749,16 @@ function runShellCommand(
           const systemRoot = Object.entries(taskkillEnv).find(
             ([key]) => key.toUpperCase() === "SYSTEMROOT",
           )?.[1];
-          // The explicit environment is necessary to keep the renderer URL out
-          // of the helper, so resolve taskkill without relying on its PATH.
           const taskkill = systemRoot
             ? path.join(systemRoot, "System32", "taskkill.exe")
             : "taskkill";
-          spawnSync(taskkill, taskkillArgs, {
+          const result = spawnSync(taskkill, taskkillArgs, {
             env: taskkillEnv,
             stdio: "ignore",
           });
+          if (result.status !== 0) {
+            child.kill(signal);
+          }
         }
       } catch (error) {
         environmentRuntimeLog.warn("codex-environment-command-kill-failed", {
@@ -758,6 +797,10 @@ function runShellCommand(
       if (forceSettleHandle) {
         clearTimeout(forceSettleHandle);
         forceSettleHandle = undefined;
+      }
+      if (windowsJobReadyTimer) {
+        clearTimeout(windowsJobReadyTimer);
+        windowsJobReadyTimer = undefined;
       }
       cleanupShellEnvironmentCaptureTarget(capture);
       callback();
@@ -868,6 +911,7 @@ function runShellCommand(
         processId,
         message,
       });
+      windowsJobLaunch?.cleanup();
       settle(() => {
         reject(new CodexEnvironmentCommandError(message));
       });
@@ -875,7 +919,6 @@ function runShellCommand(
 
     if (params.mode === "detach") {
       child.once("spawn", () => {
-        registerDetachedProcess();
         // Let the parent exit independently of this child. child.unref()
         // alone doesn't suffice when stdio is "pipe": the libuv pipe
         // handles on child.stdout/stderr also keep the parent's event
@@ -901,9 +944,44 @@ function runShellCommand(
         // Node versions where the type might tighten.
         (child.stdout as { unref?: () => void } | null)?.unref?.();
         (child.stderr as { unref?: () => void } | null)?.unref?.();
-        settle(() => {
-          resolve({ pid: child.pid });
-        });
+        const resolveStarted = () => {
+          // Do not expose the command to Stop/Quit until its Windows Job owns
+          // the shell. Otherwise an immediate stop can kill the launcher while
+          // startup is still pending and reject an action that was reported as
+          // registered.
+          registerDetachedProcess();
+          settle(() => {
+            resolve({ pid: child.pid });
+          });
+        };
+        if (!windowsJobLaunch) {
+          resolveStarted();
+          return;
+        }
+        const readyDeadline = Date.now() + WINDOWS_JOB_READY_TIMEOUT_MS;
+        const pollReady = () => {
+          windowsJobReadyTimer = undefined;
+          if (settled || closed) {
+            return;
+          }
+          if (existsSync(windowsJobLaunch.readyFilePath)) {
+            resolveStarted();
+            return;
+          }
+          if (Date.now() >= readyDeadline) {
+            terminateChild("SIGKILL");
+            settle(() => {
+              reject(
+                new CodexEnvironmentCommandError(
+                  `Windows Job shell did not become ready within ${WINDOWS_JOB_READY_TIMEOUT_MS}ms`,
+                ),
+              );
+            });
+            return;
+          }
+          windowsJobReadyTimer = setTimeout(pollReady, 25);
+        };
+        pollReady();
       });
       // Even in detach mode, log non-zero exits so failed `pnpm dev` /
       // PwrSnap-style launches don't disappear silently, and fire
@@ -911,6 +989,10 @@ function runShellCommand(
       // overlay state for the anchored env-action output UI.
       child.once("close", (code, signal) => {
         closed = true;
+        if (windowsJobReadyTimer) {
+          clearTimeout(windowsJobReadyTimer);
+          windowsJobReadyTimer = undefined;
+        }
         if (params.detachedTerminationKey) {
           const processEntry = detachedCommandProcesses.get(
             params.detachedTerminationKey,
@@ -928,6 +1010,26 @@ function runShellCommand(
         }
         const durationMs = Date.now() - startedAt;
         const output = combinedOutput.trimEnd();
+        if (!settled) {
+          if (windowsJobLaunch && existsSync(windowsJobLaunch.readyFilePath)) {
+            settle(() => {
+              resolve({ pid: child.pid });
+            });
+          } else {
+            settle(() => {
+              reject(
+                new CodexEnvironmentCommandError(
+                  `Codex environment command exited before its Windows Job became ready${buildExitErrorSuffix(output)}`,
+                  {
+                    durationMs,
+                    exitCode: typeof code === "number" ? code : undefined,
+                    output,
+                  },
+                ),
+              );
+            });
+          }
+        }
         if (code === 0) {
           environmentRuntimeLog.info("codex-environment-detached-exit", {
             processId,
@@ -966,12 +1068,14 @@ function runShellCommand(
             },
           );
         }
+        windowsJobLaunch?.cleanup();
       });
       return;
     }
 
     child.once("close", (code, signal) => {
       closed = true;
+      windowsJobLaunch?.cleanup();
       if (killHandle) {
         clearTimeout(killHandle);
         killHandle = undefined;
@@ -1207,18 +1311,25 @@ function isParentElectronRuntimeEnvKey(key: string): boolean {
 
 function resolveCommandShell(env: NodeJS.ProcessEnv): string {
   const requested = env.SHELL?.trim() || process.env.SHELL?.trim();
+  const preferredRequested = requested
+    ? preferStableWindowsBashPath(requested)
+    : undefined;
   // Windows has no /bin/sh; run the agent's bash scripts through
   // Git-for-Windows bash (already a hard dependency) instead.
   const candidates =
     process.platform === "win32"
-      ? [requested, ...windowsBashCandidates()]
+      ? [preferredRequested, requested, ...windowsBashCandidates()]
       : [requested, "/bin/zsh", "/bin/bash", "/bin/sh"];
   const inspected: Array<{ shell: string; reason: string }> = [];
 
   for (const shell of [...new Set(candidates.filter(Boolean))] as string[]) {
     const availability = inspectCommandPath(shell);
     if (availability.available) {
-      if (requested && shell !== requested) {
+      if (
+        requested
+        && shell !== requested
+        && shell !== preferredRequested
+      ) {
         environmentRuntimeLog.warn("codex-environment-shell-fallback", {
           requested,
           shell,
@@ -1344,12 +1455,14 @@ function wrapShellCommand(
   shell: string,
   command: string,
   captureEnvPath?: string,
+  processMarker?: string,
 ): string {
   return [
     ...shellStartupCommands(shell),
     '[ -n "${NVM_DIR:-}" ] && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"',
     '[ -z "${NVM_DIR:-}" ] && [ -s "$HOME/.nvm/nvm.sh" ] && . "$HOME/.nvm/nvm.sh"',
     "set -e",
+    ...(processMarker ? [`: ${processMarker}`] : []),
     command,
     ...(captureEnvPath
       ? [`{ /usr/bin/env || /bin/env || env; } > ${quoteShellArg(captureEnvPath)} || true`]

--- a/apps/desktop/src/main/automations/automation-gate-runner.ts
+++ b/apps/desktop/src/main/automations/automation-gate-runner.ts
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import type { AutomationGateConfig, AutomationGateRunResult } from "@pwragent/shared";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
+import { wrapCommandInWindowsJob } from "../windows-job-wrapper";
 import { resolveWindowsBashShell } from "../windows-shell";
 
 const DEFAULT_GATE_TIMEOUT_MS = 60_000;
@@ -42,13 +43,40 @@ function runShellGate(config: AutomationGateConfig): Promise<AutomationGateRunRe
   const shell =
     childEnv.SHELL?.trim() ||
     (process.platform === "win32" ? resolveWindowsBashShell() : "/bin/sh");
+  let windowsJobLaunch: ReturnType<typeof wrapCommandInWindowsJob> | undefined;
+  try {
+    windowsJobLaunch =
+      process.platform === "win32"
+        ? wrapCommandInWindowsJob({
+            args: ["-lc", command],
+            command: shell,
+            cwd: config.cwd,
+            env: childEnv,
+          })
+        : undefined;
+  } catch (error) {
+    return Promise.resolve({
+      status: "failed",
+      command,
+      cwd: config.cwd,
+      durationMs: Date.now() - startedAt,
+      output: "",
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+  }
+  const launch = windowsJobLaunch ?? {
+    args: ["-lc", command],
+    command: shell,
+    env: childEnv,
+  };
 
   return new Promise((resolve) => {
-    const child = spawn(shell, ["-lc", command], {
+    const child = spawn(launch.command, launch.args, {
       cwd: config.cwd,
-      detached: Boolean(timeoutMs),
-      env: childEnv,
+      detached: !windowsJobLaunch && Boolean(timeoutMs),
+      env: launch.env,
       stdio: "pipe",
+      windowsHide: true,
     });
 
     let output = "";
@@ -72,6 +100,7 @@ function runShellGate(config: AutomationGateConfig): Promise<AutomationGateRunRe
         clearTimeout(forceSettleHandle);
         forceSettleHandle = undefined;
       }
+      windowsJobLaunch?.cleanup();
       resolve(result);
     };
 
@@ -80,7 +109,11 @@ function runShellGate(config: AutomationGateConfig): Promise<AutomationGateRunRe
         return;
       }
       try {
-        if (process.platform !== "win32") {
+        if (windowsJobLaunch) {
+          // The wrapper owns the shell and all descendants in a
+          // KILL_ON_JOB_CLOSE Job, so terminating this one process is atomic.
+          child.kill("SIGKILL");
+        } else if (process.platform !== "win32") {
           process.kill(-child.pid, "SIGTERM");
         } else {
           // child.kill only terminates the immediate bash.exe; its children

--- a/apps/desktop/src/main/windows-job-wrapper.ts
+++ b/apps/desktop/src/main/windows-job-wrapper.ts
@@ -1,0 +1,468 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const EXECUTABLE_ENV = "PWRAGENT_JOB_WRAPPER_EXECUTABLE";
+const ARGUMENT_0_ENV = "PWRAGENT_JOB_WRAPPER_ARGUMENT_0";
+const ARGUMENT_1_ENV = "PWRAGENT_JOB_WRAPPER_ARGUMENT_1";
+const WORKING_DIRECTORY_ENV = "PWRAGENT_JOB_WRAPPER_CWD";
+const READY_FILE_ENV = "PWRAGENT_JOB_WRAPPER_READY_FILE";
+const EXIT_FILE_ENV = "PWRAGENT_JOB_WRAPPER_EXIT_FILE";
+const BASH_EXIT_TRAP =
+  "trap 'pwragent_exit=$?; trap - EXIT; printf \"%s\" \"$pwragent_exit\" > \"$PWRAGENT_JOB_WRAPPER_EXIT_FILE\"; exit \"$pwragent_exit\"' EXIT";
+
+/**
+ * PowerShell hosts this small native launcher because Node does not expose the
+ * Windows Job Object APIs. The target starts suspended, enters a
+ * KILL_ON_JOB_CLOSE job, and only then resumes, so even MSYS fork descendants
+ * cannot escape between process creation and ownership assignment.
+ */
+const WINDOWS_JOB_WRAPPER_SCRIPT = String.raw`
+$ErrorActionPreference = 'Stop'
+$application = [string]$env:PWRAGENT_JOB_WRAPPER_EXECUTABLE
+$argument0 = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String([string]$env:PWRAGENT_JOB_WRAPPER_ARGUMENT_0))
+$argument1 = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String([string]$env:PWRAGENT_JOB_WRAPPER_ARGUMENT_1))
+$workingDirectory = [string]$env:PWRAGENT_JOB_WRAPPER_CWD
+$readyFile = [string]$env:PWRAGENT_JOB_WRAPPER_READY_FILE
+$exitFile = [string]$env:PWRAGENT_JOB_WRAPPER_EXIT_FILE
+Remove-Item Env:PWRAGENT_JOB_WRAPPER_EXECUTABLE -ErrorAction SilentlyContinue
+Remove-Item Env:PWRAGENT_JOB_WRAPPER_ARGUMENT_0 -ErrorAction SilentlyContinue
+Remove-Item Env:PWRAGENT_JOB_WRAPPER_ARGUMENT_1 -ErrorAction SilentlyContinue
+Remove-Item Env:PWRAGENT_JOB_WRAPPER_CWD -ErrorAction SilentlyContinue
+Remove-Item Env:PWRAGENT_JOB_WRAPPER_READY_FILE -ErrorAction SilentlyContinue
+
+$source = @'
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+
+public static class PwrAgentWindowsJobRunner
+{
+    private const uint CREATE_SUSPENDED = 0x00000004;
+    private const uint CREATE_NO_WINDOW = 0x08000000;
+    private const uint HANDLE_FLAG_INHERIT = 0x00000001;
+    private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000;
+    private const int JobObjectExtendedLimitInformation = 9;
+    private const uint STARTF_USESTDHANDLES = 0x00000100;
+    private const uint INFINITE = 0xFFFFFFFF;
+    private const uint WAIT_FAILED = 0xFFFFFFFF;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct STARTUPINFO
+    {
+        public uint cb;
+        public IntPtr lpReserved;
+        public IntPtr lpDesktop;
+        public IntPtr lpTitle;
+        public uint dwX;
+        public uint dwY;
+        public uint dwXSize;
+        public uint dwYSize;
+        public uint dwXCountChars;
+        public uint dwYCountChars;
+        public uint dwFillAttribute;
+        public uint dwFlags;
+        public short wShowWindow;
+        public short cbReserved2;
+        public IntPtr lpReserved2;
+        public IntPtr hStdInput;
+        public IntPtr hStdOutput;
+        public IntPtr hStdError;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PROCESS_INFORMATION
+    {
+        public IntPtr hProcess;
+        public IntPtr hThread;
+        public uint dwProcessId;
+        public uint dwThreadId;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IO_COUNTERS
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+    {
+        public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+        public IO_COUNTERS IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_BASIC_ACCOUNTING_INFORMATION
+    {
+        public long TotalUserTime;
+        public long TotalKernelTime;
+        public long ThisPeriodTotalUserTime;
+        public long ThisPeriodTotalKernelTime;
+        public uint TotalPageFaultCount;
+        public uint TotalProcesses;
+        public uint ActiveProcesses;
+        public uint TotalTerminatedProcesses;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr CreateJobObject(IntPtr jobAttributes, string name);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetInformationJobObject(
+        IntPtr job,
+        int informationClass,
+        IntPtr information,
+        uint informationLength);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool QueryInformationJobObject(
+        IntPtr job,
+        int informationClass,
+        out JOBOBJECT_BASIC_ACCOUNTING_INFORMATION information,
+        uint informationLength,
+        out uint returnLength);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool CreateProcess(
+        string applicationName,
+        StringBuilder commandLine,
+        IntPtr processAttributes,
+        IntPtr threadAttributes,
+        bool inheritHandles,
+        uint creationFlags,
+        IntPtr environment,
+        string currentDirectory,
+        ref STARTUPINFO startupInfo,
+        out PROCESS_INFORMATION processInformation);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint ResumeThread(IntPtr thread);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool GetExitCodeProcess(IntPtr process, out uint exitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool TerminateProcess(IntPtr process, uint exitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CloseHandle(IntPtr handle);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr GetStdHandle(int standardHandle);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetHandleInformation(
+        IntPtr handle,
+        uint mask,
+        uint flags);
+
+    private static void ThrowLastWin32Error(string operation)
+    {
+        throw new Win32Exception(
+            Marshal.GetLastWin32Error(),
+            operation + " failed");
+    }
+
+    private static void MakeInheritable(IntPtr handle)
+    {
+        if (handle == IntPtr.Zero || handle == new IntPtr(-1))
+        {
+            return;
+        }
+        if (!SetHandleInformation(handle, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT))
+        {
+            ThrowLastWin32Error("SetHandleInformation");
+        }
+    }
+
+    private static string QuoteArgument(string value)
+    {
+        if (value.Length > 0 && value.IndexOfAny(new char[] { ' ', '\t', '\n', '\v', '"' }) < 0)
+        {
+            return value;
+        }
+        StringBuilder quoted = new StringBuilder();
+        quoted.Append('"');
+        int backslashes = 0;
+        foreach (char character in value)
+        {
+            if (character == '\\')
+            {
+                backslashes += 1;
+                continue;
+            }
+            if (character == '"')
+            {
+                quoted.Append('\\', backslashes * 2 + 1);
+                quoted.Append('"');
+                backslashes = 0;
+                continue;
+            }
+            quoted.Append('\\', backslashes);
+            quoted.Append(character);
+            backslashes = 0;
+        }
+        quoted.Append('\\', backslashes * 2);
+        quoted.Append('"');
+        return quoted.ToString();
+    }
+
+    private static uint ReadActiveProcessCount(IntPtr job)
+    {
+        JOBOBJECT_BASIC_ACCOUNTING_INFORMATION accounting;
+        uint returnLength;
+        if (!QueryInformationJobObject(
+            job,
+            1,
+            out accounting,
+            (uint)Marshal.SizeOf(typeof(JOBOBJECT_BASIC_ACCOUNTING_INFORMATION)),
+            out returnLength))
+        {
+            ThrowLastWin32Error("QueryInformationJobObject");
+        }
+        return accounting.ActiveProcesses;
+    }
+
+    public static int Run(
+        string application,
+        string[] arguments,
+        string workingDirectory,
+        string readyFile)
+    {
+        IntPtr job = CreateJobObject(IntPtr.Zero, null);
+        if (job == IntPtr.Zero)
+        {
+            ThrowLastWin32Error("CreateJobObject");
+        }
+
+        PROCESS_INFORMATION processInformation = new PROCESS_INFORMATION();
+        bool processCreated = false;
+        try
+        {
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits =
+                new JOBOBJECT_EXTENDED_LIMIT_INFORMATION();
+            limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            int limitsSize = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+            IntPtr limitsPointer = Marshal.AllocHGlobal(limitsSize);
+            try
+            {
+                Marshal.StructureToPtr(limits, limitsPointer, false);
+                if (!SetInformationJobObject(
+                    job,
+                    JobObjectExtendedLimitInformation,
+                    limitsPointer,
+                    (uint)limitsSize))
+                {
+                    ThrowLastWin32Error("SetInformationJobObject");
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(limitsPointer);
+            }
+
+            STARTUPINFO startupInfo = new STARTUPINFO();
+            startupInfo.cb = (uint)Marshal.SizeOf(typeof(STARTUPINFO));
+            startupInfo.dwFlags = STARTF_USESTDHANDLES;
+            startupInfo.hStdInput = GetStdHandle(-10);
+            startupInfo.hStdOutput = GetStdHandle(-11);
+            startupInfo.hStdError = GetStdHandle(-12);
+            MakeInheritable(startupInfo.hStdInput);
+            MakeInheritable(startupInfo.hStdOutput);
+            MakeInheritable(startupInfo.hStdError);
+
+            StringBuilder commandLine = new StringBuilder(QuoteArgument(application));
+            foreach (string argument in arguments)
+            {
+                commandLine.Append(' ');
+                commandLine.Append(QuoteArgument(argument));
+            }
+            if (!CreateProcess(
+                application,
+                commandLine,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                true,
+                CREATE_SUSPENDED | CREATE_NO_WINDOW,
+                IntPtr.Zero,
+                workingDirectory,
+                ref startupInfo,
+                out processInformation))
+            {
+                ThrowLastWin32Error("CreateProcess");
+            }
+            processCreated = true;
+
+            if (!AssignProcessToJobObject(job, processInformation.hProcess))
+            {
+                TerminateProcess(processInformation.hProcess, 127);
+                ThrowLastWin32Error("AssignProcessToJobObject");
+            }
+            if (ResumeThread(processInformation.hThread) == UInt32.MaxValue)
+            {
+                TerminateProcess(processInformation.hProcess, 127);
+                ThrowLastWin32Error("ResumeThread");
+            }
+            File.WriteAllText(readyFile, "ready");
+            if (WaitForSingleObject(processInformation.hProcess, INFINITE) == WAIT_FAILED)
+            {
+                ThrowLastWin32Error("WaitForSingleObject");
+            }
+            while (ReadActiveProcessCount(job) > 0)
+            {
+                Thread.Sleep(10);
+            }
+            uint exitCode;
+            if (!GetExitCodeProcess(processInformation.hProcess, out exitCode))
+            {
+                ThrowLastWin32Error("GetExitCodeProcess");
+            }
+            return unchecked((int)exitCode);
+        }
+        finally
+        {
+            if (processCreated)
+            {
+                CloseHandle(processInformation.hThread);
+                CloseHandle(processInformation.hProcess);
+            }
+            CloseHandle(job);
+        }
+    }
+}
+'@
+
+try {
+  Add-Type -TypeDefinition $source -Language CSharp -ErrorAction Stop
+  $exitCode = [PwrAgentWindowsJobRunner]::Run(
+    $application,
+    [string[]]@($argument0, $argument1),
+    $workingDirectory,
+    $readyFile)
+  if (Test-Path -LiteralPath $exitFile) {
+    $reportedExitCode = 0
+    if ([int]::TryParse(
+      (Get-Content -Raw -LiteralPath $exitFile),
+      [ref]$reportedExitCode)) {
+      $exitCode = $reportedExitCode
+    }
+  }
+  exit $exitCode
+} catch {
+  [Console]::Error.WriteLine('PwrAgent Windows job wrapper failed: ' + $_.Exception.Message)
+  exit 127
+}
+`;
+
+export type WindowsJobWrappedCommand = {
+  args: string[];
+  cleanup: () => void;
+  command: string;
+  env: NodeJS.ProcessEnv;
+  readyFilePath: string;
+};
+
+function encodeArgument(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64");
+}
+
+export function wrapCommandInWindowsJob(params: {
+  args: [string, string];
+  command: string;
+  cwd?: string;
+  env: NodeJS.ProcessEnv;
+}): WindowsJobWrappedCommand {
+  const stateDirectory = mkdtempSync(
+    path.join(os.tmpdir(), "pwragent-windows-job-"),
+  );
+  const readyFilePath = path.join(stateDirectory, "ready");
+  const exitFilePath = path.join(stateDirectory, "exit");
+  const scriptPath = path.join(stateDirectory, "wrapper.ps1");
+  writeFileSync(scriptPath, WINDOWS_JOB_WRAPPER_SCRIPT, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  const systemRoot = Object.entries(params.env).find(
+    ([key]) => key.toUpperCase() === "SYSTEMROOT",
+  )?.[1];
+  const powershell = systemRoot
+    ? path.win32.join(
+        systemRoot,
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe",
+      )
+    : "powershell.exe";
+  // Git-for-Windows can hand execution between multiple MSYS processes. The
+  // native process created above is therefore not always the process whose
+  // exit code represents the shell script. Have every POSIX `-lc` invocation
+  // report its own exact status for the wrapper to return.
+  const argument1 =
+    params.args[0] === "-lc"
+      ? `${BASH_EXIT_TRAP}\n${params.args[1]}`
+      : params.args[1];
+  return {
+    command: powershell,
+    args: [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+      scriptPath,
+    ],
+    cleanup: () => {
+      rmSync(stateDirectory, {
+        force: true,
+        maxRetries: 5,
+        recursive: true,
+        retryDelay: 100,
+      });
+    },
+    env: {
+      ...params.env,
+      [EXECUTABLE_ENV]: params.command,
+      [ARGUMENT_0_ENV]: encodeArgument(params.args[0]),
+      [ARGUMENT_1_ENV]: encodeArgument(argument1),
+      [WORKING_DIRECTORY_ENV]: params.cwd ?? process.cwd(),
+      [READY_FILE_ENV]: readyFilePath,
+      [EXIT_FILE_ENV]: exitFilePath,
+    },
+    readyFilePath,
+  };
+}

--- a/apps/desktop/src/main/windows-shell.ts
+++ b/apps/desktop/src/main/windows-shell.ts
@@ -16,16 +16,45 @@ export function windowsBashCandidates(): string[] {
   const localAppData = process.env.LOCALAPPDATA;
 
   const candidates = [
-    path.join(programFiles, "Git", "bin", "bash.exe"),
-    path.join(programFiles, "Git", "usr", "bin", "bash.exe"),
-    path.join(programFilesX86, "Git", "bin", "bash.exe"),
+    path.win32.join(programFiles, "Git", "usr", "bin", "bash.exe"),
+    path.win32.join(programFiles, "Git", "bin", "bash.exe"),
+    path.win32.join(programFilesX86, "Git", "usr", "bin", "bash.exe"),
+    path.win32.join(programFilesX86, "Git", "bin", "bash.exe"),
   ];
   if (localAppData) {
-    candidates.push(path.join(localAppData, "Programs", "Git", "bin", "bash.exe"));
+    candidates.push(
+      path.win32.join(localAppData, "Programs", "Git", "usr", "bin", "bash.exe"),
+      path.win32.join(localAppData, "Programs", "Git", "bin", "bash.exe"),
+    );
   }
   // Last resort: rely on PATH resolution.
   candidates.push("bash.exe");
   return candidates;
+}
+
+/**
+ * Prefer Git-for-Windows' stable MSYS bash over its `bin\\bash.exe` launcher.
+ * The launcher can exit after spawning a differently-pid'd `usr\\bin\\bash.exe`,
+ * which breaks process-tree ownership and leaves detached commands behind.
+ */
+export function preferStableWindowsBashPath(
+  shell: string,
+  pathExists: (candidate: string) => boolean = existsSync,
+): string {
+  const normalized = path.win32.normalize(shell);
+  if (path.win32.basename(normalized).toLowerCase() !== "bash.exe") {
+    return shell;
+  }
+  const binDir = path.win32.dirname(normalized);
+  if (path.win32.basename(binDir).toLowerCase() !== "bin") {
+    return shell;
+  }
+  const binParent = path.win32.dirname(binDir);
+  if (path.win32.basename(binParent).toLowerCase() === "usr") {
+    return normalized;
+  }
+  const stableBash = path.win32.join(binParent, "usr", "bin", "bash.exe");
+  return pathExists(stableBash) ? stableBash : shell;
 }
 
 /**

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -282,7 +282,14 @@ describe("App", () => {
     fireEvent.click(
       screen.getByRole("button", { name: "Open Git settings" }),
     );
-    const gitSettingsButton = await screen.findByRole("button", { name: "Git" });
+    // Settings is a lazy chunk. Under a loaded Windows worker the module can
+    // settle after Testing Library's default one-second find bound, even
+    // though navigation completed normally. Wait for the import lifecycle
+    // itself so this assertion measures the selected settings section.
+    await act(async () => {
+      await vi.dynamicImportSettled();
+    });
+    const gitSettingsButton = screen.getByRole("button", { name: "Git" });
     expect(gitSettingsButton).toHaveAttribute("aria-current", "page");
   });
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -4985,11 +4985,21 @@ export function Composer(props: ComposerProps) {
             turnQueueRecord.status === "failed" ||
             turnQueueRecord.status === "cancelled")
         ) {
-          const queued = queuedTurns.find(
-            (candidate) => candidate.queueEntryId === turnQueueRecord.queueEntryId,
-          );
+          // The durable store is updated before React necessarily commits the
+          // corresponding queued-turn state. A fast terminal notification can
+          // therefore race this listener's render closure; resolve by stable
+          // queue id from the store first so the UI cannot retain a dead chip.
+          const queued =
+            draftStore.getQueuedTurns(queueScopeKey).find(
+              (candidate) =>
+                candidate.queueEntryId === turnQueueRecord.queueEntryId,
+            )
+            ?? queuedTurns.find(
+              (candidate) =>
+                candidate.queueEntryId === turnQueueRecord.queueEntryId,
+            );
           if (queued) {
-            removeQueuedTurn(queued);
+            removeQueuedTurnInScope(queueScopeKey, queued);
           }
         }
         if (

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4091,6 +4091,9 @@ describe("Composer", () => {
       expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
         "Second queued reply",
       );
+      expect(
+        screen.getAllByRole("button", { name: "Edit" })[0],
+      ).toBeEnabled();
     });
     expect(screen.queryByText("A message is already queued.")).not.toBeInTheDocument();
 
@@ -5017,7 +5020,14 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "Steer remotely" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
     await screen.findByLabelText("Queued message");
-    fireEvent.click(screen.getByRole("button", { name: "Steer" }));
+    const steerButton = screen.getByRole("button", { name: "Steer" });
+    // The local projection renders immediately but remains disabled until the
+    // owning peer returns its stable queue entry id. A click before that
+    // acknowledgement is intentionally ignored.
+    await waitFor(() => {
+      expect(steerButton).toBeEnabled();
+    });
+    fireEvent.click(steerButton);
 
     await waitFor(() => {
       expect(cancelQueuedTurn).toHaveBeenCalledWith({
@@ -5085,7 +5095,10 @@ describe("Composer", () => {
     fireEvent.keyDown(textarea, { key: "Enter" });
 
     await waitFor(() => {
-      expect(screen.getAllByRole("button", { name: "Delete" })).toHaveLength(2);
+      const buttons = screen.getAllByRole("button", { name: "Delete" });
+      expect(buttons).toHaveLength(2);
+      expect(buttons[0]).toBeEnabled();
+      expect(buttons[1]).toBeEnabled();
     });
     const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
     fireEvent.click(deleteButtons[0]!);

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4091,9 +4091,6 @@ describe("Composer", () => {
       expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
         "Second queued reply",
       );
-      expect(
-        screen.getAllByRole("button", { name: "Edit" })[0],
-      ).toBeEnabled();
     });
     expect(screen.queryByText("A message is already queued.")).not.toBeInTheDocument();
 
@@ -4941,6 +4938,9 @@ describe("Composer", () => {
       expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
         "Second queued reply",
       );
+      expect(
+        screen.getAllByRole("button", { name: "Edit" })[0],
+      ).toBeEnabled();
     });
 
     fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]!);


### PR DESCRIPTION
## Summary

- add a Windows-only, opt-in Vitest stress diagnostic that retains per-iteration logs and fails on settled Bash, Git, Node, shell, or sleep process residue
- launch detached and timeout-bound Git Bash commands inside a Windows Job Object with `KILL_ON_JOB_CLOSE`, assigning the process before it resumes
- use the same ownership boundary for Codex environment actions and automation gate commands, and wait for owned jobs during shutdown
- synchronize queue and lazy-renderer tests to stable backend IDs and actual lifecycle readiness instead of optimistic DOM/native state

## Root cause

Repeated Windows stress runs reproduced orphaned Git Bash process trees in 4/10 focused runs and 4/10 full-workspace runs. The existing `taskkill /T` cleanup could race MSYS process forking and miss a descendant, allowing an infinite shell/sleep loop to survive test shutdown and compete with later tests.

The broad runs also exposed independent renderer races:

- terminal queue events could arrive after the durable draft store was updated but before React committed the corresponding queued-turn state
- queue action tests clicked controls before the owning peer returned a stable queue entry ID
- the App shell test waited on a one-second DOM query rather than the lazy Settings import plus React commit

The originally reported SQLite migration and worktree timeout tests did not reproduce across the repeated Windows runs, so this change does not add serial lanes, shared database reuse, or wider timeouts without evidence.

## Validation

- pre-fix Windows reproduction: process residue in 4/10 focused and 4/10 full-workspace repetitions
- final Windows full-workspace stress: 10/10 repetitions passed; 62,940 tests passed and 210 skipped across 4,800 test-file executions; zero residual processes after every repetition
- post-rebase Windows integration:
  - Composer file: 10/10 repetitions passed, 2,510 tests
  - App shell file: 10/10 repetitions passed, 230 tests
  - full workspace: passed with zero residual processes
- local focused validation: 310 passed, 1 platform-specific skip
- `pnpm lint:eslint`: 0 errors
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm build` (including the main-bundle boundary check)

No test retries, broad timeout increases, worker reductions, or serial test lanes were used.
