### PR TITLE
fix(federation): relay remote terminals through gateways

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-pty-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-pty-service.test.ts
@@ -437,6 +437,7 @@ describe("federation pty router integration", () => {
     method: string,
     params: unknown,
     sourceInstanceId: string,
+    hopCount?: number,
   ): FederationRequestEnvelope {
     return {
       id: `req-${method}-${sourceInstanceId}`,
@@ -447,17 +448,18 @@ describe("federation pty router integration", () => {
       sourceInstanceId,
       targetInstanceId: "owner",
       createdAt: Date.now(),
+      hopCount,
     };
   }
 
   function createRouterHarness() {
-    const { service, sent } = createHarness();
+    const { pty, service, sent } = createHarness();
     const router = new FederationRouter({
       localInstanceId: "owner",
       methodCapabilities: { ...FEDERATION_PTY_METHOD_CAPABILITIES },
     });
     registerFederationPtyHandlers({ router, service });
-    return { router, sent, service };
+    return { pty, router, sent, service };
   }
 
   it("rejects pty methods from a peer without remote_pty", async () => {
@@ -477,21 +479,67 @@ describe("federation pty router integration", () => {
     });
   });
 
-  it("rejects a gateway-relayed open instead of streaming through a relay", async () => {
+  it("keeps a gateway-relayed session bound to its originating viewer", async () => {
+    const { pty, router, service } = createRouterHarness();
+    router.registerConnection({
+      peerId: "gateway",
+      capabilities: ["remote_pty", "gateway_relay"],
+      sendEnvelope: () => undefined,
+    });
+    const opened = await router.routeEnvelope({
+      envelope: buildEnvelope(
+        FEDERATION_PTY_METHODS.open,
+        OPEN_REQUEST,
+        "viewer",
+        1,
+      ),
+      sourcePeerId: "gateway",
+    });
+    expect(opened).toMatchObject({ status: "handled" });
+    expect(service.sessionCountForPeer("viewer")).toBe(1);
+    expect(service.sessionCountForPeer("gateway")).toBe(0);
+    const sessionId = (
+      opened as { response: { result: { sessionId: string } } }
+    ).response.result.sessionId;
+
+    await expect(router.routeEnvelope({
+      envelope: buildEnvelope(
+        FEDERATION_PTY_METHODS.input,
+        {
+          sessionId,
+          dataBase64: Buffer.from("pwd\r").toString("base64"),
+        },
+        "viewer",
+        1,
+      ),
+      sourcePeerId: "gateway",
+    })).resolves.toMatchObject({ status: "handled" });
+    expect(pty.written).toEqual(["pwd\r"]);
+
+    await expect(router.routeEnvelope({
+      envelope: buildEnvelope(
+        FEDERATION_PTY_METHODS.input,
+        { sessionId, dataBase64: "" },
+        "other_viewer",
+        1,
+      ),
+      sourcePeerId: "gateway",
+    })).resolves.toMatchObject({ status: "rejected" });
+  });
+
+  it("rejects a claimed relayed origin without a relay hop", async () => {
     const { router } = createRouterHarness();
     router.registerConnection({
       peerId: "gateway",
       capabilities: ["remote_pty", "gateway_relay"],
       sendEnvelope: () => undefined,
     });
-    // The envelope claims to originate from "viewer" but arrived over the
-    // gateway's authenticated link.
     const result = await router.routeEnvelope({
       envelope: buildEnvelope(FEDERATION_PTY_METHODS.open, OPEN_REQUEST, "viewer"),
       sourcePeerId: "gateway",
     });
     expect(result).toMatchObject({ status: "rejected" });
-    expect((result as { message?: string }).message).toMatch(/point-to-point/);
+    expect((result as { message?: string }).message).toMatch(/relay is not authorized/);
   });
 
   it("opens a session for a directly connected peer with remote_pty", async () => {

--- a/apps/desktop/src/main/__tests__/federation-pty-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-pty-service.test.ts
@@ -456,6 +456,7 @@ describe("federation pty router integration", () => {
     const { pty, service, sent } = createHarness();
     const router = new FederationRouter({
       localInstanceId: "owner",
+      trustedRelayPeerId: "gateway",
       methodCapabilities: { ...FEDERATION_PTY_METHOD_CAPABILITIES },
     });
     registerFederationPtyHandlers({ router, service });
@@ -538,8 +539,32 @@ describe("federation pty router integration", () => {
       envelope: buildEnvelope(FEDERATION_PTY_METHODS.open, OPEN_REQUEST, "viewer"),
       sourcePeerId: "gateway",
     });
-    expect(result).toMatchObject({ status: "rejected" });
-    expect((result as { message?: string }).message).toMatch(/relay is not authorized/);
+    expect(result).toMatchObject({
+      status: "rejected",
+      code: "relay_origin_mismatch",
+    });
+  });
+
+  it("rejects a fabricated origin from a non-gateway peer", async () => {
+    const { router } = createRouterHarness();
+    router.registerConnection({
+      peerId: "other_peer",
+      capabilities: ["remote_pty", "gateway_relay"],
+      sendEnvelope: () => undefined,
+    });
+    const result = await router.routeEnvelope({
+      envelope: buildEnvelope(
+        FEDERATION_PTY_METHODS.open,
+        OPEN_REQUEST,
+        "fabricated_viewer",
+        1,
+      ),
+      sourcePeerId: "other_peer",
+    });
+    expect(result).toMatchObject({
+      status: "rejected",
+      code: "relay_origin_mismatch",
+    });
   });
 
   it("opens a session for a directly connected peer with remote_pty", async () => {

--- a/apps/desktop/src/main/__tests__/federation-router.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-router.test.ts
@@ -158,6 +158,66 @@ describe("FederationRouter", () => {
     ]);
   });
 
+  it("authenticates relayed origins against the configured upstream gateway", async () => {
+    const relayed: FederationProtocolEnvelope[] = [];
+    const rejected: FederationProtocolEnvelope[] = [];
+    const gatewayRouter = new FederationRouter({
+      localInstanceId: "gateway_one",
+    });
+    gatewayRouter.registerConnection({
+      peerId: "client_one",
+      capabilities: ["gateway_relay"],
+      sendEnvelope: (envelope) => rejected.push(envelope),
+    });
+    gatewayRouter.registerConnection({
+      peerId: "client_two",
+      capabilities: ["gateway_relay"],
+      sendEnvelope: (envelope) => relayed.push(envelope),
+    });
+    const forged = {
+      id: "forged-relay-1",
+      kind: "request" as const,
+      method: "thread.read",
+      params: {},
+      protocolVersion: 1 as const,
+      sourceInstanceId: "fabricated_viewer",
+      targetInstanceId: "client_two",
+      createdAt: 1_000,
+      hopCount: 1,
+    };
+
+    await expect(gatewayRouter.routeEnvelope({
+      sourcePeerId: "client_one",
+      envelope: forged,
+    })).resolves.toMatchObject({
+      status: "rejected",
+      code: "relay_origin_mismatch",
+    });
+    expect(relayed).toEqual([]);
+    expect(rejected).toMatchObject([
+      { kind: "error", error: { code: "relay_origin_mismatch" } },
+    ]);
+
+    const ownerRouter = new FederationRouter({
+      localInstanceId: "client_two",
+      trustedRelayPeerId: "gateway_one",
+    });
+    ownerRouter.registerConnection({
+      peerId: "gateway_one",
+      capabilities: ["gateway_relay"],
+      sendEnvelope: () => undefined,
+    });
+    ownerRouter.registerHandler("thread.read", () => ({ ok: true }));
+    await expect(ownerRouter.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
+        ...forged,
+        sourceInstanceId: "client_one",
+        targetInstanceId: "client_two",
+      },
+    })).resolves.toMatchObject({ status: "handled" });
+  });
+
   it("requires scheduler authorization before invoking a durable steer fallback", async () => {
     let handled = 0;
     const router = new FederationRouter({

--- a/apps/desktop/src/main/__tests__/federation-router.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-router.test.ts
@@ -97,6 +97,67 @@ describe("FederationRouter", () => {
     ]);
   });
 
+  it("enforces method capabilities on the originating peer before relaying", async () => {
+    const replies: FederationProtocolEnvelope[] = [];
+    const relayed: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "gateway_one",
+      methodCapabilities: {
+        "pty.open": "remote_pty",
+      },
+    });
+    router.registerConnection({
+      peerId: "client_one",
+      capabilities: ["gateway_relay"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    router.registerConnection({
+      peerId: "client_two",
+      capabilities: ["gateway_relay", "remote_pty"],
+      sendEnvelope: (envelope) => relayed.push(envelope),
+    });
+    const request = {
+      id: "pty-open-1",
+      kind: "request" as const,
+      method: "pty.open",
+      params: {},
+      protocolVersion: 1 as const,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "client_two",
+      createdAt: 1_000,
+    };
+
+    await expect(router.routeEnvelope({
+      sourcePeerId: "client_one",
+      envelope: request,
+    })).resolves.toMatchObject({
+      status: "rejected",
+      code: "capability_denied",
+    });
+    expect(relayed).toEqual([]);
+    expect(replies).toMatchObject([
+      { kind: "error", error: { code: "capability_denied" } },
+    ]);
+
+    router.registerConnection({
+      peerId: "client_one",
+      capabilities: ["gateway_relay", "remote_pty"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    await expect(router.routeEnvelope({
+      sourcePeerId: "client_one",
+      envelope: request,
+    })).resolves.toMatchObject({ status: "relayed" });
+    expect(relayed).toMatchObject([
+      {
+        method: "pty.open",
+        sourceInstanceId: "client_one",
+        targetInstanceId: "client_two",
+        hopCount: 1,
+      },
+    ]);
+  });
+
   it("requires scheduler authorization before invoking a durable steer fallback", async () => {
     let handled = 0;
     const router = new FederationRouter({

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -57,6 +57,10 @@ type RuntimeHarness = {
     }) => void,
   ) => () => void;
   remotePeerDirectory: Map<FederationInstanceId, unknown>;
+  ptyService?: {
+    notifyPeerConnected: (peerId: FederationInstanceId) => void;
+    notifyPeerDisconnected: (peerId: FederationInstanceId) => void;
+  };
   onPeerStatusChanged: (listener: () => void) => () => void;
   recordClientConnection: (params: {
     gatewayInstanceId: FederationInstanceId;
@@ -389,6 +393,70 @@ describe("DesktopFederationRuntime", () => {
     ]);
   });
 
+  it("propagates advertised viewer disconnects and reconnects to remote PTY sessions", () => {
+    const connected: FederationInstanceId[] = [];
+    const disconnected: FederationInstanceId[] = [];
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "owner_one";
+    runtime.ptyService = {
+      notifyPeerConnected: (peerId) => connected.push(peerId),
+      notifyPeerDisconnected: (peerId) => disconnected.push(peerId),
+    };
+    const directory = (
+      id: string,
+      status?: "connected" | "disconnected",
+    ): FederationProtocolEnvelope => ({
+      id,
+      kind: "notification",
+      method: "federation.peerDirectory",
+      params: {
+        peers: status
+          ? [{
+              id: "viewer_one",
+              label: "Viewer",
+              role: "client",
+              status,
+              capabilities: ["remote_pty"],
+            }]
+          : [],
+      },
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: "gateway_one",
+      targetInstanceId: "owner_one",
+      createdAt: 2_000,
+    });
+
+    runtime.applyPeerDirectory(directory("peers-1", "connected"));
+    expect(connected).toEqual(["viewer_one"]);
+    runtime.applyPeerDirectory(directory("peers-2", "disconnected"));
+    expect(disconnected).toEqual(["viewer_one"]);
+    runtime.applyPeerDirectory(directory("peers-3", "connected"));
+    expect(connected).toEqual(["viewer_one", "viewer_one"]);
+    runtime.applyPeerDirectory(directory("peers-4"));
+    expect(disconnected).toEqual(["viewer_one", "viewer_one"]);
+  });
+
+  it("disconnects every relayed PTY viewer when the upstream gateway closes", () => {
+    const disconnected: FederationInstanceId[] = [];
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "owner_one";
+    runtime.ptyService = {
+      notifyPeerConnected: () => undefined,
+      notifyPeerDisconnected: (peerId) => disconnected.push(peerId),
+    };
+    runtime.remotePeerDirectory.set("viewer_one", {
+      id: "viewer_one",
+      label: "Viewer",
+      role: "client",
+      status: "connected",
+      capabilities: ["remote_pty"],
+    });
+
+    runtime.disconnectAdvertisedPeers("Gateway disconnected.");
+
+    expect(disconnected).toEqual(["viewer_one"]);
+  });
+
   it("records a successful client session and preserves its timing", () => {
     const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
     const audits: Array<{
@@ -605,7 +673,10 @@ describe("DesktopFederationRuntime", () => {
 
   it("resolves sibling RPC responses received from the gateway transport", async () => {
     const sentToGateway: FederationProtocolEnvelope[] = [];
-    const router = new FederationRouter({ localInstanceId: "client_one" });
+    const router = new FederationRouter({
+      localInstanceId: "client_one",
+      trustedRelayPeerId: "gateway_one",
+    });
     router.registerConnection(
       createConnection({
         peerId: "gateway_one",
@@ -633,6 +704,7 @@ describe("DesktopFederationRuntime", () => {
         sourceInstanceId: "client_two",
         targetInstanceId: "client_one",
         createdAt: 2_000,
+        hopCount: 1,
         result: { backend: "codex", fetchedAt: 2_000, threads: [] },
       },
       "gateway_one",
@@ -1160,7 +1232,10 @@ describe("DesktopFederationRuntime", () => {
       },
     ]);
 
-    const viewerRouter = new FederationRouter({ localInstanceId: "viewer_one" });
+    const viewerRouter = new FederationRouter({
+      localInstanceId: "viewer_one",
+      trustedRelayPeerId: "gateway_one",
+    });
     viewerRouter.registerConnection(createConnection({
       peerId: "gateway_one",
       capabilities: ["gateway_relay", "remote_pty"],
@@ -1182,6 +1257,12 @@ describe("DesktopFederationRuntime", () => {
         params: { sessionId: "session-1", seq: 1 },
       },
     ]);
+
+    expect(viewer.publishRemotePtyStreamEvent(
+      relayed[0]!,
+      "other_peer",
+    )).toBe(true);
+    expect(events).toHaveLength(1);
   });
 
   it("sends owner PTY notifications through the enrolled gateway fallback", () => {

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -40,6 +40,22 @@ type RuntimeHarness = {
     envelope: FederationProtocolEnvelope,
     sourcePeerId: FederationInstanceId,
   ) => boolean;
+  publishRemotePtyStreamEvent: (
+    envelope: FederationProtocolEnvelope,
+    sourcePeerId: FederationInstanceId,
+  ) => boolean;
+  sendPtyNotification: (
+    peerId: FederationInstanceId,
+    method: string,
+    params: unknown,
+  ) => boolean;
+  onRemotePtyEvent: (
+    listener: (event: {
+      kind: string;
+      peerId: FederationInstanceId;
+      params: unknown;
+    }) => void,
+  ) => () => void;
   remotePeerDirectory: Map<FederationInstanceId, unknown>;
   onPeerStatusChanged: (listener: () => void) => () => void;
   recordClientConnection: (params: {
@@ -119,7 +135,10 @@ type RuntimeHarness = {
   revokePeer: (peerId: FederationInstanceId) => Promise<unknown>;
   visiblePeers: () => Array<{
     id: FederationInstanceId;
+    label?: string;
+    role?: "gateway" | "client" | "dual";
     status: string;
+    capabilities?: FederationCapability[];
   }>;
   connectedPeerTargets: () => Array<{
     target: { scope: "remote"; instanceId: FederationInstanceId };
@@ -213,7 +232,13 @@ describe("DesktopFederationRuntime", () => {
     });
     // remoteNavigationSnapshot also consults the live peer view for the
     // granted-capability set; there is no app state db in this harness.
-    runtime.visiblePeers = () => [];
+    runtime.visiblePeers = () => [{
+      id: "client_one",
+      label: "Studio Mac",
+      role: "client",
+      status: "connected",
+      capabilities: ["remote_pty"],
+    }];
 
     const snapshot = await runtime.remoteNavigationSnapshot(
       { scope: "remote", instanceId: "client_one" },
@@ -238,6 +263,7 @@ describe("DesktopFederationRuntime", () => {
     expect(snapshot.inboxThreadKeys).toEqual([]);
     expect(snapshot.directories[0]?.threadKeys).toEqual(["codex:thread-1"]);
     expect(snapshot.threads[0]?.gitWorkingState).toEqual(gitWorkingState);
+    expect(snapshot.threads[0]?.federation?.capabilities).toContain("remote_pty");
     expect(findPreferredReviewWorkspaceCwd(snapshot.threads[0])).toBe(
       pwrAgentWorktree,
     );
@@ -1091,6 +1117,97 @@ describe("DesktopFederationRuntime", () => {
         sourceInstanceId: "client_two",
         targetInstanceId: "client_one",
         hopCount: 1,
+      },
+    ]);
+  });
+
+  it("routes PTY stream notifications through a gateway and preserves the owner identity", () => {
+    const relayed: FederationProtocolEnvelope[] = [];
+    const gatewayRouter = new FederationRouter({ localInstanceId: "gateway_one" });
+    gatewayRouter.registerConnection(createConnection({
+      peerId: "owner_one",
+      capabilities: ["gateway_relay", "remote_pty"],
+    }));
+    gatewayRouter.registerConnection(createConnection({
+      peerId: "viewer_one",
+      capabilities: ["gateway_relay", "remote_pty"],
+      sendEnvelope: (envelope) => relayed.push(envelope),
+    }));
+    const gateway = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    gateway.localInstanceId = "gateway_one";
+    gateway.router = gatewayRouter;
+
+    expect(gateway.publishRemotePtyStreamEvent({
+      id: "pty-output-1",
+      kind: "notification",
+      method: "pty.output",
+      params: {
+        sessionId: "session-1",
+        seq: 1,
+        dataBase64: "b2s=",
+      },
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 2_000,
+    }, "owner_one")).toBe(true);
+    expect(relayed).toMatchObject([
+      {
+        method: "pty.output",
+        sourceInstanceId: "owner_one",
+        targetInstanceId: "viewer_one",
+        hopCount: 1,
+      },
+    ]);
+
+    const viewerRouter = new FederationRouter({ localInstanceId: "viewer_one" });
+    viewerRouter.registerConnection(createConnection({
+      peerId: "gateway_one",
+      capabilities: ["gateway_relay", "remote_pty"],
+    }));
+    const viewer = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    viewer.localInstanceId = "viewer_one";
+    viewer.router = viewerRouter;
+    const events: Array<{
+      kind: string;
+      peerId: FederationInstanceId;
+      params: unknown;
+    }> = [];
+    viewer.onRemotePtyEvent((event) => events.push(event));
+    expect(viewer.publishRemotePtyStreamEvent(relayed[0]!, "gateway_one")).toBe(true);
+    expect(events).toMatchObject([
+      {
+        kind: "output",
+        peerId: "owner_one",
+        params: { sessionId: "session-1", seq: 1 },
+      },
+    ]);
+  });
+
+  it("sends owner PTY notifications through the enrolled gateway fallback", () => {
+    const sentToGateway: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({ localInstanceId: "owner_one" });
+    router.registerConnection(createConnection({
+      peerId: "gateway_one",
+      capabilities: ["gateway_relay", "remote_pty"],
+      sendEnvelope: (envelope) => sentToGateway.push(envelope),
+    }));
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "owner_one";
+    runtime.gatewayInstanceId = "gateway_one";
+    runtime.router = router;
+
+    expect(runtime.sendPtyNotification(
+      "viewer_one",
+      "pty.output",
+      { sessionId: "session-1", seq: 1, dataBase64: "b2s=" },
+    )).toBe(true);
+    expect(sentToGateway).toMatchObject([
+      {
+        kind: "notification",
+        method: "pty.output",
+        sourceInstanceId: "owner_one",
+        targetInstanceId: "viewer_one",
       },
     ]);
   });

--- a/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
@@ -296,8 +296,8 @@ describe("integrated terminal IPC federation branch", () => {
         federationTarget: { scope: "remote", instanceId },
       });
 
-    // Malformed id never reaches the transport (where an unknown peer falls
-    // through to the gateway relay and surfaces as an opaque error).
+    // Malformed id never reaches the transport (where an unknown peer could
+    // otherwise fall through to the gateway relay as an opaque error).
     await expect(create("x")).rejects.toThrow(/invalid remote terminal/i);
     // Well-formed but not a connected peer.
     await expect(create("peer-unknown")).rejects.toThrow(/not connected/i);

--- a/apps/desktop/src/main/federation/federation-pty-service.ts
+++ b/apps/desktop/src/main/federation/federation-pty-service.ts
@@ -594,11 +594,7 @@ export function registerFederationPtyHandlers(params: {
     if (sourcePeerId === originInstanceId) {
       return originInstanceId;
     }
-    const relay = params.router.getConnection(sourcePeerId);
-    if (
-      (envelope.hopCount ?? 0) < 1
-      || !relay?.capabilities.includes("gateway_relay")
-    ) {
+    if (!params.router.authenticatesOrigin(envelope, sourcePeerId)) {
       throw new Error(
         "Remote terminal relay is not authorized for the claimed origin.",
       );

--- a/apps/desktop/src/main/federation/federation-pty-service.ts
+++ b/apps/desktop/src/main/federation/federation-pty-service.ts
@@ -5,6 +5,7 @@ import type {
   FederationInstanceId,
   FederationRequestEnvelope,
 } from "@pwragent/shared";
+import { isFederationInstanceId } from "@pwragent/shared";
 import type { FederationRouter } from "./federation-router";
 import type { FederationRpcEndpoint } from "./federation-rpc";
 
@@ -14,9 +15,9 @@ import type { FederationRpcEndpoint } from "./federation-rpc";
  * Control plane (viewer → owner, capability-checked RPC requests):
  * `pty.open` / `pty.input` / `pty.resize` / `pty.ack` / `pty.close`.
  * Stream plane (owner → viewer, notifications): `pty.output` / `pty.exit` /
- * `pty.error`. Sessions are point-to-point with the owning instance — the
- * stream is never relayed through a gateway, and only the opener peer may
- * write input to or close a session.
+ * `pty.error`. Sessions stay bound end-to-end to the opener instance even
+ * when their frames transit a gateway: only the opener may write input to or
+ * close a session.
  *
  * This module must stay importable outside Electron (no settings singleton,
  * no electron imports): the in-process E2E federation gateway harness runs the
@@ -175,8 +176,8 @@ type FederationPtyServiceOptions = {
     backend: AppServerBackendKind;
     threadId: string;
   }) => Promise<string | undefined>;
-  /** Direct-to-peer notification send. MUST NOT fall back to gateway relay —
-   *  returns false when the peer has no direct connection. */
+  /** End-to-end notification send. May route through the enrolled gateway;
+   *  returns false when the opener is unreachable. */
   sendNotification: (
     peerId: FederationInstanceId,
     method: string,
@@ -571,32 +572,44 @@ export class FederationPtyService {
 }
 
 /**
- * Register the owner-side control handlers. The stream is point-to-point:
- * a request that reached this instance through a gateway relay (its
- * authenticated source peer differs from the envelope's origin) is rejected
- * outright rather than opening a session whose output could never be
- * delivered without relaying.
+ * Register the owner-side control handlers. A relayed request remains keyed
+ * to its end-to-end origin, not the gateway that carried it, so another
+ * client cannot operate the opener's session. Only a gateway-authorized,
+ * already-relayed envelope may name an origin other than its transport peer.
  */
 export function registerFederationPtyHandlers(params: {
   router: FederationRouter;
   service: FederationPtyService;
 }): void {
-  const direct = (
+  const requester = (
     envelope: FederationRequestEnvelope,
     sourcePeerId: FederationInstanceId | undefined,
   ): FederationInstanceId => {
-    if (!sourcePeerId || sourcePeerId !== envelope.sourceInstanceId) {
+    const originInstanceId = envelope.sourceInstanceId;
+    if (!sourcePeerId || !isFederationInstanceId(originInstanceId)) {
       throw new Error(
-        "Remote terminal sessions are point-to-point; gateway relay is not supported.",
+        "Remote terminal request is missing a valid authenticated origin.",
       );
     }
-    return sourcePeerId;
+    if (sourcePeerId === originInstanceId) {
+      return originInstanceId;
+    }
+    const relay = params.router.getConnection(sourcePeerId);
+    if (
+      (envelope.hopCount ?? 0) < 1
+      || !relay?.capabilities.includes("gateway_relay")
+    ) {
+      throw new Error(
+        "Remote terminal relay is not authorized for the claimed origin.",
+      );
+    }
+    return originInstanceId;
   };
   params.router.registerHandler(
     FEDERATION_PTY_METHODS.open,
     async (envelope, sourcePeerId) =>
       await params.service.open(
-        direct(envelope, sourcePeerId),
+        requester(envelope, sourcePeerId),
         envelope.params as FederationPtyOpenRequest,
       ),
   );
@@ -604,7 +617,7 @@ export function registerFederationPtyHandlers(params: {
     FEDERATION_PTY_METHODS.input,
     (envelope, sourcePeerId) => {
       params.service.input(
-        direct(envelope, sourcePeerId),
+        requester(envelope, sourcePeerId),
         envelope.params as FederationPtyInputRequest,
       );
       return {};
@@ -614,7 +627,7 @@ export function registerFederationPtyHandlers(params: {
     FEDERATION_PTY_METHODS.resize,
     (envelope, sourcePeerId) => {
       params.service.resize(
-        direct(envelope, sourcePeerId),
+        requester(envelope, sourcePeerId),
         envelope.params as FederationPtyResizeRequest,
       );
       return {};
@@ -624,7 +637,7 @@ export function registerFederationPtyHandlers(params: {
     FEDERATION_PTY_METHODS.ack,
     (envelope, sourcePeerId) => {
       params.service.ack(
-        direct(envelope, sourcePeerId),
+        requester(envelope, sourcePeerId),
         envelope.params as FederationPtyAckRequest,
       );
       return {};
@@ -634,7 +647,7 @@ export function registerFederationPtyHandlers(params: {
     FEDERATION_PTY_METHODS.close,
     (envelope, sourcePeerId) => {
       params.service.close(
-        direct(envelope, sourcePeerId),
+        requester(envelope, sourcePeerId),
         envelope.params as FederationPtyCloseRequest,
       );
       return {};

--- a/apps/desktop/src/main/federation/federation-router.ts
+++ b/apps/desktop/src/main/federation/federation-router.ts
@@ -19,8 +19,9 @@ export type FederationRequestHandler = (
   /**
    * The authenticated peer the envelope arrived from. For direct connections
    * this matches `envelope.sourceInstanceId`; for gateway-relayed requests it
-   * is the relaying gateway. Handlers that must be point-to-point (remote
-   * PTY) compare the two — the envelope field alone is peer-asserted.
+   * is the relaying gateway. Handlers that preserve end-to-end ownership
+   * compare the two and verify the relay hop — the envelope field alone is
+   * peer-asserted.
    */
   sourcePeerId?: FederationInstanceId,
 ) => Promise<unknown> | unknown;
@@ -91,6 +92,18 @@ export class FederationRouter {
     }
 
     if (params.envelope.kind === "request") {
+      const capabilityFailure = this.checkCapability(
+        params.envelope,
+        params.sourcePeerId,
+      );
+      if (capabilityFailure) {
+        this.replyToSource(params.sourcePeerId, capabilityFailure);
+        return {
+          status: "rejected",
+          code: capabilityFailure.error.code,
+          message: capabilityFailure.error.message,
+        };
+      }
       const additionalCapabilityFailure = this.checkAdditionalCapabilities(
         params.envelope,
         params.sourcePeerId,
@@ -114,19 +127,6 @@ export class FederationRouter {
 
     if (params.envelope.kind !== "request") {
       return { status: "handled" };
-    }
-
-    const capabilityFailure = this.checkCapability(
-      params.envelope,
-      params.sourcePeerId,
-    );
-    if (capabilityFailure) {
-      this.replyToSource(params.sourcePeerId, capabilityFailure);
-      return {
-        status: "rejected",
-        code: capabilityFailure.error.code,
-        message: capabilityFailure.error.message,
-      };
     }
 
     const handler = this.handlers.get(params.envelope.method);

--- a/apps/desktop/src/main/federation/federation-router.ts
+++ b/apps/desktop/src/main/federation/federation-router.ts
@@ -42,6 +42,11 @@ export class FederationRouter {
       additionalRequiredCapabilities?: (
         envelope: FederationRequestEnvelope,
       ) => readonly FederationCapability[];
+      /** The one authenticated upstream gateway allowed to forward envelopes
+       * whose end-to-end origin differs from the transport peer. */
+      trustedRelayPeerId?:
+        | FederationInstanceId
+        | (() => FederationInstanceId | undefined);
       maxHopCount?: number;
       now?: () => number;
     },
@@ -81,6 +86,18 @@ export class FederationRouter {
     envelope: FederationProtocolEnvelope;
     sourcePeerId?: FederationInstanceId;
   }): Promise<FederationRouteResult> {
+    if (!this.authenticatesOrigin(params.envelope, params.sourcePeerId)) {
+      const failure = this.errorEnvelope(params.envelope, {
+        code: "relay_origin_mismatch",
+        message: "Federation relay origin is not authenticated by this connection.",
+      });
+      this.replyToSource(params.sourcePeerId, failure);
+      return {
+        status: "rejected",
+        code: failure.error.code,
+        message: failure.error.message,
+      };
+    }
     const deadlineFailure = this.checkDeadline(params.envelope);
     if (deadlineFailure) {
       this.replyToSource(params.sourcePeerId, deadlineFailure);
@@ -169,6 +186,24 @@ export class FederationRouter {
         message: failure.error.message,
       };
     }
+  }
+
+  /**
+   * Authenticate the claimed end-to-end source against the Noise-authenticated
+   * transport peer. A direct peer must name itself. Only this instance's
+   * configured upstream gateway may preserve another source after a relay hop.
+   */
+  authenticatesOrigin(
+    envelope: FederationProtocolEnvelope,
+    sourcePeerId: FederationInstanceId | undefined,
+  ): boolean {
+    if (!sourcePeerId) return true;
+    if (!envelope.sourceInstanceId) return false;
+    if (envelope.sourceInstanceId === sourcePeerId) return true;
+    return (
+      (envelope.hopCount ?? 0) >= 1
+      && this.trustedRelayPeerId() === sourcePeerId
+    );
   }
 
   private relayEnvelope(params: {
@@ -305,5 +340,10 @@ export class FederationRouter {
 
   private now(): number {
     return this.options.now?.() ?? Date.now();
+  }
+
+  private trustedRelayPeerId(): FederationInstanceId | undefined {
+    const configured = this.options.trustedRelayPeerId;
+    return typeof configured === "function" ? configured() : configured;
   }
 }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -973,6 +973,11 @@ export class DesktopFederationRuntime {
     const localInstanceId = this.ensureLocalInstanceId();
     const router = new FederationRouter({
       localInstanceId,
+      trustedRelayPeerId: () =>
+        this.gatewayInstanceId
+        ?? (isAppStateInitialized()
+          ? getAppStateDb().getMeta(GATEWAY_INSTANCE_ID_META_KEY) || undefined
+          : undefined),
       methodCapabilities: {
         ...FEDERATION_BACKEND_METHOD_CAPABILITIES,
         ...FEDERATION_PTY_METHOD_CAPABILITIES,
@@ -1575,6 +1580,9 @@ export class DesktopFederationRuntime {
         status: peer.status === "revoked" ? "revoked" : "disconnected",
         unavailableReason: reason,
       });
+      if (peer.status === "connected") {
+        this.ptyService?.notifyPeerDisconnected(peerId);
+      }
       this.publishPeerStatus(
         peerId,
         peer.status === "revoked" ? "revoked" : "disconnected",
@@ -1591,6 +1599,16 @@ export class DesktopFederationRuntime {
     envelope: FederationProtocolEnvelope,
     sourcePeerId: FederationInstanceId,
   ): Promise<void> {
+    if (
+      this.router
+      && !this.router.authenticatesOrigin(envelope, sourcePeerId)
+    ) {
+      log.warn("federation envelope claimed an unauthenticated relay origin", {
+        claimedSourceInstanceId: envelope.sourceInstanceId,
+        sourcePeerId,
+      });
+      return;
+    }
     if (this.applyPeerDirectory(envelope)) {
       return;
     }
@@ -1671,16 +1689,11 @@ export class DesktopFederationRuntime {
     if (!isFederationInstanceId(originInstanceId)) {
       return true;
     }
-    // Direct frames must name their authenticated peer. A different origin
-    // is accepted only from an enrolled relay-capable gateway after a hop.
-    if (originInstanceId !== sourcePeerId) {
-      const relay = this.router?.getConnection(sourcePeerId);
-      if (
-        (envelope.hopCount ?? 0) < 1
-        || !relay?.capabilities.includes("gateway_relay")
-      ) {
-        return true;
-      }
+    if (
+      originInstanceId !== sourcePeerId
+      && !this.router?.authenticatesOrigin(envelope, sourcePeerId)
+    ) {
+      return true;
     }
     const kind =
       envelope.method === FEDERATION_PTY_OUTPUT_METHOD
@@ -1948,6 +1961,13 @@ export class DesktopFederationRuntime {
           lastActivityAt: peer.lastActivityAt ?? previous?.lastActivityAt,
           canRevoke: false,
         });
+        if (peer.status === "connected") {
+          if (previous?.status !== "connected") {
+            this.ptyService?.notifyPeerConnected(peer.id);
+          }
+        } else if (previous?.status === "connected") {
+          this.ptyService?.notifyPeerDisconnected(peer.id);
+        }
         previousPeers.delete(peer.id);
       }
     }
@@ -1961,6 +1981,9 @@ export class DesktopFederationRuntime {
       this.publishPeerStatus(peer.id, peer.status, peer.unavailableReason);
     }
     for (const peerId of previousPeers.keys()) {
+      if (previousPeers.get(peerId)?.status === "connected") {
+        this.ptyService?.notifyPeerDisconnected(peerId);
+      }
       this.publishPeerStatus(
         peerId,
         "disconnected",

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -860,15 +860,13 @@ export class DesktopFederationRuntime {
     const instanceLabel = peer
       ? formatFederationPeerDisplayLabel(peer, visible)
       : target.instanceId;
-    // The granted set the viewer can act on. remote_pty is stripped when the
-    // peer is only reachable through a gateway relay: PTY streams are
-    // point-to-point in v1, so the toggle must read as unavailable there.
+    // The granted set the viewer can act on. Gateway-advertised capabilities
+    // remain authoritative for relayed peers just as live connection
+    // capabilities are for direct peers.
     const directConnection = this.router?.getConnection(target.instanceId);
     const capabilities = directConnection
       ? [...directConnection.capabilities]
-      : (visiblePeer?.capabilities ?? []).filter(
-          (capability) => capability !== "remote_pty",
-        );
+      : [...(visiblePeer?.capabilities ?? [])];
     const peerStatus = visiblePeer?.status ?? peer?.status;
     const threads = response.threads.map((thread) => {
       const ref = buildFederatedThreadRef({
@@ -1626,30 +1624,28 @@ export class DesktopFederationRuntime {
     await this.router?.routeEnvelope({ envelope, sourcePeerId });
   }
 
-  /**
-   * Owner → viewer PTY stream frame. Deliberately DIRECT-only: no gateway
-   * fallback, so `hopCount` stays 0 and a shell stream can never transit a
-   * relay. Returns false when the peer has no direct connection — the
-   * service's disconnect reap owns cleanup in that case.
-   */
+  /** Owner → viewer PTY stream frame, routed directly when possible and
+   * through this client's enrolled gateway otherwise. */
   private sendPtyNotification(
     peerId: FederationInstanceId,
     method: string,
     params: unknown,
   ): boolean {
-    const connection = this.router?.getConnection(peerId);
-    if (!connection) return false;
-    connection.sendEnvelope({
-      id: `federation-pty:${randomUUID()}`,
-      kind: "notification",
-      method,
-      params,
-      protocolVersion: FEDERATION_PROTOCOL_VERSION,
-      sourceInstanceId: this.ensureLocalInstanceId(),
-      targetInstanceId: peerId,
-      createdAt: Date.now(),
-    });
-    return true;
+    try {
+      this.sendEnvelopeToTarget(peerId, {
+        id: `federation-pty:${randomUUID()}`,
+        kind: "notification",
+        method,
+        params,
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: this.ensureLocalInstanceId(),
+        targetInstanceId: peerId,
+        createdAt: Date.now(),
+      });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private publishRemotePtyStreamEvent(
@@ -1662,21 +1658,29 @@ export class DesktopFederationRuntime {
     ) {
       return false;
     }
-    // Point-to-point invariant, receive side: a PTY frame addressed to some
-    // other instance is dropped, never relayed onward; and a frame whose
-    // claimed origin differs from the authenticated link it arrived on is
-    // spoofed, not trusted.
+    // Gateway hop: keep the end-to-end source/target intact and let the
+    // router enforce relay authorization + hop limits.
     if (
       envelope.targetInstanceId &&
       envelope.targetInstanceId !== this.ensureLocalInstanceId()
     ) {
+      void this.router?.routeEnvelope({ envelope, sourcePeerId });
       return true;
     }
-    if (
-      envelope.sourceInstanceId &&
-      envelope.sourceInstanceId !== sourcePeerId
-    ) {
+    const originInstanceId = envelope.sourceInstanceId ?? sourcePeerId;
+    if (!isFederationInstanceId(originInstanceId)) {
       return true;
+    }
+    // Direct frames must name their authenticated peer. A different origin
+    // is accepted only from an enrolled relay-capable gateway after a hop.
+    if (originInstanceId !== sourcePeerId) {
+      const relay = this.router?.getConnection(sourcePeerId);
+      if (
+        (envelope.hopCount ?? 0) < 1
+        || !relay?.capabilities.includes("gateway_relay")
+      ) {
+        return true;
+      }
     }
     const kind =
       envelope.method === FEDERATION_PTY_OUTPUT_METHOD
@@ -1686,7 +1690,7 @@ export class DesktopFederationRuntime {
           : "error";
     const event = {
       kind,
-      peerId: sourcePeerId,
+      peerId: originInstanceId,
       params: envelope.params,
     } as FederationPtyStreamEvent;
     for (const listener of this.remotePtyEventListeners) {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -72,11 +72,8 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
     ref: FederatedThreadRef;
     instanceLabel: string;
     peerStatus?: FederationPeerSummary["status"];
-    /**
-     * Capabilities the owning instance granted this viewer over a DIRECT
-     * connection. `remote_pty` is stripped when the peer is only reachable
-     * through a gateway relay — PTY streams are point-to-point in v1.
-     */
+    /** Capabilities the owning instance granted this viewer, whether the
+     * peer is connected directly or advertised through a gateway relay. */
     capabilities?: FederationCapability[];
     /**
      * The owning instance's celestial identity icon, resolved from the


### PR DESCRIPTION
## Summary

- preserve gateway-advertised `remote_pty` capabilities on relayed thread summaries
- relay PTY control requests and output/exit/error notifications through the gateway
- keep remote terminal sessions bound end-to-end to the originating viewer instance
- enforce method capabilities on the originating peer before a gateway forwards the request
- authenticate forwarded origins against the locally enrolled upstream gateway
- reap relayed sessions when the viewer or its gateway disconnects, with grace-period reconnect recovery

## Root cause

The initial remote PTY implementation intentionally supported direct peer connections only. It stripped `remote_pty` from gateway-only peer summaries, rejected control requests whose authenticated transport peer was the gateway, and consumed stream notifications instead of relaying them. That made the terminal appear unsupported for every client-to-client path routed through a gateway.

## Impact

Federation clients can now open and use terminals on sibling client machines through the gateway. Direct terminal connections continue to work, and a relayed session cannot be operated by a different client instance.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/federation-*.test.ts packages/shared/src/contracts/__tests__/federation.test.ts` (25 files, 247 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
