### PR TITLE
fix(desktop): preserve remote viewer history

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -347,8 +347,19 @@ describe("federation backend bridge", () => {
     expect(backend.readThread).toHaveBeenNthCalledWith(1, {
       backend: "codex",
       threadId: "thread-1",
+      limit: 2,
     });
     expect(backend.readThread).toHaveBeenNthCalledWith(2, {
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(backend.readThread).toHaveBeenNthCalledWith(3, {
+      backend: "codex",
+      threadId: "thread-1",
+      before: "entry-3",
+      limit: 2,
+    });
+    expect(backend.readThread).toHaveBeenNthCalledWith(4, {
       backend: "codex",
       threadId: "thread-1",
     });
@@ -431,11 +442,16 @@ describe("federation backend bridge", () => {
       },
     });
 
-    expect(backend.readThread).toHaveBeenCalledWith({
+    expect(backend.readThread).toHaveBeenNthCalledWith(1, {
+      backend: "codex",
+      threadId: "thread-1",
+      limit: 2,
+    });
+    expect(backend.readThread).toHaveBeenNthCalledWith(2, {
       backend: "codex",
       threadId: "thread-1",
     });
-    expect(backend.readThread).toHaveBeenCalledTimes(1);
+    expect(backend.readThread).toHaveBeenCalledTimes(2);
     expect(replies[0]).toMatchObject({
       kind: "response",
       requestId: "latest-request",
@@ -503,14 +519,10 @@ describe("federation backend bridge", () => {
     expect(backend.readThread).toHaveBeenNthCalledWith(1, {
       backend: "codex",
       threadId: "thread-1",
-    });
-    expect(backend.readThread).toHaveBeenNthCalledWith(2, {
-      backend: "codex",
-      threadId: "thread-1",
       before: "cursor-1",
       limit: 2,
     });
-    expect(backend.readThread).toHaveBeenCalledTimes(2);
+    expect(backend.readThread).toHaveBeenCalledTimes(1);
     expect(replies).toHaveLength(1);
   });
 

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type {
+  AppServerReadThreadRequest,
   AppServerReadThreadResponse,
   FederationProtocolEnvelope,
   TrustCodexProjectRequest,
@@ -221,7 +222,7 @@ describe("federation backend bridge", () => {
     ]);
   });
 
-  it("pages unbounded thread history before sending it over federation", async () => {
+  it("reads complete thread history before minting federation cursors", async () => {
     const response: AppServerReadThreadResponse = {
       backend: "codex",
       fetchedAt: 1_000,
@@ -346,14 +347,171 @@ describe("federation backend bridge", () => {
     expect(backend.readThread).toHaveBeenNthCalledWith(1, {
       backend: "codex",
       threadId: "thread-1",
-      limit: 2,
     });
     expect(backend.readThread).toHaveBeenNthCalledWith(2, {
       backend: "codex",
       threadId: "thread-1",
-      before: "entry-3",
+    });
+  });
+
+  it("does not lose older history when an unpaginated backend honors limit", async () => {
+    const allEntries: AppServerReadThreadResponse["replay"]["entries"] = [
+      {
+        type: "message",
+        id: "older-user",
+        role: "user",
+        text: "Older question",
+      },
+      {
+        type: "message",
+        id: "older-assistant",
+        role: "assistant",
+        text: "Older answer",
+      },
+      {
+        type: "message",
+        id: "latest-user",
+        role: "user",
+        text: "Latest question",
+      },
+      {
+        type: "message",
+        id: "latest-assistant",
+        role: "assistant",
+        text: "Latest answer",
+      },
+    ];
+    const backend = {
+      readThread: vi.fn(async (request: AppServerReadThreadRequest) => {
+        const entries = request.limit === undefined
+          ? allEntries
+          : allEntries.slice(-request.limit);
+        return {
+          backend: "codex" as const,
+          fetchedAt: 1_000,
+          threadId: "thread-1",
+          replay: {
+            entries,
+            messages: entries.flatMap((entry) =>
+              entry.type === "message"
+                ? [{ id: entry.id, role: entry.role, text: entry.text }]
+                : []
+            ),
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        };
+      }),
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["thread_detail"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "latest-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.readThread,
+        params: { backend: "codex", threadId: "thread-1", limit: 2 },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(backend.readThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(backend.readThread).toHaveBeenCalledTimes(1);
+    expect(replies[0]).toMatchObject({
+      kind: "response",
+      requestId: "latest-request",
+      result: {
+        replay: {
+          entries: [{ id: "latest-user" }, { id: "latest-assistant" }],
+          pagination: {
+            supportsPagination: true,
+            hasPreviousPage: true,
+            previousCursor: "latest-user",
+          },
+        },
+      },
+    });
+  });
+
+  it("delegates bounded reads to backends with native pagination", async () => {
+    const response: AppServerReadThreadResponse = {
+      backend: "codex",
+      fetchedAt: 1_000,
+      threadId: "thread-1",
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: true,
+          hasPreviousPage: false,
+        },
+      },
+    };
+    const backend = {
+      readThread: vi.fn(async () => response),
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["thread_detail"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "native-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.readThread,
+        params: {
+          backend: "codex",
+          threadId: "thread-1",
+          before: "cursor-1",
+          limit: 2,
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(backend.readThread).toHaveBeenNthCalledWith(1, {
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(backend.readThread).toHaveBeenNthCalledWith(2, {
+      backend: "codex",
+      threadId: "thread-1",
+      before: "cursor-1",
       limit: 2,
     });
+    expect(backend.readThread).toHaveBeenCalledTimes(2);
+    expect(replies).toHaveLength(1);
   });
 
   it("compacts an oversized retained entry below the frame ceiling", async () => {

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -401,23 +401,23 @@ export function registerFederationBackendHandlers(params: {
     FEDERATION_BACKEND_METHODS.readThread,
     async (envelope) => {
       const request = envelope.params as AppServerReadThreadRequest;
-      const {
-        before: _before,
-        limit: _limit,
-        ...unpagedRequest
-      } = request;
-      let response = await params.backend.readThread(unpagedRequest);
+      let response = await params.backend.readThread(request);
 
       // Federation needs the complete replay to mint reliable cursors for a
       // backend that does not expose native pagination. Some backends honor
-      // before/limit while still reporting supportsPagination=false; passing
-      // the viewer's bounds into that first read makes older history
-      // unreachable as soon as a new turn slides the bounded window forward.
+      // before/limit while still reporting supportsPagination=false, so retry
+      // without those bounds only after the bounded read proves that native
+      // pagination is unavailable.
       if (
-        response.replay.pagination.supportsPagination
+        !response.replay.pagination.supportsPagination
         && (request.before !== undefined || request.limit !== undefined)
       ) {
-        response = await params.backend.readThread(request);
+        const {
+          before: _before,
+          limit: _limit,
+          ...unpagedRequest
+        } = request;
+        response = await params.backend.readThread(unpagedRequest);
       }
 
       // Bound non-paginating replays before they reach the federation

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -401,10 +401,27 @@ export function registerFederationBackendHandlers(params: {
     FEDERATION_BACKEND_METHODS.readThread,
     async (envelope) => {
       const request = envelope.params as AppServerReadThreadRequest;
-      const response = await params.backend.readThread(request);
-      // Codex currently accepts before/limit but can still return the complete
-      // transcript without pagination metadata. Bound that response before it
-      // reaches the federation transport's per-frame receive ceiling.
+      const {
+        before: _before,
+        limit: _limit,
+        ...unpagedRequest
+      } = request;
+      let response = await params.backend.readThread(unpagedRequest);
+
+      // Federation needs the complete replay to mint reliable cursors for a
+      // backend that does not expose native pagination. Some backends honor
+      // before/limit while still reporting supportsPagination=false; passing
+      // the viewer's bounds into that first read makes older history
+      // unreachable as soon as a new turn slides the bounded window forward.
+      if (
+        response.replay.pagination.supportsPagination
+        && (request.before !== undefined || request.limit !== undefined)
+      ) {
+        response = await params.backend.readThread(request);
+      }
+
+      // Bound non-paginating replays before they reach the federation
+      // transport's per-frame receive ceiling.
       const pagedReplay = response.replay.pagination.supportsPagination
         ? response.replay
         : pageNormalizedReplay(response.replay, request);


### PR DESCRIPTION
## What changed

- read the complete owner-side replay before synthesizing federation pagination cursors for backends that do not expose native pagination
- continue delegating bounded reads to backends that do expose native pagination
- add regression coverage for backends that honor `limit` while still reporting `supportsPagination: false`

## Why

A recently added federation frame-size guard forwarded the remote viewer's bounded `thread/read` request to the owner before deciding whether it needed to synthesize pagination. Codex can honor that limit without returning pagination metadata. After a new turn completed, the bounded window contained only the new tail, so the bridge marked `hasPreviousPage: false` and made the thread's older history unreachable from the remote viewer.

The bridge now obtains an unbounded replay for the non-native-pagination path, slices it for transport, and mints a reliable previous-page cursor. Native pagination remains authoritative when available.

## Impact

Remote viewers keep access to earlier transcript pages after replying to long threads. The replay remains bounded before crossing the federation transport frame limit.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with existing warnings)
- `pnpm lint:boundaries`
