### PR TITLE
fix(federation): preserve ordered remote thread reactions

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1911,6 +1911,71 @@ describe("app server ipc", () => {
     expect(appDirectory?.needsAttentionCount).toBe(2);
   });
 
+  it("marks a pinned remote snapshot changed when only reactions change", async () => {
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const { buildFederatedThreadRef } = await import("@pwragent/shared");
+    const ref = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "peer-laptop",
+      threadId: "remote-reactions",
+    });
+    const pin = { ref, addedAt: 1_000, instanceLabel: "Laptop" };
+    const localSnapshot = (unchanged: boolean) => ({
+      backend: "all" as const,
+      fetchedAt: 1_000,
+      unchanged,
+      threads: [],
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    });
+    const remoteRow = (reactions: string[]) => ({
+      source: "codex" as const,
+      id: "remote-reactions",
+      title: "Remote reactions",
+      titleSource: "explicit" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      reactions,
+      federation: {
+        ref,
+        instanceLabel: "Laptop",
+        peerStatus: "connected" as const,
+        capabilities: [],
+      },
+    });
+    reconcileNavigationSnapshot
+      .mockResolvedValueOnce(localSnapshot(false))
+      .mockResolvedValueOnce(localSnapshot(true));
+    listRemoteThreadPins
+      .mockResolvedValueOnce([pin])
+      .mockResolvedValueOnce([pin]);
+    federationMock.remoteThreadSummaries.resolvePinnedThreads
+      .mockResolvedValueOnce({
+        threads: [remoteRow(["✋"])],
+        refreshed: [],
+        archived: [],
+      })
+      .mockResolvedValueOnce({
+        threads: [remoteRow(["✋", "👀"])],
+        refreshed: [],
+        archived: [],
+      });
+    registerAppServerIpcHandlers();
+
+    const first = await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    const second = await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+
+    expect(first).toMatchObject({ unchanged: false });
+    expect(second).toMatchObject({
+      unchanged: false,
+      threads: [expect.objectContaining({ reactions: ["✋", "👀"] })],
+    });
+  });
+
   it("removes a viewer-side remote pin when the owner proves it is archived", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
@@ -3219,6 +3284,31 @@ describe("app server ipc", () => {
       backend: "codex",
       threadId: "thread-remote",
       reactions: ["✋", "👀"],
+    });
+  });
+
+  it("publishes local reaction mutations to navigation subscribers", async () => {
+    const { NAVIGATION_SET_THREAD_REACTION_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_SET_THREAD_REACTION_CHANNEL)?.({}, {
+      backend: "codex",
+      threadId: "thread-local",
+      emoji: "👀",
+      present: true,
+    });
+
+    expect(publishLocalEvent).toHaveBeenCalledWith({
+      backend: "codex",
+      notification: {
+        method: "thread/reactions/updated",
+        params: {
+          threadId: "thread-local",
+          reactions: ["👀"],
+        },
+      },
     });
   });
 

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -44,6 +44,14 @@ const federationMock = vi.hoisted(() => {
       seenAt: request.seenAt ?? 6_000,
       seenUpdatedAt: request.seenUpdatedAt,
     })),
