### PR TITLE
feat(desktop): add per-line log copy

### DIFF
--- a/apps/desktop/src/renderer/src/features/logs/LogsWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/logs/LogsWindow.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import type { AppLogEntry, AppLogSnapshot } from "../../../../shared/app-metadata";
-import { CopyIcon, FolderIcon } from "../../icons";
+import { CheckIcon, CopyIcon, FolderIcon } from "../../icons";
 import { copyText } from "../../lib/copy-text";
 import { useDesktopApi } from "../../lib/desktop-api";
 
@@ -72,12 +72,14 @@ export function LogsWindow() {
   const syncDebugCollectionRef = useRef<() => void>(() => undefined);
   const entryBufferRef = useRef(createRenderedLogEntryBuffer());
   const copyResetTimerRef = useRef<number | undefined>(undefined);
+  const lineCopyResetTimerRef = useRef<number | undefined>(undefined);
   const [renderVersion, setRenderVersion] = useState(0);
   const [truncated, setTruncated] = useState(false);
   const [logFilePath, setLogFilePath] = useState<string | undefined>(
     readBootstrapLogFilePath,
   );
   const [copiedLogFilePath, setCopiedLogFilePath] = useState(false);
+  const [copiedLineNumber, setCopiedLineNumber] = useState<number | undefined>();
   const [error, setError] = useState<string | undefined>();
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState("");
@@ -148,6 +150,9 @@ export function LogsWindow() {
     return () => {
       if (copyResetTimerRef.current) {
         window.clearTimeout(copyResetTimerRef.current);
+      }
+      if (lineCopyResetTimerRef.current) {
+        window.clearTimeout(lineCopyResetTimerRef.current);
       }
     };
   }, []);
@@ -348,6 +353,26 @@ export function LogsWindow() {
     });
   }, [desktopApi, logFilePath]);
 
+  const handleCopyLogLine = useCallback(
+    (lineNumber: number, text: string) => {
+      void copyText(text, desktopApi)
+        .then(() => {
+          if (lineCopyResetTimerRef.current) {
+            window.clearTimeout(lineCopyResetTimerRef.current);
+          }
+          setCopiedLineNumber(lineNumber);
+          lineCopyResetTimerRef.current = window.setTimeout(() => {
+            setCopiedLineNumber(undefined);
+            lineCopyResetTimerRef.current = undefined;
+          }, 1400);
+        })
+        .catch((copyError: unknown) => {
+          console.error("Failed to copy log line", copyError);
+        });
+    },
+    [desktopApi],
+  );
+
   const activeMatchLabel =
     rendered.matchCount > 0 ? `${activeMatchIndex + 1} / ${rendered.matchCount}` : "0";
 
@@ -500,8 +525,10 @@ export function LogsWindow() {
                   <LogLine
                     key={line.lineNumber}
                     activeMatchIndex={activeMatchIndex}
+                    copied={copiedLineNumber === line.lineNumber}
                     line={line}
                     activeMatchRef={activeMatchRef}
+                    onCopy={handleCopyLogLine}
                   />
                 ))}
               </pre>
