### PR TITLE
fix(desktop): keep log following after copy

### DIFF
--- a/apps/desktop/src/renderer/src/features/logs/LogsWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/logs/LogsWindow.tsx
@@ -627,6 +627,7 @@ function LogLine(props: {
           title={copyLabel}
           type="button"
           onClick={() => props.onCopy(props.line.lineNumber, lineText)}
+          onPointerDown={(event) => event.stopPropagation()}
         >
           {props.copied ? (
             <CheckIcon aria-hidden="true" size={12} />

--- a/apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx
@@ -196,7 +196,8 @@ describe("LogsWindow", () => {
     });
   });
 
-  it("copies an individual log line without its line number", async () => {
+  it("copies an individual log line without pausing following", async () => {
+    let listener: Parameters<NonNullable<DesktopApi["onAppLogEntry"]>>[0] | undefined;
     const copyText = vi.fn(async () => undefined);
     const desktopApi = {
       copyText,
@@ -215,13 +216,18 @@ describe("LogsWindow", () => {
         readAt: Date.now(),
         truncated: false,
       })),
-      onAppLogEntry: vi.fn(() => () => undefined),
+      onAppLogEntry: vi.fn((callback) => {
+        listener = callback;
+        return () => undefined;
+      }),
     } as unknown as DesktopApi;
     (window as Window & { pwragent?: DesktopApi }).pwragent = desktopApi;
 
     render(<LogsWindow />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Copy line 1" }));
+    const copyButton = await screen.findByRole("button", { name: "Copy line 1" });
+    fireEvent.pointerDown(copyButton);
+    fireEvent.click(copyButton);
 
     await waitFor(() => {
       expect(copyText).toHaveBeenCalledWith(
@@ -231,6 +237,18 @@ describe("LogsWindow", () => {
     expect(
       screen.getByRole("button", { name: "Copied line 1" }),
     ).toBeInTheDocument();
+    expect(screen.getByText("Live app log stream")).toBeInTheDocument();
+
+    act(() => {
+      listener?.({
+        sequence: 2,
+        timestamp: Date.now(),
+        level: "info",
+        line: "[2026-05-12 20:06:29.000] [info] (pwragent:main) next line",
+      });
+    });
+
+    expect(await screen.findByText(/next line/)).toBeInTheDocument();
   });
 
   it("defaults to Error, Warning, and Info toggles with Debug off", async () => {


### PR DESCRIPTION
## Summary

- keep the Logs viewer in follow mode when an operator clicks a per-line copy control
- stop the copy button pointer-down before it reaches the viewport interaction handler
- extend the focused test to verify the live state remains active and subsequent log entries still stream after copying

## Root cause

The Logs viewport intentionally pauses following on pointer-down so operators can select log text without the content moving. The line copy button lives inside that viewport, so its pointer-down bubbled into the same handler and paused the stream before the copy click completed.

## User impact

Copying a complete log line no longer freezes the live stream. Direct interaction with log text still pauses following as designed.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx`
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:colors`
- `pnpm lint:boundaries`
