### PR TITLE
fix(desktop): bound the star map's pan and add a reset view

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -63,6 +63,12 @@ import {
   STAR_MAP_AGENT_FILTER_LABELS,
   type StarMapViewPreferences,
 } from "./star-map-preferences";
+import {
+  centerStarMapView,
+  clampStarMapView,
+  MAX_ZOOM,
+  MIN_ZOOM,
+} from "./star-map-view-geometry";
 import { StarMapViewOptions } from "./StarMapViewOptions";
 import { StarMapInstanceCard } from "./StarMapInstanceCard";
 import { StarMapThreadCard } from "./StarMapThreadCard";
@@ -76,8 +82,6 @@ const STAR_COUNT = 130;
 const ORBIT_CARD_WIDTH = 200;
 /** Rings hold far more than a lane column, so orbit shows deeper. */
 const ORBIT_MAX_CARDS_PER_INSTANCE = 16;
-const MIN_ZOOM = 0.35;
-const MAX_ZOOM = 2;
 /**
  * Chat cards float above the map chrome (close button, filters, view
  * options) so a card being read is never underneath a control strip.
@@ -235,44 +239,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
     });
   });
 
-  // Trackpad: two-finger drag pans, pinch (ctrl+wheel) zooms about the
-  // pointer. Registered natively because the listener must not be passive.
-  useEffect(() => {
-    const element = viewportRef.current;
-    if (!element || !panZoomMode) return;
-    const onWheel = (event: WheelEvent) => {
-      event.preventDefault();
-      if (event.ctrlKey) {
-        operatorMovedViewRef.current = true;
-        const rect = element.getBoundingClientRect();
-        const pointerX = event.clientX - rect.left;
-        const pointerY = event.clientY - rect.top;
-        setView((current) => {
-          const scale = Math.min(
-            MAX_ZOOM,
-            Math.max(MIN_ZOOM, current.scale * (1 - event.deltaY / 240)),
-          );
-          const ratio = scale / current.scale;
-          return {
-            scale,
-            // Keep the point under the cursor pinned while scaling.
-            x: pointerX - (pointerX - current.x) * ratio,
-            y: pointerY - (pointerY - current.y) * ratio,
-          };
-        });
-        return;
-      }
-      operatorMovedViewRef.current = true;
-      setView((current) => ({
-        ...current,
-        x: current.x - event.deltaX,
-        y: current.y - event.deltaY,
-      }));
-    };
-    element.addEventListener("wheel", onWheel, { passive: false });
-    return () => element.removeEventListener("wheel", onWheel);
-  }, [panZoomMode]);
-
   const startCanvasPan = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (!panZoomMode || event.button !== 0) return;
     if (!shouldStartCanvasPan(event.target)) return;
@@ -288,8 +254,21 @@ export function StarMapScreen(props: StarMapScreenProps) {
     let lastY = base.y;
     let frame = 0;
     const move = (pointerEvent: globalThis.PointerEvent) => {
-      lastX = base.x + pointerEvent.clientX - startX;
-      lastY = base.y + pointerEvent.clientY - startY;
+      // Clamped per frame, not just on release: the drag writes the
+      // transform straight onto the canvas, so an unclamped live path
+      // would let the map leave the window and then jump back on
+      // pointerup when the clamped state landed.
+      const clamped = clampStarMapView({
+        view: {
+          x: base.x + pointerEvent.clientX - startX,
+          y: base.y + pointerEvent.clientY - startY,
+          scale: base.scale,
+        },
+        canvas: panZoomCanvas,
+        viewport: viewportSize,
+      });
+      lastX = clamped.x;
+      lastY = clamped.y;
       if (!frame) {
         frame = requestAnimationFrame(() => {
           frame = 0;
@@ -308,7 +287,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
       }
       viewport?.classList.remove("is-panning");
       operatorMovedViewRef.current = true;
-      setView((current) => ({ ...current, x: lastX, y: lastY }));
+      // Clamped again rather than trusting the drag's own bookkeeping: the
+      // committed value is the one every later frame builds on, so it is
+      // the one that must be in bounds.
+      setView((current) =>
+        clampStarMapView({
+          view: { ...current, x: lastX, y: lastY },
+          canvas: panZoomCanvas,
+          viewport: viewportSize,
+        }),
+      );
     };
     window.addEventListener("pointermove", move);
     window.addEventListener("pointerup", stop);
@@ -611,6 +599,63 @@ export function StarMapScreen(props: StarMapScreenProps) {
     ? { width: orbit.canvasWidth, height: orbit.canvasHeight }
     : { width: projectLayout.canvasWidth, height: projectLayout.canvasHeight };
 
+  // Trackpad: two-finger drag pans, pinch (ctrl+wheel) zooms about the
+  // pointer. Registered natively because the listener must not be passive.
+  // Sits below panZoomCanvas because the clamp needs the canvas size.
+  useEffect(() => {
+    const element = viewportRef.current;
+    if (!element || !panZoomMode) return;
+    const bounds = {
+      canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
+      viewport: { width: viewportSize.width, height: viewportSize.height },
+    };
+    const onWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      if (event.ctrlKey) {
+        operatorMovedViewRef.current = true;
+        const rect = element.getBoundingClientRect();
+        const pointerX = event.clientX - rect.left;
+        const pointerY = event.clientY - rect.top;
+        setView((current) => {
+          const scale = Math.min(
+            MAX_ZOOM,
+            Math.max(MIN_ZOOM, current.scale * (1 - event.deltaY / 240)),
+          );
+          const ratio = scale / current.scale;
+          return clampStarMapView({
+            view: {
+              scale,
+              // Keep the point under the cursor pinned while scaling.
+              x: pointerX - (pointerX - current.x) * ratio,
+              y: pointerY - (pointerY - current.y) * ratio,
+            },
+            ...bounds,
+          });
+        });
+        return;
+      }
+      operatorMovedViewRef.current = true;
+      setView((current) =>
+        clampStarMapView({
+          view: {
+            ...current,
+            x: current.x - event.deltaX,
+            y: current.y - event.deltaY,
+          },
+          ...bounds,
+        }),
+      );
+    };
+    element.addEventListener("wheel", onWheel, { passive: false });
+    return () => element.removeEventListener("wheel", onWheel);
+  }, [
+    panZoomMode,
+    panZoomCanvas.width,
+    panZoomCanvas.height,
+    viewportSize.width,
+    viewportSize.height,
+  ]);
+
   // A lens switch is a different map, so the view starts centred again.
   useEffect(() => {
     operatorMovedViewRef.current = false;
@@ -633,11 +678,43 @@ export function StarMapScreen(props: StarMapScreenProps) {
       setView({ x: 0, y: 0, scale: 1 });
       return;
     }
-    setView({
-      x: (viewportSize.width - panZoomCanvas.width) / 2,
-      y: (viewportSize.height - panZoomCanvas.height) / 2,
-      scale: 1,
-    });
+    setView(
+      centerStarMapView({
+        canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
+        viewport: { width: viewportSize.width, height: viewportSize.height },
+      }),
+    );
+  }, [
+    panZoomMode,
+    panZoomCanvas.width,
+    panZoomCanvas.height,
+    viewportSize.width,
+    viewportSize.height,
+  ]);
+
+  /**
+   * "Reset view": put the map back where it opens and hand ownership of the
+   * view back to the app.
+   *
+   * Needed because the ownership rule is sticky for the life of the mounted
+   * map — once the operator has moved the view, nothing else may place it.
+   * That is right while they are working, but it leaves no way back from a
+   * view that has drifted off the interesting part of the map, and the
+   * clamp deliberately does not re-run when a cloud resizes. Clearing the
+   * ref as well as re-centring means auto-centring resumes afterwards.
+   */
+  const resetView = useCallback(() => {
+    operatorMovedViewRef.current = false;
+    if (!panZoomMode) {
+      setView({ x: 0, y: 0, scale: 1 });
+      return;
+    }
+    setView(
+      centerStarMapView({
+        canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
+        viewport: { width: viewportSize.width, height: viewportSize.height },
+      }),
+    );
   }, [
     panZoomMode,
     panZoomCanvas.width,
@@ -1306,6 +1383,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
             setPreferences(next);
             writeStoredPreferences(next);
           }}