@@ -579,14 +606,36 @@ function shouldShowLogEntry(
 function LogLine(props: {
   activeMatchIndex: number;
   activeMatchRef: MutableRefObject<HTMLElement | null>;
+  copied: boolean;
   line: RenderedLogLine;
+  onCopy: (lineNumber: number, text: string) => void;
 }) {
   const levelClass = props.line.level
     ? ` log-window__line--${props.line.level}`
     : "";
+  const copyLabel = props.copied
+    ? `Copied line ${props.line.lineNumber}`
+    : `Copy line ${props.line.lineNumber}`;
+  const lineText = props.line.parts.map((part) => part.text).join("");
   return (
     <span className={`log-window__line${levelClass}`}>
-      <span className="log-window__line-number">{props.line.lineNumber}</span>
+      <span className="log-window__line-gutter">
+        <button
+          aria-label={copyLabel}
+          className="log-window__line-copy"
+          data-copied={props.copied ? "true" : undefined}
+          title={copyLabel}
+          type="button"
+          onClick={() => props.onCopy(props.line.lineNumber, lineText)}
+        >
+          {props.copied ? (
+            <CheckIcon aria-hidden="true" size={12} />
+          ) : (
+            <CopyIcon aria-hidden="true" size={12} />
+          )}
+        </button>
+        <span className="log-window__line-number">{props.line.lineNumber}</span>
+      </span>
       <span className="log-window__line-text">
         {props.line.parts.map((part, index) =>
           renderLogLinePart({

--- a/apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx
@@ -196,6 +196,43 @@ describe("LogsWindow", () => {
     });
   });
 
+  it("copies an individual log line without its line number", async () => {
+    const copyText = vi.fn(async () => undefined);
+    const desktopApi = {
+      copyText,
+      readAppLogSnapshot: vi.fn(async () => ({
+        kind: "log-snapshot",
+        title: "Logs",
+        debugCollectionEnabled: false,
+        entries: [
+          {
+            sequence: 1,
+            timestamp: Date.now(),
+            level: "info",
+            line: "[2026-05-12 20:06:28.722] [info] (pwragent:main) exact line",
+          },
+        ],
+        readAt: Date.now(),
+        truncated: false,
+      })),
+      onAppLogEntry: vi.fn(() => () => undefined),
+    } as unknown as DesktopApi;
+    (window as Window & { pwragent?: DesktopApi }).pwragent = desktopApi;
+
+    render(<LogsWindow />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Copy line 1" }));
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(
+        "[2026-05-12 20:06:28.722] [info] (pwragent:main) exact line",
+      );
+    });
+    expect(
+      screen.getByRole("button", { name: "Copied line 1" }),
+    ).toBeInTheDocument();
+  });
+
   it("defaults to Error, Warning, and Info toggles with Debug off", async () => {
     const entries = [
       {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2292,19 +2292,72 @@ textarea,
   background: var(--danger-surface);
 }
 
-.log-window__line-number {
+.log-window__line-gutter {
   display: inline-block;
   position: sticky;
   left: 0;
   width: 56px;
   margin-right: 12px;
-  padding: 0 10px;
   border-right: 1px solid var(--border-subtle);
   background: var(--bg-sidebar);
-  color: var(--text-subtle);
-  text-align: right;
   user-select: none;
   -webkit-user-select: none;
+}
+
+.log-window__line-number {
+  display: block;
+  padding: 0 10px;
+  color: var(--text-subtle);
+  text-align: right;
+  transition: opacity 120ms ease;
+}
+
+.log-window__line-copy {
+  display: inline-flex;
+  position: absolute;
+  inset: 0 5px 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 18px;
+  margin: auto 0;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: var(--bg-sidebar);
+  color: var(--text-muted);
+  opacity: 0;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease,
+    opacity 120ms ease;
+}
+
+.log-window__line:hover .log-window__line-number,
+.log-window__line:focus-within .log-window__line-number,
+.log-window__line-copy[data-copied="true"] + .log-window__line-number {
+  opacity: 0;
+}
+
+.log-window__line:hover .log-window__line-copy,
+.log-window__line:focus-within .log-window__line-copy,
+.log-window__line-copy[data-copied="true"] {
+  opacity: 1;
+}
+
+.log-window__line-copy:hover,
+.log-window__line-copy:focus-visible,
+.log-window__line-copy[data-copied="true"] {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
+.log-window__line-copy:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
 }
 
 .log-window__line-text {


### PR DESCRIPTION
## Summary

- add a copy control to the sticky left gutter of every Logs viewer line
- reveal the control on row hover or keyboard focus, then show a copied check state
- copy the exact raw log line without its displayed line number or a trailing newline
- cover the clipboard payload and copied-state accessibility label with a focused test

## Why

Long log entries are difficult to select completely with a mouse. A line-level action makes copying the full entry reliable and immediate.

## User impact

Operators can hover any log row and copy the complete entry from the left gutter. The control is also keyboard accessible and uses the existing theme tokens for hover, focus, and confirmation states.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx`
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:colors`
- `pnpm lint:boundaries`
