### PR TITLE
feat(desktop): expose agent thread turn controls

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -26211,6 +26211,280 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("stops and steers another active local thread with distinct dispositions", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["thread/resume", "turn/interrupt", "turn/steer"],
+      },
+      threads: [{
+        id: "target-thread",
+        title: "target-thread",
+        titleSource: "fallback",
+        source: "codex",
+        linkedDirectories: [],
+      }],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    for (const [threadId, turnId] of [
+      ["target-thread", "target-turn"],
+      ["parent-thread", "parent-turn"],
+    ] as const) {
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId,
+            turnId,
+            turn: { id: turnId },
+          },
+        },
+      });
+    }
+
+    const steer = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "parent-turn",
+      tool: "steer_thread",
+      args: {
+        backend: "codex",
+        threadId: "target-thread",
+        requestId: "steer-request-1",
+        expectedTurnId: "target-turn",
+        prompt: "Use the smaller fixture before continuing.",
+      },
+    });
+    expect(steer).toMatchObject({
+      structuredContent: {
+        backend: "codex",
+        threadId: "target-thread",
+        requestId: "steer-request-1",
+        turnId: "target-turn",
+        disposition: "steered",
+        promptPreview: "Use the smaller fixture before continuing.",
+      },
+    });
+    expect(codexClient.lastSteerTurnParams).toEqual({
+      threadId: "target-thread",
+      expectedTurnId: "target-turn",
+      input: [{
+        type: "text",
+        text: "Use the smaller fixture before continuing.",
+      }],
+    });
+    expect(codexClient.startTurnCallCount).toBe(0);
+
+    const stopArgs = {
+      backend: "codex",
+      threadId: "target-thread",
+      requestId: "stop-request-1",
+      expectedTurnId: "target-turn",
+    };
+    const stop = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "parent-turn",
+      tool: "stop_thread",
+      args: stopArgs,
+    });
+    expect(stop).toMatchObject({
+      structuredContent: {
+        backend: "codex",
+        threadId: "target-thread",
+        requestId: "stop-request-1",
+        turnId: "target-turn",
+        disposition: "interrupted",
+        interruptedAt: expect.any(Number),
+      },
+    });
+    expect(codexClient.interruptTurnCallCount).toBe(1);
+
+    const stopReplay = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "parent-turn",
+      tool: "stop_thread",
+      args: stopArgs,
+    });
+    expect(stopReplay).toMatchObject({
+      structuredContent: {
+        disposition: "interrupted",
+        idempotentReplay: true,
+        requestId: "stop-request-1",
+      },
+    });
+    expect(codexClient.interruptTurnCallCount).toBe(1);
+
+    await registry.close();
+  });
+
+  it("rejects self-control, idle targets, and stale expected turns", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["thread/resume", "turn/interrupt", "turn/steer"],
+      },
+      threads: [{
+        id: "idle-thread",
+        title: "idle-thread",
+        titleSource: "fallback",
+        source: "codex",
+        linkedDirectories: [],
+      }, {
+        id: "live-thread",
+        title: "live-thread",
+        titleSource: "fallback",
+        source: "codex",
+        linkedDirectories: [],
+      }],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    for (const [threadId, turnId] of [
+      ["live-thread", "turn-new"],
+      ["parent-thread", "parent-turn"],
+    ] as const) {
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: { threadId, turnId, turn: { id: turnId } },
+        },
+      });
+    }
+
+    const idle = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "parent-turn",
+      tool: "stop_thread",
+      args: {
+        backend: "codex",
+        threadId: "idle-thread",
+        requestId: "stop-idle",
+      },
+    });
+    expect(idle).toMatchObject({
+      isError: true,
+      structuredContent: { code: "no_active_turn" },
+    });
+
+    const stale = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "parent-turn",
+      tool: "steer_thread",
+      args: {
+        backend: "codex",
+        threadId: "live-thread",
+        requestId: "steer-stale",
+        expectedTurnId: "turn-old",
+        prompt: "Stop now.",
+      },
+    });
+    expect(stale).toMatchObject({
+      isError: true,
+      structuredContent: {
+        code: "stale_target",
+        data: {
+          activeTurnId: "turn-new",
+          expectedTurnId: "turn-old",
+        },
+      },
+    });
+
+    const self = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "parent-turn",
+      tool: "stop_thread",
+      args: {
+        backend: "codex",
+        threadId: "parent-thread",
+        requestId: "stop-self",
+      },
+    });
+    expect(self).toMatchObject({
+      isError: true,
+      structuredContent: { code: "forbidden" },
+    });
+    expect(codexClient.interruptTurnCallCount).toBe(0);
+
+    await registry.close();
+  });
+
+  it("reports a local backend turn-control capability denial", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/resume"] },
+      threads: [{
+        id: "target-thread",
+        title: "target-thread",
+        titleSource: "fallback",
+        source: "codex",
+        linkedDirectories: [],
+      }],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    for (const [threadId, turnId] of [
+      ["target-thread", "target-turn"],
+      ["parent-thread", "parent-turn"],
+    ] as const) {
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: { threadId, turnId, turn: { id: turnId } },
+        },
+      });
+    }
+
+    const response = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "parent-turn",
+      tool: "stop_thread",
+      args: {
+        backend: "codex",
+        threadId: "target-thread",
+        requestId: "stop-unsupported",
+      },
+    });
+
+    expect(response).toMatchObject({
+      isError: true,
+      structuredContent: { code: "unsupported_capability" },
+    });
+    expect(codexClient.interruptTurnCallCount).toBe(0);
+    await registry.close();
+  });
+
   it("queues a follow-up prompt while a Grok target has an active turn", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
@@ -27008,6 +27282,131 @@ script = "printf setup"
       approvalPolicy: undefined,
       sandbox: undefined,
     });
+
+    await registry.close();
+  });
+
+  it("routes stop and steer controls to an explicit federated owner", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    const federatedControl = vi.fn(async (controlRequest) => ({
+      backend: controlRequest.backend,
+      threadId: controlRequest.threadId,
+      turnId: "remote-turn-live",
+      disposition: controlRequest.operation === "stop"
+        ? "interrupted" as const
+        : "steered" as const,
+      instanceId: "pwr_studio",
+      instanceLabel: "Studio Mac",
+    }));
+    registry.setFederatedThreadControlHandler(federatedControl);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "parent-thread",
+          turnId: "parent-turn",
+          turn: { id: "parent-turn" },
+        },
+      },
+    });
+
+    const steer = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "parent-turn",
+      tool: "steer_thread",
+      args: {
+        backend: "codex",
+        threadId: "remote-thread",
+        instanceId: "pwr_studio",
+        requestId: "steer-remote",
+        prompt: "Avoid the expensive test lane.",
+      },
+    });
+    expect(steer).toMatchObject({
+      structuredContent: {
+        instanceId: "pwr_studio",
+        disposition: "steered",
+        turnId: "remote-turn-live",
+      },
+    });
+    expect(federatedControl).toHaveBeenLastCalledWith({
+      operation: "steer",
+      backend: "codex",
+      threadId: "remote-thread",
+      instanceId: "pwr_studio",
+      requestId: "steer-remote",
+      input: [{ type: "text", text: "Avoid the expensive test lane." }],
+    });
+
+    const stop = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "parent-turn",
+      tool: "stop_thread",
+      args: {
+        backend: "codex",
+        threadId: "remote-thread",
+        instanceId: "pwr_studio",
+        requestId: "stop-remote",
+      },
+    });
+    expect(stop).toMatchObject({
+      structuredContent: {
+        instanceId: "pwr_studio",
+        disposition: "interrupted",
+        turnId: "remote-turn-live",
+      },
+    });
+    await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "parent-turn",
+      tool: "stop_thread",
+      args: {
+        backend: "codex",
+        threadId: "remote-thread",
+        instanceId: "pwr_studio",
+        requestId: "stop-remote",
+      },
+    });
+    expect(federatedControl).toHaveBeenCalledTimes(2);
+    expect(codexClient.interruptTurnCallCount).toBe(0);
+    expect(codexClient.steerTurnCallCount).toBe(0);
+
+    federatedControl.mockClear();
+    const localOnly = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "parent-turn",
+      tool: "stop_thread",
+      args: {
+        backend: "codex",
+        threadId: "remote-thread",
+        includeRemote: false,
+        requestId: "stop-local-only",
+      },
+    });
+    expect(localOnly).toMatchObject({
+      isError: true,
+      structuredContent: { code: "not_found" },
+    });
+    expect(federatedControl).not.toHaveBeenCalled();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -26326,6 +26326,119 @@ script = "printf setup"
     });
     expect(codexClient.interruptTurnCallCount).toBe(1);
 
+    await expect(registry.controlActiveTurn({
+      operation: "stop",
+      backend: "codex",
+      threadId: "target-thread",
+      requestId: "stop-request-1",
+      expectedTurnId: "target-turn",
+      messageOrigin: {
+        kind: "agent",
+        sourceThread: {
+          backend: "codex",
+          threadId: "parent-thread",
+        },
+      },
+    })).resolves.toMatchObject({
+      ok: true,
+      disposition: "interrupted",
+      idempotentReplay: true,
+    });
+    expect(codexClient.interruptTurnCallCount).toBe(1);
+
+    await registry.close();
+  });
+
+  it("atomically rejects a stale ACP stop and replays an accepted owner stop", async () => {
+    const acpBackendId = "acp:kimi" as AcpBackendId;
+    const { acpClient, registry } = createKimiAcpRegistry({
+      acpBackendId,
+      sessionId: "acp-target-thread",
+      sessions: [{
+        backendId: acpBackendId,
+        sessionId: "acp-target-thread",
+        title: "ACP target thread",
+        createdAt: 1_000,
+        updatedAt: 1_000,
+        executionMode: "default",
+        status: "idle",
+      }],
+    });
+    await registry.publishLocalEvent({
+      backend: acpBackendId,
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "acp-target-thread",
+          turnId: "turn-a",
+          turn: { id: "turn-a" },
+        },
+      },
+    });
+    await registry.publishLocalEvent({
+      backend: acpBackendId,
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "acp-target-thread",
+          turnId: "turn-a",
+          turn: {
+            id: "turn-a",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    });
+    await registry.publishLocalEvent({
+      backend: acpBackendId,
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "acp-target-thread",
+          turnId: "turn-b",
+          turn: { id: "turn-b" },
+        },
+      },
+    });
+
+    await expect(registry.controlActiveTurn({
+      operation: "stop",
+      backend: acpBackendId,
+      threadId: "acp-target-thread",
+      requestId: "stop-stale-a",
+      expectedTurnId: "turn-a",
+    })).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: "stale_target",
+        activeTurnId: "turn-b",
+        expectedTurnId: "turn-a",
+      },
+    });
+    expect(acpClient.cancelSession).not.toHaveBeenCalled();
+
+    const acceptedRequest = {
+      operation: "stop" as const,
+      backend: acpBackendId,
+      threadId: "acp-target-thread",
+      requestId: "stop-turn-b",
+      expectedTurnId: "turn-b",
+    };
+    await expect(registry.controlActiveTurn(acceptedRequest)).resolves.toMatchObject({
+      ok: true,
+      turnId: "turn-b",
+      disposition: "interrupted",
+    });
+    await expect(registry.controlActiveTurn(acceptedRequest)).resolves.toMatchObject({
+      ok: true,
+      turnId: "turn-b",
+      disposition: "interrupted",
+      idempotentReplay: true,
+    });
+    expect(acpClient.cancelSession).toHaveBeenCalledTimes(1);
+    expect(acpClient.cancelSession).toHaveBeenCalledWith("acp-target-thread");
+
     await registry.close();
   });
 
@@ -27349,6 +27462,13 @@ script = "printf setup"
       instanceId: "pwr_studio",
       requestId: "steer-remote",
       input: [{ type: "text", text: "Avoid the expensive test lane." }],
