### PR TITLE
fix(desktop): dismiss composer autocomplete on global Escape

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -9104,6 +9104,20 @@ export function Composer(props: ComposerProps) {
     return true;
   };
 
+  const dismissAutocomplete = useCallback((restoreFocus = false): void => {
+    if (!autocompleteKey) {
+      return;
+    }
+    setDismissedAutocompleteKey(autocompleteKey);
+    setActiveSkillIndex(0);
+    setActiveSlashIndex(0);
+    setActiveDirectoryRefIndex(0);
+    setActiveHashReferenceIndex(0);
+    if (restoreFocus) {
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [autocompleteKey]);
+
   const handleAutocompleteKeyDown = (
     event: ReactKeyboardEvent<HTMLElement>,
   ): void => {
@@ -9167,14 +9181,7 @@ export function Composer(props: ComposerProps) {
 
     if (event.key === "Escape") {
       event.preventDefault();
-      if (autocompleteKey) {
-        setDismissedAutocompleteKey(autocompleteKey);
-      }
-      setActiveSkillIndex(0);
-      setActiveSlashIndex(0);
-      setActiveDirectoryRefIndex(0);
-      setActiveHashReferenceIndex(0);
-      requestAnimationFrame(() => inputRef.current?.focus());
+      dismissAutocomplete(true);
       return;
     }
 
@@ -9201,6 +9208,23 @@ export function Composer(props: ComposerProps) {
       commitActiveAutocomplete();
     }
   };
+
+  // Autocomplete stays open when focus moves into the transcript, so Escape
+  // must dismiss it at window scope instead of relying on the editor handler.
+  useEffect(() => {
+    if (!autocompleteKind) {
+      return;
+    }
+    const dismissOnEscape = (event: globalThis.KeyboardEvent): void => {
+      if (event.key !== "Escape" || event.defaultPrevented) {
+        return;
+      }
+      event.preventDefault();
+      dismissAutocomplete();
+    };
+    window.addEventListener("keydown", dismissOnEscape);
+    return () => window.removeEventListener("keydown", dismissOnEscape);
+  }, [autocompleteKind, dismissAutocomplete]);
 
   // Backend availability gates submission and remote actions, not the draft.
   // Keeping the editor live lets an operator inspect, copy, revise, or remove

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -17634,6 +17634,62 @@ describe("Composer", () => {
     expect(textarea).toHaveValue("$ce:pl");
   });
 
+  it("dismisses directory autocomplete with Escape after focus leaves the composer", () => {
+    const directory: NavigationDirectorySummary = {
+      key: "directory:/repo/search",
+      kind: "directory",
+      label: "search",
+      path: "/repo/search",
+      threadKeys: [],
+      needsAttentionCount: 0,
+    };
+
+    render(
+      <>
+        <button type="button">Transcript blank area</button>
+        <Composer
+          desktopApi={{
+            onAgentEvent: () => () => undefined,
+            startTurn: async () => ({
+              backend: "codex",
+              threadId: "thread-1",
+              turnId: "turn-1",
+            }),
+          }}
+          directories={[directory]}
+          disabled={false}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Search thread",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />
+      </>
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Check @sea" } });
+    expect(
+      screen.getByRole("listbox", { name: "Directories" })
+    ).toBeInTheDocument();
+
+    const transcript = screen.getByRole("button", {
+      name: "Transcript blank area",
+    });
+    transcript.focus();
+    fireEvent.keyDown(transcript, { key: "Escape", code: "Escape" });
+
+    expect(
+      screen.queryByRole("listbox", { name: "Directories" })
+    ).not.toBeInTheDocument();
+    expect(textarea).toHaveValue("Check @sea");
+    expect(transcript).toHaveFocus();
+  });
+
   it("shows a stop button for an active turn and interrupts it", async () => {
     let agentEventHandler:
       | ((event: {


### PR DESCRIPTION
## What changed

- listen for Escape at window scope while composer autocomplete is open
- dismiss all composer autocomplete variants after focus moves outside the composer
- preserve the draft and the operator's current focus target
- keep the existing focus-return behavior when Escape originates inside the autocomplete

## Why

Composer autocomplete previously handled Escape only through editor and option key handlers. Clicking into the transcript moved focus outside those handlers, leaving the popup open after Escape.

This follows the existing desktop convention used by transient pickers, menus, popovers, find bars, dialogs, and lightboxes without introducing an app-wide popup registry or changing persistent-surface cancellation semantics.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` (262 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
