### PR TITLE
fix(desktop): prune archived remote thread pins

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -53,9 +53,14 @@ const federationMock = vi.hoisted(() => {
   };
   const remoteThreadSummaries = {
     resolvePinnedThreads: vi.fn(
-      async (): Promise<{ threads: unknown[]; refreshed: unknown[] }> => ({
+      async (): Promise<{
+        threads: unknown[];
+        refreshed: unknown[];
+        archived: unknown[];
+      }> => ({
         threads: [],
         refreshed: [],
+        archived: [],
       }),
     ),
     searchForJump: vi.fn(async () => ({ results: [] })),
@@ -277,6 +282,7 @@ const reconcileNavigationSnapshot = vi.fn(async (params: unknown) => ({
 const rememberCompleteNavigationSnapshot = vi.fn();
 const listRemoteThreadPins = vi.fn(async (): Promise<unknown[]> => []);
 const updateRemoteThreadPinSnapshots = vi.fn(async () => {});
+const removeRemoteThreadPinStore = vi.fn(async () => true);
 const addRemoteThreadPinStore = vi.fn(
   async (params: { ref: unknown; instanceLabel: string }) => ({
     ref: params.ref,
@@ -748,6 +754,7 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     writeThreadGitWorkingStateCacheEntry,
     listRemoteThreadPins,
     updateRemoteThreadPinSnapshots,
+    removeRemoteThreadPin: removeRemoteThreadPinStore,
     addRemoteThreadPin: addRemoteThreadPinStore,
     hasRemoteThreadPin,
     setRemoteThreadLocalPin,
@@ -1739,6 +1746,7 @@ describe("app server ipc", () => {
     federationMock.remoteThreadSummaries.resolvePinnedThreads.mockResolvedValueOnce({
       threads: [remoteRow],
       refreshed: [{ ref, summary: remoteRow, instanceLabel: "Laptop" }],
+      archived: [],
     });
 
     registerAppServerIpcHandlers();
@@ -1776,6 +1784,38 @@ describe("app server ipc", () => {
       (directory) => directory.key === "directory:/repo/app",
     );
     expect(appDirectory?.threadKeys).toContain("codex:remote-1");
+  });
+
+  it("removes a viewer-side remote pin when the owner proves it is archived", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const { buildFederatedThreadRef } = await import("@pwragent/shared");
+
+    const ref = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "peer-laptop",
+      threadId: "remote-archived",
+    });
+    const pin = { ref, addedAt: 1_000, instanceLabel: "Laptop" };
+    removeRemoteThreadPinStore.mockClear();
+    listRemoteThreadPins.mockResolvedValueOnce([pin]);
+    federationMock.remoteThreadSummaries.resolvePinnedThreads.mockResolvedValueOnce({
+      threads: [],
+      refreshed: [],
+      archived: [ref],
+    });
+
+    registerAppServerIpcHandlers();
+
+    const response = (await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.(
+      {},
+      {} satisfies GetNavigationSnapshotRequest,
+    )) as { threads: Array<{ id: string }> };
+
+    expect(removeRemoteThreadPinStore).toHaveBeenCalledWith({ ref });
+    expect(response.threads).not.toContainEqual(
+      expect.objectContaining({ id: "remote-archived" }),
+    );
   });
 
   it("groups a multi-directory remote thread into exactly one local project", async () => {
@@ -1862,6 +1902,7 @@ describe("app server ipc", () => {
         },
       ],
       refreshed: [],
+      archived: [],
     });
 
     registerAppServerIpcHandlers();
@@ -1917,6 +1958,7 @@ describe("app server ipc", () => {
         },
       ],
       refreshed: [],
+      archived: [],
     });
 
     registerAppServerIpcHandlers();
@@ -2198,6 +2240,7 @@ describe("app server ipc", () => {
         },
       ],
       refreshed: [],
+      archived: [],
     });
 
     registerAppServerIpcHandlers();

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -79,6 +79,8 @@ function snapshotOf(threads: NavigationThreadSummary[]): NavigationSnapshot {
   } as unknown as NavigationSnapshot;
 }
 
+const noArchivedThreads = async () => [];
+
 function pin(params: {
   instanceId: string;
   threadId: string;
@@ -117,6 +119,7 @@ describe("RemoteThreadSummaryCache — searchForJump", () => {
     const cache = new RemoteThreadSummaryCache({
       peers: () => [peer("peer-a")],
       fetchSnapshot: async () => snapshotOf(threads),
+      fetchArchivedThreads: noArchivedThreads,
       peerStatus: () => ({}),
     });
 
@@ -138,6 +141,7 @@ describe("RemoteThreadSummaryCache — searchForJump", () => {
     const cache = new RemoteThreadSummaryCache({
       peers: () => [peer("peer-a")],
       fetchSnapshot: async () => snapshotOf(threads),
+      fetchArchivedThreads: noArchivedThreads,
       peerStatus: () => ({}),
     });
 
@@ -155,6 +159,7 @@ describe("RemoteThreadSummaryCache — searchForJump", () => {
     const cache = new RemoteThreadSummaryCache({
       peers: () => [peer("peer-a")],
       fetchSnapshot,
+      fetchArchivedThreads: noArchivedThreads,
       peerStatus: () => ({}),
       ttlMs: 100,
       now: () => now,
@@ -180,6 +185,7 @@ describe("RemoteThreadSummaryCache — searchForJump", () => {
           stampedThread({ instanceId: "peer-fast", threadId: "t1", title: "match" }),
         ]);
       },
+      fetchArchivedThreads: noArchivedThreads,
       peerStatus: () => ({}),
       peerTimeoutMs: 20,
     });
@@ -199,6 +205,7 @@ describe("RemoteThreadSummaryCache — searchForJump", () => {
         },
       ],
       fetchSnapshot,
+      fetchArchivedThreads: noArchivedThreads,
       peerStatus: () => ({}),
     });
 
@@ -215,6 +222,7 @@ describe("RemoteThreadSummaryCache — threadFromPeer", () => {
         snapshotOf([
           stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Parent" }),
         ]),
+      fetchArchivedThreads: noArchivedThreads,
       peerStatus: () => ({}),
     });
 
@@ -238,6 +246,7 @@ describe("RemoteThreadSummaryCache — threadFromPeer", () => {
     const cache = new RemoteThreadSummaryCache({
       peers: () => [],
       fetchSnapshot,
+      fetchArchivedThreads: noArchivedThreads,
       peerStatus: () => ({}),
     });
 
@@ -262,6 +271,7 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
     const cache = new RemoteThreadSummaryCache({
       peers: () => [peer("peer-a", "Laptop")],
       fetchSnapshot: async () => snapshotOf([fresh]),
+      fetchArchivedThreads: noArchivedThreads,
       peerStatus: () => ({ status: "connected", label: "Laptop" }),
     });
 
@@ -286,6 +296,7 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
       fetchSnapshot: async () => {
         throw new Error("unreachable");
       },
+      fetchArchivedThreads: noArchivedThreads,
       peerStatus: () => ({ status: "disconnected", label: "Laptop" }),
     });
 
@@ -305,6 +316,7 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
       fetchSnapshot: async () => {
         throw new Error("boom");
       },
+      fetchArchivedThreads: noArchivedThreads,
       peerStatus: () => ({ status: "connected" }),
     });
 
@@ -318,6 +330,7 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
     const cache = new RemoteThreadSummaryCache({
       peers: () => [],
       fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: noArchivedThreads,
       peerStatus: () => ({}),
     });
 
@@ -333,6 +346,7 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
     const cache = new RemoteThreadSummaryCache({
       peers: () => [peer("peer-a")],
       fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: noArchivedThreads,
       peerStatus: () => ({ status: "connected" }),
     });
 
@@ -348,5 +362,58 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
     expect(resolved.threads[0].title).toBe("Archived on owner");
     expect(resolved.threads[0].federation?.peerStatus).toBe("connected");
     expect(resolved.refreshed).toEqual([]);
+    expect(resolved.archived).toEqual([]);
+  });
+
+  it("omits pins proven to be archived on a reachable owner", async () => {
+    const fetchArchivedThreads = vi.fn(async () => [
+      stampedThread({
+        instanceId: "peer-a",
+        threadId: "archived",
+        title: "Archived on owner",
+      }),
+    ]);
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads,
+      peerStatus: () => ({ status: "connected" }),
+    });
+    const archivedPin = pin({ instanceId: "peer-a", threadId: "archived" });
+
+    const resolved = await cache.resolvePinnedThreads([archivedPin]);
+
+    expect(fetchArchivedThreads).toHaveBeenCalledWith(
+      remoteTarget("peer-a"),
+      "codex",
+    );
+    expect(resolved.threads).toEqual([]);
+    expect(resolved.refreshed).toEqual([]);
+    expect(resolved.archived).toEqual([archivedPin.ref]);
+  });
+
+  it("keeps the cached row when archive detection fails", async () => {
+    const cached = stampedThread({
+      instanceId: "peer-a",
+      threadId: "missing",
+      title: "Cached title",
+    });
+    delete cached.federation;
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: async () => {
+        throw new Error("archive lookup failed");
+      },
+      peerStatus: () => ({ status: "connected" }),
+    });
+
+    const resolved = await cache.resolvePinnedThreads([
+      pin({ instanceId: "peer-a", threadId: "missing", summary: cached }),
+    ]);
+
+    expect(resolved.threads).toHaveLength(1);
+    expect(resolved.threads[0].title).toBe("Cached title");
+    expect(resolved.archived).toEqual([]);
   });
 });

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -392,6 +392,78 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
     expect(resolved.archived).toEqual([archivedPin.ref]);
   });
 
