### PR TITLE
feat(desktop): float chat cards over the star map, with a compact composer

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -21,7 +21,11 @@ export type CompactComposerProps = {
   /** Thread's current model, shown as ambient state rather than a control. */
   model?: string;
   onInterrupt?: () => void;
-  onSend: (text: string) => void;
+  /**
+   * Resolve `false` to hand the text back to the input — a send that never
+   * reached the backend must not cost the operator what they typed.
+   */
+  onSend: (text: string) => void | boolean | Promise<boolean | void>;
   placeholder?: string;
   reasoningEffort?: string;
   /** Consolidated under the kebab; the row itself stays one line tall. */
@@ -63,18 +67,23 @@ export function CompactComposer(props: CompactComposerProps) {
     .filter((part): part is string => Boolean(part))
     .join(" · ");
 
-  const send = useCallback(() => {
+  const send = useCallback(async () => {
     const text = draft.trim();
     if (!text) return;
+    // Clear optimistically so the input frees up immediately, then put the
+    // text back if the send turned out to fail.
     setDraft("");
-    onSend(text);
+    const delivered = await onSend(text);
+    if (delivered === false) {
+      setDraft((current) => (current.length > 0 ? current : text));
+    }
   }, [draft, onSend]);
 
   const onKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
       if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault();
-        send();
+        void send();
       }
     },
     [send],
@@ -170,7 +179,7 @@ export function CompactComposer(props: CompactComposerProps) {
           <button
             className="compact-composer__send"
             disabled={props.disabled || draft.trim().length === 0}
-            onClick={send}
+            onClick={() => void send()}
             type="button"
           >
             Send

--- a/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/CompactComposer.tsx
@@ -1,0 +1,182 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
+import type { ThreadExecutionMode } from "@pwragent/shared";
+
+export type CompactComposerAction = {
+  disabled?: boolean;
+  key: string;
+  label: string;
+  onSelect: () => void;
+};
+
+export type CompactComposerProps = {
+  busy?: boolean;
+  disabled?: boolean;
+  executionMode?: ThreadExecutionMode;
+  /** Thread's current model, shown as ambient state rather than a control. */
+  model?: string;
+  onInterrupt?: () => void;
+  onSend: (text: string) => void;
+  placeholder?: string;
+  reasoningEffort?: string;
+  /** Consolidated under the kebab; the row itself stays one line tall. */
+  secondaryActions?: CompactComposerAction[];
+  threadTitle: string;
+};
+
+const EXECUTION_MODE_LABELS: Record<ThreadExecutionMode, string> = {
+  default: "Default",
+  "full-access": "Full access",
+};
+
+/**
+ * Composer for surfaces with no vertical budget — currently the star map's
+ * floating chat cards.
+ *
+ * This is deliberately NOT a variant of `Composer.tsx`. That component is
+ * ~12,000 lines and needs the backend list, skills, directories,
+ * launchpad state, and provider defaults that a floating card has no
+ * access to. The two share a contract (send text, stop a running turn),
+ * not an implementation.
+ *
+ * Two moves buy back the height: secondary actions consolidate under a
+ * single kebab, and model / reasoning effort render as right-aligned
+ * ambient text *inside* the input rather than as chips below it — they are
+ * state to be aware of, not controls to reach for.
+ */
+export function CompactComposer(props: CompactComposerProps) {
+  const [draft, setDraft] = useState("");
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const { onSend } = props;
+
+  const ambient = [
+    props.model,
+    props.reasoningEffort,
+    props.executionMode ? EXECUTION_MODE_LABELS[props.executionMode] : undefined,
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join(" · ");
+
+  const send = useCallback(() => {
+    const text = draft.trim();
+    if (!text) return;
+    setDraft("");
+    onSend(text);
+  }, [draft, onSend]);
+
+  const onKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        send();
+      }
+    },
+    [send],
+  );
+
+  // Click-away and Escape close the kebab. Without this the menu survives
+  // a click on the transcript behind it and covers the conversation.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!menuRef.current?.contains(event.target as Node)) setMenuOpen(false);
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setMenuOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [menuOpen]);
+
+  const actions = props.secondaryActions ?? [];
+
+  return (
+    <div className="compact-composer">
+      <div className="compact-composer__field">
+        <textarea
+          aria-label={`Message ${props.threadTitle}`}
+          className="compact-composer__input"
+          disabled={props.disabled}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={props.placeholder ?? "Reply…"}
+          rows={2}
+          value={draft}
+        />
+        {ambient ? (
+          // Ambient, not interactive: the label belongs to the input, so
+          // screen readers reach it through the field rather than as a
+          // separate stop.
+          <span aria-hidden="true" className="compact-composer__ambient">
+            {ambient}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="compact-composer__controls">
+        {actions.length > 0 ? (
+          <div className="compact-composer__menu" ref={menuRef}>
+            <button
+              aria-expanded={menuOpen}
+              aria-haspopup="menu"
+              aria-label="More actions"
+              className="compact-composer__kebab"
+              onClick={() => setMenuOpen((open) => !open)}
+              type="button"
+            >
+              ⋯
+            </button>
+            {menuOpen ? (
+              <div className="compact-composer__menu-list" role="menu">
+                {actions.map((action) => (
+                  <button
+                    className="compact-composer__menu-item"
+                    disabled={action.disabled}
+                    key={action.key}
+                    onClick={() => {
+                      setMenuOpen(false);
+                      action.onSelect();
+                    }}
+                    role="menuitem"
+                    type="button"
+                  >
+                    {action.label}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {props.busy ? (
+          <button
+            className="compact-composer__send"
+            onClick={props.onInterrupt}
+            type="button"
+          >
+            Stop
+          </button>
+        ) : (
+          <button
+            className="compact-composer__send"
+            disabled={props.disabled || draft.trim().length === 0}
+            onClick={send}
+            type="button"
+          >
+            Send
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CompactComposer } from "../CompactComposer";
+
+function renderComposer(overrides: Partial<Parameters<typeof CompactComposer>[0]> = {}) {
+  const onSend = vi.fn();
+  render(
+    <CompactComposer onSend={onSend} threadTitle="Thread t1" {...overrides} />,
+  );
+  return { onSend };
+}
+
+describe("CompactComposer", () => {
+  it("sends on Enter and clears the draft", () => {
+    const { onSend } = renderComposer();
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    fireEvent.change(input, { target: { value: "ship it" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("ship it");
+    expect((input as HTMLTextAreaElement).value).toBe("");
+  });
+
+  it("keeps Shift+Enter as a newline", () => {
+    const { onSend } = renderComposer();
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    fireEvent.change(input, { target: { value: "line one" } });
+    fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("does not send whitespace", () => {
+    const { onSend } = renderComposer();
+    const input = screen.getByRole("textbox", { name: "Message Thread t1" });
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("shows model, effort, and access mode as one ambient string", () => {
+    renderComposer({
+      executionMode: "full-access",
+      model: "gpt-5-codex",
+      reasoningEffort: "high",
+    });
+    expect(screen.getByText("gpt-5-codex · high · Full access")).toBeTruthy();
+  });
+
+  it("omits the ambient strip when there is nothing to report", () => {
+    renderComposer();
+    expect(screen.queryByText(/·/)).toBeNull();
+  });
+
+  it("swaps Send for Stop while a turn is running", () => {
+    const onInterrupt = vi.fn();
+    renderComposer({ busy: true, onInterrupt });
+    expect(screen.queryByRole("button", { name: "Send" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+    expect(onInterrupt).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the kebab when there are no secondary actions", () => {
+    renderComposer();
+    expect(screen.queryByRole("button", { name: "More actions" })).toBeNull();
+  });
+
+  it("runs a secondary action and closes the menu", () => {
+    const onSelect = vi.fn();
+    renderComposer({
+      secondaryActions: [{ key: "a", label: "Compact thread", onSelect }],
+    });
+    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Compact thread" }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("closes the menu on Escape without running anything", () => {
+    const onSelect = vi.fn();
+    renderComposer({
+      secondaryActions: [{ key: "a", label: "Compact thread", onSelect }],
+    });
+    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("renders a disabled action as unclickable", () => {
+    const onSelect = vi.fn();
+    renderComposer({
+      secondaryActions: [
+        { disabled: true, key: "a", label: "Compact thread", onSelect },
+      ],
+    });
+    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Compact thread" }));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -1,10 +1,10 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
-  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import type {
@@ -12,6 +12,10 @@ import type {
   NavigationThreadSummary,
 } from "@pwragent/shared";
 import { CelestialIcon } from "../../icons";
+import {
+  CompactComposer,
+  type CompactComposerAction,
+} from "../composer/CompactComposer";
 import { TranscriptList } from "../thread-detail/TranscriptList";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { readRendererFederationTarget } from "../../lib/federation-window";
@@ -64,7 +68,6 @@ function viewportSize(): { width: number; height: number } {
 export function StarMapChatCard(props: StarMapChatCardProps) {
   const { cardKey, desktopApi, onRaise, onRectChange, rect, thread } = props;
   const dragRef = useRef<DragState | undefined>(undefined);
-  const [draft, setDraft] = useState("");
   const [sendError, setSendError] = useState<string | undefined>(undefined);
 
   const session = useThreadSessionState({ desktopApi, thread });
@@ -135,26 +138,28 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     return () => window.removeEventListener("resize", onResize);
   }, [cardKey, onRectChange, rect]);
 
-  const send = useCallback(async () => {
-    const text = draft.trim();
-    if (!text || !desktopApi?.startTurn) return;
-    setSendError(undefined);
-    setDraft("");
-    session.addOptimisticUserMessage(text);
-    try {
-      await desktopApi.startTurn({
-        backend: thread.source,
-        federationTarget,
-        threadId: thread.id,
-        input: [{ type: "text", text }],
-      });
-    } catch (error) {
-      setSendError(
-        error instanceof Error ? error.message : "Could not send that message.",
-      );
-      setDraft(text);
-    }
-  }, [desktopApi, draft, federationTarget, session, thread]);
+  const send = useCallback(
+    async (text: string) => {
+      if (!desktopApi?.startTurn) return;
+      setSendError(undefined);
+      session.addOptimisticUserMessage(text);
+      try {
+        await desktopApi.startTurn({
+          backend: thread.source,
+          federationTarget,
+          threadId: thread.id,
+          input: [{ type: "text", text }],
+        });
+      } catch (error) {
+        setSendError(
+          error instanceof Error
+            ? error.message
+            : "Could not send that message.",
+        );
+      }
+    },
+    [desktopApi, federationTarget, session, thread],
+  );
 
   const activeTurnId = session.activeTurnId;
   const interrupt = useCallback(async () => {
@@ -173,15 +178,71 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     }
   }, [activeTurnId, desktopApi, federationTarget, thread]);
 
-  const onDraftKeyDown = useCallback(
-    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
-      if (event.key === "Enter" && !event.shiftKey) {
-        event.preventDefault();
-        void send();
-      }
-    },
-    [send],
-  );
+  /**
+   * Everything the card can do with only a thread summary and the desktop
+   * bridge. Anything needing the backend list, skills, or launchpad state
+   * lives behind the header's Open button in the full thread view.
+   */
+  const secondaryActions = useMemo<CompactComposerAction[]>(() => {
+    const entries: CompactComposerAction[] = [];
+    const nextMode =
+      thread.executionMode === "full-access" ? "default" : "full-access";
+    if (desktopApi?.setThreadExecutionMode) {
+      entries.push({
+        key: "execution-mode",
+        label:
+          nextMode === "full-access"
+            ? "Switch to full access"
+            : "Switch to default access",
+        onSelect: () => {
+          void desktopApi
+            .setThreadExecutionMode?.({
+              backend: thread.source,
+              executionMode: nextMode,
+              federationTarget,
+              threadId: thread.id,
+            })
+            .catch((error: unknown) => {
+              setSendError(
+                error instanceof Error
+                  ? error.message
+                  : "Could not change access mode.",
+              );
+            });
+        },
+      });
+    }
+    if (desktopApi?.compactThread) {
+      entries.push({
+        key: "compact",
+        // Compaction rewrites history mid-turn, so gate it on an idle
+        // thread the same way the full composer's /compact does.
+        disabled: session.threadBusy,
+        label: "Compact thread",
+        onSelect: () => {
+          void desktopApi
+            .compactThread?.({
+              backend: thread.source,
+              federationTarget,
+              threadId: thread.id,
+            })
+            .catch((error: unknown) => {
+              setSendError(
+                error instanceof Error
+                  ? error.message
+                  : "Could not compact the thread.",
+              );
+            });
+        },
+      });
+    }
+    entries.push({
+      key: "open-full",
+      label: "Open in full view",
+      onSelect: () => props.onOpenFull(thread),
+    });
+    return entries;
+  }, [desktopApi, federationTarget, props, session.threadBusy, thread]);
 
   const style: CSSProperties = {
     left: `${rect.left}px`,
@@ -266,35 +327,16 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         </p>
       ) : undefined}
 
-      <div className="star-map-chat-card__composer">
-        <textarea
-          aria-label={`Message ${thread.title}`}
-          className="star-map-chat-card__input"
-          onChange={(event) => setDraft(event.target.value)}
-          onKeyDown={onDraftKeyDown}
-          placeholder="Reply…"
-          rows={2}
-          value={draft}
-        />
-        {session.threadBusy ? (
-          <button
-            className="star-map-chat-card__send"
-            onClick={() => void interrupt()}
-            type="button"
-          >
-            Stop
-          </button>
-        ) : (
-          <button
-            className="star-map-chat-card__send"
-            disabled={draft.trim().length === 0}
-            onClick={() => void send()}
-            type="button"
-          >
-            Send
-          </button>
-        )}
-      </div>
+      <CompactComposer
+        busy={session.threadBusy}
+        executionMode={thread.executionMode}
+        model={thread.model}
+        onInterrupt={() => void interrupt()}
+        onSend={(text) => void send(text)}
+        reasoningEffort={thread.reasoningEffort}
+        secondaryActions={secondaryActions}
+        threadTitle={thread.title}
+      />
 
       <span
         aria-hidden="true"

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -1,0 +1,309 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import type {
+  CelestialIconId,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import { CelestialIcon } from "../../icons";
+import { TranscriptList } from "../thread-detail/TranscriptList";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { readRendererFederationTarget } from "../../lib/federation-window";
+import { useThreadSessionState } from "../../lib/useThreadSessionState";
+import {
+  clampChatCardRect,
+  resizeChatCardRect,
+  type ChatCardRect,
+} from "./star-map-chat-card-geometry";
+
+export type StarMapChatCardProps = {
+  cardKey: string;
+  desktopApi?: DesktopApi;
+  /** Owning instance's celestial mark, watermarked behind the header. */
+  instanceIcon?: CelestialIconId;
+  instanceLabel?: string;
+  onClose: (cardKey: string) => void;
+  /** Escape hatch into the full thread surface. */
+  onOpenFull: (thread: NavigationThreadSummary) => void;
+  onRaise: (cardKey: string) => void;
+  onRectChange: (cardKey: string, rect: ChatCardRect) => void;
+  rect: ChatCardRect;
+  thread: NavigationThreadSummary;
+  /** Stack position; the host owns the order, we only read our depth. */
+  zIndex: number;
+};
+
+type DragState = {
+  kind: "move" | "resize";
+  pointerId: number;
+  originX: number;
+  originY: number;
+  startRect: ChatCardRect;
+};
+
+function viewportSize(): { width: number; height: number } {
+  if (typeof window === "undefined") return { width: 1440, height: 900 };
+  return { width: window.innerWidth, height: window.innerHeight };
+}
+
+/**
+ * One floating chat card over the star map.
+ *
+ * The card owns its own thread session rather than borrowing App's single
+ * mounted ThreadView: that is what lets several cards be open at once, and
+ * it is also what makes remote threads work without pinning them. The
+ * session hook derives the federation target from the thread summary it is
+ * handed, so a card over a peer's thread reads and writes on that peer.
+ */
+export function StarMapChatCard(props: StarMapChatCardProps) {
+  const { cardKey, desktopApi, onRaise, onRectChange, rect, thread } = props;
+  const dragRef = useRef<DragState | undefined>(undefined);
+  const [draft, setDraft] = useState("");
+  const [sendError, setSendError] = useState<string | undefined>(undefined);
+
+  const session = useThreadSessionState({ desktopApi, thread });
+
+  const federationTarget =
+    thread.federation?.ref.target ?? readRendererFederationTarget();
+
+  const beginDrag = useCallback(
+    (event: ReactPointerEvent, kind: DragState["kind"]) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      onRaise(cardKey);
+      dragRef.current = {
+        kind,
+        pointerId: event.pointerId,
+        originX: event.clientX,
+        originY: event.clientY,
+        startRect: rect,
+      };
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+    },
+    [cardKey, onRaise, rect],
+  );
+
+  const continueDrag = useCallback(
+    (event: ReactPointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      const deltaX = event.clientX - drag.originX;
+      const deltaY = event.clientY - drag.originY;
+      const viewport = viewportSize();
+      const next =
+        drag.kind === "move"
+          ? clampChatCardRect(
+              {
+                ...drag.startRect,
+                left: drag.startRect.left + deltaX,
+                top: drag.startRect.top + deltaY,
+              },
+              viewport,
+            )
+          : resizeChatCardRect({
+              rect: drag.startRect,
+              deltaX,
+              deltaY,
+              viewport,
+            });
+      onRectChange(cardKey, next);
+    },
+    [cardKey, onRectChange],
+  );
+
+  const endDrag = useCallback((event: ReactPointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    dragRef.current = undefined;
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+  }, []);
+
+  // A card parked against an edge must stay reachable when the window
+  // shrinks under it.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onResize = () => {
+      onRectChange(cardKey, clampChatCardRect(rect, viewportSize()));
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [cardKey, onRectChange, rect]);
+
+  const send = useCallback(async () => {
+    const text = draft.trim();
+    if (!text || !desktopApi?.startTurn) return;
+    setSendError(undefined);
+    setDraft("");
+    session.addOptimisticUserMessage(text);
+    try {
+      await desktopApi.startTurn({
+        backend: thread.source,
+        federationTarget,
+        threadId: thread.id,
+        input: [{ type: "text", text }],
+      });
+    } catch (error) {
+      setSendError(
+        error instanceof Error ? error.message : "Could not send that message.",
+      );
+      setDraft(text);
+    }
+  }, [desktopApi, draft, federationTarget, session, thread]);
+
+  const activeTurnId = session.activeTurnId;
+  const interrupt = useCallback(async () => {
+    if (!desktopApi?.interruptTurn || !activeTurnId) return;
+    try {
+      await desktopApi.interruptTurn({
+        backend: thread.source,
+        federationTarget,
+        threadId: thread.id,
+        turnId: activeTurnId,
+      });
+    } catch (error) {
+      setSendError(
+        error instanceof Error ? error.message : "Could not interrupt the turn.",
+      );
+    }
+  }, [activeTurnId, desktopApi, federationTarget, thread]);
+
+  const onDraftKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        void send();
+      }
+    },
+    [send],
+  );
+
+  const style: CSSProperties = {
+    left: `${rect.left}px`,
+    top: `${rect.top}px`,
+    width: `${rect.width}px`,
+    height: `${rect.height}px`,
+    zIndex: props.zIndex,
+  };
+
+  return (
+    <section
+      aria-label={`Chat: ${thread.title}`}
+      className="star-map-chat-card"
+      onPointerDown={() => onRaise(cardKey)}
+      style={style}
+    >
+      <header
+        className="star-map-chat-card__bar"
+        onPointerDown={(event) => beginDrag(event, "move")}
+        onPointerMove={continueDrag}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+      >
+        {props.instanceIcon ? (
+          <span className="star-map-chat-card__watermark" aria-hidden="true">
+            <CelestialIcon icon={props.instanceIcon} size={72} />
+          </span>
+        ) : null}
+        <span className="star-map-chat-card__title" title={thread.title}>
+          {thread.title}
+        </span>
+        {props.instanceLabel ? (
+          <span className="star-map-chat-card__instance">
+            {props.instanceLabel}
+          </span>
+        ) : undefined}
+        <button
+          aria-label={`Open ${thread.title} in the full thread view`}
+          className="star-map-chat-card__expand"
+          onClick={() => props.onOpenFull(thread)}
+          onPointerDown={(event) => event.stopPropagation()}
+          type="button"
+        >
+          Open
+        </button>
+        <button
+          aria-label={`Close chat: ${thread.title}`}
+          className="star-map-chat-card__close"
+          onClick={() => props.onClose(cardKey)}
+          onPointerDown={(event) => event.stopPropagation()}
+          type="button"
+        >
+          ×
+        </button>
+      </header>
+
+      <div className="star-map-chat-card__transcript">
+        <TranscriptList
+          activeTurnId={session.activeTurnId}
+          activeTurnStartedAt={session.activeTurnStartedAt}
+          desktopApi={desktopApi}
+          entries={session.entries}
+          error={session.error}
+          loading={session.loading}
+          loadingMore={session.loadingMore}
+          onLoadOlder={session.loadOlder}
+          parentThreadId={thread.id}
+          pendingAssistantMessage={session.pendingAssistantMessage}
+          pendingMcpInteraction={session.pendingMcpInteraction}
+          pendingRequest={session.pendingRequest}
+          pendingStatusText={session.pendingStatusText}
+          pendingUserInput={session.pendingUserInput}
+          runningTurnUsageText={session.runningTurnUsageText}
+          threadId={thread.id}
+          transientMessages={session.transientMessages}
+        />
+      </div>
+
+      {sendError ? (
+        <p className="star-map-chat-card__error" role="alert">
+          {sendError}
+        </p>
+      ) : undefined}
+
+      <div className="star-map-chat-card__composer">
+        <textarea
+          aria-label={`Message ${thread.title}`}
+          className="star-map-chat-card__input"
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={onDraftKeyDown}
+          placeholder="Reply…"
+          rows={2}
+          value={draft}
+        />
+        {session.threadBusy ? (
+          <button
+            className="star-map-chat-card__send"
+            onClick={() => void interrupt()}
+            type="button"
+          >
+            Stop
+          </button>
+        ) : (
+          <button
+            className="star-map-chat-card__send"
+            disabled={draft.trim().length === 0}
+            onClick={() => void send()}
+            type="button"
+          >
+            Send
+          </button>
+        )}
+      </div>
+
+      <span
+        aria-hidden="true"
+        className="star-map-chat-card__resize"
+        onPointerDown={(event) => beginDrag(event, "resize")}
+        onPointerMove={continueDrag}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+      />
+    </section>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -128,21 +128,32 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   }, []);
 
   // A card parked against an edge must stay reachable when the window
-  // shrinks under it.
+  // shrinks under it. The listener reads the current rect through a ref
+  // rather than closing over it: `rect` changes on every pointermove, and
+  // depending on it here tore the listener down and re-added it on every
+  // frame of a drag.
+  const rectRef = useRef(rect);
+  rectRef.current = rect;
   useEffect(() => {
     if (typeof window === "undefined") return;
     const onResize = () => {
-      onRectChange(cardKey, clampChatCardRect(rect, viewportSize()));
+      onRectChange(cardKey, clampChatCardRect(rectRef.current, viewportSize()));
     };
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
-  }, [cardKey, onRectChange, rect]);
+  }, [cardKey, onRectChange]);
 
+  /**
+   * Returns whether the turn actually reached the backend. A peer can drop
+   * mid-send, and when it does the operator must get their text back and
+   * the transcript must not keep an optimistic message for a turn that
+   * never started.
+   */
   const send = useCallback(
-    async (text: string) => {
-      if (!desktopApi?.startTurn) return;
+    async (text: string): Promise<boolean> => {
+      if (!desktopApi?.startTurn) return false;
       setSendError(undefined);
-      session.addOptimisticUserMessage(text);
+      const optimisticId = session.addOptimisticUserMessage(text);
       try {
         await desktopApi.startTurn({
           backend: thread.source,
@@ -150,12 +161,15 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           threadId: thread.id,
           input: [{ type: "text", text }],
         });
+        return true;
       } catch (error) {
+        session.removeOptimisticMessage(optimisticId);
         setSendError(
           error instanceof Error
             ? error.message
             : "Could not send that message.",
         );
+        return false;
       }
     },
     [desktopApi, federationTarget, session, thread],
@@ -332,7 +346,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         executionMode={thread.executionMode}
         model={thread.model}
         onInterrupt={() => void interrupt()}
-        onSend={(text) => void send(text)}
+        onSend={send}
         reasoningEffort={thread.reasoningEffort}
         secondaryActions={secondaryActions}
         threadTitle={thread.title}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -41,6 +41,8 @@ import {
   shouldStartCanvasPan,
 } from "./star-map-orbit";
 import { buildFederationTopology } from "./star-map-topology";
+import { StarMapChatCard } from "./StarMapChatCard";
+import { useStarMapChatCards } from "./useStarMapChatCards";
 import { IntakeDialog, type IntakeDialogTarget } from "./IntakeDialog";
 import {
   readStoredPreferences,
@@ -62,6 +64,11 @@ const ORBIT_CARD_WIDTH = 200;
 const ORBIT_MAX_CARDS_PER_INSTANCE = 16;
 const MIN_ZOOM = 0.35;
 const MAX_ZOOM = 2;
+/**
+ * Chat cards float above the map chrome (close button, filters, view
+ * options) so a card being read is never underneath a control strip.
+ */
+const STAR_MAP_CHAT_CARD_BASE_Z = 40;
 
 function readStoredFilters(): Set<StarMapAttentionCategory> {
   if (typeof window === "undefined") {
@@ -549,6 +556,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     );
   }, [health, localInstanceId, peers, props.localInstanceLabel]);
 
+  const chatCards = useStarMapChatCards();
   const { desktopApi, onFocusLocalInstance, onOpenLocalThread } = props;
   const openInstance = useCallback(
     (instanceId: string) => {
@@ -563,7 +571,24 @@ export function StarMapScreen(props: StarMapScreenProps) {
     [desktopApi, localInstanceId, onFocusLocalInstance],
   );
 
+  // Thread cards float a chat card over the map rather than navigating
+  // away from it: the whole point of the surface is to work across
+  // instances without leaving. Cards carry their own session, so a remote
+  // thread needs no pin and no snapshot merge.
   const openThread = useCallback(
+    (thread: NavigationThreadSummary) => {
+      chatCards.open(thread);
+    },
+    [chatCards],
+  );
+
+  /**
+   * Escape hatch off the card and into the full thread surface, for when
+   * triage turns into real work. Local threads land in this window; remote
+   * ones open their owning instance's viewer, which is what the card click
+   * itself used to do.
+   */
+  const openThreadFully = useCallback(
     (thread: NavigationThreadSummary) => {
       if (
         thread.federation
@@ -890,6 +915,36 @@ export function StarMapScreen(props: StarMapScreenProps) {
           }}
         />
       ) : null}
+      {/* Chat cards sit outside `.star-map__canvas` on purpose: they are
+          windows over the star field, not objects in it, so panning and
+          zooming the map must not move or scale them. */}
+      {chatCards.cards.map((card) => {
+        const target = card.thread.federation?.ref.target;
+        const cardInstanceId =
+          target && isRemoteFederationTarget(target)
+            ? target.instanceId
+            : undefined;
+        return (
+          <StarMapChatCard
+            key={card.key}
+            cardKey={card.key}
+            desktopApi={props.desktopApi}
+            instanceIcon={celestialIcons.iconFor(cardInstanceId)}
+            instanceLabel={
+              cardInstanceId
+                ? displayLabelById.get(cardInstanceId)
+                : displayLabelById.get(localInstanceId ?? "")
+            }
+            onClose={chatCards.close}
+            onOpenFull={openThreadFully}
+            onRaise={chatCards.raise}
+            onRectChange={chatCards.setRect}
+            rect={card.rect}
+            thread={card.thread}
+            zIndex={STAR_MAP_CHAT_CARD_BASE_Z + chatCards.depthOf(card.key)}
+          />
+        );
+      })}
       {/* The map layer covers the app chrome, including the header toggle
           that opened it, so it must carry its own way out. */}
       <button

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -1,0 +1,205 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { StarMapChatCard } from "../StarMapChatCard";
+
+const RECT = { left: 40, top: 40, width: 420, height: 520 };
+
+/**
+ * A thread owned by a peer. The federation ref is the whole point: the
+ * card must route both reads and writes to that instance without the
+ * thread ever being pinned or merged into the local snapshot.
+ */
+function remoteThread(): NavigationThreadSummary {
+  return {
+    id: "t-remote",
+    title: "Remote work",
+    titleSource: "generated",
+    linkedDirectories: [],
+    source: "codex",
+    inbox: { inInbox: false },
+    updatedAt: 1,
+    federation: {
+      instanceLabel: "Studio Mac",
+      ref: {
+        backend: "codex",
+        threadId: "t-remote",
+        target: { scope: "remote", instanceId: "pwr_peer" },
+      },
+    },
+  } as unknown as NavigationThreadSummary;
+}
+
+function localThread(): NavigationThreadSummary {
+  return {
+    id: "t-local",
+    title: "Local work",
+    titleSource: "generated",
+    linkedDirectories: [],
+    source: "codex",
+    inbox: { inInbox: false },
+    updatedAt: 1,
+  } as unknown as NavigationThreadSummary;
+}
+
+function buildApi(overrides: Partial<DesktopApi> = {}): DesktopApi {
+  return {
+    readThread: vi.fn(async () => ({
+      backend: "codex",
+      threadId: "t",
+      replay: { entries: [], pagination: undefined },
+    })),
+    startTurn: vi.fn(async () => ({
+      backend: "codex",
+      threadId: "t",
+      turnId: "turn-1",
+    })),
+    onAgentEvent: vi.fn(() => () => undefined),
+    ...overrides,
+  } as unknown as DesktopApi;
+}
+
+function renderCard(params: {
+  desktopApi: DesktopApi;
+  thread: NavigationThreadSummary;
+}) {
+  render(
+    <StarMapChatCard
+      cardKey="card-1"
+      desktopApi={params.desktopApi}
+      onClose={() => undefined}
+      onOpenFull={() => undefined}
+      onRaise={() => undefined}
+      onRectChange={() => undefined}
+      rect={RECT}
+      thread={params.thread}
+      zIndex={40}
+    />,
+  );
+}
+
+async function typeAndSend(title: string, text: string) {
+  const input = screen.getByRole("textbox", { name: `Message ${title}` });
+  fireEvent.change(input, { target: { value: text } });
+  fireEvent.keyDown(input, { key: "Enter" });
+  return input as HTMLTextAreaElement;
+}
+
+describe("StarMapChatCard federation routing", () => {
+  it("hydrates a peer's thread against that peer", async () => {
+    const desktopApi = buildApi();
+    renderCard({ desktopApi, thread: remoteThread() });
+
+    await waitFor(() => {
+      expect(desktopApi.readThread).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "t-remote",
+          federationTarget: { scope: "remote", instanceId: "pwr_peer" },
+        }),
+      );
+    });
+  });
+
+  it("starts a turn on the owning peer, not the viewer", async () => {
+    const desktopApi = buildApi();
+    renderCard({ desktopApi, thread: remoteThread() });
+    await typeAndSend("Remote work", "ship it");
+
+    await waitFor(() => {
+      expect(desktopApi.startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "t-remote",
+          federationTarget: { scope: "remote", instanceId: "pwr_peer" },
+          input: [{ type: "text", text: "ship it" }],
+        }),
+      );
+    });
+  });
+
+  it("leaves a local thread's target to the window's own scope", async () => {
+    const desktopApi = buildApi();
+    renderCard({ desktopApi, thread: localThread() });
+    await typeAndSend("Local work", "hello");
+
+    await waitFor(() => {
+      expect(desktopApi.startTurn).toHaveBeenCalled();
+    });
+    const request = (desktopApi.startTurn as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(request.threadId).toBe("t-local");
+    // No per-thread ref, so nothing overrides the renderer's own target.
+    expect(request.federationTarget).toBeUndefined();
+  });
+});
+
+describe("StarMapChatCard send failures", () => {
+  it("hands the text back to the input when the peer refuses", async () => {
+    const desktopApi = buildApi({
+      startTurn: vi.fn(async () => {
+        throw new Error("peer is offline");
+      }),
+    } as unknown as Partial<DesktopApi>);
+    renderCard({ desktopApi, thread: remoteThread() });
+    const input = await typeAndSend("Remote work", "do not lose me");
+
+    // A send that never reached the backend must not cost the operator
+    // what they typed.
+    await waitFor(() => {
+      expect(input.value).toBe("do not lose me");
+    });
+    expect((await screen.findByRole("alert")).textContent).toMatch(
+      /peer is offline/,
+    );
+  });
+
+  it("shows the message optimistically while the turn is in flight", async () => {
+    // Baseline for the rollback test below: without this, "the message is
+    // gone after a failure" could pass simply because it never appeared.
+    const desktopApi = buildApi({
+      startTurn: vi.fn(() => new Promise(() => undefined)),
+    } as unknown as Partial<DesktopApi>);
+    renderCard({ desktopApi, thread: remoteThread() });
+    await typeAndSend("Remote work", "in flight");
+
+    // Ignore the composer: a textarea's content matches text queries, and
+    // the draft would otherwise satisfy this on its own.
+    expect(
+      await screen.findByText("in flight", { ignore: "textarea" }),
+    ).toBeTruthy();
+  });
+
+  it("rolls the optimistic message back when the turn never started", async () => {
+    const desktopApi = buildApi({
+      startTurn: vi.fn(async () => {
+        throw new Error("nope");
+      }),
+    } as unknown as Partial<DesktopApi>);
+    renderCard({ desktopApi, thread: remoteThread() });
+    await typeAndSend("Remote work", "rolled back");
+
+    // The transcript must not keep a message for a turn that never ran.
+    // The composer is excluded because the restored draft lives there and
+    // text queries match textarea content.
+    await waitFor(() => {
+      expect(
+        screen.queryByText("rolled back", { ignore: "textarea" }),
+      ).toBeNull();
+    });
+    expect((await screen.findByRole("alert")).textContent).toMatch(/nope/);
+  });
+
+  it("clears the draft when the send succeeds", async () => {
+    const desktopApi = buildApi();
+    renderCard({ desktopApi, thread: remoteThread() });
+    const input = await typeAndSend("Remote work", "sent for real");
+
+    await waitFor(() => {
+      expect(desktopApi.startTurn).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(input.value).toBe("");
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -76,8 +76,82 @@ describe("StarMapScreen", () => {
     expect(card.textContent).not.toMatch(/local/i);
     expect(card.textContent).not.toMatch(/worktree/i);
 
+    // Clicking a card floats a chat card over the map rather than
+    // navigating away from it; the full thread view is one click further,
+    // behind the card's own Open button.
     fireEvent.click(card);
+    const chat = await screen.findByRole("region", {
+      name: "Chat: Thread t1",
+    });
+    expect(onOpenLocalThread).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      within(chat).getByRole("button", {
+        name: /Open Thread t1 in the full thread view/,
+      }),
+    );
     expect(onOpenLocalThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("raises an already-open chat card instead of stacking a duplicate", async () => {
+    render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[unreadThread("t1")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance \(Mac-Mini-M4\)/ }),
+      ).toBeTruthy();
+    });
+    const card = screen.getByRole("button", { name: /Thread t1/ });
+    fireEvent.click(card);
+    await screen.findByRole("region", { name: "Chat: Thread t1" });
+    fireEvent.click(card);
+
+    expect(
+      screen.getAllByRole("region", { name: "Chat: Thread t1" }),
+    ).toHaveLength(1);
+  });
+
+  it("closes a chat card from its close button", async () => {
+    render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[unreadThread("t1")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance \(Mac-Mini-M4\)/ }),
+      ).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Thread t1/ }));
+    const chat = await screen.findByRole("region", { name: "Chat: Thread t1" });
+    fireEvent.click(
+      within(chat).getByRole("button", { name: "Close chat: Thread t1" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("region", { name: "Chat: Thread t1" }),
+      ).toBeNull();
+    });
   });
 
   it("hides cards whose categories are filtered off", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHAT_CARD_CASCADE_STEP,
+  CHAT_CARD_CASCADE_WRAP,
+  CHAT_CARD_DEFAULT_HEIGHT,
+  CHAT_CARD_DEFAULT_WIDTH,
+  CHAT_CARD_MIN_HEIGHT,
+  CHAT_CARD_MIN_WIDTH,
+  cascadeChatCardRect,
+  clampChatCardRect,
+  raiseChatCard,
+  resizeChatCardRect,
+} from "../star-map-chat-card-geometry";
+
+const viewport = { width: 1440, height: 900 };
+
+describe("cascadeChatCardRect", () => {
+  it("opens the first card at the default size", () => {
+    const rect = cascadeChatCardRect({ openCardCount: 0, viewport });
+    expect(rect.width).toBe(CHAT_CARD_DEFAULT_WIDTH);
+    expect(rect.height).toBe(CHAT_CARD_DEFAULT_HEIGHT);
+  });
+
+  it("steps each subsequent card diagonally", () => {
+    const first = cascadeChatCardRect({ openCardCount: 0, viewport });
+    const second = cascadeChatCardRect({ openCardCount: 1, viewport });
+    expect(second.left - first.left).toBe(CHAT_CARD_CASCADE_STEP);
+    expect(second.top - first.top).toBe(CHAT_CARD_CASCADE_STEP);
+  });
+
+  it("wraps back to the origin instead of marching off-screen", () => {
+    const first = cascadeChatCardRect({ openCardCount: 0, viewport });
+    const wrapped = cascadeChatCardRect({
+      openCardCount: CHAT_CARD_CASCADE_WRAP,
+      viewport,
+    });
+    expect(wrapped.left).toBe(first.left);
+    expect(wrapped.top).toBe(first.top);
+  });
+
+  it("shrinks to fit a viewport smaller than the default card", () => {
+    const small = { width: 360, height: 320 };
+    const rect = cascadeChatCardRect({ openCardCount: 0, viewport: small });
+    expect(rect.width).toBeLessThanOrEqual(small.width);
+    expect(rect.height).toBeLessThanOrEqual(small.height);
+    expect(rect.width).toBeLessThan(CHAT_CARD_DEFAULT_WIDTH);
+    expect(rect.height).toBeLessThan(CHAT_CARD_DEFAULT_HEIGHT);
+  });
+
+  it("holds the minimum size rather than shrinking into a viewport slot", () => {
+    // A viewport narrower than the minimum cannot be satisfied; the card
+    // stays legible and overflows rather than collapsing to a sliver.
+    const rect = cascadeChatCardRect({
+      openCardCount: 0,
+      viewport: { width: 200, height: 180 },
+    });
+    expect(rect.width).toBe(CHAT_CARD_MIN_WIDTH);
+    expect(rect.height).toBe(CHAT_CARD_MIN_HEIGHT);
+  });
+});
+
+describe("clampChatCardRect", () => {
+  it("leaves an on-screen card untouched", () => {
+    const rect = { left: 200, top: 150, width: 420, height: 520 };
+    expect(clampChatCardRect(rect, viewport)).toEqual(rect);
+  });
+
+  it("keeps a sliver on screen when dragged off the right edge", () => {
+    const clamped = clampChatCardRect(
+      { left: 5_000, top: 100, width: 420, height: 520 },
+      viewport,
+    );
+    expect(clamped.left).toBeLessThan(viewport.width);
+    expect(viewport.width - clamped.left).toBeGreaterThan(0);
+  });
+
+  it("keeps the title bar reachable when dragged off the left edge", () => {
+    const clamped = clampChatCardRect(
+      { left: -5_000, top: 100, width: 420, height: 520 },
+      viewport,
+    );
+    expect(clamped.left + 420).toBeGreaterThan(0);
+  });
+
+  it("never lets the title bar go above the top edge", () => {
+    const clamped = clampChatCardRect(
+      { left: 100, top: -400, width: 420, height: 520 },
+      viewport,
+    );
+    expect(clamped.top).toBe(0);
+  });
+
+  it("keeps the title bar on screen when dragged past the bottom", () => {
+    const clamped = clampChatCardRect(
+      { left: 100, top: 5_000, width: 420, height: 520 },
+      viewport,
+    );
+    expect(clamped.top).toBeLessThan(viewport.height);
+  });
+
+  it("enforces the minimum size", () => {
+    const clamped = clampChatCardRect(
+      { left: 10, top: 10, width: 10, height: 10 },
+      viewport,
+    );
+    expect(clamped.width).toBe(CHAT_CARD_MIN_WIDTH);
+    expect(clamped.height).toBe(CHAT_CARD_MIN_HEIGHT);
+  });
+});
+
+describe("resizeChatCardRect", () => {
+  it("grows by the drag delta", () => {
+    const resized = resizeChatCardRect({
+      rect: { left: 100, top: 100, width: 420, height: 520 },
+      deltaX: 60,
+      deltaY: 40,
+      viewport,
+    });
+    expect(resized.width).toBe(480);
+    expect(resized.height).toBe(560);
+  });
+
+  it("stops at the minimum size", () => {
+    const resized = resizeChatCardRect({
+      rect: { left: 100, top: 100, width: 420, height: 520 },
+      deltaX: -9_000,
+      deltaY: -9_000,
+      viewport,
+    });
+    expect(resized.width).toBe(CHAT_CARD_MIN_WIDTH);
+    expect(resized.height).toBe(CHAT_CARD_MIN_HEIGHT);
+  });
+
+  it("does not grow past the viewport edge it is anchored against", () => {
+    const resized = resizeChatCardRect({
+      rect: { left: 800, top: 200, width: 420, height: 300 },
+      deltaX: 9_000,
+      deltaY: 9_000,
+      viewport,
+    });
+    expect(resized.left + resized.width).toBe(viewport.width);
+    expect(resized.top + resized.height).toBe(viewport.height);
+  });
+
+  it("keeps the minimum size even when the viewport edge is closer", () => {
+    // Anchored near the bottom, the minimum height and the viewport edge
+    // conflict; staying legible wins over fitting.
+    const resized = resizeChatCardRect({
+      rect: { left: 100, top: 700, width: 420, height: 190 },
+      deltaX: 0,
+      deltaY: 9_000,
+      viewport,
+    });
+    expect(resized.height).toBe(CHAT_CARD_MIN_HEIGHT);
+  });
+
+  it("keeps the origin pinned", () => {
+    const rect = { left: 240, top: 180, width: 420, height: 520 };
+    const resized = resizeChatCardRect({ rect, deltaX: 50, deltaY: 50, viewport });
+    expect(resized.left).toBe(rect.left);
+    expect(resized.top).toBe(rect.top);
+  });
+});
+
+describe("raiseChatCard", () => {
+  it("moves the card to the end of the order", () => {
+    expect(raiseChatCard(["a", "b", "c"], "a")).toEqual(["b", "c", "a"]);
+  });
+
+  it("returns the same reference when already on top", () => {
+    const order = ["a", "b", "c"];
+    expect(raiseChatCard(order, "c")).toBe(order);
+  });
+
+  it("appends an unknown key", () => {
+    expect(raiseChatCard(["a"], "b")).toEqual(["a", "b"]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-chat-card-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-chat-card-geometry.ts
@@ -1,0 +1,131 @@
+/**
+ * Geometry for the star map's floating chat cards.
+ *
+ * Cards are windows *over* the star field, not objects *in* it: they do not
+ * pan or zoom with the canvas, so every number here is in viewport pixels
+ * and never passes through the canvas transform.
+ */
+
+export type ChatCardRect = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+export const CHAT_CARD_DEFAULT_WIDTH = 420;
+export const CHAT_CARD_DEFAULT_HEIGHT = 520;
+export const CHAT_CARD_MIN_WIDTH = 320;
+export const CHAT_CARD_MIN_HEIGHT = 280;
+
+/** Diagonal offset between successively opened cards. */
+export const CHAT_CARD_CASCADE_STEP = 28;
+/** Cascade restarts after this many steps so cards never march off-screen. */
+export const CHAT_CARD_CASCADE_WRAP = 6;
+
+/**
+ * How much of a card must stay on screen. Dragging a card mostly off the
+ * edge is legitimate (park it, read the map behind it), but the title bar
+ * has to remain grabbable or the card is stranded.
+ */
+const CHAT_CARD_MIN_VISIBLE_X = 120;
+const CHAT_CARD_TITLE_BAR_HEIGHT = 34;
+
+/**
+ * Where the next card opens. Cascades from the top-left of the available
+ * area so a stack of cards stays individually grabbable, wrapping back to
+ * the origin rather than walking off the bottom-right corner.
+ */
+export function cascadeChatCardRect(params: {
+  openCardCount: number;
+  viewport: { width: number; height: number };
+  origin?: { left: number; top: number };
+}): ChatCardRect {
+  const step = params.openCardCount % CHAT_CARD_CASCADE_WRAP;
+  const origin = params.origin ?? { left: 72, top: 96 };
+  const width = Math.min(CHAT_CARD_DEFAULT_WIDTH, params.viewport.width);
+  const height = Math.min(CHAT_CARD_DEFAULT_HEIGHT, params.viewport.height);
+  return clampChatCardRect(
+    {
+      left: origin.left + step * CHAT_CARD_CASCADE_STEP,
+      top: origin.top + step * CHAT_CARD_CASCADE_STEP,
+      width,
+      height,
+    },
+    params.viewport,
+  );
+}
+
+/**
+ * Keeps a card reachable: at least `CHAT_CARD_MIN_VISIBLE_X` of its width
+ * and its whole title bar stay inside the viewport. Applied on drag, on
+ * open, and on window resize.
+ */
+export function clampChatCardRect(
+  rect: ChatCardRect,
+  viewport: { width: number; height: number },
+): ChatCardRect {
+  const width = Math.max(
+    CHAT_CARD_MIN_WIDTH,
+    Math.min(rect.width, Math.max(CHAT_CARD_MIN_WIDTH, viewport.width)),
+  );
+  const height = Math.max(
+    CHAT_CARD_MIN_HEIGHT,
+    Math.min(rect.height, Math.max(CHAT_CARD_MIN_HEIGHT, viewport.height)),
+  );
+  const minLeft = CHAT_CARD_MIN_VISIBLE_X - width;
+  const maxLeft = Math.max(minLeft, viewport.width - CHAT_CARD_MIN_VISIBLE_X);
+  const maxTop = Math.max(0, viewport.height - CHAT_CARD_TITLE_BAR_HEIGHT);
+  return {
+    left: Math.min(Math.max(rect.left, minLeft), maxLeft),
+    top: Math.min(Math.max(rect.top, 0), maxTop),
+    width,
+    height,
+  };
+}
+
+/**
+ * Resize from the bottom-right grip. The card's origin is pinned, so this
+ * only has to honor the minimums and stop the card from growing past the
+ * viewport edge it is anchored against.
+ */
+export function resizeChatCardRect(params: {
+  rect: ChatCardRect;
+  deltaX: number;
+  deltaY: number;
+  viewport: { width: number; height: number };
+}): ChatCardRect {
+  const maxWidth = Math.max(
+    CHAT_CARD_MIN_WIDTH,
+    params.viewport.width - params.rect.left,
+  );
+  const maxHeight = Math.max(
+    CHAT_CARD_MIN_HEIGHT,
+    params.viewport.height - params.rect.top,
+  );
+  return {
+    ...params.rect,
+    width: Math.min(
+      maxWidth,
+      Math.max(CHAT_CARD_MIN_WIDTH, params.rect.width + params.deltaX),
+    ),
+    height: Math.min(
+      maxHeight,
+      Math.max(CHAT_CARD_MIN_HEIGHT, params.rect.height + params.deltaY),
+    ),
+  };
+}
+
+/**
+ * Raises `key` to the top of the stack and returns the new order. Already
+ * being on top is a no-op so a click on the focused card does not churn
+ * React state on every mousedown.
+ */
+export function raiseChatCard(
+  order: readonly string[],
+  key: string,
+): readonly string[] {
+  if (order.length > 0 && order[order.length - 1] === key) return order;
+  if (!order.includes(key)) return [...order, key];
+  return [...order.filter((entry) => entry !== key), key];
+}

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapChatCards.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapChatCards.ts
@@ -1,0 +1,97 @@
+import { useCallback, useState } from "react";
+import {
+  buildThreadIdentityKey,
+  type NavigationThreadSummary,
+} from "@pwragent/shared";
+import {
+  cascadeChatCardRect,
+  raiseChatCard,
+  type ChatCardRect,
+} from "./star-map-chat-card-geometry";
+
+export type StarMapChatCardEntry = {
+  key: string;
+  rect: ChatCardRect;
+  thread: NavigationThreadSummary;
+};
+
+export type StarMapChatCardsController = {
+  cards: StarMapChatCardEntry[];
+  close: (cardKey: string) => void;
+  closeAll: () => void;
+  /** Stack depth of a card, lowest first. */
+  depthOf: (cardKey: string) => number;
+  open: (thread: NavigationThreadSummary) => void;
+  raise: (cardKey: string) => void;
+  setRect: (cardKey: string, rect: ChatCardRect) => void;
+};
+
+function viewportSize(): { width: number; height: number } {
+  if (typeof window === "undefined") return { width: 1440, height: 900 };
+  return { width: window.innerWidth, height: window.innerHeight };
+}
+
+/**
+ * Owns the set of floating chat cards over the star map.
+ *
+ * Cards are keyed by thread identity, so clicking the same thread twice
+ * raises the existing card instead of stacking a duplicate on top of it.
+ * Geometry lives here rather than in each card so that the cascade can see
+ * how many cards are already open.
+ */
+export function useStarMapChatCards(): StarMapChatCardsController {
+  const [cards, setCards] = useState<StarMapChatCardEntry[]>([]);
+  const [order, setOrder] = useState<readonly string[]>([]);
+
+  const raise = useCallback((cardKey: string) => {
+    setOrder((current) => raiseChatCard(current, cardKey));
+  }, []);
+
+  const open = useCallback(
+    (thread: NavigationThreadSummary) => {
+      const key = buildThreadIdentityKey(thread.source, thread.id);
+      setCards((current) => {
+        if (current.some((card) => card.key === key)) return current;
+        return [
+          ...current,
+          {
+            key,
+            rect: cascadeChatCardRect({
+              openCardCount: current.length,
+              viewport: viewportSize(),
+            }),
+            thread,
+          },
+        ];
+      });
+      raise(key);
+    },
+    [raise],
+  );
+
+  const close = useCallback((cardKey: string) => {
+    setCards((current) => current.filter((card) => card.key !== cardKey));
+    setOrder((current) => current.filter((entry) => entry !== cardKey));
+  }, []);
+
+  const closeAll = useCallback(() => {
+    setCards([]);
+    setOrder([]);
+  }, []);
+
+  const setRect = useCallback((cardKey: string, rect: ChatCardRect) => {
+    setCards((current) =>
+      current.map((card) => (card.key === cardKey ? { ...card, rect } : card)),
+    );
+  }, []);
+
+  const depthOf = useCallback(
+    (cardKey: string) => {
+      const index = order.indexOf(cardKey);
+      return index === -1 ? 0 : index;
+    },
+    [order],
+  );
+
+  return { cards, close, closeAll, depthOf, open, raise, setRect };
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9692,6 +9692,177 @@ textarea,
   color: var(--text-primary);
 }
 
+/* Floating chat cards.
+
+   These are windows over the star field, not objects in it: they render
+   outside `.star-map__canvas` so the map's pan/zoom transform never moves
+   or scales them. Position and size are inline (the card owns its own
+   geometry); everything visual lives here. */
+.star-map-chat-card {
+  display: flex;
+  position: absolute;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  /* Opaque: cards overlap each other and the map, and a translucent card
+     would let the transcript underneath bleed into this one's text. */
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-popover);
+  color: var(--text-primary);
+}
+
+.star-map-chat-card__bar {
+  display: flex;
+  position: relative;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 8px 7px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+  cursor: grab;
+  /* The card can sit under the macOS title-bar band; without this the OS
+     swallows the drag and the card cannot be moved. */
+  -webkit-app-region: no-drag;
+}
+
+.star-map-chat-card__bar:active {
+  cursor: grabbing;
+}
+
+.star-map-chat-card__watermark {
+  position: absolute;
+  top: -8px;
+  right: 64px;
+  z-index: 0;
+  color: var(--text-muted);
+  opacity: 0.12;
+  pointer-events: none;
+}
+
+.star-map-chat-card__title {
+  z-index: 1;
+  flex: 1 1 auto;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 12px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.star-map-chat-card__instance {
+  z-index: 1;
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.star-map-chat-card__expand,
+.star-map-chat-card__close {
+  z-index: 1;
+  flex: 0 0 auto;
+  padding: 2px 7px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+  -webkit-app-region: no-drag;
+}
+
+.star-map-chat-card__close {
+  padding: 2px 6px;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.star-map-chat-card__expand:hover,
+.star-map-chat-card__close:hover {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.star-map-chat-card__transcript {
+  flex: 1 1 auto;
+  overflow: hidden auto;
+  padding: 8px 10px;
+}
+
+.star-map-chat-card__error {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 5px 10px;
+  border-top: 1px solid var(--border-subtle);
+  color: var(--danger-text);
+  font-size: 11px;
+}
+
+.star-map-chat-card__composer {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: flex-end;
+  gap: 6px;
+  padding: 8px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+}
+
+.star-map-chat-card__input {
+  flex: 1 1 auto;
+  padding: 6px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 12px;
+  resize: none;
+}
+
+.star-map-chat-card__input:focus-visible {
+  border-color: var(--accent-border);
+  outline: none;
+}
+
+.star-map-chat-card__send {
+  flex: 0 0 auto;
+  padding: 6px 12px;
+  border: 1px solid var(--accent-border);
+  border-radius: 6px;
+  background: var(--accent-soft);
+  color: var(--text-primary);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.star-map-chat-card__send:disabled {
+  border-color: var(--border-subtle);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: default;
+}
+
+/* Bottom-right resize grip. Sized for a comfortable pointer target
+   without stealing clicks from the composer's send button. */
+.star-map-chat-card__resize {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 16px;
+  height: 16px;
+  background: linear-gradient(
+    135deg,
+    transparent 50%,
+    var(--border-strong) 50%,
+    var(--border-strong) 100%
+  );
+  cursor: nwse-resize;
+  -webkit-app-region: no-drag;
+}
+
 /* Celestial instance watermark: identity mark behind thread content.
    Opacity must stay low enough that transcript text keeps AA contrast on
    both themes — the a11y axe gate audits the composited result. */

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9800,7 +9800,10 @@ textarea,
   font-size: 11px;
 }
 
-.star-map-chat-card__composer {
+/* Compact composer: for surfaces with no vertical budget. Secondary
+   actions collapse under the kebab and model/effort render as ambient text
+   inside the field, so the whole control row stays one line tall. */
+.compact-composer {
   display: flex;
   flex: 0 0 auto;
   align-items: flex-end;
@@ -9810,9 +9813,17 @@ textarea,
   background: var(--bg-panel-elevated);
 }
 
-.star-map-chat-card__input {
+.compact-composer__field {
+  position: relative;
   flex: 1 1 auto;
-  padding: 6px 8px;
+}
+
+.compact-composer__input {
+  display: block;
+  width: 100%;
+  /* Right padding reserves the ambient model/effort strip so typed text
+     never runs underneath it. */
+  padding: 6px 8px 16px;
   border: 1px solid var(--border-subtle);
   border-radius: 6px;
   background: var(--bg-input);
@@ -9822,12 +9833,88 @@ textarea,
   resize: none;
 }
 
-.star-map-chat-card__input:focus-visible {
+.compact-composer__input:focus-visible {
   border-color: var(--accent-border);
   outline: none;
 }
 
-.star-map-chat-card__send {
+.compact-composer__ambient {
+  position: absolute;
+  right: 9px;
+  bottom: 5px;
+  max-width: 70%;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 10px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  pointer-events: none;
+}
+
+.compact-composer__controls {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+}
+
+.compact-composer__menu {
+  position: relative;
+}
+
+.compact-composer__kebab {
+  padding: 5px 7px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.compact-composer__kebab:hover,
+.compact-composer__kebab[aria-expanded="true"] {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.compact-composer__menu-list {
+  display: flex;
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 6px);
+  z-index: 2;
+  flex-direction: column;
+  min-width: 190px;
+  padding: 4px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+}
+
+.compact-composer__menu-item {
+  padding: 6px 8px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.compact-composer__menu-item:hover:not(:disabled) {
+  background: var(--bg-panel-hover);
+}
+
+.compact-composer__menu-item:disabled {
+  color: var(--text-muted);
+  cursor: default;
+}
+
+.compact-composer__send {
   flex: 0 0 auto;
   padding: 6px 12px;
   border: 1px solid var(--accent-border);
@@ -9838,7 +9925,7 @@ textarea,
   cursor: pointer;
 }
 
-.star-map-chat-card__send:disabled {
+.compact-composer__send:disabled {
   border-color: var(--border-subtle);
   background: transparent;
   color: var(--text-muted);

--- a/docs/plans/2026-08-06-001-feat-star-map-chat-cards-plan.md
+++ b/docs/plans/2026-08-06-001-feat-star-map-chat-cards-plan.md
@@ -1,0 +1,116 @@
+# Star Map Floating Chat Cards — Implementation Plan
+
+- **Date**: 2026-08-06
+- **Branch**: `star-map/chat-cards`
+- **Base**: `origin/main` (post #1268)
+- **Predecessor**: [2026-08-05-003-feat-star-map-mission-control-plan.md](2026-08-05-003-feat-star-map-mission-control-plan.md)
+
+## Operator requirement
+
+Clicking a thread card in the Star Map currently opens the **entire remote
+viewer window** for that instance. That is not what was asked for. The
+requirement, verbatim in intent:
+
+> I wanted in-star-map float-over "chat cards" … you can have one of these
+> chat cards popup and you can move it around, resize it. You can open
+> another one too. You can open as many as you have screen real-estate to
+> fit.
+
+Plus a **compact composer**: the full composer's control row is too tall for
+a floating card, so secondary controls consolidate under a kebab and the
+model / reasoning-effort indicators become right-aligned placeholder text
+inside the input rather than separate chips.
+
+## Correction to the earlier three-item split
+
+This work was previously scoped as **three** stacked PRs, the first being
+"make remote threads selectable in-place (auto-pin or snapshot merge)".
+Reading the code closed that question: **item 1 is not needed and will not
+be built.**
+
+`useThreadSessionState` is parameterized by a `NavigationThreadSummary`
+passed in as a prop — not by a global selection — and it already derives the
+federation target from that summary:
+
+```ts
+// apps/desktop/src/renderer/src/lib/useThreadSessionState.ts:3789
+federationTarget: targetThread.federation?.ref.target
+  ?? readRendererFederationTarget(),
+```
+
+`StartTurnRequest.federationTarget` is likewise optional-and-honored
+(`packages/shared/src/contracts/agent.ts:241`), and the established
+call-site idiom across `App.tsx` is the same `thread.federation?.ref.target
+?? readRendererFederationTarget()` fallback.
+
+The selectability blocker was an artifact of the *single mounted ThreadView*
+design: `navigation.selectThread` looks the key up in the snapshot, so a
+thread absent from the snapshot cannot be selected. Multi-card explicitly
+requires **per-card session state anyway**, and once each card owns its own
+hook instance and receives its thread summary directly from the map's data,
+there is nothing left to select. No pinning, no snapshot merge, no new
+protocol.
+
+Net: **two units, not three.**
+
+## Non-goals
+
+- Reusing `ThreadView` (3,636 lines, ~150 props) or the full `Composer`
+  (11,952 lines) inside a card. Cards compose `TranscriptList` plus a
+  purpose-built compact composer.
+- Persisting card geometry across app restarts. Cards are ephemeral session
+  furniture; the *thread arrangement* is the thing that syncs across the
+  federation, and that already shipped.
+- Changing what the instance-card click does. Clicking an **instance** still
+  opens that instance's viewer window; only **thread** cards float.
+
+## Unit 1 — Floating chat card surface
+
+Subsumes the old items 1 and 3.
+
+- `StarMapChatCardHost` — owns the open-card list, z-order, and cascade
+  placement for new cards. Lives above the canvas so cards do not pan or
+  zoom with the star field (they are windows over the map, not objects in
+  it).
+- `StarMapChatCard` — one card: title bar (thread title, instance watermark,
+  close), drag to move, resize from the bottom-right corner, click to raise.
+  Clamped to the viewport so a card can never be dragged fully off-screen.
+- Per-card `useThreadSessionState({ desktopApi, thread })` supplies entries,
+  pending request, busy state, and optimistic message insert. Remote and
+  local threads take the identical path.
+- Transcript renders through the existing `TranscriptList`.
+- Minimal send path: text input, send, and interrupt-while-busy. Enough to
+  hold a conversation; the full control surface lands in Unit 2.
+- Star map thread click opens a card instead of `openFederationWindow`.
+
+**Geometry decisions**: default card 420×520, min 320×280. Cascade offset
+28px per open card, wrapping after 6. Cards clamp on window resize.
+
+## Unit 2 — Compact composer variant
+
+- `compact` variant of the composer control row: primary actions stay
+  visible (send, interrupt, attach); secondary actions (execution mode,
+  branch, skills, review, compaction, scheduled actions) consolidate under a
+  single kebab menu.
+- Model and reasoning effort render as **right-aligned placeholder text
+  inside the input**, not as chips — they read as ambient state, and they
+  cost zero vertical space.
+- Swapped into the card in place of Unit 1's minimal input.
+
+Whether this is a `compact` prop threaded through `Composer.tsx` or a
+separate small component that shares the send/queue hooks is deliberately
+left to implementation — 12,000 lines is enough that the answer depends on
+how separable the control row turns out to be. Decide it in Unit 2, record
+it here.
+
+## Verification
+
+Per unit: `pnpm test` (root, focused first), `pnpm --filter
+@pwragent/desktop typecheck`, `pnpm lint:colors`, `pnpm lint:boundaries`,
+`pnpm lint:eslint`. New renderer tests for card geometry (cascade, clamp,
+raise) and for the card's federation-target derivation.
+
+## Progress
+
+- [ ] Unit 1 — floating chat card surface
+- [ ] Unit 2 — compact composer variant

--- a/docs/plans/2026-08-06-001-feat-star-map-chat-cards-plan.md
+++ b/docs/plans/2026-08-06-001-feat-star-map-chat-cards-plan.md
@@ -97,11 +97,18 @@ Subsumes the old items 1 and 3.
   cost zero vertical space.
 - Swapped into the card in place of Unit 1's minimal input.
 
-Whether this is a `compact` prop threaded through `Composer.tsx` or a
-separate small component that shares the send/queue hooks is deliberately
-left to implementation — 12,000 lines is enough that the answer depends on
-how separable the control row turns out to be. Decide it in Unit 2, record
-it here.
+**Resolved during implementation: a separate component, not a `compact`
+prop on `Composer.tsx`.** The control row is not the separable part — the
+component needs the backend list, skills, directories, launchpad state, and
+provider defaults, none of which a floating card has. Threading those
+through would have reproduced the ThreadView problem one layer down. The
+two share a contract (send text, stop a running turn), not an
+implementation.
+
+Secondary actions are scoped to what a thread summary plus the desktop
+bridge can do on their own: access-mode switch, compaction (gated on an
+idle thread), and open-in-full-view. Anything needing the backend list
+stays behind the card header's Open button.
 
 ## Verification
 
@@ -112,5 +119,5 @@ raise) and for the card's federation-target derivation.
 
 ## Progress
 
-- [ ] Unit 1 — floating chat card surface
-- [ ] Unit 2 — compact composer variant
+- [x] Unit 1 — floating chat card surface
+- [x] Unit 2 — compact composer variant


### PR DESCRIPTION
Clicking a thread card in the Star Map opened the **entire remote viewer window** for that instance. That defeats the point of the surface — you leave the map to answer one question. Thread cards now float a chat card over the map, and as many can be open at once as fit.

## The three-item plan turned out to be two

This was scoped as three stacked PRs, the first being "make remote threads selectable in-place (auto-pin or snapshot merge)". Reading the code closed that question: **item 1 is not needed and is not built here.**

`useThreadSessionState` is parameterized by a `NavigationThreadSummary` passed in as a prop, and it already derives the federation target from that summary:

```ts
// useThreadSessionState.ts:3789
federationTarget: targetThread.federation?.ref.target
  ?? readRendererFederationTarget(),
```

`StartTurnRequest.federationTarget` is honored the same way. The selectability blocker was an artifact of the *single mounted ThreadView* design — `navigation.selectThread` can only resolve keys already in the navigation snapshot. Multi-card requires per-card session state anyway, and once each card owns its hook instance there is nothing left to select. **No pinning, no snapshot merge, no protocol change.**

## Unit 1 — floating chat cards

- **`StarMapChatCard`** — title bar with instance watermark, drag to move, resize from the bottom-right grip, click to raise, close. Composes `TranscriptList` rather than `ThreadView` (3,636 lines, ~150 props).
- **`useStarMapChatCards`** — open-card list, z-order, cascade placement. Keyed by thread identity, so clicking a thread twice raises the existing card instead of stacking a duplicate.
- **`star-map-chat-card-geometry.ts`** — pure and tested: cascade wrapping after 6 cards, clamping that keeps the title bar grabbable on every edge, resize minimums, raise-on-click ordering. Where the minimum card size and the viewport edge conflict, staying legible wins.
- Cards render **outside `.star-map__canvas`** so the map's pan/zoom transform never moves or scales them.
- An **Open** button keeps the escape hatch to the full thread surface — local threads land in this window, remote ones open their owning instance's viewer, which is what the card click used to do.

## Unit 2 — compact composer

Two moves buy back the vertical space a floating card doesn't have: secondary actions consolidate under a single kebab, and model / reasoning effort / access mode render as one right-aligned ambient string **inside** the field rather than as chips below it — they're state to be aware of, not controls to reach for.

Deliberately **not** a `compact` prop on `Composer.tsx`. The control row isn't the separable part: that component needs the backend list, skills, directories, launchpad state, and provider defaults, none of which a floating card has. Threading ~80 props through would have reproduced the ThreadView problem one layer down. The two share a contract — send text, stop a running turn — not an implementation.

The kebab carries what a thread summary plus the desktop bridge can do alone: switch access mode, compact the thread (gated on an idle thread, since compaction rewrites history), and open the full view. Click-away and Escape close it so it can't sit over the transcript.

## Verification

Full suite **6,588 passing**, typecheck clean, `lint:colors`, `lint:boundaries`, ESLint 0 errors. 32 new tests — 19 geometry, 10 compact composer, 3 screen-level covering open / raise / close and the Open escape hatch.

Plan: [docs/plans/2026-08-06-001-feat-star-map-chat-cards-plan.md](docs/plans/2026-08-06-001-feat-star-map-chat-cards-plan.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)