### PR TITLE
feat(desktop): show unpublished commit diffs in Edits

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -5862,6 +5862,7 @@ describe("app server ipc", () => {
       unpushedCommits: 0,
       baseBranch: "main",
     };
+    const cachedFetchedAt = Date.now();
     listThreads.mockResolvedValue([
       {
         id: "thread-1",
@@ -5876,7 +5877,7 @@ describe("app server ipc", () => {
     readThreadGitWorkingStateCache.mockResolvedValueOnce({
       [worktreePath]: {
         worktreePath,
-        fetchedAt: Date.now(),
+        fetchedAt: cachedFetchedAt,
         gitWorkingState,
       },
     });
@@ -5893,6 +5894,14 @@ describe("app server ipc", () => {
     ).resolves.toEqual({ scheduled: false });
     expect(invalidateWorktreeWorkingState).not.toHaveBeenCalled();
 
+    readWorktreeWorkingStateEntries.mockImplementationOnce((worktreePaths) =>
+      (async function* () {
+        for (const path of worktreePaths) {
+          yield { worktreePath: path, gitWorkingState };
+        }
+      })(),
+    );
+    publishLocalEvent.mockClear();
     await expect(
       handlers.get(NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL)?.(
         {},
@@ -5910,7 +5919,21 @@ describe("app server ipc", () => {
       expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalledWith(
         expect.objectContaining({ worktreePath }),
       );
+      expect(publishLocalEvent).toHaveBeenCalledWith({
+        backend: "codex",
+        notification: {
+          method: "navigation/threadGitWorkingState/updated",
+          params: expect.objectContaining({
+            worktreePath,
+            gitWorkingState,
+            fetchedAt: expect.any(Number),
+          }),
+        },
+      });
     });
+    const refreshedCacheEntry = writeThreadGitWorkingStateCacheEntry.mock.calls
+      .at(-1)?.[0];
+    expect(refreshedCacheEntry?.fetchedAt).toBeGreaterThan(cachedFetchedAt);
   });
 
   it("hydrates working state from linked worktrees when the thread has no project key", async () => {
@@ -5960,6 +5983,7 @@ describe("app server ipc", () => {
         expect.objectContaining({
           id: "thread-1",
           gitWorkingState,
+          gitWorkingStateFetchedAt: 1000,
         }),
       ],
     });

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -50,6 +50,14 @@ const federationMock = vi.hoisted(() => {
       renamedAt: 6_000,
     })),
     refreshDirectoryGitStatuses: vi.fn(async () => ({ scheduledCount: 1 })),
+    listWorktreeUnpublishedCommits: vi.fn(async () => ({
+      commits: [],
+      totalCommits: 0,
+      truncated: false,
+      maxCommits: 20,
+      maxFilesPerCommit: 50,
+    })),
+    getWorktreeUnpublishedCommitDiff: vi.fn(async () => ({})),
   };
   const remoteThreadSummaries = {
     resolvePinnedThreads: vi.fn(
@@ -892,6 +900,8 @@ describe("app server ipc", () => {
     federationMock.remoteBackend.archiveThread.mockClear();
     federationMock.remoteBackend.markThreadSeen.mockClear();
     federationMock.remoteBackend.refreshDirectoryGitStatuses.mockClear();
+    federationMock.remoteBackend.listWorktreeUnpublishedCommits.mockClear();
+    federationMock.remoteBackend.getWorktreeUnpublishedCommitDiff.mockClear();
     federationMock.runtime.remoteBackend.mockClear();
     federationMock.runtime.remoteNavigationSnapshot.mockReset();
     listThreads.mockClear();
@@ -5673,6 +5683,62 @@ describe("app server ipc", () => {
     });
     expect(readDirectoryStatusEntries).not.toHaveBeenCalled();
     expect(invalidateDirectoryStatus).not.toHaveBeenCalled();
+  });
+
+  it("routes remote unpublished commit reads to the owning federation peer", async () => {
+    const {
+      NAVIGATION_GET_WORKTREE_UNPUBLISHED_COMMIT_DIFF_CHANNEL,
+      NAVIGATION_LIST_WORKTREE_UNPUBLISHED_COMMITS_CHANNEL,
+    } = await import("../../shared/ipc");
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const baseRequest = {
+      backend: "codex" as const,
+      threadId: "thread-1",
+      worktreePath: "/remote/repo",
+      federationTarget,
+    };
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_LIST_WORKTREE_UNPUBLISHED_COMMITS_CHANNEL)?.(
+      {},
+      { ...baseRequest, maxCommits: 20, maxFilesPerCommit: 50 },
+    );
+    await handlers.get(NAVIGATION_GET_WORKTREE_UNPUBLISHED_COMMIT_DIFF_CHANNEL)?.(
+      {},
+      {
+        ...baseRequest,
+        commitSha: "a".repeat(40),
+        path: "/remote/repo/file.ts",
+        maxBytes: 200_000,
+      },
+    );
+
+    expect(federationMock.runtime.remoteBackend).toHaveBeenCalledWith(
+      federationTarget,
+    );
+    expect(
+      federationMock.remoteBackend.listWorktreeUnpublishedCommits,
+    ).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath: "/remote/repo",
+      maxCommits: 20,
+      maxFilesPerCommit: 50,
+    });
+    expect(
+      federationMock.remoteBackend.getWorktreeUnpublishedCommitDiff,
+    ).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath: "/remote/repo",
+      commitSha: "a".repeat(40),
+      path: "/remote/repo/file.ts",
+      maxBytes: 200_000,
+    });
   });
 
   it("coalesces rapid forced directory git status re-enqueues for the same key", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2695,6 +2695,72 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
+  it("authorizes federated commit reads against the owner thread and PR overlay", async () => {
+    const worktreePath = "/worktrees/PwrAgnt";
+    const attachedCommitSha = "a".repeat(40);
+    const detachedCommitSha = "b".repeat(40);
+    const mergedPr = (number: number, commitSha: string): PrSummary => ({
+      provider: "github.com",
+      number,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "merged",
+      lifecycleState: "merged",
+      commitShas: [commitSha],
+      url: `https://github.com/pwrdrvr/PwrAgent/pull/${number}`,
+    });
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Federated unpublished work",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: worktreePath,
+      linkedDirectories: [],
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [thread] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": {
+            backend: "codex",
+            threadId: "thread-1",
+            extraLinkedDirectories: [],
+            prs: [{
+              ...mergedPr(735, attachedCommitSha),
+              state: "unknown",
+              lifecycleState: "open",
+            }],
+            detachedPrs: [mergedPr(734, detachedCommitSha)],
+          },
+        },
+      }),
+    });
+    registry.setThreadPullRequestCanonicalizer(async (prs) =>
+      prs.map((pr) => pr.number === 735
+        ? { ...pr, state: "merged", lifecycleState: "merged" }
+        : pr),
+    );
+
+    try {
+      await expect(registry.resolveThreadWorktreeGitReadContext({
+        backend: "codex",
+        threadId: "thread-1",
+        worktreePath,
+      })).resolves.toEqual({
+        worktreePath,
+        acceptedPushedCommitShas: [attachedCommitSha, detachedCommitSha],
+      });
+      await expect(registry.resolveThreadWorktreeGitReadContext({
+        backend: "codex",
+        threadId: "thread-1",
+        worktreePath: "/outside/repo",
+      })).resolves.toBeUndefined();
+    } finally {
+      await registry.close();
+    }
+  });
+
   it("evaluates the current PR state when auto-fix is enabled", async () => {
     const preferenceChanged = vi.fn(async () => undefined);
     const sendPendingNow = vi.fn(async () => true);

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -61,6 +61,127 @@ describe("federation backend bridge", () => {
     });
   });
 
