### PR TITLE
fix(desktop): preserve remote UI during reconnect

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -451,6 +451,8 @@ test.describe("federation remote window", () => {
       const recoveryDraft = "Keep this draft while the gateway reconnects";
       await expect(remoteReply).toBeVisible();
       await remoteReply.fill(recoveryDraft);
+      const sendButton = remote.getByRole("button", { name: "Send" });
+      await expect(sendButton).toBeEnabled();
 
       // The gateway only ever served federation RPCs — no local PR
       // refresh or other local-only method leaked across the wire.
@@ -469,7 +471,7 @@ test.describe("federation remote window", () => {
         remote.locator(".composer-tiptap-input__editor"),
       ).toHaveAttribute("contenteditable", "true", { timeout: 15_000 });
       await expect(remoteReply).toContainText(recoveryDraft);
-      await expect(remote.getByRole("button", { name: "Send" })).toBeDisabled();
+      await expect(sendButton).toBeDisabled();
       await expect(remoteRowOne).toBeVisible();
       await expect(remoteRowOne).toHaveClass(/is-remote-offline/);
       await expect(locallyMountedRemoteRow).toBeVisible();
@@ -491,7 +493,7 @@ test.describe("federation remote window", () => {
       await expect(remoteRowOne).not.toHaveClass(/is-remote-offline/);
       await expect(locallyMountedRemoteRow).not.toHaveClass(/is-remote-offline/);
       await expect(remoteReply).toContainText(recoveryDraft);
-      await expect(remote.getByRole("button", { name: "Send" })).toBeEnabled();
+      await expect(sendButton).toBeEnabled();
     } finally {
       await app?.close();
       await gateway?.close();

--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -251,8 +251,8 @@ test.describe("federation remote window", () => {
 
       // Opening a remote thread renders the peer transcript with the
       // remote-PTY terminal toggle enabled (the gateway granted remote_pty).
-      const remoteRowOne = remote.locator(".thread-row__title", {
-        hasText: "Remote gateway thread one",
+      const remoteRowOne = remote.getByRole("button", {
+        name: "Remote gateway thread one",
       });
       await remoteRowOne.click();
       await expect(
@@ -400,9 +400,10 @@ test.describe("federation remote window", () => {
         remote.getByTestId("composer-tiptap-input"),
       ).toHaveAttribute("data-value", "");
       await remoteRowOne.click();
-      await expect(
-        remote.getByRole("textbox", { name: "Reply" }),
-      ).toBeVisible();
+      const remoteReply = remote.getByRole("textbox", { name: "Reply" });
+      const recoveryDraft = "Keep this draft while the gateway reconnects";
+      await expect(remoteReply).toBeVisible();
+      await remoteReply.fill(recoveryDraft);
 
       // The gateway only ever served federation RPCs — no local PR
       // refresh or other local-only method leaked across the wire.
@@ -410,16 +411,20 @@ test.describe("federation remote window", () => {
         gateway.calls.map((call) => call.method),
       ).not.toContain("refreshThreadPullRequests");
 
-      // Peer death: the window flips to an explicit read-only state —
-      // disconnected banner, composer disabled — instead of a half-dead
-      // surface hammering the peer with failing RPCs.
+      // Peer death: the window keeps its stale navigation and durable draft
+      // visible. Remote writes are disabled, but the editor stays live so the
+      // operator can inspect, copy, and revise text while reconnecting.
       await gateway.stop();
       await expect(
         remote.locator(".federation-disconnected-banner"),
       ).toBeVisible({ timeout: 30_000 });
       await expect(
         remote.locator(".composer-tiptap-input__editor"),
-      ).toHaveAttribute("contenteditable", "false", { timeout: 15_000 });
+      ).toHaveAttribute("contenteditable", "true", { timeout: 15_000 });
+      await expect(remoteReply).toContainText(recoveryDraft);
+      await expect(remote.getByRole("button", { name: "Send" })).toBeDisabled();
+      await expect(remoteRowOne).toBeVisible();
+      await expect(remoteRowOne).toHaveClass(/is-remote-offline/);
 
       // Recovery: the same identity returns on the same port; the client
       // reconnects on its own backoff and the window heals without a
@@ -434,6 +439,9 @@ test.describe("federation remote window", () => {
           hasText: "Remote gateway thread one",
         }),
       ).toBeVisible({ timeout: 30_000 });
+      await expect(remoteRowOne).not.toHaveClass(/is-remote-offline/);
+      await expect(remoteReply).toContainText(recoveryDraft);
+      await expect(remote.getByRole("button", { name: "Send" })).toBeEnabled();
     } finally {
       await app?.close();
       await gateway?.close();

--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -221,6 +221,53 @@ test.describe("federation remote window", () => {
       ).toBeVisible();
       await expect(remote.getByText("Local control thread")).toHaveCount(0);
 
+      // Mount one remote thread into the local main window. This is the same
+      // viewer-owned pin path as choosing a federated result from Cmd+K, but
+      // invoking the bridge directly keeps this E2E focused on reconnect
+      // behavior instead of duplicating the search-popup suite.
+      await window.evaluate(async ({ instanceId }) => {
+        const api = (window as typeof window & {
+          pwragent?: {
+            addRemoteThreadPin?: (request: unknown) => Promise<unknown>;
+          };
+        }).pwragent;
+        if (!api?.addRemoteThreadPin) {
+          throw new Error("addRemoteThreadPin API is unavailable");
+        }
+        await api.addRemoteThreadPin({
+          ref: {
+            backend: "codex",
+            target: { scope: "remote", instanceId },
+            threadId: "remote-thread-1",
+          },
+          instanceLabel: "E2E Gateway",
+          summary: {
+            source: "codex",
+            id: "remote-thread-1",
+            title: "Remote gateway thread one",
+            titleSource: "explicit",
+            linkedDirectories: [],
+            inbox: { inInbox: true },
+            updatedAt: 2_000,
+            federation: {
+              ref: {
+                backend: "codex",
+                target: { scope: "remote", instanceId },
+                threadId: "remote-thread-1",
+              },
+              instanceLabel: "E2E Gateway",
+              peerStatus: "connected",
+            },
+          },
+        });
+      }, { instanceId: gateway.instanceId });
+      await window.getByRole("button", { name: /Exit Settings/i }).click();
+      const locallyMountedRemoteRow = window.getByRole("button", {
+        name: "Remote gateway thread one",
+      });
+      await expect(locallyMountedRemoteRow).toBeVisible({ timeout: 30_000 });
+      await expect(locallyMountedRemoteRow).not.toHaveClass(/is-remote-offline/);
+
       // Local-only chrome stays hidden in the remote window.
       await expect(
         remote.getByRole("button", { name: "Open settings" }),
@@ -425,6 +472,8 @@ test.describe("federation remote window", () => {
       await expect(remote.getByRole("button", { name: "Send" })).toBeDisabled();
       await expect(remoteRowOne).toBeVisible();
       await expect(remoteRowOne).toHaveClass(/is-remote-offline/);
+      await expect(locallyMountedRemoteRow).toBeVisible();
+      await expect(locallyMountedRemoteRow).toHaveClass(/is-remote-offline/);
 
       // Recovery: the same identity returns on the same port; the client
       // reconnects on its own backoff and the window heals without a
@@ -440,6 +489,7 @@ test.describe("federation remote window", () => {
         }),
       ).toBeVisible({ timeout: 30_000 });
       await expect(remoteRowOne).not.toHaveClass(/is-remote-offline/);
+      await expect(locallyMountedRemoteRow).not.toHaveClass(/is-remote-offline/);
       await expect(remoteReply).toContainText(recoveryDraft);
       await expect(remote.getByRole("button", { name: "Send" })).toBeEnabled();
     } finally {

--- a/apps/desktop/e2e/fixtures/federation-gateway.ts
+++ b/apps/desktop/e2e/fixtures/federation-gateway.ts
@@ -6,6 +6,7 @@ import type {
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
   AppServerThreadSummary,
+  ListBackendsResponse,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   NavigationSnapshot,
@@ -205,9 +206,41 @@ export async function startInProcessFederationGateway(params: {
       calls.push({ method: "listSkills", params: {} });
       return { backend: "codex" as const, fetchedAt: Date.now(), data: [] };
     },
-    async listBackends() {
+    async listBackends(): Promise<ListBackendsResponse> {
       calls.push({ method: "listBackends", params: {} });
-      return { backends: [] };
+      return {
+        fetchedAt: Date.now(),
+        backends: [
+          {
+            kind: "codex",
+            label: "OpenAI",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start"],
+            capabilities: {
+              listThreads: true,
+              createThread: true,
+              resumeThread: true,
+              renameThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: true,
+              steerTurn: false,
+              transcriptPagination: false,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          },
+        ],
+      };
     },
     async markThreadSeen(request: { threadId: string }) {
       calls.push({ method: "markThreadSeen", params: request });

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -66,6 +66,7 @@ const federationMock = vi.hoisted(() => {
     remoteThreadSummaries,
     runtime: {
       remoteBackend: vi.fn(() => remoteBackend),
+      remoteNavigationSnapshot: vi.fn(),
       remoteThreadSummaries: vi.fn(() => remoteThreadSummaries),
     },
   };
@@ -860,6 +861,7 @@ describe("app server ipc", () => {
     federationMock.remoteBackend.markThreadSeen.mockClear();
     federationMock.remoteBackend.refreshDirectoryGitStatuses.mockClear();
     federationMock.runtime.remoteBackend.mockClear();
+    federationMock.runtime.remoteNavigationSnapshot.mockReset();
     listThreads.mockClear();
     readThread.mockClear();
     getThreadTranscriptImageRoots.mockClear();
@@ -1627,6 +1629,87 @@ describe("app server ipc", () => {
     });
     expect(registerThreadPrStatusWatch).toHaveBeenCalledOnce();
     expect(claimThreadPrStatusWatches).not.toHaveBeenCalled();
+  });
+
+  it("serves the last remote navigation snapshot during an expected disconnect", async () => {
+    const { FederationPeerUnavailableError } = await import(
+      "../federation/federation-peer-unavailable-error"
+    );
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "peer_navigation_stale",
+    };
+    const fresh = {
+      backend: "all" as const,
+      fetchedAt: 1_000,
+      federationTarget,
+      unchanged: false,
+      threads: [{
+        id: "remote-thread",
+        title: "Remote thread",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: true },
+        federation: {
+          ref: {
+            backend: "codex" as const,
+            target: federationTarget,
+            threadId: "remote-thread",
+          },
+          instanceLabel: "Remote fixture",
+          peerStatus: "connected" as const,
+        },
+      }],
+      inboxThreadKeys: ["codex:remote-thread"],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    };
+    federationMock.runtime.remoteNavigationSnapshot
+      .mockResolvedValueOnce(fresh)
+      .mockRejectedValueOnce(
+        new FederationPeerUnavailableError("peer_navigation_stale"),
+      );
+
+    registerAppServerIpcHandlers();
+    const handler = handlers.get(NAVIGATION_SNAPSHOT_CHANNEL);
+
+    await expect(handler?.({}, { federationTarget })).resolves.toBe(fresh);
+    const stale = await handler?.({}, {
+      federationTarget,
+      forceRefresh: true,
+      refreshMode: "full",
+    }) as typeof fresh;
+    expect(stale).toMatchObject({
+      federationTarget,
+      unchanged: false,
+      threads: [{
+        id: "remote-thread",
+        federation: { peerStatus: "disconnected" },
+      }],
+    });
+  });
+
+  it("keeps unexpected remote navigation failures actionable", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    federationMock.runtime.remoteNavigationSnapshot.mockRejectedValueOnce(
+      new Error("invalid remote navigation payload"),
+    );
+
+    registerAppServerIpcHandlers();
+
+    await expect(handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {
+      federationTarget: {
+        scope: "remote",
+        instanceId: "peer_navigation_broken",
+      },
+    })).rejects.toThrow("invalid remote navigation payload");
   });
 
   it("aggregates navigation snapshots across backends by default", async () => {

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -19,6 +19,10 @@ import {
   FEDERATION_ENVIRONMENT_SETUP_PROGRESS_METHOD,
 } from "../federation/federation-backend-bridge";
 import { DesktopFederationRuntime } from "../federation/federation-runtime";
+import {
+  FEDERATION_PEER_UNAVAILABLE_ERROR_CODE,
+  FederationPeerUnavailableError,
+} from "../federation/federation-peer-unavailable-error";
 import { FederationRouter } from "../federation/federation-router";
 import type { FederationGatewayConnection } from "../federation/federation-transport";
 
@@ -575,6 +579,35 @@ describe("DesktopFederationRuntime", () => {
     runtime.sendEnvelopeToTarget("client_two", request);
 
     expect(sentToGateway).toEqual([request]);
+  });
+
+  it("classifies a missing route as expected peer unavailability", () => {
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.gatewayInstanceId = "gateway_one";
+    runtime.localInstanceId = "client_one";
+    runtime.router = new FederationRouter({ localInstanceId: "client_one" });
+    const request: FederationProtocolEnvelope = {
+      id: "request-unavailable",
+      kind: "request",
+      method: "backend.listThreads",
+      params: {},
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "client_two",
+      createdAt: 2_000,
+    };
+
+    expect(() => runtime.sendEnvelopeToTarget("client_two", request)).toThrow(
+      FederationPeerUnavailableError,
+    );
+    try {
+      runtime.sendEnvelopeToTarget("client_two", request);
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: FEDERATION_PEER_UNAVAILABLE_ERROR_CODE,
+        instanceId: "client_two",
+      });
+    }
   });
 
   it("resolves sibling RPC responses received from the gateway transport", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
@@ -61,6 +61,14 @@ const messagingRoutesServiceMock = vi.hoisted(() => ({
   resetDesktopMessagingToolUpdateBindings: vi.fn(),
   setDesktopMessagingDefaultAgent: vi.fn(),
 }));
+const federationMock = vi.hoisted(() => {
+  const readMessagingPlatformStatuses = vi.fn(async () => [] as unknown[]);
+  return {
+    readMessagingPlatformStatuses,
+    remoteBackend: vi.fn(() => ({ readMessagingPlatformStatuses })),
+    setStatusReader: vi.fn(),
+  };
+});
 
 vi.mock("electron", () => ({
   BrowserWindow: {
@@ -80,6 +88,13 @@ vi.mock("electron", () => ({
 
 vi.mock("../messaging/messaging-runtime", () => ({
   getDesktopMessagingRuntime: vi.fn(() => runtimeMock),
+}));
+
+vi.mock("../federation/federation-runtime", () => ({
+  getDesktopFederationRuntime: vi.fn(() => ({
+    remoteBackend: federationMock.remoteBackend,
+  })),
+  setFederationMessagingPlatformStatusReader: federationMock.setStatusReader,
 }));
 
 vi.mock("../settings/desktop-settings-singleton", () => ({
@@ -160,6 +175,65 @@ describe("messaging status ipc", () => {
     messagingRoutesServiceMock.listDesktopMessagingRoutes.mockReset();
     messagingRoutesServiceMock.resetDesktopMessagingToolUpdateBindings.mockReset();
     messagingRoutesServiceMock.setDesktopMessagingDefaultAgent.mockReset();
+    federationMock.readMessagingPlatformStatuses.mockReset();
+    federationMock.readMessagingPlatformStatuses.mockResolvedValue([]);
+    federationMock.remoteBackend.mockClear();
+    federationMock.setStatusReader.mockClear();
+  });
+
+  it("serves the last remote platform status during an expected disconnect", async () => {
+    const { FederationPeerUnavailableError } = await import(
+      "../federation/federation-peer-unavailable-error"
+    );
+    const { registerMessagingStatusIpcHandlers } = await import(
+      "../ipc/messaging-status"
+    );
+    const { MESSAGING_GET_PLATFORM_STATUSES_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "peer_stale",
+    };
+    const fresh = [{
+      changedAt: 1_000,
+      health: "enabled",
+      platform: "telegram",
+    }];
+    federationMock.readMessagingPlatformStatuses
+      .mockResolvedValueOnce(fresh)
+      .mockRejectedValueOnce(
+        new FederationPeerUnavailableError("peer_stale"),
+      );
+
+    registerMessagingStatusIpcHandlers();
+    const handler = handlers.get(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL);
+
+    await expect(handler?.({}, { federationTarget })).resolves.toBe(fresh);
+    await expect(handler?.({}, { federationTarget })).resolves.toBe(fresh);
+  });
+
+  it("keeps unexpected remote platform-status failures actionable", async () => {
+    const { registerMessagingStatusIpcHandlers } = await import(
+      "../ipc/messaging-status"
+    );
+    const { MESSAGING_GET_PLATFORM_STATUSES_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    federationMock.readMessagingPlatformStatuses.mockRejectedValueOnce(
+      new Error("invalid remote messaging payload"),
+    );
+
+    registerMessagingStatusIpcHandlers();
+
+    await expect(
+      handlers.get(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL)?.({}, {
+        federationTarget: {
+          scope: "remote",
+          instanceId: "peer_broken",
+        },
+      }),
+    ).rejects.toThrow("invalid remote messaging payload");
   });
 
   it("lists and mutates default Agent routes through IPC", async () => {

--- a/apps/desktop/src/main/__tests__/scheduled-actions-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/scheduled-actions-ipc.test.ts
@@ -125,4 +125,58 @@ describe("scheduled action IPC", () => {
     });
     expect(serviceMock.create).not.toHaveBeenCalled();
   });
+
+  it("serves the last remote list during an expected disconnect", async () => {
+    const { FederationPeerUnavailableError } = await import(
+      "../federation/federation-peer-unavailable-error"
+    );
+    const { registerScheduledActionIpcHandlers } = await import(
+      "../ipc/scheduled-actions-ipc"
+    );
+    const { SCHEDULED_ACTIONS_LIST_CHANNEL } = await import("../../shared/ipc");
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "client_stale",
+    };
+    const fresh = {
+      actions: [],
+      observedAt: 1_000,
+    };
+    remoteBackendMock.listScheduledThreadActions
+      .mockResolvedValueOnce(fresh)
+      .mockRejectedValueOnce(
+        new FederationPeerUnavailableError("client_stale"),
+      );
+
+    registerScheduledActionIpcHandlers();
+    const handler = handlers.get(SCHEDULED_ACTIONS_LIST_CHANNEL);
+
+    await expect(handler?.({}, {
+      federationTarget,
+      includeFailed: true,
+    })).resolves.toBe(fresh);
+    await expect(handler?.({}, {
+      federationTarget,
+      terminalUpdatedAfter: 1_000,
+    })).resolves.toBe(fresh);
+  });
+
+  it("keeps unexpected remote list failures actionable", async () => {
+    const { registerScheduledActionIpcHandlers } = await import(
+      "../ipc/scheduled-actions-ipc"
+    );
+    const { SCHEDULED_ACTIONS_LIST_CHANNEL } = await import("../../shared/ipc");
+    remoteBackendMock.listScheduledThreadActions.mockRejectedValueOnce(
+      new Error("remote scheduler protocol mismatch"),
+    );
+
+    registerScheduledActionIpcHandlers();
+
+    await expect(handlers.get(SCHEDULED_ACTIONS_LIST_CHANNEL)?.({}, {
+      federationTarget: {
+        scope: "remote",
+        instanceId: "client_broken",
+      },
+    })).rejects.toThrow("remote scheduler protocol mismatch");
+  });
 });

--- a/apps/desktop/src/main/federation/federation-peer-unavailable-error.ts
+++ b/apps/desktop/src/main/federation/federation-peer-unavailable-error.ts
@@ -1,0 +1,35 @@
+import type { FederationInstanceId } from "@pwragent/shared";
+
+export const FEDERATION_PEER_UNAVAILABLE_ERROR_CODE =
+  "FEDERATION_PEER_UNAVAILABLE";
+
+/**
+ * Expected, transient loss of a route to a known federation peer.
+ *
+ * IPC read handlers catch this exact type and serve their last successful
+ * snapshot instead of rejecting through Electron (which prints the entire
+ * handler stack). Other errors remain exceptional and keep their diagnostics.
+ */
+export class FederationPeerUnavailableError extends Error {
+  readonly code = FEDERATION_PEER_UNAVAILABLE_ERROR_CODE;
+
+  constructor(
+    readonly instanceId: FederationInstanceId,
+    message = `Federation peer ${instanceId} is not connected.`,
+  ) {
+    super(message);
+    this.name = "FederationPeerUnavailableError";
+  }
+}
+
+export function isFederationPeerUnavailableError(
+  error: unknown,
+): error is FederationPeerUnavailableError {
+  return error instanceof FederationPeerUnavailableError
+    || (
+      typeof error === "object"
+      && error !== null
+      && "code" in error
+      && error.code === FEDERATION_PEER_UNAVAILABLE_ERROR_CODE
+    );
+}

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -183,6 +183,9 @@ import {
 } from "./federation-pty-service";
 import { FederationRouter } from "./federation-router";
 import { FederationRpcEndpoint } from "./federation-rpc";
+import {
+  FederationPeerUnavailableError,
+} from "./federation-peer-unavailable-error";
 import { FederationStore } from "./federation-store";
 import {
   classifyFederationClientFailure,
@@ -1559,7 +1562,10 @@ export class DesktopFederationRuntime {
     // peer reconnects first, registerGatewayConnection cancels the reap.
     this.ptyService?.notifyPeerDisconnected(peerId);
     this.rpcByPeer.get(peerId)?.rejectAll(
-      new Error(`Federation peer ${peerId} disconnected.`),
+      new FederationPeerUnavailableError(
+        peerId,
+        `Federation peer ${peerId} disconnected.`,
+      ),
     );
     this.rpcByPeer.delete(peerId);
   }
@@ -1583,8 +1589,8 @@ export class DesktopFederationRuntime {
         reason,
       );
     }
-    for (const rpc of this.rpcByPeer.values()) {
-      rpc.rejectAll(new Error(reason));
+    for (const [peerId, rpc] of this.rpcByPeer) {
+      rpc.rejectAll(new FederationPeerUnavailableError(peerId, reason));
     }
     this.rpcByPeer.clear();
   }
@@ -1784,7 +1790,7 @@ export class DesktopFederationRuntime {
       return;
     }
 
-    throw new Error(`Federation peer ${targetInstanceId} is not connected.`);
+    throw new FederationPeerUnavailableError(targetInstanceId);
   }
 
   private visiblePeers(): FederationPeerSummary[] {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -245,6 +245,9 @@ import { githubPrAccessTargetKey } from "../../shared/github-pr-access";
 import { subscribersForChannel } from "../window-channels";
 import { isFederationWindowWebContents } from "../window";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
+import {
+  isFederationPeerUnavailableError,
+} from "../federation/federation-peer-unavailable-error";
 import { FocusedDiffService } from "../diff-focus/focused-diff-service";
 import { renderComposerPdfPreview } from "../pdf/composer-pdf-preview";
 import { getMainLogger } from "../log";
@@ -757,6 +760,21 @@ function getNavigationSnapshotRequestKey(
   });
 }
 
+function getRemoteNavigationSnapshotCacheKey(
+  request: GetNavigationSnapshotRequest & {
+    federationTarget: { scope: "remote"; instanceId: string };
+  },
+): string {
+  // forceRefresh / refreshMode are renderer scheduling hints. The remote RPC
+  // reads the same owner snapshot either way, so every variant shares one
+  // last-known fallback during a disconnect.
+  return JSON.stringify({
+    backend: request.backend ?? "all",
+    federationTarget: request.federationTarget,
+    filter: request.filter ?? "",
+  });
+}
+
 function buildThreadSnapshotCacheKey(
   backend: AppServerBackendScope,
   filter?: string,
@@ -1177,6 +1195,10 @@ class DesktopAppServerService {
   private readonly pendingNavigationSnapshots = new Map<
     string,
     Promise<NavigationSnapshot>
+  >();
+  private readonly remoteNavigationSnapshotCache = new Map<
+    string,
+    NavigationSnapshot
   >();
   private readonly pendingThreadPullRequestRefreshes = new Map<
     string,
@@ -1753,7 +1775,13 @@ class DesktopAppServerService {
   async getNavigationSnapshot(
     request: GetNavigationSnapshotRequest = {},
   ): Promise<NavigationSnapshot> {
-    const requestKey = getNavigationSnapshotRequestKey(request);
+    const requestKey = request.federationTarget
+      && isRemoteFederationTarget(request.federationTarget)
+      ? getRemoteNavigationSnapshotCacheKey({
+          ...request,
+          federationTarget: request.federationTarget,
+        })
+      : getNavigationSnapshotRequestKey(request);
     const pending = this.pendingNavigationSnapshots.get(requestKey);
     if (pending) {
       return await pending;
@@ -1785,13 +1813,55 @@ class DesktopAppServerService {
     request: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot> {
     if (request.federationTarget && isRemoteFederationTarget(request.federationTarget)) {
-      return await getDesktopFederationRuntime().remoteNavigationSnapshot(
-        request.federationTarget,
-        {
-          backend: request.backend === "all" ? undefined : request.backend,
-          filter: request.filter,
-        },
-      );
+      const cacheKey = getRemoteNavigationSnapshotCacheKey({
+        ...request,
+        federationTarget: request.federationTarget,
+      });
+      try {
+        const snapshot = await getDesktopFederationRuntime()
+          .remoteNavigationSnapshot(
+            request.federationTarget,
+            {
+              backend: request.backend === "all" ? undefined : request.backend,
+              filter: request.filter,
+            },
+          );
+        this.remoteNavigationSnapshotCache.set(cacheKey, snapshot);
+        return snapshot;
+      } catch (error) {
+        if (!isFederationPeerUnavailableError(error)) {
+          throw error;
+        }
+        const cached = this.remoteNavigationSnapshotCache.get(cacheKey);
+        const fallback: NavigationSnapshot = cached ?? {
+          backend: request.backend ?? "all",
+          fetchedAt: Date.now(),
+          federationTarget: request.federationTarget,
+          unchanged: false,
+          threads: [],
+          inboxThreadKeys: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex",
+            executionMode: "default",
+          },
+        };
+        return {
+          ...fallback,
+          unchanged: false,
+          threads: fallback.threads.map((thread) =>
+            thread.federation
+              ? {
+                  ...thread,
+                  federation: {
+                    ...thread.federation,
+                    peerStatus: "disconnected",
+                  },
+                }
+              : thread,
+          ),
+        };
+      }
     }
     const backend: AppServerBackendScope = request.backend ?? "all";
     const refreshMode = request.refreshMode ?? "full";
@@ -6340,6 +6410,7 @@ class DesktopAppServerService {
     this.attachedPrsByThreadKey.clear();
     this.publishedPrimaryGitRepositoriesByThreadKey.clear();
     this.pendingNavigationSnapshots.clear();
+    this.remoteNavigationSnapshotCache.clear();
     this.pendingThreadPullRequestRefreshes.clear();
     this.pendingEditCommitResolves.clear();
     this.prStatusRegistry.clear();

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -48,6 +48,9 @@ import {
   getDesktopFederationRuntime,
   setFederationMessagingPlatformStatusReader,
 } from "../federation/federation-runtime";
+import {
+  isFederationPeerUnavailableError,
+} from "../federation/federation-peer-unavailable-error";
 import { loadDesktopMessagingConfigFromSettings } from "../messaging/messaging-config";
 import { getDesktopMessagingActivityLog } from "../messaging/desktop-messaging-activity-log";
 import { getDesktopMessagingPairingStore } from "../messaging/desktop-messaging-pairing-store";
@@ -515,6 +518,47 @@ function recordPairingActivity(entry: MessagingPairingEntry, summary: string): v
 
 export function registerMessagingStatusIpcHandlers(): void {
   const runtime = getDesktopMessagingRuntime();
+  const cachedRemotePlatformStatuses = new Map<
+    string,
+    MessagingPlatformStatus[]
+  >();
+  const pendingRemotePlatformStatuses = new Map<
+    string,
+    Promise<MessagingPlatformStatus[]>
+  >();
+
+  const readRemotePlatformStatuses = async (
+    target: Extract<
+      NonNullable<GetMessagingPlatformStatusesRequest["federationTarget"]>,
+      { scope: "remote" }
+    >,
+  ): Promise<MessagingPlatformStatus[]> => {
+    const cacheKey = target.instanceId;
+    const pending = pendingRemotePlatformStatuses.get(cacheKey);
+    if (pending) {
+      return await pending;
+    }
+    const operation = (async () => {
+      try {
+        const statuses = await getDesktopFederationRuntime()
+          .remoteBackend(target)
+          .readMessagingPlatformStatuses();
+        cachedRemotePlatformStatuses.set(cacheKey, statuses);
+        return statuses;
+      } catch (error) {
+        if (!isFederationPeerUnavailableError(error)) {
+          throw error;
+        }
+        // The connectivity banner owns outage state. Preserve the last owner
+        // status here and resolve normally so Electron emits no handler stack.
+        return cachedRemotePlatformStatuses.get(cacheKey) ?? [];
+      }
+    })().finally(() => {
+      pendingRemotePlatformStatuses.delete(cacheKey);
+    });
+    pendingRemotePlatformStatuses.set(cacheKey, operation);
+    return await operation;
+  };
 
   // Let remote federation viewers read this instance's messaging health
   // for their MSG chip. Registered here (not in the federation runtime)
@@ -545,9 +589,7 @@ export function registerMessagingStatusIpcHandlers(): void {
       ) {
         // A federation window's MSG chip shows the OWNING instance's
         // messaging health; local runtime state would read as the peer's.
-        return await getDesktopFederationRuntime()
-          .remoteBackend(request.federationTarget)
-          .readMessagingPlatformStatuses();
+        return await readRemotePlatformStatuses(request.federationTarget);
       }
       return await timeStartupProfileOperation({
         type: "ipc-main:getMessagingPlatformStatuses",

--- a/apps/desktop/src/main/ipc/scheduled-actions-ipc.ts
+++ b/apps/desktop/src/main/ipc/scheduled-actions-ipc.ts
@@ -17,6 +17,9 @@ import {
 } from "../../shared/ipc";
 import { getScheduledThreadActionService } from "../scheduled-actions/scheduled-thread-action-service";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
+import {
+  isFederationPeerUnavailableError,
+} from "../federation/federation-peer-unavailable-error";
 
 function remoteBackendFor(request: {
   federationTarget?: CreateScheduledThreadActionRequest["federationTarget"];
@@ -36,6 +39,58 @@ function stripFederationTarget<T extends {
 
 export function registerScheduledActionIpcHandlers(): void {
   getScheduledThreadActionService();
+  const cachedRemoteLists = new Map<
+    string,
+    ListScheduledThreadActionsResponse
+  >();
+  const pendingRemoteLists = new Map<
+    string,
+    Promise<ListScheduledThreadActionsResponse>
+  >();
+
+  const listRemoteActions = async (
+    request: ListScheduledThreadActionsRequest,
+  ): Promise<ListScheduledThreadActionsResponse> => {
+    const target = request.federationTarget;
+    if (!target || !isRemoteFederationTarget(target)) {
+      return getScheduledThreadActionService().list(request);
+    }
+    const localRequest = stripFederationTarget(request);
+    // terminalUpdatedAfter advances every reconciliation pass, but the last
+    // successful response remains the correct stale projection for this
+    // target/thread scope during an outage.
+    const cacheKey = JSON.stringify({
+      instanceId: target.instanceId,
+      backend: request.backend ?? "all",
+      threadId: request.threadId ?? "",
+    });
+    const pendingKey = JSON.stringify({ cacheKey, request: localRequest });
+    const pending = pendingRemoteLists.get(pendingKey);
+    if (pending) {
+      return await pending;
+    }
+    const operation = (async () => {
+      try {
+        const response = await getDesktopFederationRuntime()
+          .remoteBackend(target)
+          .listScheduledThreadActions(localRequest);
+        cachedRemoteLists.set(cacheKey, response);
+        return response;
+      } catch (error) {
+        if (!isFederationPeerUnavailableError(error)) {
+          throw error;
+        }
+        // Resolve normally so Electron never prints an expected disconnect
+        // stack. Do not advance observedAt: reconnect must resume from the
+        // last owner clock cursor and collect terminal actions from the gap.
+        return cachedRemoteLists.get(cacheKey) ?? { actions: [] };
+      }
+    })().finally(() => {
+      pendingRemoteLists.delete(pendingKey);
+    });
+    pendingRemoteLists.set(pendingKey, operation);
+    return await operation;
+  };
 
   ipcMain.removeHandler(SCHEDULED_ACTIONS_LIST_CHANNEL);
   ipcMain.handle(
@@ -45,12 +100,7 @@ export function registerScheduledActionIpcHandlers(): void {
       request?: ListScheduledThreadActionsRequest,
     ): Promise<ListScheduledThreadActionsResponse> => {
       const routedRequest = request ?? {};
-      const remote = remoteBackendFor(routedRequest);
-      return remote
-        ? await remote.listScheduledThreadActions(
-            stripFederationTarget(routedRequest),
-          )
-        : getScheduledThreadActionService().list(routedRequest);
+      return await listRemoteActions(routedRequest);
     },
   );
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -844,6 +844,7 @@ function DesktopAppShell(props: {
   const backendSummaries = useBackendSummaries(desktopApi, {
     enabled: normalAppEnabled,
     federationTarget: activeFederationTarget,
+    suspended: !peerConnectivity.connected,
   });
   const refreshAcpAgents = backendSummaries.refreshAcpAgents;
   const refreshSelectedAcpProvider = useCallback(

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1647,6 +1647,7 @@ function DesktopAppShell(props: {
           activeProfile={profiles.activeProfile}
           profiles={profiles.profiles}
           launchpadError={navigation.launchpadError}
+          loaded={navigation.loaded}
           loading={navigation.loading}
           approvalRequestThreadKeys={session.approvalRequestThreadKeys}
           inputRequestThreadKeys={session.inputRequestThreadKeys}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -8816,8 +8816,10 @@ export function Composer(props: ComposerProps) {
     }
   };
 
-  const composerDisabled =
-    launchpadSubmitting || (props.disabled && !hasComposerContent);
+  // Backend availability gates submission and remote actions, not the draft.
+  // Keeping the editor live lets an operator inspect, copy, revise, or remove
+  // durable text and attachments while federation reconnects.
+  const composerDisabled = launchpadSubmitting;
   const composerPlaceholder = isLaunchpad
     ? `Start a new thread in ${props.launchpad?.directoryLabel ?? "this directory"}`
     : "Reply to this thread";

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1159,6 +1159,55 @@ describe("Composer", () => {
     expect(screen.getByText(unavailableReason)).toHaveClass("composer__meta--error");
   });
 
+  it("keeps an unavailable thread draft and its images editable", async () => {
+    const file = new File([new Uint8Array([1])], "recovery.png", {
+      type: "image/png",
+    });
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={true}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Recover this draft",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    const reply = screen.getByLabelText("Reply");
+    expect(reply).toHaveAttribute("contenteditable", "true");
+    fireEvent.change(reply, {
+      target: { value: "Continue editing while disconnected" },
+    });
+    fireEvent.paste(reply, {
+      clipboardData: {
+        files: [],
+        items: [{ kind: "file", type: file.type, getAsFile: () => file }],
+      },
+    });
+
+    expect(await screen.findByAltText("recovery.png")).toBeInTheDocument();
+    expect(reply).toHaveTextContent("Continue editing while disconnected");
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+    expect(
+      screen.getByText(
+        "This thread's backend is unavailable right now. You can keep drafting, but send is unavailable.",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove recovery.png" }),
+    );
+    expect(screen.queryByAltText("recovery.png")).not.toBeInTheDocument();
+  });
+
   it("opens a remote thread workspace on its owning instance", async () => {
     const openApplication = vi.fn(async () => ({ opened: true as const }));
 

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
@@ -573,6 +573,86 @@ describe("MessagingStatusBar", () => {
       delete federationWindow.__pwragentFederationTarget;
     }
   });
+
+  it("stops remote status polling until the peer reconnects", async () => {
+    vi.useFakeTimers();
+    const federationWindow = window as typeof window & {
+      __pwragentFederationTarget?: { scope: string; instanceId: string };
+    };
+    federationWindow.__pwragentFederationTarget = {
+      scope: "remote",
+      instanceId: "peer_polling",
+    };
+    const listeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const getMessagingPlatformStatuses = vi.fn(async () => []);
+    const desktopApi: DesktopApi = {
+      getMessagingPlatformStatuses,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => listeners.delete(callback);
+      },
+    };
+
+    try {
+      const view = render(<MessagingStatusBar desktopApi={desktopApi} />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(getMessagingPlatformStatuses).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        for (const listener of listeners) {
+          listener({
+            backend: "codex",
+            federationTarget: {
+              scope: "remote",
+              instanceId: "peer_polling",
+            },
+            notification: {
+              method: "federation/peerStatus/changed",
+              params: {
+                instanceId: "peer_polling",
+                status: "disconnected",
+              },
+            },
+          });
+        }
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(getMessagingPlatformStatuses).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        for (const listener of listeners) {
+          listener({
+            backend: "codex",
+            federationTarget: {
+              scope: "remote",
+              instanceId: "peer_polling",
+            },
+            notification: {
+              method: "federation/peerStatus/changed",
+              params: {
+                instanceId: "peer_polling",
+                status: "connected",
+              },
+            },
+          });
+        }
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(getMessagingPlatformStatuses).toHaveBeenCalledTimes(2);
+      view.unmount();
+    } finally {
+      delete federationWindow.__pwragentFederationTarget;
+      vi.useRealTimers();
+    }
+  });
 });
 
 function messagingSettingsSnapshot(enabled: {

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../lib/messaging-platform-branding";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { readRendererFederationTarget } from "../../lib/federation-window";
+import { useFederationPeerConnectivity } from "../../lib/useFederationPeerConnectivity";
 import { SettingsIcon } from "../../icons/SettingsIcon";
 import { useMessagingPlatformStatuses } from "./useMessagingPlatformStatuses";
 import type { DesktopApi } from "../../lib/desktop-api";
@@ -76,9 +77,14 @@ export function MessagingStatusBar(props: {
   const federationTarget = useMemo(() => readRendererFederationTarget(), []);
   const isFederationWindow = Boolean(federationTarget);
   const desktopApi = isFederationWindow ? undefined : props.desktopApi;
+  const peerConnectivity = useFederationPeerConnectivity({
+    desktopApi: props.desktopApi,
+    target: federationTarget,
+  });
   const { statuses, activeAtByPlatform } = useMessagingPlatformStatuses(
     props.desktopApi,
     federationTarget,
+    !peerConnectivity.connected,
   );
   const [open, setOpen] = useState(false);
   const [pinned, setPinned] = useState(false);

--- a/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
+++ b/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
@@ -26,6 +26,7 @@ const REMOTE_STATUS_POLL_INTERVAL_MS = 30_000;
 export function useMessagingPlatformStatuses(
   desktopApi: DesktopApi | undefined,
   federationTarget?: FederationRemoteTarget,
+  suspended = false,
 ): {
   statuses: MessagingPlatformStatus[];
   activeAtByPlatform: Record<string, number>;
@@ -37,6 +38,9 @@ export function useMessagingPlatformStatuses(
 
   useEffect(() => {
     if (!desktopApi?.getMessagingPlatformStatuses) {
+      return;
+    }
+    if (federationTarget && suspended) {
       return;
     }
     let cancelled = false;
@@ -91,7 +95,7 @@ export function useMessagingPlatformStatuses(
       cancelled = true;
       unsubscribe?.();
     };
-  }, [desktopApi, federationTarget]);
+  }, [desktopApi, federationTarget, suspended]);
 
   // Sweep stale activity timestamps so the dot stops blinking even if
   // we never receive an "activity end" event (we don't; the runtime

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -79,6 +79,8 @@ type SidebarProps = {
   error?: string;
   inboxThreads?: NavigationThreadSummary[];
   recentThreads?: NavigationThreadSummary[];
+  /** A snapshot exists even if its latest refresh failed. */
+  loaded?: boolean;
   loading: boolean;
   creatingThread?: {
     backend: AppServerBackendKind;
@@ -1555,7 +1557,7 @@ export function Sidebar(props: SidebarProps) {
         <div className="sidebar__scroll-region">
           {props.loading ? (
             <p className="sidebar-empty">Loading threads…</p>
-          ) : props.error ? (
+          ) : props.error && !props.loaded ? (
             <p className="sidebar-error">{props.error}</p>
           ) : props.browseMode === "directories" ? (
             <DirectoriesList

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -227,6 +227,46 @@ afterEach(() => {
 });
 
 describe("Sidebar", () => {
+  it("keeps a loaded thread snapshot visible when its refresh fails", () => {
+    const staleThread: NavigationThreadSummary = {
+      ...sharedThread,
+      federation: {
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "remote-instance" },
+          threadId: sharedThread.id,
+        },
+        instanceLabel: "Remote fixture",
+        peerStatus: "disconnected",
+      },
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        directories={directories}
+        error="Error invoking remote method: peer is not connected"
+        inboxThreads={[staleThread]}
+        loaded
+        loading={false}
+        selectedItemKey="codex:thread-1"
+        threads={[staleThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Cross-project cleanup" }),
+    ).toHaveClass("is-remote-offline");
+    expect(
+      screen.queryByText("Error invoking remote method: peer is not connected"),
+    ).not.toBeInTheDocument();
+  });
+
   it("labels a remote window without showing the controller's runtime identity", () => {
     (window as unknown as {
       __pwragentFederationLabel?: unknown;

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2292,7 +2292,7 @@ describe("ThreadView", () => {
     ).toHaveClass("composer__meta--error");
     expect(composerTextbox).toHaveAttribute(
       "contenteditable",
-      "false",
+      "true",
     );
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
@@ -524,4 +524,84 @@ describe("useBackendSummaries", () => {
       expect(listBackends).toHaveBeenCalledTimes(3);
     });
   });
+
+  it("preserves remote backend summaries while disconnected and refreshes on reconnect", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const codexBackend = {
+      kind: "codex" as const,
+      label: "OpenAI",
+      available: true,
+      methods: [],
+      capabilities: {
+        listThreads: true,
+        createThread: true,
+        resumeThread: true,
+        renameThread: true,
+        readThread: true,
+        startTurn: true,
+        interruptTurn: true,
+        steerTurn: false,
+        transcriptPagination: false,
+        toolUse: false,
+        approvalRequests: false,
+        multiDirectoryThreads: true,
+      },
+      executionModes: [],
+    };
+    let rejectOutageRead: ((error: Error) => void) | undefined;
+    const outageRead = new Promise<never>((_resolve, reject) => {
+      rejectOutageRead = reject;
+    });
+    const listBackends = vi
+      .fn<NonNullable<DesktopApi["listBackends"]>>()
+      .mockResolvedValueOnce({
+        fetchedAt: 1,
+        backends: [codexBackend],
+      })
+      .mockReturnValueOnce(outageRead)
+      .mockResolvedValueOnce({
+        fetchedAt: 2,
+        backends: [{ ...codexBackend, label: "OpenAI reconnected" }],
+      });
+    const desktopApi: DesktopApi = {
+      listBackends,
+    };
+    const { rerender, result } = renderHook(
+      ({ suspended }) => useBackendSummaries(desktopApi, {
+        federationTarget,
+        suspended,
+      }),
+      { initialProps: { suspended: false } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.backends[0]?.label).toBe("OpenAI");
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
+    });
+    await waitFor(() => {
+      expect(listBackends).toHaveBeenCalledTimes(2);
+    });
+    rerender({ suspended: true });
+    await act(async () => {
+      rejectOutageRead?.(new Error("Federation peer is not connected"));
+      await outageRead.catch(() => undefined);
+    });
+
+    expect(result.current.backends[0]?.label).toBe("OpenAI");
+    expect(result.current.error).toBeUndefined();
+    window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
+    expect(listBackends).toHaveBeenCalledTimes(2);
+
+    rerender({ suspended: false });
+    await waitFor(() => {
+      expect(result.current.backends[0]?.label).toBe("OpenAI reconnected");
+    });
+    expect(listBackends).toHaveBeenCalledTimes(3);
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useScheduledThreadActionProjection.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useScheduledThreadActionProjection.test.ts
@@ -136,6 +136,52 @@ describe("scheduled thread action projections", () => {
     vi.useRealTimers();
   });
 
+  it("suspends remote reconciliation until the peer reconnects", async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useComposerDraftStore());
+    const listScheduledThreadActions = vi.fn(async () => ({
+      actions: [],
+      observedAt: 1_000,
+    }));
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "peer-one",
+    };
+    const desktopApi = {
+      listScheduledThreadActions,
+      onAgentEvent: () => () => undefined,
+    } as unknown as DesktopApi;
+    const projection = renderHook(
+      ({ suspended }) => useScheduledThreadActionProjection({
+        composerDraftStore: result.current,
+        desktopApi,
+        federationTarget,
+        suspended,
+      }),
+      { initialProps: { suspended: false } },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(listScheduledThreadActions).toHaveBeenCalledTimes(1);
+
+    projection.rerender({ suspended: true });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+    expect(listScheduledThreadActions).toHaveBeenCalledTimes(1);
+
+    projection.rerender({ suspended: false });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(listScheduledThreadActions).toHaveBeenCalledTimes(2);
+
+    projection.unmount();
+    vi.useRealTimers();
+  });
+
   it("hydrates failures retained before the renderer subscribed", async () => {
     const { result } = renderHook(() => useComposerDraftStore());
     const listScheduledThreadActions = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2458,6 +2458,124 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("re-enables a locally mounted remote thread after reconnect", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const listeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    let peerStatus: "connected" | "disconnected" = "connected";
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-local", "codex:thread-remote"],
+      threads: [
+        {
+          id: "thread-local",
+          title: "Local thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+        },
+        {
+          id: "thread-remote",
+          title: "Mounted remote thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+          federation: {
+            ref: {
+              backend: "codex" as const,
+              target: federationTarget,
+              threadId: "thread-remote",
+            },
+            instanceLabel: "Remote fixture",
+            peerStatus,
+          },
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads[1]?.federation?.peerStatus).toBe(
+        "connected",
+      );
+    });
+
+    act(() => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          federationTarget,
+          notification: {
+            method: "federation/peerStatus/changed",
+            params: {
+              instanceId: "remote-instance",
+              status: "disconnected",
+              unavailableReason: "Federation gateway connection closed.",
+            },
+          },
+        });
+      }
+    });
+
+    expect(result.current.threads[0]?.federation).toBeUndefined();
+    expect(result.current.threads[1]?.federation?.peerStatus).toBe(
+      "disconnected",
+    );
+    // A mounted peer going away must not turn the otherwise-local main
+    // window into a global navigation error surface.
+    expect(result.current.error).toBeUndefined();
+
+    peerStatus = "connected";
+    act(() => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          federationTarget,
+          notification: {
+            method: "federation/peerStatus/changed",
+            params: {
+              instanceId: "remote-instance",
+              status: "connected",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+      expect(result.current.threads[1]?.federation?.peerStatus).toBe(
+        "connected",
+      );
+    });
+    expect(getNavigationSnapshot).toHaveBeenLastCalledWith({
+      forceRefresh: true,
+      refreshMode: "full",
+    });
+  });
+
   it("retries a failed remote snapshot until its route recovers", async () => {
     const federationTarget = {
       scope: "remote" as const,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2351,6 +2351,113 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("reconciles a status-only remote thread change after reconnect", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = federationTarget;
+    const listeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    let peerStatus: "connected" | "disconnected" = "connected";
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      federationTarget,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-remote"],
+      threads: [
+        {
+          id: "thread-remote",
+          title: "Unchanged remote title",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+          federation: {
+            ref: {
+              backend: "codex" as const,
+              target: federationTarget,
+              threadId: "thread-remote",
+            },
+            instanceLabel: "Remote fixture",
+            peerStatus,
+          },
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.federation?.peerStatus).toBe(
+        "connected",
+      );
+    });
+
+    act(() => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          federationTarget,
+          notification: {
+            method: "federation/peerStatus/changed",
+            params: {
+              instanceId: "remote-instance",
+              status: "disconnected",
+              unavailableReason: "Federation gateway connection closed.",
+            },
+          },
+        });
+      }
+    });
+
+    expect(result.current.selectedThread?.federation?.peerStatus).toBe(
+      "disconnected",
+    );
+
+    peerStatus = "connected";
+    act(() => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          federationTarget,
+          notification: {
+            method: "federation/peerStatus/changed",
+            params: {
+              instanceId: "remote-instance",
+              status: "connected",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+      expect(result.current.selectedThread?.federation?.peerStatus).toBe(
+        "connected",
+      );
+      expect(result.current.error).toBeUndefined();
+    });
+  });
+
   it("retries a failed remote snapshot until its route recovers", async () => {
     const federationTarget = {
       scope: "remote" as const,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2431,6 +2431,10 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedThread?.federation?.peerStatus).toBe(
       "disconnected",
     );
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
 
     peerStatus = "connected";
     act(() => {

--- a/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
+++ b/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
@@ -20,13 +20,19 @@ export function useBackendSummaries(
   options: {
     enabled?: boolean;
     federationTarget?: FederationTarget;
+    suspended?: boolean;
   } = {},
 ): BackendSummaryState {
   const enabled = options.enabled ?? true;
   const federationTarget = options.federationTarget;
+  const suspended = options.suspended ?? false;
   const [state, setState] = useState<BackendSummaryData>({
     backends: []
   });
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const suspendedRef = useRef(suspended);
+  suspendedRef.current = suspended;
   const acpRefreshPromiseRef =
     useRef<Promise<BackendSummary[]> | undefined>(undefined);
 
@@ -37,6 +43,10 @@ export function useBackendSummaries(
         error: undefined
       });
       return [];
+    }
+
+    if (suspended) {
+      return stateRef.current.backends;
     }
 
     if (!desktopApi?.listBackends) {
@@ -58,13 +68,19 @@ export function useBackendSummaries(
       });
       return response.backends;
     } catch (error) {
+      // A peer-status event can suspend this hook while an earlier remote
+      // read is still in flight. Keep the last usable summaries in that race;
+      // reconnecting changes `suspended` and immediately refreshes them.
+      if (suspendedRef.current) {
+        return stateRef.current.backends;
+      }
       setState({
         backends: [],
         error: error instanceof Error ? error.message : String(error)
       });
       return [];
     }
-  }, [desktopApi, enabled, federationTarget]);
+  }, [desktopApi, enabled, federationTarget, suspended]);
 
   const refreshAcpAgents = useCallback(async (): Promise<BackendSummary[]> => {
     if (federationTarget?.scope === "remote") {

--- a/apps/desktop/src/renderer/src/lib/useScheduledThreadActionProjection.ts
+++ b/apps/desktop/src/renderer/src/lib/useScheduledThreadActionProjection.ts
@@ -120,6 +120,7 @@ export function useScheduledThreadActionProjection(params: {
     params.composerDraftStore,
     params.desktopApi,
     params.federationTarget,
+    params.suspended,
   ]);
 }
 

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -714,6 +714,11 @@ function threadSummariesEqual(
     left.gitBranch === right.gitBranch &&
     left.observedGitBranch === right.observedGitBranch &&
     left.primaryGitRepository === right.primaryGitRepository &&
+    // Federation reachability changes independently of owner thread data.
+    // Include the whole stamp so a successful reconnect cannot reuse the
+    // previous disconnected row and leave it dimmed indefinitely.
+    JSON.stringify(left.federation ?? null) ===
+      JSON.stringify(right.federation ?? null) &&
     // Working state is probed on its own cadence (background refresh +
     // post-turn invalidation), independent of `updatedAt` — like PRs and
     // messaging bindings below. Without this check the reconciler would

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2656,6 +2656,7 @@ export function useThreadNavigation(
   const focusRefreshQueuedRef = useRef(false);
   const lastFocusRefreshCompletedAtRef = useRef(0);
   const remoteRecoveryAttemptRef = useRef(0);
+  const remotePeerDisconnectedRef = useRef(false);
   const lastNavigationActivityAtRef = useRef(Date.now());
   const backgroundRefreshIdleRef = useRef(false);
   const launchpadUpdateRevisionRef = useRef(new Map<string, number>());
@@ -2744,6 +2745,14 @@ export function useThreadNavigation(
         return;
       }
 
+      const federationTarget = readRendererFederationTarget();
+      if (federationTarget && remotePeerDisconnectedRef.current) {
+        // Peer-status events are the live connectivity source. While the
+        // route is known down, preserve the current response and let the
+        // connected transition below schedule the one authoritative refresh.
+        return;
+      }
+
       setState((current) => ({
         ...current,
         loading: !current.response,
@@ -2757,7 +2766,6 @@ export function useThreadNavigation(
           hasCurrentResponse: Boolean(stateRef.current.response),
           preferredSelectionKey: preferredSelectionKey ?? null,
         });
-        const federationTarget = readRendererFederationTarget();
         const snapshotRequest =
           options?.forceRefresh || options?.refreshMode || federationTarget
             ? {
@@ -3262,12 +3270,14 @@ export function useThreadNavigation(
           unavailableReason?: string;
         };
         if (params.status === "connected") {
+          remotePeerDisconnectedRef.current = false;
           scheduleRefresh(undefined, undefined, false, {
             forceRefresh: true,
             refreshMode: "full",
           });
           return;
         }
+        remotePeerDisconnectedRef.current = true;
         setState((current) => ({
           ...current,
           // Patch the live peer status onto the affected rows so surfaces


### PR DESCRIPTION
## Summary

- I keep the last successful remote navigation snapshot visible during a federation outage, with disconnected rows dimmed instead of replacing the whole list with a raw IPC error.
- I keep composer text and image attachments visible and editable while remote submission is unavailable; Send and other remote actions remain disabled until reconnection.
- I reconcile federation status changes even when owner thread data is otherwise unchanged, so recovered rows no longer remain stuck in the disconnected visual state.
- I classify a known missing federation route as expected transient unavailability and serve the last successful navigation, scheduled-action, and messaging-status reads without rejecting through Electron or printing handler stack traces.
- I suspend remote navigation, scheduled-action, messaging-status, and backend-summary reads while the peer is known disconnected, coalesce in-flight reads, and refresh every affected surface immediately after reconnection.
- I preserve the last usable backend capabilities across the outage so reconnection also releases the composer Send guard.
- I continue to reject unexpected protocol, payload, authorization, and other failures so actionable diagnostics are preserved.

## Verification

- I ran the reconnect-focused main-process, IPC, renderer, composer, and navigation suites: 704 tests passed.
- I ran `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:boundaries`, and `pnpm lint:codex-storage` successfully.

## Notes

- I expanded the federation remote-window Electron E2E scenario to cover stale-list visibility, editable draft preservation, disabled sending during the outage, and complete visual and submission recovery after reconnection.
- GitHub Actions reproduced the missing backend-summary recovery on both Linux and macOS; the new focused hook test covers the in-flight disconnect race and refresh on reconnect.
- I did not run the headed Electron E2E locally because the repository requires the operator's off-desktop lab for headed desktop E2E runs; its TypeScript is covered by the desktop typecheck.
