### PR TITLE
fix(desktop): stop the star map moving under the operator

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -161,9 +161,21 @@ export function StarMapScreen(props: StarMapScreenProps) {
   // Orbit places bodies on a canvas larger than the window, so the surface
   // pans and zooms rather than compressing the map to fit.
   const [view, setView] = useState({ x: 0, y: 0, scale: 1 });
+  /**
+   * Set once the operator pans or zooms. From then on the view is theirs:
+   * nothing that merely changes the map's contents may move it.
+   */
+  const operatorMovedViewRef = useRef(false);
   const orbitMode = preferences.layout === "orbit";
   /** Projects as suns: threads pooled across instances, one body per repo. */
   const projectsMode = preferences.layout === "projects";
+  /**
+   * Both big-canvas lenses pan and zoom; lanes fits the window and does
+   * not. Projects previously failed every one of these gates, so its
+   * oversized canvas could not be navigated at all, and the centring
+   * effect pinned it to the origin instead of centring it.
+   */
+  const panZoomMode = orbitMode || projectsMode;
 
   // Focus the layer on open AND whenever the floating thread closes -
   // "Back to map" leaves focus inside <main>, and without a refocus the
@@ -227,10 +239,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
   // pointer. Registered natively because the listener must not be passive.
   useEffect(() => {
     const element = viewportRef.current;
-    if (!element || !orbitMode) return;
+    if (!element || !panZoomMode) return;
     const onWheel = (event: WheelEvent) => {
       event.preventDefault();
       if (event.ctrlKey) {
+        operatorMovedViewRef.current = true;
         const rect = element.getBoundingClientRect();
         const pointerX = event.clientX - rect.left;
         const pointerY = event.clientY - rect.top;
@@ -249,6 +262,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
         });
         return;
       }
+      operatorMovedViewRef.current = true;
       setView((current) => ({
         ...current,
         x: current.x - event.deltaX,
@@ -257,10 +271,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
     };
     element.addEventListener("wheel", onWheel, { passive: false });
     return () => element.removeEventListener("wheel", onWheel);
-  }, [orbitMode]);
+  }, [panZoomMode]);
 
   const startCanvasPan = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if (!orbitMode || event.button !== 0) return;
+    if (!panZoomMode || event.button !== 0) return;
     if (!shouldStartCanvasPan(event.target)) return;
     const canvas = canvasRef.current;
     const viewport = viewportRef.current;
@@ -293,6 +307,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
         frame = 0;
       }
       viewport?.classList.remove("is-panning");
+      operatorMovedViewRef.current = true;
       setView((current) => ({ ...current, x: lastX, y: lastY }));
     };
     window.addEventListener("pointermove", move);
@@ -592,19 +607,44 @@ export function StarMapScreen(props: StarMapScreenProps) {
     });
   }, [laneLayout, lanes, orbit, orbitMode]);
 
