### PR TITLE
fix(desktop): route remote sub-agent stops

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -144,6 +144,12 @@ const federationMock = vi.hoisted(() => {
       threadId: request.threadId,
       turnId: request.turnId,
     })),
+    stopSubAgent: vi.fn(async (request: StopSubAgentRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      monitorId: request.monitorId,
+      stoppedAt: 1,
+    })),
     steerTurn: vi.fn(async (request: SteerTurnRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
@@ -364,6 +370,7 @@ describe("agent ipc", () => {
       AGENT_START_REVIEW_CHANNEL,
       AGENT_START_THREAD_CHANNEL,
       AGENT_STEER_TURN_CHANNEL,
+      AGENT_STOP_SUB_AGENT_CHANNEL,
       AGENT_SUBMIT_SERVER_REQUEST_CHANNEL,
       AGENT_TRUST_CODEX_PROJECT_CHANNEL,
       AGENT_UPDATE_THREAD_EXPECTED_BRANCH_CHANNEL,
@@ -416,6 +423,12 @@ describe("agent ipc", () => {
       federationTarget,
       threadId: "thread-1",
       turnId: "turn-1",
+    });
+    await handlers.get(AGENT_STOP_SUB_AGENT_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      monitorId: "monitor-1",
     });
     await handlers.get(AGENT_STEER_TURN_CHANNEL)?.({}, {
       backend: "codex",
@@ -547,6 +560,12 @@ describe("agent ipc", () => {
       threadId: "thread-1",
       turnId: "turn-1",
     });
+    expect(federationMock.remoteBackend.stopSubAgent).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId: "monitor-1",
+    });
+    expect(registry.stopSubAgent).not.toHaveBeenCalled();
     expect(federationMock.remoteBackend.steerTurn).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-1",

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -559,6 +559,60 @@ describe("federation backend bridge", () => {
     ).toBe("turn_control");
   });
 
+  it("routes sub-agent stops to the owning peer with turn-control authorization", async () => {
+    const backend = {
+      stopSubAgent: vi.fn(async (request) => ({
+        ...request,
+        stoppedAt: 1_100,
+      })),
+    } as unknown as FederationBackendOperations;
+    const ownerRouter = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    ownerRouter.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["turn_control"],
+      sendEnvelope: (envelope) => {
+        rpc.receiveEnvelope(envelope);
+      },
+    });
+    registerFederationBackendHandlers({ router: ownerRouter, backend });
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "viewer_one",
+      remoteInstanceId: "owner_one",
+      sendEnvelope: (envelope) => {
+        void ownerRouter.routeEnvelope({
+          envelope,
+          sourcePeerId: "viewer_one",
+        });
+      },
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+
+    await expect(client.stopSubAgent({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId: "monitor-1",
+    })).resolves.toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId: "monitor-1",
+      stoppedAt: 1_100,
+    });
+
+    expect(backend.stopSubAgent).toHaveBeenCalledExactlyOnceWith({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId: "monitor-1",
+    });
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.stopSubAgent
+      ],
+    ).toBe("turn_control");
+  });
+
   it("routes pin reorder over RPC with thread_navigation authorization", async () => {
     const sent: FederationProtocolEnvelope[] = [];
     const rpc = new FederationRpcEndpoint({
@@ -1419,6 +1473,7 @@ describe("federation backend bridge", () => {
         turnId: "compact-1",
       })),
       interruptTurn: vi.fn(),
+      stopSubAgent: vi.fn(),
       steerTurn: vi.fn(),
       setThreadExecutionMode: vi.fn(),
       queueThreadExecutionMode: vi.fn(),
@@ -1630,6 +1685,7 @@ describe("federation backend bridge", () => {
         sendScheduledThreadActionNow: vi.fn(),
         compactThread: vi.fn(),
         interruptTurn: vi.fn(),
+        stopSubAgent: vi.fn(),
         steerTurn: vi.fn(),
         setThreadExecutionMode: vi.fn(),
         queueThreadExecutionMode: vi.fn(),

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -82,6 +82,8 @@ import type {
   StartReviewResponse,
   StartThreadRequest,
   StartThreadResponse,
+  StopSubAgentRequest,
+  StopSubAgentResponse,
   StopCodexEnvironmentActionRequest,
   StopCodexEnvironmentActionResponse,
   SubmitServerRequestRequest,
@@ -137,6 +139,7 @@ export const FEDERATION_BACKEND_METHODS = {
   sendScheduledThreadActionNow: "backend.sendScheduledThreadActionNow",
   compactThread: "backend.compactThread",
   interruptTurn: "backend.interruptTurn",
+  stopSubAgent: "backend.stopSubAgent",
   steerTurn: "backend.steerTurn",
   setThreadExecutionMode: "backend.setThreadExecutionMode",
   queueThreadExecutionMode: "backend.queueThreadExecutionMode",
@@ -211,6 +214,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.sendScheduledThreadActionNow]: "scheduled_actions",
   [FEDERATION_BACKEND_METHODS.compactThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.interruptTurn]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.stopSubAgent]: "turn_control",
   [FEDERATION_BACKEND_METHODS.steerTurn]: "turn_control",
   [FEDERATION_BACKEND_METHODS.setThreadExecutionMode]: "turn_control",
   [FEDERATION_BACKEND_METHODS.queueThreadExecutionMode]: "turn_control",
@@ -310,6 +314,7 @@ export type FederationBackendOperations = {
   ): Promise<ScheduledThreadActionMutationResponse>;
   compactThread(request: CompactThreadRequest): Promise<CompactThreadResponse>;
   interruptTurn(request: InterruptTurnRequest): Promise<InterruptTurnResponse>;
+  stopSubAgent(request: StopSubAgentRequest): Promise<StopSubAgentResponse>;
   steerTurn(request: SteerTurnRequest): Promise<SteerTurnResponse>;
   setThreadExecutionMode(
     request: SetThreadExecutionModeRequest,
@@ -573,6 +578,13 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.interruptTurn(
         envelope.params as InterruptTurnRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.stopSubAgent,
+    async (envelope) =>
+      await params.backend.stopSubAgent(
+        envelope.params as StopSubAgentRequest,
       ),
   );
   params.router.registerHandler(
@@ -957,6 +969,15 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<InterruptTurnResponse> {
     return await this.rpc.request<InterruptTurnResponse>({
       method: FEDERATION_BACKEND_METHODS.interruptTurn,
+      params: request,
+    });
+  }
+
+  async stopSubAgent(
+    request: StopSubAgentRequest,
+  ): Promise<StopSubAgentResponse> {
+    return await this.rpc.request<StopSubAgentResponse>({
+      method: FEDERATION_BACKEND_METHODS.stopSubAgent,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -50,6 +50,7 @@ import type {
   StartThreadResponse,
   SteerTurnResponse,
   StopCodexEnvironmentActionResponse,
+  StopSubAgentResponse,
   SubmitServerRequestResponse,
   TrustCodexProjectResponse,
   UpdateThreadExpectedBranchResponse,
@@ -114,6 +115,7 @@ import {
   type StartTurnResponse,
   type SubmitServerRequestRequest,
   type StopCodexEnvironmentActionRequest,
+  type StopSubAgentRequest,
   type TrustCodexProjectRequest,
   type UpdateThreadExpectedBranchRequest,
 } from "@pwragent/shared";
@@ -2614,6 +2616,11 @@ function localBackendOperations(): FederationBackendOperations {
       request: InterruptTurnRequest,
     ): Promise<InterruptTurnResponse> {
       return await getDesktopBackendRegistry().interruptTurn(request);
+    },
+    async stopSubAgent(
+      request: StopSubAgentRequest,
+    ): Promise<StopSubAgentResponse> {
+      return await getDesktopBackendRegistry().stopSubAgent(request);
     },
     async steerTurn(request: SteerTurnRequest): Promise<SteerTurnResponse> {
       const registry = getDesktopBackendRegistry();

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -663,6 +663,14 @@ export function registerAgentIpcHandlers(): void {
       });
 
       try {
+        if (
+          request.federationTarget
+          && isRemoteFederationTarget(request.federationTarget)
+        ) {
+          return await getDesktopFederationRuntime()
+            .remoteBackend(request.federationTarget)
+            .stopSubAgent(stripFederationTarget(request));
+        }
         return await registry.stopSubAgent(request);
       } catch (error) {
         appServerLog.error("stopSubAgent failed", {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -69,6 +69,9 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
     try {
       await props.desktopApi.stopSubAgent({
         backend: props.thread.source,
+        ...(props.thread.federation?.ref.target
+          ? { federationTarget: props.thread.federation.ref.target }
+          : {}),
         threadId: props.thread.id,
         monitorId: subAgent.monitorId,
       });

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
@@ -91,4 +91,45 @@ describe("SubAgentsPanel", () => {
     ).toHaveTextContent("Sub-agent is no longer running.");
     expect(screen.getByRole("button", { name: "Stop" })).toBeEnabled();
   });
+
+  it("targets the owning instance when stopping a remote sub-agent", async () => {
+    const stopSubAgent = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "parent-thread",
+      monitorId: "monitor-1",
+      stoppedAt: 1_800_000_000_100,
+    }));
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "owner_one",
+    };
+
+    render(
+      <SubAgentsPanel
+        desktopApi={{ stopSubAgent } as DesktopApi}
+        thread={{
+          ...thread,
+          federation: {
+            instanceLabel: "Owner One",
+            ref: {
+              target: federationTarget,
+              backend: "codex",
+              threadId: "parent-thread",
+            },
+          },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    await waitFor(() => {
+      expect(stopSubAgent).toHaveBeenCalledWith({
+        backend: "codex",
+        federationTarget,
+        threadId: "parent-thread",
+        monitorId: "monitor-1",
+      });
+    });
+  });
 });

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -305,6 +305,7 @@ export type InterruptTurnResponse = {
 
 export type StopSubAgentRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   monitorId: string;
 };


### PR DESCRIPTION
## What changed

- add the optional federation target to sub-agent stop requests
- route remote stop requests through the owning peer instead of the viewer local registry
- add the capability-guarded `backend.stopSubAgent` federation RPC and owner-side implementation
- cover the renderer request, IPC dispatch, and federation bridge with regression tests

## Root cause

The Stop button used the local Electron `agent:stop-sub-agent` IPC channel correctly, but the request did not identify the remote owner and the IPC handler always called the viewer local backend registry. The federation backend protocol also had no `backend.stopSubAgent` method. For a remote thread, the viewer therefore searched its own overlay state and returned `Sub-agent was not found on this thread.`

## Impact

Operators can stop running sub-agents from remote/federated thread views. Local sub-agent stops remain unchanged.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx apps/desktop/src/main/__tests__/agent-ipc.test.ts apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts` (31 tests)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` (no errors; existing warning baseline only)
- `git diff --check`