### PR TITLE
feat(desktop): release pricing settings

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -121,6 +121,7 @@ const SETTINGS_SECTIONS = new Set<SettingsSection>([
   "worktrees",
   "messaging",
   "models",
+  "pricing",
   "experimental",
   "about",
 ]);

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -62,16 +62,6 @@ const DEFAULT_THREAD_PRICING_SUMMARY = {
   source: "default" as const,
 };
 
-const DEFAULT_THREAD_PRICING_DISPLAY_USD = {
-  value: true,
-  source: "default" as const,
-};
-
-const DEFAULT_THREAD_PRICING_DISPLAY_CODEX_CREDITS = {
-  value: false,
-  source: "default" as const,
-};
-
 const DEFAULT_THREAD_TOOL_ACCOUNTING = {
   value: false,
   source: "default" as const,
@@ -85,9 +75,6 @@ export function ExperimentalSettings(props: {
   onLiveTranscriptEventFilteringChange: (enabled: boolean) => Promise<void>;
   onLightweightNavigationRefreshChange: (enabled: boolean) => Promise<void>;
   onMarkdownMathRenderingChange: (enabled: boolean) => Promise<void>;
-  onThreadPricingSummaryChange: (enabled: boolean) => Promise<void>;
-  onThreadPricingDisplayUsdChange: (enabled: boolean) => Promise<void>;
-  onThreadPricingDisplayCodexCreditsChange: (enabled: boolean) => Promise<void>;
   onThreadToolAccountingChange: (enabled: boolean) => Promise<void>;
   onCodexDefaultModeRequestUserInputChange: (
     enabled: boolean,
@@ -108,12 +95,6 @@ export function ExperimentalSettings(props: {
   const threadPricingSummary =
     props.snapshot.experimental.threadPricingSummary ??
     DEFAULT_THREAD_PRICING_SUMMARY;
-  const threadPricingDisplayUsd =
-    props.snapshot.experimental.threadPricingDisplayUsd ??
-    DEFAULT_THREAD_PRICING_DISPLAY_USD;
-  const threadPricingDisplayCodexCredits =
-    props.snapshot.experimental.threadPricingDisplayCodexCredits ??
-    DEFAULT_THREAD_PRICING_DISPLAY_CODEX_CREDITS;
   const threadToolAccounting =
     props.snapshot.experimental.threadToolAccounting ??
     DEFAULT_THREAD_TOOL_ACCOUNTING;
@@ -142,64 +123,16 @@ export function ExperimentalSettings(props: {
 
       <SettingsSection
         eyebrow="Experimental"
-        title="Thread Pricing Summary"
-        description="Show list-price usage totals in the thread context rail. Enabled by default while pricing reconstruction and provider coverage continue to be validated."
-        chip={threadPricingSummary.value ? "On" : "Off"}
-        chipKind={threadPricingSummary.value ? "ok" : "default"}
+        title="Tool Output Accounting"
+        description="Show tool-output volume and noisy-polling alerts inside the released Pricing panel."
+        chip={threadToolAccounting.value ? "On" : "Off"}
+        chipKind={threadToolAccounting.value ? "ok" : "default"}
       >
         <div className="settings-fields">
           <SettingsField
-            label="Enable thread pricing summary"
-            sub="Show the Pricing tab in the thread context rail."
-            help="Surfaces list-price totals and per-turn usage rows for the thread."
-            source={sourceBadge(threadPricingSummary)}
-            control={
-              <SettingsSwitch
-                checked={threadPricingSummary.value}
-                disabled={props.saving}
-                label="Enable thread pricing summary"
-                onChange={(enabled) => {
-                  void props.onThreadPricingSummaryChange(enabled);
-                }}
-              />
-            }
-          />
-          <SettingsField
-            label="Display USD"
-            sub="Show list-price estimates in USD."
-            help="Estimated from OpenAI API list prices."
-            source={sourceBadge(threadPricingDisplayUsd)}
-            control={
-              <SettingsSwitch
-                checked={threadPricingDisplayUsd.value}
-                disabled={props.saving || !threadPricingSummary.value}
-                label="Display USD"
-                onChange={(enabled) => {
-                  void props.onThreadPricingDisplayUsdChange(enabled);
-                }}
-              />
-            }
-          />
-          <SettingsField
-            label="Display Codex Credits"
-            sub="Show Codex Credits estimates."
-            help="Estimated from Codex's token-based credit rate card."
-            source={sourceBadge(threadPricingDisplayCodexCredits)}
-            control={
-              <SettingsSwitch
-                checked={threadPricingDisplayCodexCredits.value}
-                disabled={props.saving || !threadPricingSummary.value}
-                label="Display Codex Credits"
-                onChange={(enabled) => {
-                  void props.onThreadPricingDisplayCodexCreditsChange(enabled);
-                }}
-              />
-            }
-          />
-          <SettingsField
             label="Display tool output accounting"
             sub="Show experimental tool-output volume and noisy-polling alerts."
-            help="Collection stays on either way; this only controls the operator-facing Pricing panel section."
+            help="Collection stays on either way; this only controls the operator-facing section. Requires thread pricing under Settings → Usage & Pricing."
             source={sourceBadge(threadToolAccounting)}
             control={
               <SettingsSwitch

--- a/apps/desktop/src/renderer/src/features/settings/PricingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PricingSettings.tsx
@@ -76,7 +76,7 @@ export function PricingSettings(props: {
           <SettingsField
             label="Price displays"
             sub="Choose one or both estimates to show with thread usage."
-            help="Dollars use OpenAI API list prices. Codex Credits use Codex's token-based credit rate card."
+            help="List Price uses each provider's published rates. Codex Credits use Codex's token-based credit rate card."
             control={
               <div
                 className="settings-segmented"
@@ -96,7 +96,7 @@ export function PricingSettings(props: {
                     );
                   }}
                 >
-                  Dollars
+                  List Price
                 </button>
                 <button
                   aria-pressed={threadPricingDisplayCodexCredits.value}

--- a/apps/desktop/src/renderer/src/features/settings/PricingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PricingSettings.tsx
@@ -1,0 +1,123 @@
+import type { DesktopSettingsSnapshot } from "@pwragent/shared";
+import {
+  SettingsField,
+  SettingsPanelHead,
+  SettingsSection,
+  SettingsSectionStack,
+} from "./SettingsLayout";
+import { SettingsSwitch } from "./SettingsSwitch";
+import { sourceBadge } from "./settings-fields";
+
+const DEFAULT_THREAD_PRICING_SUMMARY = {
+  value: true,
+  source: "default" as const,
+};
+
+const DEFAULT_THREAD_PRICING_DISPLAY_USD = {
+  value: true,
+  source: "default" as const,
+};
+
+const DEFAULT_THREAD_PRICING_DISPLAY_CODEX_CREDITS = {
+  value: false,
+  source: "default" as const,
+};
+
+export function PricingSettings(props: {
+  saving: boolean;
+  snapshot: DesktopSettingsSnapshot;
+  onThreadPricingSummaryChange: (enabled: boolean) => Promise<void>;
+  onThreadPricingDisplayUsdChange: (enabled: boolean) => Promise<void>;
+  onThreadPricingDisplayCodexCreditsChange: (enabled: boolean) => Promise<void>;
+}) {
+  const threadPricingSummary =
+    props.snapshot.experimental.threadPricingSummary ??
+    DEFAULT_THREAD_PRICING_SUMMARY;
+  const threadPricingDisplayUsd =
+    props.snapshot.experimental.threadPricingDisplayUsd ??
+    DEFAULT_THREAD_PRICING_DISPLAY_USD;
+  const threadPricingDisplayCodexCredits =
+    props.snapshot.experimental.threadPricingDisplayCodexCredits ??
+    DEFAULT_THREAD_PRICING_DISPLAY_CODEX_CREDITS;
+  const displayControlsDisabled = props.saving || !threadPricingSummary.value;
+
+  return (
+    <SettingsSectionStack paneId="pricing" aria-label="Usage and pricing settings">
+      <SettingsPanelHead
+        eyebrow="Pricing"
+        title="Usage & pricing"
+        help="Control how estimated thread usage costs are shown."
+      />
+
+      <SettingsSection
+        eyebrow="Pricing"
+        title="Thread pricing"
+        description="Show estimated usage totals and per-turn details in the thread context rail."
+        chip={threadPricingSummary.value ? "On" : "Off"}
+        chipKind={threadPricingSummary.value ? "ok" : "default"}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Show thread pricing"
+            sub="Show the Pricing tab in the thread context rail."
+            help="Pricing is estimated from published provider rates and may differ from billed usage."
+            source={sourceBadge(threadPricingSummary)}
+            control={
+              <SettingsSwitch
+                checked={threadPricingSummary.value}
+                disabled={props.saving}
+                label="Show thread pricing"
+                onChange={(enabled) => {
+                  void props.onThreadPricingSummaryChange(enabled);
+                }}
+              />
+            }
+          />
+          <SettingsField
+            label="Price displays"
+            sub="Choose one or both estimates to show with thread usage."
+            help="Dollars use OpenAI API list prices. Codex Credits use Codex's token-based credit rate card."
+            control={
+              <div
+                className="settings-segmented"
+                role="group"
+                aria-label="Price displays"
+              >
+                <button
+                  aria-pressed={threadPricingDisplayUsd.value}
+                  className={`settings-segmented__button${
+                    threadPricingDisplayUsd.value ? " is-active" : ""
+                  }`}
+                  disabled={displayControlsDisabled}
+                  type="button"
+                  onClick={() => {
+                    void props.onThreadPricingDisplayUsdChange(
+                      !threadPricingDisplayUsd.value,
+                    );
+                  }}
+                >
+                  Dollars
+                </button>
+                <button
+                  aria-pressed={threadPricingDisplayCodexCredits.value}
+                  className={`settings-segmented__button${
+                    threadPricingDisplayCodexCredits.value ? " is-active" : ""
+                  }`}
+                  disabled={displayControlsDisabled}
+                  type="button"
+                  onClick={() => {
+                    void props.onThreadPricingDisplayCodexCreditsChange(
+                      !threadPricingDisplayCodexCredits.value,
+                    );
+                  }}
+                >
+                  Codex Credits
+                </button>
+              </div>
+            }
+          />
+        </div>
+      </SettingsSection>
+    </SettingsSectionStack>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -21,6 +21,7 @@ import { GitSettings } from "./GitSettings";
 import { MessagingSettings } from "./MessagingSettings";
 import { ModelsSettings } from "./ModelsSettings";
 import { ProfilesSettings } from "./ProfilesSettings";
+import { PricingSettings } from "./PricingSettings";
 import { ApplicationsSettings } from "./ApplicationsSettings";
 import { ArchivedThreadsSettings } from "./ArchivedThreadsSettings";
 import { ThreadManagementSettings } from "./ThreadManagementSettings";
@@ -45,6 +46,7 @@ export type SettingsSection =
   | "federation"
   | "models"
   | "profiles"
+  | "pricing"
   | "applications"
   | "worktrees"
   | "thread-management"
@@ -57,6 +59,7 @@ const SECTIONS: Array<{ id: SettingsSection; label: string }> = [
   { id: "applications", label: "Applications" },
   { id: "profiles", label: "Profiles" },
   { id: "models", label: "AI Providers" },
+  { id: "pricing", label: "Usage & Pricing" },
   { id: "messaging", label: "Messaging" },
   { id: "git", label: "Git" },
   { id: "federation", label: "Federation" },
@@ -73,6 +76,7 @@ const PRIMARY_SECTIONS: SettingsSection[] = [
   "applications",
   "profiles",
   "models",
+  "pricing",
   "messaging",
   "federation",
 ];
@@ -431,6 +435,30 @@ function SettingsSectionBody(props: {
     );
   }
 
+  if (props.section === "pricing") {
+    return (
+      <PricingSettings
+        saving={props.settings.saving}
+        snapshot={props.snapshot}
+        onThreadPricingSummaryChange={async (enabled: boolean) => {
+          await props.settings.writeConfig({
+            experimental: { threadPricingSummary: enabled },
+          });
+        }}
+        onThreadPricingDisplayUsdChange={async (enabled: boolean) => {
+          await props.settings.writeConfig({
+            experimental: { threadPricingDisplayUsd: enabled },
+          });
+        }}
+        onThreadPricingDisplayCodexCreditsChange={async (enabled: boolean) => {
+          await props.settings.writeConfig({
+            experimental: { threadPricingDisplayCodexCredits: enabled },
+          });
+        }}
+      />
+    );
+  }
+
   if (props.section === "experimental") {
     return (
       <ExperimentalSettings
@@ -459,21 +487,6 @@ function SettingsSectionBody(props: {
         onMarkdownMathRenderingChange={async (enabled: boolean) => {
           await props.settings.writeConfig({
             experimental: { markdownMathRendering: enabled },
-          });
-        }}
-        onThreadPricingSummaryChange={async (enabled: boolean) => {
-          await props.settings.writeConfig({
-            experimental: { threadPricingSummary: enabled },
-          });
-        }}
-        onThreadPricingDisplayUsdChange={async (enabled: boolean) => {
-          await props.settings.writeConfig({
-            experimental: { threadPricingDisplayUsd: enabled },
-          });
-        }}
-        onThreadPricingDisplayCodexCreditsChange={async (enabled: boolean) => {
-          await props.settings.writeConfig({
-            experimental: { threadPricingDisplayCodexCredits: enabled },
           });
         }}
         onThreadToolAccountingChange={async (enabled: boolean) => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -824,6 +824,27 @@ describe("SettingsScreen", () => {
       });
     });
 
+    fireEvent.click(
+      within(sections).getByRole("button", { name: "Usage & Pricing" }),
+    );
+    expect(
+      screen.getByRole("heading", { name: "Usage & pricing" }),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Show thread pricing",
+      }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        experimental: { threadPricingSummary: false },
+      });
+    });
+    expect(screen.getByRole("button", { name: "Dollars" })).not.toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Codex Credits" }),
+    ).not.toBeDisabled();
+
     fireEvent.click(within(sections).getByRole("button", { name: "Experimental" }));
     expect(screen.queryByRole("radiogroup", { name: "Chat Reply Composer" })).not.toBeInTheDocument();
     expect(
@@ -850,25 +871,12 @@ describe("SettingsScreen", () => {
       });
     });
 
-    fireEvent.click(
-      screen.getByRole("switch", {
-        name: "Enable thread pricing summary",
-      }),
-    );
-    await waitFor(() => {
-      expect(settings.writeConfig).toHaveBeenCalledWith({
-        experimental: { threadPricingSummary: false },
-      });
-    });
-    expect(
-      screen.getByRole("switch", { name: "Display USD" }),
-    ).not.toBeDisabled();
-    expect(
-      screen.getByRole("switch", { name: "Display Codex Credits" }),
-    ).not.toBeDisabled();
     expect(
       screen.getByRole("switch", { name: "Display tool output accounting" }),
     ).not.toBeDisabled();
+    expect(
+      screen.queryByRole("heading", { name: "Thread pricing" }),
+    ).not.toBeInTheDocument();
 
     fireEvent.click(
       screen.getByRole("switch", {
@@ -1205,7 +1213,7 @@ describe("SettingsScreen", () => {
     });
   });
 
-  it("saves thread pricing display unit toggles", async () => {
+  it("saves thread pricing display chips", async () => {
     const baseSnapshot = createSnapshot();
     const settings = createSettingsState(
       createSnapshot({
@@ -1221,34 +1229,31 @@ describe("SettingsScreen", () => {
 
     render(<SettingsScreen settings={settings} onClose={() => undefined} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Experimental" }));
+    fireEvent.click(screen.getByRole("button", { name: "Usage & Pricing" }));
 
-    const usdSwitch = screen.getByRole("switch", { name: "Display USD" });
-    const creditsSwitch = screen.getByRole("switch", {
-      name: "Display Codex Credits",
-    });
-    const toolAccountingSwitch = screen.getByRole("switch", {
-      name: "Display tool output accounting",
-    });
-    expect(usdSwitch).not.toBeDisabled();
-    expect(creditsSwitch).not.toBeDisabled();
-    expect(toolAccountingSwitch).not.toBeDisabled();
+    const dollarsChip = screen.getByRole("button", { name: "Dollars" });
+    const creditsChip = screen.getByRole("button", { name: "Codex Credits" });
+    expect(dollarsChip).toHaveAttribute("aria-pressed", "true");
+    expect(creditsChip).toHaveAttribute("aria-pressed", "false");
 
-    fireEvent.click(usdSwitch);
+    fireEvent.click(dollarsChip);
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         experimental: { threadPricingDisplayUsd: false },
       });
     });
 
-    fireEvent.click(creditsSwitch);
+    fireEvent.click(creditsChip);
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         experimental: { threadPricingDisplayCodexCredits: true },
       });
     });
 
-    fireEvent.click(toolAccountingSwitch);
+    fireEvent.click(screen.getByRole("button", { name: "Experimental" }));
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Display tool output accounting" }),
+    );
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         experimental: { threadToolAccounting: true },
@@ -1256,7 +1261,7 @@ describe("SettingsScreen", () => {
     });
   });
 
-  it("disables thread pricing display unit toggles when summary is off", () => {
+  it("disables thread pricing display chips when summary is off", () => {
     const baseSnapshot = createSnapshot();
     const settings = createSettingsState(
       createSnapshot({
@@ -1272,12 +1277,14 @@ describe("SettingsScreen", () => {
 
     render(<SettingsScreen settings={settings} onClose={() => undefined} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Experimental" }));
+    fireEvent.click(screen.getByRole("button", { name: "Usage & Pricing" }));
 
-    expect(screen.getByRole("switch", { name: "Display USD" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Dollars" })).toBeDisabled();
     expect(
-      screen.getByRole("switch", { name: "Display Codex Credits" }),
+      screen.getByRole("button", { name: "Codex Credits" }),
     ).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Experimental" }));
     expect(
       screen.getByRole("switch", { name: "Display tool output accounting" }),
     ).toBeDisabled();
@@ -4203,6 +4210,7 @@ describe("SettingsScreen", () => {
       "Applications",
       "Profiles",
       "AI Providers",
+      "Usage & Pricing",
       "Messaging",
       "Federation",
       "Git",

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -840,7 +840,9 @@ describe("SettingsScreen", () => {
         experimental: { threadPricingSummary: false },
       });
     });
-    expect(screen.getByRole("button", { name: "Dollars" })).not.toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "List Price" }),
+    ).not.toBeDisabled();
     expect(
       screen.getByRole("button", { name: "Codex Credits" }),
     ).not.toBeDisabled();
@@ -1231,12 +1233,17 @@ describe("SettingsScreen", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Usage & Pricing" }));
 
-    const dollarsChip = screen.getByRole("button", { name: "Dollars" });
+    expect(
+      screen.getByText(
+        "List Price uses each provider's published rates. Codex Credits use Codex's token-based credit rate card.",
+      ),
+    ).toBeInTheDocument();
+    const listPriceChip = screen.getByRole("button", { name: "List Price" });
     const creditsChip = screen.getByRole("button", { name: "Codex Credits" });
-    expect(dollarsChip).toHaveAttribute("aria-pressed", "true");
+    expect(listPriceChip).toHaveAttribute("aria-pressed", "true");
     expect(creditsChip).toHaveAttribute("aria-pressed", "false");
 
-    fireEvent.click(dollarsChip);
+    fireEvent.click(listPriceChip);
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         experimental: { threadPricingDisplayUsd: false },
@@ -1279,7 +1286,7 @@ describe("SettingsScreen", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Usage & Pricing" }));
 
-    expect(screen.getByRole("button", { name: "Dollars" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "List Price" })).toBeDisabled();
     expect(
       screen.getByRole("button", { name: "Codex Credits" }),
     ).toBeDisabled();

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -633,19 +633,18 @@ export type DesktopSettingsSnapshot = {
      */
     markdownMathRendering?: DesktopSettingsValue<boolean>;
     /**
-     * Gates the thread context-rail Pricing tab. The pricing ledger may still
-     * collect data for validation, but the user-visible summary stays hidden
-     * while this experimental setting is disabled.
+     * Controls whether the released thread context-rail Pricing tab is visible.
+     * The pricing ledger continues collecting usage while the tab is hidden.
      */
     threadPricingSummary?: DesktopSettingsValue<boolean>;
     /**
-     * Shows provider API list-price estimates in USD when the experimental
-     * thread pricing tab is visible.
+     * Shows provider API list-price estimates in USD when the thread Pricing
+     * tab is visible.
      */
     threadPricingDisplayUsd?: DesktopSettingsValue<boolean>;
     /**
-     * Shows Codex Credits estimates when the experimental thread pricing tab
-     * is visible. Credits use Codex's token-based credit rate card rather than
+     * Shows Codex Credits estimates when the thread Pricing tab is visible.
+     * Credits use Codex's token-based credit rate card rather than
      * a currency conversion from USD.
      */
     threadPricingDisplayCodexCredits?: DesktopSettingsValue<boolean>;


### PR DESCRIPTION
## What changed

- promote thread usage pricing from Experimental to a dedicated released **Usage & Pricing** settings page
- replace separate list-price and Codex Credits switches with a shared segmented multi-select control, preserving the ability to show either or both
- use provider-neutral **List Price** naming and published-provider-rate copy while keeping **Codex Credits** explicitly Codex-branded
- keep tool-output accounting in Experimental and link it to the released pricing setting
- update settings routing, contract documentation, and renderer coverage

## Why

Thread pricing is enabled by default and ready to be presented as a released feature. Its two independent display toggles also consumed unnecessary vertical space and obscured that they are related display choices. List-price estimates now cover providers beyond Codex/OpenAI, including Grok, so the stable pricing language must remain provider-neutral.

## Impact

Operators can find stable pricing controls directly in Settings → Usage & Pricing. Provider list prices and Codex Credits remain independently selectable, the existing persisted configuration remains compatible, and pricing collection behavior is unchanged.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
