### PR TITLE
fix(messaging): label routed responses by binding kind

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1715,9 +1715,11 @@ describe("MessagingController", () => {
     );
     expect(assistantReplies).toHaveLength(1);
     expect(assistantReplies[0]?.bindingId).toMatch(/^default-agent-route:/);
+    expect(assistantReplies[0]).not.toHaveProperty("attribution");
   });
 
   async function createSlackPrivateResponseHarness(options?: {
+    agentName?: string | null;
     deliveryBudget?: MessagingDeliveryBudget;
     deliver?: (intent: MessagingSurfaceIntent) => Promise<MessagingDeliveryResult>;
     inboundText?: string;
@@ -1728,6 +1730,8 @@ describe("MessagingController", () => {
     sleepUntil?: MessagingControllerOptions["sleepUntil"];
     startTurn?: NonNullable<MessagingBackendBridge["startTurn"]>;
     streamingResponsesDefault?: boolean;
+    targetKind?: "agent_thread" | "thread";
+    threadTitle?: string;
     toolUpdateDefaultMode?:
       | MessagingToolUpdateMode
       | ((targetKind: "thread" | "agent_thread") => MessagingToolUpdateMode);
@@ -1799,14 +1803,22 @@ describe("MessagingController", () => {
       updatedAt: 1000,
     }));
     const navigation = buildNavigationSnapshot();
+    const agentName = options?.agentName === undefined
+      ? "Signals Agent"
+      : options.agentName;
     navigation.threads[0] = {
       ...navigation.threads[0]!,
-      agent: {
-        name: "Signals Agent",
-        instructionLineCount: 1,
-        instructionsTooLong: false,
-        updatedAt: 1000,
-      },
+      title: options?.threadTitle ?? navigation.threads[0]!.title,
+      ...(agentName
+        ? {
+            agent: {
+              name: agentName,
+              instructionLineCount: 1,
+              instructionsTooLong: false,
+              updatedAt: 1000,
+            },
+          }
+        : { agent: undefined }),
     };
     const harness = await createHarness({
       channel: "slack",
@@ -1843,7 +1855,7 @@ describe("MessagingController", () => {
       channel,
       createdAt: 1000,
       routingState: { opaque: { channelId: "C012SIGNALS" } },
-      targetKind: "agent_thread",
+      targetKind: options?.targetKind ?? "agent_thread",
       threadId: "thread-1",
       updatedAt: 1000,
     });
@@ -1857,6 +1869,108 @@ describe("MessagingController", () => {
     harness.delivered.length = 0;
     return { channel, harness, resolvePrivateConversation };
   }
+
+  it("uses normalized Agent metadata for private response identity", async () => {
+    const { harness } = await createSlackPrivateResponseHarness({
+      agentName: "Signals Agent",
+      targetKind: "agent_thread",
+      threadTitle: "Investigate an alert from the first prompt",
+    });
+
+    await harness.controller.handlePwrAgentMessagingRequest({
+      operation: "send_private_response",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      args: { text: "Private details" },
+    });
+
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        attribution: expect.objectContaining({ label: "Signals Agent" }),
+        kind: "message",
+      }),
+    );
+  });
+
+  it("does not derive an Agent identity from its thread title", async () => {
+    const { harness } = await createSlackPrivateResponseHarness({
+      agentName: null,
+      targetKind: "agent_thread",
+      threadTitle: "Investigate an alert from the first prompt",
+    });
+
+    await harness.controller.handlePwrAgentMessagingRequest({
+      operation: "send_private_response",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      args: { text: "Private details" },
+    });
+
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        attribution: expect.objectContaining({ label: "PwrAgent Agent" }),
+        kind: "message",
+      }),
+    );
+  });
+
+  it("uses the bound ordinary thread title for private response identity", async () => {
+    const { harness } = await createSlackPrivateResponseHarness({
+      agentName: "Unrelated Agent Metadata",
+      targetKind: "thread",
+      threadTitle: "AWS incident follow-up",
+    });
+
+    await harness.controller.handlePwrAgentMessagingRequest({
+      operation: "send_private_response",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      args: { text: "Private details" },
+    });
+
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        attribution: expect.objectContaining({
+          label: "AWS incident follow-up",
+        }),
+        kind: "message",
+      }),
+    );
+  });
+
+  it("uses a restrained fallback for an untitled ordinary thread", async () => {
+    const { harness } = await createSlackPrivateResponseHarness({
+      agentName: null,
+      targetKind: "thread",
+      threadTitle: "",
+    });
+
+    await harness.controller.handlePwrAgentMessagingRequest({
+      operation: "send_private_response",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      args: { text: "Private details" },
+    });
+
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        attribution: expect.objectContaining({ label: "PwrAgent thread" }),
+        kind: "message",
+      }),
+    );
+  });
 
   it("delivers a terminal private response to the requesting Slack user", async () => {
     const {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1732,6 +1732,7 @@ describe("MessagingController", () => {
     streamingResponsesDefault?: boolean;
     targetKind?: "agent_thread" | "thread";
     threadTitle?: string;
+    threadTitleSource?: NavigationSnapshot["threads"][number]["titleSource"];
     toolUpdateDefaultMode?:
       | MessagingToolUpdateMode
       | ((targetKind: "thread" | "agent_thread") => MessagingToolUpdateMode);
@@ -1809,6 +1810,8 @@ describe("MessagingController", () => {
     navigation.threads[0] = {
       ...navigation.threads[0]!,
       title: options?.threadTitle ?? navigation.threads[0]!.title,
+      titleSource:
+        options?.threadTitleSource ?? navigation.threads[0]!.titleSource,
       ...(agentName
         ? {
             agent: {
@@ -1951,7 +1954,8 @@ describe("MessagingController", () => {
     const { harness } = await createSlackPrivateResponseHarness({
       agentName: null,
       targetKind: "thread",
-      threadTitle: "",
+      threadTitle: "Untitled thread",
+      threadTitleSource: "fallback",
     });
 
     await harness.controller.handlePwrAgentMessagingRequest({

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -18542,6 +18542,7 @@ function summarizeNavigationThreadForMessaging(
   const gitBranch = thread.gitBranch ?? thread.observedGitBranch;
   return {
     title: thread.title,
+    titleSource: thread.titleSource,
     ...(thread.projectKey ? { projectKey: thread.projectKey } : {}),
     ...(gitBranch ? { gitBranch } : {}),
     ...(thread.model ? { model: thread.model } : {}),
@@ -18557,7 +18558,9 @@ function privateResponseAttributionLabel(
   const targetKind = binding.targetKind ?? "thread";
   const identity = targetKind === "agent_thread"
     ? thread?.agentName
-    : thread?.title;
+    : thread?.titleSource === "fallback"
+      ? undefined
+      : thread?.title;
   const normalized = identity?.replace(/\s+/g, " ").trim();
   if (normalized) {
     return normalized;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -15749,9 +15749,9 @@ export class MessagingController {
     const sourceThread = sourceBinding
       ? await this.resolveBoundThreadSummary(sourceBinding)
       : undefined;
-    const attributionLabel = sourceThread?.agentName
-      ?? sourceThread?.title
-      ?? "PwrAgent Agent";
+    const attributionLabel = sourceBinding
+      ? privateResponseAttributionLabel(sourceBinding, sourceThread)
+      : "PwrAgent Agent";
     const result = await this.deliver(
       {
         id: this.newIntentId("private-response"),
@@ -18548,6 +18548,23 @@ function summarizeNavigationThreadForMessaging(
     ...(thread.executionMode ? { executionMode: thread.executionMode } : {}),
     ...(thread.agent?.name ? { agentName: thread.agent.name } : {}),
   };
+}
+
+function privateResponseAttributionLabel(
+  binding: MessagingBindingRecord,
+  thread: PwrAgentMessagingBoundThreadSummary | undefined,
+): string {
+  const targetKind = binding.targetKind ?? "thread";
+  const identity = targetKind === "agent_thread"
+    ? thread?.agentName
+    : thread?.title;
+  const normalized = identity?.replace(/\s+/g, " ").trim();
+  if (normalized) {
+    return normalized;
+  }
+  return targetKind === "agent_thread"
+    ? "PwrAgent Agent"
+    : "PwrAgent thread";
 }
 
 function eventFromBinding(

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -123,9 +123,9 @@ conversation. Providers should render it as restrained secondary context, such
 as a Slack Block Kit context block. Producers omit it for routine replies when
 the destination already identifies the bound thread. For bound Agent threads,
 desktop orchestration uses normalized Agent metadata only; for ordinary bound
-threads it uses the normalized thread title, with `PwrAgent thread` as the
-untitled fallback. A missing Agent name must not be inferred from a derived
-thread title, prompt text, or `AGENTS.md` content.
+threads it uses the normalized thread title unless its title source is
+`fallback`, then uses `PwrAgent thread`. A missing Agent name must not be
+inferred from a derived thread title, prompt text, or `AGENTS.md` content.
 
 Telegram currently uses Bot API long polling, HTML-safe text, inline keyboards,
 `sendPhoto` for image URLs/data images, and `sendDocument` for generic file

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -117,6 +117,16 @@ link syntax or a future structured link part. Platform clients may still apply
 native autolinking to plain text; neutralize that only with a provider-specific
 policy and tests for the concrete platform behavior.
 
+`MessagingMessageIntent.attribution` carries optional source identity and
+secondary delivery context for responses routed away from their bound
+conversation. Providers should render it as restrained secondary context, such
+as a Slack Block Kit context block. Producers omit it for routine replies when
+the destination already identifies the bound thread. For bound Agent threads,
+desktop orchestration uses normalized Agent metadata only; for ordinary bound
+threads it uses the normalized thread title, with `PwrAgent thread` as the
+untitled fallback. A missing Agent name must not be inferred from a derived
+thread title, prompt text, or `AGENTS.md` content.
+
 Telegram currently uses Bot API long polling, HTML-safe text, inline keyboards,
 `sendPhoto` for image URLs/data images, and `sendDocument` for generic file
 parts. Discord uses Gateway events, REST message delivery, defensive

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -815,6 +815,11 @@ export type MessagingBaseSurfaceIntent = {
 
 export type MessagingMessageIntent = MessagingBaseSurfaceIntent & {
   kind: "message";
+  /**
+   * Optional source identity and delivery context for a response routed away
+   * from its bound conversation. Routine replies should omit this when their
+   * destination already makes the source identity unambiguous.
+   */
   attribution?: {
     label: string;
     hint?: string;

--- a/packages/shared/src/contracts/messaging-tools.ts
+++ b/packages/shared/src/contracts/messaging-tools.ts
@@ -1,5 +1,6 @@
 import type {
   AppServerBackendKind,
+  AppServerThreadTitleSource,
   ThreadExecutionMode,
   ThreadIdentifier,
 } from "./normalized-app-server";
@@ -83,6 +84,7 @@ export type PwrAgentMessagingActorSummary = {
 
 export type PwrAgentMessagingBoundThreadSummary = {
   title: string;
+  titleSource: AppServerThreadTitleSource;
   projectKey?: string;
   gitBranch?: string;
   model?: string;


### PR DESCRIPTION
## What changed

- Select private-response identity labels from the bound target kind.
- Use normalized Agent metadata for Agent-thread bindings.
- Use the normalized thread title for ordinary-thread bindings, with `PwrAgent thread` for untitled threads.
- Preserve the existing private-request/reply-in-thread guidance and Slack Block Kit context rendering.
- Keep routine replies free of redundant attribution when their destination already identifies the binding.

## Why

Privately routed Slack responses can land in a shared DM alongside responses from several PwrAgent Agents or threads. The existing selector always preferred any available Agent metadata, even for ordinary bindings, and could emit an empty label for an untitled ordinary thread. It could also fall back from an Agent binding to a derived thread title.

This follow-up is intentionally separate from #1216.

## Impact

Operators now see the actual bound Agent name or ordinary thread title in routed response context without prompt-derived Agent identities or added noise on routine replies.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm test packages/messaging/providers/slack/src/__tests__/slack-formatting.test.ts packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
