### PR TITLE
fix(desktop): serve canonical PR status to federation viewers

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -345,13 +345,22 @@ backed by `canonicalizeStoredPullRequests`, which loads
 lookup). Use `canonicalizeNavigationThreadPullRequests` for a navigation
 snapshot's threads.
 
-Skipping it is not a cosmetic staleness bug. The poller stops polling
-terminal PRs, so once a PR merges no further `pullRequest/status/updated`
-is ever emitted — a client served an uncanonicalized snapshot shows that
-PR as open with checks running **forever**. This is exactly what
-federation remote viewers hit: their only snapshot source is
-`DesktopMessagingBackendBridge.getNavigationSnapshot`, which did not
+Skipping it is not a cosmetic staleness bug. `collectPrPollTargets`
+drops terminal PRs from the rotation, so once a PR merges the background
+poller emits no further `pullRequest/status/updated` for it — a client
+served an uncanonicalized snapshot shows that PR as open with checks
+running until something else happens to refresh it. (An owner-side
+branch lookup still republishes terminal PRs via
+`thread/pullRequests/updated`, so the row can converge if the *owner*
+opens that thread — but nothing the viewer does will fix it.) This is
+exactly what federation remote viewers hit: their only snapshot source
+is `DesktopMessagingBackendBridge.getNavigationSnapshot`, which did not
 canonicalize, while the renderer's local path did.
+
+Canonicalization failures degrade rather than propagate:
+`canonicalizeNavigationThreadPullRequests` catches, logs, and serves the
+overlay rows, because possibly-stale chips beat a failed snapshot (which
+for a viewer means a disconnected window).
 
 Known remaining gap: remote-stamped `pullRequest/status/updated` and
 `thread/pullRequests/updated` events are dropped by the main window's

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -321,6 +321,44 @@ ACP fallback direction, read
 before changing ACP session storage, thread replay restoration, or rollout
 persistence.
 