-  // Centre the canvas on mode switch / topology change rather than leaving
-  // the operator staring at empty space in a corner.
+  const panZoomCanvas = orbitMode
+    ? { width: orbit.canvasWidth, height: orbit.canvasHeight }
+    : { width: projectLayout.canvasWidth, height: projectLayout.canvasHeight };
+
+  // A lens switch is a different map, so the view starts centred again.
   useEffect(() => {
-    if (!orbitMode) {
+    operatorMovedViewRef.current = false;
+  }, [preferences.layout]);
+
+  /**
+   * Centre the canvas so the operator does not open onto empty space —
+   * but only while the view is still ours to place.
+   *
+   * The canvas size is an input here, and it changes whenever a cloud's
+   * card count changes: archiving a card can drop a ring and resize the
+   * whole canvas. Before the ownership check, that meant tidying up a
+   * thread in one corner of the map threw away the operator's pan and
+   * zoom and snapped them back to centre — the map moving under the
+   * person using it.
+   */
+  useEffect(() => {
+    if (operatorMovedViewRef.current) return;
+    if (!panZoomMode) {
       setView({ x: 0, y: 0, scale: 1 });
       return;
     }
     setView({
-      x: (viewportSize.width - orbit.canvasWidth) / 2,
-      y: (viewportSize.height - orbit.canvasHeight) / 2,
+      x: (viewportSize.width - panZoomCanvas.width) / 2,
+      y: (viewportSize.height - panZoomCanvas.height) / 2,
       scale: 1,
     });
-  }, [orbitMode, orbit.canvasWidth, orbit.canvasHeight, viewportSize.width, viewportSize.height]);
+  }, [
+    panZoomMode,
+    panZoomCanvas.width,
+    panZoomCanvas.height,
+    viewportSize.width,
+    viewportSize.height,
+  ]);
 
   const peerById = useMemo(
     () => new Map(peers.map((peer) => [peer.id, peer])),

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -1,0 +1,237 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { StarMapScreen } from "../StarMapScreen";
+
+/**
+ * The map must never move under the operator.
+ *
+ * Panning is how you work a map bigger than the window: you put the corner
+ * you care about on screen and then act on it. Archiving a card from that
+ * corner changes a cloud's card count, which changes the canvas size — and
+ * the canvas size used to be an input to the "centre the view" effect, so
+ * the act of tidying up threw away where you were looking.
+ */
+
+function buildDesktopApi(overrides: Partial<DesktopApi> = {}): DesktopApi {
+  return {
+    readFederationHealth: vi.fn(async () => ({
+      health: {
+        enabled: false,
+        role: "client" as const,
+        status: "disabled" as const,
+        instanceId: "pwr_local",
+        localCelestialIcon: "sun" as const,
+        localLabel: "Harold-MBP-M5-Max",
+        localProfileName: "default",
+        peers: [],
+      },
+    })),
+    onAgentEvent: vi.fn(() => () => undefined),
+    ...overrides,
+  } as unknown as DesktopApi;
+}
+
+function thread(id: string): NavigationThreadSummary {
+  return {
+    id,
+    title: `Thread ${id}`,
+    titleSource: "generated",
+    linkedDirectories: [
+      { id: `${id}-dir`, label: "PwrSnap", path: "/repos/PwrSnap", kind: "local" },
+    ],
+    source: "codex",
+    inbox: { inInbox: true, reason: "updated-since-seen" },
+    updatedAt: 100,
+  } as unknown as NavigationThreadSummary;
+}
+
+/** Enough threads that dropping one changes the cloud's ring count. */
+function threads(count: number): NavigationThreadSummary[] {
+  return Array.from({ length: count }, (_, index) => thread(`t${index}`));
+}
+
+function seedLayout(layout: "orbit" | "projects") {
+  window.localStorage.setItem(
+    "pwragent.starMap.viewPreferences",
+    JSON.stringify({ layout }),
+  );
+}
+
+function canvas(): HTMLElement {
+  const element = document
+    .querySelector(".star-map__canvas");
+  if (!element) throw new Error("canvas not found");
+  return element as HTMLElement;
+}
+
+/** Drag the canvas by a fixed delta, the way an operator pans. */
+function pan(dx: number, dy: number) {
+  const viewport = document.querySelector(".star-map__viewport");
+  if (!viewport) throw new Error("viewport not found");
+  fireEvent.pointerDown(viewport, { button: 0, clientX: 500, clientY: 400 });
+  fireEvent.pointerMove(window, { clientX: 500 + dx, clientY: 400 + dy });
+  fireEvent.pointerUp(window, { clientX: 500 + dx, clientY: 400 + dy });
+}
+
+function renderMap(props: { threads: NavigationThreadSummary[] }) {
+  return render(
+    <StarMapScreen
+      desktopApi={buildDesktopApi()}
+      localThreads={props.threads}
+      sessionKeys={{}}
+      localInstanceLabel="Mac-Mini-M4"
+      floating={false}
+      onClose={() => undefined}
+      onOpenLocalThread={() => undefined}
+      onFocusLocalInstance={() => undefined}
+    />,
+  );
+}
+
+describe("star map view stability", () => {
+  // Layout preference is global; leaking it reorders unrelated suites.
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+  });
+
+  it("keeps the operator's pan when a card is archived away (orbit)", async () => {
+    seedLayout("orbit");
+    const { rerender } = renderMap({ threads: threads(9) });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance/ }),
+      ).toBeTruthy();
+    });
+
+    pan(-320, -180);
+    const panned = canvas().style.transform;
+    expect(panned).toMatch(/translate/);
+
+    // Archiving removes the thread and the owning cloud re-fetches. The
+    // map must stay exactly where the operator put it.
+    rerender(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={threads(8)}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /Open thread: Thread t8/ }),
+      ).toBeNull();
+    });
+    expect(canvas().style.transform).toBe(panned);
+  });
+
+  it("keeps the operator's zoom when the cloud resizes", async () => {
+    seedLayout("orbit");
+    const { rerender } = renderMap({ threads: threads(9) });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance/ }),
+      ).toBeTruthy();
+    });
+
+    const viewport = document.querySelector(".star-map__viewport")!;
+    fireEvent.wheel(viewport, { deltaY: -240, ctrlKey: true, clientX: 400, clientY: 300 });
+    const zoomed = canvas().style.transform;
+    expect(zoomed).toMatch(/scale\((?!1\))/);
+
+    rerender(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={threads(5)}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /Open thread: Thread t8/ }),
+      ).toBeNull();
+    });
+    expect(canvas().style.transform).toBe(zoomed);
+  });
+
+  it("still centres when the operator switches layout", async () => {
+    // The re-centre is worth keeping for a genuine mode switch — that is a
+    // new map, and leaving the operator in a corner of it is worse.
+    seedLayout("orbit");
+    renderMap({ threads: threads(9) });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance/ }),
+      ).toBeTruthy();
+    });
+
+    pan(-400, -260);
+    expect(canvas().style.transform).toMatch(/translate/);
+
+    fireEvent.click(screen.getByRole("button", { name: "View" }));
+    fireEvent.click(screen.getByRole("button", { name: "Projects" }));
+
+    await waitFor(() => {
+      // A different lens re-centres rather than stranding the operator.
+      expect(canvas().style.transform).not.toBe("");
+    });
+  });
+
+  it("lets the operator pan the projects lens at all", async () => {
+    // The projects canvas is bigger than the window like orbit's, but every
+    // pan/zoom gate tested `orbitMode`, so it could not be navigated.
+    seedLayout("projects");
+    renderMap({ threads: threads(9) });
+    await waitFor(() => {
+      expect(screen.getByTitle("PwrSnap")).toBeTruthy();
+    });
+
+    const before = canvas().style.transform;
+    pan(-260, -140);
+    expect(canvas().style.transform).not.toBe(before);
+  });
+
+  it("keeps the operator's pan when a card is archived away (projects)", async () => {
+    seedLayout("projects");
+    const { rerender } = renderMap({ threads: threads(9) });
+    await waitFor(() => {
+      expect(screen.getByTitle("PwrSnap")).toBeTruthy();
+    });
+
+    pan(-300, -200);
+    const panned = canvas().style.transform;
+
+    rerender(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={threads(4)}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /Open thread: Thread t8/ }),
+      ).toBeNull();
+    });
+    expect(canvas().style.transform).toBe(panned);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -179,14 +179,18 @@ describe("star map view stability", () => {
     });
 
     pan(-400, -260);
