### PR TITLE
ci: prime platform caches before dependent jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,10 +212,28 @@ jobs:
         timeout-minutes: 10
         run: pnpm run test
 
+  windows-install-deps:
+    name: Setup Windows Dependencies
+    runs-on: windows-latest
+    needs: changes
+    if: needs.changes.outputs.code_impacting == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        timeout-minutes: 10
+
+      - name: Install Node.js and dependencies
+        uses: pwrdrvr/configure-nodejs@841bcfd6ddfb5ed049c39db6bd121a1c3aba0fc3
+        timeout-minutes: 10
+        with:
+          node-version: 24.14.1
+          working-directory: .
+          lookup-only: "true"
+
   windows-verify:
     name: Windows verify
     runs-on: windows-latest
-    needs: changes
+    needs: [changes, windows-install-deps]
     if: needs.changes.outputs.code_impacting == 'true'
     timeout-minutes: 30
     steps:
@@ -223,15 +241,12 @@ jobs:
         uses: actions/checkout@v7
         timeout-minutes: 10
 
-      # pwrdrvr/configure-nodejs is POSIX-only, so use a Windows-specific
-      # setup action that activates the repo-pinned pnpm through Corepack.
-      - name: Setup Node.js and pnpm
-        uses: ./.github/actions/configure-windows-nodejs
+      - name: Install Node.js and dependencies
+        uses: pwrdrvr/configure-nodejs@841bcfd6ddfb5ed049c39db6bd121a1c3aba0fc3
         timeout-minutes: 10
-
-      - name: Install dependencies
-        timeout-minutes: 15
-        run: pnpm install --frozen-lockfile
+        with:
+          node-version: 24.14.1
+          working-directory: .
 
       - name: Type check
         timeout-minutes: 10
@@ -244,7 +259,7 @@ jobs:
   windows-desktop-main:
     name: Windows desktop-main
     runs-on: windows-latest
-    needs: changes
+    needs: [changes, windows-install-deps]
     if: needs.changes.outputs.code_impacting == 'true'
     timeout-minutes: 30
     steps:
@@ -252,13 +267,12 @@ jobs:
         uses: actions/checkout@v7
         timeout-minutes: 10
 
-      - name: Setup Node.js and pnpm
-        uses: ./.github/actions/configure-windows-nodejs
+      - name: Install Node.js and dependencies
+        uses: pwrdrvr/configure-nodejs@841bcfd6ddfb5ed049c39db6bd121a1c3aba0fc3
         timeout-minutes: 10
-
-      - name: Install dependencies
-        timeout-minutes: 15
-        run: pnpm install --frozen-lockfile
+        with:
+          node-version: 24.14.1
+          working-directory: .
 
       - name: Test
         timeout-minutes: 20
@@ -267,7 +281,7 @@ jobs:
   windows-renderer-packages:
     name: Windows renderer + packages
     runs-on: windows-latest
-    needs: changes
+    needs: [changes, windows-install-deps]
     if: needs.changes.outputs.code_impacting == 'true'
     timeout-minutes: 30
     steps:
@@ -275,13 +289,12 @@ jobs:
         uses: actions/checkout@v7
         timeout-minutes: 10
 
-      - name: Setup Node.js and pnpm
-        uses: ./.github/actions/configure-windows-nodejs
+      - name: Install Node.js and dependencies
+        uses: pwrdrvr/configure-nodejs@841bcfd6ddfb5ed049c39db6bd121a1c3aba0fc3
         timeout-minutes: 10
-
-      - name: Install dependencies
-        timeout-minutes: 15
-        run: pnpm install --frozen-lockfile
+        with:
+          node-version: 24.14.1
+          working-directory: .
 
       - name: Install ripgrep
         timeout-minutes: 5
@@ -375,6 +388,30 @@ jobs:
             apps/desktop/test-results/
           retention-days: 30
 
+  macos-install-deps:
+    name: Setup macOS Dependencies
+    # Keep the same fork guard as the macOS E2E consumer. A public fork must
+    # never execute arbitrary code on the self-hosted runner.
+    if: >-
+      needs.changes.outputs.code_impacting == 'true' &&
+      (github.event_name == 'push' ||
+       (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository))
+    runs-on: [self-hosted, macOS, ARM64, pwrdrvr-macos]
+    needs: changes
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        timeout-minutes: 10
+
+      - name: Install Node.js and dependencies
+        uses: pwrdrvr/configure-nodejs@v1
+        timeout-minutes: 10
+        with:
+          node-version: 24.x
+          lookup-only: "true"
+
   desktop-e2e-macos:
     name: macOS Desktop E2E (shared VM)
     # The restricted PwrDrvr organization runner group exposes this label only
@@ -389,7 +426,7 @@ jobs:
        (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: [self-hosted, macOS, ARM64, pwrdrvr-macos]
-    needs: [changes, install-deps]
+    needs: [changes, macos-install-deps]
     timeout-minutes: 30
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- add a Windows dependency-prime job before the three parallel ordinary Windows lanes
- use `pwrdrvr/configure-nodejs` pinned to immutable commit `841bcfd6ddfb5ed049c39db6bd121a1c3aba0fc3` for that gate and all three consumers
- add the equivalent platform-local macOS dependency-prime job using released `pwrdrvr/configure-nodejs@v1`
- remove duplicate standalone installs from the three ordinary Windows lanes

## Controlled experiment

This remains a controlled integration and timing experiment against the unmerged configure-nodejs candidate from draft PR pwrdrvr/configure-nodejs#8. It intentionally uses the immutable candidate SHA, not the moving `v1` tag, for Windows and must remain draft and unmerged pending timing results and operator direction.

After this experiment started, PR #1334 merged the three-lane Windows split. PwrDrvr LLC approved rebasing onto that split and adding the dependency-prime graph.

`Setup Windows Dependencies` uses `lookup-only: "true"`. On a cache hit it checks availability without restoring dependencies. On a miss it installs Node.js, activates the repository-pinned pnpm, performs the frozen install, and saves the workspace-local pnpm store before the three ordinary Windows jobs fan out. Each consumer then restores that cache and performs the action-owned frozen install. The label-gated Windows packaging job and repository-local Windows action remain unchanged.

`Setup macOS Dependencies` applies the same cache-prime pattern on the guarded self-hosted macOS runner. It uses the same released `v1` ref and `24.x` input as its macOS E2E consumer, so both jobs share a cache key. The existing same-repository/fork guard remains in force for both macOS jobs.

## Candidate behavior verified

- public immutable candidate commit: `841bcfd6ddfb5ed049c39db6bd121a1c3aba0fc3`
- package manager detected from `package.json`: `pnpm@10.33.0`; no explicit `package-manager` input is needed
- frozen install selected by the candidate: `pnpm install --frozen-lockfile --store-dir .pnpm-store`
- pnpm store contained within the checkout at `.pnpm-store`
- candidate cache/resolver unit tests: 18 passed

## Local validation

- parsed `.github/workflows/ci.yml` as YAML
- passed actionlint, excluding only the repository's known custom `pwrdrvr-macos` runner-label diagnostic
- passed `pnpm lint:boundaries` across 1,382 modules and 4,408 dependencies
- passed `git diff --check`

No headed desktop E2E was run.
