### PR TITLE
fix(desktop): align composer chips on the prose baseline

### DIFF
--- a/apps/desktop/e2e/composer-chip-alignment.spec.ts
+++ b/apps/desktop/e2e/composer-chip-alignment.spec.ts
@@ -1,0 +1,221 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Locator } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+/**
+ * Measures where the composer's inline mention chips actually land, which
+ * the CSS contract test in
+ * `src/renderer/src/styles/__tests__/composer-chip-alignment.test.ts`
+ * cannot: jsdom does not lay out CSS, so that test can only assert the
+ * declarations the alignment depends on.
+ *
+ * The chips are inline-flex, and an inline-flex box takes its baseline from
+ * its FIRST flex item. The kinds disagree on what that is — the `$skill`
+ * chip leads with its label text, `#thread` leads with a 1em SVG icon — so
+ * before the `::before` strut they aligned from different origins.
+ *
+ * Measured on this fixture at this window size, with the fix and with it
+ * reverted:
+ *
+ *              chip top vs its line's text top      paragraph height
+ *   fixed      skill -0.95   thread -0.95  (0.00)   44.78 = 2 x 22.39
+ *   reverted   skill -2.77   thread -4.25  (1.48)   47.80 (+3.02)
+ *
+ * Hence the 0.5px and 1px tolerances below: roughly three times the
+ * observed spread in the passing state, and roughly a third of the
+ * regression they exist to catch.
+ *
+ * Coverage note: this drives the two autocompletes that need no fixture
+ * work, which is also the pair that was furthest apart. The PR pill (a
+ * third structure, leading with an 8px dot) is not covered — its `#`
+ * autocomplete entry only appears for a numeric query against a thread
+ * carrying an attached PR, and no E2E fixture seeds one today.
+ */
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(
+  specDir,
+  "fixtures/skill-autocomplete-interactions/replay.fixture.json",
+);
+
+/** Chips must agree this closely on where they sit within their line. */
+const OFFSET_TOLERANCE_PX = 0.5;
+/** Slack for the line-grid and chip-height comparisons. */
+const HEIGHT_TOLERANCE_PX = 1;
+
+type ChipPlacement = {
+  height: number;
+  kind: string;
+  /** Chip top edge relative to the top of its own line's text. */
+  offsetInLine: number;
+};
+
+type ComposerMetrics = {
+  height: number;
+  /** Rendered lines, counted from the paragraph's own text runs. */
+  lines: number;
+  chips: ChipPlacement[];
+};
+
+/**
+ * Line count and per-chip placement in one pass.
+ *
+ * Every reference comes from the paragraph's TEXT runs, never from a chip's
+ * own box. That distinction is the whole measurement: a chip that rides too
+ * high also drags the top of its line box up with it, so measuring a chip
+ * against its line box compares it to itself and reports zero no matter how
+ * misaligned it is. A text run sits on the baseline, so its box top is a
+ * fixed reference the chip can be wrong against.
+ */
+async function composerMetrics(paragraph: Locator): Promise<ComposerMetrics> {
+  return await paragraph.evaluate((element) => {
+    const textTops: number[] = [];
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+      const owner = node.parentElement;
+      if (owner?.closest(".composer-tiptap-input__mention")) {
+        continue;
+      }
+      const range = document.createRange();
+      range.selectNodeContents(node);
+      for (const rect of range.getClientRects()) {
+        if (rect.height > 0) {
+          textTops.push(rect.top);
+        }
+      }
+    }
+
+    // One line contributes a top per text run, all equal; 1px absorbs
+    // sub-pixel noise without merging lines a whole line-height apart.
+    const sorted = [...textTops].sort((left, right) => left - right);
+    const lineTops = sorted.filter(
+      (top, index) => index === 0 || top - sorted[index - 1] > 1,
+    );
+
+    const chips = [
+      ...element.querySelectorAll<HTMLElement>(".composer-tiptap-input__mention"),
+    ].map((chip) => {
+      const box = chip.getBoundingClientRect();
+      const centre = (box.top + box.bottom) / 2;
+      const nearest = lineTops.reduce(
+        (best, top) =>
+          Math.abs(top - centre) < Math.abs(best - centre) ? top : best,
+        lineTops[0] ?? box.top,
+      );
+      return {
+        height: box.height,
+        kind: chip.getAttribute("data-mention-kind") ?? "skill",
+        offsetInLine: box.top - nearest,
+      };
+    });
+
+    return {
+      chips,
+      height: element.getBoundingClientRect().height,
+      lines: Math.max(lineTops.length, 1),
+    };
+  });
+}
+
+test("composer chips of every structure sit at one height in the prose", async () => {
+  const app = await launchElectronApp({
+    fixturePath,
+    windowSize: {
+      width: 1180,
+      height: 760,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Skill autocomplete replay/i })
+      .first()
+      .click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Skill autocomplete replay",
+      }),
+    ).toBeVisible();
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "Reply" });
+    const paragraph = tiptapInput.locator(".composer-tiptap-input__editor > p");
+
+    // Baseline: plain prose, before any chip interrupts it. Typed rather
+    // than filled so the caret is left at the end of the draft without
+    // depending on where `fill()` parks it in a contenteditable.
+    await textbox.click();
+    await app.window.keyboard.type("Run");
+    await expect(tiptapInput).toHaveAttribute("data-value", "Run");
+    const plain = await composerMetrics(paragraph);
+    expect(plain.lines).toBe(1);
+    const plainLineHeight = plain.height;
+
+    // `$skill` — a chip whose first flex item is its label text.
+    await app.window.keyboard.type(" $ce:plan");
+    await expect(app.window.getByRole("listbox", { name: "Skills" })).toBeVisible();
+    await app.window.keyboard.press("Enter");
+    await expect(app.window.getByRole("listbox", { name: "Skills" })).toBeHidden();
+
+    // `#thread` — a chip whose first flex item is a 1em SVG icon. The
+    // trailing word matters: the composer is 342px wide here, so the draft
+    // wraps and this keeps a text run on the second line for that chip to
+    // be measured against.
+    await app.window.keyboard.type("on #");
+    const hashOptions = app.window.getByRole("listbox", {
+      name: "Threads and pull requests",
+    });
+    await expect(hashOptions).toBeVisible();
+    await app.window.keyboard.press("Enter");
+    await expect(hashOptions).toBeHidden();
+    await app.window.keyboard.type("today");
+
+    const skillChip = tiptapInput.locator(
+      ".composer-tiptap-input__mention:not([data-mention-kind])",
+    );
+    const threadChip = tiptapInput.locator(
+      '.composer-tiptap-input__mention[data-mention-kind="thread"]',
+    );
+    await expect(skillChip).toHaveCount(1);
+    await expect(threadChip).toHaveCount(1);
+
+    // Guard against a vacuous pass: the whole point is that these two chips
+    // lead with different elements, so if the thread chip ever stops
+    // rendering its icon there is nothing left to disagree about and the
+    // comparison below proves nothing.
+    expect(
+      await skillChip.evaluate((element) => element.firstElementChild?.tagName ?? null),
+    ).toBeNull();
+    expect(
+      await threadChip.evaluate((element) =>
+        element.firstElementChild?.tagName.toLowerCase() ?? null,
+      ),
+    ).toBe("svg");
+
+    const chipped = await composerMetrics(paragraph);
+    expect(chipped.chips).toHaveLength(2);
+    const [first, ...rest] = chipped.chips;
+
+    for (const placement of rest) {
+      expect(
+        Math.abs(placement.offsetInLine - first.offsetInLine),
+        `${placement.kind} chip vs ${first.kind} chip, top edge within its own line`,
+      ).toBeLessThanOrEqual(OFFSET_TOLERANCE_PX);
+      expect(Math.abs(placement.height - first.height)).toBeLessThanOrEqual(
+        HEIGHT_TOLERANCE_PX,
+      );
+    }
+
+    // And no chip pushes its line taller than plain prose. Compared as a
+    // total against the expected total rather than as an average per line:
+    // the chips land on different lines here, and an average halves
+    // whatever any one of them contributes.
+    expect(
+      Math.abs(chipped.height - chipped.lines * plainLineHeight),
+      `${chipped.lines} lines of ${plainLineHeight}px`,
+    ).toBeLessThanOrEqual(HEIGHT_TOLERANCE_PX);
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/renderer/src/styles/__tests__/composer-chip-alignment.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/composer-chip-alignment.test.ts
@@ -4,24 +4,21 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 /**
- * Locks the vertical alignment contract for the composer's inline mention
- * chips (`$skill`, `@file`, `@directory`, `#thread`, PR pill).
+ * Locks the vertical alignment of the composer's inline mention chips
+ * (`$skill`, `@file`, `@directory`, `#thread`, PR pill) against the
+ * paragraph baseline.
  *
- * These chips are inline-flex, and an inline-flex box takes its baseline
- * from its FIRST flex item. The kinds do not agree on what that item is:
- * the `$`/`@` chips lead with their label text, `#thread` leads with a 1em
- * SVG icon, and the PR pill leads with an 8px dot — each of which sits at
- * a different height. A shared `vertical-align: <length>` is therefore
- * measured from three different origins and lands in three places (the
- * shipped 0.13em nudge spread the chips over 3.0px on an 18.9px chip).
+ * Alignment is a layout outcome and jsdom does not lay out CSS, so what is
+ * asserted here is every declaration the outcome depends on. That is a
+ * narrower net than it sounds: with the `::before` strut in place the chips
+ * no longer take their baseline from whichever child happens to be first,
+ * so a DOM change in `ComposerTiptapInput`'s `renderHTML` can no longer
+ * move them — only these declarations can. Change an assertion in the same
+ * commit as any deliberate change to the alignment.
  *
- * The fix is a zero-width-space `::before` strut that gives every kind the
- * same text baseline, plus `vertical-align: baseline` so that baseline is
- * the paragraph's. Both halves are load-bearing and neither reads as
- * obviously necessary at a glance, which is what this test is for. Layout
- * itself cannot be asserted here — jsdom does not lay out CSS — so the
- * contract is asserted on the declarations. Change these assertions in the
- * same commit as any deliberate change to the alignment.
+ * What this cannot see: `align-items` and `font-size` reaching the chip
+ * from `.chip` / `.pr-chip`, and anything that only shows up in real
+ * layout. Measuring the chips themselves needs a browser.
  */
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const css = readFileSync(path.resolve(testDir, "../app.css"), "utf8");
@@ -50,21 +47,17 @@ const STRUT = `${MENTION}::before`;
 
 describe("composer inline chip alignment contract", () => {
   it("aligns every mention chip on the paragraph baseline, not a nudge", () => {
-    const body = ruleBody(MENTION);
-
     // A length here would reintroduce the per-kind spread: it is measured
-    // from the chip's own synthesized baseline, which the strut — not the
-    // nudge — is what makes uniform.
-    expect(declaration(body, "vertical-align")).toBe("baseline");
+    // from the chip's own synthesized baseline, and the strut — not the
+    // nudge — is what makes that baseline uniform.
+    expect(declaration(ruleBody(MENTION), "vertical-align")).toBe("baseline");
   });
 
   it("keeps the zero-width baseline strut in front of every chip", () => {
-    const body = ruleBody(STRUT);
-
-    // U+200B. The strut must carry text, not `content: ""`: an empty box
-    // synthesizes its baseline from its bottom edge and the chips go back
-    // to disagreeing.
-    expect(declaration(body, "content")).toBe('"\\200b"');
+    // U+200B, with empty alt text so it stays out of accessible names. The
+    // strut must carry text: an empty box synthesizes its baseline from its
+    // bottom edge and the chip kinds go back to disagreeing.
+    expect(declaration(ruleBody(STRUT), "content")).toBe('"\\200b" / ""');
   });
 
   it("cancels exactly the one flex gap the strut opens", () => {
@@ -77,11 +70,25 @@ describe("composer inline chip alignment contract", () => {
     expect(cancel).toBe(`-${gap}`);
   });
 
-  it("outranks the chip primitives on specificity, not on source order", () => {
+  it("keeps the strut's own line box unstyled", () => {
+    // The strut is text, so its baseline sits inside its line box. A
+    // unitless or fixed `line-height` here would move that box — and every
+    // chip with it — without touching anything that reads as alignment.
+    expect(declaration(ruleBody(MENTION), "line-height")).toBe("normal");
+  });
+
+  it("keeps chips inside the line box they interrupt", () => {
+    // 1.35em = 18.9px against the composer's 22.4px line box, which leaves
+    // the chip 14.7px above and 4.2px below the baseline — inside the
+    // 16.0/6.4 the text strut already claims, so a chip never pushes its
+    // own line taller than a plain one.
+    expect(declaration(ruleBody(MENTION), "height")).toBe("1.35em");
+  });
+
+  it("does not leave an unqualified base rule to lose the cascade with", () => {
     // `.chip` (24px/12px) and `.pr-chip` (22px/11px) are row and header
-    // geometry; the composer's em-based sizing has to win regardless of
-    // where these rules end up in the file.
-    expect(css).toContain(MENTION);
+    // geometry. The composer's em-based sizing has to outrank them on
+    // specificity, not on where these rules land in the file.
     expect(css).not.toMatch(/\n\.composer-tiptap-input__mention\s*\{/);
   });
 });

--- a/apps/desktop/src/renderer/src/styles/__tests__/composer-chip-alignment.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/composer-chip-alignment.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Locks the vertical alignment contract for the composer's inline mention
+ * chips (`$skill`, `@file`, `@directory`, `#thread`, PR pill).
+ *
+ * These chips are inline-flex, and an inline-flex box takes its baseline
+ * from its FIRST flex item. The kinds do not agree on what that item is:
+ * the `$`/`@` chips lead with their label text, `#thread` leads with a 1em
+ * SVG icon, and the PR pill leads with an 8px dot — each of which sits at
+ * a different height. A shared `vertical-align: <length>` is therefore
+ * measured from three different origins and lands in three places (the
+ * shipped 0.13em nudge spread the chips over 3.0px on an 18.9px chip).
+ *
+ * The fix is a zero-width-space `::before` strut that gives every kind the
+ * same text baseline, plus `vertical-align: baseline` so that baseline is
+ * the paragraph's. Both halves are load-bearing and neither reads as
+ * obviously necessary at a glance, which is what this test is for. Layout
+ * itself cannot be asserted here — jsdom does not lay out CSS — so the
+ * contract is asserted on the declarations. Change these assertions in the
+ * same commit as any deliberate change to the alignment.
+ */
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(path.resolve(testDir, "../app.css"), "utf8");
+
+/** Body of the first top-level CSS rule whose selector matches exactly. */
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(
+    new RegExp(`(?:^|\\n)${escaped}\\s*\\{(?<body>[\\s\\S]*?)\\n\\}`)
+  );
+  if (!match?.groups?.body) {
+    throw new Error(`Expected app.css to define ${selector}`);
+  }
+  return match.groups.body;
+}
+
+function declaration(body: string, property: string): string | undefined {
+  const match = body.match(
+    new RegExp(`(?:^|\\n)\\s*${property}:\\s*(?<value>[^;]+);`)
+  );
+  return match?.groups?.value.trim();
+}
+
+const MENTION = ".composer-tiptap-input__editor .composer-tiptap-input__mention";
+const STRUT = `${MENTION}::before`;
+
+describe("composer inline chip alignment contract", () => {
+  it("aligns every mention chip on the paragraph baseline, not a nudge", () => {
+    const body = ruleBody(MENTION);
+
+    // A length here would reintroduce the per-kind spread: it is measured
+    // from the chip's own synthesized baseline, which the strut — not the
+    // nudge — is what makes uniform.
+    expect(declaration(body, "vertical-align")).toBe("baseline");
+  });
+
+  it("keeps the zero-width baseline strut in front of every chip", () => {
+    const body = ruleBody(STRUT);
+
+    // U+200B. The strut must carry text, not `content: ""`: an empty box
+    // synthesizes its baseline from its bottom edge and the chips go back
+    // to disagreeing.
+    expect(declaration(body, "content")).toBe('"\\200b"');
+  });
+
+  it("cancels exactly the one flex gap the strut opens", () => {
+    const gap = declaration(ruleBody(MENTION), "gap");
+    const cancel = declaration(ruleBody(STRUT), "margin-inline-end");
+
+    // The strut is a real flex item, so `gap` applies in front of the
+    // icon/dot until this margin takes it back. Drift between the two
+    // shifts every chip's contents sideways.
+    expect(cancel).toBe(`-${gap}`);
+  });
+
+  it("outranks the chip primitives on specificity, not on source order", () => {
+    // `.chip` (24px/12px) and `.pr-chip` (22px/11px) are row and header
+    // geometry; the composer's em-based sizing has to win regardless of
+    // where these rules end up in the file.
+    expect(css).toContain(MENTION);
+    expect(css).not.toMatch(/\n\.composer-tiptap-input__mention\s*\{/);
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -17728,7 +17728,24 @@ a.transcript-message__messaging-origin:focus-visible {
   pointer-events: none;
 }
 
-.composer-tiptap-input__mention {
+/* Inline mention chips inside the composer: `$skill`, `@file`, `@directory`,
+   `#thread`, and PR pills. They interrupt running prose, so they are sized in
+   `em` off the paragraph (14px/1.6) rather than off the chip primitives —
+   `.chip` (24px / 12px) and `.pr-chip` (22px / 11px) are row-and-header
+   geometry and do not belong in a sentence.
+
+   Qualified with `.composer-tiptap-input__editor` so this block outranks
+   `.chip` / `.pr-chip` / `.thread-chip` (each 0,1,0) on specificity instead of
+   on source order. The geometry used to depend on this block sitting later in
+   the file; moving `.thread-chip`'s `height: 22px` below it would silently
+   resize every composer chip.
+
+   ALIGNMENT (see the ::before strut below): every chip's own label sits on the
+   paragraph's baseline, so a chip reads as a word in the sentence rather than a
+   badge floating over it. Do not swap this for a `vertical-align` nudge — a
+   length here is measured from the chip's *synthesized* baseline, which differs
+   per chip kind and is what made them disagree in the first place. */
+.composer-tiptap-input__editor .composer-tiptap-input__mention {
   display: inline-flex;
   height: 1.35em;
   gap: 0.35em;
@@ -17736,7 +17753,30 @@ a.transcript-message__messaging-origin:focus-visible {
   padding: 0 0.5em;
   font-size: inherit;
   line-height: normal;
-  vertical-align: 0.13em;
+  vertical-align: baseline;
+}
+
+/* Zero-width baseline strut, and the whole reason these chips line up.
+   An inline-flex box takes its baseline from its FIRST flex item, so each
+   chip kind used to hand the line a different one: the `$`/`@` chips gave
+   their label's text baseline, `#thread` gave the bottom edge of its 1em SVG
+   icon (1.75px higher), and the PR pill gave the bottom edge of its 8px dot
+   (1.25px lower). One shared `vertical-align` offset therefore landed in three
+   different places — a 3.0px spread on an 18.9px chip.
+
+   A zero-width-space item in front makes that first baseline the chip font's
+   own text baseline in every kind, so `vertical-align: baseline` above lands
+   each chip's label exactly on the paragraph's baseline. Measured box spread
+   after this change: 0.5px, and that remainder is the PR pill's mono metrics
+   holding ITS label on the baseline — the labels themselves agree.
+
+   The negative inline-end margin cancels the one `gap` the strut would
+   otherwise open in front of the icon/dot; it must stay equal to `gap` above.
+   Generated content never enters the ProseMirror document, so the strut
+   cannot reach the draft, the clipboard, or the text the composer sends. */
+.composer-tiptap-input__editor .composer-tiptap-input__mention::before {
+  content: "\200b";
+  margin-inline-end: -0.35em;
 }
 
 .composer-tiptap-input__mention.thread-chip {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -17729,22 +17729,12 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 /* Inline mention chips inside the composer: `$skill`, `@file`, `@directory`,
-   `#thread`, and PR pills. They interrupt running prose, so they are sized in
-   `em` off the paragraph (14px/1.6) rather than off the chip primitives —
-   `.chip` (24px / 12px) and `.pr-chip` (22px / 11px) are row-and-header
-   geometry and do not belong in a sentence.
-
-   Qualified with `.composer-tiptap-input__editor` so this block outranks
-   `.chip` / `.pr-chip` / `.thread-chip` (each 0,1,0) on specificity instead of
-   on source order. The geometry used to depend on this block sitting later in
-   the file; moving `.thread-chip`'s `height: 22px` below it would silently
-   resize every composer chip.
-
-   ALIGNMENT (see the ::before strut below): every chip's own label sits on the
-   paragraph's baseline, so a chip reads as a word in the sentence rather than a
-   badge floating over it. Do not swap this for a `vertical-align` nudge — a
-   length here is measured from the chip's *synthesized* baseline, which differs
-   per chip kind and is what made them disagree in the first place. */
+   `#thread`, PR pills. They interrupt running prose, so they are sized in `em`
+   off the paragraph rather than off `.chip` (24px / 12px) and `.pr-chip`
+   (22px / 11px), which are row and header geometry. Qualified by the editor so
+   that sizing wins on specificity rather than on this block happening to sit
+   below those two. Height stays under the 22.4px line box so a chip never
+   pushes its line taller than a plain one. */
 .composer-tiptap-input__editor .composer-tiptap-input__mention {
   display: inline-flex;
   height: 1.35em;
@@ -17756,26 +17746,19 @@ a.transcript-message__messaging-origin:focus-visible {
   vertical-align: baseline;
 }
 
-/* Zero-width baseline strut, and the whole reason these chips line up.
-   An inline-flex box takes its baseline from its FIRST flex item, so each
-   chip kind used to hand the line a different one: the `$`/`@` chips gave
-   their label's text baseline, `#thread` gave the bottom edge of its 1em SVG
-   icon (1.75px higher), and the PR pill gave the bottom edge of its 8px dot
-   (1.25px lower). One shared `vertical-align` offset therefore landed in three
-   different places — a 3.0px spread on an 18.9px chip.
-
-   A zero-width-space item in front makes that first baseline the chip font's
-   own text baseline in every kind, so `vertical-align: baseline` above lands
-   each chip's label exactly on the paragraph's baseline. Measured box spread
-   after this change: 0.5px, and that remainder is the PR pill's mono metrics
-   holding ITS label on the baseline — the labels themselves agree.
-
-   The negative inline-end margin cancels the one `gap` the strut would
-   otherwise open in front of the icon/dot; it must stay equal to `gap` above.
-   Generated content never enters the ProseMirror document, so the strut
-   cannot reach the draft, the clipboard, or the text the composer sends. */
+/* Zero-width baseline strut — load-bearing, not decoration. An inline-flex box
+   takes its baseline from its FIRST flex item, and the kinds disagree on what
+   that is: label text for `$`/`@`, a 1em SVG icon for `#thread`, an 8px dot for
+   the PR pill. Every `vertical-align` is measured from that baseline, so one
+   shared offset landed in three places (a 3.0px spread on an 18.9px chip). A
+   text-bearing item in front makes the first baseline the chip font's own, so
+   `vertical-align: baseline` above puts each label on the paragraph's baseline.
+   `content: ""` will not do — an empty box synthesizes its baseline from its
+   bottom edge, and the chips go back to disagreeing. The `/ ""` keeps the strut
+   out of the accessible name; the negative margin cancels the single `gap` it
+   opens and must stay equal to that `gap`. */
 .composer-tiptap-input__editor .composer-tiptap-input__mention::before {
-  content: "\200b";
+  content: "\200b" / "";
   margin-inline-end: -0.35em;
 }
 


### PR DESCRIPTION
## What

Composer inline chips (`$skill`, `@file`, `@directory`, `#thread`, PR pill) sat at three different heights within the same sentence, and none of them shared the paragraph's baseline. This pins all of them to the prose baseline.

## Why they disagreed

The chips are `inline-flex`, and an inline-flex box takes its baseline from its **first flex item**. The kinds don't agree on what that item is:

| chip | first flex item | baseline it hands the line |
|---|---|---|
| `$skill`, `@file`, `@directory` | label text | the text baseline |
| `#thread` | 1em SVG icon | bottom edge of the icon (1.75px higher) |
| PR pill | 8px status dot | bottom edge of the dot (1.25px lower) |

`.composer-tiptap-input__mention` then applied one shared `vertical-align: 0.13em` to all of them — but a `vertical-align` length is measured *from the box's own baseline*, so the single nudge landed in three different places.

## Measurements

Taken against the shipping stylesheet in Chromium at the composer's real prose metrics (14px / line-height 1.6 → 22.4px line box; cap ascent 9.86px). Distances are from the paragraph baseline, positive = above.

**Before**

| chip | box top | box bottom | center vs cap-height center | line-box inflation |
|---|---|---|---|---|
| `$skill` | 16.51 | −2.39 | +2.13 high | +0.51px |
| `@file` | 16.51 | −2.39 | +2.13 high | +0.51px |
| `@directory` | 16.51 | −2.39 | +2.13 high | +0.51px |
| `#thread` | 18.26 | −0.64 | +3.88 high | +2.26px |
| PR | 15.26 | −3.64 | +0.88 high | 0 |

**3.0px spread on an 18.9px chip** (16% of chip height), and lines carrying a chip grew by up to 2.26px, so paragraph leading changed with chip kind.

**After**

| chip | box top | box bottom | center vs cap-height center | label vs prose baseline | line-box inflation |
|---|---|---|---|---|---|
| `$skill` | 14.70 | −4.20 | +0.31 | 0.00 | 0 |
| `@file` | 14.70 | −4.20 | +0.31 | 0.00 | 0 |
| `@directory` | 14.70 | −4.20 | +0.31 | 0.00 | 0 |
| `#thread` | 14.70 | −4.20 | +0.31 | 0.00 | 0 |
| PR | 14.20 | −4.70 | −0.19 | 0.00 | 0 |

Box spread **3.0px → 0.5px**, and the 0.5px remainder is IBM Plex Mono's metrics inside the PR pill holding *its* label on the baseline — the labels themselves agree exactly. Chip widths are byte-identical before and after (107.21 / 119.66 / 84.64 / 191.73 / 71.05px).

## The fix

`vertical-align: baseline` plus a zero-width-space `::before` strut, so every kind hands the line the same text baseline to align from:

```css
.composer-tiptap-input__editor .composer-tiptap-input__mention {
  vertical-align: baseline;
}
.composer-tiptap-input__editor .composer-tiptap-input__mention::before {
  content: "\200b";
  margin-inline-end: -0.35em; /* cancel the one flex gap the strut opens */
}
```

Why not a retuned `vertical-align` length: it is measured from the per-kind synthesized baseline, so any single value re-creates the spread. Why not `vertical-align: middle` (what the transcript uses): it aligns box centers, which is uniform, but parks every chip's label ~1.1px below the sentence's baseline. Aligning the labels themselves is what makes a chip read as a word in the sentence instead of a badge floating over it.

The rule is also qualified with `.composer-tiptap-input__editor` so the composer's em-based geometry outranks `.chip` (24px/12px) and `.pr-chip` (22px/11px) on **specificity** rather than on source order — today, moving `.thread-chip`'s `height: 22px` below this block would silently resize every composer chip.

## Not changed (deliberately)

- **Transcript prose** (`.thread-markdown`) measures consistently already: its chips land at −1.24 / −1.24 / −0.93 vs cap center, a 0.31px spread. Chips do change size across the send boundary (`#thread` is 18.9px/14px in the composer, 22px/12px in the transcript; a PR pill is 14px mono vs 11px mono), which is a separate sizing decision, not this alignment bug.
- **`.pr-chip--draft`'s −1px label nudge**: composer PR chips always render `pr-chip--unknown`, so the draft variant is unreachable there.

## Testing

- `apps/desktop/src/renderer/src/styles/__tests__/composer-chip-alignment.test.ts` (new) locks `vertical-align: baseline`, the strut's `content`, and the `margin-inline-end` == `-gap` invariant, so the strut isn't removed later as dead CSS. jsdom can't lay out CSS, so the layout numbers above came from a throwaway Chromium harness that loads the shipping `app.css` and the exact DOM `renderHTML` emits; the contract test is what stays.
- `pnpm test apps/desktop/src/renderer/src/styles apps/desktop/src/renderer/src/features/composer` → 454 passed.
- `pnpm lint:eslint` → 0 errors; `pnpm lint:colors` → passed.
- Not run: desktop E2E (no local runner on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)