### PR TITLE
fix(desktop): page federated history by turn

### DIFF
--- a/apps/desktop/src/main/__tests__/thread-replay-pagination.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-replay-pagination.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AppServerThreadEntry,
+  AppServerThreadReplay,
+} from "@pwragent/shared";
+import { pageNormalizedReplay } from "../app-server/thread-replay-pagination";
+
+describe("thread replay pagination", () => {
+  it("keeps complete turns when a backend needs synthetic pagination", () => {
+    const replay = buildReplay([
+      turnEntry("turn-1", "user", "Question one"),
+      turnEntry("turn-1", "assistant", "Working one", "commentary"),
+      turnEntry("turn-1", "assistant", "Answer one", "final"),
+      turnEntry("turn-2", "user", "Question two"),
+      turnEntry("turn-2", "assistant", "Working two", "commentary"),
+      turnEntry("turn-2", "assistant", "Answer two", "final"),
+    ]);
+
+    const page = pageNormalizedReplay(replay, { limit: 2 });
+
+    expect(page.entries.map((entry) => entry.id)).toEqual([
+      "turn-1-user-Question one",
+      "turn-1-assistant-Working one",
+      "turn-1-assistant-Answer one",
+      "turn-2-user-Question two",
+      "turn-2-assistant-Working two",
+      "turn-2-assistant-Answer two",
+    ]);
+    expect(page.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: false,
+    });
+  });
+
+  it("starts a synthetic page at the first entry of its oldest retained turn", () => {
+    const replay = buildReplay([
+      turnEntry("turn-1", "user", "Question one"),
+      turnEntry("turn-1", "assistant", "Answer one", "final"),
+      turnEntry("turn-2", "user", "Question two"),
+      turnEntry("turn-2", "assistant", "Working two", "commentary"),
+      turnEntry("turn-2", "assistant", "Answer two", "final"),
+      turnEntry("turn-3", "user", "Question three"),
+      turnEntry("turn-3", "assistant", "Answer three", "final"),
+    ]);
+
+    const page = pageNormalizedReplay(replay, { limit: 2 });
+
+    expect(page.entries.map((entry) => entry.id)).toEqual([
+      "turn-2-user-Question two",
+      "turn-2-assistant-Working two",
+      "turn-2-assistant-Answer two",
+      "turn-3-user-Question three",
+      "turn-3-assistant-Answer three",
+    ]);
+    expect(page.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: true,
+      previousCursor: "turn-2-user-Question two",
+    });
+  });
+});
+
+function buildReplay(entries: AppServerThreadEntry[]): AppServerThreadReplay {
+  return {
+    entries,
+    messages: entries.flatMap((entry) =>
+      entry.type === "message"
+        ? [{
+            id: entry.id,
+            role: entry.role,
+            text: entry.text,
+            ...(entry.phase ? { phase: entry.phase } : {}),
+            ...(entry.turn ? { turn: entry.turn } : {}),
+          }]
+        : [],
+    ),
+    pagination: {
+      supportsPagination: false,
+      hasPreviousPage: false,
+    },
+  };
+}
+
+function turnEntry(
+  turnId: string,
+  role: "assistant" | "user",
+  text: string,
+  phase?: "commentary" | "final",
+): AppServerThreadEntry {
+  return {
+    type: "message",
+    id: `${turnId}-${role}-${text}`,
+    role,
+    text,
+    ...(phase ? { phase } : {}),
+    turn: {
+      id: turnId,
+      status: "completed",
+    },
+  };
+}

--- a/apps/desktop/src/main/__tests__/thread-replay-pagination.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-replay-pagination.test.ts
@@ -58,6 +58,27 @@ describe("thread replay pagination", () => {
       previousCursor: "turn-2-user-Question two",
     });
   });
+
+  it("uses bounded entry paging when turn metadata is only partial", () => {
+    const replay = buildReplay([
+      legacyEntry("legacy-user", "user", "Question one"),
+      turnEntry("turn-1", "assistant", "Answer one", "final"),
+      turnEntry("turn-2", "user", "Question two"),
+      turnEntry("turn-2", "assistant", "Answer two", "final"),
+    ]);
+
+    const page = pageNormalizedReplay(replay, { limit: 2 });
+
+    expect(page.entries.map((entry) => entry.id)).toEqual([
+      "turn-2-user-Question two",
+      "turn-2-assistant-Answer two",
+    ]);
+    expect(page.pagination).toEqual({
+      supportsPagination: true,
+      hasPreviousPage: true,
+      previousCursor: "turn-2-user-Question two",
+    });
+  });
 });
 
 function buildReplay(entries: AppServerThreadEntry[]): AppServerThreadReplay {
@@ -97,5 +118,18 @@ function turnEntry(
       id: turnId,
       status: "completed",
     },
+  };
+}
+
+function legacyEntry(
+  id: string,
+  role: "assistant" | "user",
+  text: string,
+): AppServerThreadEntry {
+  return {
+    type: "message",
+    id,
+    role,
+    text,
   };
 }

