### PR TITLE
fix(desktop): bound Windows Job startup readiness

### DIFF
--- a/apps/desktop/e2e/windows-vitest-stress.inspect.spec.ts
+++ b/apps/desktop/e2e/windows-vitest-stress.inspect.spec.ts
@@ -145,6 +145,7 @@ test(
         ...process.env,
         CI: "1",
         NO_COLOR: "1",
+        PWRAGENT_WINDOWS_JOB_STARTUP_DIAGNOSTICS: "1",
       },
       stdio: ["ignore", "pipe", "pipe"],
       // Windows resolves pnpm through its .cmd shim. The target is validated

--- a/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
+++ b/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
@@ -1,10 +1,16 @@
 import { spawn } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { wrapCommandInWindowsJob } from "../windows-job-wrapper";
+import {
+  formatWindowsJobStartupTelemetry,
+  readWindowsJobStartupTelemetry,
+  startWindowsJobReadyPoll,
+  WINDOWS_JOB_READY_TIMEOUT_MS,
+  wrapCommandInWindowsJob,
+} from "../windows-job-wrapper";
 import { resolveWindowsBashShell } from "../windows-shell";
 
 function decodeBase64(value: string): string {
@@ -52,6 +58,11 @@ async function runWrappedCommand(params: {
 }
 
 describe("wrapCommandInWindowsJob", () => {
+  it("keeps cold startup bounded inside the Windows test contract", () => {
+    expect(WINDOWS_JOB_READY_TIMEOUT_MS).toBe(20_000);
+    expect(WINDOWS_JOB_READY_TIMEOUT_MS).toBeLessThan(30_000);
+  });
+
   it("launches the shell through an atomic kill-on-close Job wrapper", () => {
     const originalEnv = {
       PATH: "C:\\tools",
@@ -95,7 +106,7 @@ describe("wrapCommandInWindowsJob", () => {
       decodeBase64(wrapped.env.PWRAGENT_JOB_WRAPPER_ARGUMENT_1!),
     ).toBe(
       [
-        "trap 'pwragent_exit=$?; trap - EXIT; printf \"%s\" \"$pwragent_exit\" > \"$PWRAGENT_JOB_WRAPPER_EXIT_FILE\"; exit \"$pwragent_exit\"' EXIT",
+        "trap 'pwragent_exit=$?; trap - EXIT; set +e; pwragent_exit_file=$(/usr/bin/cygpath.exe -u \"$PWRAGENT_JOB_WRAPPER_EXIT_FILE\"); if [ -n \"$pwragent_exit_file\" ]; then printf \"%s\" \"$pwragent_exit\" > \"$pwragent_exit_file\"; fi; exit \"$pwragent_exit\"' EXIT",
         command,
       ].join("\n"),
     );
@@ -106,11 +117,94 @@ describe("wrapCommandInWindowsJob", () => {
     expect(wrapped.env.PWRAGENT_JOB_WRAPPER_EXIT_FILE).toMatch(
       /pwragent-windows-job-.*[\\/]exit$/,
     );
+    expect(wrapped.env.PWRAGENT_JOB_WRAPPER_STARTUP_STATUS_FILE).toBe(
+      wrapped.startupStatusFilePath,
+    );
+    expect(readWindowsJobStartupTelemetry(wrapped)).toEqual({
+      phases: [{ detail: undefined, elapsedMs: 0, phase: "wrapper-created" }],
+    });
     expect(originalEnv).toEqual({
       PATH: "C:\\tools",
       SystemRoot: "C:\\Windows",
     });
     wrapped.cleanup();
+  });
+
+  it("waits through delayed helper phases and reports their timings", async () => {
+    const wrapped = wrapCommandInWindowsJob({
+      args: ["/c", "exit 0"],
+      command: "C:\\Windows\\System32\\cmd.exe",
+      env: { SystemRoot: "C:\\Windows" },
+    });
+    try {
+      const telemetry = await new Promise<
+        ReturnType<typeof readWindowsJobStartupTelemetry>
+      >((resolve, reject) => {
+        startWindowsJobReadyPoll({
+          launch: wrapped,
+          onReady: resolve,
+          onTimeout: () => reject(new Error("Delayed readiness timed out")),
+          timeoutMs: 500,
+        });
+        setTimeout(() => {
+          appendFileSync(
+            wrapped.startupStatusFilePath,
+            "25\tpowershell-started\t\n50\thelper-compile-started\t\n",
+          );
+        }, 25);
+        setTimeout(() => {
+          appendFileSync(
+            wrapped.startupStatusFilePath,
+            "75\thelper-ready\t\n100\ttarget-assigned\t\n125\tready\t\n",
+          );
+          writeFileSync(wrapped.readyFilePath, "ready", "utf8");
+        }, 75);
+      });
+
+      expect(telemetry.phases.map(({ phase }) => phase)).toEqual([
+        "wrapper-created",
+        "powershell-started",
+        "helper-compile-started",
+        "helper-ready",
+        "target-assigned",
+        "ready",
+      ]);
+      expect(formatWindowsJobStartupTelemetry(telemetry)).toBe(
+        "wrapper-created@0ms -> powershell-started@25ms -> helper-compile-started@50ms -> helper-ready@75ms -> target-assigned@100ms -> ready@125ms",
+      );
+    } finally {
+      wrapped.cleanup();
+    }
+  });
+
+  it("reports the last startup phase when readiness times out", async () => {
+    const wrapped = wrapCommandInWindowsJob({
+      args: ["/c", "exit 0"],
+      command: "C:\\Windows\\System32\\cmd.exe",
+      env: { SystemRoot: "C:\\Windows" },
+    });
+    try {
+      appendFileSync(
+        wrapped.startupStatusFilePath,
+        "12\tpowershell-started\t\n18\thelper-compile-started\t\n",
+      );
+      const telemetry = await new Promise<
+        ReturnType<typeof readWindowsJobStartupTelemetry>
+      >((resolve, reject) => {
+        startWindowsJobReadyPoll({
+          launch: wrapped,
+          onReady: () => reject(new Error("Unexpected readiness")),
+          onTimeout: resolve,
+          timeoutMs: 40,
+        });
+      });
+      expect(telemetry.phases.at(-1)).toMatchObject({
+        elapsedMs: 18,
+        phase: "helper-compile-started",
+      });
+    } finally {
+      wrapped.cleanup();
+    }
   });
 
   it.skipIf(process.platform !== "win32")(
@@ -154,6 +248,30 @@ describe("wrapCommandInWindowsJob", () => {
           code: 0,
           stderr: "",
           stdout: "job-bash",
+        });
+      } finally {
+        await rm(root, { force: true, recursive: true });
+      }
+    },
+    30_000,
+  );
+
+  it.skipIf(process.platform !== "win32")(
+    "preserves a nonzero Git Bash exit through the status side channel",
+    async () => {
+      const root = await mkdtemp(
+        path.join(os.tmpdir(), "pwragent-windows-job-exit-test-"),
+      );
+      try {
+        const result = await runWrappedCommand({
+          args: ["-lc", 'printf "job-bash-failure"; exit 23'],
+          command: resolveWindowsBashShell(),
+          cwd: root,
+        });
+        expect(result, result.stderr).toMatchObject({
+          code: 23,
+          stderr: "",
+          stdout: "job-bash-failure",
         });
       } finally {
         await rm(root, { force: true, recursive: true });

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -23,7 +23,13 @@ import {
 } from "@pwragent/shared";
 import { getMainLogger } from "../log";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
-import { wrapCommandInWindowsJob } from "../windows-job-wrapper";
+import {
+  formatWindowsJobStartupTelemetry,
+  readWindowsJobStartupTelemetry,
+  startWindowsJobReadyPoll,
+  WINDOWS_JOB_READY_TIMEOUT_MS,
+  wrapCommandInWindowsJob,
+} from "../windows-job-wrapper";
 import {
   preferStableWindowsBashPath,
   windowsBashCandidates,
@@ -167,7 +173,8 @@ export type CodexEnvironmentDetachedOutput = {
 
 export const DETACHED_OUTPUT_SNAPSHOT_MS = 500;
 const DETACHED_STOP_SIGKILL_GRACE_MS = 2_000;
-const WINDOWS_JOB_READY_TIMEOUT_MS = 10_000;
+const WINDOWS_JOB_STARTUP_DIAGNOSTICS_ENV =
+  "PWRAGENT_WINDOWS_JOB_STARTUP_DIAGNOSTICS";
 
 export type CodexEnvironmentCommandResult = {
   durationMs?: number;
@@ -722,7 +729,9 @@ function runShellCommand(
     let timeoutHandle: NodeJS.Timeout | undefined;
     let killHandle: NodeJS.Timeout | undefined;
     let forceSettleHandle: NodeJS.Timeout | undefined;
-    let windowsJobReadyTimer: NodeJS.Timeout | undefined;
+    let windowsJobReadyPoll:
+      | ReturnType<typeof startWindowsJobReadyPoll>
+      | undefined;
 
     const appendOutput = (text: string) => {
       combinedOutput = `${combinedOutput}${text}`.slice(-32_000);
@@ -798,10 +807,8 @@ function runShellCommand(
         clearTimeout(forceSettleHandle);
         forceSettleHandle = undefined;
       }
-      if (windowsJobReadyTimer) {
-        clearTimeout(windowsJobReadyTimer);
-        windowsJobReadyTimer = undefined;
-      }
+      windowsJobReadyPoll?.cancel();
+      windowsJobReadyPoll = undefined;
       cleanupShellEnvironmentCaptureTarget(capture);
       callback();
     };
@@ -958,30 +965,39 @@ function runShellCommand(
           resolveStarted();
           return;
         }
-        const readyDeadline = Date.now() + WINDOWS_JOB_READY_TIMEOUT_MS;
-        const pollReady = () => {
-          windowsJobReadyTimer = undefined;
-          if (settled || closed) {
-            return;
-          }
-          if (existsSync(windowsJobLaunch.readyFilePath)) {
+        windowsJobReadyPoll = startWindowsJobReadyPoll({
+          launch: windowsJobLaunch,
+          onReady: (startupTelemetry) => {
+            windowsJobReadyPoll = undefined;
+            if (settled || closed) return;
+            const durationMs = Date.now() - startedAt;
+            environmentRuntimeLog.info("codex-environment-windows-job-ready", {
+              processId,
+              durationMs,
+              startupPhases: startupTelemetry.phases,
+            });
+            if (
+              process.env[WINDOWS_JOB_STARTUP_DIAGNOSTICS_ENV] === "1"
+            ) {
+              process.stderr.write(
+                `Windows Job startup ready after ${durationMs}ms: ${formatWindowsJobStartupTelemetry(startupTelemetry)}\n`,
+              );
+            }
             resolveStarted();
-            return;
-          }
-          if (Date.now() >= readyDeadline) {
+          },
+          onTimeout: (startupTelemetry) => {
+            windowsJobReadyPoll = undefined;
+            if (settled || closed) return;
             terminateChild("SIGKILL");
             settle(() => {
               reject(
                 new CodexEnvironmentCommandError(
-                  `Windows Job shell did not become ready within ${WINDOWS_JOB_READY_TIMEOUT_MS}ms`,
+                  `Windows Job shell did not become ready within ${WINDOWS_JOB_READY_TIMEOUT_MS}ms: ${formatWindowsJobStartupTelemetry(startupTelemetry)}`,
                 ),
               );
             });
-            return;
-          }
-          windowsJobReadyTimer = setTimeout(pollReady, 25);
-        };
-        pollReady();
+          },
+        });
       });
       // Even in detach mode, log non-zero exits so failed `pnpm dev` /
       // PwrSnap-style launches don't disappear silently, and fire
@@ -989,10 +1005,8 @@ function runShellCommand(
       // overlay state for the anchored env-action output UI.
       child.once("close", (code, signal) => {
         closed = true;
-        if (windowsJobReadyTimer) {
-          clearTimeout(windowsJobReadyTimer);
-          windowsJobReadyTimer = undefined;
-        }
+        windowsJobReadyPoll?.cancel();
+        windowsJobReadyPoll = undefined;
         if (params.detachedTerminationKey) {
           const processEntry = detachedCommandProcesses.get(
             params.detachedTerminationKey,
@@ -1011,6 +1025,9 @@ function runShellCommand(
         const durationMs = Date.now() - startedAt;
         const output = combinedOutput.trimEnd();
         if (!settled) {
+          const windowsStartup = windowsJobLaunch
+            ? readWindowsJobStartupTelemetry(windowsJobLaunch)
+            : undefined;
           if (windowsJobLaunch && existsSync(windowsJobLaunch.readyFilePath)) {
             settle(() => {
               resolve({ pid: child.pid });
@@ -1019,7 +1036,13 @@ function runShellCommand(
             settle(() => {
               reject(
                 new CodexEnvironmentCommandError(
-                  `Codex environment command exited before its Windows Job became ready${buildExitErrorSuffix(output)}`,
+                  [
+                    "Codex environment command exited before its Windows Job became ready",
+                    windowsStartup
+                      ? `: ${formatWindowsJobStartupTelemetry(windowsStartup)}`
+                      : "",
+                    buildExitErrorSuffix(output),
+                  ].join(""),
                   {
                     durationMs,
                     exitCode: typeof code === "number" ? code : undefined,

--- a/apps/desktop/src/main/windows-job-wrapper.ts
+++ b/apps/desktop/src/main/windows-job-wrapper.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -8,8 +14,10 @@ const ARGUMENT_1_ENV = "PWRAGENT_JOB_WRAPPER_ARGUMENT_1";
 const WORKING_DIRECTORY_ENV = "PWRAGENT_JOB_WRAPPER_CWD";
 const READY_FILE_ENV = "PWRAGENT_JOB_WRAPPER_READY_FILE";
 const EXIT_FILE_ENV = "PWRAGENT_JOB_WRAPPER_EXIT_FILE";
+const STARTED_AT_ENV = "PWRAGENT_JOB_WRAPPER_STARTED_AT";
+const STARTUP_STATUS_FILE_ENV = "PWRAGENT_JOB_WRAPPER_STARTUP_STATUS_FILE";
 const BASH_EXIT_TRAP =
-  "trap 'pwragent_exit=$?; trap - EXIT; printf \"%s\" \"$pwragent_exit\" > \"$PWRAGENT_JOB_WRAPPER_EXIT_FILE\"; exit \"$pwragent_exit\"' EXIT";
+  "trap 'pwragent_exit=$?; trap - EXIT; set +e; pwragent_exit_file=$(/usr/bin/cygpath.exe -u \"$PWRAGENT_JOB_WRAPPER_EXIT_FILE\"); if [ -n \"$pwragent_exit_file\" ]; then printf \"%s\" \"$pwragent_exit\" > \"$pwragent_exit_file\"; fi; exit \"$pwragent_exit\"' EXIT";
 
 /**
  * PowerShell hosts this small native launcher because Node does not expose the
@@ -25,11 +33,33 @@ $argument1 = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String([string
 $workingDirectory = [string]$env:PWRAGENT_JOB_WRAPPER_CWD
 $readyFile = [string]$env:PWRAGENT_JOB_WRAPPER_READY_FILE
 $exitFile = [string]$env:PWRAGENT_JOB_WRAPPER_EXIT_FILE
+$startupStartedAt = [long]$env:PWRAGENT_JOB_WRAPPER_STARTED_AT
+$startupStatusFile = [string]$env:PWRAGENT_JOB_WRAPPER_STARTUP_STATUS_FILE
 Remove-Item Env:PWRAGENT_JOB_WRAPPER_EXECUTABLE -ErrorAction SilentlyContinue
 Remove-Item Env:PWRAGENT_JOB_WRAPPER_ARGUMENT_0 -ErrorAction SilentlyContinue
 Remove-Item Env:PWRAGENT_JOB_WRAPPER_ARGUMENT_1 -ErrorAction SilentlyContinue
 Remove-Item Env:PWRAGENT_JOB_WRAPPER_CWD -ErrorAction SilentlyContinue
 Remove-Item Env:PWRAGENT_JOB_WRAPPER_READY_FILE -ErrorAction SilentlyContinue
+Remove-Item Env:PWRAGENT_JOB_WRAPPER_STARTED_AT -ErrorAction SilentlyContinue
+Remove-Item Env:PWRAGENT_JOB_WRAPPER_STARTUP_STATUS_FILE -ErrorAction SilentlyContinue
+
+function Write-StartupPhase {
+  param(
+    [Parameter(Mandatory = $true)][string]$Phase,
+    [string]$Detail = ''
+  )
+  try {
+    $elapsedMs = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds() - $startupStartedAt
+    $encodedDetail = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Detail))
+    [IO.File]::AppendAllText(
+      $startupStatusFile,
+      ([string]$elapsedMs + [char]9 + $Phase + [char]9 + $encodedDetail + [Environment]::NewLine))
+  } catch {
+    # Startup telemetry is best-effort and must never weaken Job ownership.
+  }
+}
+
+Write-StartupPhase -Phase 'powershell-started'
 
 $source = @'
 using System;
@@ -196,6 +226,24 @@ public static class PwrAgentWindowsJobRunner
             operation + " failed");
     }
 
+    private static void WriteStartupPhase(
+        string startupStatusFile,
+        long startupStartedAt,
+        string phase)
+    {
+        try
+        {
+            long elapsedMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - startupStartedAt;
+            File.AppendAllText(
+                startupStatusFile,
+                elapsedMs.ToString() + "\t" + phase + "\t" + Environment.NewLine);
+        }
+        catch
+        {
+            // Startup telemetry is best-effort and must never weaken Job ownership.
+        }
+    }
+
     private static void MakeInheritable(IntPtr handle)
     {
         if (handle == IntPtr.Zero || handle == new IntPtr(-1))
@@ -260,8 +308,11 @@ public static class PwrAgentWindowsJobRunner
         string application,
         string[] arguments,
         string workingDirectory,
-        string readyFile)
+        string readyFile,
+        string startupStatusFile,
+        long startupStartedAt)
     {
+        WriteStartupPhase(startupStatusFile, startupStartedAt, "native-job-started");
         IntPtr job = CreateJobObject(IntPtr.Zero, null);
         if (job == IntPtr.Zero)
         {
@@ -293,6 +344,7 @@ public static class PwrAgentWindowsJobRunner
             {
                 Marshal.FreeHGlobal(limitsPointer);
             }
+            WriteStartupPhase(startupStatusFile, startupStartedAt, "job-configured");
 
             STARTUPINFO startupInfo = new STARTUPINFO();
             startupInfo.cb = (uint)Marshal.SizeOf(typeof(STARTUPINFO));
@@ -325,18 +377,25 @@ public static class PwrAgentWindowsJobRunner
                 ThrowLastWin32Error("CreateProcess");
             }
             processCreated = true;
+            WriteStartupPhase(
+                startupStatusFile,
+                startupStartedAt,
+                "target-created-suspended");
 
             if (!AssignProcessToJobObject(job, processInformation.hProcess))
             {
                 TerminateProcess(processInformation.hProcess, 127);
                 ThrowLastWin32Error("AssignProcessToJobObject");
             }
+            WriteStartupPhase(startupStatusFile, startupStartedAt, "target-assigned");
             if (ResumeThread(processInformation.hThread) == UInt32.MaxValue)
             {
                 TerminateProcess(processInformation.hProcess, 127);
                 ThrowLastWin32Error("ResumeThread");
             }
+            WriteStartupPhase(startupStatusFile, startupStartedAt, "target-resumed");
             File.WriteAllText(readyFile, "ready");
+            WriteStartupPhase(startupStatusFile, startupStartedAt, "ready");
             if (WaitForSingleObject(processInformation.hProcess, INFINITE) == WAIT_FAILED)
             {
                 ThrowLastWin32Error("WaitForSingleObject");
@@ -366,12 +425,16 @@ public static class PwrAgentWindowsJobRunner
 '@
 
 try {
+  Write-StartupPhase -Phase 'helper-compile-started'
   Add-Type -TypeDefinition $source -Language CSharp -ErrorAction Stop
+  Write-StartupPhase -Phase 'helper-ready'
   $exitCode = [PwrAgentWindowsJobRunner]::Run(
     $application,
     [string[]]@($argument0, $argument1),
     $workingDirectory,
-    $readyFile)
+    $readyFile,
+    $startupStatusFile,
+    $startupStartedAt)
   if (Test-Path -LiteralPath $exitFile) {
     $reportedExitCode = 0
     if ([int]::TryParse(
@@ -382,6 +445,7 @@ try {
   }
   exit $exitCode
 } catch {
+  Write-StartupPhase -Phase 'failed' -Detail $_.Exception.Message
   [Console]::Error.WriteLine('PwrAgent Windows job wrapper failed: ' + $_.Exception.Message)
   exit 127
 }
@@ -393,7 +457,111 @@ export type WindowsJobWrappedCommand = {
   command: string;
   env: NodeJS.ProcessEnv;
   readyFilePath: string;
+  startupStatusFilePath: string;
 };
+
+export type WindowsJobStartupPhase = {
+  detail?: string;
+  elapsedMs: number;
+  phase: string;
+};
+
+export type WindowsJobStartupTelemetry = {
+  phases: WindowsJobStartupPhase[];
+};
+
+export type WindowsJobReadyPoll = {
+  cancel: () => void;
+};
+
+// Public Windows CI placed cold startup on both sides of the former 10-second
+// edge while warm launches completed much sooner. Doubling that observed edge
+// gives helper compilation bounded headroom without approaching the existing
+// 30-second Windows test contract or weakening atomic Job ownership.
+export const WINDOWS_JOB_READY_TIMEOUT_MS = 20_000;
+const WINDOWS_JOB_READY_POLL_INTERVAL_MS = 25;
+
+export function readWindowsJobStartupTelemetry(
+  launch: Pick<WindowsJobWrappedCommand, "startupStatusFilePath">,
+): WindowsJobStartupTelemetry {
+  let content: string;
+  try {
+    content = readFileSync(launch.startupStatusFilePath, "utf8");
+  } catch {
+    return { phases: [] };
+  }
+  const phases: WindowsJobStartupPhase[] = [];
+  for (const line of content.split(/\r?\n/)) {
+    if (!line) continue;
+    const [elapsedValue, phase, encodedDetail = ""] = line.split("\t", 3);
+    const elapsedMs = Number(elapsedValue);
+    if (!phase || !Number.isFinite(elapsedMs) || elapsedMs < 0) {
+      continue;
+    }
+    let detail: string | undefined;
+    if (encodedDetail) {
+      try {
+        detail = Buffer.from(encodedDetail, "base64").toString("utf8");
+      } catch {
+        // Ignore a partial final telemetry line while the wrapper is appending.
+      }
+    }
+    phases.push({ detail, elapsedMs, phase });
+  }
+  return { phases };
+}
+
+export function formatWindowsJobStartupTelemetry(
+  telemetry: WindowsJobStartupTelemetry,
+): string {
+  if (telemetry.phases.length === 0) {
+    return "startup phases unavailable";
+  }
+  return telemetry.phases
+    .map(({ detail, elapsedMs, phase }) =>
+      `${phase}@${elapsedMs}ms${detail ? ` (${detail})` : ""}`,
+    )
+    .join(" -> ");
+}
+
+export function startWindowsJobReadyPoll(params: {
+  launch: Pick<
+    WindowsJobWrappedCommand,
+    "readyFilePath" | "startupStatusFilePath"
+  >;
+  onReady: (telemetry: WindowsJobStartupTelemetry) => void;
+  onTimeout: (telemetry: WindowsJobStartupTelemetry) => void;
+  timeoutMs?: number;
+}): WindowsJobReadyPoll {
+  const timeoutMs = params.timeoutMs ?? WINDOWS_JOB_READY_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  let cancelled = false;
+  let timer: NodeJS.Timeout | undefined;
+  const cancel = () => {
+    cancelled = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+  const poll = () => {
+    timer = undefined;
+    if (cancelled) return;
+    if (existsSync(params.launch.readyFilePath)) {
+      cancelled = true;
+      params.onReady(readWindowsJobStartupTelemetry(params.launch));
+      return;
+    }
+    if (Date.now() >= deadline) {
+      cancelled = true;
+      params.onTimeout(readWindowsJobStartupTelemetry(params.launch));
+      return;
+    }
+    timer = setTimeout(poll, WINDOWS_JOB_READY_POLL_INTERVAL_MS);
+  };
+  poll();
+  return { cancel };
+}
 
 function encodeArgument(value: string): string {
   return Buffer.from(value, "utf8").toString("base64");
@@ -410,7 +578,13 @@ export function wrapCommandInWindowsJob(params: {
   );
   const readyFilePath = path.join(stateDirectory, "ready");
   const exitFilePath = path.join(stateDirectory, "exit");
+  const startupStatusFilePath = path.join(stateDirectory, "startup-status.tsv");
   const scriptPath = path.join(stateDirectory, "wrapper.ps1");
+  const startupStartedAt = Date.now();
+  writeFileSync(startupStatusFilePath, "0\twrapper-created\t\n", {
+    encoding: "utf8",
+    mode: 0o600,
+  });
   writeFileSync(scriptPath, WINDOWS_JOB_WRAPPER_SCRIPT, {
     encoding: "utf8",
     mode: 0o600,
@@ -462,7 +636,10 @@ export function wrapCommandInWindowsJob(params: {
       [WORKING_DIRECTORY_ENV]: params.cwd ?? process.cwd(),
       [READY_FILE_ENV]: readyFilePath,
       [EXIT_FILE_ENV]: exitFilePath,
+      [STARTED_AT_ENV]: String(startupStartedAt),
+      [STARTUP_STATUS_FILE_ENV]: startupStatusFilePath,
     },
     readyFilePath,
+    startupStatusFilePath,
   };
 }


### PR DESCRIPTION
## Summary

- keep the atomic suspended-process → Job assignment → resume design while expanding the ready-marker contract from 10 seconds to a bounded 20 seconds
- journal PowerShell, C# helper compilation, native Job configuration, suspended target creation, assignment, resume, and ready phases with elapsed timing and error detail
- surface phase telemetry in timeout/early-exit errors and opt the existing Windows Vitest stress diagnostic into success timing output
- translate the native exit-file path to Git-Bash POSIX form before the EXIT trap writes it, while preserving the exact script exit status and leaving PowerShell on the native path

## Root cause and bound

Public Windows CI placed cold wrapper startup on both sides of the former 10-second edge: failures arrived at 10.013–10.023 seconds, while a nearby pass took 9.657 seconds; successful runs also showed much faster 1.026- and 5.140-second launches. A fresh PowerShell performs `Add-Type` before the ready marker, but the old implementation recorded no intermediate phases, so cold helper compilation is the leading hypothesis rather than an asserted root cause.

The new 20-second bound is twice the observed failure edge and remains below the existing 30-second Windows Vitest contract. No workspace test timeout, retry, worker count, or serial lane changed. Future failures report the last completed phase and its timing so helper preparation can be distinguished from native Job assignment and shell readiness.

## Ownership invariants

The target still starts suspended, enters a `KILL_ON_JOB_CLOSE` Job before resume, and remains owned while the launcher waits for the complete Job to drain. Readiness remains the marker written only after assignment and resume; telemetry is best-effort and cannot weaken or replace ownership.

## Regression coverage

- delayed ready-marker polling with intermediate phase/timing reporting
- bounded timeout reporting of the last helper phase
- wrapper generation and atomic Job invariants
- deliberate Git Bash exit 23, including the status side channel

## Validation

- focused Vitest: 3 files, 484 passed, 2 Windows-only skips
- `pnpm lint:eslint`: 0 errors (existing warnings only)
- `pnpm typecheck`
- `pnpm lint:boundaries`: 1,337 modules / 4,265 dependencies
- `pnpm lint:codex-storage`
- `pnpm build` including main-bundle boundary validation
- `git diff --check`

Repeated Windows validation is still pending. The first supported-controller attempt was rejected before any product test process started, so it produced no readiness timings, test counts, or residue evidence. The controller is undergoing a separate private fix; this draft will be updated after at least 10 focused and 10 full-workspace repetitions run with retries disabled.

