### PR TITLE
fix(desktop): stop thread search after PR references

### DIFF
--- a/apps/desktop/e2e/composer-hash-reference-search.spec.ts
+++ b/apps/desktop/e2e/composer-hash-reference-search.spec.ts
@@ -1,0 +1,82 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+
+test("typing prose after a PR number does not reopen thread reference search", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/smoke/replay.fixture.json",
+    ),
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Replay smoke thread/i })
+      .first()
+      .click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Replay smoke thread",
+      }),
+    ).toBeVisible();
+
+    const reply = app.window.getByRole("textbox", { name: "Reply" });
+    const remoteSearchStatus = app.window.getByText(
+      "Searching other instances…",
+    );
+
+    // A numeric `#` reference is complete once the operator types a space.
+    // Let the initial lookup settle, then observe the exact regression: every
+    // later character used to reopen the remote-search status because the
+    // trigger treated the rest of the line as part of the PR query.
+    await reply.fill("But the thread has PR #1349 ");
+    await expect(remoteSearchStatus).toHaveCount(0);
+
+    await app.window.evaluate(() => {
+      const state = {
+        observer: undefined as MutationObserver | undefined,
+        seen: false,
+      };
+      state.observer = new MutationObserver(() => {
+        if (document.body.textContent?.includes("Searching other instances…")) {
+          state.seen = true;
+        }
+      });
+      state.observer.observe(document.body, {
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+      (window as typeof window & {
+        __composerHashSearchRegression?: typeof state;
+      }).__composerHashSearchRegression = state;
+    });
+
+    await reply.pressSequentially("so clearly it has changes.", { delay: 50 });
+
+    const searchingPopupSeen = await app.window.evaluate(() => {
+      const testWindow = window as typeof window & {
+        __composerHashSearchRegression?: {
+          observer?: MutationObserver;
+          seen: boolean;
+        };
+      };
+      const seen = testWindow.__composerHashSearchRegression?.seen ?? false;
+      testWindow.__composerHashSearchRegression?.observer?.disconnect();
+      delete testWindow.__composerHashSearchRegression;
+      return seen;
+    });
+
+    expect(
+      searchingPopupSeen,
+      "ordinary prose after `#1349 ` should not flash thread search",
+    ).toBe(false);
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts
@@ -49,6 +49,21 @@ describe("findHashReferenceTrigger", () => {
     expect(findHashReferenceTrigger("repo#123", 8)).toBeUndefined();
     expect(findHashReferenceTrigger("#first\nplain", 12)).toBeUndefined();
   });
+
+  it("ends a numeric PR reference at the first whitespace", () => {
+    const activeDraft = "Check PR #1349";
+    expect(findHashReferenceTrigger(activeDraft, activeDraft.length)).toEqual({
+      start: 9,
+      end: activeDraft.length,
+      query: "1349",
+    });
+
+    expect(findHashReferenceTrigger("Check PR #1349 ", 15)).toBeUndefined();
+    const continuingDraft = "Check PR #1349 before merging";
+    expect(
+      findHashReferenceTrigger(continuingDraft, continuingDraft.length),
+    ).toBeUndefined();
+  });
 });
 
 describe("filterHashReferenceCandidates", () => {

--- a/apps/desktop/src/renderer/src/lib/hash-references.ts
+++ b/apps/desktop/src/renderer/src/lib/hash-references.ts
@@ -35,11 +35,18 @@ export function findHashReferenceTrigger(
     return undefined;
   }
 
+  const query = match[1] ?? "";
+  // A numeric hash is a pull-request query, so the first whitespace ends
+  // autocomplete. Thread-title queries may still span spaces.
+  if (/^\d{1,7}\s/.test(query)) {
+    return undefined;
+  }
+
   const start = prefix.length - match[0].length + match[0].lastIndexOf("#");
   return {
     start,
     end: caret,
-    query: match[1] ?? "",
+    query,
   };
 }
 


### PR DESCRIPTION
## Summary

Stops composer thread-reference search after a numeric PR query reaches its first whitespace, while preserving spaces in normal thread-title queries.

Adds replay-backed Electron coverage for the reported behavior and helper-level coverage for the trigger boundary.

## Root cause

`findHashReferenceTrigger` allows spaces because thread titles can contain them. In prose such as `PR #1349 so clearly it has changes`, that made everything from `#1349` through the caret an active hash-reference query.

`useFederatedThreadSearch` debounces the lookup by 200 ms but enters its loading state immediately for every query change, so ordinary typing repeatedly displayed `Searching other instances…` and could dispatch searches after typing pauses.

## Fix

- Keep `#1349` active while the numeric PR query is being typed.
- End autocomplete when a 1–7 digit numeric query is followed by whitespace.
- Continue allowing spaces for non-numeric thread-title queries.
- Cover the transient popup with the replay-backed Electron spec.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts`
- `pnpm exec eslint apps/desktop/src/renderer/src/lib/hash-references.ts apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts apps/desktop/e2e/composer-hash-reference-search.spec.ts`
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop test:e2e e2e/composer-hash-reference-search.spec.ts`
