### PR TITLE
feat(desktop): star map orbit layout with pan and zoom

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -33,8 +33,10 @@ import {
   STAR_MAP_BODY_ROW_Y,
   STAR_MAP_ESTIMATED_CARD_HEIGHT,
   visibleCardCount,
-  type StarMapInstancePosition,
+  type StarMapCardSlot,
 } from "./star-map-layout";
+import { computeOrbitPlacement } from "./star-map-orbit";
+import { buildFederationTopology } from "./star-map-topology";
 import { IntakeDialog, type IntakeDialogTarget } from "./IntakeDialog";
 import {
   readStoredPreferences,
@@ -50,6 +52,10 @@ import { useStarMapThreads } from "./useStarMapThreads";
 const FILTERS_STORAGE_KEY = "pwragent.starMap.filters";
 const MAX_CARDS_PER_INSTANCE = 8;
 const STAR_COUNT = 130;
+/** Orbit rings use a fixed card width; lanes narrow theirs to fit. */
+const ORBIT_CARD_WIDTH = 220;
+const MIN_ZOOM = 0.35;
+const MAX_ZOOM = 2;
 
 function readStoredFilters(): Set<StarMapAttentionCategory> {
   if (typeof window === "undefined") {
@@ -124,6 +130,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const [preferences, setPreferences] = useState<StarMapViewPreferences>(
     readStoredPreferences,
   );
+  // Orbit places bodies on a canvas larger than the window, so the surface
+  // pans and zooms rather than compressing the map to fit.
+  const [view, setView] = useState({ x: 0, y: 0, scale: 1 });
+  const orbitMode = preferences.layout === "orbit";
 
   // Focus the layer on open AND whenever the floating thread closes -
   // "Back to map" leaves focus inside <main>, and without a refocus the
@@ -183,6 +193,42 @@ export function StarMapScreen(props: StarMapScreenProps) {
     });
   });
 
