### PR TITLE
fix(desktop): repair forked Codex histories

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1359,7 +1359,11 @@ class MockBackendClient {
   startTurnCalls: Array<NonNullable<MockBackendClient["lastStartTurnParams"]>> = [];
   startTurnCallCount = 0;
   closeCallCount = 0;
-  invalidIdRecoveryCalls: Array<{ failureMessage: string; threadId: string }> = [];
+  invalidIdRecoveryCalls: Array<{
+    failureMessage: string;
+    forkLineageThreadIds?: string[];
+    threadId: string;
+  }> = [];
   lastSteerTurnParams?: {
     threadId: string;
     input: AppServerTurnInputItem[];
@@ -1727,6 +1731,7 @@ class MockBackendClient {
 
   async recoverInvalidPersistedResponseMessageIds(params: {
     failureMessage: string;
+    forkLineageThreadIds?: string[];
     threadId: string;
   }): Promise<{
     backupPath: string;
@@ -8018,6 +8023,8 @@ script = "echo setup"
 
   it("repairs an exact invalid message-ID failure and retries the turn once", async () => {
     const threadId = "019fb6c7-1545-77c1-be52-98f86cae3c11";
+    const forkSourceThreadId = "019fb6c7-1545-77c1-be52-98f86cae3c10";
+    const forkRootThreadId = "019fb6c7-1545-77c1-be52-98f86cae3c0f";
     const backupPath = "/codex/sessions/thread.invalid-id-backup.jsonl";
     const codexClient = new MockBackendClient({
       initializeResult: {
@@ -8034,7 +8041,24 @@ script = "echo setup"
         threadId,
       },
     });
-    const overlayStore = createOverlayStoreMock();
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        [`codex:${threadId}`]: {
+          backend: "codex",
+          threadId,
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          forkSourceThreadId,
+        },
+        [`codex:${forkSourceThreadId}`]: {
+          backend: "codex",
+          threadId: forkSourceThreadId,
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          forkSourceThreadId: forkRootThreadId,
+        },
+      },
+    });
     const registry = new DesktopBackendRegistry({
       codexClient,
       grokClient: new MockBackendClient({}),
@@ -8085,6 +8109,10 @@ script = "echo setup"
 
     expect(codexClient.invalidIdRecoveryCalls).toEqual([
       {
+        forkLineageThreadIds: [
+          forkSourceThreadId,
+          forkRootThreadId,
+        ],
         failureMessage: expect.stringContaining("[invalid_id_prefix]"),
         threadId,
       },

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2062,6 +2062,7 @@ describe("CodexAppServerClient", () => {
 
   it("stops Codex, repairs the protocol-identified rollout, reloads, and resumes", async () => {
     const threadId = "019fb6c7-1545-77c1-be52-98f86cae3c11";
+    const forkSourceThreadId = "019fb6c7-1545-77c1-be52-98f86cae3c10";
     const tempRoot = await fs.mkdtemp(
       path.join(os.tmpdir(), "pwragent-codex-client-id-recovery-"),
     );
@@ -2077,7 +2078,10 @@ describe("CodexAppServerClient", () => {
       [
         JSON.stringify({
           type: "session_meta",
-          payload: { id: threadId, session_id: threadId },
+          payload: {
+            id: forkSourceThreadId,
+            session_id: forkSourceThreadId,
+          },
         }),
         JSON.stringify({
           type: "response_item",
@@ -2123,6 +2127,7 @@ describe("CodexAppServerClient", () => {
           "[ApiIdParam] [input[1].id] [invalid_id_prefix] "
           + "Invalid 'input[1].id': 'review_rollout_user'. "
           + "Expected an ID that begins with 'msg'.",
+        forkLineageThreadIds: [forkSourceThreadId],
         threadId,
       });
       const transport = MockTransport.instances.at(-1)!;

--- a/apps/desktop/src/main/__tests__/invalid-response-message-id-recovery.test.ts
+++ b/apps/desktop/src/main/__tests__/invalid-response-message-id-recovery.test.ts
@@ -128,6 +128,32 @@ describe("invalid persisted Codex response-message ID recovery", () => {
     );
   });
 
+  it("repairs a fork rollout carrying authorized source-thread metadata", async () => {
+    const sourceThreadId = "019fb19b-637e-72f0-b567-56f624e2ee2c";
+    const forkThreadId = "019fb19b-637e-72f0-b567-56f624e2ee2d";
+    const fixture = await readFile(
+      path.join(fixtureRoot, "bare-uuid-message-id.jsonl"),
+    );
+    const target = await createRolloutTarget({
+      fixture,
+      threadId: forkThreadId,
+    });
+
+    const result = await repairCodexInvalidResponseMessageIds({
+      codexHome: target.codexHome,
+      forkLineageThreadIds: [sourceThreadId],
+      rolloutPath: target.rolloutPath,
+      threadId: forkThreadId,
+      uniqueSuffix: () => "fork-backup",
+    });
+
+    expect(result.removedMessageIdCount).toBe(1);
+    const records = await readJsonl(target.rolloutPath);
+    expect(records[0]!.payload.id).toBe(sourceThreadId);
+    expect(records[0]!.payload.session_id).toBe(sourceThreadId);
+    expect(records[1]!.payload).not.toHaveProperty("id");
+  });
+
   it("rejects a rollout path outside the configured Codex session roots", async () => {
     const threadId = "019fb19b-637e-72f0-b567-56f624e2ee2c";
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-codex-id-path-"));

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -657,6 +657,7 @@ type BackendClient = {
   }>;
   recoverInvalidPersistedResponseMessageIds?(params: {
     failureMessage: string;
+    forkLineageThreadIds?: string[];
     threadId: string;
   }): Promise<CodexInvalidResponseMessageIdRecoveryResult>;
   startReview?(params: {
@@ -16013,7 +16014,14 @@ export class DesktopBackendRegistry {
       const recovery = this.pendingCodexInvalidIdRecoveries.shift()!;
       let retrySubmitted = false;
       try {
+        const forkLineageThreadIds =
+          await this.resolveCodexInvalidIdRecoveryForkLineage(
+            recovery.params.threadId,
+          );
         const repaired = await recover.call(this.codexClient, {
+          ...(forkLineageThreadIds.length > 0
+            ? { forkLineageThreadIds }
+            : {}),
           failureMessage: recovery.failureMessage,
           threadId: recovery.params.threadId,
         });
@@ -16177,6 +16185,32 @@ export class DesktopBackendRegistry {
           });
         }
       }
+    }
+  }
+
+  private async resolveCodexInvalidIdRecoveryForkLineage(
+    threadId: string,
+  ): Promise<string[]> {
+    const lineage: string[] = [];
+    const seen = new Set([threadId]);
+    let currentThreadId = threadId;
+    while (true) {
+      const overlay = await this.overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: currentThreadId,
+      });
+      const sourceThreadId = overlay?.forkSourceThreadId?.trim();
+      if (!sourceThreadId) {
+        return lineage;
+      }
+      if (seen.has(sourceThreadId)) {
+        throw new Error(
+          `Codex invalid-message-ID recovery found cyclic fork provenance for thread ${threadId}`,
+        );
+      }
+      seen.add(sourceThreadId);
+      lineage.push(sourceThreadId);
+      currentThreadId = sourceThreadId;
     }
   }
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -6897,6 +6897,7 @@ export class CodexAppServerClient {
 
   async recoverInvalidPersistedResponseMessageIds(params: {
     failureMessage: string;
+    forkLineageThreadIds?: string[];
     threadId: string;
   }): Promise<CodexInvalidResponseMessageIdRecoveryResult> {
     if (!isCodexInvalidResponseMessageIdError(params.failureMessage)) {
@@ -6947,6 +6948,7 @@ export class CodexAppServerClient {
     try {
       recoveryResult = await repairCodexInvalidResponseMessageIds({
         codexHome,
+        forkLineageThreadIds: params.forkLineageThreadIds,
         rolloutPath,
         threadId: params.threadId,
       });

--- a/apps/desktop/src/main/codex-app-server/invalid-response-message-id-recovery.ts
+++ b/apps/desktop/src/main/codex-app-server/invalid-response-message-id-recovery.ts
@@ -30,12 +30,21 @@ export function isCodexInvalidResponseMessageIdError(error: unknown): boolean {
 
 export async function repairCodexInvalidResponseMessageIds(params: {
   codexHome: string;
+  forkLineageThreadIds?: string[];
   now?: () => number;
   rolloutPath: string;
   threadId: string;
   uniqueSuffix?: () => string;
 }): Promise<CodexInvalidResponseMessageIdRecoveryResult> {
   assertCodexThreadId(params.threadId);
+  const allowedSessionMetadataThreadIds = new Set([params.threadId]);
+  // Codex thread/fork can preserve an ancestor's session metadata in the
+  // child-named rollout. The caller derives these IDs from PwrAgent-owned fork
+  // provenance; arbitrary alternate thread IDs must never be supplied here.
+  for (const threadId of params.forkLineageThreadIds ?? []) {
+    assertCodexThreadId(threadId);
+    allowedSessionMetadataThreadIds.add(threadId);
+  }
   const rolloutPath = await resolveAuthorizedRolloutPath({
     codexHome: params.codexHome,
     rolloutPath: params.rolloutPath,
@@ -53,6 +62,7 @@ export async function repairCodexInvalidResponseMessageIds(params: {
   }
 
   const repaired = repairJsonlText({
+    allowedSessionMetadataThreadIds,
     source: originalText,
     threadId: params.threadId,
     rolloutPath,
@@ -115,6 +125,7 @@ export async function repairCodexInvalidResponseMessageIds(params: {
 }
 
 function repairJsonlText(params: {
+  allowedSessionMetadataThreadIds: ReadonlySet<string>;
   rolloutPath: string;
   source: string;
   threadId: string;
@@ -147,7 +158,7 @@ function repairJsonlText(params: {
     const sessionMetadata = readSessionMetadataThreadIds(record);
     if (sessionMetadata.length > 0) {
       const wrongThreadId = sessionMetadata.find(
-        (threadId) => threadId !== params.threadId,
+        (threadId) => !params.allowedSessionMetadataThreadIds.has(threadId),
       );
       if (wrongThreadId) {
         throw new Error(


### PR DESCRIPTION
## Summary

- authorize automatic invalid-message-ID recovery against PwrAgent-recorded Codex fork ancestry
- preserve exact protocol path, child rollout filename, session root, symlink, and metadata validation
- cover direct and nested fork lineage while continuing to reject unrelated thread metadata

## Root cause

Codex `thread/fork` can preserve the source thread `session_meta` inside the child-named rollout. PwrAgent selected the correct child path through the Codex App Server protocol, but the recovery validator required every session metadata ID to equal the child ID. That made legitimate fork provenance look like a misrouted recovery target.

The registry now walks only PwrAgent-owned `forkSourceThreadId` provenance and passes that bounded lineage into the repair helper. Arbitrary alternate thread IDs still fail closed.

## Impact

Forked Codex threads containing legacy review message IDs such as `review_rollout_user` can be repaired, backed up, resumed, and retried once instead of remaining permanently blocked.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/invalid-response-message-id-recovery.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts` — 595 passed
- `pnpm typecheck`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — 0 errors; existing warning baseline only
- `pnpm lint:codex-storage`
- `pnpm lint:boundaries`
- `git diff --check`

## CI note

GitHub Actions is experiencing an outage while this PR is being opened. Job-start failures are expected infrastructure noise; local validation above completed successfully.