### PR TITLE
feat(desktop): viewer-owned local pin rank for remote threads

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -299,6 +299,18 @@ const setThreadPinOverlay = vi.fn(
     pinnedRank: params.pinnedRank ?? undefined,
   }),
 );
+const listPinnedThreadOverlayRanks = vi.fn(
+  async (): Promise<Array<{ pinnedRank: string; parentThreadId?: string }>> => [],
+);
+const reorderThreadPinsStore = vi.fn(
+  async (params: { threadKeys: string[] }): Promise<Record<string, string>> =>
+    Object.fromEntries(
+      params.threadKeys.map((threadKey, index) => [
+        threadKey,
+        String((index + 1) * 1024),
+      ]),
+    ),
+);
 const readDirectoryStatuses = vi.fn(async () => ({
   "directory:/repo/app": {
     currentBranch: "main",
@@ -740,6 +752,8 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     hasRemoteThreadPin,
     setRemoteThreadLocalPin,
     setThreadPin: setThreadPinOverlay,
+    listPinnedThreadOverlayRanks,
+    reorderThreadPins: reorderThreadPinsStore,
   }),
 }));
 
@@ -1928,8 +1942,7 @@ describe("app server ipc", () => {
       instanceId: "peer-laptop",
       threadId: "remote-pin",
     });
-    setRemoteThreadLocalPin.mockClear();
-    setThreadPinOverlay.mockClear();
+    reorderThreadPinsStore.mockClear();
     listRemoteThreadPins.mockResolvedValueOnce([
       { ref: remoteRef, addedAt: 1_000, instanceLabel: "Laptop" },
     ]);
@@ -1941,19 +1954,15 @@ describe("app server ipc", () => {
       { threadKeys: ["codex:remote-pin", "codex:local-pin"] },
     )) as { pinnedRanks: Record<string, string> };
 
-    // Ranks come from the FULL order so both kinds interleave correctly.
-    expect(setRemoteThreadLocalPin).toHaveBeenCalledWith({
-      ref: remoteRef,
-      pinnedRank: "0",
-    });
-    expect(setThreadPinOverlay).toHaveBeenCalledWith({
-      backend: "codex",
-      threadId: "local-pin",
-      pinnedRank: "1024",
+    // The store gets the FULL order plus the remote-key routing map so both
+    // kinds interleave in one atomic write.
+    expect(reorderThreadPinsStore).toHaveBeenCalledWith({
+      threadKeys: ["codex:remote-pin", "codex:local-pin"],
+      remoteRefsByKey: { "codex:remote-pin": remoteRef },
     });
     expect(response.pinnedRanks).toEqual({
-      "codex:remote-pin": "0",
-      "codex:local-pin": "1024",
+      "codex:remote-pin": "1024",
+      "codex:local-pin": "2048",
     });
   });
 
