### PR TITLE
fix(desktop): queue agent follow-ups for active threads

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -26211,6 +26211,194 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("queues a follow-up prompt while a Grok target has an active turn", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const grokClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      threads: [{
+        id: "grok-target-thread",
+        title: "grok-target-thread",
+        titleSource: "fallback",
+        source: "grok",
+        linkedDirectories: [],
+      }],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "grok",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "grok-target-thread",
+          turnId: "grok-target-turn",
+          turn: { id: "grok-target-turn" },
+        },
+      },
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "parent-thread",
+          turnId: "parent-turn",
+          turn: { id: "parent-turn" },
+        },
+      },
+    });
+
+    const response = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "parent-turn",
+      tool: "send_message_to_thread",
+      args: {
+        backend: "grok",
+        threadId: "grok-target-thread",
+        prompt: "The controller audit is complete.",
+      },
+    });
+
+    expect(response).toMatchObject({
+      structuredContent: {
+        backend: "grok",
+        threadId: "grok-target-thread",
+        queueStatus: "queued",
+        queueEntryId: expect.stringMatching(/^thread-turn:/),
+      },
+    });
+    expect(grokClient.startTurnCallCount).toBe(0);
+
+    await registry.publishLocalEvent({
+      backend: "grok",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "grok-target-thread",
+          turnId: "grok-target-turn",
+          turn: {
+            id: "grok-target-turn",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(grokClient.lastStartTurnParams).toMatchObject({
+        threadId: "grok-target-thread",
+        input: [{ type: "text", text: "The controller audit is complete." }],
+      });
+    });
+
+    await registry.close();
+  });
+
+  it("queues a follow-up prompt while an ACP target has an active turn", async () => {
+    const acpBackendId = "acp:kimi" as AcpBackendId;
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const startPrompt = vi.fn((params: { sessionId: string }) => ({
+      sessionId: params.sessionId,
+      turnId: "queued-acp-turn",
+    }));
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      codexClient,
+      sessionId: "acp-target-thread",
+      sessions: [{
+        backendId: acpBackendId,
+        sessionId: "acp-target-thread",
+        title: "ACP target thread",
+        createdAt: 1_000,
+        updatedAt: 1_000,
+        executionMode: "default",
+        status: "idle",
+      }],
+      startPrompt,
+    });
+    await registry.publishLocalEvent({
+      backend: acpBackendId,
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "acp-target-thread",
+          turnId: "acp-target-turn",
+          turn: { id: "acp-target-turn" },
+        },
+      },
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "parent-thread",
+          turnId: "parent-turn",
+          turn: { id: "parent-turn" },
+        },
+      },
+    });
+
+    const response = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "parent-turn",
+      tool: "send_message_to_thread",
+      args: {
+        backend: acpBackendId,
+        threadId: "acp-target-thread",
+        prompt: "The controller audit is complete.",
+      },
+    });
+
+    expect(response).toMatchObject({
+      structuredContent: {
+        backend: acpBackendId,
+        threadId: "acp-target-thread",
+        queueStatus: "queued",
+        queueEntryId: expect.stringMatching(/^thread-turn:/),
+      },
+    });
+    expect(startPrompt).not.toHaveBeenCalled();
+
+    await registry.publishLocalEvent({
+      backend: acpBackendId,
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "acp-target-thread",
+          turnId: "acp-target-turn",
+          turn: {
+            id: "acp-target-turn",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(startPrompt).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: "acp-target-thread",
+        prompt: "The controller audit is complete.",
+      }));
+    });
+
+    await registry.close();
+  });
+
   it("hydrates persisted origins onto Grok replay messages without turn metadata", async () => {
     const replay: AppServerThreadReplay = {
       entries: [

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -26120,6 +26120,97 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("queues a follow-up prompt while the target thread has an active turn", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      threads: [{
+        id: "target-thread",
+        title: "target-thread",
+        titleSource: "fallback",
+        source: "codex",
+        linkedDirectories: [],
+      }],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "target-thread",
+          turnId: "target-turn",
+          turn: { id: "target-turn" },
+        },
+      },
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "parent-thread",
+          turnId: "parent-turn",
+          turn: { id: "parent-turn" },
+        },
+      },
+    });
+
+    const response = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "parent-turn",
+      tool: "send_message_to_thread",
+      args: {
+        backend: "codex",
+        threadId: "target-thread",
+        prompt: "The controller audit is complete.",
+      },
+    });
+
+    expect(response).toMatchObject({
+      structuredContent: {
+        backend: "codex",
+        threadId: "target-thread",
+        queueStatus: "queued",
+        queueEntryId: expect.stringMatching(/^thread-turn:/),
+      },
+    });
+    expect(codexClient.startTurnCallCount).toBe(0);
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "target-thread",
+          turnId: "target-turn",
+          turn: {
+            id: "target-turn",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(codexClient.lastStartTurnParams).toMatchObject({
+        threadId: "target-thread",
+        input: [{ type: "text", text: "The controller audit is complete." }],
+      });
+    });
+
+    await registry.close();
+  });
+
   it("hydrates persisted origins onto Grok replay messages without turn metadata", async () => {
     const replay: AppServerThreadReplay = {
       entries: [

--- a/apps/desktop/src/main/__tests__/federated-thread-message-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-message-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { StartTurnResponse } from "@pwragent/shared";
 import type { DesktopFederationRuntime } from "../federation/federation-runtime";
 import { createFederatedThreadMessageHandler } from "../federation/federated-thread-message-service";
 
@@ -46,7 +47,7 @@ function buildRuntime(params: {
         fetchedAt: 1_000,
         threads: peer.ownsThread ? [ownedThread] : [],
       }));
-      const startTurn = vi.fn(async () => ({
+      const startTurn = vi.fn(async (): Promise<StartTurnResponse> => ({
         backend: "codex" as const,
         threadId: request.threadId,
         turnId: "remote-turn-1",
@@ -107,6 +108,32 @@ describe("federated thread message service", () => {
       fastMode: undefined,
       approvalPolicy: undefined,
       sandbox: undefined,
+    });
+  });
+
+  it("preserves queued delivery metadata from the owning peer", async () => {
+    const { backends, runtime } = buildRuntime({
+      peers: [{
+        instanceId: "pwr_harold",
+        label: "Harold-Mac-Mini-M4",
+        ownsThread: true,
+      }],
+    });
+    backends.get("pwr_harold")!.startTurn.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: request.threadId,
+      turnId: "thread-turn:queued-1",
+      queueStatus: "queued",
+      queueEntryId: "thread-turn:queued-1",
+    });
+    const handler = createFederatedThreadMessageHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler(request)).resolves.toMatchObject({
+      turnId: "thread-turn:queued-1",
+      queueStatus: "queued",
+      queueEntryId: "thread-turn:queued-1",
     });
   });
 

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -69,6 +69,8 @@ export type PwrAgentFederatedThreadMessageResult = {
   backend: SendMessageToThreadToolArgs["backend"];
   threadId: SendMessageToThreadToolArgs["threadId"];
   turnId: string;
+  queueStatus?: "queued";
+  queueEntryId?: string;
   title?: string;
   instanceId: string;
   instanceLabel: string;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6916,10 +6916,8 @@ export class DesktopBackendRegistry {
     this.threadTurnQueue = new ThreadTurnQueue({
       startTurn: async (entry) => await this.startTurnNow(entry),
       isThreadActive: ({ backend, threadId }) =>
-        backend === "codex"
-          ? this.threadHasActiveTurn(threadId)
-            || this.threadHasBlockingWorkspaceMove({ backend, threadId })
-          : false,
+        this.threadHasActiveTurn(threadId, backend)
+        || this.threadHasBlockingWorkspaceMove({ backend, threadId }),
       onLifecycle: async (event) => await this.emitTurnQueueLifecycle(event),
     });
     this.taskMonitorWatchdogTimer = setInterval(() => {
@@ -11368,9 +11366,12 @@ export class DesktopBackendRegistry {
     this.activeCodexTurnModes.delete(
       buildActiveTurnModeKey(params.threadId, syntheticStartedTurnId),
     );
-    if (params.backend === "codex") {
-      this.activeTurnKeys.delete(
-        buildActiveTurnKey(params.backend, params.threadId, syntheticStartedTurnId),
+    this.activeTurnKeys.delete(
+      buildActiveTurnKey(params.backend, params.threadId, syntheticStartedTurnId),
+    );
+    if (params.backend === "grok") {
+      this.activeTurnKeys.add(
+        buildActiveTurnKey(params.backend, result.threadId, result.turnId),
       );
     }
     if (

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -22234,7 +22234,14 @@ export class DesktopBackendRegistry {
       };
       let targetTitle: string | undefined;
       let targetInstanceId: string | undefined;
-      let turn: { backend: AppServerBackendKind; threadId: string; turnId: string };
+      let turn: {
+        backend: AppServerBackendKind;
+        threadId: string;
+        turnId: string;
+        queueStatus?: "queued";
+        queueEntryId?: string;
+        position?: number;
+      };
       let localResolutionError: unknown;
       let localThread: AppServerThreadSummary | undefined;
       const remoteRequest = {
@@ -22271,10 +22278,11 @@ export class DesktopBackendRegistry {
           localResolutionError = error;
         }
         if (localThread) {
-          turn = await this.startTurn({
+          const submitted = await this.submitTurn({
             backend,
             threadId,
             input,
+            origin: "manual",
             messageOrigin,
             executionMode: request.args.executionMode,
             model: request.args.model,
@@ -22284,6 +22292,20 @@ export class DesktopBackendRegistry {
             approvalPolicy: request.args.approvalPolicy,
             sandbox: request.args.sandbox,
           });
+          turn = submitted.status === "started"
+            ? {
+                backend: submitted.entry.backend,
+                threadId: submitted.entry.threadId,
+                turnId: submitted.turnId,
+              }
+            : {
+                backend: submitted.entry.backend,
+                threadId: submitted.entry.threadId,
+                turnId: submitted.entry.id,
+                queueStatus: "queued",
+                queueEntryId: submitted.entry.id,
+                position: submitted.position,
+              };
           targetTitle = localThread.title;
         } else if (this.federatedThreadMessageHandler) {
           const discoveredRemoteTurn = await this.federatedThreadMessageHandler({
@@ -22318,6 +22340,13 @@ export class DesktopBackendRegistry {
           threadId: turn.threadId,
           ...(targetInstanceId ? { instanceId: targetInstanceId } : {}),
           turnId: turn.turnId,
+          ...(turn.queueStatus === "queued"
+            ? {
+                queueStatus: turn.queueStatus,
+                queueEntryId: turn.queueEntryId,
+                ...(turn.position === undefined ? {} : { position: turn.position }),
+              }
+            : {}),
           promptPreview: truncateThreadInspectionText(prompt, 240),
           threadUrl: buildThreadUrl(threadLinkRef),
           threadLink: buildThreadMarkdownLink({

--- a/apps/desktop/src/main/federation/federated-thread-message-service.ts
+++ b/apps/desktop/src/main/federation/federated-thread-message-service.ts
@@ -197,6 +197,12 @@ async function sendToRemoteThread(
     backend: turn.backend,
     threadId: turn.threadId,
     turnId: turn.turnId,
+    ...(turn.queueStatus === "queued"
+      ? {
+          queueStatus: "queued" as const,
+          queueEntryId: turn.queueEntryId ?? turn.turnId,
+        }
+      : {}),
     title: match.thread.title,
     instanceId: match.peer.target.instanceId,
     instanceLabel: match.peer.label,

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -381,6 +381,10 @@ export type SendMessageToThreadResult = {
   /** Owning remote instance when the target is federated. */
   instanceId?: FederationInstanceId;
   turnId: string;
+  /** Present when delivery was deferred behind an active target turn. */
+  queueStatus?: "queued";
+  queueEntryId?: string;
+  position?: number;
   promptPreview: string;
   /** Canonical `pwragent://thread/…` URL for the messaged thread. */
   threadUrl: string;


### PR DESCRIPTION
## What changed

- route local `send_message_to_thread` deliveries through the registry turn queue
- return queue metadata when a follow-up is deferred behind an active target turn
- preserve the same queued-delivery metadata across federated thread routing
- add regression coverage for local active-turn callbacks and federated queued results

## Root cause

Federated sends entered the registry with `submitTurn`, but same-instance sends called `startTurn` directly. When the target thread already had an active turn, that direct path rejected the completion callback instead of enqueueing it.

## Impact

Agent and controller completion messages sent to a busy local thread now receive an immediate queued-success response and automatically start after the target turn reaches a terminal state.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` (459 passed)
- `pnpm test apps/desktop/src/main/__tests__/federated-thread-message-service.test.ts` (11 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; baseline warnings only)
- `pnpm lint:boundaries`
