### PR TITLE
fix(messaging): prevent unbound bridge method failures

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -194,7 +194,9 @@ describe("MessagingController", () => {
   it("preserves the backend receiver when listing scheduled messages", async () => {
     let receiverSeen = false;
     const harness = await createHarness({
-      listScheduledThreadActions: async function () {
+      listScheduledThreadActions: async function (
+        this: MessagingBackendBridge,
+      ) {
         receiverSeen = typeof this.getNavigationSnapshot === "function";
         return { actions: [] };
       },

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -191,6 +191,23 @@ describe("MessagingController", () => {
     });
   });
 
+  it("preserves the backend receiver when listing scheduled messages", async () => {
+    let receiverSeen = false;
+    const harness = await createHarness({
+      listScheduledThreadActions: async function () {
+        receiverSeen = typeof this.getNavigationSnapshot === "function";
+        return { actions: [] };
+      },
+    });
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCommandEvent("/scheduled"),
+    );
+
+    expect(receiverSeen).toBe(true);
+  });
+
   it("reports a failed send-now mutation instead of confirming it", async () => {
     const harness = await createHarness({
       sendScheduledThreadActionNow: async () => ({

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -299,6 +299,19 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
+  it("preserves the backend bridge receiver while syncing federation subscriptions", async () => {
+    const { runtime, bridge } = await createRuntimeHarness();
+    const subscriptions: FederationEventSubscription[][] = [];
+    bridge.setRemoteEventSubscriptions = function (next) {
+      expect(this).toBe(bridge);
+      subscriptions.push([...next]);
+    };
+
+    await runtime.start();
+
+    expect(subscriptions).toEqual([[]]);
+  });
+
   it("rehydrates enabled Monitor bindings after adapter startup", async () => {
     const { runtime, adapter } = await createRuntimeHarness();
     const { getDesktopMessagingStore } = await import(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -16087,7 +16087,10 @@ export class DesktopBackendRegistry {
   }
 
   private async drainCodexInvalidIdRecoveries(): Promise<void> {
-    const recover = this.codexClient.recoverInvalidPersistedResponseMessageIds;
+    const recover =
+      this.codexClient.recoverInvalidPersistedResponseMessageIds?.bind(
+        this.codexClient,
+      );
     if (!recover) {
       return;
     }
@@ -16103,7 +16106,7 @@ export class DesktopBackendRegistry {
           await this.resolveCodexInvalidIdRecoveryForkLineage(
             recovery.params.threadId,
           );
-        const repaired = await recover.call(this.codexClient, {
+        const repaired = await recover({
           ...(forkLineageThreadIds.length > 0
             ? { forkLineageThreadIds }
             : {}),

--- a/apps/desktop/src/main/log.ts
+++ b/apps/desktop/src/main/log.ts
@@ -63,7 +63,7 @@ function installStdioErrorHandlers(): void {
 
 function guardConsoleTransport(): void {
   const transport = electronLog.transports.console;
-  const writeFn = transport.writeFn;
+  const writeFn = transport.writeFn.bind(transport);
 
   transport.writeFn = (options) => {
     if (transport.level === false) {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -2244,7 +2244,9 @@ export class MessagingController {
       await this.presentThreadCommandNeedsBinding(event);
       return;
     }
-    const list = this.options.backend.listScheduledThreadActions;
+    const list = this.options.backend.listScheduledThreadActions?.bind(
+      this.options.backend,
+    );
     if (!list) {
       await this.deliverScheduledActionError(
         binding,
@@ -4722,7 +4724,9 @@ export class MessagingController {
     targetSurface?: MessagingSurfaceRef;
     pendingIntentId?: string;
   }): Promise<void> {
-    const submitReview = this.options.backend.submitReview;
+    const submitReview = this.options.backend.submitReview?.bind(
+      this.options.backend,
+    );
     if (!submitReview || !await this.reviewSupportedForBinding(params.binding)) {
       await this.deliverReviewUnsupported(params.binding, params.event);
       return;
@@ -4733,7 +4737,7 @@ export class MessagingController {
         backend: params.binding.backend,
       });
       const settings = turnSettingsForBinding(params.binding, navigation);
-      const result = await submitReview.call(this.options.backend, {
+      const result = await submitReview({
         backend: params.binding.backend,
         threadId: params.binding.threadId,
         target: params.target,
@@ -6151,12 +6155,14 @@ export class MessagingController {
     event: AgentEvent,
     binding: MessagingBindingRecord,
   ): Promise<MessagingImagePart[]> {
-    const resolveImages = this.options.backend.resolveAssistantMessageImages;
+    const resolveImages = this.options.backend.resolveAssistantMessageImages?.bind(
+      this.options.backend,
+    );
     if (!resolveImages) {
       return [];
     }
     try {
-      const images = await resolveImages.call(this.options.backend, {
+      const images = await resolveImages({
         backend: binding.backend,
         itemId: assistantItemIdForBackendEvent(event),
         text,
@@ -6208,8 +6214,14 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     options?: { important?: boolean },
   ): Promise<void> {
-    const readLastAssistantReply = this.options.backend.readThreadLastAssistantReply;
-    const readLastAssistantMessage = this.options.backend.readThreadLastAssistantMessage;
+    const readLastAssistantReply =
+      this.options.backend.readThreadLastAssistantReply?.bind(
+        this.options.backend,
+      );
+    const readLastAssistantMessage =
+      this.options.backend.readThreadLastAssistantMessage?.bind(
+        this.options.backend,
+      );
     if (!readLastAssistantReply && !readLastAssistantMessage) {
       return;
     }
@@ -6217,13 +6229,13 @@ export class MessagingController {
     let reply: MessagingLastAssistantReply | undefined;
     try {
       if (readLastAssistantReply) {
-        reply = await readLastAssistantReply.call(this.options.backend, {
+        reply = await readLastAssistantReply({
           backend: binding.backend,
           federationTarget: federationTargetForBinding(binding),
           threadId: binding.threadId,
         });
       } else if (readLastAssistantMessage) {
-        const text = await readLastAssistantMessage.call(this.options.backend, {
+        const text = await readLastAssistantMessage({
           backend: binding.backend,
           federationTarget: federationTargetForBinding(binding),
           threadId: binding.threadId,
@@ -16265,9 +16277,8 @@ export class MessagingController {
   private async resolveManagedConversationSummary(
     origin: ActiveAgentMessagingOrigin,
   ): Promise<PwrAgentMessagingManagedConversationSummary> {
-    const providerSupportsCreation = Boolean(
-      this.options.adapter.createManagedConversation,
-    );
+    const providerSupportsCreation =
+      typeof this.options.adapter.createManagedConversation === "function";
     if (!this.options.adapter.getManagedConversationRights) {
       const operation = {
         operation: "create_child" as const,

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -746,11 +746,11 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     const adapter = this.adapters.find(
       (entry) => entry.channel === params.provider,
     );
-    const fetch = adapter?.fetchRecentMessages;
+    const fetch = adapter?.fetchRecentMessages?.bind(adapter);
     if (!adapter || !fetch) return [];
     let events: MessagingInboundEvent[];
     try {
-      events = await fetch.call(adapter, {
+      events = await fetch({
         conversationId: params.conversationId,
         ...(params.limit ? { limit: params.limit } : {}),
       });

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1609,11 +1609,9 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   }
 
   private async syncFederationEventSubscriptions(): Promise<void> {
-    const setSubscriptions =
-      this.options.backendBridge.setRemoteEventSubscriptions;
-    if (!setSubscriptions) return;
+    if (!this.options.backendBridge.setRemoteEventSubscriptions) return;
     if (!this.started || this.runningAdapters.size === 0) {
-      setSubscriptions([]);
+      this.options.backendBridge.setRemoteEventSubscriptions([]);
       return;
     }
     const instanceIds = new Set<string>();
@@ -1625,7 +1623,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         instanceIds.add(binding.federatedThread.target.instanceId);
       }
     }
-    setSubscriptions(
+    this.options.backendBridge.setRemoteEventSubscriptions(
       [...instanceIds].map((sourceInstanceId) => ({
         sourceInstanceId,
         eventClasses: [

--- a/apps/desktop/src/main/settings/command-discovery.ts
+++ b/apps/desktop/src/main/settings/command-discovery.ts
@@ -144,7 +144,10 @@ async function resolvePathCommand(
   }
 
   const delimiter = platform === "win32" ? ";" : path.delimiter;
-  const joinPath = platform === "win32" ? path.win32.join : path.join;
+  const joinPath = (...parts: string[]): string =>
+    platform === "win32"
+      ? path.win32.join(...parts)
+      : path.join(...parts);
   const commandNames = buildPathCommandNames(command, env, platform);
 
   for (const directory of pathValue

--- a/apps/desktop/src/renderer/src/lib/useThreadQueuedMessageIndicators.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadQueuedMessageIndicators.ts
@@ -40,8 +40,8 @@ export function useThreadQueuedMessageIndicators(params: {
 }): Record<string, ThreadQueuedMessageState> {
   const { composerDraftStore, threads } = params;
   const version = useSyncExternalStore(
-    composerDraftStore.subscribeQueuedTurns,
-    composerDraftStore.getQueuedTurnVersion,
+    (listener) => composerDraftStore.subscribeQueuedTurns(listener),
+    () => composerDraftStore.getQueuedTurnVersion(),
   );
 
   return useMemo(() => {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,6 +52,25 @@ export default tseslint.config(
     },
   },
   {
+    files: ["apps/desktop/src/main/**/*.{ts,tsx}"],
+    ignores: ["apps/desktop/src/main/**/__tests__/**"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // Main-process services are predominantly stateful classes. Extracting
+      // one of their methods and calling it as a plain function silently drops
+      // its receiver, which TypeScript accepts but crashes when the method
+      // reaches `this`. Keep this typed rule scoped to production main code;
+      // test mock assertions intentionally reference methods without calling
+      // them and would bury actionable findings in false positives.
+      "@typescript-eslint/unbound-method": "error",
+    },
+  },
+  {
     languageOptions: {
       globals: { ...globals.node, ...globals.browser },
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,8 +52,15 @@ export default tseslint.config(
     },
   },
   {
-    files: ["apps/desktop/src/main/**/*.{ts,tsx}"],
-    ignores: ["apps/desktop/src/main/**/__tests__/**"],
+    files: [
+      "apps/*/src/**/*.{ts,tsx}",
+      "packages/**/*.{ts,tsx}",
+    ],
+    ignores: [
+      "**/__tests__/**",
+      "**/*.test.ts",
+      "**/*.test.tsx",
+    ],
     languageOptions: {
       parserOptions: {
         projectService: true,
@@ -61,10 +68,10 @@ export default tseslint.config(
       },
     },
     rules: {
-      // Main-process services are predominantly stateful classes. Extracting
-      // one of their methods and calling it as a plain function silently drops
-      // its receiver, which TypeScript accepts but crashes when the method
-      // reaches `this`. Keep this typed rule scoped to production main code;
+      // Production services and adapters are predominantly stateful classes.
+      // Extracting one of their methods and calling it as a plain function
+      // silently drops its receiver, which TypeScript accepts but crashes when
+      // the method reaches `this`. Keep this typed rule out of test code;
       // test mock assertions intentionally reference methods without calling
       // them and would bury actionable findings in false positives.
       "@typescript-eslint/unbound-method": "error",

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -2223,7 +2223,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     conversationId: string;
     limit?: number;
   }): Promise<MessagingInboundEvent[]> {
-    const history = this.api.conversationsHistory;
+    const history = this.api.conversationsHistory?.bind(this.api);
     if (!history) return [];
     const channelId = request.conversationId;
     let messages: SlackHistoryMessageInfo[];

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -1472,7 +1472,9 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       // message in that topic can populate `channel.conversation.title`
       // for the binding chip. Telegram has no other API to fetch this.
       this.captureForumTopicNameIfPresent(message);
-      const logServiceMessage = this.options.logger?.info ?? this.options.logger?.debug;
+      const logger = this.options.logger;
+      const logServiceMessage =
+        logger?.info?.bind(logger) ?? logger?.debug?.bind(logger);
       logServiceMessage?.("telegram inbound ignored service message", {
         chatId: message.chat.id,
         messageId: message.message_id,


### PR DESCRIPTION
## What changed

- keep federation event-subscription calls bound to the messaging backend bridge
- add receiver-sensitive regression tests for messaging runtime startup and scheduled-message listing
- enable typed `@typescript-eslint/unbound-method` enforcement across production TypeScript
- bind receiver-sensitive callback extractions found by the typed audit
- fix a second latent unbound receiver in the `/scheduled` messaging command

## Root cause

`db67fcd08` added messaging-driven federation event subscriptions. The runtime copied `backendBridge.setRemoteEventSubscriptions` into a local variable and invoked it as a standalone function. That discarded the class receiver, so `DesktopMessagingBackendBridge.setRemoteEventSubscriptions()` ran with `this === undefined` and failed while reading `this.federation`.

The failure happens after an adapter starts, causing startup to reject and the runtime to suspend the adapter. Every per-platform toggle re-applies runtime config through the same path, so Telegram, Slack, Discord, Mattermost, Feishu, and LINE all appeared broken and surfaced the same `settings:write-config` error.

TypeScript accepts detached methods, and the repository previously used syntax-only TypeScript linting. The existing test bridge used plain mock functions that did not depend on `this`, masking the concrete class behavior.

## Audit findings

The typed production audit found 16 remaining method references. Most were already receiver-safe via `.call(...)`, plain callback stores, or current closure-based implementations; they are now explicit `.bind(...)`, wrapper, or direct-call patterns so the rule can prove safety. The audit also found another genuine latent crash: `/scheduled` invoked `listScheduledThreadActions` unbound even though the desktop bridge method reads `this.remoteBackend(...)`.

The typed rule covers production source in apps and packages. Test code is excluded because spy and mock assertions intentionally reference methods without invoking them and produced roughly 200 non-actionable findings; receiver-sensitive behavioral tests cover execution seams instead.

## Impact

Messaging adapters can start and platform enable/disable changes complete normally while federation subscription syncing remains active. Future detached production method calls fail lint before merge.

## Validation

- focused messaging runtime, controller, and backend registry tests: 887 passed
- receiver-sensitive controller and provider/renderer tests: 470 passed
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `git diff --check`