### PR TITLE
fix(federation): route remote thread tools

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1469,6 +1469,7 @@ class MockBackendClient {
       nativeSubAgentThreads?: AppServerThreadSummary[];
       replay?: AppServerThreadReplay;
       readThreadReplays?: AppServerThreadReplay[];
+      readThreadError?: Error;
       readThreadDelay?: Promise<unknown>;
       skills?: Array<{
         commands?: AppServerAvailableCommandSummary[];
@@ -1646,6 +1647,9 @@ class MockBackendClient {
     const replay = this.options.readThreadReplays?.shift();
     if (this.options.readThreadDelay) {
       await this.options.readThreadDelay;
+    }
+    if (this.options.readThreadError) {
+      throw this.options.readThreadError;
     }
     if (replay) {
       return replay;
@@ -26733,6 +26737,67 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("keeps send_message_to_thread local when includeRemote is false", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      threads: [{
+        source: "codex",
+        id: "local-thread",
+        title: "Local target",
+        titleSource: "explicit",
+        linkedDirectories: [],
+      }],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error(
+          "grok app server unavailable: XAI_API_KEY is not set",
+        ),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    const federatedSend = vi.fn();
+    registry.setFederatedThreadMessageHandler(federatedSend);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "parent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "turn-1",
+      tool: "send_message_to_thread",
+      args: {
+        backend: "codex",
+        threadId: "local-thread",
+        prompt: "Keep this local.",
+        includeRemote: false,
+      },
+    });
+
+    expect(response).toMatchObject({
+      structuredContent: {
+        backend: "codex",
+        threadId: "local-thread",
+      },
+    });
+    expect(federatedSend).not.toHaveBeenCalled();
+    expect(codexClient.startTurnCallCount).toBe(1);
+
+    await registry.close();
+  });
+
   it("routes a remembered remote owner before a colliding local thread", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
@@ -29319,6 +29384,253 @@ script = "printf setup"
       url: "https://github.com/pwrdrvr/PwrAgent/pull/1105",
     });
     expect(response).toMatchObject({ success: true });
