### PR TITLE
feat(desktop): notify when Grok CLI updates are available

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import type {
+  AcpAgentUpdateStatus,
   AcpBackendId,
   AgentEvent,
   AppServerPendingRequestNotification,
@@ -1803,6 +1804,156 @@ describe("AcpBackendAdapter", () => {
 
     await adapter.describeInstalledBackends();
     expect(updateCheck).toHaveBeenCalledOnce();
+    await adapter.close();
+  });
+
+  it.each([
+    {
+      change: "selected command",
+      installedVersion: "0.2.118",
+      command: "/new/grok",
+      previousCommand: "/old/grok",
+    },
+    {
+      change: "installed version",
+      installedVersion: "1.0.0",
+      command: "/opt/grok",
+      previousCommand: "/opt/grok",
+    },
+  ])("does not reuse update state after a $change change", async ({
+    installedVersion,
+    command,
+    previousCommand,
+  }) => {
+    const backendId = "acp:grok" as AcpBackendId;
+    let stored: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+      version: installedVersion,
+      activeCommand: command,
+      update: {
+        status: "available",
+        checkedAt: 100,
+        currentVersion: "0.2.118",
+        latestVersion: "1.0.0",
+      },
+      updateCommand: previousCommand,
+    };
+    const updateCheck = vi.fn(async (
+      _command: string,
+      options?: {
+        installedVersion?: string;
+        previous?: AcpAgentUpdateStatus;
+      },
+    ): Promise<AcpAgentUpdateStatus> => ({
+      status: "failed",
+      checkedAt: 500,
+      currentVersion: options?.installedVersion ?? "unknown",
+      error: "offline",
+    }));
+    const emit = vi.fn(async () => undefined);
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => stored,
+        listInstalledAgents: () => [stored],
+        upsertInstalledAgent: (record) => {
+          stored = record;
+        },
+      },
+      captureStores: [],
+      checkGrokCliUpdate: updateCheck,
+      discoverLocalAcpAgents: async () => [],
+      emit,
+      handleServerRequest: async () => ({ decision: "accept" }),
+      isAcpAgentEnabled: () => true,
+    });
+
+    await adapter.describeInstalledBackends();
+    await vi.waitFor(() => {
+      expect(emit).toHaveBeenCalledOnce();
+    });
+
+    expect(updateCheck).toHaveBeenCalledWith(command, {
+      installedVersion,
+      previous: undefined,
+    });
+    expect(stored.version).toBe(installedVersion);
+    expect(stored.update).toMatchObject({
+      status: "failed",
+      currentVersion: installedVersion,
+      error: "offline",
+    });
+    await adapter.close();
+  });
+
+  it("preserves an acknowledgement committed while an update check runs", async () => {
+    const backendId = "acp:grok" as AcpBackendId;
+    let stored: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+      version: "0.2.118",
+      activeCommand: "/opt/grok",
+      update: {
+        status: "available",
+        checkedAt: 100,
+        currentVersion: "0.2.118",
+        latestVersion: "1.0.0",
+      },
+      updateCommand: "/opt/grok",
+    };
+    let finishUpdate: ((update: AcpAgentUpdateStatus) => void) | undefined;
+    const updateCheck = vi.fn(async () =>
+      await new Promise<AcpAgentUpdateStatus>((resolve) => {
+        finishUpdate = resolve;
+      }),
+    );
+    const emit = vi.fn(async () => undefined);
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => stored,
+        listInstalledAgents: () => [stored],
+        upsertInstalledAgent: (record) => {
+          stored = record;
+        },
+      },
+      captureStores: [],
+      checkGrokCliUpdate: updateCheck,
+      discoverLocalAcpAgents: async () => [],
+      emit,
+      handleServerRequest: async () => ({ decision: "accept" }),
+      isAcpAgentEnabled: () => true,
+    });
+
+    await adapter.describeInstalledBackends();
+    await vi.waitFor(() => {
+      expect(updateCheck).toHaveBeenCalledOnce();
+    });
+    stored = {
+      ...stored,
+      update: {
+        ...stored.update!,
+        dismissedAt: 400,
+      },
+    };
+    finishUpdate?.({
+      status: "available",
+      checkedAt: 500,
+      currentVersion: "0.2.118",
+      latestVersion: "1.0.0",
+    });
+    await vi.waitFor(() => {
+      expect(emit).toHaveBeenCalledOnce();
+    });
+
+    expect(stored.update).toMatchObject({
+      checkedAt: 500,
+      latestVersion: "1.0.0",
+      dismissedAt: 400,
+    });
     await adapter.close();
   });
 

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1747,6 +1747,65 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
+  it("checks Grok updates in the background and persists one daily result", async () => {
+    const backendId = "acp:grok" as AcpBackendId;
+    let stored: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+      version: "0.2.118",
+      activeCommand: "/opt/grok",
+    };
+    const upsertInstalledAgent = vi.fn((record: AcpInstalledAgentRecord) => {
+      stored = record;
+    });
+    const updateCheck = vi.fn(async () => ({
+      status: "available" as const,
+      checkedAt: Date.now(),
+      currentVersion: "0.2.118",
+      latestVersion: "1.0.0",
+      channel: "stable",
+    }));
+    const emit = vi.fn(async () => undefined);
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => stored,
+        listInstalledAgents: () => [stored],
+        upsertInstalledAgent,
+      },
+      captureStores: [],
+      checkGrokCliUpdate: updateCheck,
+      discoverLocalAcpAgents: async () => [],
+      emit,
+      handleServerRequest: async () => ({ decision: "accept" }),
+      isAcpAgentEnabled: () => true,
+    });
+
+    const [summary] = await adapter.describeInstalledBackends();
+    expect(summary?.kind).toBe(backendId);
+    expect(updateCheck).toHaveBeenCalledOnce();
+    await vi.waitFor(() => {
+      expect(emit).toHaveBeenCalledWith({
+        backend: backendId,
+        notification: {
+          method: "backend/acpUpdateStatus/updated",
+          params: { backend: backendId },
+        },
+      });
+    });
+    expect(upsertInstalledAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ latestVersion: "1.0.0" }),
+        updateCommand: "/opt/grok",
+      }),
+    );
+
+    await adapter.describeInstalledBackends();
+    expect(updateCheck).toHaveBeenCalledOnce();
+    await adapter.close();
+  });
+
   it("registers the agent-tool HTTP MCP from initialize capabilities", async () => {
     const backendId = "acp:kimi" as AcpBackendId;
     const transport = new FakeAcpAgentTransport({

--- a/apps/desktop/src/main/__tests__/grok-cli-update.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-cli-update.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  checkGrokCliUpdate,
+  GROK_UPDATE_FAILURE_TTL_MS,
+  GROK_UPDATE_SUCCESS_TTL_MS,
+  shouldCheckGrokCliUpdate,
+} from "../acp/grok-cli-update";
+
+describe("checkGrokCliUpdate", () => {
+  it("normalizes the official JSON status and preserves same-version acknowledgement", async () => {
+    const probe = vi.fn(async () => ({
+      stdout: JSON.stringify({
+        currentVersion: "0.2.118",
+        latestVersion: "1.0.0",
+        updateAvailable: true,
+        installer: "npm",
+        channel: "stable",
+        autoUpdate: true,
+        error: null,
+      }),
+    }));
+
+    await expect(checkGrokCliUpdate("/opt/grok", {
+      now: () => 500,
+      previous: {
+        status: "available",
+        checkedAt: 100,
+        currentVersion: "0.2.118",
+        latestVersion: "1.0.0",
+        snoozedUntil: 900,
+      },
+      probe,
+    })).resolves.toEqual({
+      status: "available",
+      checkedAt: 500,
+      currentVersion: "0.2.118",
+      latestVersion: "1.0.0",
+      installer: "npm",
+      channel: "stable",
+      autoUpdate: true,
+      snoozedUntil: 900,
+    });
+    expect(probe).toHaveBeenCalledWith("/opt/grok");
+  });
+
+  it("clears acknowledgement for a new latest version", async () => {
+    const update = await checkGrokCliUpdate("grok", {
+      now: () => 500,
+      previous: {
+        status: "available",
+        checkedAt: 100,
+        currentVersion: "0.2.118",
+        latestVersion: "0.2.119",
+        dismissedAt: 200,
+      },
+      probe: async () => ({
+        stdout: JSON.stringify({
+          currentVersion: "0.2.118",
+          latestVersion: "1.0.0",
+          updateAvailable: true,
+          channel: "stable",
+          error: null,
+        }),
+      }),
+    });
+
+    expect(update.dismissedAt).toBeUndefined();
+    expect(update.latestVersion).toBe("1.0.0");
+  });
+
+  it("keeps a known available update durable across an offline retry", async () => {
+    await expect(checkGrokCliUpdate("grok", {
+      now: () => 500,
+      previous: {
+        status: "available",
+        checkedAt: 100,
+        currentVersion: "0.2.118",
+        latestVersion: "1.0.0",
+      },
+      probe: async () => ({ stdout: "not-json" }),
+    })).resolves.toMatchObject({
+      status: "available",
+      checkedAt: 500,
+      currentVersion: "0.2.118",
+      latestVersion: "1.0.0",
+      error: "Grok update check returned invalid JSON",
+    });
+  });
+
+  it("turns an initial CLI failure into quiet retryable status", async () => {
+    await expect(checkGrokCliUpdate("grok", {
+      now: () => 500,
+      installedVersion: "0.2.118",
+      probe: async () => {
+        throw new Error("offline");
+      },
+    })).resolves.toEqual({
+      status: "failed",
+      checkedAt: 500,
+      currentVersion: "0.2.118",
+      error: "offline",
+    });
+  });
+});
+
+describe("shouldCheckGrokCliUpdate", () => {
+  const previous = {
+    status: "up-to-date" as const,
+    checkedAt: 100,
+    currentVersion: "1.0.0",
+  };
+
+  it("rechecks on command or installed-version changes", () => {
+    expect(shouldCheckGrokCliUpdate({
+      command: "/new/grok",
+      installedVersion: "1.0.0",
+      now: 200,
+      previous,
+      previousCommand: "/old/grok",
+    })).toBe(true);
+    expect(shouldCheckGrokCliUpdate({
+      command: "/grok",
+      installedVersion: "1.0.1",
+      now: 200,
+      previous,
+      previousCommand: "/grok",
+    })).toBe(true);
+  });
+
+  it("uses a daily success cadence and hourly failure retry", () => {
+    expect(shouldCheckGrokCliUpdate({
+      command: "/grok",
+      installedVersion: "1.0.0",
+      now: 100 + GROK_UPDATE_SUCCESS_TTL_MS - 1,
+      previous,
+      previousCommand: "/grok",
+    })).toBe(false);
+    expect(shouldCheckGrokCliUpdate({
+      command: "/grok",
+      installedVersion: "1.0.0",
+      now: 100 + GROK_UPDATE_SUCCESS_TTL_MS,
+      previous,
+      previousCommand: "/grok",
+    })).toBe(true);
+    expect(shouldCheckGrokCliUpdate({
+      command: "/grok",
+      now: 100 + GROK_UPDATE_FAILURE_TTL_MS,
+      previous: { ...previous, status: "failed" },
+      previousCommand: "/grok",
+    })).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -1281,6 +1281,80 @@ describe("settings ipc", () => {
     }
   });
 
+  it("persists a version-keyed Grok update acknowledgement", async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "pwragent-settings-ipc-"),
+    );
+    tempRoots.push(tempRoot);
+    vi.stubEnv("PWRAGENT_HOME", tempRoot);
+    const { initializeAppState, disposeAppState, getAppStateDb } = await import(
+      "../state/app-state"
+    );
+    const { AcpAgentStore } = await import("../acp/acp-agent-store");
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const { ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    initializeAppState();
+    try {
+      const store = new AcpAgentStore(getAppStateDb());
+      store.upsertInstalledAgent({
+        backendId: "acp:grok",
+        registryId: "grok",
+        name: "Grok",
+        version: "0.2.118",
+        distributionKind: "local",
+        distributionSource: "grok agent stdio",
+        installStatus: "installed",
+        authStatus: "not-required",
+        verificationStatus: "not-applicable",
+        allowlistRuleId: "local-grok-cli",
+        installedAt: 100,
+        updatedAt: 100,
+        update: {
+          status: "available",
+          checkedAt: 200,
+          currentVersion: "0.2.118",
+          latestVersion: "1.0.0",
+        },
+      });
+      registerSettingsIpcHandlers(service);
+
+      await expect(handlers.get(ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL)?.(
+        {},
+        {
+          action: "dismiss",
+          backendId: "acp:grok",
+          latestVersion: "0.2.119",
+        },
+      )).resolves.toEqual({ applied: false });
+      const response = await handlers.get(
+        ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL,
+      )?.(
+        {},
+        {
+          action: "snooze",
+          backendId: "acp:grok",
+          latestVersion: "1.0.0",
+        },
+      ) as { applied: boolean; update: { snoozedUntil?: number } };
+
+      expect(response.applied).toBe(true);
+      expect(response.update.snoozedUntil).toBeGreaterThan(Date.now());
+      expect(
+        store.getInstalledAgent("acp:grok")?.update?.snoozedUntil,
+      ).toBe(response.update.snoozedUntil);
+    } finally {
+      disposeAppState();
+    }
+  });
+
   // The wizard PR (#491) calls this IPC the moment the operator picks
   // a Codex profile model. The handler must (1) persist the wizard
   // signal idempotently, (2) fire the same thread-list prefetch the

--- a/apps/desktop/src/main/acp/acp-registry-types.ts
+++ b/apps/desktop/src/main/acp/acp-registry-types.ts
@@ -1,4 +1,5 @@
 import type {
+  AcpAgentUpdateStatus,
   AcpAgentInstance,
   AcpBackendId,
   BackendAcpAuthStatus,
@@ -116,4 +117,6 @@ export type AcpInstalledAgentRecord = {
   /** Detected provider-name collisions that must not be launched. */
   incompatibleInstances?: AcpAgentInstance[];
   activeCommand?: string;
+  update?: AcpAgentUpdateStatus;
+  updateCommand?: string;
 };

--- a/apps/desktop/src/main/acp/grok-cli-update.ts
+++ b/apps/desktop/src/main/acp/grok-cli-update.ts
@@ -72,7 +72,7 @@ export async function checkGrokCliUpdate(
         ? { autoUpdate: parsed.autoUpdate }
         : {}),
     };
-    return preserveAcknowledgement(options.previous, update);
+    return preserveGrokUpdateAcknowledgement(options.previous, update);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (options.previous && options.previous.status !== "failed") {
@@ -139,7 +139,7 @@ function parseCheckOutput(output: string): {
   };
 }
 
-function preserveAcknowledgement(
+export function preserveGrokUpdateAcknowledgement(
   previous: AcpAgentUpdateStatus | undefined,
   next: AcpAgentUpdateStatus,
 ): AcpAgentUpdateStatus {

--- a/apps/desktop/src/main/acp/grok-cli-update.ts
+++ b/apps/desktop/src/main/acp/grok-cli-update.ts
@@ -1,0 +1,172 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import type { AcpAgentUpdateStatus } from "@pwragent/shared";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env.js";
+
+const execFile = promisify(execFileCallback);
+
+export const GROK_UPDATE_SUCCESS_TTL_MS = 24 * 60 * 60_000;
+export const GROK_UPDATE_FAILURE_TTL_MS = 60 * 60_000;
+const GROK_UPDATE_CHECK_TIMEOUT_MS = 20_000;
+const GROK_UPDATE_CHECK_MAX_BUFFER_BYTES = 64 * 1024;
+
+type GrokUpdateCheckJson = {
+  currentVersion?: unknown;
+  latestVersion?: unknown;
+  updateAvailable?: unknown;
+  installer?: unknown;
+  channel?: unknown;
+  autoUpdate?: unknown;
+  error?: unknown;
+};
+
+export type GrokCliUpdateProbe = (
+  command: string,
+) => Promise<{ stdout?: string; stderr?: string }>;
+
+export function shouldCheckGrokCliUpdate(params: {
+  command: string;
+  installedVersion?: string;
+  now: number;
+  previous?: AcpAgentUpdateStatus;
+  previousCommand?: string;
+}): boolean {
+  if (!params.previous) return true;
+  if (params.previousCommand !== params.command) return true;
+  if (
+    params.installedVersion
+    && params.installedVersion !== params.previous.currentVersion
+  ) {
+    return true;
+  }
+  const ttl =
+    params.previous.status === "failed"
+    || params.previous.error
+    ? GROK_UPDATE_FAILURE_TTL_MS
+    : GROK_UPDATE_SUCCESS_TTL_MS;
+  return params.now - params.previous.checkedAt >= ttl;
+}
+
+export async function checkGrokCliUpdate(
+  command: string,
+  options: {
+    now?: () => number;
+    installedVersion?: string;
+    previous?: AcpAgentUpdateStatus;
+    probe?: GrokCliUpdateProbe;
+  } = {},
+): Promise<AcpAgentUpdateStatus> {
+  const now = options.now?.() ?? Date.now();
+  const probe = options.probe ?? defaultProbe;
+  try {
+    const result = await probe(command);
+    const parsed = parseCheckOutput(result.stdout ?? "");
+    const update: AcpAgentUpdateStatus = {
+      status: parsed.updateAvailable ? "available" : "up-to-date",
+      checkedAt: now,
+      currentVersion: parsed.currentVersion,
+      ...(parsed.latestVersion ? { latestVersion: parsed.latestVersion } : {}),
+      ...(parsed.channel ? { channel: parsed.channel } : {}),
+      ...(parsed.installer ? { installer: parsed.installer } : {}),
+      ...(parsed.autoUpdate !== undefined
+        ? { autoUpdate: parsed.autoUpdate }
+        : {}),
+    };
+    return preserveAcknowledgement(options.previous, update);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.previous && options.previous.status !== "failed") {
+      return {
+        ...options.previous,
+        checkedAt: now,
+        error: message,
+      };
+    }
+    return {
+      status: "failed",
+      checkedAt: now,
+      currentVersion:
+        options.previous?.currentVersion ?? options.installedVersion ?? "unknown",
+      error: message,
+    };
+  }
+}
+
+function parseCheckOutput(output: string): {
+  currentVersion: string;
+  latestVersion?: string;
+  updateAvailable: boolean;
+  installer?: string;
+  channel?: string;
+  autoUpdate?: boolean;
+} {
+  let value: GrokUpdateCheckJson;
+  try {
+    value = JSON.parse(output.trim()) as GrokUpdateCheckJson;
+  } catch {
+    throw new Error("Grok update check returned invalid JSON");
+  }
+  if (typeof value.currentVersion !== "string" || !value.currentVersion.trim()) {
+    throw new Error("Grok update check omitted currentVersion");
+  }
+  if (typeof value.updateAvailable !== "boolean") {
+    throw new Error("Grok update check omitted updateAvailable");
+  }
+  if (typeof value.error === "string" && value.error.trim()) {
+    throw new Error(value.error.trim());
+  }
+  if (
+    value.updateAvailable
+    && (typeof value.latestVersion !== "string" || !value.latestVersion.trim())
+  ) {
+    throw new Error("Grok update check omitted latestVersion");
+  }
+  return {
+    currentVersion: value.currentVersion.trim(),
+    updateAvailable: value.updateAvailable,
+    ...(typeof value.latestVersion === "string" && value.latestVersion.trim()
+      ? { latestVersion: value.latestVersion.trim() }
+      : {}),
+    ...(typeof value.installer === "string" && value.installer.trim()
+      ? { installer: value.installer.trim() }
+      : {}),
+    ...(typeof value.channel === "string" && value.channel.trim()
+      ? { channel: value.channel.trim() }
+      : {}),
+    ...(typeof value.autoUpdate === "boolean"
+      ? { autoUpdate: value.autoUpdate }
+      : {}),
+  };
+}
+
+function preserveAcknowledgement(
+  previous: AcpAgentUpdateStatus | undefined,
+  next: AcpAgentUpdateStatus,
+): AcpAgentUpdateStatus {
+  if (
+    next.status !== "available"
+    || !previous
+    || previous.latestVersion !== next.latestVersion
+  ) {
+    return next;
+  }
+  return {
+    ...next,
+    ...(previous.dismissedAt !== undefined
+      ? { dismissedAt: previous.dismissedAt }
+      : {}),
+    ...(previous.snoozedUntil !== undefined
+      ? { snoozedUntil: previous.snoozedUntil }
+      : {}),
+  };
+}
+
+async function defaultProbe(
+  command: string,
+): Promise<{ stdout?: string; stderr?: string }> {
+  return await execFile(command, ["update", "--check", "--json"], {
+    env: buildPwrAgentChildProcessEnv(process.env, { NO_COLOR: "1" }),
+    maxBuffer: GROK_UPDATE_CHECK_MAX_BUFFER_BYTES,
+    timeout: GROK_UPDATE_CHECK_TIMEOUT_MS,
+  });
+}

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -83,6 +83,7 @@ import {
 import { AcpStdioJsonRpcTransport } from "../acp/acp-stdio-transport";
 import {
   checkGrokCliUpdate,
+  preserveGrokUpdateAcknowledgement,
   shouldCheckGrokCliUpdate,
 } from "../acp/grok-cli-update";
 import { getMainLogger } from "../log";
@@ -1034,7 +1035,12 @@ export class AcpBackendAdapter {
     agent: AcpInstalledAgentRecord,
   ): void {
     const checker = this.grokUpdateChecker;
-    const command = agent.launchDescriptor?.command ?? agent.activeCommand;
+    const command = agent.activeCommand ?? agent.launchDescriptor?.command;
+    const previous =
+      agent.updateCommand === command
+      && agent.version === agent.update?.currentVersion
+        ? agent.update
+        : undefined;
     if (
       !checker
       || !command
@@ -1044,7 +1050,7 @@ export class AcpBackendAdapter {
         command,
         installedVersion: agent.version,
         now: Date.now(),
-        previous: agent.update,
+        previous,
         previousCommand: agent.updateCommand,
       })
     ) {
@@ -1053,18 +1059,31 @@ export class AcpBackendAdapter {
 
     const refresh = checker(command, {
       installedVersion: agent.version,
-      previous: agent.update,
+      previous,
     })
       .then(async (update) => {
         if (this.closed) return;
         const current = this.acpAgentStore?.getInstalledAgent(agent.backendId)
           ?? agent;
+        const currentCommand =
+          current.activeCommand ?? current.launchDescriptor?.command;
+        if (
+          currentCommand !== command
+          || current.version !== agent.version
+        ) {
+          return;
+        }
+        const mergedUpdate = preserveGrokUpdateAcknowledgement(
+          current.update,
+          update,
+        );
         this.acpAgentStore?.upsertInstalledAgent({
           ...current,
-          ...(update.status !== "failed" && update.currentVersion !== "unknown"
-            ? { version: update.currentVersion }
+          ...(mergedUpdate.status !== "failed"
+            && mergedUpdate.currentVersion !== "unknown"
+            ? { version: mergedUpdate.currentVersion }
             : {}),
-          update,
+          update: mergedUpdate,
           updateCommand: command,
         });
         await this.emit({

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -81,6 +81,10 @@ import {
   shouldSurfaceAcpThoughtsAsMessages,
 } from "../acp/acp-session-normalizer";
 import { AcpStdioJsonRpcTransport } from "../acp/acp-stdio-transport";
+import {
+  checkGrokCliUpdate,
+  shouldCheckGrokCliUpdate,
+} from "../acp/grok-cli-update";
 import { getMainLogger } from "../log";
 import {
   getAppStateDb,
@@ -171,6 +175,7 @@ export type AcpBackendAdapterOptions = {
   discoverLocalAcpAgents?: LocalAcpDiscovery;
   resolveLocalAcpDiscoveryEnv?: () => Promise<NodeJS.ProcessEnv>;
   isAcpAgentEnabled?: (registryId: string) => boolean;
+  checkGrokCliUpdate?: typeof checkGrokCliUpdate | null;
   resolveMcpConnectionServers?: (context: {
     backendId: AcpBackendId;
     sessionId?: string;
@@ -921,6 +926,8 @@ export class AcpBackendAdapter {
   private readonly providerStatuses = new Map<AcpBackendId, AcpProviderStatus>();
   private readonly providerStatusRefreshAttempts = new Map<AcpBackendId, number>();
   private readonly providerStatusRefreshes = new Map<AcpBackendId, Promise<void>>();
+  private readonly grokUpdateChecker?: typeof checkGrokCliUpdate;
+  private readonly grokUpdateRefreshes = new Map<AcpBackendId, Promise<void>>();
   private closed = false;
   private closePromise?: Promise<void>;
   private readonly closeTimeoutMs: number;
@@ -935,6 +942,10 @@ export class AcpBackendAdapter {
     this.handleServerRequest = options.handleServerRequest;
     this.resolveMcpConnectionServers = options.resolveMcpConnectionServers;
     this.closeTimeoutMs = options.closeTimeoutMs ?? ACP_CLOSE_TIMEOUT_MS;
+    this.grokUpdateChecker = options.checkGrokCliUpdate === null
+      ? undefined
+      : options.checkGrokCliUpdate
+        ?? (isAppStateInitialized() ? checkGrokCliUpdate : undefined);
     this.acpAgentStore =
       options.acpAgentStore === null
         ? undefined
@@ -1004,6 +1015,7 @@ export class AcpBackendAdapter {
       if (agent.registryId !== "grok" || !summary.available) {
         return summary;
       }
+      this.refreshGrokUpdateStatusInBackground(agent);
       // Backend discovery is also used by launchpad and messaging flows.
       // Merge only cached decoration here; vendor billing must never delay it.
       const providerStatus = this.providerStatuses.get(agent.backendId);
@@ -1016,6 +1028,64 @@ export class AcpBackendAdapter {
           }
         : summary;
     });
+  }
+
+  private refreshGrokUpdateStatusInBackground(
+    agent: AcpInstalledAgentRecord,
+  ): void {
+    const checker = this.grokUpdateChecker;
+    const command = agent.launchDescriptor?.command ?? agent.activeCommand;
+    if (
+      !checker
+      || !command
+      || this.closed
+      || this.grokUpdateRefreshes.has(agent.backendId)
+      || !shouldCheckGrokCliUpdate({
+        command,
+        installedVersion: agent.version,
+        now: Date.now(),
+        previous: agent.update,
+        previousCommand: agent.updateCommand,
+      })
+    ) {
+      return;
+    }
+
+    const refresh = checker(command, {
+      installedVersion: agent.version,
+      previous: agent.update,
+    })
+      .then(async (update) => {
+        if (this.closed) return;
+        const current = this.acpAgentStore?.getInstalledAgent(agent.backendId)
+          ?? agent;
+        this.acpAgentStore?.upsertInstalledAgent({
+          ...current,
+          ...(update.status !== "failed" && update.currentVersion !== "unknown"
+            ? { version: update.currentVersion }
+            : {}),
+          update,
+          updateCommand: command,
+        });
+        await this.emit({
+          backend: agent.backendId,
+          notification: {
+            method: "backend/acpUpdateStatus/updated",
+            params: { backend: agent.backendId },
+          },
+        });
+      })
+      .catch((error) => {
+        acpBackendAdapterLog.debug("grok_update_check_failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      })
+      .finally(() => {
+        if (this.grokUpdateRefreshes.get(agent.backendId) === refresh) {
+          this.grokUpdateRefreshes.delete(agent.backendId);
+        }
+      });
+    this.grokUpdateRefreshes.set(agent.backendId, refresh);
   }
 
   private refreshProviderStatusInBackground(backend: AcpBackendId): void {
@@ -1590,6 +1660,7 @@ export class AcpBackendAdapter {
     this.providerStatuses.clear();
     this.providerStatusRefreshAttempts.clear();
     this.providerStatusRefreshes.clear();
+    this.grokUpdateRefreshes.clear();
     this.liveTurnUsage.clear();
     this.closePromise = this.closeResources(acpClients);
     return await this.closePromise;

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import type {
   AcpAgentPreference,
   AcpAgentSettingsEntry,
+  AcknowledgeAcpAgentUpdateRequest,
+  AcknowledgeAcpAgentUpdateResponse,
   CheckDesktopCodexAuthProfileStatusRequest,
   CheckDesktopCodexAuthProfileStatusResponse,
   ClearDesktopSettingsSecretRequest,
@@ -32,6 +34,7 @@ import type {
   WriteDesktopSettingsConfigRequest,
 } from "@pwragent/shared";
 import {
+  isAcpBackendId,
   isMessagingRuntimeSecret,
   sanitizeMessagingContactHandle,
   sanitizeMessagingContactLabel,
@@ -39,6 +42,7 @@ import {
 import {
   ONBOARDING_COMPLETE_CODEX_BOOTSTRAP_CHANNEL,
   ACP_AGENTS_LIST_CHANNEL,
+  ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL,
   SETTINGS_CHECK_CODEX_AUTH_PROFILE_STATUS_CHANNEL,
   SETTINGS_CLEAR_SECRET_CHANNEL,
   SETTINGS_CREATE_CODEX_AUTH_PROFILE_CHANNEL,
@@ -103,6 +107,7 @@ import {
 } from "../profile";
 
 const settingsIpcLog = getMainLogger("pwragent:settings");
+const ACP_UPDATE_SNOOZE_MS = 24 * 60 * 60_000;
 // Codex profile login now runs through @pwrdrvr/codex-discovery's
 // CodexLoginManager (extracted from this file's inline flow). PwrAgnt owns the
 // instance so the Electron seam — `shell.openExternal` — is injected and the
@@ -360,6 +365,8 @@ async function listInstalledAndLocalAcpAgents(
         const nextRecord = {
           ...record,
           runtimeCapabilities: current?.runtimeCapabilities,
+          update: current?.update,
+          updateCommand: current?.updateCommand,
           lastDiscoveredAt: current?.lastDiscoveredAt,
           lastDiscoveryError: current?.lastDiscoveryError,
           installedAt: current?.installedAt ?? record.installedAt,
@@ -547,6 +554,7 @@ function installedAcpAgentSettingsEntry(
     lastDiscoveredAt: record.lastDiscoveredAt,
     lastDiscoveryError: record.lastDiscoveryError,
     runtime: record.runtimeCapabilities,
+    update: record.update,
     ...(record.instances !== undefined ? { instances: record.instances } : {}),
     ...(record.incompatibleInstances !== undefined
       ? { incompatibleInstances: record.incompatibleInstances }
@@ -929,6 +937,41 @@ export function registerSettingsIpcHandlers(
       await listAcpAgentSettings(request, service),
   );
 
+  ipcMain.removeHandler(ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL);
+  ipcMain.handle(
+    ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL,
+    async (
+      _event,
+      request: AcknowledgeAcpAgentUpdateRequest,
+    ): Promise<AcknowledgeAcpAgentUpdateResponse> => {
+      const store = new AcpAgentStore(getAppStateDb());
+      const record = isAcpBackendId(request.backendId)
+        ? store.getInstalledAgent(request.backendId)
+        : undefined;
+      if (
+        !record?.update
+        || record.update.status !== "available"
+        || record.update.latestVersion !== request.latestVersion
+      ) {
+        return { applied: false };
+      }
+      const now = Date.now();
+      const update = request.action === "dismiss"
+        ? {
+            ...record.update,
+            dismissedAt: now,
+            snoozedUntil: undefined,
+          }
+        : {
+            ...record.update,
+            dismissedAt: undefined,
+            snoozedUntil: now + ACP_UPDATE_SNOOZE_MS,
+          };
+      store.upsertInstalledAgent({ ...record, update });
+      return { applied: true, update };
+    },
+  );
+
   ipcMain.removeHandler(SETTINGS_READ_CHANNEL);
   ipcMain.handle(
     SETTINGS_READ_CHANNEL,
@@ -1205,6 +1248,7 @@ export function registerSettingsIpcHandlers(
 export function disposeSettingsIpcHandlers(): void {
   codexLoginManager.dispose();
   ipcMain.removeHandler(ACP_AGENTS_LIST_CHANNEL);
+  ipcMain.removeHandler(ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL);
   ipcMain.removeHandler(SETTINGS_READ_CHANNEL);
   ipcMain.removeHandler(SETTINGS_WRITE_CONFIG_CHANNEL);
   ipcMain.removeHandler(SETTINGS_REPLACE_SECRET_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -91,6 +91,8 @@ import type {
   HandoffThreadWorkspaceResponse,
   ListAcpAgentSettingsRequest,
   ListAcpAgentSettingsResponse,
+  AcknowledgeAcpAgentUpdateRequest,
+  AcknowledgeAcpAgentUpdateResponse,
   NavigationBrowseMode,
   AttachDirectoryToThreadRequest,
   AttachDirectoryToThreadResponse,
@@ -401,6 +403,7 @@ import {
   AGENT_TRUST_CODEX_PROJECT_CHANNEL,
   AGENT_UPDATE_THREAD_EXPECTED_BRANCH_CHANNEL,
   ACP_AGENTS_LIST_CHANNEL,
+  ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL,
   AUTOMATIONS_CREATE_CHANNEL,
   AUTOMATIONS_DELETE_CHANNEL,
   AUTOMATIONS_DRAFT_PROMPT_CHANNEL,
@@ -984,6 +987,10 @@ const desktopApi = Object.freeze({
     request?: ListAcpAgentSettingsRequest,
   ): Promise<ListAcpAgentSettingsResponse> =>
     await ipcRenderer.invoke(ACP_AGENTS_LIST_CHANNEL, request),
+  acknowledgeAcpAgentUpdate: async (
+    request: AcknowledgeAcpAgentUpdateRequest,
+  ): Promise<AcknowledgeAcpAgentUpdateResponse> =>
+    await ipcRenderer.invoke(ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL, request),
   readSettings: async (
     request?: ReadDesktopSettingsRequest,
   ): Promise<ReadDesktopSettingsResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -94,6 +94,7 @@ import {
 } from "./features/notifications/app-notice-state";
 import { buildPrAutoDispatchBudgetNotice } from "./features/notifications/pr-auto-dispatch-budget-notice";
 import { MessagingErrorNotices } from "./features/notifications/MessagingErrorNotices";
+import { GrokCliUpdateNotice } from "./features/notifications/GrokCliUpdateNotice";
 import { buildGithubPrSamlEnforcementNotice } from "./features/notifications/github-pr-saml-notice";
 import { buildGithubPrAuthenticationNotice } from "./features/notifications/github-pr-authentication-notice";
 import {
@@ -450,6 +451,17 @@ function DesktopAppShell(props: {
       type: "dismiss-prefix",
       prefix: `messaging-platform-error:${platform}:`,
     });
+  }, [showAppNotice]);
+  const syncGrokCliUpdateNotice = useCallback((
+    notice: AppNoticeToastNotice | undefined,
+  ): void => {
+    dispatchAppNotice({
+      type: "dismiss-prefix",
+      prefix: "acp-update:acp:grok:",
+    });
+    if (notice) {
+      showAppNotice(notice);
+    }
   }, [showAppNotice]);
 
   useEffect(() => {
@@ -2236,6 +2248,10 @@ function DesktopAppShell(props: {
         <MessagingErrorNotices
           desktopApi={desktopApi}
           onNoticeChanged={syncMessagingErrorNotice}
+        />
+        <GrokCliUpdateNotice
+          desktopApi={desktopApi}
+          onNoticeChanged={syncGrokCliUpdateNotice}
         />
         <AppNoticeStack
           desktopApi={desktopApi}

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -130,7 +130,10 @@ export function AppNoticeToast(props: {
           <p className="app-notice-toast__detail">{props.notice.detail}</p>
         ) : null}
       </div>
-      <div className="app-notice-toast__actions">
+      <div
+        className="app-notice-toast__actions"
+        data-custom-actions={customActions.length > 0 ? "true" : undefined}
+      >
         {customActions.length > 0
           ? customActions.map((action) => (
               <button

--- a/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
@@ -3,6 +3,8 @@ import type { AcpAgentSettingsEntry } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import type { AppNoticeToastNotice } from "./AppNoticeToast";
 
+export const GROK_BUILD_UPDATE_URL = "https://x.ai/build";
+
 export function GrokCliUpdateNotice(props: {
   desktopApi?: DesktopApi;
   now?: () => number;
@@ -65,9 +67,8 @@ export function GrokCliUpdateNotice(props: {
   const notice = useMemo(() => buildGrokCliUpdateNotice({
     entry,
     now: clock,
-    platform: desktopApi?.platform,
-    onCopy: (command) => {
-      void desktopApi?.copyText?.(command);
+    onOpenUpdatePage: (url) => {
+      window.open(url, "_blank", "noopener,noreferrer");
     },
     onDismiss: () => {
       void acknowledge("dismiss");
@@ -75,7 +76,7 @@ export function GrokCliUpdateNotice(props: {
     onSnooze: () => {
       void acknowledge("snooze");
     },
-  }), [acknowledge, clock, desktopApi, entry]);
+  }), [acknowledge, clock, entry]);
 
   useEffect(() => {
     onNoticeChanged(notice);
@@ -87,8 +88,7 @@ export function GrokCliUpdateNotice(props: {
 export function buildGrokCliUpdateNotice(params: {
   entry?: AcpAgentSettingsEntry;
   now: number;
-  platform?: string;
-  onCopy: (command: string) => void;
+  onOpenUpdatePage: (url: string) => void;
   onDismiss: () => void;
   onSnooze: () => void;
 }): AppNoticeToastNotice | undefined {
@@ -102,40 +102,21 @@ export function buildGrokCliUpdateNotice(params: {
   ) {
     return undefined;
   }
-  const command = buildGrokCliUpdateCommand(
-    params.entry.activeCommand,
-    params.platform,
-  );
   return {
     id: `acp-update:acp:grok:${update.latestVersion}`,
     autoDismiss: false,
     title: "Grok update available",
     message: `Grok ${update.latestVersion} is available; ${update.currentVersion} is installed.`,
-    detail: `Run ${command} in a terminal, then restart active Grok sessions.`,
-    copyText: command,
+    detail: "Update Grok from x.ai/build, then restart active Grok sessions.",
     tone: "warning",
     actions: [
       {
-        label: "Copy command",
-        onClick: () => params.onCopy(command),
+        label: "Open update page",
+        onClick: () => params.onOpenUpdatePage(GROK_BUILD_UPDATE_URL),
         tone: "primary",
       },
       { label: "Tomorrow", onClick: params.onSnooze },
       { label: "Dismiss version", onClick: params.onDismiss },
     ],
   };
-}
-
-export function buildGrokCliUpdateCommand(
-  activeCommand: string | undefined,
-  platform: string | undefined,
-): string {
-  const executable = activeCommand?.trim() || "grok";
-  if (/^[A-Za-z0-9_./:@%+,=\\-]+$/.test(executable)) {
-    return `${executable} update`;
-  }
-  if (platform === "win32") {
-    return `& '${executable.replace(/'/g, "''")}' update`;
-  }
-  return `'${executable.replace(/'/g, "'\\''")}' update`;
 }

--- a/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { AcpAgentSettingsEntry } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import type { AppNoticeToastNotice } from "./AppNoticeToast";
+
+export function GrokCliUpdateNotice(props: {
+  desktopApi?: DesktopApi;
+  now?: () => number;
+  onNoticeChanged: (notice: AppNoticeToastNotice | undefined) => void;
+}) {
+  const [entry, setEntry] = useState<AcpAgentSettingsEntry>();
+  const [clock, setClock] = useState(() => props.now?.() ?? Date.now());
+  const desktopApi = props.desktopApi;
+  const now = props.now ?? Date.now;
+  const onNoticeChanged = props.onNoticeChanged;
+
+  const refresh = useCallback(async () => {
+    const response = await desktopApi?.listAcpAgents?.({ refresh: false });
+    setEntry(
+      response?.entries.find((candidate) => candidate.registryId === "grok"),
+    );
+  }, [desktopApi]);
+
+  useEffect(() => {
+    void refresh().catch(() => undefined);
+    return desktopApi?.onAgentEvent?.((event) => {
+      if (
+        event.backend === "acp:grok"
+        && event.notification.method === "backend/acpUpdateStatus/updated"
+      ) {
+        void refresh().catch(() => undefined);
+      }
+    });
+  }, [desktopApi, refresh]);
+
+  const snoozedUntil = entry?.update?.snoozedUntil;
+  useEffect(() => {
+    if (!snoozedUntil || snoozedUntil <= clock) return;
+    const timeout = window.setTimeout(
+      () => setClock(now()),
+      Math.min(snoozedUntil - clock, 2_147_483_647),
+    );
+    return () => window.clearTimeout(timeout);
+  }, [clock, now, snoozedUntil]);
+
+  const acknowledge = useCallback(
+    async (action: "dismiss" | "snooze") => {
+      const latestVersion = entry?.update?.latestVersion;
+      if (!latestVersion) return;
+      const response = await desktopApi?.acknowledgeAcpAgentUpdate?.({
+        action,
+        backendId: "acp:grok",
+        latestVersion,
+      });
+      if (response?.applied && response.update) {
+        setEntry((current) =>
+          current ? { ...current, update: response.update } : current,
+        );
+        setClock(now());
+      }
+    },
+    [desktopApi, entry?.update?.latestVersion, now],
+  );
+
+  const notice = useMemo(() => buildGrokCliUpdateNotice({
+    entry,
+    now: clock,
+    onCopy: () => {
+      void desktopApi?.copyText?.("grok update");
+    },
+    onDismiss: () => {
+      void acknowledge("dismiss");
+    },
+    onSnooze: () => {
+      void acknowledge("snooze");
+    },
+  }), [acknowledge, clock, desktopApi, entry]);
+
+  useEffect(() => {
+    onNoticeChanged(notice);
+  }, [notice, onNoticeChanged]);
+
+  return null;
+}
+
+export function buildGrokCliUpdateNotice(params: {
+  entry?: AcpAgentSettingsEntry;
+  now: number;
+  onCopy: () => void;
+  onDismiss: () => void;
+  onSnooze: () => void;
+}): AppNoticeToastNotice | undefined {
+  const update = params.entry?.update;
+  if (
+    params.entry?.registryId !== "grok"
+    || update?.status !== "available"
+    || !update.latestVersion
+    || update.dismissedAt !== undefined
+    || (update.snoozedUntil ?? 0) > params.now
+  ) {
+    return undefined;
+  }
+  return {
+    id: `acp-update:acp:grok:${update.latestVersion}`,
+    autoDismiss: false,
+    title: "Grok update available",
+    message: `Grok ${update.latestVersion} is available; ${update.currentVersion} is installed.`,
+    detail: "Run grok update in a terminal, then restart active Grok sessions.",
+    copyText: "grok update",
+    tone: "warning",
+    actions: [
+      { label: "Copy command", onClick: params.onCopy, tone: "primary" },
+      { label: "Tomorrow", onClick: params.onSnooze },
+      { label: "Dismiss version", onClick: params.onDismiss },
+    ],
+  };
+}

--- a/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
@@ -65,8 +65,9 @@ export function GrokCliUpdateNotice(props: {
   const notice = useMemo(() => buildGrokCliUpdateNotice({
     entry,
     now: clock,
-    onCopy: () => {
-      void desktopApi?.copyText?.("grok update");
+    platform: desktopApi?.platform,
+    onCopy: (command) => {
+      void desktopApi?.copyText?.(command);
     },
     onDismiss: () => {
       void acknowledge("dismiss");
@@ -86,7 +87,8 @@ export function GrokCliUpdateNotice(props: {
 export function buildGrokCliUpdateNotice(params: {
   entry?: AcpAgentSettingsEntry;
   now: number;
-  onCopy: () => void;
+  platform?: string;
+  onCopy: (command: string) => void;
   onDismiss: () => void;
   onSnooze: () => void;
 }): AppNoticeToastNotice | undefined {
@@ -100,18 +102,40 @@ export function buildGrokCliUpdateNotice(params: {
   ) {
     return undefined;
   }
+  const command = buildGrokCliUpdateCommand(
+    params.entry.activeCommand,
+    params.platform,
+  );
   return {
     id: `acp-update:acp:grok:${update.latestVersion}`,
     autoDismiss: false,
     title: "Grok update available",
     message: `Grok ${update.latestVersion} is available; ${update.currentVersion} is installed.`,
-    detail: "Run grok update in a terminal, then restart active Grok sessions.",
-    copyText: "grok update",
+    detail: `Run ${command} in a terminal, then restart active Grok sessions.`,
+    copyText: command,
     tone: "warning",
     actions: [
-      { label: "Copy command", onClick: params.onCopy, tone: "primary" },
+      {
+        label: "Copy command",
+        onClick: () => params.onCopy(command),
+        tone: "primary",
+      },
       { label: "Tomorrow", onClick: params.onSnooze },
       { label: "Dismiss version", onClick: params.onDismiss },
     ],
   };
+}
+
+export function buildGrokCliUpdateCommand(
+  activeCommand: string | undefined,
+  platform: string | undefined,
+): string {
+  const executable = activeCommand?.trim() || "grok";
+  if (/^[A-Za-z0-9_./:@%+,=\\-]+$/.test(executable)) {
+    return `${executable} update`;
+  }
+  if (platform === "win32") {
+    return `& '${executable.replace(/'/g, "''")}' update`;
+  }
+  return `'${executable.replace(/'/g, "'\\''")}' update`;
 }

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -201,6 +201,9 @@ describe("AppNoticeToast", () => {
     expect(screen.getAllByRole("button")).toHaveLength(2);
     expect(screen.queryByRole("button", { name: "Copy notice" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Dismiss notice" })).toBeNull();
+    expect(
+      container.querySelector(".app-notice-toast__actions"),
+    ).toHaveAttribute("data-custom-actions", "true");
     expect(container.querySelector(".app-notice-toast__timer")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Leave disabled" }));

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AcpAgentSettingsEntry } from "@pwragent/shared";
 import {
-  buildGrokCliUpdateCommand,
   buildGrokCliUpdateNotice,
+  GROK_BUILD_UPDATE_URL,
 } from "../GrokCliUpdateNotice";
 
 function grokEntry(
   update: AcpAgentSettingsEntry["update"],
-  activeCommand?: string,
 ): AcpAgentSettingsEntry {
   return {
     backendId: "acp:grok",
@@ -22,13 +21,12 @@ function grokEntry(
     authStatus: "not-required",
     verificationStatus: "not-applicable",
     update,
-    ...(activeCommand ? { activeCommand } : {}),
   };
 }
 
 describe("buildGrokCliUpdateNotice", () => {
   it("builds a version-keyed durable update notice", () => {
-    const onCopy = vi.fn();
+    const onOpenUpdatePage = vi.fn();
     const notice = buildGrokCliUpdateNotice({
       entry: grokEntry({
         status: "available",
@@ -37,7 +35,7 @@ describe("buildGrokCliUpdateNotice", () => {
         latestVersion: "1.0.0",
       }),
       now: 200,
-      onCopy,
+      onOpenUpdatePage,
       onDismiss: vi.fn(),
       onSnooze: vi.fn(),
     });
@@ -46,56 +44,16 @@ describe("buildGrokCliUpdateNotice", () => {
       id: "acp-update:acp:grok:1.0.0",
       autoDismiss: false,
       message: "Grok 1.0.0 is available; 0.2.118 is installed.",
-      copyText: "grok update",
-    });
-    notice?.actions?.[0]?.onClick();
-    expect(onCopy).toHaveBeenCalledWith("grok update");
-  });
-
-  it("targets the selected executable in the displayed and copied command", () => {
-    const onCopy = vi.fn();
-    const notice = buildGrokCliUpdateNotice({
-      entry: grokEntry(
-        {
-          status: "available",
-          checkedAt: 100,
-          currentVersion: "0.2.118",
-          latestVersion: "1.0.0",
-        },
-        "/Applications/Grok CLI/bin/grok",
-      ),
-      now: 200,
-      platform: "darwin",
-      onCopy,
-      onDismiss: vi.fn(),
-      onSnooze: vi.fn(),
-    });
-
-    expect(notice).toMatchObject({
-      copyText: "'/Applications/Grok CLI/bin/grok' update",
       detail:
-        "Run '/Applications/Grok CLI/bin/grok' update in a terminal, then restart active Grok sessions.",
+        "Update Grok from x.ai/build, then restart active Grok sessions.",
     });
     notice?.actions?.[0]?.onClick();
-    expect(onCopy).toHaveBeenCalledWith(
-      "'/Applications/Grok CLI/bin/grok' update",
-    );
-  });
-
-  it("quotes selected executable paths for the platform shell", () => {
-    expect(buildGrokCliUpdateCommand(
-      "/opt/Grok's CLI/grok",
-      "darwin",
-    )).toBe("'/opt/Grok'\\''s CLI/grok' update");
-    expect(buildGrokCliUpdateCommand(
-      "C:\\Program Files\\Grok's CLI\\grok.exe",
-      "win32",
-    )).toBe("& 'C:\\Program Files\\Grok''s CLI\\grok.exe' update");
+    expect(onOpenUpdatePage).toHaveBeenCalledWith(GROK_BUILD_UPDATE_URL);
   });
 
   it("hides dismissed, snoozed, current, and failed checks", () => {
     const callbacks = {
-      onCopy: vi.fn(),
+      onOpenUpdatePage: vi.fn(),
       onDismiss: vi.fn(),
       onSnooze: vi.fn(),
     };

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AcpAgentSettingsEntry } from "@pwragent/shared";
-import { buildGrokCliUpdateNotice } from "../GrokCliUpdateNotice";
+import {
+  buildGrokCliUpdateCommand,
+  buildGrokCliUpdateNotice,
+} from "../GrokCliUpdateNotice";
 
 function grokEntry(
   update: AcpAgentSettingsEntry["update"],
+  activeCommand?: string,
 ): AcpAgentSettingsEntry {
   return {
     backendId: "acp:grok",
@@ -18,6 +22,7 @@ function grokEntry(
     authStatus: "not-required",
     verificationStatus: "not-applicable",
     update,
+    ...(activeCommand ? { activeCommand } : {}),
   };
 }
 
@@ -41,9 +46,51 @@ describe("buildGrokCliUpdateNotice", () => {
       id: "acp-update:acp:grok:1.0.0",
       autoDismiss: false,
       message: "Grok 1.0.0 is available; 0.2.118 is installed.",
+      copyText: "grok update",
     });
     notice?.actions?.[0]?.onClick();
-    expect(onCopy).toHaveBeenCalledOnce();
+    expect(onCopy).toHaveBeenCalledWith("grok update");
+  });
+
+  it("targets the selected executable in the displayed and copied command", () => {
+    const onCopy = vi.fn();
+    const notice = buildGrokCliUpdateNotice({
+      entry: grokEntry(
+        {
+          status: "available",
+          checkedAt: 100,
+          currentVersion: "0.2.118",
+          latestVersion: "1.0.0",
+        },
+        "/Applications/Grok CLI/bin/grok",
+      ),
+      now: 200,
+      platform: "darwin",
+      onCopy,
+      onDismiss: vi.fn(),
+      onSnooze: vi.fn(),
+    });
+
+    expect(notice).toMatchObject({
+      copyText: "'/Applications/Grok CLI/bin/grok' update",
+      detail:
+        "Run '/Applications/Grok CLI/bin/grok' update in a terminal, then restart active Grok sessions.",
+    });
+    notice?.actions?.[0]?.onClick();
+    expect(onCopy).toHaveBeenCalledWith(
+      "'/Applications/Grok CLI/bin/grok' update",
+    );
+  });
+
+  it("quotes selected executable paths for the platform shell", () => {
+    expect(buildGrokCliUpdateCommand(
+      "/opt/Grok's CLI/grok",
+      "darwin",
+    )).toBe("'/opt/Grok'\\''s CLI/grok' update");
+    expect(buildGrokCliUpdateCommand(
+      "C:\\Program Files\\Grok's CLI\\grok.exe",
+      "win32",
+    )).toBe("& 'C:\\Program Files\\Grok''s CLI\\grok.exe' update");
   });
 
   it("hides dismissed, snoozed, current, and failed checks", () => {

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AcpAgentSettingsEntry } from "@pwragent/shared";
+import { buildGrokCliUpdateNotice } from "../GrokCliUpdateNotice";
+
+function grokEntry(
+  update: AcpAgentSettingsEntry["update"],
+): AcpAgentSettingsEntry {
+  return {
+    backendId: "acp:grok",
+    registryId: "grok",
+    name: "Grok",
+    authors: ["xAI"],
+    distributionKind: "local",
+    distributionSource: "grok agent stdio",
+    installable: false,
+    installed: true,
+    installStatus: "installed",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+    update,
+  };
+}
+
+describe("buildGrokCliUpdateNotice", () => {
+  it("builds a version-keyed durable update notice", () => {
+    const onCopy = vi.fn();
+    const notice = buildGrokCliUpdateNotice({
+      entry: grokEntry({
+        status: "available",
+        checkedAt: 100,
+        currentVersion: "0.2.118",
+        latestVersion: "1.0.0",
+      }),
+      now: 200,
+      onCopy,
+      onDismiss: vi.fn(),
+      onSnooze: vi.fn(),
+    });
+
+    expect(notice).toMatchObject({
+      id: "acp-update:acp:grok:1.0.0",
+      autoDismiss: false,
+      message: "Grok 1.0.0 is available; 0.2.118 is installed.",
+    });
+    notice?.actions?.[0]?.onClick();
+    expect(onCopy).toHaveBeenCalledOnce();
+  });
+
+  it("hides dismissed, snoozed, current, and failed checks", () => {
+    const callbacks = {
+      onCopy: vi.fn(),
+      onDismiss: vi.fn(),
+      onSnooze: vi.fn(),
+    };
+    const available = {
+      status: "available" as const,
+      checkedAt: 100,
+      currentVersion: "0.2.118",
+      latestVersion: "1.0.0",
+    };
+    expect(buildGrokCliUpdateNotice({
+      entry: grokEntry({ ...available, dismissedAt: 150 }),
+      now: 200,
+      ...callbacks,
+    })).toBeUndefined();
+    expect(buildGrokCliUpdateNotice({
+      entry: grokEntry({ ...available, snoozedUntil: 300 }),
+      now: 200,
+      ...callbacks,
+    })).toBeUndefined();
+    expect(buildGrokCliUpdateNotice({
+      entry: grokEntry({ ...available, snoozedUntil: 199 }),
+      now: 200,
+      ...callbacks,
+    })).toBeDefined();
+    expect(buildGrokCliUpdateNotice({
+      entry: grokEntry({ ...available, status: "up-to-date" }),
+      now: 200,
+      ...callbacks,
+    })).toBeUndefined();
+    expect(buildGrokCliUpdateNotice({
+      entry: grokEntry({ ...available, status: "failed" }),
+      now: 200,
+      ...callbacks,
+    })).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -93,6 +93,8 @@ import type {
   ListBackendsResponse,
   ListAcpAgentSettingsRequest,
   ListAcpAgentSettingsResponse,
+  AcknowledgeAcpAgentUpdateRequest,
+  AcknowledgeAcpAgentUpdateResponse,
   ListDesktopPwrAgentProfilesResponse,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
@@ -668,6 +670,9 @@ export type DesktopApi = {
   listAcpAgents?: (
     request?: ListAcpAgentSettingsRequest
   ) => Promise<ListAcpAgentSettingsResponse>;
+  acknowledgeAcpAgentUpdate?: (
+    request: AcknowledgeAcpAgentUpdateRequest,
+  ) => Promise<AcknowledgeAcpAgentUpdateResponse>;
   readSettings?: (
     request?: ReadDesktopSettingsRequest
   ) => Promise<ReadDesktopSettingsResponse>;

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -308,6 +308,16 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps custom toast actions from collapsing the message column", () => {
+    const customActionsRule = extractRuleBody(
+      css,
+      '.app-notice-toast__actions[data-custom-actions="true"]',
+    );
+
+    expect(customActionsRule).toContain("grid-column: 1 / -1;");
+    expect(customActionsRule).toContain("justify-content: flex-end;");
+  });
+
   it("lets transcript scroll restoration own scroll anchoring", () => {
     expect(css).toMatch(
       /\.transcript-list__items\s*\{[\s\S]*?overflow-anchor:\s*none;[\s\S]*?\}/

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5752,6 +5752,11 @@ textarea,
   align-self: start;
 }
 
+.app-notice-toast__actions[data-custom-actions="true"] {
+  grid-column: 1 / -1;
+  justify-content: flex-end;
+}
+
 .app-notice-toast__navigation {
   display: flex;
   grid-column: 1 / -1;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -51,6 +51,8 @@ export const THREAD_MIGRATION_RETRY_CHANNEL = "thread-migration:retry";
 export const FOCUSED_DIFF_ANALYZE_CHANNEL = "focused-diff:analyze";
 export const BACKEND_LIST_CHANNEL = "backend:list";
 export const ACP_AGENTS_LIST_CHANNEL = "acp-agents:list";
+export const ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL =
+  "acp-agents:acknowledge-update";
 export const AGENT_START_THREAD_CHANNEL = "agent:start-thread";
 export const AGENT_FORK_THREAD_CHANNEL = "agent:fork-thread";
 export const AGENT_START_TURN_CHANNEL = "agent:start-turn";

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -264,6 +264,7 @@ export type AcpAgentSettingsEntry = {
   lastDiscoveredAt?: number;
   lastDiscoveryError?: string;
   runtime?: BackendAcpRuntimeCapabilities;
+  update?: AcpAgentUpdateStatus;
   // Multi-install (Wave 2 / agent-acp). Every installed executable of this
   // agent found on the machine (PATH matches + fallbacks + a passing override),
   // the one currently in effect, the user's enable toggle, and their path
@@ -276,6 +277,19 @@ export type AcpAgentSettingsEntry = {
   activeCommand?: string;
   enabled?: boolean;
   preference?: AcpAgentPreference;
+};
+
+export type AcpAgentUpdateStatus = {
+  status: "available" | "up-to-date" | "failed";
+  checkedAt: number;
+  currentVersion: string;
+  latestVersion?: string;
+  channel?: string;
+  installer?: string;
+  autoUpdate?: boolean;
+  error?: string;
+  dismissedAt?: number;
+  snoozedUntil?: number;
 };
 
 /** How a discovered ACP instance's executable path was located. Mirrors the
@@ -319,4 +333,15 @@ export type ListAcpAgentSettingsResponse = {
   fetchedAt: number;
   entries: AcpAgentSettingsEntry[];
   error?: string;
+};
+
+export type AcknowledgeAcpAgentUpdateRequest = {
+  action: "dismiss" | "snooze";
+  backendId: AppServerBackendKind;
+  latestVersion: string;
+};
+
+export type AcknowledgeAcpAgentUpdateResponse = {
+  applied: boolean;
+  update?: AcpAgentUpdateStatus;
 };

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1351,6 +1351,12 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "backend/acpUpdateStatus/updated";
+      params: {
+        backend: AppServerBackendKind;
+      };
+    }
+  | {
       method: "item/commandExecution/outputDelta";
       params: {
         threadId: string;


### PR DESCRIPTION
## Summary

- check enabled, discovered Grok installations with the official no-install `grok update --check --json` command
- cache the result in the existing ACP agent store and emit a typed update-status event
- show a durable, version-keyed toast with Copy command, Tomorrow, and Dismiss version actions

## Why

Grok ACP initialization exposes the installed agent version, and the runtime emits general announcement notifications, but neither provides structured update availability or the latest compatible version. The official JSON check is the current policy-aligned source of truth.

## Behavior

- runs in the background without delaying backend discovery
- bounds each check to 20 seconds and 64 KiB, coalesces in-flight checks, and uses no shell
- checks at most every 24 hours after success and every hour after failure
- immediately rechecks after the executable path or installed version changes
- retains a previously known available update while offline; first-time failures remain silent
- persists dismiss/snooze state per PwrAgent profile and resets it when the latest version changes
- never installs the update automatically

## Validation

- `pnpm test apps/desktop/src/main/__tests__/settings-ipc.test.ts apps/desktop/src/main/__tests__/grok-cli-update.test.ts apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts apps/desktop/src/renderer/src/features/shell/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:sql`