+          onResetView={panZoomMode ? resetView : undefined}
         />
       </div>
       <div className="star-map__filters" role="group" aria-label="Attention filters">

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -249,31 +249,31 @@ export function StarMapScreen(props: StarMapScreenProps) {
     viewport?.classList.add("is-panning");
     const startX = event.clientX;
     const startY = event.clientY;
+    // Scale is captured for the whole gesture. A pinch mid-drag moves the
+    // live transform out of step with it until pointerup re-reads the real
+    // scale from state; the drag has always worked this way.
     const base = view;
-    let lastX = base.x;
-    let lastY = base.y;
+    /** Latest raw pointer position, unclamped. Both writers clamp it. */
+    let pointerX = base.x;
+    let pointerY = base.y;
     let frame = 0;
+    const bounds = { canvas: panZoomCanvas, viewport: viewportSize };
     const move = (pointerEvent: globalThis.PointerEvent) => {
-      // Clamped per frame, not just on release: the drag writes the
-      // transform straight onto the canvas, so an unclamped live path
-      // would let the map leave the window and then jump back on
-      // pointerup when the clamped state landed.
-      const clamped = clampStarMapView({
-        view: {
-          x: base.x + pointerEvent.clientX - startX,
-          y: base.y + pointerEvent.clientY - startY,
-          scale: base.scale,
-        },
-        canvas: panZoomCanvas,
-        viewport: viewportSize,
-      });
-      lastX = clamped.x;
-      lastY = clamped.y;
+      pointerX = base.x + pointerEvent.clientX - startX;
+      pointerY = base.y + pointerEvent.clientY - startY;
       if (!frame) {
         frame = requestAnimationFrame(() => {
           frame = 0;
+          // Clamped per frame, not only on release: the drag writes the
+          // transform straight onto the canvas, so an unclamped live path
+          // would let the map leave the window and then jump back on
+          // pointerup when the clamped state landed.
+          const clamped = clampStarMapView({
+            view: { x: pointerX, y: pointerY, scale: base.scale },
+            ...bounds,
+          });
           canvas.style.transform =
-            `translate(${lastX}px, ${lastY}px) scale(${base.scale})`;
+            `translate(${clamped.x}px, ${clamped.y}px) scale(${base.scale})`;
         });
       }
     };
@@ -287,14 +287,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
       }
       viewport?.classList.remove("is-panning");
       operatorMovedViewRef.current = true;
