### PR TITLE
fix(desktop): avoid transportless PwrSnap MCP aliases

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7995,6 +7995,12 @@ script = "echo setup"
 
   it("isolates a selected PwrSnap stdio bridge from global Codex MCP config", async () => {
     const codexClient = new MockBackendClient({ threads: [] });
+    Object.assign(codexClient, {
+      readConfiguredMcpServerNames: vi.fn(async () => [
+        "pwrsnap",
+        "pwragent_pwrsnap",
+      ]),
+    });
     const overlayStore = createOverlayStoreMock();
     const bindThread = vi.fn();
     const registerBridge = vi.fn(async () => ({
@@ -8059,6 +8065,51 @@ script = "echo setup"
     await registry.close();
   });
 
+  it("does not create transport-less PwrSnap disable entries", async () => {
+    const codexClient = new MockBackendClient({ threads: [] });
+    const readConfiguredMcpServerNames = vi.fn(async () => ["pwrsnap"]);
+    Object.assign(codexClient, { readConfiguredMcpServerNames });
+    const registerBridge = vi.fn(async () => ({
+      server: {
+        name: "pwrsnap",
+        command: "/Applications/PwrAgent.app/Contents/MacOS/PwrAgent",
+        args: ["/app/mcp-connection-bridge.js"],
+        env: {
+          ELECTRON_RUN_AS_NODE: "1",
+          PWRAGENT_MCP_CONNECTION_SOCKET: "/tmp/pwragent.sock",
+          PWRAGENT_MCP_CONNECTION_TOKEN: "local-grant",
+        },
+      },
+      bindThread: vi.fn(),
+      revoke: vi.fn(),
+    }));
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      mcpConnectionService: { registerBridge },
+      createScratchProjectDirectory: async () => "/tmp/pwragent-scratch",
+    });
+
+    await registry.startThread({
+      backend: "codex",
+      mcpConnectionIds: [PWRSNAP_MCP_CONNECTION_ID],
+    });
+
+    expect(readConfiguredMcpServerNames).toHaveBeenCalledWith({
+      cwd: "/tmp/pwragent-scratch",
+    });
+    const mcpServers = (
+      codexClient.lastStartThreadParams?.config as {
+        mcp_servers?: Record<string, unknown>;
+      }
+    )?.mcp_servers;
+    expect(mcpServers?.pwrsnap).toEqual({ enabled: false });
+    expect(mcpServers).not.toHaveProperty("pwragent_pwrsnap");
+
+    await registry.close();
+  });
+
   it("revokes a PwrSnap bridge when Codex thread creation fails", async () => {
     const codexClient = new MockBackendClient({ threads: [] });
     vi.spyOn(codexClient, "startThread").mockRejectedValueOnce(
@@ -8096,6 +8147,48 @@ script = "echo setup"
 
     expect(registerBridge).toHaveBeenCalledWith("pwrsnap", undefined);
     expect(revoke).toHaveBeenCalledTimes(1);
+    await registry.close();
+  });
+
+  it("explains rejected PwrSnap MCP transports without implying PwrSnap was down", async () => {
+    const codexClient = new MockBackendClient({ threads: [] });
+    vi.spyOn(codexClient, "startThread").mockRejectedValueOnce(
+      new Error(
+        "json-rpc error (-32600): failed to load configuration: invalid transport in mcp_servers.pwragent_pwrsnap",
+      ),
+    );
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      mcpConnectionService: {
+        registerBridge: async () => ({
+          server: {
+            name: "pwrsnap",
+            command: "/Applications/PwrAgent.app/Contents/MacOS/PwrAgent",
+            args: ["/app/mcp-connection-bridge.js"],
+            env: {
+              ELECTRON_RUN_AS_NODE: "1",
+              PWRAGENT_MCP_CONNECTION_SOCKET: "/tmp/pwragent.sock",
+              PWRAGENT_MCP_CONNECTION_TOKEN: "local-grant",
+            },
+          },
+          bindThread: vi.fn(),
+          revoke: vi.fn(),
+        }),
+      },
+      createScratchProjectDirectory: async () => "/tmp/pwragent-scratch",
+    });
+
+    await expect(
+      registry.startThread({
+        backend: "codex",
+        mcpConnectionIds: [PWRSNAP_MCP_CONNECTION_ID],
+      }),
+    ).rejects.toThrow(
+      "PwrSnap was not contacted: Codex rejected PwrAgent's temporary MCP configuration. Update PwrAgent and retry the thread.",
+    );
+
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1221,6 +1221,42 @@ describe("CodexAppServerClient", () => {
     );
   });
 
+  it("reads only effective MCP server names for connection setup", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const observedMessages: string[] = [];
+    const client = new CodexAppServerClient({
+      command: "codex",
+      connectionObserver: {
+        onMessage: async (event) => {
+          observedMessages.push(event.raw);
+        },
+      },
+    });
+
+    await expect(
+      client.readConfiguredMcpServerNames({
+        cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+      }),
+    ).resolves.toEqual(["context7", "github"]);
+
+    const requests = MockTransport.instances.at(-1)!.sentMessages.map(
+      (message) => JSON.parse(message) as { method?: string; params?: unknown },
+    );
+    expect(requests).toContainEqual(expect.objectContaining({
+      method: "config/read",
+      params: {
+        includeLayers: false,
+        cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+      },
+    }));
+    expect(observedMessages.join("\n")).not.toContain("never-forward-me");
+    expect(observedMessages.join("\n")).not.toContain("github-mcp-server");
+    expect(observedMessages.join("\n")).toContain('"context7":{}');
+    expect(observedMessages.join("\n")).toContain('"github":{}');
+
+    await client.close();
+  });
+
   it("initializes once and normalizes thread/list results", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -567,6 +567,9 @@ function assistantOutputForTurn(
 type BackendClient = {
   close(): Promise<void>;
   getInitializeResult(): Promise<InitializeResult>;
+  readConfiguredMcpServerNames?(params?: {
+    cwd?: string;
+  }): Promise<string[]>;
   listThreads(
     params?: {
       archived?: boolean;
@@ -5809,33 +5812,57 @@ function buildCodexConnectionMcpServerName(
 
 function buildCodexConnectionMcpConfig(
   registrations: McpConnectionBridgeRegistration[],
+  inheritedServerNames?: readonly string[],
 ): CodexThreadStartParams["config"] | undefined {
   if (registrations.length === 0) return undefined;
+  const inheritedNames = new Set(inheritedServerNames ?? []);
   return {
     mcp_servers: Object.fromEntries(
-      registrations.flatMap(({ server }) => [
+      registrations.flatMap(({ server }) => {
         // Codex recursively merges thread config over the operator's global
-        // config. Disable both the original name and our former fixed alias,
-        // then give this grant a stable hashed key so inherited HTTP fields
-        // cannot turn the stdio bridge into an invalid mixed transport.
-        [server.name, { enabled: false }],
-        [
+        // config. Disable only aliases that were actually inherited: a new
+        // `{ enabled: false }` entry has no command or URL, which Codex
+        // correctly rejects as a transport-less MCP server. The bridge itself
+        // always receives a unique hashed name so it cannot mix with an
+        // inherited HTTP server.
+        const aliases = [
+          server.name,
           `${PWRAGENT_CONNECTION_MCP_SERVER_PREFIX}${server.name}`,
-          { enabled: false },
-        ],
-        [
-          buildCodexConnectionMcpServerName(server),
-          {
-            enabled: true,
-            command: server.command,
-            args: server.args,
-            env: server.env,
-            tool_timeout_sec: MCP_CONNECTION_TOOL_TIMEOUT_SECONDS,
-          },
-        ],
-      ]),
+        ].filter((name) => inheritedNames.has(name));
+        return [
+          ...aliases.map((name) => [name, { enabled: false }] as const),
+          [
+            buildCodexConnectionMcpServerName(server),
+            {
+              enabled: true,
+              command: server.command,
+              args: server.args,
+              env: server.env,
+              tool_timeout_sec: MCP_CONNECTION_TOOL_TIMEOUT_SECONDS,
+            },
+          ] as const,
+        ];
+      }),
     ),
   } as CodexThreadStartParams["config"];
+}
+
+function userActionablePwrSnapMcpConfigError(
+  error: unknown,
+  registrations: McpConnectionBridgeRegistration[],
+): unknown {
+  if (
+    !registrations.some(({ server }) => server.name === PWRSNAP_MCP_CONNECTION_ID)
+    || !(error instanceof Error)
+    || !error.message.includes("invalid transport in mcp_servers.")
+  ) {
+    return error;
+  }
+  return new Error(
+    "PwrSnap was not contacted: Codex rejected PwrAgent's temporary MCP configuration. Update PwrAgent and retry the thread. If this still happens after updating, repair or remove the named MCP server in Codex configuration. Details: "
+      + error.message,
+    { cause: error },
+  );
 }
 
 function mergeCodexThreadConfigs(
@@ -10306,6 +10333,9 @@ export class DesktopBackendRegistry {
         : [];
     const connectionMcpConfig = buildCodexConnectionMcpConfig(
       mcpConnectionRegistrations,
+      backend === "codex" && mcpConnectionRegistrations.length > 0
+        ? await this.readConfiguredCodexMcpServerNames(cwd)
+        : undefined,
     );
     const codexMcpConfig = mergeCodexThreadConfigs(
       pdfMcpConfig,
@@ -10394,7 +10424,10 @@ export class DesktopBackendRegistry {
               : String(rollbackError),
         });
       });
-      throw error;
+      throw userActionablePwrSnapMcpConfigError(
+        error,
+        mcpConnectionRegistrations,
+      );
     }
     pdfMcpRegistration?.bindThread(result.threadId);
     for (const registration of mcpConnectionRegistrations) {
@@ -11162,6 +11195,27 @@ export class DesktopBackendRegistry {
     return registrations;
   }
 
+  private async readConfiguredCodexMcpServerNames(
+    cwd?: string,
+  ): Promise<string[] | undefined> {
+    if (!this.codexClient.readConfiguredMcpServerNames) {
+      return undefined;
+    }
+    try {
+      return await this.codexClient.readConfiguredMcpServerNames(
+        cwd ? { cwd } : undefined,
+      );
+    } catch (error) {
+      // A compatibility fallback must not prevent a selected connection from
+      // starting. Without an inventory, omit disable entries rather than
+      // creating a transport-less MCP config record.
+      backendRegistryLog.warn("connection_mcp_config_inventory_failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
   private async registerAcpMcpConnections(
     connectionIds: string[] | undefined,
     threadId?: string,
@@ -11354,6 +11408,14 @@ export class DesktopBackendRegistry {
         backend: params.backend,
         threadId: params.threadId,
       });
+      cwd =
+        params.backend === "codex"
+          ? await this.resolveThreadEnvironmentCwd(
+              params.backend,
+              params.threadId,
+              overlay,
+            )
+          : undefined;
       const hasPdfMcpToolCatalog =
         params.backend === "codex" && this.hasPdfMcpToolCatalog(overlay);
       if (hasPdfMcpToolCatalog) {
@@ -11372,7 +11434,10 @@ export class DesktopBackendRegistry {
         );
         codexMcpConfig = mergeCodexThreadConfigs(
           codexMcpConfig,
-          buildCodexConnectionMcpConfig(registrations),
+          buildCodexConnectionMcpConfig(
+            registrations,
+            await this.readConfiguredCodexMcpServerNames(cwd),
+          ),
         );
       }
       const preparedPdfInput = await preparePdfTurnInput({
@@ -11400,14 +11465,6 @@ export class DesktopBackendRegistry {
           : params.reasoningEffort ?? overlay?.reasoningEffort,
         fastMode: params.backend === "codex" ? params.fastMode ?? overlay?.fastMode : undefined,
       });
-      cwd =
-        params.backend === "codex"
-          ? await this.resolveThreadEnvironmentCwd(
-              params.backend,
-              params.threadId,
-              overlay,
-            )
-          : undefined;
       await this.emit({
         backend: params.backend,
         notification: {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -136,6 +136,7 @@ const DEFAULT_CODEX_COLLABORATION_MODEL = "gpt-5.5";
 export const DEFAULT_CODEX_THREAD_TITLE_MODEL = "gpt-5.6-luna";
 const DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS = 20_000;
 const CODEX_THREAD_TITLE_CONFIG_READ_REASON = "thread-title-mcp-inventory";
+const CODEX_CONNECTION_MCP_CONFIG_READ_REASON = "connection-mcp-inventory";
 const CODEX_THREAD_TITLE_WORKSPACE_DIR = path.join(
   tmpdir(),
   "pwragent",
@@ -572,7 +573,10 @@ function createCodexObserverWithConfigReadRedaction(
       if (
         redactedEvent.direction === "outbound"
         && redactedEvent.envelope.method === "config/read"
-        && redactedEvent.diagnostics?.callerReason === CODEX_THREAD_TITLE_CONFIG_READ_REASON
+        && (
+          redactedEvent.diagnostics?.callerReason === CODEX_THREAD_TITLE_CONFIG_READ_REASON
+          || redactedEvent.diagnostics?.callerReason === CODEX_CONNECTION_MCP_CONFIG_READ_REASON
+        )
         && requestKey
       ) {
         sensitiveRequestIds.add(requestKey);
@@ -7838,6 +7842,28 @@ export class CodexAppServerClient {
     timeoutMs?: number;
   }): Promise<ThreadTitleAdapterResult> {
     return await this.runHelperStructuredTurn(params);
+  }
+
+  /**
+   * Returns only the effective MCP server names. Connection setup uses this to
+   * avoid creating a transport-less disable entry for an alias that Codex did
+   * not inherit. The protocol observer redacts the complete config response.
+   */
+  async readConfiguredMcpServerNames(params?: {
+    cwd?: string;
+  }): Promise<string[]> {
+    await this.ensureInitialized();
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      diagnostics: { callerReason: CODEX_CONNECTION_MCP_CONFIG_READ_REASON },
+      methods: ["config/read"],
+      payloads: [{
+        includeLayers: false,
+        ...(params?.cwd ? { cwd: params.cwd } : {}),
+      }],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+    return readConfiguredMcpServerNames(result);
   }
 
   /** Read only configured MCP names; the observer wrapper strips secret values. */


### PR DESCRIPTION
## Summary

- Read the effective Codex MCP server names before configuring a selected PwrSnap bridge.
- Disable only aliases inherited from Codex, never emit a new disable-only MCP record.
- Surface a retryable explanation when Codex rejects the temporary PwrSnap configuration before PwrSnap is contacted.

## Root cause

The post-#1230 bridge configuration always emitted `pwragent_pwrsnap = { enabled = false }`. On the M4 Mini that alias did not exist in a lower configuration layer, leaving an MCP record with neither `command` nor `url`. Codex validates disabled MCP records and rejected the thread configuration as an invalid transport before the PwrSnap process, loopback port, TLS, or OAuth could be used.

## Impact

Cross-machine thread creation with a selected PwrSnap connection now avoids the invalid empty alias while preserving the hashed, complete stdio bridge configuration. No network or credential settings are changed.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm build`