+      messageOrigin: {
+        kind: "agent",
+        sourceThread: {
+          backend: "codex",
+          threadId: "parent-thread",
+        },
+      },
     });
 
     const stop = await callRegistryMcpTool({

--- a/apps/desktop/src/main/__tests__/federated-thread-message-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-message-service.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
-import type { StartTurnResponse, SteerTurnResponse } from "@pwragent/shared";
+import type {
+  ControlActiveTurnRequest,
+  ControlActiveTurnResponse,
+  StartTurnResponse,
+  SteerTurnResponse,
+} from "@pwragent/shared";
 import type { DesktopFederationRuntime } from "../federation/federation-runtime";
 import {
   createFederatedThreadControlHandler,
   createFederatedThreadMessageHandler,
 } from "../federation/federated-thread-message-service";
+import { FederationPeerUnavailableError } from "../federation/federation-peer-unavailable-error";
 
 const request = {
   backend: "codex" as const,
@@ -105,6 +111,63 @@ function buildRuntime(params: {
             : [],
         },
       }));
+      const controlActiveTurn = vi.fn(
+        async (
+          controlRequest: ControlActiveTurnRequest,
+        ): Promise<ControlActiveTurnResponse> => {
+          const base = {
+            backend: "codex" as const,
+            threadId: request.threadId,
+            requestId: controlRequest.requestId,
+          };
+          if (!activeTurnId) {
+            return {
+              ok: false,
+              ...base,
+              error: {
+                code: "no_active_turn",
+                message: `Thread ${request.threadId} has no active turn.`,
+              },
+            };
+          }
+          if (
+            controlRequest.expectedTurnId
+            && controlRequest.expectedTurnId !== activeTurnId
+          ) {
+            return {
+              ok: false,
+              ...base,
+              error: {
+                code: "stale_target",
+                message: "The active turn changed.",
+                activeTurnId,
+                expectedTurnId: controlRequest.expectedTurnId,
+              },
+            };
+          }
+          if (
+            (controlRequest.operation === "stop" && peer.interruptTurn === false)
+            || (controlRequest.operation === "steer" && peer.steerTurn === false)
+          ) {
+            return {
+              ok: false,
+              ...base,
+              error: {
+                code: "unsupported_capability",
+                message: "The backend does not support this control operation.",
+              },
+            };
+          }
+          return {
+            ok: true,
+            ...base,
+            turnId: activeTurnId,
+            disposition: controlRequest.operation === "stop"
+              ? "interrupted"
+              : "steered",
+          };
+        },
+      );
       const resolveActiveTurn = vi.fn(async () => ({
         backend: "codex" as const,
         threadId: request.threadId,
@@ -122,6 +185,7 @@ function buildRuntime(params: {
         disposition: "steered" as const,
       }));
       return [peer.instanceId, {
+        controlActiveTurn,
         interruptTurn,
         listBackends,
         listThreads,
@@ -476,15 +540,17 @@ describe("federated thread message service", () => {
       instanceId: "pwr_owner",
       instanceLabel: "Owner Mac",
     });
-    expect(backends.get("pwr_owner")?.interruptTurn).toHaveBeenCalledWith({
+    expect(backends.get("pwr_owner")?.controlActiveTurn).toHaveBeenCalledWith({
+      operation: "stop",
       backend: "codex",
       threadId: request.threadId,
-      turnId: "turn-live",
+      requestId: "stop-1",
     });
+    expect(backends.get("pwr_owner")?.interruptTurn).not.toHaveBeenCalled();
     expect(backends.get("pwr_owner")?.startTurn).not.toHaveBeenCalled();
   });
 
-  it("steers at the active turn boundary and never disguises a scheduled fallback", async () => {
+  it("delegates steer atomically and preserves a stale owner disposition", async () => {
     const { backends, runtime } = buildRuntime({
       peers: [{
         instanceId: "pwr_owner",
@@ -508,20 +574,25 @@ describe("federated thread message service", () => {
       turnId: "turn-live",
       disposition: "steered",
     });
-    expect(backends.get("pwr_owner")?.steerTurn).toHaveBeenCalledWith({
+    expect(backends.get("pwr_owner")?.controlActiveTurn).toHaveBeenCalledWith({
+      operation: "steer",
       backend: "codex",
       threadId: request.threadId,
-      expectedTurnId: "turn-live",
       requestId: "steer-1",
       input,
     });
+    expect(backends.get("pwr_owner")?.steerTurn).not.toHaveBeenCalled();
     expect(backends.get("pwr_owner")?.startTurn).not.toHaveBeenCalled();
 
-    backends.get("pwr_owner")?.steerTurn.mockResolvedValueOnce({
+    backends.get("pwr_owner")?.controlActiveTurn.mockResolvedValueOnce({
+      ok: false,
       backend: "codex",
       threadId: request.threadId,
-      turnId: "scheduled-action-1",
-      disposition: "scheduled",
+      requestId: "steer-2",
+      error: {
+        code: "stale_target",
+        message: "The active turn changed before steering.",
+      },
     });
     await expect(handler({
       operation: "steer",
@@ -586,6 +657,74 @@ describe("federated thread message service", () => {
       requestId: "steer-unsupported",
       input: [{ type: "text", text: "Stop." }],
     })).rejects.toMatchObject({ code: "unsupported_capability" });
+  });
+
+  it("preserves owner-side idempotent replay disposition", async () => {
+    const { backends, runtime } = buildRuntime({
+      peers: [{
+        instanceId: "pwr_owner",
+        label: "Owner Mac",
+        ownsThread: true,
+        activeTurnId: "turn-live",
+      }],
+    });
+    backends.get("pwr_owner")?.controlActiveTurn.mockResolvedValueOnce({
+      ok: true,
+      backend: "codex",
+      threadId: request.threadId,
+      requestId: "stop-retry",
+      turnId: "turn-live",
+      disposition: "interrupted",
+      idempotentReplay: true,
+    });
+
+    await expect(createFederatedThreadControlHandler({
+      runtime: () => runtime,
+    })({
+      operation: "stop",
+      backend: "codex",
+      threadId: request.threadId,
+      requestId: "stop-retry",
+    })).resolves.toMatchObject({
+      disposition: "interrupted",
+      idempotentReplay: true,
+    });
+  });
+
+  it("classifies control disconnects and timeouts as peer unavailable", async () => {
+    const { backends, runtime } = buildRuntime({
+      peers: [{
+        instanceId: "pwr_owner",
+        label: "Owner Mac",
+        ownsThread: true,
+        activeTurnId: "turn-live",
+      }],
+    });
+    const control = backends.get("pwr_owner")?.controlActiveTurn;
+    control?.mockRejectedValueOnce(
+      new FederationPeerUnavailableError("pwr_owner"),
+    );
+    const handler = createFederatedThreadControlHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler({
+      operation: "stop",
+      backend: "codex",
+      threadId: request.threadId,
+      requestId: "stop-disconnected",
+    })).rejects.toMatchObject({ code: "peer_unavailable" });
+
+    control?.mockRejectedValueOnce(
+      new Error("Federation request timed out: backend.controlActiveTurn"),
+    );
+    await expect(handler({
+      operation: "steer",
+      backend: "codex",
+      threadId: request.threadId,
+      requestId: "steer-timeout",
+      input: [{ type: "text", text: "Stop." }],
+    })).rejects.toMatchObject({ code: "peer_unavailable" });
   });
 
   it("reports unavailable, ambiguous, and stale federation ownership structurally", async () => {

--- a/apps/desktop/src/main/__tests__/federated-thread-message-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-message-service.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import type { StartTurnResponse } from "@pwragent/shared";
+import type { StartTurnResponse, SteerTurnResponse } from "@pwragent/shared";
 import type { DesktopFederationRuntime } from "../federation/federation-runtime";
-import { createFederatedThreadMessageHandler } from "../federation/federated-thread-message-service";
+import {
+  createFederatedThreadControlHandler,
+  createFederatedThreadMessageHandler,
+} from "../federation/federated-thread-message-service";
 
 const request = {
   backend: "codex" as const,
@@ -26,6 +29,9 @@ function buildRuntime(params: {
     capabilities?: Array<"thread_navigation" | "turn_control">;
     ownsThread?: boolean;
     resolveUnsupported?: boolean;
+    activeTurnId?: string | null;
+    interruptTurn?: boolean;
+    steerTurn?: boolean;
   }>;
 }) {
   const backends = new Map(
@@ -52,7 +58,79 @@ function buildRuntime(params: {
         threadId: request.threadId,
         turnId: "remote-turn-1",
       }));
-      return [peer.instanceId, { listThreads, resolveThread, startTurn }] as const;
+      const activeTurnId = peer.activeTurnId === undefined
+        ? "remote-active-turn"
+        : peer.activeTurnId;
+      const listBackends = vi.fn(async () => ({
+        fetchedAt: 1_000,
+        backends: [{
+          kind: "codex" as const,
+          label: "Codex",
+          available: true,
+          methods: [],
+          capabilities: {
+            listThreads: true,
+            createThread: true,
+            resumeThread: true,
+            renameThread: true,
+            readThread: true,
+            startTurn: true,
+            interruptTurn: peer.interruptTurn ?? true,
+            steerTurn: peer.steerTurn ?? true,
+            transcriptPagination: false,
+            toolUse: true,
+            approvalRequests: true,
+            multiDirectoryThreads: true,
+          },
+          executionModes: [],
+        }],
+      }));
+      const readThread = vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: request.threadId,
+        replay: {
+          backend: "codex" as const,
+          threadId: request.threadId,
+          threadStatus: activeTurnId ? "active" as const : "idle" as const,
+          entries: activeTurnId
+            ? [{
+                id: `turn:${activeTurnId}`,
+                timestamp: 1_000,
+                kind: "turn" as const,
+                turn: {
+                  id: activeTurnId,
+                  status: "in_progress" as const,
+                },
+              }]
+            : [],
+        },
+      }));
+      const resolveActiveTurn = vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: request.threadId,
+        ...(activeTurnId ? { turnId: activeTurnId } : {}),
+      }));
+      const interruptTurn = vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: request.threadId,
+        turnId: activeTurnId ?? "missing",
+      }));
+      const steerTurn = vi.fn(async (steerRequest): Promise<SteerTurnResponse> => ({
+        backend: "codex" as const,
+        threadId: request.threadId,
+        turnId: steerRequest.expectedTurnId,
+        disposition: "steered" as const,
+      }));
+      return [peer.instanceId, {
+        interruptTurn,
+        listBackends,
+        listThreads,
+        readThread,
+        resolveActiveTurn,
+        resolveThread,
+        startTurn,
+        steerTurn,
+      }] as const;
     }),
   );
   const runtime = {
@@ -370,5 +448,209 @@ describe("federated thread message service", () => {
     await expect(handler(request)).rejects.toThrow(
       "owns thread 019fd821-1450-7952-85ca-3bb8e5d150da but does not grant turn_control",
     );
+  });
+
+  it("interrupts the active turn on the owning peer without starting a turn", async () => {
+    const { backends, runtime } = buildRuntime({
+      peers: [{
+        instanceId: "pwr_owner",
+        label: "Owner Mac",
+        ownsThread: true,
+        activeTurnId: "turn-live",
+      }],
+    });
+    const handler = createFederatedThreadControlHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler({
+      operation: "stop",
+      backend: "codex",
+      threadId: request.threadId,
+      requestId: "stop-1",
+    })).resolves.toEqual({
+      backend: "codex",
+      threadId: request.threadId,
+      turnId: "turn-live",
+      disposition: "interrupted",
+      instanceId: "pwr_owner",
+      instanceLabel: "Owner Mac",
+    });
+    expect(backends.get("pwr_owner")?.interruptTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: request.threadId,
+      turnId: "turn-live",
+    });
+    expect(backends.get("pwr_owner")?.startTurn).not.toHaveBeenCalled();
+  });
+
+  it("steers at the active turn boundary and never disguises a scheduled fallback", async () => {
+    const { backends, runtime } = buildRuntime({
+      peers: [{
+        instanceId: "pwr_owner",
+        label: "Owner Mac",
+        ownsThread: true,
+        activeTurnId: "turn-live",
+      }],
+    });
+    const handler = createFederatedThreadControlHandler({
+      runtime: () => runtime,
+    });
+    const input = [{ type: "text" as const, text: "Use the smaller fixture." }];
+
+    await expect(handler({
+      operation: "steer",
+      backend: "codex",
+      threadId: request.threadId,
+      requestId: "steer-1",
+      input,
+    })).resolves.toMatchObject({
+      turnId: "turn-live",
+      disposition: "steered",
+    });
+    expect(backends.get("pwr_owner")?.steerTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: request.threadId,
+      expectedTurnId: "turn-live",
+      requestId: "steer-1",
+      input,
+    });
+    expect(backends.get("pwr_owner")?.startTurn).not.toHaveBeenCalled();
+
+    backends.get("pwr_owner")?.steerTurn.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: request.threadId,
+      turnId: "scheduled-action-1",
+      disposition: "scheduled",
+    });
+    await expect(handler({
+      operation: "steer",
+      backend: "codex",
+      threadId: request.threadId,
+      requestId: "steer-2",
+      input,
+    })).rejects.toMatchObject({ code: "stale_target" });
+  });
+
+  it("reports no-active, stale-turn, and capability dispositions structurally", async () => {
+    const noActive = buildRuntime({
+      peers: [{
+        instanceId: "pwr_idle",
+        label: "Idle Mac",
+        ownsThread: true,
+        activeTurnId: null,
+      }],
+    });
+    await expect(createFederatedThreadControlHandler({
+      runtime: () => noActive.runtime,
+    })({
+      operation: "stop",
+      backend: "codex",
+      threadId: request.threadId,
+      requestId: "stop-idle",
+    })).rejects.toMatchObject({ code: "no_active_turn" });
+
+    const stale = buildRuntime({
+      peers: [{
+        instanceId: "pwr_live",
+        label: "Live Mac",
+        ownsThread: true,
+        activeTurnId: "turn-new",
+      }],
+    });
+    await expect(createFederatedThreadControlHandler({
+      runtime: () => stale.runtime,
+    })({
+      operation: "steer",
+      backend: "codex",
+      threadId: request.threadId,
+      requestId: "steer-stale",
+      expectedTurnId: "turn-old",
+      input: [{ type: "text", text: "Stop." }],
+    })).rejects.toMatchObject({ code: "stale_target" });
+
+    const unsupported = buildRuntime({
+      peers: [{
+        instanceId: "pwr_no_steer",
+        label: "No Steer Mac",
+        ownsThread: true,
+        steerTurn: false,
+      }],
+    });
+    await expect(createFederatedThreadControlHandler({
+      runtime: () => unsupported.runtime,
+    })({
+      operation: "steer",
+      backend: "codex",
+      threadId: request.threadId,
+      requestId: "steer-unsupported",
+      input: [{ type: "text", text: "Stop." }],
+    })).rejects.toMatchObject({ code: "unsupported_capability" });
+  });
+
+  it("reports unavailable, ambiguous, and stale federation ownership structurally", async () => {
+    const unavailableRuntime = {
+      connectedPeerTargets: () => [],
+      health: async () => ({
+        enabled: true,
+        role: "gateway",
+        status: "listening",
+        instanceId: "pwr_local",
+        peers: [{
+          id: "pwr_owner",
+          label: "Owner Mac",
+          role: "client",
+          status: "disconnected",
+          capabilities: [],
+        }],
+      }),
+    } as unknown as DesktopFederationRuntime;
+    await expect(createFederatedThreadControlHandler({
+      runtime: () => unavailableRuntime,
+      targetStore: {
+        listRemoteThreadTargets: vi.fn(async () => [{
+          instanceId: "pwr_owner",
+          instanceLabel: "Owner Mac",
+          backend: "codex" as const,
+          threadId: request.threadId,
+          firstSeenAt: 500,
+          lastSeenAt: 500,
+        }]),
+        rememberRemoteThreadTarget: vi.fn(),
+      },
+    })({
+      operation: "stop",
+      backend: "codex",
+      threadId: request.threadId,
+      requestId: "stop-unavailable",
+    })).rejects.toMatchObject({ code: "peer_unavailable" });
+
+    const ambiguous = buildRuntime({
+      peers: [
+        { instanceId: "pwr_one", label: "One", ownsThread: true },
+        { instanceId: "pwr_two", label: "Two", ownsThread: true },
+      ],
+    });
+    await expect(createFederatedThreadControlHandler({
+      runtime: () => ambiguous.runtime,
+    })({
+      operation: "stop",
+      backend: "codex",
+      threadId: request.threadId,
+      requestId: "stop-ambiguous",
+    })).rejects.toMatchObject({ code: "ambiguous_owner" });
+
+    const stale = buildRuntime({
+      peers: [{ instanceId: "pwr_owner", label: "Owner Mac" }],
+    });
+    await expect(createFederatedThreadControlHandler({
+      runtime: () => stale.runtime,
+    })({
+      operation: "stop",
+      backend: "codex",
+      threadId: request.threadId,
+      instanceId: "pwr_owner",
+      requestId: "stop-stale-owner",
+    })).rejects.toMatchObject({ code: "stale_target" });
   });
 });

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1879,6 +1879,11 @@ describe("federation backend bridge", () => {
         threadId: "thread-1",
         turnId: "compact-1",
       })),
+      resolveActiveTurn: vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        turnId: "turn-live",
+      })),
       interruptTurn: vi.fn(),
       stopSubAgent: vi.fn(),
       steerTurn: vi.fn(),
