### PR TITLE
feat(desktop): scope federation event subscriptions

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -36,7 +36,15 @@ const send = vi.fn();
 // A second subscriber standing in for a federation (remote viewer)
 // window, so PR-authority fan-out can be asserted per window kind.
 const federationWindowSend = vi.fn();
-const federationWindowWebContents = { send: federationWindowSend };
+const federationWindowWebContents = { id: 2, send: federationWindowSend };
+let channelSubscribers: Array<{ id: number; send: typeof send }> = [
+  { id: 1, send },
+  federationWindowWebContents,
+];
+const channelSubscriberTargets = new Map<number, {
+  scope: "remote";
+  instanceId: string;
+}>();
 let registryListener: ((event: AgentEvent) => void | Promise<void>) | undefined;
 
 const registry = {
@@ -308,6 +316,7 @@ const federationMock = vi.hoisted(() => {
     remoteBackend,
     runtime: {
       remoteBackend: vi.fn(() => remoteBackend),
+      rendererWantsRemoteEvent: vi.fn(() => true),
       setAgentEventPublisher: vi.fn(),
       setEnvironmentSetupProgressPublisher: vi.fn(),
     },
@@ -338,18 +347,10 @@ vi.mock("electron", () => ({
 // `BrowserWindow.getAllWindows()`. The test pretends a single
 // subscriber exists for any channel, which routes back to the
 // shared `send` mock above.
-// `broadcastAgentEvent` asks which remote instance a window fronts so a
-// peer's PR observation can be withheld from windows that have a local
-// monitor for the same PR. Only the federation subscriber has a target.
-vi.mock("../window", () => ({
-  federationWindowTargetForWebContents: (webContents: unknown) =>
-    webContents === federationWindowWebContents
-      ? { scope: "remote", instanceId: "peer-1" }
-      : undefined,
-}));
-
 vi.mock("../window-channels", () => ({
-  subscribersForChannel: () => [{ send }, federationWindowWebContents],
+  federationTargetForChannelSubscriber: (webContents: { id: number }) =>
+    channelSubscriberTargets.get(webContents.id),
+  subscribersForChannel: () => channelSubscribers,
   WINDOW_KIND_MAIN: "main",
   WINDOW_KIND_MESSAGING_ACTIVITY: "messaging-activity",
   registerWindowChannels: () => undefined,
@@ -362,6 +363,7 @@ vi.mock("../app-server/backend-registry", () => ({
 }));
 
 vi.mock("../federation/federation-runtime", () => ({
+  federationEventClassForMethod: () => "transcript",
   getDesktopFederationRuntime: () => federationMock.runtime,
 }));
 
@@ -376,6 +378,12 @@ describe("agent ipc", () => {
     federationWindowSend.mockReset();
     registry.isPullRequestLocallyMonitored.mockClear();
     registry.isPullRequestLocallyMonitored.mockReturnValue(false);
+    channelSubscribers = [{ id: 1, send }, federationWindowWebContents];
+    channelSubscriberTargets.clear();
+    channelSubscriberTargets.set(2, {
+      scope: "remote",
+      instanceId: "peer-1",
+    });
     registry.listBackends.mockClear();
     registry.onEvent.mockClear();
     registry.startThread.mockClear();
@@ -391,6 +399,8 @@ describe("agent ipc", () => {
     registry.cancelThreadPrAutoDispatch.mockClear();
     registry.sendThreadPrAutoDispatchNow.mockClear();
     federationMock.runtime.remoteBackend.mockClear();
+    federationMock.runtime.rendererWantsRemoteEvent.mockReset();
+    federationMock.runtime.rendererWantsRemoteEvent.mockReturnValue(true);
     federationMock.runtime.setAgentEventPublisher.mockClear();
     federationMock.runtime.setEnvironmentSetupProgressPublisher.mockClear();
     for (const method of Object.values(federationMock.remoteBackend)) {
@@ -937,6 +947,48 @@ describe("agent ipc", () => {
     });
 
     disposeAgentIpcHandlers();
+  });
+
+  it("routes remote events only to subscribed windows for the owning instance", async () => {
+    const { broadcastAgentEvent } = await import("../ipc/agent-ipc");
+    const localSend = vi.fn();
+    const ownerSend = vi.fn();
+    const unrelatedSend = vi.fn();
+    channelSubscribers = [
+      { id: 1, send: localSend },
+      { id: 2, send: ownerSend },
+      { id: 3, send: unrelatedSend },
+    ];
+    channelSubscriberTargets.set(2, {
+      scope: "remote",
+      instanceId: "owner_one",
+    });
+    channelSubscriberTargets.set(3, {
+      scope: "remote",
+      instanceId: "owner_two",
+    });
+    federationMock.runtime.rendererWantsRemoteEvent.mockImplementation(
+      (webContentsId?: number, instanceId?: string) =>
+        webContentsId === 2 && instanceId === "owner_one",
+    );
+
+    broadcastAgentEvent({
+      backend: "codex",
+      federationTarget: { scope: "remote", instanceId: "owner_one" },
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          delta: "hello",
+          itemId: "item-1",
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+      },
+    } as AgentEvent);
+
+    expect(ownerSend).toHaveBeenCalledTimes(1);
+    expect(localSend).not.toHaveBeenCalled();
+    expect(unrelatedSend).not.toHaveBeenCalled();
   });
 
   it("caps oversized live agent event strings before broadcasting to renderer subscribers", async () => {

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -4,10 +4,13 @@ import type {
   CelestialIconAssignment,
   CodexEnvironmentSetupProgressEvent,
   FederationCapability,
+  FederationEventClass,
+  FederationEventSubscription,
   FederationInstanceId,
   FederationProtocolEnvelope,
   NavigationSnapshot,
   SetCelestialIconResponse,
+  StarMapArrangementEntry,
 } from "@pwragent/shared";
 import {
   FEDERATION_PROTOCOL_VERSION,
@@ -33,7 +36,14 @@ type RuntimeHarness = {
     sourcePeerId: FederationInstanceId,
   ) => Promise<void>;
   applyPeerDirectory: (envelope: FederationProtocolEnvelope) => boolean;
+  applyEventSubscription: (
+    envelope: FederationProtocolEnvelope,
+    sourcePeerId: FederationInstanceId,
+  ) => boolean;
   forwardLocalBackendEvent: (event: AgentEvent) => void;
+  broadcastStarMapArrangement: (
+    entries: StarMapArrangementEntry[],
+  ) => void;
   gatewayInstanceId?: FederationInstanceId;
   localInstanceId?: FederationInstanceId;
   publishRemoteBackendEvent: (
@@ -100,6 +110,24 @@ type RuntimeHarness = {
     envelope: FederationProtocolEnvelope,
   ) => void;
   setAgentEventPublisher: (publisher: (event: AgentEvent) => void) => void;
+  setEventSubscriptions: (
+    consumerId: string,
+    subscriptions: readonly FederationEventSubscription[],
+  ) => FederationEventSubscription[];
+  setRendererEventSubscriptions: (
+    webContentsId: number,
+    consumerId: "remote-window" | "star-map",
+    subscriptions: readonly FederationEventSubscription[],
+  ) => FederationEventSubscription[];
+  clearRendererEventSubscriptions: (
+    webContentsId: number,
+    consumerId?: "remote-window" | "star-map",
+  ) => void;
+  rendererWantsRemoteEvent: (
+    webContentsId: number,
+    sourceInstanceId: FederationInstanceId,
+    eventClass: FederationEventClass,
+  ) => boolean;
   setEnvironmentSetupProgressPublisher: (
     publisher: (event: CodexEnvironmentSetupProgressEvent) => void,
   ) => void;
@@ -166,6 +194,25 @@ function createConnection(params: {
     sendEnvelope: params.sendEnvelope ?? (() => undefined),
     close: () => undefined,
   };
+}
+
+function applyEventSubscription(params: {
+  runtime: RuntimeHarness;
+  sourceInstanceId: FederationInstanceId;
+  subscriberInstanceId: FederationInstanceId;
+  sourcePeerId?: FederationInstanceId;
+  eventClasses: FederationEventClass[];
+}): void {
+  expect(params.runtime.applyEventSubscription({
+    id: `subscription:${params.subscriberInstanceId}`,
+    kind: "notification",
+    method: "federation.eventSubscription",
+    params: { eventClasses: params.eventClasses },
+    protocolVersion: FEDERATION_PROTOCOL_VERSION,
+    sourceInstanceId: params.subscriberInstanceId,
+    targetInstanceId: params.sourceInstanceId,
+    createdAt: 1_000,
+  }, params.sourcePeerId ?? params.subscriberInstanceId)).toBe(true);
 }
 
 describe("DesktopFederationRuntime", () => {
@@ -750,13 +797,17 @@ describe("DesktopFederationRuntime", () => {
     });
   });
 
-  it("forwards local backend events to remote-capable peers", () => {
+  it("keeps connected peers idle until they subscribe to backend events", () => {
     const forwarded: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({ localInstanceId: "gateway_one" });
     router.registerConnection(
       createConnection({
         peerId: "client_one",
-        capabilities: ["remote_window"],
+        capabilities: [
+          "remote_window",
+          "thread_navigation",
+          "event_subscriptions",
+        ],
         sendEnvelope: (envelope) => forwarded.push(envelope),
       }),
     );
@@ -783,24 +834,276 @@ describe("DesktopFederationRuntime", () => {
       },
     } as AgentEvent);
 
-    expect(forwarded).toMatchObject([
-      {
-        kind: "notification",
-        method: FEDERATION_BACKEND_EVENT_METHOD,
-        params: {
-          backend: "codex",
-          notification: {
-            method: "turn/started",
-            params: {
-              threadId: "thread-1",
-              turnId: "turn-1",
-            },
-          },
+    expect(forwarded).toEqual([]);
+  });
+
+  it("replaces viewer subscriptions when retargeted and unsubscribes on close", () => {
+    const sentToOne: FederationProtocolEnvelope[] = [];
+    const sentToTwo: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({ localInstanceId: "viewer_one" });
+    router.registerConnection(createConnection({
+      peerId: "owner_one",
+      capabilities: [
+        "thread_navigation",
+        "event_subscriptions",
+      ],
+      sendEnvelope: (envelope) => sentToOne.push(envelope),
+    }));
+    router.registerConnection(createConnection({
+      peerId: "owner_two",
+      capabilities: ["thread_detail", "event_subscriptions"],
+      sendEnvelope: (envelope) => sentToTwo.push(envelope),
+    }));
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "viewer_one";
+    runtime.router = router;
+
+    runtime.setEventSubscriptions("renderer:7", [{
+      sourceInstanceId: "owner_one",
+      eventClasses: ["navigation"],
+    }]);
+    runtime.setEventSubscriptions("renderer:7", [{
+      sourceInstanceId: "owner_two",
+      eventClasses: ["transcript"],
+    }]);
+    runtime.setEventSubscriptions("renderer:7", []);
+
+    expect(sentToOne.map((envelope) =>
+      envelope.kind === "notification" ? envelope.params : undefined
+    )).toEqual([
+      { eventClasses: ["navigation"] },
+      { eventClasses: [] },
+    ]);
+    expect(sentToTwo.map((envelope) =>
+      envelope.kind === "notification" ? envelope.params : undefined
+    )).toEqual([
+      { eventClasses: ["transcript"] },
+      { eventClasses: [] },
+    ]);
+  });
+
+  it("keeps a viewer subscription while Star Map opens and closes in its window", () => {
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "viewer_one";
+    runtime.router = new FederationRouter({ localInstanceId: "viewer_one" });
+    runtime.router.registerConnection(createConnection({
+      peerId: "owner_one",
+      capabilities: [
+        "thread_navigation",
+        "thread_detail",
+        "event_subscriptions",
+      ],
+    }));
+    runtime.router.registerConnection(createConnection({
+      peerId: "owner_two",
+      capabilities: ["thread_navigation", "event_subscriptions"],
+    }));
+
+    runtime.setRendererEventSubscriptions(7, "remote-window", [{
+      sourceInstanceId: "owner_one",
+      eventClasses: ["navigation", "transcript"],
+    }]);
+    runtime.setRendererEventSubscriptions(7, "star-map", [{
+      sourceInstanceId: "owner_one",
+      eventClasses: ["navigation", "star_map"],
+    }, {
+      sourceInstanceId: "owner_two",
+      eventClasses: ["navigation", "star_map"],
+    }]);
+    runtime.clearRendererEventSubscriptions(7, "star-map");
+
+    expect(runtime.rendererWantsRemoteEvent(7, "owner_one", "navigation"))
+      .toBe(true);
+    expect(runtime.rendererWantsRemoteEvent(7, "owner_one", "transcript"))
+      .toBe(true);
+    expect(runtime.rendererWantsRemoteEvent(7, "owner_one", "star_map"))
+      .toBe(false);
+    expect(runtime.rendererWantsRemoteEvent(7, "owner_two", "navigation"))
+      .toBe(false);
+  });
+
+  it("publishes only the event classes and source instances Star Map requests", () => {
+    const published: AgentEvent[] = [];
+    const router = new FederationRouter({ localInstanceId: "viewer_one" });
+    for (const peerId of ["owner_one", "owner_two"] as const) {
+      router.registerConnection(createConnection({
+        peerId,
+        capabilities: [
+          "gateway_relay",
+          "thread_navigation",
+          "scheduled_actions",
+          "event_subscriptions",
+        ],
+      }));
+    }
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "viewer_one";
+    runtime.router = router;
+    runtime.setAgentEventPublisher((event) => published.push(event));
+    runtime.setEventSubscriptions("renderer:star-map", [{
+      sourceInstanceId: "owner_one",
+      eventClasses: ["navigation", "scheduled_actions", "star_map"],
+    }]);
+
+    const publish = (
+      sourceInstanceId: FederationInstanceId,
+      method: string,
+    ) => runtime.publishRemoteBackendEvent({
+      id: `event:${sourceInstanceId}:${method}`,
+      kind: "notification",
+      method: FEDERATION_BACKEND_EVENT_METHOD,
+      params: {
+        backend: "codex",
+        notification: {
+          method,
+          params: { threadId: "thread-1" },
         },
-        protocolVersion: FEDERATION_PROTOCOL_VERSION,
-        sourceInstanceId: "gateway_one",
-        targetInstanceId: "client_one",
       },
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId,
+      targetInstanceId: "viewer_one",
+      createdAt: 2_000,
+    }, sourceInstanceId);
+
+    publish("owner_one", "thread/status/changed");
+    publish("owner_one", "item/agentMessage/delta");
+    publish("owner_one", "thread/scheduledAction/updated");
+    publish("owner_one", "starMap/intake/status");
+    publish("owner_two", "thread/status/changed");
+
+    expect(published.map((event) => ({
+      instanceId: event.federationTarget?.scope === "remote"
+        ? event.federationTarget.instanceId
+        : undefined,
+      method: event.notification.method,
+    }))).toEqual([
+      { instanceId: "owner_one", method: "thread/status/changed" },
+      {
+        instanceId: "owner_one",
+        method: "thread/scheduledAction/updated",
+      },
+      { instanceId: "owner_one", method: "starMap/intake/status" },
+    ]);
+  });
+
+  it("sends Star Map arrangement deltas only to star-map subscribers", () => {
+    const subscribed: FederationProtocolEnvelope[] = [];
+    const unrelated: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({ localInstanceId: "owner_one" });
+    router.registerConnection(createConnection({
+      peerId: "viewer_one",
+      capabilities: ["thread_navigation", "event_subscriptions"],
+      sendEnvelope: (envelope) => subscribed.push(envelope),
+    }));
+    router.registerConnection(createConnection({
+      peerId: "viewer_two",
+      capabilities: ["thread_navigation", "event_subscriptions"],
+      sendEnvelope: (envelope) => unrelated.push(envelope),
+    }));
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "owner_one";
+    runtime.router = router;
+    applyEventSubscription({
+      runtime,
+      sourceInstanceId: "owner_one",
+      subscriberInstanceId: "viewer_one",
+      eventClasses: ["star_map"],
+    });
+
+    runtime.broadcastStarMapArrangement([{
+      instanceId: "owner_one",
+      threadKey: "codex:thread-1",
+      dx: 10,
+      dy: 20,
+      updatedAt: 1_000,
+      by: "owner_one",
+    }]);
+
+    expect(subscribed).toMatchObject([{
+      method: "federation.starMapArrangement",
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+    }]);
+    expect(unrelated).toEqual([]);
+  });
+
+  it("rejects a direct peer spoofing a subscribed source instance", () => {
+    const published: AgentEvent[] = [];
+    const router = new FederationRouter({ localInstanceId: "viewer_one" });
+    router.registerConnection(createConnection({
+      peerId: "owner_one",
+      capabilities: ["thread_detail", "event_subscriptions"],
+    }));
+    router.registerConnection(createConnection({
+      peerId: "owner_two",
+      capabilities: [
+        "gateway_relay",
+        "thread_detail",
+        "event_subscriptions",
+      ],
+    }));
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "viewer_one";
+    runtime.router = router;
+    runtime.setAgentEventPublisher((event) => published.push(event));
+    runtime.setEventSubscriptions("viewer", [{
+      sourceInstanceId: "owner_one",
+      eventClasses: ["transcript"],
+    }]);
+
+    runtime.publishRemoteBackendEvent({
+      id: "spoofed-event",
+      kind: "notification",
+      method: FEDERATION_BACKEND_EVENT_METHOD,
+      params: {
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: { threadId: "thread-1" },
+        },
+      },
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 2_000,
+    }, "owner_two");
+
+    expect(published).toEqual([]);
+  });
+
+  it("replays desired subscriptions once per reconnect without duplicates", () => {
+    const sent: FederationProtocolEnvelope[] = [];
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "viewer_one";
+    runtime.router = new FederationRouter({ localInstanceId: "viewer_one" });
+    runtime.setEventSubscriptions("renderer:7", [{
+      sourceInstanceId: "owner_one",
+      eventClasses: ["navigation"],
+    }]);
+    const connection = createConnection({
+      peerId: "owner_one",
+      capabilities: [
+        "thread_navigation",
+        "event_subscriptions",
+      ],
+      sendEnvelope: (envelope) => sent.push(envelope),
+    });
+
+    runtime.registerGatewayConnection(connection);
+    runtime.unregisterGatewayConnection(connection);
+    runtime.registerGatewayConnection(connection);
+
+    expect(
+      sent.filter(
+        (envelope) =>
+          envelope.kind === "notification"
+          && envelope.method === "federation.eventSubscription",
+      ).map((envelope) =>
+        envelope.kind === "notification" ? envelope.params : undefined
+      ),
+    ).toEqual([
+      { eventClasses: ["navigation"] },
+      { eventClasses: ["navigation"] },
     ]);
   });
 
@@ -810,13 +1113,19 @@ describe("DesktopFederationRuntime", () => {
     router.registerConnection(
       createConnection({
         peerId: "client_one",
-        capabilities: ["remote_window"],
+        capabilities: ["thread_detail", "event_subscriptions"],
         sendEnvelope: (envelope) => forwarded.push(envelope),
       }),
     );
     const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
     runtime.localInstanceId = "gateway_one";
     runtime.router = router;
+    applyEventSubscription({
+      runtime,
+      sourceInstanceId: "gateway_one",
+      subscriberInstanceId: "client_one",
+      eventClasses: ["transcript"],
+    });
     const ownerUrl =
       `pwragent-image://file/${encodeURIComponent("file:///Users/owner/.pwragent/profiles/default/state/image-inputs/image.png")}`;
 
@@ -869,7 +1178,7 @@ describe("DesktopFederationRuntime", () => {
     router.registerConnection(
       createConnection({
         peerId: "client_one",
-        capabilities: ["scheduled_actions"],
+        capabilities: ["scheduled_actions", "event_subscriptions"],
         sendEnvelope: (envelope) => forwarded.push(envelope),
       }),
     );
@@ -883,6 +1192,12 @@ describe("DesktopFederationRuntime", () => {
     const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
     runtime.localInstanceId = "gateway_one";
     runtime.router = router;
+    applyEventSubscription({
+      runtime,
+      sourceInstanceId: "gateway_one",
+      subscriberInstanceId: "client_one",
+      eventClasses: ["scheduled_actions"],
+    });
 
     runtime.forwardLocalBackendEvent({
       backend: "codex",
@@ -923,7 +1238,18 @@ describe("DesktopFederationRuntime", () => {
 
   it("publishes remote backend events with the source peer as federation target", () => {
     const published: AgentEvent[] = [];
+    const router = new FederationRouter({ localInstanceId: "gateway_one" });
+    router.registerConnection(createConnection({
+      peerId: "client_one",
+      capabilities: ["thread_detail", "event_subscriptions"],
+    }));
     const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "gateway_one";
+    runtime.router = router;
+    runtime.setEventSubscriptions("viewer", [{
+      sourceInstanceId: "client_one",
+      eventClasses: ["transcript"],
+    }]);
     runtime.setAgentEventPublisher((event) => {
       published.push(event);
     });
@@ -1073,50 +1399,62 @@ describe("DesktopFederationRuntime", () => {
     ]);
   });
 
-  it("relays client backend events to sibling peers through the gateway", () => {
+  it("relays client backend events only toward a subscribed sibling", () => {
     const relayedToSibling: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({ localInstanceId: "gateway_one" });
     router.registerConnection(
       createConnection({
         peerId: "client_one",
-        capabilities: ["remote_window"],
+        capabilities: ["gateway_relay", "event_subscriptions"],
       }),
     );
     router.registerConnection(
       createConnection({
         peerId: "client_two",
-        capabilities: ["remote_window"],
+        capabilities: [
+          "gateway_relay",
+          "thread_detail",
+          "event_subscriptions",
+        ],
         sendEnvelope: (envelope) => relayedToSibling.push(envelope),
       }),
     );
     const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
     runtime.localInstanceId = "gateway_one";
     runtime.router = router;
-
-    runtime.publishRemoteBackendEvent(
-      {
-        id: "event-1",
-        kind: "notification",
-        method: FEDERATION_BACKEND_EVENT_METHOD,
-        params: {
-          backend: "codex",
-          notification: {
-            method: "item/agentMessage/delta",
-            params: {
-              delta: "hello",
-              itemId: "item-1",
-              threadId: "thread-1",
-              turnId: "turn-1",
-            },
+    const event: FederationProtocolEnvelope = {
+      id: "event-1",
+      kind: "notification",
+      method: FEDERATION_BACKEND_EVENT_METHOD,
+      params: {
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            delta: "hello",
+            itemId: "item-1",
+            threadId: "thread-1",
+            turnId: "turn-1",
           },
         },
-        protocolVersion: FEDERATION_PROTOCOL_VERSION,
-        sourceInstanceId: "client_one",
-        targetInstanceId: "gateway_one",
-        createdAt: 2_000,
       },
-      "client_one",
-    );
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "client_two",
+      createdAt: 2_000,
+    };
+
+    runtime.publishRemoteBackendEvent(event, "client_one");
+    expect(relayedToSibling).toEqual([]);
+
+    applyEventSubscription({
+      runtime,
+      sourceInstanceId: "client_one",
+      subscriberInstanceId: "client_two",
+      eventClasses: ["transcript"],
+    });
+
+    runtime.publishRemoteBackendEvent(event, "client_one");
 
     expect(relayedToSibling).toMatchObject([
       {
@@ -1130,24 +1468,37 @@ describe("DesktopFederationRuntime", () => {
     ]);
   });
 
-  it("relays scheduler lifecycle events only to scheduler-capable siblings", () => {
+  it("relays scheduler lifecycle events only to an explicitly subscribed sibling", () => {
     const authorized: FederationProtocolEnvelope[] = [];
     const unauthorized: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({ localInstanceId: "gateway_one" });
-    router.registerConnection(createConnection({ peerId: "client_one" }));
+    router.registerConnection(createConnection({
+      peerId: "client_one",
+      capabilities: ["gateway_relay", "event_subscriptions"],
+    }));
     router.registerConnection(createConnection({
       peerId: "client_two",
-      capabilities: ["remote_window", "thread_detail"],
+      capabilities: ["gateway_relay", "thread_detail", "event_subscriptions"],
       sendEnvelope: (envelope) => unauthorized.push(envelope),
     }));
     router.registerConnection(createConnection({
       peerId: "client_three",
-      capabilities: ["scheduled_actions"],
+      capabilities: [
+        "gateway_relay",
+        "scheduled_actions",
+        "event_subscriptions",
+      ],
       sendEnvelope: (envelope) => authorized.push(envelope),
     }));
     const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
     runtime.localInstanceId = "gateway_one";
     runtime.router = router;
+    applyEventSubscription({
+      runtime,
+      sourceInstanceId: "client_one",
+      subscriberInstanceId: "client_three",
+      eventClasses: ["scheduled_actions"],
+    });
 
     runtime.publishRemoteBackendEvent({
       id: "scheduled-event-1",
@@ -1175,7 +1526,7 @@ describe("DesktopFederationRuntime", () => {
       },
       protocolVersion: FEDERATION_PROTOCOL_VERSION,
       sourceInstanceId: "client_one",
-      targetInstanceId: "gateway_one",
+      targetInstanceId: "client_three",
       createdAt: 2_000,
     }, "client_one");
 

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -90,6 +90,10 @@ type RuntimeHarness = {
   }) => void;
   disconnectAdvertisedPeers: (reason: string) => void;
   registerGatewayConnection: (connection: FederationGatewayConnection) => void;
+  unregisterPeer: (peerId: FederationInstanceId) => void;
+  replayRelayedEventSubscriptions: (
+    sourceInstanceId?: FederationInstanceId,
+  ) => void;
   remoteBackend: (target?: {
     scope: "remote";
     instanceId: FederationInstanceId;
@@ -202,6 +206,7 @@ function applyEventSubscription(params: {
   subscriberInstanceId: FederationInstanceId;
   sourcePeerId?: FederationInstanceId;
   eventClasses: FederationEventClass[];
+  hopCount?: number;
 }): void {
   expect(params.runtime.applyEventSubscription({
     id: `subscription:${params.subscriberInstanceId}`,
@@ -211,6 +216,7 @@ function applyEventSubscription(params: {
     protocolVersion: FEDERATION_PROTOCOL_VERSION,
     sourceInstanceId: params.subscriberInstanceId,
     targetInstanceId: params.sourceInstanceId,
+    ...(params.hopCount === undefined ? {} : { hopCount: params.hopCount }),
     createdAt: 1_000,
   }, params.sourcePeerId ?? params.subscriberInstanceId)).toBe(true);
 }
@@ -1107,6 +1113,50 @@ describe("DesktopFederationRuntime", () => {
     ]);
   });
 
+  it("replays retained downstream subscriptions after its upstream reconnects", () => {
+    const sentUpstream: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({ localInstanceId: "dual_one" });
+    router.registerConnection(createConnection({
+      peerId: "viewer_one",
+      capabilities: [
+        "gateway_relay",
+        "thread_detail",
+        "event_subscriptions",
+      ],
+    }));
+    const upstreamConnection = createConnection({
+      peerId: "gateway_one",
+      capabilities: ["gateway_relay", "event_subscriptions"],
+      sendEnvelope: (envelope) => sentUpstream.push(envelope),
+    });
+    router.registerConnection(upstreamConnection);
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.gatewayInstanceId = "gateway_one";
+    runtime.localInstanceId = "dual_one";
+    runtime.router = router;
+    applyEventSubscription({
+      runtime,
+      sourceInstanceId: "owner_one",
+      subscriberInstanceId: "viewer_one",
+      eventClasses: ["transcript"],
+    });
+    expect(sentUpstream).toHaveLength(1);
+
+    sentUpstream.length = 0;
+    runtime.unregisterPeer("gateway_one");
+    router.registerConnection(upstreamConnection);
+    runtime.replayRelayedEventSubscriptions();
+
+    expect(sentUpstream).toMatchObject([{
+      kind: "notification",
+      method: "federation.eventSubscription",
+      params: { eventClasses: ["transcript"] },
+      sourceInstanceId: "viewer_one",
+      targetInstanceId: "owner_one",
+      hopCount: 1,
+    }]);
+  });
+
   it("routes live transcript images back through their owning instance", () => {
     const forwarded: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({ localInstanceId: "gateway_one" });
@@ -1466,6 +1516,73 @@ describe("DesktopFederationRuntime", () => {
         hopCount: 1,
       },
     ]);
+  });
+
+  it("routes a delegated subscription and event through a dual instance", () => {
+    const sentToOwner: FederationProtocolEnvelope[] = [];
+    const sentToDual: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({ localInstanceId: "gateway_one" });
+    router.registerConnection(createConnection({
+      peerId: "dual_one",
+      capabilities: [
+        "gateway_relay",
+        "thread_detail",
+        "event_subscriptions",
+      ],
+      sendEnvelope: (envelope) => sentToDual.push(envelope),
+    }));
+    router.registerConnection(createConnection({
+      peerId: "owner_one",
+      capabilities: ["gateway_relay", "event_subscriptions"],
+      sendEnvelope: (envelope) => sentToOwner.push(envelope),
+    }));
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "gateway_one";
+    runtime.router = router;
+    applyEventSubscription({
+      runtime,
+      sourceInstanceId: "owner_one",
+      subscriberInstanceId: "viewer_one",
+      sourcePeerId: "dual_one",
+      eventClasses: ["transcript"],
+      hopCount: 1,
+    });
+
+    expect(sentToOwner).toMatchObject([{
+      method: "federation.eventSubscription",
+      sourceInstanceId: "viewer_one",
+      targetInstanceId: "owner_one",
+      hopCount: 1,
+    }]);
+
+    runtime.publishRemoteBackendEvent({
+      id: "event-via-dual",
+      kind: "notification",
+      method: FEDERATION_BACKEND_EVENT_METHOD,
+      params: {
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            delta: "hello",
+            itemId: "item-1",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+        },
+      },
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 2_000,
+    }, "owner_one");
+
+    expect(sentToDual).toMatchObject([{
+      id: "event-via-dual",
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      hopCount: 1,
+    }]);
   });
 
   it("relays scheduler lifecycle events only to an explicitly subscribed sibling", () => {

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -111,7 +111,7 @@ describe("DesktopMessagingRuntime", () => {
     // regression there still fails fast instead of idling for the full 30s.
   }, process.platform === "win32" ? 30_000 : 15_000);
 
-  it("subscribes only to instances with active federated messaging bindings", async () => {
+  it("subscribes only to federated bindings on running adapters", async () => {
     const { runtime, bridge } = await createRuntimeHarness();
     const { getDesktopMessagingStore } = await import(
       "../messaging/desktop-messaging-store"
@@ -128,6 +128,23 @@ describe("DesktopMessagingRuntime", () => {
         backend: "codex",
         target: { scope: "remote", instanceId: "owner_one" },
         threadId: "thread-remote",
+      },
+      authorizedActorIds: ["user-1"],
+      createdAt: 1_000,
+      updatedAt: 1_000,
+    });
+    await getDesktopMessagingStore().upsertBinding({
+      id: "binding:inactive-discord",
+      channel: {
+        channel: "discord",
+        conversation: { id: "discord-chat-1", kind: "dm" },
+      },
+      backend: "codex",
+      threadId: "thread-inactive",
+      federatedThread: {
+        backend: "codex",
+        target: { scope: "remote", instanceId: "owner_two" },
+        threadId: "thread-inactive",
       },
       authorizedActorIds: ["user-1"],
       createdAt: 1_000,

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentEvent,
+  FederationEventSubscription,
   NavigationSnapshot,
   StartTurnRequest,
 } from "@pwragent/shared";
@@ -109,6 +110,53 @@ describe("DesktopMessagingRuntime", () => {
     // budget where the cold path is comfortably fast, so a genuine hang or
     // regression there still fails fast instead of idling for the full 30s.
   }, process.platform === "win32" ? 30_000 : 15_000);
+
+  it("subscribes only to instances with active federated messaging bindings", async () => {
+    const { runtime, bridge } = await createRuntimeHarness();
+    const { getDesktopMessagingStore } = await import(
+      "../messaging/desktop-messaging-store"
+    );
+    await getDesktopMessagingStore().upsertBinding({
+      id: "binding:remote",
+      channel: {
+        channel: "telegram",
+        conversation: { id: "chat-1", kind: "dm" },
+      },
+      backend: "codex",
+      threadId: "thread-remote",
+      federatedThread: {
+        backend: "codex",
+        target: { scope: "remote", instanceId: "owner_one" },
+        threadId: "thread-remote",
+      },
+      authorizedActorIds: ["user-1"],
+      createdAt: 1_000,
+      updatedAt: 1_000,
+    });
+
+    await runtime.start();
+
+    expect(bridge.setRemoteEventSubscriptions).toHaveBeenLastCalledWith([{
+      sourceInstanceId: "owner_one",
+      eventClasses: [
+        "navigation",
+        "transcript",
+        "pending_requests",
+        "scheduled_actions",
+      ],
+    }]);
+
+    await runtime.requestBindingRevoke({
+      bindingId: "binding:remote",
+      origin: "ui",
+    });
+    await vi.waitFor(() => {
+      expect(bridge.setRemoteEventSubscriptions).toHaveBeenLastCalledWith([]);
+    });
+
+    await runtime.stop();
+    expect(bridge.setRemoteEventSubscriptions).toHaveBeenLastCalledWith([]);
+  });
 
   it("rehydrates enabled Monitor bindings after adapter startup", async () => {
     const { runtime, adapter } = await createRuntimeHarness();
@@ -3206,6 +3254,9 @@ function createAdapter(
 function createBackendBridge(): MessagingBackendBridge & {
   emitBackendEvent: (event: AgentEvent) => Promise<void>;
   onEvent: (listener: (event: AgentEvent) => void | Promise<void>) => () => void;
+  setRemoteEventSubscriptions: (
+    subscriptions: readonly FederationEventSubscription[],
+  ) => void;
 } {
   const backendListeners = new Set<(event: AgentEvent) => void | Promise<void>>();
 
@@ -3222,6 +3273,7 @@ function createBackendBridge(): MessagingBackendBridge & {
         backendListeners.delete(listener);
       };
     }),
+    setRemoteEventSubscriptions: vi.fn(),
     emitBackendEvent: async (event: AgentEvent) => {
       await Promise.all(
         [...backendListeners].map(async (listener) => {

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -16,6 +16,8 @@ import type {
   FederationConnectionState,
   FederationDiagnosticEvent,
   FederationEndpointStatus,
+  FederationEventClass,
+  FederationEventSubscription,
   FederatedSearchRequest,
   FederatedSearchResponse,
   FederationHealthStatus,
@@ -67,6 +69,7 @@ import {
   isStarMapArrangementEntry,
   isFederationGatewayEndpointUrl,
   isFederationInstanceId,
+  isFederationEventClass,
   formatFederationPeerDisplayLabel,
   isRemoteFederationTarget,
   mergeCelestialIconAssignments,
@@ -220,6 +223,7 @@ const GATEWAY_ENROLLED_AT_META_KEY = "federation_gateway_enrolled_at";
 const FEDERATION_PEER_DIRECTORY_METHOD = "federation.peerDirectory";
 const FEDERATION_CELESTIAL_ICONS_METHOD = "federation.celestialIcons";
 const FEDERATION_STAR_MAP_ARRANGEMENT_METHOD = "federation.starMapArrangement";
+const FEDERATION_EVENT_SUBSCRIPTION_METHOD = "federation.eventSubscription";
 const CELESTIAL_ICON_ASSIGNMENTS_META_KEY =
   "federation_celestial_icon_assignments";
 /**
@@ -310,6 +314,7 @@ const DEFAULT_CAPABILITIES: FederationCapability[] = [
   // permits code execution via agent turns, so the direct shell defaults to
   // granted — but stays a dedicated capability so it is revocable on its own.
   "remote_pty",
+  "event_subscriptions",
 ];
 
 type FederationPeerDirectoryNotification = {
@@ -332,6 +337,129 @@ type FederationStarMapArrangementNotification = {
     entries: StarMapArrangementEntry[];
   };
 };
+
+type FederationEventSubscriptionNotification = {
+  method: typeof FEDERATION_EVENT_SUBSCRIPTION_METHOD;
+  params: {
+    eventClasses: FederationEventClass[];
+  };
+};
+
+type IncomingEventSubscription = {
+  eventClasses: Set<FederationEventClass>;
+  viaPeerId: FederationInstanceId;
+};
+
+type RelayedEventSubscription = IncomingEventSubscription & {
+  sourceInstanceId: FederationInstanceId;
+  subscriberInstanceId: FederationInstanceId;
+};
+
+const NAVIGATION_EVENT_METHODS = new Set<string>([
+  "automation/run/updated",
+  "directory/pin/added",
+  "directory/pin/removed",
+  "directory/pin/reordered",
+  "directory/threadsCollapsed/updated",
+  "navigation/directoryGitStatus/updated",
+  "navigation/threadDirectories/updated",
+  "navigation/threadGitWorkingState/updated",
+  "pullRequest/status/updated",
+  "thread/acpRuntime/updated",
+  "thread/agent/updated",
+  "thread/archived",
+  "thread/automations/updated",
+  "thread/codexEnvironment/updated",
+  "thread/codexInvalidIdRecovery/updated",
+  "thread/executionMode/queueCleared",
+  "thread/executionMode/queued",
+  "thread/executionMode/updated",
+  "thread/modelSettings/updated",
+  "thread/name/updated",
+  "thread/parent/cleared",
+  "thread/parent/set",
+  "thread/pin/added",
+  "thread/pin/removed",
+  "thread/pin/reordered",
+  "thread/prAutoDispatch/pendingUpdated",
+  "thread/prAutoDispatch/updated",
+  "thread/pullRequests/updated",
+  "thread/started",
+  "thread/status/changed",
+  "thread/subAgents/updated",
+  "thread/subthreadOrder/updated",
+  "thread/subthreadsCollapsed/updated",
+  "thread/turnQueue/updated",
+  "thread/unarchived",
+  "turn/cancelled",
+  "turn/completed",
+  "turn/failed",
+  "turn/started",
+]);
+
+export function federationEventClassForMethod(
+  method: string,
+): FederationEventClass {
+  if (method === "thread/scheduledAction/updated") {
+    return "scheduled_actions";
+  }
+  if (
+    method === "item/tool/requestUserInput"
+    || method === "mcpServer/elicitation/request"
+    || method === "applyPatchApproval"
+    || method === "execCommandApproval"
+    || method === "serverRequest/resolved"
+    || method.toLowerCase().includes("requestapproval")
+  ) {
+    return "pending_requests";
+  }
+  if (
+    method === "starMap/arrangement/changed"
+    || method === "starMap/intake/status"
+    || method === "federation/celestialIcons/changed"
+  ) {
+    return "star_map";
+  }
+  if (NAVIGATION_EVENT_METHODS.has(method)) {
+    return "navigation";
+  }
+  // Fail closed: newly introduced notification methods do not reach
+  // navigation-only or Star Map subscribers until explicitly classified.
+  return "transcript";
+}
+
+function eventSubscriptionKey(params: {
+  sourceInstanceId: FederationInstanceId;
+  subscriberInstanceId: FederationInstanceId;
+}): string {
+  return `${params.sourceInstanceId}\u0000${params.subscriberInstanceId}`;
+}
+
+function equalEventClassSets(
+  left: ReadonlySet<FederationEventClass> | undefined,
+  right: ReadonlySet<FederationEventClass> | undefined,
+): boolean {
+  if (!left || !right) return left === right;
+  return left.size === right.size && [...left].every((value) => right.has(value));
+}
+
+function eventClassAllowedByCapabilities(
+  eventClass: FederationEventClass,
+  capabilities: readonly FederationCapability[],
+): boolean {
+  if (!capabilities.includes("event_subscriptions")) return false;
+  switch (eventClass) {
+    case "navigation":
+    case "star_map":
+      return capabilities.includes("thread_navigation");
+    case "transcript":
+      return capabilities.includes("thread_detail");
+    case "pending_requests":
+      return capabilities.includes("pending_request_control");
+    case "scheduled_actions":
+      return capabilities.includes("scheduled_actions");
+  }
+}
 
 export class DesktopFederationRuntime {
   private router?: FederationRouter;
@@ -378,6 +506,18 @@ export class DesktopFederationRuntime {
     (event: AgentEvent) => void | Promise<void>
   >();
   private readonly peerStatusListeners = new Set<() => void>();
+  private readonly desiredEventSubscriptions = new Map<
+    string,
+    Map<FederationInstanceId, Set<FederationEventClass>>
+  >();
+  private readonly incomingEventSubscriptions = new Map<
+    FederationInstanceId,
+    IncomingEventSubscription
+  >();
+  private readonly relayedEventSubscriptions = new Map<
+    string,
+    RelayedEventSubscription
+  >();
   private unsubscribeLocalBackendEvents?: () => void;
   private restartPromise: Promise<void> | undefined;
   private remoteThreadSummaryCache: RemoteThreadSummaryCache | undefined;
@@ -414,6 +554,95 @@ export class DesktopFederationRuntime {
     return () => {
       this.remoteBackendEventListeners.delete(listener);
     };
+  }
+
+  setEventSubscriptions(
+    consumerId: string,
+    subscriptions: readonly FederationEventSubscription[],
+  ): FederationEventSubscription[] {
+    const previous = this.aggregateDesiredEventSubscriptions();
+    const normalized = new Map<
+      FederationInstanceId,
+      Set<FederationEventClass>
+    >();
+    for (const subscription of subscriptions) {
+      if (!isFederationInstanceId(subscription.sourceInstanceId)) continue;
+      const eventClasses = subscription.eventClasses.filter(isFederationEventClass);
+      if (eventClasses.length === 0) continue;
+      const current = normalized.get(subscription.sourceInstanceId) ?? new Set();
+      for (const eventClass of eventClasses) current.add(eventClass);
+      normalized.set(subscription.sourceInstanceId, current);
+    }
+    if (normalized.size > 0) {
+      this.desiredEventSubscriptions.set(consumerId, normalized);
+    } else {
+      this.desiredEventSubscriptions.delete(consumerId);
+    }
+    const next = this.aggregateDesiredEventSubscriptions();
+    const sourceIds = new Set([...previous.keys(), ...next.keys()]);
+    for (const sourceInstanceId of sourceIds) {
+      if (
+        equalEventClassSets(
+          previous.get(sourceInstanceId),
+          next.get(sourceInstanceId),
+        )
+      ) {
+        continue;
+      }
+      this.sendDesiredEventSubscription(
+        sourceInstanceId,
+        next.get(sourceInstanceId) ?? new Set(),
+      );
+    }
+    return [...normalized].map(([sourceInstanceId, eventClasses]) => ({
+      sourceInstanceId,
+      eventClasses: [...eventClasses],
+    }));
+  }
+
+  setRendererEventSubscriptions(
+    webContentsId: number,
+    consumerId: "remote-window" | "star-map",
+    subscriptions: readonly FederationEventSubscription[],
+  ): FederationEventSubscription[] {
+    return this.setEventSubscriptions(
+      `renderer:${webContentsId}:${consumerId}`,
+      subscriptions,
+    );
+  }
+
+  clearRendererEventSubscriptions(
+    webContentsId: number,
+    consumerId?: "remote-window" | "star-map",
+  ): void {
+    const prefix = `renderer:${webContentsId}:`;
+    if (consumerId) {
+      this.setEventSubscriptions(`${prefix}${consumerId}`, []);
+      return;
+    }
+    for (const key of [...this.desiredEventSubscriptions.keys()]) {
+      if (key.startsWith(prefix)) {
+        this.setEventSubscriptions(key, []);
+      }
+    }
+  }
+
+  rendererWantsRemoteEvent(
+    webContentsId: number,
+    sourceInstanceId: FederationInstanceId,
+    eventClass: FederationEventClass,
+  ): boolean {
+    const prefix = `renderer:${webContentsId}:`;
+    for (const [consumerId, subscriptions] of
+      this.desiredEventSubscriptions) {
+      if (
+        consumerId.startsWith(prefix)
+        && subscriptions.get(sourceInstanceId)?.has(eventClass)
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -491,6 +720,8 @@ export class DesktopFederationRuntime {
     this.rpcByPeer.clear();
     this.remotePeerDirectory.clear();
     this.publishedPeerStatuses.clear();
+    this.incomingEventSubscriptions.clear();
+    this.relayedEventSubscriptions.clear();
     this.reconnectAttempt = 0;
     this.lastConnectionError = undefined;
     this.lastConnectionFailureKind = undefined;
@@ -1412,11 +1643,10 @@ export class DesktopFederationRuntime {
       connectedAt: Date.now(),
     });
     this.publishPeerStatus(gatewayInstanceId, "connected");
-    // Push our persisted assignments up so overrides made while offline win
-    // LWW merges at the gateway; its authoritative snapshot comes back on
-    // the same channel.
+    // Icon assignments are sparse federation control-plane state rather than
+    // a live backend event stream. Keep the existing reconnect convergence.
     this.broadcastCelestialIcons();
-    this.sendStarMapArrangementSnapshot();
+    this.syncDesiredEventSubscriptions();
     if (pendingInviteToken) {
       getAppStateDb().setMeta(PENDING_INVITE_TOKEN_META_KEY, "");
     }
@@ -1538,12 +1768,13 @@ export class DesktopFederationRuntime {
     // remote PTY sessions alive.
     this.ptyService?.notifyPeerConnected(connection.peerId);
     this.publishPeerStatus(connection.peerId, "connected");
+    this.replayEventSubscriptionsForSource(connection.peerId);
+    this.syncDesiredEventSubscriptions();
     this.broadcastPeerDirectory();
     // Mirrors the broadcastPeerDirectory guard: connections registered
     // before app state exists (unit harnesses) skip icon coordination.
     if (isAppStateInitialized()) {
       this.reconcileCelestialAssignments();
-      this.sendStarMapArrangementSnapshot();
     }
   }
 
@@ -1562,6 +1793,7 @@ export class DesktopFederationRuntime {
   }
 
   private unregisterPeer(peerId: FederationInstanceId): void {
+    this.removeEventSubscriptionsForPeer(peerId);
     this.router?.unregisterConnection(peerId);
     // Remote PTY sessions this peer opened get the 10s reap grace; if the
     // peer reconnects first, registerGatewayConnection cancels the reap.
@@ -1615,6 +1847,9 @@ export class DesktopFederationRuntime {
         claimedSourceInstanceId: envelope.sourceInstanceId,
         sourcePeerId,
       });
+      return;
+    }
+    if (this.applyEventSubscription(envelope, sourcePeerId)) {
       return;
     }
     if (this.applyPeerDirectory(envelope)) {
@@ -2381,34 +2616,38 @@ export class DesktopFederationRuntime {
   }
 
   /**
-   * Fan an arrangement delta out to connected peers. Called for local
-   * writes (broadcast to everyone) and for received deltas (re-broadcast
-   * excluding the sender), so a gateway relays client drags to siblings.
+   * Fan an arrangement delta out only to explicit Star Map subscribers.
    */
   broadcastStarMapArrangement(
     entries: StarMapArrangementEntry[],
-    excludePeerId?: FederationInstanceId,
   ): void {
-    const router = this.router;
-    if (!router || entries.length === 0) return;
-    const localInstanceId = this.ensureLocalInstanceId();
-    for (const connection of router.listConnections()) {
-      if (connection.peerId === excludePeerId) continue;
-      connection.sendEnvelope({
-        id: `federation-star-map:${randomUUID()}`,
-        kind: "notification",
-        method: FEDERATION_STAR_MAP_ARRANGEMENT_METHOD,
-        params: { entries },
-        protocolVersion: FEDERATION_PROTOCOL_VERSION,
-        sourceInstanceId: localInstanceId,
-        targetInstanceId: connection.peerId,
-        createdAt: Date.now(),
-      });
+    if (!this.router || entries.length === 0) return;
+    for (const [subscriberInstanceId, subscription] of
+      this.incomingEventSubscriptions) {
+      if (!subscription.eventClasses.has("star_map")) {
+        continue;
+      }
+      try {
+        this.sendEnvelopeToTarget(subscriberInstanceId, {
+          id: `federation-star-map:${randomUUID()}`,
+          kind: "notification",
+          method: FEDERATION_STAR_MAP_ARRANGEMENT_METHOD,
+          params: { entries },
+          protocolVersion: FEDERATION_PROTOCOL_VERSION,
+          sourceInstanceId: this.ensureLocalInstanceId(),
+          targetInstanceId: subscriberInstanceId,
+          createdAt: Date.now(),
+        });
+      } catch {
+        // Live subscribers are cleaned up with their connection.
+      }
     }
   }
 
-  /** Reconnect convergence: push the full persisted arrangement snapshot. */
-  private sendStarMapArrangementSnapshot(): void {
+  /** Subscription convergence: push the full persisted arrangement snapshot. */
+  private sendStarMapArrangementSnapshot(
+    subscriberInstanceId: FederationInstanceId,
+  ): void {
     if (!isAppStateInitialized()) return;
     let store: ReturnType<typeof getDesktopOverlayStore>;
     try {
@@ -2421,7 +2660,25 @@ export class DesktopFederationRuntime {
     }
     void store
       .readStarMapArrangement()
-      .then((entries) => this.broadcastStarMapArrangement(entries))
+      .then((entries) => {
+        const subscription = this.incomingEventSubscriptions
+          .get(subscriberInstanceId);
+        if (!subscription?.eventClasses.has("star_map")) return;
+        try {
+          this.sendEnvelopeToTarget(subscriberInstanceId, {
+            id: `federation-star-map:${randomUUID()}`,
+            kind: "notification",
+            method: FEDERATION_STAR_MAP_ARRANGEMENT_METHOD,
+            params: { entries },
+            protocolVersion: FEDERATION_PROTOCOL_VERSION,
+            sourceInstanceId: this.ensureLocalInstanceId(),
+            targetInstanceId: subscriberInstanceId,
+            createdAt: Date.now(),
+          });
+        } catch {
+          // The subscription will replay on the next connection.
+        }
+      })
       .catch((error) => {
         log.warn("star map arrangement snapshot send failed", {
           error: error instanceof Error ? error.message : String(error),
@@ -2439,6 +2696,23 @@ export class DesktopFederationRuntime {
     ) {
       return false;
     }
+    if (
+      envelope.targetInstanceId
+      && envelope.targetInstanceId !== this.ensureLocalInstanceId()
+    ) {
+      this.relaySubscribedBackendEvent(envelope, sourcePeerId, "star_map");
+      return true;
+    }
+    if (
+      !envelope.targetInstanceId
+      || !this.wantsRemoteEvent(envelope.sourceInstanceId, "star_map")
+      || (
+        envelope.sourceInstanceId !== sourcePeerId
+        && sourcePeerId !== this.gatewayInstanceId
+      )
+    ) {
+      return true;
+    }
     if (!isAppStateInitialized()) return true;
     const notification =
       envelope as FederationStarMapArrangementNotification & typeof envelope;
@@ -2451,9 +2725,6 @@ export class DesktopFederationRuntime {
       .then(({ accepted }) => {
         if (accepted.length === 0) return;
         this.publishStarMapArrangementChanged(accepted);
-        // Accepted-only re-broadcast: idempotent merges terminate the loop,
-        // and the gateway relays client drags to every sibling.
-        this.broadcastStarMapArrangement(accepted, sourcePeerId);
       })
       .catch((error) => {
         log.warn("star map arrangement merge failed", {
@@ -2563,6 +2834,235 @@ export class DesktopFederationRuntime {
     return { assignments: this.celestialIconAssignments() };
   }
 
+  private aggregateDesiredEventSubscriptions(): Map<
+    FederationInstanceId,
+    Set<FederationEventClass>
+  > {
+    const aggregated = new Map<
+      FederationInstanceId,
+      Set<FederationEventClass>
+    >();
+    for (const subscriptions of this.desiredEventSubscriptions.values()) {
+      for (const [sourceInstanceId, eventClasses] of subscriptions) {
+        const current = aggregated.get(sourceInstanceId) ?? new Set();
+        for (const eventClass of eventClasses) current.add(eventClass);
+        aggregated.set(sourceInstanceId, current);
+      }
+    }
+    return aggregated;
+  }
+
+  private wantsRemoteEvent(
+    sourceInstanceId: FederationInstanceId,
+    eventClass: FederationEventClass,
+  ): boolean {
+    for (const subscriptions of this.desiredEventSubscriptions.values()) {
+      if (subscriptions.get(sourceInstanceId)?.has(eventClass)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private sendDesiredEventSubscription(
+    sourceInstanceId: FederationInstanceId,
+    eventClasses: ReadonlySet<FederationEventClass>,
+  ): void {
+    if (sourceInstanceId === this.ensureLocalInstanceId()) return;
+    try {
+      this.sendEnvelopeToTarget(sourceInstanceId, {
+        id: `federation-subscription:${randomUUID()}`,
+        kind: "notification",
+        method: FEDERATION_EVENT_SUBSCRIPTION_METHOD,
+        params: { eventClasses: [...eventClasses] },
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: this.ensureLocalInstanceId(),
+        targetInstanceId: sourceInstanceId,
+        createdAt: Date.now(),
+      });
+    } catch {
+      // Desired state survives disconnects and is replayed after reconnect.
+    }
+  }
+
+  private syncDesiredEventSubscriptions(): void {
+    for (const [sourceInstanceId, eventClasses] of
+      this.aggregateDesiredEventSubscriptions()) {
+      this.sendDesiredEventSubscription(sourceInstanceId, eventClasses);
+    }
+  }
+
+  private applyEventSubscription(
+    envelope: FederationProtocolEnvelope,
+    sourcePeerId: FederationInstanceId,
+  ): boolean {
+    if (
+      envelope.kind !== "notification"
+      || envelope.method !== FEDERATION_EVENT_SUBSCRIPTION_METHOD
+    ) {
+      return false;
+    }
+    const subscriberInstanceId = envelope.sourceInstanceId;
+    const sourceInstanceId = envelope.targetInstanceId;
+    if (
+      !isFederationInstanceId(subscriberInstanceId)
+      || !sourceInstanceId
+      || !isFederationInstanceId(sourceInstanceId)
+    ) {
+      return true;
+    }
+    const sourceConnection = this.router?.getConnection(sourcePeerId);
+    if (
+      !sourceConnection?.capabilities.includes("event_subscriptions")
+      || (
+        subscriberInstanceId !== sourcePeerId
+        && sourcePeerId !== this.gatewayInstanceId
+      )
+    ) {
+      return true;
+    }
+    const notification =
+      envelope as FederationEventSubscriptionNotification & typeof envelope;
+    const requestedClasses = Array.isArray(notification.params?.eventClasses)
+      ? notification.params.eventClasses.filter(isFederationEventClass)
+      : [];
+
+    if (sourceInstanceId !== this.ensureLocalInstanceId()) {
+      const allowedClasses = requestedClasses.filter((eventClass) =>
+        eventClassAllowedByCapabilities(
+          eventClass,
+          sourceConnection.capabilities,
+        )
+      );
+      const key = eventSubscriptionKey({
+        sourceInstanceId,
+        subscriberInstanceId,
+      });
+      if (allowedClasses.length > 0) {
+        this.relayedEventSubscriptions.set(key, {
+          eventClasses: new Set(allowedClasses),
+          sourceInstanceId,
+          subscriberInstanceId,
+          viaPeerId: sourcePeerId,
+        });
+      } else {
+        this.relayedEventSubscriptions.delete(key);
+      }
+      void this.router?.routeEnvelope({
+        envelope: {
+          ...envelope,
+          params: { eventClasses: allowedClasses },
+        },
+        sourcePeerId,
+      });
+      return true;
+    }
+
+    const previous = this.incomingEventSubscriptions.get(subscriberInstanceId);
+    const allowedClasses = subscriberInstanceId === sourcePeerId
+      ? requestedClasses.filter((eventClass) =>
+          eventClassAllowedByCapabilities(
+            eventClass,
+            sourceConnection.capabilities,
+          )
+        )
+      : requestedClasses;
+    if (allowedClasses.length > 0) {
+      this.incomingEventSubscriptions.set(subscriberInstanceId, {
+        eventClasses: new Set(allowedClasses),
+        viaPeerId: sourcePeerId,
+      });
+    } else {
+      this.incomingEventSubscriptions.delete(subscriberInstanceId);
+    }
+    if (
+      allowedClasses.includes("star_map")
+      && !previous?.eventClasses.has("star_map")
+    ) {
+      this.sendStarMapArrangementSnapshot(subscriberInstanceId);
+    }
+    return true;
+  }
+
+  private relaySubscribedBackendEvent(
+    envelope: FederationProtocolEnvelope,
+    sourcePeerId: FederationInstanceId,
+    eventClass: FederationEventClass,
+  ): boolean {
+    const subscriberInstanceId = envelope.targetInstanceId;
+    if (!subscriberInstanceId) return false;
+    const subscription = this.relayedEventSubscriptions.get(
+      eventSubscriptionKey({
+        sourceInstanceId: envelope.sourceInstanceId,
+        subscriberInstanceId,
+      }),
+    );
+    if (!subscription?.eventClasses.has(eventClass)) return false;
+    if (
+      envelope.sourceInstanceId !== sourcePeerId
+      && sourcePeerId !== this.gatewayInstanceId
+    ) {
+      return false;
+    }
+    void this.router?.routeEnvelope({ envelope, sourcePeerId });
+    return true;
+  }
+
+  private removeEventSubscriptionsForPeer(peerId: FederationInstanceId): void {
+    for (const [subscriberInstanceId, subscription] of
+      this.incomingEventSubscriptions) {
+      if (
+        subscriberInstanceId === peerId
+        || subscription.viaPeerId === peerId
+      ) {
+        this.incomingEventSubscriptions.delete(subscriberInstanceId);
+      }
+    }
+    for (const [key, subscription] of this.relayedEventSubscriptions) {
+      if (subscription.subscriberInstanceId === peerId) {
+        this.sendRelayedEventSubscription(subscription, new Set());
+        this.relayedEventSubscriptions.delete(key);
+        continue;
+      }
+      if (subscription.viaPeerId === peerId) {
+        this.relayedEventSubscriptions.delete(key);
+      }
+    }
+  }
+
+  private sendRelayedEventSubscription(
+    subscription: RelayedEventSubscription,
+    eventClasses: ReadonlySet<FederationEventClass>,
+  ): void {
+    try {
+      this.sendEnvelopeToTarget(subscription.sourceInstanceId, {
+        id: `federation-subscription-relay:${randomUUID()}`,
+        kind: "notification",
+        method: FEDERATION_EVENT_SUBSCRIPTION_METHOD,
+        params: { eventClasses: [...eventClasses] },
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: subscription.subscriberInstanceId,
+        targetInstanceId: subscription.sourceInstanceId,
+        createdAt: Date.now(),
+      });
+    } catch {
+      // A disconnected source already cleared subscriptions via its route.
+    }
+  }
+
+  private replayEventSubscriptionsForSource(
+    sourceInstanceId: FederationInstanceId,
+  ): void {
+    for (const subscription of this.relayedEventSubscriptions.values()) {
+      if (subscription.sourceInstanceId === sourceInstanceId) {
+        this.sendRelayedEventSubscription(
+          subscription,
+          subscription.eventClasses,
+        );
+      }
+    }
+  }
+
   private publishPeerStatus(
     instanceId: FederationInstanceId,
     status: FederationConnectionState,
@@ -2610,39 +3110,37 @@ export class DesktopFederationRuntime {
   }
 
   private forwardLocalBackendEvent(event: AgentEvent): void {
-    const router = this.router;
-    if (!router) return;
+    if (!this.router) return;
     const ownerInstanceId = this.ensureLocalInstanceId();
     const federatedEvent = rewriteLiveTranscriptImagesForFederation(
       event,
       ownerInstanceId,
     );
+    const eventClass = federationEventClassForMethod(
+      federatedEvent.notification.method,
+    );
 
-    for (const connection of router.listConnections()) {
-      const scheduledActionEvent =
-        federatedEvent.notification.method === "thread/scheduledAction/updated";
-      if (
-        scheduledActionEvent
-          ? !connection.capabilities.includes("scheduled_actions")
-          : !connection.capabilities.includes("remote_window")
-            && !connection.capabilities.includes("thread_detail")
-      ) {
-        continue;
+    for (const [subscriberInstanceId, subscription] of
+      this.incomingEventSubscriptions) {
+      if (!subscription.eventClasses.has(eventClass)) continue;
+      try {
+        this.sendEnvelopeToTarget(subscriberInstanceId, {
+          id: `federation-event:${randomUUID()}`,
+          kind: "notification",
+          method: FEDERATION_BACKEND_EVENT_METHOD,
+          params: {
+            backend: federatedEvent.backend,
+            notification: federatedEvent.notification,
+          },
+          protocolVersion: FEDERATION_PROTOCOL_VERSION,
+          sourceInstanceId: ownerInstanceId,
+          targetInstanceId: subscriberInstanceId,
+          createdAt: Date.now(),
+        });
+      } catch {
+        // Connection teardown clears the subscription. A route that vanished
+        // between iteration and send simply misses this live notification.
       }
-
-      connection.sendEnvelope({
-        id: `federation-event:${randomUUID()}`,
-        kind: "notification",
-        method: FEDERATION_BACKEND_EVENT_METHOD,
-        params: {
-          backend: federatedEvent.backend,
-          notification: federatedEvent.notification,
-        },
-        protocolVersion: FEDERATION_PROTOCOL_VERSION,
-        sourceInstanceId: ownerInstanceId,
-        targetInstanceId: connection.peerId,
-        createdAt: Date.now(),
-      });
     }
   }
 
@@ -2658,11 +3156,35 @@ export class DesktopFederationRuntime {
     }
 
     const notification = envelope as FederationBackendEventNotification & typeof envelope;
+    const eventClass = federationEventClassForMethod(
+      notification.params.notification.method,
+    );
+    const targetInstanceId = envelope.targetInstanceId;
+    if (
+      targetInstanceId
+      && targetInstanceId !== this.ensureLocalInstanceId()
+    ) {
+      this.relaySubscribedBackendEvent(envelope, sourcePeerId, eventClass);
+      return true;
+    }
+    const sourceInstanceId = envelope.sourceInstanceId || sourcePeerId;
+    if (
+      !targetInstanceId
+      || !this.wantsRemoteEvent(sourceInstanceId, eventClass)
+    ) {
+      return true;
+    }
+    if (
+      sourceInstanceId !== sourcePeerId
+      && sourcePeerId !== this.gatewayInstanceId
+    ) {
+      return true;
+    }
     const event: AgentEvent = {
       backend: notification.params.backend,
       federationTarget: {
         scope: "remote",
-        instanceId: envelope.sourceInstanceId || sourcePeerId,
+        instanceId: sourceInstanceId,
       },
       notification: notification.params.notification,
     };
@@ -2675,43 +3197,7 @@ export class DesktopFederationRuntime {
         });
       });
     }
-    this.relayRemoteBackendEvent(envelope, sourcePeerId);
     return true;
-  }
-
-  private relayRemoteBackendEvent(
-    envelope: FederationProtocolEnvelope,
-    sourcePeerId: FederationInstanceId,
-  ): void {
-    const router = this.router;
-    if (!router || sourcePeerId === this.gatewayInstanceId) {
-      return;
-    }
-    const hopCount = envelope.hopCount ?? 0;
-    if (hopCount >= 1) {
-      return;
-    }
-
-    const notification = envelope as FederationBackendEventNotification & typeof envelope;
-    for (const connection of router.listConnections()) {
-      if (connection.peerId === sourcePeerId) continue;
-      const scheduledActionEvent =
-        notification.params.notification.method
-          === "thread/scheduledAction/updated";
-      if (
-        scheduledActionEvent
-          ? !connection.capabilities.includes("scheduled_actions")
-          : !connection.capabilities.includes("remote_window")
-            && !connection.capabilities.includes("thread_detail")
-      ) {
-        continue;
-      }
-      connection.sendEnvelope({
-        ...envelope,
-        hopCount: hopCount + 1,
-        targetInstanceId: connection.peerId,
-      });
-    }
   }
 }
 

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -224,6 +224,7 @@ const FEDERATION_PEER_DIRECTORY_METHOD = "federation.peerDirectory";
 const FEDERATION_CELESTIAL_ICONS_METHOD = "federation.celestialIcons";
 const FEDERATION_STAR_MAP_ARRANGEMENT_METHOD = "federation.starMapArrangement";
 const FEDERATION_EVENT_SUBSCRIPTION_METHOD = "federation.eventSubscription";
+const FEDERATION_EVENT_RELAY_MAX_HOPS = 4;
 const CELESTIAL_ICON_ASSIGNMENTS_META_KEY =
   "federation_celestial_icon_assignments";
 /**
@@ -1647,6 +1648,7 @@ export class DesktopFederationRuntime {
     // a live backend event stream. Keep the existing reconnect convergence.
     this.broadcastCelestialIcons();
     this.syncDesiredEventSubscriptions();
+    this.replayRelayedEventSubscriptions();
     if (pendingInviteToken) {
       getAppStateDb().setMeta(PENDING_INVITE_TOKEN_META_KEY, "");
     }
@@ -1768,7 +1770,7 @@ export class DesktopFederationRuntime {
     // remote PTY sessions alive.
     this.ptyService?.notifyPeerConnected(connection.peerId);
     this.publishPeerStatus(connection.peerId, "connected");
-    this.replayEventSubscriptionsForSource(connection.peerId);
+    this.replayRelayedEventSubscriptions(connection.peerId);
     this.syncDesiredEventSubscriptions();
     this.broadcastPeerDirectory();
     // Mirrors the broadcastPeerDirectory guard: connections registered
@@ -1839,6 +1841,12 @@ export class DesktopFederationRuntime {
     envelope: FederationProtocolEnvelope,
     sourcePeerId: FederationInstanceId,
   ): Promise<void> {
+    // Subscription relays authenticate their delegated subscriber and route
+    // explicitly inside applyEventSubscription. Other envelopes retain the
+    // router's stricter direct-or-configured-upstream origin check.
+    if (this.applyEventSubscription(envelope, sourcePeerId)) {
+      return;
+    }
     if (
       this.router
       && !this.router.authenticatesOrigin(envelope, sourcePeerId)
@@ -1847,9 +1855,6 @@ export class DesktopFederationRuntime {
         claimedSourceInstanceId: envelope.sourceInstanceId,
         sourcePeerId,
       });
-      return;
-    }
-    if (this.applyEventSubscription(envelope, sourcePeerId)) {
       return;
     }
     if (this.applyPeerDirectory(envelope)) {
@@ -2045,6 +2050,25 @@ export class DesktopFederationRuntime {
     }
 
     throw new FederationPeerUnavailableError(targetInstanceId);
+  }
+
+  private sendEnvelopeToEventSubscriber(
+    subscriberInstanceId: FederationInstanceId,
+    envelope: FederationProtocolEnvelope,
+  ): void {
+    if (this.router?.sendToPeer(subscriberInstanceId, envelope)) {
+      return;
+    }
+    const viaPeerId = this.incomingEventSubscriptions
+      .get(subscriberInstanceId)
+      ?.viaPeerId;
+    if (
+      viaPeerId
+      && this.router?.sendToPeer(viaPeerId, envelope)
+    ) {
+      return;
+    }
+    this.sendEnvelopeToTarget(subscriberInstanceId, envelope);
   }
 
   private visiblePeers(): FederationPeerSummary[] {
@@ -2628,7 +2652,7 @@ export class DesktopFederationRuntime {
         continue;
       }
       try {
-        this.sendEnvelopeToTarget(subscriberInstanceId, {
+        this.sendEnvelopeToEventSubscriber(subscriberInstanceId, {
           id: `federation-star-map:${randomUUID()}`,
           kind: "notification",
           method: FEDERATION_STAR_MAP_ARRANGEMENT_METHOD,
@@ -2665,7 +2689,7 @@ export class DesktopFederationRuntime {
           .get(subscriberInstanceId);
         if (!subscription?.eventClasses.has("star_map")) return;
         try {
-          this.sendEnvelopeToTarget(subscriberInstanceId, {
+          this.sendEnvelopeToEventSubscriber(subscriberInstanceId, {
             id: `federation-star-map:${randomUUID()}`,
             kind: "notification",
             method: FEDERATION_STAR_MAP_ARRANGEMENT_METHOD,
@@ -2912,12 +2936,17 @@ export class DesktopFederationRuntime {
       return true;
     }
     const sourceConnection = this.router?.getConnection(sourcePeerId);
+    const delegatedSubscriber = subscriberInstanceId !== sourcePeerId;
+    const authenticatedSubscriptionRelay =
+      delegatedSubscriber
+      && (envelope.hopCount ?? 0) >= 1
+      && (
+        sourcePeerId === this.gatewayInstanceId
+        || sourceConnection?.capabilities.includes("gateway_relay")
+      );
     if (
       !sourceConnection?.capabilities.includes("event_subscriptions")
-      || (
-        subscriberInstanceId !== sourcePeerId
-        && sourcePeerId !== this.gatewayInstanceId
-      )
+      || (delegatedSubscriber && !authenticatedSubscriptionRelay)
     ) {
       return true;
     }
@@ -2938,23 +2967,21 @@ export class DesktopFederationRuntime {
         sourceInstanceId,
         subscriberInstanceId,
       });
+      const relayedSubscription: RelayedEventSubscription = {
+        eventClasses: new Set(allowedClasses),
+        sourceInstanceId,
+        subscriberInstanceId,
+        viaPeerId: sourcePeerId,
+      };
       if (allowedClasses.length > 0) {
-        this.relayedEventSubscriptions.set(key, {
-          eventClasses: new Set(allowedClasses),
-          sourceInstanceId,
-          subscriberInstanceId,
-          viaPeerId: sourcePeerId,
-        });
+        this.relayedEventSubscriptions.set(key, relayedSubscription);
       } else {
         this.relayedEventSubscriptions.delete(key);
       }
-      void this.router?.routeEnvelope({
-        envelope: {
-          ...envelope,
-          params: { eventClasses: allowedClasses },
-        },
-        sourcePeerId,
-      });
+      this.sendRelayedEventSubscription(
+        relayedSubscription,
+        relayedSubscription.eventClasses,
+      );
       return true;
     }
 
@@ -3000,12 +3027,21 @@ export class DesktopFederationRuntime {
     if (!subscription?.eventClasses.has(eventClass)) return false;
     if (
       envelope.sourceInstanceId !== sourcePeerId
-      && sourcePeerId !== this.gatewayInstanceId
+      && !this.router?.authenticatesOrigin(envelope, sourcePeerId)
     ) {
       return false;
     }
-    void this.router?.routeEnvelope({ envelope, sourcePeerId });
-    return true;
+    const hopCount = envelope.hopCount ?? 0;
+    if (
+      hopCount >= FEDERATION_EVENT_RELAY_MAX_HOPS
+      || subscription.viaPeerId === sourcePeerId
+    ) {
+      return false;
+    }
+    return this.router?.sendToPeer(subscription.viaPeerId, {
+      ...envelope,
+      hopCount: hopCount + 1,
+    }) ?? false;
   }
 
   private removeEventSubscriptionsForPeer(peerId: FederationInstanceId): void {
@@ -3025,6 +3061,7 @@ export class DesktopFederationRuntime {
         continue;
       }
       if (subscription.viaPeerId === peerId) {
+        this.sendRelayedEventSubscription(subscription, new Set());
         this.relayedEventSubscriptions.delete(key);
       }
     }
@@ -3043,6 +3080,7 @@ export class DesktopFederationRuntime {
         protocolVersion: FEDERATION_PROTOCOL_VERSION,
         sourceInstanceId: subscription.subscriberInstanceId,
         targetInstanceId: subscription.sourceInstanceId,
+        hopCount: 1,
         createdAt: Date.now(),
       });
     } catch {
@@ -3050,11 +3088,14 @@ export class DesktopFederationRuntime {
     }
   }
 
-  private replayEventSubscriptionsForSource(
-    sourceInstanceId: FederationInstanceId,
+  private replayRelayedEventSubscriptions(
+    sourceInstanceId?: FederationInstanceId,
   ): void {
     for (const subscription of this.relayedEventSubscriptions.values()) {
-      if (subscription.sourceInstanceId === sourceInstanceId) {
+      if (
+        sourceInstanceId === undefined
+        || subscription.sourceInstanceId === sourceInstanceId
+      ) {
         this.sendRelayedEventSubscription(
           subscription,
           subscription.eventClasses,
@@ -3124,7 +3165,7 @@ export class DesktopFederationRuntime {
       this.incomingEventSubscriptions) {
       if (!subscription.eventClasses.has(eventClass)) continue;
       try {
-        this.sendEnvelopeToTarget(subscriberInstanceId, {
+        this.sendEnvelopeToEventSubscriber(subscriberInstanceId, {
           id: `federation-event:${randomUUID()}`,
           kind: "notification",
           method: FEDERATION_BACKEND_EVENT_METHOD,

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -1,6 +1,8 @@
 import { ipcMain, type IpcMainInvokeEvent } from "electron";
-import { subscribersForChannel } from "../window-channels";
-import { federationWindowTargetForWebContents } from "../window";
+import {
+  federationTargetForChannelSubscriber,
+  subscribersForChannel,
+} from "../window-channels";
 import {
   sanitizeRendererPayload,
   type AgentEvent,
@@ -65,7 +67,10 @@ import {
   type UpdateThreadExpectedBranchResponse,
 } from "@pwragent/shared";
 import { isRemoteFederationTarget } from "@pwragent/shared";
-import { getDesktopFederationRuntime } from "../federation/federation-runtime";
+import {
+  federationEventClassForMethod,
+  getDesktopFederationRuntime,
+} from "../federation/federation-runtime";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { buildLiveDiffActivityEntry } from "../app-server/live-diff-activity";
 import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
@@ -347,10 +352,28 @@ export function broadcastAgentEvent(event: AgentEvent): void {
   // default — see `apps/desktop/src/main/window-channels.ts`.
   for (const webContents of subscribersForChannel(AGENT_EVENT_CHANNEL)) {
     if (typeof webContents.send !== "function") continue;
+    const windowTarget = federationTargetForChannelSubscriber(webContents);
     if (
       federationWindowsOnly
-      && !federationWindowTargetForWebContents(webContents)
+      && !windowTarget
     ) {
+      continue;
+    }
+    if (event.federationTarget?.scope === "remote") {
+      const isLocalPeerStatus =
+        event.notification.method === "federation/peerStatus/changed"
+        && !windowTarget;
+      if (
+        !isLocalPeerStatus
+        && !getDesktopFederationRuntime().rendererWantsRemoteEvent(
+          webContents.id,
+          event.federationTarget.instanceId,
+          federationEventClassForMethod(event.notification.method),
+        )
+      ) {
+        continue;
+      }
+    } else if (windowTarget) {
       continue;
     }
     webContents.send(AGENT_EVENT_CHANNEL, rendererEvent);

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -20,8 +20,14 @@ import type {
   RevokeFederationPeerResponse,
   SetCelestialIconRequest,
   SetCelestialIconResponse,
+  SetFederationEventSubscriptionsRequest,
+  SetFederationEventSubscriptionsResponse,
 } from "@pwragent/shared";
-import { isCelestialIconId, isFederationInstanceId } from "@pwragent/shared";
+import {
+  isCelestialIconId,
+  isFederationEventClass,
+  isFederationInstanceId,
+} from "@pwragent/shared";
 import {
   FEDERATION_GET_HEALTH_CHANNEL,
   FEDERATION_GET_DIAGNOSTICS_CHANNEL,
@@ -31,12 +37,34 @@ import {
   FEDERATION_RESET_ENROLLMENT_CHANNEL,
   FEDERATION_REVOKE_PEER_CHANNEL,
   FEDERATION_SET_CELESTIAL_ICON_CHANNEL,
+  FEDERATION_SET_EVENT_SUBSCRIPTIONS_CHANNEL,
   FEDERATION_TAILSCALE_CONFIGURE_CHANNEL,
   FEDERATION_TAILSCALE_STATUS_CHANNEL,
 } from "../../shared/ipc";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { getFederationTailscaleService } from "../federation/federation-tailscale";
 import { createMainWindow } from "../window";
+
+const rendererSubscriptionCleanupIds = new Set<number>();
+
+function peerAllowsEventClass(
+  capabilities: readonly string[],
+  eventClass: string,
+): boolean {
+  switch (eventClass) {
+    case "navigation":
+    case "star_map":
+      return capabilities.includes("thread_navigation");
+    case "transcript":
+      return capabilities.includes("thread_detail");
+    case "pending_requests":
+      return capabilities.includes("pending_request_control");
+    case "scheduled_actions":
+      return capabilities.includes("scheduled_actions");
+    default:
+      return false;
+  }
+}
 
 export function registerFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_OPEN_WINDOW_CHANNEL);
@@ -49,6 +77,58 @@ export function registerFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_TAILSCALE_STATUS_CHANNEL);
   ipcMain.removeHandler(FEDERATION_TAILSCALE_CONFIGURE_CHANNEL);
   ipcMain.removeHandler(FEDERATION_SET_CELESTIAL_ICON_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_SET_EVENT_SUBSCRIPTIONS_CHANNEL);
+  ipcMain.handle(
+    FEDERATION_SET_EVENT_SUBSCRIPTIONS_CHANNEL,
+    async (
+      event,
+      request: SetFederationEventSubscriptionsRequest,
+    ): Promise<SetFederationEventSubscriptionsResponse> => {
+      const runtime = getDesktopFederationRuntime();
+      if (!rendererSubscriptionCleanupIds.has(event.sender.id)) {
+        const webContentsId = event.sender.id;
+        rendererSubscriptionCleanupIds.add(webContentsId);
+        event.sender.once("destroyed", () => {
+          rendererSubscriptionCleanupIds.delete(webContentsId);
+          runtime.clearRendererEventSubscriptions(webContentsId);
+        });
+      }
+      const peers = new Map(
+        runtime.connectedPeerTargets().map((peer) => [
+          peer.target.instanceId,
+          peer,
+        ]),
+      );
+      const subscriptions = Array.isArray(request?.subscriptions)
+        ? request.subscriptions.flatMap((subscription) => {
+            const peer = peers.get(subscription?.sourceInstanceId);
+            if (!peer || !peer.capabilities.includes("event_subscriptions")) {
+              return [];
+            }
+            const eventClasses = Array.isArray(subscription.eventClasses)
+              ? subscription.eventClasses.filter(
+                  (eventClass) =>
+                    isFederationEventClass(eventClass)
+                    && peerAllowsEventClass(peer.capabilities, eventClass),
+                )
+              : [];
+            return eventClasses.length > 0
+              ? [{
+                  sourceInstanceId: peer.target.instanceId,
+                  eventClasses,
+                }]
+              : [];
+          })
+        : [];
+      return {
+        subscriptions: runtime.setRendererEventSubscriptions(
+          event.sender.id,
+          "star-map",
+          subscriptions,
+        ),
+      };
+    },
+  );
   ipcMain.handle(
     FEDERATION_SET_CELESTIAL_ICON_CHANNEL,
     async (
@@ -133,6 +213,27 @@ export function registerFederationIpcHandlers(): void {
             }
           : undefined,
       });
+      const webContentsId = window.webContents.id;
+      runtime.setRendererEventSubscriptions(webContentsId, "remote-window", [{
+        sourceInstanceId: request.target.instanceId,
+        eventClasses: [
+          ...(peer.capabilities.includes("thread_navigation")
+            ? ["navigation" as const]
+            : []),
+          ...(peer.capabilities.includes("thread_detail")
+            ? ["transcript" as const]
+            : []),
+          ...(peer.capabilities.includes("pending_request_control")
+            ? ["pending_requests" as const]
+            : []),
+          ...(peer.capabilities.includes("scheduled_actions")
+            ? ["scheduled_actions" as const]
+            : []),
+        ],
+      }]);
+      window.once("closed", () => {
+        runtime.clearRendererEventSubscriptions(webContentsId, "remote-window");
+      });
       return {
         opened: true,
         windowId: window.id,
@@ -202,4 +303,6 @@ export function disposeFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_TAILSCALE_STATUS_CHANNEL);
   ipcMain.removeHandler(FEDERATION_TAILSCALE_CONFIGURE_CHANNEL);
   ipcMain.removeHandler(FEDERATION_SET_CELESTIAL_ICON_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_SET_EVENT_SUBSCRIPTIONS_CHANNEL);
+  rendererSubscriptionCleanupIds.clear();
 }

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -16,6 +16,7 @@ import type {
   EnsureDirectoryLaunchpadRequest,
   EnsureDirectoryLaunchpadResponse,
   FederationCapability,
+  FederationEventSubscription,
   FederationRemoteTarget,
   FederationTarget,
   GetNavigationSnapshotRequest,
@@ -78,6 +79,10 @@ export type DesktopMessagingFederationBridge = {
   onRemoteBackendEvent(
     listener: (event: AgentEvent) => void | Promise<void>,
   ): () => void;
+  setEventSubscriptions?(
+    consumerId: string,
+    subscriptions: readonly FederationEventSubscription[],
+  ): FederationEventSubscription[];
   remoteBackend(target: FederationRemoteTarget): FederationBackendOperations;
   remoteNavigationSnapshot(
     target: FederationRemoteTarget,
@@ -678,6 +683,12 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       unsubscribeLocal();
       unsubscribeRemote?.();
     };
+  }
+
+  setRemoteEventSubscriptions(
+    subscriptions: readonly FederationEventSubscription[],
+  ): void {
+    this.federation?.setEventSubscriptions?.("messaging", subscriptions);
   }
 
   private remoteBackend(

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -16,6 +16,7 @@ import type {
   AgentEvent,
   GenerateMessagingPairingTokenRequest,
   GenerateMessagingPairingTokenResponse,
+  FederationEventSubscription,
   InboundPreviewMessage,
   ListMessagingPairingRequestsRequest,
   ListMessagingPairingRequestsResponse,
@@ -373,6 +374,9 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       adapterFactory: DesktopMessagingAdapterFactory;
       backendBridge: MessagingBackendBridge & {
         onEvent?: (listener: (event: AgentEvent) => void | Promise<void>) => () => void;
+        setRemoteEventSubscriptions?: (
+          subscriptions: readonly FederationEventSubscription[],
+        ) => void;
       };
       config: DesktopMessagingConfig | DesktopMessagingConfigLoader;
       automationInboundHandler?: MessagingAutomationInboundHandler;
@@ -431,6 +435,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
 
     this.unsubscribeBackendEvents?.();
     this.unsubscribeBackendEvents = undefined;
+    this.options.backendBridge.setRemoteEventSubscriptions?.([]);
     const stoppedChannels = [...this.runningAdapters.keys()];
     await Promise.all(
       [...this.runningAdapters.values()].map(async (running) =>
@@ -594,6 +599,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         "messaging runtime started with no adapters — no platforms configured",
       );
     }
+    await this.syncFederationEventSubscriptions();
   }
 
   async applyLatestConfig(
@@ -1539,6 +1545,33 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     });
   }
 
+  private async syncFederationEventSubscriptions(): Promise<void> {
+    const setSubscriptions =
+      this.options.backendBridge.setRemoteEventSubscriptions;
+    if (!setSubscriptions) return;
+    if (!this.started || this.runningAdapters.size === 0) {
+      setSubscriptions([]);
+      return;
+    }
+    const instanceIds = new Set<string>();
+    for (const binding of await getDesktopMessagingStore().findActiveBindings()) {
+      if (binding.federatedThread?.target.scope === "remote") {
+        instanceIds.add(binding.federatedThread.target.instanceId);
+      }
+    }
+    setSubscriptions(
+      [...instanceIds].map((sourceInstanceId) => ({
+        sourceInstanceId,
+        eventClasses: [
+          "navigation",
+          "transcript",
+          "pending_requests",
+          "scheduled_actions",
+        ],
+      })),
+    );
+  }
+
   private syncRunningAdapterLists(): void {
     const running = [...this.runningAdapters.values()];
     this.adapters = running.map((record) => record.adapter);
@@ -1600,6 +1633,11 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   }
 
   private broadcastBindingsChanged(): void {
+    void this.syncFederationEventSubscriptions().catch((error) => {
+      messagingLog.warn("federation event subscription sync failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
     for (const listener of this.bindingsChangedListeners) {
       try {
         listener();

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1555,7 +1555,10 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     }
     const instanceIds = new Set<string>();
     for (const binding of await getDesktopMessagingStore().findActiveBindings()) {
-      if (binding.federatedThread?.target.scope === "remote") {
+      if (
+        this.runningAdapters.has(binding.channel.channel)
+        && binding.federatedThread?.target.scope === "remote"
+      ) {
         instanceIds.add(binding.federatedThread.target.instanceId);
       }
     }

--- a/apps/desktop/src/main/window-channels.ts
+++ b/apps/desktop/src/main/window-channels.ts
@@ -1,4 +1,5 @@
 import type { BrowserWindow, WebContents } from "electron";
+import type { FederationRemoteTarget } from "@pwragent/shared";
 
 /**
  * Per-window channel-subscription registry.
@@ -51,6 +52,7 @@ interface Entry {
   kind: WindowKind;
   channels: Set<string>;
   webContents: WebContents;
+  federationTarget?: FederationRemoteTarget;
 }
 
 const entries = new Map<WebContents, Entry>();
@@ -59,16 +61,24 @@ export function registerWindowChannels(
   window: BrowserWindow,
   kind: WindowKind,
   channels: readonly string[],
+  federationTarget?: FederationRemoteTarget,
 ): void {
   const webContents = window.webContents;
   entries.set(webContents, {
     kind,
     channels: new Set(channels),
     webContents,
+    ...(federationTarget ? { federationTarget } : {}),
   });
   window.on("closed", () => {
     entries.delete(webContents);
   });
+}
+
+export function federationTargetForChannelSubscriber(
+  webContents: WebContents,
+): FederationRemoteTarget | undefined {
+  return entries.get(webContents)?.federationTarget;
 }
 
 /** Return every WebContents that has subscribed to the given channel. */

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -824,7 +824,7 @@ export function createMainWindow(options?: {
     WINDOW_OPEN_SETTINGS_CHANNEL,
     WINDOW_REPLAY_ONBOARDING_CHANNEL,
     WINDOW_SHOW_THREAD_CHANNEL,
-  ]);
+  ], options?.federationTarget);
 
   window.on("closed", () => {
     hotCpuProfilerSyncHandlers.delete(window.id);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -277,6 +277,8 @@ import type {
   RevokeFederationPeerResponse,
   SetCelestialIconRequest,
   SetCelestialIconResponse,
+  SetFederationEventSubscriptionsRequest,
+  SetFederationEventSubscriptionsResponse,
   ReadStarMapArrangementResponse,
   SetStarMapCardPositionRequest,
   StarMapIntakeRequest,
@@ -464,6 +466,7 @@ import {
   FEDERATION_RESET_ENROLLMENT_CHANNEL,
   FEDERATION_REVOKE_PEER_CHANNEL,
   FEDERATION_SET_CELESTIAL_ICON_CHANNEL,
+  FEDERATION_SET_EVENT_SUBSCRIPTIONS_CHANNEL,
   STAR_MAP_INTAKE_CHANNEL,
   STAR_MAP_READ_ARRANGEMENT_CHANNEL,
   STAR_MAP_SET_CARD_POSITION_CHANNEL,
@@ -899,6 +902,10 @@ const desktopApi = Object.freeze({
     request: SetCelestialIconRequest,
   ): Promise<SetCelestialIconResponse> =>
     await ipcRenderer.invoke(FEDERATION_SET_CELESTIAL_ICON_CHANNEL, request),
+  setFederationEventSubscriptions: async (
+    request: SetFederationEventSubscriptionsRequest,
+  ): Promise<SetFederationEventSubscriptionsResponse> =>
+    await ipcRenderer.invoke(FEDERATION_SET_EVENT_SUBSCRIPTIONS_CHANNEL, request),
   readStarMapArrangement: async (): Promise<ReadStarMapArrangementResponse> =>
     await ipcRenderer.invoke(STAR_MAP_READ_ARRANGEMENT_CHANNEL),
   setStarMapCardPosition: async (

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -1512,6 +1512,7 @@ const FEDERATION_CAPABILITY_LABELS: Record<FederationCapability, string> = {
   pwrsnap_connection: "read PwrSnap availability",
   gateway_relay: "reach sibling instances",
   remote_pty: "open a remote terminal",
+  event_subscriptions: "stream explicitly subscribed events",
 };
 
 function formatFederationCapabilities(

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -309,6 +309,38 @@ export function StarMapScreen(props: StarMapScreenProps) {
       ? visible.filter((peer) => peer.status === "connected")
       : visible;
   }, [health, preferences.hideOfflineInstances]);
+  const eventSubscriptionsJson = JSON.stringify(
+    peers
+      .filter(
+        (peer) =>
+          peer.status === "connected"
+          && peer.capabilities.includes("event_subscriptions"),
+      )
+      .map((peer) => ({
+        sourceInstanceId: peer.id,
+        eventClasses: [
+          ...(peer.capabilities.includes("thread_navigation")
+            ? ["navigation" as const, "star_map" as const]
+            : []),
+          ...(peer.capabilities.includes("scheduled_actions")
+            ? ["scheduled_actions" as const]
+            : []),
+        ],
+      })),
+  );
+  useEffect(() => {
+    if (!props.desktopApi?.setFederationEventSubscriptions) return;
+    const subscriptions = JSON.parse(eventSubscriptionsJson) as Array<{
+      sourceInstanceId: string;
+      eventClasses: Array<"navigation" | "scheduled_actions" | "star_map">;
+    }>;
+    void props.desktopApi.setFederationEventSubscriptions({ subscriptions });
+    return () => {
+      void props.desktopApi?.setFederationEventSubscriptions?.({
+        subscriptions: [],
+      });
+    };
+  }, [eventSubscriptionsJson, props.desktopApi]);
   const remote = useStarMapThreads({
     desktopApi: props.desktopApi,
     peers,

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -208,6 +208,83 @@ describe("StarMapScreen", () => {
     expect(screen.queryByText("This instance")).toBeNull();
   });
 
+  it("subscribes only to bounded Star Map event classes while mounted", async () => {
+    const setFederationEventSubscriptions = vi.fn(async (request) => request);
+    const desktopApi: DesktopApi = {
+      readFederationHealth: vi.fn(async () => ({
+        health: {
+          enabled: true,
+          role: "gateway" as const,
+          status: "listening" as const,
+          instanceId: "pwr_local",
+          peers: [{
+            id: "pwr_remote",
+            label: "Remote",
+            role: "client" as const,
+            status: "connected" as const,
+            capabilities: [
+              "event_subscriptions",
+              "thread_navigation",
+              "scheduled_actions",
+            ],
+          }],
+        },
+      })) as unknown as DesktopApi["readFederationHealth"],
+      getNavigationSnapshot: vi.fn(async () => ({
+        backend: "all",
+        fetchedAt: 1_000,
+        threads: [],
+        inboxThreadKeys: [],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex",
+          executionMode: "default",
+        },
+      })) as unknown as DesktopApi["getNavigationSnapshot"],
+      onAgentEvent: vi.fn(() => () => undefined),
+      setFederationEventSubscriptions,
+    };
+    const rendered = render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[]}
+        sessionKeys={{}}
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(setFederationEventSubscriptions).toHaveBeenCalledWith({
+        subscriptions: [{
+          sourceInstanceId: "pwr_remote",
+          eventClasses: [
+            "navigation",
+            "star_map",
+            "scheduled_actions",
+          ],
+        }],
+      });
+    });
+    expect(setFederationEventSubscriptions).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        subscriptions: [expect.objectContaining({
+          eventClasses: expect.arrayContaining([
+            "transcript",
+            "pending_requests",
+          ]),
+        })],
+      }),
+    );
+
+    rendered.unmount();
+    expect(setFederationEventSubscriptions).toHaveBeenLastCalledWith({
+      subscriptions: [],
+    });
+  });
+
   it("drops the machine-name chip from cards - the lane already says which instance", async () => {
     render(
       <StarMapScreen

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -119,6 +119,8 @@ import type {
   RevokeFederationPeerResponse,
   SetCelestialIconRequest,
   SetCelestialIconResponse,
+  SetFederationEventSubscriptionsRequest,
+  SetFederationEventSubscriptionsResponse,
   ReadStarMapArrangementResponse,
   SetStarMapCardPositionRequest,
   StarMapIntakeRequest,
@@ -507,6 +509,9 @@ export type DesktopApi = {
   setCelestialIcon?: (
     request: SetCelestialIconRequest,
   ) => Promise<SetCelestialIconResponse>;
+  setFederationEventSubscriptions?: (
+    request: SetFederationEventSubscriptionsRequest,
+  ) => Promise<SetFederationEventSubscriptionsResponse>;
   readStarMapArrangement?: () => Promise<ReadStarMapArrangementResponse>;
   setStarMapCardPosition?: (
     request: SetStarMapCardPositionRequest,

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -13,6 +13,8 @@ export const FEDERATION_TAILSCALE_CONFIGURE_CHANNEL =
   "federation:tailscale-configure";
 export const FEDERATION_SET_CELESTIAL_ICON_CHANNEL =
   "federation:set-celestial-icon";
+export const FEDERATION_SET_EVENT_SUBSCRIPTIONS_CHANNEL =
+  "federation:set-event-subscriptions";
 export const STAR_MAP_READ_ARRANGEMENT_CHANNEL = "star-map:read-arrangement";
 export const STAR_MAP_SET_CARD_POSITION_CHANNEL = "star-map:set-card-position";
 export const STAR_MAP_INTAKE_CHANNEL = "star-map:intake";

--- a/docs/federation-architecture.md
+++ b/docs/federation-architecture.md
@@ -74,6 +74,49 @@ The scheduled-action RPC surface is part of federation protocol v1 while the
 protocol remains under development. Peers must authorize `scheduled_actions`
 explicitly; `turn_control` does not imply scheduler access.
 
+### Event subscriptions
+
+An authenticated connection does not subscribe a peer to backend events.
+Live events use the separately negotiated `event_subscriptions` capability and
+replace-style subscriptions scoped by all three of:
+
+- subscriber instance
+- owning/source instance
+- event class (`navigation`, `transcript`, `pending_requests`,
+  `scheduled_actions`, or `star_map`)
+
+Remote workspace windows subscribe to their fixed owning instance for only the
+classes supported by that peer. The Star Map subscribes while mounted to
+`navigation`, `scheduled_actions`, and `star_map` for its connected visible
+instances; it does not request transcript or pending-request traffic.
+Messaging subscribes only for instances referenced by active federated
+bindings and clears that desired state when messaging stops.
+
+Subscriptions are desired state, not additive commands. Retargeting or closing
+a consumer replaces its old set (an empty set is unsubscribe). The subscriber
+replays its aggregate desired set after reconnect. A gateway records relayed
+subscription routes, forwards events only to the named downstream subscriber,
+and removes or replays routes as downstream subscribers or source peers
+disconnect and reconnect. Owners likewise clear session-scoped incoming
+subscriptions when their authenticated next hop disconnects.
+
+Backend-event envelopes are targeted. Receivers drop an event unless its source
+instance and class match local desired state, and they accept a claimed source
+different from the authenticated peer only when that peer is their configured
+upstream gateway. This keeps one instance's stream out of unrelated local and
+remote windows.
+
+Mixed-version behavior is fail-closed on upgraded senders: a peer that does not
+advertise `event_subscriptions` receives no live events from a new owner.
+Upgraded receivers also discard unsolicited events from older senders. An old
+sender can still put legacy broadcast traffic on a connection until it is
+upgraded, so the no-unsolicited-network-traffic guarantee requires upgraded
+software on the producing side (and on a relaying gateway, when present).
+
+Peer-directory and celestial-icon LWW snapshots remain federation control-plane
+state. They exchange when a connection or assignment changes, then settle; they
+do not enable or carry the backend-event stream described above.
+
 ## Diagnostics
 
 `federation:get-health` returns a sanitized health snapshot for settings and

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -151,6 +151,14 @@ and workspace handoff to the selected instance. The owning instance persists,
 times, and dispatches scheduled work. Backend events and environment setup
 output stream back with the source instance identity.
 
+Live backend events are subscription-driven. Opening a remote workspace
+subscribes that window to its owning instance and closing it unsubscribes.
+Star Map and messaging establish their own narrower, instance-scoped
+subscriptions only while those features need them. Merely connecting or
+enrolling a peer does not opt it into transcript, approval, scheduler, PR, or
+error event traffic. Environment setup output remains a targeted response to
+the operation that started it rather than a broadcast stream.
+
 Global thread search fans out metadata queries to connected peers. Remote
 results carry their instance label and open directly in a window scoped to that
 instance.

--- a/packages/shared/src/contracts/__tests__/federation.test.ts
+++ b/packages/shared/src/contracts/__tests__/federation.test.ts
@@ -6,6 +6,7 @@ import {
   federationTargetKey,
   formatFederationPeerDisplayLabel,
   isFederationCapability,
+  isFederationEventClass,
   isFederationInstanceId,
   isRemoteFederationTarget,
   type FederationCapabilitySet,
@@ -56,7 +57,11 @@ describe("federation contracts", () => {
 
     expect(isFederationCapability("remote_window")).toBe(true);
     expect(isFederationCapability("scheduled_actions")).toBe(true);
+    expect(isFederationCapability("event_subscriptions")).toBe(true);
     expect(isFederationCapability("unknown")).toBe(false);
+    expect(isFederationEventClass("navigation")).toBe(true);
+    expect(isFederationEventClass("pending_requests")).toBe(true);
+    expect(isFederationEventClass("everything")).toBe(false);
   });
 
   it("keeps protocol envelopes correlated and versioned", () => {

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -23,9 +23,39 @@ export const FEDERATION_CAPABILITIES = [
   "pwrsnap_connection",
   "gateway_relay",
   "remote_pty",
+  "event_subscriptions",
 ] as const;
 
 export type FederationCapability = (typeof FEDERATION_CAPABILITIES)[number];
+
+/**
+ * Backend-event streams are opt-in and intentionally split by consumer need.
+ * Unknown notification methods fall into `transcript`, the most restrictive
+ * class, so a new producer cannot silently widen navigation-only subscribers.
+ */
+export const FEDERATION_EVENT_CLASSES = [
+  "navigation",
+  "transcript",
+  "pending_requests",
+  "scheduled_actions",
+  "star_map",
+] as const;
+
+export type FederationEventClass =
+  (typeof FEDERATION_EVENT_CLASSES)[number];
+
+export type FederationEventSubscription = {
+  sourceInstanceId: FederationInstanceId;
+  eventClasses: FederationEventClass[];
+};
+
+export type SetFederationEventSubscriptionsRequest = {
+  subscriptions: FederationEventSubscription[];
+};
+
+export type SetFederationEventSubscriptionsResponse = {
+  subscriptions: FederationEventSubscription[];
+};
 
 export type FederationInstanceRole = "gateway" | "client" | "dual";
 
@@ -481,6 +511,15 @@ export function isFederationCapability(
   return (
     typeof value === "string" &&
     (FEDERATION_CAPABILITIES as readonly string[]).includes(value)
+  );
+}
+
+export function isFederationEventClass(
+  value: unknown,
+): value is FederationEventClass {
+  return (
+    typeof value === "string"
+    && (FEDERATION_EVENT_CLASSES as readonly string[]).includes(value)
   );
 }
 


### PR DESCRIPTION
## Summary

- replace implicit federation backend-event fanout with desired-state subscriptions scoped by subscriber, source instance, and event class
- route source events only to explicitly subscribed peers and make gateways relay only along recorded downstream subscription routes
- give remote windows, Star Map, and messaging independent subscription lifecycles with exact close, retarget, binding-revoke, disconnect, and reconnect behavior
- make main-process renderer delivery source-aware so unrelated local and remote windows never receive another instance's subscribed stream
- document the protocol, lifecycle, and mixed-version behavior

## Root cause

A connected peer's broad capabilities (`remote_window`, `thread_detail`, or `scheduled_actions`) were treated as standing interest in live events. Owners broadcast ordinary backend notifications to every matching connection, and gateways re-fanned one-hop events to siblings without consumer intent. There was no explicit desired state to tear down when a viewer or feature stopped needing a stream.

## Architecture

This adds the negotiated `event_subscriptions` capability and five bounded classes:

- `navigation`
- `transcript`
- `pending_requests`
- `scheduled_actions`
- `star_map`

`federation.eventSubscription` uses replace semantics. A subscriber aggregates desired state across independent consumers and sends one source-targeted class set; an empty set unsubscribes. Owners retain incoming subscriptions only for the authenticated session route. Gateways retain the source/subscriber/class tuple and relay targeted events only when that tuple exists.

Desired subscriptions survive local transport loss and replay on reconnect. Incoming and relayed session state is removed on disconnect; gateways replay retained downstream desire when a source reconnects. Remote-window and Star Map renderer scopes remain independent so opening or closing Star Map cannot overwrite a viewer's baseline stream.

Notification methods fail closed into `transcript` unless explicitly classified. Direct peers cannot claim a sibling source identity; only the configured upstream gateway may carry a sibling's targeted envelope.

## Behavior and compatibility

- Connected but unsubscribed upgraded peers receive no ordinary backend events.
- Remote workspace windows subscribe only to their owning instance and supported classes.
- Star Map requests only `navigation`, `scheduled_actions`, and `star_map` for connected visible instances; it never requests transcripts or pending approvals.
- Messaging subscribes only to instances referenced by active federated bindings and clears subscriptions on revoke or runtime stop.
- Peer-directory and celestial-icon LWW snapshots remain bounded control-plane convergence traffic rather than live backend streams.
- New senders fail closed for peers that do not advertise `event_subscriptions`; new receivers discard unsolicited legacy events. Fully eliminating legacy traffic on the wire requires upgrading the producer and any relaying gateway.

This intentionally does not modify renderer toast components; the separate short-term toast-scoping fix can land independently.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/federation-*.test.ts apps/desktop/src/main/__tests__/desktop-backend-bridge.test.ts apps/desktop/src/main/__tests__/messaging-scheduled-actions.test.ts apps/desktop/src/main/__tests__/messaging-runtime.test.ts` — 26 files, 300 tests passed
- focused subscription, IPC routing, messaging, Star Map, and shared-contract suite — 114 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors (existing warning baseline only)
- `pnpm lint:codex-storage`
- `pnpm lint:boundaries`
- `git diff --check`