+
+    await registry.close();
+  });
+
+  it("resolves get_thread_status across Federation by default", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/read"] },
+      threads: [
+        {
+          id: "agent-thread",
+          title: "Coordinator",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: { "codex:agent-thread": createAgentOverlay() },
+      }),
+    });
+    const federatedInspection = vi.fn(async () => ({
+      instanceId: "pwr_remote",
+      instanceLabel: "Remote Mac",
+      thread: {
+        id: "remote-thread",
+        title: "Remote collector",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        linkedDirectories: [],
+      },
+      read: {
+        backend: "codex" as const,
+        fetchedAt: 2_000,
+        threadId: "remote-thread",
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+          threadStatus: "idle" as const,
+        },
+        threadStatus: "idle" as const,
+      },
+    }));
+    registry.setFederatedThreadInspectionHandler(federatedInspection);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-remote-status",
+        requestId: "call-remote-status",
+        namespace: "pwragent",
+        tool: "get_thread_status",
+        arguments: {
+          backend: "codex",
+          threadId: "remote-thread",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload.thread).toMatchObject({
+      backend: "codex",
+      threadId: "remote-thread",
+      instanceId: "pwr_remote",
+      instanceLabel: "Remote Mac",
+      title: "Remote collector",
+      status: "idle",
+    });
+    expect(federatedInspection).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "remote-thread",
+      limit: 0,
+      includeTurns: false,
+    });
+
+    await registry.close();
+  });
+
+  it("respects includeRemote false for thread status resolution", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: { "codex:agent-thread": createAgentOverlay() },
+      }),
+    });
+    const federatedInspection = vi.fn();
+    registry.setFederatedThreadInspectionHandler(federatedInspection);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-local-status",
+        requestId: "call-local-status",
+        namespace: "pwragent",
+        tool: "get_thread_status",
+        arguments: {
+          backend: "codex",
+          threadId: "remote-thread",
+          includeRemote: false,
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: false });
+    expect(federatedInspection).not.toHaveBeenCalled();
+
+    await registry.close();
+  });
+
+  it("reads a remote transcript after local resolution fails", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+      readThreadError: new Error("thread not loaded"),
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: { "codex:agent-thread": createAgentOverlay() },
+      }),
+    });
+    const federatedInspection = vi.fn(async () => ({
+      instanceId: "pwr_remote",
+      instanceLabel: "Remote Mac",
+      thread: {
+        id: "remote-thread",
+        title: "Remote collector",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        linkedDirectories: [],
+      },
+      read: {
+        backend: "codex" as const,
+        fetchedAt: 2_000,
+        threadId: "remote-thread",
+        replay: {
+          entries: [],
+          messages: [
+            {
+              id: "remote-result",
+              role: "assistant" as const,
+              text: "Sanitized result",
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+          threadStatus: "idle" as const,
+        },
+        threadStatus: "idle" as const,
+      },
+    }));
+    registry.setFederatedThreadInspectionHandler(federatedInspection);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-remote-read",
+        requestId: "call-remote-read",
+        namespace: "pwragent",
+        tool: "read_thread",
+        arguments: {
+          backend: "codex",
+          threadId: "remote-thread",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload.read).toMatchObject({
+      backend: "codex",
+      threadId: "remote-thread",
+      instanceId: "pwr_remote",
+      instanceLabel: "Remote Mac",
+      status: "idle",
+      messages: [{ text: "Sanitized result" }],
+    });
+    expect(federatedInspection).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "remote-thread",
+      limit: 10,
+      includeTurns: true,
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -29786,7 +29786,16 @@ script = "printf setup"
         titleSource: "explicit",
         source: "codex",
         linkedDirectories: [],
+        projectKey: "PwrSuiteLab",
         updatedAt: 1_000,
+      }, {
+        id: "local-thread-2",
+        title: "Local collector follow-up",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
+        projectKey: "PwrSuiteLab",
+        updatedAt: 900,
       }],
     });
     const registry = new DesktopBackendRegistry({
@@ -29802,6 +29811,8 @@ script = "printf setup"
       ok: true as const,
       data: {
         query: "collector",
+        totalCount: 3,
+        truncated: true,
         results: [{
           instanceId: "pwr_remote",
           instanceLabel: "Remote Mac",
@@ -29811,8 +29822,19 @@ script = "printf setup"
           title: "Remote collector",
           updatedAt: 2_000,
           projectKey: "PwrSuiteLab",
-          score: 10,
+          score: 10_000,
           threadLink: "[Remote collector](pwragent://thread/remote-thread)",
+        }, {
+          instanceId: "pwr_remote",
+          instanceLabel: "Remote Mac",
+          isLocal: false,
+          backend: "codex" as const,
+          threadId: "remote-thread-2",
+          title: "Remote collector follow-up",
+          updatedAt: 1_500,
+          projectKey: "PwrSuiteLab",
+          score: 9_000,
+          threadLink: "[Remote collector follow-up](pwragent://thread/remote-thread-2)",
         }],
         searchedInstances: [{
           instanceId: "pwr_remote",
@@ -29844,25 +29866,47 @@ script = "printf setup"
         requestId: "call-search",
         namespace: "pwragent",
         tool: "search_threads",
-        arguments: { query: "collector" },
+        arguments: {
+          query: "collector",
+          backend: "codex",
+          includeArchived: true,
+          projectKeys: ["PwrSuiteLab"],
+          updatedAfter: 500,
+          updatedBefore: 3_000,
+          limit: 2,
+        },
       },
     } as AppServerPendingRequestNotification);
     const payload = JSON.parse(
       (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
     );
 
-    expect(payload.threads).toEqual(expect.arrayContaining([
-      expect.objectContaining({ threadId: "local-thread" }),
+    expect(payload.threads).toEqual([
       expect.objectContaining({
         threadId: "remote-thread",
         instanceId: "pwr_remote",
         instanceLabel: "Remote Mac",
         linkedDirectories: [],
       }),
-    ]));
+      expect.objectContaining({ threadId: "local-thread" }),
+    ]);
+    expect(payload).toMatchObject({
+      totalCount: 5,
+      limit: 2,
+      truncated: true,
+    });
     expect(federationHandler).toHaveBeenCalledWith(expect.objectContaining({
       operation: "search_federation_threads",
-      args: expect.objectContaining({ scope: "remote", query: "collector" }),
+      args: {
+        scope: "remote",
+        query: "collector",
+        backend: "codex",
+        includeArchived: true,
+        projectKeys: ["PwrSuiteLab"],
+        updatedAfter: 500,
+        updatedBefore: 3_000,
+        limit: 2,
+      },
     }));
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -29777,6 +29777,167 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("combines local search_threads results with connected Federation metadata", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [{
+        id: "local-thread",
+        title: "Local collector",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
+        updatedAt: 1_000,
+      }],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: { "codex:agent-thread": createAgentOverlay() },
+      }),
+    });
+    const federationHandler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        query: "collector",
+        results: [{
+          instanceId: "pwr_remote",
+          instanceLabel: "Remote Mac",
+          isLocal: false,
+          backend: "codex" as const,
+          threadId: "remote-thread",
+          title: "Remote collector",
+          updatedAt: 2_000,
+          projectKey: "PwrSuiteLab",
+          score: 10,
+          threadLink: "[Remote collector](pwragent://thread/remote-thread)",
+        }],
+        searchedInstances: [{
+          instanceId: "pwr_remote",
+          instanceLabel: "Remote Mac",
+          resultCount: 1,
+        }],
+        failures: [],
+      },
+    }));
+    registry.setPwrAgentFederationHandler(federationHandler);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-search",
+        requestId: "call-search",
+        namespace: "pwragent",
+        tool: "search_threads",
+        arguments: { query: "collector" },
+      },
+    } as AppServerPendingRequestNotification);
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+
+    expect(payload.threads).toEqual(expect.arrayContaining([
+      expect.objectContaining({ threadId: "local-thread" }),
+      expect.objectContaining({
+        threadId: "remote-thread",
+        instanceId: "pwr_remote",
+        instanceLabel: "Remote Mac",
+        linkedDirectories: [],
+      }),
+    ]));
+    expect(federationHandler).toHaveBeenCalledWith(expect.objectContaining({
+      operation: "search_federation_threads",
+      args: expect.objectContaining({ scope: "remote", query: "collector" }),
+    }));
+
+    await registry.close();
+  });
+
+  it("routes mutate_thread to a remote owner when no local thread matches", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: { "codex:agent-thread": createAgentOverlay() },
+      }),
+    });
+    const mutationHandler = vi.fn(async () => ({
+      instanceId: "pwr_remote",
+      instanceLabel: "Remote Mac",
+    }));
+    registry.setFederatedThreadMutationHandler(mutationHandler);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-mutate",
+        requestId: "call-mutate",
+        namespace: "pwragent",
+        tool: "mutate_thread",
+        arguments: {
+          backend: "codex",
+          threadId: "remote-thread",
+          instanceId: "pwr_remote",
+          title: "Remote title",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+
+    expect(payload.mutation).toMatchObject({
+      backend: "codex",
+      threadId: "remote-thread",
+      instanceId: "pwr_remote",
+      instanceLabel: "Remote Mac",
+      dryRun: false,
+    });
+    expect(mutationHandler).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "remote-thread",
+      instanceId: "pwr_remote",
+      title: "Remote title",
+      dryRun: false,
+    });
+    expect(codexClient.lastRenameThreadParams).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("mutates PwrAgent thread settings from active turns", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -30252,18 +30252,10 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("resolves get_thread_status across Federation by default", async () => {
+  it("resolves enriched remote status when the local backend is unavailable", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list", "thread/read"] },
-      threads: [
-        {
-          id: "agent-thread",
-          title: "Coordinator",
-          titleSource: "explicit",
-          source: "codex",
-          linkedDirectories: [],
-        },
-      ],
+      listThreadsError: new Error("local codex backend unavailable"),
     });
     const registry = new DesktopBackendRegistry({
       codexClient,
@@ -30283,6 +30275,55 @@ script = "printf setup"
         titleSource: "explicit" as const,
         source: "codex" as const,
         linkedDirectories: [],
+      },
+      summary: {
+        id: "remote-thread",
+        title: "Remote collector",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        linkedDirectories: [{
+          id: "remote-directory",
+          label: "PwrSuiteLab",
+          path: "/remote/PwrSuiteLab",
+          kind: "worktree" as const,
+        }],
+        inbox: { inInbox: false },
+        agent: {
+          name: "Collector",
+          instructionLineCount: 1,
+          instructionsTooLong: false,
+          updatedAt: 1_000,
+        },
+        handoffOrigin: {
+          sourceBackend: "codex" as const,
+          sourceThreadId: "coordinator-thread",
+          sourceTitle: "Coordinator",
+          seedMode: "clean" as const,
+          groupingMode: "none" as const,
+          createdAt: 900,
+          workspace: {
+            mode: "none" as const,
+            git: {
+              kind: "none" as const,
+              worktreeCreationAvailable: false as const,
+              unavailableReason: "No workspace requested.",
+            },
+          },
+        },
+        prs: [{
+          provider: "github.com",
+          org: "pwrdrvr",
+          repo: "PwrAgent",
+          number: 1317,
+          state: "passing" as const,
+          url: "https://github.com/pwrdrvr/PwrAgent/pull/1317",
+        }],
+        messagingBindings: [{
+          bindingId: "binding-1",
+          platform: "telegram" as const,
+          conversationKind: "topic" as const,
+          conversationTitle: "Federation",
+        }],
       },
       read: {
         backend: "codex" as const,
@@ -30340,6 +30381,17 @@ script = "printf setup"
       instanceLabel: "Remote Mac",
       title: "Remote collector",
       status: "idle",
+      threadLink: expect.stringContaining("instanceId=pwr_remote"),
+      agent: { name: "Collector" },
+      handoffOrigin: {
+        sourceThreadId: "coordinator-thread",
+      },
+      linkedDirectories: [{ id: "remote-directory" }],
+      pullRequests: [{ number: 1317 }],
+      messagingBindings: [{
+        bindingId: "binding-1",
+        platform: "telegram",
+      }],
     });
     expect(federatedInspection).toHaveBeenCalledWith({
       backend: "codex",
@@ -30776,9 +30828,10 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("routes mutate_thread to a remote owner when no local thread matches", async () => {
+  it("routes mutate_thread remotely when local resolution fails", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
+      listThreadsError: new Error("local codex backend unavailable"),
     });
     const registry = new DesktopBackendRegistry({
       codexClient,
@@ -30818,7 +30871,6 @@ script = "printf setup"
         arguments: {
           backend: "codex",
           threadId: "remote-thread",
-          instanceId: "pwr_remote",
           title: "Remote title",
         },
       },
@@ -30837,7 +30889,6 @@ script = "printf setup"
     expect(mutationHandler).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "remote-thread",
-      instanceId: "pwr_remote",
       title: "Remote title",
       dryRun: false,
     });

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -666,6 +666,68 @@ describe("DesktopMessagingBackendBridge", () => {
     ]);
   });
 
+  it("resolves an explicit remote attach target with a federated thread ref", async () => {
+    const remoteThread: NavigationSnapshot["threads"][number] = {
+      id: "remote-thread",
+      title: "Remote collector",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const remoteNavigation: NavigationSnapshot = {
+      backend: "codex",
+      fetchedAt: 2_000,
+      unchanged: false,
+      threads: [remoteThread],
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const resolveThread = vi.fn(async () => ({
+      thread: {
+        ...remoteThread,
+        inbox: undefined,
+      },
+    }));
+    const federation = {
+      connectedPeerTargets: () => [{
+        target: { scope: "remote" as const, instanceId: "pwr_remote" },
+        label: "Remote Mac",
+        capabilities: ["thread_navigation", "messaging_route"] as const,
+      }],
+      health: async () => ({
+        enabled: true,
+        role: "dual" as const,
+        status: "connected" as const,
+        peers: [],
+      }),
+      onRemoteBackendEvent: () => () => undefined,
+      remoteBackend: () => ({ resolveThread } as unknown as FederationBackendOperations),
+      remoteNavigationSnapshot: vi.fn(async () => remoteNavigation),
+    } satisfies DesktopMessagingFederationBridge;
+    const registry = {
+      listThreads: vi.fn(async () => []),
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry, federation);
+
+    await expect(bridge.resolveThreadTarget({
+      backend: "codex",
+      threadId: "remote-thread",
+      instanceId: "pwr_remote",
+    })).resolves.toMatchObject({
+      thread: { id: "remote-thread" },
+      federatedThread: {
+        backend: "codex",
+        threadId: "remote-thread",
+        target: { scope: "remote", instanceId: "pwr_remote" },
+      },
+    });
+  });
+
   it("routes targeted messaging turns and navigation to the remote backend", async () => {
     const startTurn = vi.fn(async () => ({
       backend: "codex" as const,
@@ -714,6 +776,12 @@ describe("DesktopMessagingBackendBridge", () => {
     const listScheduledThreadActions = vi.fn(async () => ({ actions: [] }));
     const federation = {
       connectedPeerTargets: () => [],
+      health: async () => ({
+        enabled: false,
+        role: "dual" as const,
+        status: "disabled" as const,
+        peers: [],
+      }),
       onRemoteBackendEvent: () => () => undefined,
       remoteBackend: () => ({
         createScheduledThreadAction,

--- a/apps/desktop/src/main/__tests__/federated-search-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-search-service.test.ts
@@ -215,6 +215,119 @@ describe("FederatedSearchService", () => {
     });
   });
 
+  it("applies backend, project, archive, and date filters before limiting", async () => {
+    const listThreads = vi.fn(async (request?: {
+      archived?: boolean;
+      backend?: string;
+      filter?: string;
+    }) => ({
+      backend: "all" as const,
+      fetchedAt: 1_000,
+      threads: request?.archived
+        ? [{
+            ...thread("archived-match", "Collector result", 5_000),
+            archivedAt: 6_000,
+            projectKey: "PwrSuiteLab",
+          }]
+        : Array.from({ length: 10 }, (_, index) => ({
+            ...thread(`wrong-project-${index}`, "Collector result", 5_000),
+            projectKey: "OtherProject",
+          })),
+    }));
+    const service = new FederatedSearchService({
+      includeLocal: false,
+      local: { listThreads: vi.fn() },
+      peers: () => [{
+        instanceId: "pwr_remote",
+        label: "Remote Mac",
+        backend: { listThreads },
+      }],
+    });
+
+    await expect(service.search({
+      query: "collector",
+      backend: "codex",
+      includeArchived: true,
+      projectKeys: ["PwrSuiteLab"],
+      updatedAfter: 4_000,
+      updatedBefore: 6_000,
+      limit: 1,
+    })).resolves.toMatchObject({
+      results: [{ thread: { id: "archived-match", archivedAt: 6_000 } }],
+      totalCount: 1,
+      truncated: false,
+    });
+    expect(listThreads).toHaveBeenNthCalledWith(1, {
+      backend: "codex",
+      archived: false,
+      filter: "collector",
+    });
+    expect(listThreads).toHaveBeenNthCalledWith(2, {
+      backend: "codex",
+      archived: true,
+      filter: "collector",
+    });
+  });
+
+  it("reports totalCount and truncation before slicing the result page", async () => {
+    const service = new FederatedSearchService({
+      includeLocal: false,
+      local: { listThreads: vi.fn() },
+      peers: () => [{
+        instanceId: "pwr_remote",
+        label: "Remote Mac",
+        backend: {
+          listThreads: vi.fn(async () => ({
+            backend: "codex" as const,
+            fetchedAt: 1_000,
+            threads: Array.from({ length: 11 }, (_, index) =>
+              thread(`remote-${index}`, "Collector result", index)),
+          })),
+        },
+      }],
+    });
+
+    const response = await service.search({
+      query: "collector",
+      limit: 10,
+    });
+    expect(response).toMatchObject({
+      results: expect.any(Array),
+      totalCount: 11,
+      truncated: true,
+    });
+    expect(response.results).toHaveLength(10);
+  });
+
+  it("uses recency as a tie-breaker instead of an empty-query score", async () => {
+    const service = new FederatedSearchService({
+      includeLocal: false,
+      local: { listThreads: vi.fn() },
+      peers: () => [{
+        instanceId: "pwr_remote",
+        label: "Remote Mac",
+        backend: {
+          listThreads: vi.fn(async () => ({
+            backend: "codex" as const,
+            fetchedAt: 1_000,
+            threads: [
+              thread("older", "Older", 1_000),
+              thread("newer", "Newer", 2_000),
+            ],
+          })),
+        },
+      }],
+    });
+
+    const response = await service.search({ query: "", limit: 10 });
+
+    expect(response.results.map((entry) => entry.thread.id)).toEqual([
+      "newer",
+      "older",
+    ]);
+    expect(response.results.map((entry) => entry.score)).toEqual([0, 0]);
+  });
+
   it("times out a hung peer instead of stalling the search", async () => {
     const service = new FederatedSearchService({
       peerTimeoutMs: 25,

--- a/apps/desktop/src/main/__tests__/federated-thread-inspection-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-inspection-service.test.ts
@@ -41,7 +41,12 @@ function buildRuntime(params: {
         },
         threadStatus: "idle" as const,
       }));
-      return [peer.instanceId, { readThread, resolveThread }] as const;
+      const listThreads = vi.fn(async () => ({
+        backend: "codex" as const,
+        fetchedAt: 2_000,
+        threads: [],
+      }));
+      return [peer.instanceId, { listThreads, readThread, resolveThread }] as const;
     }),
   );
   const runtime = {
@@ -163,6 +168,66 @@ describe("federated thread inspection service", () => {
     })).rejects.toThrow(
       "owns thread 019fdc10-799b-7540-8884-87899f896ebc but does not grant thread_detail",
     );
+  });
+
+  it("resolves an archived thread on its explicit remote owner", async () => {
+    const archivedThread = {
+      source: "codex" as const,
+      id: threadId,
+      title: "Archived collector result",
+      archivedAt: 3_000,
+      linkedDirectories: [],
+    };
+    const listThreads = vi.fn(async (request?: { archived?: boolean }) => ({
+      backend: "codex" as const,
+      fetchedAt: 2_000,
+      threads: request?.archived ? [archivedThread] : [],
+    }));
+    const readThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      fetchedAt: 2_000,
+      threadId,
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle" as const,
+      },
+      threadStatus: "idle" as const,
+    }));
+    const runtime = {
+      connectedPeerTargets: () => [{
+        target: { scope: "remote" as const, instanceId: "pwr_owner" },
+        label: "Owner Mac",
+        capabilities: ["thread_navigation", "thread_detail"],
+      }],
+      remoteBackend: () => ({
+        resolveThread: vi.fn(async () => ({})),
+        listThreads,
+        readThread,
+      }),
+    } as unknown as DesktopFederationRuntime;
+    const handler = createFederatedThreadInspectionHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler({
+      backend: "codex",
+      threadId,
+      instanceId: "pwr_owner",
+      limit: 10,
+      includeTurns: true,
+    })).resolves.toMatchObject({
+      instanceId: "pwr_owner",
+      thread: { id: threadId, archivedAt: 3_000 },
+    });
+    expect(listThreads).toHaveBeenCalledWith({
+      backend: "codex",
+      archived: true,
+    });
   });
 
   it("returns peer_unavailable for a remembered disconnected owner", async () => {

--- a/apps/desktop/src/main/__tests__/federated-thread-inspection-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-inspection-service.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopFederationRuntime } from "../federation/federation-runtime";
+import { createFederatedThreadInspectionHandler } from "../federation/federated-thread-inspection-service";
+
+const threadId = "019fdc10-799b-7540-8884-87899f896ebc";
+
+function buildRuntime(params: {
+  peers: Array<{
+    instanceId: string;
+    label: string;
+    ownsThread?: boolean;
+    capabilities?: Array<
+      "thread_navigation" | "thread_detail" | "turn_control"
+    >;
+  }>;
+}) {
+  const backends = new Map(
+    params.peers.map((peer) => {
+      const thread = {
+        source: "codex" as const,
+        id: threadId,
+        title: "Remote collector result",
+        linkedDirectories: [],
+      };
+      const resolveThread = vi.fn(async () =>
+        peer.ownsThread ? { thread } : {},
+      );
+      const readThread = vi.fn(async () => ({
+        backend: "codex" as const,
+        fetchedAt: 2_000,
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          lastAssistantMessage: "Sanitized result",
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+          threadStatus: "idle" as const,
+        },
+        threadStatus: "idle" as const,
+      }));
+      return [peer.instanceId, { readThread, resolveThread }] as const;
+    }),
+  );
+  const runtime = {
+    connectedPeerTargets: () =>
+      params.peers.map((peer) => ({
+        target: { scope: "remote" as const, instanceId: peer.instanceId },
+        label: peer.label,
+        capabilities:
+          peer.capabilities ?? ["thread_navigation", "thread_detail"],
+      })),
+    remoteBackend: (target: { instanceId: string }) =>
+      backends.get(target.instanceId),
+  } as unknown as DesktopFederationRuntime;
+  return { backends, runtime };
+}
+
+describe("federated thread inspection service", () => {
+  it("discovers an owning peer and reads its transcript without instanceId", async () => {
+    const { backends, runtime } = buildRuntime({
+      peers: [
+        { instanceId: "pwr_other", label: "Other Mac" },
+        {
+          instanceId: "pwr_owner",
+          label: "Owner Mac",
+          ownsThread: true,
+        },
+      ],
+    });
+    const rememberRemoteThreadTarget = vi.fn(async (target) => target);
+    const handler = createFederatedThreadInspectionHandler({
+      runtime: () => runtime,
+      targetStore: {
+        listRemoteThreadTargets: vi.fn(async () => []),
+        rememberRemoteThreadTarget,
+      },
+    });
+
+    await expect(handler({
+      backend: "codex",
+      threadId,
+      limit: 10,
+      includeTurns: true,
+    })).resolves.toMatchObject({
+      instanceId: "pwr_owner",
+      instanceLabel: "Owner Mac",
+      thread: { id: threadId },
+      read: {
+        threadId,
+        threadStatus: "idle",
+      },
+    });
+    expect(backends.get("pwr_owner")?.readThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId,
+      includeTurns: true,
+      limit: 10,
+      viewOnly: true,
+    });
+    expect(rememberRemoteThreadTarget).toHaveBeenCalledWith({
+      backend: "codex",
+      instanceId: "pwr_owner",
+      instanceLabel: "Owner Mac",
+      threadId,
+    });
+  });
+
+  it("routes directly to an explicit instance", async () => {
+    const { backends, runtime } = buildRuntime({
+      peers: [
+        { instanceId: "pwr_other", label: "Other Mac" },
+        {
+          instanceId: "pwr_owner",
+          label: "Owner Mac",
+          ownsThread: true,
+        },
+      ],
+    });
+    const handler = createFederatedThreadInspectionHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler({
+      backend: "codex",
+      threadId,
+      instanceId: "pwr_owner",
+      limit: 0,
+      includeTurns: false,
+    })).resolves.toMatchObject({ instanceId: "pwr_owner" });
+    expect(backends.get("pwr_other")?.resolveThread).not.toHaveBeenCalled();
+    expect(backends.get("pwr_owner")?.readThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId,
+      includeTurns: false,
+      limit: 0,
+      viewOnly: true,
+    });
+  });
+
+  it("requires thread_detail on the owning peer", async () => {
+    const { runtime } = buildRuntime({
+      peers: [
+        {
+          instanceId: "pwr_navigation_only",
+          label: "Navigation-only Mac",
+          ownsThread: true,
+          capabilities: ["thread_navigation"],
+        },
+      ],
+    });
+    const handler = createFederatedThreadInspectionHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler({
+      backend: "codex",
+      threadId,
+      limit: 10,
+      includeTurns: true,
+    })).rejects.toThrow(
+      "owns thread 019fdc10-799b-7540-8884-87899f896ebc but does not grant thread_detail",
+    );
+  });
+
+  it("returns peer_unavailable for a remembered disconnected owner", async () => {
+    const runtime = {
+      connectedPeerTargets: () => [],
+      health: vi.fn(async () => ({ peers: [] })),
+    } as unknown as DesktopFederationRuntime;
+    const handler = createFederatedThreadInspectionHandler({
+      runtime: () => runtime,
+      targetStore: {
+        listRemoteThreadTargets: vi.fn(async () => [{
+          instanceId: "pwr_offline",
+          instanceLabel: "Offline Mac",
+          backend: "codex" as const,
+          threadId,
+          firstSeenAt: 1_000,
+          lastSeenAt: 2_000,
+        }]),
+        rememberRemoteThreadTarget: vi.fn(),
+      },
+    });
+
+    await expect(handler({
+      backend: "codex",
+      threadId,
+      limit: 10,
+      includeTurns: true,
+    })).rejects.toMatchObject({
+      code: "peer_unavailable",
+      message: expect.stringContaining("Offline Mac"),
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/federated-thread-inspection-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-inspection-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopFederationRuntime } from "../federation/federation-runtime";
 import { createFederatedThreadInspectionHandler } from "../federation/federated-thread-inspection-service";
 
@@ -14,6 +15,9 @@ function buildRuntime(params: {
     >;
   }>;
 }) {
+  const threadFromPeer = vi.fn(
+    async (): Promise<NavigationThreadSummary | undefined> => undefined,
+  );
   const backends = new Map(
     params.peers.map((peer) => {
       const thread = {
@@ -59,8 +63,9 @@ function buildRuntime(params: {
       })),
     remoteBackend: (target: { instanceId: string }) =>
       backends.get(target.instanceId),
+    remoteThreadSummaries: () => ({ threadFromPeer }),
   } as unknown as DesktopFederationRuntime;
-  return { backends, runtime };
+  return { backends, runtime, threadFromPeer };
 }
 
 describe("federated thread inspection service", () => {
@@ -142,6 +147,60 @@ describe("federated thread inspection service", () => {
       includeTurns: false,
       limit: 0,
       viewOnly: true,
+    });
+  });
+
+  it("includes the enriched owner navigation summary when available", async () => {
+    const { runtime, threadFromPeer } = buildRuntime({
+      peers: [{
+        instanceId: "pwr_owner",
+        label: "Owner Mac",
+        ownsThread: true,
+      }],
+    });
+    threadFromPeer.mockResolvedValue({
+      source: "codex",
+      id: threadId,
+      title: "Remote collector result",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      agent: {
+        name: "Collector",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1_000,
+      },
+      prs: [{
+        provider: "github.com",
+        org: "pwrdrvr",
+        repo: "PwrAgent",
+        number: 1317,
+        state: "passing",
+        url: "https://github.com/pwrdrvr/PwrAgent/pull/1317",
+      }],
+    });
+    const handler = createFederatedThreadInspectionHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler({
+      backend: "codex",
+      threadId,
+      instanceId: "pwr_owner",
+      limit: 0,
+      includeTurns: false,
+    })).resolves.toMatchObject({
+      summary: {
+        id: threadId,
+        agent: { name: "Collector" },
+        prs: [{ number: 1317 }],
+      },
+    });
+    expect(threadFromPeer).toHaveBeenCalledWith({
+      target: { scope: "remote", instanceId: "pwr_owner" },
+      backend: "codex",
+      threadId,
     });
   });
 

--- a/apps/desktop/src/main/__tests__/federated-thread-message-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-message-service.test.ts
@@ -253,6 +253,47 @@ describe("federated thread message service", () => {
     });
   });
 
+  it("does not dispatch to a thread that exists only in the remote archive", async () => {
+    const archivedThread = {
+      source: "codex" as const,
+      id: request.threadId,
+      title: "Archived remote work",
+      archivedAt: 2_000,
+      linkedDirectories: [],
+    };
+    const listThreads = vi.fn(async (params?: { archived?: boolean }) => ({
+      backend: "codex" as const,
+      fetchedAt: 1_000,
+      threads: params?.archived ? [archivedThread] : [],
+    }));
+    const startTurn = vi.fn();
+    const runtime = {
+      connectedPeerTargets: () => [{
+        target: { scope: "remote" as const, instanceId: "pwr_archive" },
+        label: "Archive Mac",
+        capabilities: ["thread_navigation", "turn_control"],
+      }],
+      remoteBackend: () => ({
+        resolveThread: vi.fn(async () => {
+          throw new Error("Unsupported federation method: backend.resolveThread");
+        }),
+        listThreads,
+        startTurn,
+      }),
+    } as unknown as DesktopFederationRuntime;
+    const handler = createFederatedThreadMessageHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler(request)).resolves.toBeUndefined();
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(listThreads).toHaveBeenCalledWith({ backend: "codex" });
+    expect(listThreads).not.toHaveBeenCalledWith({
+      backend: "codex",
+      archived: true,
+    });
+  });
+
   it("preserves queued delivery metadata from the owning peer", async () => {
     const { backends, runtime } = buildRuntime({
       peers: [{

--- a/apps/desktop/src/main/__tests__/federated-thread-mutation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-mutation-service.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopFederationRuntime } from "../federation/federation-runtime";
+import { createFederatedThreadMutationHandler } from "../federation/federated-thread-mutation-service";
+
+describe("federated thread mutation service", () => {
+  it("routes every requested mutation to the owning peer", async () => {
+    const thread = {
+      source: "codex" as const,
+      id: "remote-thread",
+      title: "Remote thread",
+      linkedDirectories: [],
+    };
+    const backend = {
+      resolveThread: vi.fn(async () => ({ thread })),
+      renameThread: vi.fn(async (request) => request),
+      setThreadModelSettings: vi.fn(async (request) => request),
+      setThreadExecutionMode: vi.fn(async (request) => request),
+    };
+    const runtime = {
+      connectedPeerTargets: () => [{
+        target: { scope: "remote" as const, instanceId: "pwr_owner" },
+        label: "Owner Mac",
+        capabilities: ["thread_navigation", "turn_control"],
+      }],
+      remoteBackend: () => backend,
+    } as unknown as DesktopFederationRuntime;
+    const handler = createFederatedThreadMutationHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler({
+      backend: "codex",
+      threadId: "remote-thread",
+      title: "Renamed remotely",
+      modelSettings: { model: "gpt-5.6", fastMode: true },
+      executionMode: "full-access",
+      dryRun: false,
+    })).resolves.toEqual({
+      instanceId: "pwr_owner",
+      instanceLabel: "Owner Mac",
+    });
+    expect(backend.renameThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "remote-thread",
+      name: "Renamed remotely",
+    });
+    expect(backend.setThreadModelSettings).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "remote-thread",
+      model: "gpt-5.6",
+      fastMode: true,
+    });
+    expect(backend.setThreadExecutionMode).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "remote-thread",
+      executionMode: "full-access",
+    });
+  });
+
+  it("resolves and validates a remote dry run without mutating it", async () => {
+    const backend = {
+      resolveThread: vi.fn(async () => ({
+        thread: {
+          source: "codex" as const,
+          id: "remote-thread",
+          title: "Remote thread",
+          linkedDirectories: [],
+        },
+      })),
+      renameThread: vi.fn(),
+      setThreadModelSettings: vi.fn(),
+      setThreadExecutionMode: vi.fn(),
+    };
+    const runtime = {
+      connectedPeerTargets: () => [{
+        target: { scope: "remote" as const, instanceId: "pwr_owner" },
+        label: "Owner Mac",
+        capabilities: ["thread_navigation", "turn_control"],
+      }],
+      remoteBackend: () => backend,
+    } as unknown as DesktopFederationRuntime;
+    const handler = createFederatedThreadMutationHandler({
+      runtime: () => runtime,
+    });
+
+    await handler({
+      backend: "codex",
+      threadId: "remote-thread",
+      title: "Dry run",
+      dryRun: true,
+    });
+
+    expect(backend.renameThread).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -143,6 +143,7 @@ const setPwrAgentAppManagementHandlerMock = vi.fn();
 const setPwrAgentFederationHandlerMock = vi.fn();
 const setFederatedThreadMessageHandlerMock = vi.fn();
 const setFederatedThreadInspectionHandlerMock = vi.fn();
+const setFederatedThreadMutationHandlerMock = vi.fn();
 const listThreadsMock = vi.fn<(request?: unknown) => Promise<unknown[]>>();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
 const registerMessagingStatusIpcHandlersMock = vi.fn();
@@ -489,6 +490,7 @@ vi.mock("../app-server/backend-registry", () => ({
     setFederatedThreadMessageHandler: setFederatedThreadMessageHandlerMock,
     setFederatedThreadInspectionHandler:
       setFederatedThreadInspectionHandlerMock,
+    setFederatedThreadMutationHandler: setFederatedThreadMutationHandlerMock,
     setMessagingArchiveCleaner: setMessagingArchiveCleanerMock,
   })),
 }));
@@ -676,6 +678,7 @@ describe("bootstrapApp", () => {
     setPwrAgentFederationHandlerMock.mockReset();
     setFederatedThreadMessageHandlerMock.mockReset();
     setFederatedThreadInspectionHandlerMock.mockReset();
+    setFederatedThreadMutationHandlerMock.mockReset();
     listThreadsMock.mockReset();
     listThreadsMock.mockResolvedValue([]);
     disposeDesktopMessagingRuntimeMock.mockReset();

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -142,6 +142,7 @@ const setMessagingAgentToolServiceMock = vi.fn();
 const setPwrAgentAppManagementHandlerMock = vi.fn();
 const setPwrAgentFederationHandlerMock = vi.fn();
 const setFederatedThreadMessageHandlerMock = vi.fn();
+const setFederatedThreadInspectionHandlerMock = vi.fn();
 const listThreadsMock = vi.fn<(request?: unknown) => Promise<unknown[]>>();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
 const registerMessagingStatusIpcHandlersMock = vi.fn();
@@ -486,6 +487,8 @@ vi.mock("../app-server/backend-registry", () => ({
     setPwrAgentAppManagementHandler: setPwrAgentAppManagementHandlerMock,
     setPwrAgentFederationHandler: setPwrAgentFederationHandlerMock,
     setFederatedThreadMessageHandler: setFederatedThreadMessageHandlerMock,
+    setFederatedThreadInspectionHandler:
+      setFederatedThreadInspectionHandlerMock,
     setMessagingArchiveCleaner: setMessagingArchiveCleanerMock,
   })),
 }));
@@ -672,6 +675,7 @@ describe("bootstrapApp", () => {
     setPwrAgentAppManagementHandlerMock.mockReset();
     setPwrAgentFederationHandlerMock.mockReset();
     setFederatedThreadMessageHandlerMock.mockReset();
+    setFederatedThreadInspectionHandlerMock.mockReset();
     listThreadsMock.mockReset();
     listThreadsMock.mockResolvedValue([]);
     disposeDesktopMessagingRuntimeMock.mockReset();

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -28,7 +28,10 @@ import type {
   SubmitServerRequestRequest,
   UpdateDirectoryLaunchpadRequest,
 } from "@pwragent/shared";
-import { applyNavigationLaunchpadProviderSettingsPatch } from "@pwragent/shared";
+import {
+  applyNavigationLaunchpadProviderSettingsPatch,
+  buildFederatedThreadRef,
+} from "@pwragent/shared";
 import {
   MESSAGING_CALLBACK_HANDLE_TTL_MS,
   type MessagingCapabilityProfile,
@@ -4039,6 +4042,80 @@ describe("MessagingController", () => {
       },
       targetKind: "thread",
       threadId: "thread-2",
+    });
+  });
+
+  it("attaches a remotely resolved thread with its Federation owner", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads.push({
+      id: "remote-thread",
+      title: "Remote collector",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      updatedAt: 2_000,
+    });
+    const resolveThreadTarget = vi.fn(async () => ({
+      navigation,
+      thread: navigation.threads.at(-1)!,
+      federatedThread: buildFederatedThreadRef({
+        backend: "codex",
+        threadId: "remote-thread",
+        instanceId: "pwr_remote",
+      }),
+    }));
+    const harness = await createHarness({ resolveThreadTarget });
+    const event = buildTextEvent("attach remote here");
+    await harness.store.upsertBinding({
+      id: "binding:source",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: event.channel,
+      createdAt: 1_000,
+      routingState: event.routingState,
+      targetKind: "agent_thread",
+      threadId: "thread-1",
+      updatedAt: 1_000,
+    });
+    await harness.controller.handleInboundEvent(event);
+
+    await expect(harness.controller.handlePwrAgentMessagingRequest({
+      operation: "attach_thread_here",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      args: {
+        backend: "codex",
+        threadId: "remote-thread",
+        instanceId: "pwr_remote",
+        placement: "current_conversation",
+      },
+    })).resolves.toMatchObject({
+      ok: true,
+      data: {
+        binding: { threadId: "remote-thread" },
+        placement: "current_conversation",
+      },
+    });
+    expect(resolveThreadTarget).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "remote-thread",
+      instanceId: "pwr_remote",
+      includeRemote: true,
+    });
+    await expect(
+      harness.store.findActiveBindingForChannel(event.channel),
+    ).resolves.toMatchObject({
+      backend: "codex",
+      threadId: "remote-thread",
+      federatedThread: {
+        backend: "codex",
+        threadId: "remote-thread",
+        target: { scope: "remote", instanceId: "pwr_remote" },
+      },
     });
   });
 
