### PR TITLE
test(desktop): gate the Star Map on the a11y audit

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -275,9 +275,32 @@ existing replay-fixture harness and runs `@axe-core/playwright`'s
 Things to know when extending the audit:
 
 - **Surface coverage.** Each `test(...)` block drives the renderer to a
-  state (open thread, settings overlay, settings → messaging) and then
-  calls `runAxe(window)`. Add a new block per surface you want gated;
-  reuse `launchElectronApp` with whatever fixture seeds that state.
+  state (open thread, settings overlay, settings → messaging, the Star
+  Map layer, the Star Map intake dialog) and then calls `runAxe(window)`.
+  Add a new block per surface you want gated; go through
+  `launchAuditApp()`, which emulates reduced motion and takes an optional
+  `fixturePath` / `theme`.
+- **Seed the fixture so the surface is actually populated.** The smoke
+  fixture's thread reaches no Star Map lane — `deriveInboxState` keeps a
+  first-snapshot thread out of the inbox, and an idle thread with no PR
+  and no unpushed commits matches no attention category — so auditing the
+  map on it would scan chrome and no cards. `e2e/fixtures/star-map/` is a
+  hand-written fixture (same class as `readme-recents-hero/`) whose
+  threads are `threadStatus: "active"` for exactly that reason. Check
+  what your surface renders before trusting a green run.
+- **`runAxe(window, { include })` narrows the scan to one subtree.** Use
+  it only when the block is about a specific composited surface — the
+  celestial-watermark blocks scope to `.thread-view__primary`, the
+  element the watermark is a child of, so the light-theme run measures
+  the watermark rather than unrelated window-wide light-theme debt.
+  Everything else stays unscoped, because an unscoped run is what catches
+  regressions nobody thought to point at.
+- **Reduced motion has to reach the element that animates.** The gate
+  emulates `prefers-reduced-motion: reduce` so it measures contrast at
+  rest; a rule that zeroes the animation on the wrong selector leaves
+  text mid-fade and axe reports a real-looking contrast miss. That is how
+  the Star Map card rise was caught: the animation lives on
+  `.star-map-card-shell`, the reduced-motion rule named `.star-map-card`.
 - **`setLegacyMode(true)` is required under Electron.** The default
   `AxeBuilder.analyze()` opens a worker page via
   `browserContext.newPage()` to scan cross-origin iframes; Electron's

--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -16,6 +16,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import AxeBuilder from "@axe-core/playwright";
+import type { DesktopAppearanceTheme } from "@pwragent/shared";
 import { expect, test, type Page } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 
@@ -36,13 +37,48 @@ const specDir = path.dirname(fileURLToPath(import.meta.url));
 // state, so the gate measures real, persistent contrast instead of a
 // sub-second animation frame. No renderer JS branches on reduced motion,
 // so this only settles CSS animation — it never changes what renders.
