### PR TITLE
fix(desktop): restore remote window live events

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -130,6 +130,11 @@ type RuntimeHarness = {
     consumerId: "remote-window" | "star-map",
     subscriptions: readonly FederationEventSubscription[],
   ) => FederationEventSubscription[];
+  setRemoteWindowEventSubscription: (
+    webContentsId: number,
+    sourceInstanceId: FederationInstanceId,
+    capabilities: readonly FederationCapability[],
+  ) => FederationEventSubscription[];
   clearRendererEventSubscriptions: (
     webContentsId: number,
     consumerId?: "remote-window" | "star-map",
@@ -896,7 +901,7 @@ describe("DesktopFederationRuntime", () => {
     ]);
   });
 
-  it("keeps a viewer subscription while Star Map opens and closes in its window", () => {
+  it("keeps a whole-desktop viewer subscription while Star Map opens and closes", () => {
     const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
     runtime.localInstanceId = "viewer_one";
     runtime.router = new FederationRouter({ localInstanceId: "viewer_one" });
@@ -905,6 +910,8 @@ describe("DesktopFederationRuntime", () => {
       capabilities: [
         "thread_navigation",
         "thread_detail",
+        "pending_request_control",
+        "scheduled_actions",
         "event_subscriptions",
       ],
     }));
@@ -913,10 +920,13 @@ describe("DesktopFederationRuntime", () => {
       capabilities: ["thread_navigation", "event_subscriptions"],
     }));
 
-    runtime.setRendererEventSubscriptions(7, "remote-window", [{
-      sourceInstanceId: "owner_one",
-      eventClasses: ["navigation", "transcript"],
-    }]);
+    runtime.setRemoteWindowEventSubscription(7, "owner_one", [
+      "thread_navigation",
+      "thread_detail",
+      "pending_request_control",
+      "scheduled_actions",
+      "event_subscriptions",
+    ]);
     runtime.setRendererEventSubscriptions(7, "star-map", [{
       sourceInstanceId: "owner_one",
       eventClasses: ["navigation", "star_map"],
@@ -931,7 +941,11 @@ describe("DesktopFederationRuntime", () => {
     expect(runtime.rendererWantsRemoteEvent(7, "owner_one", "transcript"))
       .toBe(true);
     expect(runtime.rendererWantsRemoteEvent(7, "owner_one", "star_map"))
-      .toBe(false);
+      .toBe(true);
+    expect(runtime.rendererWantsRemoteEvent(7, "owner_one", "pending_requests"))
+      .toBe(true);
+    expect(runtime.rendererWantsRemoteEvent(7, "owner_one", "scheduled_actions"))
+      .toBe(true);
     expect(runtime.rendererWantsRemoteEvent(7, "owner_two", "navigation"))
       .toBe(false);
   });

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -103,14 +103,20 @@ const rendererEventSubscriptions = new Map<number, Array<{
   sourceInstanceId: string;
   eventClasses: string[];
 }>>();
-const setRendererEventSubscriptionsMock = vi.fn((
+const setRemoteWindowEventSubscriptionMock = vi.fn((
   webContentsId: number,
-  _consumerId: string,
-  subscriptions: Array<{
-    sourceInstanceId: string;
-    eventClasses: string[];
-  }>,
+  sourceInstanceId: string,
+  capabilities: string[],
 ) => {
+  const subscriptions = [{
+    sourceInstanceId,
+    eventClasses: [
+      ...(capabilities.includes("thread_navigation")
+        ? ["navigation", "star_map"]
+        : []),
+      ...(capabilities.includes("thread_detail") ? ["transcript"] : []),
+    ],
+  }];
   rendererEventSubscriptions.set(webContentsId, subscriptions);
   return subscriptions;
 });
@@ -433,7 +439,7 @@ vi.mock("../federation/federation-runtime", () => ({
     restart: federationRuntimeRestartMock,
     connectedPeerTargets: connectedPeerTargetsMock,
     onPeerStatusChanged: federationPeerStatusChangedMock,
-    setRendererEventSubscriptions: setRendererEventSubscriptionsMock,
+    setRemoteWindowEventSubscription: setRemoteWindowEventSubscriptionMock,
     clearRendererEventSubscriptions: clearRendererEventSubscriptionsMock,
     rendererWantsRemoteEvent: rendererWantsRemoteEventMock,
   })),
@@ -642,7 +648,7 @@ describe("bootstrapApp", () => {
     connectedPeerTargetsMock.mockReturnValue([]);
     federationPeerStatusChangedMock.mockClear();
     rendererEventSubscriptions.clear();
-    setRendererEventSubscriptionsMock.mockClear();
+    setRemoteWindowEventSubscriptionMock.mockClear();
     clearRendererEventSubscriptionsMock.mockClear();
     rendererWantsRemoteEventMock.mockClear();
     messagingLeaseStartMock.mockReset();
@@ -1308,13 +1314,10 @@ describe("bootstrapApp", () => {
       federationTarget: peer.target,
       initialThread: undefined,
     });
-    expect(setRendererEventSubscriptionsMock).toHaveBeenCalledWith(
+    expect(setRemoteWindowEventSubscriptionMock).toHaveBeenCalledWith(
       remoteWindow.webContents.id,
-      "remote-window",
-      [{
-        sourceInstanceId: peer.target.instanceId,
-        eventClasses: ["navigation", "transcript"],
-      }],
+      peer.target.instanceId,
+      peer.capabilities,
     );
 
     const {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentEvent } from "@pwragent/shared";
 
 const appEventHandlers = new Map<string, (...args: unknown[]) => void>();
 const processEventHandlers = new Map<string, (...args: unknown[]) => void>();
@@ -87,6 +88,44 @@ const isAppStateInitializedMock = vi.fn();
 const messagingRuntimeStartMock = vi.fn<() => Promise<void>>();
 const federationRuntimeRestartMock = vi.fn<() => Promise<void>>();
 const disposeDesktopFederationRuntimeMock = vi.fn<() => Promise<void>>();
+const connectedPeerTargetsMock = vi.fn(() => [] as Array<{
+  target: { scope: "remote"; instanceId: string };
+  label: string;
+  capabilities: Array<
+    | "event_subscriptions"
+    | "remote_window"
+    | "thread_detail"
+    | "thread_navigation"
+  >;
+}>);
+const federationPeerStatusChangedMock = vi.fn(() => () => {});
+const rendererEventSubscriptions = new Map<number, Array<{
+  sourceInstanceId: string;
+  eventClasses: string[];
+}>>();
+const setRendererEventSubscriptionsMock = vi.fn((
+  webContentsId: number,
+  _consumerId: string,
+  subscriptions: Array<{
+    sourceInstanceId: string;
+    eventClasses: string[];
+  }>,
+) => {
+  rendererEventSubscriptions.set(webContentsId, subscriptions);
+  return subscriptions;
+});
+const clearRendererEventSubscriptionsMock = vi.fn((webContentsId: number) => {
+  rendererEventSubscriptions.delete(webContentsId);
+});
+const rendererWantsRemoteEventMock = vi.fn((
+  webContentsId: number,
+  sourceInstanceId: string,
+  eventClass: string,
+) => rendererEventSubscriptions.get(webContentsId)?.some(
+  (subscription) =>
+    subscription.sourceInstanceId === sourceInstanceId
+    && subscription.eventClasses.includes(eventClass),
+) ?? false);
 const messagingLeaseStartMock = vi.fn<() => Promise<void>>();
 const messagingLeaseShutdownSyncMock = vi.fn();
 const getRuntimeMessagingLeaseCoordinatorMock = vi.fn();
@@ -389,10 +428,14 @@ vi.mock("../messaging/messaging-runtime", () => ({
 }));
 
 vi.mock("../federation/federation-runtime", () => ({
+  federationEventClassForMethod: vi.fn(() => "transcript"),
   getDesktopFederationRuntime: vi.fn(() => ({
     restart: federationRuntimeRestartMock,
-    connectedPeerTargets: vi.fn(() => []),
-    onPeerStatusChanged: vi.fn(() => () => {}),
+    connectedPeerTargets: connectedPeerTargetsMock,
+    onPeerStatusChanged: federationPeerStatusChangedMock,
+    setRendererEventSubscriptions: setRendererEventSubscriptionsMock,
+    clearRendererEventSubscriptions: clearRendererEventSubscriptionsMock,
+    rendererWantsRemoteEvent: rendererWantsRemoteEventMock,
   })),
   disposeDesktopFederationRuntime: disposeDesktopFederationRuntimeMock,
 }));
@@ -595,6 +638,13 @@ describe("bootstrapApp", () => {
     federationRuntimeRestartMock.mockResolvedValue();
     disposeDesktopFederationRuntimeMock.mockReset();
     disposeDesktopFederationRuntimeMock.mockResolvedValue();
+    connectedPeerTargetsMock.mockReset();
+    connectedPeerTargetsMock.mockReturnValue([]);
+    federationPeerStatusChangedMock.mockClear();
+    rendererEventSubscriptions.clear();
+    setRendererEventSubscriptionsMock.mockClear();
+    clearRendererEventSubscriptionsMock.mockClear();
+    rendererWantsRemoteEventMock.mockClear();
     messagingLeaseStartMock.mockReset();
     messagingLeaseStartMock.mockResolvedValue();
     messagingLeaseShutdownSyncMock.mockReset();
@@ -1183,6 +1233,141 @@ describe("bootstrapApp", () => {
     newThread?.click?.();
 
     expect(requestOpenNewThreadMock).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a File -> Remote Instances window subscribed to live transcript events", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+    const peer = {
+      target: { scope: "remote" as const, instanceId: "owner_one" },
+      label: "Owner One",
+      capabilities: [
+        "event_subscriptions" as const,
+        "remote_window" as const,
+        "thread_detail" as const,
+        "thread_navigation" as const,
+      ],
+    };
+    connectedPeerTargetsMock.mockReturnValue([peer]);
+    const remoteWindowHandlers = new Map<string, Array<() => void>>();
+    const remoteWindowSend = vi.fn();
+    const remoteWindow = {
+      id: 42,
+      webContents: {
+        id: 42,
+        isDestroyed: () => false,
+        send: remoteWindowSend,
+      },
+      on: (event: string, handler: () => void) => {
+        const handlers = remoteWindowHandlers.get(event) ?? [];
+        handlers.push(handler);
+        remoteWindowHandlers.set(event, handlers);
+      },
+      once: (event: string, handler: () => void) => {
+        const handlers = remoteWindowHandlers.get(event) ?? [];
+        handlers.push(handler);
+        remoteWindowHandlers.set(event, handlers);
+      },
+    };
+    createMainWindowMock.mockImplementation((options?: {
+      federationTarget?: { scope: "remote"; instanceId: string };
+    }) => options?.federationTarget
+      ? remoteWindow
+      : {
+          on: (event: string, handler: (...args: unknown[]) => void) => {
+            mainWindowHandlers.set(event, handler);
+          },
+          once: (event: string, handler: (...args: unknown[]) => void) => {
+            mainWindowHandlers.set(event, handler);
+          },
+          isVisible: () => false,
+        });
+
+    await import("../index");
+    await flushMicrotasks();
+
+    type TestMenuItem = {
+      label?: string;
+      click?: () => void;
+      submenu?: TestMenuItem[];
+    };
+    const template = buildFromTemplateMock.mock.calls[0]?.[0] as
+      | TestMenuItem[]
+      | undefined;
+    const fileMenu = template?.find((item) => item.label === "File");
+    const remoteInstances = fileMenu?.submenu?.find(
+      (item) => item.label === "Remote Instances",
+    );
+    const owner = remoteInstances?.submenu?.find(
+      (item) => item.label === peer.label,
+    );
+
+    owner?.click?.();
+
+    expect(createMainWindowMock).toHaveBeenLastCalledWith({
+      federationLabel: peer.label,
+      federationTarget: peer.target,
+      initialThread: undefined,
+    });
+    expect(setRendererEventSubscriptionsMock).toHaveBeenCalledWith(
+      remoteWindow.webContents.id,
+      "remote-window",
+      [{
+        sourceInstanceId: peer.target.instanceId,
+        eventClasses: ["navigation", "transcript"],
+      }],
+    );
+
+    const {
+      _resetWindowChannelsForTests,
+      registerWindowChannels,
+      WINDOW_KIND_MAIN,
+    } = await import("../window-channels");
+    const { AGENT_EVENT_CHANNEL } = await import("../../shared/ipc");
+    _resetWindowChannelsForTests();
+    registerWindowChannels(
+      remoteWindow as never,
+      WINDOW_KIND_MAIN,
+      [AGENT_EVENT_CHANNEL],
+      peer.target,
+    );
+    const { broadcastAgentEvent } = await vi.importActual<
+      typeof import("../ipc/agent-ipc")
+    >("../ipc/agent-ipc");
+    const liveEvent = {
+      backend: "codex",
+      federationTarget: peer.target,
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          delta: "live after snapshot",
+          itemId: "item-1",
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+      },
+    } as AgentEvent;
+
+    // The renderer's initial navigation snapshot is pull-based. A later
+    // owner event must still cross the subscription gate into this window.
+    broadcastAgentEvent(liveEvent);
+
+    expect(remoteWindowSend).toHaveBeenCalledWith(
+      AGENT_EVENT_CHANNEL,
+      liveEvent,
+    );
+
+    for (const handler of remoteWindowHandlers.get("closed") ?? []) {
+      handler();
+    }
+    expect(clearRendererEventSubscriptionsMock).toHaveBeenCalledWith(
+      remoteWindow.webContents.id,
+      "remote-window",
+    );
+
+    remoteWindowSend.mockClear();
+    broadcastAgentEvent(liveEvent);
+    expect(remoteWindowSend).not.toHaveBeenCalled();
+    _resetWindowChannelsForTests();
   });
 
   it("logs unexpected background messaging startup failures", async () => {

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -63,6 +63,7 @@ import type {
   UpdateScheduledThreadActionRequest,
 } from "@pwragent/shared";
 import {
+  FEDERATION_EVENT_CLASSES,
   FEDERATION_INVITE_VERSION,
   FEDERATION_PROTOCOL_VERSION,
   MAX_CELESTIAL_ASSIGNMENTS,
@@ -616,6 +617,29 @@ export class DesktopFederationRuntime {
     return this.setEventSubscriptions(
       `renderer:${webContentsId}:${consumerId}`,
       subscriptions,
+    );
+  }
+
+  /**
+   * A full remote viewer holds one source-wide desired-state consumer for
+   * every event class its peer capabilities authorize. Narrower consumers
+   * (Star Map, pinned summaries, messaging) are unioned independently, so
+   * their cleanup cannot unsubscribe a still-open remote desktop window.
+   */
+  setRemoteWindowEventSubscription(
+    webContentsId: number,
+    sourceInstanceId: FederationInstanceId,
+    capabilities: readonly FederationCapability[],
+  ): FederationEventSubscription[] {
+    return this.setRendererEventSubscriptions(
+      webContentsId,
+      "remote-window",
+      [{
+        sourceInstanceId,
+        eventClasses: FEDERATION_EVENT_CLASSES.filter((eventClass) =>
+          eventClassAllowedByCapabilities(eventClass, capabilities)
+        ),
+      }],
     );
   }
 

--- a/apps/desktop/src/main/federation/federation-window.ts
+++ b/apps/desktop/src/main/federation/federation-window.ts
@@ -33,23 +33,11 @@ export function createFederationWindow(options: {
   });
   const runtime = getDesktopFederationRuntime();
   const webContentsId = window.webContents.id;
-  runtime.setRendererEventSubscriptions(webContentsId, "remote-window", [{
-    sourceInstanceId: peer.target.instanceId,
-    eventClasses: [
-      ...(peer.capabilities.includes("thread_navigation")
-        ? ["navigation" as const]
-        : []),
-      ...(peer.capabilities.includes("thread_detail")
-        ? ["transcript" as const]
-        : []),
-      ...(peer.capabilities.includes("pending_request_control")
-        ? ["pending_requests" as const]
-        : []),
-      ...(peer.capabilities.includes("scheduled_actions")
-        ? ["scheduled_actions" as const]
-        : []),
-    ],
-  }]);
+  runtime.setRemoteWindowEventSubscription(
+    webContentsId,
+    peer.target.instanceId,
+    peer.capabilities,
+  );
   window.once("closed", () => {
     runtime.clearRendererEventSubscriptions(webContentsId, "remote-window");
   });

--- a/apps/desktop/src/main/federation/federation-window.ts
+++ b/apps/desktop/src/main/federation/federation-window.ts
@@ -1,0 +1,57 @@
+import type {
+  AppServerBackendKind,
+  FederationCapability,
+  FederationRemoteTarget,
+} from "@pwragent/shared";
+import { getDesktopFederationRuntime } from "./federation-runtime";
+import { createMainWindow } from "../window";
+
+export type FederationWindowPeer = {
+  target: FederationRemoteTarget;
+  label: string;
+  capabilities: readonly FederationCapability[];
+};
+
+export function createFederationWindow(options: {
+  peer: FederationWindowPeer;
+  initialThread?: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  };
+}): Electron.BrowserWindow {
+  const { peer } = options;
+  if (!peer.capabilities.includes("remote_window")) {
+    throw new Error(
+      "Federation peer does not allow remote windows (remote_window capability).",
+    );
+  }
+
+  const window = createMainWindow({
+    federationLabel: peer.label,
+    federationTarget: peer.target,
+    initialThread: options.initialThread,
+  });
+  const runtime = getDesktopFederationRuntime();
+  const webContentsId = window.webContents.id;
+  runtime.setRendererEventSubscriptions(webContentsId, "remote-window", [{
+    sourceInstanceId: peer.target.instanceId,
+    eventClasses: [
+      ...(peer.capabilities.includes("thread_navigation")
+        ? ["navigation" as const]
+        : []),
+      ...(peer.capabilities.includes("thread_detail")
+        ? ["transcript" as const]
+        : []),
+      ...(peer.capabilities.includes("pending_request_control")
+        ? ["pending_requests" as const]
+        : []),
+      ...(peer.capabilities.includes("scheduled_actions")
+        ? ["scheduled_actions" as const]
+        : []),
+    ],
+  }]);
+  window.once("closed", () => {
+    runtime.clearRendererEventSubscriptions(webContentsId, "remote-window");
+  });
+  return window;
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -62,6 +62,7 @@ import {
   disposeDesktopFederationRuntime,
   getDesktopFederationRuntime,
 } from "./federation/federation-runtime";
+import { createFederationWindow } from "./federation/federation-window";
 import {
   disposeIntegratedTerminalIpcHandlers,
   registerIntegratedTerminalIpcHandlers,
@@ -819,13 +820,14 @@ function installApplicationMenu(): void {
         await shell.openExternal(PWRAGENT_DOCUMENTATION_URL);
       },
       openFederationWindow: (peer) => {
-        createMainWindow({
-          federationLabel: peer.label,
-          federationTarget: {
-            scope: "remote",
-            instanceId: peer.instanceId,
-          },
-        });
+        const connectedPeer = getDesktopFederationRuntime()
+          .connectedPeerTargets()
+          .find((candidate) => candidate.target.instanceId === peer.instanceId);
+        if (!connectedPeer) {
+          installApplicationMenu();
+          return;
+        }
+        createFederationWindow({ peer: connectedPeer });
       },
       openIssueReporter: async () => {
         await shell.openExternal(PWRAGENT_ISSUE_REPORTER_URL);

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -48,7 +48,7 @@ import {
 } from "../../shared/ipc";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { getFederationTailscaleService } from "../federation/federation-tailscale";
-import { createMainWindow } from "../window";
+import { createFederationWindow } from "../federation/federation-window";
 
 const rendererSubscriptionCleanupIds = new Set<number>();
 
@@ -195,11 +195,6 @@ export function registerFederationIpcHandlers(): void {
       if (!peer) {
         throw new Error("Federation peer is not connected.");
       }
-      if (!peer.capabilities.includes("remote_window")) {
-        throw new Error(
-          "Federation peer does not allow remote windows (remote_window capability).",
-        );
-      }
       if (
         request.initialThread &&
         (
@@ -209,36 +204,14 @@ export function registerFederationIpcHandlers(): void {
       ) {
         throw new Error("Federation initial thread target does not match its window.");
       }
-      const window = createMainWindow({
-        federationLabel: peer.label,
-        federationTarget: request.target,
+      const window = createFederationWindow({
+        peer,
         initialThread: request.initialThread
           ? {
               backend: request.initialThread.backend,
               threadId: request.initialThread.threadId,
             }
           : undefined,
-      });
-      const webContentsId = window.webContents.id;
-      runtime.setRendererEventSubscriptions(webContentsId, "remote-window", [{
-        sourceInstanceId: request.target.instanceId,
-        eventClasses: [
-          ...(peer.capabilities.includes("thread_navigation")
-            ? ["navigation" as const]
-            : []),
-          ...(peer.capabilities.includes("thread_detail")
-            ? ["transcript" as const]
-            : []),
-          ...(peer.capabilities.includes("pending_request_control")
-            ? ["pending_requests" as const]
-            : []),
-          ...(peer.capabilities.includes("scheduled_actions")
-            ? ["scheduled_actions" as const]
-            : []),
-        ],
-      }]);
-      window.once("closed", () => {
-        runtime.clearRendererEventSubscriptions(webContentsId, "remote-window");
       });
       return {
         opened: true,


### PR DESCRIPTION
## Reproduction

1. Connect a healthy federation owner and viewer.
2. On the viewer, open File → Remote Instances and select the owner.
3. The remote window loads its initial navigation snapshot and RPC controls continue to work.
4. Generate owner-side transcript, navigation, pending-request, scheduled-action, or Star Map activity.
5. Before this fix, the menu-opened window receives no live events and remains stale until reopened. Persisted session data is unaffected.

## Root cause

PR #1296 made remote event routing fail closed unless each renderer registers desired federation event subscriptions. The federation IPC / Star Map entry point registered a remote-window consumer and cleared it on close, but File → Remote Instances still called createMainWindow directly. That window therefore had no desired subscriptions after its initial snapshot, so scoped routing correctly dropped every later remote event.

## Fix

- Add one federation-window factory that creates the BrowserWindow, registers its source-wide remote-viewer desired state, and clears it on close.
- Model an open remote viewer as one whole-desktop consumer for the owning instance. It requests every event class authorized by negotiated capabilities: navigation, transcript, pending requests, scheduled actions, and Star Map. This is one replace-style subscription message per source, never one message per reachable thread.
- Keep narrower Star Map, pinned-summary, and messaging consumers independent. Desired subscriptions are unioned, so closing one narrow surface cannot unsubscribe a source while a full viewer remains open.
- Route both the federation IPC / Star Map entry point and File → Remote Instances through the same factory.
- Re-resolve the connected menu peer at click time so subscription capabilities are current.
- Keep subscription gating and capability filtering intact; this does not restore blanket remote-event broadcasts to unrelated windows.
- Add menu-path and runtime regression coverage for post-snapshot transcript delivery, all five authorized desktop event classes, consumer-union behavior, and close cleanup.

## Tests

- pnpm test apps/desktop/src/main/__tests__/index.test.ts apps/desktop/src/main/__tests__/agent-ipc.test.ts apps/desktop/src/main/__tests__/federation-runtime.test.ts apps/desktop/src/main/__tests__/federation-window-bootstrap.test.ts — 95 passed
- pnpm typecheck — passed across all workspaces
- pnpm lint:boundaries — passed, no dependency violations
- pnpm lint:eslint — passed with 0 errors; 145 existing baseline warnings