### PR TITLE
fix(desktop): reconcile ACP completion state

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -1407,6 +1407,7 @@ describe("AcpSessionReplayNormalizer", () => {
       "tool_call_delta_chunk",
       "pending_interaction",
       "interaction_resolved",
+      "response_completed",
     ]) {
       normalizer.apply({
         sessionId: "session-1",
@@ -1598,6 +1599,14 @@ describe("AcpSessionReplayNormalizer", () => {
       {
         sessionUpdate: "interaction_resolved",
         tool_call_id: "grep-1",
+      },
+      {
+        sessionUpdate: "response_completed",
+        usage: {
+          input_tokens: 1_200,
+          output_tokens: 50,
+          reasoning_tokens: 10,
+        },
       },
       {
         sessionUpdate: "model_changed",

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -52,6 +52,7 @@ export function isGrokTransientUpdateKind(kind: string | undefined): boolean {
     kind === "tool_call_delta_chunk"
     || kind === "pending_interaction"
     || kind === "interaction_resolved"
+    || kind === "response_completed"
   );
 }
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -6924,6 +6924,148 @@ describe("useThreadSessionState", () => {
     expect(result.current.activeTurnId).toBeUndefined();
   });
 
+  it("rechecks a selected thinking thread when idle has no terminal event", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [],
+        hasPreviousPage: false,
+        threadStatus: "active",
+      }))
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [],
+        hasPreviousPage: false,
+        threadStatus: "idle",
+      }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: {
+          ...buildThread({ id: "thread-1", updatedAt: 1_000 }),
+          threadStatus: "active" as const,
+        },
+      })
+    );
+
+    await waitForThreadHydration(result);
+    act(() => {
+      result.current.setActiveTurnId("turn-1");
+      result.current.setPendingStatusText("Thinking");
+    });
+
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        agentEventHandler?.({
+          backend: "codex",
+          notification: {
+            method: "thread/status/changed",
+            params: {
+              threadId: "thread-1",
+              status: { type: "idle" },
+            },
+          },
+        });
+      });
+
+      expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBe(true);
+
+      await act(async () => {
+        vi.advanceTimersByTime(1_501);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(readThread).toHaveBeenCalledTimes(2);
+      expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears renderer-owned thinking for an unfocused thread that remains idle", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const readThread = vi.fn(async ({ threadId }) =>
+      readThreadResponse({
+        entries: [],
+        hasPreviousPage: false,
+        threadId,
+        threadStatus: "idle",
+      })
+    );
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ currentThread }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: currentThread,
+        }),
+      {
+        initialProps: {
+          currentThread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+        },
+      }
+    );
+
+    await waitForThreadHydration(result);
+    act(() => {
+      result.current.setActiveTurnId("turn-1");
+      result.current.setPendingStatusText("Thinking");
+    });
+    rerender({
+      currentThread: buildThread({ id: "thread-2", updatedAt: 2_000 }),
+    });
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        agentEventHandler?.({
+          backend: "codex",
+          notification: {
+            method: "thread/status/changed",
+            params: {
+              threadId: "thread-1",
+              status: { type: "idle" },
+            },
+          },
+        });
+      });
+
+      expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(1_501);
+      });
+
+      expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
+      expect(readThread).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("shows a transcript status when context compaction starts", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -6998,14 +6998,32 @@ describe("useThreadSessionState", () => {
     let agentEventHandler:
       | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
       | undefined;
-    const readThread = vi.fn(async ({ threadId }) =>
-      readThreadResponse({
-        entries: [],
+    let threadOneReadCount = 0;
+    const readThread = vi.fn(async ({ threadId }) => {
+      const isDurableCompletion =
+        threadId === "thread-1" && ++threadOneReadCount === 2;
+      return readThreadResponse({
+        entries: isDurableCompletion
+          ? [
+              {
+                ...messageEntry({
+                  createdAt: 3_000,
+                  id: "assistant-final",
+                  text: "Durable final response.",
+                }),
+                phase: "final" as const,
+                turn: {
+                  id: "turn-1",
+                  status: "completed" as const,
+                },
+              },
+            ]
+          : [],
         hasPreviousPage: false,
         threadId,
         threadStatus: "idle",
-      })
-    );
+      });
+    });
     const desktopApi: DesktopApi = {
       onAgentEvent: (callback) => {
         agentEventHandler = callback;
@@ -7064,6 +7082,16 @@ describe("useThreadSessionState", () => {
     } finally {
       vi.useRealTimers();
     }
+
+    rerender({
+      currentThread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+    });
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+      expect(result.current.messages.map((message) => message.text)).toContain(
+        "Durable final response."
+      );
+    });
   });
 
   it("shows a transcript status when context compaction starts", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -4252,6 +4252,62 @@ export function useThreadSessionState(params: {
   }, [loadLatest, sessions, thread, threadKey, updateSession]);
 
   useEffect(() => {
+    const timers = Object.entries(sessions).flatMap(
+      ([sessionThreadKey, session]) => {
+        if (
+          sessionThreadKey === threadKey
+          || typeof session.staleThinkingRecheckAt !== "number"
+        ) {
+          return [];
+        }
+
+        const recheckAt = session.staleThinkingRecheckAt;
+        return [
+          setTimeout(() => {
+            updateSession(sessionThreadKey, (current) => {
+              if (
+                current.staleThinkingRecheckAt !== recheckAt
+                || current.backendReportedActive
+                || hasPendingInteraction(current)
+              ) {
+                return current;
+              }
+
+              // Unfocused threads do not have a NavigationThreadSummary to
+              // feed through loadLatest(). Once the backend has remained idle
+              // for the completion grace, clear only renderer-owned live
+              // state. Durable transcript entries hydrate when the thread is
+              // next selected.
+              const settled = settleTransientMessage(current);
+              return {
+                ...settled,
+                activeTurnId: undefined,
+                activeTurnStartedAt: undefined,
+                backendReportedActive: false,
+                completionHydrationRetries: 0,
+                expectOwnUpdate: false,
+                needsHydrationAfterCompletion: false,
+                optimisticEntries: settled.optimisticEntries.filter(
+                  (entry) => !isLiveOptimisticEntry(entry)
+                ),
+                pendingAssistantMessage: undefined,
+                pendingStatusText: undefined,
+                staleThinkingRecheckAt: undefined,
+              };
+            });
+          }, Math.max(0, recheckAt - Date.now()) + 1),
+        ];
+      }
+    );
+
+    return () => {
+      for (const timer of timers) {
+        clearTimeout(timer);
+      }
+    };
+  }, [sessions, threadKey, updateSession]);
+
+  useEffect(() => {
     if (!desktopApi?.onAgentEvent) {
       return;
     }
@@ -5198,11 +5254,15 @@ export function useThreadSessionState(params: {
           }
 
           if (statusType === "idle") {
-            if (current.activeTurnId || current.pendingStatusText) {
+            const shouldRecheckStaleThinking =
+              hasThinkingState(current) && !hasPendingInteraction(current);
+            if (shouldRecheckStaleThinking) {
               return {
                 ...current,
                 backendReportedActive: false,
                 lastTouchedAt: nextLastTouchedAt,
+                staleThinkingRecheckAt:
+                  nextLastTouchedAt + OWN_UPDATE_IDLE_GRACE_MS,
               };
             }
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -4286,7 +4286,8 @@ export function useThreadSessionState(params: {
                 backendReportedActive: false,
                 completionHydrationRetries: 0,
                 expectOwnUpdate: false,
-                needsHydrationAfterCompletion: false,
+                hydratedUpdatedAt: undefined,
+                needsHydrationAfterCompletion: true,
                 optimisticEntries: settled.optimisticEntries.filter(
                   (entry) => !isLiveOptimisticEntry(entry)
                 ),


### PR DESCRIPTION
## Summary

- treat Grok `response_completed` notifications as transient transport/usage metadata instead of expandable transcript activity
- schedule stale-thinking reconciliation when an idle backend status arrives without a matching terminal event
- clear renderer-owned live state for unfocused idle threads after the existing completion grace, while selected threads perform an authoritative transcript re-read

## Root cause

Grok 0.2.118 emitted `response_completed` once per model response before subsequent tool calls, so it is not a turn terminal. PwrAgent preserved the unknown update as an expandable activity whose only detail was the placeholder `Unknown ACP session update`.

A later provider-owned child-result follow-up streamed activity without a PwrAgent `turn/started` or turn id. Its final idle status therefore had no matching normalized `turn/completed`. The renderer intentionally retained thinking state across an early idle boundary, but did not schedule its existing stale-state reconciliation fallback, leaving the thread-list scanner active until another refresh or hydration.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx` (152 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