-      // Clamped again rather than trusting the drag's own bookkeeping: the
-      // committed value is the one every later frame builds on, so it is
-      // the one that must be in bounds.
+      // Clamps the raw pointer position independently of the frame above,
+      // rather than committing whatever that frame happened to compute.
+      // The committed value is what every later gesture builds on, so it
+      // has to be in bounds on its own account — and a flick released
+      // before any frame ran still commits where the pointer actually
+      // ended up.
       setView((current) =>
         clampStarMapView({
-          view: { ...current, x: lastX, y: lastY },
-          canvas: panZoomCanvas,
-          viewport: viewportSize,
+          view: { ...current, x: pointerX, y: pointerY },
+          ...bounds,
         }),
       );
     };

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapViewOptions.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapViewOptions.tsx
@@ -22,6 +22,11 @@ const CARD_FIELD_ORDER: (keyof StarMapCardFields)[] = [
 export function StarMapViewOptions(props: {
   preferences: StarMapViewPreferences;
   onChange: (next: StarMapViewPreferences) => void;
+  /**
+   * Re-centre the map at 1:1. Omitted by lenses that fit the window and so
+   * have no view to lose.
+   */
+  onResetView?: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -92,6 +97,21 @@ export function StarMapViewOptions(props: {
               </button>
             ))}
           </div>
+          {props.onResetView ? (
+            <>
+              <p className="star-map__view-heading">Position</p>
+              <button
+                type="button"
+                className="star-map__view-action"
+                onClick={() => {
+                  props.onResetView?.();
+                  setOpen(false);
+                }}
+              >
+                Reset view
+              </button>
+            </>
+          ) : null}
           <p className="star-map__view-heading">Card details</p>
           {CARD_FIELD_ORDER.map((field) => (
             <label key={field} className="star-map__view-row">

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-geometry.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-geometry.test.ts
@@ -3,6 +3,7 @@ import {
   centerStarMapView,
   clampStarMapView,
   MAX_ZOOM,
+  MIN_VISIBLE_FRACTION,
   MIN_ZOOM,
   type StarMapView,
 } from "../star-map-view-geometry";
@@ -10,9 +11,9 @@ import {
 const VIEWPORT = { width: 1280, height: 800 };
 const CANVAS = { width: 2400, height: 1800 };
 
-/** The 15% strip the clamp guarantees, per axis. */
-const MIN_VISIBLE_X = VIEWPORT.width * 0.15;
-const MIN_VISIBLE_Y = VIEWPORT.height * 0.15;
+/** The strip the clamp guarantees, per axis. */
+const MIN_VISIBLE_X = VIEWPORT.width * MIN_VISIBLE_FRACTION;
+const MIN_VISIBLE_Y = VIEWPORT.height * MIN_VISIBLE_FRACTION;
 
 function clamp(view: StarMapView, canvas = CANVAS, viewport = VIEWPORT) {
   return clampStarMapView({ view, canvas, viewport });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-geometry.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-geometry.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  centerStarMapView,
+  clampStarMapView,
+  MAX_ZOOM,
+  MIN_ZOOM,
+  type StarMapView,
+} from "../star-map-view-geometry";
+
+const VIEWPORT = { width: 1280, height: 800 };
+const CANVAS = { width: 2400, height: 1800 };
+
+/** The 15% strip the clamp guarantees, per axis. */
+const MIN_VISIBLE_X = VIEWPORT.width * 0.15;
+const MIN_VISIBLE_Y = VIEWPORT.height * 0.15;
+
+function clamp(view: StarMapView, canvas = CANVAS, viewport = VIEWPORT) {
+  return clampStarMapView({ view, canvas, viewport });
+}
+
+/** Overlap between the placed canvas and the window, on one axis. */
+function overlap(position: number, content: number, viewportExtent: number) {
+  return Math.max(
+    0,
+    Math.min(viewportExtent, position + content) - Math.max(0, position),
+  );
+}
+
+describe("clampStarMapView", () => {
+  it("leaves a view that is already within bounds alone", () => {
+    const view = { x: -400, y: -300, scale: 1 };
+    expect(clamp(view)).toEqual(view);
+  });
+
+  it("stops the canvas being dragged off the right and bottom edges", () => {
+    const clamped = clamp({ x: 9000, y: 9000, scale: 1 });
+    expect(clamped.x).toBe(VIEWPORT.width - MIN_VISIBLE_X);
+    expect(clamped.y).toBe(VIEWPORT.height - MIN_VISIBLE_Y);
+  });
+
+  it("stops the canvas being dragged off the left and top edges", () => {
+    const clamped = clamp({ x: -9000, y: -9000, scale: 1 });
+    expect(clamped.x).toBe(MIN_VISIBLE_X - CANVAS.width);
+    expect(clamped.y).toBe(MIN_VISIBLE_Y - CANVAS.height);
+  });
+
+  it("keeps the guaranteed strip on screen from any starting position", () => {
+    for (const x of [-1e6, -5000, -2208, -900, 0, 640, 1088, 5000, 1e6]) {
+      const clamped = clamp({ x, y: 0, scale: 1 });
+      expect(
+        overlap(clamped.x, CANVAS.width, VIEWPORT.width),
+      ).toBeGreaterThanOrEqual(MIN_VISIBLE_X);
+    }
+  });
+
+  it("scales the bounds with the zoom level", () => {
+    // At MIN_ZOOM the canvas is far smaller than its untransformed box, so
+    // the left bound has to move in by the same factor or the operator can
+    // still push the shrunken map clean off the window.
+    const clamped = clamp({ x: -9000, y: -9000, scale: MIN_ZOOM });
+    expect(clamped.x).toBe(MIN_VISIBLE_X - CANVAS.width * MIN_ZOOM);
+    expect(clamped.y).toBe(MIN_VISIBLE_Y - CANVAS.height * MIN_ZOOM);
+    expect(
+      overlap(clamped.x, CANVAS.width * MIN_ZOOM, VIEWPORT.width),
+    ).toBeCloseTo(MIN_VISIBLE_X);
+  });
+
+  it("never demands more overlap than a small canvas can supply", () => {
+    // A canvas narrower than the 15% strip would otherwise have no legal
+    // position at all; it simply may not leave the window.
+    const canvas = { width: 80, height: 60 };
+    expect(clamp({ x: -9000, y: -9000, scale: 1 }, canvas)).toMatchObject({
+      x: 0,
+      y: 0,
+    });
+    expect(clamp({ x: 9000, y: 9000, scale: 1 }, canvas)).toMatchObject({
+      x: VIEWPORT.width - canvas.width,
+      y: VIEWPORT.height - canvas.height,
+    });
+  });
+
+  it("holds the scale inside the zoom range", () => {
+    expect(clamp({ x: 0, y: 0, scale: 12 }).scale).toBe(MAX_ZOOM);
+    expect(clamp({ x: 0, y: 0, scale: 0.01 }).scale).toBe(MIN_ZOOM);
+  });
+
+  it("leaves the position alone when a box has not been measured yet", () => {
+    const view = { x: -700, y: -500, scale: 1 };
+    expect(clamp(view, { width: 0, height: 0 })).toEqual(view);
+    expect(clamp(view, CANVAS, { width: 0, height: 0 })).toEqual(view);
+  });
+});
+
+describe("centerStarMapView", () => {
+  it("puts the middle of the canvas in the middle of the window at 1:1", () => {
+    expect(centerStarMapView({ canvas: CANVAS, viewport: VIEWPORT })).toEqual({
+      x: (VIEWPORT.width - CANVAS.width) / 2,
+      y: (VIEWPORT.height - CANVAS.height) / 2,
+      scale: 1,
+    });
+  });
+
+  it("produces a view the clamp accepts unchanged", () => {
+    // Reset view must not itself be corrected by the bounds it restores to.
+    for (const canvas of [CANVAS, { width: 400, height: 300 }]) {
+      const centered = centerStarMapView({ canvas, viewport: VIEWPORT });
+      expect(clamp(centered, canvas)).toEqual(centered);
+    }
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
@@ -52,7 +52,7 @@ function threads(count: number): NavigationThreadSummary[] {
   return Array.from({ length: count }, (_, index) => thread(`t${index}`));
 }
 
-function seedLayout(layout: "orbit" | "projects") {
+function seedLayout(layout: "lanes" | "orbit" | "projects") {
   window.localStorage.setItem(
     "pwragent.starMap.viewPreferences",
     JSON.stringify({ layout }),
@@ -73,6 +73,40 @@ function pan(dx: number, dy: number) {
   fireEvent.pointerDown(viewport, { button: 0, clientX: 500, clientY: 400 });
   fireEvent.pointerMove(window, { clientX: 500 + dx, clientY: 400 + dy });
   fireEvent.pointerUp(window, { clientX: 500 + dx, clientY: 400 + dy });
+}
+
+/**
+ * jsdom measures every element as 0x0, so the screen keeps its unmeasured
+ * default viewport. The bounds below are computed against it.
+ */
+const VIEWPORT = { width: 1280, height: 800 };
+/** Mirrors MIN_VISIBLE_FRACTION in star-map-view-geometry. */
+const MIN_VISIBLE_FRACTION = 0.15;
+
+function readTransform(): { x: number; y: number; scale: number } {
+  const raw = canvas().style.transform;
+  const match = /translate\((-?[\d.]+)px, (-?[\d.]+)px\) scale\(([\d.]+)\)/.exec(
+    raw,
+  );
+  if (!match) throw new Error(`unparsable transform: ${raw}`);
+  return { x: Number(match[1]), y: Number(match[2]), scale: Number(match[3]) };
+}
+
+/** The canvas's untransformed size, as the screen sized the element. */
+function canvasBox(): { width: number; height: number } {
+  const style = canvas().style;
+  return {
+    width: Number.parseFloat(style.width),
+    height: Number.parseFloat(style.height),
+  };
+}
+
+/** How much of the canvas the operator can still see, on one axis. */
+function visible(position: number, content: number, viewportExtent: number) {
+  return Math.max(
+    0,
+    Math.min(viewportExtent, position + content) - Math.max(0, position),
+  );
 }
 
 function renderMap(props: { threads: NavigationThreadSummary[] }) {
@@ -237,5 +271,219 @@ describe("star map view stability", () => {
       ).toBeNull();
     });
     expect(canvas().style.transform).toBe(panned);
+  });
+});
+
+/**
+ * The map must also never leave.
+ *
+ * A pan/zoom surface with no bounds can be dragged until every body is
+ * outside the window, and an empty star field offers nothing to drag back
+ * — before this, closing and reopening the map was the only way out. The
+ * view being sticky (above) is what makes that state permanent, so the two
+ * rules ship together: the operator owns the view, and the view stays
+ * within reach of the content.
+ */
+describe("star map view bounds", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+  });
+
+  async function openOrbit() {
+    seedLayout("orbit");
+    const rendered = renderMap({ threads: threads(9) });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance/ }),
+      ).toBeTruthy();
+    });
+    return rendered;
+  }
+
+  /** Let the pan's animation frame run so it writes the live transform. */
+  async function flushFrame() {
+    await act(async () => {
+      await new Promise((resolve) => {
+        requestAnimationFrame(() => resolve(undefined));
+      });
+    });
+  }
+
+  it("keeps a strip of canvas on screen when dragged off the top-left", async () => {
+    await openOrbit();
+    const box = canvasBox();
+
+    pan(-40000, -40000);
+
+    const after = readTransform();
+    expect(visible(after.x, box.width, VIEWPORT.width)).toBeGreaterThanOrEqual(
+      VIEWPORT.width * MIN_VISIBLE_FRACTION,
+    );
+    expect(
+      visible(after.y, box.height, VIEWPORT.height),
+    ).toBeGreaterThanOrEqual(VIEWPORT.height * MIN_VISIBLE_FRACTION);
+  });
+
+  it("keeps a strip of canvas on screen when dragged off the bottom-right", async () => {
+    await openOrbit();
+    const box = canvasBox();
+
+    pan(40000, 40000);
+
+    const after = readTransform();
+    expect(after.x).toBe(VIEWPORT.width * (1 - MIN_VISIBLE_FRACTION));
+    expect(visible(after.x, box.width, VIEWPORT.width)).toBeGreaterThanOrEqual(
+      VIEWPORT.width * MIN_VISIBLE_FRACTION,
+    );
+    expect(
+      visible(after.y, box.height, VIEWPORT.height),
+    ).toBeGreaterThanOrEqual(VIEWPORT.height * MIN_VISIBLE_FRACTION);
+  });
+
+  it("bounds the trackpad two-finger pan as well as the drag", async () => {
+    await openOrbit();
+    const box = canvasBox();
+    const viewport = document.querySelector(".star-map__viewport")!;
+
+    // One flick is enough; a real trackpad emits a stream of these.
+    fireEvent.wheel(viewport, { deltaX: 40000, deltaY: 40000 });
+
+    const after = readTransform();
+    expect(visible(after.x, box.width, VIEWPORT.width)).toBeGreaterThanOrEqual(
+      VIEWPORT.width * MIN_VISIBLE_FRACTION,
+    );
+    expect(
+      visible(after.y, box.height, VIEWPORT.height),
+    ).toBeGreaterThanOrEqual(VIEWPORT.height * MIN_VISIBLE_FRACTION);
+  });
+
+  it("does not snap the canvas back when the drag is released", async () => {
+    // The drag writes the transform onto the canvas itself on every frame,
+    // bypassing React state. Clamping only the committed value would let
+    // the map run off during the drag and jump back on pointerup.
+    await openOrbit();
+    const viewport = document.querySelector(".star-map__viewport")!;
+
+    fireEvent.pointerDown(viewport, { button: 0, clientX: 500, clientY: 400 });
+    fireEvent.pointerMove(window, { clientX: -39500, clientY: -39600 });
+    await flushFrame();
+    const midDrag = canvas().style.transform;
+    expect(midDrag).toMatch(/translate/);
+
+    fireEvent.pointerUp(window, { clientX: -39500, clientY: -39600 });
+
+    expect(canvas().style.transform).toBe(midDrag);
+  });
+
+  it("bounds the projects lens too", async () => {
+    seedLayout("projects");
+    renderMap({ threads: threads(9) });
+    await waitFor(() => {
+      expect(screen.getByTitle("PwrSnap")).toBeTruthy();
+    });
+    const box = canvasBox();
+
+    pan(-40000, -40000);
+
+    const after = readTransform();
+    expect(visible(after.x, box.width, VIEWPORT.width)).toBeGreaterThanOrEqual(
+      VIEWPORT.width * MIN_VISIBLE_FRACTION,
+    );
+    expect(
+      visible(after.y, box.height, VIEWPORT.height),
+    ).toBeGreaterThanOrEqual(VIEWPORT.height * MIN_VISIBLE_FRACTION);
+  });
+
+  it("re-centres the map on Reset view", async () => {
+    await openOrbit();
+    const centred = canvas().style.transform;
+
+    pan(-900, -600);
+    expect(canvas().style.transform).not.toBe(centred);
+
+    fireEvent.click(screen.getByRole("button", { name: "View" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reset view" }));
+
+    expect(canvas().style.transform).toBe(centred);
+    const box = canvasBox();
+    expect(readTransform()).toEqual({
+      x: (VIEWPORT.width - box.width) / 2,
+      y: (VIEWPORT.height - box.height) / 2,
+      scale: 1,
+    });
+  });
+
+  it("resets the zoom as well as the position", async () => {
+    await openOrbit();
+    const viewport = document.querySelector(".star-map__viewport")!;
+
+    fireEvent.wheel(viewport, {
+      deltaY: -240,
+      ctrlKey: true,
+      clientX: 400,
+      clientY: 300,
+    });
+    expect(readTransform().scale).not.toBe(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "View" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reset view" }));
+
+    expect(readTransform().scale).toBe(1);
+  });
+
+  it("hands the view back to the map on Reset view", async () => {
+    // Resetting is also how the operator says "you place it again" — the
+    // ownership flag has to clear, or auto-centring stays off for the life
+    // of the mounted map.
+    const { rerender } = await openOrbit();
+
+    pan(-900, -600);
+    fireEvent.click(screen.getByRole("button", { name: "View" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reset view" }));
+    const beforeResize = canvas().style.transform;
+
+    rerender(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={threads(4)}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /Open thread: Thread t8/ }),
+      ).toBeNull();
+    });
+    // The smaller cloud re-centres, which it would not do if the map were
+    // still treating the view as the operator's.
+    expect(canvas().style.transform).not.toBe(beforeResize);
+    const box = canvasBox();
+    expect(readTransform()).toEqual({
+      x: (VIEWPORT.width - box.width) / 2,
+      y: (VIEWPORT.height - box.height) / 2,
+      scale: 1,
+    });
+  });
+
+  it("offers no reset in the lens that has no view to lose", async () => {
+    // Lanes fits the window: there is nothing to pan, so a reset control
+    // would be a button that does nothing.
+    seedLayout("lanes");
+    renderMap({ threads: threads(9) });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance/ }),
+      ).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "View" }));
+
+    expect(screen.queryByRole("button", { name: "Reset view" })).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
+import { MIN_VISIBLE_FRACTION } from "../star-map-view-geometry";
 import { StarMapScreen } from "../StarMapScreen";
 
 /**
@@ -80,16 +81,17 @@ function pan(dx: number, dy: number) {
  * default viewport. The bounds below are computed against it.
  */
 const VIEWPORT = { width: 1280, height: 800 };
-/** Mirrors MIN_VISIBLE_FRACTION in star-map-view-geometry. */
-const MIN_VISIBLE_FRACTION = 0.15;
 
-function readTransform(): { x: number; y: number; scale: number } {
-  const raw = canvas().style.transform;
+function parseTransform(raw: string): { x: number; y: number; scale: number } {
   const match = /translate\((-?[\d.]+)px, (-?[\d.]+)px\) scale\(([\d.]+)\)/.exec(
     raw,
   );
   if (!match) throw new Error(`unparsable transform: ${raw}`);
   return { x: Number(match[1]), y: Number(match[2]), scale: Number(match[3]) };
+}
+
+function readTransform(): { x: number; y: number; scale: number } {
+  return parseTransform(canvas().style.transform);
 }
 
 /** The canvas's untransformed size, as the screen sized the element. */
@@ -469,6 +471,80 @@ describe("star map view bounds", () => {
       y: (VIEWPORT.height - box.height) / 2,
       scale: 1,
     });
+  });
+
+  it("lets a shrinking canvas strand the view, recovered by Reset", async () => {
+    // Pins the known gap rather than implying there isn't one. The bounds
+    // are a function of canvas size, and the clamp deliberately does not
+    // re-run on a content change — so a canvas that shrinks out from under
+    // a legally-parked view can leave nothing on screen. Recovery is
+    // manual. If a future change closes this properly, this test should
+    // fail and be rewritten, not deleted.
+    const { rerender } = await openOrbit();
+    const wide = canvasBox();
+
+    // Park hard against the left bound: the canvas's right edge is all
+    // that remains on screen, so any shrink eats straight into it.
+    pan(-40000, -40000);
+    expect(
+      visible(readTransform().x, wide.width, VIEWPORT.width),
+    ).toBeGreaterThanOrEqual(VIEWPORT.width * MIN_VISIBLE_FRACTION);
+
+    rerender(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={threads(1)}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /Open thread: Thread t8/ }),
+      ).toBeNull();
+    });
+
+    const narrow = canvasBox();
+    // The shrink has to exceed the guaranteed strip for this to be the
+    // gap rather than a rounding artefact.
+    expect(narrow.width).toBeLessThan(
+      wide.width - VIEWPORT.width * MIN_VISIBLE_FRACTION,
+    );
+    const stranded = readTransform();
+    expect(visible(stranded.x, narrow.width, VIEWPORT.width)).toBe(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "View" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reset view" }));
+
+    const recovered = readTransform();
+    expect(
+      visible(recovered.x, narrow.width, VIEWPORT.width),
+    ).toBeGreaterThanOrEqual(VIEWPORT.width * MIN_VISIBLE_FRACTION);
+    expect(
+      visible(recovered.y, narrow.height, VIEWPORT.height),
+    ).toBeGreaterThanOrEqual(VIEWPORT.height * MIN_VISIBLE_FRACTION);
+  });
+
+  it("commits a flick released before any frame runs", async () => {
+    // The live transform is written inside requestAnimationFrame, but the
+    // committed value must not depend on a frame having fired — a quick
+    // drag-and-release would otherwise throw the gesture away.
+    await openOrbit();
+    const before = canvas().style.transform;
+    const viewport = document.querySelector(".star-map__viewport")!;
+
+    fireEvent.pointerDown(viewport, { button: 0, clientX: 500, clientY: 400 });
+    fireEvent.pointerMove(window, { clientX: 300, clientY: 250 });
+    fireEvent.pointerUp(window, { clientX: 300, clientY: 250 });
+
+    const after = readTransform();
+    const start = parseTransform(before);
+    expect(after.x).toBe(start.x - 200);
+    expect(after.y).toBe(start.y - 150);
   });
 
   it("offers no reset in the lens that has no view to lose", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
@@ -28,8 +28,10 @@ export const MAX_ZOOM = 2;
  *
  * Per-axis rather than by area: an area rule is satisfied by a one-pixel-tall
  * band across the window, which is not a usable handle.
+ *
+ * Exported so tests assert against this number rather than a copy of it.
  */
-const MIN_VISIBLE_FRACTION = 0.15;
+export const MIN_VISIBLE_FRACTION = 0.15;
 
 /**
  * Clamp one axis so the canvas's overlap with the viewport stays at or above
@@ -75,8 +77,21 @@ function clampAxis(params: {
  * Deliberately NOT applied when the map's *contents* change. A cloud that
  * resizes must never move a view the operator positioned; that is the whole
  * point of the view-ownership rule, and re-clamping on a content change
- * would reintroduce exactly the jerk it removed. A content change that
- * leaves the operator off the map is recovered with "Reset view".
+ * would reintroduce exactly the jerk it removed.
+ *
+ * That leaves a real gap, and it is a reachable one rather than a corner
+ * case: the bounds are a function of canvas size, so a canvas that SHRINKS
+ * can strand a view that was legal when the operator placed it. Parked at
+ * the left bound (`x = minVisible - canvasWidth`, looking at the canvas's
+ * right edge) and then archiving enough cards to drop an orbit ring narrows
+ * the canvas by roughly 2 * RING_STEP_RX — far more than the strip this
+ * guarantees — and the content ends up off-screen entirely.
+ *
+ * So this bounds the operator's own movement and nothing else. Recovery
+ * from a content-induced strand is "Reset view", which is a cheap in-app
+ * action rather than the reopen-the-map it replaced, but it is still a
+ * manual step. Closing that gap needs a rescue that fires only for an
+ * already-out-of-bounds view; see the note on centerStarMapView.
  */
 export function clampStarMapView(params: {
   view: StarMapView;
@@ -104,6 +119,14 @@ export function clampStarMapView(params: {
  * The view that puts the middle of the canvas in the middle of the window
  * at 1:1. Used to place the map on open, on a lens switch, and by "Reset
  * view".
+ *
+ * This is also the manual half of the content-shrink gap described on
+ * clampStarMapView. A rescue that re-placed the view automatically would
+ * have to fire only when the current view is already out of bounds — a
+ * no-op for every view the operator can still use — so that it never moves
+ * a usable view and never reintroduces the jerk the ownership rule fixed.
+ * Deliberately not attempted here: it changes when the map is allowed to
+ * move itself, which wants its own change and its own tests.
  */
 export function centerStarMapView(params: {
   canvas: StarMapViewBox;

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
@@ -1,0 +1,117 @@
+/**
+ * Geometry for the star map's pan/zoom view.
+ *
+ * The orbit and projects lenses lay their bodies out on a canvas larger
+ * than the window and move it under a `translate(x, y) scale(s)` with
+ * `transform-origin: 0 0`, so the canvas occupies the viewport-pixel rect
+ * `[x, x + width * scale] x [y, y + height * scale]`.
+ *
+ * Everything here is pure: the screen owns the state, this owns the rules.
+ */
+
+export type StarMapView = { x: number; y: number; scale: number };
+
+export type StarMapViewBox = { width: number; height: number };
+
+export const MIN_ZOOM = 0.35;
+export const MAX_ZOOM = 2;
+
+/**
+ * How much of the canvas has to stay on screen, per axis, as a fraction of
+ * the viewport.
+ *
+ * A pan/zoom surface with no bounds can be dragged until the populated area
+ * is entirely outside the window, and an empty star field gives the operator
+ * nothing to drag back — the map is only recoverable by closing it. Keeping
+ * a strip of canvas in view on both axes means there is always something to
+ * grab and always a direction that leads back to the bodies.
+ *
+ * Per-axis rather than by area: an area rule is satisfied by a one-pixel-tall
+ * band across the window, which is not a usable handle.
+ */
+const MIN_VISIBLE_FRACTION = 0.15;
+
+/**
+ * Clamp one axis so the canvas's overlap with the viewport stays at or above
+ * the minimum.
+ *
+ * With canvas extent `content` placed at `position` against a viewport of
+ * `viewportExtent`, the overlap is the least of `viewportExtent`, `content`,
+ * `position + content`, and `viewportExtent - position`. The first two do
+ * not depend on `position`, so requiring the overlap to be at least
+ * `minVisible` reduces to the two bounds below.
+ */
+function clampAxis(params: {
+  position: number;
+  content: number;
+  viewportExtent: number;
+}): number {
+  const { position, content, viewportExtent } = params;
+  // A zero-sized canvas or an unmeasured viewport has no meaningful bounds;
+  // leaving the position alone beats clamping it to an arbitrary origin.
+  if (
+    !Number.isFinite(position)
+    || !(content > 0)
+    || !(viewportExtent > 0)
+  ) {
+    return position;
+  }
+  // Never demand more overlap than the canvas can supply — a canvas smaller
+  // than the demanded strip would otherwise have no legal position at all.
+  const minVisible = Math.min(content, viewportExtent * MIN_VISIBLE_FRACTION);
+  const min = minVisible - content;
+  const max = viewportExtent - minVisible;
+  return Math.min(Math.max(position, min), max);
+}
+
+/**
+ * Keep a pan/zoom view within reach of its content.
+ *
+ * Applied to every operator-driven write of the view — wheel pan, pinch
+ * zoom, and each animation frame of a pointer drag. Clamping the live drag
+ * frames as well as the value committed on pointerup is what stops the
+ * canvas visibly snapping back when the operator lets go.
+ *
+ * Deliberately NOT applied when the map's *contents* change. A cloud that
+ * resizes must never move a view the operator positioned; that is the whole
+ * point of the view-ownership rule, and re-clamping on a content change
+ * would reintroduce exactly the jerk it removed. A content change that
+ * leaves the operator off the map is recovered with "Reset view".
+ */
+export function clampStarMapView(params: {
+  view: StarMapView;
+  /** Untransformed canvas size for the current lens. */
+  canvas: StarMapViewBox;
+  viewport: StarMapViewBox;
+}): StarMapView {
+  const scale = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, params.view.scale));
+  return {
+    scale,
+    x: clampAxis({
+      position: params.view.x,
+      content: params.canvas.width * scale,
+      viewportExtent: params.viewport.width,
+    }),
+    y: clampAxis({
+      position: params.view.y,
+      content: params.canvas.height * scale,
+      viewportExtent: params.viewport.height,
+    }),
+  };
+}
+
+/**
+ * The view that puts the middle of the canvas in the middle of the window
+ * at 1:1. Used to place the map on open, on a lens switch, and by "Reset
+ * view".
+ */
+export function centerStarMapView(params: {
+  canvas: StarMapViewBox;
+  viewport: StarMapViewBox;
+}): StarMapView {
+  return {
+    x: (params.viewport.width - params.canvas.width) / 2,
+    y: (params.viewport.height - params.canvas.height) / 2,
+    scale: 1,
+  };
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9756,6 +9756,24 @@ textarea,
   color: var(--text-primary);
 }
 
+/* Action row in the View popover ("Reset view"). Reads as the layout
+   switch's sibling rather than a new control species. */
+.star-map__view-action {
+  padding: 4px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.star-map__view-action:hover {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
 .star-map__view-heading {
   margin: 4px 0 2px;
   color: var(--text-muted);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9774,6 +9774,11 @@ textarea,
   color: var(--text-primary);
 }
 
+.star-map__view-action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
 .star-map__view-heading {
   margin: 4px 0 2px;
   color: var(--text-muted);


### PR DESCRIPTION
## Summary

- The orbit and projects lenses pan/zoom an oversized canvas with no bounds. Drag far enough and every body leaves the window, and an empty star field offers nothing to drag back — closing and reopening the map was the only recovery.
- New pure module `star-map-view-geometry.ts` exports `clampStarMapView` and `centerStarMapView`, and takes over `MIN_ZOOM`/`MAX_ZOOM` from `StarMapScreen`. The clamp keeps at least 15% of each viewport axis covered by the canvas, capped by what the canvas can actually supply and scaled by the current zoom.
- Applied to all three writers of the view: the native wheel listener (two-finger pan and ctrl/pinch zoom), the pointer drag, and the auto-centring effect.
- "Reset view" added to the View popover. It re-centres, resets the scale to 1, clears the view-ownership flag so auto-centring resumes, and closes the popover. It is omitted in the lanes lens, which fits the window and has no view to lose.

#1314 made this reachable rather than causing it. Before it, the auto-centring effect re-fired on canvas resize and would accidentally rescue a lost operator; making the view sticky is correct, but it also made the stranded state permanent. That is why the clamp alone isn't enough and the reset ships with it.

## Known gap — read this before approving

**A shrinking canvas can still strand the view.** The clamp deliberately does not re-run on content change (that is #1314's guarantee), but the bounds are a function of canvas size. Parked at the left bound and then archiving enough cards to drop an orbit ring narrows the canvas by ~`2 * RING_STEP_RX` (456px) — far more than the 192px strip this guarantees — and the content ends up fully off-screen.

So this PR bounds the operator's own movement and nothing else. It downgrades the failure from "close and reopen the map" to "click Reset view", which is a real improvement, but recovery is still manual. `lets a shrinking canvas strand the view, recovered by Reset` pins that boundary deterministically (9 threads → 1 shrinks the canvas 1423px → 720px) so the gap is documented rather than assumed.

Closing it properly needs a rescue that fires **only** for an already-out-of-bounds view — a no-op for anything the operator can still use, so it never moves a usable view. That changes when the map is allowed to move itself, which wants its own change and its own tests; the existing stability tests pan modestly and would stay green through a botched threshold, so it should not ride along here.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/star-map` — 142 passed (10 files), including #1314's `star-map-view-stability.test.tsx`.
- `pnpm test apps/desktop/src/renderer` — 2149 passed (135 files).
- `pnpm --filter @pwragent/desktop typecheck`, `pnpm lint:colors`, `pnpm lint:boundaries`, and `pnpm exec eslint` over `features/star-map/` — all clean.
- New coverage: 10 unit tests in `__tests__/star-map-view-geometry.test.ts`, 11 component tests appended to `__tests__/star-map-view-stability.test.tsx`.

Tests were checked against a sabotaged implementation rather than assumed meaningful. Stubbing the clamp to identity fails the bounds tests; sabotaging only the per-frame clamp fails the "no snap" test alone; sabotaging only the committed clamp fails five. The no-snap test earned that teeth in review — the release path originally committed whatever the drag had computed, so both paths were wrong together and agreed. They are now independently derived from the same raw pointer position.

Not done: no manual run of the app. Happy to drive it against the dev profile if you want the boundary feel confirmed before merge.

## Notes

- **Per-axis, not by area.** An area rule is satisfied by a one-pixel band across the window, which is not a grabbable handle. Each axis independently keeps 15% of its viewport dimension covered.
- **The wheel effect moved down the file**, below `panZoomCanvas`. It needs the canvas size, and referencing it from the old position would be a TDZ error in the dependency array. The listener body is otherwise unchanged apart from the clamp calls.
- **The live drag path matters.** `startCanvasPan` writes `canvas.style.transform` directly on each animation frame, bypassing React state. Clamping only the committed value would let the map leave the window during the drag and visibly jump back on pointerup.
- **The drag captures scale for the whole gesture**, so a pinch mid-drag runs out of step with the live transform until pointerup re-reads state. Pre-existing behaviour, now documented rather than changed.
- Reset-view styling reuses the layout-switch tokens plus a `:focus-visible` ring matching `.star-map__filter-chip`; no new color literals, `lint:colors` is clean. The sibling `.star-map__layout-option` has the same missing focus ring, left alone here to keep the diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
