### PR TITLE
feat(desktop): link failed CI runs from auto-fix cards

### DIFF
--- a/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
@@ -83,6 +83,8 @@ describe("buildBatchedPrQuery", () => {
     expect(query).toContain("headRefName");
     expect(query).toContain("contexts(first: 100)");
     expect(query).toContain("pageInfo { hasNextPage endCursor }");
+    expect(query).toContain("conclusion detailsUrl status");
+    expect(query).toContain("state targetUrl");
   });
 
   it("passes every input as a variable rather than interpolating it", () => {
@@ -119,6 +121,8 @@ describe("buildBatchedStatusContextQuery", () => {
     expect(query).toContain("r1: node(id: $id1)");
     expect(query).toContain("contexts(first: 100, after: $c0)");
     expect(query).toContain("contexts(first: 100, after: $c1)");
+    expect(query).toContain("conclusion detailsUrl status");
+    expect(query).toContain("state targetUrl");
     expect(variables).toEqual({
       id0: "commit-1",
       c0: "cursor-1",
@@ -224,6 +228,7 @@ describe("mapGraphqlPrNode", () => {
                     {
                       __typename: "CheckRun",
                       conclusion: "FAILURE",
+                      detailsUrl: "https://github.com/pwrdrvr/PwrAgent/actions/runs/123",
                       status: "COMPLETED",
                     },
                     {
@@ -243,6 +248,7 @@ describe("mapGraphqlPrNode", () => {
     expect(summary).toMatchObject({
       checkState: "failing",
       checksStillRunning: true,
+      failedCheckUrl: "https://github.com/pwrdrvr/PwrAgent/actions/runs/123",
     });
   });
 
@@ -384,6 +390,7 @@ describe("GithubGraphqlPrClient", () => {
                 nodes: [{
                   __typename: "CheckRun",
                   conclusion: "FAILURE",
+                  detailsUrl: "https://github.com/pwrdrvr/PwrAgent/actions/runs/456",
                   status: "COMPLETED",
                 }],
               },
@@ -440,6 +447,7 @@ describe("GithubGraphqlPrClient", () => {
     expect(pr).toMatchObject({
       checkState: "failing",
       checksStillRunning: true,
+      failedCheckUrl: "https://github.com/pwrdrvr/PwrAgent/actions/runs/456",
     });
   });
 

--- a/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
@@ -79,6 +79,24 @@ describe("parseGhPrPayload", () => {
     expect(summary.org).toBe("");
     expect(summary.repo).toBe("");
   });
+
+  it("retains the first safe failed-check destination", () => {
+    const summary = parseGhPrPayload({
+      ...rawMergedPr(),
+      statusCheckRollup: [
+        {
+          __typename: "CheckRun",
+          conclusion: "FAILURE",
+          detailsUrl: "https://github.com/pwrdrvr/PwrAgent/actions/runs/123",
+          status: "COMPLETED",
+        },
+      ],
+    });
+
+    expect(summary.failedCheckUrl).toBe(
+      "https://github.com/pwrdrvr/PwrAgent/actions/runs/123",
+    );
+  });
 });
 
 describe("derive PR states", () => {

--- a/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
@@ -97,6 +97,38 @@ describe("parseGhPrPayload", () => {
       "https://github.com/pwrdrvr/PwrAgent/actions/runs/123",
     );
   });
+
+  it("retains loopback HTTP failed-check destinations", () => {
+    const summary = parseGhPrPayload({
+      ...rawMergedPr(),
+      statusCheckRollup: [
+        {
+          __typename: "CheckRun",
+          conclusion: "FAILURE",
+          detailsUrl: "http://localhost:3000/runs/123",
+          status: "COMPLETED",
+        },
+      ],
+    });
+
+    expect(summary.failedCheckUrl).toBe("http://localhost:3000/runs/123");
+  });
+
+  it("rejects remote HTTP failed-check destinations", () => {
+    const summary = parseGhPrPayload({
+      ...rawMergedPr(),
+      statusCheckRollup: [
+        {
+          __typename: "CheckRun",
+          conclusion: "FAILURE",
+          detailsUrl: "http://ci.example.com/runs/123",
+          status: "COMPLETED",
+        },
+      ],
+    });
+
+    expect(summary).not.toHaveProperty("failedCheckUrl");
+  });
 });
 
 describe("derive PR states", () => {

--- a/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
@@ -392,8 +392,11 @@ describe("PrAutoDispatchCoordinator", () => {
   });
 
   it("dispatches only after the countdown and includes structured PR context", async () => {
-    const harness = createHarness();
-    await observe(harness.coordinator);
+    const failedCheckUrl =
+      "https://github.com/pwrdrvr/PwrAgent/actions/runs/123";
+    const failedPr = pr({ failedCheckUrl });
+    const harness = createHarness({ currentPr: failedPr });
+    await observe(harness.coordinator, failedPr);
 
     await vi.advanceTimersByTimeAsync(PR_AUTO_DISPATCH_DELAY_MS - 1);
     expect(harness.submitTurnIfIdle).not.toHaveBeenCalled();
@@ -413,6 +416,7 @@ describe("PrAutoDispatchCoordinator", () => {
         prAutomation: {
           kind: "auto-fix",
           prNumber: 1105,
+          failedCheckUrl,
           eventKinds: ["ci-failure"],
         },
       },

--- a/apps/desktop/src/main/external-url-policy.ts
+++ b/apps/desktop/src/main/external-url-policy.ts
@@ -1,0 +1,37 @@
+/**
+ * Gate for handing a URL to the OS via `shell.openExternal`.
+ *
+ * PwrAgent's own `pwragent:` scheme is deliberately NOT allowed here. Thread
+ * links are resolved in-app by the transcript renderer, which intercepts the
+ * click and navigates; they must never round-trip out through the OS.
+ */
+export function isSafeExternalOpenUrl(url: string): boolean {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (
+    parsed.protocol === "https:"
+    || parsed.protocol === "mailto:"
+    || parsed.protocol === "file:"
+  ) {
+    return true;
+  }
+
+  return parsed.protocol === "http:" && isLoopbackHost(parsed.hostname);
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+
+  return (
+    normalized === "localhost"
+    || normalized.endsWith(".localhost")
+    || normalized === "127.0.0.1"
+    || normalized === "::1"
+  );
+}

--- a/apps/desktop/src/main/pr-status/github-graphql-client.ts
+++ b/apps/desktop/src/main/pr-status/github-graphql-client.ts
@@ -9,6 +9,7 @@ import {
   deriveLifecycleState,
   deriveMergeState,
   deriveReviewState,
+  findFailedCheckUrl,
   hasChecksStillRunning,
   normalizeCommitShas,
   parsePullRequestProvider,
@@ -128,7 +129,8 @@ export function parsePrRefFromUrl(url: string): PrRef | undefined {
 /**
  * The PullRequest fields the poller reads. `contexts` carries only enough
  * state to distinguish a completed failure from a failure while sibling
- * checks still run; we deliberately do not fetch names, URLs, or output.
+ * checks still run. Failed destinations are retained for the auto-fix card;
+ * names and output remain deliberately excluded.
  * Later pages are fetched only when this page cannot already prove a check is
  * running.
  */
@@ -155,8 +157,8 @@ fragment PrStatus on PullRequest {
             pageInfo { hasNextPage endCursor }
             nodes {
               __typename
-              ... on CheckRun { conclusion status }
-              ... on StatusContext { state }
+              ... on CheckRun { conclusion detailsUrl status }
+              ... on StatusContext { state targetUrl }
             }
           }
         }
@@ -168,8 +170,15 @@ fragment PrStatus on PullRequest {
 type GraphqlCheckContext = {
   __typename?: string;
   conclusion?: string | null;
+  detailsUrl?: string | null;
   status?: string | null;
   state?: string | null;
+  targetUrl?: string | null;
+};
+
+type PrCheckResolution = {
+  checksStillRunning: boolean;
+  failedCheckUrl?: string;
 };
 
 type GraphqlStatusContextPage = {
@@ -288,8 +297,8 @@ export function buildBatchedStatusContextQuery(refs: StatusContextPageRef[]): {
           pageInfo { hasNextPage endCursor }
           nodes {
             __typename
-            ... on CheckRun { conclusion status }
-            ... on StatusContext { state }
+            ... on CheckRun { conclusion detailsUrl status }
+            ... on StatusContext { state targetUrl }
           }
         }
       }
@@ -374,7 +383,7 @@ ${PR_STATUS_FRAGMENT}`;
 /** Map one GraphQL PullRequest node onto our shared PrSummary. */
 export function mapGraphqlPrNode(
   node: GraphqlPrNode,
-  checksStillRunningOverride?: boolean,
+  checkResolution?: PrCheckResolution,
 ): PrSummary {
   const headCommit = getHeadCommit(node);
   const checkContexts = headCommit?.statusCheckRollup?.contexts?.nodes ?? [];
@@ -382,8 +391,15 @@ export function mapGraphqlPrNode(
     headCommit?.statusCheckRollup?.state,
   );
   const checksStillRunning =
-    checksStillRunningOverride
+    checkResolution?.checksStillRunning
     ?? hasChecksStillRunning(
+      checkContexts.filter(
+        (context): context is GraphqlCheckContext => context !== null,
+      ),
+    );
+  const failedCheckUrl =
+    checkResolution?.failedCheckUrl
+    ?? findFailedCheckUrl(
       checkContexts.filter(
         (context): context is GraphqlCheckContext => context !== null,
       ),
@@ -412,6 +428,7 @@ export function mapGraphqlPrNode(
     state: checkState,
     checkState,
     ...(checksStillRunning ? { checksStillRunning: true } : {}),
+    ...(failedCheckUrl ? { failedCheckUrl } : {}),
     lifecycleState: deriveLifecycleState(shaped),
     reviewState: deriveReviewState(shaped),
     mergeState: deriveMergeState(shaped),
@@ -677,19 +694,19 @@ export class GithubGraphqlPrClient {
           this.notifyRepositoryAccess(ref, "available");
         }
       });
-      const checksStillRunning = await this.resolveChecksStillRunning(
+      const checkResolutions = await this.resolveCheckContexts(
         answers.flatMap((answer) => answer.nodes),
         token,
       );
       answers.forEach(({ ref, repository, nodes }) => {
-        if (!repository || nodes.some((node) => !checksStillRunning.has(node))) {
+        if (!repository || nodes.some((node) => !checkResolutions.has(node))) {
           // An unresolved alias or context page is not an authoritative answer;
           // leave the key absent so callers retain prior state.
           return;
         }
         results.set(
           branchRefKey(ref),
-          nodes.map((node) => mapGraphqlPrNode(node, checksStillRunning.get(node)!)),
+          nodes.map((node) => mapGraphqlPrNode(node, checkResolutions.get(node)!)),
         );
       });
     }
@@ -697,17 +714,18 @@ export class GithubGraphqlPrClient {
   }
 
   /**
-   * Resolve whether each PR has a running check without treating the first
-   * context page as terminal. A failed follow-up page leaves that PR unresolved
-   * so callers retain the last known status instead of clearing its indicator.
+   * Resolve each PR's running state and first failed destination without
+   * treating the first context page as terminal. A failed follow-up page leaves
+   * that PR unresolved so callers retain the last known status.
    */
-  private async resolveChecksStillRunning(
+  private async resolveCheckContexts(
     nodes: GraphqlPrNode[],
     token: string,
-  ): Promise<Map<GraphqlPrNode, boolean>> {
-    const resolved = new Map<GraphqlPrNode, boolean>();
+  ): Promise<Map<GraphqlPrNode, PrCheckResolution>> {
+    const resolved = new Map<GraphqlPrNode, PrCheckResolution>();
     const pendingNodes = new Map<GraphqlPrNode, string>();
     const pendingByCommitId = new Map<string, StatusContextPageRef>();
+    const failedCheckUrlByCommitId = new Map<string, string>();
     const seenCursorsByCommitId = new Map<string, Set<string>>();
 
     const queueNextPage = (commitId: string, cursor: string): boolean => {
@@ -728,23 +746,33 @@ export class GithubGraphqlPrClient {
       const headCommit = getHeadCommit(node);
       const rollup = headCommit?.statusCheckRollup;
       if (!rollup) {
-        resolved.set(node, false);
+        resolved.set(node, { checksStillRunning: false });
         continue;
       }
       const contexts = readCheckContexts(rollup.contexts);
       if (!contexts) {
         continue;
       }
+      const failedCheckUrl = findFailedCheckUrl(contexts);
+      const commitId = headCommit?.id?.trim();
+      if (commitId && failedCheckUrl) {
+        failedCheckUrlByCommitId.set(commitId, failedCheckUrl);
+      }
       if (hasChecksStillRunning(contexts)) {
-        resolved.set(node, true);
+        resolved.set(node, {
+          checksStillRunning: true,
+          ...(failedCheckUrl ? { failedCheckUrl } : {}),
+        });
         continue;
       }
       const pageInfo = rollup.contexts?.pageInfo;
       if (pageInfo?.hasNextPage === false) {
-        resolved.set(node, false);
+        resolved.set(node, {
+          checksStillRunning: false,
+          ...(failedCheckUrl ? { failedCheckUrl } : {}),
+        });
         continue;
       }
-      const commitId = headCommit?.id?.trim();
       const cursor = pageInfo?.endCursor?.trim();
       if (
         pageInfo?.hasNextPage === true
@@ -756,7 +784,7 @@ export class GithubGraphqlPrClient {
       }
     }
 
-    const completedByCommitId = new Map<string, boolean>();
+    const completedByCommitId = new Map<string, PrCheckResolution>();
     while (pendingByCommitId.size > 0) {
       const pending = [...pendingByCommitId.values()];
       pendingByCommitId.clear();
@@ -776,13 +804,25 @@ export class GithubGraphqlPrClient {
           if (!contexts) {
             return;
           }
+          const failedCheckUrl =
+            failedCheckUrlByCommitId.get(ref.commitId)
+            ?? findFailedCheckUrl(contexts);
+          if (failedCheckUrl) {
+            failedCheckUrlByCommitId.set(ref.commitId, failedCheckUrl);
+          }
           if (hasChecksStillRunning(contexts)) {
-            completedByCommitId.set(ref.commitId, true);
+            completedByCommitId.set(ref.commitId, {
+              checksStillRunning: true,
+              ...(failedCheckUrl ? { failedCheckUrl } : {}),
+            });
             return;
           }
           const pageInfo = page?.pageInfo;
           if (pageInfo?.hasNextPage === false) {
-            completedByCommitId.set(ref.commitId, false);
+            completedByCommitId.set(ref.commitId, {
+              checksStillRunning: false,
+              ...(failedCheckUrl ? { failedCheckUrl } : {}),
+            });
             return;
           }
           const cursor = pageInfo?.endCursor?.trim();
@@ -899,7 +939,7 @@ export class GithubGraphqlPrClient {
         this.notifyRepositoryAccess(ref, "available");
       }
     });
-    const checksStillRunning = await this.resolveChecksStillRunning(nodes, token);
+    const checkResolutions = await this.resolveCheckContexts(nodes, token);
     const prs: PrSummary[] = [];
     let dropped = 0;
     let incompleteContexts = 0;
@@ -909,11 +949,11 @@ export class GithubGraphqlPrClient {
         dropped += 1;
         return;
       }
-      if (!checksStillRunning.has(node)) {
+      if (!checkResolutions.has(node)) {
         incompleteContexts += 1;
         return;
       }
-      prs.push(mapGraphqlPrNode(node, checksStillRunning.get(node)!));
+      prs.push(mapGraphqlPrNode(node, checkResolutions.get(node)!));
     });
 
     if (dropped > 0 || incompleteContexts > 0) {

--- a/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
+++ b/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
@@ -287,6 +287,9 @@ export class PrAutoDispatchCoordinator {
         prNumber: params.pr.number,
         ...(params.pr.title ? { prTitle: params.pr.title } : {}),
         prUrl: params.pr.url,
+        ...(params.pr.failedCheckUrl
+          ? { failedCheckUrl: params.pr.failedCheckUrl }
+          : {}),
         headSha: event.headSha,
         eventKinds: event.eventKinds,
         createdAt: params.observedAt,
@@ -540,6 +543,9 @@ export class PrAutoDispatchCoordinator {
             prNumber: begin.record.pending.prNumber,
             ...(begin.record.pending.prTitle
               ? { prTitle: begin.record.pending.prTitle }
+              : {}),
+            ...(begin.record.pending.failedCheckUrl
+              ? { failedCheckUrl: begin.record.pending.failedCheckUrl }
               : {}),
             headSha: begin.record.pending.headSha,
             eventKinds: begin.record.pending.eventKinds,

--- a/apps/desktop/src/main/pr-status/pr-derivations.ts
+++ b/apps/desktop/src/main/pr-status/pr-derivations.ts
@@ -47,10 +47,20 @@ export type GhPrPayload = {
 export type GhCheckRunPayload = {
   __typename?: string;
   conclusion?: string | null;
+  detailsUrl?: string | null;
   status?: string | null;
   state?: string | null;
   name?: string;
+  targetUrl?: string | null;
 };
+
+const FAILING_CHECK_CONCLUSIONS = new Set([
+  "FAILURE",
+  "CANCELLED",
+  "TIMED_OUT",
+  "STARTUP_FAILURE",
+  "ACTION_REQUIRED",
+]);
 
 /**
  * Map a `gh pr list` row to our PrSummary. Exported for direct testing
@@ -59,6 +69,7 @@ export type GhCheckRunPayload = {
 export function parseGhPrPayload(row: GhPrPayload): PrSummary {
   const checkState = deriveChipState(row);
   const checksStillRunning = hasChecksStillRunning(row.statusCheckRollup ?? []);
+  const failedCheckUrl = findFailedCheckUrl(row.statusCheckRollup ?? []);
   const headSha = normalizeCommitShas([
     row.commits?.[row.commits.length - 1]?.oid,
   ])[0];
@@ -73,6 +84,7 @@ export function parseGhPrPayload(row: GhPrPayload): PrSummary {
     state: checkState,
     checkState,
     ...(checksStillRunning ? { checksStillRunning: true } : {}),
+    ...(failedCheckUrl ? { failedCheckUrl } : {}),
     lifecycleState: deriveLifecycleState(row),
     reviewState: deriveReviewState(row),
     mergeState: deriveMergeState(row),
@@ -139,13 +151,6 @@ export function deriveChipState(row: GhPrPayload): PrChipState {
   const checks = row.statusCheckRollup ?? [];
   if (checks.length === 0) return "unknown";
 
-  const failingConclusions = new Set([
-    "FAILURE",
-    "CANCELLED",
-    "TIMED_OUT",
-    "STARTUP_FAILURE",
-    "ACTION_REQUIRED",
-  ]);
   const passingConclusions = new Set([
     "SUCCESS",
     "SKIPPED",
@@ -158,7 +163,7 @@ export function deriveChipState(row: GhPrPayload): PrChipState {
   let hasUnknown = false;
   for (const check of checks) {
     const conclusion = check.conclusion?.trim();
-    if (conclusion && failingConclusions.has(conclusion)) {
+    if (conclusion && FAILING_CHECK_CONCLUSIONS.has(conclusion)) {
       hasFailure = true;
       continue;
     }
@@ -198,6 +203,36 @@ export function hasChecksStillRunning(
   checks: readonly GhCheckRunPayload[],
 ): boolean {
   return checks.some(isCheckStillRunning);
+}
+
+/** Return the first safe destination attached to a failed check or status. */
+export function findFailedCheckUrl(
+  checks: readonly GhCheckRunPayload[],
+): string | undefined {
+  for (const check of checks) {
+    const conclusion = check.conclusion?.trim();
+    const state = check.state?.trim();
+    if (
+      !(
+        (conclusion && FAILING_CHECK_CONCLUSIONS.has(conclusion))
+        || state === "FAILURE"
+        || state === "ERROR"
+      )
+    ) {
+      continue;
+    }
+    const candidate = check.detailsUrl?.trim() || check.targetUrl?.trim();
+    if (!candidate) continue;
+    try {
+      const parsed = new URL(candidate);
+      if (parsed.protocol === "https:" || parsed.protocol === "http:") {
+        return parsed.toString();
+      }
+    } catch {
+      // Ignore malformed provider data instead of exposing an unsafe link.
+    }
+  }
+  return undefined;
 }
 
 function isCheckStillRunning(check: GhCheckRunPayload): boolean {

--- a/apps/desktop/src/main/pr-status/pr-derivations.ts
+++ b/apps/desktop/src/main/pr-status/pr-derivations.ts
@@ -6,6 +6,7 @@ import type {
   PrSummary,
 } from "@pwragent/shared";
 import { DEFAULT_PULL_REQUEST_PROVIDER } from "@pwragent/shared";
+import { isSafeExternalOpenUrl } from "../external-url-policy";
 
 /**
  * Shared PR-status derivations.
@@ -225,7 +226,10 @@ export function findFailedCheckUrl(
     if (!candidate) continue;
     try {
       const parsed = new URL(candidate);
-      if (parsed.protocol === "https:" || parsed.protocol === "http:") {
+      if (
+        (parsed.protocol === "https:" || parsed.protocol === "http:")
+        && isSafeExternalOpenUrl(parsed.toString())
+      ) {
         return parsed.toString();
       }
     } catch {

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -21,6 +21,7 @@ import { createHotCpuProfileSession } from "./diagnostics/hot-cpu-profile-sessio
 import { MainProcessHeapMonitor } from "./diagnostics/main-process-heap-monitor";
 import { RendererHeapMonitor } from "./diagnostics/renderer-heap-monitor";
 import { RendererHotCpuProfiler } from "./diagnostics/renderer-hot-cpu-profiler";
+import { isSafeExternalOpenUrl } from "./external-url-policy";
 import { getMainLogger } from "./log";
 import { lockMainWindowTitle, mainWindowTitle } from "./main-window-title";
 import { recordStartupProfileEvent } from "./diagnostics/startup-profile-events";
@@ -64,6 +65,8 @@ import {
 } from "./navigation-browse-mode-bootstrap";
 import { placementForCursorDisplay } from "./window-placement";
 import { federationWindowTargetAdditionalArguments } from "../shared/federation-window";
+
+export { isSafeExternalOpenUrl } from "./external-url-policy";
 
 /**
  * WebContents of windows created with a federationTarget. Remote windows
@@ -300,45 +303,6 @@ function isSafeRendererNavigation(targetUrl: string): boolean {
   }
 }
 
-/**
- * Gate for handing a URL to the OS via `shell.openExternal`.
- *
- * PwrAgent's own `pwragent:` scheme is deliberately NOT allowed here. Thread
- * links are resolved in-app by the transcript renderer, which intercepts the
- * click and navigates; they must never round-trip out through the OS. Keeping
- * the scheme out of this allowlist is what makes that a property of the code
- * rather than a convention — see `contracts/thread-link.ts`.
- */
-export function isSafeExternalOpenUrl(url: string): boolean {
-  let parsed: URL;
-
-  try {
-    parsed = new URL(url);
-  } catch {
-    return false;
-  }
-
-  if (
-    parsed.protocol === "https:" ||
-    parsed.protocol === "mailto:" ||
-    parsed.protocol === "file:"
-  ) {
-    return true;
-  }
-
-  return parsed.protocol === "http:" && isLoopbackHost(parsed.hostname);
-}
-
-function isLoopbackHost(hostname: string): boolean {
-  const normalized = hostname.toLowerCase();
-
-  return (
-    normalized === "localhost" ||
-    normalized.endsWith(".localhost") ||
-    normalized === "127.0.0.1" ||
-    normalized === "::1"
-  );
-}
 
 function resolveRepoRoot(): string {
   return resolve(app.getAppPath(), "../..");

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -132,6 +132,18 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
                 : "PR watch completed"}
             </span>
           </button>
+          {prAutomationOrigin.kind === "auto-fix"
+            && prAutomationOrigin.eventKinds?.includes("ci-failure")
+            && prAutomationOrigin.failedCheckUrl ? (
+              <a
+                className="transcript-monitor-result__run-link"
+                href={prAutomationOrigin.failedCheckUrl}
+                rel="noreferrer"
+                target="_blank"
+              >
+                View failed run
+              </a>
+            ) : null}
           <RailStatusChip
             alert={outcomeTone === "error"}
             tone={outcomeTone}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -363,6 +363,7 @@ describe("TranscriptList", () => {
                 prKey: "github.com/pwrdrvr/pwragent#1128",
                 prNumber: 1128,
                 prTitle: "Wake threads on PR completion",
+                failedCheckUrl: "https://github.com/pwrdrvr/PwrAgent/actions/runs/123",
                 headSha: "a".repeat(40),
                 eventKinds: ["ci-failure"],
               },
@@ -382,6 +383,11 @@ describe("TranscriptList", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("CI failed")).toBeInTheDocument();
+    const failedRunLink = screen.getByRole("link", { name: "View failed run" });
+    expect(failedRunLink).toHaveAttribute(
+      "href",
+      "https://github.com/pwrdrvr/PwrAgent/actions/runs/123",
+    );
     expect(
       screen.queryByText("Pull request event"),
     ).not.toBeInTheDocument();
@@ -393,8 +399,42 @@ describe("TranscriptList", () => {
     expect(toggle).toHaveAttribute("aria-expanded", "false");
     fireEvent.click(toggle);
     expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(failedRunLink).toBeInTheDocument();
     expect(screen.getByText("Pull request event")).toBeInTheDocument();
     expect(screen.getByText(/Dedupe fingerprint/)).toBeInTheDocument();
+  });
+
+  it("omits the failed-run link for merge-conflict auto-fix cards", () => {
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "pr-auto-fix-conflict",
+            role: "user",
+            text: "PwrAgent scheduled this bounded repair turn because an attached pull request needs attention.",
+            origin: {
+              kind: "pwragent",
+              prAutomation: {
+                kind: "auto-fix",
+                prKey: "github.com/pwrdrvr/pwragent#1128",
+                prNumber: 1128,
+                headSha: "a".repeat(40),
+                eventKinds: ["merge-conflict"],
+              },
+            },
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />,
+    );
+
+    expect(screen.getByText("Conflict")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "View failed run" }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders a completed PR watch with its result pill", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11614,7 +11614,8 @@ textarea,
 }
 
 .transcript-monitor-result__toggle:focus-visible,
-.transcript-monitor-result__details:focus-visible {
+.transcript-monitor-result__details:focus-visible,
+.transcript-monitor-result__run-link:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
 }
@@ -11641,6 +11642,29 @@ textarea,
   min-height: 26px;
   padding: 0 9px;
   font-size: 11px;
+}
+
+.transcript-monitor-result__run-link {
+  display: inline-flex;
+  flex: 0 0 auto;
+  min-height: 26px;
+  align-items: center;
+  padding: 0 9px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  background: transparent;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.transcript-monitor-result__run-link:hover {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+  background: var(--bg-panel-hover);
 }
 
 .transcript-monitor-result__content {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -343,6 +343,8 @@ export type PrSummary = {
   mergeState?: PrMergeState;
   /** Head commit observed with this status snapshot. */
   headSha?: string;
+  /** Direct destination for the first failed CI check in this snapshot. */
+  failedCheckUrl?: string;
   /**
    * Commit OIDs attached to this PR when the provider returns them. Used to
    * keep merged PR commits from reading as local-only after the remote head
@@ -362,6 +364,7 @@ export type ThreadPrAutoDispatchPending = {
   prNumber: number;
   prTitle?: string;
   prUrl: string;
+  failedCheckUrl?: string;
   headSha: string;
   eventKinds: ThreadPrAutoDispatchEventKind[];
   createdAt: number;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -454,6 +454,7 @@ export type AppServerThreadMessageOrigin = {
     prKey: string;
     prNumber: number;
     prTitle?: string;
+    failedCheckUrl?: string;
     headSha: string;
     eventKinds?: ThreadPrAutoDispatchEventKind[];
     outcome?: "success" | "failure";


### PR DESCRIPTION
## What changed

- capture GitHub check-run `detailsUrl` and status-context `targetUrl` values while polling PR status, including paginated check lists
- carry the first failed check URL through the durable auto-fix pending record and message origin
- show a `View failed run` external link in both collapsed and expanded auto-fix cards for CI failures
- omit the action for merge-conflict-only cards

## Why

The auto-fix card identified a CI failure but did not expose the failed run itself, forcing operators to navigate back through the pull request. The direct link also supports the normal browser context menu for copying the destination.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/github-graphql-client.test.ts apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx` (202 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `git diff --check`