### PR TITLE
feat(desktop): schedule new thread starts

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -43,6 +43,7 @@ import type {
   BackendModelOption,
   BackendRateLimitSummary,
   CodexThreadEnvironmentRuntime,
+  CreateScheduledThreadActionRequest,
   DesktopProviderThreadModelMigration,
   LinkedDirectorySummary,
   NavigationLaunchpadDefaults,
@@ -756,6 +757,29 @@ function createOverlayStoreMock(params?: {
       const next = {
         ...current,
         pinnedRank: pinnedRank?.trim() || undefined,
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
+    setThreadScheduledStart: async ({
+      backend,
+      threadId,
+      scheduledStart,
+    }: {
+      backend: "codex" | "grok";
+      threadId: string;
+      scheduledStart?: ThreadOverlayState["scheduledStart"];
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      const next = {
+        ...current,
+        scheduledStart,
       } as ThreadOverlayState;
       overlays.set(key, next);
       return next;
@@ -5519,6 +5543,109 @@ describe("DesktopBackendRegistry", () => {
         configValues: expect.objectContaining({ mode: "auto" }),
       }),
     });
+    await registry.close();
+  });
+
+  it("materializes and names a thread now while scheduling its first turn", async () => {
+    const scheduledFor = Date.parse("2026-08-08T14:00:00Z");
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Scheduled launchpad work",
+      })),
+    };
+    const createScheduledThreadAction = vi.fn(async (
+      request: CreateScheduledThreadActionRequest,
+      options: { id: string },
+    ) => ({
+      action: {
+        ...request,
+        id: options.id,
+        origin: request.origin ?? "desktop" as const,
+        status: "scheduled" as const,
+        createdAt: 1_000,
+        updatedAt: 1_000,
+      },
+    }));
+    const overlayStore = createOverlayStoreMock();
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["thread/start", "thread/name/set"],
+      },
+      threads: [],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+      createScheduledThreadAction,
+      createScratchProjectDirectory: async () => "/tmp/pwragent-scheduled",
+      threadTitleGenerationService: titleService,
+    });
+
+    const response = await registry.materializeDirectoryLaunchpad({
+      directoryKey: "workspace:scheduled",
+      scheduledFor,
+      input: [{ type: "text", text: "Start this work tomorrow" }],
+      launchpad: {
+        directoryKey: "workspace:scheduled",
+        directoryKind: "workspace",
+        directoryLabel: "Workspaces",
+        backend: "codex",
+        executionMode: "full-access",
+        prompt: "Start this work tomorrow",
+        workMode: "local",
+        model: "gpt-5.6-sol",
+        reasoningEffort: "high",
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+    });
+
+    expect(response.scheduledAction).toMatchObject({
+      scheduledFor,
+      status: "scheduled",
+      threadId: "thread-1",
+    });
+    expect(createScheduledThreadAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        displayText: "Start this work tomorrow",
+        scheduledFor,
+        threadId: "thread-1",
+        turn: expect.objectContaining({
+          executionMode: "full-access",
+          input: [{ type: "text", text: "Start this work tomorrow" }],
+          model: "gpt-5.6-sol",
+          reasoningEffort: "high",
+        }),
+      }),
+      { id: expect.stringMatching(/^scheduled-action:/) },
+    );
+    expect(codexClient.startTurnCallCount).toBe(0);
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      scheduledStart: {
+        actionId: response.scheduledAction?.id,
+        scheduledFor,
+        state: "scheduled",
+      },
+    });
+    await waitForCondition(() => codexClient.lastRenameThreadParams !== undefined);
+    expect(titleService.generateTitle).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      userPrompt: "Start this work tomorrow",
+    });
+    expect(codexClient.lastRenameThreadParams).toEqual({
+      threadId: "thread-1",
+      name: "Scheduled launchpad work",
+    });
+
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5712,6 +5712,40 @@ describe("DesktopBackendRegistry", () => {
       name: "Scheduled launchpad work",
     });
 