+    setThreadReaction: vi.fn(async (request: {
+      backend?: "codex" | "grok";
+      threadId: string;
+    }) => ({
+      backend: request.backend ?? "codex",
+      threadId: request.threadId,
+      reactions: ["✋", "👀"],
+    })),
     renameThread: vi.fn(async (request: RenameThreadRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
@@ -466,6 +474,17 @@ const markThreadSeen = vi.fn(async (request: MarkThreadSeenRequest) => ({
   seenAt: request.seenAt ?? 2000,
   seenUpdatedAt: request.seenUpdatedAt,
 }));
+const setThreadReactionOverlay = vi.fn(async (request: {
+  backend: "codex" | "grok";
+  threadId: string;
+  emoji: string;
+}) => ({
+  backend: request.backend,
+  threadId: request.threadId,
+  executionMode: "default" as const,
+  extraLinkedDirectories: [],
+  reactions: [request.emoji],
+}));
 const registerDirectoryFromDiskService = vi.fn(async (request: { path: string }) => {
   const directoryPath = path.resolve(request.path);
   return {
@@ -771,6 +790,7 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     addRemoteThreadPin: addRemoteThreadPinStore,
     hasRemoteThreadPin,
     setRemoteThreadLocalPin,
+    setThreadReaction: setThreadReactionOverlay,
     setThreadPin: setThreadPinOverlay,
     listPinnedThreadOverlayRanks,
     reorderThreadPins: reorderThreadPinsStore,
@@ -891,6 +911,7 @@ describe("app server ipc", () => {
     federationMock.remoteBackend.renameThread.mockClear();
     federationMock.remoteBackend.archiveThread.mockClear();
     federationMock.remoteBackend.markThreadSeen.mockClear();
+    federationMock.remoteBackend.setThreadReaction.mockClear();
     federationMock.remoteBackend.refreshDirectoryGitStatuses.mockClear();
     federationMock.runtime.remoteBackend.mockClear();
     federationMock.runtime.remoteNavigationSnapshot.mockReset();
@@ -930,6 +951,7 @@ describe("app server ipc", () => {
     setThreadPrAutoDispatchBatch.mockClear();
     ensureDirectoryLaunchpad.mockClear();
     markThreadSeen.mockClear();
+    setThreadReactionOverlay.mockClear();
     registerDirectoryFromDiskService.mockClear();
     addLinkedDirectory.mockClear();
     removeLinkedDirectory.mockClear();
@@ -3160,6 +3182,43 @@ describe("app server ipc", () => {
       threadId: "thread-remote",
       seenAt: 6_000,
       seenUpdatedAt: 3_000,
+    });
+  });
+
+  it("adds remote thread reactions on the owner without replacing its ordered reactions", async () => {
+    const { NAVIGATION_SET_THREAD_REACTION_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(
+      NAVIGATION_SET_THREAD_REACTION_CHANNEL,
+    )?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-remote",
+      emoji: "👀",
+      present: true,
+    });
+
+    expect(federationMock.runtime.remoteBackend).toHaveBeenCalledWith(
+      federationTarget,
+    );
+    expect(federationMock.remoteBackend.setThreadReaction).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-remote",
+      emoji: "👀",
+      present: true,
+    });
+    expect(setThreadReactionOverlay).not.toHaveBeenCalled();
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-remote",
+      reactions: ["✋", "👀"],
     });
   });
 

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -17,6 +17,60 @@ import { FederationRpcEndpoint } from "../federation/federation-rpc";
 import { FEDERATION_MAX_FRAME_BYTES } from "../federation/federation-transport";
 
 describe("federation backend bridge", () => {
+  it("routes thread reactions through the thread-navigation capability", async () => {
+    const sent: FederationProtocolEnvelope[] = [];
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "viewer_one",
+      remoteInstanceId: "owner_one",
+      sendEnvelope: (envelope) => sent.push(envelope),
+      now: () => 1_000,
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+
+    const pending = client.setThreadReaction({
+      backend: "codex",
+      threadId: "thread-remote",
+      emoji: "👀",
+      present: true,
+    });
+    const request = sent.at(-1)!;
+    expect(request).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.setThreadReaction,
+      params: {
+        backend: "codex",
+        threadId: "thread-remote",
+        emoji: "👀",
+        present: true,
+      },
+    });
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.setThreadReaction
+      ],
+    ).toBe("thread_navigation");
+
+    rpc.receiveEnvelope({
+      id: "response-reaction",
+      kind: "response",
+      requestId: request.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_100,
+      result: {
+        backend: "codex",
+        threadId: "thread-remote",
+        reactions: ["✋", "👀"],
+      },
+    });
+    await expect(pending).resolves.toEqual({
+      backend: "codex",
+      threadId: "thread-remote",
+      reactions: ["✋", "👀"],
+    });
+  });
+
   it("reads remote PwrSnap status through its dedicated capability", async () => {
     const sent: FederationProtocolEnvelope[] = [];
     const rpc = new FederationRpcEndpoint({
@@ -1798,6 +1852,7 @@ describe("federation backend bridge", () => {
       listSkills: vi.fn(),
       listBackends: vi.fn(),
       markThreadSeen: vi.fn(),
+      setThreadReaction: vi.fn(),
       setThreadPin: vi.fn(),
       reorderThreadPins: vi.fn(),
       detachThreadPullRequest: vi.fn(),
@@ -2018,6 +2073,7 @@ describe("federation backend bridge", () => {
         listSkills: vi.fn(),
         listBackends: vi.fn(),
         markThreadSeen: vi.fn(),
+        setThreadReaction: vi.fn(),
       setThreadPin: vi.fn(),
       reorderThreadPins: vi.fn(),
         detachThreadPullRequest: vi.fn(),

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -1420,6 +1420,50 @@ describe("DesktopFederationRuntime", () => {
     expect(invalidated).toEqual(["client_one"]);
   });
 
+  it("invalidates cached remote summaries when a peer updates reactions", () => {
+    const invalidated: Array<string | undefined> = [];
+    const router = new FederationRouter({ localInstanceId: "gateway_one" });
+    router.registerConnection(createConnection({
+      peerId: "client_one",
+      capabilities: ["thread_navigation", "event_subscriptions"],
+    }));
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "gateway_one";
+    runtime.router = router;
+    runtime.setEventSubscriptions("viewer", [{
+      sourceInstanceId: "client_one",
+      eventClasses: ["navigation"],
+    }]);
+    runtime.remoteThreadSummaryCache = {
+      invalidate: (instanceId) => invalidated.push(instanceId),
+    };
+
+    runtime.publishRemoteBackendEvent(
+      {
+        id: "event-reactions",
+        kind: "notification",
+        method: FEDERATION_BACKEND_EVENT_METHOD,
+        params: {
+          backend: "codex",
+          notification: {
+            method: "thread/reactions/updated",
+            params: {
+              threadId: "thread-1",
+              reactions: ["✋", "👀"],
+            },
+          },
+        },
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: "client_one",
+        targetInstanceId: "gateway_one",
+        createdAt: 2_000,
+      },
+      "client_one",
+    );
+
+    expect(invalidated).toEqual(["client_one"]);
+  });
+
   it("subscribes Cmd+K snapshot peers to navigation updates for the cache TTL", async () => {
     vi.useFakeTimers();
     const sent: FederationProtocolEnvelope[] = [];

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -43,6 +43,8 @@ import type {
   MarkThreadSeenResponse,
   MessagingPlatformStatus,
   PwrSnapConnectionStatus,
+  SetThreadReactionRequest,
+  SetThreadReactionResponse,
   SetThreadPinRequest,
   SetThreadPinResponse,
   SetThreadPrAutoDispatchRequest,
@@ -136,6 +138,7 @@ export const FEDERATION_BACKEND_METHODS = {
   listSkills: "backend.listSkills",
   listBackends: "backend.listBackends",
   markThreadSeen: "backend.markThreadSeen",
+  setThreadReaction: "backend.setThreadReaction",
   setThreadPin: "backend.setThreadPin",
   reorderThreadPins: "backend.reorderThreadPins",
   detachThreadPullRequest: "backend.detachThreadPullRequest",
@@ -212,6 +215,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.listSkills]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.listBackends]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.markThreadSeen]: "thread_navigation",
+  [FEDERATION_BACKEND_METHODS.setThreadReaction]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.setThreadPin]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.reorderThreadPins]: "thread_navigation",
   // PR detach cancels pending auto-dispatch work and auto-dispatch arms
@@ -297,6 +301,9 @@ export type FederationBackendOperations = {
   ): Promise<AppServerListSkillsResponse>;
   listBackends(request?: ListBackendsRequest): Promise<ListBackendsResponse>;
   markThreadSeen(request: MarkThreadSeenRequest): Promise<MarkThreadSeenResponse>;
+  setThreadReaction(
+    request: SetThreadReactionRequest,
+  ): Promise<SetThreadReactionResponse>;
   setThreadPin(request: SetThreadPinRequest): Promise<SetThreadPinResponse>;
   reorderThreadPins(
     request: ReorderThreadPinsRequest,
@@ -506,6 +513,13 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.markThreadSeen(
         envelope.params as MarkThreadSeenRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.setThreadReaction,
+    async (envelope) =>
+      await params.backend.setThreadReaction(
+        envelope.params as SetThreadReactionRequest,
       ),
   );
   params.router.registerHandler(
@@ -918,6 +932,15 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<SetThreadPinResponse> {
     return await this.rpc.request<SetThreadPinResponse>({
       method: FEDERATION_BACKEND_METHODS.setThreadPin,
+      params: request,
+    });
+  }
+
+  async setThreadReaction(
+    request: SetThreadReactionRequest,
+  ): Promise<SetThreadReactionResponse> {
+    return await this.rpc.request<SetThreadReactionResponse>({
+      method: FEDERATION_BACKEND_METHODS.setThreadReaction,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -392,6 +392,7 @@ const NAVIGATION_EVENT_METHODS = new Set<string>([
   "thread/pin/added",
   "thread/pin/removed",
   "thread/pin/reordered",
+  "thread/reactions/updated",
   "thread/prAutoDispatch/pendingUpdated",
   "thread/prAutoDispatch/updated",
   "thread/pullRequests/updated",
@@ -3496,7 +3497,10 @@ export class DesktopFederationRuntime {
       },
       notification: notification.params.notification,
     };
-    if (event.notification.method === "thread/pullRequests/updated") {
+    if (
+      event.notification.method === "thread/pullRequests/updated"
+      || event.notification.method === "thread/reactions/updated"
+    ) {
       this.remoteThreadSummaryCache?.invalidate(sourceInstanceId);
     }
     this.publishAgentEvent?.(event);
@@ -3654,10 +3658,21 @@ function localBackendOperations(): FederationBackendOperations {
         emoji: request.emoji,
         present: request.present,
       });
+      const reactions = overlay.reactions ?? [];
+      await getDesktopBackendRegistry().publishLocalEvent({
+        backend,
+        notification: {
+          method: "thread/reactions/updated",
+          params: {
+            threadId: request.threadId,
+            reactions,
+          },
+        },
+      });
       return {
         backend,
         threadId: request.threadId,
-        reactions: overlay.reactions ?? [],
+        reactions,
       };
     },
     async readMessagingPlatformStatuses(): Promise<MessagingPlatformStatus[]> {

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -100,6 +100,8 @@ import {
   type MarkThreadSeenRequest,
   type SetThreadPinRequest,
   type SetThreadPinResponse,
+  type SetThreadReactionRequest,
+  type SetThreadReactionResponse,
   type SetThreadPrAutoDispatchRequest,
   type SetThreadPrAutoDispatchResponse,
   type CancelThreadPrAutoDispatchRequest,
@@ -3640,6 +3642,22 @@ function localBackendOperations(): FederationBackendOperations {
         backend,
         threadId: request.threadId,
         pinnedRank: overlay.pinnedRank,
+      };
+    },
+    async setThreadReaction(
+      request: SetThreadReactionRequest,
+    ): Promise<SetThreadReactionResponse> {
+      const backend = request.backend ?? "codex";
+      const overlay = await getDesktopOverlayStore().setThreadReaction({
+        backend,
+        threadId: request.threadId,
+        emoji: request.emoji,
+        present: request.present,
+      });
+      return {
+        backend,
+        threadId: request.threadId,
+        reactions: overlay.reactions ?? [],
       };
     },
     async readMessagingPlatformStatuses(): Promise<MessagingPlatformStatus[]> {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -5466,6 +5466,15 @@ class DesktopAppServerService {
   async setThreadReaction(
     request: SetThreadReactionRequest,
   ): Promise<SetThreadReactionResponse> {
+    if (
+      request.federationTarget
+      && isRemoteFederationTarget(request.federationTarget)
+    ) {
+      const { federationTarget, ...remoteRequest } = request;
+      return await getDesktopFederationRuntime()
+        .remoteBackend(federationTarget)
+        .setThreadReaction(remoteRequest);
+    }
     const backend = request.backend ?? "codex";
 
     const overlay = await this.getOverlayStore().setThreadReaction({

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2047,7 +2047,7 @@ class DesktopAppServerService {
    * background and land via `navigation/remoteThreadPins/changed`, so
    * navigation refresh latency stays independent of peer responsiveness.
    * The merged rows get their own change hash so a peer-side
-   * title/PR/status change can never be suppressed by the local
+   * title/PR/reaction/status change can never be suppressed by the local
    * `unchanged` optimization.
    */
   private async mergePinnedRemoteThreads(): Promise<{
@@ -2113,6 +2113,7 @@ class DesktopAppServerService {
         updatedAt: thread.updatedAt,
         prs: thread.prs,
         federation: thread.federation,
+        reactions: thread.reactions,
         // Viewer-owned rank: a local pin/unpin must invalidate the snapshot.
         pinnedRank: thread.pinnedRank,
         // Directory-group membership derives from these; a peer-side project
@@ -5492,10 +5493,22 @@ class DesktopAppServerService {
       reactionCount: overlay.reactions?.length ?? 0,
     });
 
+    const reactions = overlay.reactions ?? [];
+    await getDesktopBackendRegistry().publishLocalEvent({
+      backend,
+      notification: {
+        method: "thread/reactions/updated",
+        params: {
+          threadId: request.threadId,
+          reactions,
+        },
+      },
+    });
+
     return {
       backend,
       threadId: request.threadId,
-      reactions: overlay.reactions ?? [],
+      reactions,
     };
   }
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -8979,6 +8979,87 @@ describe("useThreadNavigation", () => {
     expect(result.current.threads[0]?.prs?.[0]?.number).toBe(999);
   });
 
+  it("applies a peer's reaction event only to its pinned row", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+      threads: [
+        {
+          id: "shared-thread-id",
+          title: "Local thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+          reactions: ["🏠"],
+        },
+        {
+          id: "shared-thread-id",
+          title: "Pinned remote thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+          reactions: ["✋"],
+          federation: {
+            instanceLabel: "Remote Mac",
+            ref: {
+              backend: "codex" as const,
+              target: federationTarget,
+              threadId: "shared-thread-id",
+            },
+          },
+        },
+      ],
+    }));
+    const desktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (
+        callback: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0],
+      ) => {
+        agentEventHandler = callback;
+        return () => {
+          agentEventHandler = undefined;
+        };
+      },
+    } as unknown as DesktopApi;
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(2);
+    });
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        federationTarget,
+        notification: {
+          method: "thread/reactions/updated",
+          params: {
+            threadId: "shared-thread-id",
+            reactions: ["✋", "👀"],
+          },
+        },
+      } as never);
+    });
+
+    expect(result.current.threads[0]?.reactions).toEqual(["🏠"]);
+    expect(result.current.threads[1]?.reactions).toEqual(["✋", "👀"]);
+  });
+
   describe("pickAndRegisterDirectory (issue #223)", () => {
     const launchpadDefaults = {
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2259,6 +2259,77 @@ describe("useThreadNavigation", () => {
     expect(setRemoteThreadLocalPin).not.toHaveBeenCalled();
   });
 
+  it("adds reactions through the owner in a remote-viewer window", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    (window as typeof window & {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = federationTarget;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: 1_000,
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [
+        {
+          id: "thread-remote",
+          title: "Remote thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          reactions: ["✋"],
+          inbox: { inInbox: false },
+          federation: {
+            instanceLabel: "Remote Mac",
+            ref: {
+              backend: "codex" as const,
+              target: federationTarget,
+              threadId: "thread-remote",
+            },
+          },
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const setThreadReaction = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-remote",
+      reactions: ["✋", "👀"],
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      setThreadReaction,
+      onAgentEvent: () => () => undefined,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.reactions).toEqual(["✋"]);
+    });
+    await act(async () => {
+      await result.current.setThreadReaction(
+        result.current.threads[0]!,
+        "👀",
+        true,
+      );
+    });
+
+    expect(setThreadReaction).toHaveBeenCalledWith({
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-remote",
+      emoji: "👀",
+      present: true,
+    });
+    expect(result.current.threads[0]?.reactions).toEqual(["✋", "👀"]);
+  });
+
   it("marks a remote snapshot unavailable and refreshes it after reconnect", async () => {
     const federationTarget = {
       scope: "remote" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -5970,6 +5970,8 @@ export function useThreadNavigation(
       try {
         const result = await setThreadReactionRequest({
           backend: thread.source,
+          federationTarget: thread.federation?.ref.target ??
+            readRendererFederationTarget(),
           threadId: thread.id,
           emoji,
           present,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -890,6 +890,7 @@ function updateThreadReactionsInSnapshot(
   snapshot: NavigationSnapshot | undefined,
   params: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
     reactions: string[];
   },
@@ -902,6 +903,14 @@ function updateThreadReactionsInSnapshot(
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
     if (buildThreadIdentityKey(thread.source, thread.id) !== threadKey) {
+      return thread;
+    }
+    if (
+      !federationTargetsEqual(
+        thread.federation?.ref.target,
+        params.federationTarget,
+      )
+    ) {
       return thread;
     }
     const current = thread.reactions ?? [];
@@ -3227,24 +3236,25 @@ export function useThreadNavigation(
     return desktopApi.onAgentEvent((event) => {
       const windowTarget = readRendererFederationTarget();
       const method = event.notification.method as string;
-      // A peer's PR events are stamped with its own remote target, so they
-      // never match the main window's (absent) target — yet this window
-      // hosts that peer's threads as viewer-side remote pins, and those
-      // rows are the only place their PR chips are shown. Let them past
-      // the target filter and into the shared appliers below.
+      // A peer's row-state events carry its own remote target, which never
+      // matches the main window's absent target — yet this window
+      // hosts that peer's threads as viewer-side remote pins. Let PR and
+      // reaction updates past the target filter and into their origin-scoped
+      // appliers below.
       //
       // Safe against duelling monitors: the main process drops a peer
       // observation for any PR this instance monitors itself, so whatever
       // arrives here has no local poller to contradict. When we do own the
       // PR, our own local event patches the pinned row instead — status
       // updates match by prKey across every thread in the snapshot.
-      const remotePullRequestPassthrough =
+      const remoteThreadStatePassthrough =
         !windowTarget
         && Boolean(event.federationTarget)
         && (method === "pullRequest/status/updated"
-          || method === "thread/pullRequests/updated");
+          || method === "thread/pullRequests/updated"
+          || method === "thread/reactions/updated");
       if (
-        !remotePullRequestPassthrough
+        !remoteThreadStatePassthrough
         && !federationTargetsEqual(event.federationTarget, windowTarget)
       ) {
         // Peer-status events are stamped with the peer's own remote target,
@@ -3415,6 +3425,23 @@ export function useThreadNavigation(
           };
         });
         scheduleRefresh();
+        return;
+      }
+
+      if (method === "thread/reactions/updated") {
+        const { threadId, reactions } = event.notification.params as {
+          threadId: string;
+          reactions: string[];
+        };
+        setState((current) => ({
+          ...current,
+          response: updateThreadReactionsInSnapshot(current.response, {
+            backend: event.backend,
+            federationTarget: event.federationTarget,
+            threadId,
+            reactions,
+          }),
+        }));
         return;
       }
 
@@ -5962,6 +5989,8 @@ export function useThreadNavigation(
         ...current,
         response: updateThreadReactionsInSnapshot(current.response, {
           backend: thread.source,
+          federationTarget: thread.federation?.ref.target ??
+            readRendererFederationTarget(),
           threadId: thread.id,
           reactions: optimisticReactions,
         }),
@@ -5981,6 +6010,8 @@ export function useThreadNavigation(
           ...current,
           response: updateThreadReactionsInSnapshot(current.response, {
             backend: thread.source,
+            federationTarget: thread.federation?.ref.target ??
+              readRendererFederationTarget(),
             threadId: thread.id,
             reactions: result.reactions,
           }),

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1036,6 +1036,7 @@ export type MarkThreadSeenResponse = {
 
 export type SetThreadReactionRequest = {
   backend?: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   emoji: string;
   /** true → add the reaction; false → remove it */

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1609,6 +1609,14 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "thread/reactions/updated";
+      params: {
+        threadId: string;
+        /** Complete reaction set, ordered by insertion. */
+        reactions: string[];
+      };
+    }
+  | {
       method: "thread/pin/added";
       params: {
         threadId: string;


### PR DESCRIPTION
## What changed

- route reaction mutations for federated thread rows to the thread-owning instance
- add `backend.setThreadReaction` to the federation backend bridge under `thread_navigation`
- reconcile the viewer with the owner's complete ordered reaction array
- add renderer, IPC routing, protocol, and overlay regression coverage

## Root cause

A remote snapshot displayed the owner’s reactions, but the reaction mutation omitted its federation target. The viewer therefore wrote a separate local overlay and reconciled the row from that one-emoji response, making each newly selected emoji appear to replace the previous remote reaction.

## Impact

Remote full-instance viewers and locally mounted remote rows now preserve multiple reactions in the same insertion order as local threads.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts` (253 tests)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `git diff --check`
