### PR TITLE
feat(desktop): let peers drive PR chips they alone can see

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -373,7 +373,7 @@ gap it alone can see**:
 
 - `broadcastAgentEvent` drops a remote-stamped `pullRequest/status/updated`
   before it reaches any non-federation window when
-  `registry.isPullRequestAttachedLocally(prKey)` — the PR is attached to
+  `registry.isPullRequestLocallyMonitored(prKey)` — the PR is attached to
   a local thread's primary workspace, so our own poller owns it. The
   resolver is injected from `DesktopAppServerService` and uses the same
   test as `collectPrPollTargets`. Terminal PRs still count as ours: they
@@ -386,11 +386,28 @@ gap it alone can see**:
   the snapshot, so the local observation lands on the remote row too.
   That is why dropping the peer's copy loses nothing.
 
-`thread/pullRequests/updated` is not gated: a thread's *attachment list*
-is owned by the instance the thread lives on. It is instead scoped by
-origin in `applyThreadPullRequestsUpdate`, which matches the thread's
+`thread/pullRequests/updated` is **not** gated: a thread's *attachment
+list* is owned by the instance the thread lives on, so a peer is always
+authoritative for its own threads' lists. It is instead scoped by origin
+in `applyThreadPullRequestsUpdate`, which matches the thread's
 `federation.ref.target` against the event's, so a peer's event cannot
-rewrite a local thread that happens to share an id.
+rewrite a local thread that happens to share an id. Do not "fix" the
+asymmetry by adding this method to the gate — status and attachment
+lists have different owners, and a test pins the distinction.
+
+Two deliberate cases where we defer to the peer rather than claim
+ownership, both because claiming it would assert a freshness we do not
+have:
+
+- **Non-primary attachments.** The test is the PR matching a local
+  thread's *primary* repository, matching `collectPrPollTargets`. A PR
+  attached to a local thread some other way is not polled by us either,
+  so the peer's observation is the fresher one.
+- **Before the first local snapshot.** `attachedPrsByThreadKey` is
+  populated by the local navigation-snapshot path, so until it first
+  runs every PR answers "not monitored" and peer observations flow
+  through. The local poller corrects any row it owns on its next
+  observation.
 
 ## Thread-State Update Bus
 

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -362,11 +362,35 @@ Canonicalization failures degrade rather than propagate:
 overlay rows, because possibly-stale chips beat a failed snapshot (which
 for a viewer means a disconnected window).
 
-Known remaining gap: remote-stamped `pullRequest/status/updated` and
-`thread/pullRequests/updated` events are dropped by the main window's
-federation-target filter in `useThreadNavigation`, so viewer-side pinned
-remote rows converge on the next snapshot refresh rather than live.
-Dedicated remote windows do apply these events.
+### Who owns a PR's status when two instances can see it
+
+A window with no federation target shows local threads and pinned remote
+rows together, so the same GitHub PR can appear twice — once monitored
+by the local poller, once as a peer's observation. Two monitors writing
+the same rows from slightly different points in time reads as the status
+flickering. The rule is **local monitoring wins, and a peer only fills a
+gap it alone can see**:
+
+- `broadcastAgentEvent` drops a remote-stamped `pullRequest/status/updated`
+  before it reaches any non-federation window when
+  `registry.isPullRequestAttachedLocally(prKey)` — the PR is attached to
+  a local thread's primary workspace, so our own poller owns it. The
+  resolver is injected from `DesktopAppServerService` and uses the same
+  test as `collectPrPollTargets`. Terminal PRs still count as ours: they
+  leave the poll rotation, but our last observation of them is final.
+- Federation windows always receive the event. The peer is their only
+  source of truth, and their renderer-side target filter decides whether
+  it belongs to the instance they front.
+- When we *do* own the PR, the pinned remote row still updates — local
+  `pullRequest/status/updated` matches by `prKey` across every thread in
+  the snapshot, so the local observation lands on the remote row too.
+  That is why dropping the peer's copy loses nothing.
+
+`thread/pullRequests/updated` is not gated: a thread's *attachment list*
+is owned by the instance the thread lives on. It is instead scoped by
+origin in `applyThreadPullRequestsUpdate`, which matches the thread's
+`federation.ref.target` against the event's, so a peer's event cannot
+rewrite a local thread that happens to share an id.
 
 ## Thread-State Update Bus
 

