### PR TITLE
fix(federation): resolve remote thread send targets

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -25975,6 +25975,13 @@ script = "printf setup"
   it("sends a follow-up prompt to another thread from an active turn", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
+      threads: [{
+        id: "target-thread",
+        title: "target-thread",
+        titleSource: "fallback",
+        source: "codex",
+        linkedDirectories: [],
+      }],
     });
     const overlayStore = createOverlayStoreMock();
     const registry = new DesktopBackendRegistry({
@@ -26627,9 +26634,6 @@ script = "printf setup"
   it("resolves and sends to a federated thread after a local UUID miss", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
-      startTurnError: new Error(
-        "json-rpc error (-32600): thread not found: 019fd821-1450-7952-85ca-3bb8e5d150da",
-      ),
     });
     const registry = new DesktopBackendRegistry({
       codexClient,
@@ -26681,9 +26685,12 @@ script = "printf setup"
         threadId: "019fd821-1450-7952-85ca-3bb8e5d150da",
         turnId: "remote-turn-1",
         threadLink:
-          "[Thread list stays disabled after reconnect](pwragent://thread/019fd821-1450-7952-85ca-3bb8e5d150da?backend=codex)",
+          "[Thread list stays disabled after reconnect](pwragent://thread/019fd821-1450-7952-85ca-3bb8e5d150da?backend=codex&instanceId=pwr_harold)",
+        threadUrl:
+          "pwragent://thread/019fd821-1450-7952-85ca-3bb8e5d150da?backend=codex&instanceId=pwr_harold",
       },
     });
+    expect(codexClient.startTurnCallCount).toBe(0);
     expect(federatedSend).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "019fd821-1450-7952-85ca-3bb8e5d150da",
@@ -26705,6 +26712,59 @@ script = "printf setup"
       approvalPolicy: undefined,
       sandbox: undefined,
     });
+
+    await registry.close();
+  });
+
+  it("routes an ACP target through federation when no local session owns it", async () => {
+    const { acpBackendId, registry, startPrompt } = createKimiAcpRegistry({
+      sessions: [],
+    });
+    const federatedSend = vi.fn(async () => ({
+      backend: acpBackendId,
+      threadId: "remote-acp-session",
+      turnId: "remote-acp-turn",
+      title: "Remote ACP thread",
+      instanceId: "pwr_studio",
+      instanceLabel: "Studio Mac",
+    }));
+    registry.setFederatedThreadMessageHandler(federatedSend);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "parent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "turn-1",
+      tool: "send_message_to_thread",
+      args: {
+        backend: acpBackendId,
+        threadId: "remote-acp-session",
+        prompt: "Continue on the remote ACP agent.",
+      },
+    });
+
+    expect(response).toMatchObject({
+      structuredContent: {
+        backend: acpBackendId,
+        threadId: "remote-acp-session",
+        turnId: "remote-acp-turn",
+        threadUrl:
+          "pwragent://thread/remote-acp-session?backend=acp%3Akimi&instanceId=pwr_studio",
+      },
+    });
+    expect(startPrompt).not.toHaveBeenCalled();
+    expect(federatedSend).toHaveBeenCalledOnce();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -26624,6 +26624,91 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("resolves and sends to a federated thread after a local UUID miss", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      startTurnError: new Error(
+        "json-rpc error (-32600): thread not found: 019fd821-1450-7952-85ca-3bb8e5d150da",
+      ),
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error(
+          "grok app server unavailable: XAI_API_KEY is not set",
+        ),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    const federatedSend = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "019fd821-1450-7952-85ca-3bb8e5d150da",
+      turnId: "remote-turn-1",
+      title: "Thread list stays disabled after reconnect",
+      instanceId: "pwr_harold",
+      instanceLabel: "Harold-Mac-Mini-M4",
+    }));
+    registry.setFederatedThreadMessageHandler(federatedSend);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "parent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "turn-1",
+      tool: "send_message_to_thread",
+      args: {
+        backend: "codex",
+        threadId: "019fd821-1450-7952-85ca-3bb8e5d150da",
+        prompt: "Please handle the expanded reconnect scope.",
+      },
+    });
+
+    expect(response).toMatchObject({
+      structuredContent: {
+        backend: "codex",
+        threadId: "019fd821-1450-7952-85ca-3bb8e5d150da",
+        turnId: "remote-turn-1",
+        threadLink:
+          "[Thread list stays disabled after reconnect](pwragent://thread/019fd821-1450-7952-85ca-3bb8e5d150da?backend=codex)",
+      },
+    });
+    expect(federatedSend).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "019fd821-1450-7952-85ca-3bb8e5d150da",
+      input: [
+        { type: "text", text: "Please handle the expanded reconnect scope." },
+      ],
+      messageOrigin: {
+        kind: "agent",
+        sourceThread: {
+          backend: "codex",
+          threadId: "parent-thread",
+        },
+      },
+      executionMode: undefined,
+      model: undefined,
+      reasoningEffort: undefined,
+      serviceTier: undefined,
+      fastMode: undefined,
+      approvalPolicy: undefined,
+      sandbox: undefined,
+    });
+
+    await registry.close();
+  });
+
   it("rejects sending a follow-up prompt to the invoking thread", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },

