### PR TITLE
fix(messaging): surface startup failures

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -175,6 +175,73 @@ describe("DesktopMessagingRuntime", () => {
     expect(bridge.setRemoteEventSubscriptions).toHaveBeenLastCalledWith([]);
   });
 
+  it("retains a rejected config application as a startup failure for every platform", async () => {
+    await prepareRuntimeStore();
+    const telegramAdapter = createAdapter("telegram");
+    const discordAdapter = createAdapter("discord");
+    const bridge = createBackendBridge();
+    vi.mocked(bridge.setRemoteEventSubscriptions)
+      .mockImplementationOnce(() => {
+        throw new Error(
+          "Cannot read properties of undefined (reading 'federation')",
+        );
+      });
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = trackRuntime(new Runtime({
+      adapterFactory: () => [telegramAdapter, discordAdapter],
+      backendBridge: bridge,
+      config: {
+        discord: {
+          channel: "discord",
+          botToken: "discord-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    }));
+
+    await expect(runtime.start()).rejects.toThrow("reading 'federation'");
+    expect(runtime.getPlatformStatuses()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          health: "errored",
+          platform: "telegram",
+          startupFailure: true,
+        }),
+        expect.objectContaining({
+          health: "errored",
+          platform: "discord",
+          startupFailure: true,
+        }),
+      ]),
+    );
+
+    await runtime.stop();
+
+    expect(runtime.getPlatformStatuses()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          health: "suspended",
+          platform: "telegram",
+          reason: "Cannot read properties of undefined (reading 'federation')",
+          startupFailure: true,
+        }),
+        expect.objectContaining({
+          health: "suspended",
+          platform: "discord",
+          reason: "Cannot read properties of undefined (reading 'federation')",
+          startupFailure: true,
+        }),
+      ]),
+    );
+  });
+
   it("rehydrates enabled Monitor bindings after adapter startup", async () => {
     const { runtime, adapter } = await createRuntimeHarness();
     const { getDesktopMessagingStore } = await import(

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -190,7 +190,10 @@ describe("DesktopMessagingRuntime", () => {
       "../messaging/messaging-runtime"
     );
     const runtime = trackRuntime(new Runtime({
-      adapterFactory: () => [telegramAdapter, discordAdapter],
+      adapterFactory: ({ config }) => [
+        ...(config.telegram ? [telegramAdapter] : []),
+        ...(config.discord ? [discordAdapter] : []),
+      ],
       backendBridge: bridge,
       config: {
         discord: {
@@ -222,7 +225,7 @@ describe("DesktopMessagingRuntime", () => {
       ]),
     );
 
-    await runtime.stop();
+    await runtime.stop({ preserveStartupFailures: true });
 
     expect(runtime.getPlatformStatuses()).toEqual(
       expect.arrayContaining([
@@ -237,6 +240,60 @@ describe("DesktopMessagingRuntime", () => {
           platform: "discord",
           reason: "Cannot read properties of undefined (reading 'federation')",
           startupFailure: true,
+        }),
+      ]),
+    );
+
+    await runtime.applyConfig({
+      discord: {
+        channel: "discord",
+        botToken: "discord-token",
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+      },
+    });
+
+    expect(runtime.getPlatformStatuses()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          health: "suspended",
+          platform: "telegram",
+          reason: undefined,
+          startupFailure: undefined,
+        }),
+        expect.objectContaining({
+          health: "enabled",
+          platform: "discord",
+          startupFailure: undefined,
+        }),
+      ]),
+    );
+
+    vi.mocked(bridge.setRemoteEventSubscriptions)
+      .mockImplementationOnce(() => {
+        throw new Error("subscription refresh failed");
+      });
+    await expect(runtime.applyConfig({
+      discord: {
+        channel: "discord",
+        botToken: "discord-token",
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+      },
+    })).rejects.toThrow("subscription refresh failed");
+
+    await runtime.applyConfig({ enabled: false });
+
+    expect(runtime.getPlatformStatuses()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          health: "suspended",
+          platform: "discord",
+          reason: undefined,
+          startupFailure: undefined,
+        }),
+        expect.objectContaining({
+          health: "suspended",
+          platform: "telegram",
+          startupFailure: undefined,
         }),
       ]),
     );

--- a/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
@@ -394,6 +394,9 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
     ).rejects.toThrow("apply failed");
 
     expect(runtime.stop).toHaveBeenCalledTimes(1);
