### PR TITLE
fix(desktop): hide Codex git action directives

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -13461,6 +13461,31 @@ describe("MessagingController", () => {
     });
   });
 
+  it("does not deliver an empty assistant message for directive-only output", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "item-1",
+            type: "agentMessage",
+            text: `::git-stage{cwd="/workspace"}
+::git-commit{cwd="/workspace"}`,
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([]);
+  });
+
   it("routes assistant item text without completing the active turn", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -13425,6 +13425,42 @@ describe("MessagingController", () => {
     });
   });
 
+  it("strips Codex Desktop git directives from assistant output", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+    const visibleText = "Committed and pushed the branch.";
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "item-1",
+            type: "agentMessage",
+            text: `${visibleText}
+
+::git-stage{cwd="/workspace"}
+::git-commit{cwd="/workspace"}
+::git-create-branch{cwd="/workspace" branch="agent/fix"}
+::git-push{cwd="/workspace" branch="agent/fix"}
+::git-create-pr{cwd="/workspace" branch="agent/fix" url="https://github.com/acme/repo/pull/1" isDraft=true}`,
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toHaveLength(1);
+    expect(harness.delivered[0]).toMatchObject({
+      kind: "message",
+      role: "assistant",
+      parts: [{ type: "text", text: visibleText, markdown: "markdown" }],
+    });
+  });
+
   it("routes assistant item text without completing the active turn", async () => {
     const harness = await createHarness();
     await bindThread(harness);
@@ -13610,6 +13646,76 @@ describe("MessagingController", () => {
       createdAt: 1000,
     });
     expect(harness.delivered.filter((intent) => intent.kind === "message")).toEqual([]);
+  });
+
+  it("keeps Codex Desktop git directives out of streamed assistant updates", async () => {
+    let now = 1000;
+    const harness = await createHarness({
+      streamingResponsesDefault: true,
+      now: () => now,
+    });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "item-1",
+          delta: "Finished.",
+        },
+      },
+    } satisfies AgentEvent);
+
+    now += 500;
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "item-1",
+          delta: "\n\n::git-push{cwd=\"/work",
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered.filter((intent) => intent.kind === "stream_update"))
+      .toEqual([
+        expect.objectContaining({
+          text: "Finished.",
+          stream: expect.objectContaining({ isFinal: false }),
+        }),
+      ]);
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "item-1",
+            type: "agentMessage",
+            text: `Finished.
+
+::git-push{cwd="/workspace" branch="agent/fix"}`,
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered.filter((intent) => intent.kind === "stream_update").at(-1))
+      .toMatchObject({
+        text: "Finished.",
+        stream: { isFinal: true },
+      });
+    expect(JSON.stringify(harness.delivered)).not.toContain("::git-push");
   });
 
   it("ignores assistant stream deltas that are not tied to a turn", async () => {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -14918,6 +14918,13 @@ export class MessagingController {
     const displayIntent = binding?.backend === "codex"
       ? stripCodexGitActionDirectivesFromMessagingIntent(intent)
       : intent;
+    if (!displayIntent) {
+      return {
+        channel: binding?.channel.channel ?? this.options.channel ?? "telegram",
+        deliveredAt: this.now(),
+        outcome: "discarded",
+      };
+    }
     const routedIntent = this.withRoutingAudit(displayIntent, binding, event);
     const consumeDeliveryBudget = shouldConsumeDeliveryBudget(routedIntent);
     let scope = this.options.adapter.resolveDeliveryScope?.(routedIntent);
@@ -18946,7 +18953,7 @@ function shouldFlushToolUpdatesBeforeIntent(intent: MessagingSurfaceIntent): boo
 
 function stripCodexGitActionDirectivesFromMessagingIntent(
   intent: MessagingSurfaceIntent,
-): MessagingSurfaceIntent {
+): MessagingSurfaceIntent | undefined {
   if (intent.kind === "message" && intent.role === "assistant") {
     let changed = false;
     const parts = intent.parts.map((part) => {
@@ -18960,13 +18967,22 @@ function stripCodexGitActionDirectivesFromMessagingIntent(
       changed = true;
       return { ...part, text };
     });
-    return changed ? { ...intent, parts } : intent;
+    if (!changed) {
+      return intent;
+    }
+    const hasDeliverablePart = parts.some(
+      (part) => part.type !== "text" || part.text.trim().length > 0,
+    );
+    return hasDeliverablePart ? { ...intent, parts } : undefined;
   }
 
   if (intent.kind === "stream_update" && intent.role === "assistant") {
     const text = stripCodexGitActionDirectives(intent.text);
     if (text === intent.text) {
       return intent;
+    }
+    if (text.trim().length === 0) {
+      return undefined;
     }
     return {
       ...intent,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -13,6 +13,7 @@ import {
   parseCodexTurnErrorMessage,
   resolveNewThreadBackend,
   selectableNewThreadBackends,
+  stripCodexGitActionDirectives,
 } from "@pwragent/shared";
 import type {
   AgentEvent,
@@ -14914,7 +14915,10 @@ export class MessagingController {
     if (binding && shouldFlushToolUpdatesBeforeIntent(intent)) {
       await this.flushToolUpdatesForBinding(binding, { clear: false });
     }
-    const routedIntent = this.withRoutingAudit(intent, binding, event);
+    const displayIntent = binding?.backend === "codex"
+      ? stripCodexGitActionDirectivesFromMessagingIntent(intent)
+      : intent;
+    const routedIntent = this.withRoutingAudit(displayIntent, binding, event);
     const consumeDeliveryBudget = shouldConsumeDeliveryBudget(routedIntent);
     let scope = this.options.adapter.resolveDeliveryScope?.(routedIntent);
     const priority = messagingDeliveryPriority(routedIntent, {
@@ -18938,6 +18942,40 @@ function shouldFlushToolUpdatesBeforeIntent(intent: MessagingSurfaceIntent): boo
     return false;
   }
   return true;
+}
+
+function stripCodexGitActionDirectivesFromMessagingIntent(
+  intent: MessagingSurfaceIntent,
+): MessagingSurfaceIntent {
+  if (intent.kind === "message" && intent.role === "assistant") {
+    let changed = false;
+    const parts = intent.parts.map((part) => {
+      if (part.type !== "text") {
+        return part;
+      }
+      const text = stripCodexGitActionDirectives(part.text);
+      if (text === part.text) {
+        return part;
+      }
+      changed = true;
+      return { ...part, text };
+    });
+    return changed ? { ...intent, parts } : intent;
+  }
+
+  if (intent.kind === "stream_update" && intent.role === "assistant") {
+    const text = stripCodexGitActionDirectives(intent.text);
+    if (text === intent.text) {
+      return intent;
+    }
+    return {
+      ...intent,
+      delta: undefined,
+      text,
+    };
+  }
+
+  return intent;
 }
 
 function messagingEventFromAutomationSource(

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -6,6 +6,7 @@ import {
   type MouseEvent,
   type ReactNode,
 } from "react";
+import { stripCodexGitActionDirectives } from "@pwragent/shared";
 import type {
   DesktopApplicationsSnapshot,
   AppServerSkillSummary,
@@ -63,13 +64,17 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
     ? threadLinks?.resolve(props.message.origin.sourceThread)
     : undefined;
   const contentParts = useMemo(
-    () =>
-      props.message.parts && props.message.parts.length > 0
+    () => {
+      const parts = props.message.parts && props.message.parts.length > 0
         ? props.message.parts
         : props.message.text
           ? [{ type: "text", text: props.message.text } satisfies AppServerThreadMessagePart]
-          : [],
-    [props.message.parts, props.message.text],
+          : [];
+      return props.message.role === "assistant"
+        ? stripCodexGitActionDirectivesFromParts(parts)
+        : parts;
+    },
+    [props.message.parts, props.message.role, props.message.text],
   );
   const messageCopyText = useMemo(
     () => buildMessageCopyText(props.message, contentParts),
@@ -1039,7 +1044,9 @@ function buildMessageCopyText(
   parts: AppServerThreadMessagePart[]
 ): string {
   if (typeof message.text === "string" && message.text.length > 0) {
-    return message.text;
+    return message.role === "assistant"
+      ? stripCodexGitActionDirectives(message.text)
+      : message.text;
   }
 
   return parts
@@ -1048,4 +1055,16 @@ function buildMessageCopyText(
     )
     .map((part) => part.text)
     .join("\n\n");
+}
+
+function stripCodexGitActionDirectivesFromParts(
+  parts: AppServerThreadMessagePart[],
+): AppServerThreadMessagePart[] {
+  return parts.map((part) => {
+    if (part.type !== "text") {
+      return part;
+    }
+    const text = stripCodexGitActionDirectives(part.text);
+    return text === part.text ? part : { ...part, text };
+  });
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -962,6 +962,45 @@ describe("TranscriptList", () => {
     });
   });
 
+  it("hides Codex Desktop git directives from assistant messages and copied text", async () => {
+    const copyText = vi.fn(async () => undefined);
+    const visibleText =
+      "Committed and pushed `5b286a74da` to `codex/migrate-media-fingerprint-sessions`.";
+    const messageText = `${visibleText}
+
+::git-stage{cwd="/Users/vitaliy/giphy/giphy-services"}
+::git-commit{cwd="/Users/vitaliy/giphy/giphy-services"}
+::git-push{cwd="/Users/vitaliy/giphy/giphy-services" branch="codex/migrate-media-fingerprint-sessions"}`;
+
+    render(
+      <TranscriptList
+        desktopApi={{ copyText }}
+        entries={[
+          {
+            type: "message",
+            id: "message-git-directives",
+            role: "assistant",
+            text: messageText,
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByText("Committed and pushed", { exact: false })).toBeInTheDocument();
+    expect(screen.queryByText(/::git-stage/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/::git-commit/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/::git-push/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy message" }));
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(visibleText);
+    });
+  });
+
   it("copies both markdown text and rendered HTML when the rich clipboard bridge exists", async () => {
     const copyText = vi.fn(async () => undefined);
     const copyRichText = vi.fn(async () => undefined);

--- a/packages/shared/src/__tests__/codex-git-action-directives.test.ts
+++ b/packages/shared/src/__tests__/codex-git-action-directives.test.ts
@@ -41,6 +41,15 @@ After.`);
     expect(stripCodexGitActionDirectives(markdown)).toBe(markdown);
   });
 
+  it("does not close a fenced block when the fence run has an info suffix", () => {
+    const markdown = `\`\`\`text
+\`\`\`js
+::git-stage{cwd="/workspace"}
+\`\`\``;
+
+    expect(stripCodexGitActionDirectives(markdown)).toBe(markdown);
+  });
+
   it("leaves unrelated double-colon syntax untouched", () => {
     const text = "Rust uses `std::io`, and ::custom{value=1} is ordinary text.";
     expect(stripCodexGitActionDirectives(text)).toBe(text);

--- a/packages/shared/src/__tests__/codex-git-action-directives.test.ts
+++ b/packages/shared/src/__tests__/codex-git-action-directives.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { stripCodexGitActionDirectives } from "../codex-git-action-directives";
+
+describe("stripCodexGitActionDirectives", () => {
+  it("removes every Codex Desktop git action directive", () => {
+    expect(stripCodexGitActionDirectives(`Finished the work.
+
+::git-stage{cwd="/workspace"}
+::git-commit{cwd="/workspace"}
+::git-create-branch{cwd="/workspace" branch="agent/fix"}
+::git-push{cwd="/workspace" branch="agent/fix"}
+::git-create-pr{cwd="/workspace" branch="agent/fix" url="https://github.com/acme/repo/pull/1" isDraft=true}`))
+      .toBe("Finished the work.");
+  });
+
+  it("removes directives between visible paragraphs without leaving extra whitespace", () => {
+    expect(stripCodexGitActionDirectives(`Before.
+
+::git-commit{cwd="/workspace"}
+
+After.`)).toBe(`Before.
+
+After.`);
+  });
+
+  it("hides an incomplete trailing directive during streaming", () => {
+    expect(stripCodexGitActionDirectives(`Finished.
+
+::git-push{cwd="/work`)).toBe("Finished.");
+  });
+
+  it("preserves directive examples inside fenced and indented code", () => {
+    const markdown = `These are literal examples:
+
+\`\`\`text
+::git-stage{cwd="/workspace"}
+\`\`\`
+
+    ::git-commit{cwd="/workspace"}`;
+
+    expect(stripCodexGitActionDirectives(markdown)).toBe(markdown);
+  });
+
+  it("leaves unrelated double-colon syntax untouched", () => {
+    const text = "Rust uses `std::io`, and ::custom{value=1} is ordinary text.";
+    expect(stripCodexGitActionDirectives(text)).toBe(text);
+  });
+});

--- a/packages/shared/src/codex-git-action-directives.ts
+++ b/packages/shared/src/codex-git-action-directives.ts
@@ -1,0 +1,131 @@
+const CODEX_GIT_ACTION_DIRECTIVE_PREFIXES = [
+  "::git-stage{",
+  "::git-commit{",
+  "::git-create-branch{",
+  "::git-push{",
+  "::git-create-pr{",
+] as const;
+
+const COMPLETE_CODEX_GIT_ACTION_DIRECTIVE = new RegExp(
+  `^ {0,3}(?:${CODEX_GIT_ACTION_DIRECTIVE_PREFIXES
+    .map((prefix) => prefix.slice(0, -1))
+    .join("|")})\\{.*\\}\\s*$`,
+);
+
+type ClassifiedLine = {
+  kind: "blank" | "content" | "directive";
+  text: string;
+};
+
+/**
+ * Removes Codex Desktop's assistant-authored git action directives while
+ * preserving ordinary Markdown, including literal examples inside code
+ * fences. The raw App Server message remains untouched so callers can parse
+ * the directives into structured actions in the future.
+ */
+export function stripCodexGitActionDirectives(text: string): string {
+  if (
+    !text.includes("::")
+    && !CODEX_GIT_ACTION_DIRECTIVE_PREFIXES.some(
+      (prefix) => prefix.startsWith(text.trimStart()),
+    )
+  ) {
+    return text;
+  }
+
+  const lineEnding = text.includes("\r\n") ? "\r\n" : "\n";
+  const lines = text.split(/\r?\n/);
+  const classified = classifyLines(lines);
+  if (!classified.some((line) => line.kind === "directive")) {
+    return text;
+  }
+
+  const output: string[] = [];
+  let index = 0;
+  while (index < classified.length) {
+    const line = classified[index];
+    if (line.kind === "content") {
+      output.push(line.text);
+      index += 1;
+      continue;
+    }
+
+    const gap: ClassifiedLine[] = [];
+    while (index < classified.length && classified[index]?.kind !== "content") {
+      gap.push(classified[index]);
+      index += 1;
+    }
+    if (!gap.some((entry) => entry.kind === "directive")) {
+      output.push(...gap.map((entry) => entry.text));
+      continue;
+    }
+
+    if (output.length > 0 && index < classified.length) {
+      output.push("");
+    }
+  }
+
+  return output.join(lineEnding);
+}
+
+function classifyLines(lines: string[]): ClassifiedLine[] {
+  const classified: ClassifiedLine[] = [];
+  let fenceCharacter: "`" | "~" | undefined;
+  let fenceLength = 0;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const fence = /^ {0,3}(`{3,}|~{3,})/.exec(line);
+    if (fence) {
+      const marker = fence[1] ?? "";
+      const markerCharacter = marker[0] as "`" | "~";
+      if (!fenceCharacter) {
+        fenceCharacter = markerCharacter;
+        fenceLength = marker.length;
+      } else if (
+        markerCharacter === fenceCharacter
+        && marker.length >= fenceLength
+      ) {
+        fenceCharacter = undefined;
+        fenceLength = 0;
+      }
+      classified.push({ kind: "content", text: line });
+      continue;
+    }
+
+    if (
+      !fenceCharacter
+      && isCodexGitActionDirectiveLine(line, index === lines.length - 1)
+    ) {
+      classified.push({ kind: "directive", text: line });
+      continue;
+    }
+
+    classified.push({
+      kind: !fenceCharacter && line.trim() === "" ? "blank" : "content",
+      text: line,
+    });
+  }
+
+  return classified;
+}
+
+function isCodexGitActionDirectiveLine(
+  line: string,
+  isLastLine: boolean,
+): boolean {
+  if (COMPLETE_CODEX_GIT_ACTION_DIRECTIVE.test(line)) {
+    return true;
+  }
+  if (!isLastLine) {
+    return false;
+  }
+
+  const candidate = line.replace(/^ {0,3}/, "");
+  if (!candidate.startsWith("::git")) {
+    return false;
+  }
+  return CODEX_GIT_ACTION_DIRECTIVE_PREFIXES.some(
+    (prefix) => prefix.startsWith(candidate) || candidate.startsWith(prefix),
+  );
+}

--- a/packages/shared/src/codex-git-action-directives.ts
+++ b/packages/shared/src/codex-git-action-directives.ts
@@ -75,9 +75,10 @@ function classifyLines(lines: string[]): ClassifiedLine[] {
 
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? "";
-    const fence = /^ {0,3}(`{3,}|~{3,})/.exec(line);
+    const fence = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
     if (fence) {
       const marker = fence[1] ?? "";
+      const suffix = fence[2] ?? "";
       const markerCharacter = marker[0] as "`" | "~";
       if (!fenceCharacter) {
         fenceCharacter = markerCharacter;
@@ -85,6 +86,7 @@ function classifyLines(lines: string[]): ClassifiedLine[] {
       } else if (
         markerCharacter === fenceCharacter
         && marker.length >= fenceLength
+        && /^[ \t]*$/.test(suffix)
       ) {
         fenceCharacter = undefined;
         fenceLength = 0;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from "./backend-selection";
 export * from "./command-action-labels";
 export * from "./codex-environment-action-runs";
 export * from "./codex-turn-error";
+export * from "./codex-git-action-directives";
 export * from "./contracts/backend";
 export * from "./contracts/agent";
 export * from "./contracts/agent-tools";


### PR DESCRIPTION
## What changed

- strip Codex Desktop's five git action directives from assistant transcript rendering and copied message text
- strip the same directives from final and streaming messages forwarded to messaging providers
- preserve the raw App Server message so the directives can be parsed into structured UI actions later
- preserve literal directive examples inside fenced or indented code

## Root cause

Codex Desktop injects developer instructions asking the model to append `::git-stage`, `::git-commit`, `::git-create-branch`, `::git-push`, and `::git-create-pr` lines after successful git actions. The public App Server protocol carries those lines as ordinary `agentMessage.text`. Codex Desktop consumes them in its UI, while PwrAgent rendered and forwarded the raw text.

## User impact

Assistant responses no longer expose Codex Desktop's internal git action metadata in the PwrAgent transcript, copied text, or linked messaging conversations. Incomplete trailing directives are also withheld from streaming updates.

## Validation

- `pnpm test packages/shared/src/__tests__/codex-git-action-directives.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/main/__tests__/messaging-controller.test.ts` (460 tests)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