+  // Trackpad: two-finger drag pans, pinch (ctrl+wheel) zooms about the
+  // pointer. Registered natively because the listener must not be passive.
+  useEffect(() => {
+    const element = viewportRef.current;
+    if (!element || !orbitMode) return;
+    const onWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      if (event.ctrlKey) {
+        const rect = element.getBoundingClientRect();
+        const pointerX = event.clientX - rect.left;
+        const pointerY = event.clientY - rect.top;
+        setView((current) => {
+          const scale = Math.min(
+            MAX_ZOOM,
+            Math.max(MIN_ZOOM, current.scale * (1 - event.deltaY / 240)),
+          );
+          const ratio = scale / current.scale;
+          return {
+            scale,
+            // Keep the point under the cursor pinned while scaling.
+            x: pointerX - (pointerX - current.x) * ratio,
+            y: pointerY - (pointerY - current.y) * ratio,
+          };
+        });
+        return;
+      }
+      setView((current) => ({
+        ...current,
+        x: current.x - event.deltaX,
+        y: current.y - event.deltaY,
+      }));
+    };
+    element.addEventListener("wheel", onWheel, { passive: false });
+    return () => element.removeEventListener("wheel", onWheel);
+  }, [orbitMode]);
+
   const toggleFilter = useCallback((category: StarMapAttentionCategory) => {
     setFilters((current) => {
       const next = new Set(current);
@@ -234,7 +280,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     return gatewayId ?? localInstanceId;
   }, [health, localInstanceId, peers]);
 
-  const layout = useMemo(
+  const laneLayout = useMemo(
     () =>
       computeStarMapLayout(
         [
@@ -299,6 +345,93 @@ export function StarMapScreen(props: StarMapScreenProps) {
     }
     return counts;
   }, [filters, props.localThreads, props.sessionKeys, remote]);
+
+  const lanes = useMemo(() => {
+    const result = new Map<
+      string,
+      { threads: NavigationThreadSummary[]; heights: number[]; count: number }
+    >();
+    for (const [instanceId, threads] of attentionByInstance) {
+      const heights = threads.map(
+        (thread) =>
+          cardHeights.get(buildThreadIdentityKey(thread.source, thread.id))
+          ?? STAR_MAP_ESTIMATED_CARD_HEIGHT,
+      );
+      // Lanes are bounded by the window; an orbit ring grows its radius
+      // instead, so it only obeys the hard cap.
+      const count = orbitMode
+        ? Math.min(threads.length, MAX_CARDS_PER_INSTANCE)
+        : visibleCardCount({
+            heights,
+            availableHeight: viewportSize.height - STAR_MAP_BODY_ROW_Y,
+            max: MAX_CARDS_PER_INSTANCE,
+          });
+      result.set(instanceId, { threads, heights, count });
+    }
+    return result;
+  }, [attentionByInstance, cardHeights, orbitMode, viewportSize.height]);
+
+  const topology = useMemo(
+    () =>
+      buildFederationTopology({
+        localInstanceId,
+        localRole: health?.role ?? "gateway",
+        peers,
+        gatewayInstanceId: health?.clientEnrollment?.gatewayInstanceId,
+      }),
+    [health, localInstanceId, peers],
+  );
+
+  const orbit = useMemo(
+    () =>
+      computeOrbitPlacement({
+        nodes: topology,
+        cardCounts: new Map(
+          [...lanes].map(([instanceId, lane]) => [instanceId, lane.count]),
+        ),
+        cardWidth: ORBIT_CARD_WIDTH,
+      }),
+    [lanes, topology],
+  );
+
+  /** Bodies plus their card slots, in whichever space the layout uses. */
+  const bodies = useMemo(() => {
+    if (orbitMode) {
+      return orbit.instances.map((instance) => ({
+        instanceId: instance.instanceId,
+        isHub: instance.isHub,
+        x: instance.x,
+        y: instance.y,
+        slots: instance.cardSlots,
+        cardWidth: ORBIT_CARD_WIDTH,
+      }));
+    }
+    return laneLayout.positions.map((position) => {
+      const lane = lanes.get(position.instanceId);
+      return {
+        instanceId: position.instanceId,
+        isHub: position.isHub,
+        x: position.x,
+        y: position.y,
+        slots: computeCardSlots(lane?.heights.slice(0, lane.count) ?? []),
+        cardWidth: laneLayout.cardWidth,
+      };
+    });
+  }, [laneLayout, lanes, orbit, orbitMode]);
+
+  // Centre the canvas on mode switch / topology change rather than leaving
+  // the operator staring at empty space in a corner.
+  useEffect(() => {
+    if (!orbitMode) {
+      setView({ x: 0, y: 0, scale: 1 });
+      return;
+    }
+    setView({
+      x: (viewportSize.width - orbit.canvasWidth) / 2,
+      y: (viewportSize.height - orbit.canvasHeight) / 2,
+      scale: 1,
+    });
+  }, [orbitMode, orbit.canvasWidth, orbit.canvasHeight, viewportSize.width, viewportSize.height]);
 
   const peerById = useMemo(
     () => new Map(peers.map((peer) => [peer.id, peer])),
@@ -373,22 +506,18 @@ export function StarMapScreen(props: StarMapScreenProps) {
     return status;
   };
 
-  const renderCloud = (position: StarMapInstancePosition) => {
-    const threads = attentionByInstance.get(position.instanceId) ?? [];
-    const heights = threads.map(
-      (thread) =>
-        cardHeights.get(buildThreadIdentityKey(thread.source, thread.id))
-        ?? STAR_MAP_ESTIMATED_CARD_HEIGHT,
-    );
-    // Only as many cards as actually fit between the body row and the
-    // bottom of the window; the rest roll into "+N more".
-    const count = visibleCardCount({
-      heights,
-      availableHeight: viewportSize.height - STAR_MAP_BODY_ROW_Y,
-      max: MAX_CARDS_PER_INSTANCE,
-    });
-    const visible = threads.slice(0, count);
-    const slots = computeCardSlots(heights.slice(0, count));
+  const renderCloud = (position: {
+    instanceId: string;
+    x: number;
+    y: number;
+    slots: StarMapCardSlot[];
+    cardWidth: number;
+  }) => {
+    const lane = lanes.get(position.instanceId);
+    const threads = lane?.threads ?? [];
+    const heights = lane?.heights ?? [];
+    const visible = threads.slice(0, lane?.count ?? 0);
+    const slots = position.slots;
     const overflow = threads.length - visible.length;
     return (
       <div
@@ -400,12 +529,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
         }`}
         style={{ left: position.x, top: position.y }}
       >
-        {visible.length > 0 ? (
+        {visible.length > 0 && !orbitMode ? (
           <span
             className="star-map__cloud-halo"
             aria-hidden="true"
             style={{
-              width: layout.cardWidth + 56,
+              width: position.cardWidth + 56,
               height:
                 (slots[slots.length - 1]?.dy ?? 0)
                 + (heights[visible.length - 1] ?? 0)
@@ -434,7 +563,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
               )}
               baseSlot={slot}
               offset={arrangement.offsetFor(position.instanceId, threadKey)}
-              width={layout.cardWidth}
+              width={position.cardWidth}
+              centered={orbitMode}
               stackIndex={index}
               cardFields={preferences.cardFields}
               onCommitOffset={
@@ -453,7 +583,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
             />
           );
         })}
-        {overflow > 0 ? (
+        {overflow > 0 && !orbitMode ? (
           <span
             className="star-map__cloud-overflow"
             style={{
@@ -517,12 +647,52 @@ export function StarMapScreen(props: StarMapScreenProps) {
             />
           ))}
         </svg>
+        <div
+          className={`star-map__canvas${orbitMode ? " is-orbit" : ""}`}
+          style={
+            orbitMode
+              ? {
+                  width: orbit.canvasWidth,
+                  height: orbit.canvasHeight,
+                  transform: `translate(${view.x}px, ${view.y}px) scale(${view.scale})`,
+                }
+              : undefined
+          }
+        >
         <svg
           className="star-map__links"
-          viewBox={`0 0 ${viewportSize.width} ${viewportSize.height}`}
+          viewBox={
+            orbitMode
+              ? `0 0 ${orbit.canvasWidth} ${orbit.canvasHeight}`
+              : `0 0 ${viewportSize.width} ${viewportSize.height}`
+          }
           aria-hidden="true"
         >
-          {layout.links.map((link) => {
+          {(orbitMode
+            ? orbit.links.map((link) => {
+                const from = orbit.instances.find(
+                  (instance) => instance.instanceId === link.fromInstanceId,
+                );
+                const to = orbit.instances.find(
+                  (instance) => instance.instanceId === link.toInstanceId,
+                );
+                return from && to
+                  ? {
+                      ...link,
+                      path: {
+                        x1: from.x,
+                        y1: from.y,
+                        cx: (from.x + to.x) / 2,
+                        cy: (from.y + to.y) / 2,
+                        x2: to.x,
+                        y2: to.y,
+                      },
+                    }
+                  : undefined;
+              })
+            : laneLayout.links
+          ).map((link) => {
+            if (!link) return null;
             const state = linkState(
               link.toInstanceId === localInstanceId
                 ? link.fromInstanceId
@@ -550,7 +720,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
             );
           })}
         </svg>
-        {layout.positions.map((position) => {
+        {bodies.map((position) => {
           const entry = instanceEntry(position.instanceId);
           return (
             <div
@@ -606,7 +776,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
             </div>
           );
         })}
-        {layout.positions.map((position) => renderCloud(position))}
+        {bodies.map((position) => renderCloud(position))}
+        </div>
       </div>
       {intakeTarget ? (
         <IntakeDialog

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type PointerEvent as ReactPointerEvent,
 } from "react";
 import {
   buildThreadIdentityKey,
@@ -35,7 +36,10 @@ import {
   visibleCardCount,
   type StarMapCardSlot,
 } from "./star-map-layout";
-import { computeOrbitPlacement } from "./star-map-orbit";
+import {
+  computeOrbitPlacement,
+  shouldStartCanvasPan,
+} from "./star-map-orbit";
 import { buildFederationTopology } from "./star-map-topology";
 import { IntakeDialog, type IntakeDialogTarget } from "./IntakeDialog";
 import {
@@ -105,6 +109,7 @@ type StarMapScreenProps = {
 export function StarMapScreen(props: StarMapScreenProps) {
   const layerRef = useRef<HTMLDivElement>(null);
   const viewportRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLDivElement>(null);
   const { health } = useFederationHealth({ desktopApi: props.desktopApi });
   const celestialIcons = useCelestialIcons({ desktopApi: props.desktopApi });
   const [filters, setFilters] = useState<Set<StarMapAttentionCategory>>(
@@ -228,6 +233,47 @@ export function StarMapScreen(props: StarMapScreenProps) {
     element.addEventListener("wheel", onWheel, { passive: false });
     return () => element.removeEventListener("wheel", onWheel);
   }, [orbitMode]);
+
+  const startCanvasPan = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!orbitMode || event.button !== 0) return;
+    if (!shouldStartCanvasPan(event.target)) return;
+    const canvas = canvasRef.current;
+    const viewport = viewportRef.current;
+    if (!canvas) return;
+    event.preventDefault();
+    viewport?.classList.add("is-panning");
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const base = view;
+    let lastX = base.x;
+    let lastY = base.y;
+    let frame = 0;
+    const move = (pointerEvent: globalThis.PointerEvent) => {
+      lastX = base.x + pointerEvent.clientX - startX;
+      lastY = base.y + pointerEvent.clientY - startY;
+      if (!frame) {
+        frame = requestAnimationFrame(() => {
+          frame = 0;
+          canvas.style.transform =
+            `translate(${lastX}px, ${lastY}px) scale(${base.scale})`;
+        });
+      }
+    };
+    const stop = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", stop);
+      window.removeEventListener("pointercancel", stop);
+      if (frame) {
+        cancelAnimationFrame(frame);
+        frame = 0;
+      }
+      viewport?.classList.remove("is-panning");
+      setView((current) => ({ ...current, x: lastX, y: lastY }));
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", stop);
+    window.addEventListener("pointercancel", stop);
+  };
 
   const toggleFilter = useCallback((category: StarMapAttentionCategory) => {
     setFilters((current) => {
@@ -628,7 +674,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
         }
       }}
     >
-      <div ref={viewportRef} className="star-map__viewport">
+      <div
+        ref={viewportRef}
+        className="star-map__viewport"
+        onPointerDown={startCanvasPan}
+      >
         <svg
           className="star-map__sky"
           viewBox="0 0 100 100"
@@ -648,6 +698,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
           ))}
         </svg>
         <div
+          ref={canvasRef}
           className={`star-map__canvas${orbitMode ? " is-orbit" : ""}`}
           style={
             orbitMode

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -57,7 +57,9 @@ const FILTERS_STORAGE_KEY = "pwragent.starMap.filters";
 const MAX_CARDS_PER_INSTANCE = 8;
 const STAR_COUNT = 130;
 /** Orbit rings use a fixed card width; lanes narrow theirs to fit. */
-const ORBIT_CARD_WIDTH = 220;
+const ORBIT_CARD_WIDTH = 200;
+/** Rings hold far more than a lane column, so orbit shows deeper. */
+const ORBIT_MAX_CARDS_PER_INSTANCE = 16;
 const MIN_ZOOM = 0.35;
 const MAX_ZOOM = 2;
 
@@ -406,7 +408,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       // Lanes are bounded by the window; an orbit ring grows its radius
       // instead, so it only obeys the hard cap.
       const count = orbitMode
-        ? Math.min(threads.length, MAX_CARDS_PER_INSTANCE)
+        ? Math.min(threads.length, ORBIT_MAX_CARDS_PER_INSTANCE)
         : visibleCardCount({
             heights,
             availableHeight: viewportSize.height - STAR_MAP_BODY_ROW_Y,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -817,6 +817,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
         <span>Close map</span>
       </button>
       <div className="star-map__chrome">
+        {/* Same wordmark primitive as the sidebar/Settings nav so the brand
+            reads identically across every window (theme-contract test). */}
+        <p className="sidebar__brand">
+          Pwr<span className="sidebar__brand-accent">Agent</span>
+        </p>
         <StarMapViewOptions
           preferences={preferences}
           onChange={(next) => {

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -47,6 +47,8 @@ export function StarMapThreadCard(props: {
   stackIndex: number;
   /** Which chips this card carries (operator preference). */
   cardFields: StarMapCardFields;
+  /** Orbit rings centre cards on their slot; lanes hang them from the top. */
+  centered?: boolean;
   /** Owning instance's celestial mark, watermarked behind the content. */
   instanceIcon?: CelestialIconId;
   /** Present when the card is draggable; receives the clamped offset. */
@@ -69,6 +71,7 @@ export function StarMapThreadCard(props: {
     left,
     top,
     marginLeft: -props.width / 2,
+    ...(props.centered ? { transform: "translateY(-50%)" } : {}),
     zIndex: props.stackIndex,
     ...(props.riseDelayMs
       ? { animationDelay: `${props.riseDelayMs}ms` }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapViewOptions.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapViewOptions.tsx
@@ -70,6 +70,24 @@ export function StarMapViewOptions(props: {
             }
           }}
         >
+          <p className="star-map__view-heading">Layout</p>
+          <div className="star-map__layout-switch" role="group" aria-label="Layout">
+            {(["lanes", "orbit"] as const).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                className={`star-map__layout-option${
+                  props.preferences.layout === mode ? " is-on" : ""
+                }`}
+                aria-pressed={props.preferences.layout === mode}
+                onClick={() =>
+                  props.onChange({ ...props.preferences, layout: mode })
+                }
+              >
+                {mode === "lanes" ? "Lanes" : "Orbit"}
+              </button>
+            ))}
+          </div>
           <p className="star-map__view-heading">Card details</p>
           {CARD_FIELD_ORDER.map((field) => (
             <label key={field} className="star-map__view-row">

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import type { FederationPeerSummary } from "@pwragent/shared";
+import { cardRingRadius, computeOrbitPlacement } from "../star-map-orbit";
+import { buildFederationTopology, topologyEdges } from "../star-map-topology";
+
+function peer(
+  id: string,
+  role: FederationPeerSummary["role"] = "client",
+): FederationPeerSummary {
+  return {
+    id,
+    label: id,
+    role,
+    status: "connected",
+    capabilities: [],
+  } as FederationPeerSummary;
+}
+
+describe("buildFederationTopology", () => {
+  it("roots at the local instance when it is the gateway", () => {
+    const nodes = buildFederationTopology({
+      localInstanceId: "pwr_local",
+      localRole: "gateway",
+      peers: [peer("pwr_a"), peer("pwr_b")],
+    });
+    const root = nodes.find((node) => node.depth === 0);
+    expect(root?.instanceId).toBe("pwr_local");
+    expect(topologyEdges(nodes)).toEqual([
+      { fromInstanceId: "pwr_local", toInstanceId: "pwr_a" },
+      { fromInstanceId: "pwr_local", toInstanceId: "pwr_b" },
+    ]);
+  });
+
+  it("roots at the enrolled gateway when this instance is a client", () => {
+    const nodes = buildFederationTopology({
+      localInstanceId: "pwr_local",
+      localRole: "client",
+      peers: [peer("pwr_gw", "gateway"), peer("pwr_sibling")],
+      gatewayInstanceId: "pwr_gw",
+    });
+    expect(nodes.find((node) => node.depth === 0)?.instanceId).toBe("pwr_gw");
+    // The local body becomes one of the gateway's children, beside its peers.
+    const local = nodes.find((node) => node.isLocal);
+    expect(local?.parentId).toBe("pwr_gw");
+    expect(nodes.filter((node) => node.parentId === "pwr_gw")).toHaveLength(2);
+  });
+});
+
+describe("cardRingRadius", () => {
+  it("grows so cards on the ring cannot collide", () => {
+    const few = cardRingRadius(2, 220);
+    const many = cardRingRadius(10, 220);
+    expect(many).toBeGreaterThan(few);
+    // Circumference has to cover every card plus a gap.
+    expect(2 * Math.PI * many).toBeGreaterThanOrEqual(10 * 220);
+  });
+});
+
+describe("computeOrbitPlacement", () => {
+  const nodes = buildFederationTopology({
+    localInstanceId: "pwr_local",
+    localRole: "gateway",
+    peers: [peer("pwr_a"), peer("pwr_b"), peer("pwr_c")],
+  });
+
+  it("keeps every body inside a positive canvas", () => {
+    const placement = computeOrbitPlacement({
+      nodes,
+      cardCounts: new Map([
+        ["pwr_local", 6],
+        ["pwr_a", 3],
+        ["pwr_b", 0],
+        ["pwr_c", 8],
+      ]),
+      cardWidth: 220,
+    });
+    expect(placement.instances).toHaveLength(4);
+    for (const instance of placement.instances) {
+      expect(instance.x).toBeGreaterThan(0);
+      expect(instance.y).toBeGreaterThan(0);
+      expect(instance.x).toBeLessThan(placement.canvasWidth);
+      expect(instance.y).toBeLessThan(placement.canvasHeight);
+    }
+  });
+
+  it("spaces bodies so neighbouring card rings cannot touch", () => {
+    const counts = new Map([
+      ["pwr_local", 6],
+      ["pwr_a", 6],
+      ["pwr_b", 6],
+      ["pwr_c", 6],
+    ]);
+    const placement = computeOrbitPlacement({
+      nodes,
+      cardCounts: counts,
+      cardWidth: 220,
+    });
+    const ring = cardRingRadius(6, 220);
+    const spokes = placement.instances.filter((instance) => !instance.isHub);
+    for (let i = 0; i < spokes.length; i += 1) {
+      for (let j = i + 1; j < spokes.length; j += 1) {
+        const distance = Math.hypot(
+          spokes[i].x - spokes[j].x,
+          spokes[i].y - spokes[j].y,
+        );
+        expect(distance).toBeGreaterThan(ring);
+      }
+    }
+  });
+
+  it("gives each instance one card slot per visible card", () => {
+    const placement = computeOrbitPlacement({
+      nodes,
+      cardCounts: new Map([["pwr_local", 4]]),
+      cardWidth: 220,
+    });
+    const hub = placement.instances.find((instance) => instance.isHub);
+    expect(hub?.cardSlots).toHaveLength(4);
+    // Slots sit on a ring, so no two share a position.
+    const unique = new Set(
+      hub?.cardSlots.map((slot) => `${Math.round(slot.dx)}:${Math.round(slot.dy)}`),
+    );
+    expect(unique.size).toBe(4);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { FederationPeerSummary } from "@pwragent/shared";
 import {
-  cardRingRadius,
+  cardRingExtent,
+  cardRings,
+  cardRingSlots,
   computeOrbitPlacement,
   shouldStartCanvasPan,
 } from "../star-map-orbit";
@@ -50,13 +52,42 @@ describe("buildFederationTopology", () => {
   });
 });
 
-describe("cardRingRadius", () => {
-  it("grows so cards on the ring cannot collide", () => {
-    const few = cardRingRadius(2, 220);
-    const many = cardRingRadius(10, 220);
-    expect(many).toBeGreaterThan(few);
-    // Circumference has to cover every card plus a gap.
-    expect(2 * Math.PI * many).toBeGreaterThanOrEqual(10 * 220);
+describe("card rings", () => {
+  it("seats a small cloud on one tight ring near the body", () => {
+    const rings = cardRings(4, 200);
+    expect(rings).toHaveLength(1);
+    // Close in: a handful of cards should not be flung to the far orbit.
+    expect(rings[0].rx).toBeLessThan(200);
+  });
+
+  it("adds a ring instead of inflating the first one", () => {
+    const single = cardRingExtent(4, 200);
+    const many = cardRingExtent(16, 200);
+    expect(cardRings(16, 200).length).toBeGreaterThan(1);
+    // Sixteen cards on one circle would need a radius over 500; rings keep
+    // the outermost far tighter than that.
+    expect(many.rx).toBeLessThan(500);
+    expect(many.rx).toBeGreaterThan(single.rx);
+  });
+
+  it("is squashed to the card's aspect so rings hug the body vertically", () => {
+    const extent = cardRingExtent(8, 200);
+    expect(extent.ry).toBeLessThan(extent.rx);
+  });
+
+  it("gives every card a distinct slot and fills inner rings first", () => {
+    const slots = cardRingSlots(16, 200);
+    expect(slots).toHaveLength(16);
+    const unique = new Set(
+      slots.map((slot) => `${Math.round(slot.dx)}:${Math.round(slot.dy)}`),
+    );
+    expect(unique.size).toBe(16);
+    const inner = cardRings(16, 200)[0];
+    const firstRingRadius = Math.hypot(
+      slots[0].dx / inner.rx,
+      slots[0].dy / inner.ry,
+    );
+    expect(firstRingRadius).toBeCloseTo(1, 5);
   });
 });
 
@@ -99,7 +130,7 @@ describe("computeOrbitPlacement", () => {
       cardCounts: counts,
       cardWidth: 220,
     });
-    const ring = cardRingRadius(6, 220);
+    const ring = cardRingExtent(6, 220).rx;
     const spokes = placement.instances.filter((instance) => !instance.isHub);
     for (let i = 0; i < spokes.length; i += 1) {
       for (let j = i + 1; j < spokes.length; j += 1) {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { FederationPeerSummary } from "@pwragent/shared";
-import { cardRingRadius, computeOrbitPlacement } from "../star-map-orbit";
+import {
+  cardRingRadius,
+  computeOrbitPlacement,
+  shouldStartCanvasPan,
+} from "../star-map-orbit";
 import { buildFederationTopology, topologyEdges } from "../star-map-topology";
 
 function peer(
@@ -121,5 +125,40 @@ describe("computeOrbitPlacement", () => {
       hub?.cardSlots.map((slot) => `${Math.round(slot.dx)}:${Math.round(slot.dy)}`),
     );
     expect(unique.size).toBe(4);
+  });
+});
+
+describe("shouldStartCanvasPan", () => {
+  function element(html: string): Element {
+    const host = document.createElement("div");
+    host.innerHTML = html;
+    return host.firstElementChild!;
+  }
+
+  it("pans from bare sky", () => {
+    expect(shouldStartCanvasPan(element('<div class="star-map__sky" />'))).toBe(
+      true,
+    );
+  });
+
+  it("never steals a gesture from a card, body, or chrome", () => {
+    // Cards and instance bodies are buttons and drag/open themselves.
+    const card = element('<button class="star-map-card"><span>x</span></button>');
+    expect(shouldStartCanvasPan(card)).toBe(false);
+    expect(shouldStartCanvasPan(card.firstElementChild)).toBe(false);
+
+    const chrome = element(
+      '<div class="star-map__chrome"><p>PwrAgent</p></div>',
+    );
+    expect(shouldStartCanvasPan(chrome.firstElementChild)).toBe(false);
+
+    const filters = element(
+      '<div class="star-map__filters"><span>Unread</span></div>',
+    );
+    expect(shouldStartCanvasPan(filters.firstElementChild)).toBe(false);
+  });
+
+  it("ignores a non-element target", () => {
+    expect(shouldStartCanvasPan(null)).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
@@ -159,3 +159,16 @@ export function computeOrbitPlacement(params: {
     canvasHeight: maxY - minY + CANVAS_PADDING * 2,
   };
 }
+
+/**
+ * Whether a pointerdown on the map should start a canvas pan.
+ *
+ * Anything interactive owns its own gesture — cards drag themselves,
+ * bodies open, chrome clicks — so a pan only begins on bare sky.
+ */
+export function shouldStartCanvasPan(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return !target.closest(
+    "button, a, input, label, .star-map__chrome, .star-map__filters",
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
@@ -17,19 +17,91 @@ export type OrbitPlacement = {
   canvasHeight: number;
 };
 
-const CARD_RING_MIN_RADIUS = 190;
+/* Cards are wide and short (~2:1), so their rings are ellipses rather than
+   circles: horizontal spacing is the binding constraint at the top and
+   bottom of a ring, while the sides only need to clear a card's height.
+   Squashing the ring to match the card's shape pulls everything closer to
+   the body than a circle of the same capacity would. */
+const RING_BASE_RX = 178;
+const RING_BASE_RY = 130;
+/* Successive rings step out far enough that a card on one clears the card
+   height of the ring inside it. */
+const RING_STEP_RX = 228;
+const RING_STEP_RY = 124;
+/* Cards may crowd to 82% of their width at the tightest point on a ring:
+   they are opaque and hover raises the one under the pointer, so a little
+   shingling buys a much denser map. */
+const RING_PACKING = 0.82;
 const CANVAS_PADDING = 160;
-/** Depth-1 instances need room for their own card ring plus breathing space. */
-const INSTANCE_RING_MIN_RADIUS = 520;
+/** Floor on how close two instance bodies may sit, before ring clearance. */
+const INSTANCE_RING_MIN_RADIUS = 430;
+
+export type CardRing = { rx: number; ry: number; capacity: number };
+
+function ringAt(index: number, cardWidth: number): CardRing {
+  const rx = RING_BASE_RX + index * RING_STEP_RX;
+  const ry = RING_BASE_RY + index * RING_STEP_RY;
+  return {
+    rx,
+    ry,
+    capacity: Math.max(
+      3,
+      Math.floor((2 * Math.PI * rx) / (cardWidth * RING_PACKING)),
+    ),
+  };
+}
+
+/** Rings needed to seat `count` cards, innermost first. */
+export function cardRings(count: number, cardWidth: number): CardRing[] {
+  const rings: CardRing[] = [];
+  let seated = 0;
+  for (let index = 0; seated < Math.max(count, 1); index += 1) {
+    const ring = ringAt(index, cardWidth);
+    rings.push(ring);
+    seated += ring.capacity;
+  }
+  return rings;
+}
+
+/** Outermost extent of an instance's card rings, for spacing and bounds. */
+export function cardRingExtent(
+  count: number,
+  cardWidth: number,
+): { rx: number; ry: number } {
+  const rings = cardRings(count, cardWidth);
+  const outer = rings[rings.length - 1];
+  return { rx: outer.rx, ry: outer.ry };
+}
 
 /**
- * Radius that fits `count` cards around a body without them colliding:
- * the ring's circumference has to cover every card's width plus a gap.
+ * Slot per card, filling each ring before stepping outward. Alternate
+ * rings are rotated half a step so cards do not line up radially.
  */
-export function cardRingRadius(count: number, cardWidth: number): number {
-  if (count <= 1) return CARD_RING_MIN_RADIUS;
-  const needed = (count * (cardWidth + 26)) / (2 * Math.PI);
-  return Math.max(CARD_RING_MIN_RADIUS, needed);
+export function cardRingSlots(
+  count: number,
+  cardWidth: number,
+): StarMapCardSlot[] {
+  const rings = cardRings(count, cardWidth);
+  const slots: StarMapCardSlot[] = [];
+  let remaining = count;
+  rings.forEach((ring, ringIndex) => {
+    if (remaining <= 0) return;
+    const onThisRing = Math.min(remaining, ring.capacity);
+    remaining -= onThisRing;
+    for (let index = 0; index < onThisRing; index += 1) {
+      // Start below the body so the first card lands where the lane
+      // layout would have put it, then walk clockwise.
+      const angle =
+        Math.PI / 2
+        + (index * 2 * Math.PI) / onThisRing
+        + (ringIndex % 2 === 1 ? Math.PI / onThisRing : 0);
+      slots.push({
+        dx: Math.cos(angle) * ring.rx,
+        dy: Math.sin(angle) * ring.ry,
+      });
+    }
+  });
+  return slots;
 }
 
 /**
@@ -49,8 +121,9 @@ export function computeOrbitPlacement(params: {
   if (!root) {
     return { instances: [], links: [], canvasWidth: 0, canvasHeight: 0 };
   }
-  const radiusFor = (instanceId: string) =>
-    cardRingRadius(params.cardCounts.get(instanceId) ?? 0, params.cardWidth);
+  const extentFor = (instanceId: string) =>
+    cardRingExtent(params.cardCounts.get(instanceId) ?? 0, params.cardWidth);
+  const radiusFor = (instanceId: string) => extentFor(instanceId).rx;
 
   const raw = new Map<string, { x: number; y: number }>();
   raw.set(root.instanceId, { x: 0, y: 0 });
@@ -62,13 +135,13 @@ export function computeOrbitPlacement(params: {
   // Space children so the widest pair of adjacent card rings still clears.
   const widestChildRing = children.reduce(
     (widest, node) => Math.max(widest, radiusFor(node.instanceId)),
-    CARD_RING_MIN_RADIUS,
+    RING_BASE_RX,
   );
   const ringRadius = Math.max(
     INSTANCE_RING_MIN_RADIUS,
-    radiusFor(root.instanceId) + widestChildRing + 120,
+    radiusFor(root.instanceId) + widestChildRing + 80,
     children.length > 1
-      ? (children.length * (widestChildRing * 2 + 80)) / (2 * Math.PI)
+      ? (children.length * (widestChildRing * 2 + 60)) / (2 * Math.PI)
       : 0,
   );
 
@@ -95,7 +168,7 @@ export function computeOrbitPlacement(params: {
     const spread = Math.PI / 2;
     const step = siblings.length > 1 ? spread / (siblings.length - 1) : 0;
     const angle = outward - spread / 2 + position * step;
-    const distance = radiusFor(node.parentId) + radiusFor(node.instanceId) + 120;
+    const distance = radiusFor(node.parentId) + radiusFor(node.instanceId) + 80;
     raw.set(node.instanceId, {
       x: parent.x + Math.cos(angle) * distance,
       y: parent.y + Math.sin(angle) * distance,
@@ -110,11 +183,11 @@ export function computeOrbitPlacement(params: {
   for (const node of params.nodes) {
     const point = raw.get(node.instanceId);
     if (!point) continue;
-    const reach = radiusFor(node.instanceId) + params.cardWidth / 2;
-    minX = Math.min(minX, point.x - reach);
-    maxX = Math.max(maxX, point.x + reach);
-    minY = Math.min(minY, point.y - reach);
-    maxY = Math.max(maxY, point.y + reach);
+    const extent = extentFor(node.instanceId);
+    minX = Math.min(minX, point.x - extent.rx - params.cardWidth / 2);
+    maxX = Math.max(maxX, point.x + extent.rx + params.cardWidth / 2);
+    minY = Math.min(minY, point.y - extent.ry - 80);
+    maxY = Math.max(maxY, point.y + extent.ry + 80);
   }
   const offsetX = CANVAS_PADDING - minX;
   const offsetY = CANVAS_PADDING - minY;
@@ -123,19 +196,7 @@ export function computeOrbitPlacement(params: {
     const point = raw.get(node.instanceId);
     if (!point) return [];
     const count = params.cardCounts.get(node.instanceId) ?? 0;
-    const radius = radiusFor(node.instanceId);
-    const cardSlots: StarMapCardSlot[] = Array.from(
-      { length: count },
-      (_unused, index) => {
-        // Start below the body and walk clockwise, so the first card sits
-        // where the lane layout would have put it.
-        const angle = Math.PI / 2 + (index * 2 * Math.PI) / Math.max(count, 1);
-        return {
-          dx: Math.cos(angle) * radius,
-          dy: Math.sin(angle) * radius,
-        };
-      },
-    );
+    const cardSlots = cardRingSlots(count, params.cardWidth);
     return [
       {
         instanceId: node.instanceId,

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
@@ -1,0 +1,161 @@
+import type { StarMapCardSlot } from "./star-map-layout";
+import type { StarMapTopologyNode } from "./star-map-topology";
+
+export type OrbitInstancePlacement = {
+  instanceId: string;
+  isHub: boolean;
+  x: number;
+  y: number;
+  /** Slots for this instance's cards, relative to its body. */
+  cardSlots: StarMapCardSlot[];
+};
+
+export type OrbitPlacement = {
+  instances: OrbitInstancePlacement[];
+  links: { fromInstanceId: string; toInstanceId: string }[];
+  canvasWidth: number;
+  canvasHeight: number;
+};
+
+const CARD_RING_MIN_RADIUS = 190;
+const CANVAS_PADDING = 160;
+/** Depth-1 instances need room for their own card ring plus breathing space. */
+const INSTANCE_RING_MIN_RADIUS = 520;
+
+/**
+ * Radius that fits `count` cards around a body without them colliding:
+ * the ring's circumference has to cover every card's width plus a gap.
+ */
+export function cardRingRadius(count: number, cardWidth: number): number {
+  if (count <= 1) return CARD_RING_MIN_RADIUS;
+  const needed = (count * (cardWidth + 26)) / (2 * Math.PI);
+  return Math.max(CARD_RING_MIN_RADIUS, needed);
+}
+
+/**
+ * Hub-and-spoke placement: every instance is a body with its threads
+ * orbiting it, and children orbit their parent. Bodies are spaced so
+ * neighbouring card rings cannot touch, which makes the canvas larger
+ * than the window by design — the surface pans and zooms instead of
+ * compressing the map into unreadability.
+ */
+export function computeOrbitPlacement(params: {
+  nodes: readonly StarMapTopologyNode[];
+  /** Visible card count per instance. */
+  cardCounts: ReadonlyMap<string, number>;
+  cardWidth: number;
+}): OrbitPlacement {
+  const root = params.nodes.find((node) => node.depth === 0);
+  if (!root) {
+    return { instances: [], links: [], canvasWidth: 0, canvasHeight: 0 };
+  }
+  const radiusFor = (instanceId: string) =>
+    cardRingRadius(params.cardCounts.get(instanceId) ?? 0, params.cardWidth);
+
+  const raw = new Map<string, { x: number; y: number }>();
+  raw.set(root.instanceId, { x: 0, y: 0 });
+
+  const children = params.nodes
+    .filter((node) => node.parentId === root.instanceId)
+    .sort((left, right) => left.instanceId.localeCompare(right.instanceId));
+
+  // Space children so the widest pair of adjacent card rings still clears.
+  const widestChildRing = children.reduce(
+    (widest, node) => Math.max(widest, radiusFor(node.instanceId)),
+    CARD_RING_MIN_RADIUS,
+  );
+  const ringRadius = Math.max(
+    INSTANCE_RING_MIN_RADIUS,
+    radiusFor(root.instanceId) + widestChildRing + 120,
+    children.length > 1
+      ? (children.length * (widestChildRing * 2 + 80)) / (2 * Math.PI)
+      : 0,
+  );
+
+  children.forEach((node, index) => {
+    const angle = -Math.PI / 2 + (index * 2 * Math.PI) / children.length;
+    raw.set(node.instanceId, {
+      x: Math.cos(angle) * ringRadius,
+      y: Math.sin(angle) * ringRadius,
+    });
+  });
+
+  // Anything deeper orbits its own parent, in the wedge pointing outward.
+  for (const node of params.nodes) {
+    if (node.depth < 2 || !node.parentId) continue;
+    const parent = raw.get(node.parentId);
+    if (!parent) continue;
+    const siblings = params.nodes.filter(
+      (candidate) => candidate.parentId === node.parentId,
+    );
+    const position = siblings.findIndex(
+      (candidate) => candidate.instanceId === node.instanceId,
+    );
+    const outward = Math.atan2(parent.y, parent.x);
+    const spread = Math.PI / 2;
+    const step = siblings.length > 1 ? spread / (siblings.length - 1) : 0;
+    const angle = outward - spread / 2 + position * step;
+    const distance = radiusFor(node.parentId) + radiusFor(node.instanceId) + 120;
+    raw.set(node.instanceId, {
+      x: parent.x + Math.cos(angle) * distance,
+      y: parent.y + Math.sin(angle) * distance,
+    });
+  }
+
+  // Shift into positive canvas space with room for the outermost rings.
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const node of params.nodes) {
+    const point = raw.get(node.instanceId);
+    if (!point) continue;
+    const reach = radiusFor(node.instanceId) + params.cardWidth / 2;
+    minX = Math.min(minX, point.x - reach);
+    maxX = Math.max(maxX, point.x + reach);
+    minY = Math.min(minY, point.y - reach);
+    maxY = Math.max(maxY, point.y + reach);
+  }
+  const offsetX = CANVAS_PADDING - minX;
+  const offsetY = CANVAS_PADDING - minY;
+
+  const instances: OrbitInstancePlacement[] = params.nodes.flatMap((node) => {
+    const point = raw.get(node.instanceId);
+    if (!point) return [];
+    const count = params.cardCounts.get(node.instanceId) ?? 0;
+    const radius = radiusFor(node.instanceId);
+    const cardSlots: StarMapCardSlot[] = Array.from(
+      { length: count },
+      (_unused, index) => {
+        // Start below the body and walk clockwise, so the first card sits
+        // where the lane layout would have put it.
+        const angle = Math.PI / 2 + (index * 2 * Math.PI) / Math.max(count, 1);
+        return {
+          dx: Math.cos(angle) * radius,
+          dy: Math.sin(angle) * radius,
+        };
+      },
+    );
+    return [
+      {
+        instanceId: node.instanceId,
+        isHub: node.depth === 0,
+        x: point.x + offsetX,
+        y: point.y + offsetY,
+        cardSlots,
+      },
+    ];
+  });
+
+  return {
+    instances,
+    links: params.nodes
+      .filter((node) => node.parentId)
+      .map((node) => ({
+        fromInstanceId: node.parentId!,
+        toInstanceId: node.instanceId,
+      })),
+    canvasWidth: maxX - minX + CANVAS_PADDING * 2,
+    canvasHeight: maxY - minY + CANVAS_PADDING * 2,
+  };
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-preferences.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-preferences.ts
@@ -18,7 +18,11 @@ export type StarMapCardFields = {
   terminalPullRequests: boolean;
 };
 
+export type StarMapLayoutMode = "lanes" | "orbit";
+
 export type StarMapViewPreferences = {
+  /** Lane columns under a body row, or bodies with orbiting card rings. */
+  layout: StarMapLayoutMode;
   cardFields: StarMapCardFields;
   /** Drop instances that are not currently connected from the map. */
   hideOfflineInstances: boolean;
@@ -30,6 +34,7 @@ export type StarMapViewPreferences = {
  * scannable at a glance.
  */
 export const DEFAULT_STAR_MAP_PREFERENCES: StarMapViewPreferences = {
+  layout: "lanes",
   cardFields: {
     provider: false,
     branch: false,
@@ -60,6 +65,7 @@ export function readStoredPreferences(): StarMapViewPreferences {
     if (!raw) return DEFAULT_STAR_MAP_PREFERENCES;
     const parsed = JSON.parse(raw) as Partial<StarMapViewPreferences>;
     return {
+      layout: parsed.layout === "orbit" ? "orbit" : "lanes",
       cardFields: {
         ...DEFAULT_STAR_MAP_PREFERENCES.cardFields,
         ...(parsed.cardFields ?? {}),

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-topology.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-topology.ts
@@ -1,0 +1,81 @@
+import type { FederationInstanceRole, FederationPeerSummary } from "@pwragent/shared";
+
+export type StarMapTopologyNode = {
+  instanceId: string;
+  /** Undefined for the root of the federation as this viewer can see it. */
+  parentId?: string;
+  /** 0 for the root, 1 for its clients, and so on. */
+  depth: number;
+  isLocal: boolean;
+  role: FederationInstanceRole;
+};
+
+/**
+ * The federation as a tree, rooted at the gateway this viewer reaches.
+ *
+ * What is derivable today: our own parent (the enrolled gateway) and the
+ * gateway's client list. `FederationPeerSummary` carries no per-peer
+ * parent id, so a peer that is itself a gateway for further clients
+ * cannot be nested yet — those clients simply are not visible to us. The
+ * shape is a general tree so that when the protocol advertises a parent,
+ * deeper levels place without touching the layout maths.
+ */
+export function buildFederationTopology(params: {
+  localInstanceId: string;
+  localRole: FederationInstanceRole;
+  peers: readonly FederationPeerSummary[];
+  /** Gateway this instance is enrolled with, when it is a client. */
+  gatewayInstanceId?: string;
+}): StarMapTopologyNode[] {
+  const peerById = new Map(params.peers.map((peer) => [peer.id, peer]));
+  const gatewayId =
+    params.gatewayInstanceId && peerById.has(params.gatewayInstanceId)
+      ? params.gatewayInstanceId
+      : params.peers.find((peer) => peer.role === "gateway")?.id;
+
+  // A client hangs off its gateway; anything else roots at the local body.
+  const rootId =
+    params.localRole === "client" && gatewayId
+      ? gatewayId
+      : params.localInstanceId;
+
+  const nodes: StarMapTopologyNode[] = [
+    {
+      instanceId: rootId,
+      depth: 0,
+      isLocal: rootId === params.localInstanceId,
+      role: rootId === params.localInstanceId ? params.localRole : "gateway",
+    },
+  ];
+  if (rootId !== params.localInstanceId) {
+    nodes.push({
+      instanceId: params.localInstanceId,
+      parentId: rootId,
+      depth: 1,
+      isLocal: true,
+      role: params.localRole,
+    });
+  }
+  for (const peer of params.peers) {
+    if (peer.id === rootId) continue;
+    nodes.push({
+      instanceId: peer.id,
+      parentId: rootId,
+      depth: 1,
+      isLocal: false,
+      role: peer.role,
+    });
+  }
+  return nodes;
+}
+
+export function topologyEdges(
+  nodes: readonly StarMapTopologyNode[],
+): { fromInstanceId: string; toInstanceId: string }[] {
+  return nodes
+    .filter((node) => node.parentId)
+    .map((node) => ({
+      fromInstanceId: node.parentId!,
+      toInstanceId: node.instanceId,
+    }));
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9410,6 +9410,44 @@ textarea,
   box-shadow: var(--shadow-popover);
 }
 
+/* Canvas the bodies live on. Lanes fill the viewport; orbit is larger than
+   the window and pans/zooms under the pointer. */
+.star-map__canvas {
+  position: absolute;
+  inset: 0;
+}
+
+.star-map__canvas.is-orbit {
+  inset: auto;
+  left: 0;
+  top: 0;
+  transform-origin: 0 0;
+  will-change: transform;
+}
+
+.star-map__layout-switch {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.star-map__layout-option {
+  flex: 1;
+  padding: 4px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.star-map__layout-option.is-on {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+
 .star-map__view-heading {
   margin: 4px 0 2px;
   color: var(--text-muted);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9449,6 +9449,17 @@ textarea,
   will-change: transform;
 }
 
+/* Bare sky is a pan handle in orbit; cards and bodies keep their own
+   cursors because the pan never starts on them. */
+.star-map__viewport:has(.star-map__canvas.is-orbit) {
+  cursor: grab;
+}
+
+.star-map__viewport.is-panning,
+.star-map__viewport.is-panning .star-map__canvas {
+  cursor: grabbing;
+}
+
 .star-map__layout-switch {
   display: flex;
   gap: 4px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9385,10 +9385,34 @@ textarea,
 /* "View" popover: card density + instance visibility, parked opposite the
    attention filters. */
 .star-map__chrome {
+  display: flex;
   position: absolute;
   top: 14px;
   left: 16px;
   z-index: 4;
+  align-items: center;
+  gap: 12px;
+}
+
+/* The map covers the whole window, so its top-left chrome has to clear the
+   OS window controls itself. macOS floats the traffic lights over the
+   content: reserve the same 80px the sidebar masthead does, so the
+   wordmark lands in exactly the spot it occupies on the main window. */
+:root[data-platform="darwin"] .star-map__chrome {
+  padding-left: 80px;
+}
+
+/* macOS fullscreen hides the stoplights, so the reservation becomes a dead
+   gap - same fallback the masthead uses. */
+:root[data-platform="darwin"][data-fullscreen="true"] .star-map__chrome {
+  padding-left: 0;
+}
+
+/* Windows draws its caption buttons in the AppTitleBar strip above the
+   shell, and Linux uses a normal OS frame, so neither reserves anything
+   here. */
+:root[data-platform]:not([data-platform="darwin"]) .star-map__chrome {
+  padding-left: 0;
 }
 
 .star-map__view-options {


### PR DESCRIPTION
Stacked on #1265. A layout selector plus the hub-and-spoke shape, kept separate from the review-fix PR because it is a feature rather than a fix.

## Layout selector

Lives in the **View** popover (added in #1265) and is remembered per operator.

- **Lanes** (default) — the existing columns under a body row.
- **Orbit** — each instance's threads ring its own body, and bodies orbit their parent.

## Orbit

- Ring radius is derived from card count and card width, so cards on a ring cannot collide; bodies are then spaced so neighbouring rings clear each other.
- That deliberately makes the canvas larger than the window. The surface **pans with a two-finger drag** and **zooms with pinch** (ctrl+wheel), anchored under the pointer, rather than compressing the map into unreadability. The canvas recentres when the layout or topology changes.
- Connector lines are drawn between bodies and may pass under cards, as intended.

## Topology

Modelled as a **tree**, not a flat hub: the root is the gateway this viewer actually reaches — its enrolled gateway when the local instance is a pure client, otherwise itself — and everyone else hangs off it. The placement maths already handles depth ≥ 2 (children orbit their parent in an outward wedge).

**What blocks true multi-level nesting is data, not layout.** `FederationPeerSummary` carries no per-peer parent id, so a peer that is itself a gateway for further clients cannot have those clients placed under it — we simply cannot see them from here. That is documented in `star-map-topology.ts` so the follow-up is a protocol field, not a rewrite.

## Testing

New `star-map-orbit.test.ts`: topology rooting for gateway vs client, ring radius growth vs collision, every body inside a positive canvas, neighbouring bodies spaced beyond their ring radius, one slot per visible card with no duplicates.

Full workspace suite: 6518 passed / 4 skipped. Typecheck, `lint:colors`, `lint:boundaries`, ESLint (0 errors) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)