### PR TITLE
chore(ci): group dependabot npm security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,25 @@ version: 2
 
 updates:
   # pnpm workspace. Dependabot uses the npm ecosystem value for pnpm.
+  #
+  # Monorepo grouping strategy (why this shape exists):
+  # - Keep a single `directory: "/"` so version updates own the root
+  #   pnpm-lock.yaml and can rewrite every workspace package.json that
+  #   declares the dependency. Listing nested package paths as separate
+  #   `directories` tends to open package.json-only PRs without a lockfile
+  #   update (see PR #1337: `... in /apps/desktop`).
+  # - Official cross-directory `groups.*.group-by: dependency-name` only
+  #   applies when multiple `directories` are listed, and only for version
+  #   updates. We deliberately do not switch this monorepo to multi-directory
+  #   just to enable that key: with pnpm + one lockfile, root-owned updates
+  #   already collapse the same library across workspace packages into one
+  #   version-update PR.
+  # - Security updates are a separate pipeline. They ignore version-update
+  #   groups unless `applies-to: security-updates` is set, and they key off
+  #   alert manifest paths (`apps/desktop/package.json` vs `pnpm-lock.yaml`).
+  #   That is how the same library can still open two PRs (PRs #1337 + #1338
+  #   for pdfjs-dist). The `npm-security` group below groups security updates
+  #   for this npm entry so one library does not fan out per alert/manifest.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -62,6 +81,14 @@ updates:
         update-types:
           - "version-update:semver-major"
     groups:
+      # Security updates ignore the version-update groups below unless this
+      # applies-to is set. Group them so the same library does not open one PR
+      # per security alert / manifest path (package.json vs lockfile) in the
+      # monorepo — the failure mode behind PRs #1337 and #1338 for pdfjs-dist.
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
       agent-kit:
         patterns:
           - "@pwrdrvr/agent-*"
@@ -110,6 +137,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # Catch-all version-update groups: batch unrelated production/dev
+      # minor+patch bumps into summary PRs so the monorepo does not open one
+      # PR per package. Special-cased groups above still win for their patterns.
       npm-production-minor-patch:
         patterns:
           - "*"


### PR DESCRIPTION
## Summary

Dependabot opened two PRs for the same library bump:

- #1337 — `build(deps): bump pdfjs-dist … in /apps/desktop` (security-update path; package.json only)
- #1338 — `chore(deps): bump pdfjs-dist …` (version update from workspace root; package.json + lockfile)

There are open Dependabot alerts for the same package on both `apps/desktop/package.json` and `pnpm-lock.yaml`. Security updates ignore normal version-update groups unless `applies-to: security-updates` is set, so the same library can fan out into one PR per alert/manifest path.

## What changed

In `.github/dependabot.yml` (npm/pnpm entry only; github-actions untouched):

1. **`npm-security` group** with `applies-to: security-updates` and `patterns: ["*"]` so security updates for this ecosystem land in fewer/summary PRs instead of one per alert/manifest.
2. **Comments** documenting the monorepo grouping strategy:
   - Keep single `directory: "/"` so version updates own the root `pnpm-lock.yaml` and can rewrite every workspace `package.json` that declares the dependency.
   - Why we do **not** switch to multi-`directories` + `group-by: dependency-name` here (that key requires multiple directories and only covers version updates; listing nested package paths on a pnpm monorepo tends to open package.json-only PRs without lockfile updates — the #1337 shape).
3. Light clarification comments on the existing production/dev minor+patch catch-all groups (behavior unchanged).

## Grouping strategy and limitations

| Strategy | Effect |
| --- | --- |
| Single `directory: "/"` | Version updates for a shared library already update all workspace package.jsons + the root lockfile in one PR. |
| Existing specialized + catch-all version groups | Unrelated minor/patch deps still batch into summary PRs; special cases (ai-sdk, vite, electron, …) stay coordinated. |
| New `npm-security` group | Security updates for this npm entry are grouped so the same library does not open one PR per alert/manifest path. |

**Limitations (honest):**

- Official `groups.*.group-by: dependency-name` only works with multiple `directories` and only for **version** updates. We intentionally did not list every workspace package as its own directory, because this monorepo is pnpm with one lockfile at `/`.
- Security and version updates remain separate pipelines. Grouping security updates reduces multi-manifest security fan-out; it does not always merge a security PR into an already-open version-update PR for the same package.
- Incompatible version constraints across packages can still force separate PRs (Dependabot limitation).
- github-actions (and any future non-npm ecosystems) keep their own schedules and are unchanged.

## Test plan

- [x] YAML parses cleanly
- [ ] After merge, next Dependabot security run for a multi-manifest npm alert should prefer a single grouped security PR rather than one PR per path
- [ ] Version-update schedule still produces root-owned PRs with lockfile changes (not package.json-only nested paths)
- [ ] github-actions Dependabot entry behavior unchanged