### PR TITLE
ci(windows): split verification and test lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,8 +212,8 @@ jobs:
         timeout-minutes: 10
         run: pnpm run test
 
-  windows:
-    name: Windows (build + test)
+  windows-verify:
+    name: Windows verify
     runs-on: windows-latest
     needs: changes
     if: needs.changes.outputs.code_impacting == 'true'
@@ -233,10 +233,6 @@ jobs:
         timeout-minutes: 15
         run: pnpm install --frozen-lockfile
 
-      - name: Install ripgrep
-        timeout-minutes: 5
-        uses: ./.github/actions/install-ripgrep
-
       - name: Type check
         timeout-minutes: 10
         run: pnpm typecheck
@@ -245,9 +241,61 @@ jobs:
         timeout-minutes: 15
         run: pnpm run build
 
+  windows-desktop-main:
+    name: Windows desktop-main
+    runs-on: windows-latest
+    needs: changes
+    if: needs.changes.outputs.code_impacting == 'true'
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        timeout-minutes: 10
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/configure-windows-nodejs
+        timeout-minutes: 10
+
+      - name: Install dependencies
+        timeout-minutes: 15
+        run: pnpm install --frozen-lockfile
+
       - name: Test
         timeout-minutes: 20
-        run: pnpm run test
+        run: pnpm exec vitest run --config vitest.workspace.ts --project desktop-main
+
+  windows-renderer-packages:
+    name: Windows renderer + packages
+    runs-on: windows-latest
+    needs: changes
+    if: needs.changes.outputs.code_impacting == 'true'
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        timeout-minutes: 10
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/configure-windows-nodejs
+        timeout-minutes: 10
+
+      - name: Install dependencies
+        timeout-minutes: 15
+        run: pnpm install --frozen-lockfile
+
+      - name: Install ripgrep
+        timeout-minutes: 5
+        uses: ./.github/actions/install-ripgrep
+
+      - name: Test
+        timeout-minutes: 20
+        run: >-
+          pnpm exec vitest run --config vitest.workspace.ts
+          --project desktop-renderer
+          --project agent-core
+          --project grok-app-server
+          --project messaging
+          --project shared
 
   windows-package:
     name: Windows installer (label-gated)


### PR DESCRIPTION
## Summary

- split the monolithic Windows build-and-test job into three fresh GitHub-hosted runner lanes
- keep typecheck and build together in **Windows verify**
- run only the `desktop-main` Vitest project in **Windows desktop-main**
- run `desktop-renderer`, `agent-core`, `grok-app-server`, `messaging`, and `shared` in **Windows renderer + packages**
- install ripgrep only in the renderer/packages lane, where agent-core executes real ripgrep searches

## Why

The previous Windows job serialized setup, verification, build, and all six Vitest projects. The approved split reduces wall-clock time and makes failures cheaper to rerun while preserving project-level process-isolation evidence.

The expected tradeoff is lower wall-clock and rerun latency in exchange for duplicated checkout/setup/install work and some additional aggregate Windows runner compute.

## Required-check contract

The active main-branch ruleset requires `Lint`, `Build`, `Test`, and `Desktop E2E`. It does not require or reference the former `Windows (build + test)` check, and the old check name is not referenced in the repository, so no aggregator job is necessary. The four required checks, change classification, docs-only gating, workflow permissions, and label-gated Windows installer behavior are unchanged.

## Validation

- `actionlint` 1.7.12 (with only the repository's known custom `pwrdrvr-macos` runner-label diagnostic ignored)
- YAML parse and `git diff --check`
- static workflow-to-`vitest.workspace.ts` comparison: all 6 projects selected exactly once
- dynamic `vitest list` proof:
  - desktop-main: 276 files, 3,765 collected tests
  - renderer/packages: 238 files, 3,124 collected tests across the five selected projects
- exact renderer/packages command: 238 files passed, 1 skipped; 3,124 tests passed, 3 skipped in 29.02s locally
- exact desktop-main command selected only desktop-main; a local macOS run hit unrelated host-load 5-second timeouts across Git/process-heavy tests, so fresh Windows CI is the authoritative platform result. No retries, timeout changes, worker reductions, or serialization were introduced.

## Measured Windows CI

[CI run 31224881780](https://github.com/pwrdrvr/PwrAgent/actions/runs/31224881780) passed on the first attempt at head `760c395ca`.

| Lane | Checkout | Node/pnpm setup | Install | Ripgrep | Typecheck | Build | Test | Lane total | Estimated rerun |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| Windows verify | 7s | 34s | 8s | — | 59s | 26s | — | 142s | ~142s (2m22s) |
| Windows desktop-main | 9s | 39s | 9s | — | — | — | 178s | 240s | ~240s (4m00s) |
| Windows renderer + packages | 6s | 50s | 9s | 2s | — | — | 183s | 255s | ~255s (4m15s) |

- first Windows lane start to last required Windows lane completion: **255s** (`22:45:11Z`–`22:49:26Z`)
- prior Windows median: ~491s; observed reduction: **236s / 48.1%** (**1.93× faster**)
- parallel Windows test window: **193s** (`22:46:09Z`–`22:49:22Z`)
- prior test median: ~337s; observed reduction: **144s / 42.7%** (**1.75× faster**)
- aggregate Windows runner time: approximately **10.62 runner-minutes** (about 12 minutes if each lane is rounded up independently)
- no lane failed; no process-startup or Job Object failure occurred

Vitest project and count evidence:

- `desktop-main` ran once: 277 files passed, 1 skipped (278 total); 3,770 tests passed, 17 skipped (3,787 total); Vitest duration 176.88s
- `desktop-renderer`, `agent-core`, `grok-app-server`, `messaging`, and `shared` each ran once in the repeated `--project` command: 238 files passed, 1 skipped (239 total); 3,123 tests passed, 4 skipped (3,127 total); Vitest duration 181.97s
- combined: all 6 workspace projects exactly once; 515 passing and 2 skipped file executions; 6,893 passing and 21 skipped tests
