### PR TITLE
fix(desktop): avoid composer updates during render

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -7488,33 +7488,33 @@ export function Composer(props: ComposerProps) {
   };
 
   const removeImageAttachment = (id: string): void => {
-    setImageAttachments((current) => {
-      const nextAttachments = current.filter((attachment) => attachment.id !== id);
-      saveComposerDraftSnapshot(composerScopeKey, {
-        draft,
-        editorDocument,
-        imageAttachments: nextAttachments,
-        fileAttachments,
-        skillTokens,
-      });
-      persistLaunchpadImageAttachments(nextAttachments);
-      return nextAttachments;
+    const nextAttachments = imageAttachments.filter(
+      (attachment) => attachment.id !== id,
+    );
+    setImageAttachments(nextAttachments);
+    saveComposerDraftSnapshot(composerScopeKey, {
+      draft,
+      editorDocument,
+      imageAttachments: nextAttachments,
+      fileAttachments,
+      skillTokens,
     });
+    persistLaunchpadImageAttachments(nextAttachments);
   };
 
   const removeFileAttachment = (id: string): void => {
-    setFileAttachments((current) => {
-      const nextAttachments = current.filter((attachment) => attachment.id !== id);
-      saveComposerDraftSnapshot(composerScopeKey, {
-        draft,
-        editorDocument,
-        imageAttachments,
-        fileAttachments: nextAttachments,
-        skillTokens,
-      });
-      persistLaunchpadImageAttachments(imageAttachments, nextAttachments);
-      return nextAttachments;
+    const nextAttachments = fileAttachments.filter(
+      (attachment) => attachment.id !== id,
+    );
+    setFileAttachments(nextAttachments);
+    saveComposerDraftSnapshot(composerScopeKey, {
+      draft,
+      editorDocument,
+      imageAttachments,
+      fileAttachments: nextAttachments,
+      skillTokens,
     });
+    persistLaunchpadImageAttachments(imageAttachments, nextAttachments);
   };
 
   const persistLaunchpadImageAttachments = (
@@ -7837,8 +7837,8 @@ export function Composer(props: ComposerProps) {
 
       // Reject exact-duplicate pastes so the same image can't stack up. Toast
       // off the snapshot captured when this paste started — accurate for the
-      // sequential paste-the-same-image case — then re-check inside the state
-      // updater below against the freshest list for the rare paste race.
+      // sequential paste-the-same-image case — then re-check against the
+      // freshest snapshot below for the rare paste race.
       const { unique, duplicateCount } = partitionNewImageAttachments(
         pasteImageAttachments,
         nextAttachments,
@@ -7857,37 +7857,37 @@ export function Composer(props: ComposerProps) {
         return;
       }
 
-      setImageAttachments((current) => {
-        // Re-run de-dup and the cap against the latest state (not the snapshot
-        // captured when this paste began) so a second identical paste arriving
-        // while an earlier one is still normalizing can never slip a duplicate
-        // through or exceed the limit.
-        const { unique: freshlyUnique } = partitionNewImageAttachments(
-          current,
-          unique,
-          getImageSignature,
-        );
-        const mergedAttachments = [...current, ...freshlyUnique].slice(
-          0,
-          MAX_COMPOSER_IMAGE_ATTACHMENTS,
-        );
-        // Read file pills from the latest snapshot ref, not the paste-time
-        // closure — a mixed drop attaches files synchronously before this
-        // async image path lands, and the stale list would wipe them.
-        const latestFileAttachments =
-          latestDraftSnapshotRef.current.snapshot.fileAttachments ??
-          pasteFileAttachments;
-        const nextSnapshot = {
-          draft,
-          editorDocument,
-          imageAttachments: mergedAttachments,
-          fileAttachments: latestFileAttachments,
-          skillTokens,
-        };
-        saveComposerDraftSnapshot(pasteScope.key, nextSnapshot);
-        persistLaunchpadImageAttachments(mergedAttachments, latestFileAttachments);
-        return mergedAttachments;
-      });
+      // Re-run de-dup and the cap against the latest snapshot (not the one
+      // captured when this paste began) so concurrent normalizations cannot
+      // add a duplicate or exceed the limit. Update the ref synchronously so
+      // the next completion sees this one before React commits the state.
+      const latestSnapshot = latestDraftSnapshotRef.current.snapshot;
+      const { unique: freshlyUnique } = partitionNewImageAttachments(
+        latestSnapshot.imageAttachments,
+        unique,
+        getImageSignature,
+      );
+      const mergedAttachments = [
+        ...latestSnapshot.imageAttachments,
+        ...freshlyUnique,
+      ].slice(0, MAX_COMPOSER_IMAGE_ATTACHMENTS);
+      // Read file pills from the latest snapshot ref, not the paste-time
+      // closure — a mixed drop attaches files synchronously before this
+      // async image path lands, and the stale list would wipe them.
+      const latestFileAttachments =
+        latestSnapshot.fileAttachments ?? pasteFileAttachments;
+      const nextSnapshot = {
+        ...latestSnapshot,
+        imageAttachments: mergedAttachments,
+        fileAttachments: latestFileAttachments,
+      };
+      latestDraftSnapshotRef.current = {
+        scopeKey: pasteScope.key,
+        snapshot: nextSnapshot,
+      };
+      setImageAttachments(mergedAttachments);
+      saveComposerDraftSnapshot(pasteScope.key, nextSnapshot);
+      persistLaunchpadImageAttachments(mergedAttachments, latestFileAttachments);
     } catch (error) {
       if (activeComposerScopeKeyRef.current !== pasteScope.key) {
         return;

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -15306,6 +15306,76 @@ describe("Composer", () => {
     );
   });
 
+  it("does not update a launchpad parent while rendering image attachment changes", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const onUpdateLaunchpad = vi.fn();
+
+    function StatefulLaunchpadComposer() {
+      const [launchpad, setLaunchpad] = useState<NavigationLaunchpadDraft>({
+        directoryKey: "directory:/repo",
+        directoryKind: "directory",
+        directoryLabel: "PwrAgent",
+        directoryPath: "/repo",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "local",
+        createdAt: 1,
+        updatedAt: 1,
+      });
+
+      return (
+        <Composer
+          backends={[backendSummary("codex")]}
+          launchpad={launchpad}
+          onUpdateLaunchpad={async (_directoryKey, patch) => {
+            onUpdateLaunchpad(patch);
+            setLaunchpad((current) => ({
+              ...current,
+              ...patch,
+              updatedAt: current.updatedAt + 1,
+            }));
+          }}
+          skills={[]}
+        />
+      );
+    }
+
+    try {
+      render(
+        <StrictMode>
+          <StatefulLaunchpadComposer />
+        </StrictMode>,
+      );
+      const updateCallsBeforePaste = onUpdateLaunchpad.mock.calls.length;
+      const file = new File([new Uint8Array([1])], "shot.png", {
+        type: "image/png",
+      });
+
+      fireEvent.paste(screen.getByLabelText("Reply"), {
+        clipboardData: {
+          files: [],
+          items: [{ kind: "file", type: file.type, getAsFile: () => file }],
+        },
+      });
+
+      expect(await screen.findByText("32×24")).toBeInTheDocument();
+      expect(onUpdateLaunchpad).toHaveBeenCalledTimes(updateCallsBeforePaste + 1);
+      fireEvent.click(screen.getByRole("button", { name: "Remove shot.png" }));
+      await waitFor(() => {
+        expect(screen.queryByText("32×24")).not.toBeInTheDocument();
+      });
+      expect(onUpdateLaunchpad).toHaveBeenCalledTimes(updateCallsBeforePaste + 2);
+      expect(
+        consoleError.mock.calls.filter(([message]) =>
+          String(message).includes("Cannot update a component"),
+        ),
+      ).toHaveLength(0);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("stops accepting pasted images at the attachment limit and shows a toast", async () => {
     const onShowNotice = vi.fn();
     const files = Array.from(


### PR DESCRIPTION
## Summary

- keep image and file attachment state updaters free of persistence side effects
- use the latest composer snapshot to preserve paste de-duplication and attachment-cap race safety
- add StrictMode regression coverage for launchpad image attachment add/remove flows

## Root cause

After pasted-image normalization, `Composer` called `setImageAttachments` with a functional updater that also persisted the draft through `onUpdateLaunchpad`. React StrictMode can replay that updater while rendering `Composer`; the callback then updates navigation state owned by `DesktopAppShell`, producing `Cannot update a component (DesktopAppShell) while rendering a different component (Composer)`.

The same render-time persistence pattern existed in attachment removal updaters. Persistence now runs after the pure attachment state calculation instead.

## Impact

The attachment operation generally completed, but development builds logged the React warning and could issue redundant launchpad state/bridge updates. Keeping state updaters pure removes the invalid render-time parent update and its ordering risk.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` (253 passed)
- `pnpm lint:eslint` (0 errors; existing warning baseline remains)
- `pnpm typecheck`
