### PR TITLE
fix(desktop): multiplex agent event subscriptions

### DIFF
--- a/apps/desktop/src/preload/__tests__/event-subscription-multiplexer.test.ts
+++ b/apps/desktop/src/preload/__tests__/event-subscription-multiplexer.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { createEventSubscriptionMultiplexer } from "../event-subscription-multiplexer";
+
+describe("createEventSubscriptionMultiplexer", () => {
+  it("shares one source listener across more than ten consumers and releases it last", () => {
+    let sourceListener: ((event: string) => void) | undefined;
+    const unsubscribeFromSource = vi.fn(() => {
+      sourceListener = undefined;
+    });
+    const subscribeToSource = vi.fn((listener: (event: string) => void) => {
+      sourceListener = listener;
+      return unsubscribeFromSource;
+    });
+    const subscribe = createEventSubscriptionMultiplexer(subscribeToSource);
+    const consumers = Array.from({ length: 11 }, () => vi.fn());
+    const unsubscribers = consumers.map((consumer) => subscribe(consumer));
+
+    expect(subscribeToSource).toHaveBeenCalledTimes(1);
+
+    sourceListener?.("thread/updated");
+    for (const consumer of consumers) {
+      expect(consumer).toHaveBeenCalledWith("thread/updated");
+    }
+
+    for (const unsubscribe of unsubscribers.slice(0, -1)) {
+      unsubscribe();
+    }
+    expect(unsubscribeFromSource).not.toHaveBeenCalled();
+
+    unsubscribers.at(-1)?.();
+    expect(unsubscribeFromSource).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports duplicate callbacks and idempotent cleanup", () => {
+    const sourceListeners = new Set<(event: string) => void>();
+    const subscribe = createEventSubscriptionMultiplexer<string>((listener) => {
+      sourceListeners.add(listener);
+      return () => {
+        sourceListeners.delete(listener);
+      };
+    });
+    const consumer = vi.fn();
+    const unsubscribeFirst = subscribe(consumer);
+    const unsubscribeSecond = subscribe(consumer);
+
+    for (const listener of sourceListeners) {
+      listener("first");
+    }
+    expect(consumer).toHaveBeenCalledTimes(2);
+
+    unsubscribeFirst();
+    unsubscribeFirst();
+    for (const listener of sourceListeners) {
+      listener("second");
+    }
+    expect(consumer).toHaveBeenCalledTimes(3);
+    expect(sourceListeners.size).toBe(1);
+
+    unsubscribeSecond();
+    expect(sourceListeners.size).toBe(0);
+  });
+
+  it("restores a lazy source subscription after every consumer unmounts", () => {
+    const unsubscribeFromSource = vi.fn();
+    const subscribeToSource = vi.fn(() => unsubscribeFromSource);
+    const subscribe =
+      createEventSubscriptionMultiplexer<string>(subscribeToSource);
+
+    const unsubscribeFirst = subscribe(vi.fn());
+    unsubscribeFirst();
+    const unsubscribeSecond = subscribe(vi.fn());
+
+    expect(subscribeToSource).toHaveBeenCalledTimes(2);
+    expect(unsubscribeFromSource).toHaveBeenCalledTimes(1);
+
+    unsubscribeSecond();
+    expect(unsubscribeFromSource).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/preload/event-subscription-multiplexer.ts
+++ b/apps/desktop/src/preload/event-subscription-multiplexer.ts
@@ -1,0 +1,49 @@
+export type EventSubscription<T> = (
+  callback: (event: T) => void,
+) => () => void;
+
+/**
+ * Share one source subscription across independent renderer consumers.
+ * The source is attached lazily and released after the final consumer leaves.
+ */
+export function createEventSubscriptionMultiplexer<T>(
+  subscribeToSource: (callback: (event: T) => void) => () => void,
+): EventSubscription<T> {
+  const consumers = new Set<{ callback: (event: T) => void }>();
+  let unsubscribeFromSource: (() => void) | undefined;
+
+  const fanOut = (event: T): void => {
+    for (const consumer of [...consumers]) {
+      consumer.callback(event);
+    }
+  };
+
+  return (callback) => {
+    const consumer = { callback };
+    consumers.add(consumer);
+
+    if (consumers.size === 1) {
+      try {
+        unsubscribeFromSource = subscribeToSource(fanOut);
+      } catch (error) {
+        consumers.delete(consumer);
+        throw error;
+      }
+    }
+
+    let active = true;
+    return () => {
+      if (!active) {
+        return;
+      }
+      active = false;
+      consumers.delete(consumer);
+
+      if (consumers.size === 0) {
+        const unsubscribe = unsubscribeFromSource;
+        unsubscribeFromSource = undefined;
+        unsubscribe?.();
+      }
+    };
+  };
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,4 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
+import {
+  createEventSubscriptionMultiplexer,
+} from "./event-subscription-multiplexer";
 import type {
   AgentEvent,
   ApplyThreadModelMigrationRequest,
@@ -695,6 +698,17 @@ recordStartupProfileRendererEvent("preload-start", {
 });
 
 const isDevelopment = process.env.NODE_ENV !== "production";
+
+const subscribeToAgentEvent = createEventSubscriptionMultiplexer<AgentEvent>(
+  (callback) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: AgentEvent) =>
+      callback(payload);
+    ipcRenderer.on(AGENT_EVENT_CHANNEL, listener);
+    return () => {
+      ipcRenderer.off(AGENT_EVENT_CHANNEL, listener);
+    };
+  },
+);
 
 const desktopApi = Object.freeze({
   ping: () => "pong",
@@ -1724,14 +1738,7 @@ const desktopApi = Object.freeze({
   },
   getWindowPointerSnapshot: async (): Promise<WindowPointerSnapshot> =>
     await ipcRenderer.invoke(WINDOW_POINTER_SNAPSHOT_CHANNEL),
-  onAgentEvent: (callback: (event: AgentEvent) => void): (() => void) => {
-    const listener = (_event: Electron.IpcRendererEvent, payload: AgentEvent) =>
-      callback(payload);
-    ipcRenderer.on(AGENT_EVENT_CHANNEL, listener);
-    return () => {
-      ipcRenderer.off(AGENT_EVENT_CHANNEL, listener);
-    };
-  },
+  onAgentEvent: subscribeToAgentEvent,
   onPrAutoDispatchBudgetChanged: (
     callback: (status: PrAutoDispatchBudgetStatus) => void,
   ): (() => void) => {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -2026,7 +2026,7 @@ describe("App", () => {
     expect(await screen.findByRole("textbox", { name: "New thread" })).toBeInTheDocument();
   });
 
-  it("registers a queued review with the backend before navigating away", async () => {
+  it("registers a remote queued review before navigating away and cleans up event subscriptions", async () => {
     const agentEventListeners = new Set<
       (event: {
         backend: "codex";
@@ -2036,6 +2036,12 @@ describe("App", () => {
         };
       }) => void
     >();
+    (window as typeof window & {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = {
+      scope: "remote",
+      instanceId: "remote-gateway",
+    };
     const startTurn = vi.fn<
       (request: StartTurnRequest) => Promise<StartTurnResponse>
     >(async (request) => ({
@@ -2205,12 +2211,16 @@ describe("App", () => {
       }
     });
 
-    render(<App />);
+    const { unmount } = render(<App />);
 
     await screen.findByRole("heading", {
       level: 2,
       name: "Active background thread"
     });
+    // A remote viewer adds peer-connectivity ownership to the selected-thread
+    // feature subscriptions, legitimately taking the renderer past Node's
+    // default EventEmitter warning threshold.
+    expect(agentEventListeners.size).toBeGreaterThan(10);
 
     pasteComposerText(
       await screen.findByRole("textbox", { name: "Reply" }),
@@ -2243,6 +2253,10 @@ describe("App", () => {
       origin: "desktop",
       scheduledFor: expect.any(Number),
       displayText: "Review changes against main",
+      federationTarget: {
+        scope: "remote",
+        instanceId: "remote-gateway",
+      },
       review: {
         target: {
           type: "baseBranch",
@@ -2287,6 +2301,9 @@ describe("App", () => {
     await flushReactUpdates();
     expect(startReview).not.toHaveBeenCalled();
     expect(startTurn).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(agentEventListeners.size).toBe(0);
   });
 
   it("keeps assistant response text out of the thread header", async () => {

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -58,6 +58,7 @@ export default defineConfig({
             "apps/desktop/scripts/**/*.test.mjs",
             "apps/desktop/src/main/__tests__/**/*.test.ts",
             "apps/desktop/src/main/agent-tools/__tests__/**/*.test.ts",
+            "apps/desktop/src/preload/__tests__/**/*.test.ts",
             "apps/desktop/src/shared/__tests__/**/*.test.ts"
           ],
           // Inline @pwrdrvr/codex-discovery so vitest transforms it. Without


### PR DESCRIPTION
## Summary

- multiplex renderer `agent:event` consumers through one preload-owned Electron listener
- detach that listener after the final renderer consumer unsubscribes
- cover Remote Viewer fan-out, full unmount cleanup, duplicate callbacks, remounting, and the 11-consumer warning threshold

## Root cause

A selected-thread renderer legitimately mounts independent `onAgentEvent` consumers for navigation, session state, composer/transcript state, backend summaries, notifications, and related features. A Remote Viewer adds peer-connectivity ownership and crosses Node's default 10-listener EventEmitter threshold.

Each React effect already returned its unsubscribe callback, and focused coverage confirms the full Remote Viewer unmount removes every consumer. The warning was therefore legitimate fan-out mapped one-to-one onto `ipcRenderer.on`, not accumulated stale subscriptions.

This change does not raise or suppress the listener warning. It gives the preload bridge one native listener and fans events out in process while retaining lazy attachment and final-consumer cleanup.

## Validation

- `pnpm test apps/desktop/src/preload/__tests__/event-subscription-multiplexer.test.ts apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop build`