+  it("routes unpublished commit summaries and diffs through thread-detail RPC", async () => {
+    const listWorktreeUnpublishedCommits = vi.fn(async () => ({
+      commits: [],
+      totalCommits: 0,
+      truncated: false,
+      maxCommits: 20,
+      maxFilesPerCommit: 50,
+    }));
+    const getWorktreeUnpublishedCommitDiff = vi.fn(async () => ({
+      detail: undefined,
+    }));
+    const backend = {
+      listWorktreeUnpublishedCommits,
+      getWorktreeUnpublishedCommitDiff,
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+      now: () => 2_000,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["thread_detail"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+    const baseRequest = {
+      backend: "codex" as const,
+      threadId: "thread-1",
+      worktreePath: "/remote/repo",
+    };
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "list-unpublished",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.listWorktreeUnpublishedCommits,
+        params: baseRequest,
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "read-unpublished-diff",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.getWorktreeUnpublishedCommitDiff,
+        params: {
+          ...baseRequest,
+          commitSha: "a".repeat(40),
+          path: "/remote/repo/file.ts",
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_100,
+      },
+    });
+
+    expect(listWorktreeUnpublishedCommits).toHaveBeenCalledWith(baseRequest);
+    expect(getWorktreeUnpublishedCommitDiff).toHaveBeenCalledWith({
+      ...baseRequest,
+      commitSha: "a".repeat(40),
+      path: "/remote/repo/file.ts",
+    });
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.listWorktreeUnpublishedCommits
+      ],
+    ).toBe("thread_detail");
+    expect(replies).toMatchObject([
+      { kind: "response", requestId: "list-unpublished" },
+      { kind: "response", requestId: "read-unpublished-diff" },
+    ]);
+  });
+
+  it("sends unpublished commit reads from the remote backend client", async () => {
+    const sent: FederationProtocolEnvelope[] = [];
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "viewer_one",
+      remoteInstanceId: "owner_one",
+      sendEnvelope: (envelope) => sent.push(envelope),
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+    const request = {
+      backend: "codex" as const,
+      threadId: "thread-1",
+      worktreePath: "/remote/repo",
+    };
+
+    const pending = client.listWorktreeUnpublishedCommits(request);
+    const envelope = sent.at(-1)!;
+    expect(envelope).toMatchObject({
+      method: FEDERATION_BACKEND_METHODS.listWorktreeUnpublishedCommits,
+      params: request,
+    });
+    rpc.receiveEnvelope({
+      id: "list-response",
+      kind: "response",
+      requestId: envelope.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_000,
+      result: {
+        commits: [],
+        totalCommits: 0,
+        truncated: false,
+        maxCommits: 20,
+        maxFilesPerCommit: 50,
+      },
+    });
+
+    await expect(pending).resolves.toMatchObject({ totalCommits: 0 });
+  });
+
   it("maps federation backend methods to local app-server operations", async () => {
     const backend: FederationBackendOperations = {
       listThreads: vi.fn(async () => ({
@@ -1853,6 +1974,8 @@ describe("federation backend bridge", () => {
       setCodexThreadEnvironment: vi.fn(),
       materializeDirectoryLaunchpad: vi.fn(),
       refreshDirectoryGitStatuses: vi.fn(),
+      listWorktreeUnpublishedCommits: vi.fn(),
+      getWorktreeUnpublishedCommitDiff: vi.fn(),
       handoffThreadWorkspace: vi.fn(),
       renameThread: vi.fn(),
       readApplications: vi.fn(),
@@ -2053,6 +2176,8 @@ describe("federation backend bridge", () => {
         stopCodexEnvironmentAction: vi.fn(),
         setCodexThreadEnvironment: vi.fn(),
         refreshDirectoryGitStatuses: vi.fn(),
+        listWorktreeUnpublishedCommits: vi.fn(),
+        getWorktreeUnpublishedCommitDiff: vi.fn(),
         materializeDirectoryLaunchpad: vi.fn(),
         handoffThreadWorkspace: vi.fn(),
         renameThread: vi.fn(),

--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -885,6 +885,45 @@ describe("GitWorkingStateService", () => {
       .toEqual(expect.arrayContaining(["--first-parent", "--numstat", "-z"]));
   });
 
+  it("bounds concurrent unpublished commit summary probes", async () => {
+    const shas = Array.from(
+      { length: 12 },
+      (_, index) => index.toString(16).padStart(40, "0"),
+    );
+    let activeShows = 0;
+    let maxActiveShows = 0;
+    const runGit = vi.fn(async (
+      _cwd: string,
+      args: string[],
+    ): Promise<string> => {
+      if (args[args.length - 1] === "remote") return "origin\n";
+      if (args.includes("--count")) return `${shas.length}\n`;
+      if (args.includes("--max-count=21")) return `${shas.join("\n")}\n`;
+      if (args.includes("show")) {
+        const sha = args.at(-2) ?? "";
+        activeShows += 1;
+        maxActiveShows = Math.max(maxActiveShows, activeShows);
+        await new Promise<void>((resolve) => setTimeout(resolve, 5));
+        activeShows -= 1;
+        return [
+          sha,
+          sha.slice(0, 7),
+          `commit ${sha.slice(-2)}`,
+          "1718000000",
+          "\n1\t0\tfile.txt",
+        ].join("\0") + "\0";
+      }
+      throw new Error(`unexpected git invocation: ${args.join(" ")}`);
+    });
+    const service = new GitWorkingStateService({ runGit });
+
+    const response = await service.listUnpublishedCommits("/repo/wt");
+
+    expect(response.commits.map((commit) => commit.sha)).toEqual(shas);
+    expect(maxActiveShows).toBeGreaterThan(1);
+    expect(maxActiveShows).toBeLessThanOrEqual(4);
+  });
+
   it("summarizes and loads a merge commit against its first parent", async () => {
     const root = await mkdtemp(makeTempPrefix());
     const repo = path.join(root, "repo");

--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -794,8 +794,8 @@ describe("GitWorkingStateService", () => {
       const pushedSha = (await git(repo, "rev-parse", "HEAD")).trim();
 
       await writeFile(path.join(repo, "tracked.txt"), "base\nlocal\n");
-      await writeFile(path.join(repo, "new.txt"), "new\n");
-      await git(repo, "add", "tracked.txt", "new.txt");
+      await writeFile(path.join(repo, "café.txt"), "new\n");
+      await git(repo, "add", "tracked.txt", "café.txt");
       await git(repo, "commit", "-m", "local changes");
       const localSha = (await git(repo, "rev-parse", "HEAD")).trim();
       await git(repo, "checkout", "--detach");
@@ -818,7 +818,7 @@ describe("GitWorkingStateService", () => {
         ],
       });
       expect(response.commits[0]?.files.map((file) => file.repoPath).sort())
-        .toEqual(["new.txt", "tracked.txt"]);
+        .toEqual(["café.txt", "tracked.txt"]);
 
       const detail = await service.getUnpublishedCommitDiff(
         repo,
@@ -844,6 +844,101 @@ describe("GitWorkingStateService", () => {
       });
       expect(accepted.commits).toEqual([]);
       expect(accepted.totalCommits).toBe(0);
+    } finally {
+      await rm(root, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 100,
+      });
+    }
+  }, 20_000);
+
+  it("preserves tabs and newlines in NUL-delimited unpublished paths", async () => {
+    const sha = "a".repeat(40);
+    const repoPath = "folder/odd\tline\nname.txt";
+    const summaryOutput = [
+      sha,
+      sha.slice(0, 7),
+      "odd path",
+      "1718000000",
+      `\n3\t1\t${repoPath}`,
+    ].join("\0") + "\0";
+    const { runGit, calls } = fakeGit((args) => {
+      if (args[args.length - 1] === "remote") return "origin\n";
+      if (args.includes("--count")) return "1\n";
+      if (args.includes("--max-count=21")) return `${sha}\n`;
+      if (args.includes("show")) return summaryOutput;
+      return undefined;
+    });
+    const service = new GitWorkingStateService({ runGit });
+
+    const response = await service.listUnpublishedCommits("/repo/wt");
+
+    expect(response.commits[0]?.files[0]).toMatchObject({
+      path: normalizeTestPath(path.join("/repo/wt", repoPath)),
+      repoPath,
+      additions: 3,
+      removals: 1,
+    });
+    expect(calls.find((call) => call.args.includes("show"))?.args)
+      .toEqual(expect.arrayContaining(["--first-parent", "--numstat", "-z"]));
+  });
+
+  it("summarizes and loads a merge commit against its first parent", async () => {
+    const root = await mkdtemp(makeTempPrefix());
+    const repo = path.join(root, "repo");
+    const remote = path.join(root, "remote.git");
+
+    try {
+      await mkdir(repo);
+      await git(root, "init", "--bare", remote);
+      await git(repo, "init", "-b", "main");
+      await git(repo, "config", "user.email", "test@example.com");
+      await git(repo, "config", "user.name", "PwrAgent Test");
+      await writeFile(path.join(repo, "base.txt"), "base\n");
+      await git(repo, "add", "base.txt");
+      await git(repo, "commit", "-m", "base");
+      await git(repo, "remote", "add", "origin", remote);
+      await git(repo, "push", "-u", "origin", "main");
+
+      await git(repo, "checkout", "-b", "feature");
+      await writeFile(path.join(repo, "feature.txt"), "merged content\n");
+      await git(repo, "add", "feature.txt");
+      await git(repo, "commit", "-m", "feature work");
+      await git(repo, "push", "-u", "origin", "feature");
+      await git(repo, "checkout", "main");
+      await git(repo, "merge", "--no-ff", "feature", "-m", "merge feature");
+      const mergeSha = (await git(repo, "rev-parse", "HEAD")).trim();
+
+      const service = new GitWorkingStateService();
+      const response = await service.listUnpublishedCommits(repo);
+
+      expect(response).toMatchObject({
+        totalCommits: 1,
+        commits: [
+          {
+            sha: mergeSha,
+            subject: "merge feature",
+            totalFiles: 1,
+            additions: 1,
+            removals: 0,
+          },
+        ],
+      });
+      expect(response.commits[0]?.files[0]?.repoPath).toBe("feature.txt");
+
+      const detail = await service.getUnpublishedCommitDiff(
+        repo,
+        mergeSha,
+        path.join(repo, "feature.txt"),
+      );
+      expect(detail.detail?.fileDiff).toMatchObject({
+        kind: "add",
+        additions: 1,
+        removals: 0,
+      });
+      expect(detail.detail?.fileDiff?.diff).toContain("+merged content");
     } finally {
       await rm(root, {
         recursive: true,

--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -775,6 +775,85 @@ describe("GitWorkingStateService", () => {
     }
   });
 
+  it("lists unpublished commit files and loads their diffs on demand", async () => {
+    const root = await mkdtemp(makeTempPrefix());
+    const repo = path.join(root, "repo");
+    const remote = path.join(root, "remote.git");
+
+    try {
+      await mkdir(repo);
+      await git(root, "init", "--bare", remote);
+      await git(repo, "init", "-b", "main");
+      await git(repo, "config", "user.email", "test@example.com");
+      await git(repo, "config", "user.name", "PwrAgent Test");
+      await writeFile(path.join(repo, "tracked.txt"), "base\n");
+      await git(repo, "add", "tracked.txt");
+      await git(repo, "commit", "-m", "base");
+      await git(repo, "remote", "add", "origin", remote);
+      await git(repo, "push", "-u", "origin", "main");
+      const pushedSha = (await git(repo, "rev-parse", "HEAD")).trim();
+
+      await writeFile(path.join(repo, "tracked.txt"), "base\nlocal\n");
+      await writeFile(path.join(repo, "new.txt"), "new\n");
+      await git(repo, "add", "tracked.txt", "new.txt");
+      await git(repo, "commit", "-m", "local changes");
+      const localSha = (await git(repo, "rev-parse", "HEAD")).trim();
+      await git(repo, "checkout", "--detach");
+
+      const service = new GitWorkingStateService();
+      const response = await service.listUnpublishedCommits(repo);
+
+      expect(response).toMatchObject({
+        totalCommits: 1,
+        truncated: false,
+        commits: [
+          {
+            sha: localSha,
+            subject: "local changes",
+            totalFiles: 2,
+            filesTruncated: false,
+            additions: 2,
+            removals: 0,
+          },
+        ],
+      });
+      expect(response.commits[0]?.files.map((file) => file.repoPath).sort())
+        .toEqual(["new.txt", "tracked.txt"]);
+
+      const detail = await service.getUnpublishedCommitDiff(
+        repo,
+        localSha,
+        path.join(repo, "tracked.txt"),
+      );
+      expect(detail.detail?.fileDiff).toMatchObject({
+        kind: "update",
+        additions: 1,
+        removals: 0,
+      });
+      expect(detail.detail?.fileDiff?.diff).toContain("+local");
+
+      const pushed = await service.getUnpublishedCommitDiff(
+        repo,
+        pushedSha,
+        path.join(repo, "tracked.txt"),
+      );
+      expect(pushed.detail).toBeUndefined();
+
+      const accepted = await service.listUnpublishedCommits(repo, {
+        acceptedPushedCommitShas: [localSha],
+      });
+      expect(accepted.commits).toEqual([]);
+      expect(accepted.totalCommits).toBe(0);
+    } finally {
+      await rm(root, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 100,
+      });
+    }
+  }, 20_000);
+
   it("builds a single-file diff on demand for an untracked file", async () => {
     const tmpRoot = await mkdtemp(makeTempPrefix());
     const filePath = path.join(tmpRoot, "note.txt");

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9529,6 +9529,76 @@ export class DesktopBackendRegistry {
     return await this.gitWorkingStateService.listOtherChanges(worktreePath, options);
   }
 
+  /**
+   * Resolve a renderer-supplied worktree path against the owning thread before
+   * a federated peer can read commit metadata from it. The peer supplies the
+   * path it rendered, but this instance remains authoritative for both the
+   * linked-directory boundary and merged-PR exclusions.
+   */
+  async resolveThreadWorktreeGitReadContext(params: {
+    backend?: AppServerBackendKind;
+    threadId: string;
+    worktreePath: string;
+  }): Promise<{
+    acceptedPushedCommitShas: string[];
+    worktreePath: string;
+  } | undefined> {
+    const thread = await this.resolveThread({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    if (!thread) {
+      return undefined;
+    }
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: thread.source,
+      threadId: thread.id,
+    });
+    const candidatePaths = new Set<string>();
+    if (thread.projectKey?.trim()) {
+      candidatePaths.add(thread.projectKey.trim());
+    }
+    for (const directory of [
+      ...thread.linkedDirectories,
+      ...(overlay?.extraLinkedDirectories ?? []),
+    ]) {
+      const workspacePath = directory.worktreePath?.trim()
+        || (directory.kind === "local" ? directory.path.trim() : "");
+      if (workspacePath) {
+        candidatePaths.add(workspacePath);
+      }
+    }
+    const requestedPath = normalizeLinkedDirectoryPathForMatch(
+      params.worktreePath,
+    );
+    const matchedPath = [...candidatePaths].find(
+      (candidate) =>
+        normalizeLinkedDirectoryPathForMatch(candidate) === requestedPath,
+    );
+    if (!requestedPath || !matchedPath) {
+      return undefined;
+    }
+    const storedPrs = [
+      ...(overlay?.prs ?? []),
+      ...(overlay?.detachedPrs ?? []),
+    ];
+    let canonicalPrs = storedPrs;
+    if (this.threadPullRequestCanonicalizer && storedPrs.length > 0) {
+      try {
+        canonicalPrs = await this.threadPullRequestCanonicalizer(storedPrs);
+      } catch (error) {
+        backendRegistryLog.warn("federated commit PR canonicalization failed", {
+          error: error instanceof Error ? error.message : String(error),
+          threadId: thread.id,
+        });
+      }
+    }
+    return {
+      worktreePath: matchedPath,
+      acceptedPushedCommitShas: mergedPrCommitShas(canonicalPrs),
+    };
+  }
+
   async getWorktreeOtherChangeDiff(
     worktreePath: string,
     filePath: string,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9541,6 +9541,34 @@ export class DesktopBackendRegistry {
     );
   }
 
+  async listWorktreeUnpublishedCommits(
+    worktreePath: string,
+    options?: {
+      acceptedPushedCommitShas?: string[];
+      maxCommits?: number;
+      maxFilesPerCommit?: number;
+    },
+  ) {
+    return await this.gitWorkingStateService.listUnpublishedCommits(
+      worktreePath,
+      options,
+    );
+  }
+
+  async getWorktreeUnpublishedCommitDiff(
+    worktreePath: string,
+    commitSha: string,
+    filePath: string,
+    options?: { acceptedPushedCommitShas?: string[]; maxBytes?: number },
+  ) {
+    return await this.gitWorkingStateService.getUnpublishedCommitDiff(
+      worktreePath,
+      commitSha,
+      filePath,
+      options,
+    );
+  }
+
   async readThread(
     request: AppServerReadThreadRequest
   ): Promise<AppServerReadThreadResponse> {

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -6,6 +6,8 @@ import type {
   AppServerThreadActivityDetail,
   EditGroupCommitInput,
   EditGroupCommitState,
+  WorktreeUnpublishedCommit,
+  WorktreeUnpublishedCommitFile,
   ThreadGitWorkingState,
   WorktreeOtherChangeEntry,
   WorktreeOtherChangeStatus,
@@ -24,6 +26,10 @@ const HARD_OTHER_CHANGES_MAX_FILES = 100;
 const OTHER_CHANGES_MAX_FILES_PER_TOP_LEVEL = 20;
 const DEFAULT_OTHER_CHANGE_DIFF_MAX_BYTES = 200_000;
 const HARD_OTHER_CHANGE_DIFF_MAX_BYTES = 500_000;
+const DEFAULT_UNPUBLISHED_COMMITS_MAX = 20;
+const HARD_UNPUBLISHED_COMMITS_MAX = 50;
+const DEFAULT_UNPUBLISHED_COMMIT_FILES_MAX = 50;
+const HARD_UNPUBLISHED_COMMIT_FILES_MAX = 100;
 const UNTRACKED_DIRECTORY_EXPANSION_MAX_BYTES = 128_000;
 const UNTRACKED_DIRECTORY_EXPANSION_TIMEOUT_MS = 1_500;
 const MAX_BASE_BRANCH_CANDIDATES = 24;
@@ -528,6 +534,59 @@ function parseNumstatByPath(
     }
   }
   return stats;
+}
+
+function parseUnpublishedCommitSummary(
+  cwd: string,
+  output: string,
+  maxFiles: number,
+): WorktreeUnpublishedCommit | undefined {
+  const [metadataLine, ...lines] = output.split("\n");
+  const [sha, shortSha, subject, committedAtSeconds] = metadataLine?.split("\x1f")
+    ?? [];
+  if (!sha || !shortSha || subject === undefined) {
+    return undefined;
+  }
+
+  const files: WorktreeUnpublishedCommitFile[] = [];
+  let totalFiles = 0;
+  let additions = 0;
+  let removals = 0;
+  for (const line of lines) {
+    const [rawAdditions, rawRemovals, ...pathParts] = line.split("\t");
+    const repoPath = normalizeGitRelativePath(pathParts.join("\t"));
+    if (!repoPath || rawAdditions === undefined || rawRemovals === undefined) {
+      continue;
+    }
+    totalFiles += 1;
+    const binary = rawAdditions === "-" || rawRemovals === "-";
+    const fileAdditions = binary ? undefined : parseGitCount(rawAdditions);
+    const fileRemovals = binary ? undefined : parseGitCount(rawRemovals);
+    additions += fileAdditions ?? 0;
+    removals += fileRemovals ?? 0;
+    if (files.length < maxFiles) {
+      files.push({
+        path: normalizeAbsolutePath(path.resolve(cwd, repoPath)),
+        repoPath,
+        ...(binary
+          ? { binary: true }
+          : { additions: fileAdditions ?? 0, removals: fileRemovals ?? 0 }),
+      });
+    }
+  }
+
+  const committedAt = Number.parseInt(committedAtSeconds ?? "", 10);
+  return {
+    sha,
+    shortSha,
+    subject,
+    ...(Number.isFinite(committedAt) ? { committedAt: committedAt * 1_000 } : {}),
+    files,
+    totalFiles,
+    filesTruncated: totalFiles > files.length,
+    additions,
+    removals,
+  };
 }
 
 function isPathInsideWorktree(cwd: string, absolutePath: string): boolean {
@@ -1302,6 +1361,236 @@ export class GitWorkingStateService {
           ...(omittedReason ? { omittedReason } : {}),
         },
         markdown: statusLabel(status.status),
+      },
+    };
+  }
+
+  /**
+   * List commits reachable from HEAD that exist on no remote ref or accepted
+   * merged-PR head. Commit and per-commit file lists are bounded; patch text is
+   * loaded only when the renderer expands an individual file.
+   */
+  async listUnpublishedCommits(
+    worktreePath: string,
+    options: {
+      maxCommits?: number;
+      maxFilesPerCommit?: number;
+    } & AcceptedPushedCommitOptions = {},
+  ): Promise<{
+    commits: WorktreeUnpublishedCommit[];
+    totalCommits: number;
+    truncated: boolean;
+    maxCommits: number;
+    maxFilesPerCommit: number;
+  }> {
+    const cwd = worktreePath?.trim();
+    const maxCommits = clampPositiveInteger(
+      options.maxCommits,
+      DEFAULT_UNPUBLISHED_COMMITS_MAX,
+      HARD_UNPUBLISHED_COMMITS_MAX,
+    );
+    const maxFilesPerCommit = clampPositiveInteger(
+      options.maxFilesPerCommit,
+      DEFAULT_UNPUBLISHED_COMMIT_FILES_MAX,
+      HARD_UNPUBLISHED_COMMIT_FILES_MAX,
+    );
+    const empty = {
+      commits: [],
+      totalCommits: 0,
+      truncated: false,
+      maxCommits,
+      maxFilesPerCommit,
+    };
+    if (!cwd) {
+      return empty;
+    }
+
+    const noLocks = (args: string[], input?: string): Promise<string> =>
+      this.runGit(cwd, ["--no-optional-locks", ...args], this.gitEnv, input);
+    const remotes = await noLocks(["remote"]).catch(() => "");
+    if (!remotes.trim()) {
+      return empty;
+    }
+
+    const exclusionInput = buildRevisionExclusionInput(
+      buildAcceptedPushedCommitSet(options.acceptedPushedCommitShas),
+    );
+    const readRevisions = async (
+      input?: string,
+    ): Promise<{ countOutput: string; shasOutput: string }> => {
+      const stdinArg = input ? ["--stdin"] : [];
+      const [countOutput, shasOutput] = await Promise.all([
+        noLocks(
+          [
+            "rev-list",
+            "--ignore-missing",
+            "--count",
+            "HEAD",
+            "--not",
+            "--remotes",
+            ...stdinArg,
+          ],
+          input,
+        ),
+        noLocks(
+          [
+            "rev-list",
+            "--ignore-missing",
+            `--max-count=${maxCommits + 1}`,
+            "HEAD",
+            "--not",
+            "--remotes",
+            ...stdinArg,
+          ],
+          input,
+        ),
+      ]);
+      return { countOutput, shasOutput };
+    };
+    let revisionData: { countOutput: string; shasOutput: string };
+    try {
+      revisionData = await readRevisions(exclusionInput);
+    } catch {
+      if (!exclusionInput) {
+        return empty;
+      }
+      // Mirror the working-state badge: a false-positive raw list is safer
+      // than hiding genuinely local work when the accepted-head probe fails.
+      revisionData = await readRevisions().catch(() => ({
+        countOutput: "",
+        shasOutput: "",
+      }));
+    }
+    const { countOutput, shasOutput } = revisionData;
+    const shas = parseGitLines(shasOutput).filter((sha) =>
+      /^[0-9a-f]{40}$/i.test(sha),
+    );
+    const visibleShas = shas.slice(0, maxCommits);
+    const summaries = await Promise.all(
+      visibleShas.map(async (sha) =>
+        parseUnpublishedCommitSummary(
+          cwd,
+          await noLocks([
+            "show",
+            "--no-ext-diff",
+            "--no-renames",
+            "--format=%H%x1f%h%x1f%s%x1f%ct",
+            "--numstat",
+            sha,
+            "--",
+          ]).catch(() => ""),
+          maxFilesPerCommit,
+        ),
+      ),
+    );
+    const commits = summaries.filter(
+      (commit): commit is WorktreeUnpublishedCommit => Boolean(commit),
+    );
+    const totalCommits = Math.max(parseGitCount(countOutput), shas.length);
+    return {
+      commits,
+      totalCommits,
+      truncated: totalCommits > commits.length,
+      maxCommits,
+      maxFilesPerCommit,
+    };
+  }
+
+  async getUnpublishedCommitDiff(
+    worktreePath: string,
+    commitSha: string,
+    filePath: string,
+    options: { maxBytes?: number } & AcceptedPushedCommitOptions = {},
+  ): Promise<{ detail?: AppServerThreadActivityDetail }> {
+    const cwd = worktreePath?.trim();
+    const sha = commitSha?.trim();
+    const absolutePath = normalizeAbsolutePath(path.resolve(filePath));
+    const maxBytes = clampPositiveInteger(
+      options.maxBytes,
+      DEFAULT_OTHER_CHANGE_DIFF_MAX_BYTES,
+      HARD_OTHER_CHANGE_DIFF_MAX_BYTES,
+    );
+    if (
+      !cwd
+      || !/^[0-9a-f]{40}$/i.test(sha)
+      || !isPathInsideWorktree(cwd, absolutePath)
+    ) {
+      return {};
+    }
+
+    const noLocks = (args: string[], input?: string): Promise<string> =>
+      this.runGit(cwd, ["--no-optional-locks", ...args], this.gitEnv, input);
+    const [remotes, isAncestor] = await Promise.all([
+      noLocks(["remote"]).catch(() => ""),
+      noLocks(["merge-base", "--is-ancestor", sha, "HEAD"])
+        .then(() => true)
+        .catch(() => false),
+    ]);
+    if (!remotes.trim() || !isAncestor) {
+      return {};
+    }
+
+    const exclusionInput = buildRevisionExclusionInput(
+      buildAcceptedPushedCommitSet(options.acceptedPushedCommitShas),
+    );
+    const unpublished = await noLocks(
+      [
+        "rev-list",
+        "--ignore-missing",
+        "-1",
+        sha,
+        "--not",
+        "--remotes",
+        ...(exclusionInput ? ["--stdin"] : []),
+      ],
+      exclusionInput,
+    ).catch(() => "");
+    if (!unpublished.trim()) {
+      return {};
+    }
+
+    const repoPath = normalizeGitRelativePath(path.relative(cwd, absolutePath));
+    let diff = await noLocks([
+      "show",
+      "--format=",
+      "--no-ext-diff",
+      "--no-renames",
+      sha,
+      "--",
+      repoPath,
+    ]).catch(() => "");
+    if (!diff) {
+      return {};
+    }
+
+    let omittedReason: string | undefined;
+    if (/^(?:Binary files |GIT binary patch)/m.test(diff)) {
+      omittedReason = "Diff omitted for binary committed file.";
+      diff = "";
+    } else if (diff.length > maxBytes) {
+      omittedReason = `Diff omitted because it exceeds ${maxBytes.toLocaleString()} bytes.`;
+      diff = "";
+    }
+    const stats = summarizeDiffText(diff);
+    const kind = diff.includes("deleted file mode")
+      ? "delete"
+      : diff.includes("new file mode")
+        ? "add"
+        : "update";
+    return {
+      detail: {
+        id: `unpublished-commit:${sha}:${repoPath}`,
+        kind: "write",
+        label: path.basename(repoPath) || repoPath,
+        path: absolutePath,
+        fileDiff: {
+          kind,
+          diff,
+          additions: stats.additions,
+          removals: stats.removals,
+          ...(omittedReason ? { omittedReason } : {}),
+        },
+        markdown: `Unpublished commit ${sha.slice(0, 7)}`,
       },
     };
   }

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -541,9 +541,8 @@ function parseUnpublishedCommitSummary(
   output: string,
   maxFiles: number,
 ): WorktreeUnpublishedCommit | undefined {
-  const [metadataLine, ...lines] = output.split("\n");
-  const [sha, shortSha, subject, committedAtSeconds] = metadataLine?.split("\x1f")
-    ?? [];
+  const [sha, shortSha, subject, committedAtSeconds, ...rawRecords] =
+    output.split("\0");
   if (!sha || !shortSha || subject === undefined) {
     return undefined;
   }
@@ -552,10 +551,19 @@ function parseUnpublishedCommitSummary(
   let totalFiles = 0;
   let additions = 0;
   let removals = 0;
-  for (const line of lines) {
-    const [rawAdditions, rawRemovals, ...pathParts] = line.split("\t");
-    const repoPath = normalizeGitRelativePath(pathParts.join("\t"));
-    if (!repoPath || rawAdditions === undefined || rawRemovals === undefined) {
+  for (const [index, rawRecord] of rawRecords.entries()) {
+    const record = index === 0 && rawRecord.startsWith("\n")
+      ? rawRecord.slice(1)
+      : rawRecord;
+    const additionsSeparator = record.indexOf("\t");
+    const removalsSeparator = record.indexOf("\t", additionsSeparator + 1);
+    if (additionsSeparator < 0 || removalsSeparator < 0) {
+      continue;
+    }
+    const rawAdditions = record.slice(0, additionsSeparator);
+    const rawRemovals = record.slice(additionsSeparator + 1, removalsSeparator);
+    const repoPath = normalizeGitRelativePath(record.slice(removalsSeparator + 1));
+    if (!repoPath) {
       continue;
     }
     totalFiles += 1;
@@ -1472,10 +1480,12 @@ export class GitWorkingStateService {
           cwd,
           await noLocks([
             "show",
+            "--first-parent",
             "--no-ext-diff",
             "--no-renames",
-            "--format=%H%x1f%h%x1f%s%x1f%ct",
+            "--format=%H%x00%h%x00%s%x00%ct",
             "--numstat",
+            "-z",
             sha,
             "--",
           ]).catch(() => ""),
@@ -1552,6 +1562,7 @@ export class GitWorkingStateService {
     const repoPath = normalizeGitRelativePath(path.relative(cwd, absolutePath));
     let diff = await noLocks([
       "show",
+      "--first-parent",
       "--format=",
       "--no-ext-diff",
       "--no-renames",

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -30,6 +30,7 @@ const DEFAULT_UNPUBLISHED_COMMITS_MAX = 20;
 const HARD_UNPUBLISHED_COMMITS_MAX = 50;
 const DEFAULT_UNPUBLISHED_COMMIT_FILES_MAX = 50;
 const HARD_UNPUBLISHED_COMMIT_FILES_MAX = 100;
+const UNPUBLISHED_COMMIT_SUMMARY_CONCURRENCY = 4;
 const UNTRACKED_DIRECTORY_EXPANSION_MAX_BYTES = 128_000;
 const UNTRACKED_DIRECTORY_EXPANSION_TIMEOUT_MS = 1_500;
 const MAX_BASE_BRANCH_CANDIDATES = 24;
@@ -1474,9 +1475,13 @@ export class GitWorkingStateService {
       /^[0-9a-f]{40}$/i.test(sha),
     );
     const visibleShas = shas.slice(0, maxCommits);
-    const summaries = await Promise.all(
-      visibleShas.map(async (sha) =>
-        parseUnpublishedCommitSummary(
+    const summaries: Array<WorktreeUnpublishedCommit | undefined> =
+      new Array(visibleShas.length);
+    for await (const entry of new IterableMapper(
+      visibleShas,
+      async (sha, index) => ({
+        index,
+        summary: parseUnpublishedCommitSummary(
           cwd,
           await noLocks([
             "show",
@@ -1491,8 +1496,14 @@ export class GitWorkingStateService {
           ]).catch(() => ""),
           maxFilesPerCommit,
         ),
-      ),
-    );
+      }),
+      {
+        concurrency: UNPUBLISHED_COMMIT_SUMMARY_CONCURRENCY,
+        maxUnread: UNPUBLISHED_COMMIT_SUMMARY_CONCURRENCY * 2,
+      },
+    )) {
+      summaries[entry.index] = entry.summary;
+    }
     const commits = summaries.filter(
       (commit): commit is WorktreeUnpublishedCommit => Boolean(commit),
     );

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -28,6 +28,8 @@ import type {
   ForkThreadRequest,
   ForkThreadResponse,
   GetNavigationSnapshotRequest,
+  GetWorktreeUnpublishedCommitDiffRequest,
+  GetWorktreeUnpublishedCommitDiffResponse,
   HandoffThreadWorkspaceRequest,
   HandoffThreadWorkspaceResponse,
   InterruptTurnRequest,
@@ -36,6 +38,8 @@ import type {
   ListBackendsResponse,
   ListScheduledThreadActionsRequest,
   ListScheduledThreadActionsResponse,
+  ListWorktreeUnpublishedCommitsRequest,
+  ListWorktreeUnpublishedCommitsResponse,
   MaterializeDirectoryLaunchpadOptions,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
@@ -171,6 +175,8 @@ export const FEDERATION_BACKEND_METHODS = {
   stopCodexEnvironmentAction: "backend.stopCodexEnvironmentAction",
   setCodexThreadEnvironment: "backend.setCodexThreadEnvironment",
   refreshDirectoryGitStatuses: "backend.refreshDirectoryGitStatuses",
+  listWorktreeUnpublishedCommits: "backend.listWorktreeUnpublishedCommits",
+  getWorktreeUnpublishedCommitDiff: "backend.getWorktreeUnpublishedCommitDiff",
   materializeDirectoryLaunchpad: "backend.materializeDirectoryLaunchpad",
   handoffThreadWorkspace: "backend.handoffThreadWorkspace",
   renameThread: "backend.renameThread",
@@ -250,6 +256,8 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.stopCodexEnvironmentAction]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.setCodexThreadEnvironment]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.refreshDirectoryGitStatuses]: "thread_navigation",
+  [FEDERATION_BACKEND_METHODS.listWorktreeUnpublishedCommits]: "thread_detail",
+  [FEDERATION_BACKEND_METHODS.getWorktreeUnpublishedCommitDiff]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.handoffThreadWorkspace]: "turn_control",
   [FEDERATION_BACKEND_METHODS.renameThread]: "turn_control",
@@ -388,6 +396,12 @@ export type FederationBackendOperations = {
   refreshDirectoryGitStatuses(
     request: RefreshDirectoryGitStatusesRequest,
   ): Promise<RefreshDirectoryGitStatusesResponse>;
+  listWorktreeUnpublishedCommits(
+    request: ListWorktreeUnpublishedCommitsRequest,
+  ): Promise<ListWorktreeUnpublishedCommitsResponse>;
+  getWorktreeUnpublishedCommitDiff(
+    request: GetWorktreeUnpublishedCommitDiffRequest,
+  ): Promise<GetWorktreeUnpublishedCommitDiffResponse>;
   materializeDirectoryLaunchpad(
     request: MaterializeDirectoryLaunchpadRequest,
     options?: MaterializeDirectoryLaunchpadOptions,
@@ -759,6 +773,20 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.refreshDirectoryGitStatuses(
         envelope.params as RefreshDirectoryGitStatusesRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.listWorktreeUnpublishedCommits,
+    async (envelope) =>
+      await params.backend.listWorktreeUnpublishedCommits(
+        envelope.params as ListWorktreeUnpublishedCommitsRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.getWorktreeUnpublishedCommitDiff,
+    async (envelope) =>
+      await params.backend.getWorktreeUnpublishedCommitDiff(
+        envelope.params as GetWorktreeUnpublishedCommitDiffRequest,
       ),
   );
   params.router.registerHandler(
@@ -1216,6 +1244,24 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<RefreshDirectoryGitStatusesResponse> {
     return await this.rpc.request<RefreshDirectoryGitStatusesResponse>({
       method: FEDERATION_BACKEND_METHODS.refreshDirectoryGitStatuses,
+      params: request,
+    });
+  }
+
+  async listWorktreeUnpublishedCommits(
+    request: ListWorktreeUnpublishedCommitsRequest,
+  ): Promise<ListWorktreeUnpublishedCommitsResponse> {
+    return await this.rpc.request<ListWorktreeUnpublishedCommitsResponse>({
+      method: FEDERATION_BACKEND_METHODS.listWorktreeUnpublishedCommits,
+      params: request,
+    });
+  }
+
+  async getWorktreeUnpublishedCommitDiff(
+    request: GetWorktreeUnpublishedCommitDiffRequest,
+  ): Promise<GetWorktreeUnpublishedCommitDiffResponse> {
+    return await this.rpc.request<GetWorktreeUnpublishedCommitDiffResponse>({
+      method: FEDERATION_BACKEND_METHODS.getWorktreeUnpublishedCommitDiff,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -94,7 +94,11 @@ import {
   type FederationRemoteTarget,
   type DesktopApplicationsSnapshot,
   type HandoffThreadWorkspaceRequest,
+  type GetWorktreeUnpublishedCommitDiffRequest,
+  type GetWorktreeUnpublishedCommitDiffResponse,
   type InterruptTurnRequest,
+  type ListWorktreeUnpublishedCommitsRequest,
+  type ListWorktreeUnpublishedCommitsResponse,
   type MaterializeDirectoryLaunchpadRequest,
   type MaterializeDirectoryLaunchpadOptions,
   type MarkThreadSeenRequest,
@@ -3538,6 +3542,33 @@ export function setFederationMessagingPlatformStatusReader(
   messagingPlatformStatusReader = reader;
 }
 
+async function resolveFederatedWorktreeGitReadContext(request: {
+  backend?: ListWorktreeUnpublishedCommitsRequest["backend"];
+  threadId?: string;
+  worktreePath: string;
+}): Promise<{
+  acceptedPushedCommitShas: string[];
+  worktreePath: string;
+}> {
+  if (!request.backend || !request.threadId?.trim()) {
+    throw new Error(
+      "Federated unpublished commit reads require an owning thread identity.",
+    );
+  }
+  const context = await getDesktopBackendRegistry()
+    .resolveThreadWorktreeGitReadContext({
+      backend: request.backend,
+      threadId: request.threadId,
+      worktreePath: request.worktreePath,
+    });
+  if (!context) {
+    throw new Error(
+      "Federated unpublished commit reads must target the owning thread's worktree.",
+    );
+  }
+  return context;
+}
+
 function localBackendOperations(): FederationBackendOperations {
   return {
     async getNavigationSnapshot(request = {}): Promise<NavigationSnapshot> {
@@ -3892,6 +3923,33 @@ function localBackendOperations(): FederationBackendOperations {
       request: RefreshDirectoryGitStatusesRequest,
     ): Promise<RefreshDirectoryGitStatusesResponse> {
       return await getDesktopBackendRegistry().refreshDirectoryGitStatuses(request);
+    },
+    async listWorktreeUnpublishedCommits(
+      request: ListWorktreeUnpublishedCommitsRequest,
+    ): Promise<ListWorktreeUnpublishedCommitsResponse> {
+      const context = await resolveFederatedWorktreeGitReadContext(request);
+      return await getDesktopBackendRegistry().listWorktreeUnpublishedCommits(
+        context.worktreePath,
+        {
+          acceptedPushedCommitShas: context.acceptedPushedCommitShas,
+          maxCommits: request.maxCommits,
+          maxFilesPerCommit: request.maxFilesPerCommit,
+        },
+      );
+    },
+    async getWorktreeUnpublishedCommitDiff(
+      request: GetWorktreeUnpublishedCommitDiffRequest,
+    ): Promise<GetWorktreeUnpublishedCommitDiffResponse> {
+      const context = await resolveFederatedWorktreeGitReadContext(request);
+      return await getDesktopBackendRegistry().getWorktreeUnpublishedCommitDiff(
+        context.worktreePath,
+        request.commitSha,
+        request.path,
+        {
+          acceptedPushedCommitShas: context.acceptedPushedCommitShas,
+          maxBytes: request.maxBytes,
+        },
+      );
     },
     async materializeDirectoryLaunchpad(
       request: MaterializeDirectoryLaunchpadRequest,

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -136,6 +136,10 @@ import {
   type ListWorktreeOtherChangesResponse,
   type GetWorktreeOtherChangeDiffRequest,
   type GetWorktreeOtherChangeDiffResponse,
+  type ListWorktreeUnpublishedCommitsRequest,
+  type ListWorktreeUnpublishedCommitsResponse,
+  type GetWorktreeUnpublishedCommitDiffRequest,
+  type GetWorktreeUnpublishedCommitDiffResponse,
   type RestoreThreadRequest,
   type RestoreThreadResponse,
   type ThreadGitWorkingState,
@@ -210,6 +214,8 @@ import {
   NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
   NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL,
   NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL,
+  NAVIGATION_LIST_WORKTREE_UNPUBLISHED_COMMITS_CHANNEL,
+  NAVIGATION_GET_WORKTREE_UNPUBLISHED_COMMIT_DIFF_CHANNEL,
   FEDERATION_JUMP_SEARCH_CHANNEL,
   NAVIGATION_ADD_REMOTE_THREAD_PIN_CHANNEL,
   NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL,
@@ -2176,6 +2182,37 @@ class DesktopAppServerService {
       request.worktreePath,
       request.path,
       { maxBytes: request.maxBytes },
+    );
+  }
+
+  async listWorktreeUnpublishedCommits(
+    request: ListWorktreeUnpublishedCommitsRequest,
+  ): Promise<ListWorktreeUnpublishedCommitsResponse> {
+    return await getDesktopBackendRegistry().listWorktreeUnpublishedCommits(
+      request.worktreePath,
+      {
+        acceptedPushedCommitShas: this.getMergedPrCommitShasForWorktree(
+          request.worktreePath,
+        ),
+        maxCommits: request.maxCommits,
+        maxFilesPerCommit: request.maxFilesPerCommit,
+      },
+    );
+  }
+
+  async getWorktreeUnpublishedCommitDiff(
+    request: GetWorktreeUnpublishedCommitDiffRequest,
+  ): Promise<GetWorktreeUnpublishedCommitDiffResponse> {
+    return await getDesktopBackendRegistry().getWorktreeUnpublishedCommitDiff(
+      request.worktreePath,
+      request.commitSha,
+      request.path,
+      {
+        acceptedPushedCommitShas: this.getMergedPrCommitShasForWorktree(
+          request.worktreePath,
+        ),
+        maxBytes: request.maxBytes,
+      },
     );
   }
 
@@ -7336,6 +7373,26 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.getWorktreeOtherChangeDiff(request);
     },
   );
+  ipcMain.removeHandler(NAVIGATION_LIST_WORKTREE_UNPUBLISHED_COMMITS_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_LIST_WORKTREE_UNPUBLISHED_COMMITS_CHANNEL,
+    async (
+      _event,
+      request: ListWorktreeUnpublishedCommitsRequest,
+    ): Promise<ListWorktreeUnpublishedCommitsResponse> => {
+      return await appServerService.listWorktreeUnpublishedCommits(request);
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_GET_WORKTREE_UNPUBLISHED_COMMIT_DIFF_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_GET_WORKTREE_UNPUBLISHED_COMMIT_DIFF_CHANNEL,
+    async (
+      _event,
+      request: GetWorktreeUnpublishedCommitDiffRequest,
+    ): Promise<GetWorktreeUnpublishedCommitDiffResponse> => {
+      return await appServerService.getWorktreeUnpublishedCommitDiff(request);
+    },
+  );
   ipcMain.removeHandler(NAVIGATION_GET_GH_STATUS_CHANNEL);
   ipcMain.handle(
     NAVIGATION_GET_GH_STATUS_CHANNEL,
@@ -7516,6 +7573,8 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_LIST_WORKTREE_UNPUBLISHED_COMMITS_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_GET_WORKTREE_UNPUBLISHED_COMMIT_DIFF_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_GET_GH_STATUS_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2188,6 +2188,25 @@ class DesktopAppServerService {
   async listWorktreeUnpublishedCommits(
     request: ListWorktreeUnpublishedCommitsRequest,
   ): Promise<ListWorktreeUnpublishedCommitsResponse> {
+    if (
+      request.federationTarget
+      && isRemoteFederationTarget(request.federationTarget)
+    ) {
+      if (!request.backend || !request.threadId?.trim()) {
+        throw new Error(
+          "Remote unpublished commit reads require an owning thread identity.",
+        );
+      }
+      return await getDesktopFederationRuntime()
+        .remoteBackend(request.federationTarget)
+        .listWorktreeUnpublishedCommits({
+          backend: request.backend,
+          threadId: request.threadId,
+          worktreePath: request.worktreePath,
+          maxCommits: request.maxCommits,
+          maxFilesPerCommit: request.maxFilesPerCommit,
+        });
+    }
     return await getDesktopBackendRegistry().listWorktreeUnpublishedCommits(
       request.worktreePath,
       {
@@ -2203,6 +2222,26 @@ class DesktopAppServerService {
   async getWorktreeUnpublishedCommitDiff(
     request: GetWorktreeUnpublishedCommitDiffRequest,
   ): Promise<GetWorktreeUnpublishedCommitDiffResponse> {
+    if (
+      request.federationTarget
+      && isRemoteFederationTarget(request.federationTarget)
+    ) {
+      if (!request.backend || !request.threadId?.trim()) {
+        throw new Error(
+          "Remote unpublished commit reads require an owning thread identity.",
+        );
+      }
+      return await getDesktopFederationRuntime()
+        .remoteBackend(request.federationTarget)
+        .getWorktreeUnpublishedCommitDiff({
+          backend: request.backend,
+          threadId: request.threadId,
+          worktreePath: request.worktreePath,
+          commitSha: request.commitSha,
+          path: request.path,
+          maxBytes: request.maxBytes,
+        });
+    }
     return await getDesktopBackendRegistry().getWorktreeUnpublishedCommitDiff(
       request.worktreePath,
       request.commitSha,
@@ -7377,9 +7416,20 @@ export function registerAppServerIpcHandlers(): void {
   ipcMain.handle(
     NAVIGATION_LIST_WORKTREE_UNPUBLISHED_COMMITS_CHANNEL,
     async (
-      _event,
+      event,
       request: ListWorktreeUnpublishedCommitsRequest,
     ): Promise<ListWorktreeUnpublishedCommitsResponse> => {
+      if (
+        isFederationWindowWebContents(event?.sender)
+        && !(
+          request.federationTarget
+          && isRemoteFederationTarget(request.federationTarget)
+        )
+      ) {
+        throw new Error(
+          "Unpublished commit reads for a remote thread must target the owning instance.",
+        );
+      }
       return await appServerService.listWorktreeUnpublishedCommits(request);
     },
   );
@@ -7387,9 +7437,20 @@ export function registerAppServerIpcHandlers(): void {
   ipcMain.handle(
     NAVIGATION_GET_WORKTREE_UNPUBLISHED_COMMIT_DIFF_CHANNEL,
     async (
-      _event,
+      event,
       request: GetWorktreeUnpublishedCommitDiffRequest,
     ): Promise<GetWorktreeUnpublishedCommitDiffResponse> => {
+      if (
+        isFederationWindowWebContents(event?.sender)
+        && !(
+          request.federationTarget
+          && isRemoteFederationTarget(request.federationTarget)
+        )
+      ) {
+        throw new Error(
+          "Unpublished commit reads for a remote thread must target the owning instance.",
+        );
+      }
       return await appServerService.getWorktreeUnpublishedCommitDiff(request);
     },
   );

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2535,8 +2535,14 @@ class DesktopAppServerService {
     // Threads arrive without working state (the enricher no longer computes
     // it), so hydration only ever adds the cached value. A worktree the cache
     // doesn't know about yet shows no chips until the background probe lands.
-    if (cached?.gitWorkingState && thread.gitWorkingState !== cached.gitWorkingState) {
-      return { ...thread, gitWorkingState: cached.gitWorkingState };
+    if (cached) {
+      return {
+        ...thread,
+        gitWorkingStateFetchedAt: cached.fetchedAt,
+        ...(cached.gitWorkingState
+          ? { gitWorkingState: cached.gitWorkingState }
+          : {}),
+      };
     }
     return thread;
   }
@@ -3051,31 +3057,25 @@ class DesktopAppServerService {
     gitWorkingState?: ThreadGitWorkingState;
   }): Promise<void> {
     const previous = this.workingStateByWorktree.get(params.worktreePath);
+    const fetchedAt = Math.max(
+      params.fetchedAt,
+      (previous?.fetchedAt ?? params.fetchedAt - 1) + 1,
+    );
     const cacheEntry: WorktreeGitWorkingStateCacheEntry = {
       worktreePath: params.worktreePath,
-      fetchedAt: params.fetchedAt,
+      fetchedAt,
       ...(params.gitWorkingState ? { gitWorkingState: params.gitWorkingState } : {}),
     };
     this.workingStateByWorktree.set(params.worktreePath, cacheEntry);
     await getDesktopBackendRegistry()
       .rememberThreadGitWorkingStateCacheEntry(cacheEntry);
 
-    // Skip the push when the probed value is identical to what clients
-    // already hold — avoids a snapshot patch + re-render on every idle
-    // background refresh that found nothing changed.
-    if (
-      JSON.stringify(previous?.gitWorkingState ?? null) ===
-      JSON.stringify(params.gitWorkingState ?? null)
-    ) {
-      return;
-    }
-
     const notification: NavigationThreadGitWorkingStateUpdatedNotification = {
       method: "navigation/threadGitWorkingState/updated",
       params: {
         worktreePath: params.worktreePath,
         gitWorkingState: params.gitWorkingState ?? null,
-        fetchedAt: params.fetchedAt,
+        fetchedAt,
       },
     };
     await getDesktopBackendRegistry().publishLocalEvent({

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -191,6 +191,10 @@ import type {
   ListWorktreeOtherChangesResponse,
   GetWorktreeOtherChangeDiffRequest,
   GetWorktreeOtherChangeDiffResponse,
+  ListWorktreeUnpublishedCommitsRequest,
+  ListWorktreeUnpublishedCommitsResponse,
+  GetWorktreeUnpublishedCommitDiffRequest,
+  GetWorktreeUnpublishedCommitDiffResponse,
   NavigationSnapshot,
   ResetDirectoryLaunchpadRequest,
   ResetDirectoryLaunchpadResponse,
@@ -535,6 +539,8 @@ import {
   NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
   NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL,
   NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL,
+  NAVIGATION_LIST_WORKTREE_UNPUBLISHED_COMMITS_CHANNEL,
+  NAVIGATION_GET_WORKTREE_UNPUBLISHED_COMMIT_DIFF_CHANNEL,
   FEDERATION_JUMP_SEARCH_CHANNEL,
   NAVIGATION_ADD_REMOTE_THREAD_PIN_CHANNEL,
   NAVIGATION_REMOVE_REMOTE_THREAD_PIN_CHANNEL,
@@ -1556,6 +1562,20 @@ const desktopApi = Object.freeze({
   ): Promise<GetWorktreeOtherChangeDiffResponse> =>
     await ipcRenderer.invoke(
       NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL,
+      request,
+    ),
+  listWorktreeUnpublishedCommits: async (
+    request: ListWorktreeUnpublishedCommitsRequest,
+  ): Promise<ListWorktreeUnpublishedCommitsResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_LIST_WORKTREE_UNPUBLISHED_COMMITS_CHANNEL,
+      request,
+    ),
+  getWorktreeUnpublishedCommitDiff: async (
+    request: GetWorktreeUnpublishedCommitDiffRequest,
+  ): Promise<GetWorktreeUnpublishedCommitDiffResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_GET_WORKTREE_UNPUBLISHED_COMMIT_DIFF_CHANNEL,
       request,
     ),
   getGhStatus: async (request?: GetGhStatusRequest): Promise<GhStatus> =>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -705,7 +705,10 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             commitStatesByKey={props.editedFileCommitStates}
             worktreeRoot={props.editedFilesWorktreeRoot}
             desktopApi={props.desktopApi}
-            workingStateRefreshKey={JSON.stringify(props.thread.gitWorkingState ?? null)}
+            workingStateRefreshKey={JSON.stringify({
+              fetchedAt: props.thread.gitWorkingStateFetchedAt,
+              state: props.thread.gitWorkingState ?? null,
+            })}
             onOpenFile={props.onOpenEditedFile}
             preferredEditor={props.preferredEditor}
             onScrollToTurn={props.onScrollToTurn}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -35,6 +35,7 @@ import {
   type IconProps,
 } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { resolveThreadWorkingStatePath } from "../../lib/thread-working-state-path";
 import { ThreadAutomationsPanel } from "../automations/ThreadAutomationsPanel";
 import { ThreadInfoPanel } from "./context-panels/ThreadInfoPanel";
 import { ProviderStatusPanel } from "./context-panels/ProviderStatusPanel";
@@ -193,6 +194,8 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   );
   const topTabs = visibleTabs.filter((tab) => !tab.bottom);
   const bottomTabs = visibleTabs.filter((tab) => tab.bottom);
+  const editsWorktreeRoot = props.editedFilesWorktreeRoot
+    ?? (props.thread ? resolveThreadWorkingStatePath(props.thread) : undefined);
 
   const rememberMousePosition = useCallback((event: MouseEvent<HTMLElement>) => {
     lastMousePositionRef.current = {
@@ -704,7 +707,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             backend={props.thread.source}
             groups={props.editedFileGroups ?? []}
             commitStatesByKey={props.editedFileCommitStates}
-            worktreeRoot={props.editedFilesWorktreeRoot}
+            worktreeRoot={editsWorktreeRoot}
             desktopApi={props.desktopApi}
             threadId={props.thread.id}
             workingStateRefreshKey={JSON.stringify({

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -701,10 +701,12 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
         if (!props.thread) return null;
         return (
           <EditsPanel
+            backend={props.thread.source}
             groups={props.editedFileGroups ?? []}
             commitStatesByKey={props.editedFileCommitStates}
             worktreeRoot={props.editedFilesWorktreeRoot}
             desktopApi={props.desktopApi}
+            threadId={props.thread.id}
             workingStateRefreshKey={JSON.stringify({
               fetchedAt: props.thread.gitWorkingStateFetchedAt,
               state: props.thread.gitWorkingState ?? null,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -3029,7 +3029,7 @@ describe("ThreadContextPanel", () => {
     renderPanel({ activeTab: "edits", pinned: true });
 
     expect(
-      screen.getByText(/No uncommitted file edits yet/),
+      screen.getByText(/No uncommitted file edits or unpublished commits/),
     ).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -3033,6 +3033,44 @@ describe("ThreadContextPanel", () => {
     ).toBeInTheDocument();
   });
 
+  it("loads unpublished commits from a linked worktree without a project key", async () => {
+    const listWorktreeUnpublishedCommits = vi.fn(async () => ({
+      commits: [],
+      totalCommits: 0,
+      truncated: false,
+      maxCommits: 20,
+      maxFilesPerCommit: 50,
+    }));
+
+    renderPanel({
+      activeTab: "edits",
+      desktopApi: { listWorktreeUnpublishedCommits },
+      pinned: true,
+      thread: {
+        ...baseThread,
+        linkedDirectories: [
+          {
+            id: "linked-worktree",
+            kind: "worktree",
+            label: "PwrAgent",
+            path: "/repo",
+            worktreePath: "/repo/.worktrees/thread-1",
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(listWorktreeUnpublishedCommits).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        worktreePath: "/repo/.worktrees/thread-1",
+        maxCommits: 20,
+        maxFilesPerCommit: 50,
+      });
+    });
+  });
+
   it("renders accumulated edit groups on the Edits tab and toggles the dock", () => {
     const groups = collectEditedFileGroups({
       entries: [

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useMemo, useState } from "react";
 import type {
+  AppServerBackendKind,
   AppServerThreadActivityDetail,
   DesktopApplicationDiscoveryCandidate,
   EditGroupCommitState,
@@ -25,6 +26,8 @@ import {
 import type { EditedFilesDock } from "./context-tab";
 
 type EditsPanelProps = {
+  backend?: AppServerBackendKind;
+  threadId?: string;
   /** Newest-first accumulated edited-file groups for the open thread. */
   groups: EditedFileGroup[];
   /** Git commit lifecycle per group key, from `useEditCommitStates`. */
@@ -170,7 +173,9 @@ function useOtherWorktreeChanges(params: {
 }
 
 function useUnpublishedCommits(params: {
+  backend?: AppServerBackendKind;
   desktopApi?: Pick<DesktopApi, "listWorktreeUnpublishedCommits">;
+  threadId?: string;
   worktreeRoot?: string;
   refreshKey?: string;
 }) {
@@ -192,6 +197,8 @@ function useUnpublishedCommits(params: {
     let cancelled = false;
     setState({ commits: [], totalCommits: 0, truncated: false, loading: true });
     void listCommits({
+      backend: params.backend,
+      threadId: params.threadId,
       worktreePath,
       maxCommits: UNPUBLISHED_COMMITS_MAX,
       maxFilesPerCommit: UNPUBLISHED_COMMIT_FILES_MAX,
@@ -222,7 +229,9 @@ function useUnpublishedCommits(params: {
     };
   }, [
     params.desktopApi?.listWorktreeUnpublishedCommits,
+    params.backend,
     params.refreshKey,
+    params.threadId,
     params.worktreeRoot,
   ]);
 
@@ -430,7 +439,9 @@ export function EditsPanel(props: EditsPanelProps) {
     worktreeRoot: props.worktreeRoot,
   });
   const unpublishedCommits = useUnpublishedCommits({
+    backend: props.backend,
     desktopApi: props.desktopApi,
+    threadId: props.threadId,
     worktreeRoot: props.worktreeRoot,
     refreshKey: props.workingStateRefreshKey,
   });
@@ -467,11 +478,13 @@ export function EditsPanel(props: EditsPanelProps) {
       <div className="edits-panel__body">
         {hasUnpublishedCommits ? (
           <UnpublishedCommitsSection
+            backend={props.backend}
             commits={unpublishedCommits.commits}
             totalCommits={unpublishedCommits.totalCommits}
             truncated={unpublishedCommits.truncated}
             worktreeRoot={props.worktreeRoot}
             desktopApi={props.desktopApi}
+            threadId={props.threadId}
             onOpenFile={props.onOpenFile}
           />
         ) : null}
@@ -519,11 +532,13 @@ function unpublishedCommitsSummary(totalCommits: number): string {
 }
 
 function UnpublishedCommitsSection(props: {
+  backend?: AppServerBackendKind;
   commits: WorktreeUnpublishedCommit[];
   totalCommits: number;
   truncated: boolean;
   worktreeRoot?: string;
   desktopApi?: Pick<DesktopApi, "getWorktreeUnpublishedCommitDiff">;
+  threadId?: string;
   onOpenFile?: (absolutePath: string) => void;
 }) {
   const [expanded, setExpanded] = useState(true);
@@ -567,11 +582,13 @@ function UnpublishedCommitsSection(props: {
           <div className="unpublished-commits__list">
             {props.commits.map((commit, index) => (
               <UnpublishedCommitSection
+                backend={props.backend}
                 key={commit.sha}
                 commit={commit}
                 initiallyExpanded={index === 0}
                 worktreeRoot={props.worktreeRoot}
                 desktopApi={props.desktopApi}
+                threadId={props.threadId}
                 onOpenFile={props.onOpenFile}
               />
             ))}
@@ -588,10 +605,12 @@ function UnpublishedCommitsSection(props: {
 }
 
 function UnpublishedCommitSection(props: {
+  backend?: AppServerBackendKind;
   commit: WorktreeUnpublishedCommit;
   initiallyExpanded: boolean;
   worktreeRoot?: string;
   desktopApi?: Pick<DesktopApi, "getWorktreeUnpublishedCommitDiff">;
+  threadId?: string;
   onOpenFile?: (absolutePath: string) => void;
 }) {
   const [expanded, setExpanded] = useState(props.initiallyExpanded);
@@ -632,10 +651,12 @@ function UnpublishedCommitSection(props: {
               {props.commit.files.map((file) => (
                 <li key={file.repoPath} className="live-work-rail__file-row">
                   <UnpublishedCommitFileRow
+                    backend={props.backend}
                     commitSha={props.commit.sha}
                     file={file}
                     worktreeRoot={props.worktreeRoot}
                     desktopApi={props.desktopApi}
+                    threadId={props.threadId}
                     onOpenFile={props.onOpenFile}
                   />
                 </li>
@@ -654,10 +675,12 @@ function UnpublishedCommitSection(props: {
 }
 
 function UnpublishedCommitFileRow(props: {
+  backend?: AppServerBackendKind;
   commitSha: string;
   file: WorktreeUnpublishedCommitFile;
   worktreeRoot?: string;
   desktopApi?: Pick<DesktopApi, "getWorktreeUnpublishedCommitDiff">;
+  threadId?: string;
   onOpenFile?: (absolutePath: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -682,6 +705,8 @@ function UnpublishedCommitFileRow(props: {
     let cancelled = false;
     setLoading(true);
     void getDiff({
+      backend: props.backend,
+      threadId: props.threadId,
       worktreePath,
       commitSha: props.commitSha,
       path: props.file.path,
@@ -708,9 +733,11 @@ function UnpublishedCommitFileRow(props: {
   }, [
     detail,
     expanded,
+    props.backend,
     props.commitSha,
     props.desktopApi,
     props.file.path,
+    props.threadId,
     props.worktreeRoot,
   ]);
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -5,6 +5,8 @@ import type {
   EditGroupCommitState,
   WorktreeOtherChangeEntry,
   WorktreeOtherChangeStatus,
+  WorktreeUnpublishedCommit,
+  WorktreeUnpublishedCommitFile,
 } from "@pwragent/shared";
 import { ArrowUpIcon, EditorIcon } from "../../../icons";
 import type { DesktopApi } from "../../../lib/desktop-api";
@@ -39,13 +41,18 @@ type EditsPanelProps = {
   onDockChange: (dock: EditedFilesDock) => void;
   desktopApi?: Pick<
     DesktopApi,
-    "listWorktreeOtherChanges" | "getWorktreeOtherChangeDiff"
+    | "listWorktreeOtherChanges"
+    | "getWorktreeOtherChangeDiff"
+    | "listWorktreeUnpublishedCommits"
+    | "getWorktreeUnpublishedCommitDiff"
   >;
   workingStateRefreshKey?: string;
 };
 
 const OTHER_CHANGES_MAX_FILES = 50;
 const OTHER_CHANGE_DIFF_MAX_BYTES = 200_000;
+const UNPUBLISHED_COMMITS_MAX = 20;
+const UNPUBLISHED_COMMIT_FILES_MAX = 50;
 
 function isAbsolutePathLike(value: string): boolean {
   return value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value);
@@ -157,6 +164,66 @@ function useOtherWorktreeChanges(params: {
     editedPathSignature,
     sortedEditedPaths,
     params.refreshKey,
+  ]);
+
+  return state;
+}
+
+function useUnpublishedCommits(params: {
+  desktopApi?: Pick<DesktopApi, "listWorktreeUnpublishedCommits">;
+  worktreeRoot?: string;
+  refreshKey?: string;
+}) {
+  const [state, setState] = useState<{
+    commits: WorktreeUnpublishedCommit[];
+    totalCommits: number;
+    truncated: boolean;
+    loading: boolean;
+  }>({ commits: [], totalCommits: 0, truncated: false, loading: false });
+
+  useEffect(() => {
+    const listCommits = params.desktopApi?.listWorktreeUnpublishedCommits;
+    const worktreePath = params.worktreeRoot?.trim();
+    if (!listCommits || !worktreePath) {
+      setState({ commits: [], totalCommits: 0, truncated: false, loading: false });
+      return;
+    }
+
+    let cancelled = false;
+    setState({ commits: [], totalCommits: 0, truncated: false, loading: true });
+    void listCommits({
+      worktreePath,
+      maxCommits: UNPUBLISHED_COMMITS_MAX,
+      maxFilesPerCommit: UNPUBLISHED_COMMIT_FILES_MAX,
+    })
+      .then((response) => {
+        if (!cancelled) {
+          setState({
+            commits: response.commits,
+            totalCommits: response.totalCommits,
+            truncated: response.truncated,
+            loading: false,
+          });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState({
+            commits: [],
+            totalCommits: 0,
+            truncated: false,
+            loading: false,
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    params.desktopApi?.listWorktreeUnpublishedCommits,
+    params.refreshKey,
+    params.worktreeRoot,
   ]);
 
   return state;
@@ -324,10 +391,10 @@ function FileSizeStat(props: { bytes: number }) {
 }
 
 /**
- * Context-rail Edits tab: the accumulated uncommitted file edits for
- * the open thread, grouped per turn (newest first). Shows the same
- * data as the LiveWorkRail's Edited Files section; the dock toggle
- * controls whether that above-composer copy renders at all.
+ * Context-rail Edits tab: unpublished commits plus the accumulated
+ * uncommitted file edits for the open thread, grouped per turn (newest
+ * first). The turn groups mirror the LiveWorkRail's Edited Files section;
+ * the dock toggle controls whether that above-composer copy renders at all.
  *
  * The panel is a flex column with a FIXED header (title + view toggle +
  * dock toggle) and an internally scrolling body, so the chrome never
@@ -362,7 +429,13 @@ export function EditsPanel(props: EditsPanelProps) {
     refreshKey: props.workingStateRefreshKey,
     worktreeRoot: props.worktreeRoot,
   });
+  const unpublishedCommits = useUnpublishedCommits({
+    desktopApi: props.desktopApi,
+    worktreeRoot: props.worktreeRoot,
+    refreshKey: props.workingStateRefreshKey,
+  });
   const hasOtherChanges = otherChanges.changes.length > 0;
+  const hasUnpublishedCommits = unpublishedCommits.commits.length > 0;
 
   return (
     <section className="context-panel__section context-panel__section--edits">
@@ -392,6 +465,16 @@ export function EditsPanel(props: EditsPanelProps) {
         {dockTooltip.tooltipNode}
       </div>
       <div className="edits-panel__body">
+        {hasUnpublishedCommits ? (
+          <UnpublishedCommitsSection
+            commits={unpublishedCommits.commits}
+            totalCommits={unpublishedCommits.totalCommits}
+            truncated={unpublishedCommits.truncated}
+            worktreeRoot={props.worktreeRoot}
+            desktopApi={props.desktopApi}
+            onOpenFile={props.onOpenFile}
+          />
+        ) : null}
         {hasOtherChanges ? (
           <OtherChangesSection
             changes={otherChanges.changes}
@@ -415,15 +498,277 @@ export function EditsPanel(props: EditsPanelProps) {
             showSingleGroupHeader
           />
         ) : (
-          !hasOtherChanges && !otherChanges.loading ? (
+          !hasOtherChanges
+          && !hasUnpublishedCommits
+          && !otherChanges.loading
+          && !unpublishedCommits.loading ? (
             <p className="context-empty">
-              No uncommitted file edits yet. Edits from agent turns accumulate
-              here until they are committed.
+              No uncommitted file edits or unpublished commits.
             </p>
           ) : null
         )}
       </div>
     </section>
+  );
+}
+
+function unpublishedCommitsSummary(totalCommits: number): string {
+  return `Unpublished ${totalCommits.toLocaleString()} ${
+    totalCommits === 1 ? "commit" : "commits"
+  }`;
+}
+
+function UnpublishedCommitsSection(props: {
+  commits: WorktreeUnpublishedCommit[];
+  totalCommits: number;
+  truncated: boolean;
+  worktreeRoot?: string;
+  desktopApi?: Pick<DesktopApi, "getWorktreeUnpublishedCommitDiff">;
+  onOpenFile?: (absolutePath: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(true);
+  const bodyId = useId();
+  const hiddenCount = Math.max(0, props.totalCommits - props.commits.length);
+  const totals = useMemo(
+    () =>
+      props.commits.reduce(
+        (sum, commit) => ({
+          additions: sum.additions + commit.additions,
+          removals: sum.removals + commit.removals,
+        }),
+        { additions: 0, removals: 0 },
+      ),
+    [props.commits],
+  );
+
+  return (
+    <section className="edited-file-groups__group unpublished-commits">
+      <div className="edited-file-groups__group-header unpublished-commits__header">
+        <button
+          type="button"
+          className="edited-file-groups__group-toggle unpublished-commits__toggle"
+          aria-expanded={expanded}
+          aria-controls={bodyId}
+          onClick={() => setExpanded((current) => !current)}
+        >
+          <span className="live-work-rail__chevron" aria-hidden="true" />
+          <span className="edited-file-groups__group-summary">
+            {unpublishedCommitsSummary(props.totalCommits)}
+          </span>
+        </button>
+        <DiffStat
+          additions={totals.additions}
+          removals={totals.removals}
+          className="diff-stat--chip"
+        />
+      </div>
+      <div id={bodyId} hidden={!expanded}>
+        {expanded ? (
+          <div className="unpublished-commits__list">
+            {props.commits.map((commit, index) => (
+              <UnpublishedCommitSection
+                key={commit.sha}
+                commit={commit}
+                initiallyExpanded={index === 0}
+                worktreeRoot={props.worktreeRoot}
+                desktopApi={props.desktopApi}
+                onOpenFile={props.onOpenFile}
+              />
+            ))}
+            {props.truncated ? (
+              <p className="other-changes__truncated">
+                {hiddenCount.toLocaleString()} more not shown.
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function UnpublishedCommitSection(props: {
+  commit: WorktreeUnpublishedCommit;
+  initiallyExpanded: boolean;
+  worktreeRoot?: string;
+  desktopApi?: Pick<DesktopApi, "getWorktreeUnpublishedCommitDiff">;
+  onOpenFile?: (absolutePath: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(props.initiallyExpanded);
+  const bodyId = useId();
+  const hiddenCount = Math.max(
+    0,
+    props.commit.totalFiles - props.commit.files.length,
+  );
+
+  return (
+    <section className="unpublished-commit">
+      <div className="unpublished-commit__header">
+        <button
+          type="button"
+          className="unpublished-commit__toggle"
+          aria-expanded={expanded}
+          aria-controls={bodyId}
+          onClick={() => setExpanded((current) => !current)}
+        >
+          <span className="live-work-rail__chevron" aria-hidden="true" />
+          <span className="unpublished-commit__identity">
+            <span className="unpublished-commit__subject">
+              {props.commit.subject}
+            </span>
+            <span className="unpublished-commit__sha">{props.commit.shortSha}</span>
+          </span>
+        </button>
+        <DiffStat
+          additions={props.commit.additions}
+          removals={props.commit.removals}
+          className="diff-stat--chip"
+        />
+      </div>
+      <div id={bodyId} hidden={!expanded}>
+        {expanded ? (
+          <>
+            <ul className="live-work-rail__file-list">
+              {props.commit.files.map((file) => (
+                <li key={file.repoPath} className="live-work-rail__file-row">
+                  <UnpublishedCommitFileRow
+                    commitSha={props.commit.sha}
+                    file={file}
+                    worktreeRoot={props.worktreeRoot}
+                    desktopApi={props.desktopApi}
+                    onOpenFile={props.onOpenFile}
+                  />
+                </li>
+              ))}
+            </ul>
+            {props.commit.filesTruncated ? (
+              <p className="other-changes__truncated">
+                {hiddenCount.toLocaleString()} more files not shown.
+              </p>
+            ) : null}
+          </>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function UnpublishedCommitFileRow(props: {
+  commitSha: string;
+  file: WorktreeUnpublishedCommitFile;
+  worktreeRoot?: string;
+  desktopApi?: Pick<DesktopApi, "getWorktreeUnpublishedCommitDiff">;
+  onOpenFile?: (absolutePath: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [detail, setDetail] = useState<
+    AppServerThreadActivityDetail | undefined
+  >();
+  const [loading, setLoading] = useState(false);
+  const diffId = useId();
+  const canOpen = Boolean(props.onOpenFile);
+  const hasStats =
+    props.file.additions !== undefined || props.file.removals !== undefined;
+
+  useEffect(() => {
+    if (!expanded || detail) {
+      return;
+    }
+    const getDiff = props.desktopApi?.getWorktreeUnpublishedCommitDiff;
+    const worktreePath = props.worktreeRoot?.trim();
+    if (!getDiff || !worktreePath) {
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    void getDiff({
+      worktreePath,
+      commitSha: props.commitSha,
+      path: props.file.path,
+      maxBytes: OTHER_CHANGE_DIFF_MAX_BYTES,
+    })
+      .then((response) => {
+        if (!cancelled) {
+          setDetail(response.detail);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDetail(undefined);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    detail,
+    expanded,
+    props.commitSha,
+    props.desktopApi,
+    props.file.path,
+    props.worktreeRoot,
+  ]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="live-work-rail__file-toggle"
+        aria-controls={diffId}
+        aria-expanded={expanded}
+        onClick={() => setExpanded((current) => !current)}
+      >
+        <span className="live-work-rail__chevron" aria-hidden="true" />
+        <span className="live-work-rail__file-label">
+          <span className="live-work-rail__file-path" title={props.file.path}>
+            {basename(props.file.repoPath)}
+          </span>
+        </span>
+        {hasStats ? (
+          <DiffStat
+            additions={props.file.additions ?? 0}
+            removals={props.file.removals ?? 0}
+            className="diff-stat--chip"
+          />
+        ) : props.file.binary ? (
+          <span className="unpublished-commit__binary">Binary</span>
+        ) : null}
+      </button>
+      <div id={diffId} className="live-work-rail__file-diff" hidden={!expanded}>
+        {expanded ? (
+          <>
+            <div className="edited-file-row__meta">
+              <span className="edited-file-row__path" title={props.file.path}>
+                {props.file.repoPath}
+              </span>
+              {canOpen ? (
+                <button
+                  type="button"
+                  className="edited-file-row__open"
+                  onClick={() => props.onOpenFile?.(props.file.path)}
+                  aria-label={`Open ${props.file.repoPath} in editor`}
+                  title="Open in editor"
+                >
+                  <EditorIcon className="edited-file-row__open-icon" />
+                </button>
+              ) : null}
+            </div>
+            {loading ? (
+              <p className="other-changes__loading">Loading diff...</p>
+            ) : detail ? (
+              <TranscriptDiff detail={detail} compact />
+            ) : (
+              <p className="other-changes__loading">Diff unavailable.</p>
+            )}
+          </>
+        ) : null}
+      </div>
+    </>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -184,6 +184,7 @@ function useUnpublishedCommits(params: {
     totalCommits: number;
     truncated: boolean;
     loading: boolean;
+    worktreePath?: string;
   }>({ commits: [], totalCommits: 0, truncated: false, loading: false });
 
   useEffect(() => {
@@ -195,7 +196,17 @@ function useUnpublishedCommits(params: {
     }
 
     let cancelled = false;
-    setState({ commits: [], totalCommits: 0, truncated: false, loading: true });
+    setState((current) =>
+      current.worktreePath === worktreePath
+        ? { ...current, loading: true }
+        : {
+            commits: [],
+            totalCommits: 0,
+            truncated: false,
+            loading: true,
+            worktreePath,
+          },
+    );
     void listCommits({
       backend: params.backend,
       threadId: params.threadId,
@@ -210,17 +221,23 @@ function useUnpublishedCommits(params: {
             totalCommits: response.totalCommits,
             truncated: response.truncated,
             loading: false,
+            worktreePath,
           });
         }
       })
       .catch(() => {
         if (!cancelled) {
-          setState({
-            commits: [],
-            totalCommits: 0,
-            truncated: false,
-            loading: false,
-          });
+          setState((current) =>
+            current.worktreePath === worktreePath
+              ? { ...current, loading: false }
+              : {
+                  commits: [],
+                  totalCommits: 0,
+                  truncated: false,
+                  loading: false,
+                  worktreePath,
+                },
+          );
         }
       });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
@@ -100,9 +100,11 @@ describe("EditsPanel", () => {
 
     render(
       <EditsPanel
+        backend="codex"
         groups={[]}
         dock="sidebar"
         onDockChange={vi.fn()}
+        threadId="thread-1"
         worktreeRoot="/repo"
         desktopApi={{
           listWorktreeUnpublishedCommits,
@@ -117,11 +119,20 @@ describe("EditsPanel", () => {
     expect(screen.getByText("Preserve remote callback evidence"))
       .toBeInTheDocument();
     expect(screen.getByText("bbbbbbb")).toBeInTheDocument();
+    expect(listWorktreeUnpublishedCommits).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath: "/repo",
+      maxCommits: 20,
+      maxFilesPerCommit: 50,
+    });
 
     fireEvent.click(screen.getByRole("button", { name: /config\.ts/i }));
 
     await waitFor(() => {
       expect(getWorktreeUnpublishedCommitDiff).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
         worktreePath: "/repo",
         commitSha,
         path: "/repo/src/config.ts",

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
@@ -55,6 +55,82 @@ function renderEditsPanel(groups: EditedFileGroup[]) {
 }
 
 describe("EditsPanel", () => {
+  it("shows unpublished commits and fetches a committed file diff on expansion", async () => {
+    const commitSha = "b".repeat(40);
+    const listWorktreeUnpublishedCommits = vi.fn(async () => ({
+      commits: [
+        {
+          sha: commitSha,
+          shortSha: "bbbbbbb",
+          subject: "Preserve remote callback evidence",
+          committedAt: 1_718_000_000_000,
+          files: [
+            {
+              path: "/repo/src/config.ts",
+              repoPath: "src/config.ts",
+              additions: 2,
+              removals: 1,
+            },
+          ],
+          totalFiles: 1,
+          filesTruncated: false,
+          additions: 2,
+          removals: 1,
+        },
+      ],
+      totalCommits: 1,
+      truncated: false,
+      maxCommits: 20,
+      maxFilesPerCommit: 50,
+    }));
+    const getWorktreeUnpublishedCommitDiff = vi.fn(async () => ({
+      detail: {
+        id: "commit-file",
+        kind: "write" as const,
+        label: "config.ts",
+        path: "/repo/src/config.ts",
+        fileDiff: {
+          kind: "update" as const,
+          diff: "@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+          additions: 2,
+          removals: 1,
+        },
+      },
+    }));
+
+    render(
+      <EditsPanel
+        groups={[]}
+        dock="sidebar"
+        onDockChange={vi.fn()}
+        worktreeRoot="/repo"
+        desktopApi={{
+          listWorktreeUnpublishedCommits,
+          getWorktreeUnpublishedCommitDiff,
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /Unpublished 1 commit/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Preserve remote callback evidence"))
+      .toBeInTheDocument();
+    expect(screen.getByText("bbbbbbb")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /config\.ts/i }));
+
+    await waitFor(() => {
+      expect(getWorktreeUnpublishedCommitDiff).toHaveBeenCalledWith({
+        worktreePath: "/repo",
+        commitSha,
+        path: "/repo/src/config.ts",
+        maxBytes: 200_000,
+      });
+    });
+    expect(await screen.findByText("new")).toBeInTheDocument();
+  });
+
   it("keeps the group header for a single edit history in the sidebar", () => {
     render(renderEditsPanel([editedGroup()]));
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
@@ -525,4 +525,45 @@ describe("EditsPanel", () => {
     });
     expect(getWorktreeOtherChangeDiff).toHaveBeenCalledTimes(4);
   });
+
+  it("refreshes unpublished commit metadata when the working-state probe advances", async () => {
+    let subject = "before amend";
+    const listWorktreeUnpublishedCommits = vi.fn(async () => ({
+      commits: [
+        {
+          sha: "b".repeat(40),
+          shortSha: "bbbbbbb",
+          subject,
+          files: [],
+          totalFiles: 0,
+          filesTruncated: false,
+          additions: 0,
+          removals: 0,
+        },
+      ],
+      totalCommits: 1,
+      truncated: false,
+      maxCommits: 20,
+      maxFilesPerCommit: 50,
+    }));
+    const panel = (refreshKey: string) => (
+      <EditsPanel
+        groups={[]}
+        dock="sidebar"
+        onDockChange={vi.fn()}
+        worktreeRoot="/repo"
+        workingStateRefreshKey={refreshKey}
+        desktopApi={{ listWorktreeUnpublishedCommits }}
+      />
+    );
+    const { rerender } = render(panel("probe-1"));
+
+    expect(await screen.findByText("before amend")).toBeInTheDocument();
+
+    subject = "after amend";
+    rerender(panel("probe-2"));
+
+    expect(await screen.findByText("after amend")).toBeInTheDocument();
+    expect(listWorktreeUnpublishedCommits).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
@@ -577,4 +577,88 @@ describe("EditsPanel", () => {
     expect(await screen.findByText("after amend")).toBeInTheDocument();
     expect(listWorktreeUnpublishedCommits).toHaveBeenCalledTimes(2);
   });
+
+  it("keeps expanded unpublished diffs mounted during a same-worktree refresh", async () => {
+    const commitSha = "b".repeat(40);
+    const response = {
+      commits: [
+        {
+          sha: commitSha,
+          shortSha: "bbbbbbb",
+          subject: "preserve expanded diff",
+          files: [
+            {
+              path: "/repo/src/config.ts",
+              repoPath: "src/config.ts",
+              additions: 1,
+              removals: 0,
+            },
+          ],
+          totalFiles: 1,
+          filesTruncated: false,
+          additions: 1,
+          removals: 0,
+        },
+      ],
+      totalCommits: 1,
+      truncated: false,
+      maxCommits: 20,
+      maxFilesPerCommit: 50,
+    };
+    let resolveRefresh: ((value: typeof response) => void) | undefined;
+    const listWorktreeUnpublishedCommits = vi
+      .fn()
+      .mockResolvedValueOnce(response)
+      .mockImplementationOnce(
+        () => new Promise<typeof response>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+      );
+    const getWorktreeUnpublishedCommitDiff = vi.fn(async () => ({
+      detail: {
+        id: "commit-file",
+        kind: "write" as const,
+        label: "config.ts",
+        path: "/repo/src/config.ts",
+        fileDiff: {
+          kind: "update" as const,
+          diff: "@@ -1 +1,2 @@\n old\n+preserved\n",
+          additions: 1,
+          removals: 0,
+        },
+      },
+    }));
+    const panel = (refreshKey: string) => (
+      <EditsPanel
+        groups={[]}
+        dock="sidebar"
+        onDockChange={vi.fn()}
+        worktreeRoot="/repo"
+        workingStateRefreshKey={refreshKey}
+        desktopApi={{
+          listWorktreeUnpublishedCommits,
+          getWorktreeUnpublishedCommitDiff,
+        }}
+      />
+    );
+    const { rerender } = render(panel("probe-1"));
+
+    fireEvent.click(await screen.findByRole("button", { name: /config\.ts/i }));
+    expect(await screen.findByText("preserved")).toBeInTheDocument();
+
+    rerender(panel("probe-2"));
+
+    await waitFor(() => {
+      expect(listWorktreeUnpublishedCommits).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.getByText("preserved")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /config\.ts/i }))
+      .toHaveAttribute("aria-expanded", "true");
+
+    resolveRefresh?.(response);
+    await waitFor(() => {
+      expect(screen.getByText("preserved")).toBeInTheDocument();
+    });
+    expect(getWorktreeUnpublishedCommitDiff).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/federation-desktop-api.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/federation-desktop-api.test.ts
@@ -14,10 +14,20 @@ describe("scopeDesktopApiToFederationTarget", () => {
       availability: "running" as const,
       configured: true,
     }));
+    const listWorktreeUnpublishedCommits = vi.fn(async () => ({
+      commits: [],
+      totalCommits: 0,
+      truncated: false,
+      maxCommits: 20,
+      maxFilesPerCommit: 50,
+    }));
+    const getWorktreeUnpublishedCommitDiff = vi.fn(async () => ({}));
     const desktopApi = {
       openApplication,
       refreshDirectoryGitStatuses,
       readPwrSnapConnectionStatus,
+      listWorktreeUnpublishedCommits,
+      getWorktreeUnpublishedCommitDiff,
       connectPwrSnap: vi.fn(),
       openPwrSnap: vi.fn(),
       openPwrSnapDownload: vi.fn(),
@@ -47,6 +57,18 @@ describe("scopeDesktopApiToFederationTarget", () => {
       force: true,
     });
     await scopedApi?.readPwrSnapConnectionStatus?.();
+    await scopedApi?.listWorktreeUnpublishedCommits?.({
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath: "/remote/repo",
+    });
+    await scopedApi?.getWorktreeUnpublishedCommitDiff?.({
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath: "/remote/repo",
+      commitSha: "a".repeat(40),
+      path: "/remote/repo/file.ts",
+    });
 
     expect(openApplication).toHaveBeenCalledWith({
       applicationId: "vscode",
@@ -60,6 +82,20 @@ describe("scopeDesktopApiToFederationTarget", () => {
       federationTarget,
     });
     expect(readPwrSnapConnectionStatus).toHaveBeenCalledWith({
+      federationTarget,
+    });
+    expect(listWorktreeUnpublishedCommits).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath: "/remote/repo",
+      federationTarget,
+    });
+    expect(getWorktreeUnpublishedCommitDiff).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath: "/remote/repo",
+      commitSha: "a".repeat(40),
+      path: "/remote/repo/file.ts",
       federationTarget,
     });
     expect(scopedApi?.connectPwrSnap).toBeUndefined();

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1813,6 +1813,13 @@ describe("useThreadNavigation", () => {
     });
     expect(result.current.threads[0]?.gitWorkingState).toBeUndefined();
 
+    const gitWorkingState = {
+      dirtyFiles: 3,
+      dirtyAdditions: 12,
+      dirtyDeletions: 4,
+      untrackedFiles: 1,
+      unpushedCommits: 2,
+    };
     await act(async () => {
       for (const listener of listeners) {
         listener({
@@ -1821,14 +1828,8 @@ describe("useThreadNavigation", () => {
             method: "navigation/threadGitWorkingState/updated",
             params: {
               worktreePath: "/repo/wt",
-              gitWorkingState: {
-                dirtyFiles: 3,
-                dirtyAdditions: 12,
-                dirtyDeletions: 4,
-                untrackedFiles: 1,
-                unpushedCommits: 2,
-              },
-              fetchedAt: Date.now(),
+              gitWorkingState,
+              fetchedAt: 1000,
             },
           },
         });
@@ -1841,6 +1842,26 @@ describe("useThreadNavigation", () => {
       dirtyFiles: 3,
       unpushedCommits: 2,
     });
+    expect(result.current.threads[0]?.gitWorkingStateFetchedAt).toBe(1000);
+
+    // An amend/rebase can replace commit metadata without changing any aggregate
+    // counts. The fetched-at token must still advance so detail panels reload.
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "navigation/threadGitWorkingState/updated",
+            params: {
+              worktreePath: "/repo/wt",
+              gitWorkingState,
+              fetchedAt: 2000,
+            },
+          },
+        });
+      }
+    });
+    expect(result.current.threads[0]?.gitWorkingStateFetchedAt).toBe(2000);
 
     // A clean probe (null) clears the chips.
     await act(async () => {

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -220,6 +220,10 @@ import type {
   ListWorktreeOtherChangesResponse,
   GetWorktreeOtherChangeDiffRequest,
   GetWorktreeOtherChangeDiffResponse,
+  ListWorktreeUnpublishedCommitsRequest,
+  ListWorktreeUnpublishedCommitsResponse,
+  GetWorktreeUnpublishedCommitDiffRequest,
+  GetWorktreeUnpublishedCommitDiffResponse,
   NavigationSnapshot,
   ResetDirectoryLaunchpadRequest,
   ResetDirectoryLaunchpadResponse,
@@ -875,6 +879,12 @@ export type DesktopApi = {
   getWorktreeOtherChangeDiff?: (
     request: GetWorktreeOtherChangeDiffRequest
   ) => Promise<GetWorktreeOtherChangeDiffResponse>;
+  listWorktreeUnpublishedCommits?: (
+    request: ListWorktreeUnpublishedCommitsRequest
+  ) => Promise<ListWorktreeUnpublishedCommitsResponse>;
+  getWorktreeUnpublishedCommitDiff?: (
+    request: GetWorktreeUnpublishedCommitDiffRequest
+  ) => Promise<GetWorktreeUnpublishedCommitDiffResponse>;
   getGhStatus?: (request?: GetGhStatusRequest) => Promise<GhStatus>;
   ensureDirectoryLaunchpad?: (
     request: EnsureDirectoryLaunchpadRequest

--- a/apps/desktop/src/renderer/src/lib/federation-desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/federation-desktop-api.ts
@@ -11,6 +11,10 @@ export function scopeDesktopApiToFederationTarget(
   const openApplication = desktopApi.openApplication;
   const refreshDirectoryGitStatuses = desktopApi.refreshDirectoryGitStatuses;
   const readPwrSnapConnectionStatus = desktopApi.readPwrSnapConnectionStatus;
+  const listWorktreeUnpublishedCommits =
+    desktopApi.listWorktreeUnpublishedCommits;
+  const getWorktreeUnpublishedCommitDiff =
+    desktopApi.getWorktreeUnpublishedCommitDiff;
 
   return {
     ...desktopApi,
@@ -28,6 +32,18 @@ export function scopeDesktopApiToFederationTarget(
       : undefined,
     readPwrSnapConnectionStatus: readPwrSnapConnectionStatus
       ? async () => await readPwrSnapConnectionStatus({ federationTarget })
+      : undefined,
+    listWorktreeUnpublishedCommits: listWorktreeUnpublishedCommits
+      ? async (request) => await listWorktreeUnpublishedCommits({
+          ...request,
+          federationTarget,
+        })
+      : undefined,
+    getWorktreeUnpublishedCommitDiff: getWorktreeUnpublishedCommitDiff
+      ? async (request) => await getWorktreeUnpublishedCommitDiff({
+          ...request,
+          federationTarget,
+        })
       : undefined,
     connectPwrSnap: undefined,
     openPwrSnap: undefined,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -869,18 +869,23 @@ function applyThreadGitWorkingStateUpdate(
       return thread;
     }
     if (
-      JSON.stringify(thread.gitWorkingState ?? null) ===
-      JSON.stringify(params.gitWorkingState)
+      thread.gitWorkingStateFetchedAt === params.fetchedAt
+      && JSON.stringify(thread.gitWorkingState ?? null) ===
+        JSON.stringify(params.gitWorkingState)
     ) {
       return thread;
     }
 
     changed = true;
     if (params.gitWorkingState) {
-      return { ...thread, gitWorkingState: params.gitWorkingState };
+      return {
+        ...thread,
+        gitWorkingState: params.gitWorkingState,
+        gitWorkingStateFetchedAt: params.fetchedAt,
+      };
     }
     const { gitWorkingState: _removed, ...rest } = thread;
-    return rest;
+    return { ...rest, gitWorkingStateFetchedAt: params.fetchedAt };
   });
 
   return changed ? { ...snapshot, threads } : snapshot;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13310,6 +13310,95 @@ a.transcript-message__messaging-origin:focus-visible {
   margin: 8px 0 10px;
 }
 
+.unpublished-commits {
+  margin: 8px 0 10px;
+}
+
+.unpublished-commits__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.unpublished-commit {
+  min-width: 0;
+  border-left: 1px solid var(--border-subtle);
+  padding-left: 4px;
+}
+
+.unpublished-commit__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 4px 2px;
+}
+
+.unpublished-commit__toggle {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.unpublished-commit__toggle:hover {
+  color: var(--text-primary);
+}
+
+.unpublished-commit__toggle:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.unpublished-commit__toggle[aria-expanded="false"] .live-work-rail__chevron {
+  transform: rotate(-90deg);
+}
+
+.unpublished-commit__toggle[aria-expanded="true"] .live-work-rail__chevron {
+  transform: rotate(0deg);
+}
+
+.unpublished-commit__identity {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.unpublished-commit__subject {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.unpublished-commit__sha,
+.unpublished-commit__binary {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.unpublished-commit__binary {
+  flex: 0 0 auto;
+}
+
+.unpublished-commit .live-work-rail__file-list {
+  margin-top: 2px;
+}
+
 .other-changes__truncated,
 .other-changes__loading {
   margin: 6px 0 0;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -172,6 +172,10 @@ export const NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL =
   "navigation:list-worktree-other-changes";
 export const NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL =
   "navigation:get-worktree-other-change-diff";
+export const NAVIGATION_LIST_WORKTREE_UNPUBLISHED_COMMITS_CHANNEL =
+  "navigation:list-worktree-unpublished-commits";
+export const NAVIGATION_GET_WORKTREE_UNPUBLISHED_COMMIT_DIFF_CHANNEL =
+  "navigation:get-worktree-unpublished-commit-diff";
 export const MESSAGING_GET_PLATFORM_STATUSES_CHANNEL =
   "messaging:get-platform-statuses";
 export const MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL =

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -67,6 +67,8 @@ export type NavigationLaunchpadAgent = Pick<
 >;
 
 export type NavigationThreadSummary = AppServerThreadSummary & {
+  /** Most recent completed probe for `gitWorkingState`, even when its value was unchanged. */
+  gitWorkingStateFetchedAt?: number;
   /** Present when this row describes a thread owned by another PwrAgent instance. */
   federation?: {
     ref: FederatedThreadRef;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -934,6 +934,10 @@ export type WorktreeUnpublishedCommit = {
 };
 
 export type ListWorktreeUnpublishedCommitsRequest = {
+  /** Owning thread identity; required when `federationTarget` is remote. */
+  backend?: AppServerBackendKind;
+  threadId?: ThreadIdentifier;
+  federationTarget?: FederationTarget;
   worktreePath: string;
   /** Bounded by the main process; callers can request a smaller cap. */
   maxCommits?: number;
@@ -950,6 +954,10 @@ export type ListWorktreeUnpublishedCommitsResponse = {
 };
 
 export type GetWorktreeUnpublishedCommitDiffRequest = {
+  /** Owning thread identity; required when `federationTarget` is remote. */
+  backend?: AppServerBackendKind;
+  threadId?: ThreadIdentifier;
+  federationTarget?: FederationTarget;
   worktreePath: string;
   commitSha: string;
   path: string;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -911,6 +911,54 @@ export type GetWorktreeOtherChangeDiffResponse = {
   detail?: AppServerThreadActivityDetail;
 };
 
+export type WorktreeUnpublishedCommitFile = {
+  path: string;
+  repoPath: string;
+  binary?: boolean;
+  additions?: number;
+  removals?: number;
+};
+
+export type WorktreeUnpublishedCommit = {
+  sha: string;
+  shortSha: string;
+  subject: string;
+  committedAt?: number;
+  files: WorktreeUnpublishedCommitFile[];
+  totalFiles: number;
+  filesTruncated: boolean;
+  additions: number;
+  removals: number;
+};
+
+export type ListWorktreeUnpublishedCommitsRequest = {
+  worktreePath: string;
+  /** Bounded by the main process; callers can request a smaller cap. */
+  maxCommits?: number;
+  /** Bounded per commit by the main process. */
+  maxFilesPerCommit?: number;
+};
+
+export type ListWorktreeUnpublishedCommitsResponse = {
+  commits: WorktreeUnpublishedCommit[];
+  totalCommits: number;
+  truncated: boolean;
+  maxCommits: number;
+  maxFilesPerCommit: number;
+};
+
+export type GetWorktreeUnpublishedCommitDiffRequest = {
+  worktreePath: string;
+  commitSha: string;
+  path: string;
+  /** Bounded by the main process; callers can request a smaller cap. */
+  maxBytes?: number;
+};
+
+export type GetWorktreeUnpublishedCommitDiffResponse = {
+  detail?: AppServerThreadActivityDetail;
+};
+
 const ACP_BACKEND_ID_PREFIX = "acp:";
 const ACP_REGISTRY_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
 


### PR DESCRIPTION
## What changed

- Add bounded Git APIs for commits reachable from `HEAD` but absent from remote refs.
- Show those unpublished commits at the top of the Edits sidebar with commit subjects, SHAs, file lists, and diff stats.
- Load each committed file patch only when its row is expanded.
- Keep merged-PR accepted heads excluded so the panel matches the existing unpublished badge.

## Why

Detached worktrees can be clean while still containing local-only commits. The thread row already reported that history as unpublished, but the Edits panel only queried uncommitted working-tree changes, so it incorrectly looked empty.

## Impact

Operators can inspect clean detached work before creating a branch or pushing it, directly from the same Edits surface used for uncommitted changes. Commit and file lists are capped, binary and oversized patches degrade explicitly, and Git probes remain read-only with optional locks disabled.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/git-working-state-service.test.ts apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm typecheck`
- `pnpm lint:eslint` (existing warnings only)
- `pnpm lint:colors`
- `pnpm lint:codex-storage`
- `pnpm lint:boundaries`
- `git diff --check`