### PR TITLE
docs(ci): validate docs-only workflow path

### DIFF
--- a/docs/ci-docs-only-validation.md
+++ b/docs/ci-docs-only-validation.md
@@ -1,0 +1,8 @@
+# Documentation-only CI validation
+
+This temporary document exercises the documentation-only pull-request path in
+the CI workflow. Its validation pull request targets the workflow change branch,
+so the pull request's complete diff relative to its base contains documentation
+only while GitHub evaluates the modified workflow.
+
+The validation pull request is disposable and must not be merged.


### PR DESCRIPTION
## Purpose

This disposable draft PR validates the documentation-only path introduced by #1274.

Its base is `agent/skip-docs-only-ci`, which already contains the modified workflow. The complete PR diff relative to that base is one Markdown file under `docs/`, so the classifier should report `docs_only=true` and `code_impacting=false`.

Expected CI conclusions:

- `Classify Changes`: success
- required contexts `Lint`, `Build`, `Test`, and `Desktop E2E`: conditionally skipped, not absent or pending
- Windows, macOS Desktop E2E, Windows installer, and unlabelled live-agent lanes: skipped

Do not merge this PR. It exists only to record live workflow behavior.
