### PR TITLE
feat(desktop): tombstone remote thread pins on revoke instead of deleting

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-reset-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-reset-enrollment.test.ts
@@ -19,11 +19,11 @@ const tombstoneRemoteThreadPinsForInstance = vi.hoisted(() =>
 const restoreRemoteThreadPinsForInstance = vi.hoisted(() =>
   vi.fn(async (_params: { instanceId: string }) => 0),
 );
-const listRemoteThreadPinInstanceIds = vi.hoisted(() =>
-  vi.fn(async (): Promise<string[]> => ["gateway_one"]),
-);
-const countRemoteThreadPinsForInstance = vi.hoisted(() =>
-  vi.fn(async (_params: { instanceId: string }) => ({ live: 2, revoked: 0 })),
+const countRemoteThreadPinsByInstance = vi.hoisted(() =>
+  vi.fn(
+    async (): Promise<Map<string, { live: number; revoked: number }>> =>
+      new Map([["gateway_one", { live: 2, revoked: 0 }]]),
+  ),
 );
 const publishLocalEvent = vi.hoisted(() => vi.fn(async () => undefined));
 
@@ -40,8 +40,7 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     removeRemoteThreadPinsForInstance,
     tombstoneRemoteThreadPinsForInstance,
     restoreRemoteThreadPinsForInstance,
-    listRemoteThreadPinInstanceIds,
-    countRemoteThreadPinsForInstance,
+    countRemoteThreadPinsByInstance,
   }),
 }));
 
