### PR TITLE
fix(desktop): close renderers before shutdown disposal

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -120,7 +120,7 @@ const getAppPathMock = vi.fn(() => "/test/app");
 const getVersionMock = vi.fn(() => "1.0.0-alpha.0");
 const whenReadyMock = vi.fn(() => Promise.resolve());
 const quitMock = vi.fn();
-const getAllWindowsMock = vi.fn(() => []);
+const getAllWindowsMock = vi.fn<() => unknown[]>(() => []);
 const dockSetIconMock = vi.fn();
 const protocolHandleMock = vi.fn();
 const protocolRegisterSchemesAsPrivilegedMock = vi.fn();
@@ -1306,6 +1306,43 @@ describe("bootstrapApp", () => {
     expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledTimes(1);
     expect(disposeDesktopFederationRuntimeMock).toHaveBeenCalledTimes(1);
     expect(closePwrSnapConnectionServiceMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes renderer windows before disposing their ipc handlers", async () => {
+    let closeWindow!: () => void;
+    const window = {
+      close: vi.fn(),
+      destroy: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      once: vi.fn((event: string, handler: () => void) => {
+        if (event === "closed") {
+          closeWindow = handler;
+        }
+      }),
+    };
+    getAllWindowsMock.mockReturnValue([window]);
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    const event = { preventDefault: vi.fn() };
+    appEventHandlers.get("before-quit")?.(event);
+    await flushMicrotasks();
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(window.close).toHaveBeenCalledOnce();
+    expect(disposeComposerDraftIpcHandlersMock).not.toHaveBeenCalled();
+    expect(disposeAgentIpcHandlersMock).not.toHaveBeenCalled();
+    expect(disposeAppServerIpcHandlersMock).not.toHaveBeenCalled();
+
+    closeWindow();
+    await vi.waitFor(() => expect(quitMock).toHaveBeenCalledOnce());
+
+    expect(disposeComposerDraftIpcHandlersMock).toHaveBeenCalledOnce();
+    expect(disposeAgentIpcHandlersMock).toHaveBeenCalledOnce();
+    expect(disposeAppServerIpcHandlersMock).toHaveBeenCalledOnce();
+    expect(window.destroy).not.toHaveBeenCalled();
   });
 
   it("reuses one quit barrier while messaging and app-server teardown settle", async () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -1345,6 +1345,72 @@ describe("bootstrapApp", () => {
     expect(window.destroy).not.toHaveBeenCalled();
   });
 
+  it("continues shutdown when closing windows changes the window snapshot", async () => {
+    let mainWindowClosed!: () => void;
+    let childWindowDestroyed = false;
+    let racingWindowDestroyed = false;
+    const childWindow = {
+      close: vi.fn(() => {
+        throw new Error("close called after destroy");
+      }),
+      destroy: vi.fn(),
+      id: 2,
+      isDestroyed: vi.fn(() => childWindowDestroyed),
+      once: vi.fn(),
+    };
+    const mainWindow = {
+      close: vi.fn(() => {
+        childWindowDestroyed = true;
+        mainWindowClosed();
+      }),
+      destroy: vi.fn(),
+      id: 1,
+      isDestroyed: vi.fn(() => false),
+      once: vi.fn((event: string, handler: () => void) => {
+        if (event === "closed") {
+          mainWindowClosed = handler;
+        }
+      }),
+    };
+    const racingWindow = {
+      close: vi.fn(() => {
+        racingWindowDestroyed = true;
+        throw new Error("window was destroyed while closing");
+      }),
+      destroy: vi.fn(),
+      id: 3,
+      isDestroyed: vi.fn(() => racingWindowDestroyed),
+      once: vi.fn(),
+    };
+    getAllWindowsMock.mockReturnValue([
+      mainWindow,
+      childWindow,
+      racingWindow,
+    ]);
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    appEventHandlers.get("before-quit")?.({ preventDefault: vi.fn() });
+    await vi.waitFor(() => expect(quitMock).toHaveBeenCalledOnce());
+
+    expect(mainWindow.close).toHaveBeenCalledOnce();
+    expect(childWindow.close).not.toHaveBeenCalled();
+    expect(racingWindow.close).toHaveBeenCalledOnce();
+    expect(mainLogWarnMock).toHaveBeenCalledWith(
+      "failed to close renderer window during shutdown",
+      expect.objectContaining({
+        error: "window was destroyed while closing",
+        windowId: 3,
+      }),
+    );
+    expect(disposeComposerDraftIpcHandlersMock).toHaveBeenCalledOnce();
+    expect(disposeAgentIpcHandlersMock).toHaveBeenCalledOnce();
+    expect(disposeAppServerIpcHandlersMock).toHaveBeenCalledOnce();
+    expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledOnce();
+  });
+
   it("reuses one quit barrier while messaging and app-server teardown settle", async () => {
     let finishMessaging!: () => void;
     let finishAppServer!: () => void;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -181,6 +181,7 @@ const isMac = process.platform === "darwin";
 const isDevelopment = process.env.NODE_ENV !== "production";
 const mainLog = getMainLogger("pwragent:main");
 const mainProcessStartedAt = Date.now();
+const RENDERER_WINDOW_SHUTDOWN_TIMEOUT_MS = 2_000;
 const MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS = 12_000;
 const MESSAGING_SHUTDOWN_TIMEOUT_MS = 4_000;
 const FEDERATION_SHUTDOWN_TIMEOUT_MS = 4_000;
@@ -199,6 +200,7 @@ if (process.env.PWRAGENT_E2E_DISABLE_GPU === "1") {
 let mainProcessResourcesDisposed = false;
 let mainProcessShutdownComplete = false;
 let mainProcessShutdownPromise: Promise<void> | undefined;
+let rendererWindowShutdownPromise: Promise<void> | undefined;
 let finalQuitPromise: Promise<void> | undefined;
 let quitInProgress = false;
 let profileFocusRequestWatcher: ProfileFocusRequestWatcher | null = null;
@@ -460,6 +462,72 @@ function disposeMainProcessResourcesSync(): void {
   runtimeMessagingLeaseCoordinator?.shutdownSync();
 }
 
+async function closeRendererWindowsBeforeResourceShutdown(
+  source: string,
+): Promise<void> {
+  rendererWindowShutdownPromise ??= (async () => {
+    const windows = BrowserWindow.getAllWindows().filter(
+      (window) => !window.isDestroyed(),
+    );
+    if (windows.length === 0) {
+      return;
+    }
+
+    mainLog.info("closing renderer windows before resource shutdown", {
+      source,
+      windowCount: windows.length,
+    });
+    const pendingWindows = new Set(windows);
+    const allWindowsClosed = Promise.all(
+      windows.map(
+        (window) =>
+          new Promise<void>((resolve) => {
+            window.once("closed", () => {
+              pendingWindows.delete(window);
+              resolve();
+            });
+            window.close();
+            if (window.isDestroyed()) {
+              pendingWindows.delete(window);
+              resolve();
+            }
+          }),
+      ),
+    );
+    let timeout: NodeJS.Timeout | undefined;
+    const outcome = await Promise.race([
+      allWindowsClosed.then(() => "closed" as const),
+      new Promise<"timed-out">((resolve) => {
+        timeout = setTimeout(
+          () => resolve("timed-out"),
+          RENDERER_WINDOW_SHUTDOWN_TIMEOUT_MS,
+        );
+      }),
+    ]);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    if (outcome === "timed-out") {
+      mainLog.warn("renderer window close timed out during shutdown", {
+        source,
+        remainingWindowCount: pendingWindows.size,
+        timeoutMs: RENDERER_WINDOW_SHUTDOWN_TIMEOUT_MS,
+      });
+      for (const window of pendingWindows) {
+        if (!window.isDestroyed()) {
+          window.destroy();
+        }
+      }
+    }
+    mainLog.info("renderer windows closed before resource shutdown", {
+      source,
+      durationLimitMs: RENDERER_WINDOW_SHUTDOWN_TIMEOUT_MS,
+      outcome,
+    });
+  })();
+  await rendererWindowShutdownPromise;
+}
+
 const runMainProcessShutdownBarrier = createShutdownBarrier({
   globalTimeoutMs: MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS,
   logger: mainLog,
@@ -492,6 +560,10 @@ const runMainProcessShutdownBarrier = createShutdownBarrier({
 
 async function disposeMainProcessResources(source: string): Promise<void> {
   mainProcessShutdownPromise ??= (async () => {
+    // Electron emits before-quit while renderer windows are still live. Close
+    // them first so in-flight renderer work cannot cross the boundary where
+    // IPC handlers and their backing stores are disposed.
+    await closeRendererWindowsBeforeResourceShutdown(source);
     disposeMainProcessResourcesSync();
     await runMainProcessShutdownBarrier(source);
     // Keep the scheduler subscribed until the app-server registry is closed.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -482,14 +482,26 @@ async function closeRendererWindowsBeforeResourceShutdown(
       windows.map(
         (window) =>
           new Promise<void>((resolve) => {
-            window.once("closed", () => {
+            const settle = (): void => {
               pendingWindows.delete(window);
               resolve();
-            });
-            window.close();
+            };
             if (window.isDestroyed()) {
-              pendingWindows.delete(window);
-              resolve();
+              settle();
+              return;
+            }
+            try {
+              window.once("closed", settle);
+              window.close();
+            } catch (error) {
+              mainLog.warn("failed to close renderer window during shutdown", {
+                source,
+                windowId: window.id,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+            if (window.isDestroyed()) {
+              settle();
             }
           }),
       ),
@@ -515,7 +527,18 @@ async function closeRendererWindowsBeforeResourceShutdown(
       });
       for (const window of pendingWindows) {
         if (!window.isDestroyed()) {
-          window.destroy();
+          try {
+            window.destroy();
+          } catch (error) {
+            mainLog.warn(
+              "failed to force destroy renderer window during shutdown",
+              {
+                source,
+                windowId: window.id,
+                error: error instanceof Error ? error.message : String(error),
+              },
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- close all renderer windows before disposing main-process IPC handlers and their backing stores
- bound renderer close to 2 seconds, then force-destroy any window that refuses to close
- add a regression test proving renderer IPC handlers remain registered until the window emits `closed`

## Root cause

Electron emits `before-quit` while renderer windows are still alive. PwrAgent prevents that event while its bounded messaging/federation/app-server/MCP shutdown barrier runs, but synchronously removed renderer IPC handlers at the start of the barrier. React cleanup, branch-drift checks, and navigation refreshes could therefore invoke channels such as `composer-draft:clear`, `agent:check-thread-branch-drift`, and `navigation:get-snapshot` after their handlers were removed.

The shutdown barrier itself completed successfully; the errors came from renderer work crossing the handler-disposal boundary.

## Impact

Normal quit, signal shutdown, and update-install preparation now quiesce renderer windows while IPC/state are still valid. Resource teardown begins only after the renderer is gone, preventing noisy `No handler registered` errors without weakening the existing bounded shutdown phases.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/index.test.ts apps/desktop/src/main/__tests__/shutdown-barrier.test.ts apps/desktop/src/main/__tests__/quit-manager.test.ts` (51 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`
