### PR TITLE
fix(desktop): non-blocking remote pin merge and PR #1247 follow-ups

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -262,7 +262,18 @@ const reconcileNavigationSnapshot = vi.fn(async (params: unknown) => ({
   backend: (params as { backend: "all" | "codex" | "grok" }).backend,
   fetchedAt: 1234,
   unchanged: false,
-  threads: (params as { threads: unknown[] }).threads,
+  // Mirror the real reconcile: every materialized row carries a derived
+  // inbox state, consistent with the inboxThreadKeys below. The remote-pin
+  // merge re-ranks the combined local + remote rows from these states.
+  threads: (params as { threads: Array<{ source: string; id: string }> }).threads.map(
+    (thread) => ({
+      inbox:
+        `${thread.source}:${thread.id}` === "grok:thread-1"
+          ? { inInbox: true, reason: "updated-since-seen" as const }
+          : { inInbox: false },
+      ...thread,
+    }),
+  ) as unknown[],
   inboxThreadKeys: ["grok:thread-1"],
   directories: [
     {
@@ -1838,7 +1849,11 @@ describe("app server ipc", () => {
       threads: Array<{ id: string }>;
       inboxThreadKeys: string[];
       unchanged: boolean;
-      directories: Array<{ key: string; threadKeys: string[] }>;
+      directories: Array<{
+        key: string;
+        threadKeys: string[];
+        needsAttentionCount: number;
+      }>;
     };
 
     expect(
@@ -1854,8 +1869,13 @@ describe("app server ipc", () => {
       (thread) => thread.id === "remote-1",
     ) as { pinnedRank?: string } | undefined;
     expect(mergedRemoteRow?.pinnedRank).toBeUndefined();
-    // The remote row joins the inbox ranking behind the local keys.
-    expect(response.inboxThreadKeys).toContain("codex:remote-1");
+    // Unified inbox ranking over local + remote rows: the fresher remote
+    // unread (updatedAt 9000) outranks the stale local unread (1000)
+    // instead of always trailing every local key.
+    expect(response.inboxThreadKeys).toEqual([
+      "codex:remote-1",
+      "grok:thread-1",
+    ]);
     // A newly appearing remote row must defeat the unchanged optimization.
     expect(response.unchanged).toBe(false);
     // Consolidated into the matching LOCAL project group (label "app"), so
@@ -1864,6 +1884,9 @@ describe("app server ipc", () => {
       (directory) => directory.key === "directory:/repo/app",
     );
     expect(appDirectory?.threadKeys).toContain("codex:remote-1");
+    // The unread remote row bumps the group's "N to review" badge past the
+    // reconcile-computed local count.
+    expect(appDirectory?.needsAttentionCount).toBe(2);
   });
 
   it("removes a viewer-side remote pin when the owner proves it is archived", async () => {
@@ -1908,7 +1931,10 @@ describe("app server ipc", () => {
       backend: (params as { backend: "all" | "codex" | "grok" }).backend,
       fetchedAt: 1234,
       unchanged: false,
-      threads: (params as { threads: unknown[] }).threads,
+      threads: (params as { threads: object[] }).threads.map((thread) => ({
+        inbox: { inInbox: false },
+        ...thread,
+      })),
       inboxThreadKeys: [],
       directories: [
         {
@@ -2280,6 +2306,58 @@ describe("app server ipc", () => {
     expect(addRemoteThreadPinStore.mock.calls[0][0]).toMatchObject({
       pinnedVia: "explicit",
     });
+  });
+
+  it("rejects malformed pin refs at the service boundary", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const {
+      NAVIGATION_ADD_REMOTE_THREAD_PIN_CHANNEL,
+      NAVIGATION_REMOVE_REMOTE_THREAD_PIN_CHANNEL,
+      NAVIGATION_SET_REMOTE_THREAD_LOCAL_PIN_CHANNEL,
+    } = await import("../../shared/ipc");
+
+    registerAppServerIpcHandlers();
+    addRemoteThreadPinStore.mockClear();
+    setRemoteThreadLocalPin.mockClear();
+
+    // A malformed instance id (spaces, punctuation) must never reach the
+    // store — the sqlite key would persist a row that dims forever.
+    const badInstanceRef = {
+      backend: "codex" as const,
+      target: { scope: "remote" as const, instanceId: "peer laptop!" },
+      threadId: "thread-1",
+    };
+    // An unknown backend kind is equally unresolvable later.
+    const badBackendRef = {
+      backend: "not-a-backend",
+      target: { scope: "remote" as const, instanceId: "peer-laptop" },
+      threadId: "thread-1",
+    };
+    await expect(
+      handlers.get(NAVIGATION_ADD_REMOTE_THREAD_PIN_CHANNEL)?.({}, {
+        ref: badInstanceRef,
+        instanceLabel: "Laptop",
+      }),
+    ).rejects.toThrow(/remote federation target/i);
+    await expect(
+      handlers.get(NAVIGATION_ADD_REMOTE_THREAD_PIN_CHANNEL)?.({}, {
+        ref: badBackendRef,
+        instanceLabel: "Laptop",
+      }),
+    ).rejects.toThrow(/backend/i);
+    await expect(
+      handlers.get(NAVIGATION_REMOVE_REMOTE_THREAD_PIN_CHANNEL)?.({}, {
+        ref: badInstanceRef,
+      }),
+    ).rejects.toThrow(/remote federation target/i);
+    await expect(
+      handlers.get(NAVIGATION_SET_REMOTE_THREAD_LOCAL_PIN_CHANNEL)?.({}, {
+        ref: badInstanceRef,
+        pinnedRank: "1024",
+      }),
+    ).rejects.toThrow(/remote federation target/i);
+    expect(addRemoteThreadPinStore).not.toHaveBeenCalled();
+    expect(setRemoteThreadLocalPin).not.toHaveBeenCalled();
   });
 
   it("keeps pinned remote rows, dimmed, when the owner is unreachable", async () => {

--- a/apps/desktop/src/main/__tests__/federation-reset-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-reset-enrollment.test.ts
@@ -10,6 +10,10 @@ const metaStore = vi.hoisted(() => new Map<string, string>());
 const configPatches = vi.hoisted(() => [] as DesktopSettingsConfigPatch[]);
 const clearedSecrets = vi.hoisted(() => [] as string[]);
 const federationMode = vi.hoisted(() => ({ value: "dual" as string }));
+const removeRemoteThreadPinsForInstance = vi.hoisted(() =>
+  vi.fn(async (_params: { instanceId: string }) => 2),
+);
+const publishLocalEvent = vi.hoisted(() => vi.fn(async () => undefined));
 
 vi.mock("../state/app-state", () => ({
   getAppStateDb: () => ({
@@ -17,6 +21,19 @@ vi.mock("../state/app-state", () => ({
     setMeta: (key: string, value: string) => void metaStore.set(key, value),
   }),
   isAppStateInitialized: () => true,
+}));
+
+vi.mock("../app-server/desktop-overlay-store", () => ({
+  getDesktopOverlayStore: () => ({
+    removeRemoteThreadPinsForInstance,
+  }),
+}));
+
+vi.mock("../app-server/backend-registry", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getDesktopBackendRegistry: () => ({
+    publishLocalEvent,
+  }),
 }));
 
 vi.mock("../settings/desktop-settings-singleton", () => ({
@@ -56,6 +73,8 @@ describe("federation resetEnrollment", () => {
     configPatches.length = 0;
     clearedSecrets.length = 0;
     federationMode.value = "dual";
+    removeRemoteThreadPinsForInstance.mockClear();
+    publishLocalEvent.mockClear();
     metaStore.set(GATEWAY_ID_KEY, "gateway_one");
     metaStore.set("federation_gateway_public_key_pem", "pem");
     metaStore.set("federation_gateway_noise_public_key", "noise");
@@ -98,5 +117,85 @@ describe("federation resetEnrollment", () => {
     metaStore.set(GATEWAY_ID_KEY, "");
 
     expect(await createHarness().resetEnrollment()).toEqual({ cleared: false });
+    // No pairing → no instance whose pins could be attributed to it.
+    expect(removeRemoteThreadPinsForInstance).not.toHaveBeenCalled();
+  });
+
+  it("drops the forgotten gateway's remote pins and pokes the renderer", async () => {
+    await createHarness().resetEnrollment();
+
+    expect(removeRemoteThreadPinsForInstance).toHaveBeenCalledWith({
+      instanceId: "gateway_one",
+    });
+    expect(publishLocalEvent).toHaveBeenCalledWith({
+      backend: "codex",
+      notification: {
+        method: "navigation/remoteThreadPins/changed",
+        params: { instanceId: "gateway_one", pinned: false },
+      },
+    });
+  });
+
+  it("skips the pins-changed event when the gateway had no pins", async () => {
+    removeRemoteThreadPinsForInstance.mockResolvedValueOnce(0);
+
+    await createHarness().resetEnrollment();
+
+    expect(publishLocalEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("federation revokePeer — remote pin cleanup", () => {
+  beforeEach(() => {
+    removeRemoteThreadPinsForInstance.mockClear();
+    publishLocalEvent.mockClear();
+  });
+
+  type RevokeHarness = {
+    store: () => unknown;
+    revokePeer: (peerId: string) => Promise<{ status: string }>;
+  };
+
+  function createRevokeHarness(): RevokeHarness {
+    const runtime = new DesktopFederationRuntime() as unknown as RevokeHarness;
+    runtime.store = () => ({
+      getPeer: (peerId: string) => ({
+        id: peerId,
+        label: "Old laptop",
+        role: "client",
+        status: "connected",
+        capabilities: [],
+        canRevoke: true,
+      }),
+      revokePeer: () => undefined,
+    });
+    return runtime;
+  }
+
+  it("deletes the revoked instance's pins and pokes the renderer", async () => {
+    const peer = await createRevokeHarness().revokePeer("client_one");
+
+    expect(peer.status).toBe("revoked");
+    expect(removeRemoteThreadPinsForInstance).toHaveBeenCalledWith({
+      instanceId: "client_one",
+    });
+    expect(publishLocalEvent).toHaveBeenCalledWith({
+      backend: "codex",
+      notification: {
+        method: "navigation/remoteThreadPins/changed",
+        params: { instanceId: "client_one", pinned: false },
+      },
+    });
+  });
+
+  it("still revokes when pin cleanup fails", async () => {
+    removeRemoteThreadPinsForInstance.mockRejectedValueOnce(
+      new Error("db locked"),
+    );
+
+    const peer = await createRevokeHarness().revokePeer("client_one");
+
+    expect(peer.status).toBe("revoked");
+    expect(publishLocalEvent).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/__tests__/remote-thread-pins-store.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-pins-store.test.ts
@@ -275,6 +275,73 @@ describe("SqliteOverlayStore — remote thread pins", () => {
     expect(await store.hasRemoteThreadPin({ ref: ref("nope") })).toBe(false);
   });
 
+  it("skips byte-equal snapshot rewrites", async () => {
+    await store.addRemoteThreadPin({
+      ref: ref(),
+      summary: summary(),
+      instanceLabel: "Laptop",
+    });
+    // Count actual row rewrites — the merge refreshes payloads on every
+    // navigation snapshot, and unchanged data must not churn the db.
+    stateDb.raw.exec(
+      `CREATE TEMP TABLE pin_write_log(n INTEGER);
+       CREATE TEMP TRIGGER pin_update_log AFTER UPDATE ON remote_thread_pins
+       BEGIN INSERT INTO pin_write_log VALUES (1); END;`,
+    );
+    const entry = {
+      ref: ref(),
+      summary: summary(),
+      instanceLabel: "Laptop",
+    };
+    await store.updateRemoteThreadPinSnapshots([entry]);
+    await store.updateRemoteThreadPinSnapshots([entry]);
+    const unchangedWrites = stateDb.raw
+      .prepare("SELECT COUNT(*) AS count FROM pin_write_log")
+      .get() as { count: number };
+    expect(unchangedWrites.count).toBe(0);
+
+    await store.updateRemoteThreadPinSnapshots([
+      { ...entry, summary: summary({ title: "Changed" }) },
+    ]);
+    const changedWrites = stateDb.raw
+      .prepare("SELECT COUNT(*) AS count FROM pin_write_log")
+      .get() as { count: number };
+    expect(changedWrites.count).toBe(1);
+  });
+
+  it("removes every pin for one instance in a single call", async () => {
+    await store.addRemoteThreadPin({
+      ref: ref("t1", "peer-revoked"),
+      summary: summary({ id: "t1" }),
+      instanceLabel: "Old laptop",
+    });
+    await store.addRemoteThreadPin({
+      ref: ref("t2", "peer-revoked"),
+      summary: summary({ id: "t2" }),
+      instanceLabel: "Old laptop",
+    });
+    await store.addRemoteThreadPin({
+      ref: ref("t3", "peer-kept"),
+      summary: summary({ id: "t3" }),
+      instanceLabel: "Desktop",
+    });
+
+    expect(
+      await store.removeRemoteThreadPinsForInstance({
+        instanceId: "peer-revoked",
+      }),
+    ).toBe(2);
+    const listed = await store.listRemoteThreadPins();
+    expect(listed).toHaveLength(1);
+    expect(listed[0].ref.threadId).toBe("t3");
+
+    expect(
+      await store.removeRemoteThreadPinsForInstance({
+        instanceId: "peer-revoked",
+      }),
+    ).toBe(0);
+  });
+
   it("updates cached snapshots in batch", async () => {
     await store.addRemoteThreadPin({
       ref: ref("t1"),

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -383,20 +383,40 @@ describe("RemoteThreadSummaryCache — threadFromPeer", () => {
   });
 });
 
+/** Let a kicked-off background refresh chain settle. */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
-  it("serves fresh stamped rows for reachable owners and queues payload refreshes", async () => {
+  it("serves cached stamped rows for reachable owners and queues payload refreshes", async () => {
     const fresh = stampedThread({
       instanceId: "peer-a",
       threadId: "t1",
       title: "Fresh title",
       updatedAt: 50,
     });
+    const onPinnedSummariesRefreshed = vi.fn();
     const cache = new RemoteThreadSummaryCache({
       peers: () => [peer("peer-a", "Laptop")],
       fetchSnapshot: async () => snapshotOf([fresh]),
       fetchArchivedThreads: noArchivedThreads,
       peerStatus: () => ({ status: "connected", label: "Laptop" }),
+      onPinnedSummariesRefreshed,
     });
+
+    // Cold cache: the pin's persisted payload serves immediately while the
+    // snapshot fetch runs in the background.
+    const cold = await cache.resolvePinnedThreads([
+      pin({ instanceId: "peer-a", threadId: "t1" }),
+    ]);
+    expect(cold.threads).toHaveLength(1);
+    expect(cold.threads[0].title).toBe("t1");
+    expect(cold.refreshed).toEqual([]);
+
+    await settle();
+    expect(onPinnedSummariesRefreshed).toHaveBeenCalledWith("peer-a");
 
     const resolved = await cache.resolvePinnedThreads([
       pin({ instanceId: "peer-a", threadId: "t1" }),
@@ -405,6 +425,45 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
     expect(resolved.threads[0].title).toBe("Fresh title");
     expect(resolved.refreshed).toHaveLength(1);
     expect(resolved.refreshed[0].summary.title).toBe("Fresh title");
+  });
+
+  it("returns promptly with cached rows while a peer fetch hangs", async () => {
+    let now = 0;
+    let hang = false;
+    const fetchSnapshot = vi.fn(async () => {
+      if (hang) {
+        return await new Promise<never>(() => {});
+      }
+      return snapshotOf([
+        stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Cached" }),
+      ]);
+    });
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot,
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({ status: "connected" }),
+      ttlMs: 100,
+      peerTimeoutMs: 10_000,
+      now: () => now,
+    });
+
+    await cache.resolvePinnedThreads([
+      pin({ instanceId: "peer-a", threadId: "t1" }),
+    ]);
+    await settle();
+
+    // TTL expired and the peer stops answering: the resolve must still
+    // return immediately with the stale cached rows — a slow peer can
+    // never stall the navigation snapshot.
+    now = 500;
+    hang = true;
+    const resolved = await cache.resolvePinnedThreads([
+      pin({ instanceId: "peer-a", threadId: "t1" }),
+    ]);
+    expect(fetchSnapshot).toHaveBeenCalledTimes(2);
+    expect(resolved.threads[0].title).toBe("Cached");
+    expect(resolved.threads[0].federation?.peerStatus).toBe("connected");
   });
 
   it("falls back to the cached payload, dimmed, when the owner is unreachable", async () => {
@@ -433,7 +492,8 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
     expect(resolved.refreshed).toEqual([]);
   });
 
-  it("dims rows as degraded when a connected owner fails the fetch", async () => {
+  it("dims rows as degraded once a connected owner fails the background fetch", async () => {
+    const onPinnedSummariesRefreshed = vi.fn();
     const cache = new RemoteThreadSummaryCache({
       peers: () => [peer("peer-a")],
       fetchSnapshot: async () => {
@@ -441,12 +501,180 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
       },
       fetchArchivedThreads: noArchivedThreads,
       peerStatus: () => ({ status: "connected" }),
+      onPinnedSummariesRefreshed,
     });
+
+    // First resolve is optimistic — the failure lands in the background
+    // and pokes the callback so the next merge can dim the rows.
+    await cache.resolvePinnedThreads([
+      pin({ instanceId: "peer-a", threadId: "t1" }),
+    ]);
+    await settle();
+    expect(onPinnedSummariesRefreshed).toHaveBeenCalledTimes(1);
 
     const resolved = await cache.resolvePinnedThreads([
       pin({ instanceId: "peer-a", threadId: "t1" }),
     ]);
     expect(resolved.threads[0].federation?.peerStatus).toBe("degraded");
+
+    // A repeat failure stays silent — re-firing would loop the renderer
+    // refresh cycle against a peer that keeps failing.
+    await settle();
+    expect(onPinnedSummariesRefreshed).toHaveBeenCalledTimes(1);
+  });
+
+  it("announces recovery so dimmed rows can un-dim", async () => {
+    let fail = true;
+    const onPinnedSummariesRefreshed = vi.fn();
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => {
+        if (fail) {
+          throw new Error("boom");
+        }
+        return snapshotOf([
+          stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Live" }),
+        ]);
+      },
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({ status: "connected" }),
+      onPinnedSummariesRefreshed,
+    });
+    const pins = [pin({ instanceId: "peer-a", threadId: "t1" })];
+
+    await cache.resolvePinnedThreads(pins);
+    await settle();
+    expect(onPinnedSummariesRefreshed).toHaveBeenCalledTimes(1);
+
+    fail = false;
+    await cache.resolvePinnedThreads(pins);
+    await settle();
+    expect(onPinnedSummariesRefreshed).toHaveBeenCalledTimes(2);
+
+    const resolved = await cache.resolvePinnedThreads(pins);
+    expect(resolved.threads[0].title).toBe("Live");
+    expect(resolved.threads[0].federation?.peerStatus).toBe("connected");
+  });
+
+  it("un-dims when a jump-search fetch proves the peer is alive", async () => {
+    let now = 0;
+    let fail = true;
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => {
+        if (fail) {
+          throw new Error("boom");
+        }
+        return snapshotOf([
+          stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Live" }),
+        ]);
+      },
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({ status: "connected" }),
+      ttlMs: 100,
+      now: () => now,
+    });
+    const pins = [pin({ instanceId: "peer-a", threadId: "t1" })];
+
+    await cache.resolvePinnedThreads(pins);
+    await settle();
+
+    // The peer recovers, and it is the JUMP SEARCH that observes it — the
+    // pinned-refresh path never runs. The failure flag must still clear,
+    // or live rows would render dimmed until the next TTL lapse.
+    now = 50;
+    fail = false;
+    await cache.searchForJump({ query: "Live" });
+    await settle();
+
+    const resolved = await cache.resolvePinnedThreads(pins);
+    expect(resolved.threads[0].title).toBe("Live");
+    expect(resolved.threads[0].federation?.peerStatus).toBe("connected");
+    expect(resolved.refreshed).toHaveLength(1);
+  });
+
+  it("serves stale cached rows dimmed while a connected owner keeps failing", async () => {
+    let now = 0;
+    let fail = false;
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => {
+        if (fail) {
+          throw new Error("boom");
+        }
+        return snapshotOf([
+          stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Cached" }),
+        ]);
+      },
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({ status: "connected" }),
+      ttlMs: 100,
+      now: () => now,
+    });
+
+    await cache.resolvePinnedThreads([
+      pin({ instanceId: "peer-a", threadId: "t1" }),
+    ]);
+    await settle();
+
+    now = 500;
+    fail = true;
+    await cache.resolvePinnedThreads([
+      pin({ instanceId: "peer-a", threadId: "t1" }),
+    ]);
+    await settle();
+
+    // Stale snapshot data still beats the pin payload, but must dim: the
+    // peer claims connected and is not actually serving.
+    const resolved = await cache.resolvePinnedThreads([
+      pin({ instanceId: "peer-a", threadId: "t1" }),
+    ]);
+    expect(resolved.threads[0].title).toBe("Cached");
+    expect(resolved.threads[0].federation?.peerStatus).toBe("degraded");
+    expect(resolved.refreshed).toEqual([]);
+  });
+
+  it("stamps the peer's viewer-actionable capabilities onto fallback rows", async () => {
+    // Capabilities belong to the PEER, not the cached row, so a row served
+    // before any snapshot has landed must still carry them — otherwise the
+    // thread view reports "remote terminal not granted" for a peer that
+    // grants it, on every cold start. The owner supplies the already
+    // relay-stripped set; the cache must not invent one.
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => await new Promise<never>(() => {}),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({
+        status: "connected",
+        label: "Laptop",
+        capabilities: ["thread_navigation", "remote_pty"],
+      }),
+    });
+
+    const resolved = await cache.resolvePinnedThreads([
+      pin({ instanceId: "peer-a", threadId: "t1" }),
+    ]);
+    expect(resolved.threads[0].federation?.capabilities).toEqual([
+      "thread_navigation",
+      "remote_pty",
+    ]);
+  });
+
+  it("stamps no capabilities when the owner reports none", async () => {
+    // A gateway-relayed peer arrives here already stripped of remote_pty,
+    // and an unknown peer reports nothing at all. Either way the cache
+    // passes through rather than falling back to the raw granted set.
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({ status: "disconnected", label: "Laptop" }),
+    });
+
+    const resolved = await cache.resolvePinnedThreads([
+      pin({ instanceId: "peer-a", threadId: "t1" }),
+    ]);
+    expect(resolved.threads[0].federation?.capabilities).toEqual([]);
   });
 
   it("synthesizes a minimal row when the pin has no cached summary", async () => {
@@ -504,12 +732,20 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
     });
     const archivedPin = pin({ instanceId: "peer-a", threadId: "archived" });
 
-    const resolved = await cache.resolvePinnedThreads([archivedPin]);
+    // Proving a pin archived needs a fresh snapshot AND an owner lookup,
+    // both of which run in the background so the merge never stalls. The
+    // first resolve therefore still serves the cached row; the proof is
+    // reported on the next one, which the refresh event triggers.
+    const optimistic = await cache.resolvePinnedThreads([archivedPin]);
+    expect(optimistic.archived).toEqual([]);
+    await settle();
 
     expect(fetchArchivedThreads).toHaveBeenCalledWith(
       remoteTarget("peer-a"),
       "codex",
     );
+
+    const resolved = await cache.resolvePinnedThreads([archivedPin]);
     expect(resolved.threads).toEqual([]);
     expect(resolved.refreshed).toEqual([]);
     expect(resolved.archived).toEqual([archivedPin.ref]);
@@ -525,17 +761,26 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
       .fn()
       .mockResolvedValueOnce([archivedThread])
       .mockResolvedValueOnce([]);
+    let now = 0;
     const cache = new RemoteThreadSummaryCache({
       peers: () => [peer("peer-a")],
       fetchSnapshot: async () => snapshotOf([]),
       fetchArchivedThreads,
       peerStatus: () => ({ status: "connected" }),
+      ttlMs: 100,
+      now: () => now,
     });
     const firstPin = pin({ instanceId: "peer-a", threadId: "restored" });
+
+    await cache.resolvePinnedThreads([firstPin]);
+    await settle();
     expect((await cache.resolvePinnedThreads([firstPin])).archived).toEqual([
       firstPin.ref,
     ]);
 
+    // The owner restored the thread and the viewer re-pinned it. The spent
+    // proof must never prune it a second time — only fresh evidence can,
+    // and this pass proves it is no longer archived.
     const cachedSummary = { ...archivedThread };
     delete cachedSummary.federation;
     const readdedPin = {
@@ -546,6 +791,9 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
       }),
       addedAt: 2_000,
     };
+    now = 500;
+    await cache.resolvePinnedThreads([readdedPin]);
+    await settle();
     const resolved = await cache.resolvePinnedThreads([readdedPin]);
 
     expect(fetchArchivedThreads).toHaveBeenCalledTimes(2);
@@ -554,37 +802,28 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
     expect(resolved.threads[0].title).toBe("Restored on owner");
   });
 
-  it("shares one peer deadline between the active and archived lookups", async () => {
-    vi.useFakeTimers();
-    try {
-      const cache = new RemoteThreadSummaryCache({
-        peers: () => [peer("peer-a")],
-        fetchSnapshot: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 75));
-          return snapshotOf([]);
-        },
-        fetchArchivedThreads: async () => await new Promise<never>(() => {}),
-        peerStatus: () => ({ status: "connected" }),
-        peerTimeoutMs: 100,
-      });
-      const resolution = cache.resolvePinnedThreads([
-        pin({ instanceId: "peer-a", threadId: "missing" }),
-      ]);
-      let settled = false;
-      void resolution.then(() => {
-        settled = true;
-      });
+  it("never waits on the archived lookup, even when it hangs", async () => {
+    // The archived probe used to share the merge's peer deadline, which
+    // meant a slow owner delayed navigation. It now runs in the same
+    // background pass as the snapshot fetch, so a probe that never answers
+    // costs the merge nothing — the pin simply keeps its cached row.
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: async () => await new Promise<never>(() => {}),
+      peerStatus: () => ({ status: "connected" }),
+      peerTimeoutMs: 100,
+    });
+    const missingPin = pin({ instanceId: "peer-a", threadId: "missing" });
 
-      await vi.advanceTimersByTimeAsync(99);
-      expect(settled).toBe(false);
-      await vi.advanceTimersByTimeAsync(1);
+    const resolved = await cache.resolvePinnedThreads([missingPin]);
+    expect(resolved.archived).toEqual([]);
+    expect(resolved.threads).toHaveLength(1);
 
-      const resolved = await resolution;
-      expect(resolved.archived).toEqual([]);
-      expect(resolved.threads).toHaveLength(1);
-    } finally {
-      vi.useRealTimers();
-    }
+    await settle();
+    const again = await cache.resolvePinnedThreads([missingPin]);
+    expect(again.archived).toEqual([]);
+    expect(again.threads).toHaveLength(1);
   });
 
   it("keeps the cached row when archive detection fails", async () => {

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -661,9 +661,9 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
   });
 
   it("stamps no capabilities when the owner reports none", async () => {
-    // A gateway-relayed peer arrives here already stripped of remote_pty,
-    // and an unknown peer reports nothing at all. Either way the cache
-    // passes through rather than falling back to the raw granted set.
+    // An unknown or never-seen peer reports nothing. The cache passes the
+    // owner's answer through rather than inventing a set of its own — it
+    // has no way to know what the peer granted.
     const cache = new RemoteThreadSummaryCache({
       peers: () => [],
       fetchSnapshot: async () => snapshotOf([]),

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -1141,13 +1141,10 @@ export class DesktopFederationRuntime {
     const instanceLabel = peer
       ? formatFederationPeerDisplayLabel(peer, visible)
       : target.instanceId;
-    // The granted set the viewer can act on. Gateway-advertised capabilities
-    // remain authoritative for relayed peers just as live connection
-    // capabilities are for direct peers.
-    const directConnection = this.router?.getConnection(target.instanceId);
-    const capabilities = directConnection
-      ? [...directConnection.capabilities]
-      : [...(visiblePeer?.capabilities ?? [])];
+    const capabilities = this.viewerCapabilitiesFor(
+      target.instanceId,
+      visiblePeer,
+    );
     const peerStatus = visiblePeer?.status ?? peer?.status;
     const threads = response.threads.map((thread) => {
       const ref = buildFederatedThreadRef({
@@ -1172,6 +1169,29 @@ export class DesktopFederationRuntime {
       unchanged: false,
       threads,
     };
+  }
+
+  /**
+   * The granted set the VIEWER can act on for a peer: the live connection's
+   * capabilities for a direct peer, the gateway-advertised set for a relayed
+   * one. Both are authoritative — PTY relays through gateways as of #1289,
+   * so nothing is withheld from a relayed peer.
+   *
+   * Single source of truth for every viewer-side stamp — the live snapshot
+   * rows AND the pinned-row fallback served from cache. Copying the rule
+   * into the fallback path instead would let the two drift, and the drift
+   * that matters is silent: a pinned row offering a capability the live row
+   * refuses, or withholding one it grants. `connectedPeerTargets()` is NOT a
+   * substitute — it only knows directly connected peers.
+   */
+  private viewerCapabilitiesFor(
+    instanceId: FederationInstanceId,
+    visiblePeer: FederationPeerSummary | undefined,
+  ): FederationCapability[] {
+    const directConnection = this.router?.getConnection(instanceId);
+    return directConnection
+      ? [...directConnection.capabilities]
+      : [...(visiblePeer?.capabilities ?? [])];
   }
 
   /**
@@ -1200,6 +1220,7 @@ export class DesktopFederationRuntime {
                 status: peer.status,
                 label: formatFederationPeerDisplayLabel(peer, visible),
                 celestialIcon: peer.celestialIcon,
+                capabilities: this.viewerCapabilitiesFor(instanceId, peer),
               }
             : {};
         } catch {

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -823,7 +823,8 @@ export class DesktopFederationRuntime {
    */
   async resetEnrollment(): Promise<{ cleared: boolean }> {
     const stateDb = getAppStateDb();
-    const hadEnrollment = Boolean(stateDb.getMeta(GATEWAY_INSTANCE_ID_META_KEY));
+    const gatewayInstanceId = stateDb.getMeta(GATEWAY_INSTANCE_ID_META_KEY);
+    const hadEnrollment = Boolean(gatewayInstanceId);
     stateDb.setMeta(GATEWAY_INSTANCE_ID_META_KEY, "");
     stateDb.setMeta(GATEWAY_PUBLIC_KEY_META_KEY, "");
     stateDb.setMeta(GATEWAY_NOISE_PUBLIC_KEY_META_KEY, "");
@@ -876,6 +877,12 @@ export class DesktopFederationRuntime {
       this.persistCelestialAssignments();
       this.publishCelestialIconsChanged();
     }
+    if (gatewayInstanceId) {
+      // Pins for peers reached only THROUGH the forgotten gateway keep
+      // dimming until removed by hand — attribution is unreliable — but
+      // the gateway's own pins are provably dead pairing state.
+      await this.cleanupRemoteThreadPins(gatewayInstanceId);
+    }
     await this.restart();
     return { cleared: hadEnrollment };
   }
@@ -914,11 +921,43 @@ export class DesktopFederationRuntime {
     // Free the revoked instance's celestial icon and propagate the removal
     // so it cannot squat one of the five ids forever.
     this.removeCelestialAssignment(peerId, revokedAt);
+    await this.cleanupRemoteThreadPins(peerId);
     return publicPeerSummary({
       ...peer,
       status: "revoked",
       revokedAt,
     });
+  }
+
+  /**
+   * A revoked (or forgotten) peer's pinned rows would otherwise dim
+   * forever — this viewer can never reach that instance again, so drop
+   * its pins and poke the renderer. Best-effort: pin cleanup must never
+   * block or fail the enrollment teardown itself.
+   */
+  private async cleanupRemoteThreadPins(
+    instanceId: FederationInstanceId,
+  ): Promise<void> {
+    try {
+      this.remoteThreadSummaryCache?.invalidate(instanceId);
+      const removed = await getDesktopOverlayStore()
+        .removeRemoteThreadPinsForInstance({ instanceId });
+      if (removed === 0) {
+        return;
+      }
+      await getDesktopBackendRegistry().publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "navigation/remoteThreadPins/changed",
+          params: { instanceId, pinned: false },
+        },
+      });
+    } catch (error) {
+      log.warn("remote thread pin cleanup failed", {
+        instanceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   async generateInvite(request: {
@@ -1183,6 +1222,24 @@ export class DesktopFederationRuntime {
               eventClasses: ["navigation"],
             })),
         );
+      },
+      // Pinned-summary refreshes land in the background (the snapshot
+      // merge never awaits a peer) — poke the renderer so its next
+      // navigation refresh serves the fresh rows.
+      onPinnedSummariesRefreshed: (instanceId) => {
+        void getDesktopBackendRegistry()
+          .publishLocalEvent({
+            backend: "codex",
+            notification: {
+              method: "navigation/remoteThreadPins/changed",
+              params: { instanceId },
+            },
+          })
+          .catch((error: unknown) => {
+            log.warn("remote pin summary refresh publish failed", {
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
       },
     });
     return this.remoteThreadSummaryCache;

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -89,11 +89,17 @@ export class RemoteThreadSummaryCache {
         target: FederationRemoteTarget,
         backend: RemoteThreadPin["ref"]["backend"],
       ) => Promise<Array<Pick<NavigationThreadSummary, "source" | "id">>>;
-      /** Current visible status + composed label for any peer, connected or not. */
+      /**
+       * Current visible status, composed label, and the VIEWER-actionable
+       * capability set for any peer, connected or not. Capabilities must
+       * come from the owner's single stamping rule, never from the raw
+       * granted set.
+       */
       peerStatus: (instanceId: string) => {
         status?: FederationPeerSummary["status"];
         label?: string;
         celestialIcon?: CelestialIconId;
+        capabilities?: FederationCapability[];
       };
       /** Peers whose cached summaries currently need navigation updates. */
       onPeerInterestChanged?: (instanceIds: string[]) => void;
@@ -459,7 +465,11 @@ export class RemoteThreadSummaryCache {
         ref: pin.ref,
         instanceLabel: current.label ?? pin.instanceLabel,
         peerStatus,
-        capabilities: [],
+        // Capabilities are a property of the PEER, not of the cached row,
+        // so a fallback row can carry the live set. Stamping [] here would
+        // tell the thread view "remote terminal not granted" for a peer
+        // that grants it, every time the merge serves a cached row.
+        capabilities: current.capabilities ?? [],
         celestialIcon: current.celestialIcon,
       },
     };

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -70,6 +70,13 @@ export class RemoteThreadSummaryCache {
   >();
   private globalGeneration = 0;
   private readonly peerGenerations = new Map<string, number>();
+  /** Peers whose most recent background refresh failed while connected. */
+  private readonly refreshFailures = new Set<string>();
+  /**
+   * Thread keys a background pass proved archived on their owner, keyed by
+   * instance, awaiting report to the caller that removes the pin.
+   */
+  private readonly provenArchived = new Map<string, Set<string>>();
 
   constructor(
     private readonly options: {
@@ -90,6 +97,13 @@ export class RemoteThreadSummaryCache {
       };
       /** Peers whose cached summaries currently need navigation updates. */
       onPeerInterestChanged?: (instanceIds: string[]) => void;
+      /**
+       * Fired when a background pinned-summary pass would change what
+       * `resolvePinnedThreads` serves: fresh rows landed, pins were proved
+       * archived, a failing peer recovered, or a peer failed for the first
+       * time (rows must dim).
+       */
+      onPinnedSummariesRefreshed?: (instanceId: string) => void;
       ttlMs?: number;
       peerTimeoutMs?: number;
       now?: () => number;
@@ -101,6 +115,8 @@ export class RemoteThreadSummaryCache {
       this.globalGeneration += 1;
       this.cache.clear();
       this.archivedCache.clear();
+      this.refreshFailures.clear();
+      this.provenArchived.clear();
       return;
     }
     this.peerGenerations.set(
@@ -108,6 +124,8 @@ export class RemoteThreadSummaryCache {
       (this.peerGenerations.get(instanceId) ?? 0) + 1,
     );
     this.cache.delete(instanceId);
+    this.refreshFailures.delete(instanceId);
+    this.provenArchived.delete(instanceId);
     for (const key of this.archivedCache.keys()) {
       if (key.startsWith(`${instanceId}:`)) {
         this.archivedCache.delete(key);
@@ -194,6 +212,20 @@ export class RemoteThreadSummaryCache {
     }
   }
 
+  /**
+   * Never awaits a peer: navigation-refresh latency must stay independent
+   * of peer responsiveness (a connected-but-slow owner used to stall every
+   * snapshot merge by up to the per-peer timeout). Serves the cached
+   * snapshot — stale or fresh — immediately, kicks a background refetch
+   * when the TTL has lapsed, and reports fresh data via
+   * `onPinnedSummariesRefreshed` so the owner can re-merge.
+   *
+   * Archive detection rides the same background pass: proving a pin
+   * archived needs a fresh snapshot AND an owner lookup, so it cannot
+   * happen inline without reintroducing the stall. Proofs land in
+   * `provenArchived` and are reported by the next resolve — which the
+   * refresh event triggers immediately.
+   */
   async resolvePinnedThreads(
     pins: readonly RemoteThreadPin[],
   ): Promise<ResolvedRemotePins> {
@@ -213,91 +245,189 @@ export class RemoteThreadSummaryCache {
       pinsByInstanceId.set(pin.ref.target.instanceId, group);
     }
 
-    await Promise.all(
-      [...pinsByInstanceId.entries()].map(async ([instanceId, group]) => {
-        const peer = connectedByInstanceId.get(instanceId);
-        const peerTimeoutMs =
-          this.options.peerTimeoutMs ?? REMOTE_SNAPSHOT_PEER_TIMEOUT_MS;
-        const peerDeadlineAt = (this.options.now?.() ?? Date.now()) + peerTimeoutMs;
-        let fresh: NavigationThreadSummary[] | undefined;
-        let fetchFailed = false;
-        if (peer) {
-          try {
-            fresh = await this.threadsForPeer(peer.target);
-          } catch {
-            fetchFailed = true;
-          }
+    for (const [instanceId, group] of pinsByInstanceId) {
+      const peer = connectedByInstanceId.get(instanceId);
+      let served: NavigationThreadSummary[] | undefined;
+      let fetchFailed = false;
+      if (peer) {
+        const now = this.options.now?.() ?? Date.now();
+        const ttlMs = this.options.ttlMs ?? REMOTE_SNAPSHOT_TTL_MS;
+        const cached = this.cache.get(instanceId);
+        if (!cached || now - cached.fetchedAt >= ttlMs) {
+          this.refreshPeerSummariesInBackground(peer.target, group);
         }
-        const freshByKey = new Map(
-          (fresh ?? []).map((thread) => [`${thread.source}:${thread.id}`, thread]),
-        );
-        const archivedKeys = new Set<string>();
-        if (peer && fresh) {
-          const missingBackends = new Set(
-            group
-              .filter(
-                (pin) =>
-                  !freshByKey.has(`${pin.ref.backend}:${pin.ref.threadId}`),
-              )
-              .map((pin) => pin.ref.backend),
+        served = cached?.threads;
+        fetchFailed = this.refreshFailures.has(instanceId);
+      }
+      const servedByKey = new Map(
+        (served ?? []).map((thread) => [`${thread.source}:${thread.id}`, thread]),
+      );
+      for (const pin of group) {
+        const threadKey = `${pin.ref.backend}:${pin.ref.threadId}`;
+        const servedThread = servedByKey.get(threadKey);
+        if (servedThread) {
+          threads.push(
+            fetchFailed ? this.dimDegraded(servedThread) : servedThread,
           );
-          await Promise.all(
-            [...missingBackends].map(async (backend) => {
-              const candidateKeys = new Set(
-                group
-                  .filter(
-                    (pin) =>
-                      pin.ref.backend === backend
-                      && !freshByKey.has(
-                        `${pin.ref.backend}:${pin.ref.threadId}`,
-                      ),
-                  )
-                  .map((pin) => `${pin.ref.backend}:${pin.ref.threadId}`),
-              );
-              try {
-                const remainingMs =
-                  peerDeadlineAt - (this.options.now?.() ?? Date.now());
-                if (remainingMs <= 0) {
-                  return;
-                }
-                const keys = await this.archivedThreadKeysForPeer(
-                  peer.target,
-                  backend,
-                  candidateKeys,
-                  remainingMs,
-                );
-                for (const key of keys) {
-                  archivedKeys.add(key);
-                }
-              } catch {
-                // Archive detection is proof-based. If the lookup fails, keep
-                // the cached row just as we do when the active fetch fails.
-              }
-            }),
-          );
-        }
-        for (const pin of group) {
-          const threadKey = `${pin.ref.backend}:${pin.ref.threadId}`;
-          const freshThread = freshByKey.get(threadKey);
-          if (freshThread) {
-            threads.push(freshThread);
+          if (!fetchFailed) {
             refreshed.push({
               ref: pin.ref,
-              summary: freshThread,
+              summary: servedThread,
               instanceLabel:
-                freshThread.federation?.instanceLabel ?? pin.instanceLabel,
+                servedThread.federation?.instanceLabel ?? pin.instanceLabel,
             });
-            continue;
           }
-          if (archivedKeys.has(threadKey)) {
-            archived.push(pin.ref);
-            continue;
+          continue;
+        }
+        if (this.consumeArchivedProof(instanceId, threadKey)) {
+          archived.push(pin.ref);
+          continue;
+        }
+        threads.push(this.fallbackThread(pin, fetchFailed));
+      }
+    }
+    return { threads, refreshed, archived };
+  }
+
+  /**
+   * Read-and-clear: a proof is spent the moment it is reported, so a
+   * thread the owner restored (and the viewer re-pinned) after the probe
+   * can never be deleted by yesterday's evidence. A still-archived thread
+   * simply earns a fresh proof on the next background pass.
+   */
+  private consumeArchivedProof(instanceId: string, threadKey: string): boolean {
+    const proofs = this.provenArchived.get(instanceId);
+    if (!proofs?.delete(threadKey)) {
+      return false;
+    }
+    if (proofs.size === 0) {
+      this.provenArchived.delete(instanceId);
+    }
+    return true;
+  }
+
+  /**
+   * Kick a stale-snapshot refetch without blocking the caller, then prove
+   * which of this peer's pins are archived rather than merely missing.
+   * Completion fires `onPinnedSummariesRefreshed` only when a re-merge
+   * would serve something different — fresh rows differing from the served
+   * ones, archive proofs to act on, a failing peer recovering, or a first
+   * failure (rows must dim). A repeat failure stays silent: firing on every
+   * failed attempt would loop (event → re-merge → another kick → another
+   * failure → event).
+   */
+  private refreshPeerSummariesInBackground(
+    target: FederationRemoteTarget,
+    pins: readonly RemoteThreadPin[],
+  ): void {
+    const instanceId = target.instanceId;
+    // Dedup against the CURRENT generation only: a fetch started before an
+    // invalidate is answering a question we no longer trust, so it must not
+    // suppress the fresh one.
+    if (
+      this.inFlight.get(instanceId)?.generation
+      === this.generationFor(instanceId)
+    ) {
+      return;
+    }
+    const previous = this.cache.get(instanceId)?.threads;
+    const failedBefore = this.refreshFailures.has(instanceId);
+    this.threadsForPeer(target).then(
+      async (threads) => {
+        this.refreshFailures.delete(instanceId);
+        const provedArchived = await this.proveArchivedPins(
+          target,
+          pins,
+          threads,
+        );
+        const changed =
+          previous === undefined
+          || JSON.stringify(previous) !== JSON.stringify(threads);
+        if (failedBefore || changed || provedArchived) {
+          this.options.onPinnedSummariesRefreshed?.(instanceId);
+        }
+      },
+      () => {
+        this.refreshFailures.add(instanceId);
+        if (!failedBefore) {
+          this.options.onPinnedSummariesRefreshed?.(instanceId);
+        }
+      },
+    );
+  }
+
+  /**
+   * Ask the owner which of the pins absent from its fresh snapshot are
+   * archived. Absence alone is not proof — an unreachable backend or a
+   * filtered snapshot looks identical — so only a positive archive listing
+   * authorizes removing the viewer's pin. Returns whether anything new was
+   * proved, so the caller knows a re-merge is worth announcing.
+   */
+  private async proveArchivedPins(
+    target: FederationRemoteTarget,
+    pins: readonly RemoteThreadPin[],
+    fresh: readonly NavigationThreadSummary[],
+  ): Promise<boolean> {
+    const freshKeys = new Set(
+      fresh.map((thread) => `${thread.source}:${thread.id}`),
+    );
+    const missing = pins.filter(
+      (pin) => !freshKeys.has(`${pin.ref.backend}:${pin.ref.threadId}`),
+    );
+    if (missing.length === 0) {
+      return false;
+    }
+    const timeoutMs =
+      this.options.peerTimeoutMs ?? REMOTE_SNAPSHOT_PEER_TIMEOUT_MS;
+    const backends = new Set(missing.map((pin) => pin.ref.backend));
+    let proved = false;
+    await Promise.all(
+      [...backends].map(async (backend) => {
+        const candidateKeys = new Set(
+          missing
+            .filter((pin) => pin.ref.backend === backend)
+            .map((pin) => `${pin.ref.backend}:${pin.ref.threadId}`),
+        );
+        try {
+          const keys = await this.archivedThreadKeysForPeer(
+            target,
+            backend,
+            candidateKeys,
+            timeoutMs,
+          );
+          for (const key of candidateKeys) {
+            if (!keys.has(key)) {
+              continue;
+            }
+            const proofs =
+              this.provenArchived.get(target.instanceId) ?? new Set<string>();
+            proofs.add(key);
+            this.provenArchived.set(target.instanceId, proofs);
+            proved = true;
           }
-          threads.push(this.fallbackThread(pin, fetchFailed));
+        } catch {
+          // Archive detection is proof-based. If the lookup fails, keep the
+          // cached row just as we do when the active fetch fails.
         }
       }),
     );
-    return { threads, refreshed, archived };
+    return proved;
+  }
+
+  /**
+   * A connected peer whose last background refresh failed still serves its
+   * cached rows, but they must dim like fallback rows: the data is not live.
+   */
+  private dimDegraded(
+    thread: NavigationThreadSummary,
+  ): NavigationThreadSummary {
+    if (!thread.federation) {
+      return thread;
+    }
+    return {
+      ...thread,
+      federation: { ...thread.federation, peerStatus: "degraded" },
+    };
   }
 
   private fallbackThread(
@@ -373,6 +503,10 @@ export class RemoteThreadSummaryCache {
         threads,
       });
       this.touchPeerInterest(target.instanceId, ttlMs);
+      // ANY successful fetch is proof of life, including one the jump
+      // search started. Clearing the flag only in the pinned-refresh path
+      // would keep freshly-fetched rows dimmed until the next TTL lapse.
+      this.refreshFailures.delete(target.instanceId);
       return threads;
     })();
     const entry = { generation, promise };

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -158,6 +158,7 @@ import {
   buildThreadIdentityKey,
   federatedThreadIdentityKey,
   isAppServerBackendKind,
+  isFederationInstanceId,
   isRemoteFederationTarget,
   normalizePullRequestProvider as normalizeSharedPullRequestProvider,
   parseThreadIdentityKey,
@@ -582,7 +583,10 @@ function attachRemoteThreadsToLocalDirectories(
   if (remoteThreads.length === 0) {
     return directories;
   }
-  const addedKeysByDirectoryIndex = new Map<number, string[]>();
+  const addedByDirectoryIndex = new Map<
+    number,
+    Array<{ threadKey: string; inInbox: boolean }>
+  >();
   for (const thread of remoteThreads) {
     const threadKey = buildThreadIdentityKey(thread.source, thread.id);
     const homeIndex = findRemoteHomeDirectoryIndex(
@@ -592,24 +596,53 @@ function attachRemoteThreadsToLocalDirectories(
     if (homeIndex === undefined) {
       continue;
     }
-    const added = addedKeysByDirectoryIndex.get(homeIndex) ?? [];
-    added.push(threadKey);
-    addedKeysByDirectoryIndex.set(homeIndex, added);
+    const added = addedByDirectoryIndex.get(homeIndex) ?? [];
+    added.push({ threadKey, inInbox: Boolean(thread.inbox?.inInbox) });
+    addedByDirectoryIndex.set(homeIndex, added);
   }
-  if (addedKeysByDirectoryIndex.size === 0) {
+  if (addedByDirectoryIndex.size === 0) {
     return directories;
   }
   return directories.map((directory, index) => {
-    const added = addedKeysByDirectoryIndex.get(index);
-    if (!added) {
+    const added = addedByDirectoryIndex
+      .get(index)
+      ?.filter((entry) => !directory.threadKeys.includes(entry.threadKey));
+    if (!added?.length) {
       return directory;
     }
-    const threadKeys = [
-      ...directory.threadKeys,
-      ...added.filter((key) => !directory.threadKeys.includes(key)),
-    ];
-    return { ...directory, threadKeys };
+    return {
+      ...directory,
+      threadKeys: [
+        ...directory.threadKeys,
+        ...added.map((entry) => entry.threadKey),
+      ],
+      // Unread remote rows count toward the group's "N to review" badge
+      // just like local rows do.
+      needsAttentionCount:
+        directory.needsAttentionCount
+        + added.filter((entry) => entry.inInbox).length,
+    };
   });
+}
+
+/**
+ * Service-boundary validation for remote-pin refs. The sqlite key is
+ * (instanceId, backend, threadId); a malformed ref from a buggy caller
+ * would persist a row that dims forever with no owner to resolve it, so
+ * reject anything that is not a well-formed remote target with a known
+ * backend before it reaches the store. Returns the validated instance id.
+ */
+function validateRemoteThreadPinRef(ref: FederatedThreadRef): string {
+  if (
+    !isRemoteFederationTarget(ref.target)
+    || !isFederationInstanceId(ref.target.instanceId)
+  ) {
+    throw new Error("Remote thread pins require a valid remote federation target.");
+  }
+  if (!isAppServerBackendKind(ref.backend)) {
+    throw new Error("Remote thread pins require a known backend kind.");
+  }
+  return ref.target.instanceId;
 }
 
 function logDebug(event: string, payload: Record<string, unknown>): void {
@@ -1978,10 +2011,18 @@ class DesktopAppServerService {
     return {
       ...snapshot,
       threads: [...threadsWithWorkingState, ...remotePins.threads],
-      inboxThreadKeys: [
-        ...snapshot.inboxThreadKeys,
-        ...rankInboxThreadKeys(remotePins.threads),
-      ],
+      // One unified ranking over local + remote rows: the local keys were
+      // computed by this same function inside the reconcile, so re-ranking
+      // the combined set preserves their order while letting a fresher
+      // remote unread outrank stale local entries instead of always
+      // trailing them.
+      inboxThreadKeys:
+        remotePins.threads.length === 0
+          ? snapshot.inboxThreadKeys
+          : rankInboxThreadKeys([
+              ...threadsWithWorkingState,
+              ...remotePins.threads,
+            ]),
       directories: attachRemoteThreadsToLocalDirectories(
         directories,
         remotePins.threads,
@@ -1997,11 +2038,15 @@ class DesktopAppServerService {
 
   /**
    * Viewer-side remote thread pins, merged into the main window's snapshot.
-   * Reachable owners serve fresh stamped rows (and refresh the cached pin
-   * payload); unreachable owners fall back to the cached payload stamped
-   * with their current non-connected status so rows render dimmed. The
-   * merged rows get their own change hash so a peer-side title/PR/status
-   * change can never be suppressed by the local `unchanged` optimization.
+   * Reachable owners serve their cached stamped rows (and refresh the
+   * cached pin payload); unreachable owners fall back to the persisted
+   * payload stamped with their current non-connected status so rows render
+   * dimmed. The merge never awaits a peer — stale summaries refetch in the
+   * background and land via `navigation/remoteThreadPins/changed`, so
+   * navigation refresh latency stays independent of peer responsiveness.
+   * The merged rows get their own change hash so a peer-side
+   * title/PR/status change can never be suppressed by the local
+   * `unchanged` optimization.
    */
   private async mergePinnedRemoteThreads(): Promise<{
     threads: NavigationThreadSummary[];
@@ -5559,10 +5604,7 @@ class DesktopAppServerService {
   async addRemoteThreadPin(
     request: AddRemoteThreadPinRequest,
   ): Promise<AddRemoteThreadPinResponse> {
-    if (!isRemoteFederationTarget(request.ref.target)) {
-      throw new Error("Remote thread pins require a remote federation target.");
-    }
-    const instanceId = request.ref.target.instanceId;
+    const instanceId = validateRemoteThreadPinRef(request.ref);
     const instanceLabel =
       request.instanceLabel
       ?? request.summary?.federation?.instanceLabel
@@ -5769,9 +5811,7 @@ class DesktopAppServerService {
   async removeRemoteThreadPin(
     request: RemoveRemoteThreadPinRequest,
   ): Promise<RemoveRemoteThreadPinResponse> {
-    if (!isRemoteFederationTarget(request.ref.target)) {
-      throw new Error("Remote thread pins require a remote federation target.");
-    }
+    const instanceId = validateRemoteThreadPinRef(request.ref);
     // Local DELETE only — removal must keep working while the owning
     // instance is unreachable, and the owner's thread is untouched.
     const removed = await this.getOverlayStore().removeRemoteThreadPin({
@@ -5780,7 +5820,7 @@ class DesktopAppServerService {
 
     logDebug("removeRemoteThreadPin", {
       backend: request.ref.backend,
-      instanceId: request.ref.target.instanceId,
+      instanceId,
       threadId: request.ref.threadId,
       removed,
     });
@@ -5791,7 +5831,7 @@ class DesktopAppServerService {
         notification: {
           method: "navigation/remoteThreadPins/changed",
           params: {
-            instanceId: request.ref.target.instanceId,
+            instanceId,
             threadId: request.ref.threadId,
             pinned: false,
           },
@@ -5811,9 +5851,7 @@ class DesktopAppServerService {
   async setRemoteThreadLocalPin(
     request: SetRemoteThreadLocalPinRequest,
   ): Promise<SetRemoteThreadLocalPinResponse> {
-    if (!isRemoteFederationTarget(request.ref.target)) {
-      throw new Error("Remote thread pins require a remote federation target.");
-    }
+    const instanceId = validateRemoteThreadPinRef(request.ref);
     const result = await this.getOverlayStore().setRemoteThreadLocalPin({
       ref: request.ref,
       pinnedRank: request.pinnedRank,
@@ -5823,7 +5861,7 @@ class DesktopAppServerService {
       notification: {
         method: "navigation/remoteThreadPins/changed",
         params: {
-          instanceId: request.ref.target.instanceId,
+          instanceId,
           threadId: request.ref.threadId,
           pinned: Boolean(result.pinnedRank),
         },

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2029,18 +2029,38 @@ export class SqliteOverlayStore {
             parsed = {};
           }
         }
+        const nextPayload = JSON.stringify({
+          ...parsed,
+          instanceLabel: entry.instanceLabel,
+          summary: stripFederationStamp(entry.summary),
+        });
+        // The merge re-serves cached rows on every navigation refresh;
+        // skip the write when nothing actually changed.
+        if (row && row.payload === nextPayload) {
+          continue;
+        }
         update.run(
-          JSON.stringify({
-            ...parsed,
-            instanceLabel: entry.instanceLabel,
-            summary: stripFederationStamp(entry.summary),
-          }),
+          nextPayload,
           instanceId,
           entry.ref.backend,
           entry.ref.threadId,
         );
       }
     })();
+  }
+
+  /**
+   * Drop every pin owned by one instance — peer-revocation / forgotten-
+   * enrollment cleanup, where the rows would otherwise dim forever.
+   * Returns the number of pins removed.
+   */
+  async removeRemoteThreadPinsForInstance(params: {
+    instanceId: string;
+  }): Promise<number> {
+    const result = this.stateDb.raw
+      .prepare("DELETE FROM remote_thread_pins WHERE instance_id = ?")
+      .run(params.instanceId);
+    return result.changes;
   }
 
   async setThreadAgent(params: {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1623,8 +1623,12 @@ export type AppServerNotification =
       params: {
         /** Instance the pinned/unpinned thread lives on. */
         instanceId: string;
-        threadId: string;
-        pinned: boolean;
+        /**
+         * Absent for instance-wide changes: a background pinned-summary
+         * refresh landing, or peer-revocation pin cleanup.
+         */
+        threadId?: string;
+        pinned?: boolean;
       };
     }
   | {


### PR DESCRIPTION
## Summary

Code-review follow-ups from #1247 (unified Cmd+K with viewer-side remote thread pins). Deliberately excluded by operator decision: the label/basename name-only remote-to-local directory matching stays as-is.

### 1. Non-blocking snapshot merge (the main one)

`resolvePinnedThreads` no longer awaits any peer, so a connected-but-slow peer can no longer stall every navigation refresh (or the Enter-to-open pin flow) by up to the 10s per-peer timeout. It now serves the cached snapshot (stale or fresh) — or the pin's persisted payload — immediately, kicks a background refetch when the TTL has lapsed, and a new `onPinnedSummariesRefreshed` callback (wired in `federation-runtime.ts`) publishes the existing `navigation/remoteThreadPins/changed` event when fresh data lands so the renderer re-fetches.

Two design points worth reviewing:

- **Loop guard.** The callback fires on fresh-data-changed, first failure, and recovery — but a *repeat* failure stays silent. Firing on every failed attempt would cycle event → re-merge → refetch → failure → event forever against a persistently failing peer.
- **Dimming semantics.** A connected peer's first paint is optimistic (cached rows, undimmed); once a background fetch fails, the next merge dims rows as degraded — including stale cached snapshot rows, which previously could not be served at all after a fetch failure.

The test "returns promptly with cached rows while a peer fetch hangs" proves a never-resolving peer fetch cannot stall the snapshot.

### 2. Pin ref validation at the service boundary

`addRemoteThreadPin` / `removeRemoteThreadPin` / `setRemoteThreadLocalPin` now validate `isFederationInstanceId` and `isAppServerBackendKind` (in addition to the existing `isRemoteFederationTarget` check) via a shared `validateRemoteThreadPinRef`, so a malformed ref from a buggy caller can never be persisted.

### 3. Pin cleanup on peer revoke / forget

`revokePeer` and `resetEnrollment` call a shared best-effort `cleanupRemoteThreadPins`: invalidates the summary cache, deletes the instance's rows via a new `removeRemoteThreadPinsForInstance` store method, and publishes the pins-changed event — instead of leaving rows dimming forever. Reset-enrollment deletion is scoped to the forgotten gateway's own instance id: pins for third-party peers reached *through* that gateway cannot be reliably attributed, and a dual-mode instance's directly-enrolled clients remain valid. Cleanup is try/caught so it can never block or fail the enrollment teardown itself. (The revoke path on main has no celestial-assignment GC from the #1249 follow-up yet, so there was nothing to coordinate with.)

### 4. Directory attention badge

`attachRemoteThreadsToLocalDirectories` bumps `needsAttentionCount` for attached remote rows whose `inbox.inInbox` is true, so the "N to review" badge counts unread remote rows.

### 5. Write churn

`updateRemoteThreadPinSnapshots` skips the payload rewrite when the serialized payload is byte-equal to the stored one (verified with a sqlite trigger counting actual row rewrites).

### 6. Unified inbox ranking

Merged inbox keys now come from one `rankInboxThreadKeys` pass over the combined local + remote rows instead of appending remote keys after all local ones. Since the local keys are themselves `rankInboxThreadKeys(threads)` from the reconcile, the combined pass preserves local order exactly while letting a fresher remote unread outrank stale local entries. The `navigation/remoteThreadPins/changed` contract params now allow omitting `threadId`/`pinned` for instance-wide changes (background refresh, revoke cleanup); the renderer ignores params and just refreshes, so no renderer change was needed.

## Verification

- `pnpm typecheck`, `pnpm lint:eslint` (0 errors, no new warnings in touched files), `pnpm lint:boundaries`, `pnpm lint:sql` — all clean
- `app-server-ipc` (98), `remote-thread-summary-cache` + `remote-thread-pins-store` + `federation-reset-enrollment` (37), all `federation-*`/`overlay-store-*` suites (329), `packages/shared` (256) — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)