@@ -94,8 +93,10 @@ describe("federation resetEnrollment", () => {
     removeRemoteThreadPinsForInstance.mockClear();
     tombstoneRemoteThreadPinsForInstance.mockClear();
     restoreRemoteThreadPinsForInstance.mockClear();
-    listRemoteThreadPinInstanceIds.mockClear();
-    listRemoteThreadPinInstanceIds.mockResolvedValue(["gateway_one"]);
+    countRemoteThreadPinsByInstance.mockClear();
+    countRemoteThreadPinsByInstance.mockResolvedValue(
+      new Map([["gateway_one", { live: 2, revoked: 0 }]]),
+    );
     publishLocalEvent.mockClear();
     metaStore.set(GATEWAY_ID_KEY, "gateway_one");
     metaStore.set("federation_gateway_public_key_pem", "pem");
@@ -137,7 +138,7 @@ describe("federation resetEnrollment", () => {
 
   it("reports nothing cleared when no pairing existed", async () => {
     metaStore.set(GATEWAY_ID_KEY, "");
-    listRemoteThreadPinInstanceIds.mockResolvedValue([]);
+    countRemoteThreadPinsByInstance.mockResolvedValue(new Map());
 
     expect(await createHarness().resetEnrollment()).toEqual({ cleared: false });
     expect(tombstoneRemoteThreadPinsForInstance).not.toHaveBeenCalled();
@@ -166,10 +167,12 @@ describe("federation resetEnrollment", () => {
   it("covers every instance reachable only through the forgotten gateway", async () => {
     // The gap in the first cut: pins for relayed peers, not just the
     // gateway's own threads, are equally unreachable afterwards.
-    listRemoteThreadPinInstanceIds.mockResolvedValue([
-      "gateway_one",
-      "relayed_peer",
-    ]);
+    countRemoteThreadPinsByInstance.mockResolvedValue(
+      new Map([
+        ["gateway_one", { live: 2, revoked: 0 }],
+        ["relayed_peer", { live: 1, revoked: 0 }],
+      ]),
+    );
 
     await createHarness().resetEnrollment();
 
@@ -261,12 +264,20 @@ describe("federation remote pin impact", () => {
   };
 
   beforeEach(() => {
-    countRemoteThreadPinsForInstance.mockClear();
-    countRemoteThreadPinsForInstance.mockResolvedValue({ live: 2, revoked: 0 });
-    listRemoteThreadPinInstanceIds.mockResolvedValue(["gateway_one"]);
+    countRemoteThreadPinsByInstance.mockClear();
+    countRemoteThreadPinsByInstance.mockResolvedValue(
+      new Map([["client_one", { live: 2, revoked: 0 }]]),
+    );
   });
 
-  it("reports one peer's counts", async () => {
+  it("reports one peer's counts, ignoring other pinned instances", async () => {
+    countRemoteThreadPinsByInstance.mockResolvedValue(
+      new Map([
+        ["client_one", { live: 2, revoked: 0 }],
+        // A second pinned instance must not leak into a peer-scoped read.
+        ["other_peer", { live: 9, revoked: 9 }],
+      ]),
+    );
     const runtime = new DesktopFederationRuntime() as unknown as ImpactHarness;
 
     expect(
@@ -281,11 +292,12 @@ describe("federation remote pin impact", () => {
   });
 
   it("sums every instance a gateway forget would affect", async () => {
-    listRemoteThreadPinInstanceIds.mockResolvedValue([
-      "gateway_one",
-      "relayed_peer",
-    ]);
-    countRemoteThreadPinsForInstance.mockResolvedValue({ live: 1, revoked: 2 });
+    countRemoteThreadPinsByInstance.mockResolvedValue(
+      new Map([
+        ["gateway_one", { live: 1, revoked: 2 }],
+        ["relayed_peer", { live: 1, revoked: 2 }],
+      ]),
+    );
 
     const runtime = new DesktopFederationRuntime() as unknown as ImpactHarness;
 
@@ -301,7 +313,7 @@ describe("federation remote pin impact", () => {
   it("reports zero for an instance with nothing pinned", async () => {
     // The renderer keys the whole keep-or-forget prompt off this: no pins
     // means no question worth asking.
-    countRemoteThreadPinsForInstance.mockResolvedValue({ live: 0, revoked: 0 });
+    countRemoteThreadPinsByInstance.mockResolvedValue(new Map());
 
     const runtime = new DesktopFederationRuntime() as unknown as ImpactHarness;
 

--- a/apps/desktop/src/main/__tests__/federation-reset-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-reset-enrollment.test.ts
@@ -13,6 +13,18 @@ const federationMode = vi.hoisted(() => ({ value: "dual" as string }));
 const removeRemoteThreadPinsForInstance = vi.hoisted(() =>
   vi.fn(async (_params: { instanceId: string }) => 2),
 );
+const tombstoneRemoteThreadPinsForInstance = vi.hoisted(() =>
+  vi.fn(async (_params: { instanceId: string; revokedAt?: number }) => 2),
+);
+const restoreRemoteThreadPinsForInstance = vi.hoisted(() =>
+  vi.fn(async (_params: { instanceId: string }) => 0),
+);
+const listRemoteThreadPinInstanceIds = vi.hoisted(() =>
+  vi.fn(async (): Promise<string[]> => ["gateway_one"]),
+);
+const countRemoteThreadPinsForInstance = vi.hoisted(() =>
+  vi.fn(async (_params: { instanceId: string }) => ({ live: 2, revoked: 0 })),
+);
 const publishLocalEvent = vi.hoisted(() => vi.fn(async () => undefined));
 
 vi.mock("../state/app-state", () => ({
@@ -26,6 +38,10 @@ vi.mock("../state/app-state", () => ({
 vi.mock("../app-server/desktop-overlay-store", () => ({
   getDesktopOverlayStore: () => ({
     removeRemoteThreadPinsForInstance,
+    tombstoneRemoteThreadPinsForInstance,
+    restoreRemoteThreadPinsForInstance,
+    listRemoteThreadPinInstanceIds,
+    countRemoteThreadPinsForInstance,
   }),
 }));
 
@@ -56,7 +72,9 @@ const LAST_ENDPOINT_KEY = "federation_gateway_last_endpoint";
 
 type ResetHarness = {
   restart: () => Promise<void>;
-  resetEnrollment: () => Promise<{ cleared: boolean }>;
+  resetEnrollment: (request?: {
+    pinDisposition?: "forget" | "remember";
+  }) => Promise<{ cleared: boolean }>;
 };
 
 function createHarness(): ResetHarness {
@@ -74,6 +92,10 @@ describe("federation resetEnrollment", () => {
     clearedSecrets.length = 0;
     federationMode.value = "dual";
     removeRemoteThreadPinsForInstance.mockClear();
+    tombstoneRemoteThreadPinsForInstance.mockClear();
+    restoreRemoteThreadPinsForInstance.mockClear();
+    listRemoteThreadPinInstanceIds.mockClear();
+    listRemoteThreadPinInstanceIds.mockResolvedValue(["gateway_one"]);
     publishLocalEvent.mockClear();
     metaStore.set(GATEWAY_ID_KEY, "gateway_one");
     metaStore.set("federation_gateway_public_key_pem", "pem");
@@ -115,18 +137,23 @@ describe("federation resetEnrollment", () => {
 
   it("reports nothing cleared when no pairing existed", async () => {
     metaStore.set(GATEWAY_ID_KEY, "");
+    listRemoteThreadPinInstanceIds.mockResolvedValue([]);
 
     expect(await createHarness().resetEnrollment()).toEqual({ cleared: false });
-    // No pairing → no instance whose pins could be attributed to it.
+    expect(tombstoneRemoteThreadPinsForInstance).not.toHaveBeenCalled();
     expect(removeRemoteThreadPinsForInstance).not.toHaveBeenCalled();
   });
 
-  it("drops the forgotten gateway's remote pins and pokes the renderer", async () => {
+  it("tombstones the forgotten federation's pins and pokes the renderer", async () => {
     await createHarness().resetEnrollment();
 
-    expect(removeRemoteThreadPinsForInstance).toHaveBeenCalledWith({
+    // Default disposition is non-destructive: the rows stop rendering but
+    // survive a later re-enrollment.
+    expect(tombstoneRemoteThreadPinsForInstance).toHaveBeenCalledWith({
       instanceId: "gateway_one",
+      revokedAt: undefined,
     });
+    expect(removeRemoteThreadPinsForInstance).not.toHaveBeenCalled();
     expect(publishLocalEvent).toHaveBeenCalledWith({
       backend: "codex",
       notification: {
@@ -136,8 +163,34 @@ describe("federation resetEnrollment", () => {
     });
   });
 
-  it("skips the pins-changed event when the gateway had no pins", async () => {
-    removeRemoteThreadPinsForInstance.mockResolvedValueOnce(0);
+  it("covers every instance reachable only through the forgotten gateway", async () => {
+    // The gap in the first cut: pins for relayed peers, not just the
+    // gateway's own threads, are equally unreachable afterwards.
+    listRemoteThreadPinInstanceIds.mockResolvedValue([
+      "gateway_one",
+      "relayed_peer",
+    ]);
+
+    await createHarness().resetEnrollment();
+
+    expect(
+      tombstoneRemoteThreadPinsForInstance.mock.calls.map(
+        (call) => call[0].instanceId,
+      ),
+    ).toEqual(["gateway_one", "relayed_peer"]);
+  });
+
+  it("hard-deletes only when the operator explicitly forgets", async () => {
+    await createHarness().resetEnrollment({ pinDisposition: "forget" });
+
+    expect(removeRemoteThreadPinsForInstance).toHaveBeenCalledWith({
+      instanceId: "gateway_one",
+    });
+    expect(tombstoneRemoteThreadPinsForInstance).not.toHaveBeenCalled();
+  });
+
+  it("skips the pins-changed event when nothing was pinned", async () => {
+    tombstoneRemoteThreadPinsForInstance.mockResolvedValueOnce(0);
 
     await createHarness().resetEnrollment();
 
@@ -145,15 +198,138 @@ describe("federation resetEnrollment", () => {
   });
 });
 
-describe("federation revokePeer — remote pin cleanup", () => {
+describe("federation remote pin restore", () => {
+  type StatusHarness = {
+    publishPeerStatus: (instanceId: string, status: string) => void;
+  };
+
+  beforeEach(() => {
+    restoreRemoteThreadPinsForInstance.mockClear();
+    restoreRemoteThreadPinsForInstance.mockResolvedValue(3);
+    publishLocalEvent.mockClear();
+  });
+
+  it("restores tombstoned pins when the instance connects again", async () => {
+    const runtime = new DesktopFederationRuntime() as unknown as StatusHarness;
+
+    runtime.publishPeerStatus("client_one", "connected");
+    await vi.waitFor(() =>
+      expect(restoreRemoteThreadPinsForInstance).toHaveBeenCalledWith({
+        instanceId: "client_one",
+      }),
+    );
+    await vi.waitFor(() =>
+      expect(publishLocalEvent).toHaveBeenCalledWith({
+        backend: "codex",
+        notification: {
+          method: "navigation/remoteThreadPins/changed",
+          params: { instanceId: "client_one", pinned: true },
+        },
+      }),
+    );
+  });
+
+  it("does not restore on a non-connected transition", async () => {
+    const runtime = new DesktopFederationRuntime() as unknown as StatusHarness;
+
+    runtime.publishPeerStatus("client_one", "disconnected");
+    runtime.publishPeerStatus("client_one", "degraded");
+
+    expect(restoreRemoteThreadPinsForInstance).not.toHaveBeenCalled();
+  });
+
+  it("restores once per connect transition, not per repeat publish", async () => {
+    const runtime = new DesktopFederationRuntime() as unknown as StatusHarness;
+
+    runtime.publishPeerStatus("client_one", "connected");
+    runtime.publishPeerStatus("client_one", "connected");
+    await vi.waitFor(() =>
+      expect(restoreRemoteThreadPinsForInstance).toHaveBeenCalledTimes(1),
+    );
+  });
+});
+
+describe("federation remote pin impact", () => {
+  type ImpactHarness = {
+    readRemoteThreadPinImpact: (request: {
+      scope: { kind: "peer"; peerId: string } | { kind: "enrollment" };
+    }) => Promise<{
+      pinnedThreadCount: number;
+      tombstonedThreadCount: number;
+      instanceLabels: string[];
+    }>;
+  };
+
+  beforeEach(() => {
+    countRemoteThreadPinsForInstance.mockClear();
+    countRemoteThreadPinsForInstance.mockResolvedValue({ live: 2, revoked: 0 });
+    listRemoteThreadPinInstanceIds.mockResolvedValue(["gateway_one"]);
+  });
+
+  it("reports one peer's counts", async () => {
+    const runtime = new DesktopFederationRuntime() as unknown as ImpactHarness;
+
+    expect(
+      await runtime.readRemoteThreadPinImpact({
+        scope: { kind: "peer", peerId: "client_one" },
+      }),
+    ).toEqual({
+      pinnedThreadCount: 2,
+      tombstonedThreadCount: 0,
+      instanceLabels: ["client_one"],
+    });
+  });
+
+  it("sums every instance a gateway forget would affect", async () => {
+    listRemoteThreadPinInstanceIds.mockResolvedValue([
+      "gateway_one",
+      "relayed_peer",
+    ]);
+    countRemoteThreadPinsForInstance.mockResolvedValue({ live: 1, revoked: 2 });
+
+    const runtime = new DesktopFederationRuntime() as unknown as ImpactHarness;
+
+    expect(
+      await runtime.readRemoteThreadPinImpact({ scope: { kind: "enrollment" } }),
+    ).toEqual({
+      pinnedThreadCount: 2,
+      tombstonedThreadCount: 4,
+      instanceLabels: ["gateway_one", "relayed_peer"],
+    });
+  });
+
+  it("reports zero for an instance with nothing pinned", async () => {
+    // The renderer keys the whole keep-or-forget prompt off this: no pins
+    // means no question worth asking.
+    countRemoteThreadPinsForInstance.mockResolvedValue({ live: 0, revoked: 0 });
+
+    const runtime = new DesktopFederationRuntime() as unknown as ImpactHarness;
+
+    expect(
+      await runtime.readRemoteThreadPinImpact({
+        scope: { kind: "peer", peerId: "never_pinned" },
+      }),
+    ).toEqual({
+      pinnedThreadCount: 0,
+      tombstonedThreadCount: 0,
+      instanceLabels: [],
+    });
+  });
+});
+
+describe("federation revokePeer — remote pin disposition", () => {
   beforeEach(() => {
     removeRemoteThreadPinsForInstance.mockClear();
+    tombstoneRemoteThreadPinsForInstance.mockClear();
     publishLocalEvent.mockClear();
   });
 
   type RevokeHarness = {
     store: () => unknown;
-    revokePeer: (peerId: string) => Promise<{ status: string }>;
+    revokePeer: (
+      peerId: string,
+      request?: { pinDisposition?: "forget" | "remember" },
+    ) => Promise<{ status: string }>;
   };
 
   function createRevokeHarness(): RevokeHarness {
@@ -172,13 +348,15 @@ describe("federation revokePeer — remote pin cleanup", () => {
     return runtime;
   }
 
-  it("deletes the revoked instance's pins and pokes the renderer", async () => {
+  it("tombstones the revoked instance's pins by default", async () => {
     const peer = await createRevokeHarness().revokePeer("client_one");
 
     expect(peer.status).toBe("revoked");
-    expect(removeRemoteThreadPinsForInstance).toHaveBeenCalledWith({
+    expect(tombstoneRemoteThreadPinsForInstance).toHaveBeenCalledWith({
       instanceId: "client_one",
+      revokedAt: expect.any(Number),
     });
+    expect(removeRemoteThreadPinsForInstance).not.toHaveBeenCalled();
     expect(publishLocalEvent).toHaveBeenCalledWith({
       backend: "codex",
       notification: {
@@ -188,8 +366,19 @@ describe("federation revokePeer — remote pin cleanup", () => {
     });
   });
 
-  it("still revokes when pin cleanup fails", async () => {
-    removeRemoteThreadPinsForInstance.mockRejectedValueOnce(
+  it("hard-deletes only on an explicit forget", async () => {
+    await createRevokeHarness().revokePeer("client_one", {
+      pinDisposition: "forget",
+    });
+
+    expect(removeRemoteThreadPinsForInstance).toHaveBeenCalledWith({
+      instanceId: "client_one",
+    });
+    expect(tombstoneRemoteThreadPinsForInstance).not.toHaveBeenCalled();
+  });
+
+  it("still revokes when pin bookkeeping fails", async () => {
+    tombstoneRemoteThreadPinsForInstance.mockRejectedValueOnce(
       new Error("db locked"),
     );
 

--- a/apps/desktop/src/main/__tests__/remote-thread-pins-store.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-pins-store.test.ts
@@ -358,6 +358,53 @@ describe("SqliteOverlayStore — remote thread pins", () => {
     expect(t1?.summary?.title).toBe("Remote fix");
   });
 
+  it("re-pinning a tombstoned thread brings it straight back", async () => {
+    // Restoring on reconnect is best-effort. If it never ran, an explicit
+    // pin must still land visibly — otherwise the operator clicks pin, the
+    // write succeeds, and nothing appears.
+    await store.addRemoteThreadPin({
+      ref: ref(),
+      summary: summary({ title: "Old" }),
+      instanceLabel: "Laptop",
+    });
+    await store.tombstoneRemoteThreadPinsForInstance({
+      instanceId: "peer-laptop",
+    });
+    expect(await store.listRemoteThreadPins()).toHaveLength(0);
+
+    await store.addRemoteThreadPin({
+      ref: ref(),
+      summary: summary({ title: "Fresh" }),
+      instanceLabel: "Laptop",
+    });
+
+    const live = await store.listRemoteThreadPins();
+    expect(live).toHaveLength(1);
+    expect(live[0].revokedAt).toBeUndefined();
+    expect(live[0].summary?.title).toBe("Fresh");
+  });
+
+  it("reports a tombstoned pin as absent so it can be re-pinned", async () => {
+    // `hasRemoteThreadPin` gates companion-parent pinning. Counting a
+    // hidden row would skip a parent that never renders, stranding its
+    // child as a bare top-level row.
+    await store.addRemoteThreadPin({
+      ref: ref("parent"),
+      instanceLabel: "Laptop",
+    });
+    expect(await store.hasRemoteThreadPin({ ref: ref("parent") })).toBe(true);
+
+    await store.tombstoneRemoteThreadPinsForInstance({
+      instanceId: "peer-laptop",
+    });
+    expect(await store.hasRemoteThreadPin({ ref: ref("parent") })).toBe(false);
+
+    await store.restoreRemoteThreadPinsForInstance({
+      instanceId: "peer-laptop",
+    });
+    expect(await store.hasRemoteThreadPin({ ref: ref("parent") })).toBe(true);
+  });
+
   it("keeps the original tombstone timestamp on a repeat revoke", async () => {
     await store.addRemoteThreadPin({
       ref: ref("t1", "peer-revoked"),
@@ -394,21 +441,13 @@ describe("SqliteOverlayStore — remote thread pins", () => {
     });
     await store.tombstoneRemoteThreadPinsForInstance({ instanceId: "peer-b" });
 
-    expect(
-      await store.countRemoteThreadPinsForInstance({ instanceId: "peer-a" }),
-    ).toEqual({ live: 2, revoked: 0 });
-    expect(
-      await store.countRemoteThreadPinsForInstance({ instanceId: "peer-b" }),
-    ).toEqual({ live: 0, revoked: 1 });
-    // An instance the operator never pinned from must report zero, so the
+    const counts = await store.countRemoteThreadPinsByInstance();
+    expect(counts.get("peer-a")).toEqual({ live: 2, revoked: 0 });
+    expect(counts.get("peer-b")).toEqual({ live: 0, revoked: 1 });
+    // An instance the operator never pinned from is simply absent, so the
     // keep-or-forget prompt stays hidden.
-    expect(
-      await store.countRemoteThreadPinsForInstance({ instanceId: "peer-none" }),
-    ).toEqual({ live: 0, revoked: 0 });
-
-    expect(
-      (await store.listRemoteThreadPinInstanceIds()).sort(),
-    ).toEqual(["peer-a", "peer-b"]);
+    expect(counts.get("peer-none")).toBeUndefined();
+    expect([...counts.keys()].sort()).toEqual(["peer-a", "peer-b"]);
   });
 
   it("migrates a v44 database to v45 with the revoked_at column", () => {

--- a/apps/desktop/src/main/__tests__/remote-thread-pins-store.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-pins-store.test.ts
@@ -309,6 +309,154 @@ describe("SqliteOverlayStore — remote thread pins", () => {
     expect(changedWrites.count).toBe(1);
   });
 
+  it("tombstones an instance's pins, hides them, and restores them", async () => {
+    await store.addRemoteThreadPin({
+      ref: ref("t1", "peer-revoked"),
+      summary: summary({ id: "t1" }),
+      instanceLabel: "Old laptop",
+      pinnedVia: "explicit",
+    });
+    await store.setRemoteThreadLocalPin({
+      ref: ref("t1", "peer-revoked"),
+      pinnedRank: "2048",
+    });
+    await store.addRemoteThreadPin({
+      ref: ref("t2", "peer-kept"),
+      summary: summary({ id: "t2" }),
+      instanceLabel: "Desktop",
+    });
+
+    expect(
+      await store.tombstoneRemoteThreadPinsForInstance({
+        instanceId: "peer-revoked",
+        revokedAt: 7_000,
+      }),
+    ).toBe(1);
+
+    // Hidden from the default list — the merge must never serve a row the
+    // viewer cannot reach for cause — but still on disk.
+    const live = await store.listRemoteThreadPins();
+    expect(live.map((pin) => pin.ref.threadId)).toEqual(["t2"]);
+    const all = await store.listRemoteThreadPins({ includeRevoked: true });
+    expect(all).toHaveLength(2);
+    expect(
+      all.find((pin) => pin.ref.threadId === "t1")?.revokedAt,
+    ).toBe(7_000);
+
+    // Re-enrolling brings the row back with its viewer-owned state intact.
+    expect(
+      await store.restoreRemoteThreadPinsForInstance({
+        instanceId: "peer-revoked",
+      }),
+    ).toBe(1);
+    const restored = await store.listRemoteThreadPins();
+    expect(restored).toHaveLength(2);
+    const t1 = restored.find((pin) => pin.ref.threadId === "t1");
+    expect(t1?.revokedAt).toBeUndefined();
+    expect(t1?.localPinnedRank).toBe("2048");
+    expect(t1?.pinnedVia).toBe("explicit");
+    expect(t1?.summary?.title).toBe("Remote fix");
+  });
+
+  it("keeps the original tombstone timestamp on a repeat revoke", async () => {
+    await store.addRemoteThreadPin({
+      ref: ref("t1", "peer-revoked"),
+      instanceLabel: "Old laptop",
+    });
+    await store.tombstoneRemoteThreadPinsForInstance({
+      instanceId: "peer-revoked",
+      revokedAt: 1_000,
+    });
+    // A second revoke touches nothing: restating when the list was put
+    // away would misreport how long it has been gone.
+    expect(
+      await store.tombstoneRemoteThreadPinsForInstance({
+        instanceId: "peer-revoked",
+        revokedAt: 9_000,
+      }),
+    ).toBe(0);
+    const all = await store.listRemoteThreadPins({ includeRevoked: true });
+    expect(all[0].revokedAt).toBe(1_000);
+  });
+
+  it("counts live and tombstoned pins per instance", async () => {
+    await store.addRemoteThreadPin({
+      ref: ref("t1", "peer-a"),
+      instanceLabel: "A",
+    });
+    await store.addRemoteThreadPin({
+      ref: ref("t2", "peer-a"),
+      instanceLabel: "A",
+    });
+    await store.addRemoteThreadPin({
+      ref: ref("t3", "peer-b"),
+      instanceLabel: "B",
+    });
+    await store.tombstoneRemoteThreadPinsForInstance({ instanceId: "peer-b" });
+
+    expect(
+      await store.countRemoteThreadPinsForInstance({ instanceId: "peer-a" }),
+    ).toEqual({ live: 2, revoked: 0 });
+    expect(
+      await store.countRemoteThreadPinsForInstance({ instanceId: "peer-b" }),
+    ).toEqual({ live: 0, revoked: 1 });
+    // An instance the operator never pinned from must report zero, so the
+    // keep-or-forget prompt stays hidden.
+    expect(
+      await store.countRemoteThreadPinsForInstance({ instanceId: "peer-none" }),
+    ).toEqual({ live: 0, revoked: 0 });
+
+    expect(
+      (await store.listRemoteThreadPinInstanceIds()).sort(),
+    ).toEqual(["peer-a", "peer-b"]);
+  });
+
+  it("migrates a v44 database to v45 with the revoked_at column", () => {
+    const { dbPath, tempDir } = createTempStateDb("pwragent-pin-tombstone-");
+    try {
+      const seeded = StateDb.open(dbPath);
+      seeded.raw.exec("DROP TABLE remote_thread_pins");
+      seeded.raw.exec(`
+CREATE TABLE remote_thread_pins (
+  instance_id TEXT NOT NULL,
+  backend     TEXT NOT NULL,
+  thread_id   TEXT NOT NULL,
+  added_at    INTEGER NOT NULL,
+  payload     TEXT NOT NULL,
+  PRIMARY KEY (instance_id, backend, thread_id)
+);`);
+      seeded.raw
+        .prepare(
+          `INSERT INTO remote_thread_pins(instance_id, backend, thread_id, added_at, payload)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run("peer-laptop", "codex", "thread-1", 1_000, "{}");
+      seeded.raw.pragma("user_version = 44");
+      seeded.close();
+
+      const migrated = StateDb.open(dbPath);
+      try {
+        expect(migrated.raw.pragma("user_version", { simple: true })).toBe(
+          CURRENT_STATE_DB_USER_VERSION,
+        );
+        const columns = (
+          migrated.raw.prepare("PRAGMA table_info(remote_thread_pins)").all() as
+            Array<{ name: string }>
+        ).map((column) => column.name);
+        expect(columns).toContain("revoked_at");
+        // A pin that predates the column is live, not tombstoned.
+        const row = migrated.raw
+          .prepare("SELECT revoked_at FROM remote_thread_pins")
+          .get() as { revoked_at: number | null };
+        expect(row.revoked_at).toBeNull();
+      } finally {
+        migrated.close();
+      }
+    } finally {
+      removeTempStateDbDir(tempDir);
+    }
+  });
+
   it("removes every pin for one instance in a single call", async () => {
     await store.addRemoteThreadPin({
       ref: ref("t1", "peer-revoked"),

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -889,7 +889,11 @@ export class DesktopFederationRuntime {
     // exactly as unreachable, and leaving them behind was the gap in the
     // first cut of this cleanup.
     const pinDisposition = request?.pinDisposition ?? "remember";
-    for (const instanceId of await this.enrollmentScopedPinInstanceIds()) {
+    const pinCountsByInstance = await getDesktopOverlayStore()
+      .countRemoteThreadPinsByInstance();
+    for (const instanceId of this.enrollmentScopedPinInstanceIds(
+      pinCountsByInstance,
+    )) {
       await this.cleanupRemoteThreadPins(instanceId, pinDisposition);
     }
     await this.restart();
@@ -1039,11 +1043,12 @@ export class DesktopFederationRuntime {
   async readRemoteThreadPinImpact(
     request: ReadFederationPinImpactRequest,
   ): Promise<ReadFederationPinImpactResponse> {
+    const countsByInstance = await getDesktopOverlayStore()
+      .countRemoteThreadPinsByInstance();
     const instanceIds =
       request.scope.kind === "peer"
         ? [request.scope.peerId]
-        : await this.enrollmentScopedPinInstanceIds();
-    const overlayStore = getDesktopOverlayStore();
+        : this.enrollmentScopedPinInstanceIds(countsByInstance);
     let pinnedThreadCount = 0;
     let tombstonedThreadCount = 0;
     const instanceLabels: string[] = [];
@@ -1054,10 +1059,8 @@ export class DesktopFederationRuntime {
       visible = [];
     }
     for (const instanceId of instanceIds) {
-      const counts = await overlayStore.countRemoteThreadPinsForInstance({
-        instanceId,
-      });
-      if (counts.live === 0 && counts.revoked === 0) {
+      const counts = countsByInstance.get(instanceId);
+      if (!counts) {
         continue;
       }
       pinnedThreadCount += counts.live;
@@ -1077,12 +1080,10 @@ export class DesktopFederationRuntime {
    * client) survives the upstream reset, so its pins must not be touched —
    * the same reasoning `resetEnrollment` applies to celestial icons.
    */
-  private async enrollmentScopedPinInstanceIds(): Promise<
-    FederationInstanceId[]
-  > {
-    const pinnedInstanceIds = await getDesktopOverlayStore()
-      .listRemoteThreadPinInstanceIds();
-    return pinnedInstanceIds.filter(
+  private enrollmentScopedPinInstanceIds(
+    countsByInstance: ReadonlyMap<string, unknown>,
+  ): FederationInstanceId[] {
+    return [...countsByInstance.keys()].filter(
       (instanceId) => !this.router?.getConnection(instanceId),
     );
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -25,6 +25,7 @@ import type {
   FederationInstanceId,
   FederationInstanceRole,
   FederationPeerSummary,
+  FederationPinDisposition,
   FederationProtocolEnvelope,
   FederationSessionId,
   ForkThreadResponse,
@@ -38,7 +39,10 @@ import type {
   PwrSnapConnectionStatus,
   OpenDesktopApplicationResponse,
   QueueThreadExecutionModeResponse,
+  ReadFederationPinImpactRequest,
+  ReadFederationPinImpactResponse,
   RefreshDirectoryGitStatusesResponse,
+  ResetFederationEnrollmentRequest,
   RetainThreadBranchDriftResponse,
   RenameThreadResponse,
   RunCodexEnvironmentActionResponse,
@@ -821,10 +825,13 @@ export class DesktopFederationRuntime {
    * the runtime. A client-only instance falls back to disabled mode so
    * it does not sit in a doomed reconnect loop against nothing.
    */
-  async resetEnrollment(): Promise<{ cleared: boolean }> {
+  async resetEnrollment(
+    request?: ResetFederationEnrollmentRequest,
+  ): Promise<{ cleared: boolean }> {
     const stateDb = getAppStateDb();
-    const gatewayInstanceId = stateDb.getMeta(GATEWAY_INSTANCE_ID_META_KEY);
-    const hadEnrollment = Boolean(gatewayInstanceId);
+    const hadEnrollment = Boolean(
+      stateDb.getMeta(GATEWAY_INSTANCE_ID_META_KEY),
+    );
     stateDb.setMeta(GATEWAY_INSTANCE_ID_META_KEY, "");
     stateDb.setMeta(GATEWAY_PUBLIC_KEY_META_KEY, "");
     stateDb.setMeta(GATEWAY_NOISE_PUBLIC_KEY_META_KEY, "");
@@ -877,11 +884,13 @@ export class DesktopFederationRuntime {
       this.persistCelestialAssignments();
       this.publishCelestialIconsChanged();
     }
-    if (gatewayInstanceId) {
-      // Pins for peers reached only THROUGH the forgotten gateway keep
-      // dimming until removed by hand — attribution is unreliable — but
-      // the gateway's own pins are provably dead pairing state.
-      await this.cleanupRemoteThreadPins(gatewayInstanceId);
+    // Every pinned instance reachable only through the forgotten gateway
+    // goes with it, not just the gateway's own threads — those rows are
+    // exactly as unreachable, and leaving them behind was the gap in the
+    // first cut of this cleanup.
+    const pinDisposition = request?.pinDisposition ?? "remember";
+    for (const instanceId of await this.enrollmentScopedPinInstanceIds()) {
+      await this.cleanupRemoteThreadPins(instanceId, pinDisposition);
     }
     await this.restart();
     return { cleared: hadEnrollment };
@@ -905,7 +914,10 @@ export class DesktopFederationRuntime {
     };
   }
 
-  async revokePeer(peerId: FederationInstanceId): Promise<FederationPeerSummary> {
+  async revokePeer(
+    peerId: FederationInstanceId,
+    request?: { pinDisposition?: FederationPinDisposition },
+  ): Promise<FederationPeerSummary> {
     const store = this.store();
     const peer = store.getPeer(peerId);
     if (!peer) {
@@ -921,7 +933,11 @@ export class DesktopFederationRuntime {
     // Free the revoked instance's celestial icon and propagate the removal
     // so it cannot squat one of the five ids forever.
     this.removeCelestialAssignment(peerId, revokedAt);
-    await this.cleanupRemoteThreadPins(peerId);
+    await this.cleanupRemoteThreadPins(
+      peerId,
+      request?.pinDisposition ?? "remember",
+      revokedAt,
+    );
     return publicPeerSummary({
       ...peer,
       status: "revoked",
@@ -930,21 +946,41 @@ export class DesktopFederationRuntime {
   }
 
   /**
-   * A revoked (or forgotten) peer's pinned rows would otherwise dim
-   * forever — this viewer can never reach that instance again, so drop
-   * its pins and poke the renderer. Best-effort: pin cleanup must never
-   * block or fail the enrollment teardown itself.
+   * Put away (or discard) one instance's pinned rows. They must stop
+   * rendering either way: unlike a peer that is merely offline, a revoked
+   * instance is unreachable FOR CAUSE, so leaving the rows to dim would be
+   * noise the operator cannot act on.
+   *
+   * `remember` tombstones, and is the default. Revoking a peer and
+   * re-enrolling it to clear up a problem is a routine repair, and hard
+   * deletion would make the operator re-find and re-pin every thread each
+   * time. `forget` is reserved for the operator explicitly asking to
+   * discard. Best-effort throughout: pin bookkeeping must never block or
+   * fail the revocation itself.
    */
   private async cleanupRemoteThreadPins(
     instanceId: FederationInstanceId,
+    disposition: FederationPinDisposition,
+    revokedAt?: number,
   ): Promise<void> {
     try {
       this.remoteThreadSummaryCache?.invalidate(instanceId);
-      const removed = await getDesktopOverlayStore()
-        .removeRemoteThreadPinsForInstance({ instanceId });
-      if (removed === 0) {
+      const overlayStore = getDesktopOverlayStore();
+      const affected =
+        disposition === "forget"
+          ? await overlayStore.removeRemoteThreadPinsForInstance({ instanceId })
+          : await overlayStore.tombstoneRemoteThreadPinsForInstance({
+              instanceId,
+              revokedAt,
+            });
+      if (affected === 0) {
         return;
       }
+      log.info("remote thread pins cleaned up after revocation", {
+        instanceId,
+        disposition,
+        affected,
+      });
       await getDesktopBackendRegistry().publishLocalEvent({
         backend: "codex",
         notification: {
@@ -958,6 +994,97 @@ export class DesktopFederationRuntime {
         error: error instanceof Error ? error.message : String(error),
       });
     }
+  }
+
+  /**
+   * A peer that connects again has been re-enrolled (federation policy
+   * refuses revoked peers), so its tombstoned pins are live again. This is
+   * the payoff for tombstoning: the revoke → fix → re-enroll cycle returns
+   * the operator's curated list without them lifting a finger.
+   */
+  private async restoreRemoteThreadPins(
+    instanceId: FederationInstanceId,
+  ): Promise<void> {
+    try {
+      const restored = await getDesktopOverlayStore()
+        .restoreRemoteThreadPinsForInstance({ instanceId });
+      if (restored === 0) {
+        return;
+      }
+      this.remoteThreadSummaryCache?.invalidate(instanceId);
+      log.info("remote thread pins restored after re-enrollment", {
+        instanceId,
+        restored,
+      });
+      await getDesktopBackendRegistry().publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "navigation/remoteThreadPins/changed",
+          params: { instanceId, pinned: true },
+        },
+      });
+    } catch (error) {
+      log.warn("remote thread pin restore failed", {
+        instanceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * How many pinned threads a pending revoke / forget would affect, so the
+   * renderer can skip the keep-or-forget prompt entirely when the operator
+   * has nothing pinned from the affected instances.
+   */
+  async readRemoteThreadPinImpact(
+    request: ReadFederationPinImpactRequest,
+  ): Promise<ReadFederationPinImpactResponse> {
+    const instanceIds =
+      request.scope.kind === "peer"
+        ? [request.scope.peerId]
+        : await this.enrollmentScopedPinInstanceIds();
+    const overlayStore = getDesktopOverlayStore();
+    let pinnedThreadCount = 0;
+    let tombstonedThreadCount = 0;
+    const instanceLabels: string[] = [];
+    let visible: FederationPeerSummary[];
+    try {
+      visible = this.visiblePeers();
+    } catch {
+      visible = [];
+    }
+    for (const instanceId of instanceIds) {
+      const counts = await overlayStore.countRemoteThreadPinsForInstance({
+        instanceId,
+      });
+      if (counts.live === 0 && counts.revoked === 0) {
+        continue;
+      }
+      pinnedThreadCount += counts.live;
+      tombstonedThreadCount += counts.revoked;
+      const peer = visible.find((candidate) => candidate.id === instanceId);
+      instanceLabels.push(
+        peer ? formatFederationPeerDisplayLabel(peer, visible) : instanceId,
+      );
+    }
+    return { pinnedThreadCount, tombstonedThreadCount, instanceLabels };
+  }
+
+  /**
+   * Instances whose pins a "forget gateway pairing" would affect: the
+   * gateway itself plus every pinned instance this viewer reaches only
+   * THROUGH it. A directly connected peer (a dual instance's own enrolled
+   * client) survives the upstream reset, so its pins must not be touched —
+   * the same reasoning `resetEnrollment` applies to celestial icons.
+   */
+  private async enrollmentScopedPinInstanceIds(): Promise<
+    FederationInstanceId[]
+  > {
+    const pinnedInstanceIds = await getDesktopOverlayStore()
+      .listRemoteThreadPinInstanceIds();
+    return pinnedInstanceIds.filter(
+      (instanceId) => !this.router?.getConnection(instanceId),
+    );
   }
 
   async generateInvite(request: {
@@ -3223,6 +3350,13 @@ export class DesktopFederationRuntime {
       return;
     }
     this.publishedPeerStatuses.set(instanceId, { status, unavailableReason });
+    if (status === "connected") {
+      // Hooked to the status TRANSITION (this method already de-dupes
+      // repeats) rather than to a specific enrollment call site, so every
+      // way a peer can come back — invite redemption, gateway re-pairing,
+      // a relayed peer reappearing — restores its pins through one path.
+      void this.restoreRemoteThreadPins(instanceId);
+    }
     for (const listener of this.peerStatusListeners) {
       try {
         listener();

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -2,6 +2,7 @@ import { ipcMain } from "electron";
 import type {
   ConfigureFederationTailscaleRequest,
   ConfigureFederationTailscaleResponse,
+  FederationPinDisposition,
   GenerateFederationInviteRequest,
   GenerateFederationInviteResponse,
   ImportFederationInviteRequest,
@@ -14,6 +15,8 @@ import type {
   ReadFederationHealthResponse,
   ReadFederationDiagnosticsRequest,
   ReadFederationDiagnosticsResponse,
+  ReadFederationPinImpactRequest,
+  ReadFederationPinImpactResponse,
   ReadFederationTailscaleStatusRequest,
   ReadFederationTailscaleStatusResponse,
   RevokeFederationPeerRequest,
@@ -27,6 +30,7 @@ import {
   isCelestialIconId,
   isFederationEventClass,
   isFederationInstanceId,
+  isFederationPinDisposition,
 } from "@pwragent/shared";
 import {
   FEDERATION_GET_HEALTH_CHANNEL,
@@ -34,6 +38,7 @@ import {
   FEDERATION_GENERATE_INVITE_CHANNEL,
   FEDERATION_IMPORT_INVITE_CHANNEL,
   FEDERATION_OPEN_WINDOW_CHANNEL,
+  FEDERATION_PIN_IMPACT_CHANNEL,
   FEDERATION_RESET_ENROLLMENT_CHANNEL,
   FEDERATION_REVOKE_PEER_CHANNEL,
   FEDERATION_SET_CELESTIAL_ICON_CHANNEL,
@@ -78,6 +83,7 @@ export function registerFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_TAILSCALE_CONFIGURE_CHANNEL);
   ipcMain.removeHandler(FEDERATION_SET_CELESTIAL_ICON_CHANNEL);
   ipcMain.removeHandler(FEDERATION_SET_EVENT_SUBSCRIPTIONS_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_PIN_IMPACT_CHANNEL);
   ipcMain.handle(
     FEDERATION_SET_EVENT_SUBSCRIPTIONS_CHANNEL,
     async (
@@ -272,9 +278,11 @@ export function registerFederationIpcHandlers(): void {
     FEDERATION_RESET_ENROLLMENT_CHANNEL,
     async (
       _event,
-      _request?: ResetFederationEnrollmentRequest,
+      request?: ResetFederationEnrollmentRequest,
     ): Promise<ResetFederationEnrollmentResponse> =>
-      await getDesktopFederationRuntime().resetEnrollment(),
+      await getDesktopFederationRuntime().resetEnrollment({
+        pinDisposition: readPinDisposition(request?.pinDisposition),
+      }),
   );
   ipcMain.handle(
     FEDERATION_REVOKE_PEER_CHANNEL,
@@ -286,10 +294,43 @@ export function registerFederationIpcHandlers(): void {
         throw new Error("Invalid federation peer id");
       }
       return {
-        peer: await getDesktopFederationRuntime().revokePeer(request.peerId),
+        peer: await getDesktopFederationRuntime().revokePeer(request.peerId, {
+          pinDisposition: readPinDisposition(request.pinDisposition),
+        }),
       };
     },
   );
+  ipcMain.handle(
+    FEDERATION_PIN_IMPACT_CHANNEL,
+    async (
+      _event,
+      request: ReadFederationPinImpactRequest,
+    ): Promise<ReadFederationPinImpactResponse> => {
+      const scope = request?.scope;
+      if (scope?.kind === "peer") {
+        if (!isFederationInstanceId(scope.peerId)) {
+          throw new Error("Invalid federation peer id");
+        }
+      } else if (scope?.kind !== "enrollment") {
+        throw new Error("Invalid federation pin impact scope");
+      }
+      return await getDesktopFederationRuntime().readRemoteThreadPinImpact({
+        scope,
+      });
+    },
+  );
+}
+
+/**
+ * An absent or unrecognized disposition means "remember". Discarding an
+ * operator's pinned threads is irreversible, so an out-of-date renderer or
+ * a malformed payload must never be able to select the destructive branch
+ * by accident — only an explicit "forget" does.
+ */
+function readPinDisposition(value: unknown): FederationPinDisposition {
+  return isFederationPinDisposition(value) && value === "forget"
+    ? "forget"
+    : "remember";
 }
 
 export function disposeFederationIpcHandlers(): void {
@@ -304,5 +345,6 @@ export function disposeFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_TAILSCALE_CONFIGURE_CHANNEL);
   ipcMain.removeHandler(FEDERATION_SET_CELESTIAL_ICON_CHANNEL);
   ipcMain.removeHandler(FEDERATION_SET_EVENT_SUBSCRIPTIONS_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_PIN_IMPACT_CHANNEL);
   rendererSubscriptionCleanupIds.clear();
 }

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -328,9 +328,7 @@ export function registerFederationIpcHandlers(): void {
  * by accident — only an explicit "forget" does.
  */
 function readPinDisposition(value: unknown): FederationPinDisposition {
-  return isFederationPinDisposition(value) && value === "forget"
-    ? "forget"
-    : "remember";
+  return isFederationPinDisposition(value) ? value : "remember";
 }
 
 export function disposeFederationIpcHandlers(): void {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1940,12 +1940,29 @@ export class SqliteOverlayStore {
     return result.changes > 0;
   }
 
-  async listRemoteThreadPins(): Promise<RemoteThreadPin[]> {
+  /**
+   * Live pins, newest first. Tombstoned rows (owning instance revoked or
+   * its gateway pairing forgotten) are excluded by default: we know they
+   * are unreachable FOR CAUSE, so unlike a peer that is merely offline
+   * they must not sit in the list dimming. Pass `includeRevoked` for
+   * impact counts and restore bookkeeping.
+   */
+  async listRemoteThreadPins(options?: {
+    includeRevoked?: boolean;
+  }): Promise<RemoteThreadPin[]> {
+    // Two fully-written statements rather than one with an interpolated
+    // WHERE: the SQL guard rejects assembled query text outright, and a
+    // literal pair is what the rest of this file does.
     const rows = this.stateDb.raw
       .prepare(
-        `SELECT instance_id, backend, thread_id, added_at, payload
-         FROM remote_thread_pins
-         ORDER BY added_at DESC`,
+        options?.includeRevoked
+          ? `SELECT instance_id, backend, thread_id, added_at, payload, revoked_at
+             FROM remote_thread_pins
+             ORDER BY added_at DESC`
+          : `SELECT instance_id, backend, thread_id, added_at, payload, revoked_at
+             FROM remote_thread_pins
+             WHERE revoked_at IS NULL
+             ORDER BY added_at DESC`,
       )
       .all() as Array<{
         instance_id: string;
@@ -1953,6 +1970,7 @@ export class SqliteOverlayStore {
         thread_id: string;
         added_at: number;
         payload: string;
+        revoked_at: number | null;
       }>;
     const pins: RemoteThreadPin[] = [];
     for (const row of rows) {
@@ -1989,6 +2007,7 @@ export class SqliteOverlayStore {
         ...(typeof parsed.localPinnedRank === "string" && parsed.localPinnedRank
           ? { localPinnedRank: parsed.localPinnedRank }
           : {}),
+        ...(row.revoked_at !== null ? { revokedAt: row.revoked_at } : {}),
       });
     }
     return pins;
@@ -2050,8 +2069,10 @@ export class SqliteOverlayStore {
   }
 
   /**
-   * Drop every pin owned by one instance — peer-revocation / forgotten-
-   * enrollment cleanup, where the rows would otherwise dim forever.
+   * Permanently drop every pin owned by one instance. This is the operator
+   * explicitly choosing "forget these threads" at revoke time — the
+   * default path tombstones instead, because revoke-then-re-enroll to
+   * repair a peer is common and losing the curated list would be hostile.
    * Returns the number of pins removed.
    */
   async removeRemoteThreadPinsForInstance(params: {
@@ -2061,6 +2082,69 @@ export class SqliteOverlayStore {
       .prepare("DELETE FROM remote_thread_pins WHERE instance_id = ?")
       .run(params.instanceId);
     return result.changes;
+  }
+
+  /**
+   * Hide one instance's pins without discarding them. Already-tombstoned
+   * rows keep their original timestamp so a second revoke does not restate
+   * when the list was actually put away.
+   */
+  async tombstoneRemoteThreadPinsForInstance(params: {
+    instanceId: string;
+    revokedAt?: number;
+  }): Promise<number> {
+    const result = this.stateDb.raw
+      .prepare(
+        `UPDATE remote_thread_pins
+         SET revoked_at = ?
+         WHERE instance_id = ? AND revoked_at IS NULL`,
+      )
+      .run(params.revokedAt ?? Date.now(), params.instanceId);
+    return result.changes;
+  }
+
+  /** Bring one instance's tombstoned pins back after a re-enrollment. */
+  async restoreRemoteThreadPinsForInstance(params: {
+    instanceId: string;
+  }): Promise<number> {
+    const result = this.stateDb.raw
+      .prepare(
+        `UPDATE remote_thread_pins
+         SET revoked_at = NULL
+         WHERE instance_id = ? AND revoked_at IS NOT NULL`,
+      )
+      .run(params.instanceId);
+    return result.changes;
+  }
+
+  /**
+   * Live vs tombstoned pin counts for one instance. Drives the
+   * keep-or-forget prompt, which must stay hidden when the operator has
+   * nothing pinned from that instance — there would be nothing to decide.
+   */
+  async countRemoteThreadPinsForInstance(params: {
+    instanceId: string;
+  }): Promise<{ live: number; revoked: number }> {
+    const row = this.stateDb.raw
+      .prepare(
+        `SELECT
+           SUM(CASE WHEN revoked_at IS NULL THEN 1 ELSE 0 END) AS live,
+           SUM(CASE WHEN revoked_at IS NULL THEN 0 ELSE 1 END) AS revoked
+         FROM remote_thread_pins
+         WHERE instance_id = ?`,
+      )
+      .get(params.instanceId) as
+        | { live: number | null; revoked: number | null }
+        | undefined;
+    return { live: row?.live ?? 0, revoked: row?.revoked ?? 0 };
+  }
+
+  /** Every instance id with at least one pin, tombstoned or not. */
+  async listRemoteThreadPinInstanceIds(): Promise<string[]> {
+    const rows = this.stateDb.raw
+      .prepare("SELECT DISTINCT instance_id FROM remote_thread_pins")
+      .all() as Array<{ instance_id: string }>;
+    return rows.map((row) => row.instance_id);
   }
 
   async setThreadAgent(params: {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1811,7 +1811,13 @@ export class SqliteOverlayStore {
            payload
          ) VALUES (?, ?, ?, ?, ?)
          ON CONFLICT(instance_id, backend, thread_id) DO UPDATE SET
-           payload = excluded.payload`,
+           payload = excluded.payload,
+           -- Pinning is unambiguous intent that this row should be live.
+           -- Leaving a tombstone in place would swallow the click: the pin
+           -- succeeds in the db and never appears in the list. Restoring on
+           -- reconnect is best-effort, so the invariant has to hold here too
+           -- rather than depend on that hook having run.
+           revoked_at = NULL`,
       )
       .run(instanceId, params.ref.backend, params.ref.threadId, addedAt, payload);
     const row = this.stateDb.raw
@@ -1912,11 +1918,19 @@ export class SqliteOverlayStore {
     return ranks;
   }
 
+  /**
+   * Whether a LIVE pin exists. A tombstoned row must answer false: callers
+   * ask this to decide whether they still need to pin something, and a
+   * hidden row cannot satisfy that. Counting one would, for instance, let
+   * companion-parent pinning skip a parent that never renders, leaving its
+   * child as a bare top-level row.
+   */
   async hasRemoteThreadPin(params: { ref: FederatedThreadRef }): Promise<boolean> {
     const row = this.stateDb.raw
       .prepare(
         `SELECT 1 FROM remote_thread_pins
-         WHERE instance_id = ? AND backend = ? AND thread_id = ?`,
+         WHERE instance_id = ? AND backend = ? AND thread_id = ?
+           AND revoked_at IS NULL`,
       )
       .get(
         remotePinInstanceId(params.ref),
@@ -2118,33 +2132,35 @@ export class SqliteOverlayStore {
   }
 
   /**
-   * Live vs tombstoned pin counts for one instance. Drives the
+   * Live vs tombstoned pin counts, keyed by instance. Drives the
    * keep-or-forget prompt, which must stay hidden when the operator has
-   * nothing pinned from that instance — there would be nothing to decide.
+   * nothing pinned from the affected instances — there would be nothing to
+   * decide. One grouped read rather than a query per instance: the caller
+   * needs several at once and an absent instance is simply a missing key.
    */
-  async countRemoteThreadPinsForInstance(params: {
-    instanceId: string;
-  }): Promise<{ live: number; revoked: number }> {
-    const row = this.stateDb.raw
+  async countRemoteThreadPinsByInstance(): Promise<
+    Map<string, { live: number; revoked: number }>
+  > {
+    const rows = this.stateDb.raw
       .prepare(
         `SELECT
+           instance_id,
            SUM(CASE WHEN revoked_at IS NULL THEN 1 ELSE 0 END) AS live,
            SUM(CASE WHEN revoked_at IS NULL THEN 0 ELSE 1 END) AS revoked
          FROM remote_thread_pins
-         WHERE instance_id = ?`,
+         GROUP BY instance_id`,
       )
-      .get(params.instanceId) as
-        | { live: number | null; revoked: number | null }
-        | undefined;
-    return { live: row?.live ?? 0, revoked: row?.revoked ?? 0 };
-  }
-
-  /** Every instance id with at least one pin, tombstoned or not. */
-  async listRemoteThreadPinInstanceIds(): Promise<string[]> {
-    const rows = this.stateDb.raw
-      .prepare("SELECT DISTINCT instance_id FROM remote_thread_pins")
-      .all() as Array<{ instance_id: string }>;
-    return rows.map((row) => row.instance_id);
+      .all() as Array<{
+        instance_id: string;
+        live: number | null;
+        revoked: number | null;
+      }>;
+    return new Map(
+      rows.map((row) => [
+        row.instance_id,
+        { live: row.live ?? 0, revoked: row.revoked ?? 0 },
+      ]),
+    );
   }
 
   async setThreadAgent(params: {

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 44;
+export const CURRENT_STATE_DB_USER_VERSION = 45;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -886,11 +886,26 @@ CREATE TABLE IF NOT EXISTS remote_thread_pins (
   thread_id   TEXT NOT NULL,
   added_at    INTEGER NOT NULL,
   payload     TEXT NOT NULL,
+  revoked_at  INTEGER,
   PRIMARY KEY (instance_id, backend, thread_id)
 );
 CREATE INDEX IF NOT EXISTS idx_remote_thread_pins_instance
   ON remote_thread_pins(instance_id, added_at DESC);
 `;
+
+/**
+ * `revoked_at` tombstones a pin whose owning instance was revoked or whose
+ * gateway pairing was forgotten. The row stops rendering but survives, so
+ * the very common revoke-then-re-enroll repair cycle restores the operator's
+ * curated list instead of making them re-find every thread.
+ */
+function ensureRemoteThreadPinRevokedAtColumn(
+  db: BetterSqlite3.Database,
+): void {
+  if (!tableColumnExists(db, "remote_thread_pins", "revoked_at")) {
+    db.exec("ALTER TABLE remote_thread_pins ADD COLUMN revoked_at INTEGER");
+  }
+}
 
 export const FEDERATION_SCHEMA = `
 CREATE TABLE IF NOT EXISTS federation_peers (
@@ -1289,6 +1304,14 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 44) {
       db.transaction(() => {
         db.exec(STAR_MAP_ARRANGEMENT_SCHEMA);
+        db.pragma("user_version = 44");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 45) {
+      db.transaction(() => {
+        // Revoking a peer used to hard-delete its pins. Tombstone them
+        // instead so a re-enrollment can restore the operator's list.
+        ensureRemoteThreadPinRevokedAtColumn(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1476,6 +1499,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     ensureThreadMessageOriginSchema(db);
     db.exec(FEDERATION_SCHEMA);
     db.exec(REMOTE_THREAD_PIN_SCHEMA);
+    ensureRemoteThreadPinRevokedAtColumn(db);
     db.exec(STAR_MAP_ARRANGEMENT_SCHEMA);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
       db.pragma("user_version = 4");
@@ -2501,6 +2525,7 @@ function tableColumnExists(
     | "pr_status_cache"
     | "thread_message_origins"
     | "thread_pricing_summaries"
+    | "remote_thread_pins"
     | "thread_search_fts"
     | "thread_usage_lines"
     | "thread_usage_turns",
@@ -2539,6 +2564,7 @@ function readTableInfo(
     | "pr_status_cache"
     | "thread_message_origins"
     | "thread_pricing_summaries"
+    | "remote_thread_pins"
     | "thread_search_fts"
     | "thread_usage_lines"
     | "thread_usage_turns",
@@ -2566,6 +2592,10 @@ function readTableInfo(
       }>;
     case "thread_pricing_summaries":
       return db.prepare("PRAGMA table_info(thread_pricing_summaries)").all() as Array<{
+        name: string;
+      }>;
+    case "remote_thread_pins":
+      return db.prepare("PRAGMA table_info(remote_thread_pins)").all() as Array<{
         name: string;
       }>;
     case "thread_search_fts":

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -269,6 +269,8 @@ import type {
   ReadFederationHealthResponse,
   ReadFederationDiagnosticsRequest,
   ReadFederationDiagnosticsResponse,
+  ReadFederationPinImpactRequest,
+  ReadFederationPinImpactResponse,
   ReadFederationTailscaleStatusRequest,
   ReadFederationTailscaleStatusResponse,
   ResetFederationEnrollmentRequest,
@@ -463,6 +465,7 @@ import {
   FEDERATION_GENERATE_INVITE_CHANNEL,
   FEDERATION_IMPORT_INVITE_CHANNEL,
   FEDERATION_OPEN_WINDOW_CHANNEL,
+  FEDERATION_PIN_IMPACT_CHANNEL,
   FEDERATION_RESET_ENROLLMENT_CHANNEL,
   FEDERATION_REVOKE_PEER_CHANNEL,
   FEDERATION_SET_CELESTIAL_ICON_CHANNEL,
@@ -890,6 +893,10 @@ const desktopApi = Object.freeze({
     request?: ResetFederationEnrollmentRequest,
   ): Promise<ResetFederationEnrollmentResponse> =>
     await ipcRenderer.invoke(FEDERATION_RESET_ENROLLMENT_CHANNEL, request),
+  readFederationPinImpact: async (
+    request: ReadFederationPinImpactRequest,
+  ): Promise<ReadFederationPinImpactResponse> =>
+    await ipcRenderer.invoke(FEDERATION_PIN_IMPACT_CHANNEL, request),
   readFederationTailscaleStatus: async (
     request?: ReadFederationTailscaleStatusRequest,
   ): Promise<ReadFederationTailscaleStatusResponse> =>

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -11,8 +11,11 @@ import type {
   FederationEndpointStatus,
   FederationHealthStatus,
   FederationInstanceRole,
+  FederationPinDisposition,
+  FederationPinImpactScope,
   FederationTailscaleMode,
   FederationTailscaleStatus,
+  ReadFederationPinImpactResponse,
 } from "@pwragent/shared";
 import {
   CELESTIAL_ICON_IDS,
@@ -71,6 +74,17 @@ export function FederationSettings(props: FederationSettingsProps) {
   const [settingIconFor, setSettingIconFor] = useState<string>();
   const [confirmingForget, setConfirmingForget] = useState(false);
   const [forgetting, setForgetting] = useState(false);
+  // The revoke the operator is currently confirming, plus what it would do
+  // to their pinned threads. An absent `impact` means nothing is pinned
+  // from that instance — the common case, which must not raise a
+  // keep-or-forget question at all. Peer id and impact live in one state
+  // value so a slow impact read can never attach to a different peer.
+  const [revokeConfirm, setRevokeConfirm] = useState<{
+    peerId: string;
+    impact?: ReadFederationPinImpactResponse;
+  }>();
+  const [forgetPinImpact, setForgetPinImpact] =
+    useState<ReadFederationPinImpactResponse>();
   const [mode, setMode] = useState<DesktopFederationMode>(
     props.snapshot.federation.mode.value,
   );
@@ -322,6 +336,77 @@ export function FederationSettings(props: FederationSettingsProps) {
       )
       .finally(() => setSettingIconFor(undefined));
   };
+  /**
+   * Read how many pinned threads a teardown would affect. A missing API
+   * (older preload) or a failed read resolves to undefined, which routes
+   * the caller through the plain confirm — never a silent forget.
+   */
+  const readPinImpact = async (
+    scope: FederationPinImpactScope,
+  ): Promise<ReadFederationPinImpactResponse | undefined> => {
+    if (!props.desktopApi?.readFederationPinImpact) return undefined;
+    try {
+      const impact = await props.desktopApi.readFederationPinImpact({ scope });
+      return impact.pinnedThreadCount + impact.tombstonedThreadCount > 0
+        ? impact
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
+  const beginRevokePeer = (peerId: string) => {
+    setActionError(undefined);
+    setRevokeConfirm({ peerId });
+    void readPinImpact({ kind: "peer", peerId }).then((impact) => {
+      // Drop a late read whose confirm the operator already dismissed or
+      // moved to another peer.
+      setRevokeConfirm((current) =>
+        current?.peerId === peerId ? { peerId, impact } : current,
+      );
+    });
+  };
+
+  const revokePeer = (
+    peerId: string,
+    pinDisposition: FederationPinDisposition,
+  ) => {
+    setActionError(undefined);
+    setRevokingPeerId(peerId);
+    props.desktopApi?.revokeFederationPeer?.({ peerId, pinDisposition })
+      .then(() => {
+        setRevokeConfirm(undefined);
+        return loadHealth();
+      })
+      .catch((err: unknown) =>
+        setActionError(err instanceof Error ? err.message : String(err)),
+      )
+      .finally(() => setRevokingPeerId(undefined));
+  };
+
+  const beginForgetGateway = () => {
+    setActionError(undefined);
+    setConfirmingForget(true);
+    setForgetPinImpact(undefined);
+    void readPinImpact({ kind: "enrollment" }).then(setForgetPinImpact);
+  };
+
+  const forgetGateway = (pinDisposition: FederationPinDisposition) => {
+    setActionError(undefined);
+    setForgetting(true);
+    props.desktopApi?.resetFederationEnrollment?.({ pinDisposition })
+      .then(async () => {
+        setConfirmingForget(false);
+        setForgetPinImpact(undefined);
+        await props.onSettingsChanged();
+        await loadHealth();
+      })
+      .catch((err: unknown) =>
+        setActionError(err instanceof Error ? err.message : String(err)),
+      )
+      .finally(() => setForgetting(false));
+  };
+
   const connectionRemediation = effectiveHealth.unavailableReason
     ? remediationForConnectionFailure(effectiveHealth.unavailableReason)
     : undefined;
@@ -791,30 +876,32 @@ export function FederationSettings(props: FederationSettingsProps) {
                         className="button button--primary"
                         type="button"
                         disabled={forgetting}
-                        onClick={() => {
-                          setActionError(undefined);
-                          setForgetting(true);
-                          props.desktopApi?.resetFederationEnrollment?.({})
-                            .then(async () => {
-                              setConfirmingForget(false);
-                              await props.onSettingsChanged();
-                              await loadHealth();
-                            })
-                            .catch((err: unknown) =>
-                              setActionError(
-                                err instanceof Error ? err.message : String(err),
-                              ),
-                            )
-                            .finally(() => setForgetting(false));
-                        }}
+                        onClick={() => forgetGateway("remember")}
                       >
-                        {forgetting ? "Forgetting..." : "Confirm forget"}
+                        {forgetting
+                          ? "Forgetting..."
+                          : forgetPinImpact
+                            ? "Forget gateway, keep my threads"
+                            : "Confirm forget"}
                       </button>
+                      {forgetPinImpact ? (
+                        <button
+                          className="button button--ghost"
+                          type="button"
+                          disabled={forgetting}
+                          onClick={() => forgetGateway("forget")}
+                        >
+                          Forget gateway and threads
+                        </button>
+                      ) : null}
                       <button
                         className="button button--ghost"
                         type="button"
                         disabled={forgetting}
-                        onClick={() => setConfirmingForget(false)}
+                        onClick={() => {
+                          setConfirmingForget(false);
+                          setForgetPinImpact(undefined);
+                        }}
                       >
                         Cancel
                       </button>
@@ -824,7 +911,7 @@ export function FederationSettings(props: FederationSettingsProps) {
                       className="button button--ghost"
                       type="button"
                       disabled={!props.desktopApi?.resetFederationEnrollment}
-                      onClick={() => setConfirmingForget(true)}
+                      onClick={beginForgetGateway}
                     >
                       Forget gateway
                     </button>
@@ -835,6 +922,9 @@ export function FederationSettings(props: FederationSettingsProps) {
                     Forgetting removes the pinned gateway identity and keys
                     from this instance. Reconnecting later requires a fresh
                     invite from the gateway.
+                    {forgetPinImpact
+                      ? ` ${describePinImpact(forgetPinImpact)}`
+                      : ""}
                   </p>
                 ) : null}
               </>
@@ -1008,31 +1098,58 @@ export function FederationSettings(props: FederationSettingsProps) {
                     Browse remote threads
                   </button>
                   {peer.canRevoke ? (
-                    <button
-                      className="button button--ghost"
-                      type="button"
-                      disabled={
-                        peer.status === "revoked" ||
-                        revokingPeerId === peer.id ||
-                        !props.desktopApi?.revokeFederationPeer
-                      }
-                      onClick={() => {
-                        setActionError(undefined);
-                        setRevokingPeerId(peer.id);
-                        props.desktopApi?.revokeFederationPeer?.({
-                          peerId: peer.id,
-                        })
-                          .then(() => loadHealth())
-                          .catch((err: unknown) =>
-                            setActionError(
-                              err instanceof Error ? err.message : String(err),
-                            ),
-                          )
-                          .finally(() => setRevokingPeerId(undefined));
-                      }}
-                    >
-                      {revokingPeerId === peer.id ? "Revoking..." : "Revoke"}
-                    </button>
+                    revokeConfirm?.peerId === peer.id ? (
+                      <>
+                        <button
+                          className="button button--primary"
+                          type="button"
+                          disabled={revokingPeerId === peer.id}
+                          onClick={() => revokePeer(peer.id, "remember")}
+                        >
+                          {revokingPeerId === peer.id
+                            ? "Revoking..."
+                            : revokeConfirm.impact
+                              ? "Revoke, keep my threads"
+                              : "Confirm revoke"}
+                        </button>
+                        {revokeConfirm.impact ? (
+                          <button
+                            className="button button--ghost"
+                            type="button"
+                            disabled={revokingPeerId === peer.id}
+                            onClick={() => revokePeer(peer.id, "forget")}
+                          >
+                            Revoke and forget threads
+                          </button>
+                        ) : null}
+                        <button
+                          className="button button--ghost"
+                          type="button"
+                          disabled={revokingPeerId === peer.id}
+                          onClick={() => setRevokeConfirm(undefined)}
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        className="button button--ghost"
+                        type="button"
+                        disabled={
+                          peer.status === "revoked" ||
+                          revokingPeerId === peer.id ||
+                          !props.desktopApi?.revokeFederationPeer
+                        }
+                        onClick={() => beginRevokePeer(peer.id)}
+                      >
+                        Revoke
+                      </button>
+                    )
+                  ) : null}
+                  {revokeConfirm?.peerId === peer.id && revokeConfirm.impact ? (
+                    <p className="federation-security-note">
+                      {describePinImpact(revokeConfirm.impact, peer.label)}
+                    </p>
                   ) : null}
                 </dd>
               </div>
@@ -1530,6 +1647,31 @@ function formatFederationCapabilities(
  * for transport-level failures where "keep retrying" is already the
  * right answer.
  */
+/**
+ * Explains what happens to the operator's pinned remote threads, and makes
+ * clear that keeping them is reversible while forgetting is not. Only
+ * rendered when something is actually pinned — see `readPinImpact`.
+ */
+function describePinImpact(
+  impact: ReadFederationPinImpactResponse,
+  peerLabel?: string,
+): string {
+  const source =
+    peerLabel
+    ?? (impact.instanceLabels.length === 1
+      ? impact.instanceLabels[0]
+      : `${impact.instanceLabels.length} instances`);
+  const pinned = impact.pinnedThreadCount;
+  const subject =
+    pinned === 1 ? "1 pinned thread" : `${pinned} pinned threads`;
+  if (pinned === 0) {
+    // Only tombstones left: an earlier revoke already put these away, so
+    // the live/forget distinction is about the remembered list itself.
+    return `Threads from ${source} are already put away. Keeping them means they return if you re-enroll; forgetting removes them for good.`;
+  }
+  return `${subject} from ${source} will stop showing in your list. Keeping them means they come back automatically if you re-enroll; forgetting removes them for good.`;
+}
+
 function remediationForConnectionFailure(reason: string): string | undefined {
   if (
     reason.includes("unknown_peer") ||

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -85,6 +85,7 @@ export function FederationSettings(props: FederationSettingsProps) {
   }>();
   const [forgetPinImpact, setForgetPinImpact] =
     useState<ReadFederationPinImpactResponse>();
+  const forgetImpactGenerationRef = useRef(0);
   const [mode, setMode] = useState<DesktopFederationMode>(
     props.snapshot.federation.mode.value,
   );
@@ -388,7 +389,21 @@ export function FederationSettings(props: FederationSettingsProps) {
     setActionError(undefined);
     setConfirmingForget(true);
     setForgetPinImpact(undefined);
-    void readPinImpact({ kind: "enrollment" }).then(setForgetPinImpact);
+    // Generation guard, the counterpart to the peer-id check on the revoke
+    // side: a read from a confirm the operator already cancelled must not
+    // paint its copy onto the next one.
+    const generation = ++forgetImpactGenerationRef.current;
+    void readPinImpact({ kind: "enrollment" }).then((impact) => {
+      if (forgetImpactGenerationRef.current === generation) {
+        setForgetPinImpact(impact);
+      }
+    });
+  };
+
+  const cancelForgetGateway = () => {
+    forgetImpactGenerationRef.current += 1;
+    setConfirmingForget(false);
+    setForgetPinImpact(undefined);
   };
 
   const forgetGateway = (pinDisposition: FederationPinDisposition) => {
@@ -898,10 +913,7 @@ export function FederationSettings(props: FederationSettingsProps) {
                         className="button button--ghost"
                         type="button"
                         disabled={forgetting}
-                        onClick={() => {
-                          setConfirmingForget(false);
-                          setForgetPinImpact(undefined);
-                        }}
+                        onClick={cancelForgetGateway}
                       >
                         Cancel
                       </button>

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -398,10 +398,20 @@ describe("FederationSettings", () => {
       .toBeDisabled();
 
     fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+    // With no pin-impact reader wired (older preload), the confirm stays a
+    // plain one — never a silent forget.
+    const confirm = await screen.findByRole("button", {
+      name: "Confirm revoke",
+    });
+    expect(
+      screen.queryByRole("button", { name: "Revoke and forget threads" }),
+    ).toBeNull();
+    fireEvent.click(confirm);
 
     await waitFor(() =>
       expect(revokeFederationPeer).toHaveBeenCalledWith({
         peerId: "client_one",
+        pinDisposition: "remember",
       }),
     );
     expect(openFederationWindow).not.toHaveBeenCalled();
@@ -908,8 +918,142 @@ describe("FederationSettings", () => {
       await screen.findByRole("button", { name: "Confirm forget" }),
     );
     await waitFor(() =>
-      expect(resetFederationEnrollment).toHaveBeenCalledWith({}),
+      expect(resetFederationEnrollment).toHaveBeenCalledWith({
+        pinDisposition: "remember",
+      }),
     );
+  });
+
+  it("offers keep-or-forget only when the revoked peer has pinned threads", async () => {
+    const revokeFederationPeer = vi.fn(async () => ({
+      peer: {
+        id: "client_one",
+        label: "Studio Mac",
+        role: "client" as const,
+        status: "revoked" as const,
+        capabilities: [],
+      },
+    }));
+    const readFederationPinImpact = vi.fn(async () => ({
+      pinnedThreadCount: 3,
+      tombstonedThreadCount: 0,
+      instanceLabels: ["Studio Mac"],
+    }));
+
+    render(
+      <FederationSettings
+        desktopApi={{
+          readFederationHealth: vi.fn(async () => ({
+            health: {
+              enabled: true,
+              role: "gateway" as const,
+              status: "listening" as const,
+              peers: [
+                {
+                  id: "client_one",
+                  label: "Studio Mac",
+                  role: "client" as const,
+                  status: "connected" as const,
+                  capabilities: [],
+                  canRevoke: true,
+                },
+              ],
+            },
+          })),
+          revokeFederationPeer,
+          readFederationPinImpact,
+        }}
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={vi.fn(async () => true)}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Revoke" }));
+
+    // The operator is told what is at stake and that keeping is reversible.
+    expect(
+      await screen.findByText(
+        /3 pinned threads from Studio Mac will stop showing/,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/come back automatically if you re-enroll/),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Revoke and forget threads" }),
+    );
+    await waitFor(() =>
+      expect(revokeFederationPeer).toHaveBeenCalledWith({
+        peerId: "client_one",
+        pinDisposition: "forget",
+      }),
+    );
+  });
+
+  it("skips the keep-or-forget question when nothing is pinned", async () => {
+    const revokeFederationPeer = vi.fn(async () => ({
+      peer: {
+        id: "client_one",
+        label: "Studio Mac",
+        role: "client" as const,
+        status: "revoked" as const,
+        capabilities: [],
+      },
+    }));
+    const readFederationPinImpact = vi.fn(async () => ({
+      pinnedThreadCount: 0,
+      tombstonedThreadCount: 0,
+      instanceLabels: [],
+    }));
+
+    render(
+      <FederationSettings
+        desktopApi={{
+          readFederationHealth: vi.fn(async () => ({
+            health: {
+              enabled: true,
+              role: "gateway" as const,
+              status: "listening" as const,
+              peers: [
+                {
+                  id: "client_one",
+                  label: "Studio Mac",
+                  role: "client" as const,
+                  status: "connected" as const,
+                  capabilities: [],
+                  canRevoke: true,
+                },
+              ],
+            },
+          })),
+          revokeFederationPeer,
+          readFederationPinImpact,
+        }}
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={vi.fn(async () => true)}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Revoke" }));
+    await waitFor(() => expect(readFederationPinImpact).toHaveBeenCalled());
+
+    // Nothing pinned means nothing to decide: one plain confirm, no
+    // forget-threads button, no scary copy.
+    expect(
+      await screen.findByRole("button", { name: "Confirm revoke" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Revoke and forget threads" }),
+    ).toBeNull();
   });
 });
 

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -103,6 +103,8 @@ import type {
   ReadFederationHealthResponse,
   ReadFederationDiagnosticsRequest,
   ReadFederationDiagnosticsResponse,
+  ReadFederationPinImpactRequest,
+  ReadFederationPinImpactResponse,
   ReadFederationTailscaleStatusRequest,
   ReadFederationTailscaleStatusResponse,
   AddRemoteThreadPinRequest,
@@ -500,6 +502,9 @@ export type DesktopApi = {
   resetFederationEnrollment?: (
     request?: ResetFederationEnrollmentRequest,
   ) => Promise<ResetFederationEnrollmentResponse>;
+  readFederationPinImpact?: (
+    request: ReadFederationPinImpactRequest,
+  ) => Promise<ReadFederationPinImpactResponse>;
   readFederationTailscaleStatus?: (
     request?: ReadFederationTailscaleStatusRequest,
   ) => Promise<ReadFederationTailscaleStatusResponse>;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -8,6 +8,7 @@ export const FEDERATION_IMPORT_INVITE_CHANNEL = "federation:import-invite";
 export const FEDERATION_REVOKE_PEER_CHANNEL = "federation:revoke-peer";
 export const FEDERATION_RESET_ENROLLMENT_CHANNEL =
   "federation:reset-enrollment";
+export const FEDERATION_PIN_IMPACT_CHANNEL = "federation:pin-impact";
 export const FEDERATION_TAILSCALE_STATUS_CHANNEL = "federation:tailscale-status";
 export const FEDERATION_TAILSCALE_CONFIGURE_CHANNEL =
   "federation:tailscale-configure";

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -371,12 +371,54 @@ export type ReadFederationDiagnosticsResponse = {
   events: FederationDiagnosticEvent[];
 };
 
+/**
+ * What a revoke / forget-pairing does to the viewer's pinned remote
+ * threads for the affected instances.
+ *
+ * `remember` (the default everywhere) tombstones them: the rows stop
+ * rendering, but a later re-enrollment restores the operator's curated
+ * list. `forget` is the explicit, irreversible discard. Defaulting to
+ * `remember` keeps an un-updated or buggy caller on the non-destructive
+ * path — the reverse default would silently delete operator data.
+ */
+export type FederationPinDisposition = "forget" | "remember";
+
+export function isFederationPinDisposition(
+  value: unknown,
+): value is FederationPinDisposition {
+  return value === "forget" || value === "remember";
+}
+
 export type RevokeFederationPeerRequest = {
   peerId: FederationPeerId;
+  pinDisposition?: FederationPinDisposition;
 };
 
 export type RevokeFederationPeerResponse = {
   peer: FederationPeerSummary;
+};
+
+/** Which instances a pending revoke / forget would affect. */
+export type FederationPinImpactScope =
+  | { kind: "peer"; peerId: FederationPeerId }
+  | { kind: "enrollment" };
+
+export type ReadFederationPinImpactRequest = {
+  scope: FederationPinImpactScope;
+};
+
+/**
+ * Drives the keep-or-forget prompt. Both counts zero means the operator
+ * has nothing pinned from the affected instances, so the prompt must not
+ * appear at all — there is nothing to preserve or discard.
+ */
+export type ReadFederationPinImpactResponse = {
+  /** Live pins that would be hidden (remember) or deleted (forget). */
+  pinnedThreadCount: number;
+  /** Pins already tombstoned by an earlier revoke of the same scope. */
+  tombstonedThreadCount: number;
+  /** Display labels of the affected instances, for the prompt copy. */
+  instanceLabels: string[];
 };
 
 export type GenerateFederationInviteRequest = {
@@ -405,7 +447,9 @@ export type ImportFederationInviteResponse = {
   gatewayEndpoints: string[];
 };
 
-export type ResetFederationEnrollmentRequest = Record<string, never>;
+export type ResetFederationEnrollmentRequest = {
+  pinDisposition?: FederationPinDisposition;
+};
 
 export type ResetFederationEnrollmentResponse = {
   cleared: boolean;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1076,6 +1076,14 @@ export type RemoteThreadPin = {
    * list): pin or unpin here and only the viewer knows.
    */
   localPinnedRank?: string;
+  /**
+   * Set when the owning instance was revoked or its gateway pairing was
+   * forgotten. Tombstoned pins are hidden rather than deleted, because
+   * revoking and re-enrolling to repair a peer is routine and the operator
+   * would otherwise have to re-find and re-pin every thread. Cleared when
+   * that instance connects again.
+   */
+  revokedAt?: number;
 };
 
 export type SetRemoteThreadLocalPinRequest = {


### PR DESCRIPTION
> **Stacked on #1267.** Base is `claude/wonderful-wilbur-0b3eb9`; review that one first. Rebase to `main` once it merges.

## Why

#1267 added pin cleanup so a revoked peer's rows stop dimming forever — but it did it with a hard `DELETE`. Operator feedback on that PR: revoke-then-re-enroll is a *routine repair* (clearing up a bad pairing, re-pairing a machine), and hard deletion means the operator loses every remote thread they curated and has to re-find and re-pin them all. That's an anti-pattern users will strongly dislike.

This PR replaces the delete with a tombstone, and asks the operator which they want.

## What changed

**Tombstone.** New `remote_thread_pins.revoked_at` (state-db v45, additive column, migration + test). A tombstoned pin **stops rendering** — unlike a peer that's merely offline, a revoked one is unreachable *for cause*, so leaving the rows to dim would be noise the operator can't act on — but it survives on disk with its viewer-owned rank, `pinnedVia`, and cached summary intact. `listRemoteThreadPins()` excludes tombstoned rows by default so the snapshot merge never serves one.

**Restore.** Hooked to the peer-status **transition** to connected (`publishPeerStatus` already de-dupes repeats) rather than to any one enrollment call site — so every way a peer can come back (invite redemption, gateway re-pairing, a relayed peer reappearing) restores its pins through one path. Federation policy refuses revoked peers, so "connected again" reliably means "re-enrolled".

**Disposition.** `pinDisposition: "forget" | "remember"` on revoke and reset-enrollment. `remember` is the default *everywhere*, including for an absent or unrecognized value at the IPC boundary — an out-of-date renderer or malformed payload can never select the irreversible branch by accident. `forget` is the explicit discard and still hard-deletes.

**The prompt.** Settings offers the choice inline, matching the file's existing confirm idiom (no modal), and **only when the affected instances actually have pins** — a new `federation:pin-impact` read answers that first. Nothing pinned → the plain confirm, unchanged. A missing API (older preload) or a failed read also falls back to the plain confirm, never a silent forget. Copy states that keeping is reversible and forgetting is not.

**Gateway attribution gap closed.** #1267 only cleaned up the gateway's *own* pins on forget-pairing; pins for peers reached only *through* it were left dimming. Forgetting now covers every pinned instance with no direct router connection, while directly connected peers (a dual instance's own enrolled clients) survive the upstream reset — mirroring the rule #1256 applies to celestial icons.

## Review notes

- The one behavior change beyond pins: clicking **Revoke** now opens a confirm step instead of revoking immediately. That's required to offer the choice, and it's a destructive action that arguably wanted confirming anyway.
- `listRemoteThreadPins` uses two fully-written SQL statements rather than one with an interpolated `WHERE` — `pnpm lint:sql` rejects assembled query text, and the literal pair matches the rest of the file.
- Pin bookkeeping stays best-effort and try/caught throughout: it must never block or fail the revocation itself. Covered by a test.

## Verification

`pnpm typecheck`, `pnpm lint:eslint` (0 errors, no new warnings in touched files), `lint:boundaries`, `lint:sql`, `lint:codex-storage`, `lint:colors` — all clean. Full suite: **6551 passed**, including new coverage for the tombstone/restore lifecycle, repeat-revoke timestamp stability, per-instance counts, the v44→v45 migration, revoke/reset disposition routing, restore-on-reconnect (fires once per transition, not on non-connected ones), and both renderer paths (choice shown with pins, skipped without).

🤖 Generated with [Claude Code](https://claude.com/claude-code)