@@ -1955,6 +1960,19 @@ describe("federation backend bridge", () => {
     await router.routeEnvelope({
       sourcePeerId: "gateway_one",
       envelope: {
+        id: "resolve-active-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.resolveActiveTurn,
+        params: { backend: "codex", threadId: "thread-1" },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "client_one",
+        createdAt: 1_050,
+      },
+    });
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
         id: "approval-request",
         kind: "request",
         method: FEDERATION_BACKEND_METHODS.submitServerRequest,
@@ -2010,6 +2028,10 @@ describe("federation backend bridge", () => {
       backend: "codex",
       threadId: "thread-1",
     });
+    expect(backend.resolveActiveTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
     expect(backend.submitServerRequest).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-1",
@@ -2032,6 +2054,11 @@ describe("federation backend bridge", () => {
         kind: "response",
         requestId: "compact-request",
         result: { turnId: "compact-1" },
+      },
+      {
+        kind: "response",
+        requestId: "resolve-active-request",
+        result: { turnId: "turn-live" },
       },
       {
         kind: "response",
@@ -2096,6 +2123,7 @@ describe("federation backend bridge", () => {
         cancelScheduledThreadAction: vi.fn(),
         sendScheduledThreadActionNow: vi.fn(),
         compactThread: vi.fn(),
+        resolveActiveTurn: vi.fn(),
         interruptTurn: vi.fn(),
         stopSubAgent: vi.fn(),
         steerTurn: vi.fn(),

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1879,6 +1879,14 @@ describe("federation backend bridge", () => {
         threadId: "thread-1",
         turnId: "compact-1",
       })),
+      controlActiveTurn: vi.fn(async (request) => ({
+        ok: true as const,
+        backend: request.backend,
+        threadId: request.threadId,
+        requestId: request.requestId,
+        turnId: "turn-live",
+        disposition: "interrupted" as const,
+      })),
       resolveActiveTurn: vi.fn(async () => ({
         backend: "codex" as const,
         threadId: "thread-1",
@@ -1960,6 +1968,25 @@ describe("federation backend bridge", () => {
     await router.routeEnvelope({
       sourcePeerId: "gateway_one",
       envelope: {
+        id: "control-active-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.controlActiveTurn,
+        params: {
+          operation: "stop",
+          backend: "codex",
+          threadId: "thread-1",
+          requestId: "stop-1",
+          expectedTurnId: "turn-live",
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "client_one",
+        createdAt: 1_025,
+      },
+    });
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
         id: "resolve-active-request",
         kind: "request",
         method: FEDERATION_BACKEND_METHODS.resolveActiveTurn,
@@ -2032,6 +2059,18 @@ describe("federation backend bridge", () => {
       backend: "codex",
       threadId: "thread-1",
     });
+    expect(backend.controlActiveTurn).toHaveBeenCalledWith({
+      operation: "stop",
+      backend: "codex",
+      threadId: "thread-1",
+      requestId: "stop-1",
+      expectedTurnId: "turn-live",
+    });
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.controlActiveTurn
+      ],
+    ).toBe("turn_control");
     expect(backend.submitServerRequest).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-1",
@@ -2054,6 +2093,15 @@ describe("federation backend bridge", () => {
         kind: "response",
         requestId: "compact-request",
         result: { turnId: "compact-1" },
+      },
+      {
+        kind: "response",
+        requestId: "control-active-request",
+        result: {
+          disposition: "interrupted",
+          requestId: "stop-1",
+          turnId: "turn-live",
+        },
       },
       {
         kind: "response",

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -142,6 +142,7 @@ const setMessagingAgentToolServiceMock = vi.fn();
 const setPwrAgentAppManagementHandlerMock = vi.fn();
 const setPwrAgentFederationHandlerMock = vi.fn();
 const setFederatedThreadMessageHandlerMock = vi.fn();
+const setFederatedThreadControlHandlerMock = vi.fn();
 const listThreadsMock = vi.fn<(request?: unknown) => Promise<unknown[]>>();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
 const registerMessagingStatusIpcHandlersMock = vi.fn();
@@ -486,6 +487,7 @@ vi.mock("../app-server/backend-registry", () => ({
     setPwrAgentAppManagementHandler: setPwrAgentAppManagementHandlerMock,
     setPwrAgentFederationHandler: setPwrAgentFederationHandlerMock,
     setFederatedThreadMessageHandler: setFederatedThreadMessageHandlerMock,
+    setFederatedThreadControlHandler: setFederatedThreadControlHandlerMock,
     setMessagingArchiveCleaner: setMessagingArchiveCleanerMock,
   })),
 }));
@@ -672,6 +674,7 @@ describe("bootstrapApp", () => {
     setPwrAgentAppManagementHandlerMock.mockReset();
     setPwrAgentFederationHandlerMock.mockReset();
     setFederatedThreadMessageHandlerMock.mockReset();
+    setFederatedThreadControlHandlerMock.mockReset();
     listThreadsMock.mockReset();
     listThreadsMock.mockResolvedValue([]);
     disposeDesktopMessagingRuntimeMock.mockReset();

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-task-monitor-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-task-monitor-agent-tools.test.ts
@@ -30,7 +30,7 @@ describe("PwrAgent task monitor agent tools", () => {
       "render_messaging_pdf_pages",
       "search_messaging_pdf_text",
     ]);
-    expect(dynamicTools).toHaveLength(31);
+    expect(dynamicTools).toHaveLength(33);
     expect(mcpTools).toEqual(
       dynamicTools.filter((tool) => !dynamicOnlyToolNames.has(tool.name)),
     );
@@ -40,6 +40,10 @@ describe("PwrAgent task monitor agent tools", () => {
       .toContain("cancel_monitor_delegation");
     expect(mcpTools.map((tool) => tool.name))
       .toContain("start_review");
+    expect(mcpTools.map((tool) => tool.name))
+      .toContain("stop_thread");
+    expect(mcpTools.map((tool) => tool.name))
+      .toContain("steer_thread");
     expect(mcpTools.map((tool) => tool.name))
       .not.toEqual(expect.arrayContaining([...dynamicOnlyToolNames]));
     const createMonitorTool = mcpTools.find(

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
@@ -100,12 +100,43 @@ describe("pwragent thread orchestration agent tools", () => {
           expect.objectContaining({
             type: "function",
             name: "send_message_to_thread",
-            description: expect.stringContaining("instanceId"),
+            description: expect.stringMatching(/schedules\/queues.*steer_thread/),
             deferLoading: false,
             inputSchema: expect.objectContaining({
               required: ["backend", "threadId", "prompt"],
               properties: expect.objectContaining({
                 instanceId: expect.objectContaining({ type: "string" }),
+                includeRemote: expect.objectContaining({ type: "boolean" }),
+              }),
+            }),
+          }),
+          expect.objectContaining({
+            type: "function",
+            name: "steer_thread",
+            description: expect.stringMatching(
+              /next tool completion or message boundary.*never reports a queued follow-up as steered/,
+            ),
+            deferLoading: false,
+            inputSchema: expect.objectContaining({
+              required: ["backend", "threadId", "requestId", "prompt"],
+              properties: expect.objectContaining({
+                instanceId: expect.objectContaining({ type: "string" }),
+                includeRemote: expect.objectContaining({ type: "boolean" }),
+                expectedTurnId: expect.objectContaining({ type: "string" }),
+              }),
+            }),
+          }),
+          expect.objectContaining({
+            type: "function",
+            name: "stop_thread",
+            description: expect.stringMatching(/high-urgency.*never queues text/),
+            deferLoading: false,
+            inputSchema: expect.objectContaining({
+              required: ["backend", "threadId", "requestId"],
+              properties: expect.objectContaining({
+                instanceId: expect.objectContaining({ type: "string" }),
+                includeRemote: expect.objectContaining({ type: "boolean" }),
+                expectedTurnId: expect.objectContaining({ type: "string" }),
               }),
             }),
           }),

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -15,7 +15,9 @@ import type {
   PwrAgentThreadOrchestrationRequest,
   PwrAgentThreadOrchestrationResponse,
   SendMessageToThreadToolArgs,
+  SteerThreadToolArgs,
   StartReviewToolArgs,
+  StopThreadToolArgs,
 } from "@pwragent/shared";
 import {
   ATTACH_THREAD_DIRECTORY_WORKSPACE_MODES,
@@ -80,9 +82,39 @@ export type PwrAgentFederatedThreadMessageHandler = (
   request: PwrAgentFederatedThreadMessageRequest,
 ) => Promise<PwrAgentFederatedThreadMessageResult | undefined>;
 
+export type PwrAgentFederatedThreadControlRequest = {
+  operation: "steer" | "stop";
+  backend: StopThreadToolArgs["backend"];
+  threadId: StopThreadToolArgs["threadId"];
+  instanceId?: StopThreadToolArgs["instanceId"];
+  resolutionMode?: "remembered_only" | "discover_only";
+  requestId: string;
+  expectedTurnId?: string;
+  input?: AppServerTurnInputItem[];
+};
+
+export type PwrAgentFederatedThreadControlResult = {
+  backend: StopThreadToolArgs["backend"];
+  threadId: StopThreadToolArgs["threadId"];
+  turnId: string;
+  disposition: "interrupted" | "steered";
+  instanceId: string;
+  instanceLabel: string;
+};
+
+export type PwrAgentFederatedThreadControlHandler = (
+  request: PwrAgentFederatedThreadControlRequest,
+) => Promise<PwrAgentFederatedThreadControlResult | undefined>;
+
 export class PwrAgentFederatedThreadMessageError extends Error {
   constructor(
-    readonly code: "peer_unavailable",
+    readonly code:
+      | "ambiguous_owner"
+      | "no_active_turn"
+      | "peer_unavailable"
+      | "stale_target"
+      | "unsupported_backend"
+      | "unsupported_capability",
     message: string,
   ) {
     super(message);
@@ -157,7 +189,11 @@ function descriptionForOperation(
     case "move_thread_workspace":
       return "Move the current PwrAgent thread runtime workspace after the invoking turn reaches a terminal boundary. Use this when the user asks to continue this same thread from an isolated worktree instead of creating a child handoff thread. The operation is path-keyed: pass sourcePath when the thread has multiple linked directories or when the intended workspace is not obvious. The tool returns a pending workspaceMoveId and stop-and-wait guidance; after the current turn ends, PwrAgent performs the move, updates future-turn cwd metadata, rebinds an ACP session when required, and starts a same-thread continuation with the result. Do not keep editing after a successful call in the invoking turn; wait for the continuation or inspect get_thread_status pendingWorkspaceMoves.";
     case "send_message_to_thread":
-      return "Send a follow-up prompt to another existing PwrAgent thread. Use search_threads or read_thread first when the target threadId is unknown. Pass instanceId when a remote create/search result or thread link supplied it; omit it for local threads and older results, which PwrAgent resolves through durable ownership metadata and connected-peer discovery. Do not use this for the current thread; reply normally instead. The result includes threadLink, a ready-made markdown link to the target thread. When you mention that thread to the user, include threadLink verbatim instead of the raw threadId so it renders as a clickable chip.";
+      return "Send an ordinary follow-up prompt as a new turn to another existing PwrAgent thread. If the target already has an active turn, this schedules/queues the follow-up instead of steering that turn. Use steer_thread when guidance must reach a long-running active turn at its next tool completion or message boundary, and stop_thread only for an urgent interruption. Use search_threads or read_thread first when the target threadId is unknown. Pass instanceId when a remote create/search result or thread link supplied it; omit it for local threads and older results, which PwrAgent resolves through durable ownership metadata and connected-peer discovery. Set includeRemote=false for a local-only lookup. Do not use this for the current thread; reply normally instead. The result includes threadLink, a ready-made markdown link to the target thread. When you mention that thread to the user, include threadLink verbatim instead of the raw threadId so it renders as a clickable chip.";
+    case "steer_thread":
+      return "Steer the active turn on another PwrAgent thread. Use this when the target is likely to run for a while and guidance needs to reach it at the next tool completion or message boundary, avoiding wasted time and tokens. This preserves real steer semantics: it never reports a queued follow-up as steered. Use send_message_to_thread for an ordinary queued/new-turn follow-up and stop_thread for an urgent interruption. The owning local or federated instance discovers the active turn and rejects stale expectedTurnId races. Pass instanceId when known; set includeRemote=false for local-only resolution. requestId is an idempotency key: reuse it only to retry the exact same steer. The current thread cannot steer itself through this tool; reply normally instead.";
+    case "stop_thread":
+      return "Immediately interrupt the active turn on another PwrAgent thread. Use this high-urgency control only when the target must stop promptly; it calls the owning backend's interrupt operation and never queues text. It works for local and federated targets through turn-control routing. The owning instance discovers the active turn and rejects stale expectedTurnId races. Pass instanceId when known; set includeRemote=false for local-only resolution. requestId is an idempotency key: reuse it only to retry the exact same stop. The current turn cannot stop itself through this tool because its tool result could not be delivered safely.";
     case "start_review":
       return "Schedule a code review of the invoking PwrAgent thread after the current turn completes successfully. Use this only when the operator explicitly asks for a review. Choose one structured target: uncommittedChanges, baseBranch, commit, or custom. The tool returns a pendingReviewId; after a successful call, stop work and let the current turn finish so PwrAgent can start the review. Do not poll or call the tool again for the same request.";
   }
@@ -356,6 +392,11 @@ function inputSchemaForOperation(
             description:
               "Owning remote instance id from create_instance_thread, search_federation_threads, or a cross-instance thread link. Omit for local threads or when unknown.",
           },
+          includeRemote: {
+            type: "boolean",
+            description:
+              "Defaults to true. Set false to restrict resolution to the local instance.",
+          },
           prompt: {
             type: "string",
             description:
@@ -370,6 +411,10 @@ function inputSchemaForOperation(
           sandbox: { type: "string" },
         },
       };
+    case "steer_thread":
+      return threadTurnControlInputSchema({ prompt: true });
+    case "stop_thread":
+      return threadTurnControlInputSchema({ prompt: false });
     case "start_review":
       return {
         type: "object",
@@ -417,7 +462,9 @@ function normalizeArgsForOperation(
   | HandoffTaskToolArgs
   | MoveThreadWorkspaceToolArgs
   | SendMessageToThreadToolArgs
+  | SteerThreadToolArgs
   | StartReviewToolArgs
+  | StopThreadToolArgs
   | undefined {
   switch (operation) {
     case "attach_thread_directory":
@@ -430,6 +477,10 @@ function normalizeArgsForOperation(
       return normalizeMoveThreadWorkspaceArgs(args);
     case "send_message_to_thread":
       return normalizeSendMessageToThreadArgs(args);
+    case "steer_thread":
+      return normalizeSteerThreadArgs(args);
+    case "stop_thread":
+      return normalizeStopThreadArgs(args);
     case "start_review":
       return normalizeStartReviewArgs(args);
   }
@@ -449,6 +500,10 @@ function invalidArgumentsMessageForOperation(
       return "move_thread_workspace accepts only known direction/strategy values and non-empty string fields.";
     case "send_message_to_thread":
       return "send_message_to_thread requires non-empty backend, threadId, and prompt strings.";
+    case "steer_thread":
+      return "steer_thread requires non-empty backend, threadId, requestId, and prompt strings; includeRemote must be boolean when supplied, and instanceId cannot be combined with includeRemote=false.";
+    case "stop_thread":
+      return "stop_thread requires non-empty backend, threadId, and requestId strings; includeRemote must be boolean when supplied, and instanceId cannot be combined with includeRemote=false.";
     case "start_review":
       return "start_review requires a valid structured target and non-empty target-specific fields.";
   }
@@ -635,10 +690,20 @@ function normalizeSendMessageToThreadArgs(
   if (Object.hasOwn(args, "instanceId") && !instanceId) {
     return undefined;
   }
+  if (
+    (Object.hasOwn(args, "includeRemote")
+      && typeof args.includeRemote !== "boolean")
+    || (instanceId && args.includeRemote === false)
+  ) {
+    return undefined;
+  }
   return {
     backend: backend as SendMessageToThreadToolArgs["backend"],
     threadId,
     ...(instanceId ? { instanceId } : {}),
+    ...(typeof args.includeRemote === "boolean"
+      ? { includeRemote: args.includeRemote }
+      : {}),
     prompt,
     ...(readTrimmedString(args.model)
       ? { model: readTrimmedString(args.model) }
@@ -664,6 +729,114 @@ function normalizeSendMessageToThreadArgs(
       ? { sandbox: readTrimmedString(args.sandbox) }
       : {}),
   };
+}
+
+function threadTurnControlInputSchema(
+  options: { prompt: boolean },
+): Record<string, unknown> {
+  return {
+    type: "object",
+    additionalProperties: false,
+    required: options.prompt
+      ? ["backend", "threadId", "requestId", "prompt"]
+      : ["backend", "threadId", "requestId"],
+    properties: {
+      backend: {
+        type: "string",
+        description: "Backend type for the target thread.",
+      },
+      threadId: {
+        type: "string",
+        description: "Existing target thread id to control.",
+      },
+      instanceId: {
+        type: "string",
+        description:
+          "Owning remote instance id when known. Omit for local threads or automatic ownership resolution.",
+      },
+      includeRemote: {
+        type: "boolean",
+        description:
+          "Defaults to true. Set false to restrict resolution to the local instance.",
+      },
+      requestId: {
+        type: "string",
+        description:
+          "Stable idempotency key. Reuse only to retry this exact action with identical arguments.",
+      },
+      expectedTurnId: {
+        type: "string",
+        description:
+          "Optional compare-and-act guard. The action fails as stale if the owning instance reports another active turn.",
+      },
+      ...(options.prompt
+        ? {
+            prompt: {
+              type: "string",
+              description:
+                "Guidance to deliver into the active turn at the next tool completion or message boundary.",
+            },
+          }
+        : {}),
+    },
+  };
+}
+
+function normalizeStopThreadArgs(
+  args: Record<string, unknown>,
+): StopThreadToolArgs | undefined {
+  return normalizeThreadTurnControlArgs(args, false);
+}
+
+function normalizeSteerThreadArgs(
+  args: Record<string, unknown>,
+): SteerThreadToolArgs | undefined {
+  return normalizeThreadTurnControlArgs(args, true);
+}
+
+function normalizeThreadTurnControlArgs(
+  args: Record<string, unknown>,
+  promptRequired: false,
+): StopThreadToolArgs | undefined;
+function normalizeThreadTurnControlArgs(
+  args: Record<string, unknown>,
+  promptRequired: true,
+): SteerThreadToolArgs | undefined;
+function normalizeThreadTurnControlArgs(
+  args: Record<string, unknown>,
+  promptRequired: boolean,
+): StopThreadToolArgs | SteerThreadToolArgs | undefined {
+  const backend = readTrimmedString(args.backend);
+  const threadId = readTrimmedString(args.threadId);
+  const instanceId = readTrimmedString(args.instanceId);
+  const requestId = readTrimmedString(args.requestId);
+  const expectedTurnId = readTrimmedString(args.expectedTurnId);
+  const prompt = readTrimmedString(args.prompt);
+  if (!backend || !threadId || !requestId || (promptRequired && !prompt)) {
+    return undefined;
+  }
+  if (
+    (Object.hasOwn(args, "instanceId") && !instanceId)
+    || (Object.hasOwn(args, "expectedTurnId") && !expectedTurnId)
+    || (Object.hasOwn(args, "includeRemote")
+      && typeof args.includeRemote !== "boolean")
+    || (instanceId && args.includeRemote === false)
+  ) {
+    return undefined;
+  }
+  const target = {
+    backend: backend as StopThreadToolArgs["backend"],
+    threadId,
+    ...(instanceId ? { instanceId } : {}),
+    ...(typeof args.includeRemote === "boolean"
+      ? { includeRemote: args.includeRemote }
+      : {}),
+    requestId,
+    ...(expectedTurnId ? { expectedTurnId } : {}),
+  };
+  return promptRequired
+    ? { ...target, prompt: prompt as string }
+    : target;
 }
 
 function normalizeStartReviewArgs(

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -91,6 +91,7 @@ export type PwrAgentFederatedThreadControlRequest = {
   requestId: string;
   expectedTurnId?: string;
   input?: AppServerTurnInputItem[];
+  messageOrigin?: AppServerThreadMessageOrigin;
 };
 
 export type PwrAgentFederatedThreadControlResult = {
@@ -98,6 +99,7 @@ export type PwrAgentFederatedThreadControlResult = {
   threadId: StopThreadToolArgs["threadId"];
   turnId: string;
   disposition: "interrupted" | "steered";
+  idempotentReplay?: boolean;
   instanceId: string;
   instanceLabel: string;
 };
@@ -110,6 +112,8 @@ export class PwrAgentFederatedThreadMessageError extends Error {
   constructor(
     readonly code:
       | "ambiguous_owner"
+      | "internal_error"
+      | "invalid_arguments"
       | "no_active_turn"
       | "peer_unavailable"
       | "stale_target"

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -99,6 +99,8 @@ import {
   type CancelQueuedTurnResponse,
   type CheckThreadBranchDriftRequest,
   type CheckThreadBranchDriftResponse,
+  type ControlActiveTurnRequest,
+  type ControlActiveTurnResponse,
   type ForkThreadRequest,
   type ForkThreadResponse,
   isBranchDrifted,
@@ -6097,6 +6099,22 @@ type AcceptedThreadControlRequest = {
   signature: string;
 };
 
+type AcceptedActiveTurnControlRequest = {
+  promise: Promise<ControlActiveTurnResponse>;
+  signature: string;
+};
+
+class ActiveTurnControlPreconditionError extends Error {
+  constructor(
+    readonly code: "no_active_turn" | "stale_target",
+    message: string,
+    readonly activeTurnId?: string,
+  ) {
+    super(message);
+    this.name = "ActiveTurnControlPreconditionError";
+  }
+}
+
 const MAX_ACCEPTED_THREAD_CONTROL_REQUESTS = 512;
 
 function buildSteerRequestKey(params: SteerTurnRequest): string {
@@ -6292,6 +6310,10 @@ export class DesktopBackendRegistry {
     string,
     AcceptedThreadControlRequest
   >();
+  private readonly acceptedActiveTurnControlRequests = new Map<
+    string,
+    AcceptedActiveTurnControlRequest
+  >();
   private readonly codexRetryableTurnStarts = new Map<
     string,
     CodexRetryableTurnStart
@@ -6466,6 +6488,7 @@ export class DesktopBackendRegistry {
   >();
   private readonly queuedExecutionModeFlushes = new Map<string, Promise<void>>();
   private readonly acpSessionPromptLocks = new PerKeyAsyncLock();
+  private readonly activeTurnControlLocks = new PerKeyAsyncLock();
   private readonly queuedAcpRuntimeOptions = new Map<
     string,
     {
@@ -12248,30 +12271,281 @@ export class DesktopBackendRegistry {
     }
   }
 
+  async controlActiveTurn(
+    request: ControlActiveTurnRequest,
+  ): Promise<ControlActiveTurnResponse> {
+    const requestKey = [
+      request.backend,
+      request.threadId,
+      request.requestId,
+    ].join("\u0000");
+    const signature = createHash("sha256")
+      .update(JSON.stringify({
+        expectedTurnId: request.expectedTurnId ?? null,
+        input: request.input ?? [],
+        messageOrigin: request.messageOrigin ?? null,
+        operation: request.operation,
+      }))
+      .digest("hex");
+    const accepted = this.acceptedActiveTurnControlRequests.get(requestKey);
+    if (accepted) {
+      if (accepted.signature !== signature) {
+        return {
+          ok: false,
+          backend: request.backend,
+          threadId: request.threadId,
+          requestId: request.requestId,
+          error: {
+            code: "invalid_arguments",
+            message:
+              `Turn control request id ${request.requestId} was reused with different arguments.`,
+          },
+        };
+      }
+      const response = await accepted.promise;
+      return response.ok
+        ? { ...response, idempotentReplay: true }
+        : response;
+    }
+
+    const promise = this.submitActiveTurnControl(request);
+    if (
+      this.acceptedActiveTurnControlRequests.size
+      >= MAX_ACCEPTED_THREAD_CONTROL_REQUESTS
+    ) {
+      const oldestKey =
+        this.acceptedActiveTurnControlRequests.keys().next().value;
+      if (oldestKey) {
+        this.acceptedActiveTurnControlRequests.delete(oldestKey);
+      }
+    }
+    this.acceptedActiveTurnControlRequests.set(requestKey, {
+      promise,
+      signature,
+    });
+    try {
+      const response = await promise;
+      if (
+        !response.ok
+        && this.acceptedActiveTurnControlRequests.get(requestKey)?.promise
+          === promise
+      ) {
+        this.acceptedActiveTurnControlRequests.delete(requestKey);
+      }
+      return response;
+    } catch (error) {
+      if (
+        this.acceptedActiveTurnControlRequests.get(requestKey)?.promise
+        === promise
+      ) {
+        this.acceptedActiveTurnControlRequests.delete(requestKey);
+      }
+      throw error;
+    }
+  }
+
+  private async submitActiveTurnControl(
+    request: ControlActiveTurnRequest,
+  ): Promise<ControlActiveTurnResponse> {
+    const failure = (
+      code:
+        | "invalid_arguments"
+        | "no_active_turn"
+        | "stale_target"
+        | "unsupported_backend"
+        | "unsupported_capability",
+      message: string,
+      details: { activeTurnId?: string; expectedTurnId?: string } = {},
+    ): ControlActiveTurnResponse => ({
+      ok: false,
+      backend: request.backend,
+      threadId: request.threadId,
+      requestId: request.requestId,
+      error: { code, message, ...details },
+    });
+    const lockKey = executionModeQueueKey(request.backend, request.threadId);
+    const perform = async (): Promise<ControlActiveTurnResponse> => {
+      const backend = (
+        await this.listBackends({ includeUnavailable: true })
+      ).backends.find((candidate) => candidate.kind === request.backend);
+      if (!backend?.available) {
+        return failure(
+          "unsupported_backend",
+          `Backend ${request.backend} is not available on this instance.`,
+        );
+      }
+      const capability = request.operation === "stop"
+        ? "interruptTurn"
+        : "steerTurn";
+      if (!backend.capabilities[capability]) {
+        return failure(
+          "unsupported_capability",
+          `Backend ${request.backend} does not support ${request.operation === "stop" ? "turn interruption" : "turn steering"}.`,
+        );
+      }
+      if (request.operation === "steer" && !(request.input?.length)) {
+        return failure(
+          "invalid_arguments",
+          "Steering an active turn requires non-empty input.",
+        );
+      }
+
+      const active = this.getActiveTurnForThread({
+        backend: request.backend,
+        threadId: request.threadId,
+      });
+      if (!active) {
+        return failure(
+          "no_active_turn",
+          `Thread ${request.threadId} has no active turn.`,
+        );
+      }
+      if (
+        request.expectedTurnId
+        && request.expectedTurnId !== active.turnId
+      ) {
+        return failure(
+          "stale_target",
+          `Thread ${request.threadId} now has active turn ${active.turnId}, not expected turn ${request.expectedTurnId}.`,
+          {
+            activeTurnId: active.turnId,
+            expectedTurnId: request.expectedTurnId,
+          },
+        );
+      }
+
+      try {
+        if (request.operation === "stop") {
+          const stopped = isAcpBackendId(request.backend)
+            ? await this.interruptAcpTurn(active, true)
+            : await this.interruptTurn(active);
+          return {
+            ok: true,
+            backend: stopped.backend,
+            threadId: stopped.threadId,
+            requestId: request.requestId,
+            turnId: stopped.turnId,
+            disposition: "interrupted",
+          };
+        }
+        const steered = await this.steerTurn(
+          {
+            backend: request.backend,
+            threadId: request.threadId,
+            expectedTurnId: active.turnId,
+            requestId: request.requestId,
+            input: request.input ?? [],
+          },
+          request.messageOrigin,
+        );
+        if (steered.disposition === "scheduled") {
+          return failure(
+            "stale_target",
+            "The active turn changed before steering; no queued fallback was created.",
+            {
+              expectedTurnId: active.turnId,
+            },
+          );
+        }
+        return {
+          ok: true,
+          backend: steered.backend,
+          threadId: steered.threadId,
+          requestId: request.requestId,
+          turnId: steered.turnId,
+          disposition: "steered",
+        };
+      } catch (error) {
+        if (error instanceof ActiveTurnControlPreconditionError) {
+          return failure(error.code, error.message, {
+            ...(error.activeTurnId
+              ? { activeTurnId: error.activeTurnId }
+              : {}),
+            ...(request.expectedTurnId
+              ? { expectedTurnId: request.expectedTurnId }
+              : {}),
+          });
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        if (/unsupported|does not support/i.test(message)) {
+          return failure("unsupported_capability", message);
+        }
+        if (/active|expected turn|stale|in progress/i.test(message)) {
+          return failure("stale_target", message, {
+            expectedTurnId: active.turnId,
+          });
+        }
+        throw error;
+      }
+    };
+
+    return await this.activeTurnControlLocks.run(
+      lockKey,
+      async () =>
+        isAcpBackendId(request.backend)
+          ? await this.acpSessionPromptLocks.run(lockKey, perform)
+          : await perform(),
+    );
+  }
+
+  private async interruptAcpTurn(
+    params: {
+      backend: AppServerBackendKind;
+      threadId: string;
+      turnId: string;
+    },
+    validateActiveTurn = false,
+  ): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
+    if (!isAcpBackendId(params.backend)) {
+      throw new Error(`Backend ${params.backend} is not an ACP backend.`);
+    }
+    const client = await this.acpBackend.getClient(params.backend);
+    if (validateActiveTurn) {
+      const active = this.getActiveTurnForThread(params);
+      if (!active) {
+        throw new ActiveTurnControlPreconditionError(
+          "no_active_turn",
+          `Thread ${params.threadId} has no active turn.`,
+        );
+      }
+      if (active.turnId !== params.turnId) {
+        throw new ActiveTurnControlPreconditionError(
+          "stale_target",
+          `Thread ${params.threadId} now has active turn ${active.turnId}, not expected turn ${params.turnId}.`,
+          active.turnId,
+        );
+      }
+    }
+    // Invoke cancel without an intervening await after the final active-turn
+    // check. The shared ACP prompt lock prevents the next queued prompt from
+    // starting until this cancellation request has been delivered.
+    const cancellation = client.cancelSession(params.threadId);
+    await cancellation;
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "turn/cancelled",
+        params: {
+          threadId: params.threadId,
+          turnId: params.turnId,
+          turn: {
+            id: params.turnId,
+            status: "cancelled",
+            completedAt: Date.now(),
+          },
+        },
+      },
+    });
+    return params;
+  }
+
   async interruptTurn(params: {
     backend: AppServerBackendKind;
     threadId: string;
     turnId: string;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
     if (isAcpBackendId(params.backend)) {
-      const client = await this.acpBackend.getClient(params.backend);
-      await client.cancelSession(params.threadId);
-      await this.emit({
-        backend: params.backend,
-        notification: {
-          method: "turn/cancelled",
-          params: {
-            threadId: params.threadId,
-            turnId: params.turnId,
-            turn: {
-              id: params.turnId,
-              status: "cancelled",
-              completedAt: Date.now(),
-            },
-          },
-        },
-      });
-      return params;
+      return await this.interruptAcpTurn(params);
     }
 
     const managedReview = this.findManagedReviewForParentTurn({
@@ -15516,6 +15790,8 @@ export class DesktopBackendRegistry {
   async close(): Promise<void> {
     this.closed = true;
     this.acceptedSteerRequests.clear();
+    this.acceptedThreadControlRequests.clear();
+    this.acceptedActiveTurnControlRequests.clear();
     this.workingStateByWorktree.clear();
     this.workingStateCacheLoad = undefined;
     if (this.taskMonitorWatchdogTimer) {
@@ -22537,6 +22813,13 @@ export class DesktopBackendRegistry {
             input: [{ type: "text" as const, text: request.args.prompt }],
           }
         : {}),
+      messageOrigin: {
+        kind: "agent" as const,
+        sourceThread: {
+          backend: request.context.backend,
+          threadId: request.context.threadId,
+        },
+      },
     };
 
     try {
@@ -22547,6 +22830,7 @@ export class DesktopBackendRegistry {
             threadId: string;
             turnId: string;
             disposition: "interrupted" | "steered";
+            idempotentReplay?: boolean;
           }
         | undefined;
       const rememberedRemote =
@@ -22598,58 +22882,32 @@ export class DesktopBackendRegistry {
               { backend, threadId },
             );
           }
-          const active = this.getActiveTurnForThread({ backend, threadId });
-          if (!active) {
+          const controlled = await this.controlActiveTurn(remoteRequest);
+          if (!controlled.ok) {
             return threadOrchestrationFailure(
-              "no_active_turn",
-              `Thread ${threadId} has no active turn.`,
-              { backend, threadId },
-            );
-          }
-          if (
-            request.args.expectedTurnId
-            && request.args.expectedTurnId !== active.turnId
-          ) {
-            return threadOrchestrationFailure(
-              "stale_target",
-              `Thread ${threadId} now has active turn ${active.turnId}, not expected turn ${request.args.expectedTurnId}.`,
+              controlled.error.code,
+              controlled.error.message,
               {
-                activeTurnId: active.turnId,
+                ...(controlled.error.activeTurnId
+                  ? { activeTurnId: controlled.error.activeTurnId }
+                  : {}),
                 backend,
-                expectedTurnId: request.args.expectedTurnId,
+                ...(controlled.error.expectedTurnId
+                  ? { expectedTurnId: controlled.error.expectedTurnId }
+                  : {}),
                 threadId,
               },
             );
           }
-          if (request.operation === "stop_thread") {
-            const stopped = await this.interruptTurn(active);
-            result = { ...stopped, disposition: "interrupted" };
-          } else {
-            const steered = await this.steerTurn(
-              {
-                backend,
-                threadId,
-                expectedTurnId: active.turnId,
-                requestId: request.args.requestId,
-                input: [{ type: "text", text: request.args.prompt }],
-              },
-              {
-                kind: "agent",
-                sourceThread: {
-                  backend: request.context.backend,
-                  threadId: request.context.threadId,
-                },
-              },
-            );
-            if (steered.disposition === "scheduled") {
-              return threadOrchestrationFailure(
-                "stale_target",
-                "The active turn changed before steering; no queued fallback was created.",
-                { backend, threadId },
-              );
-            }
-            result = { ...steered, disposition: "steered" };
-          }
+          result = {
+            backend: controlled.backend,
+            threadId: controlled.threadId,
+            turnId: controlled.turnId,
+            disposition: controlled.disposition,
+            ...(controlled.idempotentReplay
+              ? { idempotentReplay: true }
+              : {}),
+          };
         } else if (includeRemote && this.federatedThreadControlHandler) {
           const discovered = await this.federatedThreadControlHandler({
             ...remoteRequest,
@@ -22687,6 +22945,7 @@ export class DesktopBackendRegistry {
         ...(targetInstanceId ? { instanceId: targetInstanceId } : {}),
         requestId: request.args.requestId,
         turnId: result.turnId,
+        ...(result.idempotentReplay ? { idempotentReplay: true } : {}),
       };
       return request.operation === "stop_thread"
         ? {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -350,6 +350,7 @@ import {
 } from "../agent-tools/pwragent-thread-orchestration-codex-tools";
 import {
   PwrAgentFederatedThreadMessageError,
+  type PwrAgentFederatedThreadControlHandler,
   type PwrAgentFederatedThreadMessageHandler,
   type PwrAgentThreadOrchestrationHandler,
 } from "../agent-tools/pwragent-thread-orchestration-agent-tools";
@@ -6091,6 +6092,13 @@ type AcceptedSteerRequest = {
   signature: string;
 };
 
+type AcceptedThreadControlRequest = {
+  promise: Promise<PwrAgentThreadOrchestrationResponse>;
+  signature: string;
+};
+
+const MAX_ACCEPTED_THREAD_CONTROL_REQUESTS = 512;
+
 function buildSteerRequestKey(params: SteerTurnRequest): string {
   return [
     params.backend,
@@ -6280,6 +6288,10 @@ export class DesktopBackendRegistry {
     string,
     AcceptedSteerRequest
   >();
+  private readonly acceptedThreadControlRequests = new Map<
+    string,
+    AcceptedThreadControlRequest
+  >();
   private readonly codexRetryableTurnStarts = new Map<
     string,
     CodexRetryableTurnStart
@@ -6401,6 +6413,9 @@ export class DesktopBackendRegistry {
   private federationHandler: PwrAgentFederationHandler | undefined;
   private federatedThreadMessageHandler:
     | PwrAgentFederatedThreadMessageHandler
+    | undefined;
+  private federatedThreadControlHandler:
+    | PwrAgentFederatedThreadControlHandler
     | undefined;
   private threadPullRequestStatusToolHandler:
     | ThreadPullRequestStatusToolHandler
@@ -7120,6 +7135,12 @@ export class DesktopBackendRegistry {
     handler: PwrAgentFederatedThreadMessageHandler | null | undefined,
   ): void {
     this.federatedThreadMessageHandler = handler ?? undefined;
+  }
+
+  setFederatedThreadControlHandler(
+    handler: PwrAgentFederatedThreadControlHandler | null | undefined,
+  ): void {
+    this.federatedThreadControlHandler = handler ?? undefined;
   }
 
   setThreadPullRequestStatusToolHandler(
@@ -21127,6 +21148,12 @@ export class DesktopBackendRegistry {
     if (request.operation === "send_message_to_thread") {
       return await this.sendMessageToThread(request);
     }
+    if (
+      request.operation === "steer_thread"
+      || request.operation === "stop_thread"
+    ) {
+      return await this.controlThreadTurn(request);
+    }
     if (request.operation === "start_review") {
       return await this.startReviewFromAgentTool(request);
     }
@@ -22209,6 +22236,7 @@ export class DesktopBackendRegistry {
     }
     const threadId = request.args.threadId.trim();
     const instanceId = request.args.instanceId?.trim();
+    const includeRemote = request.args.includeRemote !== false;
     const prompt = request.args.prompt.trim();
     if (!threadId || !prompt) {
       return threadOrchestrationFailure(
@@ -22280,7 +22308,7 @@ export class DesktopBackendRegistry {
         approvalPolicy: request.args.approvalPolicy,
         sandbox: request.args.sandbox,
       };
-      const rememberedRemoteTurn = this.federatedThreadMessageHandler
+      const rememberedRemoteTurn = includeRemote && this.federatedThreadMessageHandler
         ? await this.federatedThreadMessageHandler({
             ...remoteRequest,
             ...(instanceId
@@ -22330,7 +22358,7 @@ export class DesktopBackendRegistry {
                 position: submitted.position,
               };
           targetTitle = localThread.title;
-        } else if (this.federatedThreadMessageHandler) {
+        } else if (includeRemote && this.federatedThreadMessageHandler) {
           const discoveredRemoteTurn = await this.federatedThreadMessageHandler({
             ...remoteRequest,
             resolutionMode: "discover_only",
@@ -22388,6 +22416,311 @@ export class DesktopBackendRegistry {
             ? "not_found"
             : "turn_start_failed",
         message,
+      );
+    }
+  }
+
+  private async controlThreadTurn(
+    request: PwrAgentThreadOrchestrationRequest<"steer_thread" | "stop_thread">,
+  ): Promise<PwrAgentThreadOrchestrationResponse> {
+    const requestKey = [
+      request.operation,
+      request.args.backend,
+      request.args.threadId,
+      request.args.instanceId ?? "local-or-discover",
+      request.args.requestId,
+    ].join("\u0000");
+    const signature = createHash("sha256")
+      .update(JSON.stringify({
+        args: request.args,
+        sourceBackend: request.context.backend,
+        sourceThreadId: request.context.threadId,
+      }))
+      .digest("hex");
+    const accepted = this.acceptedThreadControlRequests.get(requestKey);
+    if (accepted) {
+      if (accepted.signature !== signature) {
+        return threadOrchestrationFailure(
+          "invalid_arguments",
+          `Thread control request id ${request.args.requestId} was reused with different arguments.`,
+        );
+      }
+      const response = await accepted.promise;
+      return response.ok
+        ? {
+            ok: true,
+            data: {
+              ...response.data,
+              idempotentReplay: true,
+            },
+          }
+        : response;
+    }
+
+    const promise = this.performThreadTurnControl(request);
+    if (
+      this.acceptedThreadControlRequests.size
+      >= MAX_ACCEPTED_THREAD_CONTROL_REQUESTS
+    ) {
+      const oldestKey = this.acceptedThreadControlRequests.keys().next().value;
+      if (oldestKey) {
+        this.acceptedThreadControlRequests.delete(oldestKey);
+      }
+    }
+    this.acceptedThreadControlRequests.set(requestKey, { promise, signature });
+    try {
+      const response = await promise;
+      if (
+        !response.ok
+        && this.acceptedThreadControlRequests.get(requestKey)?.promise === promise
+      ) {
+        this.acceptedThreadControlRequests.delete(requestKey);
+      }
+      return response;
+    } catch (error) {
+      if (this.acceptedThreadControlRequests.get(requestKey)?.promise === promise) {
+        this.acceptedThreadControlRequests.delete(requestKey);
+      }
+      throw error;
+    }
+  }
+
+  private async performThreadTurnControl(
+    request: PwrAgentThreadOrchestrationRequest<"steer_thread" | "stop_thread">,
+  ): Promise<PwrAgentThreadOrchestrationResponse> {
+    const sourceTurnId = request.context.turnId?.trim();
+    if (
+      !sourceTurnId
+      || !this.isLiveDynamicToolCall(request.context.backend, {
+        threadId: request.context.threadId,
+        turnId: sourceTurnId,
+      })
+    ) {
+      return threadOrchestrationFailure(
+        "forbidden",
+        "Thread control tools must be invoked from a live turn.",
+      );
+    }
+    const backend = request.args.backend;
+    if (!isAppServerBackendKind(backend)) {
+      return threadOrchestrationFailure(
+        "unsupported_backend",
+        "backend must be a known PwrAgent backend.",
+      );
+    }
+    const threadId = request.args.threadId.trim();
+    const instanceId = request.args.instanceId?.trim();
+    const includeRemote = request.args.includeRemote !== false;
+    if (
+      backend === request.context.backend
+      && threadId === request.context.threadId
+      && !instanceId
+    ) {
+      return threadOrchestrationFailure(
+        "forbidden",
+        request.operation === "stop_thread"
+          ? "stop_thread cannot interrupt its own current turn because the tool result could not be delivered safely."
+          : "steer_thread cannot steer its own current turn; reply normally to add guidance.",
+      );
+    }
+
+    const remoteRequest = {
+      operation: request.operation === "stop_thread" ? "stop" as const : "steer" as const,
+      backend,
+      threadId,
+      requestId: request.args.requestId,
+      ...(request.args.expectedTurnId
+        ? { expectedTurnId: request.args.expectedTurnId }
+        : {}),
+      ...(request.operation === "steer_thread"
+        ? {
+            input: [{ type: "text" as const, text: request.args.prompt }],
+          }
+        : {}),
+    };
+
+    try {
+      let targetInstanceId: string | undefined;
+      let result:
+        | {
+            backend: AppServerBackendKind;
+            threadId: string;
+            turnId: string;
+            disposition: "interrupted" | "steered";
+          }
+        | undefined;
+      const rememberedRemote =
+        includeRemote && this.federatedThreadControlHandler
+          ? await this.federatedThreadControlHandler({
+              ...remoteRequest,
+              ...(instanceId
+                ? { instanceId }
+                : { resolutionMode: "remembered_only" as const }),
+            })
+          : undefined;
+      if (rememberedRemote) {
+        result = rememberedRemote;
+        targetInstanceId = rememberedRemote.instanceId;
+      } else if (instanceId) {
+        return threadOrchestrationFailure(
+          this.federatedThreadControlHandler
+            ? "stale_target"
+            : "peer_unavailable",
+          this.federatedThreadControlHandler
+            ? `Thread ${threadId} was not found on federation instance ${instanceId}.`
+            : `Federation routing is unavailable; instance ${instanceId} could not be reached.`,
+          { backend, instanceId, threadId },
+        );
+      } else {
+        let localThread: AppServerThreadSummary | undefined;
+        try {
+          localThread = await this.resolveThread({ backend, threadId });
+        } catch {
+          localThread = undefined;
+        }
+        if (localThread) {
+          const backendSummary = (
+            await this.listBackends({ includeUnavailable: true })
+          ).backends.find((candidate) => candidate.kind === backend);
+          if (!backendSummary?.available) {
+            return threadOrchestrationFailure(
+              "unsupported_backend",
+              `Backend ${backend} is not available on this instance.`,
+              { backend, threadId },
+            );
+          }
+          const capability =
+            request.operation === "stop_thread" ? "interruptTurn" : "steerTurn";
+          if (!backendSummary.capabilities[capability]) {
+            return threadOrchestrationFailure(
+              "unsupported_capability",
+              `Backend ${backend} does not support ${request.operation === "stop_thread" ? "turn interruption" : "turn steering"}.`,
+              { backend, threadId },
+            );
+          }
+          const active = this.getActiveTurnForThread({ backend, threadId });
+          if (!active) {
+            return threadOrchestrationFailure(
+              "no_active_turn",
+              `Thread ${threadId} has no active turn.`,
+              { backend, threadId },
+            );
+          }
+          if (
+            request.args.expectedTurnId
+            && request.args.expectedTurnId !== active.turnId
+          ) {
+            return threadOrchestrationFailure(
+              "stale_target",
+              `Thread ${threadId} now has active turn ${active.turnId}, not expected turn ${request.args.expectedTurnId}.`,
+              {
+                activeTurnId: active.turnId,
+                backend,
+                expectedTurnId: request.args.expectedTurnId,
+                threadId,
+              },
+            );
+          }
+          if (request.operation === "stop_thread") {
+            const stopped = await this.interruptTurn(active);
+            result = { ...stopped, disposition: "interrupted" };
+          } else {
+            const steered = await this.steerTurn(
+              {
+                backend,
+                threadId,
+                expectedTurnId: active.turnId,
+                requestId: request.args.requestId,
+                input: [{ type: "text", text: request.args.prompt }],
+              },
+              {
+                kind: "agent",
+                sourceThread: {
+                  backend: request.context.backend,
+                  threadId: request.context.threadId,
+                },
+              },
+            );
+            if (steered.disposition === "scheduled") {
+              return threadOrchestrationFailure(
+                "stale_target",
+                "The active turn changed before steering; no queued fallback was created.",
+                { backend, threadId },
+              );
+            }
+            result = { ...steered, disposition: "steered" };
+          }
+        } else if (includeRemote && this.federatedThreadControlHandler) {
+          const discovered = await this.federatedThreadControlHandler({
+            ...remoteRequest,
+            resolutionMode: "discover_only",
+          });
+          if (discovered) {
+            result = discovered;
+            targetInstanceId = discovered.instanceId;
+          }
+        }
+      }
+
+      if (!result) {
+        if (!includeRemote) {
+          const localBackend = (
+            await this.listBackends({ includeUnavailable: true })
+          ).backends.find((candidate) => candidate.kind === backend);
+          if (!localBackend?.available) {
+            return threadOrchestrationFailure(
+              "unsupported_backend",
+              `Backend ${backend} is not available on this instance.`,
+              { backend, threadId },
+            );
+          }
+        }
+        return threadOrchestrationFailure(
+          "not_found",
+          `Thread ${backend}:${threadId} was not found${includeRemote ? " locally or on a connected Federation peer" : " locally"}.`,
+          { backend, threadId },
+        );
+      }
+      const base = {
+        backend: result.backend,
+        threadId: result.threadId,
+        ...(targetInstanceId ? { instanceId: targetInstanceId } : {}),
+        requestId: request.args.requestId,
+        turnId: result.turnId,
+      };
+      return request.operation === "stop_thread"
+        ? {
+            ok: true,
+            data: {
+              ...base,
+              disposition: "interrupted",
+              interruptedAt: Date.now(),
+            },
+          }
+        : {
+            ok: true,
+            data: {
+              ...base,
+              disposition: "steered",
+              promptPreview: truncateThreadInspectionText(request.args.prompt, 240),
+            },
+          };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return threadOrchestrationFailure(
+        error instanceof PwrAgentFederatedThreadMessageError
+          ? error.code
+          : /unsupported|does not support/i.test(message)
+            ? "unsupported_capability"
+            : /active|expected turn|stale/i.test(message)
+              ? "stale_target"
+              : "internal_error",
+        message,
+        {
+          backend,
+          ...(instanceId ? { instanceId } : {}),
+          threadId,
+        },
       );
     }
   }

--- a/apps/desktop/src/main/federation/federated-thread-message-service.ts
+++ b/apps/desktop/src/main/federation/federated-thread-message-service.ts
@@ -18,6 +18,7 @@ import type {
 import { getMainLogger } from "../log";
 import type { RemoteThreadTargetStore } from "../state/remote-thread-target-store";
 import type { FederationBackendOperations } from "./federation-backend-bridge";
+import { isFederationPeerUnavailableError } from "./federation-peer-unavailable-error";
 import {
   getDesktopFederationRuntime,
   type DesktopFederationRuntime,
@@ -295,90 +296,39 @@ async function controlRemoteThread(
     threadId: request.threadId,
   });
 
-  const backends = await match.backend.listBackends({ includeUnavailable: true });
-  const backend = backends.backends.find(
-    (candidate) => candidate.kind === request.backend,
-  );
-  if (!backend?.available) {
-    throw new PwrAgentFederatedThreadMessageError(
-      "unsupported_backend",
-      `Backend ${request.backend} is not available on federation instance ${match.peer.label}.`,
-    );
-  }
-  const capability = request.operation === "stop" ? "interruptTurn" : "steerTurn";
-  if (!backend.capabilities[capability]) {
+  if (!match.backend.controlActiveTurn) {
     throw new PwrAgentFederatedThreadMessageError(
       "unsupported_capability",
-      `Backend ${request.backend} on federation instance ${match.peer.label} does not support ${request.operation === "stop" ? "turn interruption" : "turn steering"}.`,
-    );
-  }
-
-  let active: { turnId?: string };
-  try {
-    active = await match.backend.resolveActiveTurn({
-      backend: request.backend,
-      threadId: request.threadId,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (/unsupported|unknown method|not implemented/i.test(message)) {
-      throw new PwrAgentFederatedThreadMessageError(
-        "unsupported_capability",
-        `Federation instance ${match.peer.label} does not support active-turn resolution required for remote ${request.operation}.`,
-      );
-    }
-    throw error;
-  }
-  const activeTurnId = active.turnId;
-  if (!activeTurnId) {
-    throw new PwrAgentFederatedThreadMessageError(
-      "no_active_turn",
-      `Thread ${request.threadId} has no active turn on federation instance ${match.peer.label}.`,
-    );
-  }
-  if (
-    request.expectedTurnId
-    && request.expectedTurnId !== activeTurnId
-  ) {
-    throw new PwrAgentFederatedThreadMessageError(
-      "stale_target",
-      `Thread ${request.threadId} now has active turn ${activeTurnId}, not expected turn ${request.expectedTurnId}.`,
+      `Federation instance ${match.peer.label} does not support atomic active-turn control required for remote ${request.operation}.`,
     );
   }
 
   try {
-    if (request.operation === "stop") {
-      const stopped = await match.backend.interruptTurn({
-        backend: request.backend,
-        threadId: request.threadId,
-        turnId: activeTurnId,
-      });
-      return {
-        backend: stopped.backend,
-        threadId: stopped.threadId,
-        turnId: stopped.turnId,
-        disposition: "interrupted",
-        instanceId: match.peer.target.instanceId,
-        instanceLabel: match.peer.label,
-      };
-    }
-    const steered = await match.backend.steerTurn({
+    const controlled = await match.backend.controlActiveTurn({
+      operation: request.operation,
       backend: request.backend,
       threadId: request.threadId,
-      expectedTurnId: activeTurnId,
       requestId: request.requestId,
-      input: request.input ?? [],
+      ...(request.expectedTurnId
+        ? { expectedTurnId: request.expectedTurnId }
+        : {}),
+      ...(request.input ? { input: request.input } : {}),
+      ...(request.messageOrigin
+        ? { messageOrigin: request.messageOrigin }
+        : {}),
     });
-    if (steered.disposition && steered.disposition !== "steered") {
-      throw new Error(
-        `Owning instance returned ${steered.disposition} instead of steering the active turn.`,
+    if (!controlled.ok) {
+      throw new PwrAgentFederatedThreadMessageError(
+        controlled.error.code,
+        controlled.error.message,
       );
     }
     return {
-      backend: steered.backend,
-      threadId: steered.threadId,
-      turnId: steered.turnId,
-      disposition: "steered",
+      backend: controlled.backend,
+      threadId: controlled.threadId,
+      turnId: controlled.turnId,
+      disposition: controlled.disposition,
+      ...(controlled.idempotentReplay ? { idempotentReplay: true } : {}),
       instanceId: match.peer.target.instanceId,
       instanceLabel: match.peer.label,
     };
@@ -387,10 +337,21 @@ async function controlRemoteThread(
       throw error;
     }
     const message = error instanceof Error ? error.message : String(error);
+    if (
+      isFederationPeerUnavailableError(error)
+      || /federation request timed out/i.test(message)
+    ) {
+      throw new PwrAgentFederatedThreadMessageError(
+        "peer_unavailable",
+        `Federation instance ${match.peer.label} became unavailable while attempting remote ${request.operation}: ${message}`,
+      );
+    }
     throw new PwrAgentFederatedThreadMessageError(
       /unsupported|does not support/i.test(message)
         ? "unsupported_capability"
-        : "stale_target",
+        : /active|expected turn|stale|in progress/i.test(message)
+          ? "stale_target"
+          : "internal_error",
       message,
     );
   }

--- a/apps/desktop/src/main/federation/federated-thread-message-service.ts
+++ b/apps/desktop/src/main/federation/federated-thread-message-service.ts
@@ -1,4 +1,5 @@
 import type {
+  AppServerBackendKind,
   AppServerThreadSummary,
   FederationCapability,
   FederationRemoteTarget,
@@ -8,6 +9,9 @@ import {
   PwrAgentFederatedThreadMessageError,
 } from "../agent-tools/pwragent-thread-orchestration-agent-tools";
 import type {
+  PwrAgentFederatedThreadControlHandler,
+  PwrAgentFederatedThreadControlRequest,
+  PwrAgentFederatedThreadControlResult,
   PwrAgentFederatedThreadMessageHandler,
   PwrAgentFederatedThreadMessageResult,
 } from "../agent-tools/pwragent-thread-orchestration-agent-tools";
@@ -31,6 +35,13 @@ type ResolvedRemoteThread = {
 
 const log = getMainLogger("pwragent:federated-thread-message");
 
+type FederatedThreadTargetRequest = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  instanceId?: string;
+  resolutionMode?: "remembered_only" | "discover_only";
+};
+
 export function createFederatedThreadMessageHandler(
   options: {
     runtime?: () => DesktopFederationRuntime;
@@ -39,109 +50,166 @@ export function createFederatedThreadMessageHandler(
 ): PwrAgentFederatedThreadMessageHandler {
   const runtime = options.runtime ?? getDesktopFederationRuntime;
   return async (request) => {
-    const activeRuntime = runtime();
-    const connectedPeers = activeRuntime.connectedPeerTargets();
-    const rememberedTargets = request.instanceId
-      || request.resolutionMode === "discover_only"
-      ? []
-      : await readRememberedTargets(options.targetStore, request);
-    if (rememberedTargets.length > 1) {
-      throw new Error(
-        `Thread ${request.threadId} has multiple remembered federation owners: ${rememberedTargets
-          .map((target) => target.instanceLabel)
-          .join(", ")}. Pass instanceId to select the intended target.`,
+    try {
+      const match = await resolveRemoteThread(
+        runtime(),
+        request,
+        options.targetStore,
       );
-    }
-    const targetInstanceId =
-      request.instanceId ?? rememberedTargets[0]?.instanceId;
-    if (targetInstanceId) {
-      const peer = connectedPeers.find(
-        (candidate) => candidate.target.instanceId === targetInstanceId,
-      );
-      if (!peer) {
-        const health = await activeRuntime.health();
-        const knownPeer = health.peers.find(
-          (candidate) => candidate.id === targetInstanceId,
-        );
-        const instanceLabel = knownPeer
-          ? formatFederationPeerDisplayLabel(knownPeer, health.peers)
-          : rememberedTargets[0]?.instanceLabel ?? targetInstanceId;
-        const status = knownPeer?.status ?? "not enrolled";
+      return match
+        ? await sendToRemoteThread(match, request, options.targetStore)
+        : undefined;
+    } catch (error) {
+      if (
+        error instanceof PwrAgentFederatedThreadMessageError
+        && error.code === "peer_unavailable"
+      ) {
         throw new PwrAgentFederatedThreadMessageError(
-          "peer_unavailable",
-          `Federation instance ${instanceLabel}, the known owner of thread ${request.threadId}, is ${status}; the message was not sent.`,
+          error.code,
+          `${error.message.replace(/\.$/, "")}; the message was not sent.`,
         );
       }
-      if (!peer.capabilities.includes("thread_navigation")) {
-        throw new Error(
-          `Federation instance ${peer.label} owns thread ${request.threadId} but does not grant thread_navigation.`,
-        );
+      if (error instanceof PwrAgentFederatedThreadMessageError) {
+        // Preserve the legacy send_message_to_thread error classification.
+        // The new structured routing codes are specific to stop/steer control.
+        throw new Error(error.message, { cause: error });
       }
-      const match = await resolveThreadOnPeer(activeRuntime, peer, request);
-      if (!match) {
-        if (
-          rememberedTargets.length > 0
-          && request.resolutionMode === "remembered_only"
-        ) {
-          throw new Error(
-            `Thread ${request.threadId} was not found on its remembered federation owner ${peer.label}.`,
-          );
-        }
-        return undefined;
-      }
-      return await sendToRemoteThread(match, request, options.targetStore);
+      throw error;
     }
+  };
+}
 
-    if (request.resolutionMode === "remembered_only") {
-      return undefined;
-    }
-
-    const peers = connectedPeers.filter((peer) =>
-      peer.capabilities.includes("thread_navigation"),
+export function createFederatedThreadControlHandler(
+  options: {
+    runtime?: () => DesktopFederationRuntime;
+    targetStore?: RemoteThreadTargetStore;
+  } = {},
+): PwrAgentFederatedThreadControlHandler {
+  const runtime = options.runtime ?? getDesktopFederationRuntime;
+  return async (request) => {
+    const match = await resolveRemoteThread(
+      runtime(),
+      request,
+      options.targetStore,
     );
-    const failures: Array<{ label: string; message: string }> = [];
-    const matches = (
-      await Promise.all(
-        peers.map(async (peer): Promise<ResolvedRemoteThread | undefined> => {
-          try {
-            return await resolveThreadOnPeer(activeRuntime, peer, request);
-          } catch (error) {
-            failures.push({
-              label: peer.label,
-              message: error instanceof Error ? error.message : String(error),
-            });
-            return undefined;
-          }
-        }),
-      )
-    ).filter((match): match is ResolvedRemoteThread => Boolean(match));
+    return match
+      ? await controlRemoteThread(match, request, options.targetStore)
+      : undefined;
+  };
+}
 
-    if (matches.length > 1) {
-      throw new Error(
-        `Thread ${request.threadId} was reported by multiple federation instances: ${matches
-          .map((match) => match.peer.label)
-          .join(", ")}.`,
+async function resolveRemoteThread(
+  activeRuntime: DesktopFederationRuntime,
+  request: FederatedThreadTargetRequest,
+  targetStore: RemoteThreadTargetStore | undefined,
+): Promise<ResolvedRemoteThread | undefined> {
+  const connectedPeers = activeRuntime.connectedPeerTargets();
+  const rememberedTargets = request.instanceId
+    || request.resolutionMode === "discover_only"
+      ? []
+      : await readRememberedTargets(targetStore, request);
+  if (rememberedTargets.length > 1) {
+    throw new PwrAgentFederatedThreadMessageError(
+      "ambiguous_owner",
+      `Thread ${request.threadId} has multiple remembered federation owners: ${rememberedTargets
+        .map((target) => target.instanceLabel)
+        .join(", ")}. Pass instanceId to select the intended target.`,
+    );
+  }
+  const targetInstanceId =
+    request.instanceId ?? rememberedTargets[0]?.instanceId;
+  if (targetInstanceId) {
+    const peer = connectedPeers.find(
+      (candidate) => candidate.target.instanceId === targetInstanceId,
+    );
+    if (!peer) {
+      const health = await activeRuntime.health();
+      const knownPeer = health.peers.find(
+        (candidate) => candidate.id === targetInstanceId,
+      );
+      const instanceLabel = knownPeer
+        ? formatFederationPeerDisplayLabel(knownPeer, health.peers)
+        : rememberedTargets[0]?.instanceLabel ?? targetInstanceId;
+      const status = knownPeer?.status ?? "not enrolled";
+      throw new PwrAgentFederatedThreadMessageError(
+        "peer_unavailable",
+        `Federation instance ${instanceLabel}, the known owner of thread ${request.threadId}, is ${status}.`,
       );
     }
-    const match = matches[0];
+    if (!peer.capabilities.includes("thread_navigation")) {
+      throw new PwrAgentFederatedThreadMessageError(
+        "unsupported_capability",
+        `Federation instance ${peer.label} owns thread ${request.threadId} but does not grant thread_navigation.`,
+      );
+    }
+    const match = await resolveThreadOnPeer(activeRuntime, peer, request);
     if (!match) {
-      if (failures.length > 0) {
-        throw new Error(
-          `Could not resolve thread ${request.threadId} because federation lookup failed on ${failures
-            .map((failure) => `${failure.label}: ${failure.message}`)
-            .join("; ")}.`,
+      if (
+        rememberedTargets.length > 0
+        || request.instanceId
+      ) {
+        throw new PwrAgentFederatedThreadMessageError(
+          "stale_target",
+          rememberedTargets.length > 0
+            ? `Thread ${request.threadId} was not found on its remembered federation owner ${peer.label}.`
+            : `Thread ${request.threadId} was not found on its selected federation owner ${peer.label}.`,
         );
       }
       return undefined;
     }
-    return await sendToRemoteThread(match, request, options.targetStore);
-  };
+    return match;
+  }
+
+  if (request.resolutionMode === "remembered_only") {
+    return undefined;
+  }
+
+  const peers = connectedPeers.filter((peer) =>
+    peer.capabilities.includes("thread_navigation"),
+  );
+  const failures: Array<{ label: string; message: string }> = [];
+  const matches = (
+    await Promise.all(
+      peers.map(async (peer): Promise<ResolvedRemoteThread | undefined> => {
+        try {
+          return await resolveThreadOnPeer(activeRuntime, peer, request);
+        } catch (error) {
+          failures.push({
+            label: peer.label,
+            message: error instanceof Error ? error.message : String(error),
+          });
+          return undefined;
+        }
+      }),
+    )
+  ).filter((match): match is ResolvedRemoteThread => Boolean(match));
+
+  if (matches.length > 1) {
+    throw new PwrAgentFederatedThreadMessageError(
+      "ambiguous_owner",
+      `Thread ${request.threadId} was reported by multiple federation instances: ${matches
+        .map((match) => match.peer.label)
+        .join(", ")}.`,
+    );
+  }
+  const match = matches[0];
+  if (!match) {
+    if (failures.length > 0) {
+      throw new Error(
+        `Could not resolve thread ${request.threadId} because federation lookup failed on ${failures
+          .map((failure) => `${failure.label}: ${failure.message}`)
+          .join("; ")}.`,
+      );
+    }
+    return undefined;
+  }
+  return match;
 }
 
 async function resolveThreadOnPeer(
   runtime: DesktopFederationRuntime,
   peer: ResolvedRemoteThread["peer"],
-  request: Parameters<PwrAgentFederatedThreadMessageHandler>[0],
+  request: FederatedThreadTargetRequest,
 ): Promise<ResolvedRemoteThread | undefined> {
   const backend = runtime.remoteBackend(peer.target);
   let thread: AppServerThreadSummary | undefined;
@@ -209,9 +277,128 @@ async function sendToRemoteThread(
   } satisfies PwrAgentFederatedThreadMessageResult;
 }
 
+async function controlRemoteThread(
+  match: ResolvedRemoteThread,
+  request: PwrAgentFederatedThreadControlRequest,
+  targetStore: RemoteThreadTargetStore | undefined,
+): Promise<PwrAgentFederatedThreadControlResult> {
+  if (!match.peer.capabilities.includes("turn_control")) {
+    throw new PwrAgentFederatedThreadMessageError(
+      "unsupported_capability",
+      `Federation instance ${match.peer.label} owns thread ${request.threadId} but does not grant turn_control.`,
+    );
+  }
+  await rememberTarget(targetStore, {
+    instanceId: match.peer.target.instanceId,
+    instanceLabel: match.peer.label,
+    backend: request.backend,
+    threadId: request.threadId,
+  });
+
+  const backends = await match.backend.listBackends({ includeUnavailable: true });
+  const backend = backends.backends.find(
+    (candidate) => candidate.kind === request.backend,
+  );
+  if (!backend?.available) {
+    throw new PwrAgentFederatedThreadMessageError(
+      "unsupported_backend",
+      `Backend ${request.backend} is not available on federation instance ${match.peer.label}.`,
+    );
+  }
+  const capability = request.operation === "stop" ? "interruptTurn" : "steerTurn";
+  if (!backend.capabilities[capability]) {
+    throw new PwrAgentFederatedThreadMessageError(
+      "unsupported_capability",
+      `Backend ${request.backend} on federation instance ${match.peer.label} does not support ${request.operation === "stop" ? "turn interruption" : "turn steering"}.`,
+    );
+  }
+
+  let active: { turnId?: string };
+  try {
+    active = await match.backend.resolveActiveTurn({
+      backend: request.backend,
+      threadId: request.threadId,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/unsupported|unknown method|not implemented/i.test(message)) {
+      throw new PwrAgentFederatedThreadMessageError(
+        "unsupported_capability",
+        `Federation instance ${match.peer.label} does not support active-turn resolution required for remote ${request.operation}.`,
+      );
+    }
+    throw error;
+  }
+  const activeTurnId = active.turnId;
+  if (!activeTurnId) {
+    throw new PwrAgentFederatedThreadMessageError(
+      "no_active_turn",
+      `Thread ${request.threadId} has no active turn on federation instance ${match.peer.label}.`,
+    );
+  }
+  if (
+    request.expectedTurnId
+    && request.expectedTurnId !== activeTurnId
+  ) {
+    throw new PwrAgentFederatedThreadMessageError(
+      "stale_target",
+      `Thread ${request.threadId} now has active turn ${activeTurnId}, not expected turn ${request.expectedTurnId}.`,
+    );
+  }
+
+  try {
+    if (request.operation === "stop") {
+      const stopped = await match.backend.interruptTurn({
+        backend: request.backend,
+        threadId: request.threadId,
+        turnId: activeTurnId,
+      });
+      return {
+        backend: stopped.backend,
+        threadId: stopped.threadId,
+        turnId: stopped.turnId,
+        disposition: "interrupted",
+        instanceId: match.peer.target.instanceId,
+        instanceLabel: match.peer.label,
+      };
+    }
+    const steered = await match.backend.steerTurn({
+      backend: request.backend,
+      threadId: request.threadId,
+      expectedTurnId: activeTurnId,
+      requestId: request.requestId,
+      input: request.input ?? [],
+    });
+    if (steered.disposition && steered.disposition !== "steered") {
+      throw new Error(
+        `Owning instance returned ${steered.disposition} instead of steering the active turn.`,
+      );
+    }
+    return {
+      backend: steered.backend,
+      threadId: steered.threadId,
+      turnId: steered.turnId,
+      disposition: "steered",
+      instanceId: match.peer.target.instanceId,
+      instanceLabel: match.peer.label,
+    };
+  } catch (error) {
+    if (error instanceof PwrAgentFederatedThreadMessageError) {
+      throw error;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new PwrAgentFederatedThreadMessageError(
+      /unsupported|does not support/i.test(message)
+        ? "unsupported_capability"
+        : "stale_target",
+      message,
+    );
+  }
+}
+
 async function readRememberedTargets(
   targetStore: RemoteThreadTargetStore | undefined,
-  request: Parameters<PwrAgentFederatedThreadMessageHandler>[0],
+  request: FederatedThreadTargetRequest,
 ) {
   if (!targetStore) {
     return [];

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -19,6 +19,8 @@ import type {
   CheckThreadBranchDriftResponse,
   CompactThreadRequest,
   CompactThreadResponse,
+  ControlActiveTurnRequest,
+  ControlActiveTurnResponse,
   CreateScheduledThreadActionRequest,
   CodexEnvironmentSetupProgressEvent,
   DetachThreadPullRequestRequest,
@@ -159,6 +161,7 @@ export const FEDERATION_BACKEND_METHODS = {
   cancelScheduledThreadAction: "backend.cancelScheduledThreadAction",
   sendScheduledThreadActionNow: "backend.sendScheduledThreadActionNow",
   compactThread: "backend.compactThread",
+  controlActiveTurn: "backend.controlActiveTurn",
   resolveActiveTurn: "backend.resolveActiveTurn",
   interruptTurn: "backend.interruptTurn",
   stopSubAgent: "backend.stopSubAgent",
@@ -240,6 +243,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.cancelScheduledThreadAction]: "scheduled_actions",
   [FEDERATION_BACKEND_METHODS.sendScheduledThreadActionNow]: "scheduled_actions",
   [FEDERATION_BACKEND_METHODS.compactThread]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.controlActiveTurn]: "turn_control",
   [FEDERATION_BACKEND_METHODS.resolveActiveTurn]: "turn_control",
   [FEDERATION_BACKEND_METHODS.interruptTurn]: "turn_control",
   [FEDERATION_BACKEND_METHODS.stopSubAgent]: "turn_control",
@@ -354,6 +358,9 @@ export type FederationBackendOperations = {
     request: ScheduledThreadActionIdRequest,
   ): Promise<ScheduledThreadActionMutationResponse>;
   compactThread(request: CompactThreadRequest): Promise<CompactThreadResponse>;
+  controlActiveTurn?(
+    request: ControlActiveTurnRequest,
+  ): Promise<ControlActiveTurnResponse>;
   resolveActiveTurn(
     request: ResolveActiveTurnRequest,
   ): Promise<ResolveActiveTurnResponse>;
@@ -663,6 +670,15 @@ export function registerFederationBackendHandlers(params: {
         envelope.params as CompactThreadRequest,
       ),
   );
+  if (params.backend.controlActiveTurn) {
+    params.router.registerHandler(
+      FEDERATION_BACKEND_METHODS.controlActiveTurn,
+      async (envelope) =>
+        await params.backend.controlActiveTurn!(
+          envelope.params as ControlActiveTurnRequest,
+        ),
+    );
+  }
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.resolveActiveTurn,
     async (envelope) =>
@@ -1102,6 +1118,15 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<CompactThreadResponse> {
     return await this.rpc.request<CompactThreadResponse>({
       method: FEDERATION_BACKEND_METHODS.compactThread,
+      params: request,
+    });
+  }
+
+  async controlActiveTurn(
+    request: ControlActiveTurnRequest,
+  ): Promise<ControlActiveTurnResponse> {
+    return await this.rpc.request<ControlActiveTurnResponse>({
+      method: FEDERATION_BACKEND_METHODS.controlActiveTurn,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -69,6 +69,8 @@ import type {
   RetainThreadBranchDriftResponse,
   RenameThreadRequest,
   RenameThreadResponse,
+  ResolveActiveTurnRequest,
+  ResolveActiveTurnResponse,
   RunCodexEnvironmentActionRequest,
   RunCodexEnvironmentActionResponse,
   ScheduledThreadActionIdRequest,
@@ -157,6 +159,7 @@ export const FEDERATION_BACKEND_METHODS = {
   cancelScheduledThreadAction: "backend.cancelScheduledThreadAction",
   sendScheduledThreadActionNow: "backend.sendScheduledThreadActionNow",
   compactThread: "backend.compactThread",
+  resolveActiveTurn: "backend.resolveActiveTurn",
   interruptTurn: "backend.interruptTurn",
   stopSubAgent: "backend.stopSubAgent",
   steerTurn: "backend.steerTurn",
@@ -237,6 +240,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.cancelScheduledThreadAction]: "scheduled_actions",
   [FEDERATION_BACKEND_METHODS.sendScheduledThreadActionNow]: "scheduled_actions",
   [FEDERATION_BACKEND_METHODS.compactThread]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.resolveActiveTurn]: "turn_control",
   [FEDERATION_BACKEND_METHODS.interruptTurn]: "turn_control",
   [FEDERATION_BACKEND_METHODS.stopSubAgent]: "turn_control",
   [FEDERATION_BACKEND_METHODS.steerTurn]: "turn_control",
@@ -350,6 +354,9 @@ export type FederationBackendOperations = {
     request: ScheduledThreadActionIdRequest,
   ): Promise<ScheduledThreadActionMutationResponse>;
   compactThread(request: CompactThreadRequest): Promise<CompactThreadResponse>;
+  resolveActiveTurn(
+    request: ResolveActiveTurnRequest,
+  ): Promise<ResolveActiveTurnResponse>;
   interruptTurn(request: InterruptTurnRequest): Promise<InterruptTurnResponse>;
   stopSubAgent(request: StopSubAgentRequest): Promise<StopSubAgentResponse>;
   steerTurn(request: SteerTurnRequest): Promise<SteerTurnResponse>;
@@ -654,6 +661,13 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.compactThread(
         envelope.params as CompactThreadRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.resolveActiveTurn,
+    async (envelope) =>
+      await params.backend.resolveActiveTurn(
+        envelope.params as ResolveActiveTurnRequest,
       ),
   );
   params.router.registerHandler(
@@ -1088,6 +1102,15 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<CompactThreadResponse> {
     return await this.rpc.request<CompactThreadResponse>({
       method: FEDERATION_BACKEND_METHODS.compactThread,
+      params: request,
+    });
+  }
+
+  async resolveActiveTurn(
+    request: ResolveActiveTurnRequest,
+  ): Promise<ResolveActiveTurnResponse> {
+    return await this.rpc.request<ResolveActiveTurnResponse>({
+      method: FEDERATION_BACKEND_METHODS.resolveActiveTurn,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -118,6 +118,8 @@ import {
   type RefreshDirectoryGitStatusesRequest,
   type RetainThreadBranchDriftRequest,
   type RenameThreadRequest,
+  type ResolveActiveTurnRequest,
+  type ResolveActiveTurnResponse,
   type RunCodexEnvironmentActionRequest,
   type SetAcpSessionRuntimeOptionRequest,
   type SetCelestialIconRequest,
@@ -3828,6 +3830,16 @@ function localBackendOperations(): FederationBackendOperations {
       request: CompactThreadRequest,
     ): Promise<CompactThreadResponse> {
       return await getDesktopBackendRegistry().compactThread(request);
+    },
+    async resolveActiveTurn(
+      request: ResolveActiveTurnRequest,
+    ): Promise<ResolveActiveTurnResponse> {
+      const active = getDesktopBackendRegistry().getActiveTurnForThread(request);
+      return {
+        backend: request.backend,
+        threadId: request.threadId,
+        ...(active ? { turnId: active.turnId } : {}),
+      };
     },
     async interruptTurn(
       request: InterruptTurnRequest,

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -10,6 +10,7 @@ import type {
   CancelThreadExecutionModeQueueResponse,
   CheckThreadBranchDriftResponse,
   CompactThreadResponse,
+  ControlActiveTurnResponse,
   CreateScheduledThreadActionRequest,
   CodexEnvironmentSetupProgressEvent,
   FederationCapability,
@@ -90,6 +91,7 @@ import {
   type CelestialIconId,
   type CheckThreadBranchDriftRequest,
   type CompactThreadRequest,
+  type ControlActiveTurnRequest,
   type ForkThreadRequest,
   type FederationRemoteTarget,
   type DesktopApplicationsSnapshot,
@@ -3830,6 +3832,11 @@ function localBackendOperations(): FederationBackendOperations {
       request: CompactThreadRequest,
     ): Promise<CompactThreadResponse> {
       return await getDesktopBackendRegistry().compactThread(request);
+    },
+    async controlActiveTurn(
+      request: ControlActiveTurnRequest,
+    ): Promise<ControlActiveTurnResponse> {
+      return await getDesktopBackendRegistry().controlActiveTurn(request);
     },
     async resolveActiveTurn(
       request: ResolveActiveTurnRequest,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -4,7 +4,10 @@ import { getDesktopBackendRegistry } from "./app-server/backend-registry";
 import { getDesktopOverlayStore } from "./app-server/desktop-overlay-store";
 import { createPwrAgentAppManagementHandler } from "./agent-tools/pwragent-app-management-service";
 import { createFederationAgentToolsHandler } from "./federation/federation-agent-tools-service";
-import { createFederatedThreadMessageHandler } from "./federation/federated-thread-message-service";
+import {
+  createFederatedThreadControlHandler,
+  createFederatedThreadMessageHandler,
+} from "./federation/federated-thread-message-service";
 import { disposeAgentIpcHandlers, registerAgentIpcHandlers } from "./ipc/agent-ipc";
 import {
   disposeScheduledActionIpcHandlers,
@@ -1012,6 +1015,11 @@ export function bootstrapApp(): void {
     );
     getDesktopBackendRegistry().setFederatedThreadMessageHandler(
       createFederatedThreadMessageHandler({
+        targetStore: getDesktopOverlayStore(),
+      }),
+    );
+    getDesktopBackendRegistry().setFederatedThreadControlHandler(
+      createFederatedThreadControlHandler({
         targetStore: getDesktopOverlayStore(),
       }),
     );

--- a/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
@@ -23,6 +23,8 @@ describe("thread orchestration tool contracts", () => {
       "detach_thread_directory",
       "handoff_task",
       "move_thread_workspace",
+      "stop_thread",
+      "steer_thread",
       "send_message_to_thread",
       "start_review",
     ]);
@@ -32,9 +34,13 @@ describe("thread orchestration tool contracts", () => {
     expect(PWRAGENT_THREAD_ORCHESTRATION_ERROR_CODES).toEqual([
       "invalid_arguments",
       "not_found",
+      "no_active_turn",
       "peer_unavailable",
       "forbidden",
+      "stale_target",
+      "ambiguous_owner",
       "unsupported_backend",
+      "unsupported_capability",
       "unsupported_workspace",
       "unsupported_operation",
       "ambiguous_workspace",

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -309,6 +309,17 @@ export type InterruptTurnResponse = {
   turnId: string;
 };
 
+export type ResolveActiveTurnRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+};
+
+export type ResolveActiveTurnResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  turnId?: string;
+};
+
 export type StopSubAgentRequest = {
   backend: AppServerBackendKind;
   federationTarget?: FederationTarget;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -320,6 +320,46 @@ export type ResolveActiveTurnResponse = {
   turnId?: string;
 };
 
+export type ControlActiveTurnRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  operation: "stop" | "steer";
+  requestId: string;
+  expectedTurnId?: string;
+  input?: AppServerTurnInputItem[];
+  messageOrigin?: AppServerThreadMessageOrigin;
+};
+
+export type ControlActiveTurnErrorCode =
+  | "invalid_arguments"
+  | "no_active_turn"
+  | "stale_target"
+  | "unsupported_backend"
+  | "unsupported_capability";
+
+export type ControlActiveTurnResponse =
+  | {
+      ok: true;
+      backend: AppServerBackendKind;
+      threadId: ThreadIdentifier;
+      requestId: string;
+      turnId: string;
+      disposition: "interrupted" | "steered";
+      idempotentReplay?: boolean;
+    }
+  | {
+      ok: false;
+      backend: AppServerBackendKind;
+      threadId: ThreadIdentifier;
+      requestId: string;
+      error: {
+        code: ControlActiveTurnErrorCode;
+        message: string;
+        activeTurnId?: string;
+        expectedTurnId?: string;
+      };
+    };
+
 export type StopSubAgentRequest = {
   backend: AppServerBackendKind;
   federationTarget?: FederationTarget;

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -20,6 +20,8 @@ export const PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES = [
   "detach_thread_directory",
   "handoff_task",
   "move_thread_workspace",
+  "stop_thread",
+  "steer_thread",
   "send_message_to_thread",
   "start_review",
 ] as const;
@@ -30,9 +32,13 @@ export type PwrAgentThreadOrchestrationOperationName =
 export const PWRAGENT_THREAD_ORCHESTRATION_ERROR_CODES = [
   "invalid_arguments",
   "not_found",
+  "no_active_turn",
   "peer_unavailable",
   "forbidden",
+  "stale_target",
+  "ambiguous_owner",
   "unsupported_backend",
+  "unsupported_capability",
   "unsupported_workspace",
   "unsupported_operation",
   "ambiguous_workspace",
@@ -124,6 +130,8 @@ export type SendMessageToThreadToolArgs = {
    * local threads and legacy callers; PwrAgent falls back to durable lookup.
    */
   instanceId?: FederationInstanceId;
+  /** Defaults to true. Set false to restrict resolution to this instance. */
+  includeRemote?: boolean;
   prompt: string;
   model?: string;
   reasoningEffort?: string;
@@ -132,6 +140,34 @@ export type SendMessageToThreadToolArgs = {
   executionMode?: ThreadExecutionMode;
   approvalPolicy?: string;
   sandbox?: string;
+};
+
+export type ThreadTurnControlToolTargetArgs = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  /**
+   * Owning remote instance when known. Omit for local threads and legacy
+   * links; PwrAgent falls back to durable ownership and peer discovery.
+   */
+  instanceId?: FederationInstanceId;
+  /** Defaults to true. Set false to restrict resolution to this instance. */
+  includeRemote?: boolean;
+  /**
+   * Stable caller-generated idempotency key. Retry the same action with the
+   * same value; never reuse it for different arguments.
+   */
+  requestId: string;
+  /**
+   * Optional compare-and-act guard. When supplied, PwrAgent refuses to act if
+   * the owning instance reports a different active turn.
+   */
+  expectedTurnId?: string;
+};
+
+export type StopThreadToolArgs = ThreadTurnControlToolTargetArgs;
+
+export type SteerThreadToolArgs = ThreadTurnControlToolTargetArgs & {
+  prompt: string;
 };
 
 export type StartReviewToolArgs = {
@@ -401,6 +437,32 @@ export type SendMessageToThreadResult = {
   };
 };
 
+export type StopThreadResult = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  /** Owning remote instance when the target is federated. */
+  instanceId?: FederationInstanceId;
+  requestId: string;
+  turnId: string;
+  disposition: "interrupted";
+  interruptedAt: number;
+  /** True when this response replays an already accepted requestId. */
+  idempotentReplay?: boolean;
+};
+
+export type SteerThreadResult = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  /** Owning remote instance when the target is federated. */
+  instanceId?: FederationInstanceId;
+  requestId: string;
+  turnId: string;
+  disposition: "steered";
+  promptPreview: string;
+  /** True when this response replays an already accepted requestId. */
+  idempotentReplay?: boolean;
+};
+
 export type StartReviewToolResult = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
@@ -419,6 +481,8 @@ export type PwrAgentThreadOrchestrationToolArgsByOperation = {
   handoff_task: HandoffTaskToolArgs;
   move_thread_workspace: MoveThreadWorkspaceToolArgs;
   send_message_to_thread: SendMessageToThreadToolArgs;
+  steer_thread: SteerThreadToolArgs;
+  stop_thread: StopThreadToolArgs;
   start_review: StartReviewToolArgs;
 };
 
@@ -447,6 +511,8 @@ export type PwrAgentThreadOrchestrationResponse =
         | HandoffTaskResult
         | MoveThreadWorkspaceResult
         | SendMessageToThreadResult
+        | SteerThreadResult
+        | StopThreadResult
         | StartReviewToolResult;
     }
   | {


### PR DESCRIPTION
## Summary

- **HIGH urgency — stop:** add `pwragent.stop_thread`, which promptly interrupts another thread's active turn through the existing backend interruption and Federation `turn_control` paths. It never queues text.
- **MEDIUM urgency — steer:** add `pwragent.steer_thread`, which delivers guidance to an active turn at its next tool-completion/message boundary through the existing steer paths. It never reports an ordinary queued follow-up as a successful steer.
- **LOW urgency / next move — queue:** preserve `pwragent.send_message_to_thread` as the ordinary follow-up/new-turn mechanism. Its default behavior is unchanged and its description now says that an active target queues the new turn behind current work.
- Align the shared contracts, unified dynamic-tool catalog, MCP dispatch, local backend registry, Federation bridge/runtime, capability checks, and local/remote ownership resolution.

## Why queued follow-ups were insufficient

`send_message_to_thread` calls `startTurn`. When the target is already active, that is intentionally a future queued turn. It cannot promptly stop costly or incorrect work, and it cannot steer an in-flight turn at the next safe boundary. These new tools expose the existing lower-level interrupt and steer capabilities without changing the queue tool's service contract.

## API and dispositions

Both new tools target `{ backend, threadId }`, accept optional `instanceId`, `includeRemote` (default `true`), and `expectedTurnId`, and require a stable `requestId` idempotency key.

`stop_thread` succeeds with:

```ts
{
  backend,
  threadId,
  instanceId?,
  requestId,
  turnId,
  disposition: "interrupted",
  interruptedAt,
  idempotentReplay?,
}
```

`steer_thread` additionally requires `prompt` and succeeds with:

```ts
{
  backend,
  threadId,
  instanceId?,
  requestId,
  turnId,
  disposition: "steered",
  promptPreview,
  idempotentReplay?,
}
```

Structured failures distinguish `no_active_turn`, `stale_target`, `unsupported_backend`, `unsupported_capability`, `peer_unavailable`, `ambiguous_owner`, `target_not_found`, and invalid arguments. `expectedTurnId` provides compare-and-act protection against stale-turn races. Replaying the same accepted request returns the original disposition with `idempotentReplay: true`; reusing a request ID with different arguments is rejected.

Self-targeting the invoking thread is rejected safely: stop cannot return its own tool result after interrupting itself, and steer should be expressed as the caller's normal response. Neither operation falls back to queued text.

## Local and Federation behavior

- Local control validates the owning backend capability and performs active-turn discovery plus stop/steer through one owner-side control operation.
- Federated control uses the existing remembered-owner / explicit-`instanceId` / discovery conventions through one shared resolver. `includeRemote: false` is a strict local-only request.
- Federation adds an additive `backend.controlActiveTurn` operation under the existing `turn_control` capability. It carries `requestId`, optional `expectedTurnId`, operation, steer input, and message origin to the owner, where compare-and-act and accepted-request replay are performed.
- ACP stop uses the same per-session prompt lock as turn start, rechecks the active turn immediately before issuing cancellation, and prevents a queued newer turn from being cancelled by a stale request.
- Remote ownership discovery uses `thread_navigation`; atomic active-turn control uses `turn_control`. Disconnections and RPC timeouts return `peer_unavailable`; actual active-turn changes return `stale_target`.
- `cancel_monitor_delegation` remains separate; it is not used as a substitute for general thread interruption.

## Compatibility

- The new tools and Federation operation are additive.
- Existing persisted `send_message_to_thread` schemas remain valid; `includeRemote` is optional and defaults to the prior local-then-remote behavior.
- Existing callers keep `startTurn` queue/new-turn semantics.
- New threads receive `stop_thread` and `steer_thread` through the unified `pwragent` catalog and MCP dispatch. Frozen legacy namespaces are unchanged.

## Validation

- Focused contracts/catalog/MCP/registry/Federation suite: **576 tests passed across 7 files**
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors (existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:sql`
- `git diff --check`
- Added-line secret and debug-marker scans

Headed desktop E2E was not run because this change is contract and routing work with focused non-UI coverage.

## Coordination and remaining limitations

- This branch is based on `origin/main` at `b816101459e92ae9770d0e95dff433f33d817d67`.
- PR #1317 also changes remote thread target resolution. This PR intentionally uses a shared resolver within the current-main message service rather than importing pending commits. If #1317 lands first, the control handler should be rebased onto its extracted target service; the public contracts and `turn_control` transport do not need to change.
- Agent-layer and owner-side accepted-request replay protection is process-local and bounded to the 512 most recent entries in each cache.
- A mixed-version peer that advertises `turn_control` but lacks additive `backend.controlActiveTurn` returns `unsupported_capability` instead of guessing, interrupting a newer turn, or queueing a fallback.