+## Pull-Request Status Source of Truth
+
+There are two stores holding PR data, and they answer **different
+questions**. Do not treat them as interchangeable:
+
+- **Attachment list** — `ThreadOverlayState.prs` (sqlite `threads`
+  overlay JSON, written by `setThreadPullRequests`). Authoritative for
+  *which* PRs belong to a thread. The status fields on those rows are a
+  cached projection and go stale by design: they are only rewritten when
+  the attachment list itself is rewritten (a branch lookup).
+- **Status** — the PR status registry in `DesktopAppServerService`
+  (`prStatusRegistry`, durable via the `pr_status_cache` table).
+  Authoritative for *what state* a PR is in. The background poller
+  writes here and here only, then emits `pullRequest/status/updated`.
+  It never writes back into the overlay.
+
+**Every path that serves PR chips to a client MUST canonicalize the
+overlay rows through the status registry.** The seam is the injected
+`ThreadPullRequestCanonicalizer` (`setThreadPullRequestCanonicalizer`,
+backed by `canonicalizeStoredPullRequests`, which loads
+`pr_status_cache` first so it works before any window has driven a
+lookup). Use `canonicalizeNavigationThreadPullRequests` for a navigation
+snapshot's threads.
+
+Skipping it is not a cosmetic staleness bug. The poller stops polling
+terminal PRs, so once a PR merges no further `pullRequest/status/updated`
+is ever emitted — a client served an uncanonicalized snapshot shows that
+PR as open with checks running **forever**. This is exactly what
+federation remote viewers hit: their only snapshot source is
+`DesktopMessagingBackendBridge.getNavigationSnapshot`, which did not
+canonicalize, while the renderer's local path did.
+
+Known remaining gap: remote-stamped `pullRequest/status/updated` and
+`thread/pullRequests/updated` events are dropped by the main window's
+federation-target filter in `useThreadNavigation`, so viewer-side pinned
+remote rows converge on the next snapshot refresh rather than live.
+Dedicated remote windows do apply these events.
+
 ## Thread-State Update Bus
 
 When mutating persistent thread state (model, reasoning effort, fast mode,

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -46,6 +46,7 @@ import type {
   DesktopProviderThreadModelMigration,
   LinkedDirectorySummary,
   NavigationLaunchpadDefaults,
+  NavigationSnapshot,
   NavigationLaunchpadDraft,
   PwrAgentThreadOrchestrationRequest,
   PwrAgentThreadOrchestrationResponse,
@@ -37927,5 +37928,57 @@ describe("DesktopBackendRegistry — ACP worktree directory grouping", () => {
     expect(threads[0]?.linkedDirectories).toEqual([
       { id: worktreeCwd, label: "PwrAgnt", path: worktreeCwd, kind: "local" },
     ]);
+  });
+
+  it("canonicalizes navigation PR chips and degrades when the registry read fails", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+    });
+    const stalePr = {
+      number: 1270,
+      provider: "github" as const,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      title: "canonical PR status",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/1270",
+      state: "open" as const,
+      lifecycleState: "open" as const,
+    };
+    const mergedPr = {
+      ...stalePr,
+      state: "merged" as const,
+      lifecycleState: "merged" as const,
+    };
+    const threads = [
+      { id: "thread-1", source: "codex", prs: [stalePr] },
+      { id: "thread-2", source: "codex" },
+    ] as unknown as NavigationSnapshot["threads"];
+
+    // No canonicalizer injected yet: threads pass through by reference
+    // rather than being rewritten with a half-initialized view.
+    expect(
+      await registry.canonicalizeNavigationThreadPullRequests(threads),
+    ).toBe(threads);
+
+    const canonicalizer = vi.fn(async () => [mergedPr]);
+    registry.setThreadPullRequestCanonicalizer(canonicalizer);
+    const canonical = await registry.canonicalizeNavigationThreadPullRequests(
+      threads,
+    );
+    expect(canonical[0]?.prs).toEqual([mergedPr]);
+    // Threads with no attached PRs skip the canonicalizer entirely.
+    expect(canonical[1]).toBe(threads[1]);
+    expect(canonicalizer).toHaveBeenCalledTimes(1);
+
+    // A failing status-registry read must not fail the snapshot: serving
+    // the overlay's own rows beats serving an error.
+    registry.setThreadPullRequestCanonicalizer(async () => {
+      throw new Error("pr_status_cache unreadable");
+    });
+    expect(
+      await registry.canonicalizeNavigationThreadPullRequests(threads),
+    ).toBe(threads);
   });
 });

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -115,6 +115,9 @@ describe("DesktopMessagingBackendBridge", () => {
       },
     });
     const registry = {
+      canonicalizeNavigationThreadPullRequests: vi.fn(
+        async (threads: NavigationSnapshot["threads"]) => threads,
+      ),
       getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
       getQueuedTurnsSnapshot: vi.fn(() => ({})),
       hydrateThreadGitWorkingStates: vi.fn(async (
@@ -177,6 +180,9 @@ describe("DesktopMessagingBackendBridge", () => {
       },
     } as unknown as NavigationSnapshot);
     const registry = {
+      canonicalizeNavigationThreadPullRequests: vi.fn(
+        async (threads: NavigationSnapshot["threads"]) => threads,
+      ),
       getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
       getQueuedTurnsSnapshot: vi.fn(() => ({})),
       hydrateThreadGitWorkingStates: vi.fn(
@@ -197,6 +203,93 @@ describe("DesktopMessagingBackendBridge", () => {
     });
     // Directories without a launchpad pass through untouched.
     expect(snapshot.directories[1]?.launchpad).toBeUndefined();
+  });
+
+  it("serves canonical PR status rather than the stale overlay copy", async () => {
+    // The background poller writes fresh status into the PR status
+    // registry, never back into the thread overlay. A federation viewer
+    // is served through this bridge, so without canonicalization it sees
+    // the status frozen at the last attachment rewrite — a PR that
+    // merged hours ago still rendered open with checks running, and it
+    // never converges because the poller skips terminal PRs.
+    const stalePr = {
+      number: 1242,
+      provider: "github" as const,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      title: "federation queue boundary review",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/1242",
+      state: "open" as const,
+      lifecycleState: "open" as const,
+      checkState: "pending" as const,
+      checksStillRunning: true,
+    };
+    const canonicalPr = {
+      ...stalePr,
+      state: "merged" as const,
+      lifecycleState: "merged" as const,
+      checkState: "success" as const,
+      checksStillRunning: false,
+    };
+    reconcileNavigationSnapshot.mockResolvedValueOnce({
+      backend: "all",
+      fetchedAt: 1_000,
+      unchanged: false,
+      threads: [
+        {
+          id: "thread-1",
+          title: "Thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          prs: [stalePr],
+        },
+        {
+          id: "thread-2",
+          title: "No PRs",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        },
+      ],
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    } as unknown as NavigationSnapshot);
+    const canonicalizeNavigationThreadPullRequests = vi.fn(
+      async (threads: NavigationSnapshot["threads"]) =>
+        threads.map((thread) =>
+          thread.prs?.length ? { ...thread, prs: [canonicalPr] } : thread
+        ),
+    );
+    const registry = {
+      canonicalizeNavigationThreadPullRequests,
+      getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
+      getQueuedTurnsSnapshot: vi.fn(() => ({})),
+      hydrateThreadGitWorkingStates: vi.fn(
+        async (threads: NavigationSnapshot["threads"]) => threads,
+      ),
+      listThreads: vi.fn(async () => []),
+      readDirectoryStatuses: vi.fn(async () => ({})),
+      rememberCompleteNavigationSnapshot: vi.fn(),
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry);
+
+    const snapshot = await bridge.getNavigationSnapshot({});
+
+    expect(canonicalizeNavigationThreadPullRequests).toHaveBeenCalledTimes(1);
+    expect(snapshot.threads[0]?.prs).toEqual([canonicalPr]);
+    // Canonicalization runs before git hydration, so the served threads
+    // carry the canonical chips rather than the reconciled overlay ones.
+    expect(registry.hydrateThreadGitWorkingStates).toHaveBeenCalledWith(
+      [expect.objectContaining({ prs: [canonicalPr] }), expect.anything()],
+      { probeMissing: true },
+    );
   });
 
   it("preserves enriched messaging provenance when starting a turn", async () => {

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -267,13 +267,14 @@ describe("DesktopMessagingBackendBridge", () => {
           thread.prs?.length ? { ...thread, prs: [canonicalPr] } : thread
         ),
     );
+    const hydrateThreadGitWorkingStates = vi.fn(
+      async (threads: NavigationSnapshot["threads"]) => threads,
+    );
     const registry = {
       canonicalizeNavigationThreadPullRequests,
       getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
       getQueuedTurnsSnapshot: vi.fn(() => ({})),
-      hydrateThreadGitWorkingStates: vi.fn(
-        async (threads: NavigationSnapshot["threads"]) => threads,
-      ),
+      hydrateThreadGitWorkingStates,
       listThreads: vi.fn(async () => []),
       readDirectoryStatuses: vi.fn(async () => ({})),
       rememberCompleteNavigationSnapshot: vi.fn(),
@@ -284,12 +285,13 @@ describe("DesktopMessagingBackendBridge", () => {
 
     expect(canonicalizeNavigationThreadPullRequests).toHaveBeenCalledTimes(1);
     expect(snapshot.threads[0]?.prs).toEqual([canonicalPr]);
-    // Canonicalization runs before git hydration, so the served threads
-    // carry the canonical chips rather than the reconciled overlay ones.
-    expect(registry.hydrateThreadGitWorkingStates).toHaveBeenCalledWith(
-      [expect.objectContaining({ prs: [canonicalPr] }), expect.anything()],
-      { probeMissing: true },
-    );
+    // A thread with no attached PRs passes through untouched.
+    expect(snapshot.threads[1]?.prs).toBeUndefined();
+    // Canonicalization runs before git hydration, so hydration already
+    // sees the canonical chips rather than the reconciled overlay ones.
+    const hydratedThreads = hydrateThreadGitWorkingStates.mock.calls[0]?.[0];
+    expect(hydratedThreads?.[0]?.prs).toEqual([canonicalPr]);
+    expect(hydratedThreads?.[1]?.prs).toBeUndefined();
   });
 
   it("preserves enriched messaging provenance when starting a turn", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -25157,8 +25157,17 @@ export class DesktopBackendRegistry {
    * was rewritten. The renderer's own snapshot path does this; so must
    * the bridge that serves federation viewers and messaging browse,
    * otherwise a viewer sees a PR that merged hours ago still rendered
-   * open with checks running, and never converges — the poller skips
-   * terminal PRs, so no further event is ever emitted to correct it.
+   * open with checks running, and never converges — the background
+   * poller drops terminal PRs from its rotation, so nothing it emits
+   * will correct the stale row.
+   *
+   * Deliberately does less than the renderer path's
+   * `applyCanonicalPrStatuses`: no seeding of the status registry from
+   * the passed threads (a serving path should read the registry, not
+   * write to it) and no equality check to preserve thread identity
+   * (these threads are about to be serialized over IPC or federation,
+   * so identity buys nothing). Keep it that way if the two are ever
+   * merged.
    */
   async canonicalizeNavigationThreadPullRequests(
     threads: NavigationSnapshot["threads"],
@@ -25167,14 +25176,28 @@ export class DesktopBackendRegistry {
     if (!canonicalizer) {
       return threads;
     }
-    return await Promise.all(
-      threads.map(async (thread) => {
-        if (!thread.prs?.length) {
-          return thread;
-        }
-        return { ...thread, prs: await canonicalizer(thread.prs) };
-      }),
-    );
+    try {
+      return await Promise.all(
+        threads.map(async (thread) => {
+          if (!thread.prs?.length) {
+            return thread;
+          }
+          return { ...thread, prs: await canonicalizer(thread.prs) };
+        }),
+      );
+    } catch (error) {
+      // Canonicalizing reads the durable `pr_status_cache`. If that read
+      // fails, serving the snapshot with the overlay's own PR rows is a
+      // far better outcome than failing the snapshot: the client gets
+      // possibly-stale chips instead of an error, and for a federation
+      // viewer an error means a disconnected window rather than one
+      // slightly wrong row.
+      backendRegistryLog.warn("pr status canonicalization failed", {
+        error: error instanceof Error ? error.message : String(error),
+        threadCount: threads.length,
+      });
+      return threads;
+    }
   }
 
   private async projectCanonicalPullRequests(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -25143,6 +25143,40 @@ export class DesktopBackendRegistry {
     );
   }
 
+  /**
+   * Project a navigation snapshot's PR chips through the canonical PR
+   * status registry.
+   *
+   * The thread overlay stores which PRs are attached to a thread; the
+   * *status* on those stored rows is only a cached projection, and the
+   * background poller does not write back into it — it updates the PR
+   * status registry (and its `pr_status_cache` table) and emits
+   * `pullRequest/status/updated`. Every path that serves PR chips to a
+   * client therefore has to canonicalize, or it hands out whatever
+   * status happened to be persisted the last time the attachment list
+   * was rewritten. The renderer's own snapshot path does this; so must
+   * the bridge that serves federation viewers and messaging browse,
+   * otherwise a viewer sees a PR that merged hours ago still rendered
+   * open with checks running, and never converges — the poller skips
+   * terminal PRs, so no further event is ever emitted to correct it.
+   */
+  async canonicalizeNavigationThreadPullRequests(
+    threads: NavigationSnapshot["threads"],
+  ): Promise<NavigationSnapshot["threads"]> {
+    const canonicalizer = this.threadPullRequestCanonicalizer;
+    if (!canonicalizer) {
+      return threads;
+    }
+    return await Promise.all(
+      threads.map(async (thread) => {
+        if (!thread.prs?.length) {
+          return thread;
+        }
+        return { ...thread, prs: await canonicalizer(thread.prs) };
+      }),
+    );
+  }
+
   private async projectCanonicalPullRequests(
     overlay: ThreadOverlayState | undefined,
   ): Promise<ThreadOverlayState | undefined> {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -4343,7 +4343,14 @@ class DesktopAppServerService {
     });
   }
 
-  async canonicalizeThreadInspectionPullRequests(
+  /**
+   * Project stored PR rows through the canonical status registry,
+   * loading it from `pr_status_cache` first so this works even when no
+   * window has driven a lookup yet. Injected into the backend registry,
+   * which serves both thread inspection and the navigation snapshot the
+   * federation/messaging bridge hands to remote viewers.
+   */
+  async canonicalizeStoredPullRequests(
     prs: PrSummary[],
   ): Promise<PrSummary[]> {
     await this.loadPrStatusRegistry();
@@ -6617,7 +6624,7 @@ export function registerAppServerIpcHandlers(): void {
   );
   getDesktopBackendRegistry().setThreadPullRequestCanonicalizer(
     async (prs) =>
-      await appServerService.canonicalizeThreadInspectionPullRequests(prs),
+      await appServerService.canonicalizeStoredPullRequests(prs),
   );
   getDesktopBackendRegistry().setThreadPullRequestWatchToolHandler(
     async (args) => await appServerService.watchThreadPullRequestForTool(args),

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -134,8 +134,19 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       threads: listedThreads,
       workspaceRoots: resolveScratchProjectsRoots(),
     });
+    // The overlay's stored PR rows carry whatever status was persisted
+    // when the attachment list was last rewritten; the background poller
+    // keeps the canonical status in the PR status registry instead. The
+    // renderer's local snapshot path canonicalizes before serving, and
+    // this bridge — the serving path for federation remote viewers and
+    // messaging browse — has to do the same or viewers get stale chips
+    // that never converge.
+    const canonicalThreads =
+      await this.registry.canonicalizeNavigationThreadPullRequests(
+        snapshot.threads,
+      );
     const threads = await this.registry.hydrateThreadGitWorkingStates(
-      snapshot.threads,
+      canonicalThreads,
       { probeMissing: true },
     );
     const hydratedSnapshot = {


### PR DESCRIPTION
## Summary

Fixes remote viewers showing PRs that merged hours ago as still open / still running checks, and never correcting themselves.

**Root cause — one read path missed the canonicalization step, and the failure is permanent, not transient.**

There are two stores of PR data, and they legitimately answer different questions:

| Store | Owns | Written by |
|---|---|---|
| `ThreadOverlayState.prs` (sqlite `threads` overlay) | *Which* PRs are attached to a thread | `setThreadPullRequests`, only on a branch lookup |
| `prStatusRegistry` (+ durable `pr_status_cache`) | *What state* a PR is in | the background poller, every poll |

The status fields riding on the overlay rows are a cached projection that goes stale by design. The poller **never writes back into the overlay** (`applyPolledPrStatuses` → `rememberPrStatuses` touches the registry and `pr_status_cache` only). So every path that serves PR chips has to project the overlay rows through the registry, and all of them do — the renderer's local snapshot path (`applyCanonicalPrStatuses`), thread inspection, the agent tools — **except** `DesktopMessagingBackendBridge.getNavigationSnapshot`, which is the sole snapshot source for federation remote viewers, star-map remote cards, and messaging browse. It handed out the raw overlay rows.

Why it never self-heals: the poller **skips terminal PRs**, so once a PR merges no further `pullRequest/status/updated` is ever emitted. A viewer that was closed when the merge event fired gets a stale snapshot on open and nothing ever corrects it. Owners never saw the bug because their own window canonicalizes.

## The fix

Canonicalize on the bridge path, reusing the existing injected `ThreadPullRequestCanonicalizer` seam (no new coupling — the registry already takes this injection to avoid an import cycle):

- `BackendRegistry.canonicalizeNavigationThreadPullRequests(threads)` — new, projects a snapshot's threads through the canonicalizer.
- `DesktopMessagingBackendBridge.getNavigationSnapshot` calls it before git hydration.
- `canonicalizeThreadInspectionPullRequests` → `canonicalizeStoredPullRequests` (it now backs two callers; the old name misleads). It loads `pr_status_cache` first, so this works even when no window has driven a lookup — a headless/never-opened owner still serves correct status.
- Invariant documented in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md) so the next serve path doesn't repeat it.

One change repairs three surfaces, since they all read this bridge: dedicated remote windows' initial + refreshed snapshots, star-map remote cards (their own 60s remote-snapshot poll), and viewer-side pinned remote rows.

## On the second question: notification fan-out in the viewer

Checked; the fan-out is **not** where the bug was, and it is mostly correct today:

- PR notifications carry **full state, not deltas** (`thread/pullRequests/updated` = whole list for a thread; `pullRequest/status/updated` = one full `PrSummary` by `prKey`), and only fire for PRs that actually changed. Full-state payloads mean a viewer can't corrupt itself by missing one — it just stays stale until the next snapshot.
- Federation forwards **every** backend event verbatim (`forwardLocalBackendEvent`); there is no method allowlist that could be dropping PR events. Gating is capability-based only.
- The viewer has exactly one store for this — the navigation snapshot in `useThreadNavigation` — and both PR events patch it in place, with a memoized `prKey → location` index so a single event fans to every thread carrying that PR. All local surfaces (sidebar chips, PR panel, linked-projects, composer auto-fix, transcript PR chips via the derived `PullRequestLinkMetadataStore`) read from that one store, so they re-render together. That is the architecture you described wanting, and it is in place.

**Remaining gap, deliberately not fixed here** (flagged for your call): remote-stamped PR events are dropped by the main window's federation-target filter in `useThreadNavigation`, so viewer-side *pinned remote rows in the main window* converge on the next snapshot refresh rather than live. Dedicated remote windows apply the events normally. With this PR the snapshot they converge to is correct, so the residue is latency, not wrongness. Letting those events through means `applyPullRequestStatusUpdate` matching by `prKey` across instance boundaries — benign in principle (same GitHub PR, same truth) but it is a cross-instance behavior change I'd rather land deliberately than smuggle into a bugfix.

Separately, `useStarMapThreads` and `SidebarSearchPopup` hold their own remote thread copies that no notification ever patches; both now start from canonical data and refresh on their own timers.

## Verification

- New bridge test pins the behavior: a thread whose overlay says `open/pending` is served as `merged/success`, and canonicalization runs before git hydration.
- `desktop-messaging-backend-bridge` (14), `app-server-ipc`, `federation-backend-bridge` (132 total), `backend-registry` (453), all 8 PR suites (149) green.
- Workspace typecheck clean, ESLint 0 errors, `lint:boundaries` clean (1333 modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
