### PR TITLE
fix(desktop): bound star map card drags to the instance body

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -30,7 +30,7 @@ import {
   type StarMapSessionKeys,
 } from "./attention";
 import {
-  cloudDragRadius,
+  cloudDetentRadius,
   computeCardSlots,
   computeStarMapLayout,
   generateStarField,
@@ -772,6 +772,27 @@ export function StarMapScreen(props: StarMapScreenProps) {
           },
         });
       }
+      // Cards may be dragged out past the detent on purpose — an island of
+      // threads off to one side — and a lane does not pan, so a card pulled
+      // beyond the window has no other way back to its cloud.
+      if (
+        desktopApi?.setStarMapCardPosition
+        && arrangement.offsetFor(
+          instanceId,
+          buildThreadIdentityKey(thread.source, thread.id),
+        )
+      ) {
+        actions.push({
+          key: "reset-position",
+          label: "Reset position",
+          onSelect: () =>
+            arrangement.setCardPosition(
+              instanceId,
+              buildThreadIdentityKey(thread.source, thread.id),
+              null,
+            ),
+        });
+      }
       if (desktopApi?.archiveThread) {
         actions.push({
           danger: true,
@@ -802,7 +823,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       }
       return actions;
     },
-    [chatCards, desktopApi, openThreadFully, refreshOwner],
+    [arrangement, chatCards, desktopApi, openThreadFully, refreshOwner],
   );
 
   const linkState = (peerId: string) => {
@@ -825,7 +846,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     const slots = position.slots;
     // One region for the whole cloud, sized to the slots this lens drew,
     // so every card in it can reach every other card's position.
-    const dragRadius = cloudDragRadius(slots);
+    const detentRadius = cloudDetentRadius(slots);
     const overflow = threads.length - visible.length;
     return (
       <div
@@ -871,22 +892,24 @@ export function StarMapScreen(props: StarMapScreenProps) {
               )}
               baseSlot={slot}
               offset={arrangement.offsetFor(position.instanceId, threadKey)}
-              dragRadius={dragRadius}
               width={position.cardWidth}
               centered={orbitMode}
               stackIndex={index}
               cardFields={preferences.cardFields}
               menuActions={cardMenuActions(thread, position.instanceId)}
-              onCommitOffset={
+              drag={
                 // Drags persist + sync only once the durable instance id is
                 // known; before that, cards stay in their default slots.
                 health?.instanceId
-                  ? (offset) =>
-                      arrangement.setCardPosition(
-                        position.instanceId,
-                        threadKey,
-                        offset,
-                      )
+                  ? {
+                      detentRadius,
+                      onCommitOffset: (offset) =>
+                        arrangement.setCardPosition(
+                          position.instanceId,
+                          threadKey,
+                          offset,
+                        ),
+                    }
                   : undefined
               }
               onOpen={openThread}
@@ -1116,7 +1139,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
                 ORBIT_MAX_CARDS_PER_INSTANCE,
               );
               const slots = cardRingSlots(visible.length, ORBIT_CARD_WIDTH);
-              const dragRadius = cloudDragRadius(slots);
               return (
                 <div
                   key={`project:${placement.key}`}
@@ -1151,7 +1173,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
                           owner === localInstanceId ? undefined : owner,
                         )}
                         baseSlot={slots[index]}
-                        dragRadius={dragRadius}
                         // No drag here on purpose: arrangements are keyed
                         // and synced per federation instance, and a project
                         // is not an instance. Giving projects their own

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -30,6 +30,7 @@ import {
   type StarMapSessionKeys,
 } from "./attention";
 import {
+  cloudDragRadius,
   computeCardSlots,
   computeStarMapLayout,
   generateStarField,
@@ -822,6 +823,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
     const heights = lane?.heights ?? [];
     const visible = threads.slice(0, lane?.count ?? 0);
     const slots = position.slots;
+    // One region for the whole cloud, sized to the slots this lens drew,
+    // so every card in it can reach every other card's position.
+    const dragRadius = cloudDragRadius(slots);
     const overflow = threads.length - visible.length;
     return (
       <div
@@ -867,6 +871,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
               )}
               baseSlot={slot}
               offset={arrangement.offsetFor(position.instanceId, threadKey)}
+              dragRadius={dragRadius}
               width={position.cardWidth}
               centered={orbitMode}
               stackIndex={index}
@@ -1111,6 +1116,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
                 ORBIT_MAX_CARDS_PER_INSTANCE,
               );
               const slots = cardRingSlots(visible.length, ORBIT_CARD_WIDTH);
+              const dragRadius = cloudDragRadius(slots);
               return (
                 <div
                   key={`project:${placement.key}`}
@@ -1145,6 +1151,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
                           owner === localInstanceId ? undefined : owner,
                         )}
                         baseSlot={slots[index]}
+                        dragRadius={dragRadius}
                         // No drag here on purpose: arrangements are keyed
                         // and synced per federation instance, and a project
                         // is not an instance. Giving projects their own

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -15,7 +15,7 @@ import {
   getThreadRowStatus,
   ThreadRowStatus,
 } from "../navigation/ThreadRowStatus";
