### PR TITLE
ci(windows): test sparse dependency checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         timeout-minutes: 10
+        with:
+          sparse-checkout: |
+            **/package.json
+            .npmrc
+            .pnpmfile.cjs
+            pnpm-lock.yaml
+            pnpm-workspace.yaml
+            apps/desktop/scripts/ensure-electron-runtime.mjs
+            apps/desktop/scripts/rebuild-native-for-electron.mjs
+          sparse-checkout-cone-mode: false
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@841bcfd6ddfb5ed049c39db6bd121a1c3aba0fc3


### PR DESCRIPTION
## Summary

- make the `Setup Windows Dependencies` job use non-cone sparse checkout
- fetch only package-manager inputs, every workspace manifest, and the two scripts required by the desktop install-time lifecycle hook
- leave the cache key, configure-nodejs action, Windows consumer jobs, and all other checkout steps unchanged

## Stacked A/B experiment

This draft is intentionally stacked on #1336 (`agent/configure-nodejs-windows-experiment`). Merge or close the parent experiment first; do not merge this PR independently.

The parent run's Windows dependency-prime baseline was:

- checkout: approximately 17 seconds (`2026-08-07T23:19:47Z`–`23:20:04Z`)
- configure-nodejs lookup-only cache hit: 1,133 ms
- total setup job: approximately 25 seconds

This PR changes only that job's checkout inputs so the next run measures whether sparse checkout materially reduces the checkout and total-job spans on the same runner class with the same warm cache.

## Cache-miss safety

The sparse set contains:

- every tracked `package.json` via `**/package.json`
- `pnpm-lock.yaml` and `pnpm-workspace.yaml`
- `.npmrc` and `.pnpmfile.cjs`
- `apps/desktop/scripts/ensure-electron-runtime.mjs`
- `apps/desktop/scripts/rebuild-native-for-electron.mjs`

Those two scripts are the only tracked first-party install-time lifecycle script dependencies. The repository has no tracked pnpm patch files and no `file:`, `link:`, or `portal:` package dependencies.

A fresh sparse worktree using exactly these patterns completed `pnpm install --frozen-lockfile --store-dir .pnpm-store` across all 13 workspace projects. That exercised native package installation plus the desktop Electron/better-sqlite3 postinstall, so a cache miss remains able to prime and save the dependency cache.

## Validation

- fresh sparse cache-miss frozen install: passed
- workflow YAML parse: passed
- actionlint: passed, excluding only the repository's known custom `pwrdrvr-macos` runner-label diagnostic
- `pnpm lint:boundaries`: passed across 1,382 modules and 4,408 dependencies
- `git diff --check`: passed

No headed desktop E2E was run.
