### PR TITLE
fix(desktop): reconcile admitted queued turns

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -87,6 +87,11 @@ const registry = {
     turnId: "turn-review-1",
   })),
   cancelQueuedTurn: vi.fn(() => true),
+  cancelQueuedTurnWithDisposition: vi.fn((queueEntryId: string) => ({
+    queueEntryId,
+    cancelled: true,
+    disposition: "cancelled" as const,
+  })),
   interruptTurn: vi.fn(async (request: InterruptTurnRequest) => ({
     backend: request.backend,
     threadId: request.threadId,
@@ -391,6 +396,7 @@ describe("agent ipc", () => {
     registry.submitTurn.mockClear();
     registry.startReview.mockClear();
     registry.cancelQueuedTurn.mockClear();
+    registry.cancelQueuedTurnWithDisposition.mockClear();
     registry.interruptTurn.mockClear();
     registry.stopSubAgent.mockClear();
     registry.steerTurn.mockClear();
@@ -631,6 +637,7 @@ describe("agent ipc", () => {
       queueEntryId: "queue-1",
     });
     expect(registry.cancelQueuedTurn).not.toHaveBeenCalled();
+    expect(registry.cancelQueuedTurnWithDisposition).not.toHaveBeenCalled();
     expect(federationMock.remoteBackend.startReview).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-1",
@@ -848,8 +855,9 @@ describe("agent ipc", () => {
     ).toEqual({
       queueEntryId: "queue-2",
       cancelled: true,
+      disposition: "cancelled",
     });
-    expect(registry.cancelQueuedTurn).toHaveBeenCalledWith(
+    expect(registry.cancelQueuedTurnWithDisposition).toHaveBeenCalledWith(
       "queue-2",
       "Cancelled from the desktop composer.",
     );

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1212,12 +1212,16 @@ describe("federation backend bridge", () => {
       createdAt: 1_400,
       result: {
         queueEntryId: "queue-1",
-        cancelled: true,
+        cancelled: false,
+        disposition: "already_admitted",
+        turnId: "turn-1",
       },
     });
     await expect(cancelPending).resolves.toEqual({
       queueEntryId: "queue-1",
-      cancelled: true,
+      cancelled: false,
+      disposition: "already_admitted",
+      turnId: "turn-1",
     });
   });
 

--- a/apps/desktop/src/main/__tests__/thread-turn-queue.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-turn-queue.test.ts
@@ -218,10 +218,44 @@ describe("ThreadTurnQueue", () => {
 
     await queue.submit(buildEntry({ id: "queued-1" }));
 
-    expect(queue.cancelEntry("queued-1", "test cancel")).toMatchObject({
-      id: "queued-1",
+    expect(
+      queue.cancelEntryWithDisposition("queued-1", "test cancel"),
+    ).toMatchObject({
+      disposition: "cancelled",
+      entry: { id: "queued-1" },
     });
     expect(queue.getQueuedEntries({ backend: "codex", threadId: "thread-1" }))
       .toEqual([]);
+    expect(queue.cancelEntryWithDisposition("missing")).toEqual({
+      disposition: "not_found",
+    });
+  });
+
+  it("recognizes a queue entry that was already admitted", async () => {
+    const queue = new ThreadTurnQueue({
+      startTurn: async (entry) => ({
+        backend: entry.backend,
+        threadId: entry.threadId,
+        turnId: `turn-${entry.id}`,
+      }),
+    });
+
+    await queue.submit(buildEntry({ id: "admitted-1" }));
+
+    expect(queue.cancelEntryWithDisposition("admitted-1")).toMatchObject({
+      disposition: "already_admitted",
+      entryId: "admitted-1",
+      turnId: "turn-admitted-1",
+    });
+
+    await queue.releaseThread({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-admitted-1",
+    });
+    expect(queue.cancelEntryWithDisposition("admitted-1")).toMatchObject({
+      disposition: "already_admitted",
+      turnId: "turn-admitted-1",
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/thread-turn-queue.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-turn-queue.test.ts
@@ -258,4 +258,38 @@ describe("ThreadTurnQueue", () => {
       turnId: "turn-admitted-1",
     });
   });
+
+  it("reports an admission without a turn id while backend startup is pending", async () => {
+    let rejectStart!: (reason?: unknown) => void;
+    const starting = new Promise<never>((_resolve, reject) => {
+      rejectStart = reject;
+    });
+    const events: ThreadTurnQueueLifecycleEvent[] = [];
+    const queue = new ThreadTurnQueue({
+      startTurn: () => starting,
+      onLifecycle: (event) => {
+        events.push(event);
+      },
+    });
+
+    const submission = queue.submit(buildEntry({ id: "starting-1" }));
+    await Promise.resolve();
+
+    expect(queue.cancelEntryWithDisposition("starting-1")).toEqual({
+      disposition: "already_admitted",
+      entryId: "starting-1",
+    });
+
+    rejectStart(new Error("backend startup failed"));
+    await expect(submission).rejects.toThrow("backend startup failed");
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "failed",
+        entry: expect.objectContaining({ id: "starting-1" }),
+      }),
+    ]);
+    expect(queue.cancelEntryWithDisposition("starting-1")).toEqual({
+      disposition: "not_found",
+    });
+  });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -96,6 +96,7 @@ import {
   type BackendSummary,
   type DesktopProviderModelDefaults,
   type DesktopProviderThreadModelMigration,
+  type CancelQueuedTurnResponse,
   type CheckThreadBranchDriftRequest,
   type CheckThreadBranchDriftResponse,
   type ForkThreadRequest,
@@ -10713,6 +10714,24 @@ export class DesktopBackendRegistry {
 
   cancelQueuedTurn(entryId: string, reason?: string): boolean {
     return Boolean(this.threadTurnQueue.cancelEntry(entryId, reason));
+  }
+
+  cancelQueuedTurnWithDisposition(
+    entryId: string,
+    reason?: string,
+  ): CancelQueuedTurnResponse {
+    const result = this.threadTurnQueue.cancelEntryWithDisposition(
+      entryId,
+      reason,
+    );
+    return {
+      queueEntryId: entryId,
+      cancelled: result.disposition === "cancelled",
+      disposition: result.disposition,
+      ...(result.disposition === "already_admitted" && result.turnId
+        ? { turnId: result.turnId }
+        : {}),
+    };
   }
 
   updateQueuedTurnInput(

--- a/apps/desktop/src/main/app-server/thread-turn-queue.ts
+++ b/apps/desktop/src/main/app-server/thread-turn-queue.ts
@@ -56,6 +56,20 @@ export type ThreadTurnQueueImmediateSubmissionResult =
   | Extract<ThreadTurnQueueSubmissionResult, { status: "started" }>
   | { status: "busy" };
 
+export type ThreadTurnQueueCancellationResult =
+  | {
+      disposition: "cancelled";
+      entry: ThreadTurnQueueEntry;
+    }
+  | {
+      disposition: "already_admitted";
+      entryId: string;
+      turnId?: string;
+    }
+  | {
+      disposition: "not_found";
+    };
+
 export type ThreadTurnQueueLifecycleEvent =
   | {
       type: "queued";
@@ -99,10 +113,18 @@ type RunningEntry = {
   turnId?: string;
 };
 
+type AdmittedEntry = {
+  entryId: string;
+  turnId?: string;
+};
+
+const RECENT_ADMITTED_ENTRY_LIMIT = 1_000;
+
 export class ThreadTurnQueue {
   private readonly queuedEntries = new Map<string, ThreadTurnQueueEntry[]>();
   private readonly startingKeys = new Set<string>();
   private readonly runningEntries = new Map<string, RunningEntry>();
+  private readonly recentlyAdmittedEntries = new Map<string, AdmittedEntry>();
   private readonly releasingKeys = new Set<string>();
 
   constructor(private readonly options: ThreadTurnQueueOptions) {}
@@ -202,6 +224,28 @@ export class ThreadTurnQueue {
     return undefined;
   }
 
+  cancelEntryWithDisposition(
+    entryId: string,
+    reason?: string,
+  ): ThreadTurnQueueCancellationResult {
+    const cancelled = this.cancelEntry(entryId, reason);
+    if (cancelled) {
+      return {
+        disposition: "cancelled",
+        entry: cancelled,
+      };
+    }
+    const admitted = this.recentlyAdmittedEntries.get(entryId);
+    if (admitted) {
+      return {
+        disposition: "already_admitted",
+        entryId: admitted.entryId,
+        ...(admitted.turnId ? { turnId: admitted.turnId } : {}),
+      };
+    }
+    return { disposition: "not_found" };
+  }
+
   updateQueuedEntryInput(
     entryId: string,
     input: AppServerTurnInputItem[],
@@ -272,15 +316,22 @@ export class ThreadTurnQueue {
   private async startEntry(entry: ThreadTurnQueueEntry): Promise<ThreadTurnQueueStartResult> {
     const key = this.keyFor(entry);
     this.startingKeys.add(key);
+    this.rememberAdmittedEntry({ entryId: entry.id });
     try {
       const result = await this.options.startTurn(entry);
-      this.runningEntries.set(key, {
+      const running = {
         entry,
+        turnId: result.turnId,
+      };
+      this.runningEntries.set(key, running);
+      this.rememberAdmittedEntry({
+        entryId: entry.id,
         turnId: result.turnId,
       });
       await this.emit({ type: "started", entry, turnId: result.turnId });
       return result;
     } catch (error) {
+      this.recentlyAdmittedEntries.delete(entry.id);
       const normalized = error instanceof Error ? error : new Error(String(error));
       await this.emit({ type: "failed", entry, error: normalized });
       throw normalized;
@@ -295,6 +346,16 @@ export class ThreadTurnQueue {
     const nextQueue: ThreadTurnQueueEntry[] = [];
     this.queuedEntries.set(key, nextQueue);
     return nextQueue;
+  }
+
+  private rememberAdmittedEntry(entry: AdmittedEntry): void {
+    this.recentlyAdmittedEntries.delete(entry.entryId);
+    this.recentlyAdmittedEntries.set(entry.entryId, entry);
+    while (this.recentlyAdmittedEntries.size > RECENT_ADMITTED_ENTRY_LIMIT) {
+      const oldestId = this.recentlyAdmittedEntries.keys().next().value;
+      if (typeof oldestId !== "string") break;
+      this.recentlyAdmittedEntries.delete(oldestId);
+    }
   }
 
   private keyFor(params: {

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -3746,13 +3746,10 @@ function localBackendOperations(): FederationBackendOperations {
     async cancelQueuedTurn(
       request: CancelQueuedTurnRequest,
     ): Promise<CancelQueuedTurnResponse> {
-      return {
-        queueEntryId: request.queueEntryId,
-        cancelled: getDesktopBackendRegistry().cancelQueuedTurn(
-          request.queueEntryId,
-          "Cancelled from a federated desktop composer.",
-        ),
-      };
+      return getDesktopBackendRegistry().cancelQueuedTurnWithDisposition(
+        request.queueEntryId,
+        "Cancelled from a federated desktop composer.",
+      );
     },
     async listScheduledThreadActions(
       request: ListScheduledThreadActionsRequest = {},

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -597,13 +597,10 @@ export function registerAgentIpcHandlers(): void {
           .remoteBackend(federationTarget)
           .cancelQueuedTurn(remoteRequest);
       }
-      return {
-        queueEntryId: request.queueEntryId,
-        cancelled: registry.cancelQueuedTurn(
-          request.queueEntryId,
-          "Cancelled from the desktop composer.",
-        ),
-      };
+      return registry.cancelQueuedTurnWithDisposition(
+        request.queueEntryId,
+        "Cancelled from the desktop composer.",
+      );
     },
   );
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -4028,7 +4028,7 @@ export function Composer(props: ComposerProps) {
   const cancelServerManagedQueuedTurn = async (
     queued: QueuedTurnDraft,
     scopeKey = composerScopeKey,
-  ): Promise<boolean> => {
+  ): Promise<"cancelled" | "already_admitted" | "failed"> => {
     const reportError = (message: string): void => {
       if (activeComposerScopeKeyRef.current === scopeKey) {
         setSendError(message);
@@ -4037,7 +4037,7 @@ export function Composer(props: ComposerProps) {
     if (queued.scheduledActionId) {
       if (!props.desktopApi?.cancelScheduledThreadAction) {
         reportError("Scheduled action cancellation is unavailable.");
-        return false;
+        return "failed";
       }
       try {
         await props.desktopApi.cancelScheduledThreadAction({
@@ -4045,18 +4045,18 @@ export function Composer(props: ComposerProps) {
             ?? rendererFederationTarget,
           id: queued.scheduledActionId,
         });
-        return true;
+        return "cancelled";
       } catch (error) {
         reportError(error instanceof Error ? error.message : String(error));
-        return false;
+        return "failed";
       }
     }
     if (!queued.queueEntryId) {
-      return true;
+      return "cancelled";
     }
     if (!props.desktopApi?.cancelQueuedTurn) {
       reportError("Queued turn cancellation is unavailable.");
-      return false;
+      return "failed";
     }
     try {
       const federationTarget =
@@ -4067,13 +4067,20 @@ export function Composer(props: ComposerProps) {
         queueEntryId: queued.queueEntryId,
       });
       if (!response.cancelled) {
+        if (response.disposition === "already_admitted") {
+          removeQueuedTurnInScope(scopeKey, queued);
+          if (activeComposerScopeKeyRef.current === scopeKey) {
+            setSendError(undefined);
+          }
+          return "already_admitted";
+        }
         reportError("The queued turn is no longer waiting.");
-        return false;
+        return "failed";
       }
-      return true;
+      return "cancelled";
     } catch (error) {
       reportError(error instanceof Error ? error.message : String(error));
-      return false;
+      return "failed";
     }
   };
   const removeLocalQueuedTurn = (queued: QueuedTurnDraft): void => {
@@ -6712,7 +6719,11 @@ export function Composer(props: ComposerProps) {
     if (!expectedTurnId) {
       return;
     }
-    if (!(await cancelServerManagedQueuedTurn(queued, expectedScopeKey))) {
+    const cancellation = await cancelServerManagedQueuedTurn(
+      queued,
+      expectedScopeKey,
+    );
+    if (cancellation !== "cancelled") {
       return;
     }
     if (
@@ -9563,12 +9574,11 @@ export function Composer(props: ComposerProps) {
                     return;
                   }
                   void (async () => {
-                    if (
-                      !(await cancelServerManagedQueuedTurn(
-                        queued,
-                        queuedScopeKey,
-                      ))
-                    ) {
+                    const cancellation = await cancelServerManagedQueuedTurn(
+                      queued,
+                      queuedScopeKey,
+                    );
+                    if (cancellation !== "cancelled") {
                       return;
                     }
                     editQueuedTurn();
@@ -9587,12 +9597,11 @@ export function Composer(props: ComposerProps) {
                     return;
                   }
                   void (async () => {
-                    if (
-                      await cancelServerManagedQueuedTurn(
-                        queued,
-                        queuedScopeKey,
-                      )
-                    ) {
+                    const cancellation = await cancelServerManagedQueuedTurn(
+                      queued,
+                      queuedScopeKey,
+                    );
+                    if (cancellation === "cancelled") {
                       removeQueuedTurnInScope(queuedScopeKey, queued);
                     }
                   })();

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -4068,7 +4068,14 @@ export function Composer(props: ComposerProps) {
       });
       if (!response.cancelled) {
         if (response.disposition === "already_admitted") {
-          removeQueuedTurnInScope(scopeKey, queued);
+          // The owner records admission before awaiting backend startup so a
+          // second cancellation cannot race back into the FIFO. Until startup
+          // returns a turn id, however, this draft is still the recovery copy
+          // for a possible failed lifecycle event. Keep it visible and durable
+          // until `started` or `failed` resolves the admission.
+          if (response.turnId) {
+            removeQueuedTurnInScope(scopeKey, queued);
+          }
           if (activeComposerScopeKeyRef.current === scopeKey) {
             setSendError(undefined);
           }

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5174,6 +5174,143 @@ describe("Composer", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("preserves a remote queued projection while admission is still pending", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          federationTarget?: {
+            scope: "remote";
+            instanceId: string;
+          };
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const draftStore = createComposerDraftStore();
+    const cancelQueuedTurn = vi.fn(async ({ queueEntryId }: {
+      queueEntryId: string;
+    }) => ({
+      queueEntryId,
+      cancelled: false,
+      disposition: "already_admitted" as const,
+    }));
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        backends={[
+          {
+            ...backendSummary("codex"),
+            capabilities: {
+              ...backendSummary("codex").capabilities,
+              steerTurn: true,
+            },
+          },
+        ]}
+        desktopApi={{
+          cancelQueuedTurn,
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: vi.fn(async () => ({
+            backend: "codex" as const,
+            threadId: "thread-1",
+            turnId: "queue-entry-1",
+            queueStatus: "queued" as const,
+            queueEntryId: "queue-entry-1",
+          })),
+          steerTurn,
+        }}
+        disabled={false}
+        draftStore={draftStore}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Remote active turn",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          federation: {
+            ref: {
+              backend: "codex",
+              target: federationTarget,
+              threadId: "thread-1",
+            },
+            instanceLabel: "Remote",
+            peerStatus: "connected",
+          },
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Preserve until admitted" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    await screen.findByLabelText("Queued message");
+
+    fireEvent.click(screen.getByRole("button", { name: "Steer" }));
+
+    await waitFor(() => {
+      expect(cancelQueuedTurn).toHaveBeenCalledWith({
+        federationTarget,
+        queueEntryId: "queue-entry-1",
+      });
+    });
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Preserve until admitted",
+    );
+    expect(
+      draftStore.getQueuedTurn("thread:codex:thread-1"),
+    ).toMatchObject({
+      queueEntryId: "queue-entry-1",
+      text: "Preserve until admitted",
+    });
+    expect(steerTurn).not.toHaveBeenCalled();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        federationTarget,
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        federationTarget,
+        notification: {
+          method: "thread/turnQueue/updated",
+          params: {
+            threadId: "thread-1",
+            queueEntryId: "queue-entry-1",
+            status: "failed",
+            errorMessage: "Remote queue startup failed",
+          },
+        },
+      });
+    });
+
+    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+    expect(screen.getByText("Remote queue startup failed")).toBeInTheDocument();
+  });
+
   it("removes concurrently cancelled queue entries by stable id", async () => {
     const cancellationOne = createDeferred<{
       queueEntryId: string;

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5089,6 +5089,91 @@ describe("Composer", () => {
     });
   });
 
+  it("clears a remote queued projection when its owner already admitted it", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const cancelQueuedTurn = vi.fn(async ({ queueEntryId }: {
+      queueEntryId: string;
+    }) => ({
+      queueEntryId,
+      cancelled: false,
+      disposition: "already_admitted" as const,
+      turnId: "turn-1",
+    }));
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        backends={[
+          {
+            ...backendSummary("codex"),
+            capabilities: {
+              ...backendSummary("codex").capabilities,
+              steerTurn: true,
+            },
+          },
+        ]}
+        desktopApi={{
+          cancelQueuedTurn,
+          onAgentEvent: () => () => undefined,
+          startTurn: vi.fn(async () => ({
+            backend: "codex" as const,
+            threadId: "thread-1",
+            turnId: "queue-entry-1",
+            queueStatus: "queued" as const,
+            queueEntryId: "queue-entry-1",
+          })),
+          steerTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Remote active turn",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          federation: {
+            ref: {
+              backend: "codex",
+              target: federationTarget,
+              threadId: "thread-1",
+            },
+            instanceLabel: "Remote",
+            peerStatus: "connected",
+          },
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Already admitted once" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    await screen.findByLabelText("Queued message");
+
+    fireEvent.click(screen.getByRole("button", { name: "Steer" }));
+
+    await waitFor(() => {
+      expect(cancelQueuedTurn).toHaveBeenCalledWith({
+        federationTarget,
+        queueEntryId: "queue-entry-1",
+      });
+      expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+    });
+    expect(steerTurn).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText("The queued turn is no longer waiting."),
+    ).not.toBeInTheDocument();
+  });
+
   it("removes concurrently cancelled queue entries by stable id", async () => {
     const cancellationOne = createDeferred<{
       queueEntryId: string;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -268,6 +268,12 @@ export type CancelQueuedTurnRequest = {
 export type CancelQueuedTurnResponse = {
   queueEntryId: string;
   cancelled: boolean;
+  /**
+   * Owner-authoritative lifecycle result. Optional so a newer viewer remains
+   * compatible with peers that only return the legacy boolean.
+   */
+  disposition?: "cancelled" | "already_admitted" | "not_found";
+  turnId?: string;
 };
 
 export type StartReviewRequest = {


### PR DESCRIPTION
## Summary

- retain a bounded owner-side ledger of recently admitted queue entry UUIDs
- return cancellation dispositions over local IPC and Federation
- reconcile stale remote queued cards without issuing a duplicate steer or showing a false error

## Root cause

The renderer retained the owner-generated queue entry UUID, but the owner discarded its lifecycle state as soon as the entry left the waiting FIFO. A remote Steer racing admission therefore received `cancelled: false`, indistinguishable from an unknown entry, even when that exact message had already been submitted.

## User impact

When Steer arrives just after a queued message has been admitted, PwrAgent now recognizes the queue UUID as already submitted, clears the stale queued/steering indicator, and avoids sending the message twice.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/thread-turn-queue.test.ts apps/desktop/src/main/__tests__/agent-ipc.test.ts apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` (297 passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm test apps/desktop/src/main/__tests__/worktree-archive-service.test.ts` (4 passed)

The full `pnpm test` suite was also attempted, but unrelated filesystem/process-heavy suites exceeded their existing 5-second timeouts under this host's parallel load. A representative timed-out suite passes in isolation, and every affected suite passes.