+    expect(runtime.stop).toHaveBeenCalledWith({
+      preserveStartupFailures: true,
+    });
     expect(store.getMessagingLease()).toMatchObject({
       ownerInstanceId: "instance-a",
       status: "released",

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -83,7 +83,10 @@ import {
   publishInboundPreview,
 } from "./inbound-preview-bus";
 import { getDesktopMessagingPairingStore } from "./desktop-messaging-pairing-store";
-import { loadConfiguredMessagingAdapters } from "./provider-loader";
+import {
+  configuredMessagingProviderIds,
+  loadConfiguredMessagingAdapters,
+} from "./provider-loader";
 import {
   MessagingDeliveryBudget,
   type MessagingDeliveryPriority,
@@ -404,7 +407,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     this.pendingAdapterStartCancellationReasons.clear();
     await this.enqueueLifecycle(async () => {
       const config = await this.loadConfig({ logStartupEligibility: true });
-      await this.applyConfigNow(config);
+      await this.applyConfigWithFailureStatus(config);
     });
   }
 
@@ -464,7 +467,11 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     // so the renderer keeps the icon visible with a gray dot — the user
     // knows it's configured but currently off.
     for (const channel of stoppedChannels) {
-      this.setPlatformHealth(channel, "suspended");
+      const previous = this.platformStatuses.get(channel);
+      this.setPlatformHealth(channel, "suspended", {
+        reason: previous?.startupFailure ? previous.reason : undefined,
+        startupFailure: previous?.startupFailure,
+      });
     }
   }
 
@@ -474,8 +481,30 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   ): Promise<void> {
     this.updatePendingAdapterStartIntent(config);
     await this.enqueueLifecycle(async () => {
-      await this.applyConfigNow(config, options);
+      await this.applyConfigWithFailureStatus(config, options);
     });
+  }
+
+  private async applyConfigWithFailureStatus(
+    config: DesktopMessagingConfig,
+    options: { allowStart?: boolean } = {},
+  ): Promise<void> {
+    try {
+      await this.applyConfigNow(config, options);
+    } catch (error) {
+      // Config application can reject after adapters have already reported
+      // enabled (for example, a post-start federation subscription sync).
+      // Mark every configured platform before cleanup so the failure remains
+      // visible even when stopNow subsequently suspends running adapters.
+      const reason = error instanceof Error ? error.message : String(error);
+      for (const platform of configuredMessagingProviderIds(config)) {
+        this.setPlatformHealth(platform, "errored", {
+          reason,
+          startupFailure: true,
+        });
+      }
+      throw error;
+    }
   }
 
   private async applyConfigNow(
@@ -621,7 +650,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     options: { allowStart?: boolean } = {},
   ): Promise<void> {
     await this.enqueueLifecycle(async () => {
-      await this.applyConfigNow(await this.loadConfig(), options);
+      await this.applyConfigWithFailureStatus(await this.loadConfig(), options);
     });
   }
 
@@ -1673,6 +1702,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     options: {
       credentialMetadata?: MessagingCredentialMetadata;
       reason?: string;
+      startupFailure?: boolean;
     } = {},
   ): void {
     const at = Date.now();
@@ -1711,6 +1741,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       changedAt: at,
       ...definedCredentialMetadata(credentialMetadata ?? {}),
       reason: options.reason,
+      startupFailure: options.startupFailure,
       degradationReasons,
       // Preserve the existing activity timestamp through health
       // transitions; activity is independent of health and shouldn't
@@ -1724,6 +1755,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       health: effectiveHealth,
       ...definedCredentialMetadata(next),
       reason: options.reason,
+      startupFailure: options.startupFailure,
       degradationReasons,
       at,
     });

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -411,12 +411,14 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     });
   }
 
-  async stop(): Promise<void> {
+  async stop(
+    options: { preserveStartupFailures?: boolean } = {},
+  ): Promise<void> {
     const reason = "Messaging was stopped while adapter startup was still pending.";
     this.pendingAdapterStopReason = reason;
     this.cancelPendingAdapterStarts(reason);
     await this.enqueueLifecycle(async () => {
-      await this.stopNow();
+      await this.stopNow(options);
     });
   }
 
@@ -444,8 +446,13 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     };
   }
 
