### PR TITLE
fix(desktop): refresh stale thread base state

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -5802,8 +5802,10 @@ describe("app server ipc", () => {
     }
   });
 
-  it("keeps each automatic working-state refresh batch bounded", async () => {
+  it("rotates bounded automatic working-state refreshes past the first batch", async () => {
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const now = 20_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
     const threads = Array.from({ length: 9 }, (_, index) => ({
       id: `thread-${index}`,
       title: `Thread ${index}`,
@@ -5815,15 +5817,100 @@ describe("app server ipc", () => {
     }));
     listThreads.mockResolvedValue(threads as never);
 
+    try {
+      registerAppServerIpcHandlers();
+      await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+
+      await vi.waitFor(() => {
+        expect(readWorktreeWorkingStateEntries).toHaveBeenCalledTimes(1);
+        expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalledTimes(8);
+      });
+      const firstBatch = readWorktreeWorkingStateEntries.mock.calls[0]?.[0];
+      expect(firstBatch).toEqual(
+        threads.slice(0, 8).map((thread) => thread.projectKey),
+      );
+
+      nowSpy.mockReturnValue(now + 31_000);
+      await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+
+      await vi.waitFor(() => {
+        expect(readWorktreeWorkingStateEntries).toHaveBeenCalledTimes(2);
+        expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalledTimes(16);
+      });
+      const secondBatch = readWorktreeWorkingStateEntries.mock.calls[1]?.[0];
+      expect(secondBatch).toHaveLength(8);
+      expect(secondBatch).toContain(threads[8]!.projectKey);
+      expect(new Set([...firstBatch!, ...secondBatch!])).toEqual(
+        new Set(threads.map((thread) => thread.projectKey)),
+      );
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("lets a user-triggered working-state refresh bypass fresh cache", async () => {
+    const {
+      NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL,
+      NAVIGATION_SNAPSHOT_CHANNEL,
+    } = await import("../../shared/ipc");
+    const worktreePath = "/repo/wt";
+    const gitWorkingState = {
+      dirtyFiles: 0,
+      dirtyAdditions: 0,
+      dirtyDeletions: 0,
+      untrackedFiles: 0,
+      unpushedCommits: 0,
+      baseBranch: "main",
+    };
+    listThreads.mockResolvedValue([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: worktreePath,
+        linkedDirectories: [],
+        updatedAt: 2_000,
+      },
+    ] as never);
+    readThreadGitWorkingStateCache.mockResolvedValueOnce({
+      [worktreePath]: {
+        worktreePath,
+        fetchedAt: Date.now(),
+        gitWorkingState,
+      },
+    });
+
     registerAppServerIpcHandlers();
     await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    expect(readWorktreeWorkingStateEntries).not.toHaveBeenCalled();
 
-    await vi.waitFor(() => {
-      expect(readWorktreeWorkingStateEntries).toHaveBeenCalledTimes(1);
-    });
-    expect(readWorktreeWorkingStateEntries.mock.calls[0]?.[0]).toEqual(
-      threads.slice(0, 8).map((thread) => thread.projectKey),
+    await expect(
+      handlers.get(NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL)?.(
+        {},
+        { backend: "codex", threadId: "thread-1", trigger: "scheduled" },
+      ),
+    ).resolves.toEqual({ scheduled: false });
+    expect(invalidateWorktreeWorkingState).not.toHaveBeenCalled();
+
+    await expect(
+      handlers.get(NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL)?.(
+        {},
+        { backend: "codex", threadId: "thread-1", trigger: "user" },
+      ),
+    ).resolves.toEqual({ scheduled: true });
+    expect(invalidateWorktreeWorkingState).toHaveBeenCalledExactlyOnceWith(
+      worktreePath,
     );
+    await vi.waitFor(() => {
+      expect(readWorktreeWorkingStateEntries).toHaveBeenCalledWith(
+        [worktreePath],
+        expect.any(Object),
+      );
+      expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ worktreePath }),
+      );
+    });
   });
 
   it("hydrates working state from linked worktrees when the thread has no project key", async () => {

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -5764,6 +5764,68 @@ describe("app server ipc", () => {
     });
   });
 
+  it("reprobes stale working state after the automatic startup batch", async () => {
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const now = 10_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    const threads = Array.from({ length: 8 }, (_, index) => ({
+      id: `thread-${index}`,
+      title: `Thread ${index}`,
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      projectKey: `/repo/wt-${index}`,
+      linkedDirectories: [],
+      updatedAt: 2_000 - index,
+    }));
+    listThreads.mockResolvedValue(threads as never);
+
+    try {
+      registerAppServerIpcHandlers();
+      await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+      await vi.waitFor(() => {
+        expect(readWorktreeWorkingStateEntries).toHaveBeenCalledTimes(1);
+        expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalledTimes(8);
+      });
+
+      nowSpy.mockReturnValue(now + 31_000);
+      await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+
+      await vi.waitFor(() => {
+        expect(readWorktreeWorkingStateEntries).toHaveBeenCalledTimes(2);
+        expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalledTimes(16);
+      });
+      expect(readWorktreeWorkingStateEntries.mock.calls[1]?.[0]).toEqual(
+        threads.map((thread) => thread.projectKey),
+      );
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("keeps each automatic working-state refresh batch bounded", async () => {
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const threads = Array.from({ length: 9 }, (_, index) => ({
+      id: `thread-${index}`,
+      title: `Thread ${index}`,
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      projectKey: `/repo/wt-${index}`,
+      linkedDirectories: [],
+      updatedAt: 2_000 - index,
+    }));
+    listThreads.mockResolvedValue(threads as never);
+
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+
+    await vi.waitFor(() => {
+      expect(readWorktreeWorkingStateEntries).toHaveBeenCalledTimes(1);
+    });
+    expect(readWorktreeWorkingStateEntries.mock.calls[0]?.[0]).toEqual(
+      threads.slice(0, 8).map((thread) => thread.projectKey),
+    );
+  });
+
   it("hydrates working state from linked worktrees when the thread has no project key", async () => {
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
 

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -318,7 +318,7 @@ const DIRECTORY_GIT_STATUS_CACHE_MAX_AGE_MS = 5 * 60_000;
 // closes the sequential post-completion gap so "747, 732, 747, 747, 732,
 // 747" collapses to "747, 732".
 const DIRECTORY_GIT_STATUS_FORCE_COALESCE_WINDOW_MS = 3_000;
-const STARTUP_WORKTREE_WORKING_STATE_REFRESH_LIMIT = 8;
+const AUTOMATIC_WORKTREE_WORKING_STATE_REFRESH_LIMIT = 8;
 // PR discovery (Layer B): a slow branch-lookup rotation across ALL open threads
 // to catch newly opened PRs on projects the operator is not looking at. Tick
 // often, but sweep each thread rarely and only a few per tick, so discovery
@@ -1339,7 +1339,6 @@ class DesktopAppServerService {
     WorktreeGitWorkingStateCacheEntry
   >();
   private workingStateCacheLoaded = false;
-  private automaticWorktreeWorkingStateRefreshesStarted = 0;
   private readonly pendingWorktreeWorkingStateRefreshes = new Map<
     string,
     Promise<void>
@@ -2868,9 +2867,9 @@ class DesktopAppServerService {
   /**
    * Schedule a background per-worktree working-state probe. Mirrors
    * `startDirectoryGitStatusRefresh`: concurrent same-key requests coalesce
-   * through `pendingWorktreeWorkingStateKeys`, automatic refreshes obey a
-   * startup budget + cache freshness, and `force` (event-driven invalidation)
-   * bypasses freshness. Returns the number of worktrees scheduled.
+   * through `pendingWorktreeWorkingStateKeys`, each automatic refresh obeys a
+   * bounded batch size + cache freshness, and `force` (event-driven
+   * invalidation) bypasses freshness. Returns the number of worktrees scheduled.
    */
   private startWorktreeWorkingStateRefresh(params: {
     automatic: boolean;
@@ -2892,9 +2891,6 @@ class DesktopAppServerService {
       return 0;
     }
 
-    if (params.automatic) {
-      this.automaticWorktreeWorkingStateRefreshesStarted += worktreePaths.length;
-    }
     for (const worktreePath of worktreePaths) {
       this.pendingWorktreeWorkingStateKeys.add(worktreePath);
     }
@@ -2939,13 +2935,7 @@ class DesktopAppServerService {
       return candidates;
     }
 
-    const remaining =
-      STARTUP_WORKTREE_WORKING_STATE_REFRESH_LIMIT -
-      this.automaticWorktreeWorkingStateRefreshesStarted;
-    if (remaining <= 0) {
-      return [];
-    }
-    return candidates.slice(0, remaining);
+    return candidates.slice(0, AUTOMATIC_WORKTREE_WORKING_STATE_REFRESH_LIMIT);
   }
 
   private async refreshWorktreeWorkingStates(
@@ -6506,7 +6496,6 @@ class DesktopAppServerService {
     this.pendingWorktreeWorkingStateKeys.clear();
     this.workingStateByWorktree.clear();
     this.workingStateCacheLoaded = false;
-    this.automaticWorktreeWorkingStateRefreshesStarted = 0;
     this.worktreePathByThreadKey.clear();
     this.prRefreshContextByThreadKey.clear();
     await disposeDesktopBackendRegistry();

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -71,6 +71,8 @@ import {
   type DesktopSettingsSnapshot,
   type RefreshDirectoryGitStatusesRequest,
   type RefreshDirectoryGitStatusesResponse,
+  type RefreshThreadGitWorkingStateRequest,
+  type RefreshThreadGitWorkingStateResponse,
   type RefreshThreadPullRequestsRequest,
   type SetPullRequestPollingFocusRequest,
   type RefreshThreadPullRequestsResponse,
@@ -204,6 +206,7 @@ import {
   FOCUSED_DIFF_ANALYZE_CHANNEL,
   NAVIGATION_GET_GH_STATUS_CHANNEL,
   NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
+  NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL,
   NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
   NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL,
   NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL,
@@ -318,7 +321,7 @@ const DIRECTORY_GIT_STATUS_CACHE_MAX_AGE_MS = 5 * 60_000;
 // closes the sequential post-completion gap so "747, 732, 747, 747, 732,
 // 747" collapses to "747, 732".
 const DIRECTORY_GIT_STATUS_FORCE_COALESCE_WINDOW_MS = 3_000;
-const AUTOMATIC_WORKTREE_WORKING_STATE_REFRESH_LIMIT = 8;
+const BACKGROUND_WORKTREE_WORKING_STATE_REFRESH_BATCH_SIZE = 8;
 // PR discovery (Layer B): a slow branch-lookup rotation across ALL open threads
 // to catch newly opened PRs on projects the operator is not looking at. Tick
 // often, but sweep each thread rarely and only a few per tick, so discovery
@@ -2913,6 +2916,29 @@ class DesktopAppServerService {
     return worktreePaths.length;
   }
 
+  async refreshThreadGitWorkingState(
+    request: RefreshThreadGitWorkingStateRequest,
+  ): Promise<RefreshThreadGitWorkingStateResponse> {
+    const threadKey = buildThreadIdentityKey(request.backend, request.threadId);
+    const worktreePath = this.worktreePathByThreadKey.get(threadKey);
+    if (!worktreePath) {
+      return { scheduled: false };
+    }
+
+    await this.loadThreadGitWorkingStateCache();
+    const force = request.trigger === "user";
+    if (force) {
+      getDesktopBackendRegistry().invalidateWorktreeWorkingState(worktreePath);
+    }
+    return {
+      scheduled: this.startWorktreeWorkingStateRefresh({
+        automatic: false,
+        worktreePaths: [worktreePath],
+        force,
+      }) > 0,
+    };
+  }
+
   private selectWorktreeWorkingStateRefreshCandidates(params: {
     automatic: boolean;
     worktreePaths: string[];
@@ -2935,7 +2961,24 @@ class DesktopAppServerService {
       return candidates;
     }
 
-    return candidates.slice(0, AUTOMATIC_WORKTREE_WORKING_STATE_REFRESH_LIMIT);
+    // Stable thread ordering must not make the same prefix win forever.
+    // Unseen worktrees sort first; after that, rotate the oldest probes
+    // forward. Selected and hover-inspected threads use the focused/user lane.
+    candidates.sort((left, right) => {
+      const leftFetchedAt = this.workingStateByWorktree.get(left)?.fetchedAt;
+      const rightFetchedAt = this.workingStateByWorktree.get(right)?.fetchedAt;
+      if (leftFetchedAt === undefined) {
+        return rightFetchedAt === undefined ? 0 : -1;
+      }
+      if (rightFetchedAt === undefined) {
+        return 1;
+      }
+      return leftFetchedAt - rightFetchedAt;
+    });
+    return candidates.slice(
+      0,
+      BACKGROUND_WORKTREE_WORKING_STATE_REFRESH_BATCH_SIZE,
+    );
   }
 
   private async refreshWorktreeWorkingStates(
@@ -7180,6 +7223,21 @@ export function registerAppServerIpcHandlers(): void {
       });
     },
   );
+  ipcMain.removeHandler(NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL,
+    async (
+      event,
+      request: RefreshThreadGitWorkingStateRequest,
+    ): Promise<RefreshThreadGitWorkingStateResponse> => {
+      if (isFederationWindowWebContents(event?.sender)) {
+        throw new Error(
+          "Git working-state refreshes for remote threads run on the owning instance.",
+        );
+      }
+      return await appServerService.refreshThreadGitWorkingState(request);
+    },
+  );
   ipcMain.removeHandler(NAVIGATION_SET_PR_POLLING_FOCUS_CHANNEL);
   ipcMain.handle(
     NAVIGATION_SET_PR_POLLING_FOCUS_CHANNEL,
@@ -7452,6 +7510,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_SET_THREAD_REACTION_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_SET_THREAD_AGENT_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_DETACH_THREAD_PR_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -176,6 +176,8 @@ import type {
   UnbindMessagingThreadRequest,
   UnbindMessagingThreadResponse,
   RefreshThreadPullRequestsRequest,
+  RefreshThreadGitWorkingStateRequest,
+  RefreshThreadGitWorkingStateResponse,
   SetPullRequestPollingFocusRequest,
   RefreshThreadPullRequestsResponse,
   RefreshDirectoryGitStatusesRequest,
@@ -524,6 +526,7 @@ import {
   NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL,
   NAVIGATION_RECORD_RECENT_FILE_REFERENCES_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
+  NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL,
   NAVIGATION_SET_PR_POLLING_FOCUS_CHANNEL,
   NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
   NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
@@ -1495,6 +1498,13 @@ const desktopApi = Object.freeze({
     await invokeWithStartupProfileTiming(
       "refreshThreadPullRequests",
       NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
+      request,
+    ),
+  refreshThreadGitWorkingState: async (
+    request: RefreshThreadGitWorkingStateRequest,
+  ): Promise<RefreshThreadGitWorkingStateResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL,
       request,
     ),
   setPullRequestPollingFocus: async (

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -73,6 +73,7 @@ import { MarkdownRenderingOptionsProvider } from "./lib/markdown-rendering-optio
 import { useThreadNavigation } from "./lib/useThreadNavigation";
 import { usePwrAgentProfiles } from "./lib/usePwrAgentProfiles";
 import { usePullRequestRefresh } from "./features/pr-status/usePullRequestRefresh";
+import { useThreadGitWorkingStateRefresh } from "./features/navigation/useThreadGitWorkingStateRefresh";
 import { useThreadSessionState } from "./lib/useThreadSessionState";
 import { DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT } from "./lib/thread-history-limits";
 import { setSidebarResizing } from "./lib/sidebar-resize-signal";
@@ -872,6 +873,10 @@ function DesktopAppShell(props: {
   const pullRequests = usePullRequestRefresh({
     desktopApi,
     onRefreshNavigation: navigation.refresh,
+    selectedThread: navigation.selectedThread,
+  });
+  const gitWorkingState = useThreadGitWorkingStateRefresh({
+    desktopApi,
     selectedThread: navigation.selectedThread,
   });
   // Browser-style back/forward across threads, project launchpads, and the
@@ -1807,6 +1812,7 @@ function DesktopAppShell(props: {
             void navigation.removeDirectory(directory.key);
           }}
           onPrefetchPullRequests={pullRequests.prefetch}
+          onPrefetchGitWorkingState={gitWorkingState.prefetch}
           onDetachPullRequest={async (thread, pr) => {
             if (!desktopApi?.detachThreadPullRequest) return;
             await desktopApi.detachThreadPullRequest({

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -91,6 +91,7 @@ type DirectoriesListProps = {
     selectionOrder: string[],
   ) => void;
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
+  onPrefetchGitWorkingState?: (thread: NavigationThreadSummary) => void;
   onDetachPullRequest?: (
     thread: NavigationThreadSummary,
     pr: PrSummary,
@@ -784,6 +785,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
               onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
               onDetachPullRequest={props.onDetachPullRequest}
               onPrefetchPullRequests={props.onPrefetchPullRequests}
+              onPrefetchGitWorkingState={props.onPrefetchGitWorkingState}
               onRevealSelectedThreadComplete={
                 props.onRevealSelectedThreadComplete
               }
@@ -918,6 +920,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
             onDetachPullRequest={props.onDetachPullRequest}
             onPrefetchPullRequests={props.onPrefetchPullRequests}
+            onPrefetchGitWorkingState={props.onPrefetchGitWorkingState}
             onRevealSelectedThreadComplete={props.onRevealSelectedThreadComplete}
             onSelectThread={(target, event) =>
               props.onSelectThread(target, event, selectionOrder)
@@ -1317,6 +1320,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
                           onDetachPullRequest={props.onDetachPullRequest}
                           onPrefetchPullRequests={props.onPrefetchPullRequests}
+                          onPrefetchGitWorkingState={props.onPrefetchGitWorkingState}
                           onRevealSelectedThreadComplete={
                             props.onRevealSelectedThreadComplete
                           }

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -47,6 +47,7 @@ type RecentsListProps = {
     position: { x: number; y: number; anchorTop?: number }
   ) => void;
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
+  onPrefetchGitWorkingState?: (thread: NavigationThreadSummary) => void;
   onDetachPullRequest?: (
     thread: NavigationThreadSummary,
     pr: PrSummary,
@@ -243,6 +244,7 @@ export function RecentsList(props: RecentsListProps) {
               onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
               onDetachPullRequest={props.onDetachPullRequest}
               onPrefetchPullRequests={props.onPrefetchPullRequests}
+              onPrefetchGitWorkingState={props.onPrefetchGitWorkingState}
               onRevealSelectedThreadComplete={
                 props.onRevealSelectedThreadComplete
               }
@@ -391,6 +393,7 @@ export function RecentsList(props: RecentsListProps) {
           onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
           onDetachPullRequest={props.onDetachPullRequest}
           onPrefetchPullRequests={props.onPrefetchPullRequests}
+          onPrefetchGitWorkingState={props.onPrefetchGitWorkingState}
           onRevealSelectedThreadComplete={props.onRevealSelectedThreadComplete}
           onSelectThread={(target, event) =>
             props.onSelectThread(target, event, selectionOrder)

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -207,6 +207,7 @@ type SidebarProps = {
    * fresh PR status before they click in.
    */
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
+  onPrefetchGitWorkingState?: (thread: NavigationThreadSummary) => void;
   onDetachPullRequest?: (
     thread: NavigationThreadSummary,
     pr: PrSummary,
@@ -1576,6 +1577,7 @@ export function Sidebar(props: SidebarProps) {
               onOpenThreadContextMenu={openThreadContextMenu}
               onOpenLaunchpad={props.onOpenLaunchpad}
               onPrefetchPullRequests={props.onPrefetchPullRequests}
+              onPrefetchGitWorkingState={props.onPrefetchGitWorkingState}
               onRevealSelectedThreadComplete={
                 props.onRevealSelectedThreadComplete
               }
@@ -1618,6 +1620,7 @@ export function Sidebar(props: SidebarProps) {
                 onOpenThreadContextMenu={openThreadContextMenu}
                 onOpenPullRequestContextMenu={openPullRequestContextMenu}
                 onPrefetchPullRequests={props.onPrefetchPullRequests}
+                onPrefetchGitWorkingState={props.onPrefetchGitWorkingState}
                 onRevealSelectedThreadComplete={
                   props.onRevealSelectedThreadComplete
                 }

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -79,6 +79,8 @@ type ThreadRowProps = {
    * thread key, respect terminal-state short-circuit on the main side).
    */
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
+  /** Fired with the same hover intent signal to refresh local Git state. */
+  onPrefetchGitWorkingState?: (thread: NavigationThreadSummary) => void;
   onDetachPullRequest?: (
     thread: NavigationThreadSummary,
     pr: PrSummary,
@@ -192,11 +194,17 @@ export function ThreadRow(props: ThreadRowProps) {
     active,
   ]);
   const armHoverPrefetch = (): void => {
-    if (!props.onPrefetchPullRequests) return;
+    if (
+      !props.onPrefetchPullRequests
+      && !props.onPrefetchGitWorkingState
+    ) {
+      return;
+    }
     if (hoverTimerRef.current !== undefined) return;
     hoverTimerRef.current = window.setTimeout(() => {
       hoverTimerRef.current = undefined;
       props.onPrefetchPullRequests?.(props.thread);
+      props.onPrefetchGitWorkingState?.(props.thread);
     }, HOVER_PREFETCH_DELAY_MS);
   };
   const cancelHoverPrefetch = (): void => {
@@ -310,8 +318,16 @@ export function ThreadRow(props: ThreadRowProps) {
             flow so it cannot reserve a phantom wrapped row while hidden. */}
         <span
           className="thread-row__chips"
-          onMouseEnter={prs.length > 0 ? armHoverPrefetch : undefined}
-          onMouseLeave={prs.length > 0 ? cancelHoverPrefetch : undefined}
+          onMouseEnter={
+            prs.length > 0 || props.onPrefetchGitWorkingState
+              ? armHoverPrefetch
+              : undefined
+          }
+          onMouseLeave={
+            prs.length > 0 || props.onPrefetchGitWorkingState
+              ? cancelHoverPrefetch
+              : undefined
+          }
         >
           <ThreadMetaChips
             hasApprovalRequest={props.approvalRequestThreadKeys?.[threadKey] === true}

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -203,7 +203,9 @@ export function ThreadRow(props: ThreadRowProps) {
     if (hoverTimerRef.current !== undefined) return;
     hoverTimerRef.current = window.setTimeout(() => {
       hoverTimerRef.current = undefined;
-      props.onPrefetchPullRequests?.(props.thread);
+      if (prs.length > 0) {
+        props.onPrefetchPullRequests?.(props.thread);
+      }
       props.onPrefetchGitWorkingState?.(props.thread);
     }, HOVER_PREFETCH_DELAY_MS);
   };

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -346,6 +346,25 @@ describe("ThreadRow chip flow", () => {
     }
   });
 
+  it("prefetches Git working state after hover dwell without a PR", () => {
+    vi.useFakeTimers();
+    try {
+      const onPrefetchGitWorkingState = vi.fn();
+      const { container } = renderRow({ onPrefetchGitWorkingState });
+
+      fireEvent.mouseEnter(container.querySelector(".thread-row__chips")!);
+      vi.advanceTimersByTime(749);
+      expect(onPrefetchGitWorkingState).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(onPrefetchGitWorkingState).toHaveBeenCalledWith(
+        expect.objectContaining({ id: baseThread.id }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses a full card without action controls for the drag preview", () => {
     vi.useFakeTimers();
     try {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -350,7 +350,11 @@ describe("ThreadRow chip flow", () => {
     vi.useFakeTimers();
     try {
       const onPrefetchGitWorkingState = vi.fn();
-      const { container } = renderRow({ onPrefetchGitWorkingState });
+      const onPrefetchPullRequests = vi.fn();
+      const { container } = renderRow({
+        onPrefetchGitWorkingState,
+        onPrefetchPullRequests,
+      });
 
       fireEvent.mouseEnter(container.querySelector(".thread-row__chips")!);
       vi.advanceTimersByTime(749);
@@ -360,6 +364,7 @@ describe("ThreadRow chip flow", () => {
       expect(onPrefetchGitWorkingState).toHaveBeenCalledWith(
         expect.objectContaining({ id: baseThread.id }),
       );
+      expect(onPrefetchPullRequests).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadGitWorkingStateRefresh.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadGitWorkingStateRefresh.test.tsx
@@ -1,0 +1,98 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildFederatedThreadRef,
+  type NavigationThreadSummary,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { useThreadGitWorkingStateRefresh } from "../useThreadGitWorkingStateRefresh";
+
+function buildThread(
+  overrides: Partial<NavigationThreadSummary> = {},
+): NavigationThreadSummary {
+  return {
+    id: "thread-1",
+    source: "codex",
+    title: "Thread",
+    titleSource: "explicit",
+    createdAt: 1,
+    updatedAt: 2,
+    inbox: { inInbox: false },
+    linkedDirectories: [],
+    projectKey: "/repo/worktree",
+    ...overrides,
+  };
+}
+
+describe("useThreadGitWorkingStateRefresh", () => {
+  it("puts the selected thread on the scheduled refresh tier", async () => {
+    const refreshThreadGitWorkingState = vi.fn(async () => ({ scheduled: true }));
+    const desktopApi = {
+      refreshThreadGitWorkingState,
+    } satisfies DesktopApi;
+
+    renderHook(() =>
+      useThreadGitWorkingStateRefresh({
+        desktopApi,
+        selectedThread: buildThread(),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(refreshThreadGitWorkingState).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        trigger: "scheduled",
+      });
+    });
+  });
+
+  it("marks deliberate hover prefetches as user-triggered", async () => {
+    const refreshThreadGitWorkingState = vi.fn(async () => ({ scheduled: true }));
+    const desktopApi = {
+      refreshThreadGitWorkingState,
+    } satisfies DesktopApi;
+    const { result } = renderHook(() =>
+      useThreadGitWorkingStateRefresh({ desktopApi }),
+    );
+
+    result.current.prefetch(buildThread());
+
+    await waitFor(() => {
+      expect(refreshThreadGitWorkingState).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        trigger: "user",
+      });
+    });
+  });
+
+  it("does not refresh remote-owned threads from the viewer", async () => {
+    const refreshThreadGitWorkingState = vi.fn(async () => ({ scheduled: true }));
+    const desktopApi = {
+      refreshThreadGitWorkingState,
+    } satisfies DesktopApi;
+    const remoteThread = buildThread({
+      federation: {
+        ref: buildFederatedThreadRef({
+          backend: "codex",
+          instanceId: "peer-laptop",
+          threadId: "thread-1",
+        }),
+        instanceLabel: "Laptop",
+        peerStatus: "connected",
+      },
+    });
+    const { result } = renderHook(() =>
+      useThreadGitWorkingStateRefresh({
+        desktopApi,
+        selectedThread: remoteThread,
+      }),
+    );
+
+    result.current.prefetch(remoteThread);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(refreshThreadGitWorkingState).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadGitWorkingStateRefresh.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadGitWorkingStateRefresh.test.tsx
@@ -67,6 +67,38 @@ describe("useThreadGitWorkingStateRefresh", () => {
     });
   });
 
+  it("refreshes a selected thread from its linked local directory", async () => {
+    const refreshThreadGitWorkingState = vi.fn(async () => ({ scheduled: true }));
+    const desktopApi = {
+      refreshThreadGitWorkingState,
+    } satisfies DesktopApi;
+
+    renderHook(() =>
+      useThreadGitWorkingStateRefresh({
+        desktopApi,
+        selectedThread: buildThread({
+          projectKey: undefined,
+          linkedDirectories: [
+            {
+              id: "directory:/repo/local",
+              kind: "local",
+              label: "local",
+              path: "/repo/local",
+            },
+          ],
+        }),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(refreshThreadGitWorkingState).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        trigger: "scheduled",
+      });
+    });
+  });
+
   it("does not refresh remote-owned threads from the viewer", async () => {
     const refreshThreadGitWorkingState = vi.fn(async () => ({ scheduled: true }));
     const desktopApi = {

--- a/apps/desktop/src/renderer/src/features/navigation/useThreadGitWorkingStateRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/useThreadGitWorkingStateRefresh.ts
@@ -6,6 +6,7 @@ import {
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { readRendererFederationTarget } from "../../lib/federation-window";
+import { resolveThreadWorkingStatePath } from "../../lib/thread-working-state-path";
 
 const SELECTED_REFRESH_INTERVAL_MS = 60_000;
 const USER_REFRESH_COOLDOWN_MS = 10_000;
@@ -28,7 +29,7 @@ export function useThreadGitWorkingStateRefresh(params: {
     ): void => {
       if (!desktopApi?.refreshThreadGitWorkingState) return;
       if (isFederationWindow || isRemoteFederatedThread(thread)) return;
-      if (!resolveWorkingStatePath(thread)) return;
+      if (!resolveThreadWorkingStatePath(thread)) return;
       void desktopApi.refreshThreadGitWorkingState({
         backend: thread.source,
         threadId: thread.id,
@@ -90,22 +91,12 @@ export function useThreadGitWorkingStateRefresh(params: {
 function buildRefreshRequestKey(
   thread: NavigationThreadSummary,
 ): string | undefined {
-  const worktreePath = resolveWorkingStatePath(thread);
+  const worktreePath = resolveThreadWorkingStatePath(thread);
   if (!worktreePath) return undefined;
   return JSON.stringify({
     threadKey: buildThreadIdentityKey(thread.source, thread.id),
     worktreePath,
   });
-}
-
-function resolveWorkingStatePath(
-  thread: NavigationThreadSummary,
-): string | undefined {
-  const projectKey = thread.projectKey?.trim();
-  if (projectKey) return projectKey;
-  return thread.linkedDirectories.find((directory) =>
-    Boolean(directory.worktreePath?.trim())
-  )?.worktreePath?.trim();
 }
 
 function isRemoteFederatedThread(thread: NavigationThreadSummary): boolean {

--- a/apps/desktop/src/renderer/src/features/navigation/useThreadGitWorkingStateRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/useThreadGitWorkingStateRefresh.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import {
+  buildThreadIdentityKey,
+  isRemoteFederationTarget,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { readRendererFederationTarget } from "../../lib/federation-window";
+
+const SELECTED_REFRESH_INTERVAL_MS = 60_000;
+const USER_REFRESH_COOLDOWN_MS = 10_000;
+
+/**
+ * Keeps the selected thread's Git chips on a focused refresh tier and exposes
+ * a user-triggered hover prefetch. The broad navigation refresh remains a
+ * bounded slow lane; these requests target only the worktree being inspected.
+ */
+export function useThreadGitWorkingStateRefresh(params: {
+  desktopApi?: DesktopApi;
+  selectedThread?: NavigationThreadSummary;
+}): { prefetch: (thread: NavigationThreadSummary) => void } {
+  const desktopApi = params.desktopApi;
+  const isFederationWindow = Boolean(readRendererFederationTarget());
+  const refresh = useCallback(
+    (
+      thread: NavigationThreadSummary,
+      trigger: "scheduled" | "user",
+    ): void => {
+      if (!desktopApi?.refreshThreadGitWorkingState) return;
+      if (isFederationWindow || isRemoteFederatedThread(thread)) return;
+      if (!resolveWorkingStatePath(thread)) return;
+      void desktopApi.refreshThreadGitWorkingState({
+        backend: thread.source,
+        threadId: thread.id,
+        trigger,
+      }).catch(() => {
+        // Logged in main — keep the renderer silent.
+      });
+    },
+    [desktopApi, isFederationWindow],
+  );
+
+  const selected = params.selectedThread;
+  const selectedRef = useRef<NavigationThreadSummary | undefined>(selected);
+  const selectedRefreshKey = useMemo(
+    () => selected ? buildRefreshRequestKey(selected) : undefined,
+    [selected],
+  );
+  useEffect(() => {
+    selectedRef.current = selected;
+  }, [selected]);
+  useEffect(() => {
+    if (!selectedRefreshKey) return;
+    const refreshSelected = (): void => {
+      const currentSelected = selectedRef.current;
+      if (!currentSelected) return;
+      if (buildRefreshRequestKey(currentSelected) !== selectedRefreshKey) return;
+      refresh(currentSelected, "scheduled");
+    };
+
+    refreshSelected();
+    const intervalId = window.setInterval(
+      refreshSelected,
+      SELECTED_REFRESH_INTERVAL_MS,
+    );
+    return () => window.clearInterval(intervalId);
+  }, [refresh, selectedRefreshKey]);
+
+  const lastUserRefreshAtByThreadKey = useRef(new Map<string, number>());
+  const prefetch = useCallback(
+    (thread: NavigationThreadSummary): void => {
+      const key = buildThreadIdentityKey(thread.source, thread.id);
+      const now = Date.now();
+      const lastRefreshAt = lastUserRefreshAtByThreadKey.current.get(key);
+      if (
+        lastRefreshAt !== undefined
+        && now - lastRefreshAt < USER_REFRESH_COOLDOWN_MS
+      ) {
+        return;
+      }
+      lastUserRefreshAtByThreadKey.current.set(key, now);
+      refresh(thread, "user");
+    },
+    [refresh],
+  );
+
+  return { prefetch };
+}
+
+function buildRefreshRequestKey(
+  thread: NavigationThreadSummary,
+): string | undefined {
+  const worktreePath = resolveWorkingStatePath(thread);
+  if (!worktreePath) return undefined;
+  return JSON.stringify({
+    threadKey: buildThreadIdentityKey(thread.source, thread.id),
+    worktreePath,
+  });
+}
+
+function resolveWorkingStatePath(
+  thread: NavigationThreadSummary,
+): string | undefined {
+  const projectKey = thread.projectKey?.trim();
+  if (projectKey) return projectKey;
+  return thread.linkedDirectories.find((directory) =>
+    Boolean(directory.worktreePath?.trim())
+  )?.worktreePath?.trim();
+}
+
+function isRemoteFederatedThread(thread: NavigationThreadSummary): boolean {
+  const target = thread.federation?.ref.target;
+  return Boolean(target && isRemoteFederationTarget(target));
+}

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1773,8 +1773,15 @@ describe("useThreadNavigation", () => {
           titleSource: "explicit" as const,
           summary: "First thread summary",
           source: "codex" as const,
-          projectKey: "/repo/wt",
-          linkedDirectories: [],
+          linkedDirectories: [
+            {
+              id: "directory:/repo/wt",
+              kind: "worktree" as const,
+              label: "wt",
+              path: "/repo",
+              worktreePath: "/repo/wt",
+            },
+          ],
           inbox: {
             inInbox: true,
             reason: "new-thread" as const,

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -208,6 +208,8 @@ import type {
   UnbindMessagingThreadRequest,
   UnbindMessagingThreadResponse,
   RefreshThreadPullRequestsRequest,
+  RefreshThreadGitWorkingStateRequest,
+  RefreshThreadGitWorkingStateResponse,
   SetPullRequestPollingFocusRequest,
   RefreshThreadPullRequestsResponse,
   RefreshDirectoryGitStatusesRequest,
@@ -848,6 +850,9 @@ export type DesktopApi = {
   refreshThreadPullRequests?: (
     request: RefreshThreadPullRequestsRequest
   ) => Promise<RefreshThreadPullRequestsResponse>;
+  refreshThreadGitWorkingState?: (
+    request: RefreshThreadGitWorkingStateRequest
+  ) => Promise<RefreshThreadGitWorkingStateResponse>;
   /**
    * Tell the main-process PR poller which threads are selected / on screen so
    * their PRs refresh on the fast tier.

--- a/apps/desktop/src/renderer/src/lib/thread-working-state-path.ts
+++ b/apps/desktop/src/renderer/src/lib/thread-working-state-path.ts
@@ -1,0 +1,30 @@
+import type { NavigationThreadSummary } from "@pwragent/shared";
+
+/** Mirrors the main-process working-state owner-path resolution contract. */
+export function resolveThreadWorkingStatePath(
+  thread: Pick<NavigationThreadSummary, "projectKey" | "linkedDirectories">,
+): string | undefined {
+  const projectKey = thread.projectKey?.trim();
+  if (projectKey) {
+    return projectKey;
+  }
+
+  for (const directory of thread.linkedDirectories) {
+    const worktreePath = directory.worktreePath?.trim();
+    if (worktreePath) {
+      return worktreePath;
+    }
+  }
+
+  for (const directory of thread.linkedDirectories) {
+    if (directory.kind !== "local") {
+      continue;
+    }
+    const directoryPath = directory.path.trim();
+    if (directoryPath) {
+      return directoryPath;
+    }
+  }
+
+  return undefined;
+}

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -42,6 +42,7 @@ import {
 import type { DesktopApi } from "./desktop-api";
 import { fileLabelFromPath } from "./directory-references";
 import { readRendererFederationTarget } from "./federation-window";
+import { resolveThreadWorkingStatePath } from "./thread-working-state-path";
 import {
   agentEventThreadIdentityKey,
   federationTargetsEqual,
@@ -864,7 +865,7 @@ function applyThreadGitWorkingStateUpdate(
 
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
-    if (thread.projectKey !== params.worktreePath) {
+    if (resolveThreadWorkingStatePath(thread) !== params.worktreePath) {
       return thread;
     }
     if (

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -152,6 +152,8 @@ export const NAVIGATION_SET_DIRECTORY_THREADS_COLLAPSED_CHANNEL =
   "navigation:set-directory-threads-collapsed";
 export const NAVIGATION_REFRESH_THREAD_PRS_CHANNEL =
   "navigation:refresh-thread-prs";
+export const NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL =
+  "navigation:refresh-thread-git-working-state";
 export const NAVIGATION_SET_PR_POLLING_FOCUS_CHANNEL =
   "navigation:set-pr-polling-focus";
 export const NAVIGATION_DETACH_THREAD_PR_CHANNEL =

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -799,6 +799,17 @@ export type NavigationThreadGitWorkingStateUpdatedNotification = {
   };
 };
 
+export type RefreshThreadGitWorkingStateRequest = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  /** User inspection bypasses cache freshness; scheduled focus refreshes do not. */
+  trigger: "scheduled" | "user";
+};
+
+export type RefreshThreadGitWorkingStateResponse = {
+  scheduled: boolean;
+};
+
 export type RefreshDirectoryGitStatusesRequest = {
   directoryKeys: string[];
   /** Route filesystem inspection to the instance that owns these directories. */


### PR DESCRIPTION
## What changed

- Replace the one-time eight-worktree allowance with a fair slow lane that probes unseen and least-recently-refreshed worktrees first.
- Keep each background pass bounded while ensuring stable lists larger than one batch cannot starve.
- Add a focused lane that refreshes the selected thread immediately and every 60 seconds.
- Add a user-triggered lane after deliberate thread-chip hover; it bypasses cache freshness for exactly that local worktree.
- Keep PR hover prefetch gated to rows that actually have PRs.
- Resolve focused refreshes and streamed updates through the same project/worktree/local-directory path contract.
- Reject viewer-side refreshes for remote-owned threads so filesystem probes stay on the owning machine.

## Root cause

The branch tooltip was not showing the local `main...origin/main` count. It had cached a valid earlier branch-base calculation: the thread forked at `f7bb5e0`, and the then-observed base tip `3671432` was three commits ahead.

The original working-state scheduler allowed only eight automatic probes for the entire desktop process lifetime. A first revision made that limit per pass, but a stable list larger than eight would still refresh the same prefix every time. The final scheduler now rotates the background batch by persisted `fetchedAt`, while selected and deliberately inspected threads refresh through focused paths modeled after PR refresh behavior.

## Impact

Thread branch tooltips refresh stale base commit, base tip, behind, and ahead metadata without allowing active/recent threads or worktrees beyond the first batch to remain stale indefinitely. Background Git work stays bounded, user inspection can request a fresh value immediately, and PR-less rows avoid unnecessary PR lookup traffic.

## Validation

- 158 focused main/renderer tests passed.
- `pnpm typecheck`
- `pnpm lint:eslint` — passes with repository baseline warnings.
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`