@@ -20868,6 +20945,7 @@ async function createHarness(options?: {
   readThreadLastAssistantReply?: NonNullable<
     MessagingBackendBridge["readThreadLastAssistantReply"]
   >;
+  resolveThreadTarget?: NonNullable<MessagingBackendBridge["resolveThreadTarget"]>;
   resolveAssistantMessageImages?: NonNullable<
     MessagingBackendBridge["resolveAssistantMessageImages"]
   >;
@@ -21351,6 +21429,9 @@ async function createHarness(options?: {
     readThreadLastAssistantReply,
     readThreadLastAssistantMessage,
     readThreadStatus,
+    ...(options?.resolveThreadTarget
+      ? { resolveThreadTarget: options.resolveThreadTarget }
+      : {}),
     ...(options?.resolveAssistantMessageImages
       ? { resolveAssistantMessageImages: options.resolveAssistantMessageImages }
       : {}),

--- a/apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts
@@ -68,6 +68,17 @@ describe("PwrAgent messaging agent tools", () => {
       "send_private_response",
       "attach_thread_here",
     ]);
+    const attachTool = specs[0]?.type === "namespace"
+      ? specs[0].tools.find((tool) => tool.name === "attach_thread_here")
+      : undefined;
+    expect(attachTool).toMatchObject({
+      inputSchema: expect.objectContaining({
+        properties: expect.objectContaining({
+          instanceId: expect.objectContaining({ type: "string" }),
+          includeRemote: expect.objectContaining({ type: "boolean" }),
+        }),
+      }),
+    });
     expect(
       isPwrAgentMessagingDynamicToolCall({
         namespace: "pwragent_messaging",

--- a/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
@@ -70,6 +70,16 @@ describe("PwrAgent thread agent tools", () => {
           }),
         }),
       });
+    for (const name of ["search_threads", "mutate_thread"]) {
+      expect(tools.find((tool) => tool.name === name)).toMatchObject({
+        inputSchema: expect.objectContaining({
+          properties: expect.objectContaining({
+            instanceId: expect.objectContaining({ type: "string" }),
+            includeRemote: expect.objectContaining({ type: "boolean" }),
+          }),
+        }),
+      });
+    }
 
     await expect(
       router.handleDynamicToolCall({

--- a/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
@@ -52,6 +52,24 @@ describe("PwrAgent thread agent tools", () => {
         name: "watch_thread_pull_request",
         description: expect.stringContaining("end the current turn"),
       });
+    expect(tools.find((tool) => tool.name === "read_thread")).toMatchObject({
+      description: expect.stringContaining("connected Federation peer"),
+      inputSchema: expect.objectContaining({
+        properties: expect.objectContaining({
+          instanceId: expect.objectContaining({ type: "string" }),
+          includeRemote: expect.objectContaining({ type: "boolean" }),
+        }),
+      }),
+    });
+    expect(tools.find((tool) => tool.name === "get_thread_status"))
+      .toMatchObject({
+        inputSchema: expect.objectContaining({
+          properties: expect.objectContaining({
+            instanceId: expect.objectContaining({ type: "string" }),
+            includeRemote: expect.objectContaining({ type: "boolean" }),
+          }),
+        }),
+      });
 
     await expect(
       router.handleDynamicToolCall({

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts
@@ -60,6 +60,11 @@ describe("pwragent federation agent tools", () => {
             inputSchema: expect.objectContaining({
               required: ["query"],
               properties: expect.objectContaining({
+                backend: expect.objectContaining({ type: "string" }),
+                includeArchived: expect.objectContaining({ type: "boolean" }),
+                projectKeys: expect.objectContaining({ type: "array" }),
+                updatedAfter: expect.objectContaining({ type: "integer" }),
+                updatedBefore: expect.objectContaining({ type: "integer" }),
                 scope: expect.objectContaining({
                   enum: ["all", "local", "remote"],
                 }),
@@ -303,6 +308,8 @@ describe("pwragent federation agent tools", () => {
       ok: true as const,
       data: {
         query: "recorder crash",
+        totalCount: 0,
+        truncated: false,
         results: [],
         searchedInstances: [],
         failures: [],
@@ -318,7 +325,16 @@ describe("pwragent federation agent tools", () => {
         callId: "call-1",
         namespace: "pwragent",
         tool: "search_federation_threads",
-        arguments: { query: " recorder crash ", instanceId: " pwr_studio ", limit: 5 },
+        arguments: {
+          query: " recorder crash ",
+          backend: "codex",
+          includeArchived: true,
+          projectKeys: [" PwrAgent "],
+          updatedAfter: 1_000,
+          updatedBefore: 2_000,
+          instanceId: " pwr_studio ",
+          limit: 5,
+        },
       },
     });
 
@@ -332,6 +348,11 @@ describe("pwragent federation agent tools", () => {
       },
       args: {
         query: "recorder crash",
+        backend: "codex",
+        includeArchived: true,
+        projectKeys: ["PwrAgent"],
+        updatedAfter: 1_000,
+        updatedBefore: 2_000,
         instanceId: "pwr_studio",
         limit: 5,
       },

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
@@ -106,6 +106,7 @@ describe("pwragent thread orchestration agent tools", () => {
               required: ["backend", "threadId", "prompt"],
               properties: expect.objectContaining({
                 instanceId: expect.objectContaining({ type: "string" }),
+                includeRemote: expect.objectContaining({ type: "boolean" }),
               }),
             }),
           }),
@@ -517,6 +518,7 @@ describe("pwragent thread orchestration agent tools", () => {
           backend: "codex",
           threadId: " target-thread ",
           instanceId: " pwr_studio ",
+          includeRemote: true,
           prompt: " Check CI ",
           model: " gpt-5.5 ",
           fastMode: true,
@@ -536,6 +538,7 @@ describe("pwragent thread orchestration agent tools", () => {
         backend: "codex",
         threadId: "target-thread",
         instanceId: "pwr_studio",
+        includeRemote: true,
         prompt: "Check CI",
         model: "gpt-5.5",
         fastMode: true,

--- a/apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts
@@ -11,6 +11,7 @@ import type {
 } from "@pwragent/shared";
 import {
   FEDERATION_SEARCH_SCOPES,
+  isAppServerBackendKind,
   PWRAGENT_FEDERATION_OPERATION_NAMES,
   PWRAGENT_TOOL_NAMESPACE,
 } from "@pwragent/shared";
@@ -98,7 +99,7 @@ function descriptionForOperation(
     case "create_instance_thread":
       return "Create and start a new PwrAgent thread in a project on a chosen instance, local or remote. Pass instanceId from list_federation_instances and projectKey from list_instance_projects; input becomes the first prompt of the created thread. Omitted settings inherit the project's launchpad presets, then the instance defaults — only pass model/executionMode/workMode overrides the user asked for. Consult ~/.pwragent/AGENTS.md (when it exists) for the operator's thread-startup preferences such as default projects and settings before choosing values. For delegating work on the local instance from an ordinary thread, prefer handoff_task, which offers richer workspace and grouping options; use create_instance_thread when targeting another instance or when routing intake work by instance. Thread startup can take minutes while a worktree or environment is prepared; if this call is slow, do not call it again — use search_federation_threads to check whether the thread appeared. The result includes threadLink and instanceId. Include threadLink verbatim when telling the user about the thread so it renders as a clickable chip, and preserve instanceId when passing the remote target to send_message_to_thread.";
     case "search_federation_threads":
-      return "Search threads across every reachable PwrAgent instance, including the local one, in a single call — use it to find 'the PwrSnap thread about X' wherever it lives. Use scope to pick the search surface: `all` (default) is local plus every connected peer, `local` is this instance only, and `remote` is every connected peer excluding local — the right choice when the user knows the thread is not on this machine. Pass instanceId to target one specific instance; scope and instanceId intersect when both are given. Results carry the owning instanceId, its display label, an isLocal flag, and a threadLink that preserves cross-instance routing; failures lists peers that could not be searched. This is a metadata search (titles, summaries, project paths). For deeper local-only search with transcript content modes, use search_threads instead. Include threadLink verbatim when mentioning a result so it renders as a clickable chip, and preserve instanceId when passing a remote target to send_message_to_thread.";
+      return "Search threads across every reachable PwrAgent instance, including the local one, in a single call — use it to find 'the PwrSnap thread about X' wherever it lives. Use scope to pick the search surface: `all` (default) is local plus every connected peer, `local` is this instance only, and `remote` is every connected peer excluding local — the right choice when the user knows the thread is not on this machine. Pass instanceId to target one specific instance; scope and instanceId intersect when both are given. Backend, project, archive, and update-time filters are applied on each instance before the global result limit. Results carry the owning instanceId, its display label, an isLocal flag, and a threadLink that preserves cross-instance routing; failures lists peers that could not be searched. This is a metadata search (titles, summaries, project paths). For deeper local-only search with transcript content modes, use search_threads instead. Include threadLink verbatim when mentioning a result so it renders as a clickable chip, and preserve instanceId when passing a remote target to send_message_to_thread.";
   }
 }
 
@@ -189,6 +190,31 @@ function inputSchemaForOperation(
             type: "string",
             description: "Search text matched against thread titles, summaries, and project paths.",
           },
+          backend: {
+            type: "string",
+            description:
+              "Backend to search. Defaults to all known PwrAgent backends.",
+          },
+          includeArchived: {
+            type: "boolean",
+            description:
+              "When true, search active threads plus archived threads. Defaults to active threads only.",
+          },
+          projectKeys: {
+            type: "array",
+            items: { type: "string" },
+            description: "Exact PwrAgent project keys to require.",
+          },
+          updatedAfter: {
+            type: "integer",
+            description:
+              "Only include threads updated at or after this Unix epoch millisecond timestamp.",
+          },
+          updatedBefore: {
+            type: "integer",
+            description:
+              "Only include threads updated at or before this Unix epoch millisecond timestamp.",
+          },
           scope: {
             type: "string",
             enum: FEDERATION_SEARCH_SCOPES,
@@ -243,7 +269,7 @@ function invalidArgumentsMessageForOperation(
     case "create_instance_thread":
       return "create_instance_thread requires non-empty instanceId and projectKey strings, and accepts only known workMode values.";
     case "search_federation_threads":
-      return "search_federation_threads requires a non-empty query string; scope must be all, local, or remote; limit must be an integer between 1 and 200.";
+      return "search_federation_threads requires a non-empty query string; scope must be all, local, or remote; backend and filters must be valid; limit must be an integer between 1 and 200.";
   }
 }
 
@@ -363,12 +389,59 @@ function normalizeSearchFederationThreadsArgs(
     limit = args.limit;
   }
   const instanceId = readTrimmedString(args.instanceId);
+  let backend: SearchFederationThreadsToolArgs["backend"];
+  if (args.backend !== undefined) {
+    if (
+      typeof args.backend !== "string"
+      || (args.backend !== "all" && !isAppServerBackendKind(args.backend))
+    ) {
+      return undefined;
+    }
+    backend = args.backend;
+  }
+  if (
+    args.includeArchived !== undefined
+    && typeof args.includeArchived !== "boolean"
+  ) {
+    return undefined;
+  }
+  const projectKeys = readNonEmptyStringArray(args.projectKeys);
+  if (args.projectKeys !== undefined && !projectKeys) {
+    return undefined;
+  }
+  for (const field of ["updatedAfter", "updatedBefore"] as const) {
+    if (
+      args[field] !== undefined
+      && (typeof args[field] !== "number" || !Number.isInteger(args[field]))
+    ) {
+      return undefined;
+    }
+  }
   return {
     query,
+    ...(backend ? { backend } : {}),
+    ...(args.includeArchived === true ? { includeArchived: true } : {}),
+    ...(projectKeys ? { projectKeys } : {}),
+    ...(typeof args.updatedAfter === "number"
+      ? { updatedAfter: args.updatedAfter }
+      : {}),
+    ...(typeof args.updatedBefore === "number"
+      ? { updatedBefore: args.updatedBefore }
+      : {}),
     ...(scope ? { scope: scope as FederationSearchScope } : {}),
     ...(instanceId ? { instanceId } : {}),
     ...(limit !== undefined ? { limit } : {}),
   };
+}
+
+function readNonEmptyStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value) || value.length === 0) {
+    return undefined;
+  }
+  const strings = value.map(readTrimmedString);
+  return strings.every((entry): entry is string => Boolean(entry))
+    ? strings
+    : undefined;
 }
 
 function readTrimmedString(value: unknown): string | undefined {

--- a/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
@@ -121,7 +121,7 @@ function descriptionForOperation(operation: PwrAgentMessagingOperationName): str
     case "send_private_response":
       return "Send the terminal response privately to the user who initiated the current messaging turn. Use this only when the user explicitly asks for a private reply or the response contains secrets that should not be posted to the source conversation. On success, PwrAgent suppresses the normal final response on the source surface; end the turn without repeating the private content. Set awaitReply=true with replyInstructions when the private message asks the user for a response: their first reply starts a one-shot continuation turn whose final answer is delivered back to the originating surface, and PwrAgent then removes the temporary private-thread route. This cannot target an arbitrary user or be called outside an active messaging turn.";
     case "attach_thread_here":
-      return "Attach a known PwrAgent thread to the current messaging surface, creating a native child thread/topic when the provider supports it. This does not rename the PwrAgent thread.";
+      return "Attach a known PwrAgent thread to the current messaging surface, creating a native child thread/topic when the provider supports it. Pass instanceId for a remote thread when known; otherwise PwrAgent checks the local instance and then resolves a remembered or connected Federation peer. This does not rename the PwrAgent thread.";
     case "inspect_messaging_pdfs":
       return "List PDF attachments available only for the current active PwrAgent turn. The initial turn input already includes page metadata when probing succeeded; call this only for an attachment whose metadata was unavailable. Returns local metadata and render limits, not PDF bytes or extracted document text. In Codex Code Mode, JSON.parse the returned string; native MCP callers receive the response directly.";
     case "search_messaging_pdf_text":
@@ -179,6 +179,16 @@ function inputSchemaForOperation(
             type: "string",
           },
           threadId: { type: "string" },
+          instanceId: {
+            type: "string",
+            description:
+              "Federation instance that owns the thread. Omit to check the local instance, then remembered and connected peers.",
+          },
+          includeRemote: {
+            type: "boolean",
+            description:
+              "Whether to resolve the thread across connected Federation peers after checking locally. Defaults to true.",
+          },
           title: {
             type: "string",
             description:

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
@@ -3,6 +3,7 @@ import type {
   AppServerReadThreadResponse,
   AppServerThreadSummary,
   FederationInstanceId,
+  NavigationThreadSummary,
   SetThreadModelSettingsRequest,
   ThreadExecutionMode,
   PwrAgentThreadInspectionOperationName,
@@ -43,6 +44,8 @@ export type PwrAgentFederatedThreadInspectionResult = {
   instanceId: FederationInstanceId;
   instanceLabel: string;
   thread: AppServerThreadSummary;
+  /** Enriched owner navigation row when the thread is active and available. */
+  summary?: NavigationThreadSummary;
   read: AppServerReadThreadResponse;
 };
 

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
@@ -3,6 +3,8 @@ import type {
   AppServerReadThreadResponse,
   AppServerThreadSummary,
   FederationInstanceId,
+  SetThreadModelSettingsRequest,
+  ThreadExecutionMode,
   PwrAgentThreadInspectionOperationName,
   PwrAgentThreadInspectionRequest,
   PwrAgentThreadInspectionResponse,
@@ -47,6 +49,25 @@ export type PwrAgentFederatedThreadInspectionResult = {
 export type PwrAgentFederatedThreadInspectionHandler = (
   request: PwrAgentFederatedThreadInspectionRequest,
 ) => Promise<PwrAgentFederatedThreadInspectionResult | undefined>;
+
+export type PwrAgentFederatedThreadMutationRequest = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  instanceId?: FederationInstanceId;
+  title?: string;
+  modelSettings?: Omit<SetThreadModelSettingsRequest, "backend" | "threadId">;
+  executionMode?: ThreadExecutionMode;
+  dryRun: boolean;
+};
+
+export type PwrAgentFederatedThreadMutationResult = {
+  instanceId: FederationInstanceId;
+  instanceLabel: string;
+};
+
+export type PwrAgentFederatedThreadMutationHandler = (
+  request: PwrAgentFederatedThreadMutationRequest,
+) => Promise<PwrAgentFederatedThreadMutationResult | undefined>;
 
 export class PwrAgentFederatedThreadInspectionError extends Error {
   constructor(
@@ -105,7 +126,7 @@ function descriptionForOperation(
 ): string {
   switch (operation) {
     case "search_threads":
-      return "Search known PwrAgent threads by title, summary, Agent metadata, backend, and linked directory. Omit query to inspect recent lightweight thread candidates before choosing a thread. The response may include pendingHandoffs for handoff_task calls that are still creating a child thread and pendingWorkspaceMoves for move_thread_workspace calls that are still moving the same thread; do not retry those operations while they are starting.";
+      return "Search known PwrAgent threads by title, summary, Agent metadata, backend, and linked directory. By default PwrAgent combines local results with metadata matches from connected Federation instances; pass instanceId to target one instance or includeRemote=false to search locally only. Omit query to inspect recent lightweight thread candidates before choosing a thread. Advanced transcript, semantic, Agent, model, and directory filters remain local-only. The response may include pendingHandoffs for handoff_task calls that are still creating a child thread and pendingWorkspaceMoves for move_thread_workspace calls that are still moving the same thread; do not retry those operations while they are starting.";
     case "read_thread":
       return "Read a bounded page of another known PwrAgent thread's recent transcript and activity. Use search_threads first when the threadId is unknown. Pass instanceId for a remote thread when known; otherwise PwrAgent checks the local instance and then resolves a remembered or connected Federation peer.";
     case "get_thread_status":
@@ -117,7 +138,7 @@ function descriptionForOperation(
     case "watch_thread_pull_request":
       return "Create a durable one-shot watch for a pull request attached to the thread's primary workspace at its current head. PwrAgent starts one follow-up turn on the first requested terminal outcome: an early CI failure or merge conflict, or full CI success. Informational PRs from secondary linked repositories are not eligible. If several threads watch the same PR and head, the oldest watch receives the result and the others are satisfied without duplicate turns. If the current provider snapshot is already terminal, the result returns currentOutcome immediately without creating a watch. Omit backend and threadId for the current thread, and omit url only when exactly one eligible PR is attached. After a watch is created, end the current turn—do not poll CI and do not create a monitor thread. When Auto-fix PR is active at failure time, its repair dispatch satisfies the failure wake-up so the watch does not create a duplicate turn.";
     case "mutate_thread":
-      return "Mutate guarded PwrAgent thread settings such as the PwrAgent thread title, model settings, or execution mode. This does not rename any attached Telegram topic, Discord thread, or other messaging surface.";
+      return "Mutate guarded PwrAgent thread settings such as the PwrAgent thread title, model settings, or execution mode. Pass instanceId for a remote thread when known; otherwise PwrAgent checks the local instance and then resolves a remembered or connected Federation peer. This does not rename any attached Telegram topic, Discord thread, or other messaging surface.";
   }
 }
 
@@ -139,6 +160,16 @@ function inputSchemaForOperation(
             type: "string",
             description:
               "Backend to search. Defaults to all known PwrAgent backends.",
+          },
+          instanceId: {
+            type: "string",
+            description:
+              "Restrict the search to one connected Federation instance. Omit to combine local and connected remote results.",
+          },
+          includeRemote: {
+            type: "boolean",
+            description:
+              "Whether to include metadata matches from connected Federation instances. Defaults to true.",
           },
           includeArchived: {
             type: "boolean",
@@ -404,6 +435,16 @@ function inputSchemaForOperation(
             type: "string",
           },
           threadId: { type: "string" },
+          instanceId: {
+            type: "string",
+            description:
+              "Federation instance that owns the thread. Omit to check the local instance, then remembered and connected peers.",
+          },
+          includeRemote: {
+            type: "boolean",
+            description:
+              "Whether to resolve the thread across connected Federation peers after checking locally. Defaults to true.",
+          },
           title: {
             type: "string",
             description:

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
@@ -1,4 +1,8 @@
 import type {
+  AppServerBackendKind,
+  AppServerReadThreadResponse,
+  AppServerThreadSummary,
+  FederationInstanceId,
   PwrAgentThreadInspectionOperationName,
   PwrAgentThreadInspectionRequest,
   PwrAgentThreadInspectionResponse,
@@ -23,6 +27,36 @@ export const PWRAGENT_THREAD_INSPECTION_UNAVAILABLE_MESSAGE =
 export type PwrAgentThreadInspectionHandler = (
   request: PwrAgentThreadInspectionRequest,
 ) => PwrAgentThreadInspectionResponse | Promise<PwrAgentThreadInspectionResponse>;
+
+export type PwrAgentFederatedThreadInspectionRequest = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  instanceId?: FederationInstanceId;
+  before?: string;
+  limit: number;
+  includeTurns: boolean;
+};
+
+export type PwrAgentFederatedThreadInspectionResult = {
+  instanceId: FederationInstanceId;
+  instanceLabel: string;
+  thread: AppServerThreadSummary;
+  read: AppServerReadThreadResponse;
+};
+
+export type PwrAgentFederatedThreadInspectionHandler = (
+  request: PwrAgentFederatedThreadInspectionRequest,
+) => Promise<PwrAgentFederatedThreadInspectionResult | undefined>;
+
+export class PwrAgentFederatedThreadInspectionError extends Error {
+  constructor(
+    readonly code: "peer_unavailable",
+    message: string,
+  ) {
+    super(message);
+    this.name = "PwrAgentFederatedThreadInspectionError";
+  }
+}
 
 export function buildPwrAgentThreadToolRouter(
   handler: PwrAgentThreadInspectionHandler | undefined,
@@ -73,9 +107,9 @@ function descriptionForOperation(
     case "search_threads":
       return "Search known PwrAgent threads by title, summary, Agent metadata, backend, and linked directory. Omit query to inspect recent lightweight thread candidates before choosing a thread. The response may include pendingHandoffs for handoff_task calls that are still creating a child thread and pendingWorkspaceMoves for move_thread_workspace calls that are still moving the same thread; do not retry those operations while they are starting.";
     case "read_thread":
-      return "Read a bounded page of another known PwrAgent thread's recent transcript and activity. Use search_threads first when the threadId is unknown.";
+      return "Read a bounded page of another known PwrAgent thread's recent transcript and activity. Use search_threads first when the threadId is unknown. Pass instanceId for a remote thread when known; otherwise PwrAgent checks the local instance and then resolves a remembered or connected Federation peer.";
     case "get_thread_status":
-      return "Read status and compact metadata for a PwrAgent thread, including linked directories, repository groups, pull requests, live PR automation state, pendingHandoffs when this thread has child handoffs that are still being created, and pendingWorkspaceMoves when this thread has same-thread workspace moves in progress. Omit backend and threadId to inspect the current thread; use this for questions like which directories or projects this thread is attached to. Follow prAutomation.guidance: when Auto-fix PR is active, do not poll CI or create a monitor thread.";
+      return "Read status and compact metadata for a PwrAgent thread, including linked directories, repository groups, pull requests, live PR automation state, pendingHandoffs when this thread has child handoffs that are still being created, and pendingWorkspaceMoves when this thread has same-thread workspace moves in progress. Omit backend and threadId to inspect the current thread; pass instanceId for a remote thread when known. Follow prAutomation.guidance: when Auto-fix PR is active, do not poll CI or create a monitor thread.";
     case "attach_thread_pull_request":
       return "Attach a pull request reference to a PwrAgent thread. Omit backend and threadId to attach to the current thread. Use this when a PR was created outside the thread's current working directory or automatic branch-based discovery will not see it. Accepts a full PR/MR URL, a full provider/org/repo/number identity, or a bare number when the thread has exactly one inferable repository.";
     case "check_thread_pull_request_status":
@@ -180,6 +214,16 @@ function inputSchemaForOperation(
             description:
               "Thread id to inspect. Defaults to the invoking PwrAgent thread id.",
           },
+          instanceId: {
+            type: "string",
+            description:
+              "Federation instance that owns the thread. Omit to check the local instance, then remembered and connected peers.",
+          },
+          includeRemote: {
+            type: "boolean",
+            description:
+              "Whether to resolve the thread across connected Federation peers after checking locally. Defaults to true.",
+          },
         },
       };
     case "read_thread":
@@ -192,6 +236,16 @@ function inputSchemaForOperation(
             type: "string",
           },
           threadId: { type: "string" },
+          instanceId: {
+            type: "string",
+            description:
+              "Federation instance that owns the thread. Omit to check the local instance, then remembered and connected peers.",
+          },
+          includeRemote: {
+            type: "boolean",
+            description:
+              "Whether to resolve the thread across connected Federation peers after checking locally. Defaults to true.",
+          },
           before: {
             type: "string",
             description:

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -155,7 +155,7 @@ function descriptionForOperation(
     case "move_thread_workspace":
       return "Move the current PwrAgent thread runtime workspace after the invoking turn reaches a terminal boundary. Use this when the user asks to continue this same thread from an isolated worktree instead of creating a child handoff thread. The operation is path-keyed: pass sourcePath when the thread has multiple linked directories or when the intended workspace is not obvious. The tool returns a pending workspaceMoveId and stop-and-wait guidance; after the current turn ends, PwrAgent performs the move, updates future-turn cwd metadata, rebinds an ACP session when required, and starts a same-thread continuation with the result. Do not keep editing after a successful call in the invoking turn; wait for the continuation or inspect get_thread_status pendingWorkspaceMoves.";
     case "send_message_to_thread":
-      return "Send a follow-up prompt to another existing PwrAgent thread. Use search_threads or read_thread first when the target threadId is unknown. Pass instanceId when a remote create/search result or thread link supplied it; omit it for local threads and older results, which PwrAgent resolves through durable ownership metadata and connected-peer discovery. Do not use this for the current thread; reply normally instead. The result includes threadLink, a ready-made markdown link to the target thread. When you mention that thread to the user, include threadLink verbatim instead of the raw threadId so it renders as a clickable chip.";
+      return "Send a follow-up prompt to another existing PwrAgent thread. Use search_threads or read_thread first when the target threadId is unknown. Pass instanceId when a remote create/search result or thread link supplied it; otherwise PwrAgent checks local ownership, durable remote ownership metadata, and connected peers. Set includeRemote=false to restrict resolution to the local instance. Do not use this for the current thread; reply normally instead. The result includes threadLink, a ready-made markdown link to the target thread. When you mention that thread to the user, include threadLink verbatim instead of the raw threadId so it renders as a clickable chip.";
     case "start_review":
       return "Schedule a code review of the invoking PwrAgent thread after the current turn completes successfully. Use this only when the operator explicitly asks for a review. Choose one structured target: uncommittedChanges, baseBranch, commit, or custom. The tool returns a pendingReviewId; after a successful call, stop work and let the current turn finish so PwrAgent can start the review. Do not poll or call the tool again for the same request.";
   }
@@ -353,6 +353,11 @@ function inputSchemaForOperation(
             type: "string",
             description:
               "Owning remote instance id from create_instance_thread, search_federation_threads, or a cross-instance thread link. Omit for local threads or when unknown.",
+          },
+          includeRemote: {
+            type: "boolean",
+            description:
+              "Whether to resolve the target across connected Federation peers. Defaults to true; set false for local-only resolution.",
           },
           prompt: {
             type: "string",
@@ -633,10 +638,22 @@ function normalizeSendMessageToThreadArgs(
   if (Object.hasOwn(args, "instanceId") && !instanceId) {
     return undefined;
   }
+  if (
+    Object.hasOwn(args, "includeRemote")
+    && typeof args.includeRemote !== "boolean"
+  ) {
+    return undefined;
+  }
+  if (instanceId && args.includeRemote === false) {
+    return undefined;
+  }
   return {
     backend: backend as SendMessageToThreadToolArgs["backend"],
     threadId,
     ...(instanceId ? { instanceId } : {}),
+    ...(typeof args.includeRemote === "boolean"
+      ? { includeRemote: args.includeRemote }
+      : {}),
     prompt,
     ...(readTrimmedString(args.model)
       ? { model: readTrimmedString(args.model) }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -184,7 +184,9 @@ import {
   type WatchThreadPullRequestToolArgs,
   type ThreadPullRequestAutomationStatus,
   type DetachThreadDirectoryToolArgs,
+  type GetThreadStatusToolArgs,
   type ReadThreadToolArgs,
+  type PwrAgentThreadInspectionErrorCode,
   type PwrAgentThreadInspectionRequest,
   type PwrAgentThreadInspectionResponse,
   type ThreadReadEntrySummary,
@@ -330,7 +332,12 @@ import {
   isPwrAgentThreadDynamicToolCall,
   readPwrAgentThreadDynamicToolCall,
 } from "../agent-tools/pwragent-thread-codex-tools";
-import type { PwrAgentThreadInspectionHandler } from "../agent-tools/pwragent-thread-agent-tools";
+import {
+  PwrAgentFederatedThreadInspectionError,
+  type PwrAgentFederatedThreadInspectionHandler,
+  type PwrAgentFederatedThreadInspectionResult,
+  type PwrAgentThreadInspectionHandler,
+} from "../agent-tools/pwragent-thread-agent-tools";
 import {
   buildPwrAgentMessagingDynamicToolErrorResponse,
   handlePwrAgentMessagingDynamicToolCall,
@@ -5896,6 +5903,30 @@ function threadOrchestrationFailure(
   };
 }
 
+function threadInspectionFailure(
+  code: PwrAgentThreadInspectionErrorCode,
+  message: string,
+): PwrAgentThreadInspectionResponse {
+  return {
+    ok: false,
+    error: { code, message },
+  };
+}
+
+function federatedThreadInspectionFailure(
+  error: unknown,
+): PwrAgentThreadInspectionResponse {
+  const message = error instanceof Error ? error.message : String(error);
+  return threadInspectionFailure(
+    error instanceof PwrAgentFederatedThreadInspectionError
+      ? error.code
+      : /not found/i.test(message)
+        ? "not_found"
+        : "internal_error",
+    message,
+  );
+}
+
 function buildHandoffTaskPrompt(params: {
   task: string;
   context?: string;
@@ -6395,6 +6426,9 @@ export class DesktopBackendRegistry {
     };
   private readonly threadInspectionHandler: PwrAgentThreadInspectionHandler =
     async (request) => await this.handleThreadInspectionRequest(request);
+  private federatedThreadInspectionHandler:
+    | PwrAgentFederatedThreadInspectionHandler
+    | undefined;
   private readonly threadOrchestrationHandler: PwrAgentThreadOrchestrationHandler =
     async (request) => await this.handleThreadOrchestrationRequest(request);
   private federationHandler: PwrAgentFederationHandler | undefined;
@@ -7121,6 +7155,12 @@ export class DesktopBackendRegistry {
     handler: PwrAgentFederatedThreadMessageHandler | null | undefined,
   ): void {
     this.federatedThreadMessageHandler = handler ?? undefined;
+  }
+
+  setFederatedThreadInspectionHandler(
+    handler: PwrAgentFederatedThreadInspectionHandler | null | undefined,
+  ): void {
+    this.federatedThreadInspectionHandler = handler ?? undefined;
   }
 
   setThreadPullRequestStatusToolHandler(
@@ -22186,11 +22226,18 @@ export class DesktopBackendRegistry {
     }
     const threadId = request.args.threadId.trim();
     const instanceId = request.args.instanceId?.trim();
+    const includeRemote = request.args.includeRemote !== false;
     const prompt = request.args.prompt.trim();
     if (!threadId || !prompt) {
       return threadOrchestrationFailure(
         "invalid_arguments",
         "send_message_to_thread requires non-empty threadId and prompt strings.",
+      );
+    }
+    if (instanceId && !includeRemote) {
+      return threadOrchestrationFailure(
+        "invalid_arguments",
+        "instanceId cannot be used when includeRemote is false.",
       );
     }
     if (
@@ -22250,7 +22297,8 @@ export class DesktopBackendRegistry {
         approvalPolicy: request.args.approvalPolicy,
         sandbox: request.args.sandbox,
       };
-      const rememberedRemoteTurn = this.federatedThreadMessageHandler
+      const rememberedRemoteTurn =
+        includeRemote && this.federatedThreadMessageHandler
         ? await this.federatedThreadMessageHandler({
             ...remoteRequest,
             ...(instanceId
@@ -22285,7 +22333,7 @@ export class DesktopBackendRegistry {
             sandbox: request.args.sandbox,
           });
           targetTitle = localThread.title;
-        } else if (this.federatedThreadMessageHandler) {
+        } else if (includeRemote && this.federatedThreadMessageHandler) {
           const discoveredRemoteTurn = await this.federatedThreadMessageHandler({
             ...remoteRequest,
             resolutionMode: "discover_only",
@@ -24590,86 +24638,11 @@ export class DesktopBackendRegistry {
     }
 
     if (request.operation === "get_thread_status") {
-      const backend = request.args.backend ?? request.context.backend;
-      if (!isAppServerBackendKind(backend)) {
-        return {
-          ok: false,
-          error: {
-            code: "invalid_arguments",
-            message: "backend must be a known PwrAgent backend.",
-          },
-        };
-      }
-      const threadId = request.args.threadId?.trim() || request.context.threadId;
-      if (!threadId) {
-        return {
-          ok: false,
-          error: {
-            code: "invalid_arguments",
-            message: "threadId is required.",
-          },
-        };
-      }
-      const activeThreads = await this.listThreads({
-        backend,
-        archived: false,
-        callerReason: "agent-thread-inspection",
+      return await this.handleGetThreadStatusInspectionRequest({
+        ...request.args,
+        backend: request.args.backend ?? request.context.backend,
+        threadId: request.args.threadId ?? request.context.threadId,
       });
-      let candidateThreads = activeThreads.filter((thread) => thread.id === threadId);
-      if (candidateThreads.length === 0) {
-        candidateThreads = (
-          await this.listThreads({
-            backend,
-            archived: true,
-            callerReason: "agent-thread-inspection:archived",
-          })
-        ).filter((thread) => thread.id === threadId);
-      }
-      const [summary] = await this.enrichThreadInspectionSummaries(candidateThreads);
-      if (!summary) {
-        return {
-          ok: false,
-          error: {
-            code: "not_found",
-            message: `Thread ${backend}:${threadId} was not found.`,
-          },
-        };
-      }
-      const status = await this.readThread({
-        backend,
-        includeTurns: false,
-        limit: 0,
-        threadId,
-      })
-        .then((response) => response.threadStatus ?? response.replay.threadStatus)
-        .catch((): AppServerThreadStatus | undefined => undefined);
-      const queueKey = buildThreadIdentityKey(backend, threadId);
-      const queued = this.getQueuedExecutionModesSnapshot()[queueKey];
-      const pendingHandoffs = this.getPendingThreadHandoffsForInspection({
-        backend,
-        sourceThreadId: threadId,
-      });
-      const pendingWorkspaceMoves =
-        this.getPendingThreadWorkspaceMovesForInspection({
-          backend,
-          sourceThreadId: threadId,
-        });
-      const prAutomation =
-        await this.threadPrAutoDispatchHandler?.inspect?.({ backend, threadId });
-      return {
-        ok: true,
-        data: {
-          thread: {
-            ...summary,
-            status,
-            queuedExecutionMode: queued?.mode,
-            queuedExecutionModeAt: queued?.queuedAt,
-            ...(prAutomation ? { prAutomation } : {}),
-            ...(pendingHandoffs.length ? { pendingHandoffs } : {}),
-            ...(pendingWorkspaceMoves.length ? { pendingWorkspaceMoves } : {}),
-          },
-        },
-      };
     }
 
     if (request.operation === "read_thread") {
@@ -24729,6 +24702,139 @@ export class DesktopBackendRegistry {
         message: "Unsupported PwrAgent thread inspection operation.",
       },
     };
+  }
+
+  private async handleGetThreadStatusInspectionRequest(
+    args: GetThreadStatusToolArgs & {
+      backend: AppServerBackendKind;
+      threadId: string;
+    },
+  ): Promise<PwrAgentThreadInspectionResponse> {
+    if (!isAppServerBackendKind(args.backend)) {
+      return threadInspectionFailure(
+        "invalid_arguments",
+        "backend must be a known PwrAgent backend.",
+      );
+    }
+    const threadId = args.threadId.trim();
+    const instanceId = args.instanceId?.trim();
+    const includeRemote = args.includeRemote !== false;
+    if (!threadId) {
+      return threadInspectionFailure("invalid_arguments", "threadId is required.");
+    }
+    if (Object.hasOwn(args, "instanceId") && !instanceId) {
+      return threadInspectionFailure(
+        "invalid_arguments",
+        "instanceId must be a non-empty string when provided.",
+      );
+    }
+    if (instanceId && !includeRemote) {
+      return threadInspectionFailure(
+        "invalid_arguments",
+        "instanceId cannot be used when includeRemote is false.",
+      );
+    }
+
+    if (!instanceId) {
+      const activeThreads = await this.listThreads({
+        backend: args.backend,
+        archived: false,
+        callerReason: "agent-thread-inspection",
+      });
+      let candidateThreads = activeThreads.filter(
+        (thread) => thread.id === threadId,
+      );
+      if (candidateThreads.length === 0) {
+        candidateThreads = (
+          await this.listThreads({
+            backend: args.backend,
+            archived: true,
+            callerReason: "agent-thread-inspection:archived",
+          })
+        ).filter((thread) => thread.id === threadId);
+      }
+      const [summary] =
+        await this.enrichThreadInspectionSummaries(candidateThreads);
+      if (summary) {
+        const status = await this.readThread({
+          backend: args.backend,
+          includeTurns: false,
+          limit: 0,
+          threadId,
+        })
+          .then(
+            (response) =>
+              response.threadStatus ?? response.replay.threadStatus,
+          )
+          .catch((): AppServerThreadStatus | undefined => undefined);
+        const queueKey = buildThreadIdentityKey(args.backend, threadId);
+        const queued = this.getQueuedExecutionModesSnapshot()[queueKey];
+        const pendingHandoffs = this.getPendingThreadHandoffsForInspection({
+          backend: args.backend,
+          sourceThreadId: threadId,
+        });
+        const pendingWorkspaceMoves =
+          this.getPendingThreadWorkspaceMovesForInspection({
+            backend: args.backend,
+            sourceThreadId: threadId,
+          });
+        const prAutomation =
+          await this.threadPrAutoDispatchHandler?.inspect?.({
+            backend: args.backend,
+            threadId,
+          });
+        return {
+          ok: true,
+          data: {
+            thread: {
+              ...summary,
+              status,
+              queuedExecutionMode: queued?.mode,
+              queuedExecutionModeAt: queued?.queuedAt,
+              ...(prAutomation ? { prAutomation } : {}),
+              ...(pendingHandoffs.length ? { pendingHandoffs } : {}),
+              ...(pendingWorkspaceMoves.length ? { pendingWorkspaceMoves } : {}),
+            },
+          },
+        };
+      }
+    }
+
+    if (includeRemote && this.federatedThreadInspectionHandler) {
+      try {
+        const remote = await this.federatedThreadInspectionHandler({
+          backend: args.backend,
+          threadId,
+          ...(instanceId ? { instanceId } : {}),
+          limit: 0,
+          includeTurns: false,
+        });
+        if (remote) {
+          return {
+            ok: true,
+            data: {
+              thread: {
+                ...toThreadInspectionSummary(remote.thread, undefined, undefined),
+                instanceId: remote.instanceId,
+                instanceLabel: remote.instanceLabel,
+                status:
+                  remote.read.threadStatus
+                  ?? remote.read.replay.threadStatus,
+              },
+            },
+          };
+        }
+      } catch (error) {
+        return federatedThreadInspectionFailure(error);
+      }
+    }
+
+    return threadInspectionFailure(
+      "not_found",
+      `Thread ${args.backend}:${threadId} was not found${
+        includeRemote ? " locally or on a connected Federation peer" : " locally"
+      }.`,
+    );
   }
 
   private async handleAttachThreadPullRequestInspectionRequest(
@@ -25144,6 +25250,20 @@ export class DesktopBackendRegistry {
         },
       };
     }
+    const instanceId = args.instanceId?.trim();
+    const includeRemote = args.includeRemote !== false;
+    if (Object.hasOwn(args, "instanceId") && !instanceId) {
+      return threadInspectionFailure(
+        "invalid_arguments",
+        "instanceId must be a non-empty string when provided.",
+      );
+    }
+    if (instanceId && !includeRemote) {
+      return threadInspectionFailure(
+        "invalid_arguments",
+        "instanceId cannot be used when includeRemote is false.",
+      );
+    }
     const before = args.before?.trim();
     const limit = clampInteger(
       args.limit,
@@ -25156,14 +25276,55 @@ export class DesktopBackendRegistry {
       MAX_THREAD_INSPECTION_READ_ENTRY_CHARS,
     );
 
+    let response: AppServerReadThreadResponse | undefined;
+    let remote: PwrAgentFederatedThreadInspectionResult | undefined;
+    let localError: unknown;
+    if (!instanceId) {
+      try {
+        response = await this.readThread({
+          backend: args.backend,
+          threadId,
+          includeTurns: true,
+          ...(before ? { before } : {}),
+          limit,
+        });
+      } catch (error) {
+        localError = error;
+      }
+    }
+    if (!response && includeRemote && this.federatedThreadInspectionHandler) {
+      try {
+        remote = await this.federatedThreadInspectionHandler({
+          backend: args.backend,
+          threadId,
+          ...(instanceId ? { instanceId } : {}),
+          ...(before ? { before } : {}),
+          limit,
+          includeTurns: true,
+        });
+        response = remote?.read;
+      } catch (error) {
+        return federatedThreadInspectionFailure(error);
+      }
+    }
+    if (!response) {
+      if (localError) {
+        const message =
+          localError instanceof Error ? localError.message : String(localError);
+        return threadInspectionFailure(
+          /not found/i.test(message) ? "not_found" : "internal_error",
+          message,
+        );
+      }
+      return threadInspectionFailure(
+        "not_found",
+        `Thread ${args.backend}:${threadId} was not found${
+          includeRemote ? " locally or on a connected Federation peer" : " locally"
+        }.`,
+      );
+    }
+
     try {
-      const response = await this.readThread({
-        backend: args.backend,
-        threadId,
-        includeTurns: true,
-        ...(before ? { before } : {}),
-        limit,
-      });
       const replay = response.replay;
       const status = response.threadStatus ?? replay.threadStatus;
       return {
@@ -25172,6 +25333,12 @@ export class DesktopBackendRegistry {
           read: {
             backend: args.backend,
             threadId,
+            ...(remote
+              ? {
+                  instanceId: remote.instanceId,
+                  instanceLabel: remote.instanceLabel,
+                }
+              : {}),
             limit,
             ...(before ? { before } : {}),
             maxCharsPerEntry,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -336,6 +336,7 @@ import {
   PwrAgentFederatedThreadInspectionError,
   type PwrAgentFederatedThreadInspectionHandler,
   type PwrAgentFederatedThreadInspectionResult,
+  type PwrAgentFederatedThreadMutationHandler,
   type PwrAgentThreadInspectionHandler,
 } from "../agent-tools/pwragent-thread-agent-tools";
 import {
@@ -6429,6 +6430,9 @@ export class DesktopBackendRegistry {
   private federatedThreadInspectionHandler:
     | PwrAgentFederatedThreadInspectionHandler
     | undefined;
+  private federatedThreadMutationHandler:
+    | PwrAgentFederatedThreadMutationHandler
+    | undefined;
   private readonly threadOrchestrationHandler: PwrAgentThreadOrchestrationHandler =
     async (request) => await this.handleThreadOrchestrationRequest(request);
   private federationHandler: PwrAgentFederationHandler | undefined;
@@ -7161,6 +7165,12 @@ export class DesktopBackendRegistry {
     handler: PwrAgentFederatedThreadInspectionHandler | null | undefined,
   ): void {
     this.federatedThreadInspectionHandler = handler ?? undefined;
+  }
+
+  setFederatedThreadMutationHandler(
+    handler: PwrAgentFederatedThreadMutationHandler | null | undefined,
+  ): void {
+    this.federatedThreadMutationHandler = handler ?? undefined;
   }
 
   setThreadPullRequestStatusToolHandler(
@@ -24501,6 +24511,20 @@ export class DesktopBackendRegistry {
           },
         };
       }
+      const instanceId = request.args.instanceId?.trim();
+      const includeRemote = request.args.includeRemote !== false;
+      if (Object.hasOwn(request.args, "instanceId") && !instanceId) {
+        return threadInspectionFailure(
+          "invalid_arguments",
+          "instanceId must be a non-empty string when provided.",
+        );
+      }
+      if (instanceId && !includeRemote) {
+        return threadInspectionFailure(
+          "invalid_arguments",
+          "instanceId cannot be used when includeRemote is false.",
+        );
+      }
       const hasQuery = Boolean(request.args.query?.trim());
       if (
         request.args.contentMode !== undefined &&
@@ -24533,6 +24557,24 @@ export class DesktopBackendRegistry {
           : DEFAULT_THREAD_INSPECTION_RECENT_LIMIT,
         MAX_THREAD_INSPECTION_SEARCH_LIMIT,
       );
+      if (instanceId) {
+        return await this.mergeFederatedThreadSearchResults({
+          args: request.args,
+          context: request.context,
+          instanceId,
+          includeRemote,
+          limit,
+          localResponse: {
+            ok: true,
+            data: {
+              threads: [],
+              totalCount: 0,
+              limit,
+              truncated: false,
+            },
+          },
+        });
+      }
       const pendingHandoffs = this.getPendingThreadHandoffsForInspection({
         backend,
         query: request.args.query,
@@ -24585,22 +24627,29 @@ export class DesktopBackendRegistry {
         const threads = filtered
           .slice(0, limit)
           .map(toThreadInspectionSearchSummary);
-        return {
-          ok: true,
-          data: {
-            threads,
-            totalCount: filtered.length,
-            limit,
-            truncated: response.truncated === true || filtered.length > limit,
-            ...(pendingHandoffs.length ? { pendingHandoffs } : {}),
-            ...(pendingWorkspaceMoves.length ? { pendingWorkspaceMoves } : {}),
-            query: response.query,
-            searchedScopes: response.searchedScopes,
-            unavailableScopes: response.unavailableScopes,
-            contentMode: response.contentMode,
-            semanticMode: response.semanticMode,
+        return await this.mergeFederatedThreadSearchResults({
+          args: request.args,
+          context: request.context,
+          instanceId,
+          includeRemote,
+          limit,
+          localResponse: {
+            ok: true,
+            data: {
+              threads,
+              totalCount: filtered.length,
+              limit,
+              truncated: response.truncated === true || filtered.length > limit,
+              ...(pendingHandoffs.length ? { pendingHandoffs } : {}),
+              ...(pendingWorkspaceMoves.length ? { pendingWorkspaceMoves } : {}),
+              query: response.query,
+              searchedScopes: response.searchedScopes,
+              unavailableScopes: response.unavailableScopes,
+              contentMode: response.contentMode,
+              semanticMode: response.semanticMode,
+            },
           },
-        };
+        });
       }
       const listBackend = backend === "all" ? undefined : backend;
       const activeThreads = await this.listThreads({
@@ -24624,17 +24673,24 @@ export class DesktopBackendRegistry {
         agentOnly: request.args.agentOnly === true,
         query: request.args.query,
       });
-      return {
-        ok: true,
-        data: {
-          threads: filtered.slice(0, limit).map(toThreadInspectionSearchSummary),
-          totalCount: filtered.length,
-          limit,
-          truncated: filtered.length > limit,
-          ...(pendingHandoffs.length ? { pendingHandoffs } : {}),
-          ...(pendingWorkspaceMoves.length ? { pendingWorkspaceMoves } : {}),
+      return await this.mergeFederatedThreadSearchResults({
+        args: request.args,
+        context: request.context,
+        instanceId,
+        includeRemote,
+        limit,
+        localResponse: {
+          ok: true,
+          data: {
+            threads: filtered.slice(0, limit).map(toThreadInspectionSearchSummary),
+            totalCount: filtered.length,
+            limit,
+            truncated: filtered.length > limit,
+            ...(pendingHandoffs.length ? { pendingHandoffs } : {}),
+            ...(pendingWorkspaceMoves.length ? { pendingWorkspaceMoves } : {}),
+          },
         },
-      };
+      });
     }
 
     if (request.operation === "get_thread_status") {
@@ -24700,6 +24756,123 @@ export class DesktopBackendRegistry {
       error: {
         code: "unsupported_operation",
         message: "Unsupported PwrAgent thread inspection operation.",
+      },
+    };
+  }
+
+  private async mergeFederatedThreadSearchResults(params: {
+    args: Extract<
+      PwrAgentThreadInspectionRequest,
+      { operation: "search_threads" }
+    >["args"];
+    context: PwrAgentThreadInspectionRequest["context"];
+    instanceId?: string;
+    includeRemote: boolean;
+    limit: number;
+    localResponse: Extract<PwrAgentThreadInspectionResponse, { ok: true }>;
+  }): Promise<PwrAgentThreadInspectionResponse> {
+    if (!params.includeRemote || !this.federationHandler) {
+      return params.localResponse;
+    }
+    const localData = params.localResponse.data;
+    if (!("threads" in localData)) {
+      return params.localResponse;
+    }
+
+    const hasUnsupportedRemoteFilters =
+      params.args.agentOnly === true
+      || Boolean(nonEmptyStringArray(params.args.directoryPaths))
+      || Boolean(nonEmptyStringArray(params.args.models))
+      || params.args.contentMode === "required"
+      || params.args.semanticMode === "required";
+    if (hasUnsupportedRemoteFilters) {
+      if (params.instanceId) {
+        return threadInspectionFailure(
+          "invalid_arguments",
+          "instanceId cannot be combined with local-only Agent, directory, model, required transcript, or required semantic filters.",
+        );
+      }
+      return params.localResponse;
+    }
+
+    const response = await this.federationHandler({
+      operation: "search_federation_threads",
+      context: params.context,
+      args: {
+        query: params.args.query?.trim() ?? "",
+        scope: "remote",
+        ...(params.instanceId ? { instanceId: params.instanceId } : {}),
+        limit: params.limit,
+      },
+    });
+    if (!response.ok) {
+      if (params.instanceId) {
+        return threadInspectionFailure(
+          response.error.code === "turn_start_failed"
+            ? "internal_error"
+            : response.error.code,
+          response.error.message,
+        );
+      }
+      return params.localResponse;
+    }
+    if (!("results" in response.data)) {
+      return params.localResponse;
+    }
+
+    const backend = readThreadInspectionBackend(params.args.backend);
+    const projectKeys = nonEmptyStringArray(params.args.projectKeys);
+    const remoteThreads = response.data.results
+      .filter((entry) => backend === "all" || !backend || entry.backend === backend)
+      .filter(
+        (entry) =>
+          !projectKeys
+          || Boolean(entry.projectKey && projectKeys.includes(entry.projectKey)),
+      )
+      .filter(
+        (entry) =>
+          params.args.updatedAfter === undefined
+          || (entry.updatedAt ?? 0) >= params.args.updatedAfter,
+      )
+      .filter(
+        (entry) =>
+          params.args.updatedBefore === undefined
+          || (entry.updatedAt ?? Number.POSITIVE_INFINITY)
+            <= params.args.updatedBefore,
+      )
+      .map(
+        (entry): ThreadInspectionSummary => ({
+          backend: entry.backend,
+          threadId: entry.threadId,
+          instanceId: entry.instanceId,
+          instanceLabel: entry.instanceLabel,
+          threadLink: entry.threadLink,
+          title: entry.title,
+          updatedAt: entry.updatedAt,
+          projectKey: entry.projectKey,
+          linkedDirectories: [],
+          score: entry.score,
+        }),
+      );
+    const localThreads = params.instanceId ? [] : localData.threads;
+    const threads = [...localThreads, ...remoteThreads]
+      .sort(
+        (left, right) =>
+          (right.score ?? 0) - (left.score ?? 0)
+          || (right.updatedAt ?? right.createdAt ?? 0)
+            - (left.updatedAt ?? left.createdAt ?? 0),
+      );
+    const totalCount = (params.instanceId ? 0 : localData.totalCount)
+      + remoteThreads.length;
+    return {
+      ok: true,
+      data: {
+        ...localData,
+        threads: threads.slice(0, params.limit),
+        totalCount,
+        truncated: localData.truncated || threads.length > params.limit,
+        searchedInstances: response.data.searchedInstances,
+        federationFailures: response.data.failures,
       },
     };
   }
@@ -24859,7 +25032,6 @@ export class DesktopBackendRegistry {
         },
       };
     }
-
     const summary = await this.readThreadInspectionSummaryForMutation({
       backend: args.backend,
       threadId,
@@ -25115,6 +25287,20 @@ export class DesktopBackendRegistry {
         },
       };
     }
+    const instanceId = args.instanceId?.trim();
+    const includeRemote = args.includeRemote !== false;
+    if (Object.hasOwn(args, "instanceId") && !instanceId) {
+      return threadInspectionFailure(
+        "invalid_arguments",
+        "instanceId must be a non-empty string when provided.",
+      );
+    }
+    if (instanceId && !includeRemote) {
+      return threadInspectionFailure(
+        "invalid_arguments",
+        "instanceId cannot be used when includeRemote is false.",
+      );
+    }
 
     const dryRun = args.dryRun === true;
 
@@ -25191,7 +25377,47 @@ export class DesktopBackendRegistry {
       };
     }
 
-    if (title !== undefined && !dryRun) {
+    const localSummary = !instanceId
+      ? await this.readThreadInspectionSummaryForMutation({
+          backend: args.backend,
+          threadId,
+        })
+      : undefined;
+    const localOverlay = !instanceId && !localSummary
+      ? await this.overlayStore.getThreadOverlayState({
+          backend: args.backend,
+          threadId,
+        })
+      : undefined;
+    const mutateLocally = Boolean(localSummary || localOverlay);
+    let remoteOwner:
+      | { instanceId: string; instanceLabel: string }
+      | undefined;
+    if (!mutateLocally && includeRemote && this.federatedThreadMutationHandler) {
+      try {
+        remoteOwner = await this.federatedThreadMutationHandler({
+          backend: args.backend,
+          threadId,
+          ...(instanceId ? { instanceId } : {}),
+          ...(title !== undefined ? { title } : {}),
+          ...(modelSettings.value ? { modelSettings: modelSettings.value } : {}),
+          ...(executionMode !== undefined ? { executionMode } : {}),
+          dryRun,
+        });
+      } catch (error) {
+        return federatedThreadInspectionFailure(error);
+      }
+    }
+    if (!mutateLocally && !remoteOwner) {
+      return threadInspectionFailure(
+        "not_found",
+        `Thread ${args.backend}:${threadId} was not found${
+          includeRemote ? " locally or on a connected Federation peer" : " locally"
+        }.`,
+      );
+    }
+
+    if (mutateLocally && title !== undefined && !dryRun) {
       await this.renameThread({
         backend: args.backend,
         threadId,
@@ -25199,7 +25425,7 @@ export class DesktopBackendRegistry {
       });
     }
 
-    if (modelSettings.value && !dryRun) {
+    if (mutateLocally && modelSettings.value && !dryRun) {
       await this.setThreadModelSettings({
         backend: args.backend,
         threadId,
@@ -25207,7 +25433,7 @@ export class DesktopBackendRegistry {
       });
     }
 
-    if (executionMode !== undefined && !dryRun) {
+    if (mutateLocally && executionMode !== undefined && !dryRun) {
       await this.setThreadExecutionMode({
         backend: args.backend,
         threadId,
@@ -25221,6 +25447,7 @@ export class DesktopBackendRegistry {
         mutation: {
           backend: args.backend,
           threadId,
+          ...(remoteOwner ?? {}),
           dryRun,
           changes,
         },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -24795,12 +24795,25 @@ export class DesktopBackendRegistry {
       return params.localResponse;
     }
 
+    const backend = readThreadInspectionBackend(params.args.backend);
+    const projectKeys = nonEmptyStringArray(params.args.projectKeys);
     const response = await this.federationHandler({
       operation: "search_federation_threads",
       context: params.context,
       args: {
         query: params.args.query?.trim() ?? "",
         scope: "remote",
+        ...(backend ? { backend } : {}),
+        ...(params.args.includeArchived === true
+          ? { includeArchived: true }
+          : {}),
+        ...(projectKeys ? { projectKeys } : {}),
+        ...(params.args.updatedAfter !== undefined
+          ? { updatedAfter: params.args.updatedAfter }
+          : {}),
+        ...(params.args.updatedBefore !== undefined
+          ? { updatedBefore: params.args.updatedBefore }
+          : {}),
         ...(params.instanceId ? { instanceId: params.instanceId } : {}),
         limit: params.limit,
       },
@@ -24820,26 +24833,7 @@ export class DesktopBackendRegistry {
       return params.localResponse;
     }
 
-    const backend = readThreadInspectionBackend(params.args.backend);
-    const projectKeys = nonEmptyStringArray(params.args.projectKeys);
     const remoteThreads = response.data.results
-      .filter((entry) => backend === "all" || !backend || entry.backend === backend)
-      .filter(
-        (entry) =>
-          !projectKeys
-          || Boolean(entry.projectKey && projectKeys.includes(entry.projectKey)),
-      )
-      .filter(
-        (entry) =>
-          params.args.updatedAfter === undefined
-          || (entry.updatedAt ?? 0) >= params.args.updatedAfter,
-      )
-      .filter(
-        (entry) =>
-          params.args.updatedBefore === undefined
-          || (entry.updatedAt ?? Number.POSITIVE_INFINITY)
-            <= params.args.updatedBefore,
-      )
       .map(
         (entry): ThreadInspectionSummary => ({
           backend: entry.backend,
@@ -24849,13 +24843,19 @@ export class DesktopBackendRegistry {
           threadLink: entry.threadLink,
           title: entry.title,
           updatedAt: entry.updatedAt,
+          archivedAt: entry.archivedAt,
           projectKey: entry.projectKey,
           linkedDirectories: [],
           score: entry.score,
         }),
       );
-    const localThreads = params.instanceId ? [] : localData.threads;
-    const threads = [...localThreads, ...remoteThreads]
+    const localThreads = normalizeThreadInspectionSearchRanks(
+      params.instanceId ? [] : localData.threads,
+    );
+    const normalizedRemoteThreads = normalizeThreadInspectionSearchRanks(
+      remoteThreads,
+    );
+    const threads = [...localThreads, ...normalizedRemoteThreads]
       .sort(
         (left, right) =>
           (right.score ?? 0) - (left.score ?? 0)
@@ -24863,14 +24863,17 @@ export class DesktopBackendRegistry {
             - (left.updatedAt ?? left.createdAt ?? 0),
       );
     const totalCount = (params.instanceId ? 0 : localData.totalCount)
-      + remoteThreads.length;
+      + response.data.totalCount;
     return {
       ok: true,
       data: {
         ...localData,
         threads: threads.slice(0, params.limit),
         totalCount,
-        truncated: localData.truncated || threads.length > params.limit,
+        truncated:
+          localData.truncated
+          || response.data.truncated
+          || totalCount > params.limit,
         searchedInstances: response.data.searchedInstances,
         federationFailures: response.data.failures,
       },
@@ -26961,6 +26964,15 @@ function filterThreadInspectionSummaries(
           (left.thread.updatedAt ?? left.thread.createdAt ?? 0),
     )
     .map((entry) => entry.thread);
+}
+
+function normalizeThreadInspectionSearchRanks(
+  threads: ThreadInspectionSummary[],
+): ThreadInspectionSummary[] {
+  return threads.map((thread, index) => ({
+    ...thread,
+    score: 1 / (index + 1),
+  }));
 }
 
 function toThreadInspectionSummary(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -122,6 +122,7 @@ import {
   type NavigationLaunchpadDraft,
   type NavigationLaunchpadDefaults,
   type NavigationSnapshot,
+  type NavigationThreadSummary,
   type ResetDirectoryLaunchpadRequest,
   type ResetDirectoryLaunchpadResponse,
   type RetainThreadBranchDriftRequest,
@@ -25652,68 +25653,75 @@ export class DesktopBackendRegistry {
       );
     }
 
+    let localError: unknown;
     if (!instanceId) {
-      const activeThreads = await this.listThreads({
-        backend: args.backend,
-        archived: false,
-        callerReason: "agent-thread-inspection",
-      });
-      let candidateThreads = activeThreads.filter(
-        (thread) => thread.id === threadId,
-      );
-      if (candidateThreads.length === 0) {
-        candidateThreads = (
-          await this.listThreads({
-            backend: args.backend,
-            archived: true,
-            callerReason: "agent-thread-inspection:archived",
-          })
-        ).filter((thread) => thread.id === threadId);
-      }
-      const [summary] =
-        await this.enrichThreadInspectionSummaries(candidateThreads);
-      if (summary) {
-        const status = await this.readThread({
+      try {
+        const activeThreads = await this.listThreads({
           backend: args.backend,
-          includeTurns: false,
-          limit: 0,
-          threadId,
-        })
-          .then(
-            (response) =>
-              response.threadStatus ?? response.replay.threadStatus,
-          )
-          .catch((): AppServerThreadStatus | undefined => undefined);
-        const queueKey = buildThreadIdentityKey(args.backend, threadId);
-        const queued = this.getQueuedExecutionModesSnapshot()[queueKey];
-        const pendingHandoffs = this.getPendingThreadHandoffsForInspection({
-          backend: args.backend,
-          sourceThreadId: threadId,
+          archived: false,
+          callerReason: "agent-thread-inspection",
         });
-        const pendingWorkspaceMoves =
-          this.getPendingThreadWorkspaceMovesForInspection({
+        let candidateThreads = activeThreads.filter(
+          (thread) => thread.id === threadId,
+        );
+        if (candidateThreads.length === 0) {
+          candidateThreads = (
+            await this.listThreads({
+              backend: args.backend,
+              archived: true,
+              callerReason: "agent-thread-inspection:archived",
+            })
+          ).filter((thread) => thread.id === threadId);
+        }
+        const [summary] =
+          await this.enrichThreadInspectionSummaries(candidateThreads);
+        if (summary) {
+          const status = await this.readThread({
+            backend: args.backend,
+            includeTurns: false,
+            limit: 0,
+            threadId,
+          })
+            .then(
+              (response) =>
+                response.threadStatus ?? response.replay.threadStatus,
+            )
+            .catch((): AppServerThreadStatus | undefined => undefined);
+          const queueKey = buildThreadIdentityKey(args.backend, threadId);
+          const queued = this.getQueuedExecutionModesSnapshot()[queueKey];
+          const pendingHandoffs = this.getPendingThreadHandoffsForInspection({
             backend: args.backend,
             sourceThreadId: threadId,
           });
-        const prAutomation =
-          await this.threadPrAutoDispatchHandler?.inspect?.({
-            backend: args.backend,
-            threadId,
-          });
-        return {
-          ok: true,
-          data: {
-            thread: {
-              ...summary,
-              status,
-              queuedExecutionMode: queued?.mode,
-              queuedExecutionModeAt: queued?.queuedAt,
-              ...(prAutomation ? { prAutomation } : {}),
-              ...(pendingHandoffs.length ? { pendingHandoffs } : {}),
-              ...(pendingWorkspaceMoves.length ? { pendingWorkspaceMoves } : {}),
+          const pendingWorkspaceMoves =
+            this.getPendingThreadWorkspaceMovesForInspection({
+              backend: args.backend,
+              sourceThreadId: threadId,
+            });
+          const prAutomation =
+            await this.threadPrAutoDispatchHandler?.inspect?.({
+              backend: args.backend,
+              threadId,
+            });
+          return {
+            ok: true,
+            data: {
+              thread: {
+                ...summary,
+                status,
+                queuedExecutionMode: queued?.mode,
+                queuedExecutionModeAt: queued?.queuedAt,
+                ...(prAutomation ? { prAutomation } : {}),
+                ...(pendingHandoffs.length ? { pendingHandoffs } : {}),
+                ...(pendingWorkspaceMoves.length
+                  ? { pendingWorkspaceMoves }
+                  : {}),
+              },
             },
-          },
-        };
+          };
+        }
+      } catch (error) {
+        localError = error;
       }
     }
 
@@ -25727,13 +25735,22 @@ export class DesktopBackendRegistry {
           includeTurns: false,
         });
         if (remote) {
+          const summary = remote.summary
+            ? toThreadInspectionSummaryFromNavigation(remote.summary)
+            : toThreadInspectionSummary(remote.thread, undefined, undefined);
           return {
             ok: true,
             data: {
               thread: {
-                ...toThreadInspectionSummary(remote.thread, undefined, undefined),
+                ...summary,
                 instanceId: remote.instanceId,
                 instanceLabel: remote.instanceLabel,
+                threadLink: buildThreadMarkdownLink({
+                  backend: args.backend,
+                  threadId,
+                  instanceId: remote.instanceId,
+                  title: summary.title,
+                }),
                 status:
                   remote.read.threadStatus
                   ?? remote.read.replay.threadStatus,
@@ -25744,6 +25761,10 @@ export class DesktopBackendRegistry {
       } catch (error) {
         return federatedThreadInspectionFailure(error);
       }
+    }
+
+    if (localError) {
+      return federatedThreadInspectionFailure(localError);
     }
 
     return threadInspectionFailure(
@@ -26121,12 +26142,18 @@ export class DesktopBackendRegistry {
       };
     }
 
-    const localSummary = !instanceId
-      ? await this.readThreadInspectionSummaryForMutation({
+    let localError: unknown;
+    let localSummary: ThreadInspectionSummary | undefined;
+    if (!instanceId) {
+      try {
+        localSummary = await this.readThreadInspectionSummaryForMutation({
           backend: args.backend,
           threadId,
-        })
-      : undefined;
+        });
+      } catch (error) {
+        localError = error;
+      }
+    }
     const localOverlay = !instanceId && !localSummary
       ? await this.overlayStore.getThreadOverlayState({
           backend: args.backend,
@@ -26153,6 +26180,9 @@ export class DesktopBackendRegistry {
       }
     }
     if (!mutateLocally && !remoteOwner) {
+      if (localError) {
+        return federatedThreadInspectionFailure(localError);
+      }
       return threadInspectionFailure(
         "not_found",
         `Thread ${args.backend}:${threadId} was not found${
@@ -27748,6 +27778,17 @@ function toThreadInspectionSummary(
     linkedDirectories,
     linkedRepositories: summarizeLinkedRepositories(linkedDirectories),
     ...(overlay?.prs?.length ? { pullRequests: overlay.prs } : {}),
+  };
+}
+
+function toThreadInspectionSummaryFromNavigation(
+  thread: NavigationThreadSummary,
+): ThreadInspectionSummary {
+  return {
+    ...toThreadInspectionSummary(thread, undefined, thread.messagingBindings),
+    agent: thread.agent,
+    handoffOrigin: thread.handoffOrigin,
+    ...(thread.prs?.length ? { pullRequests: thread.prs } : {}),
   };
 }
 

--- a/apps/desktop/src/main/federation/federated-search-service.ts
+++ b/apps/desktop/src/main/federation/federated-search-service.ts
@@ -54,11 +54,11 @@ export class FederatedSearchService {
     const resultGroups = await Promise.all([
       ...(this.options.includeLocal === false
         ? []
-        : [this.searchLocal(query, request.backend)]),
+        : [this.searchLocal(query, request)]),
       ...this.options.peers().map(async (peer) => {
         try {
           const peerResults = await withTimeout(
-            this.searchPeer(peer, query, request.backend),
+            this.searchPeer(peer, query, request),
             peerTimeoutMs,
             `Federated search timed out after ${Math.round(peerTimeoutMs / 1000)}s.`,
           );
@@ -78,18 +78,20 @@ export class FederatedSearchService {
         }
       }),
     ]);
-    const results = resultGroups
+    const matches = resultGroups
       .flat()
       .sort((left, right) => {
         if (right.score !== left.score) return right.score - left.score;
         return (right.thread.updatedAt ?? 0) - (left.thread.updatedAt ?? 0);
-      })
-      .slice(0, limit);
+      });
+    const results = matches.slice(0, limit);
 
     return {
       query,
       searchedAt,
       results,
+      totalCount: matches.length,
+      truncated: matches.length > limit,
       failures,
       searchedInstances,
     };
@@ -97,12 +99,12 @@ export class FederatedSearchService {
 
   private async searchLocal(
     query: string,
-    backend?: FederatedSearchRequest["backend"],
+    request: FederatedSearchRequest,
   ): Promise<FederatedSearchResponse["results"]> {
     const resolved = await this.resolveExactThreadId(
       this.options.local,
       query,
-      backend,
+      request,
     );
     if (resolved !== undefined) {
       return resolved
@@ -117,11 +119,12 @@ export class FederatedSearchService {
           }]
         : [];
     }
-    const response = await this.options.local.listThreads({
-      backend: backend === "all" ? undefined : backend,
-      filter: query,
-    });
-    return response.threads.map((thread) => ({
+    const threads = await listFederatedSearchThreads(
+      this.options.local,
+      query,
+      request,
+    );
+    return threads.map((thread) => ({
       ref: buildFederatedThreadRef({
         backend: thread.source,
         threadId: thread.id,
@@ -135,12 +138,12 @@ export class FederatedSearchService {
   private async searchPeer(
     peer: FederatedSearchPeer,
     query: string,
-    backend?: FederatedSearchRequest["backend"],
+    request: FederatedSearchRequest,
   ): Promise<FederatedSearchResponse["results"]> {
     const resolved = await this.resolveExactThreadId(
       peer.backend,
       query,
-      backend,
+      request,
     );
     if (resolved !== undefined) {
       return resolved
@@ -157,11 +160,12 @@ export class FederatedSearchService {
           }]
         : [];
     }
-    const response: AppServerListThreadsResponse = await peer.backend.listThreads({
-      backend: backend === "all" ? undefined : backend,
-      filter: query,
-    });
-    return response.threads.map((thread) => ({
+    const threads = await listFederatedSearchThreads(
+      peer.backend,
+      query,
+      request,
+    );
+    return threads.map((thread) => ({
       ref: buildFederatedThreadRef({
         backend: thread.source,
         instanceId: peer.instanceId,
@@ -177,7 +181,7 @@ export class FederatedSearchService {
   private async resolveExactThreadId(
     backendOperations: FederatedSearchPeer["backend"],
     query: string,
-    backend?: FederatedSearchRequest["backend"],
+    request: FederatedSearchRequest,
   ): Promise<AppServerThreadSummary | null | undefined> {
     if (
       !backendOperations.resolveThread
@@ -187,19 +191,82 @@ export class FederatedSearchService {
     }
     try {
       const response = await backendOperations.resolveThread({
-        ...(backend && backend !== "all" ? { backend } : {}),
+        ...(request.backend && request.backend !== "all"
+          ? { backend: request.backend }
+          : {}),
         threadId: query,
       });
-      return response.thread ?? null;
+      if (
+        response.thread
+        && matchesFederatedSearchFilters(response.thread, request)
+      ) {
+        return response.thread;
+      }
+      if (!request.includeArchived) {
+        return null;
+      }
     } catch {
-      // Mixed-version peers may not expose the exact lookup RPC yet. Avoid
-      // their provider's fuzzy UUID filter and scan the active list exactly.
-      const response = await backendOperations.listThreads({
-        backend: backend === "all" ? undefined : backend,
-      });
-      return response.threads.find((thread) => thread.id === query) ?? null;
+      // Mixed-version peers may not expose the exact lookup RPC yet. Fall
+      // through to exact list scans rather than using fuzzy UUID filtering.
+    }
+    const threads = await listFederatedSearchThreads(
+      backendOperations,
+      "",
+      request,
+    );
+    return threads.find((thread) => thread.id === query) ?? null;
+  }
+}
+
+async function listFederatedSearchThreads(
+  backendOperations: FederatedSearchPeer["backend"],
+  query: string,
+  request: FederatedSearchRequest,
+): Promise<AppServerThreadSummary[]> {
+  const list = async (archived: boolean) =>
+    await backendOperations.listThreads({
+      backend: request.backend === "all" ? undefined : request.backend,
+      archived,
+      ...(query ? { filter: query } : {}),
+    });
+  const responses: AppServerListThreadsResponse[] = [await list(false)];
+  if (request.includeArchived) {
+    responses.push(await list(true));
+  }
+  const byIdentity = new Map<string, AppServerThreadSummary>();
+  for (const thread of responses.flatMap((response) => response.threads)) {
+    if (matchesFederatedSearchFilters(thread, request)) {
+      byIdentity.set(`${thread.source}:${thread.id}`, thread);
     }
   }
+  return [...byIdentity.values()];
+}
+
+function matchesFederatedSearchFilters(
+  thread: AppServerThreadSummary,
+  request: FederatedSearchRequest,
+): boolean {
+  if (
+    request.backend
+    && request.backend !== "all"
+    && thread.source !== request.backend
+  ) {
+    return false;
+  }
+  if (
+    request.projectKeys?.length
+    && (!thread.projectKey || !request.projectKeys.includes(thread.projectKey))
+  ) {
+    return false;
+  }
+  const updatedAt = thread.updatedAt ?? thread.createdAt ?? 0;
+  if (request.updatedAfter !== undefined && updatedAt < request.updatedAfter) {
+    return false;
+  }
+  if (request.updatedBefore !== undefined && updatedAt > request.updatedBefore) {
+    return false;
+  }
+  return true;
 }
 
 function looksLikeExactThreadId(query: string): boolean {
@@ -231,7 +298,7 @@ function withTimeout<T>(
 }
 
 function scoreThread(thread: AppServerThreadSummary, query: string): number {
-  if (!query) return thread.updatedAt ?? thread.createdAt ?? 0;
+  if (!query) return 0;
   const normalized = query.toLowerCase();
   const title = thread.title.toLowerCase();
   const summary = thread.summary?.toLowerCase() ?? "";
@@ -245,6 +312,5 @@ function scoreThread(thread: AppServerThreadSummary, query: string): number {
   if (title.includes(normalized)) score += 250;
   if (summary.includes(normalized)) score += 100;
   if (directories.includes(normalized)) score += 50;
-  score += Math.min(thread.updatedAt ?? thread.createdAt ?? 0, 9_999_999_999) / 1_000_000;
   return score;
 }

--- a/apps/desktop/src/main/federation/federated-thread-inspection-service.ts
+++ b/apps/desktop/src/main/federation/federated-thread-inspection-service.ts
@@ -1,0 +1,63 @@
+import {
+  PwrAgentFederatedThreadInspectionError,
+  type PwrAgentFederatedThreadInspectionHandler,
+} from "../agent-tools/pwragent-thread-agent-tools";
+import type { RemoteThreadTargetStore } from "../state/remote-thread-target-store";
+import {
+  FederatedThreadTargetError,
+  resolveFederatedThreadTarget,
+  type ResolvedFederatedThreadTarget,
+} from "./federated-thread-target-service";
+import {
+  getDesktopFederationRuntime,
+  type DesktopFederationRuntime,
+} from "./federation-runtime";
+
+export function createFederatedThreadInspectionHandler(
+  options: {
+    runtime?: () => DesktopFederationRuntime;
+    targetStore?: RemoteThreadTargetStore;
+  } = {},
+): PwrAgentFederatedThreadInspectionHandler {
+  const runtime = options.runtime ?? getDesktopFederationRuntime;
+  return async (request) => {
+    let match: ResolvedFederatedThreadTarget | undefined;
+    try {
+      match = await resolveFederatedThreadTarget({
+        runtime: runtime(),
+        targetStore: options.targetStore,
+        request,
+      });
+    } catch (error) {
+      if (error instanceof FederatedThreadTargetError) {
+        throw new PwrAgentFederatedThreadInspectionError(
+          error.code,
+          error.message,
+        );
+      }
+      throw error;
+    }
+    if (!match) {
+      return undefined;
+    }
+    if (!match.peer.capabilities.includes("thread_detail")) {
+      throw new Error(
+        `Federation instance ${match.peer.label} owns thread ${request.threadId} but does not grant thread_detail.`,
+      );
+    }
+    const read = await match.backend.readThread({
+      backend: request.backend,
+      threadId: request.threadId,
+      includeTurns: request.includeTurns,
+      ...(request.before ? { before: request.before } : {}),
+      limit: request.limit,
+      viewOnly: true,
+    });
+    return {
+      instanceId: match.peer.target.instanceId,
+      instanceLabel: match.peer.label,
+      thread: match.thread,
+      read,
+    };
+  };
+}

--- a/apps/desktop/src/main/federation/federated-thread-inspection-service.ts
+++ b/apps/desktop/src/main/federation/federated-thread-inspection-service.ts
@@ -21,10 +21,11 @@ export function createFederatedThreadInspectionHandler(
 ): PwrAgentFederatedThreadInspectionHandler {
   const runtime = options.runtime ?? getDesktopFederationRuntime;
   return async (request) => {
+    const activeRuntime = runtime();
     let match: ResolvedFederatedThreadTarget | undefined;
     try {
       match = await resolveFederatedThreadTarget({
-        runtime: runtime(),
+        runtime: activeRuntime,
         targetStore: options.targetStore,
         request,
       });
@@ -53,10 +54,16 @@ export function createFederatedThreadInspectionHandler(
       limit: request.limit,
       viewOnly: true,
     });
+    const summary = await activeRuntime.remoteThreadSummaries?.().threadFromPeer({
+      target: match.peer.target,
+      backend: request.backend,
+      threadId: request.threadId,
+    });
     return {
       instanceId: match.peer.target.instanceId,
       instanceLabel: match.peer.label,
       thread: match.thread,
+      ...(summary ? { summary } : {}),
       read,
     };
   };

--- a/apps/desktop/src/main/federation/federated-thread-message-service.ts
+++ b/apps/desktop/src/main/federation/federated-thread-message-service.ts
@@ -1,9 +1,3 @@
-import type {
-  AppServerThreadSummary,
-  FederationCapability,
-  FederationRemoteTarget,
-} from "@pwragent/shared";
-import { formatFederationPeerDisplayLabel } from "@pwragent/shared";
 import {
   PwrAgentFederatedThreadMessageError,
 } from "../agent-tools/pwragent-thread-orchestration-agent-tools";
@@ -11,25 +5,16 @@ import type {
   PwrAgentFederatedThreadMessageHandler,
   PwrAgentFederatedThreadMessageResult,
 } from "../agent-tools/pwragent-thread-orchestration-agent-tools";
-import { getMainLogger } from "../log";
 import type { RemoteThreadTargetStore } from "../state/remote-thread-target-store";
-import type { FederationBackendOperations } from "./federation-backend-bridge";
+import {
+  FederatedThreadTargetError,
+  resolveFederatedThreadTarget,
+  type ResolvedFederatedThreadTarget,
+} from "./federated-thread-target-service";
 import {
   getDesktopFederationRuntime,
   type DesktopFederationRuntime,
 } from "./federation-runtime";
-
-type ResolvedRemoteThread = {
-  backend: FederationBackendOperations;
-  peer: {
-    target: FederationRemoteTarget;
-    label: string;
-    capabilities: FederationCapability[];
-  };
-  thread: AppServerThreadSummary;
-};
-
-const log = getMainLogger("pwragent:federated-thread-message");
 
 export function createFederatedThreadMessageHandler(
   options: {
@@ -40,146 +25,38 @@ export function createFederatedThreadMessageHandler(
   const runtime = options.runtime ?? getDesktopFederationRuntime;
   return async (request) => {
     const activeRuntime = runtime();
-    const connectedPeers = activeRuntime.connectedPeerTargets();
-    const rememberedTargets = request.instanceId
-      || request.resolutionMode === "discover_only"
-      ? []
-      : await readRememberedTargets(options.targetStore, request);
-    if (rememberedTargets.length > 1) {
-      throw new Error(
-        `Thread ${request.threadId} has multiple remembered federation owners: ${rememberedTargets
-          .map((target) => target.instanceLabel)
-          .join(", ")}. Pass instanceId to select the intended target.`,
-      );
-    }
-    const targetInstanceId =
-      request.instanceId ?? rememberedTargets[0]?.instanceId;
-    if (targetInstanceId) {
-      const peer = connectedPeers.find(
-        (candidate) => candidate.target.instanceId === targetInstanceId,
-      );
-      if (!peer) {
-        const health = await activeRuntime.health();
-        const knownPeer = health.peers.find(
-          (candidate) => candidate.id === targetInstanceId,
-        );
-        const instanceLabel = knownPeer
-          ? formatFederationPeerDisplayLabel(knownPeer, health.peers)
-          : rememberedTargets[0]?.instanceLabel ?? targetInstanceId;
-        const status = knownPeer?.status ?? "not enrolled";
+    let match: ResolvedFederatedThreadTarget | undefined;
+    try {
+      match = await resolveFederatedThreadTarget({
+        runtime: activeRuntime,
+        targetStore: options.targetStore,
+        request,
+      });
+    } catch (error) {
+      if (error instanceof FederatedThreadTargetError) {
+        const message = error.message.endsWith(".")
+          ? error.message.slice(0, -1)
+          : error.message;
         throw new PwrAgentFederatedThreadMessageError(
-          "peer_unavailable",
-          `Federation instance ${instanceLabel}, the known owner of thread ${request.threadId}, is ${status}; the message was not sent.`,
+          error.code,
+          `${message}; the message was not sent.`,
         );
       }
-      if (!peer.capabilities.includes("thread_navigation")) {
-        throw new Error(
-          `Federation instance ${peer.label} owns thread ${request.threadId} but does not grant thread_navigation.`,
-        );
-      }
-      const match = await resolveThreadOnPeer(activeRuntime, peer, request);
-      if (!match) {
-        if (
-          rememberedTargets.length > 0
-          && request.resolutionMode === "remembered_only"
-        ) {
-          throw new Error(
-            `Thread ${request.threadId} was not found on its remembered federation owner ${peer.label}.`,
-          );
-        }
-        return undefined;
-      }
-      return await sendToRemoteThread(match, request, options.targetStore);
+      throw error;
     }
-
-    if (request.resolutionMode === "remembered_only") {
-      return undefined;
-    }
-
-    const peers = connectedPeers.filter((peer) =>
-      peer.capabilities.includes("thread_navigation"),
-    );
-    const failures: Array<{ label: string; message: string }> = [];
-    const matches = (
-      await Promise.all(
-        peers.map(async (peer): Promise<ResolvedRemoteThread | undefined> => {
-          try {
-            return await resolveThreadOnPeer(activeRuntime, peer, request);
-          } catch (error) {
-            failures.push({
-              label: peer.label,
-              message: error instanceof Error ? error.message : String(error),
-            });
-            return undefined;
-          }
-        }),
-      )
-    ).filter((match): match is ResolvedRemoteThread => Boolean(match));
-
-    if (matches.length > 1) {
-      throw new Error(
-        `Thread ${request.threadId} was reported by multiple federation instances: ${matches
-          .map((match) => match.peer.label)
-          .join(", ")}.`,
-      );
-    }
-    const match = matches[0];
-    if (!match) {
-      if (failures.length > 0) {
-        throw new Error(
-          `Could not resolve thread ${request.threadId} because federation lookup failed on ${failures
-            .map((failure) => `${failure.label}: ${failure.message}`)
-            .join("; ")}.`,
-        );
-      }
-      return undefined;
-    }
-    return await sendToRemoteThread(match, request, options.targetStore);
+    return match ? await sendToRemoteThread(match, request) : undefined;
   };
 }
 
-async function resolveThreadOnPeer(
-  runtime: DesktopFederationRuntime,
-  peer: ResolvedRemoteThread["peer"],
-  request: Parameters<PwrAgentFederatedThreadMessageHandler>[0],
-): Promise<ResolvedRemoteThread | undefined> {
-  const backend = runtime.remoteBackend(peer.target);
-  let thread: AppServerThreadSummary | undefined;
-  try {
-    thread = (
-      await backend.resolveThread({
-        backend: request.backend,
-        threadId: request.threadId,
-      })
-    ).thread;
-  } catch {
-    // Mixed-version peers may predate backend.resolveThread. Their unfiltered
-    // list still provides an exact-ID compatibility path.
-    thread = (
-      await backend.listThreads({ backend: request.backend })
-    ).threads.find((candidate) => candidate.id === request.threadId);
-  }
-  return thread ? { backend, peer, thread } : undefined;
-}
-
 async function sendToRemoteThread(
-  match: ResolvedRemoteThread,
+  match: ResolvedFederatedThreadTarget,
   request: Parameters<PwrAgentFederatedThreadMessageHandler>[0],
-  targetStore: RemoteThreadTargetStore | undefined,
 ): Promise<PwrAgentFederatedThreadMessageResult> {
   if (!match.peer.capabilities.includes("turn_control")) {
     throw new Error(
       `Federation instance ${match.peer.label} owns thread ${request.threadId} but does not grant turn_control.`,
     );
   }
-  // Ownership was confirmed even if turn admission subsequently fails (busy,
-  // policy, or backend error), so retain the route before attempting the send.
-  await rememberTarget(targetStore, {
-    instanceId: match.peer.target.instanceId,
-    instanceLabel: match.peer.label,
-    backend: request.backend,
-    threadId: request.threadId,
-  });
   const turn = await match.backend.startTurn({
     backend: request.backend,
     threadId: request.threadId,
@@ -201,45 +78,4 @@ async function sendToRemoteThread(
     instanceId: match.peer.target.instanceId,
     instanceLabel: match.peer.label,
   } satisfies PwrAgentFederatedThreadMessageResult;
-}
-
-async function readRememberedTargets(
-  targetStore: RemoteThreadTargetStore | undefined,
-  request: Parameters<PwrAgentFederatedThreadMessageHandler>[0],
-) {
-  if (!targetStore) {
-    return [];
-  }
-  try {
-    return await targetStore.listRemoteThreadTargets({
-      backend: request.backend,
-      threadId: request.threadId,
-    });
-  } catch (error) {
-    log.warn("failed to read remote thread target", {
-      backend: request.backend,
-      error: error instanceof Error ? error.message : String(error),
-      threadId: request.threadId,
-    });
-    return [];
-  }
-}
-
-async function rememberTarget(
-  targetStore: RemoteThreadTargetStore | undefined,
-  target: Parameters<RemoteThreadTargetStore["rememberRemoteThreadTarget"]>[0],
-): Promise<void> {
-  if (!targetStore) {
-    return;
-  }
-  try {
-    await targetStore.rememberRemoteThreadTarget(target);
-  } catch (error) {
-    log.warn("failed to remember remote thread target", {
-      backend: target.backend,
-      error: error instanceof Error ? error.message : String(error),
-      instanceId: target.instanceId,
-      threadId: target.threadId,
-    });
-  }
 }

--- a/apps/desktop/src/main/federation/federated-thread-message-service.ts
+++ b/apps/desktop/src/main/federation/federated-thread-message-service.ts
@@ -228,14 +228,6 @@ async function resolveThreadOnPeer(
       await backend.listThreads({ backend: request.backend })
     ).threads.find((candidate) => candidate.id === request.threadId);
   }
-  if (!thread) {
-    thread = (
-      await backend.listThreads({
-        backend: request.backend,
-        archived: true,
-      })
-    ).threads.find((candidate) => candidate.id === request.threadId);
-  }
   return thread ? { backend, peer, thread } : undefined;
 }
 

--- a/apps/desktop/src/main/federation/federated-thread-mutation-service.ts
+++ b/apps/desktop/src/main/federation/federated-thread-mutation-service.ts
@@ -1,0 +1,76 @@
+import {
+  PwrAgentFederatedThreadInspectionError,
+  type PwrAgentFederatedThreadMutationHandler,
+} from "../agent-tools/pwragent-thread-agent-tools";
+import type { RemoteThreadTargetStore } from "../state/remote-thread-target-store";
+import {
+  FederatedThreadTargetError,
+  resolveFederatedThreadTarget,
+  type ResolvedFederatedThreadTarget,
+} from "./federated-thread-target-service";
+import {
+  getDesktopFederationRuntime,
+  type DesktopFederationRuntime,
+} from "./federation-runtime";
+
+export function createFederatedThreadMutationHandler(
+  options: {
+    runtime?: () => DesktopFederationRuntime;
+    targetStore?: RemoteThreadTargetStore;
+  } = {},
+): PwrAgentFederatedThreadMutationHandler {
+  const runtime = options.runtime ?? getDesktopFederationRuntime;
+  return async (request) => {
+    let match: ResolvedFederatedThreadTarget | undefined;
+    try {
+      match = await resolveFederatedThreadTarget({
+        runtime: runtime(),
+        targetStore: options.targetStore,
+        request,
+      });
+    } catch (error) {
+      if (error instanceof FederatedThreadTargetError) {
+        throw new PwrAgentFederatedThreadInspectionError(
+          error.code,
+          error.message,
+        );
+      }
+      throw error;
+    }
+    if (!match) {
+      return undefined;
+    }
+    if (!match.peer.capabilities.includes("turn_control")) {
+      throw new Error(
+        `Federation instance ${match.peer.label} owns thread ${request.threadId} but does not grant turn_control.`,
+      );
+    }
+    if (!request.dryRun) {
+      if (request.title !== undefined) {
+        await match.backend.renameThread({
+          backend: request.backend,
+          threadId: request.threadId,
+          name: request.title,
+        });
+      }
+      if (request.modelSettings) {
+        await match.backend.setThreadModelSettings({
+          backend: request.backend,
+          threadId: request.threadId,
+          ...request.modelSettings,
+        });
+      }
+      if (request.executionMode !== undefined) {
+        await match.backend.setThreadExecutionMode({
+          backend: request.backend,
+          threadId: request.threadId,
+          executionMode: request.executionMode,
+        });
+      }
+    }
+    return {
+      instanceId: match.peer.target.instanceId,
+      instanceLabel: match.peer.label,
+    };
+  };
+}

--- a/apps/desktop/src/main/federation/federated-thread-target-service.ts
+++ b/apps/desktop/src/main/federation/federated-thread-target-service.ts
@@ -2,6 +2,7 @@ import type {
   AppServerBackendKind,
   AppServerThreadSummary,
   FederationCapability,
+  FederationHealthStatus,
   FederationInstanceId,
   FederationRemoteTarget,
   ThreadIdentifier,
@@ -10,7 +11,16 @@ import { formatFederationPeerDisplayLabel } from "@pwragent/shared";
 import { getMainLogger } from "../log";
 import type { RemoteThreadTargetStore } from "../state/remote-thread-target-store";
 import type { FederationBackendOperations } from "./federation-backend-bridge";
-import type { DesktopFederationRuntime } from "./federation-runtime";
+
+export type FederatedThreadTargetRuntime = {
+  connectedPeerTargets(): Array<{
+    target: FederationRemoteTarget;
+    label: string;
+    capabilities: FederationCapability[];
+  }>;
+  health(): Promise<FederationHealthStatus>;
+  remoteBackend(target: FederationRemoteTarget): FederationBackendOperations;
+};
 
 export type FederatedThreadTargetRequest = {
   backend: AppServerBackendKind;
@@ -42,7 +52,7 @@ export class FederatedThreadTargetError extends Error {
 const log = getMainLogger("pwragent:federated-thread-target");
 
 export async function resolveFederatedThreadTarget(params: {
-  runtime: DesktopFederationRuntime;
+  runtime: FederatedThreadTargetRuntime;
   targetStore?: RemoteThreadTargetStore;
   request: FederatedThreadTargetRequest;
 }): Promise<ResolvedFederatedThreadTarget | undefined> {
@@ -146,7 +156,7 @@ export async function resolveFederatedThreadTarget(params: {
 }
 
 async function resolveThreadOnPeer(
-  runtime: DesktopFederationRuntime,
+  runtime: FederatedThreadTargetRuntime,
   peer: ResolvedFederatedThreadTarget["peer"],
   request: FederatedThreadTargetRequest,
 ): Promise<ResolvedFederatedThreadTarget | undefined> {

--- a/apps/desktop/src/main/federation/federated-thread-target-service.ts
+++ b/apps/desktop/src/main/federation/federated-thread-target-service.ts
@@ -1,0 +1,217 @@
+import type {
+  AppServerBackendKind,
+  AppServerThreadSummary,
+  FederationCapability,
+  FederationInstanceId,
+  FederationRemoteTarget,
+  ThreadIdentifier,
+} from "@pwragent/shared";
+import { formatFederationPeerDisplayLabel } from "@pwragent/shared";
+import { getMainLogger } from "../log";
+import type { RemoteThreadTargetStore } from "../state/remote-thread-target-store";
+import type { FederationBackendOperations } from "./federation-backend-bridge";
+import type { DesktopFederationRuntime } from "./federation-runtime";
+
+export type FederatedThreadTargetRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  instanceId?: FederationInstanceId;
+  resolutionMode?: "remembered_only" | "discover_only";
+};
+
+export type ResolvedFederatedThreadTarget = {
+  backend: FederationBackendOperations;
+  peer: {
+    target: FederationRemoteTarget;
+    label: string;
+    capabilities: FederationCapability[];
+  };
+  thread: AppServerThreadSummary;
+};
+
+export class FederatedThreadTargetError extends Error {
+  constructor(
+    readonly code: "peer_unavailable",
+    message: string,
+  ) {
+    super(message);
+    this.name = "FederatedThreadTargetError";
+  }
+}
+
+const log = getMainLogger("pwragent:federated-thread-target");
+
+export async function resolveFederatedThreadTarget(params: {
+  runtime: DesktopFederationRuntime;
+  targetStore?: RemoteThreadTargetStore;
+  request: FederatedThreadTargetRequest;
+}): Promise<ResolvedFederatedThreadTarget | undefined> {
+  const { request, runtime, targetStore } = params;
+  const connectedPeers = runtime.connectedPeerTargets();
+  const rememberedTargets = request.instanceId
+    || request.resolutionMode === "discover_only"
+    ? []
+    : await readRememberedTargets(targetStore, request);
+  if (rememberedTargets.length > 1) {
+    throw new Error(
+      `Thread ${request.threadId} has multiple remembered federation owners: ${rememberedTargets
+        .map((target) => target.instanceLabel)
+        .join(", ")}. Pass instanceId to select the intended target.`,
+    );
+  }
+  const targetInstanceId = request.instanceId ?? rememberedTargets[0]?.instanceId;
+  if (targetInstanceId) {
+    const peer = connectedPeers.find(
+      (candidate) => candidate.target.instanceId === targetInstanceId,
+    );
+    if (!peer) {
+      const health = await runtime.health();
+      const knownPeer = health.peers.find(
+        (candidate) => candidate.id === targetInstanceId,
+      );
+      const instanceLabel = knownPeer
+        ? formatFederationPeerDisplayLabel(knownPeer, health.peers)
+        : rememberedTargets[0]?.instanceLabel ?? targetInstanceId;
+      const status = knownPeer?.status ?? "not enrolled";
+      throw new FederatedThreadTargetError(
+        "peer_unavailable",
+        `Federation instance ${instanceLabel}, the known owner of thread ${request.threadId}, is ${status}.`,
+      );
+    }
+    if (!peer.capabilities.includes("thread_navigation")) {
+      throw new Error(
+        `Federation instance ${peer.label} owns thread ${request.threadId} but does not grant thread_navigation.`,
+      );
+    }
+    const match = await resolveThreadOnPeer(runtime, peer, request);
+    if (!match) {
+      if (
+        rememberedTargets.length > 0
+        && request.resolutionMode === "remembered_only"
+      ) {
+        throw new Error(
+          `Thread ${request.threadId} was not found on its remembered federation owner ${peer.label}.`,
+        );
+      }
+      return undefined;
+    }
+    await rememberTarget(targetStore, match, request);
+    return match;
+  }
+
+  if (request.resolutionMode === "remembered_only") {
+    return undefined;
+  }
+
+  const peers = connectedPeers.filter((peer) =>
+    peer.capabilities.includes("thread_navigation"),
+  );
+  const failures: Array<{ label: string; message: string }> = [];
+  const matches = (
+    await Promise.all(
+      peers.map(async (peer): Promise<ResolvedFederatedThreadTarget | undefined> => {
+        try {
+          return await resolveThreadOnPeer(runtime, peer, request);
+        } catch (error) {
+          failures.push({
+            label: peer.label,
+            message: error instanceof Error ? error.message : String(error),
+          });
+          return undefined;
+        }
+      }),
+    )
+  ).filter((match): match is ResolvedFederatedThreadTarget => Boolean(match));
+
+  if (matches.length > 1) {
+    throw new Error(
+      `Thread ${request.threadId} was reported by multiple federation instances: ${matches
+        .map((match) => match.peer.label)
+        .join(", ")}.`,
+    );
+  }
+  const match = matches[0];
+  if (!match) {
+    if (failures.length > 0) {
+      throw new Error(
+        `Could not resolve thread ${request.threadId} because federation lookup failed on ${failures
+          .map((failure) => `${failure.label}: ${failure.message}`)
+          .join("; ")}.`,
+      );
+    }
+    return undefined;
+  }
+  await rememberTarget(targetStore, match, request);
+  return match;
+}
+
+async function resolveThreadOnPeer(
+  runtime: DesktopFederationRuntime,
+  peer: ResolvedFederatedThreadTarget["peer"],
+  request: FederatedThreadTargetRequest,
+): Promise<ResolvedFederatedThreadTarget | undefined> {
+  const backend = runtime.remoteBackend(peer.target);
+  let thread: AppServerThreadSummary | undefined;
+  try {
+    thread = (
+      await backend.resolveThread({
+        backend: request.backend,
+        threadId: request.threadId,
+      })
+    ).thread;
+  } catch {
+    // Mixed-version peers may predate backend.resolveThread. Their unfiltered
+    // list still provides an exact-ID compatibility path.
+    thread = (
+      await backend.listThreads({ backend: request.backend })
+    ).threads.find((candidate) => candidate.id === request.threadId);
+  }
+  return thread ? { backend, peer, thread } : undefined;
+}
+
+async function readRememberedTargets(
+  targetStore: RemoteThreadTargetStore | undefined,
+  request: FederatedThreadTargetRequest,
+) {
+  if (!targetStore) {
+    return [];
+  }
+  try {
+    return await targetStore.listRemoteThreadTargets({
+      backend: request.backend,
+      threadId: request.threadId,
+    });
+  } catch (error) {
+    log.warn("failed to read remote thread target", {
+      backend: request.backend,
+      error: error instanceof Error ? error.message : String(error),
+      threadId: request.threadId,
+    });
+    return [];
+  }
+}
+
+async function rememberTarget(
+  targetStore: RemoteThreadTargetStore | undefined,
+  match: ResolvedFederatedThreadTarget,
+  request: FederatedThreadTargetRequest,
+): Promise<void> {
+  if (!targetStore) {
+    return;
+  }
+  try {
+    await targetStore.rememberRemoteThreadTarget({
+      instanceId: match.peer.target.instanceId,
+      instanceLabel: match.peer.label,
+      backend: request.backend,
+      threadId: request.threadId,
+    });
+  } catch (error) {
+    log.warn("failed to remember remote thread target", {
+      backend: request.backend,
+      error: error instanceof Error ? error.message : String(error),
+      instanceId: match.peer.target.instanceId,
+      threadId: request.threadId,
+    });
+  }
+}

--- a/apps/desktop/src/main/federation/federated-thread-target-service.ts
+++ b/apps/desktop/src/main/federation/federated-thread-target-service.ts
@@ -176,6 +176,14 @@ async function resolveThreadOnPeer(
       await backend.listThreads({ backend: request.backend })
     ).threads.find((candidate) => candidate.id === request.threadId);
   }
+  if (!thread) {
+    thread = (
+      await backend.listThreads({
+        backend: request.backend,
+        archived: true,
+      })
+    ).threads.find((candidate) => candidate.id === request.threadId);
+  }
   return thread ? { backend, peer, thread } : undefined;
 }
 

--- a/apps/desktop/src/main/federation/federation-agent-tools-service.ts
+++ b/apps/desktop/src/main/federation/federation-agent-tools-service.ts
@@ -378,6 +378,11 @@ async function searchFederationThreads(
   const response = await service.search({
     query: args.query,
     limit: args.limit,
+    backend: args.backend,
+    includeArchived: args.includeArchived,
+    projectKeys: args.projectKeys,
+    updatedAfter: args.updatedAfter,
+    updatedBefore: args.updatedBefore,
   });
   const results = response.results.map(
     (entry): FederationThreadSearchResultSummary => {
@@ -393,6 +398,7 @@ async function searchFederationThreads(
         threadId: entry.thread.id,
         title: entry.thread.title,
         updatedAt: entry.thread.updatedAt,
+        archivedAt: entry.thread.archivedAt,
         projectKey: entry.thread.projectKey,
         gitBranch: entry.thread.gitBranch,
         score: entry.score,
@@ -421,6 +427,8 @@ async function searchFederationThreads(
   const result: SearchFederationThreadsResult = {
     query: response.query,
     results,
+    totalCount: response.totalCount,
+    truncated: response.truncated,
     searchedInstances: [
       ...(includeLocal && localId
         ? [

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -3570,8 +3570,14 @@ function localBackendOperations(): FederationBackendOperations {
       const response = await getDesktopBackendRegistry().readThread({
         backend,
         threadId: request.threadId,
+        ...(request.includeTurns !== undefined
+          ? { includeTurns: request.includeTurns }
+          : {}),
         before: request.before,
         limit: request.limit,
+        ...(request.viewOnly !== undefined
+          ? { viewOnly: request.viewOnly }
+          : {}),
       });
       return rewriteTranscriptImageUrlsForRenderer(response);
     },

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -4,6 +4,7 @@ import { getDesktopBackendRegistry } from "./app-server/backend-registry";
 import { getDesktopOverlayStore } from "./app-server/desktop-overlay-store";
 import { createPwrAgentAppManagementHandler } from "./agent-tools/pwragent-app-management-service";
 import { createFederationAgentToolsHandler } from "./federation/federation-agent-tools-service";
+import { createFederatedThreadInspectionHandler } from "./federation/federated-thread-inspection-service";
 import { createFederatedThreadMessageHandler } from "./federation/federated-thread-message-service";
 import { disposeAgentIpcHandlers, registerAgentIpcHandlers } from "./ipc/agent-ipc";
 import {
@@ -1012,6 +1013,11 @@ export function bootstrapApp(): void {
     );
     getDesktopBackendRegistry().setFederatedThreadMessageHandler(
       createFederatedThreadMessageHandler({
+        targetStore: getDesktopOverlayStore(),
+      }),
+    );
+    getDesktopBackendRegistry().setFederatedThreadInspectionHandler(
+      createFederatedThreadInspectionHandler({
         targetStore: getDesktopOverlayStore(),
       }),
     );

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -5,6 +5,7 @@ import { getDesktopOverlayStore } from "./app-server/desktop-overlay-store";
 import { createPwrAgentAppManagementHandler } from "./agent-tools/pwragent-app-management-service";
 import { createFederationAgentToolsHandler } from "./federation/federation-agent-tools-service";
 import { createFederatedThreadInspectionHandler } from "./federation/federated-thread-inspection-service";
+import { createFederatedThreadMutationHandler } from "./federation/federated-thread-mutation-service";
 import { createFederatedThreadMessageHandler } from "./federation/federated-thread-message-service";
 import { disposeAgentIpcHandlers, registerAgentIpcHandlers } from "./ipc/agent-ipc";
 import {
@@ -1018,6 +1019,11 @@ export function bootstrapApp(): void {
     );
     getDesktopBackendRegistry().setFederatedThreadInspectionHandler(
       createFederatedThreadInspectionHandler({
+        targetStore: getDesktopOverlayStore(),
+      }),
+    );
+    getDesktopBackendRegistry().setFederatedThreadMutationHandler(
+      createFederatedThreadMutationHandler({
         targetStore: getDesktopOverlayStore(),
       }),
     );

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -18,6 +18,8 @@ import type {
   InterruptTurnResponse,
   GetNavigationSnapshotRequest,
   FederationTarget,
+  FederatedThreadRef,
+  FederationInstanceId,
   ListBackendsRequest,
   ListBackendsResponse,
   ListScheduledThreadActionsRequest,
@@ -26,6 +28,7 @@ import type {
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   NavigationSnapshot,
+  NavigationThreadSummary,
   SetAcpSessionRuntimeOptionRequest,
   SetAcpSessionRuntimeOptionResponse,
   SetThreadExecutionModeRequest,
@@ -146,6 +149,16 @@ export type MessagingBackendBridge = {
   getNavigationSnapshot(
     request?: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot>;
+  resolveThreadTarget?(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    instanceId?: FederationInstanceId;
+    includeRemote?: boolean;
+  }): Promise<{
+    navigation: NavigationSnapshot;
+    thread: NavigationThreadSummary;
+    federatedThread?: FederatedThreadRef;
+  } | undefined>;
   readThreadAgentMetadata?(request: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -254,6 +267,16 @@ export type MessagingBackendBridge = {
     request: SubmitServerRequestRequest,
   ): Promise<SubmitServerRequestResponse>;
 };
+
+export class MessagingFederatedThreadTargetError extends Error {
+  constructor(
+    readonly code: "peer_unavailable",
+    message: string,
+  ) {
+    super(message);
+    this.name = "MessagingFederatedThreadTargetError";
+  }
+}
 
 export type MessagingInboundListener = (
   event: MessagingInboundEvent,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -139,6 +139,7 @@ import type {
   MessagingBackendBridge,
   MessagingLastAssistantReply,
 } from "./messaging-adapter.js";
+import { MessagingFederatedThreadTargetError } from "./messaging-adapter.js";
 import type { MessagingActivityLog } from "../messaging-activity-log.js";
 import {
   buildActivityIntent,
@@ -405,10 +406,26 @@ type AgentMessagingOriginResolution =
 type AttachTargetResolution =
   | {
       ok: true;
+      federatedThread?: FederatedThreadRef;
       navigation: NavigationSnapshot;
       thread: NavigationThreadSummary;
     }
   | Extract<PwrAgentMessagingResponse, { ok: false }>;
+
+function attachTargetNotFound(
+  backend: AppServerBackendKind,
+  threadId: string,
+): Extract<PwrAgentMessagingResponse, { ok: false }> {
+  return {
+    ok: false,
+    error: {
+      code: "not_found",
+      message:
+        `Thread ${backend}:${threadId} is not an active attachable thread. `
+        + "It may be archived, deleted, or unavailable; restore it in PwrAgent or choose another thread.",
+    },
+  };
+}
 
 type ExecutionModeResolution = {
   mode: ThreadExecutionMode | undefined;
@@ -15506,6 +15523,26 @@ export class MessagingController {
         },
       };
     }
+    const instanceId = args.instanceId?.trim();
+    const includeRemote = args.includeRemote !== false;
+    if (Object.hasOwn(args, "instanceId") && !instanceId) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message: "instanceId must be a non-empty string when provided.",
+        },
+      };
+    }
+    if (instanceId && !includeRemote) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message: "instanceId cannot be used when includeRemote is false.",
+        },
+      };
+    }
     const placement = args.placement ?? "auto";
     if (
       placement !== "auto" &&
@@ -15535,7 +15572,12 @@ export class MessagingController {
     if (!origin.ok) {
       return origin;
     }
-    const target = await this.resolveAttachTarget(args.backend, args.threadId);
+    const target = await this.resolveAttachTarget({
+      backend: args.backend,
+      threadId: args.threadId,
+      ...(instanceId ? { instanceId } : {}),
+      includeRemote,
+    });
     if (!target.ok) {
       return target;
     }
@@ -15601,6 +15643,7 @@ export class MessagingController {
 
     const binding = await this.bindChannelToThread(attachEvent, {
       backend: args.backend,
+      federatedThread: target.federatedThread,
       threadId: args.threadId,
       targetKind,
     });
@@ -16038,18 +16081,34 @@ export class MessagingController {
     };
   }
 
-  private async resolveAttachTarget(
-    backend: AppServerBackendKind,
-    threadId: string,
-  ): Promise<AttachTargetResolution> {
+  private async resolveAttachTarget(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    instanceId?: string;
+    includeRemote: boolean;
+  }): Promise<AttachTargetResolution> {
     let navigation: NavigationSnapshot;
     try {
-      navigation = await this.options.backend.getNavigationSnapshot({ backend });
+      if (this.options.backend.resolveThreadTarget) {
+        const resolved = await this.options.backend.resolveThreadTarget(request);
+        return resolved
+          ? { ok: true, ...resolved }
+          : attachTargetNotFound(request.backend, request.threadId);
+      }
+      if (request.instanceId || request.includeRemote === false) {
+        return attachTargetNotFound(request.backend, request.threadId);
+      }
+      navigation = await this.options.backend.getNavigationSnapshot({
+        backend: request.backend,
+      });
     } catch (error) {
       return {
         ok: false,
         error: {
-          code: "internal_error",
+          code:
+            error instanceof MessagingFederatedThreadTargetError
+              ? error.code
+              : "internal_error",
           message:
             error instanceof Error
               ? `Could not verify target thread before attaching: ${error.message}`
@@ -16059,18 +16118,12 @@ export class MessagingController {
     }
 
     const target = navigation.threads.find(
-      (thread) => thread.source === backend && thread.id === threadId,
+      (thread) =>
+        thread.source === request.backend
+        && thread.id === request.threadId,
     );
     if (!target) {
-      return {
-        ok: false,
-        error: {
-          code: "not_found",
-          message:
-            `Thread ${backend}:${threadId} is not an active attachable thread. ` +
-            "It may be archived, deleted, or unavailable; restore it in PwrAgent or choose another thread.",
-        },
-      };
+      return attachTargetNotFound(request.backend, request.threadId);
     }
 
     return { ok: true, navigation, thread: target };

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -17,6 +17,8 @@ import type {
   EnsureDirectoryLaunchpadResponse,
   FederationCapability,
   FederationEventSubscription,
+  FederationHealthStatus,
+  FederationInstanceId,
   FederationRemoteTarget,
   FederationTarget,
   GetNavigationSnapshotRequest,
@@ -56,11 +58,15 @@ import type {
   UpdateDirectoryLaunchpadResponse,
 } from "@pwragent/shared";
 import type { MessagingImagePart } from "@pwragent/messaging-interface";
-import { isRemoteFederationTarget } from "@pwragent/shared";
+import {
+  buildFederatedThreadRef,
+  isRemoteFederationTarget,
+} from "@pwragent/shared";
 import type {
   MessagingBackendBridge,
   MessagingLastAssistantReply,
 } from "./core/messaging-adapter";
+import { MessagingFederatedThreadTargetError } from "./core/messaging-adapter";
 import type { DesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
@@ -69,6 +75,10 @@ import { buildMessagingBindingsByThreadKey } from "./messaging-bindings-snapshot
 import { hydrateLaunchpadCodexEnvironmentOptions } from "../app-server/codex-environment-config";
 import { materializeTranscriptMessageImagesForMessaging } from "../transcript-image-protocol";
 import type { FederationBackendOperations } from "../federation/federation-backend-bridge";
+import {
+  FederatedThreadTargetError,
+  resolveFederatedThreadTarget,
+} from "../federation/federated-thread-target-service";
 import { getScheduledThreadActionService } from "../scheduled-actions/scheduled-thread-action-service";
 
 export type DesktopMessagingFederationBridge = {
@@ -77,6 +87,7 @@ export type DesktopMessagingFederationBridge = {
     label: string;
     capabilities: FederationCapability[];
   }>;
+  health(): Promise<FederationHealthStatus>;
   onRemoteBackendEvent(
     listener: (event: AgentEvent) => void | Promise<void>,
   ): () => void;
@@ -236,6 +247,89 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
         ...availableRemoteSnapshots.flatMap((remote) => remote.inboxThreadKeys),
       ],
     };
+  }
+
+  async resolveThreadTarget(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    instanceId?: FederationInstanceId;
+    includeRemote?: boolean;
+  }) {
+    if (!request.instanceId) {
+      const localThreads = await this.registry.listThreads({
+        backend: request.backend,
+        archived: false,
+        callerReason: "messaging-attach-thread-target",
+      });
+      const localThread = localThreads.find(
+        (thread) => thread.id === request.threadId,
+      );
+      if (localThread) {
+        const navigation = await this.getNavigationSnapshot({
+          backend: request.backend,
+        });
+        const thread = navigation.threads.find(
+          (candidate) =>
+            candidate.source === request.backend
+            && candidate.id === request.threadId,
+        );
+        if (thread) {
+          return { navigation, thread };
+        }
+      }
+    }
+    if (request.includeRemote === false || !this.federation) {
+      return undefined;
+    }
+
+    try {
+      const match = await resolveFederatedThreadTarget({
+        runtime: this.federation,
+        targetStore: getDesktopOverlayStore(),
+        request,
+      });
+      if (!match) {
+        return undefined;
+      }
+      if (!match.peer.capabilities.includes("messaging_route")) {
+        throw new Error(
+          `Federation instance ${match.peer.label} owns thread ${request.threadId} but does not grant messaging_route.`,
+        );
+      }
+      const federationTarget = match.peer.target;
+      const navigation = await this.federation.remoteNavigationSnapshot(
+        federationTarget,
+        {
+          backend: request.backend,
+          federationTarget,
+        },
+      );
+      const thread = navigation.threads.find(
+        (candidate) =>
+          candidate.source === request.backend
+          && candidate.id === request.threadId,
+      );
+      if (!thread) {
+        return undefined;
+      }
+      return {
+        navigation,
+        thread,
+        federatedThread: buildFederatedThreadRef({
+          backend: request.backend,
+          threadId: request.threadId,
+          instanceId: federationTarget.instanceId,
+        }),
+      };
+    } catch (error) {
+      if (error instanceof FederatedThreadTargetError) {
+        throw new MessagingFederatedThreadTargetError(
+          error.code,
+          error.message,
+        );
+      }
+      throw error;
+    }
   }
 
   async readThreadAgentMetadata(request: {

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -249,12 +249,20 @@ thread ID across connected peers. Exact UUID queries passed to
 `search_federation_threads` use the same ownership lookup instead of relying on
 fuzzy thread-list filtering.
 
-The `read_thread` and `get_thread_status` tools use the same local-first routing
-for exact thread IDs. Callers may pass `instanceId` to route directly to a
-known owner, but it is not required: after a local miss, PwrAgent checks durable
-ownership metadata and then connected peers. This compatibility fallback also
-lets already-running agent threads use remote inspection before their persisted
-tool schema includes the newer field. Set `includeRemote: false` on
-`read_thread`, `get_thread_status`, or `send_message_to_thread` when an
-operation must stay local. Remote transcript reads require the peer's
-`thread_detail` capability; ownership resolution requires `thread_navigation`.
+The `read_thread`, `get_thread_status`, `mutate_thread`, and
+`attach_thread_here` tools use the same local-first routing for exact thread
+IDs. Callers may pass `instanceId` to route directly to a known owner, but it is
+not required: after a local miss, PwrAgent checks durable ownership metadata
+and then connected peers. This compatibility fallback also lets already-running
+agent threads use remote routing before their persisted tool schema includes
+the newer fields. Set `includeRemote: false` on these tools or
+`send_message_to_thread` when an operation must stay local.
+
+`search_threads` also includes metadata matches from connected Federation
+instances by default, while preserving its richer local transcript, semantic,
+Agent, model, and directory filters as local-only capabilities. Pass
+`instanceId` to search one connected instance, or `includeRemote: false` for a
+strictly local search. Remote transcript reads require `thread_detail`, remote
+mutations require `turn_control`, remote messaging attachments require
+`messaging_route`, and all exact-thread ownership resolution requires
+`thread_navigation`.

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -262,7 +262,10 @@ the newer fields. Set `includeRemote: false` on these tools or
 instances by default, while preserving its richer local transcript, semantic,
 Agent, model, and directory filters as local-only capabilities. Pass
 `instanceId` to search one connected instance, or `includeRemote: false` for a
-strictly local search. Remote transcript reads require `thread_detail`, remote
+strictly local search. Supported backend, project, archive, and update-time
+filters run on each instance before the global page limit; merged local and
+remote pages report the combined total and whether more matches were truncated.
+Remote transcript reads require `thread_detail`, remote
 mutations require `turn_control`, remote messaging attachments require
 `messaging_route`, and all exact-thread ownership resolution requires
 `thread_navigation`.

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -248,3 +248,13 @@ When no durable owner is known, compatibility fallback still resolves the exact
 thread ID across connected peers. Exact UUID queries passed to
 `search_federation_threads` use the same ownership lookup instead of relying on
 fuzzy thread-list filtering.
+
+The `read_thread` and `get_thread_status` tools use the same local-first routing
+for exact thread IDs. Callers may pass `instanceId` to route directly to a
+known owner, but it is not required: after a local miss, PwrAgent checks durable
+ownership metadata and then connected peers. This compatibility fallback also
+lets already-running agent threads use remote inspection before their persisted
+tool schema includes the newer field. Set `includeRemote: false` on
+`read_thread`, `get_thread_status`, or `send_message_to_thread` when an
+operation must stay local. Remote transcript reads require the peer's
+`thread_detail` capability; ownership resolution requires `thread_navigation`.

--- a/packages/shared/src/contracts/__tests__/federation-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/federation-tools.test.ts
@@ -55,6 +55,8 @@ describe("federation tool contracts", () => {
 
     const result: SearchFederationThreadsResult = {
       query: "recorder crash",
+      totalCount: 1,
+      truncated: false,
       results: [
         {
           instanceId: "pwr_studio",

--- a/packages/shared/src/contracts/federation-tools.ts
+++ b/packages/shared/src/contracts/federation-tools.ts
@@ -168,6 +168,11 @@ export type FederationSearchScope = (typeof FEDERATION_SEARCH_SCOPES)[number];
 
 export type SearchFederationThreadsToolArgs = {
   query: string;
+  backend?: AppServerBackendKind | "all";
+  includeArchived?: boolean;
+  projectKeys?: string[];
+  updatedAfter?: number;
+  updatedBefore?: number;
   /**
    * Which instances to search: `all` (default) is local plus every
    * connected peer, `local` is this instance only, `remote` is every
@@ -188,6 +193,7 @@ export type FederationThreadSearchResultSummary = {
   threadId: ThreadIdentifier;
   title: string;
   updatedAt?: number;
+  archivedAt?: number;
   projectKey?: string;
   gitBranch?: string;
   score: number;
@@ -198,6 +204,8 @@ export type FederationThreadSearchResultSummary = {
 export type SearchFederationThreadsResult = {
   query: string;
   results: FederationThreadSearchResultSummary[];
+  totalCount: number;
+  truncated: boolean;
   searchedInstances: FederatedSearchInstanceSummary[];
   failures: FederatedSearchPeerFailure[];
 };

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -475,6 +475,10 @@ export type FederatedSearchRequest = {
   query: string;
   limit?: number;
   backend?: AppServerBackendScope;
+  includeArchived?: boolean;
+  projectKeys?: string[];
+  updatedAfter?: number;
+  updatedBefore?: number;
 };
 
 export type FederatedSearchResult = {
@@ -501,6 +505,8 @@ export type FederatedSearchResponse = {
   query: string;
   searchedAt: number;
   results: FederatedSearchResult[];
+  totalCount: number;
+  truncated: boolean;
   failures: FederatedSearchPeerFailure[];
   /** Peers that were queried successfully, so the UI can disclose scope. */
   searchedInstances?: FederatedSearchInstanceSummary[];

--- a/packages/shared/src/contracts/messaging-tools.ts
+++ b/packages/shared/src/contracts/messaging-tools.ts
@@ -4,6 +4,7 @@ import type {
   ThreadExecutionMode,
   ThreadIdentifier,
 } from "./normalized-app-server";
+import type { FederationInstanceId } from "./federation";
 import type {
   MessagingBindingTargetKind,
   MessagingChannelKind,
@@ -51,6 +52,7 @@ export type PwrAgentMessagingOperationName =
 export const PWRAGENT_MESSAGING_ERROR_CODES = [
   "invalid_arguments",
   "not_found",
+  "peer_unavailable",
   "ambiguous_location",
   "forbidden",
   "unsupported_operation",
@@ -142,6 +144,13 @@ export type AttachThreadHerePlacement =
 export type AttachThreadHereToolArgs = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  /**
+   * Federation instance that owns the thread. When omitted, PwrAgent first
+   * checks the local instance, then resolves a remembered or connected peer.
+   */
+  instanceId?: FederationInstanceId;
+  /** Defaults to true. Set false to restrict resolution to the local instance. */
+  includeRemote?: boolean;
   placement?: AttachThreadHerePlacement;
   targetKind?: MessagingBindingTargetKind;
   title?: string;

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -124,6 +124,10 @@ export type SendMessageToThreadToolArgs = {
    * local threads and legacy callers; PwrAgent falls back to durable lookup.
    */
   instanceId?: FederationInstanceId;
+  /**
+   * Defaults to true. Set false to restrict resolution to the local instance.
+   */
+  includeRemote?: boolean;
   prompt: string;
   model?: string;
   reasoningEffort?: string;

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -11,6 +11,7 @@ import type {
   ThreadWorkspaceHandoffDirection,
   ThreadWorkspaceHandoffStrategy,
 } from "./normalized-app-server";
+import type { FederationInstanceId } from "./federation";
 import type { LinkedDirectorySummary } from "./normalized-app-server";
 import type {
   MessagingThreadBindingSummary,
@@ -61,6 +62,7 @@ export const MAX_THREAD_INSPECTION_SEARCH_LIMIT = 100;
 export const PWRAGENT_THREAD_INSPECTION_ERROR_CODES = [
   "invalid_arguments",
   "not_found",
+  "peer_unavailable",
   "forbidden",
   "unsupported_operation",
   "internal_error",
@@ -99,11 +101,29 @@ export type GetThreadStatusToolArgs = {
    * Defaults to the invoking PwrAgent thread id when omitted.
    */
   threadId?: ThreadIdentifier;
+  /**
+   * Federation instance that owns the thread. When omitted, PwrAgent first
+   * checks the local instance, then resolves a remembered or connected peer.
+   */
+  instanceId?: FederationInstanceId;
+  /**
+   * Defaults to true. Set false to restrict resolution to the local instance.
+   */
+  includeRemote?: boolean;
 };
 
 export type ReadThreadToolArgs = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  /**
+   * Federation instance that owns the thread. When omitted, PwrAgent first
+   * checks the local instance, then resolves a remembered or connected peer.
+   */
+  instanceId?: FederationInstanceId;
+  /**
+   * Defaults to true. Set false to restrict resolution to the local instance.
+   */
+  includeRemote?: boolean;
   /**
    * Provider pagination cursor returned by a previous read_thread response.
    */
@@ -286,6 +306,8 @@ export type ThreadMutationResult = {
 export type ThreadInspectionSummary = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  instanceId?: FederationInstanceId;
+  instanceLabel?: string;
   title: string;
   summary?: string;
   projectKey?: string;
@@ -462,6 +484,8 @@ export type ThreadReadEntrySummary =
 export type ThreadReadResult = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  instanceId?: FederationInstanceId;
+  instanceLabel?: string;
   limit: number;
   before?: string;
   maxCharsPerEntry: number;

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -11,7 +11,11 @@ import type {
   ThreadWorkspaceHandoffDirection,
   ThreadWorkspaceHandoffStrategy,
 } from "./normalized-app-server";
-import type { FederationInstanceId } from "./federation";
+import type {
+  FederatedSearchInstanceSummary,
+  FederatedSearchPeerFailure,
+  FederationInstanceId,
+} from "./federation";
 import type { LinkedDirectorySummary } from "./normalized-app-server";
 import type {
   MessagingThreadBindingSummary,
@@ -80,6 +84,10 @@ export type PwrAgentThreadInspectionContext = {
 export type SearchThreadsToolArgs = {
   query?: string;
   backend?: AppServerBackendKind | "all";
+  /** Restrict the search to one connected Federation instance. */
+  instanceId?: FederationInstanceId;
+  /** Defaults to true. Set false to search only the local instance. */
+  includeRemote?: boolean;
   includeArchived?: boolean;
   agentOnly?: boolean;
   projectKeys?: string[];
@@ -156,6 +164,13 @@ export type ReadThreadToolArgs = {
 export type MutateThreadToolArgs = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  /**
+   * Federation instance that owns the thread. When omitted, PwrAgent first
+   * checks the local instance, then resolves a remembered or connected peer.
+   */
+  instanceId?: FederationInstanceId;
+  /** Defaults to true. Set false to restrict resolution to the local instance. */
+  includeRemote?: boolean;
   /**
    * Renames the PwrAgent thread itself. This does not rename any attached
    * Telegram topic, Discord thread, or other messaging surface.
@@ -299,6 +314,8 @@ export type ThreadMutationAppliedChange = {
 export type ThreadMutationResult = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  instanceId?: FederationInstanceId;
+  instanceLabel?: string;
   dryRun: boolean;
   changes: ThreadMutationAppliedChange[];
 };
@@ -308,6 +325,8 @@ export type ThreadInspectionSummary = {
   threadId: ThreadIdentifier;
   instanceId?: FederationInstanceId;
   instanceLabel?: string;
+  /** Canonical navigation link, including the owning instance when remote. */
+  threadLink?: string;
   title: string;
   summary?: string;
   projectKey?: string;
@@ -539,6 +558,8 @@ export type PwrAgentThreadInspectionResponse =
             unavailableScopes?: ThreadSearchUnavailableScope[];
             contentMode?: ThreadSearchContentMode;
             semanticMode?: ThreadSearchSemanticMode;
+            searchedInstances?: FederatedSearchInstanceSummary[];
+            federationFailures?: FederatedSearchPeerFailure[];
           }
         | {
             read: ThreadReadResult;


### PR DESCRIPTION
## Summary

- route `read_thread`, `get_thread_status`, `mutate_thread`, and `attach_thread_here` to an owning Federation peer after a local miss
- make `search_threads` combine local results with connected-peer metadata by default, with optional `instanceId` targeting and `includeRemote: false` local-only behavior
- preserve local-first collision handling and old active-thread schemas whose persisted tool definitions omit the new optional fields
- persist the remote owner on messaging bindings and return instance metadata from remote reads, status, mutations, and search results
- share durable-owner and exact-ID peer resolution across messaging, inspection, and mutation while enforcing `thread_navigation`, `thread_detail`, `turn_control`, and `messaging_route`

## Evidence

The supplied PwrSuiteLab fan-out began at 2026-08-07 11:49:56 UTC. #1310 merged at 12:02:43 UTC, about 13 minutes later. Its deferred `send_message_to_thread` callbacks ultimately succeeded, confirming that #1295 and #1310 cover cross-instance follow-up routing, durable ownership, and remote links. Direct `read_thread` and `get_thread_status` remained local-only and reproduced `thread not loaded` / `not_found`.

The wider MCP audit found the same routing omission in `mutate_thread`, `attach_thread_here`, and general `search_threads`. This PR now covers those tools. Advanced transcript, semantic, Agent, model, and directory filters remain local-only; remote `search_threads` rows are metadata matches. Per operator direction, PR tools and archive/restore behavior remain local-only in this change.

No other currently open PR or issue covers these remaining remote tool gaps.

## Review fixes

- normalize local and remote search ranks before merging instead of comparing unrelated scoring scales
- apply backend, project, archive, and update-time filters on each instance before the global result limit
- propagate exact remote `totalCount` and `truncated` metadata into merged `search_threads` pages
- resolve archived remote threads for exact read, status, and mutation operations after an active-thread miss

## Validation

- focused desktop regression suite across thread tools, messaging tools, mutation service, backend registry, messaging controller, desktop messaging bridge, and main-process wiring (894 tests)
- review-fix regression suite across federated search, federation Agent tools, archived inspection, mutation, contracts, and backend registry (506 tests)
- final attachment-specific regression rerun (12 tests)
- federation runtime and bridge regression suite from the initial change (72 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:sql`
- `git diff --check`

Related: #1295, #1310