### PR TITLE
fix(desktop): star map operator-review fixes

### DIFF
--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -533,6 +533,14 @@ export class DesktopFederationRuntime {
     health.localCelestialIcon = this.celestialIconAssignments().find(
       (assignment) => assignment.instanceId === health.instanceId,
     )?.icon;
+    // Resolved from settings rather than `this.instanceLabel` so the label
+    // is correct even before the runtime has started (federation disabled,
+    // or health read during boot).
+    health.localLabel =
+      settings.federation.instanceLabel.value.trim() || defaultInstanceLabel();
+    health.localProfileName = isAppStateInitialized()
+      ? getAppStateDb().getMeta("profile_name") || undefined
+      : undefined;
     return health;
   }
 

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -25,6 +25,12 @@ type ThreadMetaChipsProps = {
   queuedMessageState?: ThreadQueuedMessageState;
   includeLinkedDirectories?: boolean;
   linkedDirectoryMode?: "label" | "kind";
+  /**
+   * Suppresses the owning-instance chip for surfaces that already carry
+   * that identity (the Star Map groups cards under their instance and
+   * watermarks them), where a per-card machine name is pure noise.
+   */
+  hideInstanceChip?: boolean;
   thread: NavigationThreadSummary;
 };
 
@@ -36,6 +42,7 @@ export function ThreadMetaChips({
   queuedMessageState,
   includeLinkedDirectories = false,
   linkedDirectoryMode = "label",
+  hideInstanceChip = false,
   thread,
 }: ThreadMetaChipsProps) {
   // Hover tooltip for the icon-only pin marker — sighted users get the
@@ -165,7 +172,7 @@ export function ThreadMetaChips({
   // is already branded with its peer's identity, so per-row chips there
   // would be pure noise.
   const instanceChip =
-    thread.federation && !readRendererFederationTarget()
+    thread.federation && !hideInstanceChip && !readRendererFederationTarget()
       ? (
           <InstanceChip
             icon={thread.federation.celestialIcon}

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -26,6 +26,19 @@ type ThreadMetaChipsProps = {
   includeLinkedDirectories?: boolean;
   linkedDirectoryMode?: "label" | "kind";
   /**
+   * Optional per-surface chip trimming. Defaults keep every chip, so the
+   * thread list is unaffected; the Star Map uses it to let an operator
+   * choose how dense a card should be.
+   */
+  chipVisibility?: {
+    /** Backend/provider chip. */
+    provider?: boolean;
+    /** Git branch chip. */
+    branch?: boolean;
+    /** Cap on linked-directory chips (undefined shows all). */
+    maxLinkedDirectories?: number;
+  };
+  /**
    * Suppresses the owning-instance chip for surfaces that already carry
    * that identity (the Star Map groups cards under their instance and
    * watermarks them), where a per-card machine name is pure noise.
@@ -43,8 +56,12 @@ export function ThreadMetaChips({
   includeLinkedDirectories = false,
   linkedDirectoryMode = "label",
   hideInstanceChip = false,
+  chipVisibility,
   thread,
 }: ThreadMetaChipsProps) {
+  const showProvider = chipVisibility?.provider ?? true;
+  const showBranch = chipVisibility?.branch ?? true;
+  const maxLinkedDirectories = chipVisibility?.maxLinkedDirectories;
   // Hover tooltip for the icon-only pin marker — sighted users get the
   // "Pinned" label without the old text pill; screen readers get it from
   // the marker's role="img" + aria-label. Uses the shared viewport
@@ -193,9 +210,11 @@ export function ThreadMetaChips({
     <>
       {instanceChip}
 
-      <span className="thread-row__chip thread-row__chip--backend">
-        {formatBackendLabel(thread.source)}
-      </span>
+      {showProvider ? (
+        <span className="thread-row__chip thread-row__chip--backend">
+          {formatBackendLabel(thread.source)}
+        </span>
+      ) : null}
 
       {thread.agent ? <AgentThreadChip threadRow /> : null}
 
@@ -253,7 +272,9 @@ export function ThreadMetaChips({
         </span>
       ) : null}
 
-      {linkedDirectoryChips}
+      {maxLinkedDirectories === undefined || !Array.isArray(linkedDirectoryChips)
+        ? linkedDirectoryChips
+        : linkedDirectoryChips.slice(0, maxLinkedDirectories)}
 
       {thread.pinnedRank && !thread.parentThreadId ? (
         <span
@@ -306,7 +327,7 @@ export function ThreadMetaChips({
       ) : null}
       {pinTooltip.tooltipNode}
 
-      {branchChip ? (
+      {branchChip && showBranch ? (
         <CopyableThreadChip
           aria-label={formatBranchCopyLabel({
             branch: branchChip,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -36,6 +36,12 @@ import {
   type StarMapInstancePosition,
 } from "./star-map-layout";
 import { IntakeDialog, type IntakeDialogTarget } from "./IntakeDialog";
+import {
+  readStoredPreferences,
+  writeStoredPreferences,
+  type StarMapViewPreferences,
+} from "./star-map-preferences";
+import { StarMapViewOptions } from "./StarMapViewOptions";
 import { StarMapInstanceCard } from "./StarMapInstanceCard";
 import { StarMapThreadCard } from "./StarMapThreadCard";
 import { useStarMapArrangement } from "./useStarMapArrangement";
@@ -114,6 +120,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
   // measurements - a fixed pitch clipped tall cards mid-glyph.
   const [cardHeights, setCardHeights] = useState<Map<string, number>>(
     new Map(),
+  );
+  const [preferences, setPreferences] = useState<StarMapViewPreferences>(
+    readStoredPreferences,
   );
 
   // Focus the layer on open AND whenever the floating thread closes -
@@ -195,11 +204,17 @@ export function StarMapScreen(props: StarMapScreenProps) {
   }, []);
 
   const localInstanceId = health?.instanceId ?? "local";
-  const peers = useMemo(
-    () =>
-      (health?.peers ?? []).filter((peer) => peer.status !== "revoked"),
-    [health],
-  );
+  const peers = useMemo(() => {
+    const visible = (health?.peers ?? []).filter(
+      (peer) => peer.status !== "revoked",
+    );
+    // Hiding offline instances is about the operator's own fleet noise (an
+    // unused dev profile), so it only ever drops peers - the local body
+    // stays on the map regardless of its own connection state.
+    return preferences.hideOfflineInstances
+      ? visible.filter((peer) => peer.status === "connected")
+      : visible;
+  }, [health, preferences.hideOfflineInstances]);
   const remote = useStarMapThreads({
     desktopApi: props.desktopApi,
     peers,
@@ -421,6 +436,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
               offset={arrangement.offsetFor(position.instanceId, threadKey)}
               width={layout.cardWidth}
               stackIndex={index}
+              cardFields={preferences.cardFields}
               onCommitOffset={
                 // Drags persist + sync only once the durable instance id is
                 // known; before that, cards stay in their default slots.
@@ -629,6 +645,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
         <CloseIcon size={14} />
         <span>Close map</span>
       </button>
+      <div className="star-map__chrome">
+        <StarMapViewOptions
+          preferences={preferences}
+          onChange={(next) => {
+            setPreferences(next);
+            writeStoredPreferences(next);
+          }}
+        />
+      </div>
       <div className="star-map__filters" role="group" aria-label="Attention filters">
         {STAR_MAP_ATTENTION_CATEGORIES.map((category) => (
           <button

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -27,9 +27,12 @@ import {
   type StarMapSessionKeys,
 } from "./attention";
 import {
+  computeCardSlots,
   computeStarMapLayout,
   generateStarField,
-  starMapCardSlot,
+  STAR_MAP_BODY_ROW_Y,
+  STAR_MAP_ESTIMATED_CARD_HEIGHT,
+  visibleCardCount,
   type StarMapInstancePosition,
 } from "./star-map-layout";
 import { IntakeDialog, type IntakeDialogTarget } from "./IntakeDialog";
@@ -39,7 +42,7 @@ import { useStarMapArrangement } from "./useStarMapArrangement";
 import { useStarMapThreads } from "./useStarMapThreads";
 
 const FILTERS_STORAGE_KEY = "pwragent.starMap.filters";
-const MAX_CARDS_PER_INSTANCE = 6;
+const MAX_CARDS_PER_INSTANCE = 8;
 const STAR_COUNT = 130;
 
 function readStoredFilters(): Set<StarMapAttentionCategory> {
@@ -107,6 +110,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
     new Set(),
   );
   const [remoteRefreshNonce, setRemoteRefreshNonce] = useState(0);
+  // Cards vary in height with their chip rows, so lanes stack from real
+  // measurements - a fixed pitch clipped tall cards mid-glyph.
+  const [cardHeights, setCardHeights] = useState<Map<string, number>>(
+    new Map(),
+  );
 
   // Focus the layer on open AND whenever the floating thread closes -
   // "Back to map" leaves focus inside <main>, and without a refocus the
@@ -139,6 +147,32 @@ export function StarMapScreen(props: StarMapScreenProps) {
     observer.observe(element);
     return () => observer.disconnect();
   }, []);
+
+  // Deliberately dependency-free: a card's height changes whenever its chip
+  // content does, and no prop reliably signals that. The identity check
+  // below is the loop guard - an unchanged measurement returns the very
+  // same Map, so the state never updates and the cycle stops.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useLayoutEffect(() => {
+    const root = viewportRef.current;
+    if (!root) return;
+    const measured = new Map<string, number>();
+    for (const element of root.querySelectorAll<HTMLElement>(
+      "[data-thread-key]",
+    )) {
+      const key = element.dataset.threadKey;
+      if (key) measured.set(key, element.offsetHeight);
+    }
+    setCardHeights((current) => {
+      if (
+        current.size === measured.size
+        && [...measured].every(([key, height]) => current.get(key) === height)
+      ) {
+        return current;
+      }
+      return measured;
+    });
+  });
 
   const toggleFilter = useCallback((category: StarMapAttentionCategory) => {
     setFilters((current) => {
@@ -326,7 +360,20 @@ export function StarMapScreen(props: StarMapScreenProps) {
 
   const renderCloud = (position: StarMapInstancePosition) => {
     const threads = attentionByInstance.get(position.instanceId) ?? [];
-    const visible = threads.slice(0, MAX_CARDS_PER_INSTANCE);
+    const heights = threads.map(
+      (thread) =>
+        cardHeights.get(buildThreadIdentityKey(thread.source, thread.id))
+        ?? STAR_MAP_ESTIMATED_CARD_HEIGHT,
+    );
+    // Only as many cards as actually fit between the body row and the
+    // bottom of the window; the rest roll into "+N more".
+    const count = visibleCardCount({
+      heights,
+      availableHeight: viewportSize.height - STAR_MAP_BODY_ROW_Y,
+      max: MAX_CARDS_PER_INSTANCE,
+    });
+    const visible = threads.slice(0, count);
+    const slots = computeCardSlots(heights.slice(0, count));
     const overflow = threads.length - visible.length;
     return (
       <div
@@ -344,12 +391,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
             aria-hidden="true"
             style={{
               width: layout.cardWidth + 56,
-              height: starMapCardSlot(visible.length - 1).dy + 120,
+              height:
+                (slots[slots.length - 1]?.dy ?? 0)
+                + (heights[visible.length - 1] ?? 0)
+                + 40,
             }}
           />
         ) : null}
         {visible.map((thread, index) => {
-          const slot = starMapCardSlot(index);
+          const slot = slots[index];
           const threadKey = buildThreadIdentityKey(thread.source, thread.id);
           return (
             <StarMapThreadCard
@@ -370,6 +420,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
               baseSlot={slot}
               offset={arrangement.offsetFor(position.instanceId, threadKey)}
               width={layout.cardWidth}
+              stackIndex={index}
               onCommitOffset={
                 // Drags persist + sync only once the durable instance id is
                 // known; before that, cards stay in their default slots.
@@ -391,7 +442,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
             className="star-map__cloud-overflow"
             style={{
               transform: `translate(-50%, ${
-                starMapCardSlot(visible.length).dy + 8
+                (slots[slots.length - 1]?.dy ?? 0)
+                + (heights[visible.length - 1] ?? 0)
+                + 14
               }px)`,
             }}
           >

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -18,6 +18,8 @@ import type { DesktopApi } from "../../lib/desktop-api";
 import { useCelestialIcons } from "../../lib/useCelestialIcons";
 import { useFederationHealth } from "../../lib/useFederationHealth";
 import {
+  addFilterImpactCounts,
+  countFilterImpact,
   selectAttentionThreads,
   STAR_MAP_ATTENTION_CATEGORIES,
   STAR_MAP_ATTENTION_LABELS,
@@ -27,6 +29,7 @@ import {
 import {
   computeStarMapLayout,
   generateStarField,
+  pickHoveredCardKey,
   starMapCardSlot,
   type StarMapInstancePosition,
 } from "./star-map-layout";
@@ -105,6 +108,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
     new Set(),
   );
   const [remoteRefreshNonce, setRemoteRefreshNonce] = useState(0);
+  // Lane stacks overlap, so the hovered card raises above its neighbours.
+  const [hoveredCardKey, setHoveredCardKey] = useState<string>();
 
   // Focus the layer on open AND whenever the floating thread closes -
   // "Back to map" leaves focus inside <main>, and without a refocus the
@@ -228,6 +233,27 @@ export function StarMapScreen(props: StarMapScreenProps) {
     return result;
   }, [filters, localInstanceId, props.localThreads, props.sessionKeys, remote]);
 
+  // Chip counts answer "how many cards does flipping this change" across
+  // every lane, local session state included.
+  const filterCounts = useMemo(() => {
+    let counts = countFilterImpact({
+      threads: props.localThreads.filter(
+        (thread) =>
+          !thread.federation
+          || !isRemoteFederationTarget(thread.federation.ref.target),
+      ),
+      enabled: filters,
+      sessionKeys: props.sessionKeys,
+    });
+    for (const threads of remote.threadsByInstance.values()) {
+      counts = addFilterImpactCounts(
+        counts,
+        countFilterImpact({ threads, enabled: filters }),
+      );
+    }
+    return counts;
+  }, [filters, props.localThreads, props.sessionKeys, remote]);
+
   const peerById = useMemo(
     () => new Map(peers.map((peer) => [peer.id, peer])),
     [peers],
@@ -314,6 +340,23 @@ export function StarMapScreen(props: StarMapScreenProps) {
             : ""
         }`}
         style={{ left: position.x, top: position.y }}
+        onPointerMove={(event) => {
+          const boxes = [
+            ...event.currentTarget.querySelectorAll<HTMLElement>(
+              "[data-thread-key]",
+            ),
+          ].map((element) => ({
+            threadKey: element.dataset.threadKey ?? "",
+            rect: element.getBoundingClientRect(),
+          }));
+          setHoveredCardKey(
+            pickHoveredCardKey(boxes, {
+              x: event.clientX,
+              y: event.clientY,
+            }),
+          );
+        }}
+        onPointerLeave={() => setHoveredCardKey(undefined)}
       >
         {visible.length > 0 ? (
           <span
@@ -339,6 +382,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
               }
               riseDelayMs={index * 45}
               entering={enteringThreadKeys.has(threadKey)}
+              raised={hoveredCardKey === threadKey}
               baseSlot={slot}
               offset={arrangement.offsetFor(position.instanceId, threadKey)}
               width={layout.cardWidth}
@@ -559,7 +603,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
             aria-pressed={filters.has(category)}
             onClick={() => toggleFilter(category)}
           >
-            {STAR_MAP_ATTENTION_LABELS[category]}
+            <span>{STAR_MAP_ATTENTION_LABELS[category]}</span>
+            <span className="star-map__filter-count">
+              {filterCounts[category]}
+            </span>
           </button>
         ))}
       </div>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import {
   buildThreadIdentityKey,
+  formatFederationPeerDisplayLabel,
   isRemoteFederationTarget,
   type FederationPeerSummary,
   type NavigationThreadSummary,
@@ -232,6 +233,37 @@ export function StarMapScreen(props: StarMapScreenProps) {
     [peers],
   );
 
+  /**
+   * Display labels for every body on the map, local included. Two profiles
+   * on one machine share a hostname label, so the shared formatter appends
+   * "/ <profile>" whenever a label is ambiguous - the local instance has to
+   * be part of that set or it cannot be told apart from its own sibling.
+   */
+  const displayLabelById = useMemo(() => {
+    const localSummary = {
+      id: localInstanceId,
+      label: health?.localLabel?.trim()
+        || props.localInstanceLabel?.trim()
+        || "This instance",
+      profileName: health?.localProfileName,
+    };
+    const all = [
+      localSummary,
+      ...peers.map((peer) => ({
+        id: peer.id,
+        label: peer.label,
+        profileName: peer.profileName,
+        revokedAt: peer.revokedAt,
+      })),
+    ];
+    return new Map(
+      all.map((entry) => [
+        entry.id,
+        formatFederationPeerDisplayLabel(entry, all),
+      ]),
+    );
+  }, [health, localInstanceId, peers, props.localInstanceLabel]);
+
   const { desktopApi, onFocusLocalInstance, onOpenLocalThread } = props;
   const openInstance = useCallback(
     (instanceId: string) => {
@@ -346,12 +378,13 @@ export function StarMapScreen(props: StarMapScreenProps) {
     instanceId: string,
   ): { label: string; peer?: FederationPeerSummary } => {
     if (instanceId === localInstanceId) {
-      return {
-        label: props.localInstanceLabel?.trim() || "This instance",
-      };
+      return { label: displayLabelById.get(instanceId) ?? "This instance" };
     }
     const peer = peerById.get(instanceId);
-    return { label: peer?.label ?? instanceId, peer };
+    return {
+      label: displayLabelById.get(instanceId) ?? peer?.label ?? instanceId,
+      peer,
+    };
   };
 
   return (

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -12,6 +12,7 @@ import {
   type FederationPeerSummary,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
+import { CloseIcon } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { useCelestialIcons } from "../../lib/useCelestialIcons";
 import { useFederationHealth } from "../../lib/useFederationHealth";
@@ -275,7 +276,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
     return (
       <div
         key={`cloud:${position.instanceId}`}
-        className="star-map__cloud"
+        className={`star-map__cloud${
+          remote.staleInstanceIds.has(position.instanceId)
+            ? " star-map__cloud--stale"
+            : ""
+        }`}
         style={{ left: position.x, top: position.y }}
       >
         {visible.length > 0 ? (
@@ -499,6 +504,17 @@ export function StarMapScreen(props: StarMapScreenProps) {
           }}
         />
       ) : null}
+      {/* The map layer covers the app chrome, including the header toggle
+          that opened it, so it must carry its own way out. */}
+      <button
+        type="button"
+        className="star-map__close"
+        aria-label="Close Star Map"
+        onClick={props.onClose}
+      >
+        <CloseIcon size={14} />
+        <span>Close map</span>
+      </button>
       <div className="star-map__filters" role="group" aria-label="Attention filters">
         {STAR_MAP_ATTENTION_CATEGORIES.map((category) => (
           <button

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -29,7 +29,6 @@ import {
 import {
   computeStarMapLayout,
   generateStarField,
-  pickHoveredCardKey,
   starMapCardSlot,
   type StarMapInstancePosition,
 } from "./star-map-layout";
@@ -108,8 +107,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
     new Set(),
   );
   const [remoteRefreshNonce, setRemoteRefreshNonce] = useState(0);
-  // Lane stacks overlap, so the hovered card raises above its neighbours.
-  const [hoveredCardKey, setHoveredCardKey] = useState<string>();
 
   // Focus the layer on open AND whenever the floating thread closes -
   // "Back to map" leaves focus inside <main>, and without a refocus the
@@ -340,23 +337,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
             : ""
         }`}
         style={{ left: position.x, top: position.y }}
-        onPointerMove={(event) => {
-          const boxes = [
-            ...event.currentTarget.querySelectorAll<HTMLElement>(
-              "[data-thread-key]",
-            ),
-          ].map((element) => ({
-            threadKey: element.dataset.threadKey ?? "",
-            rect: element.getBoundingClientRect(),
-          }));
-          setHoveredCardKey(
-            pickHoveredCardKey(boxes, {
-              x: event.clientX,
-              y: event.clientY,
-            }),
-          );
-        }}
-        onPointerLeave={() => setHoveredCardKey(undefined)}
       >
         {visible.length > 0 ? (
           <span
@@ -382,7 +362,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
               }
               riseDelayMs={index * 45}
               entering={enteringThreadKeys.has(threadKey)}
-              raised={hoveredCardKey === threadKey}
+              instanceIcon={celestialIcons.iconFor(
+                position.instanceId === localInstanceId
+                  ? undefined
+                  : position.instanceId,
+              )}
               baseSlot={slot}
               offset={arrangement.offsetFor(position.instanceId, threadKey)}
               width={layout.cardWidth}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -1,8 +1,10 @@
 import { useRef, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
 import {
   buildThreadIdentityKey,
+  type CelestialIconId,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
+import { CelestialIcon } from "../../icons";
 import { PrChip } from "../pr-status/PrChip";
 import { ThreadMetaChips } from "../navigation/ThreadMetaChips";
 import {
@@ -37,8 +39,8 @@ export function StarMapThreadCard(props: {
   offset?: { dx: number; dy: number };
   /** Card width for this lane (dense federations narrow it). */
   width: number;
-  /** Raised above its neighbours while hovered (the lane stack overlaps). */
-  raised?: boolean;
+  /** Owning instance's celestial mark, watermarked behind the content. */
+  instanceIcon?: CelestialIconId;
   /** Present when the card is draggable; receives the clamped offset. */
   onCommitOffset?: (offset: { dx: number; dy: number }) => void;
   onOpen: (thread: NavigationThreadSummary) => void;
@@ -120,9 +122,7 @@ export function StarMapThreadCard(props: {
   return (
     <button
       type="button"
-      className={`star-map-card${props.entering ? " star-map-card--entering" : ""}${
-        props.raised ? " is-raised" : ""
-      }`}
+      className={`star-map-card${props.entering ? " star-map-card--entering" : ""}`}
       style={style}
       data-thread-key={threadKey}
       onPointerDown={startDrag}
@@ -134,6 +134,11 @@ export function StarMapThreadCard(props: {
         props.onOpen(thread);
       }}
     >
+      {props.instanceIcon ? (
+        <span className="star-map-card__watermark" aria-hidden="true">
+          <CelestialIcon icon={props.instanceIcon} size={84} />
+        </span>
+      ) : null}
       <span className="star-map-card__heading">
         <ThreadRowStatus status={status} />
         <span className="star-map-card__title" title={thread.title}>
@@ -151,6 +156,8 @@ export function StarMapThreadCard(props: {
           }
           includeLinkedDirectories
           linkedDirectoryMode="label"
+          // The lane and the watermark already say which machine this is.
+          hideInstanceChip
         />
         {thread.prs?.map((pr) => (
           <PrChip

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -37,6 +37,8 @@ export function StarMapThreadCard(props: {
   offset?: { dx: number; dy: number };
   /** Card width for this lane (dense federations narrow it). */
   width: number;
+  /** Raised above its neighbours while hovered (the lane stack overlaps). */
+  raised?: boolean;
   /** Present when the card is draggable; receives the clamped offset. */
   onCommitOffset?: (offset: { dx: number; dy: number }) => void;
   onOpen: (thread: NavigationThreadSummary) => void;
@@ -118,7 +120,9 @@ export function StarMapThreadCard(props: {
   return (
     <button
       type="button"
-      className={`star-map-card${props.entering ? " star-map-card--entering" : ""}`}
+      className={`star-map-card${props.entering ? " star-map-card--entering" : ""}${
+        props.raised ? " is-raised" : ""
+      }`}
       style={style}
       data-thread-key={threadKey}
       onPointerDown={startDrag}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -12,6 +12,10 @@ import {
   ThreadRowStatus,
 } from "../navigation/ThreadRowStatus";
 import { clampToCloudRadius, STAR_MAP_CLOUD_RADIUS } from "./star-map-layout";
+import {
+  visiblePullRequests,
+  type StarMapCardFields,
+} from "./star-map-preferences";
 import type { StarMapSessionKeys } from "./attention";
 
 const DRAG_THRESHOLD_PX = 4;
@@ -41,6 +45,8 @@ export function StarMapThreadCard(props: {
   width: number;
   /** Lane position, so dragged-into-overlap cards paint front-to-back. */
   stackIndex: number;
+  /** Which chips this card carries (operator preference). */
+  cardFields: StarMapCardFields;
   /** Owning instance's celestial mark, watermarked behind the content. */
   instanceIcon?: CelestialIconId;
   /** Present when the card is draggable; receives the clamped offset. */
@@ -159,12 +165,19 @@ export function StarMapThreadCard(props: {
           hasInputRequest={
             props.sessionKeys?.inputRequestThreadKeys?.[threadKey] === true
           }
-          includeLinkedDirectories
+          includeLinkedDirectories={props.cardFields.primaryDirectory}
           linkedDirectoryMode="label"
           // The lane and the watermark already say which machine this is.
           hideInstanceChip
+          chipVisibility={{
+            provider: props.cardFields.provider,
+            branch: props.cardFields.branch,
+            maxLinkedDirectories: props.cardFields.secondaryDirectories
+              ? undefined
+              : 1,
+          }}
         />
-        {thread.prs?.map((pr) => (
+        {visiblePullRequests(thread.prs, props.cardFields).map((pr) => (
           <PrChip
             key={`${pr.org}/${pr.repo}#${pr.number}`}
             pr={pr}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -134,9 +134,11 @@ export function StarMapThreadCard(props: {
         props.onOpen(thread);
       }}
     >
+      {/* Top-right, and large: the next card covers this one's bottom, so
+          the mark has to live in the strip that stays visible. */}
       {props.instanceIcon ? (
         <span className="star-map-card__watermark" aria-hidden="true">
-          <CelestialIcon icon={props.instanceIcon} size={84} />
+          <CelestialIcon icon={props.instanceIcon} size={104} />
         </span>
       ) : null}
       <span className="star-map-card__heading">

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -39,6 +39,8 @@ export function StarMapThreadCard(props: {
   offset?: { dx: number; dy: number };
   /** Card width for this lane (dense federations narrow it). */
   width: number;
+  /** Lane position, so dragged-into-overlap cards paint front-to-back. */
+  stackIndex: number;
   /** Owning instance's celestial mark, watermarked behind the content. */
   instanceIcon?: CelestialIconId;
   /** Present when the card is draggable; receives the clamped offset. */
@@ -61,6 +63,7 @@ export function StarMapThreadCard(props: {
     left,
     top,
     marginLeft: -props.width / 2,
+    zIndex: props.stackIndex,
     ...(props.riseDelayMs
       ? { animationDelay: `${props.riseDelayMs}ms` }
       : {}),

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapViewOptions.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapViewOptions.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  STAR_MAP_CARD_FIELD_LABELS,
+  type StarMapCardFields,
+  type StarMapViewPreferences,
+} from "./star-map-preferences";
+
+const CARD_FIELD_ORDER: (keyof StarMapCardFields)[] = [
+  "primaryDirectory",
+  "provider",
+  "branch",
+  "secondaryDirectories",
+  "terminalPullRequests",
+];
+
+/**
+ * "View" popover for the map: which chips a card carries, and whether
+ * offline instances are on the map at all. Card content is a taste call
+ * that changes with what the operator is hunting for, so it belongs on
+ * the surface rather than buried in Settings.
+ */
+export function StarMapViewOptions(props: {
+  preferences: StarMapViewPreferences;
+  onChange: (next: StarMapViewPreferences) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (
+        event.target instanceof Node
+        && !containerRef.current?.contains(event.target)
+      ) {
+        setOpen(false);
+      }
+    };
+    window.addEventListener("pointerdown", onPointerDown);
+    return () => window.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  const setCardField = (field: keyof StarMapCardFields, value: boolean) => {
+    props.onChange({
+      ...props.preferences,
+      cardFields: { ...props.preferences.cardFields, [field]: value },
+    });
+  };
+
+  return (
+    <div className="star-map__view-options" ref={containerRef}>
+      <button
+        type="button"
+        className={`star-map__filter-chip${open ? " is-on" : ""}`}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={() => setOpen((current) => !current)}
+      >
+        View
+      </button>
+      {open ? (
+        <div
+          className="star-map__view-panel"
+          role="dialog"
+          aria-label="Star Map view options"
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              event.stopPropagation();
+              setOpen(false);
+            }
+          }}
+        >
+          <p className="star-map__view-heading">Card details</p>
+          {CARD_FIELD_ORDER.map((field) => (
+            <label key={field} className="star-map__view-row">
+              <input
+                type="checkbox"
+                checked={props.preferences.cardFields[field]}
+                onChange={(event) => setCardField(field, event.target.checked)}
+              />
+              <span>{STAR_MAP_CARD_FIELD_LABELS[field]}</span>
+            </label>
+          ))}
+          <p className="star-map__view-heading">Instances</p>
+          <label className="star-map__view-row">
+            <input
+              type="checkbox"
+              checked={props.preferences.hideOfflineInstances}
+              onChange={(event) =>
+                props.onChange({
+                  ...props.preferences,
+                  hideOfflineInstances: event.target.checked,
+                })
+              }
+            />
+            <span>Hide offline instances</span>
+          </label>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -127,4 +127,21 @@ describe("StarMapScreen", () => {
     rerender(<StarMapScreen {...props} floating={false} />);
     expect(document.activeElement).toBe(region);
   });
+
+  it("offers a visible exit because the map covers the header toggle", async () => {
+    const onClose = vi.fn();
+    render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[]}
+        sessionKeys={{}}
+        floating={false}
+        onClose={onClose}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Close Star Map" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -207,4 +207,34 @@ describe("StarMapScreen", () => {
     // The generic placeholder must never stand in for a real instance.
     expect(screen.queryByText("This instance")).toBeNull();
   });
+
+  it("drops the machine-name chip from cards - the lane already says which instance", async () => {
+    render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[
+          {
+            ...unreadThread("t9"),
+            federation: {
+              ref: {
+                backend: "codex",
+                target: { scope: "remote", instanceId: "pwr_peer" },
+                threadId: "t9",
+              },
+              instanceLabel: "Harold-MBP-M2-Max",
+            },
+          } as unknown as NavigationThreadSummary,
+        ]}
+        sessionKeys={{}}
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("region", { name: "Star Map" })).toBeTruthy();
+    });
+    expect(screen.queryByText("Harold-MBP-M2-Max")).toBeNull();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
@@ -88,7 +94,9 @@ describe("StarMapScreen", () => {
     );
 
     expect(screen.getByRole("button", { name: /Thread t2/ })).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Unread" }));
+    // Scope to the chip row: thread cards also expose an "Unread" status.
+    const filterRow = screen.getByRole("group", { name: "Attention filters" });
+    fireEvent.click(within(filterRow).getByRole("button", { name: /^Unread/ }));
     expect(screen.queryByRole("button", { name: /Thread t2/ })).toBeNull();
   });
 

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -13,6 +13,8 @@ function buildDesktopApi(): DesktopApi {
         status: "disabled" as const,
         instanceId: "pwr_local",
         localCelestialIcon: "sun" as const,
+        localLabel: "Harold-MBP-M5-Max",
+        localProfileName: "default",
         peers: [],
       },
     })),
@@ -143,5 +145,58 @@ describe("StarMapScreen", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Close Star Map" }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disambiguates two profiles on one machine, local included", async () => {
+    const desktopApi: DesktopApi = {
+      readFederationHealth: vi.fn(async () => ({
+        health: {
+          enabled: true,
+          role: "gateway" as const,
+          status: "listening" as const,
+          instanceId: "pwr_local",
+          localLabel: "Harold-MBP-M5-Max",
+          localProfileName: "default",
+          peers: [
+            {
+              id: "pwr_dev",
+              // Same machine, different profile: raw labels collide.
+              label: "Harold-MBP-M5-Max",
+              profileName: "dev",
+              role: "client" as const,
+              status: "disconnected" as const,
+              capabilities: [],
+            },
+          ],
+        },
+      })) as unknown as DesktopApi["readFederationHealth"],
+      onAgentEvent: vi.fn(() => () => undefined),
+    };
+    render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[]}
+        sessionKeys={{}}
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: /Open this instance \(Harold-MBP-M5-Max \/ default\)/,
+        }),
+      ).toBeTruthy();
+    });
+    expect(
+      screen.getByRole("button", {
+        name: /Open remote viewer for Harold-MBP-M5-Max \/ dev/,
+      }),
+    ).toBeTruthy();
+    // The generic placeholder must never stand in for a real instance.
+    expect(screen.queryByText("This instance")).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -237,4 +237,97 @@ describe("StarMapScreen", () => {
     });
     expect(screen.queryByText("Harold-MBP-M2-Max")).toBeNull();
   });
+
+  it("shows only the project and open PRs on a card by default", async () => {
+    const thread = {
+      ...unreadThread("t7"),
+      gitBranch: "agent/some-branch",
+      prs: [
+        {
+          provider: "github",
+          number: 10,
+          org: "pwrdrvr",
+          repo: "PwrAgnt",
+          state: "passing",
+          url: "https://example.test/10",
+        },
+        {
+          provider: "github",
+          number: 11,
+          org: "pwrdrvr",
+          repo: "PwrAgnt",
+          state: "merged",
+          url: "https://example.test/11",
+        },
+      ],
+    } as unknown as NavigationThreadSummary;
+    render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[thread]}
+        sessionKeys={{}}
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    const card = await screen.findByRole("button", { name: /Thread t7/ });
+    // Project chip stays; provider and branch are opt-in.
+    expect(card.textContent).toContain("PwrSnap");
+    expect(card.textContent).not.toContain("OpenAI");
+    expect(card.textContent).not.toContain("agent/some-branch");
+    // Open PR only - the merged one is hidden.
+    expect(card.textContent).toContain("#10");
+    expect(card.textContent).not.toContain("#11");
+  });
+
+  it("hides offline instances when the view option is set", async () => {
+    window.localStorage.clear();
+    const desktopApi: DesktopApi = {
+      readFederationHealth: vi.fn(async () => ({
+        health: {
+          enabled: true,
+          role: "gateway" as const,
+          status: "listening" as const,
+          instanceId: "pwr_local",
+          localLabel: "Local",
+          peers: [
+            {
+              id: "pwr_off",
+              label: "Sleepy-Dev-Box",
+              profileName: "dev",
+              role: "client" as const,
+              status: "disconnected" as const,
+              capabilities: [],
+            },
+          ],
+        },
+      })) as unknown as DesktopApi["readFederationHealth"],
+      onAgentEvent: vi.fn(() => () => undefined),
+    };
+    render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[]}
+        sessionKeys={{}}
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      // Disambiguated label: the profile suffix rides along.
+      expect(screen.getByText(/Sleepy-Dev-Box/)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "View" }));
+    fireEvent.click(screen.getByLabelText("Hide offline instances"));
+    await waitFor(() => {
+      expect(screen.queryByText(/Sleepy-Dev-Box/)).toBeNull();
+    });
+    // The local instance is never hidden by this option.
+    expect(screen.getByText("Local")).toBeTruthy();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
@@ -9,7 +9,6 @@ import {
   clampToCloudRadius,
   computeStarMapLayout,
   generateStarField,
-  pickHoveredCardKey,
   starMapCardSlot,
 } from "../star-map-layout";
 