--- a/apps/desktop/src/main/app-server/thread-replay-pagination.ts
+++ b/apps/desktop/src/main/app-server/thread-replay-pagination.ts
@@ -38,9 +38,50 @@ export function pageNormalizedReplay(
   const boundedEndIndex = endIndex >= 0 ? endIndex : replay.entries.length;
   const limit =
     options.limit === undefined ? undefined : Math.max(0, Math.floor(options.limit));
-  const startIndex = limit === undefined ? 0 : Math.max(0, boundedEndIndex - limit);
+  const startIndex = limit === undefined
+    ? 0
+    : findTurnPageStartIndex(replay.entries, boundedEndIndex, limit);
   const entries = replay.entries.slice(startIndex, boundedEndIndex);
   return replayWithEntries(replay, entries, startIndex > 0);
+}
+
+function findTurnPageStartIndex(
+  entries: AppServerThreadEntry[],
+  endIndex: number,
+  limit: number,
+): number {
+  if (limit === 0) {
+    return endIndex;
+  }
+
+  const turnIds = new Set<string>();
+  let oldestRetainedTurnId: string | undefined;
+  for (let index = endIndex - 1; index >= 0; index -= 1) {
+    const turnId = entries[index]?.turn?.id;
+    if (!turnId || turnIds.has(turnId)) {
+      continue;
+    }
+    if (turnIds.size >= limit) {
+      break;
+    }
+    turnIds.add(turnId);
+    oldestRetainedTurnId = turnId;
+  }
+
+  // Older replay formats do not consistently carry turn metadata. Preserve
+  // their established entry-count paging instead of treating the entire
+  // transcript as one synthetic turn.
+  if (!oldestRetainedTurnId) {
+    return Math.max(0, endIndex - limit);
+  }
+  if (turnIds.size < limit) {
+    return 0;
+  }
+
+  const firstTurnEntryIndex = entries.findIndex(
+    (entry, index) => index < endIndex && entry.turn?.id === oldestRetainedTurnId,
+  );
+  return firstTurnEntryIndex >= 0 ? firstTurnEntryIndex : 0;
 }
 
 export function fitNormalizedReplayWithinByteBudget(params: {

--- a/apps/desktop/src/main/app-server/thread-replay-pagination.ts
+++ b/apps/desktop/src/main/app-server/thread-replay-pagination.ts
@@ -54,6 +54,16 @@ function findTurnPageStartIndex(
     return endIndex;
   }
 
+  // Turn metadata is optional in older replay formats and may be present on
+  // only part of a logical turn. Mixing both paging strategies can then split
+  // that turn or turn a bounded request into the entire replay, so preserve
+  // entry-count paging unless every entry in scope has a turn ID.
+  for (let index = 0; index < endIndex; index += 1) {
+    if (!entries[index]?.turn?.id) {
+      return Math.max(0, endIndex - limit);
+    }
+  }
+
   const turnIds = new Set<string>();
   let oldestRetainedTurnId: string | undefined;
   for (let index = endIndex - 1; index >= 0; index -= 1) {
@@ -68,9 +78,7 @@ function findTurnPageStartIndex(
     oldestRetainedTurnId = turnId;
   }
 
-  // Older replay formats do not consistently carry turn metadata. Preserve
-  // their established entry-count paging instead of treating the entire
-  // transcript as one synthetic turn.
+  // Empty replays still use the established entry-count paging result.
   if (!oldestRetainedTurnId) {
     return Math.max(0, endIndex - limit);
   }


### PR DESCRIPTION
## What changed

- Page non-native Federation transcript history by complete turns instead of raw timeline-entry count.
- Keep every commentary, activity, and final entry belonging to each retained turn.
- Preserve the established entry-count fallback for legacy replays without turn metadata.
- Add regression coverage for both a transcript that fits within the requested turn limit and a page boundary spanning commentary/final entries.

## Root cause

The renderer requests the latest five **turns**, but Federation's synthetic paginator interpreted that limit as five raw replay entries. A thread with only a few turns but many commentary/activity entries therefore opened on the last handful of entries from its final turn, matching the truncated remote-viewer screenshot. The renderer already supports upward-scroll and underflow backfill; it was being given a page cut at the wrong semantic boundary.

The M5 Max viewer log contained no matching Federation or renderer error and does not record readThread pagination fields or older-page requests, so there was no viewer exception to repair.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/thread-replay-pagination.test.ts apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts apps/desktop/src/main/__tests__/app-server-ipc.test.ts` (133 tests)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` (0 errors; existing warnings only)
