### PR TITLE
fix(desktop): federate pending PR auto-dispatch cancel and send-now

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -4,6 +4,7 @@ import type {
   ApplyThreadModelMigrationRequest,
   CancelQueuedTurnRequest,
   CancelThreadExecutionModeQueueRequest,
+  CancelThreadPrAutoDispatchRequest,
   CheckThreadBranchDriftRequest,
   CompactThreadRequest,
   ForkThreadRequest,
@@ -16,8 +17,10 @@ import type {
   StopCodexEnvironmentActionRequest,
   SetAcpSessionRuntimeOptionRequest,
   SetCodexThreadEnvironmentRequest,
+  SendThreadPrAutoDispatchNowRequest,
   SetThreadExecutionModeRequest,
   SetThreadModelSettingsRequest,
+  SetThreadPrAutoDispatchRequest,
   StopSubAgentRequest,
   StartReviewRequest,
   StartThreadRequest,
@@ -100,6 +103,21 @@ const registry = {
     ...request,
     trusted: true,
   })),
+  setThreadPrAutoDispatch: vi.fn(
+    async (request: SetThreadPrAutoDispatchRequest) => request,
+  ),
+  cancelThreadPrAutoDispatch: vi.fn(
+    async (request: CancelThreadPrAutoDispatchRequest) => ({
+      ...request,
+      cancelled: true,
+    }),
+  ),
+  sendThreadPrAutoDispatchNow: vi.fn(
+    async (request: SendThreadPrAutoDispatchNowRequest) => ({
+      ...request,
+      accepted: true,
+    }),
+  ),
   getLatestCodexConfigWarning: vi.fn(() => ({})),
 };
 