+  it("revalidates cached archive evidence before pruning a re-added pin", async () => {
+    const archivedThread = stampedThread({
+      instanceId: "peer-a",
+      threadId: "restored",
+      title: "Restored on owner",
+    });
+    const fetchArchivedThreads = vi
+      .fn()
+      .mockResolvedValueOnce([archivedThread])
+      .mockResolvedValueOnce([]);
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads,
+      peerStatus: () => ({ status: "connected" }),
+    });
+    const firstPin = pin({ instanceId: "peer-a", threadId: "restored" });
+    expect((await cache.resolvePinnedThreads([firstPin])).archived).toEqual([
+      firstPin.ref,
+    ]);
+
+    const cachedSummary = { ...archivedThread };
+    delete cachedSummary.federation;
+    const readdedPin = {
+      ...pin({
+        instanceId: "peer-a",
+        threadId: "restored",
+        summary: cachedSummary,
+      }),
+      addedAt: 2_000,
+    };
+    const resolved = await cache.resolvePinnedThreads([readdedPin]);
+
+    expect(fetchArchivedThreads).toHaveBeenCalledTimes(2);
+    expect(resolved.archived).toEqual([]);
+    expect(resolved.threads).toHaveLength(1);
+    expect(resolved.threads[0].title).toBe("Restored on owner");
+  });
+
+  it("shares one peer deadline between the active and archived lookups", async () => {
+    vi.useFakeTimers();
+    try {
+      const cache = new RemoteThreadSummaryCache({
+        peers: () => [peer("peer-a")],
+        fetchSnapshot: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 75));
+          return snapshotOf([]);
+        },
+        fetchArchivedThreads: async () => await new Promise<never>(() => {}),
+        peerStatus: () => ({ status: "connected" }),
+        peerTimeoutMs: 100,
+      });
+      const resolution = cache.resolvePinnedThreads([
+        pin({ instanceId: "peer-a", threadId: "missing" }),
+      ]);
+      let settled = false;
+      void resolution.then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(99);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+
+      const resolved = await resolution;
+      expect(resolved.archived).toEqual([]);
+      expect(resolved.threads).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps the cached row when archive detection fails", async () => {
     const cached = stampedThread({
       instanceId: "peer-a",

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -907,6 +907,13 @@ export class DesktopFederationRuntime {
     this.remoteThreadSummaryCache ??= new RemoteThreadSummaryCache({
       peers: () => this.connectedPeerTargets(),
       fetchSnapshot: (target) => this.remoteNavigationSnapshot(target, {}),
+      fetchArchivedThreads: async (target, backend) =>
+        (
+          await this.remoteBackend(target).listThreads({
+            backend,
+            archived: true,
+          })
+        ).threads,
       peerStatus: (instanceId) => {
         try {
           const visible = this.visiblePeers();

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -27,6 +27,9 @@ export type ResolvedRemotePins = {
     summary: NavigationThreadSummary;
     instanceLabel: string;
   }>;
+  /** Pins proven to be archived on a reachable owner. The viewer can safely
+   *  remove these instead of preserving a permanently stale fallback row. */
+  archived: RemoteThreadPin["ref"][];
 };
 
 /**
@@ -48,6 +51,11 @@ export class RemoteThreadSummaryCache {
     { fetchedAt: number; threads: NavigationThreadSummary[] }
   >();
   private readonly inFlight = new Map<string, Promise<NavigationThreadSummary[]>>();
+  private readonly archivedCache = new Map<
+    string,
+    { fetchedAt: number; threadKeys: Set<string> }
+  >();
+  private readonly archivedInFlight = new Map<string, Promise<Set<string>>>();
 
   constructor(
     private readonly options: {
@@ -55,6 +63,11 @@ export class RemoteThreadSummaryCache {
       peers: () => RemoteThreadSummaryPeer[];
       /** Stamped snapshot fetch — `DesktopFederationRuntime.remoteNavigationSnapshot`. */
       fetchSnapshot: (target: FederationRemoteTarget) => Promise<NavigationSnapshot>;
+      /** Archived threads for one backend on a connected peer. */
+      fetchArchivedThreads: (
+        target: FederationRemoteTarget,
+        backend: RemoteThreadPin["ref"]["backend"],
+      ) => Promise<Array<Pick<NavigationThreadSummary, "source" | "id">>>;
       /** Current visible status + composed label for any peer, connected or not. */
       peerStatus: (instanceId: string) => {
         status?: FederationPeerSummary["status"];
@@ -70,9 +83,15 @@ export class RemoteThreadSummaryCache {
   invalidate(instanceId?: string): void {
     if (instanceId === undefined) {
       this.cache.clear();
+      this.archivedCache.clear();
       return;
     }
     this.cache.delete(instanceId);
+    for (const key of this.archivedCache.keys()) {
+      if (key.startsWith(`${instanceId}:`)) {
+        this.archivedCache.delete(key);
+      }
+    }
   }
 
   async searchForJump(
@@ -141,6 +160,7 @@ export class RemoteThreadSummaryCache {
   ): Promise<ResolvedRemotePins> {
     const threads: NavigationThreadSummary[] = [];
     const refreshed: ResolvedRemotePins["refreshed"] = [];
+    const archived: ResolvedRemotePins["archived"] = [];
     const connectedByInstanceId = new Map(
       this.navigationPeers().map((peer) => [peer.target.instanceId, peer]),
     );
@@ -169,10 +189,36 @@ export class RemoteThreadSummaryCache {
         const freshByKey = new Map(
           (fresh ?? []).map((thread) => [`${thread.source}:${thread.id}`, thread]),
         );
-        for (const pin of group) {
-          const freshThread = freshByKey.get(
-            `${pin.ref.backend}:${pin.ref.threadId}`,
+        const archivedKeys = new Set<string>();
+        if (peer && fresh) {
+          const missingBackends = new Set(
+            group
+              .filter(
+                (pin) =>
+                  !freshByKey.has(`${pin.ref.backend}:${pin.ref.threadId}`),
+              )
+              .map((pin) => pin.ref.backend),
           );
+          await Promise.all(
+            [...missingBackends].map(async (backend) => {
+              try {
+                const keys = await this.archivedThreadKeysForPeer(
+                  peer.target,
+                  backend,
+                );
+                for (const key of keys) {
+                  archivedKeys.add(key);
+                }
+              } catch {
+                // Archive detection is proof-based. If the lookup fails, keep
+                // the cached row just as we do when the active fetch fails.
+              }
+            }),
+          );
+        }
+        for (const pin of group) {
+          const threadKey = `${pin.ref.backend}:${pin.ref.threadId}`;
+          const freshThread = freshByKey.get(threadKey);
           if (freshThread) {
             threads.push(freshThread);
             refreshed.push({
@@ -183,11 +229,15 @@ export class RemoteThreadSummaryCache {
             });
             continue;
           }
+          if (archivedKeys.has(threadKey)) {
+            archived.push(pin.ref);
+            continue;
+          }
           threads.push(this.fallbackThread(pin, fetchFailed));
         }
       }),
     );
-    return { threads, refreshed };
+    return { threads, refreshed, archived };
   }
 
   private fallbackThread(
@@ -264,6 +314,46 @@ export class RemoteThreadSummaryCache {
       return await fetch;
     } finally {
       this.inFlight.delete(target.instanceId);
+    }
+  }
+
+  private async archivedThreadKeysForPeer(
+    target: FederationRemoteTarget,
+    backend: RemoteThreadPin["ref"]["backend"],
+  ): Promise<Set<string>> {
+    const cacheKey = `${target.instanceId}:${backend}`;
+    const now = this.options.now?.() ?? Date.now();
+    const ttlMs = this.options.ttlMs ?? REMOTE_SNAPSHOT_TTL_MS;
+    const cached = this.archivedCache.get(cacheKey);
+    if (cached && now - cached.fetchedAt < ttlMs) {
+      return cached.threadKeys;
+    }
+    const pending = this.archivedInFlight.get(cacheKey);
+    if (pending) {
+      return await pending;
+    }
+    const fetch = (async () => {
+      const timeoutMs =
+        this.options.peerTimeoutMs ?? REMOTE_SNAPSHOT_PEER_TIMEOUT_MS;
+      const archivedThreads = await withTimeout(
+        this.options.fetchArchivedThreads(target, backend),
+        timeoutMs,
+        `Remote archived threads timed out after ${Math.round(timeoutMs / 1000)}s.`,
+      );
+      const threadKeys = new Set(
+        archivedThreads.map((thread) => `${thread.source}:${thread.id}`),
+      );
+      this.archivedCache.set(cacheKey, {
+        fetchedAt: this.options.now?.() ?? Date.now(),
+        threadKeys,
+      });
+      return threadKeys;
+    })();
+    this.archivedInFlight.set(cacheKey, fetch);
+    try {
+      return await fetch;
+    } finally {
+      this.archivedInFlight.delete(cacheKey);
     }
   }
 }

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -55,7 +55,6 @@ export class RemoteThreadSummaryCache {
     string,
     { fetchedAt: number; threadKeys: Set<string> }
   >();
-  private readonly archivedInFlight = new Map<string, Promise<Set<string>>>();
 
   constructor(
     private readonly options: {
@@ -177,6 +176,9 @@ export class RemoteThreadSummaryCache {
     await Promise.all(
       [...pinsByInstanceId.entries()].map(async ([instanceId, group]) => {
         const peer = connectedByInstanceId.get(instanceId);
+        const peerTimeoutMs =
+          this.options.peerTimeoutMs ?? REMOTE_SNAPSHOT_PEER_TIMEOUT_MS;
+        const peerDeadlineAt = (this.options.now?.() ?? Date.now()) + peerTimeoutMs;
         let fresh: NavigationThreadSummary[] | undefined;
         let fetchFailed = false;
         if (peer) {
@@ -201,10 +203,28 @@ export class RemoteThreadSummaryCache {
           );
           await Promise.all(
             [...missingBackends].map(async (backend) => {
+              const candidateKeys = new Set(
+                group
+                  .filter(
+                    (pin) =>
+                      pin.ref.backend === backend
+                      && !freshByKey.has(
+                        `${pin.ref.backend}:${pin.ref.threadId}`,
+                      ),
+                  )
+                  .map((pin) => `${pin.ref.backend}:${pin.ref.threadId}`),
+              );
               try {
+                const remainingMs =
+                  peerDeadlineAt - (this.options.now?.() ?? Date.now());
+                if (remainingMs <= 0) {
+                  return;
+                }
                 const keys = await this.archivedThreadKeysForPeer(
                   peer.target,
                   backend,
+                  candidateKeys,
+                  remainingMs,
                 );
                 for (const key of keys) {
                   archivedKeys.add(key);
@@ -320,41 +340,36 @@ export class RemoteThreadSummaryCache {
   private async archivedThreadKeysForPeer(
     target: FederationRemoteTarget,
     backend: RemoteThreadPin["ref"]["backend"],
+    candidateKeys: ReadonlySet<string>,
+    timeoutMs: number,
   ): Promise<Set<string>> {
     const cacheKey = `${target.instanceId}:${backend}`;
     const now = this.options.now?.() ?? Date.now();
     const ttlMs = this.options.ttlMs ?? REMOTE_SNAPSHOT_TTL_MS;
     const cached = this.archivedCache.get(cacheKey);
-    if (cached && now - cached.fetchedAt < ttlMs) {
+    if (
+      cached
+      && now - cached.fetchedAt < ttlMs
+      && [...candidateKeys].every((key) => !cached.threadKeys.has(key))
+    ) {
+      // A cached negative can only delay cleanup. A cached positive could
+      // delete a thread restored and re-pinned since the probe, so positive
+      // archive evidence is always revalidated with a fresh owner request.
       return cached.threadKeys;
     }
-    const pending = this.archivedInFlight.get(cacheKey);
-    if (pending) {
-      return await pending;
-    }
-    const fetch = (async () => {
-      const timeoutMs =
-        this.options.peerTimeoutMs ?? REMOTE_SNAPSHOT_PEER_TIMEOUT_MS;
-      const archivedThreads = await withTimeout(
-        this.options.fetchArchivedThreads(target, backend),
-        timeoutMs,
-        `Remote archived threads timed out after ${Math.round(timeoutMs / 1000)}s.`,
-      );
-      const threadKeys = new Set(
-        archivedThreads.map((thread) => `${thread.source}:${thread.id}`),
-      );
-      this.archivedCache.set(cacheKey, {
-        fetchedAt: this.options.now?.() ?? Date.now(),
-        threadKeys,
-      });
-      return threadKeys;
-    })();
-    this.archivedInFlight.set(cacheKey, fetch);
-    try {
-      return await fetch;
-    } finally {
-      this.archivedInFlight.delete(cacheKey);
-    }
+    const archivedThreads = await withTimeout(
+      this.options.fetchArchivedThreads(target, backend),
+      timeoutMs,
+      `Remote archived threads timed out after ${Math.round(timeoutMs / 1000)}s.`,
+    );
+    const threadKeys = new Set(
+      archivedThreads.map((thread) => `${thread.source}:${thread.id}`),
+    );
+    this.archivedCache.set(cacheKey, {
+      fetchedAt: this.options.now?.() ?? Date.now(),
+      threadKeys,
+    });
+    return threadKeys;
   }
 }
 

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1970,6 +1970,13 @@ class DesktopAppServerService {
             },
           ),
         };
+        if (resolution.archived.length > 0) {
+          await Promise.all(
+            resolution.archived.map(async (ref) => {
+              await this.getOverlayStore().removeRemoteThreadPin({ ref });
+            }),
+          );
+        }
         if (resolution.refreshed.length > 0) {
           await this.getOverlayStore().updateRemoteThreadPinSnapshots(
             resolution.refreshed,


### PR DESCRIPTION
## Summary

- check a connected remote owner’s archived thread list when a viewer-pinned thread disappears from its active navigation snapshot
- remove the viewer-owned remote pin only when the owner proves that exact backend/thread ID is archived
- retain cached dimmed rows when the owner is unreachable or archive detection fails
- reuse only safe cached archive misses; revalidate archive hits before destructive pruning
- keep active navigation and archive probing within one shared peer deadline

## Root cause

The remote pin projection treated every thread missing from a peer’s active navigation snapshot as temporarily unavailable. It had no archive-state check, so an archived thread fell back to its cached summary indefinitely and stayed grayed out until manually removed.

## User impact

Archived remote threads now disappear from the local Inbox/Recents/Directories projection automatically once their connected owner confirms the archive state. Offline and degraded peers keep the existing safe fallback behavior.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts apps/desktop/src/main/__tests__/app-server-ipc.test.ts` (114 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`
