### PR TITLE
fix(desktop): separate Windows Job readiness phases

### DIFF
--- a/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
+++ b/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
@@ -6,9 +6,12 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   formatWindowsJobStartupTelemetry,
+  formatWindowsJobStartupTimeout,
   readWindowsJobStartupTelemetry,
   startWindowsJobReadyPoll,
-  WINDOWS_JOB_READY_TIMEOUT_MS,
+  type WindowsJobStartupTimeout,
+  WINDOWS_JOB_OWNERSHIP_READY_TIMEOUT_MS,
+  WINDOWS_JOB_POWERSHELL_START_TIMEOUT_MS,
   wrapCommandInWindowsJob,
 } from "../windows-job-wrapper";
 import { resolveWindowsBashShell } from "../windows-shell";
@@ -58,9 +61,13 @@ async function runWrappedCommand(params: {
 }
 
 describe("wrapCommandInWindowsJob", () => {
-  it("keeps cold startup bounded inside the Windows test contract", () => {
-    expect(WINDOWS_JOB_READY_TIMEOUT_MS).toBe(20_000);
-    expect(WINDOWS_JOB_READY_TIMEOUT_MS).toBeLessThan(30_000);
+  it("bounds host launch and ownership separately inside the Windows test contract", () => {
+    expect(WINDOWS_JOB_POWERSHELL_START_TIMEOUT_MS).toBe(20_000);
+    expect(WINDOWS_JOB_OWNERSHIP_READY_TIMEOUT_MS).toBe(8_000);
+    expect(
+      WINDOWS_JOB_POWERSHELL_START_TIMEOUT_MS
+      + WINDOWS_JOB_OWNERSHIP_READY_TIMEOUT_MS,
+    ).toBeLessThan(30_000);
   });
 
   it("launches the shell through an atomic kill-on-close Job wrapper", () => {
@@ -120,6 +127,9 @@ describe("wrapCommandInWindowsJob", () => {
     expect(wrapped.env.PWRAGENT_JOB_WRAPPER_STARTUP_STATUS_FILE).toBe(
       wrapped.startupStatusFilePath,
     );
+    expect(wrapped.env.PWRAGENT_JOB_WRAPPER_STARTED_AT).toBe(
+      String(wrapped.startupStartedAt),
+    );
     expect(readWindowsJobStartupTelemetry(wrapped)).toEqual({
       phases: [{ detail: undefined, elapsedMs: 0, phase: "wrapper-created" }],
     });
@@ -130,7 +140,7 @@ describe("wrapCommandInWindowsJob", () => {
     wrapped.cleanup();
   });
 
-  it("waits through delayed helper phases and reports their timings", async () => {
+  it("gives ownership its own budget after a delayed PowerShell start", async () => {
     const wrapped = wrapCommandInWindowsJob({
       args: ["/c", "exit 0"],
       command: "C:\\Windows\\System32\\cmd.exe",
@@ -143,22 +153,24 @@ describe("wrapCommandInWindowsJob", () => {
         startWindowsJobReadyPoll({
           launch: wrapped,
           onReady: resolve,
-          onTimeout: () => reject(new Error("Delayed readiness timed out")),
-          timeoutMs: 500,
+          onTimeout: ({ stage }) =>
+            reject(new Error(`Delayed readiness timed out during ${stage}`)),
+          ownershipReadyTimeoutMs: 150,
+          powershellStartTimeoutMs: 200,
         });
         setTimeout(() => {
           appendFileSync(
             wrapped.startupStatusFilePath,
-            "25\tpowershell-started\t\n50\thelper-compile-started\t\n",
+            "150\tpowershell-started\t\n170\thelper-compile-started\t\n",
           );
-        }, 25);
+        }, 150);
         setTimeout(() => {
           appendFileSync(
             wrapped.startupStatusFilePath,
-            "75\thelper-ready\t\n100\ttarget-assigned\t\n125\tready\t\n",
+            "220\thelper-ready\t\n235\ttarget-assigned\t\n240\tready\t\n",
           );
           writeFileSync(wrapped.readyFilePath, "ready", "utf8");
-        }, 75);
+        }, 240);
       });
 
       expect(telemetry.phases.map(({ phase }) => phase)).toEqual([
@@ -170,14 +182,47 @@ describe("wrapCommandInWindowsJob", () => {
         "ready",
       ]);
       expect(formatWindowsJobStartupTelemetry(telemetry)).toBe(
-        "wrapper-created@0ms -> powershell-started@25ms -> helper-compile-started@50ms -> helper-ready@75ms -> target-assigned@100ms -> ready@125ms",
+        "wrapper-created@0ms -> powershell-started@150ms -> helper-compile-started@170ms -> helper-ready@220ms -> target-assigned@235ms -> ready@240ms",
       );
     } finally {
       wrapped.cleanup();
     }
   });
 
-  it("reports the last startup phase when readiness times out", async () => {
+  it("reports a PowerShell host-start timeout before wrapper code runs", async () => {
+    const wrapped = wrapCommandInWindowsJob({
+      args: ["/c", "exit 0"],
+      command: "C:\\Windows\\System32\\cmd.exe",
+      env: { SystemRoot: "C:\\Windows" },
+    });
+    try {
+      const startupTimeout = await new Promise<WindowsJobStartupTimeout>(
+        (resolve, reject) => {
+          startWindowsJobReadyPoll({
+            launch: wrapped,
+            onReady: () => reject(new Error("Unexpected readiness")),
+            onTimeout: resolve,
+            ownershipReadyTimeoutMs: 100,
+            powershellStartTimeoutMs: 40,
+          });
+        },
+      );
+      expect(startupTimeout).toMatchObject({
+        stage: "powershell-start",
+        timeoutMs: 40,
+        telemetry: {
+          phases: [{ elapsedMs: 0, phase: "wrapper-created" }],
+        },
+      });
+      expect(formatWindowsJobStartupTimeout(startupTimeout)).toBe(
+        "Windows Job PowerShell host did not begin executing within 40ms: wrapper-created@0ms",
+      );
+    } finally {
+      wrapped.cleanup();
+    }
+  });
+
+  it("reports the last startup phase when ownership readiness times out", async () => {
     const wrapped = wrapCommandInWindowsJob({
       args: ["/c", "exit 0"],
       command: "C:\\Windows\\System32\\cmd.exe",
@@ -188,20 +233,28 @@ describe("wrapCommandInWindowsJob", () => {
         wrapped.startupStatusFilePath,
         "12\tpowershell-started\t\n18\thelper-compile-started\t\n",
       );
-      const telemetry = await new Promise<
-        ReturnType<typeof readWindowsJobStartupTelemetry>
-      >((resolve, reject) => {
-        startWindowsJobReadyPoll({
-          launch: wrapped,
-          onReady: () => reject(new Error("Unexpected readiness")),
-          onTimeout: resolve,
-          timeoutMs: 40,
-        });
+      const startupTimeout = await new Promise<WindowsJobStartupTimeout>(
+        (resolve, reject) => {
+          startWindowsJobReadyPoll({
+            launch: wrapped,
+            onReady: () => reject(new Error("Unexpected readiness")),
+            onTimeout: resolve,
+            ownershipReadyTimeoutMs: 40,
+            powershellStartTimeoutMs: 100,
+          });
+        },
+      );
+      expect(startupTimeout).toMatchObject({
+        stage: "ownership-ready",
+        timeoutMs: 40,
       });
-      expect(telemetry.phases.at(-1)).toMatchObject({
+      expect(startupTimeout.telemetry.phases.at(-1)).toMatchObject({
         elapsedMs: 18,
         phase: "helper-compile-started",
       });
+      expect(formatWindowsJobStartupTimeout(startupTimeout)).toBe(
+        "Windows Job shell ownership did not become ready within 40ms after PowerShell started: wrapper-created@0ms -> powershell-started@12ms -> helper-compile-started@18ms",
+      );
     } finally {
       wrapped.cleanup();
     }

--- a/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
+++ b/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
@@ -10,8 +10,9 @@ import {
   readWindowsJobStartupTelemetry,
   startWindowsJobReadyPoll,
   type WindowsJobStartupTimeout,
-  WINDOWS_JOB_OWNERSHIP_READY_TIMEOUT_MS,
+  WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS,
   WINDOWS_JOB_POWERSHELL_START_TIMEOUT_MS,
+  WINDOWS_JOB_STARTUP_PROGRESS_TIMEOUT_MS,
   wrapCommandInWindowsJob,
 } from "../windows-job-wrapper";
 import { resolveWindowsBashShell } from "../windows-shell";
@@ -61,13 +62,11 @@ async function runWrappedCommand(params: {
 }
 
 describe("wrapCommandInWindowsJob", () => {
-  it("bounds host launch and ownership separately inside the Windows test contract", () => {
+  it("bounds host launch, phase progress, and overall readiness", () => {
     expect(WINDOWS_JOB_POWERSHELL_START_TIMEOUT_MS).toBe(20_000);
-    expect(WINDOWS_JOB_OWNERSHIP_READY_TIMEOUT_MS).toBe(8_000);
-    expect(
-      WINDOWS_JOB_POWERSHELL_START_TIMEOUT_MS
-      + WINDOWS_JOB_OWNERSHIP_READY_TIMEOUT_MS,
-    ).toBeLessThan(30_000);
+    expect(WINDOWS_JOB_STARTUP_PROGRESS_TIMEOUT_MS).toBe(10_000);
+    expect(WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS).toBe(28_000);
+    expect(WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS).toBeLessThan(30_000);
   });
 
   it("launches the shell through an atomic kill-on-close Job wrapper", () => {
@@ -140,7 +139,7 @@ describe("wrapCommandInWindowsJob", () => {
     wrapped.cleanup();
   });
 
-  it("gives ownership its own budget after a delayed PowerShell start", async () => {
+  it("honors journaled progress inside the overall readiness bound", async () => {
     const wrapped = wrapCommandInWindowsJob({
       args: ["/c", "exit 0"],
       command: "C:\\Windows\\System32\\cmd.exe",
@@ -155,8 +154,9 @@ describe("wrapCommandInWindowsJob", () => {
           onReady: resolve,
           onTimeout: ({ stage }) =>
             reject(new Error(`Delayed readiness timed out during ${stage}`)),
-          ownershipReadyTimeoutMs: 150,
+          overallReadyTimeoutMs: 350,
           powershellStartTimeoutMs: 200,
+          progressTimeoutMs: 100,
         });
         setTimeout(() => {
           appendFileSync(
@@ -167,10 +167,19 @@ describe("wrapCommandInWindowsJob", () => {
         setTimeout(() => {
           appendFileSync(
             wrapped.startupStatusFilePath,
-            "220\thelper-ready\t\n235\ttarget-assigned\t\n240\tready\t\n",
+            "240\thelper-ready\t\n",
           );
-          writeFileSync(wrapped.readyFilePath, "ready", "utf8");
         }, 240);
+        setTimeout(() => {
+          appendFileSync(
+            wrapped.startupStatusFilePath,
+            "300\ttarget-assigned\t\n",
+          );
+        }, 300);
+        setTimeout(() => {
+          appendFileSync(wrapped.startupStatusFilePath, "320\tready\t\n");
+          writeFileSync(wrapped.readyFilePath, "ready", "utf8");
+        }, 320);
       });
 
       expect(telemetry.phases.map(({ phase }) => phase)).toEqual([
@@ -182,7 +191,7 @@ describe("wrapCommandInWindowsJob", () => {
         "ready",
       ]);
       expect(formatWindowsJobStartupTelemetry(telemetry)).toBe(
-        "wrapper-created@0ms -> powershell-started@150ms -> helper-compile-started@170ms -> helper-ready@220ms -> target-assigned@235ms -> ready@240ms",
+        "wrapper-created@0ms -> powershell-started@150ms -> helper-compile-started@170ms -> helper-ready@240ms -> target-assigned@300ms -> ready@320ms",
       );
     } finally {
       wrapped.cleanup();
@@ -202,8 +211,9 @@ describe("wrapCommandInWindowsJob", () => {
             launch: wrapped,
             onReady: () => reject(new Error("Unexpected readiness")),
             onTimeout: resolve,
-            ownershipReadyTimeoutMs: 100,
+            overallReadyTimeoutMs: 100,
             powershellStartTimeoutMs: 40,
+            progressTimeoutMs: 100,
           });
         },
       );
@@ -222,7 +232,7 @@ describe("wrapCommandInWindowsJob", () => {
     }
   });
 
-  it("reports the last startup phase when ownership readiness times out", async () => {
+  it("reports the last startup phase when progress stalls", async () => {
     const wrapped = wrapCommandInWindowsJob({
       args: ["/c", "exit 0"],
       command: "C:\\Windows\\System32\\cmd.exe",
@@ -239,13 +249,14 @@ describe("wrapCommandInWindowsJob", () => {
             launch: wrapped,
             onReady: () => reject(new Error("Unexpected readiness")),
             onTimeout: resolve,
-            ownershipReadyTimeoutMs: 40,
+            overallReadyTimeoutMs: 200,
             powershellStartTimeoutMs: 100,
+            progressTimeoutMs: 40,
           });
         },
       );
       expect(startupTimeout).toMatchObject({
-        stage: "ownership-ready",
+        stage: "progress-stall",
         timeoutMs: 40,
       });
       expect(startupTimeout.telemetry.phases.at(-1)).toMatchObject({
@@ -253,7 +264,42 @@ describe("wrapCommandInWindowsJob", () => {
         phase: "helper-compile-started",
       });
       expect(formatWindowsJobStartupTimeout(startupTimeout)).toBe(
-        "Windows Job shell ownership did not become ready within 40ms after PowerShell started: wrapper-created@0ms -> powershell-started@12ms -> helper-compile-started@18ms",
+        "Windows Job startup made no progress for 40ms after helper-compile-started@18ms: wrapper-created@0ms -> powershell-started@12ms -> helper-compile-started@18ms",
+      );
+    } finally {
+      wrapped.cleanup();
+    }
+  });
+
+  it("keeps progress extensions inside the overall readiness bound", async () => {
+    const wrapped = wrapCommandInWindowsJob({
+      args: ["/c", "exit 0"],
+      command: "C:\\Windows\\System32\\cmd.exe",
+      env: { SystemRoot: "C:\\Windows" },
+    });
+    try {
+      appendFileSync(
+        wrapped.startupStatusFilePath,
+        "12\tpowershell-started\t\n18\thelper-compile-started\t\n25\thelper-ready\t\n",
+      );
+      const startupTimeout = await new Promise<WindowsJobStartupTimeout>(
+        (resolve, reject) => {
+          startWindowsJobReadyPoll({
+            launch: wrapped,
+            onReady: () => reject(new Error("Unexpected readiness")),
+            onTimeout: resolve,
+            overallReadyTimeoutMs: 40,
+            powershellStartTimeoutMs: 100,
+            progressTimeoutMs: 100,
+          });
+        },
+      );
+      expect(startupTimeout).toMatchObject({
+        stage: "overall-ready",
+        timeoutMs: 40,
+      });
+      expect(formatWindowsJobStartupTimeout(startupTimeout)).toBe(
+        "Windows Job shell ownership did not become ready within 40ms overall: wrapper-created@0ms -> powershell-started@12ms -> helper-compile-started@18ms -> helper-ready@25ms",
       );
     } finally {
       wrapped.cleanup();

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -25,9 +25,9 @@ import { getMainLogger } from "../log";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import {
   formatWindowsJobStartupTelemetry,
+  formatWindowsJobStartupTimeout,
   readWindowsJobStartupTelemetry,
   startWindowsJobReadyPoll,
-  WINDOWS_JOB_READY_TIMEOUT_MS,
   wrapCommandInWindowsJob,
 } from "../windows-job-wrapper";
 import {
@@ -985,14 +985,14 @@ function runShellCommand(
             }
             resolveStarted();
           },
-          onTimeout: (startupTelemetry) => {
+          onTimeout: (startupTimeout) => {
             windowsJobReadyPoll = undefined;
             if (settled || closed) return;
             terminateChild("SIGKILL");
             settle(() => {
               reject(
                 new CodexEnvironmentCommandError(
-                  `Windows Job shell did not become ready within ${WINDOWS_JOB_READY_TIMEOUT_MS}ms: ${formatWindowsJobStartupTelemetry(startupTelemetry)}`,
+                  formatWindowsJobStartupTimeout(startupTimeout),
                 ),
               );
             });

--- a/apps/desktop/src/main/windows-job-wrapper.ts
+++ b/apps/desktop/src/main/windows-job-wrapper.ts
@@ -476,20 +476,21 @@ export type WindowsJobReadyPoll = {
 };
 
 export type WindowsJobStartupTimeout = {
-  stage: "powershell-start" | "ownership-ready";
+  stage: "overall-ready" | "powershell-start" | "progress-stall";
   telemetry: WindowsJobStartupTelemetry;
   timeoutMs: number;
 };
 
-// The PowerShell host and Job ownership are separate readiness contracts.
-// Hosted Windows CI has taken 16.7 seconds before the wrapper's first
-// PowerShell statement executed, while repeated native Job assignment stayed
-// well below one second once that statement ran. Keep host launch bounded at
-// the existing 20 seconds, then reserve a distinct ownership budget. Their
-// 28-second maximum remains inside the existing 30-second Windows test
-// contract without making a slow host consume the ownership budget.
+// Keep cold PowerShell launch, forward progress, and overall readiness as
+// separate contracts. Hosted Windows CI has taken 16.7 seconds to enter the
+// wrapper and 7.1 seconds to compile its helper, but each journaled phase still
+// proved forward progress. A phase-relative stall watchdog keeps real hangs
+// bounded without letting one slow phase consume the next phase's allowance.
+// The 28-second overall maximum remains inside the existing 30-second Windows
+// test contract and does not weaken atomic Job ownership.
 export const WINDOWS_JOB_POWERSHELL_START_TIMEOUT_MS = 20_000;
-export const WINDOWS_JOB_OWNERSHIP_READY_TIMEOUT_MS = 8_000;
+export const WINDOWS_JOB_STARTUP_PROGRESS_TIMEOUT_MS = 10_000;
+export const WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS = 28_000;
 const WINDOWS_JOB_READY_POLL_INTERVAL_MS = 25;
 
 export function readWindowsJobStartupTelemetry(
@@ -538,10 +539,21 @@ export function formatWindowsJobStartupTelemetry(
 export function formatWindowsJobStartupTimeout(
   timeout: WindowsJobStartupTimeout,
 ): string {
-  const timeoutDescription =
-    timeout.stage === "powershell-start"
-      ? `PowerShell host did not begin executing within ${timeout.timeoutMs}ms`
-      : `shell ownership did not become ready within ${timeout.timeoutMs}ms after PowerShell started`;
+  let timeoutDescription: string;
+  if (timeout.stage === "powershell-start") {
+    timeoutDescription =
+      `PowerShell host did not begin executing within ${timeout.timeoutMs}ms`;
+  } else if (timeout.stage === "progress-stall") {
+    const lastPhase = timeout.telemetry.phases.at(-1);
+    timeoutDescription =
+      `startup made no progress for ${timeout.timeoutMs}ms`
+      + (lastPhase
+        ? ` after ${lastPhase.phase}@${lastPhase.elapsedMs}ms`
+        : " after the last recorded phase");
+  } else {
+    timeoutDescription =
+      `shell ownership did not become ready within ${timeout.timeoutMs}ms overall`;
+  }
   return `Windows Job ${timeoutDescription}: ${formatWindowsJobStartupTelemetry(timeout.telemetry)}`;
 }
 
@@ -552,15 +564,21 @@ export function startWindowsJobReadyPoll(params: {
   >;
   onReady: (telemetry: WindowsJobStartupTelemetry) => void;
   onTimeout: (timeout: WindowsJobStartupTimeout) => void;
-  ownershipReadyTimeoutMs?: number;
+  overallReadyTimeoutMs?: number;
   powershellStartTimeoutMs?: number;
+  progressTimeoutMs?: number;
 }): WindowsJobReadyPoll {
-  const ownershipReadyTimeoutMs =
-    params.ownershipReadyTimeoutMs
-    ?? WINDOWS_JOB_OWNERSHIP_READY_TIMEOUT_MS;
+  const overallReadyTimeoutMs =
+    params.overallReadyTimeoutMs
+    ?? WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS;
   const powershellStartTimeoutMs =
     params.powershellStartTimeoutMs
     ?? WINDOWS_JOB_POWERSHELL_START_TIMEOUT_MS;
+  const progressTimeoutMs =
+    params.progressTimeoutMs
+    ?? WINDOWS_JOB_STARTUP_PROGRESS_TIMEOUT_MS;
+  const overallReadyDeadline =
+    params.launch.startupStartedAt + overallReadyTimeoutMs;
   const powershellStartDeadline =
     params.launch.startupStartedAt + powershellStartTimeoutMs;
   let cancelled = false;
@@ -604,16 +622,26 @@ export function startWindowsJobReadyPoll(params: {
         });
         return;
       }
-      const ownershipReadyDeadline =
+      const lastPhase = telemetry.phases.at(-1) ?? powershellStarted;
+      const progressDeadline =
         params.launch.startupStartedAt
-        + powershellStarted.elapsedMs
-        + ownershipReadyTimeoutMs;
-      if (now >= ownershipReadyDeadline) {
+        + lastPhase.elapsedMs
+        + progressTimeoutMs;
+      if (now >= overallReadyDeadline) {
         cancelled = true;
         params.onTimeout({
-          stage: "ownership-ready",
+          stage: "overall-ready",
           telemetry,
-          timeoutMs: ownershipReadyTimeoutMs,
+          timeoutMs: overallReadyTimeoutMs,
+        });
+        return;
+      }
+      if (now >= progressDeadline) {
+        cancelled = true;
+        params.onTimeout({
+          stage: "progress-stall",
+          telemetry,
+          timeoutMs: progressTimeoutMs,
         });
         return;
       }

--- a/apps/desktop/src/main/windows-job-wrapper.ts
+++ b/apps/desktop/src/main/windows-job-wrapper.ts
@@ -457,6 +457,7 @@ export type WindowsJobWrappedCommand = {
   command: string;
   env: NodeJS.ProcessEnv;
   readyFilePath: string;
+  startupStartedAt: number;
   startupStatusFilePath: string;
 };
 
@@ -474,11 +475,21 @@ export type WindowsJobReadyPoll = {
   cancel: () => void;
 };
 
-// Public Windows CI placed cold startup on both sides of the former 10-second
-// edge while warm launches completed much sooner. Doubling that observed edge
-// gives helper compilation bounded headroom without approaching the existing
-// 30-second Windows test contract or weakening atomic Job ownership.
-export const WINDOWS_JOB_READY_TIMEOUT_MS = 20_000;
+export type WindowsJobStartupTimeout = {
+  stage: "powershell-start" | "ownership-ready";
+  telemetry: WindowsJobStartupTelemetry;
+  timeoutMs: number;
+};
+
+// The PowerShell host and Job ownership are separate readiness contracts.
+// Hosted Windows CI has taken 16.7 seconds before the wrapper's first
+// PowerShell statement executed, while repeated native Job assignment stayed
+// well below one second once that statement ran. Keep host launch bounded at
+// the existing 20 seconds, then reserve a distinct ownership budget. Their
+// 28-second maximum remains inside the existing 30-second Windows test
+// contract without making a slow host consume the ownership budget.
+export const WINDOWS_JOB_POWERSHELL_START_TIMEOUT_MS = 20_000;
+export const WINDOWS_JOB_OWNERSHIP_READY_TIMEOUT_MS = 8_000;
 const WINDOWS_JOB_READY_POLL_INTERVAL_MS = 25;
 
 export function readWindowsJobStartupTelemetry(
@@ -524,17 +535,34 @@ export function formatWindowsJobStartupTelemetry(
     .join(" -> ");
 }
 
+export function formatWindowsJobStartupTimeout(
+  timeout: WindowsJobStartupTimeout,
+): string {
+  const timeoutDescription =
+    timeout.stage === "powershell-start"
+      ? `PowerShell host did not begin executing within ${timeout.timeoutMs}ms`
+      : `shell ownership did not become ready within ${timeout.timeoutMs}ms after PowerShell started`;
+  return `Windows Job ${timeoutDescription}: ${formatWindowsJobStartupTelemetry(timeout.telemetry)}`;
+}
+
 export function startWindowsJobReadyPoll(params: {
   launch: Pick<
     WindowsJobWrappedCommand,
-    "readyFilePath" | "startupStatusFilePath"
+    "readyFilePath" | "startupStartedAt" | "startupStatusFilePath"
   >;
   onReady: (telemetry: WindowsJobStartupTelemetry) => void;
-  onTimeout: (telemetry: WindowsJobStartupTelemetry) => void;
-  timeoutMs?: number;
+  onTimeout: (timeout: WindowsJobStartupTimeout) => void;
+  ownershipReadyTimeoutMs?: number;
+  powershellStartTimeoutMs?: number;
 }): WindowsJobReadyPoll {
-  const timeoutMs = params.timeoutMs ?? WINDOWS_JOB_READY_TIMEOUT_MS;
-  const deadline = Date.now() + timeoutMs;
+  const ownershipReadyTimeoutMs =
+    params.ownershipReadyTimeoutMs
+    ?? WINDOWS_JOB_OWNERSHIP_READY_TIMEOUT_MS;
+  const powershellStartTimeoutMs =
+    params.powershellStartTimeoutMs
+    ?? WINDOWS_JOB_POWERSHELL_START_TIMEOUT_MS;
+  const powershellStartDeadline =
+    params.launch.startupStartedAt + powershellStartTimeoutMs;
   let cancelled = false;
   let timer: NodeJS.Timeout | undefined;
   const cancel = () => {
@@ -547,15 +575,48 @@ export function startWindowsJobReadyPoll(params: {
   const poll = () => {
     timer = undefined;
     if (cancelled) return;
+    const telemetry = readWindowsJobStartupTelemetry(params.launch);
     if (existsSync(params.launch.readyFilePath)) {
       cancelled = true;
-      params.onReady(readWindowsJobStartupTelemetry(params.launch));
+      params.onReady(telemetry);
       return;
     }
-    if (Date.now() >= deadline) {
+    const powershellStarted = telemetry.phases.find(
+      ({ phase }) => phase === "powershell-started",
+    );
+    const now = Date.now();
+    if (!powershellStarted && now >= powershellStartDeadline) {
       cancelled = true;
-      params.onTimeout(readWindowsJobStartupTelemetry(params.launch));
+      params.onTimeout({
+        stage: "powershell-start",
+        telemetry,
+        timeoutMs: powershellStartTimeoutMs,
+      });
       return;
+    }
+    if (powershellStarted) {
+      if (powershellStarted.elapsedMs > powershellStartTimeoutMs) {
+        cancelled = true;
+        params.onTimeout({
+          stage: "powershell-start",
+          telemetry,
+          timeoutMs: powershellStartTimeoutMs,
+        });
+        return;
+      }
+      const ownershipReadyDeadline =
+        params.launch.startupStartedAt
+        + powershellStarted.elapsedMs
+        + ownershipReadyTimeoutMs;
+      if (now >= ownershipReadyDeadline) {
+        cancelled = true;
+        params.onTimeout({
+          stage: "ownership-ready",
+          telemetry,
+          timeoutMs: ownershipReadyTimeoutMs,
+        });
+        return;
+      }
     }
     timer = setTimeout(poll, WINDOWS_JOB_READY_POLL_INTERVAL_MS);
   };
@@ -640,6 +701,7 @@ export function wrapCommandInWindowsJob(params: {
       [STARTUP_STATUS_FILE_ENV]: startupStatusFilePath,
     },
     readyFilePath,
+    startupStartedAt,
     startupStatusFilePath,
   };
 }


### PR DESCRIPTION
## Summary

- keep a dedicated 20-second bound for the Windows PowerShell host to begin executing
- use the existing startup phase journal as a 10-second no-progress watchdog once PowerShell starts
- keep a separate 28-second overall bound for Job ownership readiness
- preserve the suspended target → Job assignment → resume sequence and ready marker
- distinguish host-start, progress-stall, and overall-readiness failures, including the full phase journal in every error
- add synthetic regression coverage for slow-but-progressing startup and all three timeout boundaries

## Root cause

[PR #1292's Windows job](https://github.com/pwrdrvr/PwrAgent/actions/runs/31133932062/job/92729001349?pr=1292) first exposed the conflated absolute deadline:

```
wrapper-created@0ms -> powershell-started@16761ms -> helper-compile-started@16869ms
```

The old 20-second absolute deadline began before `powershell.exe` launched, so external host-launch latency consumed 16.7 seconds and left only about 3.1 seconds for helper compilation and atomic Job ownership.

The first PR revision separated host launch from one 8-second post-PowerShell ownership clock. [Its hosted Windows check](https://github.com/pwrdrvr/PwrAgent/actions/runs/31141322625/job/92751664861) supplied the missing phase evidence:

```
wrapper-created@0ms
-> powershell-started@11910ms
-> helper-compile-started@12330ms
-> helper-ready@19423ms
-> native-job-started@19730ms
-> job-configured@19732ms
```

Helper compilation took 7.093 seconds and native Job setup was still making forward progress when the post-PowerShell clock expired at about 19.91 seconds. The failure was not a stuck owner; the timeout was still anchored to the wrong boundary.

The broader evidence agrees:

- 19 successful hosted-runner samples put the first real Job-wrapped action at 4.4–14.1 seconds, while immediately subsequent wrappers took 0.7–2.1 seconds.
- 40 repeated focused Windows launches put PowerShell start at 267–533ms and PowerShell-started → ready at 281–648ms.
- 120 full-workspace Windows launches put PowerShell start at 395–691ms and PowerShell-started → ready at 421–1011ms.
- No repeated Windows run left a process behind.

## Bounded contract

The watchdog now uses the phase journal directly:

1. PowerShell must begin executing within 20 seconds.
2. After that, no journaled startup phase may go 10 seconds without forward progress.
3. The target must still reach `ready` within 28 seconds overall.

The overall maximum remains unchanged from the first revision and stays inside the existing 30-second Windows Vitest contract. This does not add retries, reduce workers, serialize tests, or weaken the ready marker: the target still starts suspended and becomes ready only after assignment and resume.

## Validation

Passed:

- focused wrapper Vitest: 1 file, 6 passed, 2 Windows-only skipped
- ESLint: 0 errors
- desktop and workspace typecheck
- dependency boundaries
- Codex storage boundary
- production build, including main-bundle boundary validation
- `git diff --check` and clean committed checkout
- focused Windows stress: 10/10 Playwright iterations; all Vitest exits 0; 40/40 wrapper launches ready; no process residue
- full-workspace Windows startup/process evidence: 120/120 wrapper launches ready; no readiness timeout; no process residue in any of 10 iterations

The earlier 10× full-workspace stress run finished 7 iterations green and found three unrelated assertion flakes in existing messaging/renderer tests:

- two dismiss-intent expectations in `messaging-controller.test.ts`
- one KaTeX render expectation in `thread-markdown.test.tsx`

Those failures had no Windows Job timeout and no process residue; they are intentionally reported here rather than masked by retries.