-import { clampToCloudRadius, STAR_MAP_CLOUD_RADIUS } from "./star-map-layout";
+import { clampCardOffset } from "./star-map-layout";
 import {
   visiblePullRequests,
   type StarMapCardFields,
@@ -49,6 +49,12 @@ export function StarMapThreadCard(props: {
   width: number;
   /** Lane position, so dragged-into-overlap cards paint front-to-back. */
   stackIndex: number;
+  /**
+   * How far from the INSTANCE BODY a drag may reach — one region shared by
+   * the whole cloud (`cloudDragRadius`), not a per-card allowance, so any
+   * card can be placed where any other card sits.
+   */
+  dragRadius: number;
   /** Which chips this card carries (operator preference). */
   cardFields: StarMapCardFields;
   /** Orbit rings centre cards on their slot; lanes hang them from the top. */
@@ -110,11 +116,14 @@ export function StarMapThreadCard(props: {
       }
       dragging = true;
       suppressClickRef.current = true;
-      const clamped = clampToCloudRadius(
-        startOffset.dx + deltaX,
-        startOffset.dy + deltaY,
-        STAR_MAP_CLOUD_RADIUS,
-      );
+      const clamped = clampCardOffset({
+        baseSlot: props.baseSlot,
+        offset: {
+          dx: startOffset.dx + deltaX,
+          dy: startOffset.dy + deltaY,
+        },
+        radius: props.dragRadius,
+      });
       lastDx = clamped.dx;
       lastDy = clamped.dy;
       if (!frame) {

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -15,7 +15,7 @@ import {
   getThreadRowStatus,
   ThreadRowStatus,
 } from "../navigation/ThreadRowStatus";
-import { clampCardOffset } from "./star-map-layout";
+import { resolveCardDragOffset } from "./star-map-layout";
 import {
   visiblePullRequests,
   type StarMapCardFields,
@@ -49,20 +49,26 @@ export function StarMapThreadCard(props: {
   width: number;
   /** Lane position, so dragged-into-overlap cards paint front-to-back. */
   stackIndex: number;
-  /**
-   * How far from the INSTANCE BODY a drag may reach — one region shared by
-   * the whole cloud (`cloudDragRadius`), not a per-card allowance, so any
-   * card can be placed where any other card sits.
-   */
-  dragRadius: number;
   /** Which chips this card carries (operator preference). */
   cardFields: StarMapCardFields;
   /** Orbit rings centre cards on their slot; lanes hang them from the top. */
   centered?: boolean;
   /** Owning instance's celestial mark, watermarked behind the content. */
   instanceIcon?: CelestialIconId;
-  /** Present when the card is draggable; receives the clamped offset. */
-  onCommitOffset?: (offset: { dx: number; dy: number }) => void;
+  /**
+   * Present when the card is draggable. Radius and commit travel together
+   * so a draggable card cannot exist without the region it drags in.
+   */
+  drag?: {
+    /**
+     * Where drag resistance begins, measured from the INSTANCE BODY — one
+     * region shared by the whole cloud (`cloudDetentRadius`), not a
+     * per-card allowance, so any card can be placed where any other card
+     * sits. Past it the drag is resisted, not stopped.
+     */
+    detentRadius: number;
+    onCommitOffset: (offset: { dx: number; dy: number }) => void;
+  };
   onOpen: (thread: NavigationThreadSummary) => void;
   /** Kebab entries; the kebab is hidden when empty. */
   menuActions?: StarMapCardMenuAction[];
@@ -96,7 +102,8 @@ export function StarMapThreadCard(props: {
   };
 
   const startDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if (!props.onCommitOffset || event.button !== 0) return;
+    const drag = props.drag;
+    if (!drag || event.button !== 0) return;
     const element = event.currentTarget;
     const startX = event.clientX;
     const startY = event.clientY;
@@ -116,16 +123,16 @@ export function StarMapThreadCard(props: {
       }
       dragging = true;
       suppressClickRef.current = true;
-      const clamped = clampCardOffset({
+      const resolved = resolveCardDragOffset({
         baseSlot: props.baseSlot,
         offset: {
           dx: startOffset.dx + deltaX,
           dy: startOffset.dy + deltaY,
         },
-        radius: props.dragRadius,
+        detentRadius: drag.detentRadius,
       });
-      lastDx = clamped.dx;
-      lastDy = clamped.dy;
+      lastDx = resolved.dx;
+      lastDy = resolved.dy;
       if (!frame) {
         frame = requestAnimationFrame(() => {
           frame = 0;
@@ -143,7 +150,7 @@ export function StarMapThreadCard(props: {
         frame = 0;
       }
       if (dragging) {
-        props.onCommitOffset?.({ dx: lastDx, dy: lastDy });
+        drag.onCommitOffset({ dx: lastDx, dy: lastDy });
       }
     };
     window.addEventListener("pointermove", move);

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -619,4 +619,184 @@ describe("StarMapScreen", () => {
       window.localStorage.removeItem("pwragent.starMap.viewPreferences");
     }
   });
+
+  /** Body-relative position of a card, read off its rendered shell. */
+  function cardPosition(threadKey: string): { dx: number; dy: number } {
+    const shell = document.querySelector<HTMLElement>(
+      `[data-thread-key="${threadKey}"]`,
+    );
+    if (!shell) throw new Error(`no card shell for ${threadKey}`);
+    return {
+      dx: Number.parseFloat(shell.style.left),
+      dy: Number.parseFloat(shell.style.top),
+    };
+  }
+
+  function dragCard(
+    threadKey: string,
+    delta: { dx: number; dy: number },
+  ): void {
+    const shell = document.querySelector<HTMLElement>(
+      `[data-thread-key="${threadKey}"]`,
+    );
+    if (!shell) throw new Error(`no card shell for ${threadKey}`);
+    fireEvent.pointerDown(shell, { button: 0, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(window, { clientX: delta.dx, clientY: delta.dy });
+    fireEvent.pointerUp(window);
+  }
+
+  it("drops two cards from one cloud onto the same spot, whatever their slots", async () => {
+    // The whole point of a body-centred region: the drag geometry is a
+    // property of the cloud, not of where a card happens to start. Drives
+    // it through the real wiring, so a per-card radius would fail here
+    // even though the pure geometry tests pass.
+    const committed = new Map<string, { dx: number; dy: number }>();
+    const setStarMapCardPosition = vi.fn(
+      async (request: {
+        threadKey: string;
+        dx: number | null;
+        dy: number | null;
+      }) => {
+        committed.set(request.threadKey, {
+          dx: request.dx ?? 0,
+          dy: request.dy ?? 0,
+        });
+        return { entries: [] };
+      },
+    );
+    render(
+      <StarMapScreen
+        desktopApi={
+          { ...buildDesktopApi(), setStarMapCardPosition } as unknown as DesktopApi
+        }
+        localThreads={[unreadThread("t1"), unreadThread("t2")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open thread: Thread t1/ }),
+      ).toBeTruthy();
+    });
+
+    // Stacked in one lane, so the two cards start at different distances
+    // from the body — which used to hand them different regions.
+    const first = cardPosition("codex:t1");
+    const second = cardPosition("codex:t2");
+    expect(second.dy).not.toBeCloseTo(first.dy);
+
+    // Same destination for both, out past the detent so resistance applies.
+    const target = { dx: -900, dy: -600 };
+    dragCard("codex:t1", {
+      dx: target.dx - first.dx,
+      dy: target.dy - first.dy,
+    });
+    dragCard("codex:t2", {
+      dx: target.dx - second.dx,
+      dy: target.dy - second.dy,
+    });
+
+    await waitFor(() => {
+      expect(committed.size).toBe(2);
+    });
+    const landedFirst = {
+      dx: first.dx + committed.get("codex:t1")!.dx,
+      dy: first.dy + committed.get("codex:t1")!.dy,
+    };
+    const landedSecond = {
+      dx: second.dx + committed.get("codex:t2")!.dx,
+      dy: second.dy + committed.get("codex:t2")!.dy,
+    };
+    expect(landedFirst.dx).toBeCloseTo(landedSecond.dx);
+    expect(landedFirst.dy).toBeCloseTo(landedSecond.dy);
+    // And they got there: an island well outside the cloud, not a card
+    // pinned to the edge of its own little bubble.
+    expect(Math.hypot(landedFirst.dx, landedFirst.dy)).toBeGreaterThan(600);
+  });
+
+  it("offers a way back for a card parked away from its cloud", async () => {
+    const setStarMapCardPosition = vi.fn(async () => ({ entries: [] }));
+    const readStarMapArrangement = vi.fn(async () => ({
+      entries: [
+        {
+          instanceId: "pwr_local",
+          threadKey: "codex:t1",
+          dx: -1800,
+          dy: -1400,
+          updatedAt: 1,
+          by: "pwr_local",
+        },
+      ],
+    }));
+    render(
+      <StarMapScreen
+        desktopApi={
+          {
+            ...buildDesktopApi(),
+            readStarMapArrangement,
+            setStarMapCardPosition,
+          } as unknown as DesktopApi
+        }
+        localThreads={[unreadThread("t1")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    // A lane does not pan, so a card dragged this far out is off the
+    // window with no way to grab it again.
+    await waitFor(() => {
+      expect(cardPosition("codex:t1").dx).toBeLessThan(-1000);
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Thread t1" }),
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Reset position" }));
+
+    await waitFor(() => {
+      expect(setStarMapCardPosition).toHaveBeenCalledWith(
+        expect.objectContaining({ threadKey: "codex:t1", dx: null, dy: null }),
+      );
+    });
+    // Optimistic, so the card is back in its slot without a round trip.
+    expect(cardPosition("codex:t1").dx).toBeCloseTo(0);
+  });
+
+  it("keeps the reset action off a card that has not been moved", async () => {
+    render(
+      <StarMapScreen
+        desktopApi={
+          {
+            ...buildDesktopApi(),
+            setStarMapCardPosition: vi.fn(async () => ({ entries: [] })),
+          } as unknown as DesktopApi
+        }
+        localThreads={[unreadThread("t1")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Actions for Thread t1" }),
+      ).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Thread t1" }),
+    );
+    expect(screen.queryByRole("menuitem", { name: "Reset position" })).toBeNull();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
@@ -9,12 +9,16 @@ import {
 } from "../attention";
 import { nextAgentFilter } from "../star-map-preferences";
 import {
+  clampCardOffset,
   clampToCloudRadius,
+  cloudDragRadius,
   computeStarMapLayout,
   computeCardSlots,
   generateStarField,
   visibleCardCount,
+  type StarMapCardSlot,
 } from "../star-map-layout";
+import { cardRingSlots } from "../star-map-orbit";
 
 function thread(
   overrides: Partial<NavigationThreadSummary> & { id: string },
@@ -268,6 +272,92 @@ describe("clampToCloudRadius", () => {
     expect(clampToCloudRadius(30, 40, 100)).toEqual({ dx: 30, dy: 40 });
     const clamped = clampToCloudRadius(300, 400, 100);
     expect(Math.hypot(clamped.dx, clamped.dy)).toBeCloseTo(100);
+  });
+});
+
+describe("cloudDragRadius", () => {
+  it("contains every slot the cloud drew", () => {
+    // A lane stacks downward, so its last slot is the far one; an orbit
+    // ring puts slots all around the body. Both must land inside.
+    for (const slots of [
+      computeCardSlots([112, 112, 112, 112, 112]),
+      cardRingSlots(16, 200),
+    ]) {
+      const radius = cloudDragRadius(slots);
+      for (const slot of slots) {
+        expect(Math.hypot(slot.dx, slot.dy)).toBeLessThan(radius);
+      }
+    }
+  });
+
+  it("grows with the cloud rather than fixing one lens's bound", () => {
+    expect(cloudDragRadius(computeCardSlots([112, 112, 112]))).toBeGreaterThan(
+      cloudDragRadius(computeCardSlots([112])),
+    );
+    expect(cloudDragRadius([])).toBeGreaterThan(0);
+  });
+});
+
+describe("clampCardOffset", () => {
+  const slots = computeCardSlots([112, 112, 112, 112]);
+  const radius = cloudDragRadius(slots);
+  /** Where a card based at `baseSlot` ends up when dragged onto `target`. */
+  const dragTo = (baseSlot: StarMapCardSlot, target: StarMapCardSlot) => {
+    const committed = clampCardOffset({
+      baseSlot,
+      offset: {
+        dx: target.dx - baseSlot.dx,
+        dy: target.dy - baseSlot.dy,
+      },
+      radius,
+    });
+    return {
+      dx: baseSlot.dx + committed.dx,
+      dy: baseSlot.dy + committed.dy,
+    };
+  };
+
+  it("commits an offset from the card's own slot, not a position", () => {
+    // The persisted shape syncs across the federation, so it stays an
+    // offset even though the clamp runs on the body-relative position.
+    const baseSlot = slots[2];
+    expect(
+      clampCardOffset({ baseSlot, offset: { dx: 12, dy: -8 }, radius }),
+    ).toEqual({ dx: 12, dy: -8 });
+  });
+
+  it("lets a far-out card reach the mirror position across the body", () => {
+    // The outermost lane slot, dragged to where the same distance on the
+    // opposite side of the body would put it. Bounding the offset instead
+    // of the position would stop this drag short.
+    const baseSlot = slots[slots.length - 1];
+    const mirror = { dx: -baseSlot.dx, dy: -baseSlot.dy };
+    const landed = dragTo(baseSlot, mirror);
+    expect(landed.dx).toBeCloseTo(mirror.dx);
+    expect(landed.dy).toBeCloseTo(mirror.dy);
+  });
+
+  it("gives every card in the cloud the same reachable region", () => {
+    const near = slots[0];
+    const far = slots[slots.length - 1];
+    const targets: StarMapCardSlot[] = [
+      // Each other's slots, either way round.
+      near,
+      far,
+      // Off to one side, and out past the region so both get clamped.
+      { dx: 260, dy: -180 },
+      { dx: -2000, dy: 900 },
+      { dx: 0, dy: 4000 },
+    ];
+    for (const target of targets) {
+      const fromNear = dragTo(near, target);
+      const fromFar = dragTo(far, target);
+      expect(fromNear.dx).toBeCloseTo(fromFar.dx);
+      expect(fromNear.dy).toBeCloseTo(fromFar.dy);
+      expect(Math.hypot(fromNear.dx, fromNear.dy)).toBeLessThanOrEqual(
+        radius + 1e-6,
+      );
+    }
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
@@ -9,12 +9,11 @@ import {
 } from "../attention";
 import { nextAgentFilter } from "../star-map-preferences";
 import {
-  clampCardOffset,
-  clampToCloudRadius,
-  cloudDragRadius,
+  cloudDetentRadius,
   computeStarMapLayout,
   computeCardSlots,
   generateStarField,
+  resolveCardDragOffset,
   visibleCardCount,
   type StarMapCardSlot,
 } from "../star-map-layout";
@@ -267,23 +266,15 @@ describe("generateStarField", () => {
   });
 });
 
-describe("clampToCloudRadius", () => {
-  it("keeps offsets inside the radius and scales outliers back", () => {
-    expect(clampToCloudRadius(30, 40, 100)).toEqual({ dx: 30, dy: 40 });
-    const clamped = clampToCloudRadius(300, 400, 100);
-    expect(Math.hypot(clamped.dx, clamped.dy)).toBeCloseTo(100);
-  });
-});
-
-describe("cloudDragRadius", () => {
-  it("contains every slot the cloud drew", () => {
+describe("cloudDetentRadius", () => {
+  it("never starts resisting inside the cloud the lens drew", () => {
     // A lane stacks downward, so its last slot is the far one; an orbit
-    // ring puts slots all around the body. Both must land inside.
+    // ring puts slots all around the body. No slot may sit on the detent.
     for (const slots of [
       computeCardSlots([112, 112, 112, 112, 112]),
       cardRingSlots(16, 200),
     ]) {
-      const radius = cloudDragRadius(slots);
+      const radius = cloudDetentRadius(slots);
       for (const slot of slots) {
         expect(Math.hypot(slot.dx, slot.dy)).toBeLessThan(radius);
       }
@@ -291,25 +282,29 @@ describe("cloudDragRadius", () => {
   });
 
   it("grows with the cloud rather than fixing one lens's bound", () => {
-    expect(cloudDragRadius(computeCardSlots([112, 112, 112]))).toBeGreaterThan(
-      cloudDragRadius(computeCardSlots([112])),
-    );
-    expect(cloudDragRadius([])).toBeGreaterThan(0);
+    expect(
+      cloudDetentRadius(computeCardSlots([112, 112, 112])),
+    ).toBeGreaterThan(cloudDetentRadius(computeCardSlots([112])));
   });
 });
 
-describe("clampCardOffset", () => {
-  const slots = computeCardSlots([112, 112, 112, 112]);
-  const radius = cloudDragRadius(slots);
+describe("resolveCardDragOffset", () => {
+  // Ring slots, because the reported symptom was horizontal: a card to the
+  // LEFT of a body could not reach where the cards on the right sit.
+  const slots = cardRingSlots(8, 200);
+  const detentRadius = cloudDetentRadius(slots);
+  const leftmost = slots.reduce((far, slot) => (slot.dx < far.dx ? slot : far));
+  const rightmost = slots.reduce((far, slot) => (slot.dx > far.dx ? slot : far));
+  const distance = (point: StarMapCardSlot) => Math.hypot(point.dx, point.dy);
   /** Where a card based at `baseSlot` ends up when dragged onto `target`. */
   const dragTo = (baseSlot: StarMapCardSlot, target: StarMapCardSlot) => {
-    const committed = clampCardOffset({
+    const committed = resolveCardDragOffset({
       baseSlot,
       offset: {
         dx: target.dx - baseSlot.dx,
         dy: target.dy - baseSlot.dy,
       },
-      radius,
+      detentRadius,
     });
     return {
       dx: baseSlot.dx + committed.dx,
@@ -319,45 +314,66 @@ describe("clampCardOffset", () => {
 
   it("commits an offset from the card's own slot, not a position", () => {
     // The persisted shape syncs across the federation, so it stays an
-    // offset even though the clamp runs on the body-relative position.
-    const baseSlot = slots[2];
+    // offset even though the detent applies to the body-relative position.
     expect(
-      clampCardOffset({ baseSlot, offset: { dx: 12, dy: -8 }, radius }),
+      resolveCardDragOffset({
+        baseSlot: leftmost,
+        offset: { dx: 12, dy: -8 },
+        detentRadius,
+      }),
     ).toEqual({ dx: 12, dy: -8 });
   });
 
-  it("lets a far-out card reach the mirror position across the body", () => {
-    // The outermost lane slot, dragged to where the same distance on the
-    // opposite side of the body would put it. Bounding the offset instead
-    // of the position would stop this drag short.
-    const baseSlot = slots[slots.length - 1];
-    const mirror = { dx: -baseSlot.dx, dy: -baseSlot.dy };
-    const landed = dragTo(baseSlot, mirror);
-    expect(landed.dx).toBeCloseTo(mirror.dx);
-    expect(landed.dy).toBeCloseTo(mirror.dy);
+  it("carries a left-side card onto the position a right-side card holds", () => {
+    // The symptom this geometry exists to fix. Resisting the offset
+    // instead of the position would stop this drag well short.
+    expect(leftmost.dx).toBeLessThan(0);
+    expect(rightmost.dx).toBeGreaterThan(0);
+    const landed = dragTo(leftmost, rightmost);
+    expect(landed.dx).toBeCloseTo(rightmost.dx);
+    expect(landed.dy).toBeCloseTo(rightmost.dy);
   });
 
-  it("gives every card in the cloud the same reachable region", () => {
-    const near = slots[0];
-    const far = slots[slots.length - 1];
+  it("gives every card in the cloud the same region and the same resistance", () => {
     const targets: StarMapCardSlot[] = [
       // Each other's slots, either way round.
-      near,
-      far,
-      // Off to one side, and out past the region so both get clamped.
-      { dx: 260, dy: -180 },
+      leftmost,
+      rightmost,
+      // Just inside the detent, into it, and far beyond it.
+      { dx: detentRadius - 20, dy: 0 },
+      { dx: 0, dy: detentRadius + 60 },
       { dx: -2000, dy: 900 },
-      { dx: 0, dy: 4000 },
     ];
     for (const target of targets) {
-      const fromNear = dragTo(near, target);
-      const fromFar = dragTo(far, target);
-      expect(fromNear.dx).toBeCloseTo(fromFar.dx);
-      expect(fromNear.dy).toBeCloseTo(fromFar.dy);
-      expect(Math.hypot(fromNear.dx, fromNear.dy)).toBeLessThanOrEqual(
-        radius + 1e-6,
-      );
+      const fromLeft = dragTo(leftmost, target);
+      const fromRight = dragTo(rightmost, target);
+      expect(fromLeft.dx).toBeCloseTo(fromRight.dx);
+      expect(fromLeft.dy).toBeCloseTo(fromRight.dy);
     }
+  });
+
+  it("follows the pointer exactly up to the detent", () => {
+    const target = { dx: detentRadius - 1, dy: 0 };
+    expect(dragTo(leftmost, target).dx).toBeCloseTo(target.dx);
+  });
+
+  it("resists inside the detent instead of stopping the drag", () => {
+    const pushedTo = detentRadius + 60;
+    const landed = distance(dragTo(leftmost, { dx: 0, dy: pushedTo }));
+    // Past the detent, so it moved — but it gave up most of the overshoot.
+    expect(landed).toBeGreaterThan(detentRadius);
+    expect(landed).toBeLessThan(detentRadius + 60);
+  });
+
+  it("breaks through so a card can be parked in an island of its own", () => {
+    const near = distance(dragTo(leftmost, { dx: 0, dy: detentRadius + 400 }));
+    const far = distance(dragTo(leftmost, { dx: 0, dy: detentRadius + 900 }));
+    // Through the detent the pointer is tracked one-for-one again: another
+    // 500px of drag buys another 500px of travel.
+    expect(far - near).toBeCloseTo(500);
+    // The resistance already absorbed stays behind as a constant lag.
+    expect(near).toBeLessThan(detentRadius + 400);
+    expect(near).toBeGreaterThan(detentRadius + 200);
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
@@ -48,16 +48,27 @@ const ARC_MIN_LIFT = 60;
 const ARC_LIFT_RATIO = 0.14;
 
 /**
- * Reach a drag gets beyond the outermost card of its cloud.
+ * Free reach past the outermost card of a cloud, before a drag meets the
+ * detent.
  *
- * The drag bound is measured from the instance body, not from the card's
- * own slot, so every card in a cloud shares one reachable region — that is
- * what lets any card be dropped where any other card already sits. The
- * outermost slot therefore has to fall inside the region, and this is the
- * freedom the card sitting there gets on top of it. Cards nearer the body
- * get more, which is the point.
+ * The detent is measured from the instance body, not from the card's own
+ * slot, so every card in a cloud shares one region — that is what lets any
+ * card be dropped where any other card already sits. The outermost slot has
+ * to fall inside it, and this is the free travel the card sitting there
+ * gets on top of that. Cards nearer the body get more, which is the point.
  */
-export const STAR_MAP_CLOUD_DRAG_SLACK = 340;
+export const STAR_MAP_CLOUD_DETENT_SLACK = 340;
+
+/**
+ * Overshoot the detent absorbs before a drag breaks through, in px.
+ *
+ * Past the detent a card is out on its own — that is a real thing to want
+ * (ten cards pulled aside into an island for one project), so this resists
+ * the drag rather than stopping it.
+ */
+const DETENT_WIDTH = 120;
+/** Share of the overshoot inside the detent the card actually travels. */
+const DETENT_TRAVEL = 0.3;
 
 /**
  * Deterministic constellation: spokes sorted by instance id with the hub
@@ -186,64 +197,72 @@ export function visibleCardCount(params: {
   return Math.max(count, Math.min(1, params.heights.length));
 }
 
-/** Clamp a body-relative vector to a radius around the instance anchor. */
-export function clampToCloudRadius(
-  dx: number,
-  dy: number,
-  radius: number,
-): StarMapCardSlot {
-  const distance = Math.hypot(dx, dy);
-  if (distance <= radius || distance === 0) {
-    return { dx, dy };
-  }
-  const scale = radius / distance;
-  return { dx: dx * scale, dy: dy * scale };
-}
-
 /**
- * Radius a cloud's cards may be dragged within, measured from the body.
+ * Distance from the body at which a cloud's drags meet the detent.
  *
  * Read off the drawn slots rather than a per-lens constant: lanes stack
  * downward from the body while orbit and projects ring it, and both have to
- * yield a region that already contains every card the cloud drew — a bound
- * tighter than that would snap a far-out card inward the moment its drag
- * began. (`cardRingExtent` in star-map-orbit.ts measures the same placed
- * slots for body spacing, in the two lenses that ring.)
+ * yield a region that already contains every card the cloud drew — a detent
+ * tighter than that would fight a far-out card the moment its drag began.
+ * (`cardRingExtent` in star-map-orbit.ts measures the same placed slots for
+ * body spacing, in the two lenses that ring.)
  */
-export function cloudDragRadius(slots: readonly StarMapCardSlot[]): number {
+export function cloudDetentRadius(slots: readonly StarMapCardSlot[]): number {
   let outermost = 0;
   for (const slot of slots) {
     outermost = Math.max(outermost, Math.hypot(slot.dx, slot.dy));
   }
-  return outermost + STAR_MAP_CLOUD_DRAG_SLACK;
+  return outermost + STAR_MAP_CLOUD_DETENT_SLACK;
 }
 
 /**
- * Clamp a dragged card into its cloud's reachable region, and hand back the
- * offset to commit.
- *
- * A card sits at `baseSlot + offset` in body-relative pixels and the region
- * is a radius around the body, so the clamp has to run on that position and
- * the offset be derived back out. Clamping the offset alone would centre a
- * separate region on every card's own slot: a card to the left of the body
- * could not reach the positions cards on the right already occupy, and each
- * card's freedom would depend on where its slot happened to land. The
- * committed value stays an offset because arrangements persist and sync
- * across the federation in that shape.
+ * How far from the body a card actually travels when the pointer has taken
+ * it `distance` out. Continuous and monotonic, so the card never jumps.
  */
-export function clampCardOffset(params: {
+function detentTravel(distance: number, radius: number): number {
+  const overshoot = distance - radius;
+  if (overshoot <= 0) return distance;
+  if (overshoot <= DETENT_WIDTH) {
+    return radius + overshoot * DETENT_TRAVEL;
+  }
+  // Through the detent: the card tracks the pointer one-for-one again,
+  // keeping the travel it gave up as a constant lag.
+  return radius + DETENT_WIDTH * DETENT_TRAVEL + (overshoot - DETENT_WIDTH);
+}
+
+/**
+ * Resolve a dragged card's pointer position against its cloud's detent, and
+ * hand back the offset to commit.
+ *
+ * A card sits at `baseSlot + offset` in body-relative pixels and the detent
+ * is a radius around the body, so the resistance has to be applied to that
+ * position and the offset derived back out. Resisting the offset alone
+ * would centre a separate region on every card's own slot: a card to the
+ * left of the body could not reach the positions cards on the right already
+ * occupy, and each card's freedom would depend on where its slot happened
+ * to land. The committed value stays an offset because arrangements persist
+ * and sync across the federation in that shape.
+ *
+ * Apply this to the live pointer position only. The result is what gets
+ * stored, so running it over a stored offset again would compress a card
+ * that is deliberately parked out past the detent.
+ */
+export function resolveCardDragOffset(params: {
   baseSlot: StarMapCardSlot;
   offset: StarMapCardSlot;
-  radius: number;
+  detentRadius: number;
 }): StarMapCardSlot {
-  const position = clampToCloudRadius(
-    params.baseSlot.dx + params.offset.dx,
-    params.baseSlot.dy + params.offset.dy,
-    params.radius,
-  );
+  const x = params.baseSlot.dx + params.offset.dx;
+  const y = params.baseSlot.dy + params.offset.dy;
+  const distance = Math.hypot(x, y);
+  const travel = detentTravel(distance, params.detentRadius);
+  // Inside the detent the pointer is followed exactly; hand the offset
+  // straight back rather than round-tripping it through the arithmetic.
+  if (travel === distance) return params.offset;
+  const scale = travel / distance;
   return {
-    dx: position.dx - params.baseSlot.dx,
-    dy: position.dy - params.baseSlot.dy,
+    dx: x * scale - params.baseSlot.dx,
+    dy: y * scale - params.baseSlot.dy,
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
@@ -47,8 +47,17 @@ const ARC_MIN_LIFT = 60;
 /** Extra arc lift per pixel of horizontal distance - long links fly higher. */
 const ARC_LIFT_RATIO = 0.14;
 
-/** How far a dragged card may stray from its instance anchor. */
-export const STAR_MAP_CLOUD_RADIUS = 340;
+/**
+ * Reach a drag gets beyond the outermost card of its cloud.
+ *
+ * The drag bound is measured from the instance body, not from the card's
+ * own slot, so every card in a cloud shares one reachable region — that is
+ * what lets any card be dropped where any other card already sits. The
+ * outermost slot therefore has to fall inside the region, and this is the
+ * freedom the card sitting there gets on top of it. Cards nearer the body
+ * get more, which is the point.
+ */
+export const STAR_MAP_CLOUD_DRAG_SLACK = 340;
 
 /**
  * Deterministic constellation: spokes sorted by instance id with the hub
@@ -177,7 +186,7 @@ export function visibleCardCount(params: {
   return Math.max(count, Math.min(1, params.heights.length));
 }
 
-/** Clamp an offset to the cloud radius around the instance anchor. */
+/** Clamp a body-relative vector to a radius around the instance anchor. */
 export function clampToCloudRadius(
   dx: number,
   dy: number,
@@ -189,6 +198,53 @@ export function clampToCloudRadius(
   }
   const scale = radius / distance;
   return { dx: dx * scale, dy: dy * scale };
+}
+
+/**
+ * Radius a cloud's cards may be dragged within, measured from the body.
+ *
+ * Read off the drawn slots rather than a per-lens constant: lanes stack
+ * downward from the body while orbit and projects ring it, and both have to
+ * yield a region that already contains every card the cloud drew — a bound
+ * tighter than that would snap a far-out card inward the moment its drag
+ * began. (`cardRingExtent` in star-map-orbit.ts measures the same placed
+ * slots for body spacing, in the two lenses that ring.)
+ */
+export function cloudDragRadius(slots: readonly StarMapCardSlot[]): number {
+  let outermost = 0;
+  for (const slot of slots) {
+    outermost = Math.max(outermost, Math.hypot(slot.dx, slot.dy));
+  }
+  return outermost + STAR_MAP_CLOUD_DRAG_SLACK;
+}
+
+/**
+ * Clamp a dragged card into its cloud's reachable region, and hand back the
+ * offset to commit.
+ *
+ * A card sits at `baseSlot + offset` in body-relative pixels and the region
+ * is a radius around the body, so the clamp has to run on that position and
+ * the offset be derived back out. Clamping the offset alone would centre a
+ * separate region on every card's own slot: a card to the left of the body
+ * could not reach the positions cards on the right already occupy, and each
+ * card's freedom would depend on where its slot happened to land. The
+ * committed value stays an offset because arrangements persist and sync
+ * across the federation in that shape.
+ */
+export function clampCardOffset(params: {
+  baseSlot: StarMapCardSlot;
+  offset: StarMapCardSlot;
+  radius: number;
+}): StarMapCardSlot {
+  const position = clampToCloudRadius(
+    params.baseSlot.dx + params.offset.dx,
+    params.baseSlot.dy + params.offset.dy,
+    params.radius,
+  );
+  return {
+    dx: position.dx - params.baseSlot.dx,
+    dy: position.dy - params.baseSlot.dy,
+  };
 }
 
 export type StarMapStar = {


### PR DESCRIPTION
## Summary

- Star Map card drags were bounded by the card's offset **from its own base slot**, so the reachable region was a circle centred wherever that card started rather than on the instance. Operator-visible symptom: a card sitting left of a body could be dragged in an arc that barely crossed past the body's right edge and could not reach positions that other cards already occupied on the right; cards further out had correspondingly more freedom in some directions and less in others, which read as arbitrary.
- The bound now applies to the body-relative position (`baseSlot + offset`), with the committed offset derived back out as `clampedPosition - baseSlot`. Every card in a cloud shares one region, so any card can be placed where any other card sits.
- **The bound is a detent, not a wall.** Past the radius a drag meets resistance for 120px (it travels 30% of the overshoot), then breaks through and tracks the pointer one-for-one again, keeping the absorbed travel as a constant lag. Pulling ten cards aside into an island for one project is a real thing to want, so the geometry resists it rather than forbidding it. The curve is continuous and monotonic — no jump at the boundary.
- The committed value stays an **offset**. It feeds `useStarMapArrangement`, which persists arrangements and syncs them across the federation last-writer-wins; changing the persisted shape would break compatibility with peers on older builds.
- `STAR_MAP_CLOUD_RADIUS` → `STAR_MAP_CLOUD_DETENT_SLACK`, same 340px. As an *absolute* radius 340 is now wrong — it is smaller than most clouds' own slots, so a lane card at `dy 596` would be fought the instant you touched it. `cloudDetentRadius(slots)` sizes each cloud as *distance to its outermost drawn slot + slack*, which keeps 340 meaning what it was tuned to mean: the outermost card still gets 340px of free travel past where it sits, and every inner card gets that plus its own distance from the body.
- Because a card can now be parked deliberately outside its cloud, the card kebab grows a **Reset position** entry whenever a card carries an offset. A lane does not pan, so a card pulled past the window previously had no way back.

New pure helpers in `star-map-layout.ts`: `cloudDetentRadius(slots)` and `resolveCardDragOffset({ baseSlot, offset, detentRadius })`. `StarMapThreadCard` takes a single `drag?: { detentRadius, onCommitOffset }` prop, so a draggable card cannot exist without the region it drags in; `StarMapScreen` computes one radius per cloud.

## Verification

- `pnpm test apps/desktop/src/renderer` — 2133 passed, 133 files.
- `pnpm --filter @pwragent/desktop typecheck` — clean.
- `pnpm lint:colors` — passed.
- `pnpm lint:boundaries` — no violations (1368 modules).
- ESLint on `features/star-map/` — clean, no new warnings.

Coverage added:

- `resolveCardDragOffset`, on **ring slots** — a card left of the body lands exactly on the position a card on the right holds; a near card and a far card resolve identically across five targets spanning inside, into, and far past the detent; the pointer is followed exactly up to the detent; inside the detent the card moves but gives up most of the overshoot; past it, another 500px of drag buys another 500px of travel.
- `cloudDetentRadius` — resistance never begins inside the drawn cloud, for both a lane stack and a 16-card orbit ring.
- `StarMapScreen`, driving real pointer drags through the wiring — two cards with different base slots dropped on one target land in the same place (a per-card radius fails this even with the pure geometry right), and both end up well outside the cloud rather than pinned to a bubble. Plus: Reset position returns a far-parked card to its slot and writes the `null` tombstone, and does not appear on a card that has not been moved.

## Notes

- **Radius per lens** (lane / orbit / projects all render this component): lane 440 (1 card) → 1308 (8 cards); orbit 506 (1) → 746 (16). Orbit and projects pan and zoom on a canvas far larger than these. The projects lens passes no `drag` prop at all — arrangements are keyed per federation instance and a project is not an instance.
- The detent is applied to the live pointer position only, never to a stored offset — re-applying it on read would compress a card that is deliberately parked out past it. That is stated at the function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