+    vi.spyOn(codexClient, "startThread").mockResolvedValueOnce({
+      threadId: "thread-review",
+    });
+    createScheduledThreadAction.mockClear();
+    await registry.materializeDirectoryLaunchpad({
+      directoryKey: "workspace:scheduled-review",
+      scheduledFor,
+      reviewTarget: { type: "baseBranch", branch: "main" },
+      launchpad: {
+        directoryKey: "workspace:scheduled-review",
+        directoryKind: "workspace",
+        directoryLabel: "Workspaces",
+        backend: "codex",
+        executionMode: "full-access",
+        prompt: "",
+        workMode: "local",
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+    });
+
+    expect(createScheduledThreadAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayText: "Review changes against main",
+        kind: "review",
+        threadId: "thread-review",
+        review: expect.objectContaining({
+          draftText: "/review main",
+          target: { type: "baseBranch", branch: "main" },
+        }),
+      }),
+      { id: expect.stringMatching(/^scheduled-action:/) },
+    );
+
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/scheduled-thread-action-service.test.ts
+++ b/apps/desktop/src/main/__tests__/scheduled-thread-action-service.test.ts
@@ -39,6 +39,8 @@ function createHarness(now = 1_000) {
   const cancelQueuedTurn = vi.fn(() => true);
   const cancelPendingReview = vi.fn(() => true);
   const publishLocalEvent = vi.fn(async () => undefined);
+  const markScheduledThreadBorn = vi.fn(async () => undefined);
+  const markScheduledThreadStartTerminal = vi.fn(async () => undefined);
   const registry = {
     cancelPendingReview,
     cancelQueuedTurn,
@@ -46,6 +48,8 @@ function createHarness(now = 1_000) {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
+    markScheduledThreadBorn,
+    markScheduledThreadStartTerminal,
     publishLocalEvent,
     submitReview,
     submitTurn,
@@ -61,6 +65,8 @@ function createHarness(now = 1_000) {
     cancelPendingReview,
     cancelQueuedTurn,
     listeners,
+    markScheduledThreadBorn,
+    markScheduledThreadStartTerminal,
     publishLocalEvent,
     registry,
     service,
@@ -424,6 +430,12 @@ describe("ScheduledThreadActionService", () => {
       "Scheduled action cancelled.",
     );
     expect(response.action.status).toBe("cancelled");
+    expect(harness.markScheduledThreadStartTerminal).toHaveBeenCalledWith({
+      actionId: "scheduled-1",
+      backend: "codex",
+      state: "cancelled",
+      threadId: "thread-1",
+    });
   });
 
   it("accepts cancellation when the registry event wins the store race", async () => {
@@ -488,6 +500,11 @@ describe("ScheduledThreadActionService", () => {
     expect(store.get(response.action.id)).toMatchObject({
       status: "started",
       turnId: "review-turn-1",
+    });
+    expect(harness.markScheduledThreadBorn).toHaveBeenCalledWith({
+      actionId: response.action.id,
+      backend: "codex",
+      threadId: "thread-1",
     });
     harness.service.dispose();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -90,6 +90,7 @@ import {
   type CodexEnvironmentStartupFailure,
   type CodexEnvironmentSetupProgressEvent,
   type CodexThreadEnvironmentRuntime,
+  type CreateScheduledThreadActionRequest,
   type BackendLaunchpadOptions,
   type BackendModelOption,
   type BackendRateLimitSummary,
@@ -146,6 +147,7 @@ import {
   type SetThreadModelSettingsResponse,
   type SetThreadPrAutoDispatchRequest,
   type SetThreadPrAutoDispatchResponse,
+  type ScheduledThreadActionMutationResponse,
   type CancelThreadPrAutoDispatchRequest,
   type CancelThreadPrAutoDispatchResponse,
   type SendThreadPrAutoDispatchNowRequest,
@@ -6221,6 +6223,10 @@ export class DesktopBackendRegistry {
   private readonly archivedMessagingCleanupCompleted = new Set<string>();
   private readonly archivedMessagingCleanupGeneration = new Map<string, number>();
   private readonly createScratchProjectDirectory: () => Promise<string>;
+  private createScheduledThreadActionFn?: (
+    request: CreateScheduledThreadActionRequest,
+    options: { id: string },
+  ) => Promise<ScheduledThreadActionMutationResponse>;
   private readonly threadTitleGenerationService?: ThreadTitleService;
   private readonly modelCatalog: BackendModelCatalog;
   private readonly codexEnvironmentCommandEnv?: NodeJS.ProcessEnv;
@@ -6546,6 +6552,10 @@ export class DesktopBackendRegistry {
     automationInspectionMcpCommand?: string;
     appManagementHandler?: PwrAgentAppManagementHandler | null;
     createScratchProjectDirectory?: () => Promise<string>;
+    createScheduledThreadAction?: (
+      request: CreateScheduledThreadActionRequest,
+      options: { id: string },
+    ) => Promise<ScheduledThreadActionMutationResponse>;
     codexEnvironmentCommandRunner?: CodexEnvironmentCommandRunner;
     codexEnvironmentHydrationStore?: CodexEnvironmentHydrationStoreLike;
     threadTitleGenerationService?: ThreadTitleService | null;
@@ -6845,6 +6855,7 @@ export class DesktopBackendRegistry {
       });
     this.createScratchProjectDirectory =
       options?.createScratchProjectDirectory ?? createScratchProjectDirectory;
+    this.createScheduledThreadActionFn = options?.createScheduledThreadAction;
     this.threadTitleGenerationService =
       options?.threadTitleGenerationService === null
         ? undefined
@@ -6972,6 +6983,17 @@ export class DesktopBackendRegistry {
         message: error instanceof Error ? error.message : String(error),
       });
     });
+  }
+
+  setScheduledThreadActionCreator(
+    creator:
+      | ((
+          request: CreateScheduledThreadActionRequest,
+          options: { id: string },
+        ) => Promise<ScheduledThreadActionMutationResponse>)
+      | undefined,
+  ): void {
+    this.createScheduledThreadActionFn = creator;
   }
 
   /**
@@ -15217,6 +15239,12 @@ export class DesktopBackendRegistry {
     if (!launchpad) {
       throw new Error(`No launchpad found for ${request.directoryKey}`);
     }
+    if (
+      request.scheduledFor !== undefined
+      && (!Number.isFinite(request.scheduledFor) || request.scheduledFor < 0)
+    ) {
+      throw new Error("Scheduled time must be a finite Unix timestamp.");
+    }
 
     const preparedWorkspace =
       await this.gitDirectoryService.prepareLaunchpadWorkspace(launchpad);
@@ -15409,11 +15437,95 @@ export class DesktopBackendRegistry {
         ? [{ type: "text", text: launchpad.prompt } as const]
         : []);
     let turnId: string | undefined;
+    let scheduledAction:
+      | MaterializeDirectoryLaunchpadResponse["scheduledAction"]
+      | undefined;
     let turnStartFailure:
       | MaterializeDirectoryLaunchpadResponse["turnStartFailure"]
       | undefined;
     if (codexEnvironmentStartupFailure) {
       turnId = undefined;
+    } else if (request.scheduledFor !== undefined) {
+      const actionId = `scheduled-action:${randomUUID()}`;
+      await this.overlayStore.setThreadScheduledStart({
+        backend: launchpad.backend,
+        threadId: startThreadResponse.threadId,
+        scheduledStart: {
+          actionId,
+          scheduledFor: request.scheduledFor,
+          state: "scheduled",
+        },
+      });
+      this.invalidateThreadListCache(launchpad.backend);
+      try {
+        const displayText =
+          extractFirstMeaningfulTextInput(input)
+          ?? (request.reviewTarget ? "Scheduled review" : "Scheduled message");
+        const createScheduledThreadAction = this.createScheduledThreadActionFn;
+        if (!createScheduledThreadAction) {
+          throw new Error("Scheduled thread action service is unavailable");
+        }
+        const response = await createScheduledThreadAction(
+          {
+            backend: launchpad.backend,
+            threadId: startThreadResponse.threadId,
+            kind: request.reviewTarget ? "review" : "turn",
+            origin: "desktop",
+            scheduledFor: request.scheduledFor,
+            displayText,
+            imageAttachments: launchpad.imageAttachments,
+            fileAttachments: launchpad.fileAttachments,
+            ...(request.reviewTarget
+              ? {
+                  review: {
+                    target: request.reviewTarget,
+                    draftText: displayText,
+                    delivery: "inline" as const,
+                    model: launchpad.model,
+                    reasoningEffort: launchpad.reasoningEffort,
+                    serviceTier: launchpad.serviceTier,
+                    fastMode:
+                      launchpad.backend === "codex"
+                        ? launchpad.fastMode
+                        : undefined,
+                  },
+                }
+              : {
+                  turn: {
+                    input,
+                    executionMode: launchpad.executionMode,
+                    model: launchpad.model,
+                    collaborationMode: request.collaborationMode,
+                    serviceTier: launchpad.serviceTier,
+                    reasoningEffort: launchpad.reasoningEffort,
+                    fastMode:
+                      launchpad.backend === "codex"
+                        ? launchpad.fastMode
+                        : undefined,
+                    messageOrigin: options?.messageOrigin,
+                  },
+                }),
+          },
+          { id: actionId },
+        );
+        scheduledAction = response.action;
+        this.scheduleThreadTitleGeneration({
+          backend: launchpad.backend,
+          threadId: startThreadResponse.threadId,
+          input,
+        });
+      } catch (error) {
+        await this.overlayStore.setThreadScheduledStart({
+          backend: launchpad.backend,
+          threadId: startThreadResponse.threadId,
+          scheduledStart: undefined,
+        });
+        this.invalidateThreadListCache(launchpad.backend);
+        turnStartFailure = {
+          message: error instanceof Error ? error.message : String(error),
+          phase: request.reviewTarget ? "review" : "turn",
+        };
+      }
     } else if (request.reviewTarget) {
       try {
         const reviewResponse = await this.startReview({
@@ -15468,8 +15580,80 @@ export class DesktopBackendRegistry {
     return {
       ...materializedThread,
       turnId,
+      scheduledAction,
       turnStartFailure,
     };
+  }
+
+  async markScheduledThreadBorn(params: {
+    actionId: string;
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<void> {
+    const current = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    if (current?.scheduledStart?.actionId !== params.actionId) {
+      return;
+    }
+    await this.overlayStore.setThreadScheduledStart({
+      backend: params.backend,
+      threadId: params.threadId,
+      scheduledStart: undefined,
+    });
+    this.invalidateThreadListCache(params.backend);
+  }
+
+  async markScheduledThreadStartTerminal(params: {
+    actionId: string;
+    backend: AppServerBackendKind;
+    state: "cancelled" | "failed";
+    threadId: string;
+  }): Promise<void> {
+    const current = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    if (current?.scheduledStart?.actionId !== params.actionId) {
+      return;
+    }
+    await this.overlayStore.setThreadScheduledStart({
+      backend: params.backend,
+      threadId: params.threadId,
+      scheduledStart: {
+        ...current.scheduledStart,
+        state: params.state,
+      },
+    });
+    this.invalidateThreadListCache(params.backend);
+  }
+
+  async updateScheduledThreadStartTime(params: {
+    actionId: string;
+    backend: AppServerBackendKind;
+    scheduledFor: number;
+    threadId: string;
+  }): Promise<void> {
+    const current = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    if (
+      current?.scheduledStart?.actionId !== params.actionId
+      || current.scheduledStart.state !== "scheduled"
+    ) {
+      return;
+    }
+    await this.overlayStore.setThreadScheduledStart({
+      backend: params.backend,
+      threadId: params.threadId,
+      scheduledStart: {
+        ...current.scheduledStart,
+        scheduledFor: params.scheduledFor,
+      },
+    });
+    this.invalidateThreadListCache(params.backend);
   }
 
   async close(): Promise<void> {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -16,6 +16,7 @@ import type {
   MessagingApprovalDecision,
   MessagingBindingRecord,
 } from "@pwragent/messaging-interface";
+import { formatReviewCommand } from "../../shared/review-command";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import {
   getAppStateDb,
@@ -15871,9 +15872,9 @@ export class DesktopBackendRegistry {
       });
       this.invalidateThreadListCache(launchpad.backend);
       try {
-        const displayText =
-          extractFirstMeaningfulTextInput(input)
-          ?? (request.reviewTarget ? "Scheduled review" : "Scheduled message");
+        const displayText = request.reviewTarget
+          ? reviewTaskLabel(request.reviewTarget)
+          : extractFirstMeaningfulTextInput(input) ?? "Scheduled message";
         const createScheduledThreadAction = this.createScheduledThreadActionFn;
         if (!createScheduledThreadAction) {
           throw new Error("Scheduled thread action service is unavailable");
@@ -15892,7 +15893,7 @@ export class DesktopBackendRegistry {
               ? {
                   review: {
                     target: request.reviewTarget,
-                    draftText: displayText,
+                    draftText: formatReviewCommand(request.reviewTarget),
                     delivery: "inline" as const,
                     model: launchpad.model,
                     reasoningEffort: launchpad.reasoningEffort,

--- a/apps/desktop/src/main/scheduled-actions/scheduled-thread-action-service.ts
+++ b/apps/desktop/src/main/scheduled-actions/scheduled-thread-action-service.ts
@@ -46,23 +46,31 @@ export type ScheduledThreadActionServiceOptions = {
 };
 
 let service: ScheduledThreadActionService | null = null;
+let serviceRegistry: DesktopBackendRegistry | null = null;
 
 export function getScheduledThreadActionService(
   registry = getDesktopBackendRegistry(),
 ): ScheduledThreadActionService {
   if (!service) {
-    service = new ScheduledThreadActionService({
+    const nextService = new ScheduledThreadActionService({
       registry,
       store: getAppScheduledThreadActionStore(),
     });
-    service.start();
+    registry.setScheduledThreadActionCreator((request, options) =>
+      nextService.create(request, options),
+    );
+    service = nextService;
+    serviceRegistry = registry;
+    nextService.start();
   }
   return service;
 }
 
 export function disposeScheduledThreadActionService(): void {
   service?.dispose();
+  serviceRegistry?.setScheduledThreadActionCreator(undefined);
   service = null;
+  serviceRegistry = null;
 }
 
 export class ScheduledThreadActionService {
@@ -171,6 +179,12 @@ export class ScheduledThreadActionService {
     if (!updated) {
       throw new Error("The scheduled action is already being dispatched.");
     }
+    await this.options.registry.updateScheduledThreadStartTime?.({
+      actionId: updated.id,
+      backend: updated.backend,
+      scheduledFor: updated.scheduledFor,
+      threadId: updated.threadId,
+    });
     await this.publish(updated);
     this.scheduleNextTimer();
     if (updated.scheduledFor <= this.now()) {
@@ -210,6 +224,7 @@ export class ScheduledThreadActionService {
     if (!cancelled) {
       throw new Error("The scheduled action can no longer be cancelled.");
     }
+    await this.clearScheduledStartIfBorn(cancelled);
     await this.publish(cancelled);
     this.scheduleNextTimer();
     return { action: cancelled };
@@ -277,7 +292,10 @@ export class ScheduledThreadActionService {
               this.now(),
               this.ownerId,
             );
-        if (updated) await this.publish(updated);
+        if (updated) {
+          await this.clearScheduledStartIfBorn(updated);
+          await this.publish(updated);
+        }
         return;
       }
       if (!action.turn) {
@@ -304,7 +322,10 @@ export class ScheduledThreadActionService {
             this.now(),
             this.ownerId,
           );
-      if (updated) await this.publish(updated);
+      if (updated) {
+        await this.clearScheduledStartIfBorn(updated);
+        await this.publish(updated);
+      }
     } catch (error) {
       const failed = this.options.store.markFailed(
         action.id,
@@ -312,7 +333,10 @@ export class ScheduledThreadActionService {
         this.now(),
         this.ownerId,
       );
-      if (failed) await this.publish(failed);
+      if (failed) {
+        await this.clearScheduledStartIfBorn(failed);
+        await this.publish(failed);
+      }
       scheduledActionLog.error("scheduled action dispatch failed", {
         actionId: action.id,
         backend: action.backend,
@@ -361,7 +385,10 @@ export class ScheduledThreadActionService {
     } else if (params.status === "cancelled") {
       updated = this.options.store.markCancelled(actionId, this.now());
     }
-    if (updated) await this.publish(updated);
+    if (updated) {
+      await this.clearScheduledStartIfBorn(updated);
+      await this.publish(updated);
+    }
   }
 
   private async handleReviewRegistryEvent(event: AgentEvent): Promise<void> {
@@ -394,7 +421,31 @@ export class ScheduledThreadActionService {
     } else if (params.status === "cancelled") {
       updated = this.options.store.markCancelled(action.id, this.now());
     }
-    if (updated) await this.publish(updated);
+    if (updated) {
+      await this.clearScheduledStartIfBorn(updated);
+      await this.publish(updated);
+    }
+  }
+
+  private async clearScheduledStartIfBorn(
+    action: ScheduledThreadAction,
+  ): Promise<void> {
+    if (action.status === "started") {
+      await this.options.registry.markScheduledThreadBorn?.({
+        actionId: action.id,
+        backend: action.backend,
+        threadId: action.threadId,
+      });
+      return;
+    }
+    if (action.status === "cancelled" || action.status === "failed") {
+      await this.options.registry.markScheduledThreadStartTerminal?.({
+        actionId: action.id,
+        backend: action.backend,
+        state: action.status,
+        threadId: action.threadId,
+      });
+    }
   }
 
   private async publish(action: ScheduledThreadAction): Promise<void> {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1792,6 +1792,26 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     return nextState;
   }
 
+  async setThreadScheduledStart(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    scheduledStart?: ThreadOverlayState["scheduledStart"];
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const nextState: ThreadOverlayState = {
+      ...current,
+      scheduledStart: params.scheduledStart,
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
   async setThreadPin(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;
@@ -6205,6 +6225,7 @@ export type OverlayStoreLike = Pick<
   | "upsertThreadSubAgent"
   | "setThreadReaction"
   | "setThreadArchiveTombstone"
+  | "setThreadScheduledStart"
   | "setThreadPin"
   | "setThreadParent"
   | "setThreadAgent"

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1523,7 +1523,8 @@ function DesktopAppShell(props: {
       input,
       collaborationMode,
       reviewTarget,
-      extraDirectoryPaths
+      extraDirectoryPaths,
+      scheduledFor,
     ) =>
       navigation.materializeDirectoryLaunchpad(
         directoryKey,
@@ -1531,7 +1532,8 @@ function DesktopAppShell(props: {
         collaborationMode,
         reviewTarget,
         undefined,
-        extraDirectoryPaths
+        extraDirectoryPaths,
+        scheduledFor,
       ),
     onPendingStatusChange: session.setPendingStatusText,
     onRefreshNavigation: navigation.refresh,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1090,6 +1090,7 @@ function DesktopAppShell(props: {
   useScheduledThreadActionProjection({
     composerDraftStore,
     desktopApi,
+    onThreadLifecycleChanged: navigation.refresh,
     sources: scheduledActionProjectionSources,
   });
   const replayCodexProfileSetup = settings.snapshot

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -132,7 +132,10 @@ import {
   parseSkillMentionParts,
   buildSkillMentionMarkdown,
 } from "../../lib/skill-mentions";
-import { parseReviewCommand } from "../../../../shared/review-command";
+import {
+  formatReviewCommand,
+  parseReviewCommand,
+} from "../../../../shared/review-command";
 import {
   type ComposerInputChangeMetadata,
   type ComposerInputHandle,
@@ -1267,23 +1270,6 @@ function notificationIncludesDraftContent(
 function parseStaleInterruptError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return message.toLowerCase().includes("no active turn to interrupt");
-}
-
-function reviewCommandToDraftText(command: {
-  cwd?: string;
-  target: AppServerReviewTarget;
-}): string {
-  const target = command.target;
-  if (target.type === "uncommittedChanges") {
-    return "/review";
-  }
-  if (target.type === "baseBranch") {
-    return `/review ${target.branch}`;
-  }
-  if (target.type === "commit") {
-    return `/review --commit ${[target.sha, target.title].filter(Boolean).join(" ")}`;
-  }
-  return `/review --custom ${target.instructions}`;
 }
 
 function reviewSubmissionKey(command: {
@@ -6409,7 +6395,7 @@ export function Composer(props: ComposerProps) {
     options?: { scheduledSendAt?: number },
   ): Promise<void> | undefined => {
     const enqueue = async (): Promise<void> => {
-      const text = reviewCommandToDraftText(reviewCommand);
+      const text = formatReviewCommand(reviewCommand.target);
       if (!props.thread || !props.desktopApi?.createScheduledThreadAction) {
         throw new Error("Backend-owned review queuing is unavailable.");
       }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -192,7 +192,8 @@ type ComposerProps = {
      * Paths of tracked directories the draft references (`@`-inserted or
      * typed by hand). Linked to the new thread right after it is created.
      */
-    extraDirectoryPaths?: string[]
+    extraDirectoryPaths?: string[],
+    scheduledFor?: number,
   ) => Promise<void>;
   /** Discard this launchpad draft (the "Cancel" button next to "Start thread"). */
   onCancelLaunchpad?: (directoryKey: string) => void;
@@ -5515,6 +5516,13 @@ export function Composer(props: ComposerProps) {
       return;
     }
     if (futureScheduledDraftSendAt) {
+      if (props.launchpad) {
+        await scheduleLaunchpadMaterialization(
+          futureScheduledDraftSendAt,
+          configuredReviewCommand.target,
+        );
+        return;
+      }
       queueReviewCommand(configuredReviewCommand, {
         scheduledSendAt: futureScheduledDraftSendAt,
       });
@@ -6299,12 +6307,131 @@ export function Composer(props: ComposerProps) {
       ) ||
       sendingRef.current);
 
+  const scheduleLaunchpadMaterialization = async (
+    scheduledSendAt: number,
+    reviewTarget?: AppServerReviewTarget,
+  ): Promise<void> => {
+    if (
+      !props.launchpad
+      || !props.onMaterializeLaunchpad
+      || props.disabled
+    ) {
+      return;
+    }
+
+    let input: AppServerTurnInputItem[] | undefined;
+    if (!reviewTarget) {
+      const payloadOrPromise = buildTurnPayload(
+        canonicalDraft,
+        imageAttachments,
+        fileAttachments,
+        skillTokens,
+      );
+      const payload = isPromiseLike(payloadOrPromise)
+        ? await payloadOrPromise
+        : payloadOrPromise;
+      if (payload.input.length === 0) {
+        return;
+      }
+      input = payload.input;
+    }
+
+    const collaborationMode =
+      !reviewTarget && planModeEnabled && supportsPlanMode
+        ? ({
+            mode: "plan",
+            settings: {
+              developerInstructions: null,
+            },
+          } satisfies AppServerCollaborationModeRequest)
+        : undefined;
+    const submittedScopeKey = composerScopeKey;
+    markComposerDraftSubmitted(submittedScopeKey);
+    setSendError(undefined);
+    updateSending(true);
+    props.onPendingStatusChange?.(
+      props.launchpad.codexEnvironmentId && selectedCodexEnvironment?.setupScript
+        ? "Running environment setup"
+        : "Scheduling thread",
+    );
+    try {
+      await props.onMaterializeLaunchpad(
+        props.launchpad.directoryKey,
+        input,
+        collaborationMode,
+        reviewTarget,
+        listDraftReferencedDirectories(
+          appendFileReferenceMarkdown(canonicalDraft, fileAttachments),
+          skillTokens,
+        )
+          .map((directory) => directory.path)
+          .filter((path): path is string => Boolean(path)),
+        scheduledSendAt,
+      );
+      clearSubmittedComposerDraft(submittedScopeKey);
+      setReviewConfig(undefined);
+      setScheduledDraftSendAt(undefined);
+      setScheduleArmed(true);
+      if (collaborationMode) {
+        setPlanModeEnabled(false);
+      }
+    } catch (error) {
+      unmarkComposerDraftSubmitted(submittedScopeKey);
+      setSendError(error instanceof Error ? error.message : String(error));
+    } finally {
+      props.onPendingStatusChange?.(undefined);
+      updateSending(false);
+    }
+  };
+
   const scheduleCurrentDraft = (scheduledSendAt: number): void => {
-    if (props.launchpad || props.disabled) {
+    if (props.disabled) {
       return;
     }
 
     const reviewCommand = parsedReviewCommand;
+    if (props.launchpad) {
+      if (reviewCommand) {
+        if (isBareReviewCommand) {
+          setScheduledDraftSendAt(scheduledSendAt);
+          setScheduleArmed(true);
+          setReviewConfig(
+            reviewConfig ??
+              createReviewConfig({
+                directory: props.directory,
+                thread: props.thread,
+              })
+          );
+          setSendError(undefined);
+          return;
+        }
+        if (imageAttachments.length > 0) {
+          setSendError("/review does not accept image attachments.");
+          return;
+        }
+        if (reviewWorkspaceSelectionRequired) {
+          setScheduledDraftSendAt(scheduledSendAt);
+          setScheduleArmed(true);
+          setReviewConfig(
+            createReviewConfig({
+              directory: props.directory,
+              reviewCommand,
+              thread: props.thread,
+            })
+          );
+          setSendError("Choose a project to review.");
+          return;
+        }
+        void scheduleLaunchpadMaterialization(
+          scheduledSendAt,
+          reviewCommand.target,
+        );
+        return;
+      }
+      void scheduleLaunchpadMaterialization(scheduledSendAt);
+      return;
+    }
+
     if (reviewCommand) {
       if (isBareReviewCommand) {
         setScheduledDraftSendAt(scheduledSendAt);
@@ -8343,15 +8470,20 @@ export function Composer(props: ComposerProps) {
       fileAttachments.length === 0);
   const scheduleButtonDisabled =
     sendButtonDisabled ||
-    Boolean(props.launchpad) ||
-    !props.thread ||
+    (!props.thread && !props.launchpad) ||
+    Boolean(props.launchpad && !props.onMaterializeLaunchpad) ||
     isCompactCommand;
   // Only surface the schedule caret where scheduling actually applies. In the
-  // launchpad, compact command, or a thread-less composer there is nothing to
-  // schedule, so the split collapses to a plain Send pill instead of parking a
-  // permanently-dimmed half-button next to it.
+  // compact command or a thread-less composer there is nothing to schedule,
+  // so the split collapses to a plain Send pill instead of parking a
+  // permanently-dimmed half-button next to it. A launchpad is schedulable:
+  // choosing a time materializes its workspace/thread immediately and defers
+  // only the first action.
   const scheduleAffordanceVisible =
-    Boolean(props.thread) && !props.launchpad && !isCompactCommand;
+    Boolean(
+      props.thread
+      || (props.launchpad && props.onMaterializeLaunchpad)
+    ) && !isCompactCommand;
   // A pending draft schedule (e.g. after editing a scheduled item) surfaces as
   // a checkable toggle between the caret and Send rather than hijacking the
   // Send label into a countdown. Armed → Send keeps the schedule; unarmed →
@@ -9457,7 +9589,7 @@ export function Composer(props: ComposerProps) {
         const queuedLabel = queued.errorMessage
           ? "Failed to send"
           : scheduledSendAt
-          ? `Sends in ${formatScheduledSendCountdown(scheduledSendAt, scheduleNow)}`
+          ? `Scheduled · sends in ${formatScheduledSendCountdown(scheduledSendAt, scheduleNow)}`
           : index === 0
             ? "Queued next"
             : `Queued #${index + 1}`;
@@ -9471,7 +9603,15 @@ export function Composer(props: ComposerProps) {
             ]
               .filter(Boolean)
               .join(" ")}
-            aria-label={index === 0 ? "Queued message" : `Queued message ${index + 1}`}
+            aria-label={
+              scheduledSendAt
+                ? index === 0
+                  ? "Scheduled message"
+                  : `Scheduled message ${index + 1}`
+                : index === 0
+                  ? "Queued message"
+                  : `Queued message ${index + 1}`
+            }
             key={queued.id}
           >
             <div className="composer__queued-copy">
@@ -11026,7 +11166,7 @@ export function Composer(props: ComposerProps) {
                 <button
                   aria-expanded={scheduleMenuOpen}
                   aria-haspopup="menu"
-                  aria-label="Schedule message"
+                  aria-label={props.launchpad ? "Schedule thread" : "Schedule message"}
                   className="button composer__send-schedule-button"
                   disabled={scheduleButtonDisabled}
                   type="button"
@@ -11104,7 +11244,9 @@ export function Composer(props: ComposerProps) {
                       );
                     }}
                   >
-                    {option.label}
+                    {props.launchpad
+                      ? option.label.replace(/^Send /, "Start ")
+                      : option.label}
                   </button>
                 ))}
               </div>

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3397,10 +3397,10 @@ describe("Composer", () => {
 
     expect(startTurn).not.toHaveBeenCalled();
     expect(textarea).toHaveValue("");
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "Sends in 15m"
+    expect(screen.getByLabelText("Scheduled message")).toHaveTextContent(
+      "Scheduled · sends in 15m"
     );
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+    expect(screen.getByLabelText("Scheduled message")).toHaveTextContent(
       "Check this in a bit"
     );
   });
@@ -3461,10 +3461,10 @@ describe("Composer", () => {
 
     expect(startTurn).not.toHaveBeenCalled();
     expect(textarea).toHaveValue("");
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "Sends in 1h"
+    expect(screen.getByLabelText("Scheduled message")).toHaveTextContent(
+      "Scheduled · sends in 1h"
     );
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+    expect(screen.getByLabelText("Scheduled message")).toHaveTextContent(
       "Edited scheduled text"
     );
   });
@@ -3676,10 +3676,10 @@ describe("Composer", () => {
 
     expect(startReview).not.toHaveBeenCalled();
     expect(screen.queryByRole("group", { name: "Review target" })).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "Sends in 30m"
+    expect(screen.getByLabelText("Scheduled message")).toHaveTextContent(
+      "Scheduled · sends in 30m"
     );
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+    expect(screen.getByLabelText("Scheduled message")).toHaveTextContent(
       "Review changes against main"
     );
   });
@@ -3780,10 +3780,10 @@ describe("Composer", () => {
     });
 
     expect(startTurn).not.toHaveBeenCalled();
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "Sends in 2h 34m"
+    expect(screen.getByLabelText("Scheduled message")).toHaveTextContent(
+      "Scheduled · sends in 2h 34m"
     );
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+    expect(screen.getByLabelText("Scheduled message")).toHaveTextContent(
       "After the reset"
     );
   });
@@ -3811,11 +3811,52 @@ describe("Composer", () => {
 
     // The split collapses to a plain Send/Start pill: no caret, no divider.
     expect(
-      screen.queryByRole("button", { name: "Schedule message" })
+      screen.queryByRole("button", { name: "Schedule thread" })
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Start thread" })
     ).toBeInTheDocument();
+  });
+
+  it("materializes a launchpad now with its first message scheduled for later", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+    const onMaterializeLaunchpad = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        disabled={false}
+        launchpad={{
+          directoryKey: "directory:/repo/PwrAgent",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/repo/PwrAgent",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "Kick off a new thread",
+          workMode: "local",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onMaterializeLaunchpad={onMaterializeLaunchpad}
+        skills={[]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Schedule thread" }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("menuitem", { name: "Start in 30m" }));
+    });
+
+    expect(onMaterializeLaunchpad).toHaveBeenCalledWith(
+      "directory:/repo/PwrAgent",
+      [{ type: "text", text: "Kick off a new thread" }],
+      undefined,
+      undefined,
+      [],
+      Date.parse("2026-07-10T12:30:00Z"),
+    );
   });
 
   it("queues slash review submits while a turn start is pending", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5571,7 +5571,11 @@ describe("Composer", () => {
     fireEvent.keyDown(textarea, { key: "Enter" });
     await screen.findByLabelText("Queued message");
 
-    fireEvent.click(screen.getByRole("button", { name: "Steer" }));
+    const steerButton = screen.getByRole("button", { name: "Steer" });
+    await waitFor(() => {
+      expect(steerButton).toBeEnabled();
+    });
+    fireEvent.click(steerButton);
 
     await waitFor(() => {
       expect(cancelQueuedTurn).toHaveBeenCalledWith({
@@ -5673,7 +5677,11 @@ describe("Composer", () => {
     fireEvent.keyDown(textarea, { key: "Enter" });
     await screen.findByLabelText("Queued message");
 
-    fireEvent.click(screen.getByRole("button", { name: "Steer" }));
+    const steerButton = screen.getByRole("button", { name: "Steer" });
+    await waitFor(() => {
+      expect(steerButton).toBeEnabled();
+    });
+    fireEvent.click(steerButton);
 
     await waitFor(() => {
       expect(cancelQueuedTurn).toHaveBeenCalledWith({

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1028,7 +1028,8 @@ export type ThreadViewProps = {
     input?: AppServerTurnInputItem[],
     collaborationMode?: AppServerCollaborationModeRequest,
     reviewTarget?: AppServerReviewTarget,
-    extraDirectoryPaths?: string[]
+    extraDirectoryPaths?: string[],
+    scheduledFor?: number,
   ) => Promise<void>;
   onCancelLaunchpad?: (directoryKey: string) => void;
   onPendingStatusChange?: (status?: string) => void;
@@ -2858,7 +2859,8 @@ export function ThreadView(props: ThreadViewProps) {
       input,
       collaborationMode,
       reviewTarget,
-      extraDirectoryPaths
+      extraDirectoryPaths,
+      scheduledFor,
     ) => {
       if (!props.onMaterializeLaunchpad) {
         return;
@@ -2872,7 +2874,8 @@ export function ThreadView(props: ThreadViewProps) {
           input,
           collaborationMode,
           reviewTarget,
-          extraDirectoryPaths
+          extraDirectoryPaths,
+          scheduledFor,
         );
       } catch (error) {
         setLaunchpadMaterializeError(

--- a/apps/desktop/src/renderer/src/lib/__tests__/useScheduledThreadActionProjection.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useScheduledThreadActionProjection.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
-import type { ScheduledThreadAction } from "@pwragent/shared";
+import type { AgentEvent, ScheduledThreadAction } from "@pwragent/shared";
 import { useComposerDraftStore } from "../../features/composer/useComposerDraftStore";
 import type { DesktopApi } from "../desktop-api";
 import {
@@ -68,6 +68,44 @@ describe("scheduled thread action projections", () => {
     );
 
     expect(store.getQueuedTurns(scopeKey)).toEqual([]);
+  });
+
+  it("refreshes navigation when an unborn scheduled thread becomes terminal", async () => {
+    let agentEventHandler: ((event: AgentEvent) => void) | undefined;
+    const onThreadLifecycleChanged = vi.fn();
+    const { result } = renderHook(() => useComposerDraftStore());
+    const projection = renderHook(() => useScheduledThreadActionProjection({
+      composerDraftStore: result.current,
+      desktopApi: {
+        listScheduledThreadActions: vi.fn(async () => ({
+          actions: [],
+          observedAt: 1_000,
+        })),
+        onAgentEvent: (handler: (event: AgentEvent) => void) => {
+          agentEventHandler = handler;
+          return () => undefined;
+        },
+      } as unknown as DesktopApi,
+      onThreadLifecycleChanged,
+    }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/scheduledAction/updated",
+          params: {
+            action: scheduledAction({ status: "cancelled" }),
+          },
+        },
+      });
+    });
+
+    expect(onThreadLifecycleChanged).toHaveBeenCalledTimes(1);
+    projection.unmount();
   });
 
   it("turns a failed backend action into a locally recoverable draft", () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadQueuedMessageIndicators.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadQueuedMessageIndicators.test.tsx
@@ -101,6 +101,32 @@ describe("useThreadQueuedMessageIndicators", () => {
     expect(result.current.indicators).toEqual({ "codex:a": "scheduled" });
   });
 
+  it("classifies an unborn scheduled thread as scheduled without renderer queue state", () => {
+    const thread = {
+      ...makeThread("a"),
+      scheduledStart: {
+        actionId: "scheduled-action:1",
+        scheduledFor: Date.now() + 30_000,
+        state: "scheduled" as const,
+      },
+    };
+    const { result } = renderIndicators([thread]);
+    expect(result.current.indicators).toEqual({ "codex:a": "scheduled" });
+  });
+
+  it("does not chip an unborn thread whose scheduled start was cancelled", () => {
+    const thread = {
+      ...makeThread("a"),
+      scheduledStart: {
+        actionId: "scheduled-action:1",
+        scheduledFor: Date.now() + 30_000,
+        state: "cancelled" as const,
+      },
+    };
+    const { result } = renderIndicators([thread]);
+    expect(result.current.indicators).toEqual({});
+  });
+
   it("prefers 'scheduled' when a thread has both a scheduled and a plain queued turn", () => {
     const thread = makeThread("a");
     const { result } = renderIndicators([thread]);

--- a/apps/desktop/src/renderer/src/lib/useScheduledThreadActionProjection.ts
+++ b/apps/desktop/src/renderer/src/lib/useScheduledThreadActionProjection.ts
@@ -15,6 +15,7 @@ export function useScheduledThreadActionProjection(params: {
   composerDraftStore: ComposerDraftStore;
   desktopApi?: DesktopApi;
   federationTarget?: FederationTarget;
+  onThreadLifecycleChanged?: () => void;
   sources?: readonly ScheduledThreadActionProjectionSource[];
   /**
    * True while the federation peer behind `federationTarget` is
@@ -46,6 +47,7 @@ export function useScheduledThreadActionProjection(params: {
         desktopApi,
         federationTarget: source.federationTarget,
         listScheduledThreadActions,
+        onThreadLifecycleChanged: params.onThreadLifecycleChanged,
       }));
     return () => {
       for (const cleanup of cleanups) {
@@ -55,6 +57,7 @@ export function useScheduledThreadActionProjection(params: {
   }, [
     params.composerDraftStore,
     params.desktopApi,
+    params.onThreadLifecycleChanged,
     sourcesJson,
   ]);
 }
@@ -64,6 +67,7 @@ function startScheduledThreadActionProjection(params: {
   desktopApi: DesktopApi;
   federationTarget?: FederationTarget;
   listScheduledThreadActions: NonNullable<DesktopApi["listScheduledThreadActions"]>;
+  onThreadLifecycleChanged?: () => void;
 }): () => void {
   let refreshSequence = 0;
   let projectedScopeKeys = new Set<string>();
@@ -143,6 +147,13 @@ function startScheduledThreadActionProjection(params: {
         projectedFailures.set(action.id, action);
       } else {
         projectedFailures.delete(action.id);
+      }
+      if (
+        action.status === "started"
+        || action.status === "cancelled"
+        || action.status === "failed"
+      ) {
+        params.onThreadLifecycleChanged?.();
       }
       void refresh();
     }

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2205,6 +2205,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
   optimisticActiveTurn?: NavigationThreadSummary["optimisticActiveTurn"];
   parentThreadId?: string;
   pinnedRank?: string;
+  scheduledStart?: NavigationThreadSummary["scheduledStart"];
 }): NavigationThreadSummary {
   const titlePrompt =
     params.optimisticUserMessage?.text?.trim() || params.launchpad.prompt.trim();
@@ -2245,6 +2246,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
     codexEnvironmentRuntime: params.codexEnvironmentRuntime,
     optimisticUserMessage: params.optimisticUserMessage,
     optimisticActiveTurn: params.optimisticActiveTurn,
+    scheduledStart: params.scheduledStart,
     linkedDirectories:
       params.launchpad.directoryPath && params.launchpad.directoryKind !== "workspace"
         ? [
@@ -2422,6 +2424,7 @@ export function useThreadNavigation(
     reviewTarget?: AppServerReviewTarget,
     parentThreadId?: string,
     extraDirectoryPaths?: string[],
+    scheduledFor?: number,
   ) => Promise<void>;
   /** Directory the New Thread button resolves to by default, or undefined for the directory-less workspace. */
   newThreadDirectoryLabel?: string;
@@ -5436,6 +5439,7 @@ export function useThreadNavigation(
       reviewTarget?: AppServerReviewTarget,
       parentThreadId?: string,
       extraDirectoryPaths?: string[],
+      scheduledFor?: number,
     ): Promise<void> => {
       if (!desktopApi?.materializeDirectoryLaunchpad) {
         setLaunchpadError("Desktop bridge is missing materializeDirectoryLaunchpad().");
@@ -5470,6 +5474,7 @@ export function useThreadNavigation(
           input,
           collaborationMode,
           reviewTarget,
+          scheduledFor,
           ...(materializeParentThreadId
             ? { parentThreadId: materializeParentThreadId }
             : {}),
@@ -5501,6 +5506,7 @@ export function useThreadNavigation(
         workMode: response.workMode,
         codexEnvironmentRuntime: response.codexEnvironmentRuntime,
         optimisticUserMessage: response.turnStartFailure
+          || response.scheduledAction
           ? undefined
           : buildOptimisticUserMessage(input),
         optimisticActiveTurn: response.turnId && !response.turnStartFailure
@@ -5519,6 +5525,13 @@ export function useThreadNavigation(
           : undefined,
         parentThreadId: materializeParentThreadId,
         pinnedRank: response.pinnedRank,
+        scheduledStart: response.scheduledAction
+          ? {
+              actionId: response.scheduledAction.id,
+              scheduledFor: response.scheduledAction.scheduledFor,
+              state: "scheduled",
+            }
+          : undefined,
       });
       const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
       // Sub-thread launchpads drop the new child directly below their source

--- a/apps/desktop/src/renderer/src/lib/useThreadQueuedMessageIndicators.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadQueuedMessageIndicators.ts
@@ -48,7 +48,10 @@ export function useThreadQueuedMessageIndicators(params: {
     const indicators: Record<string, ThreadQueuedMessageState> = {};
     const now = Date.now();
     for (const thread of threads) {
-      if (thread.prAutoDispatchPending) {
+      if (
+        thread.prAutoDispatchPending
+        || thread.scheduledStart?.state === "scheduled"
+      ) {
         indicators[buildThreadIdentityKey(thread.source, thread.id)] =
           "scheduled";
       }

--- a/apps/desktop/src/shared/__tests__/review-command.test.ts
+++ b/apps/desktop/src/shared/__tests__/review-command.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { normalizeReviewDisplayText, parseReviewCommand } from "../review-command";
+import {
+  formatReviewCommand,
+  normalizeReviewDisplayText,
+  parseReviewCommand,
+} from "../review-command";
 
 describe("parseReviewCommand", () => {
   it("parses bare review as uncommitted changes", () => {
@@ -34,6 +38,24 @@ describe("parseReviewCommand", () => {
     expect(parseReviewCommand("/reviewer main")).toBeUndefined();
     expect(parseReviewCommand("please /review main")).toBeUndefined();
     expect(parseReviewCommand("/review --custom")).toBeUndefined();
+  });
+});
+
+describe("formatReviewCommand", () => {
+  it("formats every review target as an editable slash command", () => {
+    expect(formatReviewCommand({ type: "uncommittedChanges" })).toBe("/review");
+    expect(formatReviewCommand({ type: "baseBranch", branch: "main" })).toBe(
+      "/review main",
+    );
+    expect(formatReviewCommand({
+      type: "commit",
+      sha: "abc123",
+      title: "Fix title",
+    })).toBe("/review --commit abc123 Fix title");
+    expect(formatReviewCommand({
+      type: "custom",
+      instructions: "focus on API compatibility",
+    })).toBe("/review --custom focus on API compatibility");
   });
 });
 

--- a/apps/desktop/src/shared/review-command.ts
+++ b/apps/desktop/src/shared/review-command.ts
@@ -5,6 +5,19 @@ export type ParsedReviewCommand = {
   displayText: string;
 };
 
+export function formatReviewCommand(target: AppServerReviewTarget): string {
+  if (target.type === "uncommittedChanges") {
+    return "/review";
+  }
+  if (target.type === "baseBranch") {
+    return `/review ${target.branch}`;
+  }
+  if (target.type === "commit") {
+    return `/review --commit ${[target.sha, target.title].filter(Boolean).join(" ")}`;
+  }
+  return `/review --custom ${target.instructions}`;
+}
+
 export function normalizeReviewDisplayText(value: string): string {
   const normalized = value.trim().replace(/\s+/g, " ");
   if (!normalized) {

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -671,6 +671,11 @@ export type MaterializeDirectoryLaunchpadRequest = {
   collaborationMode?: AppServerCollaborationModeRequest;
   reviewTarget?: AppServerReviewTarget;
   parentThreadId?: ThreadIdentifier;
+  /**
+   * Create the provider thread and prepare its workspace now, but defer the
+   * first turn or review until this wall-clock time.
+   */
+  scheduledFor?: number;
 };
 
 export type MaterializedDirectoryLaunchpadThread = {
@@ -697,6 +702,7 @@ export type MaterializeDirectoryLaunchpadOptions = {
 
 export type MaterializeDirectoryLaunchpadResponse = MaterializedDirectoryLaunchpadThread & {
   turnId?: string;
+  scheduledAction?: ScheduledThreadAction;
   turnStartFailure?: {
     message: string;
     phase: "turn" | "review";

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -195,6 +195,17 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
   subAgents?: ThreadSubAgentSummary[];
   /** Durable origin metadata for threads created by an Agent handoff tool. */
   handoffOrigin?: ThreadHandoffOrigin;
+  /**
+   * The provider thread and workspace exist, but its first scheduled action
+   * has not started yet.
+   */
+  scheduledStart?: ThreadScheduledStart;
+};
+
+export type ThreadScheduledStart = {
+  actionId: string;
+  scheduledFor: number;
+  state: "scheduled" | "cancelled" | "failed";
 };
 
 export type ThreadQueuedTurnSummary = {
@@ -1577,6 +1588,8 @@ export type ThreadOverlayState = {
   subAgents?: ThreadSubAgentSummary[];
   /** Durable origin metadata for threads created by an Agent handoff tool. */
   handoffOrigin?: ThreadHandoffOrigin;
+  /** Durable unborn-thread marker, cleared when the first action starts. */
+  scheduledStart?: ThreadScheduledStart;
   /**
    * Pending permission mode change waiting for the active turn to end.
    * Lives in registry memory only — the overlay store does NOT serialize

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -254,6 +254,7 @@ export function materializeNavigationThreads(params: {
       worktreeSnapshots: overlay?.worktreeSnapshots ?? thread.worktreeSnapshots ?? [],
       reactions: overlay?.reactions ?? [],
       subAgents: overlay?.subAgents ?? [],
+      scheduledStart: overlay?.scheduledStart,
       pinnedRank: overlay?.pinnedRank,
       parentThreadId,
       forkSourceThreadId: overlay?.forkSourceThreadId,
@@ -446,6 +447,13 @@ export function buildNavigationSnapshotHash(params: {
       reasoningEffort: thread.reasoningEffort ?? null,
       serviceTier: thread.serviceTier ?? null,
       fastMode: thread.fastMode ?? null,
+      scheduledStart: thread.scheduledStart
+        ? {
+            actionId: thread.scheduledStart.actionId,
+            scheduledFor: thread.scheduledStart.scheduledFor,
+            state: thread.scheduledStart.state,
+          }
+        : null,
       prAutoDispatchEnabled: thread.prAutoDispatchEnabled ?? false,
       prAutoDispatchPending: thread.prAutoDispatchPending
         ? {


### PR DESCRIPTION
## Summary

- materialize the selected workspace and provider thread immediately when a new-thread start is scheduled
- run title generation at scheduling time and persist an unborn scheduled-start lifecycle marker until dispatch begins
- surface Scheduled in the thread list and distinguish scheduled first-message cards from ordinary queued messages
- keep edits, cancellation, failure, and eventual dispatch synchronized with the unborn-thread marker

## Why

Scheduling was available only after a thread already existed. This makes the new-thread composer use the same durable scheduler while preserving the launchpad setup, searchability, naming, and thread-first UI users expect before the first turn starts.

## Validation

- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings remain)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadQueuedMessageIndicators.test.tsx apps/desktop/src/main/__tests__/scheduled-thread-action-service.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "materializes and names a thread now while scheduling its first turn"`
- `git diff --check`