-async function launchAuditApp() {
+async function launchAuditApp(options?: {
+  /** Defaults to the smoke fixture; pass another to seed a richer state. */
+  fixturePath?: string;
+  /** Defaults to the harness default (dark). */
+  theme?: DesktopAppearanceTheme;
+}) {
   const app = await launchElectronApp({
-    fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
+    fixturePath:
+      options?.fixturePath
+      ?? path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
+    ...(options?.theme ? { appearance: { theme: options.theme } } : {}),
   });
   await app.window.emulateMedia({ reducedMotion: "reduce" });
   return app;
 }
+
+// The smoke thread never reaches the Star Map: `deriveInboxState` keeps a
+// first-snapshot thread out of the inbox, and with no PR, no unpushed
+// commits and an idle status it matches none of the attention categories,
+// so the smoke fixture's map is bodies-and-chrome with zero cards. The
+// cards are exactly what carries the contrast risk (title and status
+// indicator over the star field, meta chips, the low-opacity instance
+// watermark behind them), so the map audits run against a fixture whose
+// threads are `threadStatus: "active"` and therefore populate a lane.
+//
+// That fixture's threads deliberately carry NO linked directories. A
+// project chip renders through `CopyableThreadChip`, which is a
+// `role="button" tabIndex={0}` span, and both the sidebar thread row and
+// the star-map card wrap their content in a real `<button>` — so any
+// fixture with a directory trips `nested-interactive` on BOTH surfaces.
+// That is pre-existing renderer debt, not a Star Map regression, and the
+// fix is a structural change to the row/card (hoist the chips out of the
+// button, the way `.star-map-card-shell` already hoists the kebab).
+// Waiving it here is not an option worth taking: `KNOWN_VIOLATIONS`
+// works by `exclude()`, so waiving the rule would drop the whole card
+// from the scan and blind the very contrast pairs this block exists to
+// audit. Tracked separately; when it lands, give these threads a
+// directory so the project chip is covered too.
+const STAR_MAP_FIXTURE = path.resolve(
+  specDir,
+  "fixtures/star-map/replay.fixture.json",
+);
 
 const WCAG_AA_TAGS = [
   "wcag2a",
@@ -64,7 +100,18 @@ const KNOWN_VIOLATIONS: ReadonlyArray<{
   reason: string;
 }> = [];
 
-async function runAxe(window: Page): Promise<void> {
+async function runAxe(
+  window: Page,
+  options?: {
+    /**
+     * Narrow the scan to one subtree. Use it only when the test is about
+     * a specific composited surface rather than the whole window — an
+     * unscoped run is the default because it is what catches regressions
+     * nobody thought to point at.
+     */
+    include?: string;
+  },
+): Promise<void> {
   // setLegacyMode is required under Electron: the default analyze()
   // path tries to spawn a worker page via browserContext.newPage() to
   // audit cross-origin iframes, which Electron's CDP target doesn't
@@ -76,6 +123,9 @@ async function runAxe(window: Page): Promise<void> {
   let builder = new AxeBuilder({ page: window })
     .withTags(WCAG_AA_TAGS)
     .setLegacyMode(true);
+  if (options?.include) {
+    builder = builder.include(options.include);
+  }
   for (const known of KNOWN_VIOLATIONS) {
     // exclude() removes the node from the scan entirely. Combined with
     // the .rule mapping in KNOWN_VIOLATIONS above, this gives an
@@ -196,4 +246,114 @@ test.describe("desktop renderer accessibility (WCAG2 AA)", () => {
       await app.close();
     }
   });
+
+  test("star map layer has no violations", async () => {
+    const app = await launchAuditApp({ fixturePath: STAR_MAP_FIXTURE });
+    try {
+      await expect(
+        app.window
+          .getByRole("button", { name: /Star map attention thread/i })
+          .first(),
+      ).toBeVisible();
+      await app.window.getByRole("button", { name: "Open Star Map" }).click();
+      // `exact` because role-name matching is substring by default, and a
+      // chat card's "Chat: <title>" region can match "Star Map" too.
+      const starMap = app.window.getByRole("region", {
+        name: "Star Map",
+        exact: true,
+      });
+      await expect(starMap).toBeVisible();
+      // A single E2E instance means one body on the map. Gate on a card
+      // rather than the body: the lane populates from the navigation
+      // snapshot after the layer mounts, and auditing the empty layer
+      // would silently skip every card-borne contrast pair.
+      await expect(
+        starMap.getByRole("button", {
+          name: "Open thread: Star map attention thread",
+        }),
+      ).toBeVisible();
+      await runAxe(app.window);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test("star map intake dialog has no violations", async () => {
+    const app = await launchAuditApp({ fixturePath: STAR_MAP_FIXTURE });
+    try {
+      await expect(
+        app.window
+          .getByRole("button", { name: /Star map attention thread/i })
+          .first(),
+      ).toBeVisible();
+      await app.window.getByRole("button", { name: "Open Star Map" }).click();
+      // `exact` because role-name matching is substring by default, and a
+      // chat card's "Chat: <title>" region can match "Star Map" too.
+      const starMap = app.window.getByRole("region", {
+        name: "Star Map",
+        exact: true,
+      });
+      await expect(starMap).toBeVisible();
+      // The [+] beside the local body carries the machine label, which is
+      // the runner's hostname — match the copy, not the machine.
+      await starMap.getByRole("button", { name: /^New thread on / }).click();
+      const intake = app.window.getByRole("dialog", {
+        name: /^New thread on /,
+      });
+      await expect(intake).toBeVisible();
+      await expect(
+        intake.getByRole("button", { name: "Start thread" }),
+      ).toBeVisible();
+      await runAxe(app.window);
+    } finally {
+      await app.close();
+    }
+  });
+
+  // The celestial watermark paints the owning instance's mark behind the
+  // transcript at 0.05 opacity. That is a real compositing input to every
+  // contrast pair in the thread body, and the token it tints with
+  // (`--text-muted`) resolves differently per theme — a value that is
+  // harmless behind a dark surface can eat the margin on a light one. So
+  // this pair of blocks audits the same surface twice, once per theme,
+  // and asserts the watermark is actually painted first: without that the
+  // audit would keep passing after a regression that stopped rendering it.
+  //
+  // Scoped to `.thread-view__primary` — the element the watermark is a
+  // child of, and therefore the exact subtree it composites into. The
+  // scope is what makes the LIGHT run meaningful rather than a proxy for
+  // unrelated debt: light theme is not AA-clean window-wide today (the
+  // sidebar wordmark accent lands at 4.2:1, the active lens-switch label
+  // at 3.17:1, and the context-grid `dt` labels at 4.23:1), none of which
+  // the watermark touches. Every other block in this file stays unscoped;
+  // the dark thread surface is already audited whole by "open thread view
+  // has no violations" above.
+  for (const theme of ["dark", "light"] as const) {
+    test(`thread transcript behind the celestial watermark has no violations (${theme})`, async () => {
+      const app = await launchAuditApp({ theme });
+      try {
+        await app.window
+          .getByRole("button", { name: /Replay smoke thread/i })
+          .first()
+          .click();
+        await expect(
+          app.window.getByRole("heading", {
+            level: 2,
+            name: "Replay smoke thread",
+          }),
+        ).toBeVisible();
+        await expect(
+          app.window.getByText("The replay harness is live."),
+        ).toBeVisible();
+        // aria-hidden, so it has no role to locate it by; the class IS
+        // the contract the a11y note in app.css points at.
+        await expect(
+          app.window.locator(".thread-view__primary .celestial-watermark"),
+        ).toHaveCount(1);
+        await runAxe(app.window, { include: ".thread-view__primary" });
+      } finally {
+        await app.close();
+      }
+    });
+  }
 });

--- a/apps/desktop/e2e/fixtures/star-map/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/star-map/replay.fixture.json
@@ -1,0 +1,100 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "star-map-attention",
+    "threadId": "thread-star-map-active"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list"
+        ]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-star-map-active",
+          "title": "Star map attention thread",
+          "titleSource": "explicit",
+          "summary": "An active thread, so the map has a card to audit.",
+          "source": "codex",
+          "executionMode": "default",
+          "threadStatus": "active",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1760000100000
+        },
+        {
+          "id": "thread-star-map-second",
+          "title": "Second star map attention thread",
+          "titleSource": "explicit",
+          "summary": "A second card, so the lane stacks more than one body.",
+          "source": "codex",
+          "executionMode": "default",
+          "threadStatus": "active",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": false
+          },
+          "updatedAt": 1760000000000
+        }
+      ]
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "user",
+            "text": "Show me the star map."
+          },
+          {
+            "type": "message",
+            "id": "message-2",
+            "role": "assistant",
+            "text": "The star map is live."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "user",
+            "text": "Show me the star map."
+          },
+          {
+            "id": "message-2",
+            "role": "assistant",
+            "text": "The star map is live."
+          }
+        ],
+        "lastUserMessage": "Show me the star map.",
+        "lastAssistantMessage": "The star map is live.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/star-map-thread-flow.spec.ts
+++ b/apps/desktop/e2e/star-map-thread-flow.spec.ts
@@ -1,0 +1,97 @@
+// The Star Map's core triage loop, end to end in a real Electron launch:
+// open the map, pick a card, read the thread without leaving the map,
+// escalate into the full thread view, and come back.
+//
+// The escalation step is the one worth pinning. Clicking a card used to
+// navigate away to the thread shell; it now floats a chat card OVER the
+// map, and the trip to the full view moved onto the card's own expand
+// control. "Back to map" then un-floats without closing the map. Three
+// separate pieces of state (map open, card open, thread floating) have to
+// agree, and nothing below this level catches them disagreeing.
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+
+const THREAD_TITLE = "Star map attention thread";
+
+test("opens a thread from the star map and returns to the map", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(specDir, "fixtures/star-map/replay.fixture.json"),
+  });
+
+  try {
+    await expect(
+      app.window.getByRole("button", { name: new RegExp(THREAD_TITLE, "i") }).first(),
+    ).toBeVisible();
+
+    // The map layer covers the app chrome, so the header toggle that
+    // opens it is not the same control that closes it — the layer brings
+    // its own "Close map". Both carry the "Close Star Map" name, hence
+    // the scoping on every locator below.
+    await app.window.getByRole("button", { name: "Open Star Map" }).click();
+    // `exact` matters here: role-name matching is substring by default,
+    // and once a chat card opens its "Chat: Star map attention thread"
+    // region matches "Star Map" too.
+    const starMap = app.window.getByRole("region", {
+      name: "Star Map",
+      exact: true,
+    });
+    await expect(starMap).toBeVisible();
+
+    // One instance on a single-machine E2E launch, and its label is the
+    // runner's hostname — match the copy, not the machine.
+    await expect(
+      starMap.getByRole("button", { name: /^Open this instance / }),
+    ).toBeVisible();
+
+    const card = starMap.getByRole("button", {
+      name: `Open thread: ${THREAD_TITLE}`,
+    });
+    await expect(card).toBeVisible();
+    await card.click();
+
+    // A chat card, not a navigation: the map is still up behind it.
+    const chatCard = app.window.getByRole("region", {
+      name: `Chat: ${THREAD_TITLE}`,
+    });
+    await expect(chatCard).toBeVisible();
+    await expect(chatCard.getByText("The star map is live.")).toBeVisible();
+    await expect(starMap).toBeVisible();
+
+    await app.window
+      .getByRole("button", {
+        name: `Open ${THREAD_TITLE} in the full thread view`,
+      })
+      .click();
+
+    // Full thread view, floated over the map rather than replacing it.
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: THREAD_TITLE }),
+    ).toBeVisible();
+    await expect(app.window.getByText("The star map is live.").first()).toBeVisible();
+    const backToMap = app.window.getByRole("button", { name: "Back to map" });
+    await expect(backToMap).toBeVisible();
+    await expect(app.window.locator("main.app-main--star-map-float")).toHaveCount(1);
+
+    await backToMap.click();
+
+    // Un-floats without closing the map: the float chrome goes, the map
+    // stays, and the thread is still reachable as a card.
+    await expect(backToMap).toHaveCount(0);
+    await expect(app.window.locator("main.app-main--star-map-float")).toHaveCount(0);
+    await expect(starMap).toBeVisible();
+    await expect(card).toBeVisible();
+
+    // And the map's own exit lands back on the thread shell.
+    await starMap.getByRole("button", { name: "Close Star Map" }).click();
+    await expect(starMap).toHaveCount(0);
+    await expect(
+      app.window.getByRole("button", { name: "Open Star Map" }),
+    ).toBeVisible();
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9566,8 +9566,14 @@ textarea,
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .star-map-card {
-    animation-duration: 0s;
+  /* The rise lives on the SHELL, not the card - the card only transitions.
+     Zeroing it on `.star-map-card` left every card fading in for its full
+     380ms plus the inline stagger delay, which is both the motion the
+     operator asked not to see and, for a card still mid-fade, a real
+     contrast miss on its own title (the a11y gate caught the second card
+     of a lane at 2.02:1 against text that clears AA at rest). */
+  .star-map-card-shell {
+    animation: none;
   }
   .star-map-card {
     transition: none;


### PR DESCRIPTION
## Summary

- Extends the axe-core gate in `apps/desktop/e2e/a11y.spec.ts` to the surfaces the Star Map (#1249–#1252) added: **the map layer**, **the map's `[+]` intake dialog**, and **the thread transcript behind the celestial watermark in both themes**. `KNOWN_VIOLATIONS` stays empty.
- `launchAuditApp()` now takes `fixturePath` / `theme`; `runAxe()` takes an optional `include` scope.
- Adds `apps/desktop/e2e/fixtures/star-map/replay.fixture.json`. The smoke thread reaches no lane on the map — `deriveInboxState` keeps a first-snapshot thread out of the inbox, and an idle thread with no PR and no unpushed commits matches no attention category — so auditing the map on the smoke fixture would have scanned chrome and **zero cards**. The new fixture is hand-written (same class as `readme-recents-hero/`) with `threadStatus: "active"` threads.
- Adds `apps/desktop/e2e/star-map-thread-flow.spec.ts`, the map's triage loop end to end: open map → click a card → chat card floats over the map → "Open … in the full thread view" → floating ThreadView → "Back to map" → "Close map".
- **Fixes one real bug the new gate caught** (`app.css`): `star-map-rise` animates `.star-map-card-shell`, but the `prefers-reduced-motion: reduce` rule named `.star-map-card`, which carries no animation. Cards faded in for their full 380ms plus the inline stagger delay even for an operator who asked for no motion — and axe caught the second card of a lane mid-fade at **2.02:1** against text that clears AA at rest.
- Documents the four things that bit me in `apps/desktop/AGENTS.md` under Accessibility.

Two of the plan's assumptions didn't survive contact:

- *"click a thread card → floating ThreadView appears"* is stale. Since #1280 a card click floats a **chat card** over the map; the trip to the full view moved onto that card's expand control. The spec follows the real flow.
- *"the single-instance map on the smoke fixture"* would have audited nothing (see the fixture note above).

Why the watermark blocks are audited twice: it composites at 0.05 opacity into every contrast pair in the thread body and tints with `--text-muted`, which resolves differently per theme — a value that is harmless behind a dark surface can eat the margin on a light one. Each block also asserts the watermark is actually painted, so the audit can't keep passing after a regression that stops rendering it. **The watermark itself is clean in both themes.**

## Verification

- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/a11y.spec.ts e2e/star-map-thread-flow.spec.ts e2e/smoke.spec.ts` → **12 passed** (9 a11y blocks, incl. the 4 new ones).
- `pnpm lint:eslint` → 0 errors. `pnpm --filter @pwragent/desktop typecheck` → clean.
- Full desktop E2E: **159 passed, 21 failed**. Every one of those 21 is **pre-existing on this branch**, verified rather than assumed: I stashed this branch's changes, rebuilt, and reran all eight failing spec files on the clean tree — the same 21 fail identically. They split into a `better-sqlite3` `Database()` failure inside `preLaunchHook` (ACP runtime modes, launchpad workspace, branch drift, title reveal — looks like a native-module ABI problem in this environment) and stale `visual-regression` snapshots. Files were byte-compared after `git stash pop`.

## Notes

Two pre-existing accessibility issues surfaced and are **not** fixed here — both predate the Star Map and both want their own PR:

1. **`nested-interactive`** — `CopyableThreadChip` (`ThreadMetaChips.tsx`) renders a `role="button" tabIndex={0}` span *inside* a real `<button>`, on both the sidebar thread row and star map cards. It is invisible today only because the smoke fixture has `linkedDirectories: []`; the new fixture leaves them empty for the same reason, with a comment above `STAR_MAP_FIXTURE` explaining why and what to restore once it's fixed. **Deliberately not waived** — `KNOWN_VIOLATIONS` works via `AxeBuilder.exclude()`, so waiving it would drop the whole card from the scan and blind the very contrast pairs the new block exists to audit. The fix is structural: hoist the chips out of the button, the way `.star-map-card-shell` already hoists the kebab.
2. **Light theme is not AA-clean window-wide** — `.sidebar__brand-accent` 4.2:1, active `.lens-switch__label` 3.17:1, `.context-grid dt` 4.23:1 (all need 4.5:1). None involve the watermark, which is why the watermark blocks scope to `.thread-view__primary` — the element the watermark is a child of, and therefore the exact subtree it composites into. That scoping is what makes the light run measure the watermark instead of unrelated debt; every other block in the file stays unscoped. When light theme is clean, drop the scoping. These are token-level and brand-visible, so they need a design call, not a mechanical darkening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
