### PR TITLE
fix(desktop): star map design-review polish

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -12,6 +12,7 @@ import type {
   NavigationThreadSummary,
 } from "@pwragent/shared";
 import { CelestialIcon } from "../../icons";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
   CompactComposer,
   type CompactComposerAction,
@@ -70,6 +71,9 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     props;
   const dragRef = useRef<DragState | undefined>(undefined);
   const [sendError, setSendError] = useState<string | undefined>(undefined);
+  // The card is draggable and clipped; a native `title` fights both, and
+  // UI-THEME.md rules it out regardless.
+  const titleTooltip = useViewportTooltip({ className: "viewport-tooltip" });
 
   const session = useThreadSessionState({ desktopApi, thread });
 
@@ -286,7 +290,13 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             <CelestialIcon icon={props.instanceIcon} size={72} />
           </span>
         ) : null}
-        <span className="star-map-chat-card__title" title={thread.title}>
+        <span
+          className="star-map-chat-card__title"
+          onMouseEnter={(event) =>
+            titleTooltip.show(event.currentTarget, thread.title)
+          }
+          onMouseLeave={titleTooltip.hide}
+        >
           {thread.title}
         </span>
         {props.instanceLabel ? (
@@ -353,6 +363,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         threadTitle={thread.title}
       />
 
+      {titleTooltip.tooltipNode}
       <span
         aria-hidden="true"
         className="star-map-chat-card__resize"

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapInstanceCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapInstanceCard.tsx
@@ -1,5 +1,6 @@
 import type { CelestialIconId, FederationConnectionState } from "@pwragent/shared";
 import { CelestialIcon } from "../../icons";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 
 function statusTone(status: FederationConnectionState): string {
   switch (status) {
@@ -44,6 +45,9 @@ export function StarMapInstanceCard(props: {
   // Display stacks the two lines to stay narrow, but every accessible name
   // has to keep the profile inline: two instances on one machine would
   // otherwise expose identical button names.
+  // Native `title` is an anti-pattern here (UI-THEME.md): unstyleable,
+  // platform-dependent timing, no wrapping on macOS Electron.
+  const labelTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const fullLabel = props.profileName
     ? `${props.label} / ${props.profileName}`
     : props.label;
@@ -83,7 +87,10 @@ export function StarMapInstanceCard(props: {
       <span className="star-map-instance__row">
         <span
           className="star-map-instance__label"
-          title={fullLabel}
+          onMouseEnter={(event) =>
+            labelTooltip.show(event.currentTarget, fullLabel)
+          }
+          onMouseLeave={labelTooltip.hide}
         >
           <span className="star-map-instance__machine">{props.label}</span>
           {props.profileName ? (
@@ -106,6 +113,7 @@ export function StarMapInstanceCard(props: {
       {props.unreachable ? (
         <span className="star-map-instance__unreachable">Unreachable</span>
       ) : null}
+      {labelTooltip.tooltipNode}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapProjectBody.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapProjectBody.tsx
@@ -6,19 +6,29 @@
  * machine. Its threads come from every instance in the federation, which
  * is the whole point of the lens.
  */
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
+
 export function StarMapProjectBody(props: {
   label: string;
   projectKey: string;
   threadCount: number;
 }) {
+  const labelTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   return (
     <div className="star-map-project" data-project-key={props.projectKey}>
       <span className="star-map-project__glow" aria-hidden="true" />
       <span className="star-map-project__core" aria-hidden="true" />
-      <span className="star-map-project__label" title={props.label}>
+      <span
+        className="star-map-project__label"
+        onMouseEnter={(event) =>
+          labelTooltip.show(event.currentTarget, props.label)
+        }
+        onMouseLeave={labelTooltip.hide}
+      >
         <span className="star-map-project__name">{props.label}</span>
         <span className="star-map-project__count">{props.threadCount}</span>
       </span>
+      {labelTooltip.tooltipNode}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -349,6 +349,19 @@ export function StarMapScreen(props: StarMapScreenProps) {
       });
     };
   }, [eventSubscriptionsJson, props.desktopApi]);
+  /**
+   * Instances the view option is suppressing. Their threads are never
+   * fetched — `useStarMapThreads` only sees the filtered peer list — so
+   * an empty map caused by this setting cannot be detected by counting
+   * threads. The count of hidden bodies is what we can honestly report.
+   */
+  const hiddenInstanceCount = useMemo(() => {
+    if (!preferences.hideOfflineInstances) return 0;
+    return (health?.peers ?? []).filter(
+      (peer) => peer.status !== "revoked" && peer.status !== "connected",
+    ).length;
+  }, [health, preferences.hideOfflineInstances]);
+
   const remote = useStarMapThreads({
     desktopApi: props.desktopApi,
     peers,
@@ -463,6 +476,14 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const clearFilters = useCallback(() => {
     setFilterSelection({});
     writeStoredFilterSelection({});
+  }, []);
+
+  const showOfflineInstances = useCallback(() => {
+    setPreferences((current) => {
+      const next = { ...current, hideOfflineInstances: false };
+      writeStoredPreferences(next);
+      return next;
+    });
   }, []);
 
   // Chip counts answer "how many cards is this chip about", measured
@@ -1389,16 +1410,45 @@ export function StarMapScreen(props: StarMapScreenProps) {
           onResetView={panZoomMode ? resetView : undefined}
         />
       </div>
-      {matchedThreadCount === 0 && hasFilterSelection ? (
+      {/* Two different settings can empty the map, and a blank star field
+          looks identical either way. Name whichever one is responsible —
+          and say nothing at all when the fleet is simply idle, because
+          blaming a setting the operator did not touch is worse than
+          silence. */}
+      {matchedThreadCount === 0 && (hasFilterSelection || hiddenInstanceCount > 0) ? (
         <div className="star-map__empty" role="status">
-          <p className="star-map__empty-title">No threads match these filters</p>
-          <button
-            type="button"
-            className="star-map__empty-action"
-            onClick={clearFilters}
-          >
-            Clear filters
-          </button>
+          <p className="star-map__empty-title">
+            {hasFilterSelection
+              ? "No threads match these filters"
+              : "No threads on the visible instances"}
+          </p>
+          {hiddenInstanceCount > 0 ? (
+            <p className="star-map__empty-detail">
+              {hiddenInstanceCount === 1
+                ? "1 offline instance is hidden"
+                : `${hiddenInstanceCount} offline instances are hidden`}
+            </p>
+          ) : null}
+          <span className="star-map__empty-actions">
+            {hasFilterSelection ? (
+              <button
+                type="button"
+                className="star-map__empty-action"
+                onClick={clearFilters}
+              >
+                Clear filters
+              </button>
+            ) : null}
+            {hiddenInstanceCount > 0 ? (
+              <button
+                type="button"
+                className="star-map__empty-action"
+                onClick={showOfflineInstances}
+              >
+                Show offline instances
+              </button>
+            ) : null}
+          </span>
         </div>
       ) : null}
       <div className="star-map__filters" role="group" aria-label="Thread filters">

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -445,6 +445,26 @@ export function StarMapScreen(props: StarMapScreenProps) {
     [projects],
   );
 
+  /**
+   * A filtered-to-nothing map is otherwise indistinguishable from a
+   * broken or still-loading one: the star field renders, and every card
+   * is simply absent. The operator needs to be told it was their filter.
+   */
+  const matchedThreadCount = useMemo(
+    () =>
+      [...attentionByInstance.values()].reduce(
+        (total, threads) => total + threads.length,
+        0,
+      ),
+    [attentionByInstance],
+  );
+  const hasFilterSelection = Object.keys(filterSelection).length > 0;
+
+  const clearFilters = useCallback(() => {
+    setFilterSelection({});
+    writeStoredFilterSelection({});
+  }, []);
+
   // Chip counts answer "how many cards is this chip about", measured
   // against whatever the other facets already allow.
   const filterCounts = useMemo(() => {
@@ -1369,6 +1389,18 @@ export function StarMapScreen(props: StarMapScreenProps) {
           onResetView={panZoomMode ? resetView : undefined}
         />
       </div>
+      {matchedThreadCount === 0 && hasFilterSelection ? (
+        <div className="star-map__empty" role="status">
+          <p className="star-map__empty-title">No threads match these filters</p>
+          <button
+            type="button"
+            className="star-map__empty-action"
+            onClick={clearFilters}
+          >
+            Clear filters
+          </button>
+        </div>
+      ) : null}
       <div className="star-map__filters" role="group" aria-label="Thread filters">
         {STAR_MAP_FILTERS.map((definition) => {
           const state = filterState(filterSelection, definition.key);
@@ -1407,6 +1439,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
             </button>
           );
         })}
+        {hasFilterSelection ? (
+          <button
+            type="button"
+            className="star-map__filter-clear"
+            onClick={clearFilters}
+          >
+            Clear
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -6,6 +6,7 @@ import {
 } from "@pwragent/shared";
 import { CelestialIcon } from "../../icons";
 import { PrChip } from "../pr-status/PrChip";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
   StarMapCardMenu,
   type StarMapCardMenuAction,
@@ -87,6 +88,10 @@ export function StarMapThreadCard(props: {
   // Set while a pointer-drag exceeded the threshold, so the click that the
   // browser fires on release does not also open the thread.
   const suppressClickRef = useRef(false);
+  // Cards live inside the clipped, transformed canvas, and a native
+  // `title` cannot be styled, times out differently per platform, and
+  // does not wrap on macOS Electron — see UI-THEME.md.
+  const titleTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const left = props.baseSlot.dx + (props.offset?.dx ?? 0);
   const top = props.baseSlot.dy + (props.offset?.dy ?? 0);
   const style: CSSProperties = {
@@ -205,7 +210,13 @@ export function StarMapThreadCard(props: {
           }}
         >
           <ThreadRowStatus status={status} />
-          <span className="star-map-card__title" title={thread.title}>
+          <span
+            className="star-map-card__title"
+            onMouseEnter={(event) =>
+              titleTooltip.show(event.currentTarget, thread.title)
+            }
+            onMouseLeave={titleTooltip.hide}
+          >
             {thread.title}
           </span>
         </button>

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -5,7 +5,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { StarMapScreen } from "../StarMapScreen";
@@ -66,6 +66,15 @@ function unreadThread(id: string): NavigationThreadSummary {
 }
 
 describe("StarMapScreen", () => {
+  // Filter selection and view preferences both persist to localStorage,
+  // so without this a test that clicks a chip silently changes the
+  // starting state of every test after it.
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filters");
+  });
+
   // Mirrors the sidebar row's invariant (see thread-row-chips.test.tsx):
   // the chips carry real buttons, so nesting them inside the card's own
   // button is `nested-interactive` — invalid and unoperable.
@@ -697,7 +706,7 @@ describe("StarMapScreen", () => {
 
       // The fixture's linked directory is /tmp/pwrsnap, so the sun is the
       // repo folder rather than the worktree label.
-      const sun = await screen.findByTitle("pwrsnap");
+      const sun = await screen.findByText("pwrsnap");
       expect(sun).toBeTruthy();
 
       const card = starMapCard(
@@ -890,5 +899,83 @@ describe("StarMapScreen", () => {
       screen.getByRole("button", { name: "Actions for Thread t1" }),
     );
     expect(screen.queryByRole("menuitem", { name: "Reset position" })).toBeNull();
+  });
+
+  it("explains an empty map rather than showing a blank star field", async () => {
+    render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[unreadThread("t9")]}
+        sessionKeys={{}}
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    const filterRow = screen.getByRole("group", { name: "Thread filters" });
+    // Exclude the only reason this card is on the map.
+    const unread = () =>
+      within(filterRow).getByRole("button", { name: /^Unread:/ });
+    fireEvent.click(unread());
+    fireEvent.click(unread());
+
+    expect(
+      screen.queryByRole("button", { name: /Open thread: Thread t9/ }),
+    ).toBeNull();
+    // Without this the operator cannot tell a filtered map from a broken
+    // one: the star field renders either way.
+    const status = await screen.findByRole("status");
+    expect(status.textContent).toMatch(/No threads match these filters/);
+  });
+
+  it("offers a way back from any selection", async () => {
+    render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[unreadThread("t10")]}
+        sessionKeys={{}}
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    const filterRow = screen.getByRole("group", { name: "Thread filters" });
+    // Nothing to clear yet, so the affordance stays out of the strip.
+    expect(
+      within(filterRow).queryByRole("button", { name: "Clear" }),
+    ).toBeNull();
+
+    fireEvent.click(
+      within(filterRow).getByRole("button", { name: /^Unread:/ }),
+    );
+    fireEvent.click(within(filterRow).getByRole("button", { name: "Clear" }));
+
+    expect(
+      within(filterRow).queryByRole("button", { name: "Clear" }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /Open thread: Thread t10/ }),
+    ).toBeTruthy();
+  });
+
+  it("does not claim an unfiltered empty map is a filter problem", async () => {
+    // A fleet with nothing to show is a different state; blaming the
+    // filters there would be a lie.
+    render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[]}
+        sessionKeys={{}}
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    expect(screen.queryByRole("status")).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -978,4 +978,82 @@ describe("StarMapScreen", () => {
     );
     expect(screen.queryByRole("status")).toBeNull();
   });
+
+  it("names hidden instances when they are what emptied the map", async () => {
+    // Hidden peers are never fetched, so their threads cannot be counted.
+    // Without naming the setting, the map looks identical to an idle
+    // fleet — the same ambiguity the filter message exists to remove.
+    window.localStorage.setItem(
+      "pwragent.starMap.viewPreferences",
+      JSON.stringify({ hideOfflineInstances: true }),
+    );
+    const desktopApi = {
+      readFederationHealth: vi.fn(async () => ({
+        health: {
+          enabled: true,
+          role: "gateway" as const,
+          status: "listening" as const,
+          instanceId: "pwr_local",
+          localCelestialIcon: "sun" as const,
+          localLabel: "Harold-MBP-M5-Max",
+          localProfileName: "default",
+          peers: [
+            {
+              id: "pwr_peer",
+              label: "M4 Mini",
+              role: "client" as const,
+              status: "disconnected" as const,
+              capabilities: [],
+            },
+          ],
+        },
+      })),
+      onAgentEvent: vi.fn(() => () => undefined),
+    } as unknown as DesktopApi;
+
+    render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[]}
+        sessionKeys={{}}
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    const status = await screen.findByRole("status");
+    expect(status.textContent).toMatch(/No threads on the visible instances/);
+    expect(status.textContent).toMatch(/1 offline instance is hidden/);
+
+    fireEvent.click(
+      within(status).getByRole("button", { name: "Show offline instances" }),
+    );
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+  });
+
+  it("stays silent when an idle fleet is genuinely empty", async () => {
+    // No filters, nothing hidden — there is no setting to blame, and
+    // inventing one would be worse than saying nothing.
+    render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[]}
+        sessionKeys={{}}
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Open this instance/ }),
+      ).toBeTruthy();
+    });
+    expect(screen.queryByRole("status")).toBeNull();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -130,6 +130,7 @@ describe("star map view stability", () => {
   // Layout preference is global; leaking it reorders unrelated suites.
   afterEach(() => {
     window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
   });
 
   it("keeps the operator's pan when a card is archived away (orbit)", async () => {
@@ -236,7 +237,7 @@ describe("star map view stability", () => {
     seedLayout("projects");
     renderMap({ threads: threads(9) });
     await waitFor(() => {
-      expect(screen.getByTitle("PwrSnap")).toBeTruthy();
+      expect(screen.getByText("PwrSnap")).toBeTruthy();
     });
 
     const before = canvas().style.transform;
@@ -248,7 +249,7 @@ describe("star map view stability", () => {
     seedLayout("projects");
     const { rerender } = renderMap({ threads: threads(9) });
     await waitFor(() => {
-      expect(screen.getByTitle("PwrSnap")).toBeTruthy();
+      expect(screen.getByText("PwrSnap")).toBeTruthy();
     });
 
     pan(-300, -200);
@@ -289,6 +290,7 @@ describe("star map view stability", () => {
 describe("star map view bounds", () => {
   afterEach(() => {
     window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
   });
 
   async function openOrbit() {
@@ -381,7 +383,7 @@ describe("star map view bounds", () => {
     seedLayout("projects");
     renderMap({ threads: threads(9) });
     await waitFor(() => {
-      expect(screen.getByTitle("PwrSnap")).toBeTruthy();
+      expect(screen.getByText("PwrSnap")).toBeTruthy();
     });
     const box = canvasBox();
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9135,10 +9135,15 @@ textarea,
   /* Calmer at rest than it was: the cards are the content and the bodies
      are organisation, so the bodies must not out-shout them. The glow
      comes back up on hover, where it is answering the pointer rather
-     than competing for it. */
+     than competing for it.
+
+     Opacity carries the whole reduction (~0.69 of the former) and the
+     accent share stays put. Dropping both together compounded to 44% of
+     the original intensity, which risks trading "calm" for "cannot find
+     my instances" — the opposite failure. */
   background: radial-gradient(
     circle,
-    color-mix(in srgb, var(--accent) 11%, transparent),
+    color-mix(in srgb, var(--accent) 17%, transparent),
     transparent 70%
   );
   opacity: 0.55;
@@ -10111,7 +10116,7 @@ textarea,
   z-index: 20;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   padding: 18px 22px;
   transform: translate(-50%, -50%);
   border: 1px solid var(--border-subtle);
@@ -10124,6 +10129,18 @@ textarea,
   margin: 0;
   color: var(--text-secondary);
   font-size: 13px;
+}
+
+.star-map__empty-detail {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.star-map__empty-actions {
+  display: inline-flex;
+  gap: 8px;
+  margin-top: 2px;
 }
 
 .star-map__empty-action {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9132,18 +9132,22 @@ textarea,
   position: absolute;
   inset: -12%;
   border-radius: 999px;
+  /* Calmer at rest than it was: the cards are the content and the bodies
+     are organisation, so the bodies must not out-shout them. The glow
+     comes back up on hover, where it is answering the pointer rather
+     than competing for it. */
   background: radial-gradient(
     circle,
-    color-mix(in srgb, var(--accent) 17%, transparent),
+    color-mix(in srgb, var(--accent) 11%, transparent),
     transparent 70%
   );
-  opacity: 0.8;
+  opacity: 0.55;
   transition: opacity 160ms ease, transform 160ms ease;
   pointer-events: none;
 }
 
 .star-map-instance__body:hover .star-map-instance__glow {
-  opacity: 1;
+  opacity: 0.95;
   transform: scale(1.12);
 }
 
@@ -10078,6 +10082,58 @@ textarea,
 .star-map__filter-chip:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
+}
+
+/* Clearing is only offered when there is something to clear, so it never
+   sits in the strip as dead weight. */
+.star-map__filter-clear {
+  padding: 4px 10px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.star-map__filter-clear:hover {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+/* A map filtered down to nothing otherwise looks broken rather than
+   empty: the star field renders and the cards are simply absent. */
+.star-map__empty {
+  display: flex;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 20;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 18px 22px;
+  transform: translate(-50%, -50%);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-panel) 88%, transparent);
+  text-align: center;
+}
+
+.star-map__empty-title {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.star-map__empty-action {
+  padding: 5px 12px;
+  border: 1px solid var(--accent-border);
+  border-radius: 6px;
+  background: var(--accent-soft);
+  color: var(--text-primary);
+  font-size: 11px;
+  cursor: pointer;
 }
 
 /* How many cards this chip speaks for, given the other facets. */


### PR DESCRIPTION
Three findings from a design pass over the star map, stacked on #1333.

## 1. A filtered-to-nothing map looked broken 🔴

The star field renders either way and the cards are simply absent, so an over-narrow filter was indistinguishable from a failed load or a hung fetch. It now says so and offers the way out.

Scoped to *"there is a selection"* — a fleet with genuinely nothing to show is a different state, and blaming the filters there would be a lie. There's a test for that distinction.

## 2. No way back from a selection 🟡

With seven tri-state chips, returning to neutral cost up to **fourteen** clicks. A **Clear** affordance now appears in the strip, but only while something is selected, so it never sits there as dead weight.

## 3. The chrome out-shouted the content 🟡

Instance bodies carried more luminance than the cards they organise — an inverted hierarchy, since the cards are what you came to read. Their resting glow drops from `0.8` / 17% accent to `0.55` / 11%, and comes back up on hover where it answers the pointer instead of competing with it.

This brings instances in line with the project cores, which already got the quieter treatment — and is why the projects lens had started looking calmer than orbit.

## Plus: the last four native tooltips

`UI-THEME.md` names `title=` as an anti-pattern *by name* — unstyleable, platform-dependent timing, no wrapping on macOS Electron, which is exactly the target. The codebase already ships `useViewportTooltip` for it. All four star map uses migrated; the feature now has none.

## Note on the tests

The screen tests now clear star map localStorage between cases. Filter selection and view preferences both persist, so a test that clicked a chip was silently changing the starting state of every test after it. Two of the new cases failed on their first run for exactly this reason — worth knowing the isolation gap was already latent for view preferences before this PR added a second persisted key.

## Deliberately not done

`UI-THEME.md` also lists "decorative glows" as an anti-pattern, which the whole celestial metaphor is built on. I'd argue that rule is written for utility surfaces and the star map is a deliberate exception — but it should be **written down** as a scoped exception rather than left as an undocumented contradiction. Not doing that unilaterally in a polish PR.

## Verification

Full suite **6,951 passing**, typecheck clean, `lint:colors`, `lint:boundaries`, ESLint 0 errors. 3 new screen tests covering the empty state, the clear affordance, and the unfiltered-empty distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)