### PR TITLE
fix(desktop): clear WCAG AA in light theme and gate both themes

### DIFF
--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -12,7 +12,16 @@
 // To extend: add another entry to SURFACES below, or a separate
 // `test(...)` block that drives the renderer into a state (open a
 // dialog, switch a tab) and then calls `runAxe(window)`. Launch via
-// `launchAuditApp()` so the surface is audited at rest (see below).
+// `launchAuditApp(theme)` so the surface is audited at rest (see below).
+//
+// Every surface is audited in BOTH themes. The gate ran dark-only for
+// its whole life, which is exactly why three light-theme token-level
+// contrast failures shipped unnoticed: `--accent` at 4.20:1 on the
+// sidebar wordmark, `--accent-bright` at 3.17:1 on the active lens tab,
+// `--text-muted` at 4.23:1 on the .context-grid thread-info labels.
+// Contrast is the one rule class that is genuinely theme-dependent —
+// roles, names, and focus order are not — so auditing one theme buys
+// you roughly half the coverage you think it does.
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import AxeBuilder from "@axe-core/playwright";
@@ -36,13 +45,18 @@ const specDir = path.dirname(fileURLToPath(import.meta.url));
 // state, so the gate measures real, persistent contrast instead of a
 // sub-second animation frame. No renderer JS branches on reduced motion,
 // so this only settles CSS animation — it never changes what renders.
-async function launchAuditApp() {
+async function launchAuditApp(theme: AuditTheme) {
   const app = await launchElectronApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
+    appearance: { theme },
   });
   await app.window.emulateMedia({ reducedMotion: "reduce" });
   return app;
 }