--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -40,7 +40,7 @@ const federationWindowWebContents = { send: federationWindowSend };
 let registryListener: ((event: AgentEvent) => void | Promise<void>) | undefined;
 
 const registry = {
-  isPullRequestAttachedLocally: vi.fn((_prKey: string) => false),
+  isPullRequestLocallyMonitored: vi.fn((_prKey: string) => false),
   listBackends: vi.fn(async (_request?: ListBackendsRequest) => ({
     fetchedAt: 1,
     backends: [],
@@ -368,8 +368,8 @@ describe("agent ipc", () => {
     handlers.clear();
     send.mockReset();
     federationWindowSend.mockReset();
-    registry.isPullRequestAttachedLocally.mockClear();
-    registry.isPullRequestAttachedLocally.mockReturnValue(false);
+    registry.isPullRequestLocallyMonitored.mockClear();
+    registry.isPullRequestLocallyMonitored.mockReturnValue(false);
     registry.listBackends.mockClear();
     registry.onEvent.mockClear();
     registry.startThread.mockClear();
@@ -1111,7 +1111,7 @@ describe("agent ipc", () => {
     // Not attached locally: the peer is the only observer, so every
     // window — including the main one rendering a pinned remote row —
     // needs it.
-    registry.isPullRequestAttachedLocally.mockReturnValue(false);
+    registry.isPullRequestLocallyMonitored.mockReturnValue(false);
     await registryListener?.(remotePrEvent as unknown as AgentEvent);
     expect(send).toHaveBeenCalledWith(
       AGENT_EVENT_CHANNEL,
@@ -1125,7 +1125,7 @@ describe("agent ipc", () => {
     // to defer to and still gets it.
     send.mockReset();
     federationWindowSend.mockReset();
-    registry.isPullRequestAttachedLocally.mockReturnValue(true);
+    registry.isPullRequestLocallyMonitored.mockReturnValue(true);
     await registryListener?.(remotePrEvent as unknown as AgentEvent);
     expect(send).not.toHaveBeenCalled();
     expect(federationWindowSend).toHaveBeenCalledTimes(1);
@@ -1138,6 +1138,26 @@ describe("agent ipc", () => {
       federationTarget: undefined,
     } as unknown as AgentEvent);
     expect(send).toHaveBeenCalledTimes(1);
+
+    // A peer's ATTACHMENT LIST is never gated, even while we monitor a
+    // PR on that list ourselves: which PRs hang off a peer's thread is
+    // the peer's to declare, and only its own rows are rewritten (the
+    // renderer scopes that apply by federation origin). Widening the
+    // gate to cover this method would silently freeze pinned remote
+    // rows, so this asymmetry is pinned on purpose.
+    send.mockReset();
+    federationWindowSend.mockReset();
+    registry.isPullRequestLocallyMonitored.mockReturnValue(true);
+    await registryListener?.({
+      backend: "codex",
+      federationTarget: { scope: "remote", instanceId: "peer-1" },
+      notification: {
+        method: "thread/pullRequests/updated",
+        params: { threadId: "peer-thread-1", prs: [remotePrEvent.notification.params.pr] },
+      },
+    } as unknown as AgentEvent);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(federationWindowSend).toHaveBeenCalledTimes(1);
 
     disposeAgentIpcHandlers();
   });

--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -33,9 +33,14 @@ import type {
 
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 const send = vi.fn();
+// A second subscriber standing in for a federation (remote viewer)
+// window, so PR-authority fan-out can be asserted per window kind.
+const federationWindowSend = vi.fn();
+const federationWindowWebContents = { send: federationWindowSend };
 let registryListener: ((event: AgentEvent) => void | Promise<void>) | undefined;
 
 const registry = {
+  isPullRequestAttachedLocally: vi.fn((_prKey: string) => false),
   listBackends: vi.fn(async (_request?: ListBackendsRequest) => ({
     fetchedAt: 1,
     backends: [],
@@ -327,8 +332,18 @@ vi.mock("electron", () => ({
 // `BrowserWindow.getAllWindows()`. The test pretends a single
 // subscriber exists for any channel, which routes back to the
 // shared `send` mock above.
+// `broadcastAgentEvent` asks which remote instance a window fronts so a
+// peer's PR observation can be withheld from windows that have a local
+// monitor for the same PR. Only the federation subscriber has a target.
+vi.mock("../window", () => ({
+  federationWindowTargetForWebContents: (webContents: unknown) =>
+    webContents === federationWindowWebContents
+      ? { scope: "remote", instanceId: "peer-1" }
+      : undefined,
+}));
+
 vi.mock("../window-channels", () => ({
-  subscribersForChannel: () => [{ send }],
+  subscribersForChannel: () => [{ send }, federationWindowWebContents],
   WINDOW_KIND_MAIN: "main",
   WINDOW_KIND_MESSAGING_ACTIVITY: "messaging-activity",
   registerWindowChannels: () => undefined,
@@ -352,6 +367,9 @@ describe("agent ipc", () => {
   beforeEach(() => {
     handlers.clear();
     send.mockReset();
+    federationWindowSend.mockReset();
+    registry.isPullRequestAttachedLocally.mockClear();
+    registry.isPullRequestAttachedLocally.mockReturnValue(false);
     registry.listBackends.mockClear();
     registry.onEvent.mockClear();
     registry.startThread.mockClear();
@@ -1058,6 +1076,68 @@ describe("agent ipc", () => {
         }),
       }),
     );
+
+    disposeAgentIpcHandlers();
+  });
+
+  it("withholds a peer's PR status from windows that monitor the PR locally", async () => {
+    const { registerAgentIpcHandlers, disposeAgentIpcHandlers } = await import(
+      "../ipc/agent-ipc"
+    );
+    const { AGENT_EVENT_CHANNEL } = await import("../../shared/ipc");
+
+    registerAgentIpcHandlers();
+
+    const remotePrEvent = {
+      backend: "codex" as const,
+      federationTarget: { scope: "remote" as const, instanceId: "peer-1" },
+      notification: {
+        method: "pullRequest/status/updated" as const,
+        params: {
+          prKey: "github/pwrdrvr/pwragent#1270",
+          pr: {
+            number: 1270,
+            provider: "github" as const,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            title: "canonical PR status",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/1270",
+            state: "open" as const,
+          },
+        },
+      },
+    };
+
+    // Not attached locally: the peer is the only observer, so every
+    // window — including the main one rendering a pinned remote row —
+    // needs it.
+    registry.isPullRequestAttachedLocally.mockReturnValue(false);
+    await registryListener?.(remotePrEvent as unknown as AgentEvent);
+    expect(send).toHaveBeenCalledWith(
+      AGENT_EVENT_CHANNEL,
+      expect.objectContaining({ federationTarget: { scope: "remote", instanceId: "peer-1" } }),
+    );
+    expect(federationWindowSend).toHaveBeenCalledTimes(1);
+
+    // Attached locally: our own poller owns this PR and its events
+    // already patch the pinned row by prKey, so the peer's copy must not
+    // reach the main window. The federation window has no local monitor
+    // to defer to and still gets it.
+    send.mockReset();
+    federationWindowSend.mockReset();
+    registry.isPullRequestAttachedLocally.mockReturnValue(true);
+    await registryListener?.(remotePrEvent as unknown as AgentEvent);
+    expect(send).not.toHaveBeenCalled();
+    expect(federationWindowSend).toHaveBeenCalledTimes(1);
+
+    // The gate is scoped to remote PR status: a local observation of the
+    // same PR still reaches every window.
+    send.mockReset();
+    await registryListener?.({
+      ...remotePrEvent,
+      federationTarget: undefined,
+    } as unknown as AgentEvent);
+    expect(send).toHaveBeenCalledTimes(1);
 
     disposeAgentIpcHandlers();
   });

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -412,6 +412,7 @@ function emitRegistryEvent(event: unknown): void {
 const publishLocalEvent = vi.fn(async () => undefined);
 const setThreadPullRequestStatusToolHandler = vi.fn();
 const setThreadPullRequestCanonicalizer = vi.fn();
+const setLocalPullRequestAuthorityResolver = vi.fn();
 const setThreadPullRequestWatchToolHandler = vi.fn();
 const setThreadPrAutoDispatchHandler = vi.fn();
 const setThreadPullRequestDetachHandler = vi.fn();
@@ -784,6 +785,7 @@ vi.mock("../app-server/backend-registry", () => {
     publishLocalEvent,
     setThreadPullRequestStatusToolHandler,
     setThreadPullRequestCanonicalizer,
+    setLocalPullRequestAuthorityResolver,
     setThreadPullRequestWatchToolHandler,
     setThreadPrAutoDispatchHandler,
     setThreadPullRequestDetachHandler,
@@ -888,6 +890,7 @@ describe("app server ipc", () => {
     publishLocalEvent.mockClear();
     setThreadPullRequestStatusToolHandler.mockClear();
     setThreadPullRequestCanonicalizer.mockClear();
+    setLocalPullRequestAuthorityResolver.mockClear();
     setThreadPullRequestWatchToolHandler.mockClear();
     setThreadPrAutoDispatchHandler.mockClear();
     setThreadPullRequestDetachHandler.mockClear();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7130,10 +7130,13 @@ export class DesktopBackendRegistry {
   /**
    * True when this instance monitors the PR itself, so a federated
    * peer's observation of the same PR should not be applied on top of
-   * ours. Defaults to false when no resolver is injected — an instance
-   * that cannot answer the question has no claim to authority.
+   * ours. Defaults to false when no resolver is injected, and also
+   * answers false until the first local navigation snapshot has
+   * registered this instance's PR attachments — an instance that cannot
+   * yet answer the question has no claim to authority, and deferring to
+   * the peer beats asserting ownership we have not established.
    */
-  isPullRequestAttachedLocally(prKey: string): boolean {
+  isPullRequestLocallyMonitored(prKey: string): boolean {
     return this.localPullRequestAuthorityResolver?.(prKey) ?? false;
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1688,6 +1688,8 @@ type ThreadPullRequestCanonicalizer = (
   prs: PrSummary[],
 ) => PrSummary[] | Promise<PrSummary[]>;
 
+type LocalPullRequestAuthorityResolver = (prKey: string) => boolean;
+
 type ThreadPullRequestWatchToolHandler = (
   args: WatchThreadPullRequestToolArgs,
 ) => PwrAgentThreadInspectionResponse | Promise<PwrAgentThreadInspectionResponse>;
@@ -6405,6 +6407,9 @@ export class DesktopBackendRegistry {
   private threadPullRequestCanonicalizer:
     | ThreadPullRequestCanonicalizer
     | undefined;
+  private localPullRequestAuthorityResolver:
+    | LocalPullRequestAuthorityResolver
+    | undefined;
   private threadInspectionSearchService: ThreadSearchService | null | undefined;
   private readonly headlessAutomationTurns = new Map<
     string,
@@ -7114,6 +7119,22 @@ export class DesktopBackendRegistry {
     canonicalizer: ThreadPullRequestCanonicalizer | null | undefined,
   ): void {
     this.threadPullRequestCanonicalizer = canonicalizer ?? undefined;
+  }
+
+  setLocalPullRequestAuthorityResolver(
+    resolver: LocalPullRequestAuthorityResolver | null | undefined,
+  ): void {
+    this.localPullRequestAuthorityResolver = resolver ?? undefined;
+  }
+
+  /**
+   * True when this instance monitors the PR itself, so a federated
+   * peer's observation of the same PR should not be applied on top of
+   * ours. Defaults to false when no resolver is injected — an instance
+   * that cannot answer the question has no claim to authority.
+   */
+  isPullRequestAttachedLocally(prKey: string): boolean {
+    return this.localPullRequestAuthorityResolver?.(prKey) ?? false;
   }
 
   setThreadPullRequestWatchToolHandler(

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -1,5 +1,6 @@
 import { ipcMain, type IpcMainInvokeEvent } from "electron";
 import { subscribersForChannel } from "../window-channels";
+import { federationWindowTargetForWebContents } from "../window";
 import {
   sanitizeRendererPayload,
   type AgentEvent,
@@ -303,18 +304,55 @@ function withRendererActivityEntry(event: AgentEvent): AgentEvent {
   return rendererActivityEntry ? { ...event, rendererActivityEntry } : event;
 }
 
+/**
+ * A peer's PR-status observation is authoritative only for PRs this
+ * instance does not monitor itself.
+ *
+ * A window with no federation target renders local threads and pinned
+ * remote rows side by side. When the same PR is attached to a local
+ * thread, its status there is already driven by the local poller, and
+ * `pullRequest/status/updated` is matched by `prKey` across every thread
+ * in the snapshot — so the local observation reaches the pinned remote
+ * row too. Letting the peer's observation in as well means two monitors
+ * writing the same rows from slightly different points in time, which
+ * reads as the status flickering between values. One monitor wins:
+ * ours.
+ *
+ * A federation window has no local monitor to defer to — the peer is its
+ * only source of truth — so it always receives the event, and its own
+ * renderer-side target filter decides whether the event belongs to the
+ * instance it fronts.
+ */
+function remotePrStatusEventIsSupersededLocally(event: AgentEvent): boolean {
+  if (
+    !event.federationTarget
+    || event.notification.method !== "pullRequest/status/updated"
+  ) {
+    return false;
+  }
+  const { prKey } = event.notification.params as { prKey: string };
+  return getDesktopBackendRegistry().isPullRequestAttachedLocally(prKey);
+}
+
 export function broadcastAgentEvent(event: AgentEvent): void {
   const eventSummary = summarizeAgentEvent(event);
   if (eventSummary) {
     logAgentEventSummary(eventSummary);
   }
   const rendererEvent = sanitizeRendererPayload(withRendererActivityEntry(event));
+  const federationWindowsOnly = remotePrStatusEventIsSupersededLocally(event);
 
   // Only deliver to windows that registered for this channel.
   // Secondary windows (e.g. the Messaging Activity window) opt out by
   // default — see `apps/desktop/src/main/window-channels.ts`.
   for (const webContents of subscribersForChannel(AGENT_EVENT_CHANNEL)) {
     if (typeof webContents.send !== "function") continue;
+    if (
+      federationWindowsOnly
+      && !federationWindowTargetForWebContents(webContents)
+    ) {
+      continue;
+    }
     webContents.send(AGENT_EVENT_CHANNEL, rendererEvent);
   }
 }

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -331,7 +331,7 @@ function remotePrStatusEventIsSupersededLocally(event: AgentEvent): boolean {
     return false;
   }
   const { prKey } = event.notification.params as { prKey: string };
-  return getDesktopBackendRegistry().isPullRequestAttachedLocally(prKey);
+  return getDesktopBackendRegistry().isPullRequestLocallyMonitored(prKey);
 }
 
 export function broadcastAgentEvent(event: AgentEvent): void {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -4250,6 +4250,19 @@ class DesktopAppServerService {
     return threadKeys;
   }
 
+  /**
+   * True when this instance already owns the status of a PR, because the
+   * PR is attached to the primary workspace of one of its own threads —
+   * the same test `collectPrPollTargets` uses to decide what to poll.
+   *
+   * Terminal PRs count. They drop out of the poll rotation, but the
+   * status this instance last observed for them is final, so a peer's
+   * observation of the same PR must not be allowed to overwrite it.
+   */
+  isPullRequestAttachedLocally(prKey: string): boolean {
+    return this.findThreadKeysForPrKey(prKey).length > 0;
+  }
+
   private rememberPrLookup(entry: {
     lookupKey: string;
     provider: string;
@@ -6626,6 +6639,9 @@ export function registerAppServerIpcHandlers(): void {
     async (prs) =>
       await appServerService.canonicalizeStoredPullRequests(prs),
   );
+  getDesktopBackendRegistry().setLocalPullRequestAuthorityResolver((prKey) =>
+    appServerService.isPullRequestAttachedLocally(prKey)
+  );
   getDesktopBackendRegistry().setThreadPullRequestWatchToolHandler(
     async (args) => await appServerService.watchThreadPullRequestForTool(args),
   );
@@ -7346,6 +7362,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   const registry = getExistingDesktopBackendRegistry();
   registry?.setThreadPullRequestStatusToolHandler(undefined);
   registry?.setThreadPullRequestCanonicalizer(undefined);
+  registry?.setLocalPullRequestAuthorityResolver(undefined);
   registry?.setThreadPullRequestWatchToolHandler(undefined);
   registry?.setDirectoryGitStatusWriter(undefined);
   registry?.setThreadPrAutoDispatchHandler(undefined);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -4258,8 +4258,13 @@ class DesktopAppServerService {
    * Terminal PRs count. They drop out of the poll rotation, but the
    * status this instance last observed for them is final, so a peer's
    * observation of the same PR must not be allowed to overwrite it.
+   *
+   * Note the primary-workspace qualifier: a PR attached to a local
+   * thread but not to its primary repository is deliberately NOT ours.
+   * `collectPrPollTargets` skips those too, so we hold no fresher view
+   * of them than the peer does — deferring is the better answer.
    */
-  isPullRequestAttachedLocally(prKey: string): boolean {
+  isPullRequestLocallyMonitored(prKey: string): boolean {
     return this.findThreadKeysForPrKey(prKey).length > 0;
   }
 
@@ -6640,7 +6645,7 @@ export function registerAppServerIpcHandlers(): void {
       await appServerService.canonicalizeStoredPullRequests(prs),
   );
   getDesktopBackendRegistry().setLocalPullRequestAuthorityResolver((prKey) =>
-    appServerService.isPullRequestAttachedLocally(prKey)
+    appServerService.isPullRequestLocallyMonitored(prKey)
   );
   getDesktopBackendRegistry().setThreadPullRequestWatchToolHandler(
     async (args) => await appServerService.watchThreadPullRequestForTool(args),

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -8549,6 +8549,129 @@ describe("useThreadNavigation", () => {
     expect(result.current.directories[0]?.directoryThreadsCollapsed).toBe(true);
   });
 
+  it("applies a peer's PR events to its pinned rows without touching local threads", async () => {
+    // A pinned remote row is the only place a peer's PR chip is shown,
+    // and the main window has no federation target, so these events do
+    // not match its window target. They still have to land — scoped to
+    // the peer that sent them.
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const buildPr = (overrides: Record<string, unknown>) => ({
+      number: 1270,
+      provider: "github" as const,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      title: "canonical PR status",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/1270",
+      state: "open" as const,
+      lifecycleState: "open" as const,
+      ...overrides,
+    });
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    // Both threads deliberately share an id: only the federation origin
+    // distinguishes them.
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+      threads: [
+        {
+          id: "shared-thread-id",
+          title: "Local thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+          prs: [buildPr({ number: 999, url: "https://github.com/pwrdrvr/PwrAgent/pull/999" })],
+        },
+        {
+          id: "shared-thread-id",
+          title: "Pinned remote thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+          federation: {
+            instanceLabel: "Remote Mac",
+            ref: {
+              backend: "codex" as const,
+              target: federationTarget,
+              threadId: "shared-thread-id",
+            },
+          },
+          prs: [buildPr({})],
+        },
+      ],
+    }));
+    const desktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (
+        callback: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0],
+      ) => {
+        agentEventHandler = callback;
+        return () => {
+          agentEventHandler = undefined;
+        };
+      },
+    } as unknown as DesktopApi;
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(2);
+    });
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        federationTarget,
+        notification: {
+          method: "pullRequest/status/updated",
+          params: {
+            prKey: "github/pwrdrvr/pwragent#1270",
+            pr: buildPr({ state: "merged", lifecycleState: "merged" }),
+          },
+        },
+      } as never);
+    });
+
+    await waitFor(() => {
+      expect(result.current.threads[1]?.prs?.[0]?.lifecycleState).toBe("merged");
+    });
+    // The local thread carries a different PR and is untouched.
+    expect(result.current.threads[0]?.prs?.[0]?.number).toBe(999);
+
+    // A peer's attachment-list event must not rewrite the local thread
+    // that shares its id.
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        federationTarget,
+        notification: {
+          method: "thread/pullRequests/updated",
+          params: {
+            threadId: "shared-thread-id",
+            prs: [buildPr({ number: 4242 })],
+          },
+        },
+      } as never);
+    });
+
+    await waitFor(() => {
+      expect(result.current.threads[1]?.prs?.[0]?.number).toBe(4242);
+    });
+    expect(result.current.threads[0]?.prs?.[0]?.number).toBe(999);
+  });
+
   describe("pickAndRegisterDirectory (issue #223)", () => {
     const launchpadDefaults = {
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1547,7 +1547,12 @@ function applyThreadStatusUpdate(
 
 function applyThreadPullRequestsUpdate(
   snapshot: NavigationSnapshot | undefined,
-  params: { backend: AppServerBackendKind; threadId: string; prs: PrSummary[] }
+  params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    prs: PrSummary[];
+    federationTarget?: FederationTarget;
+  }
 ): NavigationSnapshot | undefined {
   if (!snapshot) {
     return snapshot;
@@ -1556,6 +1561,20 @@ function applyThreadPullRequestsUpdate(
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
     if (thread.source !== params.backend || thread.id !== params.threadId) {
+      return thread;
+    }
+
+    // A thread's attachment list is owned by the instance the thread
+    // lives on, so match the origin too: in a window that shows local
+    // threads alongside pinned remote ones, a peer's event must not
+    // rewrite a local thread that happens to share the id, and vice
+    // versa.
+    if (
+      !federationTargetsEqual(
+        thread.federation?.ref.target,
+        params.federationTarget,
+      )
+    ) {
       return thread;
     }
 
@@ -3194,7 +3213,26 @@ export function useThreadNavigation(
     return desktopApi.onAgentEvent((event) => {
       const windowTarget = readRendererFederationTarget();
       const method = event.notification.method as string;
-      if (!federationTargetsEqual(event.federationTarget, windowTarget)) {
+      // A peer's PR events are stamped with its own remote target, so they
+      // never match the main window's (absent) target — yet this window
+      // hosts that peer's threads as viewer-side remote pins, and those
+      // rows are the only place their PR chips are shown. Let them past
+      // the target filter and into the shared appliers below.
+      //
+      // Safe against duelling monitors: the main process drops a peer
+      // observation for any PR this instance monitors itself, so whatever
+      // arrives here has no local poller to contradict. When we do own the
+      // PR, our own local event patches the pinned row instead — status
+      // updates match by prKey across every thread in the snapshot.
+      const remotePullRequestPassthrough =
+        !windowTarget
+        && Boolean(event.federationTarget)
+        && (method === "pullRequest/status/updated"
+          || method === "thread/pullRequests/updated");
+      if (
+        !remotePullRequestPassthrough
+        && !federationTargetsEqual(event.federationTarget, windowTarget)
+      ) {
         // Peer-status events are stamped with the peer's own remote target,
         // which never matches the main window's (absent) window target. The
         // main window still hosts that peer's threads via viewer-side remote
@@ -3345,6 +3383,7 @@ export function useThreadNavigation(
         setState((current) => {
           const nextResponse = applyThreadPullRequestsUpdate(current.response, {
             backend: event.backend,
+            federationTarget: event.federationTarget,
             threadId,
             prs,
           });


### PR DESCRIPTION
> **Stacked on #1270** — review that one first; this branches off it.

## Summary

Implements the ownership rule for remote-stamped PR events: **local monitoring wins; a peer only drives PRs it alone can see.**

#1270 fixed the snapshot a viewer is served. This closes the live-update half: remote-stamped `pullRequest/status/updated` and `thread/pullRequests/updated` were dropped by the main window's federation-target filter, so viewer-side pinned remote rows only picked up a peer's PR changes on the next snapshot refresh.

Letting them through unconditionally would have been wrong. A window with no federation target renders local threads and pinned remote rows together, so the same GitHub PR can be observed twice — once by our poller, once by the peer. Two monitors writing the same rows from slightly different points in time reads as the status flickering between values.

## The gate

**Main process** — `broadcastAgentEvent` withholds a remote-stamped `pullRequest/status/updated` from every non-federation window when `registry.isPullRequestAttachedLocally(prKey)`:

- The predicate is injected from `DesktopAppServerService` through the same seam as the PR canonicalizer, and uses the same test as `collectPrPollTargets` — attached to a local thread's primary workspace.
- **Terminal PRs still count as ours.** They leave the poll rotation, but our last observation of them is final, so a peer must not overwrite it.
- Federation windows always receive the event: the peer is their only source of truth, and their renderer-side target filter decides whether it belongs to the instance they front.
- Per-window routing uses the existing `federationWindowTargetForWebContents` map, so this needed no contract change and no new plumbing.

**Nothing is lost by dropping the peer's copy.** When we do own the PR, `pullRequest/status/updated` matches by `prKey` across *every* thread in the snapshot — so our own local observation already patches the pinned remote row. The peer's copy would only have been a second writer of a value we already have.

**Renderer** — remote PR events bypass the target filter in an untargeted window and land in the shared appliers. `thread/pullRequests/updated` is deliberately *not* gated, because a thread's attachment list is owned by the instance the thread lives on; instead it is now scoped by origin in `applyThreadPullRequestsUpdate`, matching the thread's `federation.ref.target` against the event's, so a peer's event cannot rewrite a local thread that happens to share an id.

Answering the last part of your question directly: a remote viewer window does **not** start seeing local PR status updates. Local events carry no federation target, so that window's own target filter drops them — it stays a view of the peer.

## Verification

- New main-process test: a peer observation for a locally-attached PR reaches the federation window and not the main window; when not locally attached it reaches both; a local observation of the same PR is never gated.
- New renderer test: a peer's status event patches the pinned remote row while the local thread is untouched, and a peer's attachment-list event does not rewrite a local thread **sharing the same id**.
- `agent-ipc`, `app-server-ipc`, `backend-registry`, `desktop-messaging-backend-bridge`, `useThreadNavigation` — 675 tests green.
- Workspace typecheck clean, ESLint 0 errors, `lint:boundaries` clean.
- Rule documented in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md), replacing the "known remaining gap" note #1270 left there.

## Behavior change worth knowing

Letting these events past the target filter also means they now reach `markNavigationActivity({ refreshOnIdleResume: false })` and `scheduleRefresh()` in the main window — a peer's CI flip now counts as navigation activity there. `scheduleRefresh` coalesces through a single pending timer, so a burst of peer PR events collapses into one refresh rather than one per event.

## Notes on deliberate non-changes

**`isPullRequestLocallyMonitored` intentionally answers false in two cases.** A PR attached to a local thread but not to its *primary* repository is not ours — `collectPrPollTargets` skips those too, so we hold no fresher view than the peer. And before the first local navigation snapshot populates `attachedPrsByThreadKey`, every PR answers false; the local poller corrects any row it owns on its next observation. In both, claiming ownership would assert a freshness we do not have.

**The ownership check is a linear scan** over local attachments per remote status event. Poll events are seconds apart, so a `prKey` index would be premature structure with its own drift risk; noted rather than built.

A status event from peer A can still patch a row belonging to peer B when both have the same PR attached and neither is monitored locally. Both are observations of the same GitHub PR, so they agree on the truth and the fresher one wins — same behavior local events already have. Gating that too would mean per-peer PR ownership tracking for no user-visible benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

