### PR TITLE
fix(desktop): unnest copy chips from thread row and star map buttons

### DIFF
--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -71,6 +71,14 @@ async function launchAuditApp(options?: {
 // watermark behind them), so the map audits run against a fixture whose
 // threads are `threadStatus: "active"` and therefore populate a lane.
 //
+// Both themes ship, so both themes are gated. See the header note.
+// `as const`, not `readonly DesktopAppearanceTheme[]` — that type also
+// admits "system", which resolves through the OS and lands on light on
+// most Linux runners (see the note on `appearance` in
+// fixtures/electron-app.ts). Pinning the literals keeps a
+// nondeterministic third entry from typechecking its way in.
+const AUDIT_THEMES = ["dark", "light"] as const satisfies readonly DesktopAppearanceTheme[];
+
 // Its threads carry linked directories on purpose. A project chip renders
 // through `CopyableThreadChip`, a `role="button" tabIndex={0}` span, and
 // the row/card used to wrap their whole content in a real `<button>` — so
@@ -82,17 +90,14 @@ async function launchAuditApp(options?: {
 // rather than a landmine in it. Keep the directories — they are what
 // stops the nesting from creeping back, on the card and on the sidebar
 // row behind it.
-// Both themes ship, so both themes are gated. See the header note.
-// `as const`, not `readonly DesktopAppearanceTheme[]` — that type also
-// admits "system", which resolves through the OS and lands on light on
-// most Linux runners (see the note on `appearance` in
-// fixtures/electron-app.ts). Pinning the literals keeps a
-// nondeterministic third entry from typechecking its way in.
-const AUDIT_THEMES = ["dark", "light"] as const satisfies readonly DesktopAppearanceTheme[];
-
 const STAR_MAP_FIXTURE = path.resolve(
   specDir,
   "fixtures/star-map/replay.fixture.json",
+);
+
+const COPY_CHIP_FIXTURE = path.resolve(
+  specDir,
+  "fixtures/a11y-copy-chips/replay.fixture.json",
 );
 
 const WCAG_AA_TAGS = [
@@ -203,32 +208,31 @@ for (const theme of AUDIT_THEMES) {
     // carrying all three chip flavours: a worktree directory, a local one,
     // and a branch.
     //
-    // Borrowed from the context-rail spec rather than reusing
-    // STAR_MAP_FIXTURE (which now carries directories too), for one
-    // reason: those threads are
+    // Its own fixture, deliberately, on two counts. STAR_MAP_FIXTURE
+    // carries directories now, but its threads are
     // `threadStatus: "active"`, so the thread view renders its
     // `.transcript-list__pending` live region — a `role="status"` sibling
     // of the `role="listitem"` entries inside `.transcript-list__items`,
     // which is a `role="list"`. That trips `aria-required-children`,
     // pre-existing transcript debt unrelated to the chips. (The map blocks
-    // below do not hit it because the map layer covers the thread view.)
-    // An idle-thread fixture keeps this scan UNSCOPED — narrowing it with
-    // `include` would have been the cheap way out and would have quietly
-    // stopped this block catching anything outside the sidebar.
+    // below miss it only because the map layer covers the thread view.)
+    // Borrowing another spec's fixture would work too, but this gate's
+    // coverage would then hinge on a file it does not own: drop a directory
+    // there and this block goes quiet with no failure anywhere. An idle
+    // thread also keeps the scan UNSCOPED — narrowing it with `include` is
+    // the cheap way out and would stop this block catching anything outside
+    // the sidebar.
     test("sidebar rows carrying copy chips have no violations", async () => {
       const app = await launchAuditApp({
         theme,
-        fixturePath: path.resolve(
-          specDir,
-          "fixtures/context-rail-linked-directory-tooltips/replay.fixture.json",
-        ),
+        fixturePath: COPY_CHIP_FIXTURE,
       });
       try {
         // The branch chip renders last of the row's copy chips, so waiting
         // on it means the linked-directory chips are up too.
         await expect(
           app.window.getByRole("button", {
-            name: "Copy branch feature/context-tooltips",
+            name: "Copy branch feature/copy-chip-audit",
           }),
         ).toBeVisible();
         await runAxe(app.window);

--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -71,19 +71,17 @@ async function launchAuditApp(options?: {
 // watermark behind them), so the map audits run against a fixture whose
 // threads are `threadStatus: "active"` and therefore populate a lane.
 //
-// That fixture's threads deliberately carry NO linked directories. A
-// project chip renders through `CopyableThreadChip`, which is a
-// `role="button" tabIndex={0}` span, and both the sidebar thread row and
-// the star-map card wrap their content in a real `<button>` — so any
-// fixture with a directory trips `nested-interactive` on BOTH surfaces.
-// That is pre-existing renderer debt, not a Star Map regression, and the
-// fix is a structural change to the row/card (hoist the chips out of the
-// button, the way `.star-map-card-shell` already hoists the kebab).
-// Waiving it here is not an option worth taking: `KNOWN_VIOLATIONS`
-// works by `exclude()`, so waiving the rule would drop the whole card
-// from the scan and blind the very contrast pairs this block exists to
-// audit. Tracked separately; when it lands, give these threads a
-// directory so the project chip is covered too.
+// Its threads carry linked directories on purpose. A project chip renders
+// through `CopyableThreadChip`, a `role="button" tabIndex={0}` span, and
+// the row/card used to wrap their whole content in a real `<button>` — so
+// any fixture with a directory tripped `nested-interactive` on BOTH
+// surfaces, and these threads had to stay directory-less to keep the gate
+// green. That debt is paid: the chip flow is now a SIBLING of the
+// open-thread button on both surfaces (the shape `.star-map-card-shell`
+// already used for its kebab), so the chips are the point of the fixture
+// rather than a landmine in it. Keep the directories — they are what
+// stops the nesting from creeping back, on the card and on the sidebar
+// row behind it.
 // Both themes ship, so both themes are gated. See the header note.
 // `as const`, not `readonly DesktopAppearanceTheme[]` — that type also
 // admits "system", which resolves through the OS and lands on light on
@@ -190,6 +188,48 @@ for (const theme of AUDIT_THEMES) {
         // thread" row is the proxy for "renderer has hydrated".
         await expect(
           app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
+        ).toBeVisible();
+        await runAxe(app.window);
+      } finally {
+        await app.close();
+      }
+    });
+
+    // The smoke thread above has no linked directories and no branch, so
+    // its row renders none of the click-to-copy chips
+    // (`CopyableThreadChip` — a `role="button"` span). Those chips are what
+    // made the row's own button a `nested-interactive` violation, so the
+    // block above cannot catch a regression of it. This one audits a row
+    // carrying all three chip flavours: a worktree directory, a local one,
+    // and a branch.
+    //
+    // Borrowed from the context-rail spec rather than reusing
+    // STAR_MAP_FIXTURE (which now carries directories too), for one
+    // reason: those threads are
+    // `threadStatus: "active"`, so the thread view renders its
+    // `.transcript-list__pending` live region — a `role="status"` sibling
+    // of the `role="listitem"` entries inside `.transcript-list__items`,
+    // which is a `role="list"`. That trips `aria-required-children`,
+    // pre-existing transcript debt unrelated to the chips. (The map blocks
+    // below do not hit it because the map layer covers the thread view.)
+    // An idle-thread fixture keeps this scan UNSCOPED — narrowing it with
+    // `include` would have been the cheap way out and would have quietly
+    // stopped this block catching anything outside the sidebar.
+    test("sidebar rows carrying copy chips have no violations", async () => {
+      const app = await launchAuditApp({
+        theme,
+        fixturePath: path.resolve(
+          specDir,
+          "fixtures/context-rail-linked-directory-tooltips/replay.fixture.json",
+        ),
+      });
+      try {
+        // The branch chip renders last of the row's copy chips, so waiting
+        // on it means the linked-directory chips are up too.
+        await expect(
+          app.window.getByRole("button", {
+            name: "Copy branch feature/context-tooltips",
+          }),
         ).toBeVisible();
         await runAxe(app.window);
       } finally {

--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -1066,8 +1066,15 @@ test("directory launchpad keeps new worktree as the sticky default after startin
       ownerThreadId: "thread-new-worktree",
     });
 
+    // Scope to the row CARD, not the open-thread button inside it: the chip
+    // flow is the button's sibling, because chips carry buttons of their own
+    // and a button inside a button is invalid (see ThreadRow).
     const startedThreadRow = app.window
-      .getByRole("button", { name: /Use a sticky worktree default/ })
+      .locator(".thread-row", {
+        has: app.window.getByRole("button", {
+          name: /Use a sticky worktree default/,
+        }),
+      })
       .first();
     // Renamed in the chip-flow refactor: meta + PR + binding + reactions
     // chips all share a single `.thread-row__chips` flex-wrap container.

--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -265,8 +265,14 @@ test.describe("federation remote window", () => {
       const locallyMountedRemoteRow = window.getByRole("button", {
         name: "Remote gateway thread one",
       });
+      // Row state (selection, offline dim) lives on the CARD; the button is
+      // only the title line inside it, because the chip flow beside it
+      // carries buttons of its own (see ThreadRow).
+      const locallyMountedRemoteCard = window.locator(".thread-row", {
+        has: locallyMountedRemoteRow,
+      });
       await expect(locallyMountedRemoteRow).toBeVisible({ timeout: 30_000 });
-      await expect(locallyMountedRemoteRow).not.toHaveClass(/is-remote-offline/);
+      await expect(locallyMountedRemoteCard).not.toHaveClass(/is-remote-offline/);
 
       // Local-only chrome stays hidden in the remote window.
       await expect(
@@ -300,6 +306,9 @@ test.describe("federation remote window", () => {
       // remote-PTY terminal toggle enabled (the gateway granted remote_pty).
       const remoteRowOne = remote.getByRole("button", {
         name: "Remote gateway thread one",
+      });
+      const remoteCardOne = remote.locator(".thread-row", {
+        has: remoteRowOne,
       });
       await remoteRowOne.click();
       await expect(
@@ -473,9 +482,9 @@ test.describe("federation remote window", () => {
       await expect(remoteReply).toContainText(recoveryDraft);
       await expect(sendButton).toBeDisabled();
       await expect(remoteRowOne).toBeVisible();
-      await expect(remoteRowOne).toHaveClass(/is-remote-offline/);
+      await expect(remoteCardOne).toHaveClass(/is-remote-offline/);
       await expect(locallyMountedRemoteRow).toBeVisible();
-      await expect(locallyMountedRemoteRow).toHaveClass(/is-remote-offline/);
+      await expect(locallyMountedRemoteCard).toHaveClass(/is-remote-offline/);
 
       // Recovery: the same identity returns on the same port; the client
       // reconnects on its own backoff and the window heals without a

--- a/apps/desktop/e2e/fixtures/a11y-copy-chips/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/a11y-copy-chips/replay.fixture.json
@@ -1,0 +1,100 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "a11y-copy-chips",
+    "threadId": "thread-a11y-copy-chips"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list"
+        ]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-a11y-copy-chips",
+          "title": "Copy chip audit thread",
+          "titleSource": "explicit",
+          "summary": "A sidebar row carrying every click-to-copy chip flavour.",
+          "source": "codex",
+          "executionMode": "default",
+          "gitBranch": "feature/copy-chip-audit",
+          "linkedDirectories": [
+            {
+              "id": "copy-chip-worktree-dir",
+              "kind": "worktree",
+              "label": "PwrAgent",
+              "path": "/repo/PwrAgent",
+              "worktreePath": "/repo/PwrAgent/.worktrees/feature-copy-chip-audit"
+            },
+            {
+              "id": "copy-chip-local-dir",
+              "kind": "local",
+              "label": "PwrSnap",
+              "path": "/repo/PwrSnap"
+            }
+          ],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1760000000000
+        }
+      ]
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "user",
+            "text": "Show me a row with copy chips."
+          },
+          {
+            "type": "message",
+            "id": "message-2",
+            "role": "assistant",
+            "text": "The copy chip row is live."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "user",
+            "text": "Show me a row with copy chips."
+          },
+          {
+            "id": "message-2",
+            "role": "assistant",
+            "text": "The copy chip row is live."
+          }
+        ],
+        "lastUserMessage": "Show me a row with copy chips.",
+        "lastAssistantMessage": "The copy chip row is live.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/fixtures/star-map/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/star-map/replay.fixture.json
@@ -34,7 +34,16 @@
           "source": "codex",
           "executionMode": "default",
           "threadStatus": "active",
-          "linkedDirectories": [],
+          "gitBranch": "feature/star-map-audit",
+          "linkedDirectories": [
+            {
+              "id": "star-map-worktree-dir",
+              "kind": "worktree",
+              "label": "PwrAgent",
+              "path": "/repo/PwrAgent",
+              "worktreePath": "/repo/PwrAgent/.worktrees/feature-star-map-audit"
+            }
+          ],
           "inbox": {
             "inInbox": true,
             "reason": "new-thread"
@@ -49,7 +58,14 @@
           "source": "codex",
           "executionMode": "default",
           "threadStatus": "active",
-          "linkedDirectories": [],
+          "linkedDirectories": [
+            {
+              "id": "star-map-local-dir",
+              "kind": "local",
+              "label": "PwrSnap",
+              "path": "/repo/PwrSnap"
+            }
+          ],
           "inbox": {
             "inInbox": false
           },

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -136,7 +136,7 @@ export function ThreadRow(props: ThreadRowProps) {
   );
   const status = getThreadRowStatus(props.thread, props.thinkingThreadKeys);
   const [pickerOpen, setPickerOpen] = useState(false);
-  const rowButtonRef = useRef<HTMLButtonElement>(null);
+  const rowRef = useRef<HTMLDivElement>(null);
   const completedRevealRequestRef = useRef(0);
   const revealSelectedThreadRequest = props.revealSelectedThreadRequest ?? 0;
   const onRevealSelectedThreadComplete =
@@ -168,11 +168,11 @@ export function ThreadRow(props: ThreadRowProps) {
       return;
     }
 
-    if (typeof rowButtonRef.current?.scrollIntoView !== "function") {
+    if (typeof rowRef.current?.scrollIntoView !== "function") {
       return;
     }
 
-    rowButtonRef.current.scrollIntoView({
+    rowRef.current.scrollIntoView({
       block: "nearest",
     });
   }, [active, threadKey]);
@@ -265,42 +265,52 @@ export function ThreadRow(props: ThreadRowProps) {
           }}
         />
       ) : null}
-      <button
-        ref={rowButtonRef}
-        aria-label={props.thread.title}
-        aria-pressed={selected}
+      <div
+        ref={rowRef}
         className={`thread-row${props.compact ? " thread-row--compact" : ""}${
           selected ? " is-selected" : ""
         }${isComposerSource ? " is-composer-source" : ""}${
           isRemoteOffline ? " is-remote-offline" : ""
         }`}
-        type="button"
-        onKeyDown={(event) => {
-          // Reorder a pinned thread within its backend's pinned
-          // slice. Unified with the directory-pin shortcut
-          // (Cmd+Shift+Arrow) so users learn one keybind. Plain
-          // Cmd+Arrow used to drive this — that collided with
-          // macOS Finder's "go to parent folder" mental model and
-          // diverged from the directory shortcut.
-          if (
-            props.onMovePinnedThread &&
-            props.thread.pinnedRank &&
-            event.metaKey &&
-            event.shiftKey &&
-            !event.altKey &&
-            !event.ctrlKey &&
-            (event.key === "ArrowUp" || event.key === "ArrowDown")
-          ) {
-            event.preventDefault();
-            props.onMovePinnedThread(
-              props.thread,
-              event.key === "ArrowUp" ? "up" : "down",
-            );
-          }
-        }}
-        onClick={(event) => props.onSelectThread(props.thread, event)}
       >
-        <span className="thread-row__header">
+        {/* The card's primary action. It carries the title line and
+            stretches over the whole card via `.thread-row__open::after`
+            (see app.css), but it is a SIBLING of the chip flow rather
+            than its ancestor: the chips own real buttons (copy path,
+            copy branch, unpin, unbind, reactions, PR links) and a button
+            inside a button is neither valid nor operable — axe reports it
+            as `nested-interactive`. `.star-map-card-shell` uses the same
+            shape for its kebab. */}
+        <button
+          aria-label={props.thread.title}
+          aria-pressed={selected}
+          className="thread-row__header thread-row__open"
+          type="button"
+          onKeyDown={(event) => {
+            // Reorder a pinned thread within its backend's pinned
+            // slice. Unified with the directory-pin shortcut
+            // (Cmd+Shift+Arrow) so users learn one keybind. Plain
+            // Cmd+Arrow used to drive this — that collided with
+            // macOS Finder's "go to parent folder" mental model and
+            // diverged from the directory shortcut.
+            if (
+              props.onMovePinnedThread &&
+              props.thread.pinnedRank &&
+              event.metaKey &&
+              event.shiftKey &&
+              !event.altKey &&
+              !event.ctrlKey &&
+              (event.key === "ArrowUp" || event.key === "ArrowDown")
+            ) {
+              event.preventDefault();
+              props.onMovePinnedThread(
+                props.thread,
+                event.key === "ArrowUp" ? "up" : "down",
+              );
+            }
+          }}
+          onClick={(event) => props.onSelectThread(props.thread, event)}
+        >
           <span className="thread-row__heading">
             <ThreadRowStatus status={status} />
             <span className="thread-row__title">{props.thread.title}</span>
@@ -308,7 +318,7 @@ export function ThreadRow(props: ThreadRowProps) {
           <span className="thread-row__time">
             {formatRelativeTime(props.thread.updatedAt)}
           </span>
-        </span>
+        </button>
 
         {/* Single ordered chip flow: meta (provider / location / pinned /
             branch / drift) → messaging binding chips → PR chips →
@@ -394,7 +404,7 @@ export function ThreadRow(props: ThreadRowProps) {
           ))}
         </span>
 
-      </button>
+      </div>
 
       <div className="thread-row__actions">
         {canReact ? (

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -327,7 +327,14 @@ export function ThreadRow(props: ThreadRowProps) {
             fixed-width metadata packs first and single-chip orphan rows
             are minimized. flex-wrap handles overflow naturally; the
             hover-only add-reaction affordance is positioned outside the
-            flow so it cannot reserve a phantom wrapped row while hidden. */}
+            flow so it cannot reserve a phantom wrapped row while hidden.
+
+            The container is `pointer-events: none` (see app.css) so the
+            gaps between chips fall through to the open-thread overlay, so
+            these hover handlers fire when the pointer enters a CHIP —
+            React synthesizes enter/leave along the ancestor path — not
+            when it enters the container's empty space. That matches what
+            the prefetch is for; just don't read it as "hovered the row". */}
         <span
           className="thread-row__chips"
           onMouseEnter={

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -16,6 +16,22 @@ import type {
 } from "@pwragent/shared";
 import { Sidebar } from "../Sidebar";
 
+/**
+ * The whole row card for a thread, given its open-thread button.
+ *
+ * The button is only the title line: the chip flow is its SIBLING inside
+ * `.thread-row`, because chips carry buttons of their own and a button
+ * inside a button is invalid (see ThreadRow). Assertions about chips have
+ * to scope to the card, not to the button.
+ */
+function threadCard(openButton: HTMLElement): HTMLElement {
+  const card = openButton.closest(".thread-row");
+  if (!(card instanceof HTMLElement)) {
+    throw new Error("Expected the open-thread button to sit inside .thread-row");
+  }
+  return card;
+}
+
 async function clickElement(element: HTMLElement): Promise<void> {
   await act(async () => {
     fireEvent.click(element);
@@ -260,7 +276,7 @@ describe("Sidebar", () => {
     );
 
     expect(
-      screen.getByRole("button", { name: "Cross-project cleanup" }),
+      threadCard(screen.getByRole("button", { name: "Cross-project cleanup" })),
     ).toHaveClass("is-remote-offline");
     expect(
       screen.queryByText("Error invoking remote method: peer is not connected"),
@@ -1544,14 +1560,16 @@ describe("Sidebar", () => {
     );
 
     const browseSection = screen.getByRole("region", { name: "Thread browser" });
-    const threadButton = within(browseSection as HTMLElement).getByRole("button", {
-      name: /Cross-project cleanup/i,
-    });
+    const threadRow = threadCard(
+      within(browseSection as HTMLElement).getByRole("button", {
+        name: /Cross-project cleanup/i,
+      }),
+    );
 
-    expect(within(threadButton).getByLabelText("Copy path for worktree PwrAgent")).toHaveTextContent(
+    expect(within(threadRow).getByLabelText("Copy path for worktree PwrAgent")).toHaveTextContent(
       "PwrAgent"
     );
-    expect(within(threadButton).queryByText("worktree")).not.toBeInTheDocument();
+    expect(within(threadRow).queryByText("worktree")).not.toBeInTheDocument();
   });
 
   it("keeps kind chips for single-directory rows", () => {
@@ -1599,16 +1617,20 @@ describe("Sidebar", () => {
       .find((button) => button.hasAttribute("aria-expanded"));
     expect(directorySummary).toBeDefined();
     fireEvent.click(directorySummary!);
-    const worktreeThreadButton = within(browseSection as HTMLElement).getByRole("button", {
-      name: /Cross-project cleanup/i,
-    });
-    const localThreadButton = within(browseSection as HTMLElement).getByRole("button", {
-      name: /Local cleanup/i,
-    });
+    const worktreeThreadRow = threadCard(
+      within(browseSection as HTMLElement).getByRole("button", {
+        name: /Cross-project cleanup/i,
+      }),
+    );
+    const localThreadRow = threadCard(
+      within(browseSection as HTMLElement).getByRole("button", {
+        name: /Local cleanup/i,
+      }),
+    );
 
-    expect(within(worktreeThreadButton).getByText("worktree")).toBeInTheDocument();
-    expect(within(worktreeThreadButton).queryByText("PwrAgent")).not.toBeInTheDocument();
-    expect(within(localThreadButton).getByText("local")).toBeInTheDocument();
+    expect(within(worktreeThreadRow).getByText("worktree")).toBeInTheDocument();
+    expect(within(worktreeThreadRow).queryByText("PwrAgent")).not.toBeInTheDocument();
+    expect(within(localThreadRow).getByText("local")).toBeInTheDocument();
   });
 
   it("names every linked project in multi-directory rows", () => {
@@ -1673,21 +1695,23 @@ describe("Sidebar", () => {
       .find((button) => button.hasAttribute("aria-expanded"));
     expect(pwrGitDirectorySummary).toBeDefined();
     fireEvent.click(pwrGitDirectorySummary!);
-    const threadButton = within(browseSection as HTMLElement).getByRole("button", {
-      name: "Prepare PwrGit branding assets",
-    });
+    const threadRow = threadCard(
+      within(browseSection as HTMLElement).getByRole("button", {
+        name: "Prepare PwrGit branding assets",
+      }),
+    );
 
     expect(
-      within(threadButton).getByLabelText("Copy path for worktree PwrGit"),
+      within(threadRow).getByLabelText("Copy path for worktree PwrGit"),
     ).toHaveTextContent("PwrGit");
     expect(
-      within(threadButton).getByLabelText("Copy path for PwrAgnt"),
+      within(threadRow).getByLabelText("Copy path for PwrAgnt"),
     ).toHaveTextContent("PwrAgnt");
     expect(
-      within(threadButton).getByLabelText("Copy path for PwrSnap"),
+      within(threadRow).getByLabelText("Copy path for PwrSnap"),
     ).toHaveTextContent("PwrSnap");
-    expect(within(threadButton).queryByText("worktree")).not.toBeInTheDocument();
-    expect(within(threadButton).queryByText("local")).not.toBeInTheDocument();
+    expect(within(threadRow).queryByText("worktree")).not.toBeInTheDocument();
+    expect(within(threadRow).queryByText("local")).not.toBeInTheDocument();
   });
 
   it("opens the directory launchpad from the plus button", () => {
@@ -1967,11 +1991,13 @@ describe("Sidebar", () => {
     );
 
     const browseSection = screen.getByRole("region", { name: "Thread browser" });
-    const threadButton = within(browseSection as HTMLElement).getByRole("button", {
-      name: /Cross-project cleanup/i,
-    });
+    const threadRow = threadCard(
+      within(browseSection as HTMLElement).getByRole("button", {
+        name: /Cross-project cleanup/i,
+      }),
+    );
 
-    const approvalChip = within(threadButton).getByTitle("Waiting for approval");
+    const approvalChip = within(threadRow).getByTitle("Waiting for approval");
     expect(approvalChip).toHaveTextContent("Waiting for approval");
     expect(approvalChip).not.toHaveTextContent("!");
     expect(approvalChip).toHaveAttribute("title", "Waiting for approval");
@@ -1999,11 +2025,13 @@ describe("Sidebar", () => {
     );
 
     const browseSection = screen.getByRole("region", { name: "Thread browser" });
-    const threadButton = within(browseSection as HTMLElement).getByRole("button", {
-      name: /Cross-project cleanup/i,
-    });
+    const threadRow = threadCard(
+      within(browseSection as HTMLElement).getByRole("button", {
+        name: /Cross-project cleanup/i,
+      }),
+    );
 
-    const inputChip = within(threadButton).getByTitle("Input needed");
+    const inputChip = within(threadRow).getByTitle("Input needed");
     expect(inputChip).toHaveTextContent("Input needed");
     expect(inputChip).not.toHaveTextContent("Approve");
     expect(inputChip).toHaveAttribute("title", "Input needed");
@@ -2753,7 +2781,7 @@ describe("Sidebar", () => {
     });
     expect(rows[0]).toHaveTextContent("Updated thread");
     expect(
-      within(rows[0]).getByRole("button", { name: "Unpin thread" }),
+      within(threadCard(rows[0]!)).getByRole("button", { name: "Unpin thread" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("separator", { name: "Unpinned threads" })).toBeInTheDocument();
 
@@ -2926,7 +2954,7 @@ describe("Sidebar", () => {
     });
     expect(rows[0]).toHaveTextContent("Updated thread");
     expect(
-      within(rows[0]).getByRole("img", { name: "Pinned" }),
+      within(threadCard(rows[0]!)).getByRole("img", { name: "Pinned" }),
     ).toBeInTheDocument();
     expect(rows[1]).toHaveTextContent("Cross-project cleanup");
   });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -90,6 +90,26 @@ describe("ThreadRow chip flow", () => {
     expect(flow.querySelector(".thread-row__chip--add-reaction")).toBeNull();
   });
 
+  // The invariant this row's structure exists to hold. The chips carry
+  // real buttons (copy path, copy branch, unpin, unbind, reactions, PR
+  // links); nesting them inside the row's own button is `nested-interactive`
+  // — invalid and unoperable. Only the a11y E2E gate would otherwise catch
+  // a re-nesting, and only against a fixture whose thread has a directory,
+  // which is exactly how this shipped unnoticed the first time.
+  it("keeps the chip flow OUTSIDE the open-thread button", () => {
+    const { container } = renderRow();
+    const openButton = container.querySelector(".thread-row__open");
+    const flow = container.querySelector(".thread-row__chips");
+    expect(openButton).not.toBeNull();
+    expect(flow).not.toBeNull();
+    expect(openButton!.tagName).toBe("BUTTON");
+    expect(openButton!.contains(flow)).toBe(false);
+    // …and no focusable descendant hides inside the button either.
+    expect(
+      openButton!.querySelector('button, a, [tabindex], [role="button"]'),
+    ).toBeNull();
+  });
+
   it("positions the add-reaction trigger outside the wrapping chip flow", () => {
     const { container } = renderRow();
     const actions = container.querySelector(".thread-row__actions");
@@ -335,7 +355,15 @@ describe("ThreadRow chip flow", () => {
         onPrefetchPullRequests,
       });
 
-      fireEvent.mouseEnter(container.querySelector(".thread-row__chips")!);
+      // Hover the CHIP, not its container. `.thread-row__chips` is
+      // `pointer-events: none` so the gaps between chips fall through to
+      // the open-thread overlay (see app.css), which means a real pointer
+      // never enters the container directly — only a chip. jsdom has no
+      // layout and ignores `pointer-events`, so firing on the container
+      // would pass while modelling something a user cannot do. `mouseOver`
+      // is what React's enter/leave plugin synthesizes `onMouseEnter` from,
+      // and it dispatches along the ancestor path to the container.
+      fireEvent.mouseOver(container.querySelector(".pr-chip")!);
       vi.advanceTimersByTime(749);
       expect(onPrefetchPullRequests).not.toHaveBeenCalled();
 

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -143,9 +143,10 @@ export function StarMapThreadCard(props: {
   };
 
   return (
-    // Shell owns position, drag and stacking so the clickable surface can
-    // stay a plain button and the kebab can sit beside it rather than
-    // nested inside it.
+    // Shell owns position, drag and stacking so the card itself can stay a
+    // plain container and every interactive part — the open-thread button,
+    // the kebab, the chips — sits beside the others rather than nested
+    // inside one another.
     <div
       className={`star-map-card-shell${
         props.entering ? " star-map-card-shell--entering" : ""
@@ -164,64 +165,71 @@ export function StarMapThreadCard(props: {
       {props.menuActions && props.menuActions.length > 0 ? (
         <StarMapCardMenu actions={props.menuActions} threadTitle={thread.title} />
       ) : null}
-      <button
-        type="button"
-        className="star-map-card"
-        // Names the action rather than letting the button's whole content
-        // become its accessible name; the chips stay readable as content,
-        // and the kebab beside it gets a distinct name of its own.
-        aria-label={`Open thread: ${thread.title}`}
-        onClick={() => {
-          if (suppressClickRef.current) {
-            suppressClickRef.current = false;
-            return;
-          }
-          props.onOpen(thread);
-        }}
-      >
-      <span className="star-map-card__heading">
-        <ThreadRowStatus status={status} />
-        <span className="star-map-card__title" title={thread.title}>
-          {thread.title}
-        </span>
-      </span>
-      <span className="star-map-card__chips">
-        <ThreadMetaChips
-          thread={thread}
-          hasApprovalRequest={
-            props.sessionKeys?.approvalRequestThreadKeys?.[threadKey] === true
-          }
-          hasInputRequest={
-            props.sessionKeys?.inputRequestThreadKeys?.[threadKey] === true
-          }
-          includeLinkedDirectories={props.cardFields.primaryDirectory}
-          linkedDirectoryMode="label"
-          // In the instance lenses the lane and the watermark already say
-          // which machine this is; under the projects lens they do not.
-          hideInstanceChip={!props.showInstanceChip}
-          hidePinChip
-          chipVisibility={{
-            provider: props.cardFields.provider,
-            branch: props.cardFields.branch,
-            maxLinkedDirectories: props.cardFields.secondaryDirectories
-              ? undefined
-              : 1,
+      <div className="star-map-card">
+        {/* The card's primary action. It carries the heading line and
+            stretches over the whole card via `.star-map-card__open::after`
+            (see app.css), but it stays a SIBLING of the chip flow for the
+            same reason the kebab sits outside it: the chips own real
+            buttons (copy path, copy branch, PR links), and a button inside
+            a button is neither valid nor operable — axe reports it as
+            `nested-interactive`. */}
+        <button
+          type="button"
+          className="star-map-card__heading star-map-card__open"
+          // Names the action rather than letting the button's whole content
+          // become its accessible name; the chips stay readable as content,
+          // and the kebab beside it gets a distinct name of its own.
+          aria-label={`Open thread: ${thread.title}`}
+          onClick={() => {
+            if (suppressClickRef.current) {
+              suppressClickRef.current = false;
+              return;
+            }
+            props.onOpen(thread);
           }}
-        />
-        {visiblePullRequests(thread.prs, props.cardFields).map((pr) => (
-          <PrChip
-            key={`${pr.org}/${pr.repo}#${pr.number}`}
-            pr={pr}
-            showRepoPrefix={false}
-            onOpen={(url) => {
-              if (typeof window !== "undefined") {
-                window.open(url, "_blank", "noopener,noreferrer");
-              }
+        >
+          <ThreadRowStatus status={status} />
+          <span className="star-map-card__title" title={thread.title}>
+            {thread.title}
+          </span>
+        </button>
+        <span className="star-map-card__chips">
+          <ThreadMetaChips
+            thread={thread}
+            hasApprovalRequest={
+              props.sessionKeys?.approvalRequestThreadKeys?.[threadKey] === true
+            }
+            hasInputRequest={
+              props.sessionKeys?.inputRequestThreadKeys?.[threadKey] === true
+            }
+            includeLinkedDirectories={props.cardFields.primaryDirectory}
+            linkedDirectoryMode="label"
+            // In the instance lenses the lane and the watermark already say
+            // which machine this is; under the projects lens they do not.
+            hideInstanceChip={!props.showInstanceChip}
+            hidePinChip
+            chipVisibility={{
+              provider: props.cardFields.provider,
+              branch: props.cardFields.branch,
+              maxLinkedDirectories: props.cardFields.secondaryDirectories
+                ? undefined
+                : 1,
             }}
           />
-        ))}
-      </span>
-      </button>
+          {visiblePullRequests(thread.prs, props.cardFields).map((pr) => (
+            <PrChip
+              key={`${pr.org}/${pr.repo}#${pr.number}`}
+              pr={pr}
+              showRepoPrefix={false}
+              onOpen={(url) => {
+                if (typeof window !== "undefined") {
+                  window.open(url, "_blank", "noopener,noreferrer");
+                }
+              }}
+            />
+          ))}
+        </span>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -10,6 +10,24 @@ import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { StarMapScreen } from "../StarMapScreen";
 
+/**
+ * The whole card for a thread, given its open-thread button.
+ *
+ * The button is only the heading line: the chip flow is its SIBLING inside
+ * `.star-map-card`, because chips carry buttons of their own and a button
+ * inside a button is invalid (see StarMapThreadCard). Assertions about
+ * chips have to scope to the card, not to the button.
+ */
+function starMapCard(openButton: HTMLElement): HTMLElement {
+  const card = openButton.closest(".star-map-card");
+  if (!(card instanceof HTMLElement)) {
+    throw new Error(
+      "Expected the open-thread button to sit inside .star-map-card",
+    );
+  }
+  return card;
+}
+
 function buildDesktopApi(): DesktopApi {
   return {
     readFederationHealth: vi.fn(async () => ({
@@ -72,9 +90,10 @@ describe("StarMapScreen", () => {
     });
 
     const card = screen.getByRole("button", { name: /Open thread: Thread t1/ });
-    expect(card.textContent).toContain("PwrSnap");
-    expect(card.textContent).not.toMatch(/local/i);
-    expect(card.textContent).not.toMatch(/worktree/i);
+    const cardBody = starMapCard(card);
+    expect(cardBody.textContent).toContain("PwrSnap");
+    expect(cardBody.textContent).not.toMatch(/local/i);
+    expect(cardBody.textContent).not.toMatch(/worktree/i);
 
     // Clicking a card floats a chat card over the map rather than
     // navigating away from it; the full thread view is one click further,
@@ -425,7 +444,9 @@ describe("StarMapScreen", () => {
         onFocusLocalInstance={() => undefined}
       />,
     );
-    const card = await screen.findByRole("button", { name: /Open thread: Thread t7/ });
+    const card = starMapCard(
+      await screen.findByRole("button", { name: /Open thread: Thread t7/ }),
+    );
     // Project chip stays; provider and branch are opt-in.
     expect(card.textContent).toContain("PwrSnap");
     expect(card.textContent).not.toContain("OpenAI");
@@ -610,9 +631,11 @@ describe("StarMapScreen", () => {
       const sun = await screen.findByTitle("pwrsnap");
       expect(sun).toBeTruthy();
 
-      const card = screen.getByRole("button", {
-        name: /Open thread: Thread t1/,
-      });
+      const card = starMapCard(
+        screen.getByRole("button", {
+          name: /Open thread: Thread t1/,
+        }),
+      );
       // The project is the sun, so its chip is redundant here.
       expect(card.textContent).not.toContain("PwrSnap");
     } finally {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -66,6 +66,35 @@ function unreadThread(id: string): NavigationThreadSummary {
 }
 
 describe("StarMapScreen", () => {
+  // Mirrors the sidebar row's invariant (see thread-row-chips.test.tsx):
+  // the chips carry real buttons, so nesting them inside the card's own
+  // button is `nested-interactive` — invalid and unoperable.
+  it("keeps the chip flow OUTSIDE the open-thread button", async () => {
+    const { container } = render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[unreadThread("t1")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-card__open")).not.toBeNull();
+    });
+    const openButton = container.querySelector(".star-map-card__open")!;
+    const flow = container.querySelector(".star-map-card__chips");
+    expect(flow).not.toBeNull();
+    expect(openButton.tagName).toBe("BUTTON");
+    expect(openButton.contains(flow)).toBe(false);
+    expect(
+      openButton.querySelector('button, a, [tabindex], [role="button"]'),
+    ).toBeNull();
+  });
+
   it("renders the single-instance map with attention cards sans Local/Worktree labels", async () => {
     const desktopApi = buildDesktopApi();
     const onOpenLocalThread = vi.fn();

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
@@ -193,10 +193,33 @@ describe("shouldStartCanvasPan", () => {
   });
 
   it("never steals a gesture from a card, body, or chrome", () => {
-    // Cards and instance bodies are buttons and drag/open themselves.
-    const card = element('<button class="star-map-card"><span>x</span></button>');
-    expect(shouldStartCanvasPan(card)).toBe(false);
-    expect(shouldStartCanvasPan(card.firstElementChild)).toBe(false);
+    // Instance bodies are buttons and drag/open themselves.
+    const body = element(
+      '<button class="star-map-instance__body"><span>x</span></button>',
+    );
+    expect(shouldStartCanvasPan(body)).toBe(false);
+    expect(shouldStartCanvasPan(body.firstElementChild)).toBe(false);
+
+    // A thread card is a shell holding sibling controls, so its container
+    // elements match no element selector — the shell has to be named.
+    const shell = element(
+      '<div class="star-map-card-shell">'
+      + '<div class="star-map-card">'
+      + '<button class="star-map-card__open">x</button>'
+      + '<span class="star-map-card__chips"><span class="thread-row__chip">y</span></span>'
+      + "</div>"
+      + "</div>",
+    );
+    expect(shouldStartCanvasPan(shell)).toBe(false);
+    expect(shouldStartCanvasPan(shell.querySelector(".star-map-card"))).toBe(
+      false,
+    );
+    expect(shouldStartCanvasPan(shell.querySelector(".star-map-card__chips"))).toBe(
+      false,
+    );
+    expect(shouldStartCanvasPan(shell.querySelector(".thread-row__chip"))).toBe(
+      false,
+    );
 
     const chrome = element(
       '<div class="star-map__chrome"><p>PwrAgent</p></div>',

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
@@ -383,10 +383,17 @@ export function computeOrbitPlacement(params: {
  *
  * Anything interactive owns its own gesture — cards drag themselves,
  * bodies open, chrome clicks — so a pan only begins on bare sky.
+ *
+ * `.star-map-card-shell` is listed explicitly because a thread card is no
+ * longer one big `<button>`: its open-thread button, kebab, and chips are
+ * siblings inside a plain container (see StarMapThreadCard), so the card's
+ * padding and the gaps between chips match none of the element selectors.
+ * The shell is the whole card's drag target, so pressing anywhere on it
+ * must never fall through to a canvas pan.
  */
 export function shouldStartCanvasPan(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
   return !target.closest(
-    "button, a, input, label, .star-map__chrome, .star-map__filters",
+    "button, a, input, label, .star-map-card-shell, .star-map__chrome, .star-map__filters",
   );
 }

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
@@ -390,6 +390,11 @@ export function computeOrbitPlacement(params: {
  * padding and the gaps between chips match none of the element selectors.
  * The shell is the whole card's drag target, so pressing anywhere on it
  * must never fall through to a canvas pan.
+ *
+ * Naming the shell also captures `.star-map-card__watermark`, which used
+ * to match nothing here and so started a pan. It is the card's own mark
+ * and overhangs the card's top-right corner, so dragging the card from it
+ * is the right behaviour — but it is a change, not just a port.
  */
 export function shouldStartCanvasPan(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -586,6 +586,43 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  // The thread row and star-map card draw their focus ring on the CARD via
+  // `:has()`, because the focusable element inside them is a transparent
+  // overlay button (see ThreadRow / StarMapThreadCard). That indirection is
+  // exactly where a brand token drifts unnoticed: nothing else renders these
+  // rings, so a wrong token or offset ships looking plausible. Both must name
+  // `--focus-ring` — the semantic token, `var(--accent)` in both themes — and
+  // each keeps its own offset: 2px on the sidebar row, 1px on the star-map
+  // card, whose cards shingle so a wider ring bleeds onto the neighbour.
+  // Changing either is a design decision; change this test in the same commit
+  // so it is reviewed rather than accidental.
+  it("draws both card focus rings from the focus-ring token at their own offsets", () => {
+    // `extractRuleBody`, not a `[\s\S]*?` regex over the whole sheet: a lazy
+    // span like that runs straight past the closing brace and can satisfy
+    // itself from a LATER rule, so it passes on a wrong token. That is not
+    // hypothetical — the first draft of this test did exactly that and waved
+    // through a mutation to `--accent-bright` at the wrong offset.
+    const rowRing = extractRuleBody(
+      css,
+      ".thread-row:has(.thread-row__open:focus)",
+    );
+    expect(rowRing).toContain("outline: 2px solid var(--focus-ring);");
+    expect(rowRing).toContain("outline-offset: 2px;");
+
+    const cardRing = extractRuleBody(
+      css,
+      ".star-map-card:has(.star-map-card__open:focus-visible)",
+    );
+    expect(cardRing).toContain("outline: 2px solid var(--focus-ring);");
+    expect(cardRing).toContain("outline-offset: 1px;");
+    // The star-map rule this replaced keyed off the card itself being
+    // focusable. The card is a plain container now, so such a rule can never
+    // match and would only mislead the next reader. (No equivalent assertion
+    // for `.thread-row`: that class is still worn by a real `<button>` on
+    // directory summaries, so a focus rule naming it is legitimate there.)
+    expect(css).not.toMatch(/\.star-map-card:focus-visible\s*\{/);
+  });
+
   it("keeps long directory names from crowding the count and expand control", () => {
     const summaryRule = extractRuleBody(css, ".directory-row__summary");
     const summaryMetaRule = extractRuleBody(css, ".directory-row__summary-meta");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3942,6 +3942,19 @@ textarea,
   content: "";
 }
 
+/* Lift the button's OWN content above that overlay. Hit-testing resolves
+   a pseudo-element to its originating element, so an un-lifted overlay
+   makes the button itself the hover target everywhere — and a native
+   `title` resolves from the hovered element upward through ancestors,
+   never descendants. That silently killed the status indicator's
+   "Thinking" / "Unread update" tooltip. Clicks are unaffected either way:
+   these are the button's own descendants, so they activate it regardless.
+   The empty space around them still falls through to the overlay. */
+.thread-row__open > * {
+  position: relative;
+  z-index: 1;
+}
+
 /* The overlay is invisible, so the focus ring belongs on the card it
    covers — same ring the row drew when the card itself was the button.
    Deliberately `:focus`, NOT `:focus-visible`: the rule this replaces
@@ -9773,6 +9786,17 @@ textarea,
   inset: 0;
   z-index: 0;
   content: "";
+}
+
+/* Lift the button's OWN content above that overlay — same reason as the
+   sidebar row, and it matters more here: `.star-map-card__title` is
+   ellipsised, and its `title` attribute is the only way to read a
+   truncated card title. An un-lifted overlay makes the button the hover
+   target and swallows that tooltip. This also restores the z-index the
+   heading used to carry for painting above the instance watermark. */
+.star-map-card__open > * {
+  position: relative;
+  z-index: 1;
 }
 
 /* The overlay is invisible, so the focus ring belongs on the card it

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3907,6 +3907,58 @@ textarea,
   gap: 12px;
 }
 
+/* The row's open-thread action. It is the title line, NOT the card: the
+   chip flow below carries its own buttons (copy path, copy branch, unpin,
+   unbind, reactions, PR links) and nesting those inside the row button
+   made the row an invalid, unoperable control (axe `nested-interactive`).
+   `.star-map-card-shell` solved the same problem for its kebab. Reset the
+   UA button chrome so the title line looks exactly as it did when the
+   whole card was the button. */
+.thread-row__open {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  /* WCAG 2.5.8 wants a 24px target, and the title line alone is ~21px.
+     Bleed the button's box symmetrically over the row's padding — the
+     negative margin cancels the padding exactly, in every density, so
+     nothing on screen moves — and keep a 24px floor in case a density
+     ever shrinks the title line further. */
+  min-height: 24px;
+  margin-block: -4px;
+  padding-block: 4px;
+  padding-inline: 0;
+}
+
+/* …and stretch its hit area back over the whole card, so pressing the
+   card's padding or the gaps between chips still opens the thread. The
+   overlay sits at z-index 0; `.thread-row__chips` is lifted above it so
+   each chip keeps its own clicks. */
+.thread-row__open::after {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  content: "";
+}
+
+/* The overlay is invisible, so the focus ring belongs on the card it
+   covers — same ring the row drew when the card itself was the button.
+   Deliberately `:focus`, NOT `:focus-visible`: the rule this replaces
+   listed both, so a row drew its ring after a mouse click too, and the
+   desktop-shell snapshot captures exactly that. Narrowing it to
+   keyboard-only focus would be a silent visual change riding along with
+   an a11y fix. (`:focus-visible` is a subset of `:focus`, so keyboard
+   focus is still covered.) */
+.thread-row__open:focus {
+  outline: none;
+}
+
+.thread-row:has(.thread-row__open:focus) {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
 .thread-row__heading {
   display: flex;
   min-width: 0;
@@ -3997,9 +4049,19 @@ textarea,
    flex-wrap handles overflow naturally; no per-type containers. */
 .thread-row__chips {
   display: flex;
+  position: relative;
+  z-index: 1;
   flex-wrap: wrap;
   align-items: center;
   gap: 6px;
+  /* Above `.thread-row__open::after`, so a chip wins its own clicks —
+     but transparent to the pointer itself, so the gaps between chips
+     fall through to the overlay and still open the thread. */
+  pointer-events: none;
+}
+
+.thread-row__chips > * {
+  pointer-events: auto;
 }
 
 /* Focus ring for any role="button" chip in the flow (PR, binding,
@@ -9657,8 +9719,11 @@ textarea,
   pointer-events: none;
 }
 
-/* Positioned so the content paints above the watermark's z-index 0. */
-.star-map-card__heading,
+/* Positioned so the content paints above the watermark's z-index 0, and
+   above `.star-map-card__open::after` so each chip keeps its own clicks.
+   The heading is deliberately NOT positioned here: it is the open-thread
+   button, and its stretch overlay has to resolve against `.star-map-card`
+   rather than against the heading line itself. */
 .star-map-card__chips {
   position: relative;
   z-index: 1;
@@ -9679,12 +9744,66 @@ textarea,
   white-space: nowrap;
 }
 
+/* The card's open-thread action. It is the heading line, NOT the card:
+   the chips below own real buttons (copy path, copy branch, PR links),
+   and nesting those inside a card-sized button made the card an invalid,
+   unoperable control (axe `nested-interactive`) — the same reason the
+   kebab has always lived outside it. Reset the UA button chrome so the
+   heading looks exactly as it did when the card was the button. */
+.star-map-card__open {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  /* Same 24px-target bleed the sidebar row uses — the heading line alone
+     is under WCAG 2.5.8's minimum, and the negative margin cancels the
+     padding so the card's layout is unchanged. */
+  min-height: 24px;
+  margin-block: -4px;
+  padding-block: 4px;
+  padding-inline: 0;
+}
+
+/* …and stretch its hit area back over the whole card, so pressing the
+   card's padding or the gaps between chips still opens the thread. */
+.star-map-card__open::after {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  content: "";
+}
+
+/* The overlay is invisible, so the focus ring belongs on the card it
+   covers. `.star-map-card` clips its own children, so a ring drawn on
+   the button inside would be cut off; drawn on the card it is not.
+   `:focus-visible` here, unlike the sidebar row's `:focus`, because the
+   card carried no explicit focus rule before this — it was a bare
+   `<button>` drawing Chromium's UA ring, which is keyboard-only. Each
+   surface keeps the ring it already had. */
+.star-map-card__open:focus-visible {
+  outline: none;
+}
+
+.star-map-card:has(.star-map-card__open:focus-visible) {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
 .star-map-card__chips {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 4px;
   min-width: 0;
+  /* Transparent to the pointer so the gaps between chips fall through to
+     the open-thread overlay; each chip re-enables its own hits. */
+  pointer-events: none;
+}
+
+.star-map-card__chips > * {
+  pointer-events: auto;
 }
 
 /* New-thread "bubble in" entrance (AI intake). Fade only under reduced

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9686,11 +9686,6 @@ textarea,
   cursor: pointer;
 }
 
-.star-map-card:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 1px;
-}
-
 /* Cards rise into their slots with a small stagger (delay set inline).
    Position comes from left/top, so the keyframes own transform. */
 @keyframes star-map-rise {
@@ -9802,17 +9797,25 @@ textarea,
 /* The overlay is invisible, so the focus ring belongs on the card it
    covers. `.star-map-card` clips its own children, so a ring drawn on
    the button inside would be cut off; drawn on the card it is not.
-   `:focus-visible` here, unlike the sidebar row's `:focus`, because the
-   card carried no explicit focus rule before this — it was a bare
-   `<button>` drawing Chromium's UA ring, which is keyboard-only. Each
-   surface keeps the ring it already had. */
+   This REPLACES the old `.star-map-card:focus-visible`, which went dead
+   the moment the card stopped being a `<button>` — a div with no
+   tabindex can never match `:focus-visible`.
+
+   Same ring, deliberately: `--focus-ring` is `var(--accent)` in both
+   themes (locked by theme-contract.test.tsx), so this computes to the
+   exact colour the old rule painted, while naming the semantic token
+   every other focus rule in this file uses. `outline-offset` stays at
+   the Star Map's own 1px rather than the sidebar row's 2px — cards here
+   shingle by design, and a wider ring bleeds onto the neighbour beneath.
+   `:focus-visible`, unlike the sidebar row's `:focus`, because that is
+   what the rule it replaces used: this ring is keyboard-only. */
 .star-map-card__open:focus-visible {
   outline: none;
 }
 
 .star-map-card:has(.star-map-card__open:focus-visible) {
   outline: 2px solid var(--focus-ring);
-  outline-offset: 2px;
+  outline-offset: 1px;
 }
 
 .star-map-card__chips {


### PR DESCRIPTION
## Summary

- `CopyableThreadChip` renders a `role="button"` span (the click-to-copy path/branch chips, class `path-copy-target`), and it was rendered **inside a real `<button>`** on two surfaces: the sidebar thread row (`.thread-row[type="button"]`) and the Star Map thread card (`.star-map-card[type="button"]`). axe-core reports this as `nested-interactive` — serious, WCAG 4.1.2. A button inside a button is neither valid nor operable.
- #1303 ran straight into this: it had to leave its Star Map fixture's threads **directory-less** to keep the gate green, with a comment saying "when it lands, give these threads a directory so the project chip is covered too." This is that.
- Fixed **structurally**, not by waiving. `KNOWN_VIOLATIONS` works via `AxeBuilder.exclude()`, so waiving would drop the entire row/card from the scan and blind the contrast checks on those elements. `KNOWN_VIOLATIONS` remains empty.
- Both surfaces now use the shape `StarMapCardMenu` already established for its kebab ("a button inside a button is neither valid nor operable" — its file comment): a plain container holds the primary action and the secondary controls as **siblings**.
  - `.thread-row` / `.star-map-card` → plain `<div>` cards.
  - `.thread-row__header` / `.star-map-card__heading` → the open-thread `<button>`, carrying the title line.
  - The chip flow moves out of the button, beside it.

### Behaviour is preserved, not narrowed

Clicking anywhere on the card still opens the thread. A stretched `::after` on each button covers the card at `z-index: 0`; the chip containers sit at `z-index: 1` with `pointer-events: none` and `auto` on their children. Chips win their own clicks, and every gap around them falls through to the overlay — exactly as before.

### Two consequences the refactor forced

- **WCAG 2.5.8 `target-size`.** With the button reduced to the ~21px title line, axe flagged it on the open-thread surface. Both buttons take a `min-height: 24px` floor plus a cancelling `margin-block: -4px` / `padding-block: 4px` bleed, so the hit box grows without moving anything on screen — in either density, nested or not.
- **Focus rings** move to the card via `:has()`, since the button is no longer the card. On the Star Map this also matters because `.star-map-card`'s `overflow: hidden` would clip a ring drawn on a button inside it.

  The two surfaces intentionally use different selectors, and each keeps the ring it already had. The sidebar row uses **`:focus`**, because the shared rule it replaces listed `.thread-row:focus` alongside `:focus-visible` — the row drew its ring after a mouse click, and the `todo-thread-shell` snapshot captures exactly that. (A first pass used `:focus-visible` only; Chromium does not match that on a mouse click, so the selected row silently lost its bright ring and kept only the dim `--accent-border`. CI's macOS lane caught it — see Notes.) The Star Map card uses **`:focus-visible`**, because it carried no explicit focus rule before and drew Chromium's UA ring, which is keyboard-only.

### One non-obvious knock-on

`shouldStartCanvasPan` decided "bare sky" via `closest("button")`. With the card no longer a button, a pointerdown on its padding or between its chips would have started a **canvas pan** instead of a card drag. `.star-map-card-shell` is now named explicitly in that selector, with test coverage for the new markup.

### Paying off #1303's deferred coverage

- `e2e/fixtures/star-map/replay.fixture.json` gets its directories back: a **worktree** directory plus a branch on one thread, a **local** directory on the other. The Star Map layer block already runs an unscoped `runAxe`, so the project chip on the card is now genuinely gated. The comment above `STAR_MAP_FIXTURE` is rewritten — the directories are load-bearing now, not a landmine.
- A new sidebar block gates the same chips on a thread row (worktree + local + branch, all three `CopyableThreadChip` flavours).

### Review follow-ups (second commit)

A self-review of the first commit raised two suspected regressions. Both were **confirmed by measurement** in a real Chromium before anything changed, then fixed:

| Probe | Before | After |
|---|---|---|
| hit-test over the status indicator | `open` (button) ❌ | `status` ✅ |
| hit-test over the star-map title text | `open` (button) ❌ | `title` ✅ |
| hit-test over a chip / card padding / chip gap | `chipA` / `open` / `open` ✅ | unchanged ✅ |

- **Native `title` tooltips under the stretch overlay were dead.** Hit-testing resolves a pseudo-element to its *originating* element, so `::after` made the button the hover target across the whole card — and `title` resolves from the hovered element upward through ancestors, never descendants. Casualties: the row's "Thinking" / "Unread update" indicator, and `.star-map-card__title`, which is ellipsised and whose `title` is the only way to read a truncated name. Fixed by lifting the button's own children above the overlay: they hit-test normally, empty space still falls through, and clicks are unaffected because they are the button's own descendants. On the Star Map this also restores the z-index the heading previously carried for painting above the instance watermark.
- **The PR hover-prefetch unit test passed for the wrong reason.** `.thread-row__chips` is `pointer-events: none`, so a pointer only ever enters a *chip* — which matches the prefetch's own doc comment, so the behaviour stands. But the test drove `mouseEnter` on the container, and jsdom has no layout and ignores `pointer-events`, so it modelled something a user cannot do. It now hovers the chip via `mouseOver`, which is what React synthesizes `onMouseEnter` from.

Plus three smaller review items:

- **Invariant guards on both surfaces** — the chip flow stays outside the open-thread button, and no focusable node hides inside it. Verified these actually fail by re-nesting the chips; a guard that can't detect the regression is worthless. Without them, only the a11y E2E catches a re-nesting, and only against a directory-bearing fixture — exactly how this shipped unnoticed.
- **The copy-chip audit gets its own fixture** (`e2e/fixtures/a11y-copy-chips/`) instead of borrowing the context-rail spec's. Coverage hinging on a file this gate doesn't own goes quiet, with no failure anywhere, if someone drops a directory there.
- **Documented** that naming `.star-map-card-shell` in `shouldStartCanvasPan` also captures the watermark, which previously started a canvas pan — right behaviour, but a change rather than a port.

### Brand review (third commit)

A colour/branding pass over the diff. The colour surface is small — `color: inherit`, `background: transparent`, `border: 0` (UA resets on the new buttons) and two `outline` rules — and **no colour value changed**. `color: inherit` was traced through both brand-coloured row states, `.is-composer-source` (solid `--accent` fill, `--accent-on` text) and `.is-remote-offline`; both resolve identically, since those classes still sit on `.thread-row` and the button inherits from it.

Two real problems surfaced, both introduced by the refactor:

- **`.star-map-card:focus-visible` was dead code.** It keyed off the card being a `<button>`; the card is a plain `<div>` now, so a rule naming `:focus-visible` on it can never match — while still reading as authoritative. Removed; the `:has()` rule replaces it.
- **The Star Map's ring silently widened.** It drew at `outline-offset: 1px`; the replacement copied the sidebar row's `2px`. Map cards shingle by design (they crowd to 82% of their width), so a wider ring bleeds onto the card beneath. Restored to `1px`; the sidebar row keeps its own `2px`.

The token name did change, `var(--accent)` → `var(--focus-ring)`, with **no visual effect**: `--focus-ring` is `var(--accent)` in both themes and `theme-contract.test.tsx` already locks that mapping. It is the semantic token the other eight focus rules in the file use, so a future change to the focus ring now reaches this surface too.

Both rings are now pinned by `theme-contract.test.tsx`, since nothing else renders them — the focusable element is a transparent overlay button, so a wrong token or offset ships looking plausible. That guard uses the file's `extractRuleBody` rather than a `[\s\S]*?` regex over the whole sheet: a lazy span runs past the closing brace and can satisfy itself from a later rule. The first draft did exactly that and waved through a mutation to `--accent-bright` at the wrong offset. The committed form fails on wrong token, wrong offset, and a resurrected dead rule — each verified by mutation.

## Verification

- **a11y gate: 10/10 pass**, `KNOWN_VIOLATIONS` still empty.
- **Renderer unit tests: 2108/2108** (+2 invariant guards, +1 focus-ring token lock). Suites that scoped chip assertions to the row/card button are re-scoped to the card via new `threadCard()` / `starMapCard()` helpers.
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors` clean.
- **Layout is unchanged.** A throwaway probe measured `getBoundingClientRect` for the card, heading, title, time, chips container and all four chips, before and after: byte-identical. Note this proves *geometry* only — it is blind to colour, which is how the focus-ring regression below slipped past it.
- **CI is fully green on the head commit**, both E2E lanes included. `Windows (build + test)` failed once on `CodexEnvironmentStartupError: Windows Job PowerShell host did not begin executing within 20000ms` in `backend-registry.test.ts` — a known-tender path hardened by #1301 / #1277 / #1259. This PR touches **zero** main-process files, Windows was green on the previous commit and across the last six `main` runs, and a re-run with no code change passed. Not patched here: widening that bound in a renderer PR would be exactly the retry-instead-of-ownership fix the repo's guidance warns against.
- **Local desktop E2E (before the shared-VM lane took over): 177 passed, 4 failed.** Those 4 (`onboarding-wizard:674`, `provider-model-selectors:156`, and both `visual-regression` snapshots) fail identically on an unmodified checkout — confirmed by stashing and re-running, not assumed.

## Notes

- **The focus-ring regression, and what caught it.** Both `visual-regression` snapshots fail on the dev machine on an unmodified checkout, so locally they were dead signals. CI's `macOS Desktop E2E (shared VM)` lane is green on `main`, which made its `todo-thread-shell` failure attributable: pulling the artifact and cropping the diff showed the selected row had lost its focus outline. Fixed by using `:focus` rather than `:focus-visible` (above). All checks are green on the current head.
- **A pre-existing violation this uncovered, filed separately, not fixed here.** Pointing the new sidebar block at `STAR_MAP_FIXTURE` surfaced `aria-required-children` (critical) on `.transcript-list__items`. Its threads are `threadStatus: "active"`, and an active thread renders `.transcript-list__pending` with `role="status"` as a sibling of the `role="listitem"` entries inside that `role="list"`. Confirmed by DOM dump — idle fixture: `listitem, listitem`; active fixture: `listitem, listitem, status`. Nothing to do with chips, and invisible to the gate today because no block audits the thread view at rest with an active thread. The cheap way out was `runAxe(window, { include: ".sidebar" })`; that would have hidden it and stopped the block catching anything outside the sidebar, so the scan stays **unscoped** and the sidebar block uses the idle context-rail fixture instead, with the reasoning in a comment.
- Two E2E specs genuinely broke and are fixed here, both from treating the row button as the card: `directory-launchpad-workspace.spec.ts` reached for `.thread-row__chips` *inside* the button, and `federation-remote-window.spec.ts` asserted `is-remote-offline` on it (that class lives on the card). Re-scoped with `.thread-row` + `has:`.
- `turn-lifecycle.spec.ts:414` flaked once under the single-worker run and passes on re-run; unrelated to this change.
- Tab order, DOM order, and accessible names are unchanged — the button keeps `aria-label` = thread title and `aria-pressed`. Chips are now siblings after the row button rather than descendants of it, which is arguably better for AT users.
- Rebased onto `main` after #1303 merged; the only conflict was `launchAuditApp` in `a11y.spec.ts`, resolved in favour of #1303's `fixturePath` / `theme` options object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
