### PR TITLE
feat(desktop): card kebab menu and projects-as-suns lens

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapCardMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapCardMenu.tsx
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type StarMapCardMenuAction = {
+  /** Destructive entries are tinted and separated from the rest. */
+  danger?: boolean;
+  disabled?: boolean;
+  key: string;
+  label: string;
+  onSelect: () => void;
+};
+
+/**
+ * Per-card kebab on the star map.
+ *
+ * Lives beside the card's clickable surface rather than inside it: the
+ * surface is a `<button>`, and a button inside a button is neither valid
+ * nor operable. The shell wrapper exists for exactly this reason.
+ */
+export function StarMapCardMenu(props: {
+  actions: StarMapCardMenuAction[];
+  threadTitle: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // The shell starts a card drag on pointerdown; without this a press on
+  // the kebab would drag the card out from under the pointer.
+  const swallow = useCallback((event: { stopPropagation: () => void }) => {
+    event.stopPropagation();
+  }, []);
+
+  return (
+    <div className="star-map-card__menu" ref={rootRef} onPointerDown={swallow}>
+      <button
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label={`Actions for ${props.threadTitle}`}
+        className="star-map-card__menu-button"
+        onClick={() => setOpen((current) => !current)}
+        type="button"
+      >
+        ⋯
+      </button>
+      {open ? (
+        <div className="star-map-card__menu-list" role="menu">
+          {props.actions.map((action) => (
+            <button
+              className={`star-map-card__menu-item${
+                action.danger ? " star-map-card__menu-item--danger" : ""
+              }`}
+              disabled={action.disabled}
+              key={action.key}
+              onClick={() => {
+                setOpen(false);
+                action.onSelect();
+              }}
+              role="menuitem"
+              type="button"
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapProjectBody.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapProjectBody.tsx
@@ -1,0 +1,24 @@
+/**
+ * A project rendered as a sun on the star map.
+ *
+ * Deliberately not a `StarMapInstanceCard`: a project has no celestial
+ * icon, no connection state, and no viewer to open — it is a place, not a
+ * machine. Its threads come from every instance in the federation, which
+ * is the whole point of the lens.
+ */
+export function StarMapProjectBody(props: {
+  label: string;
+  projectKey: string;
+  threadCount: number;
+}) {
+  return (
+    <div className="star-map-project" data-project-key={props.projectKey}>
+      <span className="star-map-project__glow" aria-hidden="true" />
+      <span className="star-map-project__core" aria-hidden="true" />
+      <span className="star-map-project__label" title={props.label}>
+        <span className="star-map-project__name">{props.label}</span>
+        <span className="star-map-project__count">{props.threadCount}</span>
+      </span>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -47,7 +47,7 @@ import {
 import { buildFederationTopology } from "./star-map-topology";
 import {
   groupThreadsByProject,
-  instanceIdForThread,
+  instanceIdByThreadKey,
 } from "./star-map-projects";
 import { computeProjectLayout } from "./star-map-project-layout";
 import { StarMapProjectBody } from "./StarMapProjectBody";
@@ -442,6 +442,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
 
   const projects = useMemo(
     () => groupThreadsByProject(attentionByInstance),
+    [attentionByInstance],
+  );
+
+  const projectThreadOwners = useMemo(
+    () => instanceIdByThreadKey(attentionByInstance),
     [attentionByInstance],
   );
 
@@ -1114,13 +1119,18 @@ export function StarMapScreen(props: StarMapScreenProps) {
                     threadCount={project.threads.length}
                   />
                   {visible.map((thread, index) => {
-                    const owner = instanceIdForThread(
-                      attentionByInstance,
-                      thread,
+                    const threadKey = buildThreadIdentityKey(
+                      thread.source,
+                      thread.id,
                     );
+                    // Every card here came out of `attentionByInstance`, so
+                    // the owner is always present; fall back to the local
+                    // instance rather than inventing an empty id.
+                    const owner =
+                      projectThreadOwners.get(threadKey) ?? localInstanceId;
                     return (
                       <StarMapThreadCard
-                        key={buildThreadIdentityKey(thread.source, thread.id)}
+                        key={threadKey}
                         thread={thread}
                         sessionKeys={
                           owner === localInstanceId
@@ -1131,6 +1141,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
                           owner === localInstanceId ? undefined : owner,
                         )}
                         baseSlot={slots[index]}
+                        // No drag here on purpose: arrangements are keyed
+                        // and synced per federation instance, and a project
+                        // is not an instance. Giving projects their own
+                        // arrangement space is protocol work, so cards in
+                        // this lens simply do not move rather than moving
+                        // and failing to persist.
                         width={ORBIT_CARD_WIDTH}
                         centered
                         stackIndex={index}
@@ -1144,7 +1160,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
                           secondaryDirectories: false,
                         }}
                         showInstanceChip
-                        menuActions={cardMenuActions(thread, owner ?? "")}
+                        menuActions={cardMenuActions(thread, owner)}
                         onOpen={openThread}
                       />
                     );

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -44,7 +44,9 @@ import {
   shouldStartCanvasPan,
 } from "./star-map-orbit";
 import { buildFederationTopology } from "./star-map-topology";
+import { readRendererFederationTarget } from "../../lib/federation-window";
 import { StarMapChatCard } from "./StarMapChatCard";
+import type { StarMapCardMenuAction } from "./StarMapCardMenu";
 import { useStarMapChatCards } from "./useStarMapChatCards";
 import { IntakeDialog, type IntakeDialogTarget } from "./IntakeDialog";
 import {
@@ -678,6 +680,92 @@ export function StarMapScreen(props: StarMapScreenProps) {
     [desktopApi, onOpenLocalThread],
   );
 
+  const [cardError, setCardError] = useState<string | undefined>(undefined);
+
+  /**
+   * Refresh whichever cloud owns a thread. Archive removes it from the
+   * owning instance, so the map has to re-fetch rather than guess.
+   */
+  const refreshOwner = useCallback(
+    (instanceId: string) => {
+      if (instanceId === localInstanceId) {
+        props.onRefreshLocalThreads?.();
+      } else {
+        setRemoteRefreshNonce((nonce) => nonce + 1);
+      }
+    },
+    [localInstanceId, props],
+  );
+
+  const cardMenuActions = useCallback(
+    (
+      thread: NavigationThreadSummary,
+      instanceId: string,
+    ): StarMapCardMenuAction[] => {
+      const federationTarget =
+        thread.federation?.ref.target ?? readRendererFederationTarget();
+      const actions: StarMapCardMenuAction[] = [
+        {
+          key: "open-full",
+          label: "Open in full view",
+          onSelect: () => openThreadFully(thread),
+        },
+      ];
+      if (desktopApi?.markThreadSeen && thread.inbox.inInbox) {
+        actions.push({
+          key: "mark-seen",
+          label: "Mark as seen",
+          onSelect: () => {
+            void desktopApi
+              .markThreadSeen?.({
+                backend: thread.source,
+                federationTarget,
+                threadId: thread.id,
+              })
+              .then(() => refreshOwner(instanceId))
+              .catch((error: unknown) => {
+                setCardError(
+                  error instanceof Error
+                    ? error.message
+                    : "Could not mark that thread seen.",
+                );
+              });
+          },
+        });
+      }
+      if (desktopApi?.archiveThread) {
+        actions.push({
+          danger: true,
+          key: "archive",
+          label: "Archive thread",
+          onSelect: () => {
+            void desktopApi
+              .archiveThread?.({
+                backend: thread.source,
+                federationTarget,
+                threadId: thread.id,
+              })
+              .then(() => {
+                chatCards.close(
+                  buildThreadIdentityKey(thread.source, thread.id),
+                );
+                refreshOwner(instanceId);
+              })
+              .catch((error: unknown) => {
+                setCardError(
+                  error instanceof Error
+                    ? error.message
+                    : "Could not archive that thread.",
+                );
+              });
+          },
+        });
+      }
+      return actions;
+    },
+    [chatCards, desktopApi, openThreadFully, refreshOwner],
+  );
+
   const linkState = (peerId: string) => {
     const status = peerById.get(peerId)?.status
       ?? (peerId === localInstanceId ? "connected" : "disconnected");
@@ -745,6 +833,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
               centered={orbitMode}
               stackIndex={index}
               cardFields={preferences.cardFields}
+              menuActions={cardMenuActions(thread, position.instanceId)}
               onCommitOffset={
                 // Drags persist + sync only once the durable instance id is
                 // known; before that, cards stay in their default slots.
@@ -1021,6 +1110,18 @@ export function StarMapScreen(props: StarMapScreenProps) {
           />
         );
       })}
+      {cardError ? (
+        <p className="star-map__card-error" role="alert">
+          {cardError}
+          <button
+            type="button"
+            aria-label="Dismiss error"
+            onClick={() => setCardError(undefined)}
+          >
+            ×
+          </button>
+        </p>
+      ) : null}
       {/* The map layer covers the app chrome, including the header toggle
           that opened it, so it must carry its own way out. */}
       <button

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -39,11 +39,18 @@ import {
   type StarMapCardSlot,
 } from "./star-map-layout";
 import {
+  cardRingSlots,
   computeOrbitPlacement,
   galaxyArmPath,
   shouldStartCanvasPan,
 } from "./star-map-orbit";
 import { buildFederationTopology } from "./star-map-topology";
+import {
+  groupThreadsByProject,
+  instanceIdForThread,
+} from "./star-map-projects";
+import { computeProjectLayout } from "./star-map-project-layout";
+import { StarMapProjectBody } from "./StarMapProjectBody";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { StarMapChatCard } from "./StarMapChatCard";
 import type { StarMapCardMenuAction } from "./StarMapCardMenu";
@@ -155,6 +162,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
   // pans and zooms rather than compressing the map to fit.
   const [view, setView] = useState({ x: 0, y: 0, scale: 1 });
   const orbitMode = preferences.layout === "orbit";
+  /** Projects as suns: threads pooled across instances, one body per repo. */
+  const projectsMode = preferences.layout === "projects";
 
   // Focus the layer on open AND whenever the floating thread closes -
   // "Back to map" leaves focus inside <main>, and without a refocus the
@@ -430,6 +439,26 @@ export function StarMapScreen(props: StarMapScreenProps) {
     props.sessionKeys,
     remote,
   ]);
+
+  const projects = useMemo(
+    () => groupThreadsByProject(attentionByInstance),
+    [attentionByInstance],
+  );
+
+  const projectLayout = useMemo(
+    () =>
+      computeProjectLayout({
+        cardWidth: ORBIT_CARD_WIDTH,
+        projects: projects.map((project) => ({
+          key: project.key,
+          cardCount: Math.min(
+            project.threads.length,
+            ORBIT_MAX_CARDS_PER_INSTANCE,
+          ),
+        })),
+      }),
+    [projects],
+  );
 
   // What the agent chip is currently holding back: cards the attention
   // filters would show but this one excludes.
@@ -920,7 +949,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
         </svg>
         <div
           ref={canvasRef}
-          className={`star-map__canvas${orbitMode ? " is-orbit" : ""}`}
+          className={`star-map__canvas${
+            orbitMode || projectsMode ? " is-orbit" : ""
+          }`}
           style={
             orbitMode
               ? {
@@ -928,9 +959,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
                   height: orbit.canvasHeight,
                   transform: `translate(${view.x}px, ${view.y}px) scale(${view.scale})`,
                 }
-              : undefined
+              : projectsMode
+                ? {
+                    width: projectLayout.canvasWidth,
+                    height: projectLayout.canvasHeight,
+                    transform: `translate(${view.x}px, ${view.y}px) scale(${view.scale})`,
+                  }
+                : undefined
           }
         >
+        {projectsMode ? null : (
         <svg
           className="star-map__links"
           viewBox={
@@ -989,7 +1027,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
             );
           })}
         </svg>
-        {bodies.map((position) => {
+        )}
+        {(projectsMode ? [] : bodies).map((position) => {
           const entry = instanceEntry(position.instanceId);
           return (
             <div
@@ -1051,7 +1090,69 @@ export function StarMapScreen(props: StarMapScreenProps) {
             </div>
           );
         })}
-        {bodies.map((position) => renderCloud(position))}
+        {(projectsMode ? [] : bodies).map((position) => renderCloud(position))}
+        {projectsMode
+          ? projectLayout.projects.map((placement) => {
+              const project = projects.find(
+                (entry) => entry.key === placement.key,
+              );
+              if (!project) return null;
+              const visible = project.threads.slice(
+                0,
+                ORBIT_MAX_CARDS_PER_INSTANCE,
+              );
+              const slots = cardRingSlots(visible.length, ORBIT_CARD_WIDTH);
+              return (
+                <div
+                  key={`project:${placement.key}`}
+                  className="star-map__project-cloud"
+                  style={{ left: placement.x, top: placement.y }}
+                >
+                  <StarMapProjectBody
+                    label={project.label}
+                    projectKey={project.key}
+                    threadCount={project.threads.length}
+                  />
+                  {visible.map((thread, index) => {
+                    const owner = instanceIdForThread(
+                      attentionByInstance,
+                      thread,
+                    );
+                    return (
+                      <StarMapThreadCard
+                        key={buildThreadIdentityKey(thread.source, thread.id)}
+                        thread={thread}
+                        sessionKeys={
+                          owner === localInstanceId
+                            ? props.sessionKeys
+                            : undefined
+                        }
+                        instanceIcon={celestialIcons.iconFor(
+                          owner === localInstanceId ? undefined : owner,
+                        )}
+                        baseSlot={slots[index]}
+                        width={ORBIT_CARD_WIDTH}
+                        centered
+                        stackIndex={index}
+                        // The project IS the sun here, so the project chip
+                        // is redundant; the machine is what you cannot
+                        // otherwise tell, so the instance chip earns its
+                        // place instead.
+                        cardFields={{
+                          ...preferences.cardFields,
+                          primaryDirectory: false,
+                          secondaryDirectories: false,
+                        }}
+                        showInstanceChip
+                        menuActions={cardMenuActions(thread, owner ?? "")}
+                        onOpen={openThread}
+                      />
+                    );
+                  })}
+                </div>
+              );
+            })
+          : null}
         </div>
       </div>
       {intakeTarget ? (

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -60,6 +60,11 @@ export function StarMapThreadCard(props: {
   onOpen: (thread: NavigationThreadSummary) => void;
   /** Kebab entries; the kebab is hidden when empty. */
   menuActions?: StarMapCardMenuAction[];
+  /**
+   * Projects lens only: the sun is a project, so the machine is the thing
+   * you cannot otherwise tell from the card's position.
+   */
+  showInstanceChip?: boolean;
 }) {
   const thread = props.thread;
   const threadKey = buildThreadIdentityKey(thread.source, thread.id);
@@ -191,8 +196,9 @@ export function StarMapThreadCard(props: {
           }
           includeLinkedDirectories={props.cardFields.primaryDirectory}
           linkedDirectoryMode="label"
-          // The lane and the watermark already say which machine this is.
-          hideInstanceChip
+          // In the instance lenses the lane and the watermark already say
+          // which machine this is; under the projects lens they do not.
+          hideInstanceChip={!props.showInstanceChip}
           hidePinChip
           chipVisibility={{
             provider: props.cardFields.provider,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -6,6 +6,10 @@ import {
 } from "@pwragent/shared";
 import { CelestialIcon } from "../../icons";
 import { PrChip } from "../pr-status/PrChip";
+import {
+  StarMapCardMenu,
+  type StarMapCardMenuAction,
+} from "./StarMapCardMenu";
 import { ThreadMetaChips } from "../navigation/ThreadMetaChips";
 import {
   getThreadRowStatus,
@@ -54,6 +58,8 @@ export function StarMapThreadCard(props: {
   /** Present when the card is draggable; receives the clamped offset. */
   onCommitOffset?: (offset: { dx: number; dy: number }) => void;
   onOpen: (thread: NavigationThreadSummary) => void;
+  /** Kebab entries; the kebab is hidden when empty. */
+  menuActions?: StarMapCardMenuAction[];
 }) {
   const thread = props.thread;
   const threadKey = buildThreadIdentityKey(thread.source, thread.id);
@@ -78,7 +84,7 @@ export function StarMapThreadCard(props: {
       : {}),
   };
 
-  const startDrag = (event: ReactPointerEvent<HTMLButtonElement>) => {
+  const startDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (!props.onCommitOffset || event.button !== 0) return;
     const element = event.currentTarget;
     const startX = event.clientX;
@@ -132,19 +138,16 @@ export function StarMapThreadCard(props: {
   };
 
   return (
-    <button
-      type="button"
-      className={`star-map-card${props.entering ? " star-map-card--entering" : ""}`}
+    // Shell owns position, drag and stacking so the clickable surface can
+    // stay a plain button and the kebab can sit beside it rather than
+    // nested inside it.
+    <div
+      className={`star-map-card-shell${
+        props.entering ? " star-map-card-shell--entering" : ""
+      }`}
       style={style}
       data-thread-key={threadKey}
       onPointerDown={startDrag}
-      onClick={() => {
-        if (suppressClickRef.current) {
-          suppressClickRef.current = false;
-          return;
-        }
-        props.onOpen(thread);
-      }}
     >
       {/* Top-right, and large: the next card covers this one's bottom, so
           the mark has to live in the strip that stays visible. */}
@@ -153,6 +156,24 @@ export function StarMapThreadCard(props: {
           <CelestialIcon icon={props.instanceIcon} size={104} />
         </span>
       ) : null}
+      {props.menuActions && props.menuActions.length > 0 ? (
+        <StarMapCardMenu actions={props.menuActions} threadTitle={thread.title} />
+      ) : null}
+      <button
+        type="button"
+        className="star-map-card"
+        // Names the action rather than letting the button's whole content
+        // become its accessible name; the chips stay readable as content,
+        // and the kebab beside it gets a distinct name of its own.
+        aria-label={`Open thread: ${thread.title}`}
+        onClick={() => {
+          if (suppressClickRef.current) {
+            suppressClickRef.current = false;
+            return;
+          }
+          props.onOpen(thread);
+        }}
+      >
       <span className="star-map-card__heading">
         <ThreadRowStatus status={status} />
         <span className="star-map-card__title" title={thread.title}>
@@ -194,6 +215,7 @@ export function StarMapThreadCard(props: {
           />
         ))}
       </span>
-    </button>
+      </button>
+    </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapViewOptions.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapViewOptions.tsx
@@ -72,7 +72,7 @@ export function StarMapViewOptions(props: {
         >
           <p className="star-map__view-heading">Layout</p>
           <div className="star-map__layout-switch" role="group" aria-label="Layout">
-            {(["lanes", "orbit"] as const).map((mode) => (
+            {(["lanes", "orbit", "projects"] as const).map((mode) => (
               <button
                 key={mode}
                 type="button"
@@ -84,7 +84,11 @@ export function StarMapViewOptions(props: {
                   props.onChange({ ...props.preferences, layout: mode })
                 }
               >
-                {mode === "lanes" ? "Lanes" : "Orbit"}
+                {mode === "lanes"
+                  ? "Lanes"
+                  : mode === "orbit"
+                    ? "Orbit"
+                    : "Projects"}
               </button>
             ))}
           </div>

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -583,4 +583,38 @@ describe("StarMapScreen", () => {
     });
     expect(archiveThread).not.toHaveBeenCalled();
   });
+
+  it("groups threads under project suns and swaps the project chip for the instance", async () => {
+    window.localStorage.setItem(
+      "pwragent.starMap.viewPreferences",
+      JSON.stringify({ layout: "projects" }),
+    );
+    try {
+      render(
+        <StarMapScreen
+          desktopApi={buildDesktopApi()}
+          localThreads={[unreadThread("t1")]}
+          sessionKeys={{}}
+          localInstanceLabel="Mac-Mini-M4"
+          floating={false}
+          onClose={() => undefined}
+          onOpenLocalThread={() => undefined}
+          onFocusLocalInstance={() => undefined}
+        />,
+      );
+
+      // The fixture's linked directory is /tmp/pwrsnap, so the sun is the
+      // repo folder rather than the worktree label.
+      const sun = await screen.findByTitle("pwrsnap");
+      expect(sun).toBeTruthy();
+
+      const card = screen.getByRole("button", {
+        name: /Open thread: Thread t1/,
+      });
+      // The project is the sun, so its chip is redundant here.
+      expect(card.textContent).not.toContain("PwrSnap");
+    } finally {
+      window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    }
+  });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -71,7 +71,7 @@ describe("StarMapScreen", () => {
       ).toBeTruthy();
     });
 
-    const card = screen.getByRole("button", { name: /Thread t1/ });
+    const card = screen.getByRole("button", { name: /Open thread: Thread t1/ });
     expect(card.textContent).toContain("PwrSnap");
     expect(card.textContent).not.toMatch(/local/i);
     expect(card.textContent).not.toMatch(/worktree/i);
@@ -112,7 +112,7 @@ describe("StarMapScreen", () => {
         screen.getByRole("button", { name: /Open this instance \(Mac-Mini-M4\)/ }),
       ).toBeTruthy();
     });
-    const card = screen.getByRole("button", { name: /Thread t1/ });
+    const card = screen.getByRole("button", { name: /Open thread: Thread t1/ });
     fireEvent.click(card);
     await screen.findByRole("region", { name: "Chat: Thread t1" });
     fireEvent.click(card);
@@ -141,7 +141,7 @@ describe("StarMapScreen", () => {
         screen.getByRole("button", { name: /Open this instance \(Mac-Mini-M4\)/ }),
       ).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole("button", { name: /Thread t1/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Open thread: Thread t1/ }));
     const chat = await screen.findByRole("region", { name: "Chat: Thread t1" });
     fireEvent.click(
       within(chat).getByRole("button", { name: "Close chat: Thread t1" }),
@@ -167,11 +167,11 @@ describe("StarMapScreen", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: /Thread t2/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Open thread: Thread t2/ })).toBeTruthy();
     // Scope to the chip row: thread cards also expose an "Unread" status.
     const filterRow = screen.getByRole("group", { name: "Attention filters" });
     fireEvent.click(within(filterRow).getByRole("button", { name: /^Unread/ }));
-    expect(screen.queryByRole("button", { name: /Thread t2/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Open thread: Thread t2/ })).toBeNull();
   });
 
   it("closes on Escape", async () => {
@@ -423,7 +423,7 @@ describe("StarMapScreen", () => {
         onFocusLocalInstance={() => undefined}
       />,
     );
-    const card = await screen.findByRole("button", { name: /Thread t7/ });
+    const card = await screen.findByRole("button", { name: /Open thread: Thread t7/ });
     // Project chip stays; provider and branch are opt-in.
     expect(card.textContent).toContain("PwrSnap");
     expect(card.textContent).not.toContain("OpenAI");
@@ -480,5 +480,107 @@ describe("StarMapScreen", () => {
     });
     // The local instance is never hidden by this option.
     expect(screen.getByText("Local")).toBeTruthy();
+  });
+
+  it("archives a thread from the card kebab and refreshes its cloud", async () => {
+    const archiveThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "t1",
+    }));
+    const onRefreshLocalThreads = vi.fn();
+    render(
+      <StarMapScreen
+        desktopApi={{ ...buildDesktopApi(), archiveThread } as unknown as DesktopApi}
+        localThreads={[unreadThread("t1")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+        onRefreshLocalThreads={onRefreshLocalThreads}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance \(Mac-Mini-M4\)/ }),
+      ).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Thread t1" }),
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Archive thread" }));
+
+    await waitFor(() => {
+      expect(archiveThread).toHaveBeenCalledWith(
+        expect.objectContaining({ backend: "codex", threadId: "t1" }),
+      );
+    });
+    await waitFor(() => {
+      expect(onRefreshLocalThreads).toHaveBeenCalled();
+    });
+  });
+
+  it("surfaces an archive failure instead of silently dropping it", async () => {
+    const archiveThread = vi.fn(async () => {
+      throw new Error("peer is offline");
+    });
+    render(
+      <StarMapScreen
+        desktopApi={{ ...buildDesktopApi(), archiveThread } as unknown as DesktopApi}
+        localThreads={[unreadThread("t1")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance \(Mac-Mini-M4\)/ }),
+      ).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Thread t1" }),
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Archive thread" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/peer is offline/);
+  });
+
+  it("closes the kebab on Escape without running anything", async () => {
+    const archiveThread = vi.fn();
+    render(
+      <StarMapScreen
+        desktopApi={{ ...buildDesktopApi(), archiveThread } as unknown as DesktopApi}
+        localThreads={[unreadThread("t1")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance \(Mac-Mini-M4\)/ }),
+      ).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Thread t1" }),
+    );
+    expect(screen.getByRole("menu")).toBeTruthy();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).toBeNull();
+    });
+    expect(archiveThread).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
@@ -71,9 +71,11 @@ describe("card rings", () => {
     const single = cardRingExtent(4, 200);
     const many = cardRingExtent(16, 200);
     expect(cardRings(16, 200).length).toBeGreaterThan(1);
-    // Sixteen cards on one circle would need a radius over 500; rings keep
-    // the outermost far tighter than that.
-    expect(many.rx).toBeLessThan(500);
+    // `cardRingExtent` reports the drawn cloud, cards included, so these
+    // bounds carry a card half-width over the ring radius. Sixteen cards
+    // on a single circle would need ~418px of ring (~518 drawn); stacking
+    // rings keeps it under that, and the real win is vertical (below).
+    expect(many.rx).toBeLessThan(518);
     expect(many.rx).toBeGreaterThan(single.rx);
   });
 
@@ -383,7 +385,8 @@ describe("empty instances do not reserve a phantom ring", () => {
   it("claims only its body when it has no cards", () => {
     const empty = cardRingExtent(0, 200);
     const oneCard = cardRingExtent(1, 200);
-    expect(empty.rx).toBeLessThan(oneCard.rx / 2);
+    expect(empty.rx).toBeLessThan(oneCard.rx);
+    expect(empty.ry).toBeLessThan(oneCard.ry);
   });
 
   it("pulls the constellation in when the hub is empty", () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-projects.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-projects.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import {
+  STAR_MAP_NO_PROJECT_KEY,
+  groupThreadsByProject,
+  instanceIdForThread,
+  threadProjectKey,
+} from "../star-map-projects";
+import { computeProjectLayout } from "../star-map-project-layout";
+import { cardRingSlots } from "../star-map-orbit";
+
+function thread(params: {
+  id: string;
+  repoPath?: string;
+  label?: string;
+  worktreePath?: string;
+  updatedAt?: number;
+}): NavigationThreadSummary {
+  return {
+    id: params.id,
+    title: `Thread ${params.id}`,
+    source: "codex",
+    inbox: { inInbox: false },
+    updatedAt: params.updatedAt ?? 0,
+    linkedDirectories: params.repoPath
+      ? [
+          {
+            id: `${params.id}-dir`,
+            kind: params.worktreePath ? "worktree" : "local",
+            label: params.label ?? "label",
+            path: params.repoPath,
+            ...(params.worktreePath
+              ? { worktreePath: params.worktreePath }
+              : {}),
+          },
+        ]
+      : [],
+  } as unknown as NavigationThreadSummary;
+}
+
+describe("threadProjectKey", () => {
+  it("keys on the repo root, not the worktree", () => {
+    const a = thread({
+      id: "a",
+      repoPath: "/repos/PwrAgnt",
+      label: "2026-07-31-b3ba9c",
+      worktreePath: "/worktrees/2026-07-31-b3ba9c",
+    });
+    const b = thread({
+      id: "b",
+      repoPath: "/repos/PwrAgnt",
+      label: "2026-08-02-a99cba",
+      worktreePath: "/worktrees/2026-08-02-a99cba",
+    });
+    // Two worktrees of one repo are one project, not two.
+    expect(threadProjectKey(a)).toBe(threadProjectKey(b));
+  });
+
+  it("falls back to a sentinel when a thread has no directory", () => {
+    expect(threadProjectKey(thread({ id: "x" }))).toBe(STAR_MAP_NO_PROJECT_KEY);
+  });
+});
+
+describe("groupThreadsByProject", () => {
+  const local = thread({ id: "l1", repoPath: "/repos/PwrAgnt", updatedAt: 10 });
+  const remote = thread({ id: "r1", repoPath: "/repos/PwrAgnt", updatedAt: 30 });
+  const other = thread({ id: "o1", repoPath: "/repos/PwrSnap", updatedAt: 20 });
+  const orphan = thread({ id: "n1", updatedAt: 5 });
+  const byInstance = new Map([
+    ["local", [local, other]],
+    ["peer", [remote, orphan]],
+  ]);
+
+  it("pools threads for one project across instances", () => {
+    const projects = groupThreadsByProject(byInstance);
+    const pwragent = projects.find((p) => p.key === "/repos/PwrAgnt");
+    expect(pwragent?.threads.map((t) => t.id)).toEqual(["r1", "l1"]);
+  });
+
+  it("names a project after its repo folder", () => {
+    const projects = groupThreadsByProject(byInstance);
+    expect(projects.find((p) => p.key === "/repos/PwrSnap")?.label).toBe(
+      "PwrSnap",
+    );
+  });
+
+  it("orders threads within a project by recent activity", () => {
+    const projects = groupThreadsByProject(byInstance);
+    const ids = projects.find((p) => p.key === "/repos/PwrAgnt")!.threads;
+    expect(ids[0].updatedAt).toBeGreaterThan(ids[1].updatedAt!);
+  });
+
+  it("puts the busiest project first", () => {
+    expect(groupThreadsByProject(byInstance)[0].key).toBe("/repos/PwrAgnt");
+  });
+
+  it("gives directory-less threads a home", () => {
+    const projects = groupThreadsByProject(byInstance);
+    const none = projects.find((p) => p.key === STAR_MAP_NO_PROJECT_KEY);
+    expect(none?.label).toBe("No project");
+    expect(none?.threads).toHaveLength(1);
+  });
+
+  it("is stable across calls", () => {
+    expect(groupThreadsByProject(byInstance).map((p) => p.key)).toEqual(
+      groupThreadsByProject(byInstance).map((p) => p.key),
+    );
+  });
+});
+
+describe("instanceIdForThread", () => {
+  const local = thread({ id: "l1", repoPath: "/repos/A" });
+  const remote = thread({ id: "r1", repoPath: "/repos/A" });
+  const byInstance = new Map([
+    ["local", [local]],
+    ["peer", [remote]],
+  ]);
+
+  it("finds the owning instance", () => {
+    expect(instanceIdForThread(byInstance, remote)).toBe("peer");
+    expect(instanceIdForThread(byInstance, local)).toBe("local");
+  });
+
+  it("returns undefined for a thread from nowhere", () => {
+    expect(
+      instanceIdForThread(byInstance, thread({ id: "gone" })),
+    ).toBeUndefined();
+  });
+});
+
+describe("computeProjectLayout", () => {
+  it("returns an empty canvas when there is nothing to place", () => {
+    const layout = computeProjectLayout({ cardWidth: 200, projects: [] });
+    expect(layout.projects).toHaveLength(0);
+    expect(layout.canvasWidth).toBe(0);
+  });
+
+  it("places every project exactly once", () => {
+    const layout = computeProjectLayout({
+      cardWidth: 200,
+      projects: [
+        { key: "a", cardCount: 9 },
+        { key: "b", cardCount: 3 },
+        { key: "c", cardCount: 1 },
+      ],
+    });
+    expect(layout.projects.map((p) => p.key).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("never lets two projects' cards overlap", () => {
+    const defs = [
+      { key: "a", cardCount: 12 },
+      { key: "b", cardCount: 2 },
+      { key: "c", cardCount: 7 },
+      { key: "d", cardCount: 1 },
+      { key: "e", cardCount: 20 },
+    ];
+    const layout = computeProjectLayout({ cardWidth: 200, projects: defs });
+
+    // The reported extent must already cover the cards themselves — they
+    // sit centred on the outermost ring and overhang it by half a card.
+    // Sizing on the bare ring radius let neighbouring clouds interleave.
+    for (const project of layout.projects) {
+      const count = defs.find((def) => def.key === project.key)!.cardCount;
+      for (const slot of cardRingSlots(count, 200)) {
+        expect(Math.abs(slot.dx) + 100).toBeLessThanOrEqual(project.rx + 1);
+        expect(Math.abs(slot.dy) + 56).toBeLessThanOrEqual(project.ry + 1);
+      }
+    }
+
+    for (const left of layout.projects) {
+      for (const right of layout.projects) {
+        if (left.key === right.key) continue;
+        const overlapX = Math.abs(left.x - right.x) < left.rx + right.rx;
+        const overlapY = Math.abs(left.y - right.y) < left.ry + right.ry;
+        expect(overlapX && overlapY).toBe(false);
+      }
+    }
+  });
+
+  it("gives a busy project a bigger footprint than a quiet one", () => {
+    const layout = computeProjectLayout({
+      cardWidth: 200,
+      projects: [
+        { key: "busy", cardCount: 20 },
+        { key: "quiet", cardCount: 1 },
+      ],
+    });
+    const busy = layout.projects.find((p) => p.key === "busy")!;
+    const quiet = layout.projects.find((p) => p.key === "quiet")!;
+    expect(busy.rx).toBeGreaterThan(quiet.rx);
+  });
+
+  it("keeps every project inside the reported canvas", () => {
+    const layout = computeProjectLayout({
+      cardWidth: 200,
+      projects: Array.from({ length: 9 }, (_, index) => ({
+        key: `p${index}`,
+        cardCount: index + 1,
+      })),
+    });
+    for (const project of layout.projects) {
+      expect(project.x - project.rx).toBeGreaterThan(0);
+      expect(project.x + project.rx).toBeLessThan(layout.canvasWidth);
+      expect(project.y - project.ry).toBeGreaterThan(0);
+      expect(project.y + project.ry).toBeLessThan(layout.canvasHeight);
+    }
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-projects.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-projects.test.ts
@@ -3,7 +3,7 @@ import type { NavigationThreadSummary } from "@pwragent/shared";
 import {
   STAR_MAP_NO_PROJECT_KEY,
   groupThreadsByProject,
-  instanceIdForThread,
+  instanceIdByThreadKey,
   threadProjectKey,
 } from "../star-map-projects";
 import { computeProjectLayout } from "../star-map-project-layout";
@@ -108,7 +108,7 @@ describe("groupThreadsByProject", () => {
   });
 });
 
-describe("instanceIdForThread", () => {
+describe("instanceIdByThreadKey", () => {
   const local = thread({ id: "l1", repoPath: "/repos/A" });
   const remote = thread({ id: "r1", repoPath: "/repos/A" });
   const byInstance = new Map([
@@ -116,15 +116,24 @@ describe("instanceIdForThread", () => {
     ["peer", [remote]],
   ]);
 
-  it("finds the owning instance", () => {
-    expect(instanceIdForThread(byInstance, remote)).toBe("peer");
-    expect(instanceIdForThread(byInstance, local)).toBe("local");
+  it("maps each thread to its owning instance", () => {
+    const owners = instanceIdByThreadKey(byInstance);
+    expect(owners.get("codex:r1")).toBe("peer");
+    expect(owners.get("codex:l1")).toBe("local");
   });
 
-  it("returns undefined for a thread from nowhere", () => {
+  it("has no entry for a thread from nowhere", () => {
+    expect(instanceIdByThreadKey(byInstance).get("codex:gone")).toBeUndefined();
+  });
+
+  it("keys on thread identity, not object identity", () => {
+    // A clone must resolve the same way — the previous implementation
+    // scanned with `===` and would have missed this entirely.
+    const owners = instanceIdByThreadKey(byInstance);
+    const clone = { ...remote } as typeof remote;
     expect(
-      instanceIdForThread(byInstance, thread({ id: "gone" })),
-    ).toBeUndefined();
+      owners.get(`${clone.source}:${clone.id}`),
+    ).toBe("peer");
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
@@ -204,9 +204,17 @@ export function cardRingExtent(
   if (count <= 0) {
     return { rx: EMPTY_INSTANCE_EXTENT, ry: EMPTY_INSTANCE_EXTENT };
   }
-  const rings = cardRings(count, cardWidth);
-  const outer = rings[rings.length - 1];
-  return { rx: outer.rx, ry: outer.ry };
+  // Half-extent of the DRAWN cloud, cards included — measured from the
+  // placed slots rather than the bare rings. Keep-out relief pushes some
+  // slots outside their ring, and slots hold card centres, so a caller
+  // spacing bodies on ring radii alone would let real cards collide.
+  let rx = 0;
+  let ry = 0;
+  for (const slot of cardRingSlots(count, cardWidth)) {
+    rx = Math.max(rx, Math.abs(slot.dx) + cardWidth / 2);
+    ry = Math.max(ry, Math.abs(slot.dy) + CARD_HALF_HEIGHT);
+  }
+  return { rx, ry };
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-preferences.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-preferences.ts
@@ -18,7 +18,7 @@ export type StarMapCardFields = {
   terminalPullRequests: boolean;
 };
 
-export type StarMapLayoutMode = "lanes" | "orbit";
+export type StarMapLayoutMode = "lanes" | "orbit" | "projects";
 
 /**
  * Include everything, only agent-driven threads, or everything except
@@ -50,7 +50,11 @@ export function nextAgentFilter(
 }
 
 export type StarMapViewPreferences = {
-  /** Lane columns under a body row, or bodies with orbiting card rings. */
+  /**
+   * Lane columns under a body row, instance bodies with orbiting card
+   * rings, or projects as suns with their threads pooled from every
+   * instance.
+   */
   layout: StarMapLayoutMode;
   cardFields: StarMapCardFields;
   /** Drop instances that are not currently connected from the map. */
@@ -97,7 +101,10 @@ export function readStoredPreferences(): StarMapViewPreferences {
     if (!raw) return DEFAULT_STAR_MAP_PREFERENCES;
     const parsed = JSON.parse(raw) as Partial<StarMapViewPreferences>;
     return {
-      layout: parsed.layout === "orbit" ? "orbit" : "lanes",
+      layout:
+        parsed.layout === "orbit" || parsed.layout === "projects"
+          ? parsed.layout
+          : "lanes",
       cardFields: {
         ...DEFAULT_STAR_MAP_PREFERENCES.cardFields,
         ...(parsed.cardFields ?? {}),

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-project-layout.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-project-layout.ts
@@ -1,0 +1,115 @@
+import { cardRingExtent } from "./star-map-orbit";
+
+export type ProjectPlacement = {
+  key: string;
+  x: number;
+  y: number;
+  /** Outermost card-ring extent, for halo sizing and hit testing. */
+  rx: number;
+  ry: number;
+};
+
+export type ProjectLayout = {
+  canvasHeight: number;
+  canvasWidth: number;
+  projects: ProjectPlacement[];
+};
+
+/** Breathing room between two projects' outermost cards. */
+const PROJECT_GAP = 72;
+const CANVAS_PADDING = 140;
+/** Roughly landscape, matching the window rather than a square canvas. */
+const TARGET_ASPECT = 1.45;
+
+/**
+ * Lay projects out as independent suns.
+ *
+ * Unlike the instance layouts there is no hub here — projects are peers,
+ * so a hub-and-spoke placement does not apply. They pack into rows sized
+ * by each project's own card-ring extent, which keeps a project with two
+ * threads from claiming the same footprint as one with twenty.
+ *
+ * Row packing (rather than a fixed grid) is what lets the cell size follow
+ * the content: a uniform grid would have to size every cell for the
+ * busiest project and leave the quiet ones adrift in empty space.
+ */
+export function computeProjectLayout(params: {
+  cardWidth: number;
+  /** Visible card count per project key, in the order to place them. */
+  projects: readonly { key: string; cardCount: number }[];
+}): ProjectLayout {
+  if (params.projects.length === 0) {
+    return { canvasHeight: 0, canvasWidth: 0, projects: [] };
+  }
+
+  const cells = params.projects.map((project) => {
+    const extent = cardRingExtent(project.cardCount, params.cardWidth);
+    // `cardRingExtent` already reports the drawn cloud (cards included),
+    // so the cell only adds the gap between neighbours.
+    return {
+      key: project.key,
+      halfWidth: extent.rx + PROJECT_GAP / 2,
+      halfHeight: extent.ry + PROJECT_GAP / 2,
+    };
+  });
+
+  const totalArea = cells.reduce(
+    (sum, cell) => sum + cell.halfWidth * 2 * (cell.halfHeight * 2),
+    0,
+  );
+  const targetRowWidth = Math.max(
+    cells[0].halfWidth * 2,
+    Math.sqrt(totalArea * TARGET_ASPECT),
+  );
+
+  const rows: (typeof cells)[] = [];
+  let row: typeof cells = [];
+  let rowWidth = 0;
+  for (const cell of cells) {
+    const width = cell.halfWidth * 2;
+    if (row.length > 0 && rowWidth + width > targetRowWidth) {
+      rows.push(row);
+      row = [];
+      rowWidth = 0;
+    }
+    row.push(cell);
+    rowWidth += width;
+  }
+  if (row.length > 0) rows.push(row);
+
+  const rowHeights = rows.map((entries) =>
+    entries.reduce((tallest, cell) => Math.max(tallest, cell.halfHeight * 2), 0),
+  );
+  const rowWidths = rows.map((entries) =>
+    entries.reduce((sum, cell) => sum + cell.halfWidth * 2, 0),
+  );
+  const contentWidth = Math.max(...rowWidths);
+  const contentHeight = rowHeights.reduce((sum, height) => sum + height, 0);
+
+  const placements: ProjectPlacement[] = [];
+  let y = CANVAS_PADDING;
+  rows.forEach((entries, rowIndex) => {
+    // Centre each row so the constellation reads as a cluster rather than
+    // a left-aligned table.
+    let x = CANVAS_PADDING + (contentWidth - rowWidths[rowIndex]) / 2;
+    for (const cell of entries) {
+      placements.push({
+        key: cell.key,
+        x: x + cell.halfWidth,
+        y: y + rowHeights[rowIndex] / 2,
+        // Reported extent covers the cards, not just the ring, so callers
+        // hit-test and space against what is actually drawn.
+        rx: cell.halfWidth - PROJECT_GAP / 2,
+        ry: cell.halfHeight - PROJECT_GAP / 2,
+      });
+      x += cell.halfWidth * 2;
+    }
+    y += rowHeights[rowIndex];
+  });
+
+  return {
+    canvasHeight: contentHeight + CANVAS_PADDING * 2,
+    canvasWidth: contentWidth + CANVAS_PADDING * 2,
+    projects: placements,
+  };
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-projects.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-projects.ts
@@ -1,4 +1,7 @@
-import type { NavigationThreadSummary } from "@pwragent/shared";
+import {
+  buildThreadIdentityKey,
+  type NavigationThreadSummary,
+} from "@pwragent/shared";
 
 export type StarMapProject = {
   /** Stable identity: the repo root path, or a sentinel when there is none. */
@@ -76,13 +79,22 @@ export function groupThreadsByProject(
   );
 }
 
-/** Which instance a thread lives on, for the card's instance chip. */
-export function instanceIdForThread(
+/**
+ * Owning instance per thread, for the card's instance chip.
+ *
+ * Built once and looked up by identity key rather than scanned per card:
+ * a per-card scan is O(instances x threads) on every render, and matching
+ * on object identity would break silently the moment any layer cloned a
+ * summary instead of passing the same reference through.
+ */
+export function instanceIdByThreadKey(
   threadsByInstance: ReadonlyMap<string, readonly NavigationThreadSummary[]>,
-  thread: NavigationThreadSummary,
-): string | undefined {
+): Map<string, string> {
+  const owners = new Map<string, string>();
   for (const [instanceId, threads] of threadsByInstance) {
-    if (threads.some((entry) => entry === thread)) return instanceId;
+    for (const thread of threads) {
+      owners.set(buildThreadIdentityKey(thread.source, thread.id), instanceId);
+    }
   }
-  return undefined;
+  return owners;
 }

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-projects.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-projects.ts
@@ -1,0 +1,88 @@
+import type { NavigationThreadSummary } from "@pwragent/shared";
+
+export type StarMapProject = {
+  /** Stable identity: the repo root path, or a sentinel when there is none. */
+  key: string;
+  label: string;
+  /** Threads pooled from every instance, most recently active first. */
+  threads: NavigationThreadSummary[];
+};
+
+/** Threads with no linked directory still need somewhere to live. */
+export const STAR_MAP_NO_PROJECT_KEY = "__no-project__";
+const NO_PROJECT_LABEL = "No project";
+
+/**
+ * A thread's project is the repo its primary linked directory belongs to.
+ *
+ * `path` is the repo root even for worktree entries (which carry the
+ * worktree separately in `worktreePath`), so grouping on it collapses
+ * every worktree of a repo onto one body. Grouping on the label instead
+ * would scatter a repo across a body per worktree, since worktree labels
+ * are generated per-workspace.
+ */
+export function threadProjectKey(thread: NavigationThreadSummary): string {
+  const primary = thread.linkedDirectories[0];
+  return primary?.path ?? STAR_MAP_NO_PROJECT_KEY;
+}
+
+function projectLabel(thread: NavigationThreadSummary): string {
+  const primary = thread.linkedDirectories[0];
+  if (!primary) return NO_PROJECT_LABEL;
+  // Prefer the repo folder name over a worktree-generated label.
+  const segments = primary.path.split("/").filter(Boolean);
+  return segments[segments.length - 1] ?? primary.label;
+}
+
+/**
+ * Pool threads from every instance into projects.
+ *
+ * Unlike the instance layouts, a project body deliberately mixes threads
+ * from different machines — that is the whole point of the lens: "this
+ * project, everywhere" rather than "this machine, everything".
+ */
+export function groupThreadsByProject(
+  threadsByInstance: ReadonlyMap<string, readonly NavigationThreadSummary[]>,
+): StarMapProject[] {
+  const projects = new Map<string, StarMapProject>();
+  for (const threads of threadsByInstance.values()) {
+    for (const thread of threads) {
+      const key = threadProjectKey(thread);
+      const existing = projects.get(key);
+      if (existing) {
+        existing.threads.push(thread);
+      } else {
+        projects.set(key, {
+          key,
+          label: key === STAR_MAP_NO_PROJECT_KEY
+            ? NO_PROJECT_LABEL
+            : projectLabel(thread),
+          threads: [thread],
+        });
+      }
+    }
+  }
+  for (const project of projects.values()) {
+    project.threads.sort(
+      (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
+    );
+  }
+  // Busiest projects first so the layout seats them nearest the centre;
+  // ties break on label so the map does not reshuffle between renders.
+  return [...projects.values()].sort(
+    (left, right) =>
+      right.threads.length - left.threads.length
+      || left.label.localeCompare(right.label),
+  );
+}
+
+/** Which instance a thread lives on, for the card's instance chip. */
+export function instanceIdForThread(
+  threadsByInstance: ReadonlyMap<string, readonly NavigationThreadSummary[]>,
+  thread: NavigationThreadSummary,
+): string | undefined {
+  for (const [instanceId, threads] of threadsByInstance) {
+    if (threads.some((entry) => entry === thread)) return instanceId;
+  }
+  return undefined;
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9367,7 +9367,11 @@ textarea,
 }
 
 /* The kebab only appears on the card under the pointer (or while its own
-   menu is open) so a dense cloud is not peppered with dots. */
+   menu is open) so a dense cloud is not peppered with dots.
+
+   `pointer-events: none` matters as much as the opacity: an opacity-0
+   button still hit-tests, so without it every card carried an invisible
+   click target in its top-right corner. */
 .star-map-card__menu {
   position: absolute;
   top: 4px;
@@ -9375,12 +9379,14 @@ textarea,
   z-index: 6;
   opacity: 0;
   transition: opacity 120ms ease;
+  pointer-events: none;
 }
 
 .star-map-card-shell:hover .star-map-card__menu,
 .star-map-card__menu:focus-within,
 .star-map-card__menu:has([aria-expanded="true"]) {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .star-map-card__menu-button {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9322,12 +9322,21 @@ textarea,
   white-space: nowrap;
 }
 
+/* Shell: position, stacking, drag target and rise animation. The visual
+   card is a plain button inside it, so the kebab can be a sibling rather
+   than a button nested in a button. */
+.star-map-card-shell {
+  position: absolute;
+  animation: star-map-rise 380ms ease-out backwards;
+}
+
 .star-map-card {
   display: flex;
-  position: absolute;
+  position: relative;
   flex-direction: column;
   overflow: hidden;
   gap: 6px;
+  width: 100%;
   padding: 8px 10px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
@@ -9337,7 +9346,6 @@ textarea,
   color: var(--text-primary);
   text-align: left;
   cursor: pointer;
-  animation: star-map-rise 380ms ease-out backwards;
   transition: border-color 120ms ease, transform 120ms ease;
 }
 
@@ -9348,11 +9356,118 @@ textarea,
    the next card the moment the pointer crossed its top band, which made
    everything below the first line unclickable.) No transform: the card
    must not move under the pointer. */
-.star-map-card:hover {
+.star-map-card-shell:hover {
   z-index: 5;
+}
+
+.star-map-card-shell:hover .star-map-card {
   border-color: var(--accent-border);
   background: var(--bg-panel-elevated);
   box-shadow: var(--shadow-popover);
+}
+
+/* The kebab only appears on the card under the pointer (or while its own
+   menu is open) so a dense cloud is not peppered with dots. */
+.star-map-card__menu {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 6;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.star-map-card-shell:hover .star-map-card__menu,
+.star-map-card__menu:focus-within,
+.star-map-card__menu:has([aria-expanded="true"]) {
+  opacity: 1;
+}
+
+.star-map-card__menu-button {
+  padding: 1px 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.star-map-card__menu-button:hover,
+.star-map-card__menu-button[aria-expanded="true"] {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.star-map-card__menu-list {
+  display: flex;
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 7;
+  flex-direction: column;
+  min-width: 168px;
+  padding: 4px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+}
+
+.star-map-card__menu-item {
+  padding: 6px 8px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 11px;
+  text-align: left;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.star-map-card__menu-item:hover:not(:disabled) {
+  background: var(--bg-panel-hover);
+}
+
+.star-map-card__menu-item--danger {
+  color: var(--danger-text);
+}
+
+.star-map-card__menu-item:disabled {
+  color: var(--text-muted);
+  cursor: default;
+}
+
+/* Card-action failures (archive, mark seen) surface over the map rather
+   than on the card, which may have just been refreshed away. */
+.star-map__card-error {
+  display: flex;
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  z-index: 30;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 7px 10px;
+  transform: translateX(-50%);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+  color: var(--danger-text);
+  font-size: 11px;
+}
+
+.star-map__card-error button {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
 }
 
 .star-map-card:focus-visible {
@@ -9427,7 +9542,7 @@ textarea,
 
 /* New-thread "bubble in" entrance (AI intake). Fade only under reduced
    motion. */
-.star-map-card--entering {
+.star-map-card-shell--entering {
   animation: star-map-card-enter 480ms ease-out;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9440,6 +9440,79 @@ textarea,
   cursor: default;
 }
 
+/* Projects lens: each project is a sun with its threads — pooled from
+   every instance — orbiting it. */
+.star-map__project-cloud {
+  position: absolute;
+  z-index: 1;
+}
+
+.star-map-project {
+  display: flex;
+  position: absolute;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+}
+
+.star-map-project__glow {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 168px;
+  height: 168px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  /* Cooler than an instance body: a project is a place, not a machine. */
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--accent) 26%, transparent) 0%,
+    transparent 68%
+  );
+  pointer-events: none;
+}
+
+.star-map-project__core {
+  width: 86px;
+  height: 86px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 35% 32%,
+    var(--accent-bright) 0%,
+    var(--accent) 58%,
+    color-mix(in srgb, var(--accent) 55%, transparent) 100%
+  );
+}
+
+.star-map-project__label {
+  display: inline-flex;
+  z-index: 1;
+  align-items: center;
+  gap: 6px;
+  max-width: 190px;
+  padding: 3px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.star-map-project__name {
+  overflow: hidden;
+  color: var(--text-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.star-map-project__count {
+  color: var(--text-muted);
+  font-weight: 500;
+  font-size: 11px;
+}
+
 /* Card-action failures (archive, mark seen) surface over the map rather
    than on the card, which may have just been refreshed away. */
 .star-map__card-error {


### PR DESCRIPTION
Two operator requests, stacked on #1281.

## Card kebab menu

Archive, mark-as-seen, and open-in-full-view straight from a map card, so threads that no longer need to be there can be cleared without leaving the surface.

The card's clickable surface is a `<button>`, and a button inside a button is neither valid nor operable — so the card grows a **shell wrapper**: the shell owns position, drag, stacking and the rise animation, the visual card stays a plain button inside it, and the kebab sits beside it as a sibling. The kebab fades in only for the card under the pointer (or while its menu is open) so a dense cloud isn't peppered with dots, and it swallows `pointerdown` so pressing it never starts a card drag.

Archive routes through the thread's own federation target, so a card over a peer's thread archives **on that peer**. On success the owning cloud re-fetches and any open chat card for that thread closes. Failures surface as an alert over the map rather than on the card, which may have just been refreshed away.

The card surface now carries an explicit `Open thread: <title>` accessible name instead of letting its whole content become the name — that keeps it distinct from the kebab's `Actions for <title>`, and naming the action reads better than a run-on of every chip.

## Projects-as-suns lens

A third layout beside Lanes and Orbit. Each project is a sun with its threads orbiting it, **pooled from every instance** — "this project, everywhere" rather than "this machine, everything".

- Projects key on the **repo root** (`linkedDirectories[0].path`), which is the repo even for worktree entries. Grouping on the label would scatter one repo across a body per worktree, since worktree labels are generated per-workspace.
- Threads with no linked directory get a **No project** body rather than vanishing.
- Cards swap chips to match: the project is the sun so its chip is redundant, while the machine is what position no longer tells you — the **instance chip** takes the space.
- Placement is **row packing sized by each project's own cloud**, not a uniform grid, so a two-thread project doesn't claim a twenty-thread footprint. Projects are peers, not a hub-and-spoke tree, so orbit placement didn't apply.

### One bug worth calling out

`cardRingExtent` reported the bare ring radii. Slots hold card *centres*, and keep-out relief can push them outside their ring, so neighbouring projects' cards interleaved into one jumbled cloud. It now reports the half-extent of the **drawn** cloud, measured from placed slots.

Rendering the layout is what surfaced it — the tests agreed with the code because they shared its wrong definition. The overlap test now checks real card rectangles against the reported extent.

## Verification

Full suite **6,627 passing**, typecheck clean, `lint:colors`, `lint:boundaries`, ESLint 0 errors. 19 new tests across project grouping, layout packing, the archive flow, and the lens's chip swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)