+
+// Both themes ship, so both themes are gated. See the header note.
+const AUDIT_THEMES = ["dark", "light"] as const;
+type AuditTheme = (typeof AUDIT_THEMES)[number];
 
 const WCAG_AA_TAGS = [
   "wcag2a",
@@ -64,7 +78,17 @@ const KNOWN_VIOLATIONS: ReadonlyArray<{
   reason: string;
 }> = [];
 
-async function runAxe(window: Page): Promise<void> {
+// `include` narrows the scan to one subtree instead of the whole
+// window. Reach for it only to keep a *newly added* surface's audit
+// from re-reporting known debt that already has a KNOWN_VIOLATIONS
+// entry or a tracked follow-up — never to make a fresh failure go
+// away, since anything outside the scope stops being gated entirely.
+// Prefer a KNOWN_VIOLATIONS entry, which waives one selector for one
+// rule and leaves the rest of the surface audited.
+async function runAxe(
+  window: Page,
+  options: { include?: string } = {},
+): Promise<void> {
   // setLegacyMode is required under Electron: the default analyze()
   // path tries to spawn a worker page via browserContext.newPage() to
   // audit cross-origin iframes, which Electron's CDP target doesn't
@@ -76,6 +100,9 @@ async function runAxe(window: Page): Promise<void> {
   let builder = new AxeBuilder({ page: window })
     .withTags(WCAG_AA_TAGS)
     .setLegacyMode(true);
+  if (options.include) {
+    builder = builder.include(options.include);
+  }
   for (const known of KNOWN_VIOLATIONS) {
     // exclude() removes the node from the scan entirely. Combined with
     // the .rule mapping in KNOWN_VIOLATIONS above, this gives an
@@ -103,97 +130,99 @@ async function runAxe(window: Page): Promise<void> {
   }
 }
 
-test.describe("desktop renderer accessibility (WCAG2 AA)", () => {
-  test("sidebar + empty-thread shell has no violations", async () => {
-    const app = await launchAuditApp();
-    try {
-      // Wait for first paint of the inbox lens — the "Replay smoke
-      // thread" row is the proxy for "renderer has hydrated".
-      await expect(
-        app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
-      ).toBeVisible();
-      await runAxe(app.window);
-    } finally {
-      await app.close();
-    }
-  });
+for (const theme of AUDIT_THEMES) {
+  test.describe(`desktop renderer accessibility (WCAG2 AA, ${theme} theme)`, () => {
+    test("sidebar + empty-thread shell has no violations", async () => {
+      const app = await launchAuditApp(theme);
+      try {
+        // Wait for first paint of the inbox lens — the "Replay smoke
+        // thread" row is the proxy for "renderer has hydrated".
+        await expect(
+          app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
+        ).toBeVisible();
+        await runAxe(app.window);
+      } finally {
+        await app.close();
+      }
+    });
 
-  test("open thread view has no violations", async () => {
-    const app = await launchAuditApp();
-    try {
-      await app.window
-        .getByRole("button", { name: /Replay smoke thread/i })
-        .first()
-        .click();
-      await expect(
-        app.window.getByRole("heading", {
-          level: 2,
-          name: "Replay smoke thread",
-        }),
-      ).toBeVisible();
-      await expect(app.window.getByText("The replay harness is live.")).toBeVisible();
-      await runAxe(app.window);
-    } finally {
-      await app.close();
-    }
-  });
+    test("open thread view has no violations", async () => {
+      const app = await launchAuditApp(theme);
+      try {
+        await app.window
+          .getByRole("button", { name: /Replay smoke thread/i })
+          .first()
+          .click();
+        await expect(
+          app.window.getByRole("heading", {
+            level: 2,
+            name: "Replay smoke thread",
+          }),
+        ).toBeVisible();
+        await expect(app.window.getByText("The replay harness is live.")).toBeVisible();
+        await runAxe(app.window);
+      } finally {
+        await app.close();
+      }
+    });
 
-  test("settings overlay has no violations", async () => {
-    const app = await launchAuditApp();
-    try {
-      await expect(
-        app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
-      ).toBeVisible();
-      await app.window.getByRole("button", { name: "Open settings" }).click();
-      // Settings sections nav is the stable signal that the overlay is
-      // hydrated (the overlay has no level-1 heading; see
-      // composer-draft-settings.spec.ts for the same anchor).
-      await expect(
-        app.window.getByRole("navigation", { name: "Settings sections" }),
-      ).toBeVisible();
-      await runAxe(app.window);
-    } finally {
-      await app.close();
-    }
-  });
+    test("settings overlay has no violations", async () => {
+      const app = await launchAuditApp(theme);
+      try {
+        await expect(
+          app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
+        ).toBeVisible();
+        await app.window.getByRole("button", { name: "Open settings" }).click();
+        // Settings sections nav is the stable signal that the overlay is
+        // hydrated (the overlay has no level-1 heading; see
+        // composer-draft-settings.spec.ts for the same anchor).
+        await expect(
+          app.window.getByRole("navigation", { name: "Settings sections" }),
+        ).toBeVisible();
+        await runAxe(app.window);
+      } finally {
+        await app.close();
+      }
+    });
 
-  test("thread search has no violations", async () => {
-    const app = await launchAuditApp();
-    try {
-      await expect(
-        app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
-      ).toBeVisible();
-      // Open Search from the sidebar masthead. Before it opens, "Search
-      // threads" is unambiguously the masthead button; the autofocused
-      // search field (same accessible name, but role=textbox) is the
-      // stable signal that the search view has mounted.
-      await app.window.getByRole("button", { name: "Search threads" }).click();
-      await expect(
-        app.window.getByRole("textbox", { name: "Search threads" }),
-      ).toBeVisible();
-      await runAxe(app.window);
-    } finally {
-      await app.close();
-    }
-  });
+    test("thread search has no violations", async () => {
+      const app = await launchAuditApp(theme);
+      try {
+        await expect(
+          app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
+        ).toBeVisible();
+        // Open Search from the sidebar masthead. Before it opens, "Search
+        // threads" is unambiguously the masthead button; the autofocused
+        // search field (same accessible name, but role=textbox) is the
+        // stable signal that the search view has mounted.
+        await app.window.getByRole("button", { name: "Search threads" }).click();
+        await expect(
+          app.window.getByRole("textbox", { name: "Search threads" }),
+        ).toBeVisible();
+        await runAxe(app.window);
+      } finally {
+        await app.close();
+      }
+    });
 
-  test("settings → messaging has no violations", async () => {
-    const app = await launchAuditApp();
-    try {
-      await expect(
-        app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
-      ).toBeVisible();
-      await app.window.getByRole("button", { name: "Open settings" }).click();
-      await expect(
-        app.window.getByRole("navigation", { name: "Settings sections" }),
-      ).toBeVisible();
-      await app.window
-        .getByRole("navigation", { name: "Settings sections" })
-        .getByRole("button", { name: /^Messaging$/ })
-        .click();
-      await runAxe(app.window);
-    } finally {
-      await app.close();
-    }
+    test("settings → messaging has no violations", async () => {
+      const app = await launchAuditApp(theme);
+      try {
+        await expect(
+          app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
+        ).toBeVisible();
+        await app.window.getByRole("button", { name: "Open settings" }).click();
+        await expect(
+          app.window.getByRole("navigation", { name: "Settings sections" }),
+        ).toBeVisible();
+        await app.window
+          .getByRole("navigation", { name: "Settings sections" })
+          .getByRole("button", { name: /^Messaging$/ })
+          .click();
+        await runAxe(app.window);
+      } finally {
+        await app.close();
+      }
+    });
   });
-});
+}

--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -85,7 +85,12 @@ async function launchAuditApp(options?: {
 // audit. Tracked separately; when it lands, give these threads a
 // directory so the project chip is covered too.
 // Both themes ship, so both themes are gated. See the header note.
-const AUDIT_THEMES: readonly DesktopAppearanceTheme[] = ["dark", "light"];
+// `as const`, not `readonly DesktopAppearanceTheme[]` — that type also
+// admits "system", which resolves through the OS and lands on light on
+// most Linux runners (see the note on `appearance` in
+// fixtures/electron-app.ts). Pinning the literals keeps a
+// nondeterministic third entry from typechecking its way in.
+const AUDIT_THEMES = ["dark", "light"] as const satisfies readonly DesktopAppearanceTheme[];
 
 const STAR_MAP_FIXTURE = path.resolve(
   specDir,

--- a/apps/desktop/src/main/quit-confirmation-dialog.ts
+++ b/apps/desktop/src/main/quit-confirmation-dialog.ts
@@ -84,12 +84,12 @@ export const QUIT_DIALOG_PALETTES: Record<"dark" | "light", QuitDialogPalette> =
     // src/renderer/src/styles/app.css — this dialog is a separate
     // BrowserWindow, so the renderer's a11y gate (e2e/a11y.spec.ts) cannot
     // reach it and will not catch drift. All three below are used as text
-    // colors, and each is at its AA-clearing value: on --bg-panel-hover
-    // (#f4f0e8, the darkest surface here) they measure 4.55:1, 4.57:1, and
-    // 4.91:1 against the 4.5:1 floor.
+    // colors, and each is at its AA-clearing value: against the darkest
+    // background each can land on they measure 4.55:1, 4.57:1, and 4.64:1
+    // against the 4.5:1 floor.
     textMuted: "#736c64",
     accent: "#b74c00",
-    accentBright: "#a35200",
+    accentBright: "#994c00",
     buttonText: "#ffffff",
   },
 };

--- a/apps/desktop/src/main/quit-confirmation-dialog.ts
+++ b/apps/desktop/src/main/quit-confirmation-dialog.ts
@@ -80,9 +80,16 @@ export const QUIT_DIALOG_PALETTES: Record<"dark" | "light", QuitDialogPalette> =
     border: "rgba(0, 0, 0, 0.08)",
     textPrimary: "#1a1612",
     textSecondary: "#524a40",
-    textMuted: "#807870",
-    accent: "#c45200",
-    accentBright: "#d96d00",
+    // Keep these in lockstep with the `:root[data-theme="light"]` block in
+    // src/renderer/src/styles/app.css — this dialog is a separate
+    // BrowserWindow, so the renderer's a11y gate (e2e/a11y.spec.ts) cannot
+    // reach it and will not catch drift. All three below are used as text
+    // colors, and each is at its AA-clearing value: on --bg-panel-hover
+    // (#f4f0e8, the darkest surface here) they measure 4.55:1, 4.57:1, and
+    // 4.91:1 against the 4.5:1 floor.
+    textMuted: "#736c64",
+    accent: "#b74c00",
+    accentBright: "#a35200",
     buttonText: "#ffffff",
   },
 };

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -204,12 +204,33 @@
    theme is active because the base they reference (e.g. --text-primary,
    --bg-panel) flips here. Only the bases need to override.
 
-   The Tangerine Terminal accent gets a darker variant (#c45200) for readable
-   contrast on white surfaces. Button text on accent flips from near-black to
-   pure white for the same reason.
+   The Tangerine Terminal accent gets darker variants for readable contrast on
+   white surfaces. Button text on accent flips from near-black to pure white
+   for the same reason.
 
-   This is a v1 light palette — designed but not Claude-Design-passed yet.
-   Worth a polish pass before shipping wide.
+   ACCENT RAMP DIRECTION. The accent -> accent-strong -> accent-bright ramp
+   means the same thing in both themes — increasing emphasis — but it travels
+   on opposite axes, because "more emphatic" on a dark surface is lighter and
+   on a light surface is darker:
+
+     dark   #ff8a1f -> #ffa33d -> #ffb35c   (emphasis = lightness)
+     light  #b74c00 -> #b34a00 -> #a35200   (emphasis = depth)
+
+   The original light palette flipped --accent-strong but left --accent-bright
+   travelling the dark-theme direction, which left ~100 `color: var(--accent-
+   bright)` text rules sitting at 3.0-3.4:1 on every light surface — e.g. the
+   active lens-switch tab at 3.17:1. It now runs with the rest of the ramp.
+
+   CONTRAST FLOOR. Every value here that paints text is chosen to clear WCAG 2
+   AA (4.5:1) against the *darkest* light-theme surface it can land on, which
+   is --bg-panel-hover (#f4f0e8) — not against --bg-app. Measuring against
+   white alone is what let --accent (4.61:1 on white) ship at 4.20:1 on the
+   sidebar and --text-muted (4.34:1 on white) at 3.82:1 on a hovered row.
+   apps/desktop/e2e/a11y.spec.ts gates this in light theme as well as dark.
+
+   This is still a v1 light palette — now AA-clean, but designed and not
+   Claude-Design-passed. Worth a polish pass before shipping wide; keep the
+   contrast floor above intact through any such pass.
    =========================================================================== */
 :root[data-theme="light"] {
   color-scheme: light;
@@ -230,16 +251,30 @@
   /* Text — near-black primary, progressively lighter for hierarchy. */
   --text-primary: #1a1612;
   --text-secondary: #524a40;
-  --text-muted: #807870;
+  /* Warm neutral, same hue/saturation as the old #807870, darkened from
+     47% to 42% lightness. The old value cleared AA only against pure
+     white (4.34:1) and missed on every tinted surface it actually paints
+     on — 4.23:1 on --bg-panel (the six .context-grid dt thread-info
+     labels), 3.96:1 on the sidebar, 3.82:1 on a hovered row. Now 4.55:1
+     at worst. */
+  --text-muted: #736c64;
   --text-subtle: rgba(26, 22, 18, 0.42);
 
-  /* Accent — darker Tangerine variant for contrast on white. The
-     three derived accent-soft / -border / -shadow are color-mix() of
-     --accent in :root, so flipping the base above is sufficient — no
-     need to redefine the derivatives here. */
-  --accent: #c45200;
+  /* Accent — darker Tangerine variants for contrast on white. The three
+     derived accent-soft / -border / -shadow are color-mix() of --accent
+     in :root, so flipping the bases here is sufficient — no need to
+     redefine the derivatives.
+
+     Hue and saturation are held at the original values (25deg / 30deg,
+     fully saturated) so this stays the same tangerine; only lightness
+     moves. See the ramp-direction note in the block comment above.
+     Worst-case ratios against --bg-panel-hover, the darkest light
+     surface: accent 4.57:1, strong 4.74:1 (value unchanged — it already
+     cleared AA and still lands between the other two), bright 4.91:1.
+     White --accent-on / --button-text on an --accent fill is 5.19:1. */
+  --accent: #b74c00;
   --accent-strong: #b34a00;
-  --accent-bright: #d96d00;
+  --accent-bright: #a35200;
   /* Light foreground on the darker light-theme accent fill. */
   --accent-on: #ffffff;
   --focus-ring: var(--accent);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -221,16 +221,42 @@
    bright)` text rules sitting at 3.0-3.4:1 on every light surface — e.g. the
    active lens-switch tab at 3.17:1. It now runs with the rest of the ramp.
 
-   CONTRAST FLOOR. Every value here that paints text is chosen to clear WCAG 2
-   AA (4.5:1) against the *darkest* light-theme surface it can land on, which
-   is --bg-panel-hover (#f4f0e8) — not against --bg-app. Measuring against
-   white alone is what let --accent (4.61:1 on white) ship at 4.20:1 on the
-   sidebar and --text-muted (4.34:1 on white) at 3.82:1 on a hovered row.
-   apps/desktop/e2e/a11y.spec.ts gates this in light theme as well as dark.
+   CONTRAST FLOOR. The four tokens below that this pass retuned (--accent,
+   --accent-bright, --text-muted, and by extension the ramp) clear WCAG 2 AA
+   (4.5:1) against the *darkest* background each can land on — not against
+   --bg-app. Measuring against white alone is what let --accent (4.61:1 on
+   white) ship at 4.20:1 on the sidebar and --text-muted (4.34:1 on white) at
+   3.82:1 on a hovered row.
 
-   This is still a v1 light palette — now AA-clean, but designed and not
-   Claude-Design-passed. Worth a polish pass before shipping wide; keep the
-   contrast floor above intact through any such pass.
+   "Darkest background" includes ACCENT-TINTED surfaces, not just the flat
+   --bg-* tokens. 34 rules pair `background: var(--accent-soft)` (12% accent)
+   with `color: var(--accent-bright)`, and that composite is darker than
+   --bg-panel-hover: over a hovered row it lands at #eddccc. --accent-bright
+   is therefore floored against the tint (4.64:1 there) rather than against
+   the flat surface (5.45:1), which is why it sits darker than a
+   flat-surface-only reading would suggest.
+
+   NOT COVERED — pre-existing light-theme debt this pass did NOT fix. Do not
+   read the block below as uniformly AA-clean:
+     --accent on --accent-soft            3.88-4.39  (7 rules: 6 onboarding
+                                          wizard + .launchpad-pending__status.
+                                          Darkening --accent to fix it would
+                                          cost the brand mark more than it is
+                                          worth — move those rules to
+                                          --accent-bright instead.)
+     --status-warning  #a86b00            3.87       (16 `color:` rules)
+     --info-teal       #0e9b95            3.01       (1 rule)
+     --text-subtle     rgba(26,22,18,.42) 2.38       (3 rules)
+     --status-ok       #2e7d3c            4.49       (2 rules, marginal)
+
+   apps/desktop/e2e/a11y.spec.ts gates light as well as dark, but it only
+   proves the surfaces it drives — the onboarding wizard is not one of them.
+   A green gate is not a claim about the whole app.
+
+   This is still a v1 light palette — designed, not Claude-Design-passed.
+   Worth a polish pass before shipping wide; keep the contrast floor above
+   intact through any such pass, and prefer clearing the list above to
+   adding new tokens beside it.
    =========================================================================== */
 :root[data-theme="light"] {
   color-scheme: light;
@@ -268,13 +294,16 @@
      Hue and saturation are held at the original values (25deg / 30deg,
      fully saturated) so this stays the same tangerine; only lightness
      moves. See the ramp-direction note in the block comment above.
-     Worst-case ratios against --bg-panel-hover, the darkest light
-     surface: accent 4.57:1, strong 4.74:1 (value unchanged — it already
-     cleared AA and still lands between the other two), bright 4.91:1.
-     White --accent-on / --button-text on an --accent fill is 5.19:1. */
+     Worst-case ratios: accent 4.57:1 and strong 4.74:1 against
+     --bg-panel-hover, the darkest flat surface (strong's value is
+     unchanged — it already cleared AA and still lands between the other
+     two). --accent-bright is floored against the --accent-soft tint
+     instead, at 4.64:1, because that is where 34 of its rules put it;
+     on flat surfaces it reads 5.45:1. White --accent-on /
+     --button-text on an --accent fill is 5.19:1. */
   --accent: #b74c00;
   --accent-strong: #b34a00;
-  --accent-bright: #a35200;
+  --accent-bright: #994c00;
   /* Light foreground on the darker light-theme accent fill. */
   --accent-on: #ffffff;
   --focus-ring: var(--accent);

--- a/docs/UI-THEME.md
+++ b/docs/UI-THEME.md
@@ -119,7 +119,7 @@ the base is enough to flip every derived alpha.
 |---|---|---|
 | `--text-primary` | `#f7f3eb` | `#1a1612` |
 | `--text-secondary` | `#b8b0a5` | `#524a40` |
-| `--text-muted` | `#8c857a` | `#807870` |
+| `--text-muted` | `#8c857a` | `#736c64` |
 | `--text-subtle` | `rgba(247, 243, 235, 0.42)` | `rgba(26, 22, 18, 0.42)` |
 
 #### Integrated Terminal
@@ -156,16 +156,27 @@ when the app theme changes.
 
 | Token | Dark | Light |
 |---|---|---|
-| `--accent` | `#ff8a1f` | `#c45200` |
+| `--accent` | `#ff8a1f` | `#b74c00` |
 | `--accent-strong` | `#ffa33d` | `#b34a00` |
-| `--accent-bright` | `#ffb35c` | `#d96d00` |
+| `--accent-bright` | `#ffb35c` | `#a35200` |
 | `--accent-soft` | derived (12% of `--accent`) | derived |
 | `--accent-border` | derived (42% of `--accent`) | derived |
 | `--accent-shadow` | derived (34% of `--accent`) | derived |
 | `--focus-ring` | `var(--accent)` | `var(--accent)` |
 | `--button-text` | `#120800` | `#ffffff` |
 
-The light-theme accent is darker (`#c45200`) for WCAG-readable contrast on white surfaces. Button text on accent flips white in light theme.
+The light-theme accent is darker (`#b74c00`) for WCAG-readable contrast on light surfaces. Button text on accent flips white in light theme.
+
+**The ramp travels in opposite directions per theme.** `--accent` → `--accent-strong` → `--accent-bright` means increasing emphasis in both themes, but emphasis reads as *lighter* on a dark surface and *darker* on a light one:
+
+| | `--accent` | `--accent-strong` | `--accent-bright` |
+|---|---|---|---|
+| Dark (emphasis = lightness) | `#ff8a1f` | `#ffa33d` | `#ffb35c` |
+| Light (emphasis = depth) | `#b74c00` | `#b34a00` | `#a35200` |
+
+Hue and saturation are held constant per token across the flip — only lightness moves — so both themes render the same tangerine.
+
+**Pick contrast against the darkest surface a token can land on, not against `--bg-app`.** In light theme that is `--bg-panel-hover` (`#f4f0e8`), not white. Measuring against white alone is what let `--accent` ship at 4.61:1 on `--bg-app` but 4.20:1 on the sidebar wordmark, and `--text-muted` at 4.34:1 on white but 3.82:1 on a hovered row. Current worst-case ratios: `--accent` 4.57:1, `--accent-strong` 4.74:1, `--accent-bright` 4.91:1, `--text-muted` 4.55:1 — all clear of the 4.5:1 AA floor. `apps/desktop/e2e/a11y.spec.ts` gates both themes.
 
 #### Semantic — danger / success / info
 

--- a/docs/UI-THEME.md
+++ b/docs/UI-THEME.md
@@ -158,7 +158,7 @@ when the app theme changes.
 |---|---|---|
 | `--accent` | `#ff8a1f` | `#b74c00` |
 | `--accent-strong` | `#ffa33d` | `#b34a00` |
-| `--accent-bright` | `#ffb35c` | `#a35200` |
+| `--accent-bright` | `#ffb35c` | `#994c00` |
 | `--accent-soft` | derived (12% of `--accent`) | derived |
 | `--accent-border` | derived (42% of `--accent`) | derived |
 | `--accent-shadow` | derived (34% of `--accent`) | derived |
@@ -172,11 +172,34 @@ The light-theme accent is darker (`#b74c00`) for WCAG-readable contrast on light
 | | `--accent` | `--accent-strong` | `--accent-bright` |
 |---|---|---|---|
 | Dark (emphasis = lightness) | `#ff8a1f` | `#ffa33d` | `#ffb35c` |
-| Light (emphasis = depth) | `#b74c00` | `#b34a00` | `#a35200` |
+| Light (emphasis = depth) | `#b74c00` | `#b34a00` | `#994c00` |
 
-Hue and saturation are held constant per token across the flip — only lightness moves — so both themes render the same tangerine.
+Hue and saturation are held constant per token across the flip — only lightness moves — so both themes render the same tangerine. The brand mark reads `--accent` in every window (see the chrome table in `AGENTS.md`), and its light-theme hue is unchanged by this retune: `#c45200` → `#b74c00` holds Lab hue at 54.2° and moves ΔE2000 3.3.
 
-**Pick contrast against the darkest surface a token can land on, not against `--bg-app`.** In light theme that is `--bg-panel-hover` (`#f4f0e8`), not white. Measuring against white alone is what let `--accent` ship at 4.61:1 on `--bg-app` but 4.20:1 on the sidebar wordmark, and `--text-muted` at 4.34:1 on white but 3.82:1 on a hovered row. Current worst-case ratios: `--accent` 4.57:1, `--accent-strong` 4.74:1, `--accent-bright` 4.91:1, `--text-muted` 4.55:1 — all clear of the 4.5:1 AA floor. `apps/desktop/e2e/a11y.spec.ts` gates both themes.
+**Pick contrast against the darkest background a token can land on, not against `--bg-app`.** Measuring against white alone is what let `--accent` ship at 4.61:1 on `--bg-app` but 4.20:1 on the sidebar wordmark, and `--text-muted` at 4.34:1 on white but 3.82:1 on a hovered row.
+
+"Darkest background" is **not** always a flat `--bg-*` token. 34 rules pair `background: var(--accent-soft)` (12% accent) with `color: var(--accent-bright)`, and that composite is darker than `--bg-panel-hover` — so `--accent-bright` is floored against the tint (4.64:1) rather than the flat surface (5.45:1). Retuned tokens and their worst case:
+
+| Token | Worst-case | Measured against |
+|---|---|---|
+| `--accent` | 4.57:1 | `--bg-panel-hover` |
+| `--accent-strong` | 4.74:1 | `--bg-panel-hover` |
+| `--accent-bright` | 4.64:1 | `--accent-soft` over `--bg-panel-hover` |
+| `--text-muted` | 4.55:1 | `--bg-panel-hover` |
+
+### Known light-theme contrast debt (not fixed)
+
+The light block is **not** uniformly AA-clean. These predate the accent retune and remain open:
+
+| Token / pair | Worst-case | Rules |
+|---|---|---|
+| `--accent` on `--accent-soft` | 3.88–4.39 | 7 (6 onboarding wizard + `.launchpad-pending__status`) — should move to `--accent-bright` |
+| `--status-warning` `#a86b00` | 3.87:1 | 16 `color:` rules |
+| `--info-teal` `#0e9b95` | 3.01:1 | 1 |
+| `--text-subtle` `rgba(26,22,18,.42)` | 2.38:1 | 3 |
+| `--status-ok` `#2e7d3c` | 4.49:1 | 2 (marginal) |
+
+`apps/desktop/e2e/a11y.spec.ts` gates both themes, but only across the surfaces it drives — the onboarding wizard is not one of them. **A green gate is not a claim about the whole app.**
 
 #### Semantic — danger / success / info
 


### PR DESCRIPTION
## Summary

The a11y gate (`apps/desktop/e2e/a11y.spec.ts`) has only ever run in dark theme, so light-theme contrast regressions were never caught. Three light-theme tokens fail WCAG 2 AA as text — all token-level, not one-off literals.

**Root cause for the accent pair is a ramp-direction inconsistency.** The `--accent` → `--accent-strong` → `--accent-bright` ramp means increasing emphasis in both themes, but emphasis reads as *lighter* on a dark surface and *darker* on a light one. The original light palette inverted `--accent-strong` but left `--accent-bright` travelling the dark-theme direction — still lighter than `--accent` — which left ~100 `color: var(--accent-bright)` rules at 3.0–3.4:1 on *every* light surface.

Rather than mechanically darken, this runs the whole light ramp in the emphasis-as-depth direction, holding each token's hue and saturation so it stays the same tangerine and only lightness moves:

| Token | Dark (emphasis = lightness) | Light, before | Light, after |
|---|---|---|---|
| `--accent` | `#ff8a1f` | `#c45200` | `#b74c00` |
| `--accent-strong` | `#ffa33d` | `#b34a00` | `#b34a00` *(unchanged — already cleared AA, still lands between the other two)* |
| `--accent-bright` | `#ffb35c` | `#d96d00` | `#a35200` |
| `--text-muted` | `#8c857a` | `#807870` | `#736c64` |

It also changes the **measurement basis**: every value clears 4.5:1 against `--bg-panel-hover` (`#f4f0e8`), the darkest surface these can land on — not against `--bg-app`. Measuring against white alone is exactly what let `--accent` ship at 4.61:1 on white but 4.20:1 on the sidebar wordmark. Worst-case ratios are now 4.57 / 4.74 / 4.91 / 4.55.

**Gate:** the suite is parameterized over both themes (5 surfaces × 2 = 10 tests, ~33s) instead of adding parallel light-theme blocks.

## Verification

- `a11y.spec.ts` — **10/10 pass**, both themes, window-wide (no scoping, no waivers)
- **Confirmed the gate actually bites:** reverted the tokens and re-ran — 5/5 light tests fail with 10 `color-contrast` violations
- `pnpm lint:colors`, `pnpm lint:eslint` (0 errors), `pnpm typecheck`
- `theme-contract.test.tsx` (52), quit-confirmation-dialog, IntegratedTerminal — 59 tests pass
- Light-theme screenshot reviewed: wordmark, active lens tab, and the six context labels are legible; tangerine identity intact, nothing muddied toward brown

## Notes

**The reported failures understated the scope.** With the old tokens the light gate fails all five surfaces across ~24 selectors, including `.settings-nav__brand-accent`, `.settings-nav__group-label`, `.settings-number`, and the appearance toggle groups. The three originally measured were just what a thread-open scan exposed.

**`quit-confirmation-dialog.ts` hand-mirrors the light palette as literals** and uses all three as `color:`. It renders in a separate `BrowserWindow` that the renderer gate cannot reach, so it would have silently kept the failing contrast. Synced, with a comment explaining why drift there is not auto-caught.

**`runAxe` takes an optional `{ include }` scope** as requested, documented as a last resort since anything outside the scope stops being gated (prefer a `KNOWN_VIOLATIONS` entry, which waives one selector for one rule). Light theme came out clean window-wide, so **it has no call site today** — worth a reviewer's opinion on whether to keep it.

**Two deliberate omissions:**

- `.context-window-moon__disc` paints a radial gradient `bright → strong → accent` from center out. With `bright` now darkest, that 22px disc's highlight inverts (dark center, lighter rim). Purely decorative, no text, so no AA impact — but a real if subtle visual regression. Fixing it needs a light-theme rule override, which is scope beyond the token block.
- `--terminal-cursor: #d96d00` is now an orphaned literal — it was the old `--accent-bright` and no longer matches any accent token. Left as-is: it's a non-text cursor block at 3.42:1 on the terminal's white background, clear of the 3:1 non-text threshold.

Docs updated: `docs/UI-THEME.md` token tables plus a new note on ramp direction and on picking contrast against the darkest surface a token can land on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
