### PR TITLE
fix(desktop): surface Kimi compatibility failures

### DIFF
--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -36,6 +36,13 @@ const fakeProviderNames = [
   "grok",
 ] as const;
 type FakeProviderName = (typeof fakeProviderNames)[number];
+const fakeProviderVersions: Record<FakeProviderName, string> = {
+  codex: "999.0.0",
+  gemini: "999.0.0",
+  kimi: "0.999.0",
+  qwen: "999.0.0",
+  grok: "999.0.0",
+};
 
 function fakeProviderScript(): string {
   return `#!${process.execPath}
@@ -44,7 +51,11 @@ const name = path.basename(process.argv[1]);
 const args = process.argv.slice(2);
 
 if (args.includes("--version")) {
-  console.log(name + " 999.0.0");
+  // Current Kimi Code reports a bare 0.x version. Its retired Python
+  // predecessor owns the 1.x line, so the shared v999 fixture would
+  // intentionally be rejected by PwrAgent's compatibility gate.
+  const version = ${JSON.stringify(fakeProviderVersions)}[name];
+  console.log(name === "kimi" ? version : name + " " + version);
   process.exit(0);
 }
 
@@ -160,7 +171,9 @@ async function expectFakeProvidersFound(
       .getByRole("tab", { name: new RegExp(providerLabels[name], "i") })
       .click();
     const panel = app.window.getByRole("tabpanel");
-    await expect(panel.getByText("✓ Found v999.0.0")).toBeVisible();
+    await expect(
+      panel.getByText(`✓ Found v${fakeProviderVersions[name]}`),
+    ).toBeVisible();
     await expect(panel.getByText(commands[name], { exact: true })).toBeVisible();
   }
 }

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1629,6 +1629,7 @@ describe("AcpBackendAdapter", () => {
         },
         captureStores: [],
         createAcpTransport: () => transport,
+        discoverLocalAcpAgents: async () => [],
         emit: vi.fn(async () => undefined),
         handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
       });

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -352,7 +352,7 @@ describe("AcpBackendAdapter", () => {
       backendId,
       registryId: "kimi",
       name: "Kimi Code CLI",
-      version: "1.44.0",
+      version: "0.30.0",
       distributionKind: "local",
       distributionSource: "kimi acp",
       installStatus: "installed",
@@ -553,6 +553,7 @@ describe("AcpBackendAdapter", () => {
 
     transport.emitSessionUpdate(session.sessionId, {
       sessionUpdate: "turn_completed",
+      outputText: "Build succeeded",
       usage: {
         inputTokens: 1_200,
         cachedReadTokens: 1_000,
@@ -2440,6 +2441,92 @@ describe("AcpBackendAdapter", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("replaces a cached Kimi model catalog with a legacy-CLI diagnostic", async () => {
+    const backendId = "acp:kimi" as AcpBackendId;
+    const cached: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      version: "1.46.0",
+      activeCommand: "/Users/me/.local/bin/kimi",
+      launchDescriptor: {
+        backendId,
+        registryId: "kimi",
+        distributionKind: "local",
+        command: "/Users/me/.local/bin/kimi",
+        args: ["acp"],
+        env: {},
+      },
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        models: {
+          currentModelId: "kimi-code/kimi-for-coding",
+          availableModels: [
+            { id: "kimi-code/kimi-for-coding", label: "Kimi for Coding" },
+          ],
+        },
+      },
+    };
+    const diagnostic: AcpInstalledAgentRecord = {
+      backendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      version: "1.46.0",
+      distributionKind: "local",
+      distributionSource: "/Users/me/.local/bin/kimi (legacy kimi-cli ignored)",
+      installStatus: "unavailable",
+      authStatus: "not-required",
+      verificationStatus: "not-applicable",
+      allowlistRuleId: "local-kimi-cli",
+      installedAt: 2000,
+      updatedAt: 2000,
+      lastError: "Legacy Python kimi-cli was found and ignored.",
+      instances: [],
+      incompatibleInstances: [
+        {
+          command: "/Users/me/.local/bin/kimi",
+          version: "1.46.0",
+          source: "path",
+        },
+      ],
+    };
+    const upsertInstalledAgent = vi.fn();
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => cached,
+        listInstalledAgents: () => [cached],
+        upsertInstalledAgent,
+      },
+      captureStores: [],
+      discoverLocalAcpAgents: async () => [diagnostic],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    await expect(adapter.describeInstalledBackends()).resolves.toEqual([
+      expect.objectContaining({
+        kind: backendId,
+        available: false,
+        unavailableReason: diagnostic.lastError,
+        acp: expect.objectContaining({
+          installStatus: "unavailable",
+          runtime: undefined,
+        }),
+        launchpadOptions: undefined,
+      }),
+    ]);
+    expect(upsertInstalledAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installStatus: "unavailable",
+        incompatibleInstances: diagnostic.incompatibleInstances,
+      }),
+    );
+
+    await adapter.close();
   });
 
   it("does not create an ACP client when discovery finishes after close", async () => {

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -60,7 +60,10 @@ function readRawAcpSessionPayload(
 
 describe("AcpAgentClient", () => {
   it("initializes, starts sessions, sends prompts, and normalizes updates", async () => {
-    const transport = new FakeAcpAgentTransport();
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
     const sessionUpdates: string[] = [];
     const client = new AcpAgentClient({
       backendId: "acp:codex-acp",
@@ -78,7 +81,7 @@ describe("AcpAgentClient", () => {
       executionMode: "default",
       title: "Test ACP",
     });
-    const prompt = await client.prompt({
+    const promptPromise = client.prompt({
       sessionId: session.sessionId,
       prompt: "hello",
     });
@@ -86,6 +89,8 @@ describe("AcpAgentClient", () => {
       kind: "agent_message_chunk",
       content: "Done",
     });
+    promptResponse.resolve({ turnId: "turn-1" });
+    const prompt = await promptPromise;
 
     expect(transport.requests.map((request) => request.method)).toEqual([
       "initialize",
@@ -3048,6 +3053,115 @@ describe("AcpAgentClient", () => {
     await vi.waitFor(() => {
       expect(client.readReplay(session.sessionId).threadStatus).toBe("idle");
     });
+  });
+
+  it("reports a Kimi turn that resolves without an assistant response", async () => {
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      initialize: {
+        protocolVersion: 1,
+        agentInfo: {
+          name: "Kimi Code CLI",
+          version: "1.46.0",
+        },
+      },
+      "session/prompt": promptResponse.promise,
+    });
+    const errors: Array<{ sessionId: string; turnId: string; error: unknown }> = [];
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      agentDisplayName: "Kimi Code CLI",
+      store,
+      transport,
+      now: () => 1000,
+      onPromptError: (event) => {
+        errors.push(event);
+      },
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Inspect this",
+      turnId: "turn-1",
+    });
+    promptResponse.resolve({ stopReason: "end_turn" });
+
+    await vi.waitFor(() => {
+      expect(errors).toHaveLength(1);
+    });
+    const errorMessage =
+      "Kimi Code CLI ended the turn without a response. Kimi Code CLI 1.46.0 may be out of date or incompatible with the selected model. Update Kimi, refresh the model catalog, and try again.";
+    expect((errors[0]?.error as Error).message).toBe(errorMessage);
+    expect(store.getSession("acp:kimi", session.sessionId)).toMatchObject({
+      lastError: errorMessage,
+      status: "idle",
+    });
+    expect(client.readReplay(session.sessionId).entries).toEqual([
+      expect.objectContaining({
+        type: "message",
+        role: "user",
+        text: "Inspect this",
+        turn: expect.objectContaining({ status: "failed" }),
+      }),
+      expect.objectContaining({
+        type: "activity",
+        summary: "Turn failed",
+        status: "failed",
+        details: [
+          expect.objectContaining({
+            label: errorMessage,
+            status: "failed",
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("accepts an ACP response delivered only by a terminal update", async () => {
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const errors: unknown[] = [];
+    const client = new AcpAgentClient({
+      backendId: "acp:test-agent",
+      store,
+      transport,
+      now: () => 1000,
+      onPromptError: ({ error }) => {
+        errors.push(error);
+      },
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Inspect this",
+      turnId: "turn-1",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      kind: "turn_finished",
+      outputText: "Finished from the terminal update.",
+    });
+    promptResponse.resolve({ stopReason: "end_turn" });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await vi.waitFor(() => {
+      expect(store.getSession("acp:test-agent", session.sessionId)?.status).toBe(
+        "idle",
+      );
+    });
+    expect(errors).toEqual([]);
+    expect(client.readReplay(session.sessionId).threadStatus).toBe("idle");
   });
 
   it("reports fire-and-forget prompt failures", async () => {

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -3122,6 +3122,85 @@ describe("AcpAgentClient", () => {
     ]);
   });
 
+  it("accepts a cancelled fire-and-forget prompt without assistant output", async () => {
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const errors: unknown[] = [];
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      store,
+      transport,
+      now: () => 1000,
+      onPromptError: ({ error }) => {
+        errors.push(error);
+      },
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Inspect this",
+      turnId: "turn-1",
+    });
+    promptResponse.resolve({ stopReason: "cancelled" });
+
+    await vi.waitFor(() => {
+      expect(store.getSession("acp:kimi", session.sessionId)?.status).toBe(
+        "idle",
+      );
+    });
+    expect(errors).toEqual([]);
+    expect(
+      store.getSession("acp:kimi", session.sessionId)?.lastError,
+    ).toBeUndefined();
+    expect(
+      client.readReplay(session.sessionId).entries.some(
+        (entry) => entry.type === "activity" && entry.summary === "Turn failed",
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts a cancelled awaited prompt without assistant output", async () => {
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      store,
+      transport,
+      now: () => 1000,
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    const promptPromise = client.prompt({
+      sessionId: session.sessionId,
+      prompt: "Inspect this",
+    });
+    promptResponse.resolve({ stopReason: "cancelled" });
+
+    await expect(promptPromise).resolves.toEqual({
+      sessionId: session.sessionId,
+      turnId: `pending:${session.sessionId}:1000`,
+    });
+    expect(store.getSession("acp:kimi", session.sessionId)).toMatchObject({
+      status: "idle",
+    });
+    expect(
+      store.getSession("acp:kimi", session.sessionId)?.lastError,
+    ).toBeUndefined();
+  });
+
   it("accepts an ACP response delivered only by a terminal update", async () => {
     const promptResponse = createDeferred<unknown>();
     const transport = new FakeAcpAgentTransport({

--- a/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
@@ -5,6 +5,7 @@ import { resolveActiveAcpInstance } from "../acp/acp-instance-resolver";
 import {
   discoverAcpAgentInstances,
   discoverLocalAcpAgentRecords,
+  isLegacyPythonKimiCli,
 } from "../acp/acp-instance-discovery";
 
 function instance(
@@ -188,6 +189,81 @@ describe("discoverAcpAgentInstances", () => {
 });
 
 describe("discoverLocalAcpAgentRecords", () => {
+  it("distinguishes the legacy Python CLI from current Kimi Code output", () => {
+    expect(
+      isLegacyPythonKimiCli({
+        output: "kimi, version 1.46.0",
+        version: "1.46.0",
+      }),
+    ).toBe(true);
+    expect(
+      isLegacyPythonKimiCli({
+        output: "kimi-cli version: 1.49.0\npython version: 3.13.7",
+        version: "1.49.0",
+      }),
+    ).toBe(true);
+    expect(
+      isLegacyPythonKimiCli({
+        output: "kimi-code 0.30.0",
+        version: "0.30.0",
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores legacy Kimi on PATH and selects a side-by-side Kimi Code install", async () => {
+    const legacy = "/Users/me/.local/bin/kimi";
+    const current = "/Users/me/.kimi-code/bin/kimi";
+    const discover = vi.fn(async () => [
+      group("kimi", [
+        instance(legacy, "path", "1.46.0"),
+        instance(current, "fallback", "0.30.0"),
+      ]),
+    ]);
+
+    const [record, ...rest] = await discoverLocalAcpAgentRecords({
+      discover,
+      readVersionOutput: async (command) =>
+        command === legacy ? "kimi, version 1.46.0" : "kimi-code 0.30.0",
+    });
+
+    expect(rest).toHaveLength(0);
+    expect(record).toMatchObject({
+      installStatus: "installed",
+      version: "0.30.0",
+      activeCommand: current,
+      instances: [expect.objectContaining({ command: current })],
+      incompatibleInstances: [expect.objectContaining({ command: legacy })],
+      launchDescriptor: { command: current },
+    });
+  });
+
+  it("persists a non-launchable diagnostic when only legacy Python kimi-cli exists", async () => {
+    const legacy = "/Users/me/.local/bin/kimi";
+    const discover = vi.fn(async () => [
+      group("kimi", [instance(legacy, "path", "1.46.0")]),
+    ]);
+
+    const [record, ...rest] = await discoverLocalAcpAgentRecords({
+      discover,
+      now: () => 4242,
+      readVersionOutput: async () => "kimi, version 1.46.0",
+    });
+
+    expect(rest).toHaveLength(0);
+    expect(record).toMatchObject({
+      backendId: "acp:kimi",
+      installStatus: "unavailable",
+      installedAt: 4242,
+      instances: [],
+      incompatibleInstances: [expect.objectContaining({ command: legacy })],
+      lastError: expect.stringContaining(
+        "Legacy Python kimi-cli v1.46.0 was found",
+      ),
+    });
+    expect(record).not.toHaveProperty("launchDescriptor");
+    expect(record).not.toHaveProperty("runtimeCapabilities");
+  });
+
   it("builds installed-agent records with a resolved launch descriptor", async () => {
     const discover = vi.fn(async () => [
       group("qwen", [

--- a/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
@@ -208,6 +208,12 @@ describe("discoverLocalAcpAgentRecords", () => {
         version: "0.30.0",
       }),
     ).toBe(false);
+    expect(
+      isLegacyPythonKimiCli({
+        output: "0.34.0",
+        version: "0.34.0",
+      }),
+    ).toBe(false);
   });
 
   it("ignores legacy Kimi on PATH and selects a side-by-side Kimi Code install", async () => {

--- a/apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts
@@ -294,6 +294,27 @@ describe("AcpStdioJsonRpcTransport", () => {
     expect(child.killCalled).toBe(true);
   });
 
+  it("reports an unexpected ACP exit with its exit code and stderr", async () => {
+    const child = new MockAcpChildProcess();
+    const transport = new AcpStdioJsonRpcTransport({
+      launchDescriptor: createDescriptor({
+        backendId: "acp:kimi" as AcpBackendId,
+        registryId: "kimi",
+      }),
+      spawn: () => child,
+    });
+
+    const request = transport.request("initialize");
+    await vi.waitFor(() => expect(child.writes).toHaveLength(1));
+    child.stderr.write("\u001b[31mSelected model is no longer available.\u001b[0m\n");
+    child.exitCode = 1;
+    child.emit("close", 1, null);
+
+    await expect(request).rejects.toThrow(
+      "Kimi ACP agent exited unexpectedly (code 1): Selected model is no longer available.",
+    );
+  });
+
   it("waits for ACP exit and escalates when SIGTERM is resisted", async () => {
     vi.useFakeTimers();
     try {

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -901,6 +901,74 @@ describe("settings ipc", () => {
     }
   });
 
+  it("persists legacy Kimi diagnostics without probing or retaining models", async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "pwragent-settings-ipc-"),
+    );
+    tempRoots.push(tempRoot);
+    vi.stubEnv("PWRAGENT_HOME", tempRoot);
+    const legacyPath = "/Users/me/.local/bin/kimi";
+    localAcpDiscoveryMock.discoverLocalAcpAgentRecords.mockResolvedValue([
+      {
+        backendId: "acp:kimi",
+        registryId: "kimi",
+        name: "Kimi Code CLI",
+        version: "1.46.0",
+        distributionKind: "local",
+        distributionSource: `${legacyPath} (legacy kimi-cli ignored)`,
+        installStatus: "unavailable",
+        authStatus: "not-required",
+        verificationStatus: "not-applicable",
+        allowlistRuleId: "local-kimi-cli",
+        installedAt: 1234,
+        updatedAt: 1234,
+        lastError: "Legacy Python kimi-cli was found and ignored.",
+        instances: [],
+        incompatibleInstances: [
+          { command: legacyPath, version: "1.46.0", source: "path" },
+        ],
+      },
+    ]);
+    const { initializeAppState, disposeAppState } = await import(
+      "../state/app-state"
+    );
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const { ACP_AGENTS_LIST_CHANNEL } = await import("../../shared/ipc");
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+      now: () => 20,
+    });
+
+    initializeAppState("bootstrap");
+    try {
+      registerSettingsIpcHandlers(service);
+      const refreshed = (await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.(
+        {},
+        { refresh: true },
+      )) as { entries?: Array<Record<string, unknown>> } | undefined;
+      expect(refreshed?.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            backendId: "acp:kimi",
+            installed: false,
+            installStatus: "unavailable",
+            runtime: undefined,
+            incompatibleInstances: [
+              expect.objectContaining({ command: legacyPath }),
+            ],
+          }),
+        ]),
+      );
+      expect(
+        acpRuntimeDiscoveryMock.discoverAcpRuntimeCapabilities,
+      ).not.toHaveBeenCalled();
+    } finally {
+      disposeAppState();
+    }
+  });
+
   it("passes configured ACP CLI overrides to explicit local discovery refreshes", async () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), "pwragent-settings-ipc-"),

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -448,7 +448,7 @@ export class AcpAgentClient {
         ACP_PROMPT_REQUEST_TIMEOUT_MS,
       );
       result = await promptRequest;
-      this.assertPromptProducedResponse(params.sessionId);
+      this.assertPromptProducedResponse(params.sessionId, result);
     } catch (error) {
       this.finishTrackedTurn(params.sessionId, this.now());
       this.recordPromptFailure(params.sessionId, turnId, error);
@@ -577,8 +577,8 @@ export class AcpAgentClient {
       ACP_PROMPT_REQUEST_TIMEOUT_MS,
     );
     void promptRequest
-      .then(() => {
-        this.assertPromptProducedResponse(params.sessionId);
+      .then((result) => {
+        this.assertPromptProducedResponse(params.sessionId, result);
         const receivedAt = this.now();
         const finished = this.finishTrackedTurn(params.sessionId, receivedAt);
         this.appendHistoryUpdate(params.sessionId, receivedAt, {
@@ -1345,7 +1345,17 @@ export class AcpAgentClient {
     };
   }
 
-  private assertPromptProducedResponse(sessionId: string): void {
+  private assertPromptProducedResponse(
+    sessionId: string,
+    result: unknown,
+  ): void {
+    const resultRecord = asRecord(result);
+    if (
+      resultRecord?.stopReason === "cancelled"
+      || resultRecord?.stop_reason === "cancelled"
+    ) {
+      return;
+    }
     const activeTurn = this.activeTurns.get(sessionId);
     if (activeTurn?.assistantText.trim()) {
       return;

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -448,6 +448,7 @@ export class AcpAgentClient {
         ACP_PROMPT_REQUEST_TIMEOUT_MS,
       );
       result = await promptRequest;
+      this.assertPromptProducedResponse(params.sessionId);
     } catch (error) {
       this.finishTrackedTurn(params.sessionId, this.now());
       this.recordPromptFailure(params.sessionId, turnId, error);
@@ -577,6 +578,7 @@ export class AcpAgentClient {
     );
     void promptRequest
       .then(() => {
+        this.assertPromptProducedResponse(params.sessionId);
         const receivedAt = this.now();
         const finished = this.finishTrackedTurn(params.sessionId, receivedAt);
         this.appendHistoryUpdate(params.sessionId, receivedAt, {
@@ -951,6 +953,16 @@ export class AcpAgentClient {
       if (updateKind === "agent_message_chunk") {
         activeTurn.assistantText += text;
       }
+    } else if (
+      activeTurn
+      && text
+      && !activeTurn.assistantText.trim()
+      && (updateKind === "turn_finished" || updateKind === "turn_completed")
+    ) {
+      // Some ACP agents send the final answer only on the terminal update
+      // instead of streaming agent_message_chunk events. Preserve that valid
+      // response before the session/prompt result is checked for silence.
+      activeTurn.assistantText = text;
     } else if (
       !isAssistantTextUpdate
       && activeTurn
@@ -1331,6 +1343,26 @@ export class AcpAgentClient {
       replay,
       turnId: activeTurn?.turnId,
     };
+  }
+
+  private assertPromptProducedResponse(sessionId: string): void {
+    const activeTurn = this.activeTurns.get(sessionId);
+    if (activeTurn?.assistantText.trim()) {
+      return;
+    }
+
+    const displayName = this.options.agentDisplayName?.trim() || "ACP agent";
+    const version = this.runtimeCapabilities?.agentInfo?.version?.trim();
+    if (this.options.backendId === "acp:kimi") {
+      throw new Error(
+        `${displayName} ended the turn without a response.${
+          version ? ` Kimi Code CLI ${version}` : " This Kimi Code CLI"
+        } may be out of date or incompatible with the selected model. Update Kimi, refresh the model catalog, and try again.`,
+      );
+    }
+    throw new Error(
+      `${displayName} ended the turn without a response. Refresh the provider model catalog and try again.`,
+    );
   }
 
   private recordPromptFailure(

--- a/apps/desktop/src/main/acp/acp-instance-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-instance-discovery.ts
@@ -16,6 +16,8 @@ import {
   type DiscoveredAcpAgentGroup,
   type LocalAcpDiscoveryOptions,
 } from "@pwrdrvr/agent-acp";
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
 import type {
   AcpAgentInstance,
   AcpAgentPreference,
@@ -24,10 +26,14 @@ import type {
 import { resolveActiveAcpInstance } from "./acp-instance-resolver.js";
 import { acpAgentCapabilitiesForRegistryId } from "./acp-agent-capabilities.js";
 import { normalizeAcpLaunchDescriptor } from "./acp-launch-descriptor.js";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env.js";
 import type {
   AcpInstalledAgentRecord,
   AcpRegistryAgent,
 } from "./acp-registry-types.js";
+
+const execFile = promisify(execFileCallback);
+const ACP_IDENTITY_PROBE_TIMEOUT_MS = 2_000;
 
 // Qwen Code 0.21 still supports `--acp`, but no longer advertises that hidden
 // flag in `qwen --help`. The upstream strategy's `--acp` text match therefore
@@ -50,6 +56,8 @@ const ACP_DISCOVERY_STRATEGIES = BUILT_IN_ACP_STRATEGIES.map((strategy) =>
 export type AcpInstanceDiscovery = {
   /** Every installed instance, in candidate order (override → PATH → fallback). */
   instances: AcpAgentInstance[];
+  /** Detected command collisions that are intentionally excluded. */
+  incompatibleInstances?: AcpAgentInstance[];
   /** The instance command currently in effect (override → picked → first). */
   activeCommand?: string;
 };
@@ -67,6 +75,12 @@ export type DiscoverAcpAgentInstancesOptions = {
   discover?: (
     options?: LocalAcpDiscoveryOptions,
   ) => Promise<DiscoveredAcpAgentGroup[]>;
+  /** Injectable raw version-output probe used to distinguish products that
+   *  share one command name (currently legacy Python kimi-cli vs Kimi Code). */
+  readVersionOutput?: (
+    command: string,
+    env: NodeJS.ProcessEnv,
+  ) => Promise<string | undefined>;
 };
 
 /**
@@ -100,20 +114,22 @@ export async function discoverAcpAgentInstances(
 
   const byRegistryId = new Map<string, AcpInstanceDiscovery>();
   for (const group of groups) {
-    const instances: AcpAgentInstance[] = group.instances.map((instance) => ({
-      command: instance.command,
-      ...(instance.version !== undefined ? { version: instance.version } : {}),
-      source: instance.source,
-    }));
-    if (instances.length === 0) {
+    const classified = await classifyGroupInstances(group, options);
+    if (
+      classified.instances.length === 0
+      && classified.incompatibleInstances.length === 0
+    ) {
       continue;
     }
     const active = resolveActiveAcpInstance(
-      instances,
+      classified.instances,
       preferences[group.strategyId],
     );
     byRegistryId.set(group.strategyId, {
-      instances,
+      instances: classified.instances,
+      ...(classified.incompatibleInstances.length > 0
+        ? { incompatibleInstances: classified.incompatibleInstances }
+        : {}),
       ...(active !== undefined ? { activeCommand: active.command } : {}),
     });
   }
@@ -153,19 +169,30 @@ export async function discoverLocalAcpAgentRecords(
 
   const records: AcpInstalledAgentRecord[] = [];
   for (const group of groups) {
-    const instances: AcpAgentInstance[] = group.instances.map((instance) => ({
-      command: instance.command,
-      ...(instance.version !== undefined ? { version: instance.version } : {}),
-      source: instance.source,
-    }));
-    if (instances.length === 0) {
+    const classified = await classifyGroupInstances(group, options);
+    if (
+      classified.instances.length === 0
+      && classified.incompatibleInstances.length === 0
+    ) {
       continue;
     }
     const active = resolveActiveAcpInstance(
-      instances,
+      classified.instances,
       preferences[group.strategyId],
     );
     if (active === undefined) {
+      if (
+        group.strategyId === "kimi"
+        && classified.incompatibleInstances.length > 0
+      ) {
+        records.push(
+          legacyKimiUnavailableRecord({
+            group,
+            incompatibleInstances: classified.incompatibleInstances,
+            now,
+          }),
+        );
+      }
       continue;
     }
     const backendId = group.backendId as AcpBackendId;
@@ -209,11 +236,137 @@ export async function discoverLocalAcpAgentRecords(
       capabilities: acpAgentCapabilitiesForRegistryId(group.strategyId),
       launchDescriptor,
       registryAgent,
-      instances,
+      instances: classified.instances,
+      ...(classified.incompatibleInstances.length > 0
+        ? { incompatibleInstances: classified.incompatibleInstances }
+        : {}),
       activeCommand: active.command,
     });
   }
   return records;
+}
+
+async function classifyGroupInstances(
+  group: DiscoveredAcpAgentGroup,
+  options: DiscoverAcpAgentInstancesOptions | undefined,
+): Promise<{
+  instances: AcpAgentInstance[];
+  incompatibleInstances: AcpAgentInstance[];
+}> {
+  const mapped = group.instances.map((instance) => ({
+    command: instance.command,
+    ...(instance.version !== undefined ? { version: instance.version } : {}),
+    source: instance.source,
+  }));
+  if (group.strategyId !== "kimi") {
+    return { instances: mapped, incompatibleInstances: [] };
+  }
+
+  const env = buildPwrAgentChildProcessEnv(options?.env ?? process.env);
+  const readVersionOutput = options?.readVersionOutput ?? defaultReadVersionOutput;
+  const classifications = await Promise.all(
+    mapped.map(async (instance) => {
+      let output: string | undefined;
+      try {
+        output = await readVersionOutput(instance.command, env);
+      } catch {
+        // The discovery kit already proved the command runnable. If this
+        // identity-only second probe races an install change, retain the parsed
+        // version fallback below instead of dropping a possibly valid agent.
+      }
+      return {
+        instance,
+        legacy: isLegacyPythonKimiCli({ output, version: instance.version }),
+      };
+    }),
+  );
+  return {
+    instances: classifications
+      .filter((entry) => !entry.legacy)
+      .map((entry) => entry.instance),
+    incompatibleInstances: classifications
+      .filter((entry) => entry.legacy)
+      .map((entry) => entry.instance),
+  };
+}
+
+export function isLegacyPythonKimiCli(params: {
+  output?: string;
+  version?: string;
+}): boolean {
+  const output = params.output?.trim() ?? "";
+  if (/^kimi-code(?:\.exe)?\s+v?\d/i.test(output)) {
+    return false;
+  }
+  if (
+    /python version\s*:/i.test(output)
+    || /^kimi(?:-cli)?(?:\s+version\s*:|,\s*version)\s*v?\d/i.test(output)
+  ) {
+    return true;
+  }
+
+  // The current TypeScript Kimi Code line is 0.x; the deprecated Python
+  // kimi-cli line is 1.x. This fallback covers wrappers that suppress the
+  // product prefix while preserving the parsed discovery version.
+  const major = Number.parseInt(params.version?.split(".")[0] ?? "", 10);
+  return Number.isFinite(major) && major >= 1;
+}
+
+async function defaultReadVersionOutput(
+  command: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string | undefined> {
+  const result = await execFile(command, ["--version"], {
+    env,
+    timeout: ACP_IDENTITY_PROBE_TIMEOUT_MS,
+  });
+  const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`.trim();
+  return output || undefined;
+}
+
+function legacyKimiUnavailableRecord(params: {
+  group: DiscoveredAcpAgentGroup;
+  incompatibleInstances: AcpAgentInstance[];
+  now: number;
+}): AcpInstalledAgentRecord {
+  const active = params.incompatibleInstances[0];
+  const strategy = strategyById(params.group.strategyId);
+  const versionLabel = active?.version ? ` v${active.version}` : "";
+  const commandLabel = active?.command ? ` at ${active.command}` : "";
+  const registryAgent: AcpRegistryAgent = {
+    id: params.group.strategyId,
+    backendId: params.group.backendId as AcpBackendId,
+    name: params.group.name,
+    ...(active?.version !== undefined ? { version: active.version } : {}),
+    authors: strategy?.authors ?? [],
+    ...(strategy?.license !== undefined ? { license: strategy.license } : {}),
+    ...(strategy?.repositoryUrl !== undefined
+      ? { repositoryUrl: strategy.repositoryUrl }
+      : {}),
+    distributions: [],
+    distributionKinds: ["local"],
+    auth: { required: false, methods: ["agent-managed"] },
+    raw: { source: "legacy-local-cli" },
+  };
+  return {
+    backendId: params.group.backendId as AcpBackendId,
+    registryId: params.group.strategyId,
+    name: params.group.name,
+    ...(active?.version !== undefined ? { version: active.version } : {}),
+    distributionKind: "local",
+    distributionSource: `${active?.command ?? "kimi"} (legacy kimi-cli ignored)`,
+    installStatus: "unavailable",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+    allowlistRuleId: "local-kimi-cli",
+    installedAt: params.now,
+    updatedAt: params.now,
+    lastError: `Legacy Python kimi-cli${versionLabel} was found${commandLabel} and was ignored. PwrAgent requires the current Kimi Code CLI. Install Kimi Code, then refresh discovery.`,
+    capabilities: acpAgentCapabilitiesForRegistryId(params.group.strategyId),
+    registryAgent,
+    instances: [],
+    incompatibleInstances: params.incompatibleInstances,
+  };
 }
 
 function strategiesForEnabledRegistryIds(

--- a/apps/desktop/src/main/acp/acp-registry-types.ts
+++ b/apps/desktop/src/main/acp/acp-registry-types.ts
@@ -113,5 +113,7 @@ export type AcpInstalledAgentRecord = {
   // discovery, and the one currently in effect (resolved from the user's
   // preference). `launchDescriptor.command` mirrors `activeCommand`.
   instances?: AcpAgentInstance[];
+  /** Detected provider-name collisions that must not be launched. */
+  incompatibleInstances?: AcpAgentInstance[];
   activeCommand?: string;
 };

--- a/apps/desktop/src/main/acp/acp-stdio-transport.ts
+++ b/apps/desktop/src/main/acp/acp-stdio-transport.ts
@@ -23,6 +23,7 @@ import {
 const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 60_000;
 const PROCESS_CLOSE_TIMEOUT_MS = 5_000;
 const PROCESS_FORCE_CLOSE_TIMEOUT_MS = 5_000;
+const STDERR_PREVIEW_LIMIT = 4_000;
 
 const acpTransportLog = getMainLogger("pwragent:acp-transport");
 
@@ -178,6 +179,7 @@ class AcpLineStdioTransport implements JsonRpcTransport {
   private closed = false;
   private closePromise?: Promise<void>;
   private lifecycleGeneration = 0;
+  private stderrPreview = "";
 
   constructor(
     private readonly options: {
@@ -202,6 +204,7 @@ class AcpLineStdioTransport implements JsonRpcTransport {
       return;
     }
     const generation = ++this.lifecycleGeneration;
+    this.stderrPreview = "";
 
     const descriptor = normalizeAcpLaunchDescriptor(this.options.launchDescriptor);
     const env = buildPwrAgentChildProcessEnv(
@@ -250,7 +253,9 @@ class AcpLineStdioTransport implements JsonRpcTransport {
       this.messageHandler(line);
     });
 
-    child.stderr.on("data", () => undefined);
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      this.stderrPreview = appendStderrPreview(this.stderrPreview, String(chunk));
+    });
     child.on("error", (error: Error) => {
       if (this.childProcess === child && child.pid === undefined) {
         this.childProcess = null;
@@ -261,7 +266,18 @@ class AcpLineStdioTransport implements JsonRpcTransport {
       if (this.childProcess === child) {
         this.childProcess = null;
       }
-      this.closeHandler();
+      if (this.closed || generation !== this.lifecycleGeneration) {
+        this.closeHandler();
+        return;
+      }
+      this.closeHandler(
+        unexpectedAcpExitError({
+          code: child.exitCode,
+          descriptor,
+          signal: child.signalCode,
+          stderr: this.stderrPreview,
+        }),
+      );
     });
   }
 
@@ -294,6 +310,54 @@ class AcpLineStdioTransport implements JsonRpcTransport {
     }
     child.stdin.write(`${message}\n`);
   }
+}
+
+function appendStderrPreview(current: string, chunk: string): string {
+  const combined = `${current}${chunk}`;
+  return combined.length <= STDERR_PREVIEW_LIMIT
+    ? combined
+    : combined.slice(combined.length - STDERR_PREVIEW_LIMIT);
+}
+
+function unexpectedAcpExitError(params: {
+  code: number | null;
+  descriptor: AcpLaunchDescriptor;
+  signal: NodeJS.Signals | null;
+  stderr: string;
+}): Error {
+  const agent =
+    params.descriptor.registryId === "kimi"
+      ? "Kimi"
+      : params.descriptor.registryId;
+  const exit = params.signal
+    ? `signal ${params.signal}`
+    : `code ${params.code ?? "unknown"}`;
+  const stderr = stripAnsiControlSequences(params.stderr).trim();
+  return new Error(
+    `${agent} ACP agent exited unexpectedly (${exit})${
+      stderr ? `: ${stderr}` : "."
+    }`,
+  );
+}
+
+function stripAnsiControlSequences(value: string): string {
+  let output = "";
+  for (let index = 0; index < value.length; index += 1) {
+    if (value.charCodeAt(index) !== 27 || value[index + 1] !== "[") {
+      output += value[index];
+      continue;
+    }
+
+    index += 2;
+    while (index < value.length) {
+      const code = value.charCodeAt(index);
+      if (code >= 0x40 && code <= 0x7e) {
+        break;
+      }
+      index += 1;
+    }
+  }
+  return output;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -393,6 +393,14 @@ function normalizeInstalledAcpAgent(
     : { ...agent, runtimeCapabilities };
 }
 
+function isLegacyKimiInstalledRecord(agent: AcpInstalledAgentRecord): boolean {
+  if (agent.registryId !== "kimi") {
+    return false;
+  }
+  const major = Number.parseInt(agent.version?.split(".")[0] ?? "", 10);
+  return Number.isFinite(major) && major >= 1;
+}
+
 function effectiveAcpAgentCapabilities(
   agent: AcpInstalledAgentRecord,
 ): AcpAgentCapabilities {
@@ -1527,21 +1535,50 @@ export class AcpBackendAdapter {
     const installedAgents = (this.acpAgentStore?.listInstalledAgents() ?? [])
       .map(normalizeInstalledAcpAgent)
       .filter((agent) => !isBannedAcpRegistryId(agent.registryId));
-    const installedBackendIds = new Set(
-      installedAgents.map((agent) => agent.backendId),
+    const installedByBackendId = new Map(
+      installedAgents.map((agent) => [agent.backendId, agent]),
     );
     const discoveredAgents = (await this.readLocalAgentsOnce())
       .map(normalizeInstalledAcpAgent)
       .filter((agent) => !isBannedAcpRegistryId(agent.registryId));
-    for (const agent of discoveredAgents) {
-      if (!installedBackendIds.has(agent.backendId)) {
-        this.acpAgentStore?.upsertInstalledAgent(agent);
+    const effectiveDiscoveredAgents = discoveredAgents.flatMap((agent) => {
+      const cached = installedByBackendId.get(agent.backendId);
+      if (cached && !isLegacyKimiInstalledRecord(cached)) {
+        return [];
       }
+      const sameRuntime =
+        agent.installStatus === "installed"
+        && cached?.installStatus === "installed"
+        && cached.version === agent.version
+        && cached.activeCommand === agent.activeCommand;
+      return [{
+        ...agent,
+        installedAt: cached?.installedAt ?? agent.installedAt,
+        ...(sameRuntime && cached?.runtimeCapabilities
+          ? { runtimeCapabilities: cached.runtimeCapabilities }
+          : {}),
+        ...(sameRuntime && cached?.lastDiscoveredAt !== undefined
+          ? { lastDiscoveredAt: cached.lastDiscoveredAt }
+          : {}),
+        ...(sameRuntime && cached?.lastDiscoveryError !== undefined
+          ? { lastDiscoveryError: cached.lastDiscoveryError }
+          : {}),
+      }];
+    });
+    for (const agent of effectiveDiscoveredAgents) {
+      // A known legacy Kimi cache must never outrank fresh local discovery: it
+      // may now resolve to the supported side-by-side install, or to a durable
+      // non-launchable compatibility diagnostic. Other cached providers retain
+      // the existing cache-first behavior.
+      this.acpAgentStore?.upsertInstalledAgent(agent);
     }
+    const discoveredBackendIds = new Set(
+      effectiveDiscoveredAgents.map((agent) => agent.backendId),
+    );
     return [
-      ...installedAgents,
-      ...discoveredAgents.filter(
-        (agent) => !installedBackendIds.has(agent.backendId),
+      ...effectiveDiscoveredAgents,
+      ...installedAgents.filter(
+        (agent) => !discoveredBackendIds.has(agent.backendId),
       ),
     ];
   }

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -349,6 +349,13 @@ async function listInstalledAndLocalAcpAgents(
       const discoveryCwd = await ensureAcpRuntimeDiscoveryWorkspace();
       const now = Date.now();
       for (const record of discovered) {
+        if (record.installStatus !== "installed") {
+          // Compatibility diagnostics (for example a legacy Python kimi-cli)
+          // are durable records but must never inherit the previous usable
+          // runtime/model cache or launch an ACP capability probe.
+          store.upsertInstalledAgent(record);
+          continue;
+        }
         const current = store.getInstalledAgent(record.backendId);
         const nextRecord = {
           ...record,
@@ -541,6 +548,9 @@ function installedAcpAgentSettingsEntry(
     lastDiscoveryError: record.lastDiscoveryError,
     runtime: record.runtimeCapabilities,
     ...(record.instances !== undefined ? { instances: record.instances } : {}),
+    ...(record.incompatibleInstances !== undefined
+      ? { incompatibleInstances: record.incompatibleInstances }
+      : {}),
     ...(record.activeCommand !== undefined
       ? { activeCommand: record.activeCommand }
       : {}),

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import type {
   AcpAgentSettingsEntry,
   DesktopSettingsSnapshot,
@@ -7,9 +7,17 @@ import type {
 import type { DesktopApi } from "../../lib/desktop-api";
 import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
 import { SettingsField, SettingsSection } from "./SettingsLayout";
+import { SettingsCopyValue } from "./SettingsCopyValue";
 import { SettingsPathRow, type SettingsPathRowChip } from "./SettingsPathRow";
 import { SettingsSwitch } from "./SettingsSwitch";
 import { acpStatusLabel } from "./acp-agent-copy";
+
+const KIMI_CODE_INSTALL_GUIDE_URL =
+  "https://www.kimi.com/help/kimi-code/cli-getting-started";
+const KIMI_CODE_INSTALL_COMMAND =
+  "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash";
+const KIMI_CODE_WINDOWS_INSTALL_COMMAND =
+  "irm https://code.kimi.com/kimi-code/install.ps1 | iex";
 
 /** Look up the persisted CLI-path override for an agent by its registry id. */
 function cliPathSnapshotFor(
@@ -108,19 +116,27 @@ export function AcpAgentsSettings(props: {
   return (
     <>
       {entries.map((entry) => (
-        <AcpAgentSection
-          key={entry.backendId}
-          entry={entry}
-          cliPathSnapshot={cliPathSnapshotFor(props.snapshot, entry.registryId)}
-          enabled={enabledSnapshotFor(props.snapshot, entry.registryId)}
-          saving={props.saving}
-          refreshing={refreshing || loading}
-          onCliPathChange={props.onCliPathChange}
-          onEnabledChange={props.onEnabledChange}
-          onRefresh={() => {
-            void refresh(true, true);
-          }}
-        />
+        <Fragment key={entry.backendId}>
+          {entry.registryId === "kimi"
+          && entry.incompatibleInstances?.length ? (
+            <LegacyKimiCompatibilityCard
+              desktopApi={props.desktopApi}
+              entry={entry}
+            />
+          ) : null}
+          <AcpAgentSection
+            entry={entry}
+            cliPathSnapshot={cliPathSnapshotFor(props.snapshot, entry.registryId)}
+            enabled={enabledSnapshotFor(props.snapshot, entry.registryId)}
+            saving={props.saving}
+            refreshing={refreshing || loading}
+            onCliPathChange={props.onCliPathChange}
+            onEnabledChange={props.onEnabledChange}
+            onRefresh={() => {
+              void refresh(true, true);
+            }}
+          />
+        </Fragment>
       ))}
       {!loading && entries.length === 0 ? (
         <SettingsSection
@@ -134,6 +150,92 @@ export function AcpAgentsSettings(props: {
         </SettingsSection>
       ) : null}
     </>
+  );
+}
+
+function LegacyKimiCompatibilityCard(props: {
+  desktopApi?: DesktopApi;
+  entry: AcpAgentSettingsEntry;
+}) {
+  const incompatibleInstances = props.entry.incompatibleInstances ?? [];
+  const hasCurrentKimiCode = props.entry.installed;
+  const installCommand = /Windows/i.test(window.navigator.userAgent)
+    ? KIMI_CODE_WINDOWS_INSTALL_COMMAND
+    : KIMI_CODE_INSTALL_COMMAND;
+
+  return (
+    <SettingsSection
+      eyebrow="Compatibility"
+      title={
+        hasCurrentKimiCode
+          ? "Legacy Python kimi-cli ignored"
+          : "Current Kimi Code required"
+      }
+      sectionId="kimi-compatibility"
+      chip={hasCurrentKimiCode ? "Legacy ignored" : "Action required"}
+      chipKind="warn"
+    >
+      <div className="settings-fields">
+        <SettingsField
+          label="Provider collision"
+          sub={
+            hasCurrentKimiCode
+              ? "PwrAgent found the supported Kimi Code install and will not launch these older Python binaries."
+              : "The detected kimi command is the retired Python kimi-cli. Its ACP models are incompatible with current Kimi Code and are excluded from model discovery."
+          }
+          source={`${incompatibleInstances.length} ignored`}
+          control={
+            <div
+              className="settings-paths"
+              aria-label="Ignored legacy Kimi installs"
+            >
+              {incompatibleInstances.map((instance) => (
+                <SettingsPathRow
+                  key={instance.command}
+                  path={instance.command}
+                  chips={[
+                    { label: "legacy Python", tone: "muted" },
+                    {
+                      label: instance.version
+                        ? `v${instance.version}`
+                        : "version unknown",
+                      tone: "muted",
+                    },
+                  ]}
+                  selected={false}
+                  disabled
+                />
+              ))}
+            </div>
+          }
+        />
+        {!hasCurrentKimiCode ? (
+          <SettingsField
+            label="Install Kimi Code"
+            sub="Install the current TypeScript-based CLI, then click Refresh in the Kimi Code section. PwrAgent also checks the official ~/.kimi-code/bin location automatically."
+            control={
+              <div className="settings-fields">
+                <SettingsCopyValue
+                  value={installCommand}
+                  desktopApi={props.desktopApi}
+                  label="Kimi Code install command"
+                />
+                <div className="settings-inline-actions">
+                  <a
+                    className="button button--secondary"
+                    href={KIMI_CODE_INSTALL_GUIDE_URL}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Open install guide
+                  </a>
+                </div>
+              </div>
+            }
+          />
+        ) : null}
+      </div>
+    </SettingsSection>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -192,6 +192,55 @@ describe("AcpAgentsSettings", () => {
     expect(screen.getByText("Not installed.")).toBeInTheDocument();
   });
 
+  it("renders a durable remediation card for legacy Python kimi-cli", async () => {
+    const legacyPath = "/Users/me/.local/bin/kimi";
+    const desktopApi = {
+      listAcpAgents: vi.fn(async () => ({
+        fetchedAt: 1000,
+        entries: [
+          {
+            backendId: "acp:kimi",
+            registryId: "kimi",
+            name: "Kimi Code CLI",
+            version: "1.46.0",
+            authors: ["Moonshot AI"],
+            distributionKind: "local",
+            distributionSource: `${legacyPath} (legacy kimi-cli ignored)`,
+            installable: false,
+            installed: false,
+            installStatus: "unavailable",
+            authStatus: "not-required",
+            verificationStatus: "not-applicable",
+            instances: [],
+            incompatibleInstances: [
+              { command: legacyPath, version: "1.46.0", source: "path" },
+            ],
+          } satisfies AcpAgentSettingsEntry,
+        ],
+      })),
+    } as unknown as DesktopApi;
+
+    render(<AcpAgentsSettings desktopApi={desktopApi} />);
+
+    expect(
+      await screen.findByText("Current Kimi Code required"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Action required")).toBeInTheDocument();
+    expect(screen.getByText(legacyPath)).toBeInTheDocument();
+    expect(screen.getByText("legacy Python")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open install guide" }),
+    ).toHaveAttribute(
+      "href",
+      "https://www.kimi.com/help/kimi-code/cli-getting-started",
+    );
+  });
+
   it("loads exactly once under StrictMode's double-invoked mount effect", async () => {
     const listAcpAgents = vi.fn(
       async (_request?: { refresh?: boolean; force?: boolean }) => ({

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -269,6 +269,10 @@ export type AcpAgentSettingsEntry = {
   // the one currently in effect, the user's enable toggle, and their path
   // preference. Populated from the kit's `discoverLocalAcpAgentInstances`.
   instances?: AcpAgentInstance[];
+  /** Executables that matched the provider command but belong to an
+   *  unsupported predecessor product. They are shown for remediation but are
+   *  never eligible for launch or model discovery. */
+  incompatibleInstances?: AcpAgentInstance[];
   activeCommand?: string;
   enabled?: boolean;
   preference?: AcpAgentPreference;


### PR DESCRIPTION
## What changed

- identify the retired Python `kimi-cli` separately from the current TypeScript Kimi Code CLI even though both install a `kimi` command and speak ACP
- exclude legacy Python installs from launch and model discovery, while automatically selecting a side-by-side current install such as `~/.kimi-code/bin/kimi`
- persist an unavailable compatibility record that clears the stale model cache and renders a durable Settings card with the ignored path/version, official install command, and Kimi install guide
- replace cached Kimi 1.x records with fresh compatibility discovery before backend summaries are built
- treat an ACP prompt that resolves without assistant output as a failed turn and surface it through the existing in-thread failure activity and sticky backend error toast
- preserve terminal-only ACP responses so valid non-streaming agents are not misclassified
- include exit code or signal plus a bounded, ANSI-cleaned stderr preview when an ACP child exits unexpectedly

## Why

The affected thread used Python `kimi-cli` 1.46.0. That retired product still passed the generic ACP probe and advertised its old `kimi-for-coding` model catalog, so PwrAgent treated it as current Kimi Code. The prompt then completed after about six seconds with zero assistant output. PwrAgent accepted the successful `session/prompt` resolution and discarded child-process stderr, leaving no in-thread result or durable notice.

Current Kimi Code is a different TypeScript product. Its official standalone installer uses `~/.kimi-code/bin/kimi`, while the legacy Python package commonly resolves from a `uv` tool path. Discovery now verifies the product identity from raw `kimi --version` output instead of assuming any ACP-capable `kimi` is supported.

## Impact

Operators with only legacy Python `kimi-cli` see a persistent action-required card instead of stale models. Operators with both products installed automatically use current Kimi Code and see which legacy binary was ignored. If an ACP provider still exits or returns an empty turn, the thread records an actionable failure and the existing sticky backend-error toast appears.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts apps/desktop/src/main/__tests__/settings-ipc.test.ts apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx` (146 tests)
- live legacy discovery probe against Python `kimi-cli` 1.46.0 at `/Users/huntharo/.local/bin/kimi`: unavailable, no launch descriptor, stale models cleared, actionable diagnostic persisted
- live current discovery probe against Kimi Code 0.34.0 at `~/.kimi-code/bin/kimi`: installed, accepted, no incompatible instances or diagnostic
- live runtime discovery returned K2.7 Coding, K2.7 Coding Highspeed, K3, and K3-256k
- two real ACP prompt turns completed after migration/login and after removing `kimi-cli`, with assistant output and zero prompt errors
- `pnpm typecheck`
- targeted ESLint for every changed file
- `pnpm lint:boundaries`
- `git diff --check`