### PR TITLE
fix(desktop): copy complete repair failure notice

### DIFF
--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -83,7 +83,12 @@ export function AppNoticeToast(props: {
 
   const copyValue =
     props.notice.copyText ??
-    [props.notice.title, props.notice.message, props.notice.detail]
+    [
+      props.notice.title,
+      props.notice.status?.label,
+      props.notice.message,
+      props.notice.detail,
+    ]
       .filter(Boolean)
       .join("\n");
   const customActions = props.notice.actions ?? [];

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -41,6 +41,36 @@ describe("AppNoticeToast", () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
+  it("includes the visible status in the default copy value", () => {
+    const copyText = vi.fn(async () => undefined);
+    const repairNotice = {
+      ...notice,
+      status: {
+        label: "Automatic repair failed: rollout belongs to another thread",
+        state: "error" as const,
+      },
+      title: "Codex repair failed",
+    };
+
+    render(
+      <AppNoticeToast
+        desktopApi={{ copyText }}
+        notice={repairNotice}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy notice" }));
+    expect(copyText).toHaveBeenCalledWith(
+      [
+        repairNotice.title,
+        repairNotice.status.label,
+        repairNotice.message,
+        repairNotice.detail,
+      ].join("\n"),
+    );
+  });
+
   it("marks warning notices for high-contrast styling", () => {
     render(
       <AppNoticeToast

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/backend-error-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/backend-error-notice.test.ts
@@ -22,7 +22,6 @@ describe("resolveBackendErrorNotice", () => {
     );
     expect(repairing).toEqual({
       autoDismiss: false,
-      copyText: invalidIdFailure,
       detail: "Fix the flaky test",
       id: "codex-invalid-id-recovery:codex:thread-1:turn-9",
       message: invalidIdFailure,
@@ -48,7 +47,6 @@ describe("resolveBackendErrorNotice", () => {
     );
     expect(succeeded).toMatchObject({
       autoDismiss: true,
-      copyText: invalidIdFailure,
       id: repairing?.id,
       status: {
         label: "Saved history repaired. Your message was retried.",
@@ -59,7 +57,7 @@ describe("resolveBackendErrorNotice", () => {
     });
   });
 
-  it("keeps a failed Codex repair sticky with both errors visible or copyable", () => {
+  it("keeps a failed Codex repair sticky and uses the complete notice copy", () => {
     const notice = resolveBackendErrorNotice(
       {
         kind: "codex-invalid-id-recovery",
@@ -74,7 +72,6 @@ describe("resolveBackendErrorNotice", () => {
     );
     expect(notice).toMatchObject({
       autoDismiss: false,
-      copyText: invalidIdFailure,
       message: invalidIdFailure,
       status: {
         label:
@@ -84,6 +81,7 @@ describe("resolveBackendErrorNotice", () => {
       title: "Codex repair failed",
       tone: "error",
     });
+    expect(notice).not.toHaveProperty("copyText");
   });
 
   it("builds a sticky, thread-scoped, copyable notice for a failed turn", () => {

--- a/apps/desktop/src/renderer/src/features/notifications/backend-error-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/backend-error-notice.ts
@@ -49,7 +49,6 @@ export function resolveBackendErrorNotice(
 ): AppNoticeToastNotice | undefined {
   if (signal.kind === "codex-invalid-id-recovery") {
     const baseNotice = {
-      copyText: signal.failureMessage,
       detail: signal.threadLabel,
       id:
         `codex-invalid-id-recovery:codex:${signal.threadId}:${signal.turnId}`,


### PR DESCRIPTION
## What changed

- Include a toast's visible status text in its default clipboard payload.
- Let Codex invalid-ID recovery notices use that complete visible-content payload instead of overriding it with only the original backend failure.
- Add regression coverage for the full copied repair-failure notice.

## Why

When automatic Codex thread repair failed, the toast showed both the original API error and PwrAgent's repair error, but Copy only captured the API error. The recovery notice's custom `copyText` omitted the repair status, and the default toast copy path did not include status text.

Copy now follows the rendered order: title, repair status/error, original backend error, and thread label.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx apps/desktop/src/renderer/src/features/notifications/__tests__/backend-error-notice.test.ts` (17 tests passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)

GitHub Actions is experiencing a known outage while this PR is being opened, so hosted checks may fail to start or report correctly; local validation above is authoritative for this change.
