### PR TITLE
ci(windows): test taiki-e checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
         timeout-minutes: 10
 
       # pwrdrvr/configure-nodejs is POSIX-only, so use a Windows-specific


### PR DESCRIPTION
## Summary

- Replace only the ordinary `Windows (build + test)` job's `actions/checkout@v7` step with `taiki-e/checkout-action` v1.4.2 pinned to commit `7d1e50e93dc4fb3bba58f85018fadf77898aee8b`.
- Run this as a measured Windows checkout A/B experiment against the prior checkout baseline (median ~9s, p90 ~16s, outlier 17s; total job median ~491s).
- Leave Linux, macOS, LFS, packaging, and all other checkout steps unchanged.

## Experimental scope and limitations

This is intentionally a narrow experiment in a public repository. The ordinary Windows job does not use submodules or LFS, and no later step relies on persisted Git credentials. Results therefore do not establish behavior for private repositories, submodules, LFS, or credential-persistence workflows.

## Validation

- Parsed `.github/workflows/ci.yml` as YAML.
- Ran `actionlint` v1.7.7 successfully while suppressing only its pre-existing unknown custom-runner-label diagnostic for `pwrdrvr-macos`.
- Ran `git diff --check`.
- Verified the v1.4.2 tag resolves to the pinned commit SHA.

This PR remains draft while CI provides checkout timing, merge-ref correctness, warnings/retry evidence, and total Windows job duration.
