### PR TITLE
feat(desktop): add hash thread references

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1407,6 +1407,7 @@ function DesktopAppShell(props: {
     selectedDirectory: navigation.selectedDirectory,
     selectedLaunchpad: navigation.selectedLaunchpad,
     selectedThread: navigation.selectedThread,
+    threads: navigation.threads,
     suppressBranchDriftDialog: mainView === "settings",
     directories: navigation.directories,
     fullAccessRiskWarningDismissed:

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -4533,7 +4533,6 @@ export function Composer(props: ComposerProps) {
   const autocompleteKind: AutocompleteKind | undefined = reviewConfig
     ? undefined
     : displayedAutocompleteKind;
-  const hasAutocomplete = Boolean(autocompleteKind);
   const activeAutocompleteIndex =
     autocompleteKind === "skills"
       ? activeSkillIndex
@@ -4550,6 +4549,9 @@ export function Composer(props: ComposerProps) {
         : autocompleteKind === "hash-references"
           ? hashReferenceCount
           : filteredSlashCommands.length;
+  const hasAutocompleteOptions = Boolean(
+    autocompleteKind && autocompleteLength > 0,
+  );
   const autocompleteListboxId =
     autocompleteKind === "skills"
       ? skillListboxId
@@ -8987,7 +8989,7 @@ export function Composer(props: ComposerProps) {
   const handleAutocompleteKeyDown = (
     event: ReactKeyboardEvent<HTMLElement>,
   ): void => {
-    if (!hasAutocomplete && event.key !== "Escape") {
+    if (!hasAutocompleteOptions && event.key !== "Escape") {
       return;
     }
 
@@ -9177,7 +9179,7 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    if (!hasAutocomplete) {
+    if (!hasAutocompleteOptions) {
       const liveHasComposerContent = Boolean(
         (inputRef.current?.value ?? draft).trim() ||
           (inputRef.current?.skillTokenCount ?? skillTokens.length) > 0,
@@ -10247,7 +10249,7 @@ export function Composer(props: ComposerProps) {
             id="thread-composer"
             ariaActiveDescendant={activeAutocompleteOptionId}
             ariaControls={autocompleteListboxId}
-            ariaExpanded={hasAutocomplete}
+            ariaExpanded={Boolean(autocompleteKind)}
             disabled={composerDisabled}
             label={isLaunchpad ? "New thread" : "Reply"}
             markdownConversion

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -37,6 +37,7 @@ import type {
   NavigationLaunchpadFileAttachment,
   NavigationLaunchpadImageAttachment,
   NavigationThreadSummary,
+  PrSummary,
   RenderComposerPdfPreviewResponse,
   ThreadWorkspaceHandoffStrategy,
   ThreadExecutionMode,
@@ -46,6 +47,7 @@ import {
   buildThreadUrl,
   buildReviewBranchOptions,
   findPreferredReviewWorkspaceCwd,
+  isRemoteFederationTarget,
   normalizeGitOriginUrl,
   parseThreadUrl,
   readCodexEnvironmentActionRuns,
@@ -64,6 +66,7 @@ import {
   PlusIcon,
   PullRequestIcon,
   SearchIcon,
+  ThreadIcon,
 } from "../../icons";
 import { AppIcon } from "../../components/AppIcon";
 import { ImageLightbox } from "../thread-detail/ImageLightbox";
@@ -91,6 +94,10 @@ import {
   listReferencedDirectories,
 } from "../../lib/directory-references";
 import { expandTildePath } from "../../lib/tildify-path";
+import {
+  filterHashReferenceCandidates,
+  findHashReferenceTrigger,
+} from "../../lib/hash-references";
 import { normalizeImageFile } from "../../lib/image-normalization";
 import {
   AGENT_THREAD_CAPABILITIES,
@@ -98,6 +105,7 @@ import {
   canChangeExistingThreadAgentDesignation,
   createDesktopAgentThread,
 } from "../../lib/agent-thread";
+import { parseGitHubPullRequestUrl } from "../../lib/pull-request-links";
 import {
   resolveThreadHref,
   resolveThreadIdText,
@@ -170,6 +178,8 @@ type ComposerProps = {
    * surfaces don't have to provide it.
    */
   directories?: NavigationDirectorySummary[];
+  /** Threads searchable from the inline `#` reference picker. */
+  threads?: NavigationThreadSummary[];
   disabled?: boolean;
   contextWindow?: ThreadContextWindowState;
   composerImplementation?: DesktopChatReplyComposer;
@@ -496,7 +506,11 @@ type SlashCommandSuggestion = {
   sourceLabel: string;
 };
 
-type AutocompleteKind = "skills" | "slash" | "directories";
+type AutocompleteKind =
+  | "directories"
+  | "hash-references"
+  | "skills"
+  | "slash";
 type ReviewTargetChoice = AppServerReviewTarget["type"];
 
 const CONTEXT_MOON_PHASES = [
@@ -1297,6 +1311,22 @@ function HighlightedAutocompleteLabel(props: {
   );
 }
 
+function describeHashReferenceThread(thread: NavigationThreadSummary): string {
+  const parts: string[] = [];
+  const pullRequest = (thread.prs ?? [])[0];
+  if (pullRequest) {
+    parts.push(`#${pullRequest.number}`);
+  }
+  if (thread.gitBranch) {
+    parts.push(thread.gitBranch);
+  }
+  const directory = (thread.linkedDirectories ?? [])[0];
+  if (directory?.label) {
+    parts.push(directory.label);
+  }
+  return parts.join(" · ") || thread.id;
+}
+
 function createComposerSkillToken(
   skill: AppServerSkillSummary,
   index: number,
@@ -1351,6 +1381,37 @@ function createComposerThreadToken(
     path,
     id: `${path}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
     index,
+  };
+}
+
+function createComposerPullRequestToken(
+  pullRequest: PrSummary,
+  index: number,
+): ComposerSkillToken {
+  return {
+    kind: "pull-request",
+    name: `#${pullRequest.number}`,
+    path: pullRequest.url,
+    description: pullRequest.title,
+    shortDescription: `${pullRequest.org}/${pullRequest.repo}`,
+    id: `${pullRequest.url}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+    index,
+  };
+}
+
+function resolveThreadSummaryReference(
+  thread: NavigationThreadSummary,
+): ResolvedThreadLink {
+  const federationTarget = thread.federation?.ref.target;
+  return {
+    backend: thread.source,
+    ...(federationTarget && isRemoteFederationTarget(federationTarget)
+      ? { instanceId: federationTarget.instanceId }
+      : {}),
+    threadId: thread.id,
+    title: thread.title,
+    gitBranch: thread.gitBranch,
+    linkedDirectories: thread.linkedDirectories,
   };
 }
 
@@ -1564,6 +1625,10 @@ function serializeDraftWithSkillTokens(
       output += ref
         ? buildThreadMarkdownLink({ ...ref, title: token.name })
         : token.path ?? token.name;
+    } else if (token.kind === "pull-request") {
+      output += token.path
+        ? `[${token.name}](${token.path})`
+        : token.name;
     } else {
       output += buildSkillMentionMarkdown(token);
     }
@@ -1627,19 +1692,27 @@ function hydrateComposerDraft(
     }
   };
 
-  // Thread titles may legitimately begin with `$` or `@`, so recognize the
-  // destination before passing surrounding Markdown through the skill and
-  // directory parser. Unknown thread links remain literal Markdown.
-  const threadLinkPattern = /\[((?:\\.|[^\]\\\r\n])*)\]\((pwragent:\/\/thread\/[^)\s]+)\)/gi;
+  // Thread and PR labels may legitimately begin with `$` or `@`, so recognize
+  // their destinations before passing surrounding Markdown through the skill
+  // and directory parser. Unknown links remain literal Markdown.
+  const referenceLinkPattern = /\[((?:\\.|[^\]\\\r\n])*)\]\((pwragent:\/\/thread\/[^)\s]+|https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/[1-9]\d*[^)\s]*)\)/gi;
   let cursor = 0;
-  for (const match of canonicalDraft.matchAll(threadLinkPattern)) {
+  for (const match of canonicalDraft.matchAll(referenceLinkPattern)) {
     const matchIndex = match.index ?? 0;
     hydrateSkillAndDirectoryParts(canonicalDraft.slice(cursor, matchIndex));
-    const resolvedThread = resolveThreadHref(match[2] ?? "", threadLinks);
+    const href = match[2] ?? "";
+    const resolvedThread = resolveThreadHref(href, threadLinks);
     if (resolvedThread) {
       skillTokens.push(createComposerThreadToken(resolvedThread, draft.length));
     } else {
-      draft += match[0];
+      const pullRequest = parseGitHubPullRequestUrl(href);
+      if (pullRequest) {
+        skillTokens.push(
+          createComposerPullRequestToken(pullRequest, draft.length),
+        );
+      } else {
+        draft += match[0];
+      }
     }
     cursor = matchIndex + match[0].length;
   }
@@ -2731,6 +2804,7 @@ export function Composer(props: ComposerProps) {
   const skillListboxId = useId();
   const slashListboxId = useId();
   const directoryRefListboxId = useId();
+  const hashReferenceListboxId = useId();
   const hydratedLaunchpadKeyRef = useRef<string | undefined>(undefined);
   const activeAcpLaunchpadRefreshKeyRef = useRef<string | undefined>(undefined);
   const pendingProviderSelectionKeyRef = useRef<string | undefined>(undefined);
@@ -2950,6 +3024,7 @@ export function Composer(props: ComposerProps) {
   const [activeSkillIndex, setActiveSkillIndex] = useState(0);
   const [activeSlashIndex, setActiveSlashIndex] = useState(0);
   const [activeDirectoryRefIndex, setActiveDirectoryRefIndex] = useState(0);
+  const [activeHashReferenceIndex, setActiveHashReferenceIndex] = useState(0);
   const [dismissedAutocompleteKey, setDismissedAutocompleteKey] = useState<string>();
 
   useEffect(() => {
@@ -4291,6 +4366,7 @@ export function Composer(props: ComposerProps) {
   const trigger = findSkillTrigger(draft, selectionStart);
   const slashTrigger = findSlashCommandTrigger(draft, selectionStart);
   const directoryRefTrigger = findDirectoryReferenceTrigger(draft, selectionStart);
+  const hashReferenceTrigger = findHashReferenceTrigger(draft, selectionStart);
   const filteredSkills = useMemo(() => {
     if (!trigger) {
       return [];
@@ -4350,13 +4426,27 @@ export function Composer(props: ComposerProps) {
       directoryRefTrigger.query,
     );
   }, [props.directories, directoryRefTrigger]);
+  const filteredHashReferences = useMemo(() => {
+    if (!hashReferenceTrigger) {
+      return { pullRequests: [], threads: [] };
+    }
+    return filterHashReferenceCandidates(
+      props.threads ?? [],
+      hashReferenceTrigger.query,
+    );
+  }, [hashReferenceTrigger, props.threads]);
+  const hashReferenceCount =
+    filteredHashReferences.threads.length
+    + filteredHashReferences.pullRequests.length;
   const availableAutocompleteKind: AutocompleteKind | undefined = trigger && filteredSkills.length > 0
     ? "skills"
     : slashTrigger && filteredSlashCommands.length > 0
       ? "slash"
       : directoryRefTrigger && filteredDirectoryRefs.length > 0
         ? "directories"
-        : undefined;
+        : hashReferenceTrigger && hashReferenceCount > 0
+          ? "hash-references"
+          : undefined;
   const autocompleteKey =
     availableAutocompleteKind === "skills" && trigger
       ? `skills:${trigger.start}:${trigger.end}:${trigger.query}`
@@ -4364,6 +4454,8 @@ export function Composer(props: ComposerProps) {
         ? `slash:${slashTrigger.start}:${slashTrigger.end}:/${slashTrigger.query}`
         : availableAutocompleteKind === "directories" && directoryRefTrigger
           ? `directories:${directoryRefTrigger.start}:${directoryRefTrigger.end}:@${directoryRefTrigger.query}`
+          : availableAutocompleteKind === "hash-references" && hashReferenceTrigger
+            ? `hash-references:${hashReferenceTrigger.start}:${hashReferenceTrigger.end}:#${hashReferenceTrigger.query}`
           : undefined;
   const displayedAutocompleteKind =
     autocompleteKey && autocompleteKey === dismissedAutocompleteKey
@@ -4378,13 +4470,17 @@ export function Composer(props: ComposerProps) {
       ? activeSkillIndex
       : autocompleteKind === "directories"
         ? activeDirectoryRefIndex
-        : activeSlashIndex;
+        : autocompleteKind === "hash-references"
+          ? activeHashReferenceIndex
+          : activeSlashIndex;
   const autocompleteLength =
     autocompleteKind === "skills"
       ? filteredSkills.length
       : autocompleteKind === "directories"
         ? filteredDirectoryRefs.length
-        : filteredSlashCommands.length;
+        : autocompleteKind === "hash-references"
+          ? hashReferenceCount
+          : filteredSlashCommands.length;
   const autocompleteListboxId =
     autocompleteKind === "skills"
       ? skillListboxId
@@ -4392,6 +4488,8 @@ export function Composer(props: ComposerProps) {
         ? slashListboxId
         : autocompleteKind === "directories"
           ? directoryRefListboxId
+          : autocompleteKind === "hash-references"
+            ? hashReferenceListboxId
           : undefined;
   const activeAutocompleteOptionId =
     autocompleteListboxId && autocompleteKind
@@ -4733,6 +4831,10 @@ export function Composer(props: ComposerProps) {
   useEffect(() => {
     setActiveDirectoryRefIndex(0);
   }, [directoryRefTrigger?.query, props.launchpad?.directoryKey, props.thread?.id]);
+
+  useEffect(() => {
+    setActiveHashReferenceIndex(0);
+  }, [hashReferenceTrigger?.query, props.launchpad?.directoryKey, props.thread?.id]);
 
   useEffect(() => {
     if (!dismissedAutocompleteKey) {
@@ -7280,6 +7382,58 @@ export function Composer(props: ComposerProps) {
     inputRef.current.insertMentionToken(createComposerThreadToken(thread, 0));
   };
 
+  const applyHashReference = (
+    createToken: (index: number) => ComposerSkillToken,
+  ): void => {
+    if (!inputRef.current) {
+      return;
+    }
+
+    const selectionStart = Math.min(
+      inputRef.current.selectionStart ?? draft.length,
+      draft.length,
+    );
+    const selectionEnd = Math.min(
+      inputRef.current.selectionEnd ?? selectionStart,
+      draft.length,
+    );
+    const referenceTrigger =
+      findHashReferenceTrigger(draft, selectionStart)
+      ?? findHashReferenceTrigger(draft, draft.length)
+      ?? { start: selectionStart, end: selectionEnd };
+    const before = draft.slice(0, referenceTrigger.start);
+    const after = draft.slice(Math.max(referenceTrigger.end, selectionEnd));
+    const nextAfter = /^\s/.test(after) ? after : ` ${after}`;
+    const nextDraft = `${before}${nextAfter}`;
+    const tokenIndex = before.length;
+    const nextSelection = tokenIndex + 1;
+    const nextSkillTokens = [
+      ...adjustSkillTokenIndexesForTextChange({
+        currentDraft: draft,
+        nextDraft,
+        skillTokens,
+      }),
+      createToken(tokenIndex),
+    ];
+
+    pendingProgrammaticComposerChangeRef.current = {
+      expectedDraft: nextDraft,
+      expectedSkillTokensSignature:
+        getComposerSkillTokensSignature(nextSkillTokens),
+      staleDraft: draft,
+      staleSkillTokensSignature: getComposerSkillTokensSignature(skillTokens),
+    };
+    flushSync(() => {
+      setSkillTokens(nextSkillTokens);
+      setDraft(nextDraft);
+      setActiveHashReferenceIndex(0);
+    });
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(nextSelection, nextSelection);
+    });
+  };
+
   /**
    * "@ → Add directory…" / "+"-menu action: run the OS picker (which also
    * registers the pick as a tracked directory, without navigating) and
@@ -8665,6 +8819,25 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
+    if (autocompleteKind === "hash-references") {
+      const thread = filteredHashReferences.threads[activeHashReferenceIndex];
+      if (thread) {
+        applyHashReference((index) =>
+          createComposerThreadToken(resolveThreadSummaryReference(thread), index),
+        );
+        return;
+      }
+      const pullRequest = filteredHashReferences.pullRequests[
+        activeHashReferenceIndex - filteredHashReferences.threads.length
+      ];
+      if (pullRequest) {
+        applyHashReference((index) =>
+          createComposerPullRequestToken(pullRequest, index),
+        );
+      }
+      return;
+    }
+
     const currentSlashText = slashTrigger
       ? `/${slashTrigger.query}`.toLowerCase()
       : undefined;
@@ -8754,6 +8927,8 @@ export function Composer(props: ComposerProps) {
         setActiveSkillIndex(updater);
       } else if (autocompleteKind === "directories") {
         setActiveDirectoryRefIndex(updater);
+      } else if (autocompleteKind === "hash-references") {
+        setActiveHashReferenceIndex(updater);
       } else {
         setActiveSlashIndex(updater);
       }
@@ -8807,6 +8982,7 @@ export function Composer(props: ComposerProps) {
       setActiveSkillIndex(0);
       setActiveSlashIndex(0);
       setActiveDirectoryRefIndex(0);
+      setActiveHashReferenceIndex(0);
       requestAnimationFrame(() => inputRef.current?.focus());
       return;
     }
@@ -10200,6 +10376,110 @@ export function Composer(props: ComposerProps) {
                 </span>
               </button>
             ) : null}
+          </div>
+        ) : autocompleteKind === "hash-references" ? (
+          <div
+            className={`composer__autocomplete composer__autocomplete--hash-references composer__autocomplete--${autocompleteLayout.placement}`}
+            ref={autocompleteListRef}
+            role="listbox"
+            aria-label="Threads and pull requests"
+            id={hashReferenceListboxId}
+            style={{ maxHeight: autocompleteLayout.maxHeight }}
+          >
+            {filteredHashReferences.threads.map((thread, index) => (
+              <button
+                key={`${thread.source}:${thread.id}`}
+                id={`${hashReferenceListboxId}-option-${index}`}
+                ref={(node) => {
+                  autocompleteOptionRefs.current[index] = node;
+                }}
+                aria-selected={index === activeHashReferenceIndex}
+                className={`composer__autocomplete-option${index === activeHashReferenceIndex ? " is-active" : ""}`}
+                tabIndex={index === activeHashReferenceIndex ? 0 : -1}
+                type="button"
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  applyHashReference((tokenIndex) =>
+                    createComposerThreadToken(
+                      resolveThreadSummaryReference(thread),
+                      tokenIndex,
+                    ),
+                  );
+                }}
+                onClick={() => {
+                  applyHashReference((tokenIndex) =>
+                    createComposerThreadToken(
+                      resolveThreadSummaryReference(thread),
+                      tokenIndex,
+                    ),
+                  );
+                }}
+                onFocus={() => {
+                  setActiveHashReferenceIndex(index);
+                }}
+                onKeyDown={handleAutocompleteKeyDown}
+              >
+                <span className="composer__autocomplete-title">
+                  <ThreadIcon size={13} aria-hidden="true" />
+                  <HighlightedAutocompleteLabel
+                    label={`#${thread.title.replace(/^#/, "")}`}
+                    query={
+                      hashReferenceTrigger?.query
+                        ? `#${hashReferenceTrigger.query}`
+                        : "#"
+                    }
+                  />
+                  <span className="composer__autocomplete-source composer__autocomplete-source--pwragent">
+                    Thread
+                  </span>
+                </span>
+                <span className="composer__autocomplete-meta">
+                  {describeHashReferenceThread(thread)}
+                </span>
+              </button>
+            ))}
+            {filteredHashReferences.pullRequests.map((pullRequest, offset) => {
+              const index = filteredHashReferences.threads.length + offset;
+              return (
+                <button
+                  key={pullRequest.url}
+                  id={`${hashReferenceListboxId}-option-${index}`}
+                  ref={(node) => {
+                    autocompleteOptionRefs.current[index] = node;
+                  }}
+                  aria-selected={index === activeHashReferenceIndex}
+                  className={`composer__autocomplete-option${index === activeHashReferenceIndex ? " is-active" : ""}`}
+                  tabIndex={index === activeHashReferenceIndex ? 0 : -1}
+                  type="button"
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    applyHashReference((tokenIndex) =>
+                      createComposerPullRequestToken(pullRequest, tokenIndex),
+                    );
+                  }}
+                  onClick={() => {
+                    applyHashReference((tokenIndex) =>
+                      createComposerPullRequestToken(pullRequest, tokenIndex),
+                    );
+                  }}
+                  onFocus={() => {
+                    setActiveHashReferenceIndex(index);
+                  }}
+                  onKeyDown={handleAutocompleteKeyDown}
+                >
+                  <span className="composer__autocomplete-title">
+                    <PullRequestIcon size={13} aria-hidden="true" />
+                    <span>{`${pullRequest.org}/${pullRequest.repo}#${pullRequest.number}`}</span>
+                    <span className="composer__autocomplete-source composer__autocomplete-source--provider">
+                      Pull request
+                    </span>
+                  </span>
+                  <span className="composer__autocomplete-meta">
+                    {pullRequest.title || pullRequest.url}
+                  </span>
+                </button>
+              );
+            })}
           </div>
         ) : null}
       </div>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -51,6 +51,7 @@ import {
   normalizeGitOriginUrl,
   parseThreadUrl,
   readCodexEnvironmentActionRuns,
+  threadHasExactPrNumberMatch,
 } from "@pwragent/shared";
 import {
   BranchIcon,
@@ -105,7 +106,7 @@ import {
   canChangeExistingThreadAgentDesignation,
   createDesktopAgentThread,
 } from "../../lib/agent-thread";
-import { parseGitHubPullRequestUrl } from "../../lib/pull-request-links";
+import { parsePullRequestUrl } from "../../lib/pull-request-links";
 import {
   resolveThreadHref,
   resolveThreadIdText,
@@ -1311,9 +1312,16 @@ function HighlightedAutocompleteLabel(props: {
   );
 }
 
-function describeHashReferenceThread(thread: NavigationThreadSummary): string {
+function describeHashReferenceThread(
+  thread: NavigationThreadSummary,
+  query: string,
+): string {
   const parts: string[] = [];
-  const pullRequest = (thread.prs ?? [])[0];
+  const pullRequest = threadHasExactPrNumberMatch(thread, query)
+    ? (thread.prs ?? []).find(
+        (candidate) => candidate.number === Number(query.trim()),
+      )
+    : (thread.prs ?? [])[0];
   if (pullRequest) {
     parts.push(`#${pullRequest.number}`);
   }
@@ -1695,7 +1703,7 @@ function hydrateComposerDraft(
   // Thread and PR labels may legitimately begin with `$` or `@`, so recognize
   // their destinations before passing surrounding Markdown through the skill
   // and directory parser. Unknown links remain literal Markdown.
-  const referenceLinkPattern = /\[((?:\\.|[^\]\\\r\n])*)\]\((pwragent:\/\/thread\/[^)\s]+|https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/[1-9]\d*[^)\s]*)\)/gi;
+  const referenceLinkPattern = /\[((?:\\.|[^\]\\\r\n])*)\]\((pwragent:\/\/thread\/[^)\s]+|https:\/\/[^)\s]+)\)/gi;
   let cursor = 0;
   for (const match of canonicalDraft.matchAll(referenceLinkPattern)) {
     const matchIndex = match.index ?? 0;
@@ -1705,7 +1713,7 @@ function hydrateComposerDraft(
     if (resolvedThread) {
       skillTokens.push(createComposerThreadToken(resolvedThread, draft.length));
     } else {
-      const pullRequest = parseGitHubPullRequestUrl(href);
+      const pullRequest = parsePullRequestUrl(href);
       if (pullRequest) {
         skillTokens.push(
           createComposerPullRequestToken(pullRequest, draft.length),
@@ -10434,7 +10442,10 @@ export function Composer(props: ComposerProps) {
                   </span>
                 </span>
                 <span className="composer__autocomplete-meta">
-                  {describeHashReferenceThread(thread)}
+                  {describeHashReferenceThread(
+                    thread,
+                    hashReferenceTrigger?.query ?? "",
+                  )}
                 </span>
               </button>
             ))}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1,4 +1,5 @@
 import {
+  Fragment,
   type ReactNode,
   type ClipboardEvent,
   type DragEvent,
@@ -43,9 +44,12 @@ import type {
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import {
+  buildPullRequestStatusKey,
+  buildThreadIdentityKey,
   buildThreadMarkdownLink,
   buildThreadUrl,
   buildReviewBranchOptions,
+  federatedThreadIdentityKey,
   findPreferredReviewWorkspaceCwd,
   isRemoteFederationTarget,
   normalizeGitOriginUrl,
@@ -70,6 +74,7 @@ import {
   ThreadIcon,
 } from "../../icons";
 import { AppIcon } from "../../components/AppIcon";
+import { InstanceChip } from "../federation/InstanceGlyph";
 import { ImageLightbox } from "../thread-detail/ImageLightbox";
 import type { AppNoticeToastNotice } from "../notifications/AppNoticeToast";
 import { formatBackendLabel } from "../../lib/backend-label";
@@ -115,6 +120,10 @@ import {
   type ThreadLinkContextValue,
 } from "../../lib/thread-links";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
+import {
+  FEDERATED_THREAD_SEARCH_LIMIT,
+  useFederatedThreadSearch,
+} from "../../lib/useFederatedThreadSearch";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
   findSkillTrigger,
@@ -4375,6 +4384,14 @@ export function Composer(props: ComposerProps) {
   const slashTrigger = findSlashCommandTrigger(draft, selectionStart);
   const directoryRefTrigger = findDirectoryReferenceTrigger(draft, selectionStart);
   const hashReferenceTrigger = findHashReferenceTrigger(draft, selectionStart);
+  const {
+    loading: federatedHashSearchLoading,
+    results: federatedHashSearchResults,
+  } = useFederatedThreadSearch({
+    query: hashReferenceTrigger?.query ?? "",
+    limit: FEDERATED_THREAD_SEARCH_LIMIT,
+    search: props.desktopApi?.jumpSearchRemoteThreads,
+  });
   const filteredSkills = useMemo(() => {
     if (!trigger) {
       return [];
@@ -4434,25 +4451,69 @@ export function Composer(props: ComposerProps) {
       directoryRefTrigger.query,
     );
   }, [props.directories, directoryRefTrigger]);
-  const filteredHashReferences = useMemo(() => {
+  const filteredHashReferenceOptions = useMemo(() => {
     if (!hashReferenceTrigger) {
-      return { pullRequests: [], threads: [] };
+      return [];
     }
-    return filterHashReferenceCandidates(
+    const localCandidates = filterHashReferenceCandidates(
       props.threads ?? [],
       hashReferenceTrigger.query,
     );
-  }, [hashReferenceTrigger, props.threads]);
-  const hashReferenceCount =
-    filteredHashReferences.threads.length
-    + filteredHashReferences.pullRequests.length;
+    const localThreadKeys = new Set(
+      (props.threads ?? []).map((thread) =>
+        buildThreadIdentityKey(thread.source, thread.id),
+      ),
+    );
+    const remoteCandidates = filterHashReferenceCandidates(
+      federatedHashSearchResults.filter(
+        (thread) =>
+          thread.federation?.ref.target.scope === "remote"
+          && !localThreadKeys.has(
+            buildThreadIdentityKey(thread.source, thread.id),
+          ),
+      ),
+      hashReferenceTrigger.query,
+    );
+    const localPullRequestKeys = new Set(
+      localCandidates.pullRequests.map(buildPullRequestStatusKey),
+    );
+    return [
+      ...localCandidates.threads.map((thread) => ({
+        kind: "thread" as const,
+        remote: false,
+        thread,
+      })),
+      ...localCandidates.pullRequests.map((pullRequest) => ({
+        kind: "pull-request" as const,
+        pullRequest,
+        remote: false,
+      })),
+      ...remoteCandidates.threads.map((thread) => ({
+        kind: "thread" as const,
+        remote: true,
+        thread,
+      })),
+      ...remoteCandidates.pullRequests
+        .filter(
+          (pullRequest) =>
+            !localPullRequestKeys.has(buildPullRequestStatusKey(pullRequest)),
+        )
+        .map((pullRequest) => ({
+          kind: "pull-request" as const,
+          pullRequest,
+          remote: true,
+        })),
+    ];
+  }, [federatedHashSearchResults, hashReferenceTrigger, props.threads]);
+  const hashReferenceCount = filteredHashReferenceOptions.length;
   const availableAutocompleteKind: AutocompleteKind | undefined = trigger && filteredSkills.length > 0
     ? "skills"
     : slashTrigger && filteredSlashCommands.length > 0
       ? "slash"
       : directoryRefTrigger && filteredDirectoryRefs.length > 0
         ? "directories"
-        : hashReferenceTrigger && hashReferenceCount > 0
+        : hashReferenceTrigger
+            && (hashReferenceCount > 0 || federatedHashSearchLoading)
           ? "hash-references"
           : undefined;
   const autocompleteKey =
@@ -4500,7 +4561,7 @@ export function Composer(props: ComposerProps) {
             ? hashReferenceListboxId
           : undefined;
   const activeAutocompleteOptionId =
-    autocompleteListboxId && autocompleteKind
+    autocompleteListboxId && autocompleteKind && autocompleteLength > 0
       ? `${autocompleteListboxId}-option-${activeAutocompleteIndex}`
       : undefined;
   // Directories the draft references: `@` chips (authoritative, from the
@@ -8828,19 +8889,21 @@ export function Composer(props: ComposerProps) {
     }
 
     if (autocompleteKind === "hash-references") {
-      const thread = filteredHashReferences.threads[activeHashReferenceIndex];
-      if (thread) {
+      const option =
+        filteredHashReferenceOptions[activeHashReferenceIndex]
+        ?? filteredHashReferenceOptions[0];
+      if (option?.kind === "thread") {
         applyHashReference((index) =>
-          createComposerThreadToken(resolveThreadSummaryReference(thread), index),
+          createComposerThreadToken(
+            resolveThreadSummaryReference(option.thread),
+            index,
+          ),
         );
         return;
       }
-      const pullRequest = filteredHashReferences.pullRequests[
-        activeHashReferenceIndex - filteredHashReferences.threads.length
-      ];
-      if (pullRequest) {
+      if (option?.kind === "pull-request") {
         applyHashReference((index) =>
-          createComposerPullRequestToken(pullRequest, index),
+          createComposerPullRequestToken(option.pullRequest, index),
         );
       }
       return;
@@ -10394,103 +10457,151 @@ export function Composer(props: ComposerProps) {
             id={hashReferenceListboxId}
             style={{ maxHeight: autocompleteLayout.maxHeight }}
           >
-            {filteredHashReferences.threads.map((thread, index) => (
-              <button
-                key={`${thread.source}:${thread.id}`}
-                id={`${hashReferenceListboxId}-option-${index}`}
-                ref={(node) => {
-                  autocompleteOptionRefs.current[index] = node;
-                }}
-                aria-selected={index === activeHashReferenceIndex}
-                className={`composer__autocomplete-option${index === activeHashReferenceIndex ? " is-active" : ""}`}
-                tabIndex={index === activeHashReferenceIndex ? 0 : -1}
-                type="button"
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                  applyHashReference((tokenIndex) =>
-                    createComposerThreadToken(
-                      resolveThreadSummaryReference(thread),
-                      tokenIndex,
-                    ),
-                  );
-                }}
-                onClick={() => {
-                  applyHashReference((tokenIndex) =>
-                    createComposerThreadToken(
-                      resolveThreadSummaryReference(thread),
-                      tokenIndex,
-                    ),
-                  );
-                }}
-                onFocus={() => {
-                  setActiveHashReferenceIndex(index);
-                }}
-                onKeyDown={handleAutocompleteKeyDown}
-              >
-                <span className="composer__autocomplete-title">
-                  <ThreadIcon size={13} aria-hidden="true" />
-                  <HighlightedAutocompleteLabel
-                    label={`#${thread.title.replace(/^#/, "")}`}
-                    query={
-                      hashReferenceTrigger?.query
-                        ? `#${hashReferenceTrigger.query}`
-                        : "#"
-                    }
-                  />
-                  <span className="composer__autocomplete-source composer__autocomplete-source--pwragent">
-                    Thread
-                  </span>
-                </span>
-                <span className="composer__autocomplete-meta">
-                  {describeHashReferenceThread(
-                    thread,
-                    hashReferenceTrigger?.query ?? "",
-                  )}
-                </span>
-              </button>
-            ))}
-            {filteredHashReferences.pullRequests.map((pullRequest, offset) => {
-              const index = filteredHashReferences.threads.length + offset;
+            {filteredHashReferenceOptions.map((option, index) => {
+              const showRemoteDivider =
+                option.remote
+                && !filteredHashReferenceOptions[index - 1]?.remote;
+              if (option.kind === "thread") {
+                const thread = option.thread;
+                const key = thread.federation
+                  ? federatedThreadIdentityKey(thread.federation.ref)
+                  : buildThreadIdentityKey(thread.source, thread.id);
+                return (
+                  <Fragment key={key}>
+                    {showRemoteDivider ? (
+                      <div
+                        aria-hidden="true"
+                        className="composer__autocomplete-section-divider"
+                        role="presentation"
+                      >
+                        Other instances
+                      </div>
+                    ) : null}
+                    <button
+                      id={`${hashReferenceListboxId}-option-${index}`}
+                      ref={(node) => {
+                        autocompleteOptionRefs.current[index] = node;
+                      }}
+                      aria-selected={index === activeHashReferenceIndex}
+                      className={`composer__autocomplete-option${index === activeHashReferenceIndex ? " is-active" : ""}`}
+                      tabIndex={index === activeHashReferenceIndex ? 0 : -1}
+                      type="button"
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        applyHashReference((tokenIndex) =>
+                          createComposerThreadToken(
+                            resolveThreadSummaryReference(thread),
+                            tokenIndex,
+                          ),
+                        );
+                      }}
+                      onClick={() => {
+                        applyHashReference((tokenIndex) =>
+                          createComposerThreadToken(
+                            resolveThreadSummaryReference(thread),
+                            tokenIndex,
+                          ),
+                        );
+                      }}
+                      onFocus={() => {
+                        setActiveHashReferenceIndex(index);
+                      }}
+                      onKeyDown={handleAutocompleteKeyDown}
+                    >
+                      <span className="composer__autocomplete-title">
+                        <ThreadIcon size={13} aria-hidden="true" />
+                        <HighlightedAutocompleteLabel
+                          label={`#${thread.title.replace(/^#/, "")}`}
+                          query={
+                            hashReferenceTrigger?.query
+                              ? `#${hashReferenceTrigger.query}`
+                              : "#"
+                          }
+                        />
+                        <span className="composer__autocomplete-source composer__autocomplete-source--pwragent">
+                          Thread
+                        </span>
+                      </span>
+                      <span className="composer__autocomplete-meta composer__autocomplete-meta--thread">
+                        {thread.federation?.ref.target.scope === "remote" ? (
+                          <InstanceChip
+                            icon={thread.federation.celestialIcon}
+                            instanceId={thread.federation.ref.target.instanceId}
+                            label={thread.federation.instanceLabel}
+                          />
+                        ) : null}
+                        <span>
+                          {describeHashReferenceThread(
+                            thread,
+                            hashReferenceTrigger?.query ?? "",
+                          )}
+                        </span>
+                      </span>
+                    </button>
+                  </Fragment>
+                );
+              }
+
+              const pullRequest = option.pullRequest;
               return (
-                <button
-                  key={pullRequest.url}
-                  id={`${hashReferenceListboxId}-option-${index}`}
-                  ref={(node) => {
-                    autocompleteOptionRefs.current[index] = node;
-                  }}
-                  aria-selected={index === activeHashReferenceIndex}
-                  className={`composer__autocomplete-option${index === activeHashReferenceIndex ? " is-active" : ""}`}
-                  tabIndex={index === activeHashReferenceIndex ? 0 : -1}
-                  type="button"
-                  onMouseDown={(event) => {
-                    event.preventDefault();
-                    applyHashReference((tokenIndex) =>
-                      createComposerPullRequestToken(pullRequest, tokenIndex),
-                    );
-                  }}
-                  onClick={() => {
-                    applyHashReference((tokenIndex) =>
-                      createComposerPullRequestToken(pullRequest, tokenIndex),
-                    );
-                  }}
-                  onFocus={() => {
-                    setActiveHashReferenceIndex(index);
-                  }}
-                  onKeyDown={handleAutocompleteKeyDown}
-                >
-                  <span className="composer__autocomplete-title">
-                    <PullRequestIcon size={13} aria-hidden="true" />
-                    <span>{`${pullRequest.org}/${pullRequest.repo}#${pullRequest.number}`}</span>
-                    <span className="composer__autocomplete-source composer__autocomplete-source--provider">
-                      Pull request
+                <Fragment key={pullRequest.url}>
+                  {showRemoteDivider ? (
+                    <div
+                      aria-hidden="true"
+                      className="composer__autocomplete-section-divider"
+                      role="presentation"
+                    >
+                      Other instances
+                    </div>
+                  ) : null}
+                  <button
+                    id={`${hashReferenceListboxId}-option-${index}`}
+                    ref={(node) => {
+                      autocompleteOptionRefs.current[index] = node;
+                    }}
+                    aria-selected={index === activeHashReferenceIndex}
+                    className={`composer__autocomplete-option${index === activeHashReferenceIndex ? " is-active" : ""}`}
+                    tabIndex={index === activeHashReferenceIndex ? 0 : -1}
+                    type="button"
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      applyHashReference((tokenIndex) =>
+                        createComposerPullRequestToken(pullRequest, tokenIndex),
+                      );
+                    }}
+                    onClick={() => {
+                      applyHashReference((tokenIndex) =>
+                        createComposerPullRequestToken(pullRequest, tokenIndex),
+                      );
+                    }}
+                    onFocus={() => {
+                      setActiveHashReferenceIndex(index);
+                    }}
+                    onKeyDown={handleAutocompleteKeyDown}
+                  >
+                    <span className="composer__autocomplete-title">
+                      <PullRequestIcon size={13} aria-hidden="true" />
+                      <span>{`${pullRequest.org}/${pullRequest.repo}#${pullRequest.number}`}</span>
+                      <span className="composer__autocomplete-source composer__autocomplete-source--provider">
+                        Pull request
+                      </span>
                     </span>
-                  </span>
-                  <span className="composer__autocomplete-meta">
-                    {pullRequest.title || pullRequest.url}
-                  </span>
-                </button>
+                    <span className="composer__autocomplete-meta">
+                      {pullRequest.title || pullRequest.url}
+                    </span>
+                  </button>
+                </Fragment>
               );
             })}
+            {federatedHashSearchLoading ? (
+              <div
+                aria-hidden="true"
+                className="composer__autocomplete-remote-loading"
+                role="presentation"
+              >
+                Searching other instances…
+              </div>
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
@@ -16,11 +16,14 @@ import type { AppServerSkillSummary } from "@pwragent/shared";
  *   - thread references (`kind: "thread"`): `name` is the resolved thread
  *     title and `path` its canonical `pwragent://thread/...` URL; serializes
  *     to the same Markdown link the transcript recognizes as a thread chip.
+ *   - pull-request references (`kind: "pull-request"`): `name` is the short
+ *     `#123` label and `path` the repository-scoped PR URL; serializes to the
+ *     Markdown link the transcript hydrates into its live PR chip.
  */
 export type ComposerSkillToken = AppServerSkillSummary & {
   id: string;
   index: number;
-  kind?: "directory" | "file" | "thread";
+  kind?: "directory" | "file" | "pull-request" | "thread";
 };
 
 export type ComposerInputChangeMetadata = {

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -31,6 +31,7 @@ import {
   buildFileReferenceTooltip,
   findDirectoryReferenceTrigger,
 } from "../../lib/directory-references";
+import { findHashReferenceTrigger } from "../../lib/hash-references";
 import { tildifyPath } from "../../lib/tildify-path";
 import {
   ChipContextMenu,
@@ -190,7 +191,27 @@ const SkillMention = Mention.extend({
           ["path", { d: "M8 8.5h8" }],
           ["path", { d: "M8 12h5" }],
         ],
-        ["span", { class: "thread-chip__label" }, label],
+        ["span", { class: "thread-chip__label" }, `#${label.replace(/^#/, "")}`],
+      ];
+    }
+    if (node.attrs.kind === "pull-request") {
+      const label = String(node.attrs.name ?? "pull request");
+      const path = typeof node.attrs.path === "string" ? node.attrs.path : "";
+      return [
+        "span",
+        {
+          class: "pr-chip pr-chip--unknown composer-pr-chip composer-tiptap-input__mention",
+          "data-type": "mention",
+          "data-mention-kind": "pull-request",
+          "data-composer-skill-token-id": String(node.attrs.id ?? ""),
+          "data-id": String(node.attrs.id ?? ""),
+          "data-label": label,
+          "data-skill-name": label,
+          ...(path ? { "data-skill-path": path } : {}),
+          ...(path ? { "data-tooltip": path } : {}),
+        },
+        ["span", { class: "pr-chip__dot", "aria-hidden": "true" }],
+        ["span", { class: "pr-chip__label" }, label],
       ];
     }
     if (node.attrs.kind === "directory" || node.attrs.kind === "file") {
@@ -249,7 +270,10 @@ const SkillMention = Mention.extend({
     ];
   },
   renderText: ({ node }) => {
-    if (node.attrs.kind === "thread") {
+    if (
+      node.attrs.kind === "thread"
+      || node.attrs.kind === "pull-request"
+    ) {
       return String(node.attrs.path ?? node.attrs.name ?? "");
     }
     if (node.attrs.kind === "directory" || node.attrs.kind === "file") {
@@ -911,6 +935,7 @@ function mentionAttrsToSkill(
   const kind =
     attrs.kind === "directory"
     || attrs.kind === "file"
+    || attrs.kind === "pull-request"
     || attrs.kind === "thread"
       ? attrs.kind
       : undefined;
@@ -1893,11 +1918,14 @@ function applyExternalSkillInsertion(params: {
   }
 
   // Re-locate the autocomplete trigger the token replaced — `@` for a
-  // directory-reference chip, `$` for a skill.
+  // directory-reference chip, `#` for a thread/PR reference, `$` for a skill.
   const findTrigger =
     insertedSkill.kind === "directory"
       ? findDirectoryReferenceTrigger
-      : findSkillTrigger;
+      : insertedSkill.kind === "thread"
+          || insertedSkill.kind === "pull-request"
+        ? findHashReferenceTrigger
+        : findSkillTrigger;
   const trigger =
     findTrigger(params.current.value, params.selectionIndex) ??
     findTrigger(params.current.value, params.current.value.length);

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2355,6 +2355,59 @@ describe("Composer", () => {
     });
   });
 
+  it("submits while a hash reference has only a pending federation search", async () => {
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const remoteSearch = createDeferred<{ results: NavigationThreadSummary[] }>();
+    const jumpSearchRemoteThreads = vi.fn(() => remoteSearch.promise);
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: currentThread.id,
+      turnId: "turn-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          jumpSearchRemoteThreads,
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={currentThread}
+        threads={[currentThread]}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    fireEvent.change(textbox, { target: { value: "Ask #Remote" } });
+    expect(await screen.findByText("Searching other instances…"))
+      .toBeInTheDocument();
+    await waitFor(() => {
+      expect(jumpSearchRemoteThreads).toHaveBeenCalledWith({
+        query: "Remote",
+        limit: 8,
+      });
+    });
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: currentThread.id,
+        input: [{ type: "text", text: "Ask #Remote" }],
+      });
+    });
+  });
+
   it.each([
     ["acp:gemini", acpGeminiBackendSummary()],
     ["acp:kimi", backendSummary("acp:kimi")],

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3,6 +3,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testi
 import { StrictMode, useState, type ComponentProps } from "react";
 import {
   applyNavigationLaunchpadProviderSettingsPatch,
+  buildFederatedThreadRef,
   type BackendSummary,
   type CompactThreadRequest,
   type ComposerDraftRecoveryCandidate,
@@ -2255,6 +2256,102 @@ describe("Composer", () => {
         undefined,
         [],
       );
+    });
+  });
+
+  it("appends Cmd+K federation results and inserts a remote thread link", async () => {
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const remoteThread: NavigationThreadSummary = {
+      id: "thread-remote",
+      title: "Remote fix",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      federation: {
+        ref: buildFederatedThreadRef({
+          backend: "codex",
+          instanceId: "peer-laptop",
+          threadId: "thread-remote",
+        }),
+        instanceLabel: "Laptop",
+        peerStatus: "connected",
+        capabilities: [],
+      },
+    };
+    const jumpSearchRemoteThreads = vi.fn(async () => ({
+      results: [remoteThread],
+    }));
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: currentThread.id,
+      turnId: "turn-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          jumpSearchRemoteThreads,
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={currentThread}
+        threads={[currentThread]}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    fireEvent.change(textbox, { target: { value: "Ask #Remote" } });
+    expect(await screen.findByText("Searching other instances…"))
+      .toBeInTheDocument();
+
+    const listbox = await screen.findByRole("listbox", {
+      name: "Threads and pull requests",
+    });
+    const remoteOption = await within(listbox).findByRole("button", {
+      name: /#Remote fix/,
+    });
+    expect(jumpSearchRemoteThreads).toHaveBeenCalledWith({
+      query: "Remote",
+      limit: 8,
+    });
+    expect(within(listbox).getByText("Other instances")).toBeInTheDocument();
+    expect(within(remoteOption).getByLabelText("Runs on Laptop"))
+      .toBeInTheDocument();
+    fireEvent.click(remoteOption);
+
+    const chip = await waitFor(() =>
+      within(textbox)
+        .getByText("#Remote fix")
+        .closest("[data-mention-kind]"),
+    );
+    expect(chip).toHaveAttribute("data-mention-kind", "thread");
+    expect(chip).toHaveAttribute(
+      "data-skill-path",
+      "pwragent://thread/thread-remote?backend=codex&instanceId=peer-laptop",
+    );
+
+    await clickButton("Send");
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: currentThread.id,
+        input: [
+          {
+            type: "text",
+            text: "Ask [Remote fix](pwragent://thread/thread-remote?backend=codex&instanceId=peer-laptop)",
+          },
+        ],
+      });
     });
   });
 
@@ -15186,7 +15283,7 @@ describe("Composer", () => {
 
     expect(
       await within(screen.getByTestId("composer-tiptap-input"))
-        .findByText("Bob's Best Thread 3000"),
+        .findByText("#Bob's Best Thread 3000"),
     ).toBeInTheDocument();
     expect(screen.queryByText("Untitled thread")).not.toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2110,6 +2110,15 @@ describe("Composer", () => {
   });
 
   it("offers matching threads and a precise PR link for a numeric hash query", async () => {
+    const earlierPullRequest = {
+      provider: "github.com" as const,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      number: 44,
+      state: "passing" as const,
+      title: "Earlier stacked change",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/44",
+    };
     const pullRequest = {
       provider: "github.com" as const,
       org: "pwrdrvr",
@@ -2134,7 +2143,7 @@ describe("Composer", () => {
       source: "codex",
       linkedDirectories: [],
       inbox: { inInbox: false },
-      prs: [pullRequest],
+      prs: [earlierPullRequest, pullRequest],
     };
     const startTurn = vi.fn(async () => ({
       backend: "codex" as const,
@@ -2160,9 +2169,13 @@ describe("Composer", () => {
     const listbox = await screen.findByRole("listbox", {
       name: "Threads and pull requests",
     });
-    expect(
-      within(listbox).getByRole("button", { name: /#Implement hash references/ }),
-    ).toBeInTheDocument();
+    const threadOption = within(listbox).getByRole("button", {
+      name: /#Implement hash references/,
+    });
+    expect(threadOption.querySelector(".composer__autocomplete-meta"))
+      .toHaveTextContent("#123");
+    expect(threadOption.querySelector(".composer__autocomplete-meta"))
+      .not.toHaveTextContent("#44");
     fireEvent.click(
       within(listbox).getByRole("button", { name: /pwrdrvr\/PwrAgent#123/ }),
     );
@@ -2187,6 +2200,61 @@ describe("Composer", () => {
           },
         ],
       });
+    });
+  });
+
+  it("rebuilds a GitLab merge request chip from a prompt-only launchpad restore", async () => {
+    const url = "https://gitlab.com/pwrdrvr/platform/PwrAgent/-/merge_requests/49";
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "Repo",
+      directoryPath: "/repo",
+      backend: "codex",
+      executionMode: "default",
+      prompt: `check [#49](${url}) please`,
+      workMode: "local",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const onMaterializeLaunchpad = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo",
+          kind: "directory",
+          label: "Repo",
+          path: "/repo",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        draftStore={createComposerDraftStore()}
+        launchpad={launchpad}
+        onMaterializeLaunchpad={onMaterializeLaunchpad}
+        onUpdateLaunchpad={async () => undefined}
+        skills={[]}
+      />,
+    );
+
+    const richInput = screen.getByTestId("composer-tiptap-input");
+    const chip = await waitFor(() =>
+      within(richInput).getByText("#49").closest("[data-mention-kind]"),
+    );
+    expect(chip).toHaveAttribute("data-mention-kind", "pull-request");
+    expect(chip).toHaveAttribute("data-skill-path", url);
+
+    await clickButton("Start thread");
+    await waitFor(() => {
+      expect(onMaterializeLaunchpad).toHaveBeenCalledWith(
+        "directory:/repo",
+        [{ type: "text", text: `check [#49](${url}) please` }],
+        undefined,
+        undefined,
+        [],
+      );
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2037,6 +2037,159 @@ describe("Composer", () => {
     expect(screen.queryByText("No command")).not.toBeInTheDocument();
   });
 
+  it("inserts a hash-prefixed thread chip from the inline thread picker", async () => {
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const targetThread: NavigationThreadSummary = {
+      id: "019fbbbe-ad52-77c2-b7f7-28182d9a6f83",
+      title: "Bob's Best Thread 3000",
+      titleSource: "explicit",
+      source: "codex",
+      gitBranch: "agent/best-thread",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: currentThread.id,
+      turnId: "turn-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={currentThread}
+        threads={[currentThread, targetThread]}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    fireEvent.change(textbox, { target: { value: "Ask #Bob's Best" } });
+    const listbox = await screen.findByRole("listbox", {
+      name: "Threads and pull requests",
+    });
+    expect(
+      within(listbox).getByRole("button", {
+        name: /#Bob's Best Thread 3000/,
+      }),
+    ).toBeInTheDocument();
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    const chip = await waitFor(() =>
+      within(textbox)
+        .getByText("#Bob's Best Thread 3000")
+        .closest("[data-mention-kind]"),
+    );
+    expect(chip).toHaveAttribute("data-mention-kind", "thread");
+    expect(textbox).toHaveValue("Ask  ");
+
+    await clickButton("Send");
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: currentThread.id,
+        input: [
+          {
+            type: "text",
+            text: "Ask [Bob's Best Thread 3000](pwragent://thread/019fbbbe-ad52-77c2-b7f7-28182d9a6f83?backend=codex)",
+          },
+        ],
+      });
+    });
+  });
+
+  it("offers matching threads and a precise PR link for a numeric hash query", async () => {
+    const pullRequest = {
+      provider: "github.com" as const,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      number: 123,
+      state: "passing" as const,
+      title: "Ship channel-style thread references",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/123",
+    };
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const pullRequestThread: NavigationThreadSummary = {
+      id: "thread-pr-123",
+      title: "Implement hash references",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      prs: [pullRequest],
+    };
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: currentThread.id,
+      turnId: "turn-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={currentThread}
+        threads={[currentThread, pullRequestThread]}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    fireEvent.change(textbox, { target: { value: "See #123" } });
+    const listbox = await screen.findByRole("listbox", {
+      name: "Threads and pull requests",
+    });
+    expect(
+      within(listbox).getByRole("button", { name: /#Implement hash references/ }),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      within(listbox).getByRole("button", { name: /pwrdrvr\/PwrAgent#123/ }),
+    );
+
+    const chip = await waitFor(() =>
+      within(textbox)
+        .getByText("#123")
+        .closest("[data-mention-kind]"),
+    );
+    expect(chip).toHaveAttribute("data-mention-kind", "pull-request");
+    expect(chip).toHaveAttribute("data-skill-path", pullRequest.url);
+
+    await clickButton("Send");
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: currentThread.id,
+        input: [
+          {
+            type: "text",
+            text: `See [#123](${pullRequest.url})`,
+          },
+        ],
+      });
+    });
+  });
+
   it.each([
     ["acp:gemini", acpGeminiBackendSummary()],
     ["acp:kimi", backendSummary("acp:kimi")],
@@ -14848,7 +15001,7 @@ describe("Composer", () => {
     const richInput = screen.getByTestId("composer-tiptap-input");
     const chip = await waitFor(() => {
       const currentChip = within(richInput)
-        .getByText("Lovely child thread")
+        .getByText("#Lovely child thread")
         .closest("[data-mention-kind]");
       expect(currentChip).toHaveAttribute(
         "data-mention-kind",
@@ -15029,7 +15182,7 @@ describe("Composer", () => {
       expect(textbox).toHaveValue("keep  tail");
       expect(
         within(textbox)
-          .getByText("Lovely child thread")
+          .getByText("#Lovely child thread")
           .closest("[data-mention-kind]"),
       ).toHaveAttribute(
         "data-mention-kind",
@@ -15138,7 +15291,7 @@ describe("Composer", () => {
     });
 
     await waitFor(() => {
-      expect(within(textbox).getByText("Lovely child thread")).toBeInTheDocument();
+      expect(within(textbox).getByText("#Lovely child thread")).toBeInTheDocument();
     });
     expect(textbox.querySelector("h2")).toHaveTextContent("Heading");
     expect(textbox.querySelector("ul li")).toHaveTextContent("List item");

--- a/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
@@ -14,15 +14,15 @@ import {
 } from "@pwragent/shared";
 import { SearchIcon } from "../../icons";
 import { getDesktopApi } from "../../lib/desktop-api";
-import { readRendererFederationTarget } from "../../lib/federation-window";
+import {
+  FEDERATED_THREAD_SEARCH_LIMIT,
+  useFederatedThreadSearch,
+} from "../../lib/useFederatedThreadSearch";
 import { threadMatchesQuery } from "../thread-search/thread-match";
 import { AgentThreadChip } from "./AgentThreadChip";
 import { InstanceChip } from "../federation/InstanceGlyph";
 
 const MAX_RESULTS = 8;
-const MAX_REMOTE_RESULTS = 8;
-/** Remote querying waits for a typing pause; local filtering never does. */
-const REMOTE_SEARCH_DEBOUNCE_MS = 200;
 
 type SidebarSearchPopupProps = {
   threads: readonly NavigationThreadSummary[];
@@ -46,9 +46,6 @@ type SidebarSearchPopupProps = {
 export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement {
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
-  const [remoteResults, setRemoteResults] = useState<NavigationThreadSummary[]>([]);
-  const [remoteLoading, setRemoteLoading] = useState(false);
-  const remoteGenerationRef = useRef(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
 
@@ -72,41 +69,15 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
       .slice(0, MAX_RESULTS);
   }, [trimmed, props.threads]);
 
-  // A remote-viewer window already scopes to one peer; only the main window
-  // fans ⌘K out across the federation.
-  const remoteSearchAvailable =
-    !readRendererFederationTarget()
-    && typeof getDesktopApi()?.jumpSearchRemoteThreads === "function";
-
-  useEffect(() => {
-    const generation = remoteGenerationRef.current + 1;
-    remoteGenerationRef.current = generation;
-    if (!trimmed || !remoteSearchAvailable) {
-      setRemoteResults([]);
-      setRemoteLoading(false);
-      return;
-    }
-    setRemoteLoading(true);
-    const timer = setTimeout(() => {
-      getDesktopApi()
-        ?.jumpSearchRemoteThreads?.({ query: trimmed, limit: MAX_REMOTE_RESULTS })
-        .then((response) => {
-          if (remoteGenerationRef.current !== generation) {
-            return;
-          }
-          setRemoteResults(response.results);
-          setRemoteLoading(false);
-        })
-        .catch(() => {
-          if (remoteGenerationRef.current !== generation) {
-            return;
-          }
-          setRemoteResults([]);
-          setRemoteLoading(false);
-        });
-    }, REMOTE_SEARCH_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
-  }, [trimmed, remoteSearchAvailable]);
+  const {
+    available: remoteSearchAvailable,
+    loading: remoteLoading,
+    results: remoteResults,
+  } = useFederatedThreadSearch({
+    query: trimmed,
+    limit: FEDERATED_THREAD_SEARCH_LIMIT,
+    search: getDesktopApi()?.jumpSearchRemoteThreads,
+  });
 
   // A remote thread already pinned into the local list surfaces as a local
   // hit; don't show it twice.

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
@@ -83,7 +83,7 @@ export function ThreadChip(props: ThreadChipProps) {
         onMouseLeave={tooltipController.hide}
       >
         <ThreadIcon className="thread-chip__icon" size={12} />
-        <span className="thread-chip__label">{label}</span>
+        <span className="thread-chip__label">#{label.replace(/^#/, "")}</span>
       </span>
       {tooltipController.tooltipNode}
       {contextMenuPosition && contextMenuInvokerRef.current ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -3023,6 +3023,7 @@ export function ThreadView(props: ThreadViewProps) {
                   onSelectDirectoryFromPicker={props.onSelectDirectoryFromPicker}
                   onSelectNoDirectoryFromPicker={props.onSelectNoDirectoryFromPicker}
                   onPickAndRegisterDirectory={props.onPickAndRegisterDirectory}
+                  threads={props.threads}
                   onPickAndAttachDirectoryToThread={
                     props.onPickAndAttachDirectoryToThread
                   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -917,6 +917,7 @@ export type ThreadViewProps = {
   selectedDirectory?: NavigationDirectorySummary;
   selectedLaunchpad?: NavigationLaunchpadDraft;
   selectedThread?: NavigationThreadSummary;
+  threads?: NavigationThreadSummary[];
   pendingForkEnvironmentSetup?: PendingForkEnvironmentSetup;
   suppressBranchDriftDialog?: boolean;
   fullAccessRiskWarningDismissed?: boolean;
@@ -3325,6 +3326,7 @@ export function ThreadView(props: ThreadViewProps) {
             providerCommands={props.providerCommands ?? []}
             skills={props.skills}
             thread={selectedThread!}
+            threads={props.threads}
             threadBusy={props.threadBusy}
             updatingExecutionMode={props.updatingExecutionMode}
           />

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   parseGitHubPullRequestUrl,
+  parsePullRequestUrl,
   PullRequestLinkProvider,
 } from "../../../lib/pull-request-links";
 import { ThreadMarkdown } from "../ThreadMarkdown";
@@ -144,6 +145,23 @@ describe("pull request links in transcript markdown", () => {
     expect(screen.queryByRole("link", {
       name: "#13290 — Document JDK 17 for EMR jobs",
     })).not.toBeInTheDocument();
+  });
+
+  it("renders GitLab merge request links with the shared live status chip", () => {
+    const url = "https://gitlab.com/pwrdrvr/platform/PwrAgent/-/merge_requests/49";
+    const pullRequest = prSummary({
+      provider: "gitlab.com",
+      org: "pwrdrvr/platform",
+      repo: "PwrAgent",
+      number: 49,
+      url,
+    });
+    renderWithPullRequests(`Related change: [#49](${url})`, [pullRequest]);
+
+    expect(screen.getByRole("button", {
+      name: /Open pwrdrvr\/platform\/PwrAgent#49/,
+    })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "#49" })).not.toBeInTheDocument();
   });
 
   it("hydrates a bare PR number known on the active thread", () => {
@@ -544,5 +562,34 @@ describe("parseGitHubPullRequestUrl", () => {
     expect(parseGitHubPullRequestUrl(
       "https://github.com/%E0%A4%A/giphy-services/pull/13290",
     )).toBeUndefined();
+  });
+});
+
+describe("parsePullRequestUrl", () => {
+  it.each([
+    {
+      href: "https://github.corp.example/pwrdrvr/PwrAgent/pull/49/files",
+      expected: {
+        provider: "github.corp.example",
+        org: "pwrdrvr",
+        repo: "PwrAgent",
+        number: 49,
+      },
+    },
+    {
+      href: "https://gitlab.com/pwrdrvr/platform/PwrAgent/-/merge_requests/49",
+      expected: {
+        provider: "gitlab.com",
+        org: "pwrdrvr/platform",
+        repo: "PwrAgent",
+        number: 49,
+      },
+    },
+  ])("parses forge-aware pull request links for $href", ({ href, expected }) => {
+    expect(parsePullRequestUrl(href)).toMatchObject({
+      ...expected,
+      state: "unknown",
+      url: href,
+    });
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
@@ -221,6 +221,9 @@ describe("thread links in transcript markdown", () => {
     expect(
       screen.getByRole("button", { name: "Open thread RELATED query deranking issue" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Open thread RELATED query deranking issue" }),
+    ).toHaveTextContent("#RELATED query deranking issue");
     expect(screen.queryByRole("link", { name: "the handoff" })).not.toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -177,6 +177,33 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  const emptyRect = {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    toJSON: () => ({}),
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+  } as DOMRect;
+  Object.defineProperty(Text.prototype, "getClientRects", {
+    configurable: true,
+    value: () => [],
+  });
+  Object.defineProperty(Text.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: () => emptyRect,
+  });
+  Object.defineProperty(Range.prototype, "getClientRects", {
+    configurable: true,
+    value: () => [] as unknown as DOMRectList,
+  });
+  Object.defineProperty(Range.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: () => emptyRect,
+  });
   vi.stubGlobal("Highlight", class {
     ranges: Range[];
     constructor(...ranges: Range[]) {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1607,6 +1607,10 @@ describe("ThreadView", () => {
       updatedAt: 1000,
       workMode: "worktree",
     } satisfies NavigationLaunchpadDraft;
+    const referenceThread = buildTimestampTargetThread(
+      "thread-reference",
+      "Bob's Best Thread 3000",
+    );
 
     render(
       <ThreadView
@@ -1669,6 +1673,7 @@ describe("ThreadView", () => {
         selectedDirectory={selectedDirectory}
         selectedLaunchpad={selectedLaunchpad}
         skills={[]}
+        threads={[referenceThread]}
         transcriptEntries={[]}
         onLoadOlder={async () => undefined}
         removeOptimisticMessage={(_id) => undefined}
@@ -1694,6 +1699,13 @@ describe("ThreadView", () => {
       expect(screen.getByLabelText(/Telegram: Enabled/)).toBeInTheDocument();
     });
     expect(screen.getByRole("group", { name: "Messaging platform status" })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "New thread" }), {
+      target: { value: "Ask #Bob" },
+    });
+    expect(await screen.findByRole("listbox", {
+      name: "Threads and pull requests",
+    })).toHaveTextContent("#Bob's Best Thread 3000");
   });
 
   it("treats a main-window launchpad as remote from the active federation target", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import type { NavigationThreadSummary, PrSummary } from "@pwragent/shared";
+import {
+  filterHashReferenceCandidates,
+  findHashReferenceTrigger,
+} from "../hash-references";
+
+function pullRequest(
+  number: number,
+  repo = "PwrAgent",
+): PrSummary {
+  return {
+    provider: "github.com",
+    org: "pwrdrvr",
+    repo,
+    number,
+    state: "unknown",
+    url: `https://github.com/pwrdrvr/${repo}/pull/${number}`,
+  };
+}
+
+function thread(
+  id: string,
+  title: string,
+  options: Partial<NavigationThreadSummary> = {},
+): NavigationThreadSummary {
+  return {
+    id,
+    title,
+    titleSource: "explicit",
+    source: "codex",
+    linkedDirectories: [],
+    inbox: { unread: false },
+    ...options,
+  } as NavigationThreadSummary;
+}
+
+describe("findHashReferenceTrigger", () => {
+  it("matches a channel-style query with spaces", () => {
+    const draft = "Ask #Bob's Best Thread";
+    expect(findHashReferenceTrigger(draft, draft.length)).toEqual({
+      start: 4,
+      end: draft.length,
+      query: "Bob's Best Thread",
+    });
+  });
+
+  it("does not treat an embedded hash or a previous line as the trigger", () => {
+    expect(findHashReferenceTrigger("repo#123", 8)).toBeUndefined();
+    expect(findHashReferenceTrigger("#first\nplain", 12)).toBeUndefined();
+  });
+});
+
+describe("filterHashReferenceCandidates", () => {
+  it("uses Cmd+K matching for names and orders recent empty-query threads", () => {
+    const candidates = filterHashReferenceCandidates([
+      thread("older", "Bob's Best Thread 3000", { updatedAt: 10 }),
+      thread("newer", "Another thread", { updatedAt: 20 }),
+    ], "Bob's Best");
+    expect(candidates.threads.map((candidate) => candidate.id)).toEqual(["older"]);
+    expect(candidates.pullRequests).toEqual([]);
+
+    const recent = filterHashReferenceCandidates([
+      thread("older", "Older", { updatedAt: 10 }),
+      thread("newer", "Newer", { updatedAt: 20 }),
+    ], "");
+    expect(recent.threads.map((candidate) => candidate.id)).toEqual([
+      "newer",
+      "older",
+    ]);
+  });
+
+  it("shows threads and one deduplicated PR choice for a numeric query", () => {
+    const pr = pullRequest(123);
+    const candidates = filterHashReferenceCandidates([
+      thread("first", "Implement it", { prs: [pr] }),
+      thread("second", "Review it", { prs: [pr] }),
+      thread("other", "Other repository", { prs: [pullRequest(123, "PwrSnap")] }),
+    ], "123");
+
+    expect(candidates.threads.map((candidate) => candidate.id)).toEqual([
+      "first",
+      "second",
+      "other",
+    ]);
+    expect(candidates.pullRequests.map((candidate) => candidate.url)).toEqual([
+      "https://github.com/pwrdrvr/PwrAgent/pull/123",
+      "https://github.com/pwrdrvr/PwrSnap/pull/123",
+    ]);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/hash-references.ts
+++ b/apps/desktop/src/renderer/src/lib/hash-references.ts
@@ -1,0 +1,134 @@
+import {
+  buildPullRequestStatusKey,
+  threadHasExactPrNumberMatch,
+  threadMatchesQuery,
+  type NavigationThreadSummary,
+  type PrSummary,
+} from "@pwragent/shared";
+
+export type HashReferenceTrigger = {
+  end: number;
+  query: string;
+  start: number;
+};
+
+export type HashReferenceCandidates = {
+  pullRequests: PrSummary[];
+  threads: NavigationThreadSummary[];
+};
+
+const THREAD_CANDIDATE_LIMIT = 8;
+const PULL_REQUEST_CANDIDATE_LIMIT = 6;
+
+/**
+ * Match a composer `#` reference from the trigger through the caret. Thread
+ * titles can contain spaces, so the query spans the rest of the current line.
+ * A second `#` starts a new candidate instead of extending the first one.
+ */
+export function findHashReferenceTrigger(
+  text: string,
+  caret: number,
+): HashReferenceTrigger | undefined {
+  const prefix = text.slice(0, caret);
+  const match = /(?:^|\s)#([^\n#]*)$/.exec(prefix);
+  if (!match) {
+    return undefined;
+  }
+
+  const start = prefix.length - match[0].length + match[0].lastIndexOf("#");
+  return {
+    start,
+    end: caret,
+    query: match[1] ?? "",
+  };
+}
+
+/**
+ * The inline sibling of Cmd+K: filter the same thread population with the
+ * shared matcher, then add repository-scoped PR choices when the query is
+ * numeric. A PR attached to several threads appears once.
+ */
+export function filterHashReferenceCandidates(
+  threads: readonly NavigationThreadSummary[],
+  query: string,
+): HashReferenceCandidates {
+  const trimmed = query.trim();
+  const normalized = trimmed.toLowerCase();
+  const threadCandidates = threads
+    .filter((thread) => !trimmed || threadMatchesQuery(thread, trimmed))
+    .sort((left, right) => {
+      const exactPrDifference =
+        Number(threadHasExactPrNumberMatch(right, trimmed))
+        - Number(threadHasExactPrNumberMatch(left, trimmed));
+      if (exactPrDifference !== 0) {
+        return exactPrDifference;
+      }
+
+      const titleDifference =
+        threadTitleMatchRank(left.title, normalized)
+        - threadTitleMatchRank(right.title, normalized);
+      if (titleDifference !== 0) {
+        return titleDifference;
+      }
+
+      return (right.updatedAt ?? right.createdAt ?? 0)
+        - (left.updatedAt ?? left.createdAt ?? 0);
+    })
+    .slice(0, THREAD_CANDIDATE_LIMIT);
+
+  if (!/^\d{1,7}$/.test(trimmed)) {
+    return { pullRequests: [], threads: threadCandidates };
+  }
+
+  const pullRequests = new Map<string, PrSummary>();
+  for (const thread of threads) {
+    for (const pr of thread.prs ?? []) {
+      if (!String(pr.number).includes(trimmed)) {
+        continue;
+      }
+      const key = buildPullRequestStatusKey(pr);
+      if (!pullRequests.has(key)) {
+        pullRequests.set(key, pr);
+      }
+    }
+  }
+
+  return {
+    threads: threadCandidates,
+    pullRequests: [...pullRequests.values()]
+      .sort((left, right) => {
+        const leftNumber = String(left.number);
+        const rightNumber = String(right.number);
+        const exactDifference =
+          Number(rightNumber === trimmed) - Number(leftNumber === trimmed);
+        if (exactDifference !== 0) {
+          return exactDifference;
+        }
+        const prefixDifference =
+          Number(rightNumber.startsWith(trimmed))
+          - Number(leftNumber.startsWith(trimmed));
+        if (prefixDifference !== 0) {
+          return prefixDifference;
+        }
+        return left.number - right.number;
+      })
+      .slice(0, PULL_REQUEST_CANDIDATE_LIMIT),
+  };
+}
+
+function threadTitleMatchRank(title: string, query: string): number {
+  if (!query) {
+    return 0;
+  }
+  const normalizedTitle = title.toLowerCase();
+  if (normalizedTitle === query) {
+    return 0;
+  }
+  if (normalizedTitle.startsWith(query)) {
+    return 1;
+  }
+  if (normalizedTitle.includes(query)) {
+    return 2;
+  }
+  return 3;
+}

--- a/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
@@ -307,7 +307,7 @@ export function PullRequestLinkProvider(props: {
         // Keep the parsed unknown summary as the chip's durable fallback. The
         // live hook hydrates it synchronously from the store, and can return to
         // it if the last matching navigation PR is later detached.
-        return parseGitHubPullRequestUrl(href);
+        return parsePullRequestUrl(href);
       },
       subscribe(pr, listener) {
         return store.subscribe(pr, listener);
@@ -375,6 +375,17 @@ export function resolvePullRequestHref(
 }
 
 export function parseGitHubPullRequestUrl(href: string): PrSummary | undefined {
+  const pullRequest = parsePullRequestUrl(href);
+  if (
+    pullRequest?.provider !== "github.com"
+    || !pullRequestPathMarker(href, "pull")
+  ) {
+    return undefined;
+  }
+  return pullRequest;
+}
+
+export function parsePullRequestUrl(href: string): PrSummary | undefined {
   let parsed: URL;
   try {
     parsed = new URL(href);
@@ -382,33 +393,58 @@ export function parseGitHubPullRequestUrl(href: string): PrSummary | undefined {
     return undefined;
   }
 
-  if (parsed.protocol !== "https:" || parsed.hostname.toLowerCase() !== "github.com") {
+  if (parsed.protocol !== "https:") {
     return undefined;
   }
 
   const segments = parsed.pathname.split("/").filter(Boolean);
-  if (segments.length < 4 || segments[2] !== "pull") {
+  const markerIndex = segments.findIndex(
+    (segment) => segment === "pull" || segment === "merge_requests",
+  );
+  if (markerIndex <= 0 || markerIndex >= segments.length - 1) {
     return undefined;
   }
-  const numberText = segments[3] ?? "";
+  const numberText = segments[markerIndex + 1] ?? "";
   if (!/^[1-9]\d*$/.test(numberText)) {
     return undefined;
   }
 
-  const org = decodeUrlSegment(segments[0] ?? "");
-  const repo = decodeUrlSegment(segments[1] ?? "");
+  const repoIndex = segments[markerIndex - 1] === "-"
+    ? markerIndex - 2
+    : markerIndex - 1;
+  if (repoIndex <= 0) {
+    return undefined;
+  }
+  const orgSegments = segments
+    .slice(0, repoIndex)
+    .map(decodeUrlSegment);
+  const org = orgSegments.every((segment): segment is string => Boolean(segment))
+    ? orgSegments.join("/")
+    : undefined;
+  const repo = decodeUrlSegment(segments[repoIndex] ?? "");
   if (!org || !repo) {
     return undefined;
   }
 
   return {
-    provider: "github.com",
+    provider: parsed.hostname.toLowerCase(),
     org,
     repo,
     number: Number.parseInt(numberText, 10),
     state: "unknown",
     url: href,
   };
+}
+
+function pullRequestPathMarker(
+  href: string,
+  marker: "pull" | "merge_requests",
+): boolean {
+  try {
+    return new URL(href).pathname.split("/").includes(marker);
+  } catch {
+    return false;
+  }
 }
 
 function decodeUrlSegment(value: string): string | undefined {

--- a/apps/desktop/src/renderer/src/lib/useFederatedThreadSearch.ts
+++ b/apps/desktop/src/renderer/src/lib/useFederatedThreadSearch.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from "react";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { getDesktopApi, type DesktopApi } from "./desktop-api";
+import { readRendererFederationTarget } from "./federation-window";
+
+export const FEDERATED_THREAD_SEARCH_LIMIT = 8;
+export const FEDERATED_THREAD_SEARCH_DEBOUNCE_MS = 200;
+
+type RemoteThreadSearch = NonNullable<DesktopApi["jumpSearchRemoteThreads"]>;
+
+export function useFederatedThreadSearch(params: {
+  query: string;
+  limit?: number;
+  search?: RemoteThreadSearch;
+}): {
+  available: boolean;
+  loading: boolean;
+  results: NavigationThreadSummary[];
+} {
+  const [results, setResults] = useState<NavigationThreadSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const generationRef = useRef(0);
+  const query = params.query.trim();
+  const search = params.search ?? getDesktopApi()?.jumpSearchRemoteThreads;
+  // A remote-viewer window already scopes to one peer; only the main window
+  // fans a thread search out across the federation.
+  const available =
+    !readRendererFederationTarget()
+    && typeof search === "function";
+
+  useEffect(() => {
+    const generation = generationRef.current + 1;
+    generationRef.current = generation;
+    if (!query || !available || !search) {
+      setResults([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    const timer = setTimeout(() => {
+      search({
+        query,
+        limit: params.limit ?? FEDERATED_THREAD_SEARCH_LIMIT,
+      })
+        .then((response) => {
+          if (generationRef.current !== generation) {
+            return;
+          }
+          setResults(response.results);
+          setLoading(false);
+        })
+        .catch(() => {
+          if (generationRef.current !== generation) {
+            return;
+          }
+          setResults([]);
+          setLoading(false);
+        });
+    }, FEDERATED_THREAD_SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [available, params.limit, query, search]);
+
+  return { available, loading, results };
+}

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -670,8 +670,8 @@ describe("Tangerine Terminal theme contract", () => {
       "inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 6%, transparent)",
     );
     expect(autocompleteRule).not.toContain("background: rgba(10, 10, 10, 0.98);");
-    expect(directoryAutocompleteRule).toContain("right: auto;");
-    expect(directoryAutocompleteRule).toContain("width: min(100%, 440px);");
+    expect(directoryAutocompleteRule).not.toContain("right: auto;");
+    expect(directoryAutocompleteRule).not.toContain("width: min(100%, 440px);");
     expect(directoryAutocompleteRule).toContain(
       "border-color: var(--border-subtle);",
     );

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -655,6 +655,10 @@ describe("Tangerine Terminal theme contract", () => {
       css,
       ".composer__autocomplete--directories",
     );
+    const hashAutocompleteRule = extractRuleBody(
+      css,
+      ".composer__autocomplete--hash-references",
+    );
     const directoryOptionRule = extractRuleBody(
       css,
       ".composer__autocomplete--directories .composer__autocomplete-option:not(.composer__autocomplete-option--action)",
@@ -670,8 +674,10 @@ describe("Tangerine Terminal theme contract", () => {
       "inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 6%, transparent)",
     );
     expect(autocompleteRule).not.toContain("background: rgba(10, 10, 10, 0.98);");
-    expect(directoryAutocompleteRule).not.toContain("right: auto;");
-    expect(directoryAutocompleteRule).not.toContain("width: min(100%, 440px);");
+    expect(directoryAutocompleteRule).toContain("right: auto;");
+    expect(directoryAutocompleteRule).toContain("width: min(100%, 440px);");
+    expect(hashAutocompleteRule).toContain("right: auto;");
+    expect(hashAutocompleteRule).toContain("width: min(100%, 440px);");
     expect(directoryAutocompleteRule).toContain(
       "border-color: var(--border-subtle);",
     );

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -19696,12 +19696,10 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 /* The typed "@" picker mirrors the compact scan pattern of the "+" reference
-   picker: folder + name on the left, path on the same row at right. Keep the
-   autocomplete's keyboard/type-to-filter behavior, but share the reference
-   picker's panel width, density, and accent-focused row treatment. */
+   picker: folder + name on the left, path on the same row at right. Keep its
+   dense rows and accent-focused treatment while using the same full composer
+   width as the thread-reference autocomplete. */
 .composer__autocomplete--directories {
-  right: auto;
-  width: min(100%, 440px);
   gap: 0;
   padding: 6px;
   border-color: var(--border-subtle);
@@ -19860,6 +19858,38 @@ a.transcript-message__messaging-origin:focus-visible {
   color: var(--text-secondary);
   font-size: 12px;
   line-height: 1.45;
+}
+
+.composer__autocomplete-meta--thread {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+}
+
+.composer__autocomplete-meta--thread .chip--instance {
+  flex: none;
+  height: 18px;
+  padding: 0 6px;
+  font-size: 10px;
+}
+
+.composer__autocomplete-section-divider {
+  margin: 2px 4px 0;
+  padding: 6px 8px 2px;
+  border-top: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.composer__autocomplete-remote-loading {
+  padding: 6px 12px 8px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-style: italic;
 }
 
 /* Divider between the matched options and the "Add directory… / Add

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -17484,6 +17484,10 @@ a.transcript-message__messaging-origin:focus-visible {
   cursor: default;
 }
 
+.composer-tiptap-input__mention.composer-pr-chip {
+  cursor: default;
+}
+
 .composer__mentioned-skills {
   display: flex;
   flex-wrap: wrap;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -19696,14 +19696,23 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 /* The typed "@" picker mirrors the compact scan pattern of the "+" reference
-   picker: folder + name on the left, path on the same row at right. Keep its
-   dense rows and accent-focused treatment while using the same full composer
-   width as the thread-reference autocomplete. */
+   picker: folder + name on the left, path on the same row at right. Keep the
+   autocomplete's keyboard/type-to-filter behavior, but share the reference
+   picker's panel width, density, and accent-focused row treatment. */
 .composer__autocomplete--directories {
+  right: auto;
+  width: min(100%, 440px);
   gap: 0;
   padding: 6px;
   border-color: var(--border-subtle);
   box-shadow: var(--shadow-popover);
+}
+
+/* Thread and PR results use the same compact popover width as the `@` picker;
+   full composer width leaves large rows mostly empty on wide chat panes. */
+.composer__autocomplete--hash-references {
+  right: auto;
+  width: min(100%, 440px);
 }
 
 .composer__autocomplete--directories .composer__autocomplete-option:not(.composer__autocomplete-option--action) {

--- a/packages/shared/src/contracts/composer-drafts.ts
+++ b/packages/shared/src/contracts/composer-drafts.ts
@@ -31,9 +31,11 @@ export type ComposerDraftSkillToken = {
    * chip: `name` is the file's basename and `path` its absolute file
    * path. Both serialize to the same `[@label](~/path)` markdown. "thread"
    * marks a known-thread reference: `name` is its display title and `path`
-   * is its canonical `pwragent://thread/...` URL.
+   * is its canonical `pwragent://thread/...` URL. "pull-request" marks a
+   * repository-scoped PR reference: `name` is its `#123` label and `path` is
+   * the full provider URL.
    */
-  kind?: "directory" | "file" | "thread";
+  kind?: "directory" | "file" | "pull-request" | "thread";
 };
 
 export type ComposerDraftSnapshotRecord = {


### PR DESCRIPTION
## What changed

- add a composer `#` autocomplete that searches the same thread metadata as Cmd+K
- show matching threads and deduplicated, repository-scoped pull requests together for numeric queries
- insert thread references as channel-style `#Thread name` chips and PR choices as precise GitHub links
- render existing thread chips with a leading `#` in both composers and transcripts
- persist the new pull-request token kind through durable composer drafts

## Why

Threads are the primary PwrAgent object and already behave like messaging channels. A channel-style `#` reference makes cross-thread prompts discoverable without copying UUIDs, while the mixed numeric result list resolves the overlap with conventional `#123` PR references without requiring tabs.

## User impact

Typing `#` in a composer now brings the thread picker directly to the caret. Typing a thread name inserts a navigable thread chip. Typing digits shows both threads attached to matching PRs and the PR itself, with repository identity preserved when PR numbers collide.

## Validation

- 280 focused Vitest tests passed across composer behavior, rich-text input, durable drafts, thread links, and hash-reference matching
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`
