### PR TITLE
fix(desktop): clear repaired turn failure toasts

### DIFF
--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts
@@ -91,6 +91,128 @@ describe("appNoticeReducer", () => {
     });
   });
 
+  it("retires same-incident failure notices when recovery starts", () => {
+    let state: AppNoticeState = {
+      durable: [
+        {
+          autoDismiss: false,
+          id: "turn-failed:codex:thread-a:turn-1",
+          message: "invalid message id",
+          title: "Turn failed",
+        },
+        {
+          autoDismiss: false,
+          id: "system-error:codex:thread-a",
+          message: "The active turn may have stopped.",
+          title: "Agent backend error",
+        },
+        {
+          autoDismiss: false,
+          id: "turn-failed:codex:thread-a:turn-older",
+          message: "unrelated earlier failure",
+          title: "Turn failed",
+        },
+        {
+          autoDismiss: false,
+          id: "turn-failed:codex:thread-b:turn-1",
+          message: "unrelated thread failure",
+          title: "Turn failed",
+        },
+      ],
+      transient: [],
+    };
+
+    state = appNoticeReducer(state, {
+      type: "backend-error",
+      signal: {
+        kind: "codex-invalid-id-recovery",
+        failureMessage: "invalid message id",
+        status: "repairing",
+        threadId: "thread-a",
+        threadLabel: "Repair PR",
+        turnId: "turn-1",
+      },
+    });
+
+    expect(state.durable.map((notice) => notice.id)).toEqual([
+      "turn-failed:codex:thread-a:turn-older",
+      "turn-failed:codex:thread-b:turn-1",
+      "codex-invalid-id-recovery:codex:thread-a:turn-1",
+    ]);
+  });
+
+  it("leaves only auto-dismissing success after repairing a failed turn", () => {
+    let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
+      type: "backend-error",
+      signal: {
+        kind: "turn-failed",
+        backend: "codex",
+        threadId: "thread-a",
+        turnId: "turn-1",
+        errorMessage: "invalid message id",
+        threadLabel: "Repair PR",
+      },
+    });
+    const recoverySignal = {
+      kind: "codex-invalid-id-recovery" as const,
+      failureMessage: "invalid message id",
+      threadId: "thread-a",
+      threadLabel: "Repair PR",
+      turnId: "turn-1",
+    };
+    state = appNoticeReducer(state, {
+      type: "backend-error",
+      signal: { ...recoverySignal, status: "repairing" },
+    });
+    state = appNoticeReducer(state, {
+      type: "backend-error",
+      signal: { ...recoverySignal, status: "succeeded" },
+    });
+
+    expect(state.durable).toEqual([]);
+    expect(state.transient).toEqual([
+      expect.objectContaining({
+        autoDismiss: true,
+        id: "codex-invalid-id-recovery:codex:thread-a:turn-1",
+        title: "Codex thread repaired",
+      }),
+    ]);
+  });
+
+  it("leaves one durable repair failure instead of the superseded turn failure", () => {
+    let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
+      type: "backend-error",
+      signal: {
+        kind: "turn-failed",
+        backend: "codex",
+        threadId: "thread-a",
+        turnId: "turn-1",
+        errorMessage: "invalid message id",
+        threadLabel: "Repair PR",
+      },
+    });
+    state = appNoticeReducer(state, {
+      type: "backend-error",
+      signal: {
+        kind: "codex-invalid-id-recovery",
+        failureMessage: "invalid message id",
+        recoveryError: "repair target did not match",
+        status: "failed",
+        threadId: "thread-a",
+        threadLabel: "Repair PR",
+        turnId: "turn-1",
+      },
+    });
+
+    expect(state.durable).toEqual([
+      expect.objectContaining({
+        autoDismiss: false,
+        id: "codex-invalid-id-recovery:codex:thread-a:turn-1",
+        title: "Codex repair failed",
+      }),
+    ]);
+  });
+
   it("replaces transient notices from the same producer slot", () => {
     let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
       type: "show",

--- a/apps/desktop/src/renderer/src/features/notifications/app-notice-state.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/app-notice-state.ts
@@ -31,7 +31,11 @@ export function appNoticeReducer(
   if (action.type === "backend-error") {
     const current = findRelatedBackendNotice(state, action.signal);
     const notice = resolveBackendErrorNotice(action.signal, current);
-    return notice ? showNotice(state, notice) : state;
+    if (!notice) return state;
+    const nextState = action.signal.kind === "codex-invalid-id-recovery"
+      ? dismissSupersededRecoveryNotices(state, action.signal)
+      : state;
+    return showNotice(nextState, notice);
   }
 
   if (action.type === "dismiss") {
@@ -49,6 +53,32 @@ export function appNoticeReducer(
   );
   const transient = state.transient.filter(
     (notice) => !notice.id.startsWith(action.prefix),
+  );
+  if (
+    durable.length === state.durable.length
+    && transient.length === state.transient.length
+  ) return state;
+  return { durable, transient };
+}
+
+function dismissSupersededRecoveryNotices(
+  state: AppNoticeState,
+  signal: Extract<
+    BackendErrorSignal,
+    { kind: "codex-invalid-id-recovery" }
+  >,
+): AppNoticeState {
+  // Recovery status becomes the live UI for this incident. The persisted
+  // turn-failure and recovery audit remain in the thread transcript.
+  const supersededIds = new Set([
+    `turn-failed:codex:${signal.threadId}:${signal.turnId}`,
+    `system-error:codex:${signal.threadId}`,
+  ]);
+  const durable = state.durable.filter(
+    (notice) => !supersededIds.has(notice.id),
+  );
+  const transient = state.transient.filter(
+    (notice) => !supersededIds.has(notice.id),
   );
   if (
     durable.length === state.durable.length


### PR DESCRIPTION
## What

- let Codex invalid-ID recovery supersede the same turn failure and thread system-error toasts
- keep repair progress/failure durable while making successful repair auto-dismiss
- preserve unrelated turn and thread failures in the durable queue

## Why

The persisted transcript correctly records the original turn failure and repair audit, but the renderer also left the original failure toast durable after recovery succeeded. That made a repaired incident continue to look active indefinitely.

## Impact

Local and federated viewers now converge on one live toast for the scoped recovery incident. Successful recovery leaves only the temporary success toast; failed recovery leaves one actionable durable failure. Transcript history is unchanged.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/notifications/__tests__` (37 tests)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`