### PR TITLE
fix(desktop): hydrate composer thread reference names

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -14678,6 +14678,76 @@ describe("Composer", () => {
     });
   });
 
+  it("uses a live thread name when pasting an in-progress thread id", async () => {
+    const targetThreadId = "019fbbbe-ad52-77c2-b7f7-28182d9a6f83";
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-1",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const untitledTarget: NavigationThreadSummary = {
+      id: targetThreadId,
+      title: "Untitled thread",
+      titleSource: "fallback",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const onShowThread = vi.fn();
+    const { rerender } = render(
+      <ThreadLinkProvider
+        onShowThread={onShowThread}
+        threads={[currentThread, untitledTarget]}
+      >
+        <Composer
+          desktopApi={{ onAgentEvent: () => () => undefined }}
+          disabled={false}
+          skills={[]}
+          thread={currentThread}
+        />
+      </ThreadLinkProvider>,
+    );
+
+    rerender(
+      <ThreadLinkProvider
+        onShowThread={onShowThread}
+        threads={[
+          currentThread,
+          {
+            ...untitledTarget,
+            title: "Bob's Best Thread 3000",
+            titleSource: "explicit",
+          },
+        ]}
+      >
+        <Composer
+          desktopApi={{ onAgentEvent: () => () => undefined }}
+          disabled={false}
+          skills={[]}
+          thread={currentThread}
+        />
+      </ThreadLinkProvider>,
+    );
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => type === "text/plain" ? targetThreadId : "",
+        items: [],
+        types: ["text/plain"],
+      },
+    });
+
+    expect(
+      await within(screen.getByTestId("composer-tiptap-input"))
+        .findByText("Bob's Best Thread 3000"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Untitled thread")).not.toBeInTheDocument();
+  });
+
   it("replaces the selected composer text with a pasted thread chip", async () => {
     const targetThreadId = "019fbbbe-ad52-77c2-b7f7-28182d9a6f83";
     const currentThread: NavigationThreadSummary = {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
@@ -259,6 +259,46 @@ describe("thread links in transcript markdown", () => {
     });
   });
 
+  it("drops live metadata when a federated thread leaves the snapshot", () => {
+    const text =
+      `See [Remote handoff](pwragent://thread/${CHILD_THREAD_ID}?backend=codex&instanceId=pwr_harold)`;
+    const onShowThread = vi.fn();
+    const remoteThread = threadSummary({
+      title: "Old remote title",
+      gitBranch: "agent/old-remote-branch",
+      federation: {
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "pwr_harold" },
+          threadId: CHILD_THREAD_ID,
+        },
+        instanceLabel: "Harold",
+        peerStatus: "connected",
+      },
+    });
+    const { rerender } = render(
+      <ThreadLinkProvider onShowThread={onShowThread} threads={[remoteThread]}>
+        <ThreadMarkdown text={text} />
+      </ThreadLinkProvider>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Open thread Old remote title" }),
+    ).toBeInTheDocument();
+
+    rerender(
+      <ThreadLinkProvider onShowThread={onShowThread} threads={[]}>
+        <ThreadMarkdown text={text} />
+      </ThreadLinkProvider>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Open thread Remote handoff" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open thread Old remote title" }))
+      .not.toBeInTheDocument();
+  });
+
   it("linkifies a bare thread id written as inline code", () => {
     // The shape every pre-protocol handoff message used.
     renderWithLinks(`Created the PwrAgent handoff thread: \`${CHILD_THREAD_ID}\``);

--- a/apps/desktop/src/renderer/src/lib/thread-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/thread-links.tsx
@@ -261,11 +261,12 @@ export function ThreadLinkProvider(props: {
 
     return {
       resolve(ref) {
+        let resolved: ResolvedThreadLink | undefined;
         if (ref.instanceId) {
           if (!ref.backend) {
             return undefined;
           }
-          return byFederatedIdentity.get(threadLinkKey({
+          resolved = byFederatedIdentity.get(threadLinkKey({
             backend: ref.backend,
             instanceId: ref.instanceId,
             threadId: ref.threadId,
@@ -275,11 +276,16 @@ export function ThreadLinkProvider(props: {
             threadId: ref.threadId,
             title: "",
           };
+        } else if (ref.backend) {
+          resolved = byIdentity.get(`${ref.backend}:${ref.threadId}`);
+        } else {
+          resolved = byThreadId.get(ref.threadId);
         }
-        if (ref.backend) {
-          return byIdentity.get(`${ref.backend}:${ref.threadId}`);
-        }
-        return byThreadId.get(ref.threadId);
+
+        // The maps above are rebuilt only when membership changes, so their
+        // metadata may predate a live rename. Resolve through the mutable store
+        // before returning a value to one-shot consumers such as the composer.
+        return resolved ? metadataStore.getSnapshot(resolved) : undefined;
       },
       show(link) {
         onShowThreadRef.current({

--- a/apps/desktop/src/renderer/src/lib/thread-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/thread-links.tsx
@@ -270,12 +270,18 @@ export function ThreadLinkProvider(props: {
             backend: ref.backend,
             instanceId: ref.instanceId,
             threadId: ref.threadId,
-          })) ?? {
-            backend: ref.backend,
-            instanceId: ref.instanceId,
-            threadId: ref.threadId,
-            title: "",
-          };
+          }));
+          if (!resolved) {
+            // Remote links stay actionable without a navigation row, but the
+            // synthetic fallback must not hydrate through metadata that may
+            // still be awaiting removal from the store's layout effect.
+            return {
+              backend: ref.backend,
+              instanceId: ref.instanceId,
+              threadId: ref.threadId,
+              title: "",
+            };
+          }
         } else if (ref.backend) {
           resolved = byIdentity.get(`${ref.backend}:${ref.threadId}`);
         } else {


### PR DESCRIPTION
## What changed

- Resolve thread-reference metadata through the live `ThreadLinkMetadataStore` before composer consumers mint a chip.
- Add a focused composer regression that starts with an in-progress fallback title, applies the live thread name without changing membership, pastes the UUID, and asserts the hydrated name is rendered.

## Root cause

`ThreadLinkProvider` deliberately keeps its context value and identity maps stable while thread membership is unchanged. Those maps therefore retained the newly created thread's initial `Untitled thread` metadata. Transcript chips subscribed to the provider's mutable metadata store and hydrated correctly after `thread/name/updated`, but one-shot composer resolution used the stale identity-map object directly.

The identity maps now remain stable for render performance, while `resolve()` reads current metadata from the live store. UUID paste and future composer selection consumers therefore receive the same applied thread name as transcript chips.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`

This PR is intentionally limited to the live-name hydration bug and does not implement `#` autocomplete or reference UI changes.
