### PR TITLE
fix(messaging): silence ambient Slack authorization noise

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -1955,7 +1955,7 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
-  it("logs adapter-level rejected inbound IDs before provider dispatch", async () => {
+  it("logs actionable adapter rejections only after resolving a binding", async () => {
     await prepareRuntimeStore();
     let rejectedListener: MessagingInboundRejectedListener | undefined;
     const adapter = createAdapter("discord", {
@@ -1967,6 +1967,27 @@ describe("DesktopMessagingRuntime", () => {
       },
     });
     const bridge = createBackendBridge();
+    const { getDesktopMessagingStore } = await import(
+      "../messaging/desktop-messaging-store"
+    );
+    await getDesktopMessagingStore().upsertBinding({
+      id: "binding:discord:channel::1480554271907905000:codex:thread-1",
+      channel: {
+        channel: "discord",
+        conversation: {
+          id: "1480554271907905000",
+          kind: "channel",
+          parentId: "1480554271907905731",
+          title: "agent-testing",
+        },
+      },
+      targetKind: "agent_thread",
+      backend: "codex",
+      threadId: "thread-1",
+      authorizedActorIds: ["user-1"],
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
     const { DesktopMessagingRuntime: Runtime } = await import(
       "../messaging/messaging-runtime"
     );
@@ -1985,22 +2006,24 @@ describe("DesktopMessagingRuntime", () => {
     await runtime.start();
     const rejectedEvent: MessagingRejectedInboundEvent = {
       id: "discord:message:msg-1:rejected",
-      kind: "command",
+      kind: "text",
       actor: {
         platformUserId: "1177378744822943744",
         displayName: "Other User",
         username: "other",
       },
+      botMention: true,
       channel: {
         channel: "discord",
         conversation: {
           id: "1480554271907905000",
           kind: "channel",
           parentId: "1480554271907905731",
+          title: "agent-testing",
         },
       },
       receivedAt: 1234,
-      reason: "unauthorized-conversation",
+      reason: "unauthorized-actor",
     };
     await rejectedListener?.(rejectedEvent);
 
@@ -2023,22 +2046,134 @@ describe("DesktopMessagingRuntime", () => {
     });
     expect(JSON.parse(row?.payload ?? "{}")).toMatchObject({
       conversationParentId: "1480554271907905731",
-      rejectionReason: "unauthorized-conversation",
+      destinationBackend: "codex",
+      destinationThreadId: "thread-1",
+      rejectionReason: "unauthorized-actor",
+      routeSource: "binding",
     });
     expect(messagingLog.warn).toHaveBeenCalledWith(
-      "messaging event rejected before dispatch",
+      "actionable messaging event rejected for a routed destination",
       expect.objectContaining({
         actorId: "1177378744822943744",
         conversationId: "1480554271907905000",
-        reason: "unauthorized-conversation",
+        conversationDisplayName: "agent-testing",
+        conversationTitle: "agent-testing",
+        destinationBackend: "codex",
+        destinationThreadId: "thread-1",
+        reason: "unauthorized-actor",
+        routeSource: "binding",
       }),
-    );
-    const { getDesktopMessagingStore } = await import(
-      "../messaging/desktop-messaging-store"
     );
     await expect(
       getDesktopMessagingStore().findObservedSurfaces(),
-    ).resolves.toEqual([]);
+    ).resolves.toEqual([
+      expect.objectContaining({
+        channel: expect.objectContaining({
+          conversation: expect.objectContaining({
+            id: "1480554271907905000",
+          }),
+        }),
+      }),
+    ]);
+  });
+
+  it("does not log or persist ambient shared-channel rejections", async () => {
+    const { reject } = await createSlackRejectedRuntimeHarness();
+    await reject(buildRejectedSlackEvent("slack-rejected:ambient"));
+
+    const { getAppStateDb } = await import("../state/app-state");
+    const count = getAppStateDb().raw
+      .prepare("SELECT COUNT(*) AS count FROM messaging_activity_log WHERE kind = ?")
+      .get("inbound-rejected") as { count: number };
+    expect(count.count).toBe(0);
+    expect(messagingLog.warn).not.toHaveBeenCalledWith(
+      "actionable messaging event rejected for a routed destination",
+      expect.anything(),
+    );
+  });
+
+  it("does not log or persist an unauthorized mention without a route", async () => {
+    const { reject } = await createSlackRejectedRuntimeHarness();
+    await reject(buildRejectedSlackEvent(
+      "slack-rejected:unroutable-mention",
+      true,
+    ));
+
+    const { getAppStateDb } = await import("../state/app-state");
+    const count = getAppStateDb().raw
+      .prepare("SELECT COUNT(*) AS count FROM messaging_activity_log WHERE kind = ?")
+      .get("inbound-rejected") as { count: number };
+    expect(count.count).toBe(0);
+    expect(messagingLog.warn).not.toHaveBeenCalledWith(
+      "actionable messaging event rejected for a routed destination",
+      expect.anything(),
+    );
+  });
+
+  it("logs a routed unauthorized mention with friendly conversation and Agent names", async () => {
+    const { bridge, reject } = await createSlackRejectedRuntimeHarness();
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      agent: {
+        name: "PwrAgent - hhunt",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1000,
+      },
+    };
+    bridge.getNavigationSnapshot = vi.fn(async () => navigation);
+    const { getDesktopMessagingStore } = await import(
+      "../messaging/desktop-messaging-store"
+    );
+    await getDesktopMessagingStore().upsertDefaultAgentAssignment({
+      id: "default-agent:slack-provider",
+      scope: { kind: "provider", channel: "slack" },
+      target: {
+        kind: "agent",
+        backend: "codex",
+        threadId: "thread-1",
+      },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+    await reject(buildRejectedSlackEvent("slack-rejected:routed-mention", true));
+
+    expect(messagingLog.warn).toHaveBeenCalledWith(
+      "actionable messaging event rejected for a routed destination",
+      expect.objectContaining({
+        actorDisplayName: "Other User",
+        conversationId: "C012ABCDEF0",
+        conversationDisplayName: "#p-search-signals-projects",
+        conversationTitle: "p-search-signals-projects",
+        destinationAgentName: "PwrAgent - hhunt",
+        destinationBackend: "codex",
+        destinationThreadId: "thread-1",
+        routeSource: "default-agent",
+      }),
+    );
+    const { getAppStateDb } = await import("../state/app-state");
+    const row = getAppStateDb().raw
+      .prepare(
+        `SELECT conversation_title, summary, payload
+         FROM messaging_activity_log
+         WHERE kind = ?
+         ORDER BY id DESC
+         LIMIT 1`,
+      )
+      .get("inbound-rejected") as
+        | { conversation_title: string; payload: string; summary: string }
+        | undefined;
+    expect(row?.conversation_title).toBe("p-search-signals-projects");
+    expect(row?.summary).toBe(
+      "Blocked @mention to PwrAgent - hhunt from Other User in #p-search-signals-projects",
+    );
+    expect(JSON.parse(row?.payload ?? "{}")).toMatchObject({
+      destinationAgentName: "PwrAgent - hhunt",
+      destinationBackend: "codex",
+      destinationThreadId: "thread-1",
+      routeSource: "default-agent",
+    });
   });
 
   it("records adapter diagnostics in Messaging Activity", async () => {
@@ -3075,6 +3210,71 @@ describe("DesktopMessagingRuntime", () => {
     expect(runtime.getPlatformCredentialMetadata("telegram")).toBeUndefined();
   });
 });
+
+async function createSlackRejectedRuntimeHarness(): Promise<{
+  bridge: ReturnType<typeof createBackendBridge>;
+  reject: (event: MessagingRejectedInboundEvent) => Promise<void>;
+}> {
+  await prepareRuntimeStore();
+  let rejectedListener: MessagingInboundRejectedListener | undefined;
+  const adapter = createAdapter("slack", {
+    onInboundRejected: (listener: MessagingInboundRejectedListener) => {
+      rejectedListener = listener;
+      return () => {
+        rejectedListener = undefined;
+      };
+    },
+  });
+  const bridge = createBackendBridge();
+  const { DesktopMessagingRuntime: Runtime } = await import(
+    "../messaging/messaging-runtime"
+  );
+  const runtime = trackRuntime(new Runtime({
+    adapterFactory: () => [adapter],
+    backendBridge: bridge,
+    config: {
+      slack: {
+        channel: "slack",
+        appToken: "slack-app-token",
+        botToken: "slack-bot-token",
+        signingSecret: "slack-signing-secret",
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+      },
+    },
+  }));
+  await runtime.start();
+  return {
+    bridge,
+    reject: async (event) => {
+      await rejectedListener?.(event);
+    },
+  };
+}
+
+function buildRejectedSlackEvent(
+  id: string,
+  botMention = false,
+): MessagingRejectedInboundEvent {
+  return {
+    id,
+    kind: "text",
+    actor: {
+      platformUserId: "user-2",
+      displayName: "Other User",
+    },
+    ...(botMention ? { botMention: true } : {}),
+    channel: {
+      channel: "slack",
+      conversation: {
+        id: "C012ABCDEF0",
+        kind: "channel",
+        title: "p-search-signals-projects",
+      },
+    },
+    receivedAt: 1234,
+    reason: "unauthorized-actor",
+  };
+}
 
 async function createRuntimeHarness(options: {
   adapter?: ReturnType<typeof createAdapter>;

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -2110,19 +2110,57 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
+  it("logs a routed unauthorized DM without requiring a mention", async () => {
+    const { reject } = await createSlackRejectedRuntimeHarness();
+    const { getDesktopMessagingStore } = await import(
+      "../messaging/desktop-messaging-store"
+    );
+    await getDesktopMessagingStore().upsertDefaultAgentAssignment({
+      id: "default-agent:slack-provider",
+      scope: { kind: "provider", channel: "slack" },
+      target: {
+        kind: "agent",
+        backend: "codex",
+        threadId: "thread-1",
+      },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+    const event = buildRejectedSlackEvent("slack-rejected:routed-dm");
+    event.channel.conversation = {
+      id: "D012ABCDEF0",
+      isDirectMessage: true,
+      kind: "dm",
+      title: "Other User",
+    };
+
+    await reject(event);
+
+    const { getAppStateDb } = await import("../state/app-state");
+    const count = getAppStateDb().raw
+      .prepare("SELECT COUNT(*) AS count FROM messaging_activity_log WHERE kind = ?")
+      .get("inbound-rejected") as { count: number };
+    expect(count.count).toBe(1);
+    expect(messagingLog.warn).toHaveBeenCalledWith(
+      "actionable messaging event rejected for a routed destination",
+      expect.objectContaining({
+        actorId: "user-2",
+        conversationId: "D012ABCDEF0",
+        conversationKind: "dm",
+        destinationThreadId: "thread-1",
+        reason: "unauthorized-actor",
+      }),
+    );
+  });
+
   it("logs a routed unauthorized mention with friendly conversation and Agent names", async () => {
     const { bridge, reject } = await createSlackRejectedRuntimeHarness();
-    const navigation = buildNavigationSnapshot();
-    navigation.threads[0] = {
-      ...navigation.threads[0]!,
-      agent: {
-        name: "PwrAgent - hhunt",
-        instructionLineCount: 1,
-        instructionsTooLong: false,
-        updatedAt: 1000,
-      },
-    };
-    bridge.getNavigationSnapshot = vi.fn(async () => navigation);
+    bridge.readThreadAgentMetadata = vi.fn(async () => ({
+      name: "PwrAgent - hhunt",
+      instructionLineCount: 1,
+      instructionsTooLong: false,
+      updatedAt: 1000,
+    }));
     const { getDesktopMessagingStore } = await import(
       "../messaging/desktop-messaging-store"
     );
@@ -2138,6 +2176,10 @@ describe("DesktopMessagingRuntime", () => {
       updatedAt: 1000,
     });
     await reject(buildRejectedSlackEvent("slack-rejected:routed-mention", true));
+    await reject(buildRejectedSlackEvent("slack-rejected:routed-mention-2", true));
+
+    expect(bridge.getNavigationSnapshot).not.toHaveBeenCalled();
+    expect(bridge.readThreadAgentMetadata).toHaveBeenCalledTimes(1);
 
     expect(messagingLog.warn).toHaveBeenCalledWith(
       "actionable messaging event rejected for a routed destination",

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -44,6 +44,7 @@ import type {
   SteerTurnResponse,
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
+  ThreadAgentMetadata,
   ThreadMessagingBindingTransition,
   UpdateScheduledThreadActionRequest,
   UpdateDirectoryLaunchpadRequest,
@@ -145,6 +146,10 @@ export type MessagingBackendBridge = {
   getNavigationSnapshot(
     request?: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot>;
+  readThreadAgentMetadata?(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<ThreadAgentMetadata | undefined>;
   readThreadStatus?(request: {
     backend: AppServerBackendKind;
     federationTarget?: FederationTarget;

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -48,6 +48,7 @@ import type {
   StartReviewRequest,
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
+  ThreadAgentMetadata,
   ThreadMessagingBindingTransition,
   UpdateScheduledThreadActionRequest,
   UpdateDirectoryLaunchpadRequest,
@@ -219,6 +220,13 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
         ...availableRemoteSnapshots.flatMap((remote) => remote.inboxThreadKeys),
       ],
     };
+  }
+
+  async readThreadAgentMetadata(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<ThreadAgentMetadata | undefined> {
+    return await this.registry.getThreadAgentMetadata(request);
   }
 
   async readThreadStatus(request: {

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -26,6 +26,7 @@ import type {
   MessagingPlatformHealth,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
+  NavigationSnapshot,
   PwrAgentMessagingRequest,
   PwrAgentMessagingResponse,
 } from "@pwragent/shared";
@@ -193,6 +194,16 @@ type RunningMessagingAdapter = {
 type RunningMessagingAuthorization = {
   actorIds: string[];
   actorIdSet: Set<string>;
+};
+
+type RejectedInboundRoute = {
+  backend: MessagingBindingRecord["backend"];
+  bindingId?: string;
+  destinationAgentName?: string;
+  destinationThreadTitle?: string;
+  routeSource: "binding" | "default-agent";
+  targetKind: NonNullable<MessagingBindingRecord["targetKind"]>;
+  threadId: MessagingBindingRecord["threadId"];
 };
 
 type PendingAdapterStart = {
@@ -1160,21 +1171,8 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
           },
         });
       });
-      unsubscribeInboundRejected = adapter.onInboundRejected?.((event) => {
-        this.emitPlatformActivity(adapter.channel);
-        this.recordActivityFromRejected(adapter.channel, event);
-        messagingLog.warn("messaging event rejected before dispatch", {
-          actorDisplayName: event.actor.displayName,
-          actorId: event.actor.platformUserId,
-          actorIsBot: event.actor.isBot,
-          actorUsername: event.actor.username,
-          channel: adapter.channel,
-          conversationId: event.channel.conversation.id,
-          conversationKind: event.channel.conversation.kind,
-          eventId: event.id,
-          eventKind: event.kind,
-          reason: event.reason,
-        });
+      unsubscribeInboundRejected = adapter.onInboundRejected?.(async (event) => {
+        await this.handleRejectedInbound(adapter.channel, event, store);
       });
       this.setPlatformHealth(adapter.channel, "unknown");
       await this.startAdapterWithDeadline(adapter, async (event) => {
@@ -2285,17 +2283,30 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   private recordActivityFromRejected(
     platform: MessagingChannelKind,
     event: MessagingRejectedInboundEvent,
+    route: RejectedInboundRoute,
   ): void {
     try {
       const conversation = event.channel.conversation;
+      const actorName = event.actor.displayName ?? event.actor.platformUserId;
+      const destinationName =
+        route.destinationAgentName
+        ?? route.destinationThreadTitle
+        ?? route.threadId;
+      const conversationName = describeRejectedConversation(platform, conversation);
+      const attemptKind = event.botMention ? "@mention" : event.kind;
       getDesktopMessagingActivityLog().record({
         platform,
         kind: "inbound-rejected",
+        backend: route.backend,
+        threadId: route.threadId,
+        bindingId: route.bindingId,
         conversationId: conversation.id,
         conversationTitle: conversation.title,
         actorId: event.actor.platformUserId,
         actorDisplayName: event.actor.displayName,
-        summary: `Rejected inbound from ${event.actor.displayName ?? event.actor.platformUserId}`,
+        summary:
+          `Blocked ${attemptKind} to ${destinationName} from ${actorName}`
+          + ` in ${conversationName}`,
         payload: {
           eventId: event.id,
           eventKind: event.kind,
@@ -2303,7 +2314,14 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
           conversationParentId: conversation.parentId,
           actorUsername: event.actor.username,
           actorIsBot: event.actor.isBot,
+          conversationDisplayName: conversationName,
           rejectionReason: event.reason,
+          destinationAgentName: route.destinationAgentName,
+          destinationThreadTitle: route.destinationThreadTitle,
+          destinationBackend: route.backend,
+          destinationTargetKind: route.targetKind,
+          destinationThreadId: route.threadId,
+          routeSource: route.routeSource,
         },
       });
     } catch (error) {
@@ -2313,6 +2331,106 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         error: error instanceof Error ? error.message : String(error),
       });
     }
+  }
+
+  private async handleRejectedInbound(
+    platform: MessagingChannelKind,
+    event: MessagingRejectedInboundEvent,
+    store: MessagingStoreLike,
+  ): Promise<void> {
+    if (!isActionableRejectedInbound(event)) {
+      return;
+    }
+    try {
+      const route = await this.resolveRejectedInboundRoute(store, event);
+      if (!route) {
+        return;
+      }
+      this.emitPlatformActivity(platform);
+      this.recordActivityFromRejected(platform, event, route);
+      messagingLog.warn("actionable messaging event rejected for a routed destination", {
+        actorDisplayName: event.actor.displayName,
+        actorId: event.actor.platformUserId,
+        actorIsBot: event.actor.isBot,
+        actorUsername: event.actor.username,
+        channel: platform,
+        conversationId: event.channel.conversation.id,
+        conversationKind: event.channel.conversation.kind,
+        conversationDisplayName: describeRejectedConversation(
+          platform,
+          event.channel.conversation,
+        ),
+        conversationTitle: event.channel.conversation.title,
+        destinationAgentName: route.destinationAgentName,
+        destinationBackend: route.backend,
+        destinationTargetKind: route.targetKind,
+        destinationThreadId: route.threadId,
+        destinationThreadTitle: route.destinationThreadTitle,
+        eventId: event.id,
+        eventKind: event.kind,
+        reason: event.reason,
+        routeSource: route.routeSource,
+      });
+    } catch (error) {
+      messagingLog.warn("messaging rejected-event route resolution failed", {
+        channel: platform,
+        eventId: event.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async resolveRejectedInboundRoute(
+    store: MessagingStoreLike,
+    event: MessagingRejectedInboundEvent,
+  ): Promise<RejectedInboundRoute | undefined> {
+    const binding = await store.findActiveBindingForChannel(event.channel);
+    const assignments = binding
+      ? []
+      : await store.findActiveDefaultAgentAssignmentsForChannel(event.channel);
+    if (!binding && assignments.length === 0) {
+      return undefined;
+    }
+    let navigation: NavigationSnapshot | undefined;
+    try {
+      navigation = await this.options.backendBridge.getNavigationSnapshot({
+        backend: "all",
+      });
+    } catch {
+      // The durable route still identifies the intended destination even when
+      // its friendly Agent metadata is temporarily unavailable.
+    }
+    const assignment = binding
+      ? undefined
+      : navigation
+        ? assignments.find((candidate) =>
+            navigation.threads.some(
+              (thread) =>
+                thread.source === candidate.target.backend
+                && thread.id === candidate.target.threadId
+                && Boolean(thread.agent),
+            ),
+          )
+        : assignments[0];
+    if (!binding && !assignment) {
+      return undefined;
+    }
+    const backend = binding?.backend ?? assignment!.target.backend;
+    const threadId = binding?.threadId ?? assignment!.target.threadId;
+    const thread = navigation?.threads.find(
+      (candidate) =>
+        candidate.source === backend
+        && candidate.id === threadId,
+    );
+    return {
+      backend,
+      ...(binding ? { bindingId: binding.id } : {}),
+      destinationAgentName: thread?.agent?.name,
+      destinationThreadTitle: thread?.title,
+      routeSource: binding ? "binding" : "default-agent",
+      targetKind: binding?.targetKind ?? "agent_thread",
+      threadId,
+    };
   }
 
   private broadcastPlatformStatus(event: MessagingPlatformStatusEvent): void {
@@ -2764,6 +2882,36 @@ function describeConversation(
     conversation.title,
   ].filter((piece): piece is string => Boolean(piece));
   return pieces.length > 0 ? pieces.join(" / ") : conversation.id;
+}
+
+function describeRejectedConversation(
+  platform: MessagingChannelKind,
+  conversation: MessagingChannelRef["conversation"],
+): string {
+  const description = describeConversation(conversation);
+  if (
+    platform === "slack"
+    && conversation.kind !== "dm"
+    && conversation.isDirectMessage !== true
+  ) {
+    return description.startsWith("#") ? description : `#${description}`;
+  }
+  return description;
+}
+
+function isActionableRejectedInbound(
+  event: MessagingRejectedInboundEvent,
+): boolean {
+  if (
+    event.channel.conversation.kind === "dm"
+    || event.channel.conversation.isDirectMessage === true
+  ) {
+    return true;
+  }
+  if (event.kind === "text" || event.kind === "media") {
+    return event.botMention === true;
+  }
+  return true;
 }
 
 /**

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -26,7 +26,6 @@ import type {
   MessagingPlatformHealth,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
-  NavigationSnapshot,
   PwrAgentMessagingRequest,
   PwrAgentMessagingResponse,
 } from "@pwragent/shared";
@@ -200,7 +199,6 @@ type RejectedInboundRoute = {
   backend: MessagingBindingRecord["backend"];
   bindingId?: string;
   destinationAgentName?: string;
-  destinationThreadTitle?: string;
   routeSource: "binding" | "default-agent";
   targetKind: NonNullable<MessagingBindingRecord["targetKind"]>;
   threadId: MessagingBindingRecord["threadId"];
@@ -239,6 +237,7 @@ const PAIRING_TOKEN_ALPHABET =
 const RATE_LIMIT_HEALTH_BUFFER_MS = 2_000;
 const DELIVERY_BUDGET_WARNING_TTL_MS = 30_000;
 const DELIVERY_BUDGET_DIAGNOSTIC_THROTTLE_MS = 30_000;
+const REJECTED_ROUTE_AGENT_METADATA_TTL_MS = 60_000;
 const DEFAULT_ADAPTER_START_TIMEOUT_MS = 90_000;
 const FAILED_START_STOP_TIMEOUT_MS = 3_000;
 const CONFIGURABLE_MESSAGING_CHANNELS = [
@@ -355,6 +354,10 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     ReturnType<typeof setTimeout>
   >();
   private readonly deliveryBudgetDiagnosticLastLoggedAt = new Map<string, number>();
+  private readonly rejectedRouteAgentNameCache = new Map<
+    string,
+    { expiresAt: number; value: Promise<string | undefined> }
+  >();
   private readonly platformStatusListeners = new Set<
     (event: MessagingPlatformStatusEvent) => void
   >();
@@ -451,6 +454,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     this.runningAdapters.clear();
     this.adapters = [];
     this.controllers = [];
+    this.rejectedRouteAgentNameCache.clear();
     // Mark each previously-running platform as suspended (not removed),
     // so the renderer keeps the icon visible with a gray dot — the user
     // knows it's configured but currently off.
@@ -2290,7 +2294,6 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       const actorName = event.actor.displayName ?? event.actor.platformUserId;
       const destinationName =
         route.destinationAgentName
-        ?? route.destinationThreadTitle
         ?? route.threadId;
       const conversationName = describeRejectedConversation(platform, conversation);
       const attemptKind = event.botMention ? "@mention" : event.kind;
@@ -2317,7 +2320,6 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
           conversationDisplayName: conversationName,
           rejectionReason: event.reason,
           destinationAgentName: route.destinationAgentName,
-          destinationThreadTitle: route.destinationThreadTitle,
           destinationBackend: route.backend,
           destinationTargetKind: route.targetKind,
           destinationThreadId: route.threadId,
@@ -2365,7 +2367,6 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         destinationBackend: route.backend,
         destinationTargetKind: route.targetKind,
         destinationThreadId: route.threadId,
-        destinationThreadTitle: route.destinationThreadTitle,
         eventId: event.id,
         eventKind: event.kind,
         reason: event.reason,
@@ -2385,52 +2386,58 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     event: MessagingRejectedInboundEvent,
   ): Promise<RejectedInboundRoute | undefined> {
     const binding = await store.findActiveBindingForChannel(event.channel);
-    const assignments = binding
-      ? []
-      : await store.findActiveDefaultAgentAssignmentsForChannel(event.channel);
-    if (!binding && assignments.length === 0) {
-      return undefined;
-    }
-    let navigation: NavigationSnapshot | undefined;
-    try {
-      navigation = await this.options.backendBridge.getNavigationSnapshot({
-        backend: "all",
-      });
-    } catch {
-      // The durable route still identifies the intended destination even when
-      // its friendly Agent metadata is temporarily unavailable.
-    }
     const assignment = binding
       ? undefined
-      : navigation
-        ? assignments.find((candidate) =>
-            navigation.threads.some(
-              (thread) =>
-                thread.source === candidate.target.backend
-                && thread.id === candidate.target.threadId
-                && Boolean(thread.agent),
-            ),
-          )
-        : assignments[0];
+      : await store.findActiveDefaultAgentAssignmentForChannel(event.channel);
     if (!binding && !assignment) {
       return undefined;
     }
     const backend = binding?.backend ?? assignment!.target.backend;
     const threadId = binding?.threadId ?? assignment!.target.threadId;
-    const thread = navigation?.threads.find(
-      (candidate) =>
-        candidate.source === backend
-        && candidate.id === threadId,
-    );
     return {
       backend,
       ...(binding ? { bindingId: binding.id } : {}),
-      destinationAgentName: thread?.agent?.name,
-      destinationThreadTitle: thread?.title,
+      destinationAgentName: await this.resolveRejectedRouteAgentName(
+        backend,
+        threadId,
+      ),
       routeSource: binding ? "binding" : "default-agent",
       targetKind: binding?.targetKind ?? "agent_thread",
       threadId,
     };
+  }
+
+  private async resolveRejectedRouteAgentName(
+    backend: MessagingBindingRecord["backend"],
+    threadId: MessagingBindingRecord["threadId"],
+  ): Promise<string | undefined> {
+    if (!this.options.backendBridge.readThreadAgentMetadata) {
+      return undefined;
+    }
+    const key = `${backend}:${threadId}`;
+    const now = Date.now();
+    const cached = this.rejectedRouteAgentNameCache.get(key);
+    if (cached && cached.expiresAt > now) {
+      return await cached.value;
+    }
+    const value = this.options.backendBridge.readThreadAgentMetadata({
+      backend,
+      threadId,
+    })
+      .then((metadata) => clipStatusText(metadata?.name))
+      .catch((error) => {
+        messagingLog.debug("messaging rejected route Agent-name lookup failed", {
+          backend,
+          error: error instanceof Error ? error.message : String(error),
+          threadId,
+        });
+        return undefined;
+      });
+    this.rejectedRouteAgentNameCache.set(key, {
+      expiresAt: now + REJECTED_ROUTE_AGENT_METADATA_TTL_MS,
+      value,
+    });
+    return await value;
   }
 
   private broadcastPlatformStatus(event: MessagingPlatformStatusEvent): void {

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1227,6 +1227,12 @@ export type MessagingRejectedInboundEvent = {
   id: string;
   kind: MessagingInboundEventKind;
   actor: MessagingActorIdentity;
+  /**
+   * True when the rejected platform message explicitly addressed the bot.
+   * Hosts use this to distinguish actionable shared-channel attempts from
+   * ambient conversation that should remain silent.
+   */
+  botMention?: boolean;
   channel: MessagingChannelRef;
   receivedAt: number;
   reason: MessagingInboundRejectionReason;

--- a/packages/messaging/providers/line/src/__tests__/line-adapter.test.ts
+++ b/packages/messaging/providers/line/src/__tests__/line-adapter.test.ts
@@ -612,7 +612,7 @@ describe("LineAdapter", () => {
 
     expect(events).toHaveLength(0);
     expect(rejections[0]).toMatchObject({
-      kind: "text",
+      kind: "command",
       reason: "unauthorized-conversation",
       channel: {
         conversation: {
@@ -620,6 +620,36 @@ describe("LineAdapter", () => {
           kind: "channel",
         },
       },
+    });
+  });
+
+  it("marks rejected LINE self-mentions as explicit bot mentions", async () => {
+    const port = await getFreePort();
+    const config = createConfig({ callbackBaseUrl: `http://127.0.0.1:${port}/` });
+    const adapter = new LineAdapter({
+      api: createApi(),
+      callbackHandleStore: createCallbackStore(),
+      config,
+    });
+    adapters.push(adapter);
+    const rejections: MessagingRejectedInboundEvent[] = [];
+    adapter.onInboundRejected((event) => {
+      rejections.push(event);
+    });
+    await adapter.start(async () => undefined);
+
+    await postLineWebhook(port, config.channelSecret, {
+      events: [lineGroupTextEvent({
+        text: "@PwrAgent status please",
+        mentionSelf: true,
+      })],
+    });
+    await waitFor(() => rejections.length === 1);
+
+    expect(rejections[0]).toMatchObject({
+      botMention: true,
+      kind: "text",
+      reason: "unauthorized-conversation",
     });
   });
 
@@ -945,7 +975,10 @@ async function postLineWebhook(
   });
 }
 
-function lineGroupTextEvent(params: { text: string }): unknown {
+function lineGroupTextEvent(params: {
+  mentionSelf?: boolean;
+  text: string;
+}): unknown {
   return {
     type: "message",
     webhookEventId: "event-group-text",
@@ -958,6 +991,13 @@ function lineGroupTextEvent(params: { text: string }): unknown {
       id: "12345",
       type: "text",
       text: params.text,
+      ...(params.mentionSelf
+        ? {
+            mention: {
+              mentionees: [{ isSelf: true, type: "user" }],
+            },
+          }
+        : {}),
     },
   };
 }

--- a/packages/messaging/providers/line/src/line-adapter.ts
+++ b/packages/messaging/providers/line/src/line-adapter.ts
@@ -622,13 +622,22 @@ export class LineAdapter implements LineProviderAdapter {
     if (!this.listener || !event.message) return;
     const text = event.message.type === "text" ? event.message.text ?? "" : "";
     const isPairing = Boolean(extractMessagingPairingToken(text));
+    const isCommand = event.message.type === "text" && text.startsWith("/");
+    const botMention =
+      event.message.type === "text"
+      && this.eventMentionsBot(event);
     if (!isPairing && !this.shouldAcceptTextEvent(event, channel, text)) {
       return;
     }
     if (!this.authorizeInbound({
       actor,
+      botMention,
       channel,
-      kind: event.message.type === "text" ? "text" : "media",
+      kind: isCommand
+        ? "command"
+        : event.message.type === "text"
+          ? "text"
+          : "media",
       pairing: isPairing,
       routingState,
     })) {
@@ -731,6 +740,7 @@ export class LineAdapter implements LineProviderAdapter {
 
   private authorizeInbound(params: {
     actor: MessagingActorIdentity;
+    botMention?: boolean;
     channel: MessagingChannelRef;
     kind: MessagingInboundEvent["kind"];
     pairing?: boolean;
@@ -742,6 +752,7 @@ export class LineAdapter implements LineProviderAdapter {
         id: this.newEventId("line-rejected"),
         kind: params.kind,
         actor: params.actor,
+        ...(params.botMention ? { botMention: true } : {}),
         channel: params.channel,
         receivedAt: this.now(),
         reason: "unauthorized-actor",
@@ -754,6 +765,7 @@ export class LineAdapter implements LineProviderAdapter {
         id: this.newEventId("line-rejected"),
         kind: params.kind,
         actor: params.actor,
+        ...(params.botMention ? { botMention: true } : {}),
         channel: params.channel,
         receivedAt: this.now(),
         reason: "unauthorized-conversation",
@@ -784,6 +796,10 @@ export class LineAdapter implements LineProviderAdapter {
   ): boolean {
     if (channel.conversation.kind === "dm") return true;
     if (text.startsWith("/")) return true;
+    return this.eventMentionsBot(event);
+  }
+
+  private eventMentionsBot(event: LineWebhookEvent): boolean {
     const mentionees = event.message?.mention?.mentionees ?? [];
     return mentionees.some((mention) => mention.isSelf === true || mention.userId === this.botUserId);
   }

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -2144,6 +2144,129 @@ describe("SlackAdapter", () => {
     ]);
   });
 
+  it("ignores ambient channel chatter from unauthorized actors", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({
+        conversations: { C012ABCDEF0: "p-search-signals-projects" },
+      }),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    const rejected: MessagingRejectedInboundEvent[] = [];
+    adapter.onInboundRejected((event) => {
+      rejected.push(event);
+    });
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "message",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        ts: "1712023032.123456",
+        user: "U099ZZZZZZZ",
+        text: "ordinary conversation between channel members",
+      },
+    });
+
+    expect(events).toEqual([]);
+    expect(rejected).toEqual([]);
+  });
+
+  it("ignores ambient file shares from unauthorized channel actors", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    const rejected: MessagingRejectedInboundEvent[] = [];
+    adapter.onInboundRejected((event) => {
+      rejected.push(event);
+    });
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "message",
+        subtype: "file_share",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        ts: "1712023032.123456",
+        user: "U099ZZZZZZZ",
+        text: "sharing this with the channel",
+        files: [{
+          id: "F012ABCDEF0",
+          mimetype: "image/png",
+          name: "chart.png",
+        }],
+      },
+    });
+
+    expect(events).toEqual([]);
+    expect(rejected).toEqual([]);
+  });
+
+  it("marks unauthorized bot mentions with the resolved channel title", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({
+        conversations: { C012ABCDEF0: "p-search-signals-projects" },
+      }),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const rejected: MessagingRejectedInboundEvent[] = [];
+    adapter.onInboundRejected((event) => {
+      rejected.push(event);
+    });
+    await adapter.start(async () => undefined);
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "app_mention",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        ts: "1712023032.123456",
+        user: "U099ZZZZZZZ",
+        text: "<@U0BOTUSERID> can you help?",
+      },
+    });
+
+    expect(rejected).toEqual([
+      expect.objectContaining({
+        botMention: true,
+        kind: "text",
+        reason: "unauthorized-actor",
+        channel: expect.objectContaining({
+          conversation: expect.objectContaining({
+            id: "C012ABCDEF0",
+            title: "p-search-signals-projects",
+          }),
+        }),
+      }),
+    ]);
+  });
+
   it("rejects events from workspaces outside the authorized team list", async () => {
     const socket = fakeSocket();
     const adapter = new SlackAdapter({
@@ -2622,13 +2745,13 @@ describe("SlackAdapter", () => {
     await socket.emitEvent("slack_event", {
       ack: async () => undefined,
       event: {
-        type: "message",
+        type: "app_mention",
         channel: "C012ABCDEF0",
         channel_type: "channel",
         team: "TEXTERNAL",
         ts: "1712023032.123456",
         user: "U012ABCDEF0",
-        text: "blocked shared channel chatter",
+        text: "<@U0BOTUSERID> blocked shared channel request",
       },
     });
 
@@ -2780,13 +2903,13 @@ describe("SlackAdapter", () => {
     await socket.emitEvent("slack_event", {
       ack: async () => undefined,
       event: {
-        type: "message",
+        type: "app_mention",
         channel: "C012ABCDEF0",
         channel_type: "channel",
         team: "T012ABCDEF0",
         ts: "1712023036.123456",
         user: "UNOTLISTED0",
-        text: "unlisted user in an approved channel",
+        text: "<@U0BOTUSERID> unlisted user in an approved channel",
       },
     });
 

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -1024,10 +1024,16 @@ export class SlackAdapter implements SlackProviderAdapter {
 
     if (!this.authorizeInbound({
       actor,
+      botMention: isMention,
       channel,
       kind,
       isGroupDm,
       pairing: isPairingMessage,
+      reportRejection:
+        isMention
+        || Boolean(command)
+        || channel.conversation.kind === "dm"
+        || channel.conversation.isDirectMessage === true,
       routingState,
       teamId: ids.teamId,
     })) return;
@@ -1881,10 +1887,12 @@ export class SlackAdapter implements SlackProviderAdapter {
 
   private authorizeInbound(params: {
     actor: MessagingActorIdentity;
+    botMention?: boolean;
     channel: MessagingChannelRef;
     kind: MessagingInboundEvent["kind"];
     isGroupDm?: boolean;
     pairing?: boolean;
+    reportRejection?: boolean;
     routingState?: MessagingAdapterState;
     teamId?: string;
   }): boolean {
@@ -1894,15 +1902,18 @@ export class SlackAdapter implements SlackProviderAdapter {
       params.actor.platformUserId,
     );
     const reject = (reason: "unauthorized-actor" | "unauthorized-conversation"): boolean => {
-      this.emitInboundRejected({
-        id: this.newEventId("slack-rejected"),
-        kind: params.kind,
-        actor: params.actor,
-        channel: params.channel,
-        receivedAt: this.now(),
-        reason,
-        ...(params.routingState ? { routingState: params.routingState } : {}),
-      });
+      if (params.reportRejection !== false) {
+        this.emitInboundRejected({
+          id: this.newEventId("slack-rejected"),
+          kind: params.kind,
+          actor: params.actor,
+          ...(params.botMention ? { botMention: true } : {}),
+          channel: params.channel,
+          receivedAt: this.now(),
+          reason,
+          ...(params.routingState ? { routingState: params.routingState } : {}),
+        });
+      }
       return false;
     };
 


### PR DESCRIPTION
## Summary

- silently drop unauthorized ambient Slack channel text and file-share events before they enter rejection observability
- record rejected shared-channel text/media only for explicit bot mentions that have an active binding or a valid default-Agent route
- include the resolved conversation display name, destination Agent/thread, backend, target kind, and route source in logs and Messaging Activity

## Root cause

The Slack adapter resolved friendly channel metadata, but every authorization failure emitted a rejected event. The desktop runtime immediately persisted and warned on that event before checking whether the message addressed the bot or had any route. In busy channels this turned unrelated conversation into warning logs and durable Messaging Activity rows.

The live `work` profile confirms `C05RKSBL1QF` is `#p-search-signals-projects` and falls back through the Slack provider default Agent assignment.

## User impact

Unauthorized people chatting normally in a channel no longer create warnings or Messaging Activity records, including file shares. An unauthorized explicit `@mention` is still observable when PwrAgent could have routed it, and that record now identifies both the friendly Slack location and intended Agent destination.

## Validation

- regression tests were added first and failed in six cases before the implementation
- `pnpm test packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts apps/desktop/src/main/__tests__/messaging-runtime.test.ts` (133 tests)
- `pnpm lint`