@@ -179,6 +197,21 @@ const federationMock = vi.hoisted(() => {
     ),
     setThreadModelSettings: vi.fn(
       async (request: SetThreadModelSettingsRequest) => request,
+    ),
+    setThreadPrAutoDispatch: vi.fn(
+      async (request: SetThreadPrAutoDispatchRequest) => request,
+    ),
+    cancelThreadPrAutoDispatch: vi.fn(
+      async (request: CancelThreadPrAutoDispatchRequest) => ({
+        ...request,
+        cancelled: true,
+      }),
+    ),
+    sendThreadPrAutoDispatchNow: vi.fn(
+      async (request: SendThreadPrAutoDispatchNowRequest) => ({
+        ...request,
+        accepted: true,
+      }),
     ),
     applyThreadModelMigration: vi.fn(
       async (request: ApplyThreadModelMigrationRequest) => ({
@@ -330,6 +363,9 @@ describe("agent ipc", () => {
     registry.stopSubAgent.mockClear();
     registry.steerTurn.mockClear();
     registry.materializeDirectoryLaunchpad.mockClear();
+    registry.setThreadPrAutoDispatch.mockClear();
+    registry.cancelThreadPrAutoDispatch.mockClear();
+    registry.sendThreadPrAutoDispatchNow.mockClear();
     federationMock.runtime.remoteBackend.mockClear();
     federationMock.runtime.setAgentEventPublisher.mockClear();
     federationMock.runtime.setEnvironmentSetupProgressPublisher.mockClear();
@@ -346,6 +382,9 @@ describe("agent ipc", () => {
     const {
       AGENT_CANCEL_QUEUED_TURN_CHANNEL,
       AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
+      AGENT_CANCEL_THREAD_PR_AUTO_DISPATCH_CHANNEL,
+      AGENT_SEND_THREAD_PR_AUTO_DISPATCH_NOW_CHANNEL,
+      AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL,
       AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL,
       AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
       AGENT_COMPACT_THREAD_CHANNEL,
@@ -454,6 +493,24 @@ describe("agent ipc", () => {
       federationTarget,
       threadId: "thread-1",
       model: "gpt-5-codex",
+    });
+    await handlers.get(AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      enabled: true,
+    });
+    await handlers.get(AGENT_CANCEL_THREAD_PR_AUTO_DISPATCH_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      fingerprint: "fingerprint-1",
+    });
+    await handlers.get(AGENT_SEND_THREAD_PR_AUTO_DISPATCH_NOW_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      fingerprint: "fingerprint-1",
     });
     await handlers.get(AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL)?.({}, {
       backend: "codex",
@@ -581,6 +638,31 @@ describe("agent ipc", () => {
       threadId: "thread-1",
       model: "gpt-5-codex",
     });
+    expect(federationMock.remoteBackend.setThreadPrAutoDispatch).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      enabled: true,
+    });
+    expect(registry.setThreadPrAutoDispatch).not.toHaveBeenCalled();
+    // The pending dispatch and its fingerprint live only in the owner's
+    // coordinator, so a viewer that resolves these locally silently
+    // no-ops while the owner still fires the scheduled repair turn.
+    expect(
+      federationMock.remoteBackend.cancelThreadPrAutoDispatch,
+    ).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      fingerprint: "fingerprint-1",
+    });
+    expect(registry.cancelThreadPrAutoDispatch).not.toHaveBeenCalled();
+    expect(
+      federationMock.remoteBackend.sendThreadPrAutoDispatchNow,
+    ).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      fingerprint: "fingerprint-1",
+    });
+    expect(registry.sendThreadPrAutoDispatchNow).not.toHaveBeenCalled();
     expect(
       federationMock.remoteBackend.applyThreadModelMigration,
     ).toHaveBeenCalledWith({

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -767,6 +767,114 @@ describe("federation backend bridge", () => {
     });
   });
 
+  it("routes pending PR auto-dispatch cancel over RPC with turn_control authorization", async () => {
+    const sent: FederationProtocolEnvelope[] = [];
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "viewer_one",
+      remoteInstanceId: "owner_one",
+      sendEnvelope: (envelope) => sent.push(envelope),
+      now: () => 1_000,
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+
+    const pending = client.cancelThreadPrAutoDispatch({
+      backend: "codex",
+      threadId: "thread-1",
+      fingerprint: "fingerprint-1",
+    });
+    const request = sent.at(-1)!;
+    expect(request).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.cancelThreadPrAutoDispatch,
+      params: {
+        backend: "codex",
+        threadId: "thread-1",
+        fingerprint: "fingerprint-1",
+      },
+    });
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.cancelThreadPrAutoDispatch
+      ],
+    ).toBe("turn_control");
+
+    rpc.receiveEnvelope({
+      id: "response-auto-dispatch-cancel",
+      kind: "response",
+      requestId: request.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_100,
+      result: {
+        backend: "codex",
+        threadId: "thread-1",
+        fingerprint: "fingerprint-1",
+        cancelled: true,
+      },
+    });
+    await expect(pending).resolves.toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      fingerprint: "fingerprint-1",
+      cancelled: true,
+    });
+  });
+
+  it("routes pending PR auto-dispatch send-now over RPC with turn_control authorization", async () => {
+    const sent: FederationProtocolEnvelope[] = [];
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "viewer_one",
+      remoteInstanceId: "owner_one",
+      sendEnvelope: (envelope) => sent.push(envelope),
+      now: () => 1_000,
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+
+    const pending = client.sendThreadPrAutoDispatchNow({
+      backend: "codex",
+      threadId: "thread-1",
+      fingerprint: "fingerprint-1",
+    });
+    const request = sent.at(-1)!;
+    expect(request).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.sendThreadPrAutoDispatchNow,
+      params: {
+        backend: "codex",
+        threadId: "thread-1",
+        fingerprint: "fingerprint-1",
+      },
+    });
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.sendThreadPrAutoDispatchNow
+      ],
+    ).toBe("turn_control");
+
+    rpc.receiveEnvelope({
+      id: "response-auto-dispatch-send-now",
+      kind: "response",
+      requestId: request.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_100,
+      result: {
+        backend: "codex",
+        threadId: "thread-1",
+        fingerprint: "fingerprint-1",
+        accepted: true,
+      },
+    });
+    await expect(pending).resolves.toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      fingerprint: "fingerprint-1",
+      accepted: true,
+    });
+  });
+
   it("serializes remote backend requests over RPC envelopes", async () => {
     const sent: FederationProtocolEnvelope[] = [];
     const rpc = new FederationRpcEndpoint({
@@ -1402,6 +1510,8 @@ describe("federation backend bridge", () => {
       reorderThreadPins: vi.fn(),
       detachThreadPullRequest: vi.fn(),
       setThreadPrAutoDispatch: vi.fn(),
+      cancelThreadPrAutoDispatch: vi.fn(),
+      sendThreadPrAutoDispatchNow: vi.fn(),
       archiveThread: vi.fn(),
       startThread: vi.fn(),
       forkThread: vi.fn(),
@@ -1618,6 +1728,8 @@ describe("federation backend bridge", () => {
       reorderThreadPins: vi.fn(),
         detachThreadPullRequest: vi.fn(),
         setThreadPrAutoDispatch: vi.fn(),
+        cancelThreadPrAutoDispatch: vi.fn(),
+        sendThreadPrAutoDispatchNow: vi.fn(),
         archiveThread: vi.fn(),
         startThread: vi.fn(),
         forkThread: vi.fn(),

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -46,6 +46,10 @@ import type {
   SetThreadPinResponse,
   SetThreadPrAutoDispatchRequest,
   SetThreadPrAutoDispatchResponse,
+  CancelThreadPrAutoDispatchRequest,
+  CancelThreadPrAutoDispatchResponse,
+  SendThreadPrAutoDispatchNowRequest,
+  SendThreadPrAutoDispatchNowResponse,
   ReorderThreadPinsRequest,
   ReorderThreadPinsResponse,
   NavigationSnapshot,
@@ -126,6 +130,8 @@ export const FEDERATION_BACKEND_METHODS = {
   reorderThreadPins: "backend.reorderThreadPins",
   detachThreadPullRequest: "backend.detachThreadPullRequest",
   setThreadPrAutoDispatch: "backend.setThreadPrAutoDispatch",
+  cancelThreadPrAutoDispatch: "backend.cancelThreadPrAutoDispatch",
+  sendThreadPrAutoDispatchNow: "backend.sendThreadPrAutoDispatchNow",
   archiveThread: "backend.archiveThread",
   startThread: "backend.startThread",
   forkThread: "backend.forkThread",
@@ -201,6 +207,8 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   // (like archiveThread) rather than the browse-level navigation grants.
   [FEDERATION_BACKEND_METHODS.detachThreadPullRequest]: "turn_control",
   [FEDERATION_BACKEND_METHODS.setThreadPrAutoDispatch]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.cancelThreadPrAutoDispatch]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.sendThreadPrAutoDispatchNow]: "turn_control",
   [FEDERATION_BACKEND_METHODS.archiveThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.startThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.forkThread]: "turn_control",
@@ -285,6 +293,12 @@ export type FederationBackendOperations = {
   setThreadPrAutoDispatch(
     request: SetThreadPrAutoDispatchRequest,
   ): Promise<SetThreadPrAutoDispatchResponse>;
+  cancelThreadPrAutoDispatch(
+    request: CancelThreadPrAutoDispatchRequest,
+  ): Promise<CancelThreadPrAutoDispatchResponse>;
+  sendThreadPrAutoDispatchNow(
+    request: SendThreadPrAutoDispatchNowRequest,
+  ): Promise<SendThreadPrAutoDispatchNowResponse>;
   archiveThread(request: ArchiveThreadRequest): Promise<ArchiveThreadResponse>;
   startThread(request: StartThreadRequest): Promise<StartThreadResponse>;
   forkThread(
@@ -481,6 +495,20 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.setThreadPrAutoDispatch(
         envelope.params as SetThreadPrAutoDispatchRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.cancelThreadPrAutoDispatch,
+    async (envelope) =>
+      await params.backend.cancelThreadPrAutoDispatch(
+        envelope.params as CancelThreadPrAutoDispatchRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.sendThreadPrAutoDispatchNow,
+    async (envelope) =>
+      await params.backend.sendThreadPrAutoDispatchNow(
+        envelope.params as SendThreadPrAutoDispatchNowRequest,
       ),
   );
   params.router.registerHandler(
@@ -871,6 +899,24 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<SetThreadPrAutoDispatchResponse> {
     return await this.rpc.request<SetThreadPrAutoDispatchResponse>({
       method: FEDERATION_BACKEND_METHODS.setThreadPrAutoDispatch,
+      params: request,
+    });
+  }
+
+  async cancelThreadPrAutoDispatch(
+    request: CancelThreadPrAutoDispatchRequest,
+  ): Promise<CancelThreadPrAutoDispatchResponse> {
+    return await this.rpc.request<CancelThreadPrAutoDispatchResponse>({
+      method: FEDERATION_BACKEND_METHODS.cancelThreadPrAutoDispatch,
+      params: request,
+    });
+  }
+
+  async sendThreadPrAutoDispatchNow(
+    request: SendThreadPrAutoDispatchNowRequest,
+  ): Promise<SendThreadPrAutoDispatchNowResponse> {
+    return await this.rpc.request<SendThreadPrAutoDispatchNowResponse>({
+      method: FEDERATION_BACKEND_METHODS.sendThreadPrAutoDispatchNow,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -93,6 +93,10 @@ import {
   type SetThreadPinResponse,
   type SetThreadPrAutoDispatchRequest,
   type SetThreadPrAutoDispatchResponse,
+  type CancelThreadPrAutoDispatchRequest,
+  type CancelThreadPrAutoDispatchResponse,
+  type SendThreadPrAutoDispatchNowRequest,
+  type SendThreadPrAutoDispatchNowResponse,
   type DetachThreadPullRequestRequest,
   type DetachThreadPullRequestResponse,
   type ReorderThreadPinsRequest,
@@ -2815,6 +2819,20 @@ function localBackendOperations(): FederationBackendOperations {
       request: SetThreadPrAutoDispatchRequest,
     ): Promise<SetThreadPrAutoDispatchResponse> {
       return await getDesktopBackendRegistry().setThreadPrAutoDispatch(request);
+    },
+    async cancelThreadPrAutoDispatch(
+      request: CancelThreadPrAutoDispatchRequest,
+    ): Promise<CancelThreadPrAutoDispatchResponse> {
+      return await getDesktopBackendRegistry().cancelThreadPrAutoDispatch(
+        request,
+      );
+    },
+    async sendThreadPrAutoDispatchNow(
+      request: SendThreadPrAutoDispatchNowRequest,
+    ): Promise<SendThreadPrAutoDispatchNowResponse> {
+      return await getDesktopBackendRegistry().sendThreadPrAutoDispatchNow(
+        request,
+      );
     },
     async reorderThreadPins(
       request: ReorderThreadPinsRequest,

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -377,6 +377,17 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: CancelThreadPrAutoDispatchRequest,
     ): Promise<CancelThreadPrAutoDispatchResponse> => {
+      if (
+        request.federationTarget
+        && isRemoteFederationTarget(request.federationTarget)
+      ) {
+        // The pending dispatch and its fingerprint only exist in the
+        // owning instance's coordinator; cancelling locally would report
+        // a no-op while the owner still fires the scheduled repair turn.
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .cancelThreadPrAutoDispatch(stripFederationTarget(request));
+      }
       return await registry.cancelThreadPrAutoDispatch(request);
     },
   );
@@ -388,6 +399,16 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: SendThreadPrAutoDispatchNowRequest,
     ): Promise<SendThreadPrAutoDispatchNowResponse> => {
+      if (
+        request.federationTarget
+        && isRemoteFederationTarget(request.federationTarget)
+      ) {
+        // Same as cancel: only the owner holds the pending dispatch, so
+        // "send now" has to run there to promote the scheduled turn.
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .sendThreadPrAutoDispatchNow(stripFederationTarget(request));
+      }
       return await registry.sendThreadPrAutoDispatchNow(request);
     },
   );

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -6522,6 +6522,10 @@ export function useThreadNavigation(
       if (!cancelThreadPrAutoDispatchRequest) return;
       await cancelThreadPrAutoDispatchRequest({
         backend: thread.source,
+        // The pending dispatch lives in the owning instance's
+        // coordinator, so the cancel has to travel there.
+        federationTarget: thread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: thread.id,
         fingerprint,
       });
@@ -6537,6 +6541,10 @@ export function useThreadNavigation(
       if (!sendThreadPrAutoDispatchNowRequest) return;
       await sendThreadPrAutoDispatchNowRequest({
         backend: thread.source,
+        // Promoting the scheduled turn only works on the owner, which is
+        // where the pending dispatch was armed.
+        federationTarget: thread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: thread.id,
         fingerprint,
       });

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -455,6 +455,11 @@ export type CancelThreadPrAutoDispatchRequest = {
 export type CancelThreadPrAutoDispatchResponse =
   CancelThreadPrAutoDispatchRequest & { cancelled: boolean };
 
+/**
+ * Same shape as the cancel request, including its optional
+ * `federationTarget` — both operations address a pending dispatch that
+ * only exists in the owning instance's coordinator.
+ */
 export type SendThreadPrAutoDispatchNowRequest =
   CancelThreadPrAutoDispatchRequest;
 

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -447,6 +447,7 @@ export type SetEligibleThreadsPrAutoDispatchResponse = {
 
 export type CancelThreadPrAutoDispatchRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   fingerprint: string;
 };


### PR DESCRIPTION
## Summary

- `cancelThreadPrAutoDispatch` and `sendThreadPrAutoDispatchNow` were the only two Auto-fix PR operations that were never federation-routed, so they silently no-op'd in remote viewer windows.
- In a remote window the composer's pending Auto-fix PR banner (driven by `thread.prAutoDispatchPending`) offers **Cancel** and **Send now**. Both hit the VIEWER's own `PrAutoDispatchCoordinator` with a fingerprint it has never seen, returned `cancelled: false` / `accepted: false`, and did nothing — while the owning instance kept its scheduled auto-fix turn and eventually dispatched it. The operator got no feedback that the click was a no-op.
- Fixed by following the established pattern already used by the sibling `setThreadPrAutoDispatch` and by `detachThreadPullRequest`:
  - `federationTarget?: FederationTarget` on `CancelThreadPrAutoDispatchRequest` in [`packages/shared/src/contracts/agent.ts`](packages/shared/src/contracts/agent.ts). `SendThreadPrAutoDispatchNowRequest` is a type alias of it and inherits the field; a doc comment on the alias makes that discoverable from the send-now type.
  - Both methods registered in [`federation-backend-bridge.ts`](apps/desktop/src/main/federation/federation-backend-bridge.ts): type imports, `FEDERATION_BACKEND_METHODS`, the capability map, the `FederationBackendOperations` interface, the server-side router handlers, and the `FederationRemoteBackendClient` proxies. Both carry `turn_control` like their siblings — `sendPendingNow` calls `dispatchPending`, which starts a turn.
  - Remote short-circuit via `isRemoteFederationTarget` + `stripFederationTarget` in both IPC handlers in [`agent-ipc.ts`](apps/desktop/src/main/ipc/agent-ipc.ts).
  - Target stamped at the renderer call sites in [`useThreadNavigation.ts`](apps/desktop/src/renderer/src/lib/useThreadNavigation.ts) using the standard `thread.federation?.ref.target ?? readRendererFederationTarget()` pattern. The `App.tsx` call sites go through these wrappers, so nothing else needed touching.
- [`federation-runtime.ts`](apps/desktop/src/main/federation/federation-runtime.ts) also gains the two methods on its local backend-operations adapter, since it implements the widened `FederationBackendOperations` interface.

### Test coverage

Review of the first commit surfaced that the bridge marshalling tests, on their own, don't guard the defect: they exercise `FederationRemoteBackendClient` and would still pass if the IPC handlers were reverted to calling `registry.*` directly.

[`agent-ipc.test.ts`](apps/desktop/src/main/__tests__/agent-ipc.test.ts)'s *"routes remote thread controls through federation without leaking the target"* is the harness for exactly that defect class — it drives each handler with a remote target and asserts the call lands on `remoteBackend.<method>` with the target stripped. **All three** PR auto-dispatch channels were absent from it, including the pre-existing `setThreadPrAutoDispatch`, which is plausibly why cancel and send-now were missed originally. The second commit adds all three, each also asserting the local `registry.*` was *not* called — a viewer resolving these locally is precisely the silent no-op being guarded against.

## Verification

- `pnpm typecheck` — clean across all 12 workspace projects.
- `pnpm lint:eslint` — 0 errors (146 warnings, all the pre-existing burn-down baseline; none in touched files).
- `pnpm lint:boundaries` — no dependency violations (1334 modules, 4254 dependencies cruised).
- `pnpm test agent-ipc federation` — 317/317 passed across 34 files.
- `pnpm test composer thread-navigation useThreadNavigation` — 467/467 passed across 10 files.
- **Mutation-checked the new guard:** temporarily reverting the cancel handler's remote short-circuit fails the new assertion (`expected "vi.fn()" to be called with arguments…`), then passes again on restore. The test bites on the real bug rather than just passing.
- **Traced the round trip end-to-end** rather than assuming routing was sufficient: viewer click → owner's `PrAutoDispatchCoordinator.cancelPending` → `notifyPending(…, null)` → `publishLocalEvent("thread/prAutoDispatch/pendingUpdated")` → `forwardLocalBackendEvent` (forwards all backend notifications to `remote_window` / `thread_detail` connections) → the viewer's handler at `useThreadNavigation.ts:3649` clears `prAutoDispatchPending`. The banner does converge on the viewer, so this is a complete fix and not just a correctly-routed call.

## Notes

- `stripFederationTarget` removes the field before the RPC, and the registry returns `{ ...params, cancelled }` / `{ ...params, accepted }`, so a response coming back from a remote owner has no `federationTarget` on it. That matches the existing `setThreadPrAutoDispatch` path exactly, and nothing in the renderer reads the field off the response — consistent rather than a new gap.
- On the local path the request now carries `federationTarget` through into `PrAutoDispatchCoordinator.cancelPending` and on to the store. It's inert: `overlay-store-sqlite.cancelThreadPrAutoDispatch` reads named fields and binds them positionally into a prepared statement.
- Not covered here: this restores correct routing, but the banner still doesn't surface a `cancelled: false` / `accepted: false` result to the operator (e.g. when the owner has already dispatched between render and click). That failure mode predates this change and is worth a separate look.
- The renderer call sites wrap with a trailing `??` rather than the house leading-operator style, matching the adjacent `setThreadPrAutoDispatch` call site verbatim. The `&&` in the new IPC handlers uses the leading form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
