### PR TITLE
fix(desktop): harden federated PR search

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type {
   AgentEvent,
   CelestialIconAssignment,
@@ -50,6 +50,9 @@ type RuntimeHarness = {
     envelope: FederationProtocolEnvelope,
     sourcePeerId: FederationInstanceId,
   ) => boolean;
+  remoteThreadSummaryCache?: {
+    invalidate: (instanceId?: string) => void;
+  };
   publishRemoteEnvironmentSetupProgress: (
     envelope: FederationProtocolEnvelope,
     sourcePeerId: FederationInstanceId,
@@ -109,6 +112,10 @@ type RuntimeHarness = {
     target: { scope: "remote"; instanceId: FederationInstanceId },
     request: Record<string, never>,
   ) => Promise<NavigationSnapshot>;
+  remoteThreadSummaries: () => {
+    searchForJump: (request: { query: string }) => Promise<{ results: unknown[] }>;
+    dispose: () => void;
+  };
   sendEnvelopeToTarget: (
     targetInstanceId: FederationInstanceId,
     envelope: FederationProtocolEnvelope,
@@ -183,6 +190,7 @@ type RuntimeHarness = {
   connectedPeerTargets: () => Array<{
     target: { scope: "remote"; instanceId: FederationInstanceId };
     label: string;
+    capabilities: FederationCapability[];
   }>;
 };
 
@@ -1345,6 +1353,105 @@ describe("DesktopFederationRuntime", () => {
         },
       },
     ]);
+  });
+
+  it("invalidates cached remote summaries when a peer updates attached PRs", () => {
+    const invalidated: Array<string | undefined> = [];
+    const router = new FederationRouter({ localInstanceId: "gateway_one" });
+    router.registerConnection(createConnection({
+      peerId: "client_one",
+      capabilities: ["thread_detail", "event_subscriptions"],
+    }));
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "gateway_one";
+    runtime.router = router;
+    runtime.setEventSubscriptions("viewer", [{
+      sourceInstanceId: "client_one",
+      eventClasses: ["navigation"],
+    }]);
+    runtime.remoteThreadSummaryCache = {
+      invalidate: (instanceId) => invalidated.push(instanceId),
+    };
+
+    runtime.publishRemoteBackendEvent(
+      {
+        id: "event-prs",
+        kind: "notification",
+        method: FEDERATION_BACKEND_EVENT_METHOD,
+        params: {
+          backend: "codex",
+          notification: {
+            method: "thread/pullRequests/updated",
+            params: {
+              threadId: "thread-1",
+              prs: [],
+            },
+          },
+        },
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: "client_one",
+        targetInstanceId: "gateway_one",
+        createdAt: 2_000,
+      },
+      "client_one",
+    );
+
+    expect(invalidated).toEqual(["client_one"]);
+  });
+
+  it("subscribes Cmd+K snapshot peers to navigation updates for the cache TTL", async () => {
+    vi.useFakeTimers();
+    const sent: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({ localInstanceId: "viewer_one" });
+    router.registerConnection(createConnection({
+      peerId: "owner_one",
+      capabilities: ["thread_navigation", "event_subscriptions"],
+      sendEnvelope: (envelope) => sent.push(envelope),
+    }));
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "viewer_one";
+    runtime.router = router;
+    runtime.connectedPeerTargets = () => [{
+      target: { scope: "remote", instanceId: "owner_one" },
+      label: "Owner",
+      capabilities: ["thread_navigation", "event_subscriptions"],
+    }];
+    runtime.remoteNavigationSnapshot = async () => ({
+      backend: "all",
+      fetchedAt: 1_000,
+      unchanged: false,
+      threads: [],
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    });
+
+    const cache = runtime.remoteThreadSummaries();
+    try {
+      await cache.searchForJump({ query: "49" });
+      expect(sent).toMatchObject([{
+        kind: "notification",
+        method: "federation.eventSubscription",
+        params: { eventClasses: ["navigation"] },
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+      }]);
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(sent.at(-1)).toMatchObject({
+        kind: "notification",
+        method: "federation.eventSubscription",
+        params: { eventClasses: [] },
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+      });
+    } finally {
+      cache.dispose();
+      vi.useRealTimers();
+    }
   });
 
   it("publishes remote environment setup progress with its source target", () => {

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -32,7 +32,10 @@ function stampedThread(params: {
   title: string;
   updatedAt?: number;
   prNumber?: number;
+  prNumbers?: number[];
 }): NavigationThreadSummary {
+  const prNumbers = params.prNumbers
+    ?? (params.prNumber !== undefined ? [params.prNumber] : []);
   return {
     source: "codex",
     id: params.threadId,
@@ -41,18 +44,16 @@ function stampedThread(params: {
     linkedDirectories: [],
     inbox: { inInbox: false },
     updatedAt: params.updatedAt,
-    ...(params.prNumber !== undefined
+    ...(prNumbers.length > 0
       ? {
-          prs: [
-            {
-              provider: "github.com",
-              number: params.prNumber,
-              org: "pwrdrvr",
-              repo: "PwrAgent",
-              state: "pending",
-              url: `https://github.com/pwrdrvr/PwrAgent/pull/${params.prNumber}`,
-            },
-          ],
+          prs: prNumbers.map((number) => ({
+            provider: "github.com",
+            number,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            state: "pending",
+            url: `https://github.com/pwrdrvr/PwrAgent/pull/${number}`,
+          })),
         }
       : {}),
     federation: {
@@ -149,6 +150,36 @@ describe("RemoteThreadSummaryCache — searchForJump", () => {
     expect(response.results.map((thread) => thread.id)).toEqual(["new"]);
   });
 
+  it("ranks an exact attached PR ahead of newer substring matches", async () => {
+    const threads = [
+      stampedThread({
+        instanceId: "peer-a",
+        threadId: "stacked",
+        title: "Stacked PRs",
+        updatedAt: 1,
+        prNumbers: [44, 45, 46, 48, 49],
+      }),
+      ...Array.from({ length: 8 }, (_, index) =>
+        stampedThread({
+          instanceId: "peer-a",
+          threadId: `substring-${index}`,
+          title: `Substring ${index}`,
+          updatedAt: 100 + index,
+          prNumber: 149 + index * 100,
+        }),
+      ),
+    ];
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf(threads),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    const response = await cache.searchForJump({ query: "49", limit: 8 });
+    expect(response.results[0].id).toBe("stacked");
+  });
+
   it("caches snapshots within the TTL and refetches after it", async () => {
     let now = 0;
     const fetchSnapshot = vi.fn(async () =>
@@ -172,6 +203,98 @@ describe("RemoteThreadSummaryCache — searchForJump", () => {
     now = 200;
     await cache.searchForJump({ query: "match" });
     expect(fetchSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it("refetches immediately after the peer cache is invalidated", async () => {
+    const fetchSnapshot = vi.fn(async () => snapshotOf([]));
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot,
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    await cache.searchForJump({ query: "49" });
+    cache.invalidate("peer-a");
+    await cache.searchForJump({ query: "49" });
+
+    expect(fetchSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not restore a stale snapshot invalidated during its fetch", async () => {
+    let resolveFirst!: (snapshot: NavigationSnapshot) => void;
+    let resolveSecond!: (snapshot: NavigationSnapshot) => void;
+    const fetchSnapshot = vi.fn(() =>
+      new Promise<NavigationSnapshot>((resolve) => {
+        if (fetchSnapshot.mock.calls.length === 1) {
+          resolveFirst = resolve;
+        } else {
+          resolveSecond = resolve;
+        }
+      }),
+    );
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot,
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    const staleSearch = cache.searchForJump({ query: "49" });
+    expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+    cache.invalidate("peer-a");
+    const freshSearch = cache.searchForJump({ query: "49" });
+    expect(fetchSnapshot).toHaveBeenCalledTimes(2);
+
+    const freshThread = stampedThread({
+      instanceId: "peer-a",
+      threadId: "stacked",
+      title: "Stacked PRs",
+      prNumbers: [44, 49],
+    });
+    resolveSecond(snapshotOf([freshThread]));
+    await expect(freshSearch).resolves.toMatchObject({
+      results: [{ id: "stacked" }],
+    });
+    resolveFirst(snapshotOf([]));
+    await expect(staleSearch).resolves.toMatchObject({
+      results: [{ id: "stacked" }],
+    });
+
+    await expect(cache.searchForJump({ query: "49" })).resolves.toMatchObject({
+      results: [{ id: "stacked" }],
+    });
+    expect(fetchSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps navigation event interest alive for the cache TTL", async () => {
+    vi.useFakeTimers();
+    const onPeerInterestChanged = vi.fn();
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+      onPeerInterestChanged,
+      ttlMs: 100,
+    });
+
+    try {
+      await cache.searchForJump({ query: "49" });
+      expect(onPeerInterestChanged).toHaveBeenCalledTimes(1);
+      expect(onPeerInterestChanged).toHaveBeenLastCalledWith(["peer-a"]);
+
+      await vi.advanceTimersByTimeAsync(50);
+      await cache.searchForJump({ query: "49" });
+      await vi.advanceTimersByTimeAsync(99);
+      expect(onPeerInterestChanged).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(onPeerInterestChanged).toHaveBeenLastCalledWith([]);
+    } finally {
+      cache.dispose();
+      vi.useRealTimers();
+    }
   });
 
   it("skips peers that time out instead of failing the search", async () => {

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -318,6 +318,9 @@ const DEFAULT_CAPABILITIES: FederationCapability[] = [
   "event_subscriptions",
 ];
 
+const REMOTE_THREAD_SUMMARY_EVENT_CONSUMER_ID =
+  "remote-thread-summary-cache";
+
 type FederationPeerDirectoryNotification = {
   method: typeof FEDERATION_PEER_DIRECTORY_METHOD;
   params: {
@@ -704,6 +707,8 @@ export class DesktopFederationRuntime {
     }
     this.unsubscribeLocalBackendEvents?.();
     this.unsubscribeLocalBackendEvents = undefined;
+    this.remoteThreadSummaryCache?.dispose();
+    this.remoteThreadSummaryCache = undefined;
     // Owner shutdown kills every remote session immediately, mirroring how
     // the local panel's shells die with the app.
     this.ptyService?.disposeAll();
@@ -1162,6 +1167,22 @@ export class DesktopFederationRuntime {
           // Early boot: the app-state db backing visiblePeers may be absent.
           return {};
         }
+      },
+      onPeerInterestChanged: (instanceIds) => {
+        const interested = new Set(instanceIds);
+        this.setEventSubscriptions(
+          REMOTE_THREAD_SUMMARY_EVENT_CONSUMER_ID,
+          this.connectedPeerTargets()
+            .filter(
+              (peer) =>
+                interested.has(peer.target.instanceId)
+                && peer.capabilities.includes("event_subscriptions"),
+            )
+            .map((peer) => ({
+              sourceInstanceId: peer.target.instanceId,
+              eventClasses: ["navigation"],
+            })),
+        );
       },
     });
     return this.remoteThreadSummaryCache;
@@ -3236,6 +3257,9 @@ export class DesktopFederationRuntime {
       },
       notification: notification.params.notification,
     };
+    if (event.notification.method === "thread/pullRequests/updated") {
+      this.remoteThreadSummaryCache?.invalidate(sourceInstanceId);
+    }
     this.publishAgentEvent?.(event);
     for (const listener of this.remoteBackendEventListeners) {
       void Promise.resolve(listener(event)).catch((error) => {

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -9,7 +9,10 @@ import type {
   NavigationThreadSummary,
   RemoteThreadPin,
 } from "@pwragent/shared";
-import { threadMatchesQuery } from "@pwragent/shared";
+import {
+  threadHasExactPrNumberMatch,
+  threadMatchesQuery,
+} from "@pwragent/shared";
 
 export type RemoteThreadSummaryPeer = {
   target: FederationRemoteTarget;
@@ -50,11 +53,23 @@ export class RemoteThreadSummaryCache {
     string,
     { fetchedAt: number; threads: NavigationThreadSummary[] }
   >();
-  private readonly inFlight = new Map<string, Promise<NavigationThreadSummary[]>>();
+  private readonly inFlight = new Map<
+    string,
+    {
+      generation: string;
+      promise: Promise<NavigationThreadSummary[]>;
+    }
+  >();
   private readonly archivedCache = new Map<
     string,
     { fetchedAt: number; threadKeys: Set<string> }
   >();
+  private readonly peerInterestTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+  private globalGeneration = 0;
+  private readonly peerGenerations = new Map<string, number>();
 
   constructor(
     private readonly options: {
@@ -73,6 +88,8 @@ export class RemoteThreadSummaryCache {
         label?: string;
         celestialIcon?: CelestialIconId;
       };
+      /** Peers whose cached summaries currently need navigation updates. */
+      onPeerInterestChanged?: (instanceIds: string[]) => void;
       ttlMs?: number;
       peerTimeoutMs?: number;
       now?: () => number;
@@ -81,15 +98,31 @@ export class RemoteThreadSummaryCache {
 
   invalidate(instanceId?: string): void {
     if (instanceId === undefined) {
+      this.globalGeneration += 1;
       this.cache.clear();
       this.archivedCache.clear();
       return;
     }
+    this.peerGenerations.set(
+      instanceId,
+      (this.peerGenerations.get(instanceId) ?? 0) + 1,
+    );
     this.cache.delete(instanceId);
     for (const key of this.archivedCache.keys()) {
       if (key.startsWith(`${instanceId}:`)) {
         this.archivedCache.delete(key);
       }
+    }
+  }
+
+  dispose(): void {
+    const hadPeerInterest = this.peerInterestTimers.size > 0;
+    for (const timer of this.peerInterestTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.peerInterestTimers.clear();
+    if (hadPeerInterest) {
+      this.options.onPeerInterestChanged?.([]);
     }
   }
 
@@ -118,11 +151,18 @@ export class RemoteThreadSummaryCache {
     const results = groups
       .flat()
       .filter((thread) => threadMatchesQuery(thread, query))
-      .sort(
-        (left, right) =>
+      .sort((left, right) => {
+        const exactPrPriority =
+          Number(threadHasExactPrNumberMatch(right, query))
+          - Number(threadHasExactPrNumberMatch(left, query));
+        if (exactPrPriority !== 0) {
+          return exactPrPriority;
+        }
+        return (
           (right.updatedAt ?? right.createdAt ?? 0)
-          - (left.updatedAt ?? left.createdAt ?? 0),
-      )
+          - (left.updatedAt ?? left.createdAt ?? 0)
+        );
+      })
       .slice(0, limit);
     return { results };
   }
@@ -306,15 +346,17 @@ export class RemoteThreadSummaryCache {
   ): Promise<NavigationThreadSummary[]> {
     const now = this.options.now?.() ?? Date.now();
     const ttlMs = this.options.ttlMs ?? REMOTE_SNAPSHOT_TTL_MS;
+    this.touchPeerInterest(target.instanceId, ttlMs);
     const cached = this.cache.get(target.instanceId);
     if (cached && now - cached.fetchedAt < ttlMs) {
       return cached.threads;
     }
+    const generation = this.generationFor(target.instanceId);
     const pending = this.inFlight.get(target.instanceId);
-    if (pending) {
-      return await pending;
+    if (pending?.generation === generation) {
+      return await pending.promise;
     }
-    const fetch = (async () => {
+    const promise = (async () => {
       const timeoutMs =
         this.options.peerTimeoutMs ?? REMOTE_SNAPSHOT_PEER_TIMEOUT_MS;
       const snapshot = await withTimeout(
@@ -322,18 +364,25 @@ export class RemoteThreadSummaryCache {
         timeoutMs,
         `Remote thread summaries timed out after ${Math.round(timeoutMs / 1000)}s.`,
       );
+      if (this.generationFor(target.instanceId) !== generation) {
+        return await this.threadsForPeer(target);
+      }
       const threads = snapshot.threads;
       this.cache.set(target.instanceId, {
         fetchedAt: this.options.now?.() ?? Date.now(),
         threads,
       });
+      this.touchPeerInterest(target.instanceId, ttlMs);
       return threads;
     })();
-    this.inFlight.set(target.instanceId, fetch);
+    const entry = { generation, promise };
+    this.inFlight.set(target.instanceId, entry);
     try {
-      return await fetch;
+      return await promise;
     } finally {
-      this.inFlight.delete(target.instanceId);
+      if (this.inFlight.get(target.instanceId) === entry) {
+        this.inFlight.delete(target.instanceId);
+      }
     }
   }
 
@@ -346,6 +395,7 @@ export class RemoteThreadSummaryCache {
     const cacheKey = `${target.instanceId}:${backend}`;
     const now = this.options.now?.() ?? Date.now();
     const ttlMs = this.options.ttlMs ?? REMOTE_SNAPSHOT_TTL_MS;
+    const generation = this.generationFor(target.instanceId);
     const cached = this.archivedCache.get(cacheKey);
     if (
       cached
@@ -365,11 +415,43 @@ export class RemoteThreadSummaryCache {
     const threadKeys = new Set(
       archivedThreads.map((thread) => `${thread.source}:${thread.id}`),
     );
+    if (this.generationFor(target.instanceId) !== generation) {
+      return new Set();
+    }
     this.archivedCache.set(cacheKey, {
       fetchedAt: this.options.now?.() ?? Date.now(),
       threadKeys,
     });
     return threadKeys;
+  }
+
+  private generationFor(instanceId: string): string {
+    return `${this.globalGeneration}:${this.peerGenerations.get(instanceId) ?? 0}`;
+  }
+
+  private touchPeerInterest(instanceId: string, ttlMs: number): void {
+    const existing = this.peerInterestTimers.get(instanceId);
+    if (existing) {
+      clearTimeout(existing);
+    }
+    const timer = setTimeout(() => {
+      if (this.peerInterestTimers.get(instanceId) !== timer) {
+        return;
+      }
+      this.peerInterestTimers.delete(instanceId);
+      this.notifyPeerInterestChanged();
+    }, ttlMs);
+    timer.unref?.();
+    this.peerInterestTimers.set(instanceId, timer);
+    if (!existing) {
+      this.notifyPeerInterestChanged();
+    }
+  }
+
+  private notifyPeerInterestChanged(): void {
+    this.options.onPeerInterestChanged?.(
+      [...this.peerInterestTimers.keys()].sort(),
+    );
   }
 }
 

--- a/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
@@ -9,6 +9,7 @@ import {
 import {
   buildThreadIdentityKey,
   federatedThreadIdentityKey,
+  threadHasExactPrNumberMatch,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
 import { SearchIcon } from "../../icons";
@@ -63,6 +64,11 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
     }
     return props.threads
       .filter((thread) => threadMatchesQuery(thread, trimmed))
+      .sort(
+        (left, right) =>
+          Number(threadHasExactPrNumberMatch(right, trimmed))
+          - Number(threadHasExactPrNumberMatch(left, trimmed)),
+      )
       .slice(0, MAX_RESULTS);
   }, [trimmed, props.threads]);
 
@@ -182,7 +188,7 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
     thread: NavigationThreadSummary,
     index: number,
   ): ReactElement => {
-    const description = describeThread(thread);
+    const description = describeThread(thread, trimmed);
     const key = thread.federation
       ? federatedThreadIdentityKey(thread.federation.ref)
       : buildThreadIdentityKey(thread.source, thread.id);
@@ -272,9 +278,17 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
   );
 }
 
-function describeThread(thread: NavigationThreadSummary): string {
+function describeThread(
+  thread: NavigationThreadSummary,
+  query: string,
+): string {
   const parts: string[] = [];
-  const pr = (thread.prs ?? [])[0];
+  const pr = threadHasExactPrNumberMatch(thread, query)
+    ? (thread.prs ?? []).find(
+        (candidate) =>
+          candidate.number === Number(query.trim().replace(/^#/, "")),
+      )
+    : (thread.prs ?? [])[0];
   if (pr) {
     parts.push(`#${pr.number}`);
   }

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildFederatedThreadRef,
   type NavigationThreadSummary,
+  type PrSummary,
 } from "@pwragent/shared";
 import { SidebarSearchPopup } from "../SidebarSearchPopup";
 
@@ -36,6 +37,17 @@ function localThread(
     linkedDirectories: [],
     ...partial,
   } as NavigationThreadSummary;
+}
+
+function pr(number: number, repo = "PwrAgent"): PrSummary {
+  return {
+    provider: "github.com",
+    org: "pwrdrvr",
+    repo,
+    number,
+    state: "pending",
+    url: `https://github.com/pwrdrvr/${repo}/pull/${number}`,
+  };
 }
 
 function remoteThread(params: {
@@ -148,6 +160,36 @@ describe("SidebarSearchPopup", () => {
     expect(screen.getByText("Other instances")).toBeInTheDocument();
     expect(screen.getByText("Remote fix")).toBeInTheDocument();
     expect(screen.getByLabelText("Runs on Laptop")).toBeInTheDocument();
+  });
+
+  it("prioritizes and describes the exact PR when a thread has several PRs", async () => {
+    const exact = localThread({
+      id: "exact",
+      title: "Stacked PRs",
+      prs: [pr(44, "PwrGit"), pr(49, "PwrGit")],
+    });
+    const substring = localThread({
+      id: "substring",
+      title: "Newer substring",
+      prs: [pr(349)],
+    });
+
+    render(
+      <SidebarSearchPopup
+        threads={[substring, exact]}
+        onJumpToThread={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Jump to thread" }), {
+      target: { value: "49" },
+    });
+
+    const rows = screen.getAllByRole("option");
+    expect(rows[0]).toHaveTextContent("Stacked PRs");
+    expect(rows[0]).toHaveTextContent("#49");
+    await settleRemoteSearch();
   });
 
   it("arrows from local into remote rows and Enter selects the remote thread", async () => {

--- a/packages/shared/src/__tests__/thread-jump-match.test.ts
+++ b/packages/shared/src/__tests__/thread-jump-match.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { NavigationThreadSummary, PrSummary } from "../index";
-import { threadMatchesQuery } from "../thread-jump-match";
+import {
+  threadHasExactPrNumberMatch,
+  threadMatchesQuery,
+} from "../thread-jump-match";
 
 function pr(number: number, title?: string): PrSummary {
   return {
@@ -40,6 +43,18 @@ describe("threadMatchesQuery", () => {
     expect(threadMatchesQuery(t, "779")).toBe(true);
     expect(threadMatchesQuery(t, "#779")).toBe(true);
     expect(threadMatchesQuery(t, "pwragent")).toBe(true);
+  });
+
+  it("matches every attached PR and identifies an exact PR query", () => {
+    const stacked = thread({
+      prs: [pr(44), pr(45), pr(46), pr(48), pr(49)],
+    });
+
+    expect(threadMatchesQuery(stacked, "49")).toBe(true);
+    expect(threadMatchesQuery(stacked, "#49")).toBe(true);
+    expect(threadHasExactPrNumberMatch(stacked, "49")).toBe(true);
+    expect(threadHasExactPrNumberMatch(stacked, "#49")).toBe(true);
+    expect(threadHasExactPrNumberMatch(stacked, "4")).toBe(false);
   });
 
   it("matches common thread id shapes", () => {

--- a/packages/shared/src/thread-jump-match.ts
+++ b/packages/shared/src/thread-jump-match.ts
@@ -8,6 +8,23 @@ export function threadPrNumbers(thread: NavigationThreadSummary): number[] {
   return (thread.prs ?? []).map((pr) => pr.number);
 }
 
+/** True when a bare numeric query exactly identifies any attached PR. */
+export function threadHasExactPrNumberMatch(
+  thread: NavigationThreadSummary,
+  query: string,
+): boolean {
+  const match = query.trim().match(/^#?(\d{1,7})$/);
+  if (!match) {
+    return false;
+  }
+  const number = Number(match[1]);
+  return (
+    Number.isInteger(number)
+    && number > 0
+    && threadPrNumbers(thread).includes(number)
+  );
+}
+
 function threadIdMatchesQuery(threadId: string, query: string): boolean {
   const id = threadId.toLowerCase();
   if (!id.includes(query)) {


### PR DESCRIPTION
## Summary

- match and explicitly test every pull request attached to a thread
- rank exact PR-number matches ahead of broader substring matches before the federated eight-result cap
- show the PR number that actually matched in the Cmd+K result row
- invalidate cached remote navigation summaries when relayed PR attachment updates arrive

## Root cause

Federated Cmd+K already inspected the full attached-PR array, so this was not limited to the primary PR. However, a query such as `49` also matched PRs such as `149` and `349`; remote results were then ordered only by recency and capped at eight, which could hide the exact PR. The row also always displayed the first attached PR, making a PR 49 match appear as `#44`. Finally, remote PR attachment updates did not invalidate the short-lived per-peer navigation cache.

Viewer-side mounting is local-only and does not make a PR searchable on other nodes.

## Impact

Exact PR lookups remain discoverable across gateway and leaf nodes, stacked threads display the matching PR in the jump result, and relayed PR updates become searchable immediately instead of waiting for cache expiry.

## Validation

- `pnpm test packages/shared/src/__tests__/thread-jump-match.test.ts apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts apps/desktop/src/main/__tests__/federation-runtime.test.ts apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx` (63 tests)
- `pnpm --filter @pwragent/shared typecheck`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
