### PR TITLE
fix(federation): show remote agent message provenance

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -78,6 +78,7 @@ const federationMock = vi.hoisted(() => {
     remoteBackend,
     remoteThreadSummaries,
     runtime: {
+      hydrateThreadMessageOrigins: vi.fn(async (response) => response),
       remoteBackend: vi.fn(() => remoteBackend),
       remoteNavigationSnapshot: vi.fn(),
       remoteThreadSummaries: vi.fn(() => remoteThreadSummaries),
@@ -914,6 +915,7 @@ describe("app server ipc", () => {
     federationMock.remoteBackend.setThreadReaction.mockClear();
     federationMock.remoteBackend.refreshDirectoryGitStatuses.mockClear();
     federationMock.runtime.remoteBackend.mockClear();
+    federationMock.runtime.hydrateThreadMessageOrigins.mockClear();
     federationMock.runtime.remoteNavigationSnapshot.mockReset();
     listThreads.mockClear();
     readThread.mockClear();
@@ -2787,6 +2789,9 @@ describe("app server ipc", () => {
       limit: undefined,
       viewOnly: undefined,
     });
+    expect(
+      federationMock.runtime.hydrateThreadMessageOrigins,
+    ).toHaveBeenCalledWith(oversizedReadThreadResponse);
     expect(output.length).toBeLessThan(36_000);
     expect(output).toContain("PwrAgent renderer boundary: truncated");
     expect(output).toContain("$.replay.entries[0].details[0].command.output");

--- a/apps/desktop/src/main/__tests__/federated-thread-origin-hydrator.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-origin-hydrator.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AppServerReadThreadResponse } from "@pwragent/shared";
+import { hydrateFederatedThreadMessageOrigins } from "../federation/federated-thread-origin-hydrator";
+
+describe("federated thread origin hydration", () => {
+  it("hydrates unmounted source names and scopes legacy origins to the owner", async () => {
+    const response: AppServerReadThreadResponse = {
+      backend: "codex",
+      fetchedAt: 1_000,
+      threadId: "remote-child",
+      replay: {
+        entries: [
+          {
+            type: "message",
+            id: "legacy-owner-message",
+            role: "user",
+            text: "Continue from the sibling thread.",
+            origin: {
+              kind: "agent",
+              sourceThread: {
+                backend: "codex",
+                threadId: "remote-parent",
+                title: "Stale remote title",
+              },
+            },
+          },
+          {
+            type: "message",
+            id: "local-viewer-message",
+            role: "user",
+            text: "Report back to the viewer.",
+            origin: {
+              kind: "agent",
+              sourceThread: {
+                backend: "codex",
+                instanceId: "viewer_one",
+                threadId: "viewer-parent",
+              },
+            },
+          },
+        ],
+        messages: [
+          {
+            id: "legacy-owner-message",
+            role: "user",
+            text: "Continue from the sibling thread.",
+            origin: {
+              kind: "agent",
+              sourceThread: {
+                backend: "codex",
+                threadId: "remote-parent",
+                title: "Stale remote title",
+              },
+            },
+          },
+          {
+            id: "local-viewer-message",
+            role: "user",
+            text: "Report back to the viewer.",
+            origin: {
+              kind: "agent",
+              sourceThread: {
+                backend: "codex",
+                instanceId: "viewer_one",
+                threadId: "viewer-parent",
+              },
+            },
+          },
+        ],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    };
+    const resolveThread = vi.fn(async (ref: {
+      instanceId: string;
+      threadId: string;
+    }) => ({
+      instanceId: ref.instanceId,
+      thread: {
+        id: ref.threadId,
+        title:
+          ref.instanceId === "owner_one"
+            ? "Remote pagination audit"
+            : "Viewer parent thread",
+        titleSource: "explicit" as const,
+        linkedDirectories: [],
+        source: "codex" as const,
+      },
+    }));
+
+    const hydrated = await hydrateFederatedThreadMessageOrigins({
+      localInstanceId: "viewer_one",
+      ownerInstanceId: "owner_one",
+      response,
+      resolveThread,
+    });
+
+    expect(resolveThread).toHaveBeenCalledTimes(2);
+    expect(hydrated.replay.entries).toMatchObject([
+      {
+        origin: {
+          sourceThread: {
+            backend: "codex",
+            instanceId: "owner_one",
+            threadId: "remote-parent",
+            title: "Remote pagination audit",
+          },
+        },
+      },
+      {
+        origin: {
+          sourceThread: {
+            backend: "codex",
+            threadId: "viewer-parent",
+            title: "Viewer parent thread",
+          },
+        },
+      },
+    ]);
+    expect(hydrated.replay.messages).toMatchObject([
+      {
+        origin: {
+          sourceThread: {
+            instanceId: "owner_one",
+            title: "Remote pagination audit",
+          },
+        },
+      },
+      {
+        origin: {
+          sourceThread: {
+            title: "Viewer parent thread",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("accepts a uniquely discovered owner for a legacy remote origin", async () => {
+    const response: AppServerReadThreadResponse = {
+      backend: "codex",
+      fetchedAt: 1_000,
+      threadId: "local-child",
+      replay: {
+        entries: [{
+          type: "message",
+          id: "legacy-remote-message",
+          role: "user",
+          text: "Please report back.",
+          origin: {
+            kind: "agent",
+            sourceThread: {
+              backend: "codex",
+              threadId: "legacy-remote-parent",
+            },
+          },
+        }],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    };
+    const resolveThread = vi.fn(async () => ({
+      instanceId: "remote_one",
+      thread: {
+        id: "legacy-remote-parent",
+        title: "Remote parent thread",
+        titleSource: "explicit" as const,
+        linkedDirectories: [],
+        source: "codex" as const,
+      },
+    }));
+
+    const hydrated = await hydrateFederatedThreadMessageOrigins({
+      localInstanceId: "viewer_one",
+      ownerInstanceId: "viewer_one",
+      response,
+      resolveThread,
+    });
+
+    expect(resolveThread).toHaveBeenCalledWith({
+      backend: "codex",
+      discoverAcrossInstances: true,
+      instanceId: "viewer_one",
+      threadId: "legacy-remote-parent",
+    });
+    expect(hydrated.replay.entries[0]).toMatchObject({
+      origin: {
+        sourceThread: {
+          backend: "codex",
+          instanceId: "remote_one",
+          threadId: "legacy-remote-parent",
+          title: "Remote parent thread",
+        },
+      },
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/federated-thread-origin-hydrator.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-origin-hydrator.test.ts
@@ -199,4 +199,76 @@ describe("federated thread origin hydration", () => {
       },
     });
   });
+
+  it("preserves a later fallback title when a deduplicated lookup fails", async () => {
+    const response: AppServerReadThreadResponse = {
+      backend: "codex",
+      fetchedAt: 1_000,
+      threadId: "remote-child",
+      replay: {
+        entries: [{
+          type: "message",
+          id: "source-without-title",
+          role: "user",
+          text: "First occurrence has no title.",
+          origin: {
+            kind: "agent",
+            sourceThread: {
+              backend: "codex",
+              instanceId: "remote_one",
+              threadId: "remote-parent",
+            },
+          },
+        }],
+        messages: [{
+          id: "source-with-fallback-title",
+          role: "user",
+          text: "Later occurrence retains a useful title.",
+          origin: {
+            kind: "agent",
+            sourceThread: {
+              backend: "codex",
+              instanceId: "remote_one",
+              threadId: "remote-parent",
+              title: "Remote parent fallback",
+            },
+          },
+        }],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    };
+    const resolveThread = vi.fn(async () => {
+      throw new Error("peer disconnected");
+    });
+
+    const hydrated = await hydrateFederatedThreadMessageOrigins({
+      localInstanceId: "viewer_one",
+      ownerInstanceId: "owner_one",
+      response,
+      resolveThread,
+    });
+
+    expect(resolveThread).toHaveBeenCalledTimes(1);
+    expect(hydrated.replay.entries[0]).toMatchObject({
+      origin: {
+        sourceThread: {
+          instanceId: "remote_one",
+          threadId: "remote-parent",
+          title: "Remote parent fallback",
+        },
+      },
+    });
+    expect(hydrated.replay.messages[0]).toMatchObject({
+      origin: {
+        sourceThread: {
+          instanceId: "remote_one",
+          threadId: "remote-parent",
+          title: "Remote parent fallback",
+        },
+      },
+    });
+  });
 });

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1771,7 +1771,11 @@ describe("federation backend bridge", () => {
       input: [{ type: "text", text: "ship it" }],
       messageOrigin: {
         kind: "agent",
-        sourceThread: { backend: "codex", threadId: "source-thread" },
+        sourceThread: {
+          backend: "codex",
+          instanceId: "gateway_one",
+          threadId: "source-thread",
+        },
       },
     });
     expect(replies).toMatchObject([

--- a/apps/desktop/src/main/federation/federated-thread-origin-hydrator.ts
+++ b/apps/desktop/src/main/federation/federated-thread-origin-hydrator.ts
@@ -1,0 +1,153 @@
+import type {
+  AppServerBackendKind,
+  AppServerReadThreadResponse,
+  AppServerThreadMessageOrigin,
+  AppServerThreadSummary,
+  FederationInstanceId,
+} from "@pwragent/shared";
+
+type FederatedSourceThreadRef = {
+  backend: AppServerBackendKind;
+  discoverAcrossInstances: boolean;
+  instanceId: FederationInstanceId;
+  threadId: string;
+};
+
+type ResolvedFederatedSourceThread = {
+  instanceId: FederationInstanceId;
+  thread: AppServerThreadSummary;
+};
+
+type HydratedSourceThread = NonNullable<
+  AppServerThreadMessageOrigin["sourceThread"]
+>;
+
+/**
+ * Makes transcript provenance globally actionable without mounting source
+ * threads or subscribing to their navigation events.
+ *
+ * Older records predate source-thread instance ids. The serving owner is the
+ * backwards-compatible first lookup; a resolver may then accept one unique
+ * match from another connected instance.
+ */
+export async function hydrateFederatedThreadMessageOrigins(params: {
+  localInstanceId: FederationInstanceId;
+  ownerInstanceId: FederationInstanceId;
+  response: AppServerReadThreadResponse;
+  resolveThread: (
+    ref: FederatedSourceThreadRef,
+  ) => Promise<ResolvedFederatedSourceThread | undefined>;
+}): Promise<AppServerReadThreadResponse> {
+  const sources = [
+    ...params.response.replay.entries.flatMap((entry) =>
+      entry.type === "message" && entry.origin?.sourceThread
+        ? [entry.origin.sourceThread]
+        : []
+    ),
+    ...params.response.replay.messages.flatMap((message) =>
+      message.origin?.sourceThread ? [message.origin.sourceThread] : []
+    ),
+  ];
+  if (sources.length === 0) {
+    return params.response;
+  }
+
+  const hydratedByKey = new Map<string, HydratedSourceThread>();
+  await Promise.all(
+    sources.map(async (source) => {
+      const instanceId = source.instanceId ?? params.ownerInstanceId;
+      const key = sourceThreadKey({
+        backend: source.backend,
+        instanceId,
+        threadId: source.threadId,
+      });
+      if (hydratedByKey.has(key)) {
+        return;
+      }
+
+      // Reserve the key before awaiting so duplicate entry/message views of
+      // the same transcript item produce one point lookup.
+      hydratedByKey.set(key, normalizeSourceThread({
+        localInstanceId: params.localInstanceId,
+        source,
+        instanceId,
+      }));
+      let resolved: ResolvedFederatedSourceThread | undefined;
+      try {
+        resolved = await params.resolveThread({
+          backend: source.backend,
+          discoverAcrossInstances: source.instanceId === undefined,
+          instanceId,
+          threadId: source.threadId,
+        });
+      } catch {
+        // Provenance identity is still useful and click-to-mount remains
+        // available when a peer cannot hydrate the display title.
+      }
+      hydratedByKey.set(key, normalizeSourceThread({
+        localInstanceId: params.localInstanceId,
+        source,
+        instanceId: resolved?.instanceId ?? instanceId,
+        title: resolved?.thread.title || source.title?.trim(),
+      }));
+    }),
+  );
+
+  const hydrateOrigin = (
+    origin: AppServerThreadMessageOrigin | undefined,
+  ): AppServerThreadMessageOrigin | undefined => {
+    const source = origin?.sourceThread;
+    if (!origin || !source) {
+      return origin;
+    }
+    const instanceId = source.instanceId ?? params.ownerInstanceId;
+    return {
+      ...origin,
+      sourceThread:
+        hydratedByKey.get(sourceThreadKey({
+          backend: source.backend,
+          instanceId,
+          threadId: source.threadId,
+        }))
+        ?? source,
+    };
+  };
+
+  return {
+    ...params.response,
+    replay: {
+      ...params.response.replay,
+      entries: params.response.replay.entries.map((entry) =>
+        entry.type === "message"
+          ? { ...entry, origin: hydrateOrigin(entry.origin) }
+          : entry
+      ),
+      messages: params.response.replay.messages.map((message) => ({
+        ...message,
+        origin: hydrateOrigin(message.origin),
+      })),
+    },
+  };
+}
+
+function normalizeSourceThread(params: {
+  localInstanceId: FederationInstanceId;
+  source: HydratedSourceThread;
+  instanceId: FederationInstanceId;
+  title?: string;
+}): HydratedSourceThread {
+  return {
+    backend: params.source.backend,
+    ...(params.instanceId === params.localInstanceId
+      ? {}
+      : { instanceId: params.instanceId }),
+    threadId: params.source.threadId,
+    ...(params.title ? { title: params.title } : {}),
+  };
+}
+
+function sourceThreadKey(
+  ref: Pick<FederatedSourceThreadRef, "backend" | "instanceId" | "threadId">,
+): string {
+  return `${ref.instanceId}:${ref.backend}:${ref.threadId}`;
+}

--- a/apps/desktop/src/main/federation/federated-thread-origin-hydrator.ts
+++ b/apps/desktop/src/main/federation/federated-thread-origin-hydrator.ts
@@ -52,33 +52,46 @@ export async function hydrateFederatedThreadMessageOrigins(params: {
     return params.response;
   }
 
+  const sourcesByKey = new Map<
+    string,
+    {
+      discoverAcrossInstances: boolean;
+      fallbackTitle?: string;
+      instanceId: FederationInstanceId;
+      source: HydratedSourceThread;
+    }
+  >();
+  for (const source of sources) {
+    const instanceId = source.instanceId ?? params.ownerInstanceId;
+    const key = sourceThreadKey({
+      backend: source.backend,
+      instanceId,
+      threadId: source.threadId,
+    });
+    const existing = sourcesByKey.get(key);
+    if (existing) {
+      existing.discoverAcrossInstances ||= source.instanceId === undefined;
+      existing.fallbackTitle ||= source.title?.trim();
+      continue;
+    }
+    sourcesByKey.set(key, {
+      discoverAcrossInstances: source.instanceId === undefined,
+      fallbackTitle: source.title?.trim() || undefined,
+      instanceId,
+      source,
+    });
+  }
+
   const hydratedByKey = new Map<string, HydratedSourceThread>();
   await Promise.all(
-    sources.map(async (source) => {
-      const instanceId = source.instanceId ?? params.ownerInstanceId;
-      const key = sourceThreadKey({
-        backend: source.backend,
-        instanceId,
-        threadId: source.threadId,
-      });
-      if (hydratedByKey.has(key)) {
-        return;
-      }
-
-      // Reserve the key before awaiting so duplicate entry/message views of
-      // the same transcript item produce one point lookup.
-      hydratedByKey.set(key, normalizeSourceThread({
-        localInstanceId: params.localInstanceId,
-        source,
-        instanceId,
-      }));
+    [...sourcesByKey].map(async ([key, sourceGroup]) => {
       let resolved: ResolvedFederatedSourceThread | undefined;
       try {
         resolved = await params.resolveThread({
-          backend: source.backend,
-          discoverAcrossInstances: source.instanceId === undefined,
-          instanceId,
-          threadId: source.threadId,
+          backend: sourceGroup.source.backend,
+          discoverAcrossInstances: sourceGroup.discoverAcrossInstances,
+          instanceId: sourceGroup.instanceId,
+          threadId: sourceGroup.source.threadId,
         });
       } catch {
         // Provenance identity is still useful and click-to-mount remains
@@ -86,9 +99,9 @@ export async function hydrateFederatedThreadMessageOrigins(params: {
       }
       hydratedByKey.set(key, normalizeSourceThread({
         localInstanceId: params.localInstanceId,
-        source,
-        instanceId: resolved?.instanceId ?? instanceId,
-        title: resolved?.thread.title || source.title?.trim(),
+        source: sourceGroup.source,
+        instanceId: resolved?.instanceId ?? sourceGroup.instanceId,
+        title: resolved?.thread.title || sourceGroup.fallbackTitle,
       }));
     }),
   );

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -595,10 +595,27 @@ export function registerFederationBackendHandlers(params: {
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.startTurn,
-    async (envelope) =>
-      await params.backend.startTurn(
-        envelope.params as FederationStartTurnRequest,
-      ),
+    async (envelope) => {
+      const request = envelope.params as FederationStartTurnRequest;
+      const messageOrigin = request.messageOrigin;
+      const sourceThread = messageOrigin?.sourceThread;
+      return await params.backend.startTurn({
+        ...request,
+        ...(messageOrigin && sourceThread
+          ? {
+              messageOrigin: {
+                ...messageOrigin,
+                sourceThread: {
+                  ...sourceThread,
+                  // The authenticated envelope sender is authoritative. Do
+                  // not accept a caller-supplied provenance owner here.
+                  instanceId: envelope.sourceInstanceId,
+                },
+              },
+            }
+          : {}),
+      });
+    },
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.cancelQueuedTurn,
@@ -851,7 +868,9 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
     private readonly rpc: FederationRpcEndpoint,
     private readonly transformReadThreadResponse: (
       response: AppServerReadThreadResponse,
-    ) => AppServerReadThreadResponse = (response) => response,
+    ) =>
+      | AppServerReadThreadResponse
+      | Promise<AppServerReadThreadResponse> = (response) => response,
   ) {}
 
   async getNavigationSnapshot(
@@ -888,7 +907,7 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
       method: FEDERATION_BACKEND_METHODS.readThread,
       params: request,
     });
-    return this.transformReadThreadResponse(response);
+    return await this.transformReadThreadResponse(response);
   }
 
   async readTranscriptImage(

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -6,6 +6,7 @@ import type {
   AppServerListSkillsResponse,
   AppServerListThreadsResponse,
   AppServerReadThreadResponse,
+  AppServerThreadSummary,
   CancelQueuedTurnResponse,
   CancelThreadExecutionModeQueueResponse,
   CheckThreadBranchDriftResponse,
@@ -165,6 +166,7 @@ import {
 import { FederatedSearchService } from "./federated-search-service";
 import { collectFederationHostInfo } from "./federation-host-info";
 import { RemoteThreadSummaryCache } from "./remote-thread-summary-cache";
+import { hydrateFederatedThreadMessageOrigins } from "./federated-thread-origin-hydrator";
 import {
   FEDERATION_BACKEND_EVENT_METHOD,
   FEDERATION_BACKEND_METHOD_CAPABILITIES,
@@ -1217,11 +1219,77 @@ export class DesktopFederationRuntime {
   remoteBackend(target: FederationRemoteTarget): FederationBackendOperations {
     return new FederationRemoteBackendClient(
       this.rpcFor(target),
-      (response) => rewriteFederatedTranscriptImageUrlsForRenderer(
-        response,
-        target.instanceId,
-      ),
+      async (response) =>
+        await this.hydrateThreadMessageOrigins(
+          rewriteFederatedTranscriptImageUrlsForRenderer(
+            response,
+            target.instanceId,
+          ),
+          target.instanceId,
+        ),
     );
+  }
+
+  async hydrateThreadMessageOrigins(
+    response: AppServerReadThreadResponse,
+    ownerInstanceId = this.ensureLocalInstanceId(),
+  ): Promise<AppServerReadThreadResponse> {
+    return await hydrateFederatedThreadMessageOrigins({
+      localInstanceId: this.ensureLocalInstanceId(),
+      ownerInstanceId,
+      response,
+      resolveThread: async (source) => {
+        const resolveOnInstance = async (instanceId: FederationInstanceId) => {
+          if (instanceId === this.ensureLocalInstanceId()) {
+            return await getDesktopBackendRegistry().resolveThread({
+              backend: source.backend,
+              threadId: source.threadId,
+            });
+          }
+          return (
+            await new FederationRemoteBackendClient(
+              this.rpcFor({ scope: "remote", instanceId }),
+            ).resolveThread({
+              backend: source.backend,
+              threadId: source.threadId,
+            })
+          ).thread;
+        };
+        const preferred = await resolveOnInstance(source.instanceId).catch(
+          () => undefined,
+        );
+        if (preferred) {
+          return { instanceId: source.instanceId, thread: preferred };
+        }
+        if (!source.discoverAcrossInstances) {
+          return undefined;
+        }
+
+        const candidateInstanceIds = new Set<FederationInstanceId>([
+          this.ensureLocalInstanceId(),
+          ...this.connectedPeerTargets()
+            .filter((peer) => peer.capabilities.includes("thread_navigation"))
+            .map((peer) => peer.target.instanceId),
+        ]);
+        candidateInstanceIds.delete(source.instanceId);
+        const matches = (
+          await Promise.all(
+            [...candidateInstanceIds].map(async (instanceId) => {
+              const thread = await resolveOnInstance(instanceId).catch(
+                () => undefined,
+              );
+              return thread ? { instanceId, thread } : undefined;
+            }),
+          )
+        ).filter(
+          (match): match is {
+            instanceId: FederationInstanceId;
+            thread: AppServerThreadSummary;
+          } => Boolean(match),
+        );
+        return matches.length === 1 ? matches[0] : undefined;
+      },
+    });
   }
 
   /**

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1615,8 +1615,10 @@ class DesktopAppServerService {
       threadStatus: response.threadStatus ?? response.replay.threadStatus,
     });
 
+    const hydrated = await getDesktopFederationRuntime()
+      .hydrateThreadMessageOrigins(response);
     const materialized = await materializeTranscriptImageUrlsForRenderer(
-      response,
+      hydrated,
       {},
       {
         includeTemporaryImageRoots: true,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -202,6 +202,48 @@ describe("TranscriptList", () => {
     });
   });
 
+  it("links an unmounted remote Agent source thread by hydrated provenance", () => {
+    const onShowThread = vi.fn();
+
+    render(
+      <ThreadLinkProvider onShowThread={onShowThread} threads={[]}>
+        <TranscriptList
+          entries={[
+            {
+              type: "message",
+              id: "remote-message-injected",
+              role: "user",
+              text: "Please report the remote audit findings.",
+              origin: {
+                kind: "agent",
+                sourceThread: {
+                  backend: "codex",
+                  instanceId: "pwr_remote",
+                  threadId: "remote-source-thread",
+                  title: "Remote pagination audit",
+                },
+              },
+            },
+          ]}
+          loading={false}
+          loadingMore={false}
+          onLoadOlder={async () => undefined}
+        />
+      </ThreadLinkProvider>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Open thread Remote pagination audit",
+      }),
+    );
+    expect(onShowThread).toHaveBeenCalledWith({
+      backend: "codex",
+      instanceId: "pwr_remote",
+      threadId: "remote-source-thread",
+    });
+  });
+
   it("attributes monitor handoffs and keeps their raw payload collapsed", () => {
     const task = "Monitor GitHub CI for PR #1107 until all checks finish.";
     const rawHandoff = [

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -904,6 +904,7 @@ describe("useThreadSessionState", () => {
                 kind: "agent",
                 sourceThread: {
                   backend: "codex",
+                  instanceId: "pwr_source",
                   threadId: "parent-thread",
                   title: "Parent thread",
                 },
@@ -941,6 +942,7 @@ describe("useThreadSessionState", () => {
           kind: "agent",
           sourceThread: {
             backend: "codex",
+            instanceId: "pwr_source",
             threadId: "parent-thread",
             title: "Parent thread",
           },

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3173,6 +3173,9 @@ function threadMessageOriginFromUnknown(
     kind: record.kind,
     sourceThread: {
       backend: sourceRecord.backend as AppServerBackendKind,
+      ...(typeof sourceRecord.instanceId === "string"
+        ? { instanceId: sourceRecord.instanceId }
+        : {}),
       threadId: sourceRecord.threadId,
       ...(typeof sourceRecord.title === "string"
         ? { title: sourceRecord.title }

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -8,6 +8,7 @@ import type { CelestialIconAssignment } from "./celestial";
 import type { StarMapArrangementEntry, StarMapIntakePhase } from "./star-map";
 import type {
   FederationConnectionState,
+  FederationInstanceId,
   FederationTarget,
 } from "./federation";
 import type {
@@ -419,6 +420,8 @@ export type AppServerThreadMessageOrigin = {
   kind: AppServerThreadMessageOriginKind;
   sourceThread?: {
     backend: AppServerBackendKind;
+    /** Durable owner identity when the source thread belongs to another instance. */
+    instanceId?: FederationInstanceId;
     threadId: ThreadIdentifier;
     title?: string;
   };


### PR DESCRIPTION
## Summary

- add the durable federation instance ID to agent message source-thread provenance
- stamp the authenticated sender identity when a federated turn is admitted
- hydrate source-thread titles through point lookups without mounting threads or subscribing to navigation events
- discover one unique remote owner for legacy provenance records that predate the instance ID
- preserve hydrated provenance in the renderer and make unmounted remote source threads click-to-mount

## Root cause

Agent message origins only carried a backend and thread ID. Local source threads could be resolved from the viewer's mounted navigation snapshot, but remote source threads were absent unless already mounted or subscribed. The renderer therefore had neither a source title nor an actionable federated identity.

## Impact

Local and federated transcript views now show the source thread for remote agent messages. Operators can click that provenance chip to mount and open the source thread on demand.

## Validation

- `pnpm --filter @pwragent/desktop typecheck`
- 372 focused desktop main/renderer tests
- `pnpm typecheck`
- `pnpm lint:eslint` (zero errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`
