### PR TITLE
fix(desktop): keep thread model migrations instance-local

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -136,6 +136,12 @@ const registry = {
       accepted: true,
     }),
   ),
+  applyThreadModelMigration: vi.fn(
+    async (request: ApplyThreadModelMigrationRequest) => ({
+      ...request,
+      status: "acknowledged-new-thread" as const,
+    }),
+  ),
   getLatestCodexConfigWarning: vi.fn(() => ({})),
 };
 
@@ -235,12 +241,6 @@ const federationMock = vi.hoisted(() => {
       async (request: SendThreadPrAutoDispatchNowRequest) => ({
         ...request,
         accepted: true,
-      }),
-    ),
-    applyThreadModelMigration: vi.fn(
-      async (request: ApplyThreadModelMigrationRequest) => ({
-        ...request,
-        status: "acknowledged-new-thread" as const,
       }),
     ),
     checkThreadBranchDrift: vi.fn(
@@ -405,6 +405,7 @@ describe("agent ipc", () => {
     registry.setThreadPrAutoDispatch.mockClear();
     registry.cancelThreadPrAutoDispatch.mockClear();
     registry.sendThreadPrAutoDispatchNow.mockClear();
+    registry.applyThreadModelMigration.mockClear();
     federationMock.runtime.remoteBackend.mockClear();
     federationMock.runtime.hydrateLiveThreadMessageOrigin.mockReset();
     federationMock.runtime.hydrateLiveThreadMessageOrigin.mockImplementation(
@@ -722,14 +723,7 @@ describe("agent ipc", () => {
       fingerprint: "fingerprint-1",
     });
     expect(registry.sendThreadPrAutoDispatchNow).not.toHaveBeenCalled();
-    expect(
-      federationMock.remoteBackend.applyThreadModelMigration,
-    ).toHaveBeenCalledWith({
-      backend: "codex",
-      threadId: "thread-1",
-      threadCreatedAt: 1_000,
-      threadModel: "gpt-5-codex",
-    });
+    expect(registry.applyThreadModelMigration).not.toHaveBeenCalled();
     expect(federationMock.remoteBackend.checkThreadBranchDrift).toHaveBeenCalledWith({
       backend: "codex",
       expectedBranch: "feature/expected",
@@ -807,6 +801,37 @@ describe("agent ipc", () => {
       includeUnavailable: true,
     });
     expect(registry.listBackends).not.toHaveBeenCalled();
+    disposeAgentIpcHandlers();
+  });
+
+  it("refuses to apply this instance's model migration to a remote thread", async () => {
+    const { registerAgentIpcHandlers, disposeAgentIpcHandlers } = await import(
+      "../ipc/agent-ipc"
+    );
+    const { AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    registerAgentIpcHandlers();
+
+    // Migration configuration and acknowledgement state are profile-local.
+    // Forwarding this request would apply this instance's migration policy to
+    // a thread owned by another instance.
+    expect(
+      await handlers.get(AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL)?.({}, {
+        backend: "codex",
+        federationTarget: { scope: "remote", instanceId: "client_one" },
+        threadId: "thread-1",
+        threadCreatedAt: 1_000,
+        threadModel: "gpt-5-codex",
+      }),
+    ).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      status: "not-owner",
+    });
+    expect(federationMock.runtime.remoteBackend).not.toHaveBeenCalled();
+    expect(registry.applyThreadModelMigration).not.toHaveBeenCalled();
+
     disposeAgentIpcHandlers();
   });
 

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -17,6 +17,15 @@ import { FederationRpcEndpoint } from "../federation/federation-rpc";
 import { FEDERATION_MAX_FRAME_BYTES } from "../federation/federation-transport";
 
 describe("federation backend bridge", () => {
+  it("does not expose profile-local thread model migrations over federation", () => {
+    expect(FEDERATION_BACKEND_METHODS).not.toHaveProperty(
+      "applyThreadModelMigration",
+    );
+    expect(FederationRemoteBackendClient.prototype).not.toHaveProperty(
+      "applyThreadModelMigration",
+    );
+  });
+
   it("routes thread reactions through the thread-navigation capability", async () => {
     const sent: FederationProtocolEnvelope[] = [];
     const rpc = new FederationRpcEndpoint({
@@ -1040,60 +1049,6 @@ describe("federation backend bridge", () => {
     });
   });
 
-  it("routes thread model migrations over RPC with turn_control authorization", async () => {
-    const sent: FederationProtocolEnvelope[] = [];
-    const rpc = new FederationRpcEndpoint({
-      localInstanceId: "viewer_one",
-      remoteInstanceId: "owner_one",
-      sendEnvelope: (envelope) => sent.push(envelope),
-      now: () => 1_000,
-    });
-    const client = new FederationRemoteBackendClient(rpc);
-
-    const pending = client.applyThreadModelMigration({
-      backend: "codex",
-      threadId: "thread-1",
-      threadCreatedAt: 900,
-      threadModel: "gpt-5.5",
-    });
-    const request = sent.at(-1)!;
-    expect(request).toMatchObject({
-      kind: "request",
-      method: FEDERATION_BACKEND_METHODS.applyThreadModelMigration,
-      params: {
-        backend: "codex",
-        threadId: "thread-1",
-        threadCreatedAt: 900,
-        threadModel: "gpt-5.5",
-      },
-    });
-    expect(
-      FEDERATION_BACKEND_METHOD_CAPABILITIES[
-        FEDERATION_BACKEND_METHODS.applyThreadModelMigration
-      ],
-    ).toBe("turn_control");
-
-    rpc.receiveEnvelope({
-      id: "response-migration",
-      kind: "response",
-      requestId: request.id,
-      protocolVersion: 1,
-      sourceInstanceId: "owner_one",
-      targetInstanceId: "viewer_one",
-      createdAt: 1_100,
-      result: {
-        backend: "codex",
-        threadId: "thread-1",
-        status: "applied",
-      },
-    });
-    await expect(pending).resolves.toMatchObject({
-      backend: "codex",
-      threadId: "thread-1",
-      status: "applied",
-    });
-  });
-
   it("routes PR detach over RPC with turn_control authorization", async () => {
     const sent: FederationProtocolEnvelope[] = [];
     const rpc = new FederationRpcEndpoint({
@@ -2074,10 +2029,6 @@ describe("federation backend bridge", () => {
       cancelThreadExecutionModeQueue: vi.fn(),
       setAcpSessionRuntimeOption: vi.fn(),
       setThreadModelSettings: vi.fn(),
-      applyThreadModelMigration: vi.fn(async (request) => ({
-        ...request,
-        status: "acknowledged-new-thread" as const,
-      })),
       checkThreadBranchDrift: vi.fn(),
       updateThreadExpectedBranch: vi.fn(),
       retainThreadBranchDrift: vi.fn(),
@@ -2213,24 +2164,6 @@ describe("federation backend bridge", () => {
     await router.routeEnvelope({
       sourcePeerId: "gateway_one",
       envelope: {
-        id: "migration-request",
-        kind: "request",
-        method: FEDERATION_BACKEND_METHODS.applyThreadModelMigration,
-        params: {
-          backend: "codex",
-          threadId: "thread-1",
-          threadCreatedAt: 1_000,
-          threadModel: "gpt-5.6-sol",
-        },
-        protocolVersion: 1,
-        sourceInstanceId: "gateway_one",
-        targetInstanceId: "client_one",
-        createdAt: 1_150,
-      },
-    });
-    await router.routeEnvelope({
-      sourcePeerId: "gateway_one",
-      envelope: {
         id: "env-request",
         kind: "request",
         method: FEDERATION_BACKEND_METHODS.runCodexEnvironmentAction,
@@ -2284,12 +2217,6 @@ describe("federation backend bridge", () => {
       requestId: "approval-1",
       response: { decision: "approve" },
     });
-    expect(backend.applyThreadModelMigration).toHaveBeenCalledWith({
-      backend: "codex",
-      threadId: "thread-1",
-      threadCreatedAt: 1_000,
-      threadModel: "gpt-5.6-sol",
-    });
     expect(backend.runCodexEnvironmentAction).toHaveBeenCalledWith({
       actionId: "start",
       backend: "codex",
@@ -2319,11 +2246,6 @@ describe("federation backend bridge", () => {
         kind: "response",
         requestId: "approval-request",
         result: { requestId: "approval-1" },
-      },
-      {
-        kind: "response",
-        requestId: "migration-request",
-        result: { status: "acknowledged-new-thread" },
       },
       {
         kind: "response",
@@ -2387,7 +2309,6 @@ describe("federation backend bridge", () => {
         cancelThreadExecutionModeQueue: vi.fn(),
         setAcpSessionRuntimeOption: vi.fn(),
         setThreadModelSettings: vi.fn(),
-        applyThreadModelMigration: vi.fn(),
         checkThreadBranchDrift: vi.fn(),
         updateThreadExpectedBranch: vi.fn(),
         retainThreadBranchDrift: vi.fn(),

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -7,8 +7,6 @@ import type {
   AppServerReadThreadResponse,
   AppServerThreadMessageOrigin,
   AgentEvent,
-  ApplyThreadModelMigrationRequest,
-  ApplyThreadModelMigrationResponse,
   ArchiveThreadRequest,
   ArchiveThreadResponse,
   CancelQueuedTurnRequest,
@@ -246,7 +244,6 @@ export const FEDERATION_BACKEND_METHODS = {
   cancelThreadExecutionModeQueue: "backend.cancelThreadExecutionModeQueue",
   setAcpSessionRuntimeOption: "backend.setAcpSessionRuntimeOption",
   setThreadModelSettings: "backend.setThreadModelSettings",
-  applyThreadModelMigration: "backend.applyThreadModelMigration",
   checkThreadBranchDrift: "backend.checkThreadBranchDrift",
   updateThreadExpectedBranch: "backend.updateThreadExpectedBranch",
   retainThreadBranchDrift: "backend.retainThreadBranchDrift",
@@ -330,7 +327,6 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.cancelThreadExecutionModeQueue]: "turn_control",
   [FEDERATION_BACKEND_METHODS.setAcpSessionRuntimeOption]: "turn_control",
   [FEDERATION_BACKEND_METHODS.setThreadModelSettings]: "turn_control",
-  [FEDERATION_BACKEND_METHODS.applyThreadModelMigration]: "turn_control",
   [FEDERATION_BACKEND_METHODS.checkThreadBranchDrift]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.updateThreadExpectedBranch]: "turn_control",
   [FEDERATION_BACKEND_METHODS.retainThreadBranchDrift]: "turn_control",
@@ -461,9 +457,6 @@ export type FederationBackendOperations = {
   setThreadModelSettings(
     request: SetThreadModelSettingsRequest,
   ): Promise<SetThreadModelSettingsResponse>;
-  applyThreadModelMigration(
-    request: ApplyThreadModelMigrationRequest,
-  ): Promise<ApplyThreadModelMigrationResponse>;
   checkThreadBranchDrift(
     request: CheckThreadBranchDriftRequest,
   ): Promise<CheckThreadBranchDriftResponse>;
@@ -856,13 +849,6 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.setThreadModelSettings(
         envelope.params as SetThreadModelSettingsRequest,
-      ),
-  );
-  params.router.registerHandler(
-    FEDERATION_BACKEND_METHODS.applyThreadModelMigration,
-    async (envelope) =>
-      await params.backend.applyThreadModelMigration(
-        envelope.params as ApplyThreadModelMigrationRequest,
       ),
   );
   params.router.registerHandler(
@@ -1338,15 +1324,6 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<SetThreadModelSettingsResponse> {
     return await this.rpc.request<SetThreadModelSettingsResponse>({
       method: FEDERATION_BACKEND_METHODS.setThreadModelSettings,
-      params: request,
-    });
-  }
-
-  async applyThreadModelMigration(
-    request: ApplyThreadModelMigrationRequest,
-  ): Promise<ApplyThreadModelMigrationResponse> {
-    return await this.rpc.request<ApplyThreadModelMigrationResponse>({
-      method: FEDERATION_BACKEND_METHODS.applyThreadModelMigration,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -2,7 +2,6 @@ import { randomBytes, randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import type {
   AgentEvent,
-  ApplyThreadModelMigrationResponse,
   AppServerListSkillsResponse,
   AppServerListThreadsResponse,
   AppServerReadThreadResponse,
@@ -85,7 +84,6 @@ import {
   type AppServerListSkillsRequest,
   type AppServerListThreadsRequest,
   type AppServerReadThreadRequest,
-  type ApplyThreadModelMigrationRequest,
   type CancelQueuedTurnRequest,
   type CancelThreadExecutionModeQueueRequest,
   type CelestialIconAssignment,
@@ -4106,11 +4104,6 @@ function localBackendOperations(): FederationBackendOperations {
       request: SetThreadModelSettingsRequest,
     ): Promise<SetThreadModelSettingsResponse> {
       return await getDesktopBackendRegistry().setThreadModelSettings(request);
-    },
-    async applyThreadModelMigration(
-      request: ApplyThreadModelMigrationRequest,
-    ): Promise<ApplyThreadModelMigrationResponse> {
-      return await getDesktopBackendRegistry().applyThreadModelMigration(request);
     },
     async checkThreadBranchDrift(
       request: CheckThreadBranchDriftRequest,

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -945,9 +945,14 @@ export function registerAgentIpcHandlers(): void {
         request.federationTarget
         && isRemoteFederationTarget(request.federationTarget)
       ) {
-        return await getDesktopFederationRuntime()
-          .remoteBackend(request.federationTarget)
-          .applyThreadModelMigration(stripFederationTarget(request));
+        // Migration policy and acknowledgement state are profile-local. The
+        // owning instance must decide whether its own thread needs migration;
+        // forwarding this instance's policy would cross that ownership line.
+        return {
+          backend: request.backend,
+          threadId: request.threadId,
+          status: "not-owner",
+        };
       }
       return await registry.applyThreadModelMigration(request);
     },

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -49,6 +49,7 @@ import {
   buildPendingRequestResponse,
   buildThreadIdentityKey,
   isBranchDrifted,
+  isRemoteFederationTarget,
   PWRSNAP_MCP_CONNECTION_ID,
   readCodexEnvironmentActionRuns,
   resolveThreadTerminalCwd,
@@ -1900,11 +1901,17 @@ export function ThreadView(props: ThreadViewProps) {
     const migration = thread
       ? providerThreadMigrations?.[thread.source]
       : undefined;
+    const migrationFederationTarget =
+      thread?.federation?.ref.target ?? readRendererFederationTarget();
     if (
       !thread
       || selectedLaunchpad
       || !migration
       || thread.modelMigrationRevision === migration.revision
+      || (
+        migrationFederationTarget
+        && isRemoteFederationTarget(migrationFederationTarget)
+      )
       || !migrationDesktopApi?.applyThreadModelMigration
     ) {
       return;
@@ -1918,8 +1925,6 @@ export function ThreadView(props: ThreadViewProps) {
     void migrationDesktopApi
       .applyThreadModelMigration({
         backend: thread.source,
-        federationTarget: thread.federation?.ref.target ??
-          readRendererFederationTarget(),
         threadId: thread.id,
         threadCreatedAt: thread.createdAt,
         threadModel: thread.model,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -276,7 +276,7 @@ describe("ThreadView", () => {
     });
   });
 
-  it("applies a pending provider migration on the federated owner", async () => {
+  it("does not apply this instance's provider migration to a remote thread", () => {
     const applyThreadModelMigration = vi.fn(async () => ({
       backend: "codex" as const,
       threadId: "thread-old",
@@ -332,21 +332,8 @@ describe("ThreadView", () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(applyThreadModelMigration).toHaveBeenCalledWith({
-        backend: "codex",
-        federationTarget: {
-          scope: "remote",
-          instanceId: "remote-instance",
-        },
-        threadId: "thread-old",
-        threadCreatedAt: 1_000,
-        threadModel: "gpt-5.5",
-      });
-    });
-    await waitFor(() => {
-      expect(onRefreshNavigation).toHaveBeenCalledTimes(1);
-    });
+    expect(applyThreadModelMigration).not.toHaveBeenCalled();
+    expect(onRefreshNavigation).not.toHaveBeenCalled();
   });
 
   it("renders a directory-less thread with transcript history and context", () => {

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -545,7 +545,8 @@ export type ApplyThreadModelMigrationResponse = {
     | "acknowledged-source-model"
     | "metadata-unavailable"
     | "applied"
-    | "unavailable";
+    | "unavailable"
+    | "not-owner";
   revision?: string;
   model?: string;
   reasoningEffort?: string;


### PR DESCRIPTION
## Problem

Opening a federated thread combined this instance's `providerThreadMigrations` setting with the remote owner's thread summary. A remote summary does not carry this profile's migration acknowledgement revision, so a migration that was already complete for this instance's local threads appeared pending again and was forwarded to the remote owner.

That crossed two ownership boundaries: migration policy is profile-local, and migration acknowledgement state is stored by the thread-owning instance. Peer connectivity was incidental; this instance should never initiate its model migration for a remote-owned thread.

## Fix

- `ThreadView` excludes remote thread references and dedicated federation windows from local provider-migration evaluation.
- The model-migration IPC handler refuses remote targets with `not-owner` without calling either the local registry or a remote backend.
- The federation backend bridge no longer advertises, authorizes, handles, or sends `backend.applyThreadModelMigration`, preventing mixed-version or alternate callers from crossing the ownership boundary.
- The obsolete disconnected-peer retry behavior and `peer-unavailable` response status from the first PR revision are removed.

Each owning instance still applies its own configured migration to its own local threads when those threads are opened. A completed local migration stays completed because a remote thread's unrelated acknowledgement state can no longer reopen it.

## Regression coverage

- Renderer: a pending local migration is not requested for a remote thread.
- IPC: a remote migration request resolves `not-owner` and touches neither the local registry nor a federation client.
- Federation bridge: model migration is absent from the public RPC method map and remote client surface.

The renderer and IPC tests were changed first and failed against the previous implementation, demonstrating the incorrect remote call before the ownership fix.

## Verification

- Targeted suites: `agent-ipc.test.ts`, `federation-backend-bridge.test.ts`, `thread-view.test.tsx` — 101 tests passed.
- `pnpm typecheck` — passed.
- `pnpm lint:eslint` — 0 errors (existing warning baseline only).
- `pnpm lint:boundaries` — passed.

The branch is rebased onto the latest `origin/main`.