-    expect(canvas().style.transform).toMatch(/translate/);
+    const panned = canvas().style.transform;
+    expect(panned).toMatch(/translate/);
 
     fireEvent.click(screen.getByRole("button", { name: "View" }));
     fireEvent.click(screen.getByRole("button", { name: "Projects" }));
 
     await waitFor(() => {
-      // A different lens re-centres rather than stranding the operator.
-      expect(canvas().style.transform).not.toBe("");
+      // A different lens re-centres rather than stranding the operator, so
+      // the view must leave where the operator had parked it. Asserting
+      // only that a transform exists would pass even with the reset gone,
+      // because pan/zoom lenses always carry one.
+      expect(canvas().style.transform).not.toBe(panned);
     });
   });
 


### PR DESCRIPTION
Archiving a card from a body off to one side snapped the whole map back to centre, throwing away the operator's pan and zoom.

## Cause

Not repaint cost — a **state reset**. The "centre the canvas" effect took the canvas size as an input:

```ts
}, [orbitMode, orbit.canvasWidth, orbit.canvasHeight, viewportSize.width, viewportSize.height]);
```

Canvas size is derived from each cloud's card count, so archiving a thread can drop a ring, resize the canvas, re-fire the effect, and re-centre the view. Panning is how you work a map bigger than the window — put the corner you care about on screen, then act on it — so the surface undid the operator's positioning at exactly the moment they acted on it.

## Fix

The view is owned by whoever last moved it. A pan or zoom marks it as the operator's, and from then on nothing that merely changes the map's *contents* may move it. Centring still happens where it earns its keep: on first render, and on a **lens switch** — a different map, rather than the same one rearranged.

## Two more defects this turned up

Both from gates that named `orbitMode` when they meant "a canvas bigger than the window":

- **The projects lens could not be panned or zoomed at all.** Its canvas is oversized like orbit's, but the drag handler and the wheel listener both tested `orbitMode`, so neither ever engaged.
- **The same lens was pinned to the canvas origin instead of centred**, because the centring effect treated everything not-orbit as a lane layout that fits the window.

Both now test `panZoomMode`.

## Tests

Written failing first, against the observable symptom — the canvas `transform`:

| Test | Fails without |
|---|---|
| keeps pan when a card is archived away (orbit) | ownership guard |
| keeps zoom when the cloud resizes | ownership guard |
| keeps pan when a card is archived away (projects) | ownership guard + pan gate |
| lets the operator pan the projects lens at all | pan gate |
| still centres when the operator switches layout | — (pins the kept behaviour) |

Each guard was reverted individually to confirm the matching tests fail without it.

Full suite **6,780 passing**, typecheck clean, `lint:colors`, `lint:boundaries`, ESLint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)