@@ -289,34 +288,5 @@ describe("countFilterImpact", () => {
       enabled: new Set(["unread"]),
     });
     expect(counts.unread).toBe(0);
-  });
-});
-
-describe("pickHoveredCardKey", () => {
-  // Pitch is tighter than card height, so each card's top band sits under
-  // the previous card's bottom.
-  const cards = [0, 1, 2].map((index) => ({
-    threadKey: `card-${index}`,
-    rect: {
-      left: 0,
-      right: 200,
-      top: index * 84,
-      bottom: index * 84 + 100,
-    },
-  }));
-
-  it("picks the only card under the pointer", () => {
-    expect(pickHoveredCardKey(cards, { x: 10, y: 20 })).toBe("card-0");
-  });
-
-  it("flips to the lower card once the pointer crosses its start", () => {
-    // y=90 is inside card-0's tail AND card-1's head; the next card wins.
-    expect(pickHoveredCardKey(cards, { x: 10, y: 90 })).toBe("card-1");
-    expect(pickHoveredCardKey(cards, { x: 10, y: 174 })).toBe("card-2");
-  });
-
-  it("returns nothing outside the stack", () => {
-    expect(pickHoveredCardKey(cards, { x: 10, y: 400 })).toBeUndefined();
-    expect(pickHoveredCardKey(cards, { x: 900, y: 20 })).toBeUndefined();
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import {
+  countFilterImpact,
   selectAttentionThreads,
   threadAttentionCategories,
 } from "../attention";
@@ -8,6 +9,7 @@ import {
   clampToCloudRadius,
   computeStarMapLayout,
   generateStarField,
+  pickHoveredCardKey,
   starMapCardSlot,
 } from "../star-map-layout";
 
@@ -228,5 +230,93 @@ describe("clampToCloudRadius", () => {
     expect(clampToCloudRadius(30, 40, 100)).toEqual({ dx: 30, dy: 40 });
     const clamped = clampToCloudRadius(300, 400, 100);
     expect(Math.hypot(clamped.dx, clamped.dy)).toBeCloseTo(100);
+  });
+});
+
+describe("countFilterImpact", () => {
+  const threads = [
+    // Unread only: turning Unread off drops it.
+    thread({
+      id: "only-unread",
+      inbox: { inInbox: true, reason: "updated-since-seen" },
+    }),
+    // Unread AND working: neither chip alone drops it.
+    thread({
+      id: "unread-and-working",
+      inbox: { inInbox: true, reason: "updated-since-seen" },
+      threadStatus: "active",
+    }),
+    // Matches only a disabled category, so it would appear if flipped on.
+    thread({
+      id: "only-unpushed",
+      gitWorkingState: {
+        dirtyFiles: 0,
+        dirtyAdditions: 0,
+        dirtyDeletions: 0,
+        untrackedFiles: 0,
+        unpushedCommits: 3,
+      },
+    }),
+    thread({ id: "quiet" }),
+  ];
+
+  it("counts cards that a chip alone is keeping on the map", () => {
+    const counts = countFilterImpact({
+      threads,
+      enabled: new Set(["unread", "active"]),
+    });
+    expect(counts.unread).toBe(1);
+    expect(counts.active).toBe(0);
+  });
+
+  it("counts cards a disabled chip would bring back", () => {
+    const counts = countFilterImpact({
+      threads,
+      enabled: new Set(["unread", "active"]),
+    });
+    expect(counts.unpushed).toBe(1);
+  });
+
+  it("ignores archived threads", () => {
+    const counts = countFilterImpact({
+      threads: [
+        thread({
+          id: "archived",
+          archivedAt: 1,
+          inbox: { inInbox: true, reason: "updated-since-seen" },
+        }),
+      ],
+      enabled: new Set(["unread"]),
+    });
+    expect(counts.unread).toBe(0);
+  });
+});
+
+describe("pickHoveredCardKey", () => {
+  // Pitch is tighter than card height, so each card's top band sits under
+  // the previous card's bottom.
+  const cards = [0, 1, 2].map((index) => ({
+    threadKey: `card-${index}`,
+    rect: {
+      left: 0,
+      right: 200,
+      top: index * 84,
+      bottom: index * 84 + 100,
+    },
+  }));
+
+  it("picks the only card under the pointer", () => {
+    expect(pickHoveredCardKey(cards, { x: 10, y: 20 })).toBe("card-0");
+  });
+
+  it("flips to the lower card once the pointer crosses its start", () => {
+    // y=90 is inside card-0's tail AND card-1's head; the next card wins.
+    expect(pickHoveredCardKey(cards, { x: 10, y: 90 })).toBe("card-1");
+    expect(pickHoveredCardKey(cards, { x: 10, y: 174 })).toBe("card-2");
+  });
+
+  it("returns nothing outside the stack", () => {
+    expect(pickHoveredCardKey(cards, { x: 10, y: 400 })).toBeUndefined();
+    expect(pickHoveredCardKey(cards, { x: 900, y: 20 })).toBeUndefined();
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
@@ -8,8 +8,9 @@ import {
 import {
   clampToCloudRadius,
   computeStarMapLayout,
+  computeCardSlots,
   generateStarField,
-  starMapCardSlot,
+  visibleCardCount,
 } from "../star-map-layout";
 
 function thread(
@@ -197,14 +198,49 @@ describe("computeStarMapLayout", () => {
   });
 });
 
-describe("starMapCardSlot", () => {
-  it("flows cards down a single lane column", () => {
-    expect(starMapCardSlot(0).dx).toBe(0);
-    expect(starMapCardSlot(1).dx).toBe(0);
-    expect(starMapCardSlot(1).dy).toBeGreaterThan(starMapCardSlot(0).dy);
-    expect(starMapCardSlot(2).dy - starMapCardSlot(1).dy).toBe(
-      starMapCardSlot(1).dy - starMapCardSlot(0).dy,
-    );
+describe("computeCardSlots", () => {
+  it("stacks cards from their measured heights so none overlap", () => {
+    const heights = [124, 64, 96];
+    const slots = computeCardSlots(heights);
+    expect(slots.map((slot) => slot.dx)).toEqual([0, 0, 0]);
+    for (let index = 1; index < slots.length; index += 1) {
+      const previousBottom = slots[index - 1].dy + heights[index - 1];
+      expect(slots[index].dy).toBeGreaterThan(previousBottom);
+    }
+  });
+
+  it("keeps a uniform gap regardless of card height", () => {
+    const slots = computeCardSlots([100, 40], { top: 0, gap: 10 });
+    expect(slots[0].dy).toBe(0);
+    expect(slots[1].dy).toBe(110);
+  });
+});
+
+describe("visibleCardCount", () => {
+  it("stops before cards would run off the bottom", () => {
+    const count = visibleCardCount({
+      heights: [120, 120, 120, 120, 120],
+      availableHeight: 460,
+      max: 8,
+    });
+    expect(count).toBeGreaterThan(0);
+    expect(count).toBeLessThan(5);
+  });
+
+  it("never hides the only card a lane has", () => {
+    expect(
+      visibleCardCount({ heights: [400], availableHeight: 120, max: 8 }),
+    ).toBe(1);
+  });
+
+  it("respects the hard cap even with room to spare", () => {
+    expect(
+      visibleCardCount({
+        heights: Array.from({ length: 20 }, () => 40),
+        availableHeight: 5000,
+        max: 8,
+      }),
+    ).toBe(8);
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/useStarMapThreads.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/useStarMapThreads.test.tsx
@@ -1,0 +1,119 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  FederationPeerSummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { useStarMapThreads } from "../useStarMapThreads";
+
+function peer(
+  id: string,
+  status: FederationPeerSummary["status"],
+): FederationPeerSummary {
+  return {
+    id,
+    label: id,
+    role: "client",
+    status,
+    capabilities: ["thread_navigation"],
+  } as FederationPeerSummary;
+}
+
+function buildDesktopApi(): DesktopApi {
+  return {
+    getNavigationSnapshot: vi.fn(async (request) => ({
+      threads: [
+        {
+          id: `thread-${
+            (request as { federationTarget?: { instanceId?: string } })
+              ?.federationTarget?.instanceId ?? "local"
+          }`,
+        } as unknown as NavigationThreadSummary,
+      ],
+    })) as unknown as DesktopApi["getNavigationSnapshot"],
+  };
+}
+
+describe("useStarMapThreads", () => {
+  it("keeps a disconnected peer's cards, marked stale, instead of blanking", async () => {
+    const desktopApi = buildDesktopApi();
+    const { result, rerender } = renderHook(
+      ({ peers }: { peers: FederationPeerSummary[] }) =>
+        useStarMapThreads({ desktopApi, peers, enabled: true }),
+      { initialProps: { peers: [peer("pwr_a", "connected")] } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.threadsByInstance.get("pwr_a")).toHaveLength(1);
+    });
+
+    // The federation reconnect backoff tops out at 30s, so a flapping peer
+    // hits this path repeatedly; the lane must not blink out.
+    rerender({ peers: [peer("pwr_a", "disconnected")] });
+    expect(result.current.threadsByInstance.get("pwr_a")).toHaveLength(1);
+    expect(result.current.staleInstanceIds.has("pwr_a")).toBe(true);
+
+    rerender({ peers: [peer("pwr_a", "connected")] });
+    await waitFor(() => {
+      expect(result.current.staleInstanceIds.has("pwr_a")).toBe(false);
+    });
+    expect(result.current.threadsByInstance.get("pwr_a")).toHaveLength(1);
+  });
+
+  it("drops cards only when the peer leaves the directory", async () => {
+    const desktopApi = buildDesktopApi();
+    const { result, rerender } = renderHook(
+      ({ peers }: { peers: FederationPeerSummary[] }) =>
+        useStarMapThreads({ desktopApi, peers, enabled: true }),
+      {
+        initialProps: {
+          peers: [peer("pwr_a", "connected"), peer("pwr_b", "connected")],
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.threadsByInstance.size).toBe(2);
+    });
+
+    rerender({ peers: [peer("pwr_a", "connected")] });
+    await waitFor(() => {
+      expect(result.current.threadsByInstance.has("pwr_b")).toBe(false);
+    });
+    expect(result.current.threadsByInstance.has("pwr_a")).toBe(true);
+  });
+
+  it("retains cards when a refresh fails and marks the instance unreachable", async () => {
+    let failing = false;
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot: vi.fn(async () => {
+        if (failing) throw new Error("peer unreachable");
+        return {
+          threads: [{ id: "thread-1" } as unknown as NavigationThreadSummary],
+        };
+      }) as unknown as DesktopApi["getNavigationSnapshot"],
+    };
+    const { result, rerender } = renderHook(
+      ({ nonce }: { nonce: number }) =>
+        useStarMapThreads({
+          desktopApi,
+          peers: [peer("pwr_a", "connected")],
+          enabled: true,
+          refreshNonce: nonce,
+        }),
+      { initialProps: { nonce: 0 } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.threadsByInstance.get("pwr_a")).toHaveLength(1);
+    });
+
+    failing = true;
+    rerender({ nonce: 1 });
+    await waitFor(() => {
+      expect(result.current.unreachableInstanceIds.has("pwr_a")).toBe(true);
+    });
+    expect(result.current.threadsByInstance.get("pwr_a")).toHaveLength(1);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/attention.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/attention.ts
@@ -85,3 +85,49 @@ export function selectAttentionThreads(params: {
     )
     .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
 }
+
+/**
+ * How many cards each filter chip is responsible for right now: for an
+ * enabled category, the threads that would DISAPPEAR if it were switched
+ * off (it is their only enabled reason); for a disabled category, the
+ * threads that would APPEAR if it were switched on (nothing else in the
+ * enabled set currently claims them). Either way the number answers "how
+ * many cards does flipping this change".
+ */
+export function countFilterImpact(params: {
+  threads: readonly NavigationThreadSummary[];
+  enabled: ReadonlySet<StarMapAttentionCategory>;
+  sessionKeys?: StarMapSessionKeys;
+}): Record<StarMapAttentionCategory, number> {
+  const counts = Object.fromEntries(
+    STAR_MAP_ATTENTION_CATEGORIES.map((category) => [category, 0]),
+  ) as Record<StarMapAttentionCategory, number>;
+  for (const thread of params.threads) {
+    if (thread.archivedAt !== undefined) continue;
+    const categories = threadAttentionCategories(thread, params.sessionKeys);
+    const enabledMatches = categories.filter((category) =>
+      params.enabled.has(category),
+    );
+    for (const category of categories) {
+      if (params.enabled.has(category)) {
+        // Removing this chip only drops the card when nothing else keeps it.
+        if (enabledMatches.length === 1) counts[category] += 1;
+      } else if (enabledMatches.length === 0) {
+        counts[category] += 1;
+      }
+    }
+  }
+  return counts;
+}
+
+export function addFilterImpactCounts(
+  left: Record<StarMapAttentionCategory, number>,
+  right: Record<StarMapAttentionCategory, number>,
+): Record<StarMapAttentionCategory, number> {
+  return Object.fromEntries(
+    STAR_MAP_ATTENTION_CATEGORIES.map((category) => [
+      category,
+      left[category] + right[category],
+    ]),
+  ) as Record<StarMapAttentionCategory, number>;
+}

--- a/apps/desktop/src/renderer/src/features/star-map/attention.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/attention.ts
@@ -2,6 +2,7 @@ import {
   buildThreadIdentityKey,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
+import { isOpenPullRequest } from "./star-map-preferences";
 
 export const STAR_MAP_ATTENTION_CATEGORIES = [
   "unread",
@@ -50,15 +51,7 @@ export function threadAttentionCategories(
   ) {
     categories.push("approval");
   }
-  if (
-    thread.prs?.some(
-      (pr) =>
-        pr.state !== "merged"
-        && pr.state !== "closed"
-        && pr.lifecycleState !== "merged"
-        && pr.lifecycleState !== "closed",
-    )
-  ) {
+  if (thread.prs?.some(isOpenPullRequest)) {
     categories.push("pr");
   }
   if ((thread.gitWorkingState?.unpushedCommits ?? 0) > 0) {

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
@@ -186,3 +186,37 @@ export function generateStarField(count: number, seed = 7): StarMapStar[] {
   }
   return stars;
 }
+
+export type StarMapCardHitBox = {
+  threadKey: string;
+  rect: { left: number; right: number; top: number; bottom: number };
+};
+
+/**
+ * Which card the pointer is "on" in an overlapping lane stack.
+ *
+ * Cards are pitched tighter than their own height, so each card's top
+ * band sits under the previous card's bottom. Whenever the pointer is in
+ * that shared band the LATER card wins: moving down past the start of the
+ * next card flips to it, even though the raised card is painted over it.
+ * Hit-testing on layout rects (not paint order) keeps the raise from
+ * feeding back into the pick.
+ */
+export function pickHoveredCardKey(
+  cards: readonly StarMapCardHitBox[],
+  point: { x: number; y: number },
+): string | undefined {
+  let picked: string | undefined;
+  for (const card of cards) {
+    const { rect } = card;
+    if (
+      point.x >= rect.left
+      && point.x <= rect.right
+      && point.y >= rect.top
+      && point.y <= rect.bottom
+    ) {
+      picked = card.threadKey;
+    }
+  }
+  return picked;
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
@@ -186,37 +186,3 @@ export function generateStarField(count: number, seed = 7): StarMapStar[] {
   }
   return stars;
 }
-
-export type StarMapCardHitBox = {
-  threadKey: string;
-  rect: { left: number; right: number; top: number; bottom: number };
-};
-
-/**
- * Which card the pointer is "on" in an overlapping lane stack.
- *
- * Cards are pitched tighter than their own height, so each card's top
- * band sits under the previous card's bottom. Whenever the pointer is in
- * that shared band the LATER card wins: moving down past the start of the
- * next card flips to it, even though the raised card is painted over it.
- * Hit-testing on layout rects (not paint order) keeps the raise from
- * feeding back into the pick.
- */
-export function pickHoveredCardKey(
-  cards: readonly StarMapCardHitBox[],
-  point: { x: number; y: number },
-): string | undefined {
-  let picked: string | undefined;
-  for (const card of cards) {
-    const { rect } = card;
-    if (
-      point.x >= rect.left
-      && point.x <= rect.right
-      && point.y >= rect.top
-      && point.y <= rect.bottom
-    ) {
-      picked = card.threadKey;
-    }
-  }
-  return picked;
-}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
@@ -120,19 +120,61 @@ export type StarMapCardSlot = {
   dy: number;
 };
 
-const CLOUD_TOP = 116;
-const CARD_PITCH = 84;
+/** Gap between stacked cards in a lane. */
+export const STAR_MAP_CARD_GAP = 12;
+/** Distance from the instance anchor to the first card. */
+export const STAR_MAP_CLOUD_TOP = 100;
+/** Height assumed for a card that has not been measured yet. */
+export const STAR_MAP_ESTIMATED_CARD_HEIGHT = 112;
+/** Room kept below the last card for the "+N more" affordance. */
+const CLOUD_BOTTOM_RESERVE = 40;
 
 /**
- * Default position of the i-th thread card in an instance's cloud: a
- * single column flowing down the instance's lane. Arrangement sync (drag
- * offsets) layers on top of these slots.
+ * Stack a lane's cards from measured heights.
+ *
+ * Card height varies with how many chip rows a thread carries (a PR chip
+ * plus a branch chip wraps to three rows), so a fixed pitch either
+ * overlaps tall cards - clipping them mid-glyph - or wastes space under
+ * short ones. Positions are cumulative instead, and the caller re-measures
+ * when content changes.
  */
-export function starMapCardSlot(index: number): StarMapCardSlot {
-  return {
-    dx: 0,
-    dy: CLOUD_TOP + index * CARD_PITCH,
-  };
+export function computeCardSlots(
+  heights: readonly number[],
+  options?: { top?: number; gap?: number },
+): StarMapCardSlot[] {
+  const top = options?.top ?? STAR_MAP_CLOUD_TOP;
+  const gap = options?.gap ?? STAR_MAP_CARD_GAP;
+  const slots: StarMapCardSlot[] = [];
+  let y = top;
+  for (const height of heights) {
+    slots.push({ dx: 0, dy: y });
+    y += height + gap;
+  }
+  return slots;
+}
+
+/**
+ * How many cards fit between the instance anchor and the bottom of the
+ * viewport. Always yields at least one so a lane never renders empty when
+ * it has something to show.
+ */
+export function visibleCardCount(params: {
+  heights: readonly number[];
+  availableHeight: number;
+  max: number;
+}): number {
+  const limit = Math.min(params.heights.length, params.max);
+  let used = STAR_MAP_CLOUD_TOP;
+  let count = 0;
+  for (let index = 0; index < limit; index += 1) {
+    const next = used + params.heights[index];
+    if (count > 0 && next + CLOUD_BOTTOM_RESERVE > params.availableHeight) {
+      break;
+    }
+    used = next + STAR_MAP_CARD_GAP;
+    count += 1;
+  }
+  return Math.max(count, Math.min(1, params.heights.length));
 }
 
 /** Clamp an offset to the cloud radius around the instance anchor. */

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-preferences.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-preferences.ts
@@ -1,0 +1,100 @@
+import type { PrSummary } from "@pwragent/shared";
+
+/**
+ * Per-operator view preferences for the Star Map. These are viewing
+ * state, not configuration — they live in localStorage rather than
+ * config.toml so two windows can look at the fleet differently.
+ */
+export type StarMapCardFields = {
+  /** Backend/provider chip ("OpenAI"). */
+  provider: boolean;
+  /** Git branch chip. */
+  branch: boolean;
+  /** First linked directory — the project the thread is about. */
+  primaryDirectory: boolean;
+  /** Any additional linked directories. */
+  secondaryDirectories: boolean;
+  /** Merged/closed PRs. Off means open pull requests only. */
+  terminalPullRequests: boolean;
+};
+
+export type StarMapViewPreferences = {
+  cardFields: StarMapCardFields;
+  /** Drop instances that are not currently connected from the map. */
+  hideOfflineInstances: boolean;
+};
+
+/**
+ * Title, primary directory and open PRs — the "what do I need to review"
+ * signal. Everything else is available but off by default so a card stays
+ * scannable at a glance.
+ */
+export const DEFAULT_STAR_MAP_PREFERENCES: StarMapViewPreferences = {
+  cardFields: {
+    provider: false,
+    branch: false,
+    primaryDirectory: true,
+    secondaryDirectories: false,
+    terminalPullRequests: false,
+  },
+  hideOfflineInstances: false,
+};
+
+export const STAR_MAP_CARD_FIELD_LABELS: Record<
+  keyof StarMapCardFields,
+  string
+> = {
+  provider: "Provider",
+  branch: "Branch name",
+  primaryDirectory: "Project",
+  secondaryDirectories: "Other directories",
+  terminalPullRequests: "Merged / closed PRs",
+};
+
+const STORAGE_KEY = "pwragent.starMap.viewPreferences";
+
+export function readStoredPreferences(): StarMapViewPreferences {
+  if (typeof window === "undefined") return DEFAULT_STAR_MAP_PREFERENCES;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_STAR_MAP_PREFERENCES;
+    const parsed = JSON.parse(raw) as Partial<StarMapViewPreferences>;
+    return {
+      cardFields: {
+        ...DEFAULT_STAR_MAP_PREFERENCES.cardFields,
+        ...(parsed.cardFields ?? {}),
+      },
+      hideOfflineInstances:
+        parsed.hideOfflineInstances
+        ?? DEFAULT_STAR_MAP_PREFERENCES.hideOfflineInstances,
+    };
+  } catch {
+    return DEFAULT_STAR_MAP_PREFERENCES;
+  }
+}
+
+export function writeStoredPreferences(value: StarMapViewPreferences): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+  } catch {
+    // View preferences are disposable; losing them is harmless.
+  }
+}
+
+/** A pull request that still wants attention (not merged, not closed). */
+export function isOpenPullRequest(pr: PrSummary): boolean {
+  return (
+    pr.state !== "merged"
+    && pr.state !== "closed"
+    && pr.lifecycleState !== "merged"
+    && pr.lifecycleState !== "closed"
+  );
+}
+
+export function visiblePullRequests(
+  prs: readonly PrSummary[] | undefined,
+  fields: StarMapCardFields,
+): PrSummary[] {
+  if (!prs) return [];
+  return fields.terminalPullRequests ? [...prs] : prs.filter(isOpenPullRequest);
+}

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapThreads.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapThreads.ts
@@ -8,16 +8,28 @@ import type { DesktopApi } from "../../lib/desktop-api";
 const REMOTE_REFRESH_INTERVAL_MS = 60_000;
 
 export type StarMapRemoteThreads = {
-  /** Per-instance thread lists for connected, navigation-capable peers. */
+  /** Per-instance thread lists, retained across peer reconnect churn. */
   threadsByInstance: Map<string, NavigationThreadSummary[]>;
   /** Instances whose last snapshot fetch failed (rendered as unreachable). */
   unreachableInstanceIds: Set<string>;
+  /**
+   * Instances whose cards are last-known rather than live: the peer is
+   * enrolled but not currently connected, so its cloud renders dimmed
+   * instead of vanishing.
+   */
+  staleInstanceIds: Set<string>;
 };
 
 /**
  * Remote attention-thread feed for the Star Map: one navigation snapshot
  * per connected `thread_navigation` peer, refreshed on a slow tick and on
  * peer reconnects. Per-peer failures degrade that instance's cloud only.
+ *
+ * Retention rule: a peer's cards are dropped ONLY when the peer leaves the
+ * directory entirely (revoked/removed). A peer that merely disconnects
+ * keeps its last-known cards, marked stale — the federation reconnect
+ * backoff tops out at 30s, so pruning on disconnect made a flapping peer's
+ * whole cloud blink out and back on that cadence.
  */
 export function useStarMapThreads(params: {
   desktopApi?: DesktopApi;
@@ -30,9 +42,12 @@ export function useStarMapThreads(params: {
   const [state, setState] = useState<StarMapRemoteThreads>({
     threadsByInstance: new Map(),
     unreachableInstanceIds: new Set(),
+    staleInstanceIds: new Set(),
   });
-  // Peer identity list as a stable string so effect re-runs only when the
-  // connected-peer set actually changes, not on every health object.
+  // Two identity lists as stable strings so effects re-run only when the
+  // sets actually change, not on every health object:
+  //   connected -> who we can fetch from now
+  //   known     -> who still exists at all (retention scope)
   const connectedIds = params.peers
     .filter(
       (peer) =>
@@ -42,7 +57,50 @@ export function useStarMapThreads(params: {
     .map((peer) => peer.id)
     .sort()
     .join("\n");
+  const knownIds = params.peers
+    .map((peer) => peer.id)
+    .sort()
+    .join("\n");
   const generationRef = useRef(0);
+
+  // Retention pass: drop only peers that left the directory, and mark
+  // everything we hold but cannot currently reach as stale.
+  useEffect(() => {
+    const known = new Set(knownIds.length > 0 ? knownIds.split("\n") : []);
+    const connected = new Set(
+      connectedIds.length > 0 ? connectedIds.split("\n") : [],
+    );
+    setState((current) => {
+      const nextThreads = new Map(
+        [...current.threadsByInstance].filter(([instanceId]) =>
+          known.has(instanceId),
+        ),
+      );
+      const nextUnreachable = new Set(
+        [...current.unreachableInstanceIds].filter((instanceId) =>
+          known.has(instanceId),
+        ),
+      );
+      const nextStale = new Set(
+        [...nextThreads.keys()].filter(
+          (instanceId) => !connected.has(instanceId),
+        ),
+      );
+      const unchanged =
+        nextThreads.size === current.threadsByInstance.size
+        && nextUnreachable.size === current.unreachableInstanceIds.size
+        && nextStale.size === current.staleInstanceIds.size
+        && [...nextStale].every((instanceId) =>
+          current.staleInstanceIds.has(instanceId),
+        );
+      if (unchanged) return current;
+      return {
+        threadsByInstance: nextThreads,
+        unreachableInstanceIds: nextUnreachable,
+        staleInstanceIds: nextStale,
+      };
+    });
+  }, [connectedIds, knownIds]);
 
   useEffect(() => {
     if (!params.enabled || !desktopApi?.getNavigationSnapshot) {
@@ -50,31 +108,6 @@ export function useStarMapThreads(params: {
     }
     const instanceIds = connectedIds.length > 0 ? connectedIds.split("\n") : [];
     const generation = (generationRef.current += 1);
-    // Prune instances that left the connected set: without this, a
-    // disconnected peer's last thread list keeps rendering as if current
-    // under an instance card that already shows it offline.
-    setState((current) => {
-      const keep = new Set(instanceIds);
-      const stale = [...current.threadsByInstance.keys()].some(
-        (instanceId) => !keep.has(instanceId),
-      )
-        || [...current.unreachableInstanceIds].some(
-          (instanceId) => !keep.has(instanceId),
-        );
-      if (!stale) return current;
-      return {
-        threadsByInstance: new Map(
-          [...current.threadsByInstance].filter(([instanceId]) =>
-            keep.has(instanceId),
-          ),
-        ),
-        unreachableInstanceIds: new Set(
-          [...current.unreachableInstanceIds].filter((instanceId) =>
-            keep.has(instanceId),
-          ),
-        ),
-      };
-    });
 
     const fetchAll = () => {
       for (const instanceId of instanceIds) {
@@ -91,7 +124,13 @@ export function useStarMapThreads(params: {
                 current.unreachableInstanceIds,
               );
               unreachableInstanceIds.delete(instanceId);
-              return { threadsByInstance, unreachableInstanceIds };
+              const staleInstanceIds = new Set(current.staleInstanceIds);
+              staleInstanceIds.delete(instanceId);
+              return {
+                threadsByInstance,
+                unreachableInstanceIds,
+                staleInstanceIds,
+              };
             });
           })
           .catch(() => {
@@ -101,7 +140,17 @@ export function useStarMapThreads(params: {
                 current.unreachableInstanceIds,
               );
               unreachableInstanceIds.add(instanceId);
-              return { ...current, unreachableInstanceIds };
+              // A failed refresh keeps whatever cards we already had; the
+              // instance card carries the unreachable marker instead.
+              const staleInstanceIds = new Set(current.staleInstanceIds);
+              if (current.threadsByInstance.has(instanceId)) {
+                staleInstanceIds.add(instanceId);
+              }
+              return {
+                ...current,
+                unreachableInstanceIds,
+                staleInstanceIds,
+              };
             });
           });
       }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9181,9 +9181,47 @@ textarea,
   }
 }
 
+/* The map covers the app chrome (including the header toggle that opened
+   it), so it carries its own exit. Top-RIGHT to stay clear of the macOS
+   traffic lights. */
+.star-map__close {
+  display: inline-flex;
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  z-index: 4;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg-panel) 85%, transparent);
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+  -webkit-app-region: no-drag;
+}
+
+.star-map__close:hover {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.star-map__close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
 .star-map__cloud {
   position: absolute;
   z-index: 1;
+}
+
+/* Last-known cards for a peer that is not currently connected: dimmed
+   rather than dropped, so a reconnect flap never blanks the lane. */
+.star-map__cloud--stale {
+  opacity: 0.45;
+  transition: opacity 200ms ease;
 }
 
 /* Soft halo behind a lane's cards so ownership reads at a glance. */

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9251,6 +9251,7 @@ textarea,
   display: flex;
   position: absolute;
   flex-direction: column;
+  overflow: hidden;
   gap: 6px;
   padding: 8px 10px;
   border: 1px solid var(--border-subtle);
@@ -9263,16 +9264,16 @@ textarea,
   transition: border-color 120ms ease, transform 120ms ease;
 }
 
-.star-map-card:hover,
-.star-map-card.is-raised {
-  border-color: var(--accent-border);
-}
-
 /* Lane stacks overlap by design, so the pointer's card lifts clear of its
-   neighbours. Raise is z-index + shadow only: a transform here would move
-   the card's own rect and feed back into the hover hit-test. */
-.star-map-card.is-raised {
+   neighbours. Plain :hover on purpose - a raised card keeps the pointer
+   until it leaves sideways, so its PR chips and links stay clickable all
+   the way down. (An earlier version hit-tested layout rects and flipped to
+   the next card the moment the pointer crossed its top band, which made
+   everything below the first line unclickable.) No transform: the card
+   must not move under the pointer. */
+.star-map-card:hover {
   z-index: 5;
+  border-color: var(--accent-border);
   background: var(--bg-panel-elevated);
   box-shadow: var(--shadow-popover);
 }
@@ -9302,6 +9303,26 @@ textarea,
   .star-map-card {
     transition: none;
   }
+}
+
+/* The owning instance's mark, watermarked behind the card content -
+   the lane already groups by instance, so the machine name chip was
+   spending prime card width on information the position carries. */
+.star-map-card__watermark {
+  position: absolute;
+  right: -18px;
+  bottom: -22px;
+  z-index: 0;
+  color: var(--text-muted);
+  opacity: 0.09;
+  pointer-events: none;
+}
+
+/* Positioned so the content paints above the watermark's z-index 0. */
+.star-map-card__heading,
+.star-map-card__chips {
+  position: relative;
+  z-index: 1;
 }
 
 .star-map-card__heading {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9256,7 +9256,9 @@ textarea,
   padding: 8px 10px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  background: color-mix(in srgb, var(--bg-panel) 94%, transparent);
+  /* Opaque on purpose: lanes overlap, and a translucent card lets the one
+     beneath show through its own text. */
+  background: var(--bg-panel);
   color: var(--text-primary);
   text-align: left;
   cursor: pointer;
@@ -9310,11 +9312,11 @@ textarea,
    spending prime card width on information the position carries. */
 .star-map-card__watermark {
   position: absolute;
-  right: -18px;
-  bottom: -22px;
+  top: -14px;
+  right: -12px;
   z-index: 0;
   color: var(--text-muted);
-  opacity: 0.09;
+  opacity: 0.11;
   pointer-events: none;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9263,9 +9263,18 @@ textarea,
   transition: border-color 120ms ease, transform 120ms ease;
 }
 
-.star-map-card:hover {
+.star-map-card:hover,
+.star-map-card.is-raised {
   border-color: var(--accent-border);
-  transform: translateY(-1px);
+}
+
+/* Lane stacks overlap by design, so the pointer's card lifts clear of its
+   neighbours. Raise is z-index + shadow only: a transform here would move
+   the card's own rect and feed back into the hover hit-test. */
+.star-map-card.is-raised {
+  z-index: 5;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
 }
 
 .star-map-card:focus-visible {
@@ -9290,8 +9299,8 @@ textarea,
   .star-map-card {
     animation-duration: 0s;
   }
-  .star-map-card:hover {
-    transform: none;
+  .star-map-card {
+    transition: none;
   }
 }
 
@@ -9361,6 +9370,9 @@ textarea,
 }
 
 .star-map__filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   padding: 4px 10px;
   border: 1px solid var(--border-subtle);
   border-radius: 6px;
@@ -9379,6 +9391,41 @@ textarea,
 .star-map__filter-chip:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
+}
+
+/* How many cards appear/disappear if this chip is flipped. */
+.star-map__filter-count {
+  min-width: 14px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-muted) 18%, transparent);
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  line-height: 15px;
+  text-align: center;
+}
+
+.star-map__filter-chip.is-on .star-map__filter-count {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  color: var(--text-primary);
+}
+
+/* The map's top chrome sits inside the macOS title-bar drag band, and
+   Chromium ignores `-webkit-app-region` on inline-level boxes - a plain
+   <button> there has its clicks swallowed by the OS (the same trap
+   documented on .messaging-status-bar). Every interactive element gets an
+   explicit no-drag on a non-inline box; the bare sky stays draggable so
+   the window can still be moved while the map is open. */
+.star-map__filters,
+.star-map__filters *,
+.star-map__close,
+.star-map__close *,
+.star-map-instance,
+.star-map-instance *,
+.star-map-card,
+.star-map-card * {
+  -webkit-app-region: no-drag;
 }
 
 /* Floating thread over the map: the already-mounted main pane elevates

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9382,6 +9382,56 @@ textarea,
   }
 }
 
+/* "View" popover: card density + instance visibility, parked opposite the
+   attention filters. */
+.star-map__chrome {
+  position: absolute;
+  top: 14px;
+  left: 16px;
+  z-index: 4;
+}
+
+.star-map__view-options {
+  position: relative;
+}
+
+.star-map__view-panel {
+  display: flex;
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  flex-direction: column;
+  gap: 4px;
+  width: 208px;
+  padding: 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+}
+
+.star-map__view-heading {
+  margin: 4px 0 2px;
+  color: var(--text-muted);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.star-map__view-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-primary);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.star-map__chrome,
+.star-map__chrome * {
+  -webkit-app-region: no-drag;
+}
+
 .star-map__filters {
   display: flex;
   position: absolute;

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -254,6 +254,18 @@ export type FederationHealthStatus = {
   gatewayEndpoints?: FederationEndpointStatus[];
   /** This instance's own assigned celestial identity icon. */
   localCelestialIcon?: CelestialIconId;
+  /**
+   * This instance's display label — the resolved `instanceLabel` config
+   * value, falling back to the hostname default. Surfaces mirroring the
+   * peer list need the local instance's real name, not a placeholder.
+   */
+  localLabel?: string;
+  /**
+   * Active profile name for this instance. Two profiles on one machine
+   * share a label, so this is what tells them apart via
+   * {@link formatFederationPeerDisplayLabel}.
+   */
+  localProfileName?: string;
   peers: FederationPeerSummary[];
   clientEnrollment?: FederationClientEnrollment;
 };


### PR DESCRIPTION
Operator-review fixes stacked on #1252. Kept separate rather than rewriting the earlier PRs, so the series stays reviewable in the order it was built.

## Remote lanes blanked every ~30 seconds

The cloud prune added during the #1250 review pass keyed off the **connected** peer set, so any peer flap dropped that instance's cards until the next 60s fetch. The federation reconnect backoff tops out at exactly 30s, which is why lanes blinked on that cadence.

Retention now keys off the **known** peer set:

- Cards are dropped only when a peer leaves the directory (revoked/removed).
- A merely-disconnected peer keeps its last-known cards, rendered dimmed via a new `staleInstanceIds` set — the instance card already carries the offline status dot, so the lane reads as "last known" rather than vanishing.
- A failed refresh also retains cards and marks the instance unreachable instead of emptying the lane.

## No way out of the map

The map layer covers the app chrome — including the header toggle that opened it — so Escape (which requires layer focus) was the only exit. Added a persistent **Close map** button in the top-right, clear of the macOS traffic lights, with the `-webkit-app-region: no-drag` carve-out.

## Testing

- New `useStarMapThreads` hook tests: disconnect keeps cards + marks stale, reconnect clears stale, directory removal drops cards, failed refresh retains cards.
- New screen test for the close affordance.
- Full workspace suite: 6467 passed / 3 skipped. Typecheck, `lint:colors`, ESLint (0 errors) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)