### PR TITLE
fix(desktop): identify remote message provenance

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -320,6 +320,7 @@ const federationMock = vi.hoisted(() => {
   return {
     remoteBackend,
     runtime: {
+      hydrateLiveThreadMessageOrigin: vi.fn((event: AgentEvent) => event),
       remoteBackend: vi.fn(() => remoteBackend),
       rendererWantsRemoteEvent: vi.fn(() => true),
       setAgentEventPublisher: vi.fn(),
@@ -405,6 +406,10 @@ describe("agent ipc", () => {
     registry.cancelThreadPrAutoDispatch.mockClear();
     registry.sendThreadPrAutoDispatchNow.mockClear();
     federationMock.runtime.remoteBackend.mockClear();
+    federationMock.runtime.hydrateLiveThreadMessageOrigin.mockReset();
+    federationMock.runtime.hydrateLiveThreadMessageOrigin.mockImplementation(
+      (event: AgentEvent) => event,
+    );
     federationMock.runtime.rendererWantsRemoteEvent.mockReset();
     federationMock.runtime.rendererWantsRemoteEvent.mockReturnValue(true);
     federationMock.runtime.setAgentEventPublisher.mockClear();
@@ -997,6 +1002,82 @@ describe("agent ipc", () => {
     expect(ownerSend).toHaveBeenCalledTimes(1);
     expect(localSend).not.toHaveBeenCalled();
     expect(unrelatedSend).not.toHaveBeenCalled();
+  });
+
+  it("hydrates live message provenance before broadcasting it", async () => {
+    const { broadcastAgentEvent } = await import("../ipc/agent-ipc");
+    const { AGENT_EVENT_CHANNEL } = await import("../../shared/ipc");
+    federationMock.runtime.hydrateLiveThreadMessageOrigin.mockImplementation(
+      (event: AgentEvent) => ({
+        ...event,
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "user-message-1",
+              type: "userMessage",
+              origin: {
+                kind: "agent",
+                sourceThread: {
+                  backend: "codex",
+                  instanceId: "source_one",
+                  instanceLabel: "Source Mac",
+                  celestialIcon: "moon",
+                  threadId: "source-thread",
+                  title: "Source thread",
+                },
+              },
+              content: [{ type: "text", text: "Remote result" }],
+            },
+          },
+        },
+      } as AgentEvent),
+    );
+
+    broadcastAgentEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "user-message-1",
+            type: "userMessage",
+            origin: {
+              kind: "agent",
+              sourceThread: {
+                backend: "codex",
+                instanceId: "source_one",
+                threadId: "source-thread",
+                title: "Source thread",
+              },
+            },
+            content: [{ type: "text", text: "Remote result" }],
+          },
+        },
+      },
+    } as AgentEvent);
+
+    expect(send).toHaveBeenCalledWith(
+      AGENT_EVENT_CHANNEL,
+      expect.objectContaining({
+        notification: expect.objectContaining({
+          params: expect.objectContaining({
+            item: expect.objectContaining({
+              origin: expect.objectContaining({
+                sourceThread: expect.objectContaining({
+                  instanceLabel: "Source Mac",
+                  celestialIcon: "moon",
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    );
   });
 
   it("caps oversized live agent event strings before broadcasting to renderer subscribers", async () => {

--- a/apps/desktop/src/main/__tests__/federated-thread-origin-hydrator.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-origin-hydrator.test.ts
@@ -296,4 +296,63 @@ describe("federated thread origin hydration", () => {
       },
     });
   });
+
+  it("preserves provenance titles when resolution returns only a fallback", async () => {
+    const sourceThreadId = "019fde92-318a-7541-9281-029bdc1508b5";
+    const response: AppServerReadThreadResponse = {
+      backend: "codex",
+      fetchedAt: 1_000,
+      threadId: "local-child",
+      replay: {
+        entries: [{
+          type: "message",
+          id: "message-with-provenance-title",
+          role: "user",
+          text: "Remote audit complete.",
+          origin: {
+            kind: "agent",
+            sourceThread: {
+              backend: "codex",
+              instanceId: "remote_one",
+              threadId: sourceThreadId,
+              title: "Cloudflare Tunnel connector audit",
+            },
+          },
+        }],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    };
+
+    const hydrated = await hydrateFederatedThreadMessageOrigins({
+      localInstanceId: "viewer_one",
+      ownerInstanceId: "viewer_one",
+      response,
+      resolveInstance: () => ({ label: "Remote Mac" }),
+      resolveThread: async () => ({
+        instanceId: "remote_one",
+        thread: {
+          id: sourceThreadId,
+          title: sourceThreadId,
+          titleSource: "fallback",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      }),
+    });
+
+    expect(hydrated.replay.entries[0]).toMatchObject({
+      origin: {
+        sourceThread: {
+          instanceId: "remote_one",
+          instanceLabel: "Remote Mac",
+          threadId: sourceThreadId,
+          title: "Cloudflare Tunnel connector audit",
+        },
+      },
+    });
+  });
 });

--- a/apps/desktop/src/main/__tests__/federated-thread-origin-hydrator.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-origin-hydrator.test.ts
@@ -89,11 +89,17 @@ describe("federated thread origin hydration", () => {
         source: "codex" as const,
       },
     }));
+    const resolveInstance = vi.fn((instanceId: string) =>
+      instanceId === "owner_one"
+        ? { label: "Owner Mac", celestialIcon: "moon" as const }
+        : { label: "Viewer Mac", celestialIcon: "sun" as const }
+    );
 
     const hydrated = await hydrateFederatedThreadMessageOrigins({
       localInstanceId: "viewer_one",
       ownerInstanceId: "owner_one",
       response,
+      resolveInstance,
       resolveThread,
     });
 
@@ -104,6 +110,8 @@ describe("federated thread origin hydration", () => {
           sourceThread: {
             backend: "codex",
             instanceId: "owner_one",
+            instanceLabel: "Owner Mac",
+            celestialIcon: "moon",
             threadId: "remote-parent",
             title: "Remote pagination audit",
           },
@@ -124,6 +132,8 @@ describe("federated thread origin hydration", () => {
         origin: {
           sourceThread: {
             instanceId: "owner_one",
+            instanceLabel: "Owner Mac",
+            celestialIcon: "moon",
             title: "Remote pagination audit",
           },
         },
@@ -179,6 +189,10 @@ describe("federated thread origin hydration", () => {
       localInstanceId: "viewer_one",
       ownerInstanceId: "viewer_one",
       response,
+      resolveInstance: () => ({
+        label: "Remote Mac",
+        celestialIcon: "ringed-planet",
+      }),
       resolveThread,
     });
 
@@ -193,6 +207,8 @@ describe("federated thread origin hydration", () => {
         sourceThread: {
           backend: "codex",
           instanceId: "remote_one",
+          instanceLabel: "Remote Mac",
+          celestialIcon: "ringed-planet",
           threadId: "legacy-remote-parent",
           title: "Remote parent thread",
         },
@@ -216,6 +232,8 @@ describe("federated thread origin hydration", () => {
             sourceThread: {
               backend: "codex",
               instanceId: "remote_one",
+              instanceLabel: "Remembered Remote Mac",
+              celestialIcon: "moon",
               threadId: "remote-parent",
             },
           },
@@ -248,6 +266,9 @@ describe("federated thread origin hydration", () => {
       localInstanceId: "viewer_one",
       ownerInstanceId: "owner_one",
       response,
+      resolveInstance: () => {
+        throw new Error("peer metadata unavailable");
+      },
       resolveThread,
     });
 
@@ -256,6 +277,8 @@ describe("federated thread origin hydration", () => {
       origin: {
         sourceThread: {
           instanceId: "remote_one",
+          instanceLabel: "Remembered Remote Mac",
+          celestialIcon: "moon",
           threadId: "remote-parent",
           title: "Remote parent fallback",
         },
@@ -265,6 +288,8 @@ describe("federated thread origin hydration", () => {
       origin: {
         sourceThread: {
           instanceId: "remote_one",
+          instanceLabel: "Remembered Remote Mac",
+          celestialIcon: "moon",
           threadId: "remote-parent",
           title: "Remote parent fallback",
         },

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1876,7 +1876,13 @@ describe("federation backend bridge", () => {
           input: [{ type: "text", text: "ship it" }],
           messageOrigin: {
             kind: "agent",
-            sourceThread: { backend: "codex", threadId: "source-thread" },
+            sourceThread: {
+              backend: "codex",
+              instanceId: "spoofed_instance",
+              instanceLabel: "Spoofed Mac",
+              celestialIcon: "black-hole",
+              threadId: "source-thread",
+            },
           },
         },
         protocolVersion: 1,

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -283,7 +283,14 @@ describe("federation backend bridge", () => {
       ],
       sendEnvelope: (envelope) => replies.push(envelope),
     });
-    registerFederationBackendHandlers({ router, backend });
+    registerFederationBackendHandlers({
+      router,
+      backend,
+      resolveSourceInstance: () => ({
+        label: "Client Mac",
+        celestialIcon: "moon",
+      }),
+    });
 
     await router.routeEnvelope({
       sourcePeerId: "client_one",
@@ -310,7 +317,20 @@ describe("federation backend bridge", () => {
           kind: "turn",
           scheduledFor: 3_000,
           displayText: "Follow up",
-          turn: { input: [{ type: "text", text: "Follow up" }] },
+          turn: {
+            input: [{ type: "text", text: "Follow up" }],
+            messageOrigin: {
+              kind: "agent",
+              sourceThread: {
+                backend: "codex",
+                instanceId: "spoofed_instance",
+                instanceLabel: "Spoofed Mac",
+                celestialIcon: "black-hole",
+                threadId: "source-thread",
+                title: "Source thread",
+              },
+            },
+          },
         },
         protocolVersion: 1,
         sourceInstanceId: "client_one",
@@ -357,6 +377,20 @@ describe("federation backend bridge", () => {
       expect.objectContaining({
         backend: "codex",
         threadId: "thread-1",
+        turn: {
+          input: [{ type: "text", text: "Follow up" }],
+          messageOrigin: {
+            kind: "agent",
+            sourceThread: {
+              backend: "codex",
+              instanceId: "client_one",
+              instanceLabel: "Client Mac",
+              celestialIcon: "moon",
+              threadId: "source-thread",
+              title: "Source thread",
+            },
+          },
+        },
       }),
     );
     expect(replies).toMatchObject([
@@ -1862,7 +1896,14 @@ describe("federation backend bridge", () => {
       capabilities: ["turn_control"],
       sendEnvelope: (envelope) => replies.push(envelope),
     });
-    registerFederationBackendHandlers({ router, backend });
+    registerFederationBackendHandlers({
+      router,
+      backend,
+      resolveSourceInstance: () => ({
+        label: "Gateway Mac",
+        celestialIcon: "moon",
+      }),
+    });
 
     await router.routeEnvelope({
       sourcePeerId: "gateway_one",
@@ -1901,6 +1942,8 @@ describe("federation backend bridge", () => {
         sourceThread: {
           backend: "codex",
           instanceId: "gateway_one",
+          instanceLabel: "Gateway Mac",
+          celestialIcon: "moon",
           threadId: "source-thread",
         },
       },
@@ -2083,7 +2126,14 @@ describe("federation backend bridge", () => {
       ],
       sendEnvelope: (envelope) => replies.push(envelope),
     });
-    registerFederationBackendHandlers({ router, backend });
+    registerFederationBackendHandlers({
+      router,
+      backend,
+      resolveSourceInstance: () => ({
+        label: "Gateway Mac",
+        celestialIcon: "moon",
+      }),
+    });
 
     await router.routeEnvelope({
       sourcePeerId: "gateway_one",
@@ -2105,11 +2155,23 @@ describe("federation backend bridge", () => {
         kind: "request",
         method: FEDERATION_BACKEND_METHODS.controlActiveTurn,
         params: {
-          operation: "stop",
+          operation: "steer",
           backend: "codex",
           threadId: "thread-1",
-          requestId: "stop-1",
+          requestId: "steer-1",
           expectedTurnId: "turn-live",
+          input: [{ type: "text", text: "Report progress." }],
+          messageOrigin: {
+            kind: "agent",
+            sourceThread: {
+              backend: "codex",
+              instanceId: "spoofed_instance",
+              instanceLabel: "Spoofed Mac",
+              celestialIcon: "black-hole",
+              threadId: "source-thread",
+              title: "Source thread",
+            },
+          },
         },
         protocolVersion: 1,
         sourceInstanceId: "gateway_one",
@@ -2193,11 +2255,23 @@ describe("federation backend bridge", () => {
       threadId: "thread-1",
     });
     expect(backend.controlActiveTurn).toHaveBeenCalledWith({
-      operation: "stop",
+      operation: "steer",
       backend: "codex",
       threadId: "thread-1",
-      requestId: "stop-1",
+      requestId: "steer-1",
       expectedTurnId: "turn-live",
+      input: [{ type: "text", text: "Report progress." }],
+      messageOrigin: {
+        kind: "agent",
+        sourceThread: {
+          backend: "codex",
+          instanceId: "gateway_one",
+          instanceLabel: "Gateway Mac",
+          celestialIcon: "moon",
+          threadId: "source-thread",
+          title: "Source thread",
+        },
+      },
     });
     expect(
       FEDERATION_BACKEND_METHOD_CAPABILITIES[
@@ -2232,7 +2306,7 @@ describe("federation backend bridge", () => {
         requestId: "control-active-request",
         result: {
           disposition: "interrupted",
-          requestId: "stop-1",
+          requestId: "steer-1",
           turnId: "turn-live",
         },
       },

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -41,6 +41,7 @@ type RuntimeHarness = {
     sourcePeerId: FederationInstanceId,
   ) => boolean;
   forwardLocalBackendEvent: (event: AgentEvent) => void;
+  hydrateLiveThreadMessageOrigin: (event: AgentEvent) => AgentEvent;
   broadcastStarMapArrangement: (
     entries: StarMapArrangementEntry[],
   ) => void;
@@ -1248,6 +1249,62 @@ describe("DesktopFederationRuntime", () => {
       sourceInstanceId: "gateway_one",
       targetInstanceId: "client_one",
     }]);
+  });
+
+  it("hydrates trusted instance metadata on live transcript origins", () => {
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "owner_one";
+    runtime.visiblePeers = () => [{
+      id: "source_one",
+      label: "Source Mac",
+      status: "connected",
+    }];
+    runtime.celestialIconFor = () => "moon";
+
+    const hydrated = runtime.hydrateLiveThreadMessageOrigin({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "user-message-1",
+            type: "userMessage",
+            origin: {
+              kind: "agent",
+              sourceThread: {
+                backend: "codex",
+                instanceId: "source_one",
+                instanceLabel: "Spoofed Mac",
+                celestialIcon: "black-hole",
+                threadId: "source-thread",
+                title: "Source thread",
+              },
+            },
+            content: [{ type: "text", text: "Remote result" }],
+          },
+        },
+      },
+    } as AgentEvent);
+
+    expect(hydrated).toMatchObject({
+      notification: {
+        method: "item/completed",
+        params: {
+          item: {
+            origin: {
+              sourceThread: {
+                instanceId: "source_one",
+                instanceLabel: "Source Mac",
+                celestialIcon: "moon",
+                threadId: "source-thread",
+              },
+            },
+          },
+        },
+      },
+    });
   });
 
   it("forwards scheduler lifecycle events to scheduler-capable peers", () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -439,6 +439,7 @@ vi.mock("../messaging/messaging-runtime", () => ({
 vi.mock("../federation/federation-runtime", () => ({
   federationEventClassForMethod: vi.fn(() => "transcript"),
   getDesktopFederationRuntime: vi.fn(() => ({
+    hydrateLiveThreadMessageOrigin: (event: AgentEvent) => event,
     restart: federationRuntimeRestartMock,
     connectedPeerTargets: connectedPeerTargetsMock,
     onPeerStatusChanged: federationPeerStatusChangedMock,

--- a/apps/desktop/src/main/federation/federated-thread-origin-hydrator.ts
+++ b/apps/desktop/src/main/federation/federated-thread-origin-hydrator.ts
@@ -127,7 +127,11 @@ export async function hydrateFederatedThreadMessageOrigins(params: {
         instanceLabel: instance?.label ?? sourceGroup.fallbackInstanceLabel,
         celestialIcon:
           instance?.celestialIcon ?? sourceGroup.fallbackCelestialIcon,
-        title: resolved?.thread.title || sourceGroup.fallbackTitle,
+        title:
+          resolved?.thread.titleSource === "fallback"
+          && sourceGroup.fallbackTitle
+            ? sourceGroup.fallbackTitle
+            : resolved?.thread.title || sourceGroup.fallbackTitle,
       }));
     }),
   );

--- a/apps/desktop/src/main/federation/federated-thread-origin-hydrator.ts
+++ b/apps/desktop/src/main/federation/federated-thread-origin-hydrator.ts
@@ -3,6 +3,7 @@ import type {
   AppServerReadThreadResponse,
   AppServerThreadMessageOrigin,
   AppServerThreadSummary,
+  CelestialIconId,
   FederationInstanceId,
 } from "@pwragent/shared";
 
@@ -16,6 +17,11 @@ type FederatedSourceThreadRef = {
 type ResolvedFederatedSourceThread = {
   instanceId: FederationInstanceId;
   thread: AppServerThreadSummary;
+};
+
+type ResolvedFederatedSourceInstance = {
+  label: string;
+  celestialIcon?: CelestialIconId;
 };
 
 type HydratedSourceThread = NonNullable<
@@ -37,6 +43,9 @@ export async function hydrateFederatedThreadMessageOrigins(params: {
   resolveThread: (
     ref: FederatedSourceThreadRef,
   ) => Promise<ResolvedFederatedSourceThread | undefined>;
+  resolveInstance: (
+    instanceId: FederationInstanceId,
+  ) => ResolvedFederatedSourceInstance | undefined;
 }): Promise<AppServerReadThreadResponse> {
   const sources = [
     ...params.response.replay.entries.flatMap((entry) =>
@@ -56,6 +65,8 @@ export async function hydrateFederatedThreadMessageOrigins(params: {
     string,
     {
       discoverAcrossInstances: boolean;
+      fallbackCelestialIcon?: CelestialIconId;
+      fallbackInstanceLabel?: string;
       fallbackTitle?: string;
       instanceId: FederationInstanceId;
       source: HydratedSourceThread;
@@ -71,11 +82,15 @@ export async function hydrateFederatedThreadMessageOrigins(params: {
     const existing = sourcesByKey.get(key);
     if (existing) {
       existing.discoverAcrossInstances ||= source.instanceId === undefined;
+      existing.fallbackInstanceLabel ||= source.instanceLabel?.trim();
+      existing.fallbackCelestialIcon ||= source.celestialIcon;
       existing.fallbackTitle ||= source.title?.trim();
       continue;
     }
     sourcesByKey.set(key, {
       discoverAcrossInstances: source.instanceId === undefined,
+      fallbackCelestialIcon: source.celestialIcon,
+      fallbackInstanceLabel: source.instanceLabel?.trim() || undefined,
       fallbackTitle: source.title?.trim() || undefined,
       instanceId,
       source,
@@ -97,10 +112,21 @@ export async function hydrateFederatedThreadMessageOrigins(params: {
         // Provenance identity is still useful and click-to-mount remains
         // available when a peer cannot hydrate the display title.
       }
+      const instanceId = resolved?.instanceId ?? sourceGroup.instanceId;
+      let instance: ResolvedFederatedSourceInstance | undefined;
+      try {
+        instance = params.resolveInstance(instanceId);
+      } catch {
+        // Preserve any already-hydrated identity metadata when peer metadata
+        // is temporarily unavailable.
+      }
       hydratedByKey.set(key, normalizeSourceThread({
         localInstanceId: params.localInstanceId,
         source: sourceGroup.source,
-        instanceId: resolved?.instanceId ?? sourceGroup.instanceId,
+        instanceId,
+        instanceLabel: instance?.label ?? sourceGroup.fallbackInstanceLabel,
+        celestialIcon:
+          instance?.celestialIcon ?? sourceGroup.fallbackCelestialIcon,
         title: resolved?.thread.title || sourceGroup.fallbackTitle,
       }));
     }),
@@ -147,13 +173,20 @@ function normalizeSourceThread(params: {
   localInstanceId: FederationInstanceId;
   source: HydratedSourceThread;
   instanceId: FederationInstanceId;
+  instanceLabel?: string;
+  celestialIcon?: CelestialIconId;
   title?: string;
 }): HydratedSourceThread {
+  const remote = params.instanceId !== params.localInstanceId;
   return {
     backend: params.source.backend,
-    ...(params.instanceId === params.localInstanceId
-      ? {}
-      : { instanceId: params.instanceId }),
+    ...(remote ? { instanceId: params.instanceId } : {}),
+    ...(remote && params.instanceLabel
+      ? { instanceLabel: params.instanceLabel }
+      : {}),
+    ...(remote && params.celestialIcon
+      ? { celestialIcon: params.celestialIcon }
+      : {}),
     threadId: params.source.threadId,
     ...(params.title ? { title: params.title } : {}),
   };

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -634,10 +634,13 @@ export function registerFederationBackendHandlers(params: {
               messageOrigin: {
                 ...messageOrigin,
                 sourceThread: {
-                  ...sourceThread,
-                  // The authenticated envelope sender is authoritative. Do
-                  // not accept a caller-supplied provenance owner here.
+                  backend: sourceThread.backend,
+                  // The authenticated envelope sender is authoritative. Peer
+                  // label/icon metadata is hydrated locally and must not be
+                  // accepted from the caller either.
                   instanceId: envelope.sourceInstanceId,
+                  threadId: sourceThread.threadId,
+                  ...(sourceThread.title ? { title: sourceThread.title } : {}),
                 },
               },
             }

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -15,6 +15,7 @@ import type {
   CancelQueuedTurnResponse,
   CancelThreadExecutionModeQueueRequest,
   CancelThreadExecutionModeQueueResponse,
+  CelestialIconId,
   CheckThreadBranchDriftRequest,
   CheckThreadBranchDriftResponse,
   CompactThreadRequest,
@@ -136,6 +137,76 @@ export type FederatedTranscriptImageResponse = {
 export type FederationStartTurnRequest = StartTurnRequest & {
   messageOrigin?: AppServerThreadMessageOrigin;
 };
+
+type ResolvedSourceInstance = {
+  label: string;
+  celestialIcon?: CelestialIconId;
+};
+
+function authenticateMessageOrigin(params: {
+  messageOrigin: AppServerThreadMessageOrigin | undefined;
+  resolveSourceInstance?: (
+    instanceId: string,
+  ) => ResolvedSourceInstance | undefined;
+  sourceInstanceId: string;
+}): AppServerThreadMessageOrigin | undefined {
+  const sourceThread = params.messageOrigin?.sourceThread;
+  if (!params.messageOrigin || !sourceThread) {
+    return params.messageOrigin;
+  }
+
+  let sourceInstance: ResolvedSourceInstance | undefined;
+  try {
+    sourceInstance = params.resolveSourceInstance?.(params.sourceInstanceId);
+  } catch {
+    // The authenticated instance id remains useful when display metadata is
+    // temporarily unavailable. Never fall back to caller-provided identity.
+  }
+
+  return {
+    ...params.messageOrigin,
+    sourceThread: {
+      backend: sourceThread.backend,
+      instanceId: params.sourceInstanceId,
+      ...(sourceInstance?.label
+        ? { instanceLabel: sourceInstance.label }
+        : {}),
+      ...(sourceInstance?.celestialIcon
+        ? { celestialIcon: sourceInstance.celestialIcon }
+        : {}),
+      threadId: sourceThread.threadId,
+      ...(sourceThread.title ? { title: sourceThread.title } : {}),
+    },
+  };
+}
+
+function authenticateScheduledTurnOrigin<
+  T extends {
+    turn?: { messageOrigin?: AppServerThreadMessageOrigin };
+  },
+>(params: {
+  request: T;
+  resolveSourceInstance?: (
+    instanceId: string,
+  ) => ResolvedSourceInstance | undefined;
+  sourceInstanceId: string;
+}): T {
+  const messageOrigin = params.request.turn?.messageOrigin;
+  if (!params.request.turn || !messageOrigin) {
+    return params.request;
+  }
+  return {
+    ...params.request,
+    turn: {
+      ...params.request.turn,
+      messageOrigin: authenticateMessageOrigin({
+        messageOrigin,
+        resolveSourceInstance: params.resolveSourceInstance,
+        sourceInstanceId: params.sourceInstanceId,
+      }),
+    },
+  };
+}
 
 export const FEDERATION_BACKEND_METHODS = {
   getNavigationSnapshot: "backend.getNavigationSnapshot",
@@ -449,6 +520,9 @@ export type FederationBackendOperations = {
 export function registerFederationBackendHandlers(params: {
   router: FederationRouter;
   backend: FederationBackendOperations;
+  resolveSourceInstance?: (
+    instanceId: string,
+  ) => ResolvedSourceInstance | undefined;
   onEnvironmentSetupProgress?: (
     event: CodexEnvironmentSetupProgressEvent,
     targetInstanceId: string,
@@ -625,26 +699,14 @@ export function registerFederationBackendHandlers(params: {
     FEDERATION_BACKEND_METHODS.startTurn,
     async (envelope) => {
       const request = envelope.params as FederationStartTurnRequest;
-      const messageOrigin = request.messageOrigin;
-      const sourceThread = messageOrigin?.sourceThread;
+      const messageOrigin = authenticateMessageOrigin({
+        messageOrigin: request.messageOrigin,
+        resolveSourceInstance: params.resolveSourceInstance,
+        sourceInstanceId: envelope.sourceInstanceId,
+      });
       return await params.backend.startTurn({
         ...request,
-        ...(messageOrigin && sourceThread
-          ? {
-              messageOrigin: {
-                ...messageOrigin,
-                sourceThread: {
-                  backend: sourceThread.backend,
-                  // The authenticated envelope sender is authoritative. Peer
-                  // label/icon metadata is hydrated locally and must not be
-                  // accepted from the caller either.
-                  instanceId: envelope.sourceInstanceId,
-                  threadId: sourceThread.threadId,
-                  ...(sourceThread.title ? { title: sourceThread.title } : {}),
-                },
-              },
-            }
-          : {}),
+        ...(messageOrigin ? { messageOrigin } : {}),
       });
     },
   );
@@ -671,17 +733,29 @@ export function registerFederationBackendHandlers(params: {
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.createScheduledThreadAction,
-    async (envelope) =>
-      await params.backend.createScheduledThreadAction(
-        envelope.params as CreateScheduledThreadActionRequest,
-      ),
+    async (envelope) => {
+      const request = envelope.params as CreateScheduledThreadActionRequest;
+      return await params.backend.createScheduledThreadAction(
+        authenticateScheduledTurnOrigin({
+          request,
+          resolveSourceInstance: params.resolveSourceInstance,
+          sourceInstanceId: envelope.sourceInstanceId,
+        }),
+      );
+    },
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.updateScheduledThreadAction,
-    async (envelope) =>
-      await params.backend.updateScheduledThreadAction(
-        envelope.params as UpdateScheduledThreadActionRequest,
-      ),
+    async (envelope) => {
+      const request = envelope.params as UpdateScheduledThreadActionRequest;
+      return await params.backend.updateScheduledThreadAction(
+        authenticateScheduledTurnOrigin({
+          request,
+          resolveSourceInstance: params.resolveSourceInstance,
+          sourceInstanceId: envelope.sourceInstanceId,
+        }),
+      );
+    },
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.cancelScheduledThreadAction,
@@ -707,10 +781,18 @@ export function registerFederationBackendHandlers(params: {
   if (params.backend.controlActiveTurn) {
     params.router.registerHandler(
       FEDERATION_BACKEND_METHODS.controlActiveTurn,
-      async (envelope) =>
-        await params.backend.controlActiveTurn!(
-          envelope.params as ControlActiveTurnRequest,
-        ),
+      async (envelope) => {
+        const request = envelope.params as ControlActiveTurnRequest;
+        const messageOrigin = authenticateMessageOrigin({
+          messageOrigin: request.messageOrigin,
+          resolveSourceInstance: params.resolveSourceInstance,
+          sourceInstanceId: envelope.sourceInstanceId,
+        });
+        return await params.backend.controlActiveTurn!({
+          ...request,
+          ...(messageOrigin ? { messageOrigin } : {}),
+        });
+      },
     );
   }
   params.router.registerHandler(

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -1238,6 +1238,107 @@ export class DesktopFederationRuntime {
     );
   }
 
+  hydrateLiveThreadMessageOrigin(event: AgentEvent): AgentEvent {
+    if (
+      event.notification.method !== "item/started"
+      && event.notification.method !== "item/completed"
+    ) {
+      return event;
+    }
+    const notificationParams = event.notification.params as Record<string, unknown>;
+    const itemValue = notificationParams.item;
+    if (
+      !itemValue
+      || typeof itemValue !== "object"
+      || Array.isArray(itemValue)
+    ) {
+      return event;
+    }
+    const item = itemValue as Record<string, unknown>;
+    const originValue = item.origin;
+    if (
+      item.type !== "userMessage"
+      || !originValue
+      || typeof originValue !== "object"
+      || Array.isArray(originValue)
+    ) {
+      return event;
+    }
+    const origin = originValue as Record<string, unknown>;
+    const sourceThreadValue = origin.sourceThread;
+    if (
+      !sourceThreadValue
+      || typeof sourceThreadValue !== "object"
+      || Array.isArray(sourceThreadValue)
+    ) {
+      return event;
+    }
+    const sourceThread = sourceThreadValue as Record<string, unknown>;
+    if (typeof sourceThread.instanceId !== "string") {
+      return event;
+    }
+    const instance = this.resolveThreadMessageOriginInstance(
+      sourceThread.instanceId,
+    );
+    if (!instance) {
+      return event;
+    }
+    const {
+      celestialIcon: _callerCelestialIcon,
+      instanceLabel: _callerInstanceLabel,
+      ...trustedSourceThread
+    } = sourceThread;
+
+    return {
+      ...event,
+      notification: {
+        ...event.notification,
+        params: {
+          ...notificationParams,
+          item: {
+            ...item,
+            origin: {
+              ...origin,
+              sourceThread: {
+                ...trustedSourceThread,
+                instanceLabel: instance.label,
+                ...(instance.celestialIcon
+                  ? { celestialIcon: instance.celestialIcon }
+                  : {}),
+              },
+            },
+          },
+        },
+      },
+    } as AgentEvent;
+  }
+
+  private resolveThreadMessageOriginInstance(
+    instanceId: FederationInstanceId,
+  ): { label: string; celestialIcon?: CelestialIconId } | undefined {
+    let visible: FederationPeerSummary[] = [];
+    try {
+      visible = this.visiblePeers();
+    } catch {
+      // Early boot tests may not have initialized the app-state DB yet.
+    }
+    let peer = visible.find((candidate) => candidate.id === instanceId);
+    if (!peer) {
+      try {
+        peer = this.store().getPeer(instanceId);
+      } catch {
+        // A source id remains actionable even when peer metadata is gone.
+      }
+    }
+    return peer
+      ? {
+          label: formatFederationPeerDisplayLabel(peer, visible),
+          celestialIcon:
+            this.celestialIconFor(instanceId) ?? peer.celestialIcon,
+        }
+      : undefined;
+  }
+
   async hydrateThreadMessageOrigins(
     response: AppServerReadThreadResponse,
     ownerInstanceId = this.ensureLocalInstanceId(),
@@ -1246,29 +1347,8 @@ export class DesktopFederationRuntime {
       localInstanceId: this.ensureLocalInstanceId(),
       ownerInstanceId,
       response,
-      resolveInstance: (instanceId) => {
-        let visible: FederationPeerSummary[] = [];
-        try {
-          visible = this.visiblePeers();
-        } catch {
-          // Early boot tests may not have initialized the app-state DB yet.
-        }
-        let peer = visible.find((candidate) => candidate.id === instanceId);
-        if (!peer) {
-          try {
-            peer = this.store().getPeer(instanceId);
-          } catch {
-            // A source id remains actionable even when peer metadata is gone.
-          }
-        }
-        return peer
-          ? {
-              label: formatFederationPeerDisplayLabel(peer, visible),
-              celestialIcon:
-                this.celestialIconFor(instanceId) ?? peer.celestialIcon,
-            }
-          : undefined;
-      },
+      resolveInstance: (instanceId) =>
+        this.resolveThreadMessageOriginInstance(instanceId),
       resolveThread: async (source) => {
         const resolveOnInstance = async (instanceId: FederationInstanceId) => {
           if (instanceId === this.ensureLocalInstanceId()) {
@@ -1584,6 +1664,8 @@ export class DesktopFederationRuntime {
     registerFederationBackendHandlers({
       router,
       backend: localBackendOperations(),
+      resolveSourceInstance: (instanceId) =>
+        this.resolveThreadMessageOriginInstance(instanceId),
       onEnvironmentSetupProgress: (event, targetInstanceId) => {
         this.sendEnvironmentSetupProgress(event, targetInstanceId);
       },

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -1246,6 +1246,29 @@ export class DesktopFederationRuntime {
       localInstanceId: this.ensureLocalInstanceId(),
       ownerInstanceId,
       response,
+      resolveInstance: (instanceId) => {
+        let visible: FederationPeerSummary[] = [];
+        try {
+          visible = this.visiblePeers();
+        } catch {
+          // Early boot tests may not have initialized the app-state DB yet.
+        }
+        let peer = visible.find((candidate) => candidate.id === instanceId);
+        if (!peer) {
+          try {
+            peer = this.store().getPeer(instanceId);
+          } catch {
+            // A source id remains actionable even when peer metadata is gone.
+          }
+        }
+        return peer
+          ? {
+              label: formatFederationPeerDisplayLabel(peer, visible),
+              celestialIcon:
+                this.celestialIconFor(instanceId) ?? peer.celestialIcon,
+            }
+          : undefined;
+      },
       resolveThread: async (source) => {
         const resolveOnInstance = async (instanceId: FederationInstanceId) => {
           if (instanceId === this.ensureLocalInstanceId()) {

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -340,12 +340,18 @@ function remotePrStatusEventIsSupersededLocally(event: AgentEvent): boolean {
 }
 
 export function broadcastAgentEvent(event: AgentEvent): void {
-  const eventSummary = summarizeAgentEvent(event);
+  const federationRuntime = getDesktopFederationRuntime();
+  const hydratedEvent = federationRuntime.hydrateLiveThreadMessageOrigin(event);
+  const eventSummary = summarizeAgentEvent(hydratedEvent);
   if (eventSummary) {
     logAgentEventSummary(eventSummary);
   }
-  const rendererEvent = sanitizeRendererPayload(withRendererActivityEntry(event));
-  const federationWindowsOnly = remotePrStatusEventIsSupersededLocally(event);
+  const rendererEvent = sanitizeRendererPayload(
+    withRendererActivityEntry(hydratedEvent),
+  );
+  const federationWindowsOnly = remotePrStatusEventIsSupersededLocally(
+    hydratedEvent,
+  );
 
   // Only deliver to windows that registered for this channel.
   // Secondary windows (e.g. the Messaging Activity window) opt out by
@@ -359,16 +365,16 @@ export function broadcastAgentEvent(event: AgentEvent): void {
     ) {
       continue;
     }
-    if (event.federationTarget?.scope === "remote") {
+    if (hydratedEvent.federationTarget?.scope === "remote") {
       const isLocalPeerStatus =
-        event.notification.method === "federation/peerStatus/changed"
+        hydratedEvent.notification.method === "federation/peerStatus/changed"
         && !windowTarget;
       if (
         !isLocalPeerStatus
-        && !getDesktopFederationRuntime().rendererWantsRemoteEvent(
+        && !federationRuntime.rendererWantsRemoteEvent(
           webContents.id,
-          event.federationTarget.instanceId,
-          federationEventClassForMethod(event.notification.method),
+          hydratedEvent.federationTarget.instanceId,
+          federationEventClassForMethod(hydratedEvent.notification.method),
         )
       ) {
         continue;

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1414,6 +1414,7 @@ function resolveThreadSummaryReference(
       : {}),
     threadId: thread.id,
     title: thread.title,
+    titleSource: thread.titleSource,
     gitBranch: thread.gitBranch,
     linkedDirectories: thread.linkedDirectories,
   };

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
@@ -13,9 +13,9 @@ export { threadCopyTargets } from "../chrome/ThreadChipContextMenu";
 
 type ThreadChipProps = {
   /**
-   * Link text the author wrote, used only when the resolved thread has no
-   * title. The chip prefers the thread's live title so a renamed thread does
-   * not keep showing whatever it was called when the link was written.
+   * Link text the author wrote or title hydrated with message provenance.
+   * The chip prefers the thread's live title unless navigation still knows
+   * only a fallback title from before the thread received its real name.
    */
   fallbackLabel?: string;
   link: ResolvedThreadLink;
@@ -29,7 +29,11 @@ export function ThreadChip(props: ThreadChipProps) {
     useState<ChipContextMenuPosition>();
   const tooltipController = useViewportTooltip({ className: "viewport-tooltip" });
 
-  const label = link.title.trim() || props.fallbackLabel?.trim() || link.threadId;
+  const liveTitle = link.title.trim();
+  const fallbackLabel = props.fallbackLabel?.trim();
+  const label = link.titleSource === "fallback" && fallbackLabel
+    ? fallbackLabel
+    : liveTitle || fallbackLabel || link.threadId;
   const tooltip = link.gitBranch
     ? `${label}\n${link.gitBranch} — open thread`
     : `${label}\nOpen thread`;

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -20,12 +20,14 @@ import type {
   AppServerThreadTextPart,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { readRendererFederationTarget } from "../../lib/federation-window";
 import {
   formatMessagingPlatformName,
   MESSAGING_PLATFORM_ICONS,
 } from "../../lib/messaging-platform-branding";
 import { useThreadLinks, type ResolvedThreadLink } from "../../lib/thread-links";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import { InstanceChip } from "../federation/InstanceGlyph";
 import { ThreadChip } from "./ThreadChip";
 import { TranscriptImage } from "./TranscriptImage";
 import { renderMarkdownToClipboardHtml } from "./markdown-clipboard-html";
@@ -754,6 +756,20 @@ function renderMessageHeader(params: {
     || params.message.origin?.prAutomation
     ? "transcript-message__attribution transcript-message__attribution--stacked"
     : "transcript-message__attribution";
+  const sourceThread = params.message.origin?.sourceThread;
+  const rendererFederationTarget = readRendererFederationTarget();
+  const sourceInstanceChip =
+    sourceThread?.instanceId
+    && sourceThread.instanceLabel
+    && rendererFederationTarget?.instanceId !== sourceThread.instanceId
+      ? (
+          <InstanceChip
+            icon={sourceThread.celestialIcon}
+            instanceId={sourceThread.instanceId}
+            label={sourceThread.instanceLabel}
+          />
+        )
+      : null;
 
   return (
     <header className="transcript-message__header">
@@ -780,6 +796,7 @@ function renderMessageHeader(params: {
           && params.message.origin.messaging ? (
             <MessagingOriginChip origin={params.message.origin.messaging} />
           ) : null}
+        {sourceInstanceChip}
       </span>
       <span className="transcript-message__header-actions">
         {params.text ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -244,6 +244,61 @@ describe("TranscriptList", () => {
     });
   });
 
+  it("prefers hydrated provenance over a cached fallback thread title", () => {
+    const sourceThreadId = "019fde92-318a-7541-9281-029bdc1508b5";
+    const sourceThread = {
+      id: sourceThreadId,
+      title: sourceThreadId,
+      titleSource: "fallback",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: true, unread: false },
+      federation: {
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "pwr_remote" },
+          threadId: sourceThreadId,
+        },
+        instanceLabel: "Remote Mac",
+        peerStatus: "connected",
+      },
+    } as NavigationThreadSummary;
+
+    render(
+      <ThreadLinkProvider onShowThread={vi.fn()} threads={[sourceThread]}>
+        <TranscriptList
+          entries={[
+            {
+              type: "message",
+              id: "remote-message-after-title-hydration",
+              role: "user",
+              text: "The remote audit is complete.",
+              origin: {
+                kind: "agent",
+                sourceThread: {
+                  backend: "codex",
+                  instanceId: "pwr_remote",
+                  threadId: sourceThreadId,
+                  title: "Cloudflare Tunnel connector audit",
+                },
+              },
+            },
+          ]}
+          loading={false}
+          loadingMore={false}
+          onLoadOlder={async () => undefined}
+        />
+      </ThreadLinkProvider>,
+    );
+
+    expect(screen.getByRole("button", {
+      name: "Open thread Cloudflare Tunnel connector audit",
+    })).toBeInTheDocument();
+    expect(screen.queryByRole("button", {
+      name: `Open thread ${sourceThreadId}`,
+    })).not.toBeInTheDocument();
+  });
+
   it("attributes monitor handoffs and keeps their raw payload collapsed", () => {
     const task = "Monitor GitHub CI for PR #1107 until all checks finish.";
     const rawHandoff = [

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -278,6 +278,8 @@ describe("TranscriptList", () => {
                 sourceThread: {
                   backend: "codex",
                   instanceId: "pwr_remote",
+                  instanceLabel: "Harold-MBP-2018",
+                  celestialIcon: "moon",
                   threadId: sourceThreadId,
                   title: "Cloudflare Tunnel connector audit",
                 },
@@ -297,6 +299,9 @@ describe("TranscriptList", () => {
     expect(screen.queryByRole("button", {
       name: `Open thread ${sourceThreadId}`,
     })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Runs on Harold-MBP-2018")).toHaveTextContent(
+      "Harold-MBP-2018",
+    );
   });
 
   it("attributes monitor handoffs and keeps their raw payload collapsed", () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -905,6 +905,8 @@ describe("useThreadSessionState", () => {
                 sourceThread: {
                   backend: "codex",
                   instanceId: "pwr_source",
+                  instanceLabel: "Source Mac",
+                  celestialIcon: "moon",
                   threadId: "parent-thread",
                   title: "Parent thread",
                 },
@@ -943,6 +945,8 @@ describe("useThreadSessionState", () => {
           sourceThread: {
             backend: "codex",
             instanceId: "pwr_source",
+            instanceLabel: "Source Mac",
+            celestialIcon: "moon",
             threadId: "parent-thread",
             title: "Parent thread",
           },

--- a/apps/desktop/src/renderer/src/lib/thread-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/thread-links.tsx
@@ -2,6 +2,7 @@ import {
   isThreadLinkId,
   parseThreadUrl,
   type AppServerBackendKind,
+  type AppServerThreadTitleSource,
   type FederationInstanceId,
   type LinkedDirectorySummary,
   type NavigationThreadSummary,
@@ -23,6 +24,7 @@ export type ResolvedThreadLink = {
   instanceId?: FederationInstanceId;
   threadId: string;
   title: string;
+  titleSource?: AppServerThreadTitleSource;
   gitBranch?: string;
   linkedDirectories?: LinkedDirectorySummary[];
 };
@@ -52,6 +54,7 @@ function threadSummaryLink(thread: NavigationThreadSummary): ResolvedThreadLink 
     ...(target?.scope === "remote" ? { instanceId: target.instanceId } : {}),
     threadId: thread.id,
     title: thread.title,
+    titleSource: thread.titleSource,
     gitBranch: thread.gitBranch,
     linkedDirectories: thread.linkedDirectories,
   };
@@ -64,6 +67,7 @@ function sameThreadLink(
   return Boolean(
     left
     && left.title === right.title
+    && left.titleSource === right.titleSource
     && left.gitBranch === right.gitBranch
     && linkedDirectoryMetadata(left.linkedDirectories)
       === linkedDirectoryMetadata(right.linkedDirectories)
@@ -93,6 +97,7 @@ function threadLinkMetadataKey(threads: NavigationThreadSummary[]): string {
         : null,
       thread.id,
       thread.title,
+      thread.titleSource,
       thread.gitBranch ?? null,
       linkedDirectoryMetadata(thread.linkedDirectories),
     ]),

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -23,6 +23,7 @@ import type {
   MessagingConversationKind,
   NavigationThreadSummary,
 } from "@pwragent/shared";
+import { isCelestialIconId } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
 import { readRendererFederationTarget } from "./federation-window";
 import {
@@ -3175,6 +3176,12 @@ function threadMessageOriginFromUnknown(
       backend: sourceRecord.backend as AppServerBackendKind,
       ...(typeof sourceRecord.instanceId === "string"
         ? { instanceId: sourceRecord.instanceId }
+        : {}),
+      ...(typeof sourceRecord.instanceLabel === "string"
+        ? { instanceLabel: sourceRecord.instanceLabel }
+        : {}),
+      ...(isCelestialIconId(sourceRecord.celestialIcon)
+        ? { celestialIcon: sourceRecord.celestialIcon }
         : {}),
       threadId: sourceRecord.threadId,
       ...(typeof sourceRecord.title === "string"

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11784,6 +11784,11 @@ textarea,
   height: 20px;
 }
 
+.transcript-message__attribution .chip--instance {
+  height: 20px;
+  font-size: 11px;
+}
+
 .transcript-message__messaging-origin {
   height: 20px;
   border: 1px solid var(--accent-border);

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -4,7 +4,7 @@ import type {
   MessagingChannelKind,
   MessagingConversationKind,
 } from "./messaging";
-import type { CelestialIconAssignment } from "./celestial";
+import type { CelestialIconAssignment, CelestialIconId } from "./celestial";
 import type { StarMapArrangementEntry, StarMapIntakePhase } from "./star-map";
 import type {
   FederationConnectionState,
@@ -422,6 +422,10 @@ export type AppServerThreadMessageOrigin = {
     backend: AppServerBackendKind;
     /** Durable owner identity when the source thread belongs to another instance. */
     instanceId?: FederationInstanceId;
+    /** Hydrated owner label so provenance stays useful without mounting the source thread. */
+    instanceLabel?: string;
+    /** Hydrated owner identity icon, matching remote thread rows. */
+    celestialIcon?: CelestialIconId;
     threadId: ThreadIdentifier;
     title?: string;
   };


### PR DESCRIPTION
## Summary

- prefer hydrated message provenance titles over cached navigation fallback UUIDs
- hydrate each remote source owner's display label and celestial icon without mounting or subscribing to the source thread
- render the existing remote `InstanceChip` beside Agent provenance so identical thread names remain distinguishable across instances
- preserve click-to-mount behavior and suppress redundant owner chips in a federation window already branded for that same instance
- strip caller-supplied instance label/icon metadata at federation ingress and rebuild it from authenticated local federation state
- retain later fallback title and instance metadata when deduplicated hydration lookups fail

## Testing

- `pnpm test apps/desktop/src/main/__tests__/federated-thread-origin-hydrator.test.ts apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with existing warning baseline)
- `pnpm lint:boundaries`
- `git diff --check`