-  private async stopNow(): Promise<void> {
+  private async stopNow(
+    options: { preserveStartupFailures?: boolean } = {},
+  ): Promise<void> {
     if (!this.started) {
+      if (!options.preserveStartupFailures) {
+        this.clearRetainedStartupFailures();
+      }
       return;
     }
     this.started = false;
@@ -468,10 +475,15 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     // knows it's configured but currently off.
     for (const channel of stoppedChannels) {
       const previous = this.platformStatuses.get(channel);
+      const preserveStartupFailure =
+        options.preserveStartupFailures && previous?.startupFailure === true;
       this.setPlatformHealth(channel, "suspended", {
-        reason: previous?.startupFailure ? previous.reason : undefined,
-        startupFailure: previous?.startupFailure,
+        reason: preserveStartupFailure ? previous.reason : undefined,
+        startupFailure: preserveStartupFailure || undefined,
       });
+    }
+    if (!options.preserveStartupFailures) {
+      this.clearRetainedStartupFailures();
     }
   }
 
@@ -491,6 +503,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   ): Promise<void> {
     try {
       await this.applyConfigNow(config, options);
+      this.clearStartupFailuresForDisabledPlatforms(config);
     } catch (error) {
       // Config application can reject after adapters have already reported
       // enabled (for example, a post-start federation subscription sync).
@@ -504,6 +517,25 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         });
       }
       throw error;
+    }
+  }
+
+  private clearRetainedStartupFailures(): void {
+    for (const [platform, status] of this.platformStatuses) {
+      if (!status.startupFailure) continue;
+      this.setPlatformHealth(platform, "suspended");
+    }
+  }
+
+  private clearStartupFailuresForDisabledPlatforms(
+    config: DesktopMessagingConfig,
+  ): void {
+    const configuredPlatforms = new Set<MessagingChannelKind>(
+      configuredMessagingProviderIds(config),
+    );
+    for (const [platform, status] of this.platformStatuses) {
+      if (!status.startupFailure || configuredPlatforms.has(platform)) continue;
+      this.setPlatformHealth(platform, "suspended");
     }
   }
 