--- a/apps/desktop/src/main/__tests__/federated-search-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-search-service.test.ts
@@ -21,6 +21,86 @@ function thread(
 }
 
 describe("FederatedSearchService", () => {
+  it("uses exact resolution for a pasted thread UUID", async () => {
+    const threadId = "019fd821-1450-7952-85ca-3bb8e5d150da";
+    const localListThreads = vi.fn();
+    const remoteListThreads = vi.fn();
+    const service = new FederatedSearchService({
+      local: {
+        listThreads: localListThreads,
+        resolveThread: vi.fn(async () => ({})),
+      },
+      peers: () => [
+        {
+          instanceId: "pwr_harold",
+          label: "Harold-Mac-Mini-M4",
+          backend: {
+            listThreads: remoteListThreads,
+            resolveThread: vi.fn(async () => ({
+              thread: thread(
+                threadId,
+                "Thread list stays disabled after reconnect",
+                3_000,
+              ),
+            })),
+          },
+        },
+      ],
+    });
+
+    const response = await service.search({ query: threadId, backend: "codex" });
+
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0]).toMatchObject({
+      ref: {
+        backend: "codex",
+        target: { scope: "remote", instanceId: "pwr_harold" },
+        threadId,
+      },
+      instanceLabel: "Harold-Mac-Mini-M4",
+    });
+    expect(localListThreads).not.toHaveBeenCalled();
+    expect(remoteListThreads).not.toHaveBeenCalled();
+  });
+
+  it("falls back to exact list scanning when a peer lacks resolution RPC", async () => {
+    const threadId = "019fd821-1450-7952-85ca-3bb8e5d150da";
+    const service = new FederatedSearchService({
+      includeLocal: false,
+      local: { listThreads: vi.fn() },
+      peers: () => [
+        {
+          instanceId: "pwr_older",
+          label: "Older Mac",
+          backend: {
+            resolveThread: vi.fn(async () => {
+              throw new Error("Unsupported federation method");
+            }),
+            listThreads: vi.fn(async () => ({
+              backend: "codex" as const,
+              fetchedAt: 1_000,
+              threads: [thread(threadId, "Reconnect fix", 3_000)],
+            })),
+          },
+        },
+      ],
+    });
+
+    await expect(
+      service.search({ query: threadId, backend: "codex" }),
+    ).resolves.toMatchObject({
+      results: [
+        {
+          ref: {
+            target: { scope: "remote", instanceId: "pwr_older" },
+            threadId,
+          },
+        },
+      ],
+      failures: [],
+    });
+  });
+
   it("fans out to local and remote peers and preserves source identity", async () => {
     const service = new FederatedSearchService({
       now: () => 10_000,

--- a/apps/desktop/src/main/__tests__/federated-thread-message-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-message-service.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopFederationRuntime } from "../federation/federation-runtime";
+import { createFederatedThreadMessageHandler } from "../federation/federated-thread-message-service";
+
+const request = {
+  backend: "codex" as const,
+  threadId: "019fd821-1450-7952-85ca-3bb8e5d150da",
+  input: [{ type: "text" as const, text: "Please handle the expanded scope." }],
+  messageOrigin: {
+    kind: "agent" as const,
+    sourceThread: {
+      backend: "codex" as const,
+      threadId: "source-thread",
+    },
+  },
+  executionMode: "full-access" as const,
+  model: "gpt-5.6-sol",
+  reasoningEffort: "high",
+};
+
+function buildRuntime(params: {
+  peers: Array<{
+    instanceId: string;
+    label: string;
+    capabilities?: Array<"thread_navigation" | "turn_control">;
+    ownsThread?: boolean;
+    resolveUnsupported?: boolean;
+  }>;
+}) {
+  const backends = new Map(
+    params.peers.map((peer) => {
+      const ownedThread = {
+        source: "codex" as const,
+        id: request.threadId,
+        title: "Thread list stays disabled after reconnect",
+        linkedDirectories: [],
+      };
+      const resolveThread = vi.fn(async () => {
+        if (peer.resolveUnsupported) {
+          throw new Error("Unsupported federation method: backend.resolveThread");
+        }
+        return peer.ownsThread ? { thread: ownedThread } : {};
+      });
+      const listThreads = vi.fn(async () => ({
+        backend: "codex" as const,
+        fetchedAt: 1_000,
+        threads: peer.ownsThread ? [ownedThread] : [],
+      }));
+      const startTurn = vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: request.threadId,
+        turnId: "remote-turn-1",
+      }));
+      return [peer.instanceId, { listThreads, resolveThread, startTurn }] as const;
+    }),
+  );
+  const runtime = {
+    connectedPeerTargets: () =>
+      params.peers.map((peer) => ({
+        target: { scope: "remote" as const, instanceId: peer.instanceId },
+        label: peer.label,
+        capabilities: peer.capabilities ?? ["thread_navigation", "turn_control"],
+      })),
+    remoteBackend: (target: { instanceId: string }) =>
+      backends.get(target.instanceId),
+  } as unknown as DesktopFederationRuntime;
+  return { backends, runtime };
+}
+
+describe("federated thread message service", () => {
+  it("resolves a UUID owner and starts the turn on that peer", async () => {
+    const { backends, runtime } = buildRuntime({
+      peers: [
+        { instanceId: "pwr_other", label: "Other Mac" },
+        {
+          instanceId: "pwr_harold",
+          label: "Harold-Mac-Mini-M4",
+          ownsThread: true,
+        },
+      ],
+    });
+    const handler = createFederatedThreadMessageHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler(request)).resolves.toEqual({
+      backend: "codex",
+      threadId: request.threadId,
+      turnId: "remote-turn-1",
+      title: "Thread list stays disabled after reconnect",
+      instanceId: "pwr_harold",
+      instanceLabel: "Harold-Mac-Mini-M4",
+    });
+    expect(backends.get("pwr_other")?.resolveThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: request.threadId,
+    });
+    expect(backends.get("pwr_harold")?.startTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: request.threadId,
+      input: request.input,
+      messageOrigin: request.messageOrigin,
+      executionMode: "full-access",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+      serviceTier: undefined,
+      fastMode: undefined,
+      approvalPolicy: undefined,
+      sandbox: undefined,
+    });
+  });
+
+  it("returns undefined when no connected peer owns the thread", async () => {
+    const { runtime } = buildRuntime({
+      peers: [{ instanceId: "pwr_other", label: "Other Mac" }],
+    });
+    const handler = createFederatedThreadMessageHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler(request)).resolves.toBeUndefined();
+  });
+
+  it("falls back to exact list scanning for a mixed-version peer", async () => {
+    const { backends, runtime } = buildRuntime({
+      peers: [
+        {
+          instanceId: "pwr_older",
+          label: "Older Mac",
+          ownsThread: true,
+          resolveUnsupported: true,
+        },
+      ],
+    });
+    const handler = createFederatedThreadMessageHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler(request)).resolves.toMatchObject({
+      instanceId: "pwr_older",
+      turnId: "remote-turn-1",
+    });
+    expect(backends.get("pwr_older")?.listThreads).toHaveBeenCalledWith({
+      backend: "codex",
+    });
+  });
+
+  it("refuses an ambiguous UUID reported by multiple peers", async () => {
+    const { runtime } = buildRuntime({
+      peers: [
+        { instanceId: "pwr_one", label: "One", ownsThread: true },
+        { instanceId: "pwr_two", label: "Two", ownsThread: true },
+      ],
+    });
+    const handler = createFederatedThreadMessageHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler(request)).rejects.toThrow(
+      "reported by multiple federation instances: One, Two",
+    );
+  });
+
+  it("requires turn_control on the owning peer", async () => {
+    const { runtime } = buildRuntime({
+      peers: [
+        {
+          instanceId: "pwr_read_only",
+          label: "Read-only Mac",
+          capabilities: ["thread_navigation"],
+          ownsThread: true,
+        },
+      ],
+    });
+    const handler = createFederatedThreadMessageHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler(request)).rejects.toThrow(
+      "owns thread 019fd821-1450-7952-85ca-3bb8e5d150da but does not grant turn_control",
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1695,6 +1695,10 @@ describe("federation backend bridge", () => {
           backend: "codex",
           threadId: "thread-1",
           input: [{ type: "text", text: "ship it" }],
+          messageOrigin: {
+            kind: "agent",
+            sourceThread: { backend: "codex", threadId: "source-thread" },
+          },
         },
         protocolVersion: 1,
         sourceInstanceId: "gateway_one",
@@ -1707,6 +1711,10 @@ describe("federation backend bridge", () => {
       backend: "codex",
       threadId: "thread-1",
       input: [{ type: "text", text: "ship it" }],
+      messageOrigin: {
+        kind: "agent",
+        sourceThread: { backend: "codex", threadId: "source-thread" },
+      },
     });
     expect(replies).toMatchObject([
       {
@@ -1721,10 +1729,70 @@ describe("federation backend bridge", () => {
     ]);
   });
 
+  it("resolves an exact thread id through thread_navigation", async () => {
+    const resolveThread = vi.fn(async () => ({
+      thread: {
+        source: "codex" as const,
+        id: "019fd821-1450-7952-85ca-3bb8e5d150da",
+        title: "Thread list stays disabled after reconnect",
+        linkedDirectories: [],
+      },
+    }));
+    const backend = {
+      resolveThread,
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "gateway_one",
+      capabilities: ["thread_navigation"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
+        id: "request-resolve",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.resolveThread,
+        params: {
+          backend: "codex",
+          threadId: "019fd821-1450-7952-85ca-3bb8e5d150da",
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(resolveThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "019fd821-1450-7952-85ca-3bb8e5d150da",
+    });
+    expect(replies).toMatchObject([
+      {
+        kind: "response",
+        requestId: "request-resolve",
+        result: {
+          thread: {
+            id: "019fd821-1450-7952-85ca-3bb8e5d150da",
+            title: "Thread list stays disabled after reconnect",
+          },
+        },
+      },
+    ]);
+  });
+
   it("maps expanded remote control operations to capability-guarded handlers", async () => {
     const backend: FederationBackendOperations = {
       getNavigationSnapshot: vi.fn(),
       listThreads: vi.fn(),
+      resolveThread: vi.fn(),
       readThread: vi.fn(),
       readTranscriptImage: vi.fn(),
       listSkills: vi.fn(),
@@ -1944,6 +2012,7 @@ describe("federation backend bridge", () => {
       backend: {
         getNavigationSnapshot: vi.fn(),
         listThreads: vi.fn(),
+        resolveThread: vi.fn(),
         readThread: vi.fn(),
         readTranscriptImage: vi.fn(),
         listSkills: vi.fn(),

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -96,6 +96,7 @@ const setMessagingArchiveCleanerMock = vi.fn();
 const setMessagingAgentToolServiceMock = vi.fn();
 const setPwrAgentAppManagementHandlerMock = vi.fn();
 const setPwrAgentFederationHandlerMock = vi.fn();
+const setFederatedThreadMessageHandlerMock = vi.fn();
 const listThreadsMock = vi.fn<(request?: unknown) => Promise<unknown[]>>();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
 const registerMessagingStatusIpcHandlersMock = vi.fn();
@@ -431,6 +432,7 @@ vi.mock("../app-server/backend-registry", () => ({
     setMessagingAgentToolService: setMessagingAgentToolServiceMock,
     setPwrAgentAppManagementHandler: setPwrAgentAppManagementHandlerMock,
     setPwrAgentFederationHandler: setPwrAgentFederationHandlerMock,
+    setFederatedThreadMessageHandler: setFederatedThreadMessageHandlerMock,
     setMessagingArchiveCleaner: setMessagingArchiveCleanerMock,
   })),
 }));
@@ -609,6 +611,7 @@ describe("bootstrapApp", () => {
     setMessagingAgentToolServiceMock.mockReset();
     setPwrAgentAppManagementHandlerMock.mockReset();
     setPwrAgentFederationHandlerMock.mockReset();
+    setFederatedThreadMessageHandlerMock.mockReset();
     listThreadsMock.mockReset();
     listThreadsMock.mockResolvedValue([]);
     disposeDesktopMessagingRuntimeMock.mockReset();

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -1,4 +1,6 @@
 import type {
+  AppServerThreadMessageOrigin,
+  AppServerTurnInputItem,
   AttachThreadDirectoryToolArgs,
   AttachThreadDirectoryWorkspaceMode,
   AttachThreadDirectoryWorktreeBranchMode,
@@ -46,6 +48,33 @@ export type PwrAgentThreadOrchestrationHandler = (
 ) =>
   | PwrAgentThreadOrchestrationResponse
   | Promise<PwrAgentThreadOrchestrationResponse>;
+
+export type PwrAgentFederatedThreadMessageRequest = {
+  backend: SendMessageToThreadToolArgs["backend"];
+  threadId: SendMessageToThreadToolArgs["threadId"];
+  input: AppServerTurnInputItem[];
+  messageOrigin: AppServerThreadMessageOrigin;
+  model?: string;
+  reasoningEffort?: string;
+  serviceTier?: string;
+  fastMode?: boolean;
+  executionMode?: SendMessageToThreadToolArgs["executionMode"];
+  approvalPolicy?: string;
+  sandbox?: string;
+};
+
+export type PwrAgentFederatedThreadMessageResult = {
+  backend: SendMessageToThreadToolArgs["backend"];
+  threadId: SendMessageToThreadToolArgs["threadId"];
+  turnId: string;
+  title?: string;
+  instanceId: string;
+  instanceLabel: string;
+};
+
+export type PwrAgentFederatedThreadMessageHandler = (
+  request: PwrAgentFederatedThreadMessageRequest,
+) => Promise<PwrAgentFederatedThreadMessageResult | undefined>;
 
 export function buildPwrAgentThreadOrchestrationToolRouter(
   handler: PwrAgentThreadOrchestrationHandler | undefined,
@@ -114,7 +143,7 @@ function descriptionForOperation(
     case "move_thread_workspace":
       return "Move the current PwrAgent thread runtime workspace after the invoking turn reaches a terminal boundary. Use this when the user asks to continue this same thread from an isolated worktree instead of creating a child handoff thread. The operation is path-keyed: pass sourcePath when the thread has multiple linked directories or when the intended workspace is not obvious. The tool returns a pending workspaceMoveId and stop-and-wait guidance; after the current turn ends, PwrAgent performs the move, updates future-turn cwd metadata, rebinds an ACP session when required, and starts a same-thread continuation with the result. Do not keep editing after a successful call in the invoking turn; wait for the continuation or inspect get_thread_status pendingWorkspaceMoves.";
     case "send_message_to_thread":
-      return "Send a follow-up prompt to another existing PwrAgent thread. Use search_threads or read_thread first when the target threadId is unknown. Do not use this for the current thread; reply normally instead. The result includes threadLink, a ready-made markdown link to the target thread. When you mention that thread to the user, include threadLink verbatim instead of the raw threadId so it renders as a clickable chip.";
+      return "Send a follow-up prompt to another existing PwrAgent thread. Use search_threads or read_thread first when the target threadId is unknown. Federation ownership is resolved automatically from the threadId, so do not ask the user for an instance id. Do not use this for the current thread; reply normally instead. The result includes threadLink, a ready-made markdown link to the target thread. When you mention that thread to the user, include threadLink verbatim instead of the raw threadId so it renders as a clickable chip.";
     case "start_review":
       return "Schedule a code review of the invoking PwrAgent thread after the current turn completes successfully. Use this only when the operator explicitly asks for a review. Choose one structured target: uncommittedChanges, baseBranch, commit, or custom. The tool returns a pendingReviewId; after a successful call, stop work and let the current turn finish so PwrAgent can start the review. Do not poll or call the tool again for the same request.";
   }
@@ -301,7 +330,8 @@ function inputSchemaForOperation(
         properties: {
           backend: {
             type: "string",
-            description: "Backend that owns the target thread.",
+            description:
+              "Backend type for the target thread. PwrAgent resolves its owning instance automatically.",
           },
           threadId: {
             type: "string",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -347,7 +347,10 @@ import {
   isPwrAgentThreadOrchestrationDynamicToolCall,
   readPwrAgentThreadOrchestrationDynamicToolCall,
 } from "../agent-tools/pwragent-thread-orchestration-codex-tools";
-import type { PwrAgentThreadOrchestrationHandler } from "../agent-tools/pwragent-thread-orchestration-agent-tools";
+import type {
+  PwrAgentFederatedThreadMessageHandler,
+  PwrAgentThreadOrchestrationHandler,
+} from "../agent-tools/pwragent-thread-orchestration-agent-tools";
 import {
   buildPwrAgentFederationDynamicToolErrorResponse,
   handlePwrAgentFederationDynamicToolCall,
@@ -6394,6 +6397,9 @@ export class DesktopBackendRegistry {
   private readonly threadOrchestrationHandler: PwrAgentThreadOrchestrationHandler =
     async (request) => await this.handleThreadOrchestrationRequest(request);
   private federationHandler: PwrAgentFederationHandler | undefined;
+  private federatedThreadMessageHandler:
+    | PwrAgentFederatedThreadMessageHandler
+    | undefined;
   private threadPullRequestStatusToolHandler:
     | ThreadPullRequestStatusToolHandler
     | undefined;
@@ -7110,6 +7116,12 @@ export class DesktopBackendRegistry {
     this.federationHandler = handler ?? undefined;
   }
 
+  setFederatedThreadMessageHandler(
+    handler: PwrAgentFederatedThreadMessageHandler | null | undefined,
+  ): void {
+    this.federatedThreadMessageHandler = handler ?? undefined;
+  }
+
   setThreadPullRequestStatusToolHandler(
     handler: ThreadPullRequestStatusToolHandler | null | undefined,
   ): void {
@@ -7641,6 +7653,33 @@ export class DesktopBackendRegistry {
       });
     this.threadListCache.set(cacheKey, { promise });
     return await promise;
+  }
+
+  async resolveThread(params: {
+    backend?: AppServerBackendKind;
+    threadId: string;
+  }): Promise<AppServerThreadSummary | undefined> {
+    const threadId = params.threadId.trim();
+    if (!threadId) {
+      return undefined;
+    }
+    for (const state of this.threadListCache.values()) {
+      const cached = state.threads?.find(
+        (thread) =>
+          (!params.backend || thread.source === params.backend)
+          && thread.id === threadId,
+      );
+      if (cached) {
+        return cached;
+      }
+    }
+    const threads = await this.listThreads({
+      backend: params.backend,
+      archived: false,
+      callerReason: "thread-id-lookup",
+      enrichDirectories: false,
+    });
+    return threads.find((thread) => thread.id === threadId);
   }
 
   async getThreadAgentMetadata(params: {
@@ -22181,34 +22220,69 @@ export class DesktopBackendRegistry {
           : {}),
         ...(request.args.sandbox ? { sandbox: request.args.sandbox } : {}),
       };
-      const turn = await this.startTurn({
-        backend,
-        threadId,
-        input: [{ type: "text", text: prompt }],
-        messageOrigin: {
-          kind: "agent",
-          sourceThread: {
-            backend: request.context.backend,
-            threadId: request.context.threadId,
-          },
+      const input = [{ type: "text" as const, text: prompt }];
+      const messageOrigin = {
+        kind: "agent" as const,
+        sourceThread: {
+          backend: request.context.backend,
+          threadId: request.context.threadId,
         },
-        executionMode: request.args.executionMode,
-        model: request.args.model,
-        reasoningEffort: request.args.reasoningEffort,
-        serviceTier: request.args.serviceTier,
-        fastMode: request.args.fastMode,
-        approvalPolicy: request.args.approvalPolicy,
-        sandbox: request.args.sandbox,
-      });
+      };
+      let targetTitle: string | undefined;
+      let turn: { backend: AppServerBackendKind; threadId: string; turnId: string };
+      try {
+        turn = await this.startTurn({
+          backend,
+          threadId,
+          input,
+          messageOrigin,
+          executionMode: request.args.executionMode,
+          model: request.args.model,
+          reasoningEffort: request.args.reasoningEffort,
+          serviceTier: request.args.serviceTier,
+          fastMode: request.args.fastMode,
+          approvalPolicy: request.args.approvalPolicy,
+          sandbox: request.args.sandbox,
+        });
+      } catch (localError) {
+        const localMessage =
+          localError instanceof Error ? localError.message : String(localError);
+        if (
+          !this.federatedThreadMessageHandler
+          || !/thread not found/i.test(localMessage)
+        ) {
+          throw localError;
+        }
+        const remoteTurn = await this.federatedThreadMessageHandler({
+          backend,
+          threadId,
+          input,
+          messageOrigin,
+          executionMode: request.args.executionMode,
+          model: request.args.model,
+          reasoningEffort: request.args.reasoningEffort,
+          serviceTier: request.args.serviceTier,
+          fastMode: request.args.fastMode,
+          approvalPolicy: request.args.approvalPolicy,
+          sandbox: request.args.sandbox,
+        });
+        if (!remoteTurn) {
+          throw localError;
+        }
+        turn = remoteTurn;
+        targetTitle = remoteTurn.title;
+      }
       // Best-effort: give the link its human title so it reads well on
       // surfaces that can't resolve the id against the live snapshot (the
       // desktop chip shows the live title regardless). `listThreads` is
       // cached, so this usually costs nothing.
-      const targetThread = await this.findThreadForWorkspaceHandoff({
-        backend,
-        callerReason: "send-message-link",
-        threadId: turn.threadId,
-      });
+      const targetThread = targetTitle
+        ? undefined
+        : await this.findThreadForWorkspaceHandoff({
+            backend,
+            callerReason: "send-message-link",
+            threadId: turn.threadId,
+          });
       return {
         ok: true,
         data: {
@@ -22220,7 +22294,7 @@ export class DesktopBackendRegistry {
           threadLink: buildThreadMarkdownLink({
             backend,
             threadId: turn.threadId,
-            title: targetThread?.title,
+            title: targetTitle ?? targetThread?.title,
           }),
           settings,
         },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7678,6 +7678,7 @@ export class DesktopBackendRegistry {
       archived: false,
       callerReason: "thread-id-lookup",
       enrichDirectories: false,
+      forceRefresh: true,
     });
     return threads.find((thread) => thread.id === threadId);
   }
@@ -22229,8 +22230,16 @@ export class DesktopBackendRegistry {
         },
       };
       let targetTitle: string | undefined;
+      let targetInstanceId: string | undefined;
       let turn: { backend: AppServerBackendKind; threadId: string; turnId: string };
+      let localResolutionError: unknown;
+      let localThread: AppServerThreadSummary | undefined;
       try {
+        localThread = await this.resolveThread({ backend, threadId });
+      } catch (error) {
+        localResolutionError = error;
+      }
+      if (localThread) {
         turn = await this.startTurn({
           backend,
           threadId,
@@ -22244,15 +22253,8 @@ export class DesktopBackendRegistry {
           approvalPolicy: request.args.approvalPolicy,
           sandbox: request.args.sandbox,
         });
-      } catch (localError) {
-        const localMessage =
-          localError instanceof Error ? localError.message : String(localError);
-        if (
-          !this.federatedThreadMessageHandler
-          || !/thread not found/i.test(localMessage)
-        ) {
-          throw localError;
-        }
+        targetTitle = localThread.title;
+      } else if (this.federatedThreadMessageHandler) {
         const remoteTurn = await this.federatedThreadMessageHandler({
           backend,
           threadId,
@@ -22267,22 +22269,25 @@ export class DesktopBackendRegistry {
           sandbox: request.args.sandbox,
         });
         if (!remoteTurn) {
-          throw localError;
+          if (localResolutionError) {
+            throw localResolutionError;
+          }
+          throw new Error(`Thread not found: ${threadId}`);
         }
         turn = remoteTurn;
         targetTitle = remoteTurn.title;
+        targetInstanceId = remoteTurn.instanceId;
+      } else {
+        if (localResolutionError) {
+          throw localResolutionError;
+        }
+        throw new Error(`Thread not found: ${threadId}`);
       }
-      // Best-effort: give the link its human title so it reads well on
-      // surfaces that can't resolve the id against the live snapshot (the
-      // desktop chip shows the live title regardless). `listThreads` is
-      // cached, so this usually costs nothing.
-      const targetThread = targetTitle
-        ? undefined
-        : await this.findThreadForWorkspaceHandoff({
-            backend,
-            callerReason: "send-message-link",
-            threadId: turn.threadId,
-          });
+      const threadLinkRef = {
+        backend,
+        ...(targetInstanceId ? { instanceId: targetInstanceId } : {}),
+        threadId: turn.threadId,
+      };
       return {
         ok: true,
         data: {
@@ -22290,11 +22295,10 @@ export class DesktopBackendRegistry {
           threadId: turn.threadId,
           turnId: turn.turnId,
           promptPreview: truncateThreadInspectionText(prompt, 240),
-          threadUrl: buildThreadUrl({ backend, threadId: turn.threadId }),
+          threadUrl: buildThreadUrl(threadLinkRef),
           threadLink: buildThreadMarkdownLink({
-            backend,
-            threadId: turn.threadId,
-            title: targetTitle ?? targetThread?.title,
+            ...threadLinkRef,
+            title: targetTitle,
           }),
           settings,
         },

--- a/apps/desktop/src/main/federation/federated-search-service.ts
+++ b/apps/desktop/src/main/federation/federated-search-service.ts
@@ -13,13 +13,14 @@ export type FederatedSearchPeer = {
   instanceId: FederationInstanceId;
   label: string;
   status?: FederationPeerSummary["status"];
-  backend: Pick<FederationBackendOperations, "listThreads">;
+  backend: Pick<FederationBackendOperations, "listThreads">
+    & Partial<Pick<FederationBackendOperations, "resolveThread">>;
 };
 
 export type FederatedSearchLocalBackend = Pick<
   FederationBackendOperations,
   "listThreads"
->;
+> & Partial<Pick<FederationBackendOperations, "resolveThread">>;
 
 /**
  * Per-peer deadline for a search fan-out. Much tighter than the 30s RPC
@@ -98,6 +99,24 @@ export class FederatedSearchService {
     query: string,
     backend?: FederatedSearchRequest["backend"],
   ): Promise<FederatedSearchResponse["results"]> {
+    const resolved = await this.resolveExactThreadId(
+      this.options.local,
+      query,
+      backend,
+    );
+    if (resolved !== undefined) {
+      return resolved
+        ? [{
+            ref: buildFederatedThreadRef({
+              backend: resolved.source,
+              threadId: resolved.id,
+            }),
+            thread: resolved,
+            instanceLabel: "This Mac",
+            score: scoreThread(resolved, query),
+          }]
+        : [];
+    }
     const response = await this.options.local.listThreads({
       backend: backend === "all" ? undefined : backend,
       filter: query,
@@ -118,6 +137,26 @@ export class FederatedSearchService {
     query: string,
     backend?: FederatedSearchRequest["backend"],
   ): Promise<FederatedSearchResponse["results"]> {
+    const resolved = await this.resolveExactThreadId(
+      peer.backend,
+      query,
+      backend,
+    );
+    if (resolved !== undefined) {
+      return resolved
+        ? [{
+            ref: buildFederatedThreadRef({
+              backend: resolved.source,
+              instanceId: peer.instanceId,
+              threadId: resolved.id,
+            }),
+            thread: resolved,
+            instanceLabel: peer.label,
+            peerStatus: peer.status,
+            score: scoreThread(resolved, query),
+          }]
+        : [];
+    }
     const response: AppServerListThreadsResponse = await peer.backend.listThreads({
       backend: backend === "all" ? undefined : backend,
       filter: query,
@@ -134,6 +173,40 @@ export class FederatedSearchService {
       score: scoreThread(thread, query),
     }));
   }
+
+  private async resolveExactThreadId(
+    backendOperations: FederatedSearchPeer["backend"],
+    query: string,
+    backend?: FederatedSearchRequest["backend"],
+  ): Promise<AppServerThreadSummary | null | undefined> {
+    if (
+      !backendOperations.resolveThread
+      || !looksLikeExactThreadId(query)
+    ) {
+      return undefined;
+    }
+    try {
+      const response = await backendOperations.resolveThread({
+        ...(backend && backend !== "all" ? { backend } : {}),
+        threadId: query,
+      });
+      return response.thread ?? null;
+    } catch {
+      // Mixed-version peers may not expose the exact lookup RPC yet. Avoid
+      // their provider's fuzzy UUID filter and scan the active list exactly.
+      const response = await backendOperations.listThreads({
+        backend: backend === "all" ? undefined : backend,
+      });
+      return response.threads.find((thread) => thread.id === query) ?? null;
+    }
+  }
+}
+
+function looksLikeExactThreadId(query: string): boolean {
+  return (
+    /^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(query)
+    || /^session_[0-9a-z_-]{10,}$/i.test(query)
+  );
 }
 
 function withTimeout<T>(

--- a/apps/desktop/src/main/federation/federated-thread-message-service.ts
+++ b/apps/desktop/src/main/federation/federated-thread-message-service.ts
@@ -1,0 +1,116 @@
+import type {
+  AppServerThreadSummary,
+  FederationCapability,
+  FederationRemoteTarget,
+} from "@pwragent/shared";
+import type {
+  PwrAgentFederatedThreadMessageHandler,
+  PwrAgentFederatedThreadMessageResult,
+} from "../agent-tools/pwragent-thread-orchestration-agent-tools";
+import type { FederationBackendOperations } from "./federation-backend-bridge";
+import {
+  getDesktopFederationRuntime,
+  type DesktopFederationRuntime,
+} from "./federation-runtime";
+
+type ResolvedRemoteThread = {
+  backend: FederationBackendOperations;
+  peer: {
+    target: FederationRemoteTarget;
+    label: string;
+    capabilities: FederationCapability[];
+  };
+  thread: AppServerThreadSummary;
+};
+
+export function createFederatedThreadMessageHandler(
+  options: { runtime?: () => DesktopFederationRuntime } = {},
+): PwrAgentFederatedThreadMessageHandler {
+  const runtime = options.runtime ?? getDesktopFederationRuntime;
+  return async (request) => {
+    const activeRuntime = runtime();
+    const peers = activeRuntime
+      .connectedPeerTargets()
+      .filter((peer) => peer.capabilities.includes("thread_navigation"));
+    const failures: Array<{ label: string; message: string }> = [];
+    const matches = (
+      await Promise.all(
+        peers.map(async (peer): Promise<ResolvedRemoteThread | undefined> => {
+          try {
+            const backend = activeRuntime.remoteBackend(peer.target);
+            let thread: AppServerThreadSummary | undefined;
+            try {
+              thread = (
+                await backend.resolveThread({
+                  backend: request.backend,
+                  threadId: request.threadId,
+                })
+              ).thread;
+            } catch {
+              // Mixed-version peers may predate backend.resolveThread. Their
+              // unfiltered list still provides an exact-ID compatibility path.
+              thread = (
+                await backend.listThreads({ backend: request.backend })
+              ).threads.find((candidate) => candidate.id === request.threadId);
+            }
+            return thread
+              ? { backend, peer, thread }
+              : undefined;
+          } catch (error) {
+            failures.push({
+              label: peer.label,
+              message: error instanceof Error ? error.message : String(error),
+            });
+            return undefined;
+          }
+        }),
+      )
+    ).filter((match): match is ResolvedRemoteThread => Boolean(match));
+
+    if (matches.length > 1) {
+      throw new Error(
+        `Thread ${request.threadId} was reported by multiple federation instances: ${matches
+          .map((match) => match.peer.label)
+          .join(", ")}.`,
+      );
+    }
+    const match = matches[0];
+    if (!match) {
+      if (failures.length > 0) {
+        throw new Error(
+          `Could not resolve thread ${request.threadId} because federation lookup failed on ${failures
+            .map((failure) => `${failure.label}: ${failure.message}`)
+            .join("; ")}.`,
+        );
+      }
+      return undefined;
+    }
+    if (!match.peer.capabilities.includes("turn_control")) {
+      throw new Error(
+        `Federation instance ${match.peer.label} owns thread ${request.threadId} but does not grant turn_control.`,
+      );
+    }
+
+    const turn = await match.backend.startTurn({
+      backend: request.backend,
+      threadId: request.threadId,
+      input: request.input,
+      messageOrigin: request.messageOrigin,
+      executionMode: request.executionMode,
+      model: request.model,
+      reasoningEffort: request.reasoningEffort,
+      serviceTier: request.serviceTier,
+      fastMode: request.fastMode,
+      approvalPolicy: request.approvalPolicy,
+      sandbox: request.sandbox,
+    });
+    return {
+      backend: turn.backend,
+      threadId: turn.threadId,
+      turnId: turn.turnId,
+      title: match.thread.title,
+      instanceId: match.peer.target.instanceId,
+      instanceLabel: match.peer.label,
+    } satisfies PwrAgentFederatedThreadMessageResult;
+  };
+}

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -5,6 +5,7 @@ import type {
   AppServerListThreadsResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
+  AppServerThreadMessageOrigin,
   AgentEvent,
   ApplyThreadModelMigrationRequest,
   ApplyThreadModelMigrationResponse,
@@ -60,6 +61,8 @@ import type {
   QueueThreadExecutionModeResponse,
   RefreshDirectoryGitStatusesRequest,
   RefreshDirectoryGitStatusesResponse,
+  ResolveThreadRequest,
+  ResolveThreadResponse,
   RetainThreadBranchDriftRequest,
   RetainThreadBranchDriftResponse,
   RenameThreadRequest,
@@ -120,9 +123,14 @@ export type FederatedTranscriptImageResponse = {
   mimeType: string;
 };
 
+export type FederationStartTurnRequest = StartTurnRequest & {
+  messageOrigin?: AppServerThreadMessageOrigin;
+};
+
 export const FEDERATION_BACKEND_METHODS = {
   getNavigationSnapshot: "backend.getNavigationSnapshot",
   listThreads: "backend.listThreads",
+  resolveThread: "backend.resolveThread",
   readThread: "backend.readThread",
   readTranscriptImage: "backend.readTranscriptImage",
   listSkills: "backend.listSkills",
@@ -198,6 +206,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
 > = {
   [FEDERATION_BACKEND_METHODS.getNavigationSnapshot]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.listThreads]: "thread_navigation",
+  [FEDERATION_BACKEND_METHODS.resolveThread]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.readThread]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.readTranscriptImage]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.listSkills]: "thread_detail",
@@ -276,6 +285,7 @@ export type FederationBackendOperations = {
   listThreads(
     request?: AppServerListThreadsRequest,
   ): Promise<AppServerListThreadsResponse>;
+  resolveThread(request: ResolveThreadRequest): Promise<ResolveThreadResponse>;
   readThread(
     request: AppServerReadThreadRequest,
   ): Promise<AppServerReadThreadResponse>;
@@ -312,7 +322,7 @@ export type FederationBackendOperations = {
       "onCodexEnvironmentSetupProgress"
     >,
   ): Promise<ForkThreadResponse>;
-  startTurn(request: StartTurnRequest): Promise<StartTurnResponse>;
+  startTurn(request: FederationStartTurnRequest): Promise<StartTurnResponse>;
   cancelQueuedTurn(
     request: CancelQueuedTurnRequest,
   ): Promise<CancelQueuedTurnResponse>;
@@ -421,6 +431,13 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.listThreads(
         (envelope.params ?? {}) as AppServerListThreadsRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.resolveThread,
+    async (envelope) =>
+      await params.backend.resolveThread(
+        envelope.params as ResolveThreadRequest,
       ),
   );
   params.router.registerHandler(
@@ -566,7 +583,7 @@ export function registerFederationBackendHandlers(params: {
     FEDERATION_BACKEND_METHODS.startTurn,
     async (envelope) =>
       await params.backend.startTurn(
-        envelope.params as StartTurnRequest,
+        envelope.params as FederationStartTurnRequest,
       ),
   );
   params.router.registerHandler(
@@ -841,6 +858,15 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
     });
   }
 
+  async resolveThread(
+    request: ResolveThreadRequest,
+  ): Promise<ResolveThreadResponse> {
+    return await this.rpc.request<ResolveThreadResponse>({
+      method: FEDERATION_BACKEND_METHODS.resolveThread,
+      params: request,
+    });
+  }
+
   async readThread(
     request: AppServerReadThreadRequest,
   ): Promise<AppServerReadThreadResponse> {
@@ -964,7 +990,9 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
     });
   }
 
-  async startTurn(request: StartTurnRequest): Promise<StartTurnResponse> {
+  async startTurn(
+    request: FederationStartTurnRequest,
+  ): Promise<StartTurnResponse> {
     return await this.rpc.request<StartTurnResponse>({
       method: FEDERATION_BACKEND_METHODS.startTurn,
       params: request,

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -128,7 +128,6 @@ import {
   type StartReviewRequest,
   type StartThreadRequest,
   type SteerTurnRequest,
-  type StartTurnRequest,
   type StartTurnResponse,
   type SubmitServerRequestRequest,
   type StopCodexEnvironmentActionRequest,
@@ -173,6 +172,7 @@ import {
   type FederationBackendEventNotification,
   type FederationBackendOperations,
   type FederationEnvironmentSetupProgressNotification,
+  type FederationStartTurnRequest,
 } from "./federation-backend-bridge";
 import {
   buildFederationHealthStatus,
@@ -3535,6 +3535,10 @@ function localBackendOperations(): FederationBackendOperations {
         threads,
       };
     },
+    async resolveThread(request) {
+      const thread = await getDesktopBackendRegistry().resolveThread(request);
+      return thread ? { thread } : {};
+    },
     async readThread(
       request: AppServerReadThreadRequest,
     ): Promise<AppServerReadThreadResponse> {
@@ -3687,7 +3691,9 @@ function localBackendOperations(): FederationBackendOperations {
           options?.onCodexEnvironmentSetupProgress,
       });
     },
-    async startTurn(request: StartTurnRequest): Promise<StartTurnResponse> {
+    async startTurn(
+      request: FederationStartTurnRequest,
+    ): Promise<StartTurnResponse> {
       const submitted = await getDesktopBackendRegistry().submitTurn({
         ...request,
         origin: "manual",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { getDesktopBackendRegistry } from "./app-server/backend-registry";
 import { createPwrAgentAppManagementHandler } from "./agent-tools/pwragent-app-management-service";
 import { createFederationAgentToolsHandler } from "./federation/federation-agent-tools-service";
+import { createFederatedThreadMessageHandler } from "./federation/federated-thread-message-service";
 import { disposeAgentIpcHandlers, registerAgentIpcHandlers } from "./ipc/agent-ipc";
 import {
   disposeScheduledActionIpcHandlers,
@@ -1003,6 +1004,9 @@ export function bootstrapApp(): void {
     // already imports the registry, so the reverse import would be a cycle.
     getDesktopBackendRegistry().setPwrAgentFederationHandler(
       createFederationAgentToolsHandler(),
+    );
+    getDesktopBackendRegistry().setFederatedThreadMessageHandler(
+      createFederatedThreadMessageHandler(),
     );
     // Windows: serve the painted title-bar menu bar from the live application
     // menu (idempotent; the renderer mounts the bar only on win32).

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -21,6 +21,7 @@ import {
   type DesktopBootInfo,
   type DesktopCodexProfileModel,
   type DesktopPwrAgentProfileSummary,
+  type FederationInstanceId,
   type MessagingChannelKind,
   type NavigationThreadSummary,
   type PrAutoDispatchBudgetStatus,
@@ -900,11 +901,33 @@ function DesktopAppShell(props: {
   // the scheme never carries an action, so this is the entire surface it can
   // reach. Mirrors the tray/notification `onShowThreadRequested` path below.
   const showThreadFromLink = useCallback(
-    (request: { backend: AppServerBackendKind; threadId: string }): void => {
+    (request: {
+      backend: AppServerBackendKind;
+      instanceId?: FederationInstanceId;
+      threadId: string;
+    }): void => {
+      if (request.instanceId) {
+        const windowTarget = readRendererFederationTarget();
+        if (windowTarget?.instanceId !== request.instanceId) {
+          const target = {
+            scope: "remote" as const,
+            instanceId: request.instanceId,
+          };
+          void desktopApi?.openFederationWindow?.({
+            target,
+            initialThread: {
+              backend: request.backend,
+              target,
+              threadId: request.threadId,
+            },
+          });
+          return;
+        }
+      }
       setMainView("thread");
-      void showThread(request);
+      void showThread({ backend: request.backend, threadId: request.threadId });
     },
-    [showThread],
+    [desktopApi, showThread],
   );
   const restoreHistoryLocation = useCallback(
     (location: NavigationHistoryLocation): void => {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1342,6 +1342,7 @@ function createComposerThreadToken(
 ): ComposerSkillToken {
   const path = buildThreadUrl({
     backend: thread.backend,
+    ...(thread.instanceId ? { instanceId: thread.instanceId } : {}),
     threadId: thread.threadId,
   });
   return {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
@@ -238,6 +238,27 @@ describe("thread links in transcript markdown", () => {
     });
   });
 
+  it("keeps an arbitrary remote thread actionable with its owning instance", () => {
+    const onShowThread = vi.fn();
+    renderWithLinks(
+      `See [Remote handoff](pwragent://thread/${CHILD_THREAD_ID}?backend=codex&instanceId=pwr_harold)`,
+      {
+        onShowThread,
+        threads: [],
+      },
+    );
+
+    fireEvent.click(screen.getByRole("button", {
+      name: "Open thread Remote handoff",
+    }));
+
+    expect(onShowThread).toHaveBeenCalledWith({
+      backend: "codex",
+      instanceId: "pwr_harold",
+      threadId: CHILD_THREAD_ID,
+    });
+  });
+
   it("linkifies a bare thread id written as inline code", () => {
     // The shape every pre-protocol handoff message used.
     renderWithLinks(`Created the PwrAgent handoff thread: \`${CHILD_THREAD_ID}\``);

--- a/apps/desktop/src/renderer/src/lib/thread-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/thread-links.tsx
@@ -2,6 +2,7 @@ import {
   isThreadLinkId,
   parseThreadUrl,
   type AppServerBackendKind,
+  type FederationInstanceId,
   type LinkedDirectorySummary,
   type NavigationThreadSummary,
   type ThreadLinkRef,
@@ -19,6 +20,7 @@ import {
 
 export type ResolvedThreadLink = {
   backend: AppServerBackendKind;
+  instanceId?: FederationInstanceId;
   threadId: string;
   title: string;
   gitBranch?: string;
@@ -37,13 +39,17 @@ export type ThreadLinkContextValue = {
   subscribe: (link: ResolvedThreadLink, listener: () => void) => () => void;
 };
 
-function threadLinkKey(link: Pick<ResolvedThreadLink, "backend" | "threadId">): string {
-  return `${link.backend}:${link.threadId}`;
+function threadLinkKey(
+  link: Pick<ResolvedThreadLink, "backend" | "instanceId" | "threadId">,
+): string {
+  return `${link.instanceId ?? "local"}:${link.backend}:${link.threadId}`;
 }
 
 function threadSummaryLink(thread: NavigationThreadSummary): ResolvedThreadLink {
+  const target = thread.federation?.ref.target;
   return {
     backend: thread.source,
+    ...(target?.scope === "remote" ? { instanceId: target.instanceId } : {}),
     threadId: thread.id,
     title: thread.title,
     gitBranch: thread.gitBranch,
@@ -82,6 +88,9 @@ function threadLinkMetadataKey(threads: NavigationThreadSummary[]): string {
   return JSON.stringify(
     threads.map((thread) => [
       thread.source,
+      thread.federation?.ref.target.scope === "remote"
+        ? thread.federation.ref.target.instanceId
+        : null,
       thread.id,
       thread.title,
       thread.gitBranch ?? null,
@@ -189,7 +198,11 @@ export function useLiveThreadLink(link: ResolvedThreadLink): ResolvedThreadLink 
 
 export function ThreadLinkProvider(props: {
   children: ReactNode;
-  onShowThread: (request: { backend: AppServerBackendKind; threadId: string }) => void;
+  onShowThread: (request: {
+    backend: AppServerBackendKind;
+    instanceId?: FederationInstanceId;
+    threadId: string;
+  }) => void;
   threads: NavigationThreadSummary[];
 }) {
   const { onShowThread, threads } = props;
@@ -216,7 +229,9 @@ export function ThreadLinkProvider(props: {
   // reflected in the context value. The per-thread metadata store above
   // updates only chips that reference the changed thread.
   const membershipKey = useMemo(
-    () => threads.map((thread) => `${thread.source}:${thread.id}`).sort().join("\u0000"),
+    () => threads.map((thread) => threadLinkKey(threadSummaryLink(thread)))
+      .sort()
+      .join("\u0000"),
     [threads],
   );
 
@@ -228,10 +243,14 @@ export function ThreadLinkProvider(props: {
   const value = useMemo<ThreadLinkContextValue>(() => {
     const byThreadId = new Map<string, ResolvedThreadLink>();
     const byIdentity = new Map<string, ResolvedThreadLink>();
+    const byFederatedIdentity = new Map<string, ResolvedThreadLink>();
 
     for (const thread of threadsRef.current) {
       const link = threadSummaryLink(thread);
       byIdentity.set(`${thread.source}:${thread.id}`, link);
+      if (link.instanceId) {
+        byFederatedIdentity.set(threadLinkKey(link), link);
+      }
       // Thread ids are backend-generated and effectively unique, so a bare
       // `pwragent://thread/<id>` resolves without a backend hint. If two
       // backends ever collide on an id, the explicit `?backend=` form wins.
@@ -242,13 +261,32 @@ export function ThreadLinkProvider(props: {
 
     return {
       resolve(ref) {
+        if (ref.instanceId) {
+          if (!ref.backend) {
+            return undefined;
+          }
+          return byFederatedIdentity.get(threadLinkKey({
+            backend: ref.backend,
+            instanceId: ref.instanceId,
+            threadId: ref.threadId,
+          })) ?? {
+            backend: ref.backend,
+            instanceId: ref.instanceId,
+            threadId: ref.threadId,
+            title: "",
+          };
+        }
         if (ref.backend) {
           return byIdentity.get(`${ref.backend}:${ref.threadId}`);
         }
         return byThreadId.get(ref.threadId);
       },
       show(link) {
-        onShowThreadRef.current({ backend: link.backend, threadId: link.threadId });
+        onShowThreadRef.current({
+          backend: link.backend,
+          ...(link.instanceId ? { instanceId: link.instanceId } : {}),
+          threadId: link.threadId,
+        });
       },
       getSnapshot(link) {
         return metadataStore.getSnapshot(link);

--- a/apps/desktop/src/renderer/src/lib/transcript-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/transcript-links.tsx
@@ -1,5 +1,6 @@
 import type {
   AppServerBackendKind,
+  FederationInstanceId,
   NavigationThreadSummary,
 } from "@pwragent/shared";
 import type { ReactNode } from "react";
@@ -11,6 +12,7 @@ export function TranscriptLinkProvider(props: {
   children: ReactNode;
   onShowThread: (request: {
     backend: AppServerBackendKind;
+    instanceId?: FederationInstanceId;
     threadId: string;
   }) => void;
   threads: NavigationThreadSummary[];

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -235,3 +235,10 @@ describe themselves to peers with the Settings → Federation "Instance name"
 and "Purpose notes" fields, so agents can route work by what each machine is
 for. Operators can steer routing and thread-startup defaults with
 [`~/.pwragent/AGENTS.md`](agent-operator-preferences.md).
+
+The general `send_message_to_thread` tool also routes transparently across
+federation. It tries the local backend first, then resolves an exact thread ID
+across connected peers and starts the turn on the owning instance. Agents do
+not need to discover or supply an instance ID. Exact UUID queries passed to
+`search_federation_threads` use the same ownership lookup instead of relying
+on fuzzy thread-list filtering.

--- a/packages/shared/src/contracts/__tests__/thread-link.test.ts
+++ b/packages/shared/src/contracts/__tests__/thread-link.test.ts
@@ -14,14 +14,17 @@ describe("buildThreadUrl", () => {
     );
   });
 
-  it("carries backend and profile as query params", () => {
+  it("carries backend, instance, and profile as query params", () => {
     expect(
       buildThreadUrl({
         threadId: "019f5d79",
         backend: "codex",
+        instanceId: "pwr_harold",
         profile: "sstk",
       }),
-    ).toBe("pwragent://thread/019f5d79?backend=codex&profile=sstk");
+    ).toBe(
+      "pwragent://thread/019f5d79?backend=codex&instanceId=pwr_harold&profile=sstk",
+    );
   });
 
   it("percent-encodes an acp backend id rather than breaking the path", () => {
@@ -40,6 +43,7 @@ describe("parseThreadUrl", () => {
     const ref = {
       threadId: "019f5d79-a595-73f2-84d9-a0976762c303",
       backend: "codex",
+      instanceId: "pwr_harold",
       profile: "sstk",
     } as const;
 
@@ -50,8 +54,17 @@ describe("parseThreadUrl", () => {
     expect(parseThreadUrl("pwragent://thread/019f5d79")).toEqual({
       threadId: "019f5d79",
       backend: undefined,
+      instanceId: undefined,
       profile: undefined,
     });
+  });
+
+  it("drops an invalid federation instance id rather than trusting it", () => {
+    expect(
+      parseThreadUrl(
+        "pwragent://thread/019f5d79?backend=codex&instanceId=not%2Fa%2Fpeer",
+      )?.instanceId,
+    ).toBeUndefined();
   });
 
   it("drops a backend that is not a known kind rather than trusting it", () => {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -692,6 +692,15 @@ export type AppServerListThreadsResponse = {
   workspaceRoots?: string[];
 };
 
+export type ResolveThreadRequest = {
+  backend?: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+};
+
+export type ResolveThreadResponse = {
+  thread?: AppServerThreadSummary;
+};
+
 export type ArchiveThreadCleanupResult = {
   worktreePath?: string;
   branch?: string;

--- a/packages/shared/src/contracts/thread-link.ts
+++ b/packages/shared/src/contracts/thread-link.ts
@@ -1,4 +1,8 @@
 import { isAppServerBackendKind } from "./navigation";
+import {
+  isFederationInstanceId,
+  type FederationInstanceId,
+} from "./federation";
 import type {
   AppServerBackendKind,
   ThreadIdentifier,
@@ -8,7 +12,7 @@ import type {
  * PwrAgent's in-app link scheme.
  *
  * ```
- * pwragent://thread/<threadId>[?backend=<kind>][&profile=<name>]
+ * pwragent://thread/<threadId>[?backend=<kind>][&instanceId=<id>][&profile=<name>]
  * ```
  *
  * The scheme is NAVIGATION-ONLY and must stay that way. It never grows action
@@ -42,6 +46,12 @@ export type ThreadLinkRef = {
    */
   backend?: AppServerBackendKind;
   /**
+   * Optional owning federation instance. Remote emitters include it so the
+   * renderer can open an arbitrary thread on the correct peer even when that
+   * thread is not already present in the local navigation snapshot.
+   */
+  instanceId?: FederationInstanceId;
+  /**
    * Optional profile name. Only meaningful for links that travel outside the
    * app. A link naming a profile other than the running one reports the
    * mismatch rather than silently switching profiles.
@@ -66,6 +76,9 @@ export function buildThreadUrl(ref: ThreadLinkRef): string {
   const query: string[] = [];
   if (ref.backend) {
     query.push(`backend=${encodeURIComponent(ref.backend)}`);
+  }
+  if (ref.instanceId) {
+    query.push(`instanceId=${encodeURIComponent(ref.instanceId)}`);
   }
   if (ref.profile) {
     query.push(`profile=${encodeURIComponent(ref.profile)}`);
@@ -102,11 +115,14 @@ export function parseThreadUrl(value: string): ThreadLinkRef | undefined {
 
   const params = parseQuery(query);
   const backend = params.get("backend");
+  const instanceId = params.get("instanceId");
   const profile = params.get("profile");
 
   return {
     threadId,
     backend: backend && isAppServerBackendKind(backend) ? backend : undefined,
+    instanceId:
+      instanceId && isFederationInstanceId(instanceId) ? instanceId : undefined,
     profile: profile || undefined,
   };
 }


### PR DESCRIPTION
## What changed

- add a capability-gated `backend.resolveThread` federation RPC for exact thread-ID ownership lookup
- make `send_message_to_thread` fall back from a genuine local `thread not found` response to connected-peer resolution and start the turn on the owning instance
- preserve agent source-thread provenance when the turn crosses federation
- make exact UUID searches use ownership resolution instead of provider fuzzy filtering
- retain mixed-version compatibility by scanning an older peer active thread list when the new RPC is unavailable
- document that agents do not need to discover or supply an instance ID

## Root cause

The failed send in thread `019fd905-57da-7c80-9cfe-580ed0ef0eb3` called `send_message_to_thread` with the correct backend and target UUID. The implementation always invoked the local `BackendRegistry.startTurn`, so local Codex returned `thread not found`. Even after `search_federation_threads` found the target title on Harold-Mac-Mini-M4, the second send followed the same local-only path.

Exact UUID federation search also returned no result because the provider-side thread-list filter did not match thread IDs, despite title searches finding the same thread.

## Impact

Agents can now send to a known thread UUID without knowing which machine owns it. PwrAgent resolves ownership across connected peers and routes the turn automatically. Exact UUID ownership searches now return the owning instance as expected.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/federated-thread-message-service.test.ts apps/desktop/src/main/__tests__/federated-search-service.test.ts apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/index.test.ts` — 528 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors (existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`