@@ -1964,60 +1973,21 @@ describe("app server ipc", () => {
     );
     const { buildFederatedThreadRef } = await import("@pwragent/shared");
 
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
     const ref = buildFederatedThreadRef({
       backend: "codex",
       instanceId: "peer-laptop",
       threadId: "remote-hidden",
     });
     setRemoteThreadLocalPin.mockClear();
-    // The visibility check reads a fresh snapshot AFTER the pin lands: the
-    // remote row is merged and its home group ("app") reports Directory
-    // Threads collapsed while the pinned section is in use locally.
-    listRemoteThreadPins.mockResolvedValueOnce([
-      { ref, addedAt: 1_000, instanceLabel: "Laptop" },
-    ]);
-    federationMock.remoteThreadSummaries.resolvePinnedThreads.mockResolvedValueOnce({
-      threads: [
-        {
-          source: "codex" as const,
-          id: "remote-hidden",
-          title: "Hidden remote",
-          titleSource: "derived" as const,
-          linkedDirectories: [
-            {
-              id: "dir-app",
-              label: "app",
-              path: "/peer/dev/app",
-              kind: "local" as const,
-            },
-          ],
-          inbox: { inInbox: false },
-          federation: {
-            ref,
-            instanceLabel: "Laptop",
-            peerStatus: "connected" as const,
-            capabilities: [],
-          },
-        },
-      ],
-      refreshed: [],
-    });
+    // The visibility check reads the CACHED directory summaries from the
+    // last snapshot build (never a fresh snapshot) — warm the cache with a
+    // snapshot whose "app" group reports Directory Threads collapsed.
     reconcileNavigationSnapshot.mockImplementationOnce(async (params: unknown) => ({
       backend: (params as { backend: "all" | "codex" | "grok" }).backend,
       fetchedAt: 1234,
       unchanged: false,
-      threads: [
-        {
-          source: "codex" as const,
-          id: "local-pinned",
-          title: "Local pinned",
-          titleSource: "explicit" as const,
-          pinnedRank: "0",
-          linkedDirectories: [],
-          inbox: { inInbox: false },
-        },
-        ...((params as { threads: unknown[] }).threads as never[]),
-      ],
+      threads: (params as { threads: unknown[] }).threads,
       inboxThreadKeys: [],
       directories: [
         {
@@ -2038,6 +2008,36 @@ describe("app server ipc", () => {
     }));
 
     registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.(
+      {},
+      {} satisfies GetNavigationSnapshotRequest,
+    );
+
+    // The pinned section is in use locally, and the freshly added pin's
+    // payload carries the home-directory link.
+    listPinnedThreadOverlayRanks.mockResolvedValueOnce([{ pinnedRank: "0" }]);
+    listRemoteThreadPins.mockResolvedValueOnce([
+      {
+        ref,
+        addedAt: 1_000,
+        instanceLabel: "Laptop",
+        summary: {
+          source: "codex" as const,
+          id: "remote-hidden",
+          title: "Hidden remote",
+          titleSource: "derived" as const,
+          linkedDirectories: [
+            {
+              id: "dir-app",
+              label: "app",
+              path: "/peer/dev/app",
+              kind: "local" as const,
+            },
+          ],
+          inbox: { inInbox: false },
+        },
+      },
+    ]);
 
     await handlers.get(NAVIGATION_ADD_REMOTE_THREAD_PIN_CHANNEL)?.({}, {
       ref,

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -285,6 +285,20 @@ const addRemoteThreadPinStore = vi.fn(
   }),
 );
 const hasRemoteThreadPin = vi.fn(async () => false);
+const setRemoteThreadLocalPin = vi.fn(
+  async (params: { pinnedRank?: string | null }) => ({
+    ...(params.pinnedRank ? { pinnedRank: params.pinnedRank } : {}),
+  }),
+);
+const setThreadPinOverlay = vi.fn(
+  async (params: { backend: string; threadId: string; pinnedRank?: string | null }) => ({
+    backend: params.backend,
+    threadId: params.threadId,
+    executionMode: "default" as const,
+    extraLinkedDirectories: [],
+    pinnedRank: params.pinnedRank ?? undefined,
+  }),
+);
 const readDirectoryStatuses = vi.fn(async () => ({
   "directory:/repo/app": {
     currentBranch: "main",
@@ -724,6 +738,8 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     updateRemoteThreadPinSnapshots,
     addRemoteThreadPin: addRemoteThreadPinStore,
     hasRemoteThreadPin,
+    setRemoteThreadLocalPin,
+    setThreadPin: setThreadPinOverlay,
   }),
 }));
 
@@ -1852,6 +1868,196 @@ describe("app server ipc", () => {
     expect(byKey.get("directory:/repo/agent-kit")?.threadKeys).not.toContain(
       "codex:remote-multi",
     );
+  });
+
+  it("stamps the viewer-owned local rank onto merged remote rows", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const { buildFederatedThreadRef } = await import("@pwragent/shared");
+
+    const ref = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "peer-laptop",
+      threadId: "remote-ranked",
+    });
+    listRemoteThreadPins.mockResolvedValueOnce([
+      { ref, addedAt: 1_000, instanceLabel: "Laptop", localPinnedRank: "3072" },
+    ]);
+    federationMock.remoteThreadSummaries.resolvePinnedThreads.mockResolvedValueOnce({
+      threads: [
+        {
+          source: "codex" as const,
+          id: "remote-ranked",
+          title: "Ranked remote",
+          titleSource: "derived" as const,
+          // Owner-side rank must still be discarded; the VIEWER rank wins.
+          pinnedRank: "9999",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          federation: {
+            ref,
+            instanceLabel: "Laptop",
+            peerStatus: "connected" as const,
+            capabilities: [],
+          },
+        },
+      ],
+      refreshed: [],
+    });
+
+    registerAppServerIpcHandlers();
+
+    const response = (await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.(
+      {},
+      {} satisfies GetNavigationSnapshotRequest,
+    )) as { threads: Array<{ id: string; pinnedRank?: string }> };
+
+    const row = response.threads.find((thread) => thread.id === "remote-ranked");
+    expect(row?.pinnedRank).toBe("3072");
+  });
+
+  it("routes pin reorders per key: viewer rank for remote pins, overlay for local", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REORDER_THREAD_PINS_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    const { buildFederatedThreadRef } = await import("@pwragent/shared");
+
+    const remoteRef = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "peer-laptop",
+      threadId: "remote-pin",
+    });
+    setRemoteThreadLocalPin.mockClear();
+    setThreadPinOverlay.mockClear();
+    listRemoteThreadPins.mockResolvedValueOnce([
+      { ref: remoteRef, addedAt: 1_000, instanceLabel: "Laptop" },
+    ]);
+
+    registerAppServerIpcHandlers();
+
+    const response = (await handlers.get(NAVIGATION_REORDER_THREAD_PINS_CHANNEL)?.(
+      {},
+      { threadKeys: ["codex:remote-pin", "codex:local-pin"] },
+    )) as { pinnedRanks: Record<string, string> };
+
+    // Ranks come from the FULL order so both kinds interleave correctly.
+    expect(setRemoteThreadLocalPin).toHaveBeenCalledWith({
+      ref: remoteRef,
+      pinnedRank: "0",
+    });
+    expect(setThreadPinOverlay).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "local-pin",
+      pinnedRank: "1024",
+    });
+    expect(response.pinnedRanks).toEqual({
+      "codex:remote-pin": "0",
+      "codex:local-pin": "1024",
+    });
+  });
+
+  it("auto-ranks a remote pin whose home directory group is collapsed", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_ADD_REMOTE_THREAD_PIN_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    const { buildFederatedThreadRef } = await import("@pwragent/shared");
+
+    const ref = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "peer-laptop",
+      threadId: "remote-hidden",
+    });
+    setRemoteThreadLocalPin.mockClear();
+    // The visibility check reads a fresh snapshot AFTER the pin lands: the
+    // remote row is merged and its home group ("app") reports Directory
+    // Threads collapsed while the pinned section is in use locally.
+    listRemoteThreadPins.mockResolvedValueOnce([
+      { ref, addedAt: 1_000, instanceLabel: "Laptop" },
+    ]);
+    federationMock.remoteThreadSummaries.resolvePinnedThreads.mockResolvedValueOnce({
+      threads: [
+        {
+          source: "codex" as const,
+          id: "remote-hidden",
+          title: "Hidden remote",
+          titleSource: "derived" as const,
+          linkedDirectories: [
+            {
+              id: "dir-app",
+              label: "app",
+              path: "/peer/dev/app",
+              kind: "local" as const,
+            },
+          ],
+          inbox: { inInbox: false },
+          federation: {
+            ref,
+            instanceLabel: "Laptop",
+            peerStatus: "connected" as const,
+            capabilities: [],
+          },
+        },
+      ],
+      refreshed: [],
+    });
+    reconcileNavigationSnapshot.mockImplementationOnce(async (params: unknown) => ({
+      backend: (params as { backend: "all" | "codex" | "grok" }).backend,
+      fetchedAt: 1234,
+      unchanged: false,
+      threads: [
+        {
+          source: "codex" as const,
+          id: "local-pinned",
+          title: "Local pinned",
+          titleSource: "explicit" as const,
+          pinnedRank: "0",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        },
+        ...((params as { threads: unknown[] }).threads as never[]),
+      ],
+      inboxThreadKeys: [],
+      directories: [
+        {
+          key: "directory:/repo/app",
+          kind: "directory" as const,
+          label: "app",
+          path: "/repo/app",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          latestUpdatedAt: 2000,
+          directoryThreadsCollapsed: true,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_ADD_REMOTE_THREAD_PIN_CHANNEL)?.({}, {
+      ref,
+      instanceLabel: "Laptop",
+      summary: {
+        source: "codex" as const,
+        id: "remote-hidden",
+        title: "Hidden remote",
+        titleSource: "derived" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+    });
+
+    expect(setRemoteThreadLocalPin).toHaveBeenCalledTimes(1);
+    expect(setRemoteThreadLocalPin.mock.calls[0][0]).toMatchObject({ ref });
+    expect(
+      typeof (setRemoteThreadLocalPin.mock.calls[0][0] as { pinnedRank?: string })
+        .pinnedRank,
+    ).toBe("string");
   });
 
   it("pins a remote sub-thread's reachable parent as a companion", async () => {

--- a/apps/desktop/src/main/__tests__/remote-thread-pins-store.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-pins-store.test.ts
@@ -161,6 +161,39 @@ describe("SqliteOverlayStore — remote thread pins", () => {
     }
   });
 
+  it("sets and clears a viewer-owned local pin rank", async () => {
+    await store.addRemoteThreadPin({
+      ref: ref(),
+      summary: summary(),
+      instanceLabel: "Laptop",
+      pinnedVia: "explicit",
+    });
+
+    expect(
+      await store.setRemoteThreadLocalPin({ ref: ref(), pinnedRank: "2048" }),
+    ).toEqual({ pinnedRank: "2048" });
+    let listed = await store.listRemoteThreadPins();
+    expect(listed[0].localPinnedRank).toBe("2048");
+    // The rank patch must not disturb the rest of the payload.
+    expect(listed[0].summary?.title).toBe("Remote fix");
+    expect(listed[0].pinnedVia).toBe("explicit");
+
+    expect(
+      await store.setRemoteThreadLocalPin({ ref: ref(), pinnedRank: null }),
+    ).toEqual({});
+    listed = await store.listRemoteThreadPins();
+    expect(listed[0].localPinnedRank).toBeUndefined();
+
+    // A rank write for a thread that was never pinned is a no-op.
+    expect(
+      await store.setRemoteThreadLocalPin({
+        ref: ref("never-pinned"),
+        pinnedRank: "1024",
+      }),
+    ).toEqual({});
+    expect(await store.listRemoteThreadPins()).toHaveLength(1);
+  });
+
   it("round-trips pinnedVia and answers membership checks", async () => {
     await store.addRemoteThreadPin({
       ref: ref("child"),

--- a/apps/desktop/src/main/__tests__/remote-thread-pins-store.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-pins-store.test.ts
@@ -194,6 +194,64 @@ describe("SqliteOverlayStore — remote thread pins", () => {
     expect(await store.listRemoteThreadPins()).toHaveLength(1);
   });
 
+  it("keeps viewer-owned pin state through snapshot payload refreshes", async () => {
+    await store.addRemoteThreadPin({
+      ref: ref(),
+      summary: summary({ title: "Stale" }),
+      instanceLabel: "Laptop",
+      pinnedVia: "companion",
+    });
+    await store.setRemoteThreadLocalPin({ ref: ref(), pinnedRank: "4096" });
+
+    // The reachable-owner refresh path rewrites summary + label on every
+    // merge; it must PATCH, never replace — a refresh that wiped the
+    // viewer's rank would silently unpin the row seconds after pinning.
+    await store.updateRemoteThreadPinSnapshots([
+      {
+        ref: ref(),
+        summary: summary({ title: "Fresh" }),
+        instanceLabel: "Laptop (renamed)",
+      },
+    ]);
+
+    const listed = await store.listRemoteThreadPins();
+    expect(listed[0].summary?.title).toBe("Fresh");
+    expect(listed[0].instanceLabel).toBe("Laptop (renamed)");
+    expect(listed[0].localPinnedRank).toBe("4096");
+    expect(listed[0].pinnedVia).toBe("companion");
+  });
+
+  it("reorders mixed local and remote pins atomically from the full order", async () => {
+    await store.addRemoteThreadPin({
+      ref: ref("remote-1"),
+      summary: summary({ id: "remote-1" }),
+      instanceLabel: "Laptop",
+    });
+    await store.setThreadPin({
+      backend: "codex",
+      threadId: "local-1",
+      pinnedRank: "9999",
+    });
+
+    const pinnedRanks = await store.reorderThreadPins({
+      threadKeys: ["codex:remote-1", "codex:local-1"],
+      remoteRefsByKey: { "codex:remote-1": ref("remote-1") },
+    });
+
+    expect(pinnedRanks).toEqual({
+      "codex:remote-1": "1024",
+      "codex:local-1": "2048",
+    });
+    const pins = await store.listRemoteThreadPins();
+    expect(pins[0].localPinnedRank).toBe("1024");
+    // The remote key must not have leaked into the local thread overlay.
+    const localOverlay = await store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "local-1",
+    });
+    expect(localOverlay?.pinnedRank).toBe("2048");
+  });
+
   it("round-trips pinnedVia and answers membership checks", async () => {
     await store.addRemoteThreadPin({
       ref: ref("child"),

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -89,10 +89,14 @@ import {
   type PrAutoDispatchBudgetStatus,
   type AddRemoteThreadPinRequest,
   type AddRemoteThreadPinResponse,
+  type FederatedThreadRef,
   type FederationJumpSearchRequest,
   type FederationJumpSearchResponse,
+  type RemoteThreadPin,
   type RemoveRemoteThreadPinRequest,
   type RemoveRemoteThreadPinResponse,
+  type SetRemoteThreadLocalPinRequest,
+  type SetRemoteThreadLocalPinResponse,
   type ReorderDirectoryPinsRequest,
   type ReorderDirectoryPinsResponse,
   type ReorderThreadPinsRequest,
@@ -149,9 +153,11 @@ import {
   DEFAULT_PR_AUTO_DISPATCH_BUDGET_CAPACITY,
   DEFAULT_PR_AUTO_DISPATCH_BUDGET_REFILL_PER_MINUTE,
   DEFAULT_PULL_REQUEST_PROVIDER,
+  buildAppendPinRank,
   buildFederatedThreadRef,
   buildPullRequestStatusKey,
   buildThreadIdentityKey,
+  PIN_RANK_STEP,
   federatedThreadIdentityKey,
   isAppServerBackendKind,
   isRemoteFederationTarget,
@@ -206,6 +212,7 @@ import {
   NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL,
   NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL,
   NAVIGATION_REMOVE_REMOTE_THREAD_PIN_CHANNEL,
+  NAVIGATION_SET_REMOTE_THREAD_LOCAL_PIN_CHANNEL,
   NAVIGATION_DETACH_THREAD_PR_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_SET_PR_POLLING_FOCUS_CHANNEL,
@@ -326,6 +333,7 @@ type AppServerOverlayStoreLike = OverlayStoreLike &
     | "addRemoteThreadPin"
     | "hasRemoteThreadPin"
     | "removeRemoteThreadPin"
+    | "setRemoteThreadLocalPin"
     | "listRemoteThreadPins"
     | "updateRemoteThreadPinSnapshots"
   >;
@@ -1925,16 +1933,27 @@ class DesktopAppServerService {
       if (pins.length > 0) {
         const cache = getDesktopFederationRuntime().remoteThreadSummaries();
         const resolution = await cache.resolvePinnedThreads(pins);
+        // The owner's pinnedRank describes ITS pinned section — carrying it
+        // over would promote the row into the viewer's Pins section by a
+        // foreign rank and wire the pin chip to an owner-side unpin. Replace
+        // it with the VIEWER-owned rank from the pin row (usually absent):
+        // pin or unpin locally and only the viewer knows. The remote-viewer
+        // window path is untouched — owner semantics are correct there.
+        const localRankByKey = new Map(
+          pins.map((pin) => [
+            buildThreadIdentityKey(pin.ref.backend, pin.ref.threadId),
+            pin.localPinnedRank,
+          ]),
+        );
         resolved = {
           ...resolution,
-          // The owner's pinnedRank describes ITS pinned section. Carrying it
-          // into the main window would promote the row into the viewer's
-          // local Pins section (ranked by a foreign rank) and wire the pin
-          // chip to an owner-side unpin. The viewer's list membership is the
-          // remote_thread_pins row; rank stays owner-local. The remote-viewer
-          // window path is untouched — owner semantics are correct there.
           threads: resolution.threads.map(
-            ({ pinnedRank: _pinnedRank, ...thread }) => thread,
+            ({ pinnedRank: _pinnedRank, ...thread }) => {
+              const localRank = localRankByKey.get(
+                buildThreadIdentityKey(thread.source, thread.id),
+              );
+              return localRank ? { ...thread, pinnedRank: localRank } : thread;
+            },
           ),
         };
         if (resolution.refreshed.length > 0) {
@@ -1956,6 +1975,8 @@ class DesktopAppServerService {
         updatedAt: thread.updatedAt,
         prs: thread.prs,
         federation: thread.federation,
+        // Viewer-owned rank: a local pin/unpin must invalidate the snapshot.
+        pinnedRank: thread.pinnedRank,
         // Directory-group membership derives from these; a peer-side project
         // change must invalidate the snapshot like a title change does.
         linkedDirectories: thread.linkedDirectories,
@@ -5354,12 +5375,74 @@ class DesktopAppServerService {
         .remoteBackend(federationTarget)
         .reorderThreadPins(remoteRequest);
     }
-    const pinnedRanks = await this.getOverlayStore().reorderThreadPins({
-      threadKeys: request.threadKeys,
+    // The pinned section interleaves local pins and viewer-owned remote
+    // pins. Ranks come from the FULL requested order so the two kinds sort
+    // together; each key routes to its own storage — local thread overlay
+    // vs the remote pin row — and remote ranks never reach the owner.
+    const overlayStore = this.getOverlayStore();
+    const remotePins =
+      typeof overlayStore.listRemoteThreadPins === "function"
+        ? await overlayStore.listRemoteThreadPins()
+        : [];
+    const remotePinByKey = new Map(
+      remotePins.map((pin) => [
+        buildThreadIdentityKey(pin.ref.backend, pin.ref.threadId),
+        pin,
+      ]),
+    );
+    const localThreadKeys: string[] = [];
+    const remoteRankWrites: Array<{
+      key: string;
+      ref: RemoteThreadPin["ref"];
+      pinnedRank: string;
+    }> = [];
+    request.threadKeys.forEach((threadKey, index) => {
+      const remotePin = remotePinByKey.get(threadKey);
+      if (remotePin) {
+        remoteRankWrites.push({
+          key: threadKey,
+          ref: remotePin.ref,
+          pinnedRank: String(index * PIN_RANK_STEP),
+        });
+      } else {
+        localThreadKeys.push(threadKey);
+      }
     });
+    const pinnedRanks =
+      remoteRankWrites.length === 0
+        ? await overlayStore.reorderThreadPins({
+            threadKeys: request.threadKeys,
+          })
+        : Object.fromEntries(
+            await Promise.all(
+              request.threadKeys.map(async (threadKey, index) => {
+                const rank = String(index * PIN_RANK_STEP);
+                const remoteWrite = remoteRankWrites.find(
+                  (write) => write.key === threadKey,
+                );
+                if (remoteWrite) {
+                  await overlayStore.setRemoteThreadLocalPin({
+                    ref: remoteWrite.ref,
+                    pinnedRank: rank,
+                  });
+                } else {
+                  const parsed = parseThreadIdentityKey(threadKey);
+                  if (parsed) {
+                    await overlayStore.setThreadPin({
+                      backend: parsed.backend,
+                      threadId: parsed.threadId,
+                      pinnedRank: rank,
+                    });
+                  }
+                }
+                return [threadKey, rank] as const;
+              }),
+            ),
+          );
 
     logDebug("reorderThreadPins", {
       pinCount: request.threadKeys.length,
+      remotePinCount: remoteRankWrites.length,
     });
 
     // Pin order is global across backends, so this is a global notification.
@@ -5395,7 +5478,12 @@ class DesktopAppServerService {
       instanceLabel,
       pinnedVia: "explicit",
     });
-    await this.pinCompanionParent(request, instanceId, instanceLabel);
+    const companionParentRef = await this.pinCompanionParent(
+      request,
+      instanceId,
+      instanceLabel,
+    );
+    await this.rankRemotePinForVisibility(request, companionParentRef);
 
     logDebug("addRemoteThreadPin", {
       backend: request.ref.backend,
@@ -5432,10 +5520,10 @@ class DesktopAppServerService {
     request: AddRemoteThreadPinRequest,
     instanceId: string,
     instanceLabel: string,
-  ): Promise<void> {
+  ): Promise<FederatedThreadRef | undefined> {
     const parentThreadId = request.summary?.parentThreadId;
     if (!parentThreadId || parentThreadId === request.ref.threadId) {
-      return;
+      return undefined;
     }
     try {
       const parentRef = buildFederatedThreadRef({
@@ -5445,7 +5533,7 @@ class DesktopAppServerService {
       });
       const overlayStore = this.getOverlayStore();
       if (await overlayStore.hasRemoteThreadPin({ ref: parentRef })) {
-        return;
+        return parentRef;
       }
       const parentSummary = await getDesktopFederationRuntime()
         .remoteThreadSummaries()
@@ -5455,7 +5543,7 @@ class DesktopAppServerService {
           threadId: parentThreadId,
         });
       if (!parentSummary) {
-        return;
+        return undefined;
       }
       await overlayStore.addRemoteThreadPin({
         ref: parentRef,
@@ -5480,10 +5568,82 @@ class DesktopAppServerService {
           },
         },
       });
+      return parentRef;
     } catch (error) {
       // Companion pinning is a convenience — the explicit pin must succeed
       // regardless.
       appServerLog.warn("Companion parent pin failed.", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
+  /**
+   * Mirror of the created-thread visibility auto-pin (backend-registry):
+   * when the freshly pinned remote thread's home directory group has its
+   * Directory Threads section collapsed and the pinned section is in use,
+   * the row would be invisible — give its top-level row (the companion
+   * parent when one exists) a VIEWER-owned rank so it surfaces in Pins.
+   * Best-effort; the pin itself must succeed regardless.
+   */
+  private async rankRemotePinForVisibility(
+    request: AddRemoteThreadPinRequest,
+    companionParentRef: FederatedThreadRef | undefined,
+  ): Promise<void> {
+    try {
+      const snapshot = await this.getNavigationSnapshot({});
+      const targetRef = companionParentRef ?? request.ref;
+      const targetKey = buildThreadIdentityKey(
+        targetRef.backend,
+        targetRef.threadId,
+      );
+      const targetRow = snapshot.threads.find(
+        (thread) =>
+          buildThreadIdentityKey(thread.source, thread.id) === targetKey,
+      );
+      // Only top-level rows join the pinned section; an already-ranked row
+      // needs nothing.
+      if (!targetRow || targetRow.parentThreadId || targetRow.pinnedRank) {
+        return;
+      }
+      const directory = snapshot.directories.find((entry) =>
+        entry.threadKeys.includes(targetKey),
+      );
+      const hasPinnedTopLevelThread = snapshot.threads.some(
+        (thread) => thread.pinnedRank && !thread.parentThreadId,
+      );
+      if (!directory?.directoryThreadsCollapsed || !hasPinnedTopLevelThread) {
+        return;
+      }
+      const pinnedRank = buildAppendPinRank(
+        snapshot.threads.map((thread) => thread.pinnedRank),
+      );
+      await this.getOverlayStore().setRemoteThreadLocalPin({
+        ref: targetRef,
+        pinnedRank,
+      });
+      logDebug("addRemoteThreadPin:visibility-rank", {
+        backend: targetRef.backend,
+        threadId: targetRef.threadId,
+        directoryKey: directory.key,
+      });
+      await getDesktopBackendRegistry().publishLocalEvent({
+        backend: targetRef.backend,
+        notification: {
+          method: "navigation/remoteThreadPins/changed",
+          params: {
+            instanceId:
+              targetRef.target.scope === "remote"
+                ? targetRef.target.instanceId
+                : "",
+            threadId: targetRef.threadId,
+            pinned: true,
+          },
+        },
+      });
+    } catch (error) {
+      appServerLog.warn("Remote pin visibility rank failed.", {
         error: error instanceof Error ? error.message : String(error),
       });
     }
@@ -5523,6 +5683,36 @@ class DesktopAppServerService {
     }
 
     return { removed };
+  }
+
+  /**
+   * VIEWER-owned pin rank for a remote thread in the main window's list.
+   * Never routed to the owner: pin or unpin here and only the viewer knows.
+   * (Remote-viewer windows keep the existing setThreadPin owner routing —
+   * operating the owner's pinned section is intended there.)
+   */
+  async setRemoteThreadLocalPin(
+    request: SetRemoteThreadLocalPinRequest,
+  ): Promise<SetRemoteThreadLocalPinResponse> {
+    if (!isRemoteFederationTarget(request.ref.target)) {
+      throw new Error("Remote thread pins require a remote federation target.");
+    }
+    const result = await this.getOverlayStore().setRemoteThreadLocalPin({
+      ref: request.ref,
+      pinnedRank: request.pinnedRank,
+    });
+    await getDesktopBackendRegistry().publishLocalEvent({
+      backend: request.ref.backend,
+      notification: {
+        method: "navigation/remoteThreadPins/changed",
+        params: {
+          instanceId: request.ref.target.instanceId,
+          threadId: request.ref.threadId,
+          pinned: true,
+        },
+      },
+    });
+    return { ref: request.ref, pinnedRank: result.pinnedRank };
   }
 
   async jumpSearchRemoteThreads(
@@ -6728,6 +6918,16 @@ export function registerAppServerIpcHandlers(): void {
       request: RemoveRemoteThreadPinRequest,
     ): Promise<RemoveRemoteThreadPinResponse> => {
       return await appServerService.removeRemoteThreadPin(request);
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_SET_REMOTE_THREAD_LOCAL_PIN_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_SET_REMOTE_THREAD_LOCAL_PIN_CHANNEL,
+    async (
+      _event,
+      request: SetRemoteThreadLocalPinRequest,
+    ): Promise<SetRemoteThreadLocalPinResponse> => {
+      return await appServerService.setRemoteThreadLocalPin(request);
     },
   );
   ipcMain.removeHandler(FEDERATION_JUMP_SEARCH_CHANNEL);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -92,7 +92,6 @@ import {
   type FederatedThreadRef,
   type FederationJumpSearchRequest,
   type FederationJumpSearchResponse,
-  type RemoteThreadPin,
   type RemoveRemoteThreadPinRequest,
   type RemoveRemoteThreadPinResponse,
   type SetRemoteThreadLocalPinRequest,
@@ -157,7 +156,6 @@ import {
   buildFederatedThreadRef,
   buildPullRequestStatusKey,
   buildThreadIdentityKey,
-  PIN_RANK_STEP,
   federatedThreadIdentityKey,
   isAppServerBackendKind,
   isRemoteFederationTarget,
@@ -332,6 +330,7 @@ type AppServerOverlayStoreLike = OverlayStoreLike &
     | "writeThreadGitWorkingStateCacheEntry"
     | "addRemoteThreadPin"
     | "hasRemoteThreadPin"
+    | "listPinnedThreadOverlayRanks"
     | "removeRemoteThreadPin"
     | "setRemoteThreadLocalPin"
     | "listRemoteThreadPins"
@@ -527,13 +526,16 @@ async function renderExplicitComposerPdfPreview(
  * Remote threads whose project has no local counterpart stay ungrouped and
  * surface only in the Updated / Created lenses.
  */
-function attachRemoteThreadsToLocalDirectories(
-  directories: NavigationSnapshot["directories"],
-  remoteThreads: NavigationThreadSummary[],
-): NavigationSnapshot["directories"] {
-  if (remoteThreads.length === 0) {
-    return directories;
-  }
+/**
+ * The single local directory group a remote thread belongs to, by project
+ * identity (directory label / path basename — peer paths never match viewer
+ * paths). Home preference mirrors `pickHomeDirectory`: repo checkouts
+ * (`kind: "local"`) before worktree links, then the owner's linked order.
+ */
+function findRemoteHomeDirectoryIndex(
+  directories: ReadonlyArray<{ label: string; path?: string }>,
+  linkedDirectories: NavigationThreadSummary["linkedDirectories"] | undefined,
+): number | undefined {
   const directoryIndexByName = new Map<string, number>();
   directories.forEach((directory, index) => {
     const names = new Set(
@@ -547,32 +549,42 @@ function attachRemoteThreadsToLocalDirectories(
       }
     }
   });
+  const linkedByHomePreference = [...(linkedDirectories ?? [])].sort(
+    (left, right) => {
+      if (left.kind !== right.kind) {
+        return left.kind === "worktree" ? 1 : -1;
+      }
+      return 0;
+    },
+  );
+  for (const linked of linkedByHomePreference) {
+    const names = [linked.label, path.basename(linked.path)]
+      .map((name) => (name ?? "").trim().toLowerCase())
+      .filter(Boolean);
+    for (const name of names) {
+      const index = directoryIndexByName.get(name);
+      if (index !== undefined) {
+        return index;
+      }
+    }
+  }
+  return undefined;
+}
+
+function attachRemoteThreadsToLocalDirectories(
+  directories: NavigationSnapshot["directories"],
+  remoteThreads: NavigationThreadSummary[],
+): NavigationSnapshot["directories"] {
+  if (remoteThreads.length === 0) {
+    return directories;
+  }
   const addedKeysByDirectoryIndex = new Map<number, string[]>();
   for (const thread of remoteThreads) {
     const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-    const linkedByHomePreference = [...(thread.linkedDirectories ?? [])].sort(
-      (left, right) => {
-        if (left.kind !== right.kind) {
-          return left.kind === "worktree" ? 1 : -1;
-        }
-        return 0;
-      },
+    const homeIndex = findRemoteHomeDirectoryIndex(
+      directories,
+      thread.linkedDirectories,
     );
-    let homeIndex: number | undefined;
-    for (const linked of linkedByHomePreference) {
-      const names = [linked.label, path.basename(linked.path)]
-        .map((name) => (name ?? "").trim().toLowerCase())
-        .filter(Boolean);
-      for (const name of names) {
-        homeIndex = directoryIndexByName.get(name);
-        if (homeIndex !== undefined) {
-          break;
-        }
-      }
-      if (homeIndex !== undefined) {
-        break;
-      }
-    }
     if (homeIndex === undefined) {
       continue;
     }
@@ -5376,73 +5388,29 @@ class DesktopAppServerService {
         .reorderThreadPins(remoteRequest);
     }
     // The pinned section interleaves local pins and viewer-owned remote
-    // pins. Ranks come from the FULL requested order so the two kinds sort
-    // together; each key routes to its own storage — local thread overlay
-    // vs the remote pin row — and remote ranks never reach the owner.
+    // pins. The store assigns ranks from the FULL requested order in one
+    // transaction, routing each key to its own storage — local thread
+    // overlay vs the remote pin row — so remote ranks never reach the owner
+    // and a mixed reorder is atomic.
     const overlayStore = this.getOverlayStore();
     const remotePins =
       typeof overlayStore.listRemoteThreadPins === "function"
         ? await overlayStore.listRemoteThreadPins()
         : [];
-    const remotePinByKey = new Map(
+    const remoteRefsByKey = Object.fromEntries(
       remotePins.map((pin) => [
         buildThreadIdentityKey(pin.ref.backend, pin.ref.threadId),
-        pin,
+        pin.ref,
       ]),
     );
-    const localThreadKeys: string[] = [];
-    const remoteRankWrites: Array<{
-      key: string;
-      ref: RemoteThreadPin["ref"];
-      pinnedRank: string;
-    }> = [];
-    request.threadKeys.forEach((threadKey, index) => {
-      const remotePin = remotePinByKey.get(threadKey);
-      if (remotePin) {
-        remoteRankWrites.push({
-          key: threadKey,
-          ref: remotePin.ref,
-          pinnedRank: String(index * PIN_RANK_STEP),
-        });
-      } else {
-        localThreadKeys.push(threadKey);
-      }
+    const pinnedRanks = await overlayStore.reorderThreadPins({
+      threadKeys: request.threadKeys,
+      remoteRefsByKey,
     });
-    const pinnedRanks =
-      remoteRankWrites.length === 0
-        ? await overlayStore.reorderThreadPins({
-            threadKeys: request.threadKeys,
-          })
-        : Object.fromEntries(
-            await Promise.all(
-              request.threadKeys.map(async (threadKey, index) => {
-                const rank = String(index * PIN_RANK_STEP);
-                const remoteWrite = remoteRankWrites.find(
-                  (write) => write.key === threadKey,
-                );
-                if (remoteWrite) {
-                  await overlayStore.setRemoteThreadLocalPin({
-                    ref: remoteWrite.ref,
-                    pinnedRank: rank,
-                  });
-                } else {
-                  const parsed = parseThreadIdentityKey(threadKey);
-                  if (parsed) {
-                    await overlayStore.setThreadPin({
-                      backend: parsed.backend,
-                      threadId: parsed.threadId,
-                      pinnedRank: rank,
-                    });
-                  }
-                }
-                return [threadKey, rank] as const;
-              }),
-            ),
-          );
 
     logDebug("reorderThreadPins", {
       pinCount: request.threadKeys.length,
-      remotePinCount: remoteRankWrites.length,
+      remotePinCount: Object.keys(remoteRefsByKey).length,
     });
 
     // Pin order is global across backends, so this is a global notification.
@@ -5583,8 +5551,12 @@ class DesktopAppServerService {
    * Mirror of the created-thread visibility auto-pin (backend-registry):
    * when the freshly pinned remote thread's home directory group has its
    * Directory Threads section collapsed and the pinned section is in use,
-   * the row would be invisible — give its top-level row (the companion
-   * parent when one exists) a VIEWER-owned rank so it surfaces in Pins.
+   * the row would be invisible — give its top-level row a VIEWER-owned rank
+   * so it surfaces in Pins. The top-level row is the companion parent when
+   * one is pinned; otherwise the thread itself, since a child whose parent
+   * is absent from the list renders top-level. Reads overlay-store scans and
+   * the cached directory summaries from the last snapshot build — never a
+   * fresh snapshot, so pin latency stays independent of backends and peers.
    * Best-effort; the pin itself must succeed regardless.
    */
   private async rankRemotePinForVisibility(
@@ -5592,41 +5564,59 @@ class DesktopAppServerService {
     companionParentRef: FederatedThreadRef | undefined,
   ): Promise<void> {
     try {
-      const snapshot = await this.getNavigationSnapshot({});
       const targetRef = companionParentRef ?? request.ref;
-      const targetKey = buildThreadIdentityKey(
-        targetRef.backend,
-        targetRef.threadId,
+      const overlayStore = this.getOverlayStore();
+      const pins =
+        typeof overlayStore.listRemoteThreadPins === "function"
+          ? await overlayStore.listRemoteThreadPins()
+          : [];
+      const targetPin = pins.find(
+        (pin) =>
+          pin.ref.backend === targetRef.backend
+          && pin.ref.threadId === targetRef.threadId
+          && isRemoteFederationTarget(pin.ref.target)
+          && isRemoteFederationTarget(targetRef.target)
+          && pin.ref.target.instanceId === targetRef.target.instanceId,
       );
-      const targetRow = snapshot.threads.find(
-        (thread) =>
-          buildThreadIdentityKey(thread.source, thread.id) === targetKey,
-      );
-      // Only top-level rows join the pinned section; an already-ranked row
-      // needs nothing.
-      if (!targetRow || targetRow.parentThreadId || targetRow.pinnedRank) {
+      // An already-ranked row needs nothing.
+      if (!targetPin || targetPin.localPinnedRank) {
         return;
       }
-      const directory = snapshot.directories.find((entry) =>
-        entry.threadKeys.includes(targetKey),
+      const targetSummary = targetPin.summary ?? request.summary;
+      // Cached from the last snapshot build — always warm in a running
+      // window; a cold cache just skips this best-effort step.
+      const directories = [...this.lastDirectoriesByKey.values()];
+      const homeIndex = findRemoteHomeDirectoryIndex(
+        directories,
+        targetSummary?.linkedDirectories,
       );
-      const hasPinnedTopLevelThread = snapshot.threads.some(
-        (thread) => thread.pinnedRank && !thread.parentThreadId,
-      );
-      if (!directory?.directoryThreadsCollapsed || !hasPinnedTopLevelThread) {
+      const home = homeIndex === undefined ? undefined : directories[homeIndex];
+      if (!home?.directoryThreadsCollapsed) {
         return;
       }
-      const pinnedRank = buildAppendPinRank(
-        snapshot.threads.map((thread) => thread.pinnedRank),
-      );
-      await this.getOverlayStore().setRemoteThreadLocalPin({
+      const localRanks = await overlayStore.listPinnedThreadOverlayRanks();
+      // Mirror the created-thread rule: only when the pinned section is in
+      // use would the row otherwise be invisible.
+      const hasPinnedTopLevelThread =
+        localRanks.some((entry) => !entry.parentThreadId)
+        || pins.some(
+          (pin) => pin.localPinnedRank && !pin.summary?.parentThreadId,
+        );
+      if (!hasPinnedTopLevelThread) {
+        return;
+      }
+      const pinnedRank = buildAppendPinRank([
+        ...localRanks.map((entry) => entry.pinnedRank),
+        ...pins.map((pin) => pin.localPinnedRank),
+      ]);
+      await overlayStore.setRemoteThreadLocalPin({
         ref: targetRef,
         pinnedRank,
       });
       logDebug("addRemoteThreadPin:visibility-rank", {
         backend: targetRef.backend,
         threadId: targetRef.threadId,
-        directoryKey: directory.key,
+        directoryKey: home.key,
       });
       await getDesktopBackendRegistry().publishLocalEvent({
         backend: targetRef.backend,
@@ -5708,7 +5698,7 @@ class DesktopAppServerService {
         params: {
           instanceId: request.ref.target.instanceId,
           threadId: request.ref.threadId,
-          pinned: true,
+          pinned: Boolean(result.pinnedRank),
         },
       },
     });

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1827,6 +1827,54 @@ export class SqliteOverlayStore {
     };
   }
 
+  /**
+   * Set or clear the VIEWER-owned rank for a pinned remote thread. Patches
+   * the payload in place so the cached summary, label, and pinnedVia are
+   * untouched; a missing pin row is a no-op (returns undefined rank).
+   */
+  async setRemoteThreadLocalPin(params: {
+    ref: FederatedThreadRef;
+    pinnedRank?: string | null;
+  }): Promise<{ pinnedRank?: string }> {
+    const instanceId = remotePinInstanceId(params.ref);
+    const row = this.stateDb.raw
+      .prepare(
+        `SELECT payload FROM remote_thread_pins
+         WHERE instance_id = ? AND backend = ? AND thread_id = ?`,
+      )
+      .get(instanceId, params.ref.backend, params.ref.threadId) as
+        | { payload: string }
+        | undefined;
+    if (!row) {
+      return {};
+    }
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(row.payload) as Record<string, unknown>;
+    } catch {
+      parsed = {};
+    }
+    const pinnedRank = params.pinnedRank?.trim() || undefined;
+    if (pinnedRank === undefined) {
+      delete parsed.localPinnedRank;
+    } else {
+      parsed.localPinnedRank = pinnedRank;
+    }
+    this.stateDb.raw
+      .prepare(
+        `UPDATE remote_thread_pins
+         SET payload = ?
+         WHERE instance_id = ? AND backend = ? AND thread_id = ?`,
+      )
+      .run(
+        JSON.stringify(parsed),
+        instanceId,
+        params.ref.backend,
+        params.ref.threadId,
+      );
+    return pinnedRank === undefined ? {} : { pinnedRank };
+  }
+
   async hasRemoteThreadPin(params: { ref: FederatedThreadRef }): Promise<boolean> {
     const row = this.stateDb.raw
       .prepare(
@@ -1871,7 +1919,12 @@ export class SqliteOverlayStore {
       }>;
     const pins: RemoteThreadPin[] = [];
     for (const row of rows) {
-      let parsed: { instanceLabel?: unknown; summary?: unknown; pinnedVia?: unknown };
+      let parsed: {
+        instanceLabel?: unknown;
+        summary?: unknown;
+        pinnedVia?: unknown;
+        localPinnedRank?: unknown;
+      };
       try {
         parsed = JSON.parse(row.payload) as typeof parsed;
       } catch {
@@ -1895,6 +1948,9 @@ export class SqliteOverlayStore {
           : {}),
         ...(parsed.pinnedVia === "companion" || parsed.pinnedVia === "explicit"
           ? { pinnedVia: parsed.pinnedVia }
+          : {}),
+        ...(typeof parsed.localPinnedRank === "string" && parsed.localPinnedRank
+          ? { localPinnedRank: parsed.localPinnedRank }
           : {}),
       });
     }

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1875,6 +1875,39 @@ export class SqliteOverlayStore {
     return pinnedRank === undefined ? {} : { pinnedRank };
   }
 
+  /**
+   * Local threads' pin ranks (with sub-thread linkage), scanned from the
+   * overlay payloads. Cheap one-shot read for pin-visibility decisions that
+   * must not pay for a full navigation snapshot build.
+   */
+  async listPinnedThreadOverlayRanks(): Promise<
+    Array<{ pinnedRank: string; parentThreadId?: string }>
+  > {
+    const rows = this.stateDb.raw
+      .prepare("SELECT payload FROM threads")
+      .all() as Array<{ payload: string }>;
+    const ranks: Array<{ pinnedRank: string; parentThreadId?: string }> = [];
+    for (const row of rows) {
+      try {
+        const parsed = JSON.parse(row.payload) as {
+          pinnedRank?: unknown;
+          parentThreadId?: unknown;
+        };
+        if (typeof parsed.pinnedRank === "string" && parsed.pinnedRank) {
+          ranks.push({
+            pinnedRank: parsed.pinnedRank,
+            ...(typeof parsed.parentThreadId === "string" && parsed.parentThreadId
+              ? { parentThreadId: parsed.parentThreadId }
+              : {}),
+          });
+        }
+      } catch {
+        // Malformed payloads never block a best-effort visibility check.
+      }
+    }
+    return ranks;
+  }
+
   async hasRemoteThreadPin(params: { ref: FederatedThreadRef }): Promise<boolean> {
     const row = this.stateDb.raw
       .prepare(
@@ -1967,6 +2000,10 @@ export class SqliteOverlayStore {
     if (entries.length === 0) {
       return;
     }
+    const select = this.stateDb.raw.prepare(
+      `SELECT payload FROM remote_thread_pins
+       WHERE instance_id = ? AND backend = ? AND thread_id = ?`,
+    );
     const update = this.stateDb.raw.prepare(
       `UPDATE remote_thread_pins
        SET payload = ?
@@ -1974,12 +2011,27 @@ export class SqliteOverlayStore {
     );
     this.stateDb.raw.transaction(() => {
       for (const entry of entries) {
+        const instanceId = remotePinInstanceId(entry.ref);
+        // Patch, never replace: the payload also carries viewer-owned state
+        // (localPinnedRank, pinnedVia) that a snapshot refresh must not wipe.
+        const row = select.get(instanceId, entry.ref.backend, entry.ref.threadId) as
+          | { payload: string }
+          | undefined;
+        let parsed: Record<string, unknown> = {};
+        if (row) {
+          try {
+            parsed = JSON.parse(row.payload) as Record<string, unknown>;
+          } catch {
+            parsed = {};
+          }
+        }
         update.run(
           JSON.stringify({
+            ...parsed,
             instanceLabel: entry.instanceLabel,
             summary: stripFederationStamp(entry.summary),
           }),
-          remotePinInstanceId(entry.ref),
+          instanceId,
           entry.ref.backend,
           entry.ref.threadId,
         );
@@ -2070,11 +2122,55 @@ export class SqliteOverlayStore {
    */
   async reorderThreadPins(params: {
     threadKeys: string[];
+    /**
+     * Keys owned by remote thread pins: their rank writes patch the
+     * remote_thread_pins payload (viewer-owned) instead of the local thread
+     * overlay, inside the same transaction so a mixed reorder is atomic.
+     */
+    remoteRefsByKey?: Record<string, FederatedThreadRef>;
   }): Promise<Record<string, string>> {
     const pinnedRanks: Record<string, string> = {};
+    const selectRemote = this.stateDb.raw.prepare(
+      `SELECT payload FROM remote_thread_pins
+       WHERE instance_id = ? AND backend = ? AND thread_id = ?`,
+    );
+    const updateRemote = this.stateDb.raw.prepare(
+      `UPDATE remote_thread_pins
+       SET payload = ?
+       WHERE instance_id = ? AND backend = ? AND thread_id = ?`,
+    );
     const write = this.stateDb.raw.transaction(() => {
       let rankIndex = 0;
       for (const threadKey of params.threadKeys) {
+        const remoteRef = params.remoteRefsByKey?.[threadKey];
+        if (remoteRef) {
+          const instanceId = remotePinInstanceId(remoteRef);
+          const row = selectRemote.get(
+            instanceId,
+            remoteRef.backend,
+            remoteRef.threadId,
+          ) as { payload: string } | undefined;
+          if (!row) {
+            continue;
+          }
+          let parsed: Record<string, unknown>;
+          try {
+            parsed = JSON.parse(row.payload) as Record<string, unknown>;
+          } catch {
+            parsed = {};
+          }
+          rankIndex += 1;
+          const pinnedRank = String(rankIndex * 1024);
+          pinnedRanks[threadKey] = pinnedRank;
+          parsed.localPinnedRank = pinnedRank;
+          updateRemote.run(
+            JSON.stringify(parsed),
+            instanceId,
+            remoteRef.backend,
+            remoteRef.threadId,
+          );
+          continue;
+        }
         const parts = parseThreadIdentityKey(threadKey);
         if (!parts) {
           continue;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -101,6 +101,8 @@ import type {
   MarkThreadSeenResponse,
   RemoveRemoteThreadPinRequest,
   RemoveRemoteThreadPinResponse,
+  SetRemoteThreadLocalPinRequest,
+  SetRemoteThreadLocalPinResponse,
   ReorderDirectoryPinsRequest,
   ReorderDirectoryPinsResponse,
   ReorderThreadPinsRequest,
@@ -512,6 +514,7 @@ import {
   FEDERATION_JUMP_SEARCH_CHANNEL,
   NAVIGATION_ADD_REMOTE_THREAD_PIN_CHANNEL,
   NAVIGATION_REMOVE_REMOTE_THREAD_PIN_CHANNEL,
+  NAVIGATION_SET_REMOTE_THREAD_LOCAL_PIN_CHANNEL,
   NAVIGATION_REORDER_DIRECTORY_PINS_CHANNEL,
   NAVIGATION_REORDER_THREAD_PINS_CHANNEL,
   NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
@@ -1407,6 +1410,13 @@ const desktopApi = Object.freeze({
   ): Promise<RemoveRemoteThreadPinResponse> =>
     await ipcRenderer.invoke(
       NAVIGATION_REMOVE_REMOTE_THREAD_PIN_CHANNEL,
+      request,
+    ),
+  setRemoteThreadLocalPin: async (
+    request: SetRemoteThreadLocalPinRequest,
+  ): Promise<SetRemoteThreadLocalPinResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_SET_REMOTE_THREAD_LOCAL_PIN_CHANNEL,
       request,
     ),
   jumpSearchRemoteThreads: async (

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1201,11 +1201,12 @@ export function Sidebar(props: SidebarProps) {
   const contextMenuCanUnlinkSubthread = Boolean(
     contextMenuIsSubthread && props.onSetThreadParent,
   );
+  // Remote rows CAN pin here: the rank is viewer-owned (stored on the
+  // remote_thread_pins row), so the owner's list never learns about it.
   const contextMenuCanPin = Boolean(
     contextMenu &&
       !contextMenuIsBulk &&
       !contextMenuIsSubthread &&
-      !contextMenuIsMainWindowRemoteRow &&
       props.onSetThreadPin,
   );
   /**

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1047,8 +1047,9 @@ describe("Sidebar", () => {
     expect(onCreateSubthread).toHaveBeenCalledWith(sharedThread, "same-worktree");
   });
 
-  it("offers only pin removal and copy actions for a remote-pinned row", () => {
+  it("offers viewer-owned pin, pin removal, and copy actions for a remote-pinned row", () => {
     const onRemoveRemoteThreadPin = vi.fn(async () => undefined);
+    const onSetThreadPin = vi.fn(async () => undefined);
     const remotePinnedThread: NavigationThreadSummary = {
       ...sharedThread,
       id: "thread-remote",
@@ -1083,7 +1084,7 @@ describe("Sidebar", () => {
         onRemoveRemoteThreadPin={onRemoveRemoteThreadPin}
         onRenameThread={async () => undefined}
         onSelectThread={() => undefined}
-        onSetThreadPin={async () => undefined}
+        onSetThreadPin={onSetThreadPin}
       />,
     );
 
@@ -1091,15 +1092,22 @@ describe("Sidebar", () => {
       screen.getByRole("button", { name: "Remote pinned thread" }),
     );
 
-    // Owner-mutating and local-overlay actions are absent…
+    // Owner-mutating actions are absent…
     expect(screen.queryByRole("menuitem", { name: "Archive Thread" })).toBeNull();
     expect(screen.queryByRole("menuitem", { name: "Rename Thread" })).toBeNull();
-    expect(screen.queryByRole("menuitem", { name: "Pin Thread" })).toBeNull();
     expect(
       screen.queryByRole("menuitem", { name: /Sub-thread/ }),
     ).toBeNull();
 
+    // …the VIEWER-owned pin is offered (rank lives on the pin row, never
+    // the owner's list)…
+    fireEvent.click(screen.getByRole("menuitem", { name: "Pin Thread" }));
+    expect(onSetThreadPin).toHaveBeenCalledWith(remotePinnedThread, true);
+
     // …and the viewer-side removal dispatches even while disconnected.
+    fireEvent.contextMenu(
+      screen.getByRole("button", { name: "Remote pinned thread" }),
+    );
     fireEvent.click(
       screen.getByRole("menuitem", { name: /Remove from My List/ }),
     );

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2107,6 +2107,151 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("pins a main-window remote row through the viewer-owned local pin API", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const remoteRef = {
+      backend: "codex" as const,
+      target: federationTarget,
+      threadId: "thread-remote",
+    };
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: 1_000,
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [
+        {
+          id: "thread-remote",
+          title: "Remote thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          federation: {
+            instanceLabel: "Remote Mac",
+            ref: remoteRef,
+          },
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const setThreadPin = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-remote",
+      pinnedRank: "1024",
+    }));
+    const setRemoteThreadLocalPin = vi.fn(async () => ({
+      ref: remoteRef,
+      pinnedRank: "1024",
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      setThreadPin,
+      setRemoteThreadLocalPin,
+      onAgentEvent: () => () => undefined,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.id).toBe("thread-remote");
+    });
+    await act(async () => {
+      await result.current.setThreadPin(result.current.threads[0]!, true);
+    });
+
+    // Main window, remote row: the rank is VIEWER-owned — the owner-routing
+    // setThreadPin API must not be touched.
+    expect(setRemoteThreadLocalPin).toHaveBeenCalledWith({
+      ref: remoteRef,
+      pinnedRank: expect.any(String),
+    });
+    expect(setThreadPin).not.toHaveBeenCalled();
+    expect(result.current.threads[0]?.pinnedRank).toBe("1024");
+  });
+
+  it("pins through the owner in a remote-viewer window", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    (window as typeof window & {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = federationTarget;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: 1_000,
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [
+        {
+          id: "thread-remote",
+          title: "Remote thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          federation: {
+            instanceLabel: "Remote Mac",
+            ref: {
+              backend: "codex" as const,
+              target: federationTarget,
+              threadId: "thread-remote",
+            },
+          },
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const setThreadPin = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-remote",
+      pinnedRank: "1024",
+    }));
+    const setRemoteThreadLocalPin = vi.fn(async () => ({
+      ref: {
+        backend: "codex" as const,
+        target: federationTarget,
+        threadId: "thread-remote",
+      },
+      pinnedRank: "1024",
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      setThreadPin,
+      setRemoteThreadLocalPin,
+      onAgentEvent: () => () => undefined,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.id).toBe("thread-remote");
+    });
+    await act(async () => {
+      await result.current.setThreadPin(result.current.threads[0]!, true);
+    });
+
+    // Remote-viewer window: operating the OWNER's pinned section is
+    // intended, so the owner-routing API carries the federation target.
+    expect(setThreadPin).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-remote",
+      federationTarget,
+      pinnedRank: expect.any(String),
+    });
+    expect(setRemoteThreadLocalPin).not.toHaveBeenCalled();
+  });
+
   it("marks a remote snapshot unavailable and refreshes it after reconnect", async () => {
     const federationTarget = {
       scope: "remote" as const,

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -108,6 +108,8 @@ import type {
   FederationJumpSearchResponse,
   RemoveRemoteThreadPinRequest,
   RemoveRemoteThreadPinResponse,
+  SetRemoteThreadLocalPinRequest,
+  SetRemoteThreadLocalPinResponse,
   ResetFederationEnrollmentRequest,
   ResetFederationEnrollmentResponse,
   RevokeFederationPeerRequest,
@@ -783,6 +785,13 @@ export type DesktopApi = {
   removeRemoteThreadPin?: (
     request: RemoveRemoteThreadPinRequest
   ) => Promise<RemoveRemoteThreadPinResponse>;
+  /**
+   * VIEWER-owned rank for a remote row in the local Pins section. Never
+   * routed to the owner — pin or unpin and only the viewer knows.
+   */
+  setRemoteThreadLocalPin?: (
+    request: SetRemoteThreadLocalPinRequest
+  ) => Promise<SetRemoteThreadLocalPinResponse>;
   /** ⌘K federated jump search across connected peers. */
   jumpSearchRemoteThreads?: (
     request: FederationJumpSearchRequest

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -5871,6 +5871,7 @@ export function useThreadNavigation(
 
   const setThreadReactionRequest = desktopApi?.setThreadReaction;
   const setThreadPinRequest = desktopApi?.setThreadPin;
+  const setRemoteThreadLocalPinRequest = desktopApi?.setRemoteThreadLocalPin;
   const setThreadAgentRequest = desktopApi?.setThreadAgent;
   const reorderThreadPinsRequest = desktopApi?.reorderThreadPins;
   const setThreadParentRequest = desktopApi?.setThreadParent;
@@ -5956,11 +5957,33 @@ export function useThreadNavigation(
       }));
 
       try {
+        // A remote row pinned in the MAIN window takes a VIEWER-owned rank
+        // on its remote_thread_pins row — only the viewer knows. In a
+        // remote-viewer window (window-level target set) the row pins on
+        // its owning instance as before: without that target the write
+        // would land in the viewer machine's overlay store and revert on
+        // the next remote snapshot.
+        if (
+          thread.federation
+          && !readRendererFederationTarget()
+          && setRemoteThreadLocalPinRequest
+        ) {
+          const result = await setRemoteThreadLocalPinRequest({
+            ref: thread.federation.ref,
+            pinnedRank,
+          });
+          setState((current) => ({
+            ...current,
+            response: updateThreadPinInSnapshot(current.response, {
+              backend: thread.source,
+              threadId: thread.id,
+              pinnedRank: result.pinnedRank,
+            }),
+          }));
+          return;
+        }
         const result = await setThreadPinRequest({
           backend: thread.source,
-          // Remote threads pin on their owning instance; without the
-          // target the write lands in the viewer machine's overlay
-          // store and reverts on the next remote snapshot.
           federationTarget:
             thread.federation?.ref.target ?? readRendererFederationTarget(),
           threadId: thread.id,
@@ -5978,7 +6001,12 @@ export function useThreadNavigation(
         await refresh(buildThreadIdentityKey(thread.source, thread.id));
       }
     },
-    [refresh, setThreadPinRequest, state.response?.threads],
+    [
+      refresh,
+      setRemoteThreadLocalPinRequest,
+      setThreadPinRequest,
+      state.response?.threads,
+    ],
   );
 
   const reorderThreadPins = useCallback(

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -3243,6 +3243,13 @@ export function useThreadNavigation(
       }
 
       markNavigationActivity({ refreshOnIdleResume: false });
+      if (method === "navigation/remoteThreadPins/changed") {
+        // Viewer-side pin membership or rank changed (possibly in another
+        // window) — the merged snapshot is the source of truth for the row
+        // set, so refresh rather than patch.
+        scheduleRefresh();
+        return;
+      }
       if (method === "federation/peerStatus/changed") {
         const params = event.notification.params as {
           instanceId: string;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -119,6 +119,8 @@ export const NAVIGATION_ADD_REMOTE_THREAD_PIN_CHANNEL =
   "navigation:add-remote-thread-pin";
 export const NAVIGATION_REMOVE_REMOTE_THREAD_PIN_CHANNEL =
   "navigation:remove-remote-thread-pin";
+export const NAVIGATION_SET_REMOTE_THREAD_LOCAL_PIN_CHANNEL =
+  "navigation:set-remote-thread-local-pin";
 export const FEDERATION_JUMP_SEARCH_CHANNEL = "federation:jump-search";
 export const NAVIGATION_SET_THREAD_PARENT_CHANNEL =
   "navigation:set-thread-parent";

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1073,6 +1073,23 @@ export type RemoteThreadPin = {
    * treat it differently (e.g. offer group removal). Absent = explicit.
    */
   pinnedVia?: "explicit" | "companion";
+  /**
+   * VIEWER-owned rank in the local pinned section. Completely independent
+   * of the owner's own pinnedRank (which never crosses into the viewer's
+   * list): pin or unpin here and only the viewer knows.
+   */
+  localPinnedRank?: string;
+};
+
+export type SetRemoteThreadLocalPinRequest = {
+  ref: FederatedThreadRef;
+  /** Rank within the viewer's pinned section. Null/undefined removes it. */
+  pinnedRank?: string | null;
+};
+
+export type SetRemoteThreadLocalPinResponse = {
+  ref: FederatedThreadRef;
+  pinnedRank?: string;
 };
 
 export type AddRemoteThreadPinRequest = {


### PR DESCRIPTION
## Summary

Follow-up to #1247, from operator testing: remote rows in the main window could not be pinned at all — #1247 removed the owner-side pin leak but replaced it with nothing. This restores pinning as a VIEWER decision: the rank lives on the `remote_thread_pins` row (`localPinnedRank`), so pin or unpin and only the viewer knows — the owner's list mechanics (including its implicit collapsed-directory auto-pins) never leak in either direction.

- The merged snapshot stamps the viewer rank onto remote rows (the owner's rank is still discarded), so remote pins join the local Pins section ranked with local pins.
- `setThreadPin` routes main-window remote rows to a new `navigation:set-remote-thread-local-pin` channel; remote-viewer windows keep the existing owner-side routing (operating the owner's pinned section there is intended).
- `reorderThreadPins` splits per key — viewer rank writes for remote pins, thread-overlay writes for local — with ranks taken from the FULL requested order so both kinds interleave correctly (including Move Up / Move Down).
- Mirrors the created-thread visibility rule: pinning a remote thread whose home directory group has Directory Threads collapsed (while the pinned section is in use) auto-ranks its top-level row — the companion parent when one exists — so the fresh pin surfaces in Pins instead of vanishing into the collapsed group. Best-effort; the pin itself succeeds regardless.
- "Pin Thread" returns to the context menu for main-window remote rows.

## Verification

- New coverage: store rank set/clear round-trip (payload preserved, missing-row no-op), merged-row rank stamping (owner rank discarded, viewer rank wins), per-key reorder routing with interleaved ranks, collapsed-home-directory auto-rank via full snapshot, context-menu pin dispatch on remote rows.
- 626 tests across the affected suites; typecheck, `lint:eslint` (0 errors), `lint:boundaries` clean; re-verified after rebasing onto post-#1247 main.

## Notes

- The `pinnedVia`/`localPinnedRank` fields ride the existing `remote_thread_pins` payload JSON — no schema migration needed.
- Removal semantics are unchanged: "Remove from My List" deletes membership (and its rank with it) locally, working while the owner is unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)