--- a/apps/desktop/src/main/runtime-messaging-lease.ts
+++ b/apps/desktop/src/main/runtime-messaging-lease.ts
@@ -335,7 +335,7 @@ export class RuntimeMessagingLeaseCoordinator {
   ): Promise<void> {
     this.stopHeartbeat();
     try {
-      await runtime.stop();
+      await runtime.stop({ preserveStartupFailures: true });
     } catch (error) {
       leaseLog.warn("messaging runtime stop failed during startup cleanup", {
         error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
+++ b/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
@@ -145,6 +145,7 @@ function upsertHealth(
     ...(event.detail !== undefined ? { detail: event.detail } : {}),
     changedAt: event.at,
     reason: event.reason,
+    startupFailure: event.startupFailure,
     degradationReasons: event.degradationReasons,
     lastActivityAt: existing?.lastActivityAt,
   };

--- a/apps/desktop/src/renderer/src/features/notifications/MessagingErrorNotices.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/MessagingErrorNotices.tsx
@@ -131,6 +131,7 @@ function applyStatusEvent(
     health: event.health,
     changedAt: event.at,
     reason: event.reason,
+    startupFailure: event.startupFailure,
   }, "event");
 }
 
@@ -138,7 +139,7 @@ function applyPlatformHealth(
   current: Map<MessagingChannelKind, MessagingPlatformNoticeState>,
   status: Pick<
     MessagingPlatformStatus,
-    "changedAt" | "health" | "platform" | "reason"
+    "changedAt" | "health" | "platform" | "reason" | "startupFailure"
   >,
   source: MessagingPlatformNoticeState["source"],
 ): Map<MessagingChannelKind, MessagingPlatformNoticeState> {
@@ -157,7 +158,10 @@ function applyPlatformHealth(
     return current;
   }
 
-  const notice = status.health === "errored"
+  const notice = (
+    status.health === "errored"
+    || (status.health === "suspended" && status.startupFailure === true)
+  )
     ? buildMessagingErrorNotice(status)
     : undefined;
   if (
@@ -179,17 +183,19 @@ function applyPlatformHealth(
 export function buildMessagingErrorNotice(
   status: Pick<
     MessagingPlatformStatus,
-    "changedAt" | "platform" | "reason"
+    "changedAt" | "platform" | "reason" | "startupFailure"
   >,
 ): AppNoticeToastNotice {
   const platformName = formatMessagingPlatformName(status.platform);
   return {
     autoDismiss: false,
     detail: status.reason?.trim() || undefined,
-    id: `messaging-platform-error:${status.platform}:${status.changedAt}`,
-    message:
-      `${platformName} reported an adapter error. Messages may be unavailable `
-      + "until it recovers or is restarted.",
+    id: `messaging-platform-error:${status.platform}:active`,
+    message: status.startupFailure
+      ? `PwrAgent could not complete messaging startup for ${platformName}. `
+        + "Messages may be unavailable until it starts successfully."
+      : `${platformName} reported an adapter error. Messages may be unavailable `
+        + "until it recovers or is restarted.",
     title: `${platformName} messaging failed`,
     tone: "error",
   };

--- a/apps/desktop/src/renderer/src/features/notifications/MessagingErrorNotices.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/MessagingErrorNotices.tsx
@@ -90,7 +90,9 @@ export function MessagingErrorNotices(props: {
   useEffect(() => {
     if (!props.onNoticeChanged) return;
     for (const [platform, state] of statusByPlatform) {
-      const noticeKey = state.notice?.id ?? `healthy:${state.changedAt}`;
+      const noticeKey = state.notice
+        ? messagingNoticePublicationKey(state.notice)
+        : `healthy:${state.changedAt}`;
       if (publishedNoticeKeysRef.current.get(platform) === noticeKey) {
         continue;
       }
@@ -109,6 +111,21 @@ export function MessagingErrorNotices(props: {
       onDismiss={() => dismiss(platform)}
     />
   ));
+}
+
+function messagingNoticePublicationKey(
+  notice: AppNoticeToastNotice,
+): string {
+  // The notice id stays stable so App's durable stack replaces the active
+  // platform entry in place. Include visible content here so a materially new
+  // failure is still published after an earlier notice was dismissed.
+  return JSON.stringify({
+    detail: notice.detail,
+    id: notice.id,
+    message: notice.message,
+    title: notice.title,
+    tone: notice.tone,
+  });
 }
 
 function applyStatusSnapshot(

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/MessagingErrorNotices.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/MessagingErrorNotices.test.tsx
@@ -63,9 +63,29 @@ describe("MessagingErrorNotices", () => {
     act(() => {
       emitStatus?.({
         kind: "health-changed",
-        platform: "slack",
+        platform: "discord",
         health: "errored",
         at: 1_785_926_400_002,
+        reason: "bot token was revoked",
+      });
+    });
+    await waitFor(() => {
+      expect(discordPublicationCount()).toBe(2);
+    });
+    expect(onNoticeChanged).toHaveBeenLastCalledWith(
+      "discord",
+      expect.objectContaining({
+        detail: "bot token was revoked",
+        id: "messaging-platform-error:discord:active",
+      }),
+    );
+
+    act(() => {
+      emitStatus?.({
+        kind: "health-changed",
+        platform: "slack",
+        health: "errored",
+        at: 1_785_926_400_003,
         reason: "socket disconnected",
       });
     });
@@ -75,14 +95,14 @@ describe("MessagingErrorNotices", () => {
         expect.objectContaining({ title: "Slack messaging failed" }),
       );
     });
-    expect(discordPublicationCount()).toBe(1);
+    expect(discordPublicationCount()).toBe(2);
 
     act(() => {
       emitStatus?.({
         kind: "health-changed",
         platform: "discord",
         health: "enabled",
-        at: 1_785_926_400_003,
+        at: 1_785_926_400_004,
       });
     });
     await waitFor(() => {

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/MessagingErrorNotices.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/MessagingErrorNotices.test.tsx
@@ -23,6 +23,7 @@ describe("MessagingErrorNotices", () => {
             health: "errored",
             changedAt: 1_785_926_400_000,
             reason: "gateway disconnected",
+            startupFailure: true,
           }],
           onMessagingPlatformStatusEvent: (listener) => {
             emitStatus = listener;
@@ -48,9 +49,23 @@ describe("MessagingErrorNotices", () => {
     act(() => {
       emitStatus?.({
         kind: "health-changed",
+        platform: "discord",
+        health: "suspended",
+        at: 1_785_926_400_001,
+        reason: "gateway disconnected",
+        startupFailure: true,
+      });
+    });
+    await waitFor(() => {
+      expect(discordPublicationCount()).toBe(1);
+    });
+
+    act(() => {
+      emitStatus?.({
+        kind: "health-changed",
         platform: "slack",
         health: "errored",
-        at: 1_785_926_400_001,
+        at: 1_785_926_400_002,
         reason: "socket disconnected",
       });
     });
@@ -67,7 +82,7 @@ describe("MessagingErrorNotices", () => {
         kind: "health-changed",
         platform: "discord",
         health: "enabled",
-        at: 1_785_926_400_002,
+        at: 1_785_926_400_003,
       });
     });
     await waitFor(() => {
@@ -100,6 +115,73 @@ describe("MessagingErrorNotices", () => {
     expect(screen.getByRole("status")).toHaveAttribute("data-tone", "error");
     expect(container.querySelector(".app-notice-toast__timer")).toBeNull();
     expect(getMessagingPlatformStatuses).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces each platform suspended by a rejected startup until recovery", async () => {
+    let emitStatus: ((event: MessagingPlatformStatusEvent) => void) | undefined;
+    render(
+      <MessagingErrorNotices
+        desktopApi={{
+          getMessagingPlatformStatuses: async () => [
+            {
+              platform: "telegram",
+              health: "suspended",
+              changedAt: 1_785_926_400_000,
+              reason: "Cannot read properties of undefined (reading 'federation')",
+              startupFailure: true,
+            },
+            {
+              platform: "discord",
+              health: "suspended",
+              changedAt: 1_785_926_400_001,
+              reason: "Cannot read properties of undefined (reading 'federation')",
+              startupFailure: true,
+            },
+          ],
+          onMessagingPlatformStatusEvent: (listener) => {
+            emitStatus = listener;
+            return () => undefined;
+          },
+        }}
+      />,
+    );
+
+    expect(await screen.findByText("Telegram messaging failed")).toBeInTheDocument();
+    expect(screen.getByText("Discord messaging failed")).toBeInTheDocument();
+    expect(screen.getAllByText(/could not complete messaging startup/)).toHaveLength(2);
+    expect(screen.getAllByRole("status")).toHaveLength(2);
+
+    act(() => {
+      emitStatus?.({
+        kind: "health-changed",
+        platform: "telegram",
+        health: "enabled",
+        at: 1_785_926_400_002,
+      });
+    });
+
+    expect(screen.queryByText("Telegram messaging failed")).not.toBeInTheDocument();
+    expect(screen.getByText("Discord messaging failed")).toBeInTheDocument();
+  });
+
+  it("does not treat an intentional suspension as a startup failure", async () => {
+    render(
+      <MessagingErrorNotices
+        desktopApi={{
+          getMessagingPlatformStatuses: async () => [{
+            platform: "slack",
+            health: "suspended",
+            changedAt: 1_785_926_400_000,
+            reason: "Messaging is stopped for this app instance.",
+          }],
+          onMessagingPlatformStatusEvent: () => () => undefined,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
   });
 
   it("adds live failures and removes their notices when the platform recovers", async () => {

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -164,11 +164,13 @@ export type MessagingPlatformStatus = {
   health: MessagingPlatformHealth;
   /** Wall-clock ms when the health last changed. */
   changedAt: number;
+  /** Startup/config application rejected; survives cleanup suspension. */
+  startupFailure?: boolean;
   /** Public identity observed at adapter startup, e.g. bot username. */
   account?: string;
   /** Short public detail for the identity, e.g. API host or workspace. */
   detail?: string;
-  /** When errored, a human-readable reason for the UI tooltip. */
+  /** Human-readable failure reason for the UI tooltip and durable notice. */
   reason?: string;
   /** Transient provider/runtime reasons that make an enabled platform degraded. */
   degradationReasons?: MessagingDegradationReason[];
@@ -197,6 +199,7 @@ export type MessagingPlatformStatusEvent =
       account?: string;
       detail?: string;
       reason?: string;
+      startupFailure?: boolean;
       degradationReasons?: MessagingDegradationReason[];
       at: number;
     }


### PR DESCRIPTION
## What changed

- tag every configured messaging platform when runtime startup or config application rejects
- preserve that failure marker and reason when lease cleanup suspends already-started adapters
- feed failure-marked suspended states into the existing non-auto-dismissing app notice queue
- use one active notice identity per platform so errored → suspended cleanup does not enqueue duplicates
- clear a notice only after explicit dismissal or a healthy platform transition

## Root cause

The desktop already produced durable notices for `errored` adapter health, but a wider runtime/config-application rejection can happen after adapters report `enabled`. The lease coordinator then stops the partially started runtime, converting those platforms to ordinary `suspended` health and discarding the rejection reason. The renderer therefore showed only the ephemeral gray status chip.

Commit `db67fcd08` exposed this path through its federation subscription sync: the runtime extracted `setRemoteEventSubscriptions` from the backend bridge and invoked it without the class receiver. The resulting rejection happened after adapter startup, and lease cleanup left each platform silently suspended. PR #1320 independently fixes that receiver regression; this PR is based directly on `origin/main`, does not contain #1320, and provides failure visibility for that scenario and future config-application rejections regardless of merge order.

## Impact

Each affected Telegram, Discord, Slack, Mattermost, Feishu, or LINE platform now gets a sticky error notice with the failure detail. Intentional suspension remains quiet. Notices survive the runtime cleanup transition and remain until the operator dismisses them or the individual platform demonstrably recovers.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-runtime.test.ts apps/desktop/src/renderer/src/features/notifications/__tests__/MessagingErrorNotices.test.tsx` (69 passed)
- surrounding messaging-status and app-notice tests (25 passed)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `git diff --check`
