### PR TITLE
fix(desktop): scope backend toasts to federation window

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -62,6 +62,7 @@ import {
 } from "./lib/federation-window";
 import { useFederationPeerConnectivity } from "./lib/useFederationPeerConnectivity";
 import { scopeDesktopApiToFederationTarget } from "./lib/federation-desktop-api";
+import { federationTargetsEqual } from "./lib/federated-thread-events";
 import { useRuntimeIdentity } from "./lib/runtime-identity";
 import {
   useNavigationHistory,
@@ -578,10 +579,10 @@ function DesktopAppShell(props: {
 
   // Surface backend turn failures + system errors as a durable toast. The
   // matching transcript entry (rendered from the thread overlay's
-  // turnFailureLog) is the in-context record; this toast is the global
-  // "something just broke" signal that has to be acknowledged. Notices are
-  // keyed by thread and queued so a failure on one thread can't suppress a
-  // signal from another.
+  // turnFailureLog) is the in-context record; this toast is the window-scoped
+  // "something just broke" signal that has to be acknowledged.
+  // Notices are keyed by thread and queued so a failure on one thread can't
+  // suppress a signal from another.
   useEffect(() => {
     const labelForThread = (backend: string, threadId?: string): string => {
       const match = threadId
@@ -600,6 +601,14 @@ function DesktopAppShell(props: {
           : `${backend} thread`;
     };
     return desktopApi?.onAgentEvent?.((event) => {
+      if (
+        !federationTargetsEqual(
+          event.federationTarget,
+          readRendererFederationTarget(),
+        )
+      ) {
+        return;
+      }
       // Params are cast explicitly: the AppServerNotification union is too
       // wide for the discriminant to narrow `params` reliably here.
       if (event.notification.method === "turn/failed") {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -157,6 +157,9 @@ describe("App", () => {
   afterEach(async () => {
     await flushReactUpdates();
     cleanup();
+    delete (window as typeof window & {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget;
   });
 
   it("shows the thread shell without starting backends while the startup settings read is pending", async () => {
@@ -291,6 +294,76 @@ describe("App", () => {
     });
     const gitSettingsButton = screen.getByRole("button", { name: "Git" });
     expect(gitSettingsButton).toHaveAttribute("aria-current", "page");
+  });
+
+  it("only surfaces backend error toasts for the renderer window's federation target", async () => {
+    const agentEventListeners = new Set<(event: AgentEvent) => void>();
+    (window as typeof window & {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = {
+      scope: "remote",
+      instanceId: "remote-gateway",
+    };
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        listBackends: async () => ({ fetchedAt: Date.now(), backends: [] }),
+        onAgentEvent: (listener: (event: AgentEvent) => void) => {
+          agentEventListeners.add(listener);
+          return () => {
+            agentEventListeners.delete(listener);
+          };
+        },
+        readSettings: async () =>
+          await new Promise<never>(() => {
+            // Keep the shell mounted without needing a full settings fixture.
+          }),
+      },
+    });
+
+    render(<App />);
+    await waitFor(() => expect(agentEventListeners.size).toBeGreaterThan(0));
+
+    const emitSystemError = (
+      federationTarget?: AgentEvent["federationTarget"],
+    ) => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          federationTarget,
+          notification: {
+            method: "thread/status/changed",
+            params: {
+              threadId: "thread-1",
+              status: { type: "systemError" },
+            },
+          },
+        });
+      }
+    };
+
+    act(() => {
+      emitSystemError();
+      emitSystemError({ scope: "remote", instanceId: "another-peer" });
+    });
+    expect(screen.queryByText("Agent backend error")).not.toBeInTheDocument();
+
+    act(() => {
+      emitSystemError({ scope: "remote", instanceId: "remote-gateway" });
+    });
+    expect(screen.getByText("Agent backend error")).toBeInTheDocument();
   });
 
   it("reveals the sidebar when adding a project from the hidden-sidebar masthead", async () => {


### PR DESCRIPTION
## Summary

- I scoped backend failure, system-error, and Codex repair toasts to the renderer window whose federation target matches the originating agent event.
- I reused the existing federation-target equality contract already used by the other window-specific agent-event consumers.
- I added an app-shell regression test proving a Remote Gateway window ignores local and other-peer failures while still showing failures from its own peer.

## Verification

- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- `pnpm lint:eslint` (passes with the repository's existing warning baseline)
- `pnpm typecheck`
- `pnpm lint:boundaries`

## Notes

- The root cause was that agent events intentionally fan out to subscribed main-style windows and carry a `federationTarget`, but the backend-error toast subscriber did not check that target before enqueueing a notice.
