### PR TITLE
ci(windows): measure checkout without persisted credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         timeout-minutes: 10
+        with:
+          persist-credentials: false
 
       # pwrdrvr/configure-nodejs is POSIX-only, so use a Windows-specific
       # setup action that activates the repo-pinned pnpm through Corepack.


### PR DESCRIPTION
## Summary

This is a controlled, one-variable checkout timing experiment for the ordinary `Windows (build + test)` job.

- keep `actions/checkout@v7`;
- set `persist-credentials: false` only on that job's checkout step;
- leave every other job and CI setting unchanged.

The experiment is intended to measure whether disabling credential persistence changes checkout/post-checkout cost on `windows-latest`, compared with the observed baseline: checkout median ~9s, p90 ~16s, outlier 17s; post-checkout ~3s; total Windows job median ~491s.

## Authenticated Git assumption

The workflow does not need authenticated Git operations after checkout. Its remaining steps use repository-local composite actions to configure Node/pnpm and install ripgrep, then run `pnpm install --frozen-lockfile`, type checking, build, and tests. Those steps use package registries, caches, and ordinary downloads; the workflow contains no post-checkout Git fetch, push, submodule, or other authenticated Git command. Tests may exercise local Git behavior, but they do not need the checkout token.

## Evidence to collect

From the Windows job logs:

- total `Checkout repository` duration and available internal phase timings;
- Git version, auth removal/setup, submodule `foreach`, fetch, and checkout timing;
- `Post Checkout repository` duration and whether it still runs;
- total Windows job duration;
- merge-ref checkout correctness and warnings;
- whether this input affects expensive pre-checkout submodule cleanup or only post-job credential handling.

Any existing Windows PowerShell/Job Object startup failure will be classified separately and will not broaden this PR.

## Validation

- parsed `.github/workflows/ci.yml` and asserted the Windows checkout remains `actions/checkout@v7` with `persist-credentials: false`;
- `pnpm lint:boundaries`;
- `git diff --check`.

No headed desktop E2E was run.
