### PR TITLE
fix(desktop): hide Grok reasoning and preserve ACP streams

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -717,7 +717,7 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
-  it("emits Grok thoughts as transient messages instead of replayable text", async () => {
+  it("does not emit Grok thoughts as live or replayable text", async () => {
     const backendId = "acp:grok" as AcpBackendId;
     const transport = new FakeAcpAgentTransport();
     const events: AgentEvent[] = [];
@@ -833,66 +833,10 @@ describe("AcpBackendAdapter", () => {
       expect(
         events
           .filter(
-            (event) =>
-              event.notification.method === "item/transientMessage/updated" ||
-              event.notification.method === "item/agentMessage/delta",
+            (event) => event.notification.method === "item/agentMessage/delta",
           )
           .map((event) => event.notification),
       ).toEqual([
-        {
-          method: "item/transientMessage/updated",
-          params: {
-            threadId: session.sessionId,
-            turnId: "turn-1",
-            itemId: "transient-thought:turn-1",
-            role: "assistant",
-            text: "The",
-            phase: "commentary",
-          },
-        },
-        {
-          method: "item/transientMessage/updated",
-          params: {
-            threadId: session.sessionId,
-            turnId: "turn-1",
-            itemId: "transient-thought:turn-1",
-            role: "assistant",
-            text: "The code",
-            phase: "commentary",
-          },
-        },
-        {
-          method: "item/transientMessage/updated",
-          params: {
-            threadId: session.sessionId,
-            turnId: "turn-1",
-            itemId: "transient-thought:turn-1",
-            role: "assistant",
-            text: "The code seems",
-            phase: "commentary",
-          },
-        },
-        ...[
-          "The code seems to",
-          "The code seems to be",
-          "The code seems to be over",
-          "The code seems to be over here",
-          "The code seems to be over here.",
-          "So",
-          "So the",
-          "So the key",
-          "So the key logic is:",
-        ].map((text) => ({
-          method: "item/transientMessage/updated" as const,
-          params: {
-            threadId: session.sessionId,
-            turnId: "turn-1",
-            itemId: "transient-thought:turn-1",
-            role: "assistant" as const,
-            text,
-            phase: "commentary" as const,
-          },
-        })),
         {
           method: "item/agentMessage/delta",
           params: {
@@ -905,6 +849,12 @@ describe("AcpBackendAdapter", () => {
         },
       ]);
     });
+    expect(
+      events.filter(
+        (event) =>
+          event.notification.method === "item/transientMessage/updated",
+      ),
+    ).toEqual([]);
     expect(
       events.filter(
         (event) =>

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -2919,7 +2919,7 @@ describe("AcpAgentClient", () => {
     expect(client.readReplay(session.sessionId).entries).toEqual([]);
   });
 
-  it("preserves a Grok assistant stream across non-boundary vendor updates", async () => {
+  it("distinguishes known tool progress from standalone tool updates", async () => {
     const promptResponse = createDeferred<unknown>();
     const transport = new FakeAcpAgentTransport({
       "session/prompt": promptResponse.promise,
@@ -2951,6 +2951,16 @@ describe("AcpAgentClient", () => {
       method: "_x.ai/session_notification",
       sessionId: session.sessionId,
       update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "background-tool",
+        title: "Background check",
+        status: "in_progress",
+      },
+    });
+    transport.emitVendorNotification({
+      method: "_x.ai/session_notification",
+      sessionId: session.sessionId,
+      update: {
         sessionUpdate: "agent_message_chunk",
         content: "Before ",
       },
@@ -2959,7 +2969,6 @@ describe("AcpAgentClient", () => {
       "tool_call_delta_chunk",
       "pending_interaction",
       "interaction_resolved",
-      "tool_call_update",
     ]) {
       transport.emitVendorNotification({
         method: "_x.ai/session_notification",
@@ -2971,14 +2980,43 @@ describe("AcpAgentClient", () => {
       method: "_x.ai/session_notification",
       sessionId: session.sessionId,
       update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "background-tool",
+        title: "Background check",
+        status: "completed",
+      },
+    });
+    transport.emitVendorNotification({
+      method: "_x.ai/session_notification",
+      sessionId: session.sessionId,
+      update: {
         sessionUpdate: "agent_message_chunk",
         content: "after",
+      },
+    });
+    transport.emitVendorNotification({
+      method: "_x.ai/session_notification",
+      sessionId: session.sessionId,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "standalone-tool",
+        title: "Standalone check",
+        status: "completed",
+      },
+    });
+    transport.emitVendorNotification({
+      method: "_x.ai/session_notification",
+      sessionId: session.sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: "Later",
       },
     });
 
     expect(assistantMessageItemIds).toEqual([
       "assistant:turn-1:0",
       "assistant:turn-1:0",
+      "assistant:turn-1:1",
     ]);
     expect(
       client
@@ -2994,6 +3032,11 @@ describe("AcpAgentClient", () => {
         type: "message",
         role: "assistant",
         text: "Before after",
+      }),
+      expect.objectContaining({
+        type: "message",
+        role: "assistant",
+        text: "Later",
       }),
     ]);
 

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -2919,7 +2919,7 @@ describe("AcpAgentClient", () => {
     expect(client.readReplay(session.sessionId).entries).toEqual([]);
   });
 
-  it("preserves a Grok assistant stream across transient vendor updates", async () => {
+  it("preserves a Grok assistant stream across non-boundary vendor updates", async () => {
     const promptResponse = createDeferred<unknown>();
     const transport = new FakeAcpAgentTransport({
       "session/prompt": promptResponse.promise,
@@ -2959,6 +2959,7 @@ describe("AcpAgentClient", () => {
       "tool_call_delta_chunk",
       "pending_interaction",
       "interaction_resolved",
+      "tool_call_update",
     ]) {
       transport.emitVendorNotification({
         method: "_x.ai/session_notification",
@@ -2979,7 +2980,11 @@ describe("AcpAgentClient", () => {
       "assistant:turn-1:0",
       "assistant:turn-1:0",
     ]);
-    expect(client.readReplay(session.sessionId).entries).toEqual([
+    expect(
+      client
+        .readReplay(session.sessionId)
+        .entries.filter((entry) => entry.type === "message"),
+    ).toEqual([
       expect.objectContaining({
         type: "message",
         role: "user",

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -1429,17 +1429,27 @@ describe("AcpSessionReplayNormalizer", () => {
     ]);
   });
 
-  it("updates tool progress without splitting a streaming assistant message", () => {
+  it("updates known tool progress without splitting a streaming assistant message", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 
     normalizer.apply({
       sessionId: "session-1",
       receivedAt: 1000,
-      update: { sessionUpdate: "agent_message_chunk", content: "Before " },
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "background-tool",
+        title: "Background check",
+        status: "in_progress",
+      },
     });
     normalizer.apply({
       sessionId: "session-1",
       receivedAt: 1001,
+      update: { sessionUpdate: "agent_message_chunk", content: "Before " },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1002,
       update: {
         sessionUpdate: "tool_call_update",
         toolCallId: "background-tool",
@@ -1449,7 +1459,7 @@ describe("AcpSessionReplayNormalizer", () => {
     });
     const replay = normalizer.apply({
       sessionId: "session-1",
-      receivedAt: 1002,
+      receivedAt: 1003,
       update: { sessionUpdate: "agent_message_chunk", content: "after" },
     });
 
@@ -1461,6 +1471,41 @@ describe("AcpSessionReplayNormalizer", () => {
         role: "assistant",
         text: "Before after",
       }),
+    ]);
+  });
+
+  it("splits assistant messages around a standalone tool update", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { sessionUpdate: "agent_message_chunk", content: "Before" },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "standalone-tool",
+        title: "Standalone check",
+        status: "completed",
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1002,
+      update: { sessionUpdate: "agent_message_chunk", content: "After" },
+    });
+
+    expect(
+      replay.entries.map((entry) =>
+        entry.type === "message" ? `${entry.id}:${entry.text}` : entry.type
+      ),
+    ).toEqual([
+      "assistant:session-1:0:Before",
+      "activity",
+      "assistant:session-1:1:After",
     ]);
   });
 

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -1429,6 +1429,41 @@ describe("AcpSessionReplayNormalizer", () => {
     ]);
   });
 
+  it("updates tool progress without splitting a streaming assistant message", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { sessionUpdate: "agent_message_chunk", content: "Before " },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "background-tool",
+        title: "Background check",
+        status: "completed",
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1002,
+      update: { sessionUpdate: "agent_message_chunk", content: "after" },
+    });
+
+    expect(
+      replay.entries.filter((entry) => entry.type === "message"),
+    ).toEqual([
+      expect.objectContaining({
+        id: "assistant:session-1:0",
+        role: "assistant",
+        text: "Before after",
+      }),
+    ]);
+  });
+
   it("treats Grok turn_completed as an idempotent turn finish", () => {
     const normalizer = new AcpSessionReplayNormalizer();
     normalizer.recordUserPrompt({

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -15,6 +15,7 @@ import {
   AcpSessionReplayNormalizer,
   isAcpUserBoilerplateMessage,
   isGrokTransientUpdateKind,
+  readAcpToolCallId,
   readAcpContentText,
   readAcpTopicTitle,
   readAcpUpdateTimestamp,
@@ -142,6 +143,7 @@ type AcpActiveTurn = {
   activeAssistantMessagePhase?: AppServerTranscriptPhase;
   assistantText: string;
   assistantMessageSequence: number;
+  knownToolCallIds: Set<string>;
   turnId: string;
 };
 
@@ -939,6 +941,11 @@ export class AcpAgentClient {
       updateKind === "agent_message_chunk" ||
       (updateKind === "agent_thought_chunk" && this.surfaceThoughtsAsMessages);
     const text = readUpdateText(update);
+    const toolCallId = readAcpToolCallId(update);
+    const updatesKnownToolCall =
+      updateKind === "tool_call_update"
+      && toolCallId !== undefined
+      && activeTurn?.knownToolCallIds.has(toolCallId) === true;
     let assistantMessageItemId: string | undefined;
     if (shouldTrackAssistantTextUpdate && activeTurn && text) {
       const phase: AppServerTranscriptPhase =
@@ -955,10 +962,17 @@ export class AcpAgentClient {
       !isAssistantTextUpdate
       && activeTurn
       && !isGrokTransientUpdateKind(updateKind)
-      && updateKind !== "tool_call_update"
+      && !updatesKnownToolCall
     ) {
       activeTurn.activeAssistantMessageItemId = undefined;
       activeTurn.activeAssistantMessagePhase = undefined;
+    }
+    if (
+      activeTurn
+      && toolCallId
+      && (updateKind === "tool_call" || updateKind === "tool_call_update")
+    ) {
+      activeTurn.knownToolCallIds.add(toolCallId);
     }
     const replay = this.normalizerFor(sessionId).apply({
       sessionId,
@@ -1310,6 +1324,7 @@ export class AcpAgentClient {
     this.activeTurns.set(sessionId, {
       assistantText: "",
       assistantMessageSequence: 0,
+      knownToolCallIds: new Set<string>(),
       turnId,
     });
     this.updateSessionStatus(sessionId, "active");

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -955,6 +955,7 @@ export class AcpAgentClient {
       !isAssistantTextUpdate
       && activeTurn
       && !isGrokTransientUpdateKind(updateKind)
+      && updateKind !== "tool_call_update"
     ) {
       activeTurn.activeAssistantMessageItemId = undefined;
       activeTurn.activeAssistantMessagePhase = undefined;

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -41,26 +41,12 @@ export function shouldSurfaceAcpThoughtsAsMessages(backendId: string): boolean {
   return backendId !== "acp:qwen" && backendId !== "acp:grok";
 }
 
-export function shouldSurfaceAcpThoughtsAsTransientMessages(
-  backendId: string,
-): boolean {
-  return backendId === "acp:grok";
-}
-
 export function isGrokTransientUpdateKind(kind: string | undefined): boolean {
   return (
     kind === "tool_call_delta_chunk"
     || kind === "pending_interaction"
     || kind === "interaction_resolved"
   );
-}
-
-export function formatAcpTransientThoughtMessage(
-  text: string,
-): string | undefined {
-  const beforeCodeFence = text.split("```", 1)[0] ?? "";
-  const compact = beforeCodeFence.replace(/\s+/gu, " ").trim();
-  return compact || undefined;
 }
 
 type InferredAcpTurn = {
@@ -359,8 +345,14 @@ export class AcpSessionReplayNormalizer {
     } else if (readAcpTopicTitle(update.update)) {
       // Topic updates are thread metadata, not transcript entries.
     } else {
-      this.activeAssistantMessageId = undefined;
-      this.activeAssistantMessagePhase = undefined;
+      // A tool_call is the semantic boundary between assistant messages.
+      // Later tool_call_update notifications may arrive while the provider is
+      // already streaming the next assistant message, so they must update the
+      // activity without fragmenting that message.
+      if (kind !== "tool_call_update") {
+        this.activeAssistantMessageId = undefined;
+        this.activeAssistantMessagePhase = undefined;
+      }
       if (kind === "plan") {
         this.removeCurrentAgentWaitingActivity();
         this.upsertPlan(update, createdAt);

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -49,6 +49,18 @@ export function isGrokTransientUpdateKind(kind: string | undefined): boolean {
   );
 }
 
+export function readAcpToolCallId(
+  update: Record<string, unknown>,
+): string | undefined {
+  return (
+    readString(update, "toolCallId")
+    ?? readString(update, "tool_call_id")
+    ?? readString(update, "id")
+    ?? readString(update, "itemId")
+    ?? readString(update, "item_id")
+  );
+}
+
 type InferredAcpTurn = {
   id: string;
   indexes: number[];
@@ -195,6 +207,7 @@ export class AcpSessionReplayNormalizer {
   private activeAssistantMessagePhase?: AppServerTranscriptPhase;
   private assistantMessageSequence = 0;
   private generatedMessageSequence = 0;
+  private readonly knownToolCallIds = new Set<string>();
 
   constructor(private readonly options: AcpSessionReplayNormalizerOptions = {}) {}
 
@@ -214,6 +227,7 @@ export class AcpSessionReplayNormalizer {
     this.activeAssistantMessageId = undefined;
     this.activeAssistantMessagePhase = undefined;
     this.assistantMessageSequence = 0;
+    this.knownToolCallIds.clear();
     this.upsertMessage({
       id,
       role: "user",
@@ -245,6 +259,7 @@ export class AcpSessionReplayNormalizer {
     }
     this.activeAssistantMessageId = undefined;
     this.activeAssistantMessagePhase = undefined;
+    this.knownToolCallIds.clear();
     this.status = "idle";
     return this.replay();
   }
@@ -264,6 +279,7 @@ export class AcpSessionReplayNormalizer {
     }
     this.activeAssistantMessageId = undefined;
     this.activeAssistantMessagePhase = undefined;
+    this.knownToolCallIds.clear();
     this.status = "idle";
     this.upsertActivity({
       type: "activity",
@@ -322,6 +338,7 @@ export class AcpSessionReplayNormalizer {
     } else if (kind === "user_message_chunk") {
       this.activeAssistantMessageId = undefined;
       this.activeAssistantMessagePhase = undefined;
+      this.knownToolCallIds.clear();
       this.applyUserMessageChunk(update, createdAt);
     } else if (kind === "available_commands_update") {
       // Command metadata belongs in provider capabilities, not the transcript.
@@ -345,13 +362,25 @@ export class AcpSessionReplayNormalizer {
     } else if (readAcpTopicTitle(update.update)) {
       // Topic updates are thread metadata, not transcript entries.
     } else {
+      const toolCallId = readAcpToolCallId(update.update);
+      const updatesKnownToolCall =
+        kind === "tool_call_update"
+        && toolCallId !== undefined
+        && this.knownToolCallIds.has(toolCallId);
       // A tool_call is the semantic boundary between assistant messages.
-      // Later tool_call_update notifications may arrive while the provider is
-      // already streaming the next assistant message, so they must update the
-      // activity without fragmenting that message.
-      if (kind !== "tool_call_update") {
+      // Updates for that known call may arrive while the provider is already
+      // streaming the next message, so only those preserve the active bubble.
+      // A standalone tool_call_update remains a boundary for providers that
+      // use it as their only notification for a tool invocation.
+      if (!updatesKnownToolCall) {
         this.activeAssistantMessageId = undefined;
         this.activeAssistantMessagePhase = undefined;
+      }
+      if (
+        toolCallId
+        && (kind === "tool_call" || kind === "tool_call_update")
+      ) {
+        this.knownToolCallIds.add(toolCallId);
       }
       if (kind === "plan") {
         this.removeCurrentAgentWaitingActivity();
@@ -363,6 +392,7 @@ export class AcpSessionReplayNormalizer {
         this.removeCurrentAgentWaitingActivity();
         this.upsertActivity(toolActivity(update, kind, createdAt));
       } else if (kind === "turn_started") {
+        this.knownToolCallIds.clear();
         this.status = "active";
       } else if (kind === "turn_finished") {
         this.recordTurnFinished(readString(update.update, "turnId"), createdAt);
@@ -1025,11 +1055,7 @@ function toolActivity(
   createdAt: number,
 ): AppServerThreadActivityEntry {
   const id =
-    readString(update.update, "toolCallId") ??
-    readString(update.update, "tool_call_id") ??
-    readString(update.update, "id") ??
-    readString(update.update, "itemId") ??
-    readString(update.update, "item_id") ??
+    readAcpToolCallId(update.update) ??
     `${kind}:${update.sessionId}`;
   const webSearch = readAcpWebSearch(update.update);
   if (webSearch) {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -76,12 +76,9 @@ import {
 } from "../acp/acp-session-store";
 import {
   AcpSessionReplayNormalizer,
-  appendAcpTranscriptChunk,
-  formatAcpTransientThoughtMessage,
   inferAcpReplayTurns,
   readAcpContentText,
   shouldSurfaceAcpThoughtsAsMessages,
-  shouldSurfaceAcpThoughtsAsTransientMessages,
 } from "../acp/acp-session-normalizer";
 import { AcpStdioJsonRpcTransport } from "../acp/acp-stdio-transport";
 import { getMainLogger } from "../log";
@@ -920,7 +917,6 @@ export class AcpBackendAdapter {
   private closePromise?: Promise<void>;
   private readonly closeTimeoutMs: number;
   private readonly liveTurnUsage = new Map<string, AcpLiveTurnUsage>();
-  private readonly transientThoughtText = new Map<string, string>();
   private localAcpAgentsPromise?: Promise<AcpInstalledAgentRecord[]>;
 
   constructor(options: AcpBackendAdapterOptions) {
@@ -1558,7 +1554,6 @@ export class AcpBackendAdapter {
     this.providerStatusRefreshAttempts.clear();
     this.providerStatusRefreshes.clear();
     this.liveTurnUsage.clear();
-    this.transientThoughtText.clear();
     this.closePromise = this.closeResources(acpClients);
     return await this.closePromise;
   }
@@ -1738,10 +1733,6 @@ export class AcpBackendAdapter {
               turnId,
             })
           : undefined;
-        const transientThoughtKey =
-          turnId
-            ? `${agent.backendId}:${sessionId}:${turnId}`
-            : undefined;
         const agentMessageDelta =
           updateKind === "agent_message_chunk"
             ? readAcpUpdateText(update)
@@ -1755,17 +1746,6 @@ export class AcpBackendAdapter {
             }).filter((notification) =>
               this.shouldEmitLiveToolNotification(agent.backendId, notification),
             );
-        // Reset only when this callback will emit a notification that settles
-        // the renderer's active segment. Metadata and deduplicated tool updates
-        // must preserve both sides of the replacement-value contract.
-        const settlesTransientThought =
-          Boolean(agentMessageDelta)
-          || toolNotifications.length > 0
-          || (updateKind === "turn_finished" && Boolean(turnId))
-          || replay.threadStatus === "idle";
-        if (transientThoughtKey && settlesTransientThought) {
-          this.transientThoughtText.delete(transientThoughtKey);
-        }
         if (title) {
           await this.emit({
             backend: agent.backendId,
@@ -1822,38 +1802,6 @@ export class AcpBackendAdapter {
           }
         }
         if (
-          turnId &&
-          updateKind === "agent_thought_chunk" &&
-          shouldSurfaceAcpThoughtsAsTransientMessages(agent.backendId)
-        ) {
-          const rawText = readAcpUpdateText(update);
-          if (rawText && transientThoughtKey) {
-            const accumulatedText = appendAcpTranscriptChunk(
-              this.transientThoughtText.get(transientThoughtKey) ?? "",
-              rawText,
-            );
-            this.transientThoughtText.set(
-              transientThoughtKey,
-              accumulatedText,
-            );
-            const text =
-              formatAcpTransientThoughtMessage(accumulatedText) ?? "";
-            await this.emit({
-              backend: agent.backendId,
-              notification: {
-                method: "item/transientMessage/updated",
-                params: {
-                  threadId: sessionId,
-                  turnId,
-                  itemId: `transient-thought:${turnId}`,
-                  role: "assistant",
-                  text,
-                  phase: "commentary",
-                },
-              },
-            });
-          }
-        } else if (
           turnId &&
           (updateKind === "agent_message_chunk" ||
             (updateKind === "agent_thought_chunk" &&
@@ -1934,9 +1882,6 @@ export class AcpBackendAdapter {
       onPromptError: async ({ sessionId, turnId, error }) => {
         this.liveTurnUsage.delete(
           [agent.backendId, sessionId, turnId].join(":"),
-        );
-        this.transientThoughtText.delete(
-          `${agent.backendId}:${sessionId}:${turnId}`,
         );
         await this.emit({
           backend: agent.backendId,


### PR DESCRIPTION
## Summary

- stop surfacing Grok `agent_thought_chunk` reasoning as transient UI commentary
- preserve one assistant message across late `tool_call_update` progress notifications only when they belong to an already-known tool
- keep a real `tool_call` as the semantic boundary between assistant messages
- add regression coverage for live event delivery, item identity, replay coalescing, and hidden reasoning

## Root cause

Grok ACP emits tool progress updates asynchronously. In the captured failure, one final `agent_message_chunk` stream was interleaved with late `tool_call_update` events from a tool that had already started. PwrAgent treated every update as a new assistant-message boundary, fragmenting one Markdown response into multiple cards.

Separately, Grok reasoning was intentionally re-emitted as transient commentary by default. Those thought chunks are provider reasoning, not the user-facing in-turn updates that precede an actual tool call.

## Impact

Grok reasoning stays out of the transcript, while deliberate user-facing assistant updates remain visible. Final responses no longer break into malformed fragments when background tool progress arrives during streaming. Existing ACP rollout history is normalized correctly when reloaded; no migration is required.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts` — 137 passed
- `pnpm test apps/desktop/src/main/__tests__/acp-rollout-store.test.ts` — 15 passed
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` — 0 errors (144 existing warnings)
