### PR TITLE
fix(desktop): preserve queued messages until admission

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -30,6 +30,7 @@ import type {
   TrustCodexProjectRequest,
   UpdateThreadExpectedBranchRequest,
 } from "@pwragent/shared";
+import type { ThreadTurnQueueSubmissionResult } from "../app-server/thread-turn-queue";
 
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 const send = vi.fn();
@@ -68,18 +69,22 @@ const registry = {
     threadId: request.threadId,
     turnId: "turn-1",
   })),
-  submitTurn: vi.fn(async (request: StartTurnRequest & { origin: "manual" }) => ({
-    status: "started" as const,
-    entry: {
-      id: "queue-1",
-      backend: request.backend,
-      createdAt: 1,
-      input: request.input,
-      origin: request.origin,
-      threadId: request.threadId,
-    },
-    turnId: "turn-1",
-  })),
+  submitTurn: vi.fn(
+    async (
+      request: StartTurnRequest & { origin: "manual" },
+    ): Promise<ThreadTurnQueueSubmissionResult> => ({
+      status: "started" as const,
+      entry: {
+        id: "queue-1",
+        backend: request.backend,
+        createdAt: 1,
+        input: request.input,
+        origin: request.origin,
+        threadId: request.threadId,
+      },
+      turnId: "turn-1",
+    }),
+  ),
   startReview: vi.fn(async (request: StartReviewRequest) => ({
     backend: request.backend,
     threadId: request.threadId,
@@ -835,6 +840,36 @@ describe("agent ipc", () => {
       backend: "grok",
       threadId: "thread-1",
     });
+    vi.mocked(registry.submitTurn).mockResolvedValueOnce({
+      status: "queued",
+      entry: {
+        id: "renderer-queue-1",
+        backend: "grok",
+        createdAt: 2,
+        input: [{ type: "text", text: "Queue it" }],
+        origin: "manual",
+        threadId: "thread-1",
+      },
+      position: 1,
+    });
+    expect(
+      await handlers.get(AGENT_START_TURN_CHANNEL)?.({}, {
+        backend: "grok",
+        threadId: "thread-1",
+        queueEntryId: "renderer-queue-1",
+        input: [{ type: "text", text: "Queue it" }],
+      }),
+    ).toEqual({
+      backend: "grok",
+      queueEntryId: "renderer-queue-1",
+      queueEntryCreatedAt: 2,
+      queueStatus: "queued",
+      threadId: "thread-1",
+      turnId: "renderer-queue-1",
+    });
+    expect(registry.submitTurn).toHaveBeenLastCalledWith(
+      expect.objectContaining({ queueEntryId: "renderer-queue-1" }),
+    );
     expect(
       await handlers.get(AGENT_START_TURN_CHANNEL)?.({}, {
         backend: "grok",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7501,6 +7501,7 @@ export class DesktopBackendRegistry {
     const baseParams = {
       threadId: event.entry.threadId,
       queueEntryId: event.entry.id,
+      queueEntryCreatedAt: event.entry.createdAt,
       origin: event.entry.origin,
       automationRunId: event.entry.automationRunId,
       automationName: event.entry.automationName,

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -562,6 +562,7 @@ export function registerAgentIpcHandlers(): void {
                 turnId: submitted.entry.id,
                 queueStatus: "queued",
                 queueEntryId: submitted.entry.id,
+                queueEntryCreatedAt: submitted.entry.createdAt,
               };
         logDebug("startTurnResult", {
           backend: response.backend,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1067,6 +1067,7 @@ function DesktopAppShell(props: {
   );
   useQueuedTurnProjection({
     composerDraftStore,
+    snapshotFetchedAt: navigation.snapshot?.fetchedAt,
     threads: navigation.threads,
   });
   const scheduledActionProjectionSources = useMemo(

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5087,6 +5087,7 @@ export function Composer(props: ComposerProps) {
           ? (event.notification.params as {
               errorMessage?: unknown;
               queueEntryId?: unknown;
+              queueEntryCreatedAt?: unknown;
               status?: unknown;
               turnId?: unknown;
             })
@@ -5121,6 +5122,9 @@ export function Composer(props: ComposerProps) {
             {
               id: `backend-queued:${turnQueueRecord.queueEntryId}`,
               queueEntryId: turnQueueRecord.queueEntryId,
+              ...(typeof turnQueueRecord.queueEntryCreatedAt === "number"
+                ? { queueEntryCreatedAt: turnQueueRecord.queueEntryCreatedAt }
+                : {}),
               text: typeof displayText === "string" ? displayText : "",
               imageAttachments: [],
               fileAttachments: [],
@@ -5995,6 +5999,9 @@ export function Composer(props: ComposerProps) {
         federationTarget: props.thread.federation?.ref.target ??
           readRendererFederationTarget(),
         threadId: props.thread.id,
+        ...(backendQueueSubmission?.queued.queueEntryId
+          ? { queueEntryId: backendQueueSubmission.queued.queueEntryId }
+          : {}),
         input: payload.input,
         executionMode: props.thread.executionMode,
         collaborationMode,
@@ -6016,6 +6023,9 @@ export function Composer(props: ComposerProps) {
               backendQueuePending: false,
               input: payload.input,
               queueEntryId,
+              ...(typeof response.queueEntryCreatedAt === "number"
+                ? { queueEntryCreatedAt: response.queueEntryCreatedAt }
+                : {}),
             }),
           );
           if (submittedScopeIsVisible()) {
@@ -7153,9 +7163,11 @@ export function Composer(props: ComposerProps) {
             setSendError(undefined);
             updateSending(true);
           }
+          const queueEntryId = createQueuedTurnId();
           const backendQueueProjection: QueuedTurnDraft = {
-            id: createQueuedTurnId(),
+            id: queueEntryId,
             backendQueuePending: true,
+            queueEntryId,
             text: canonicalDraft,
             imageAttachments,
             fileAttachments,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5,6 +5,7 @@ import {
   applyNavigationLaunchpadProviderSettingsPatch,
   buildFederatedThreadRef,
   type BackendSummary,
+  type AgentEvent,
   type CompactThreadRequest,
   type ComposerDraftRecoveryCandidate,
   type CreateScheduledThreadActionRequest,
@@ -6019,6 +6020,86 @@ describe("Composer", () => {
 
     unmount();
     expect(startTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconciles queue admission that arrives before the enqueue response", async () => {
+    const draftStore = createComposerDraftStore();
+    const startTurnDeferred = createDeferred<StartTurnResponse>();
+    const startTurn = vi.fn(
+      (_request: StartTurnRequest) => startTurnDeferred.promise,
+    );
+    let agentEventHandler: ((event: AgentEvent) => void) | undefined;
+
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        desktopApi={{
+          onAgentEvent: (listener) => {
+            agentEventHandler = listener;
+            return () => undefined;
+          },
+          startTurn,
+        }}
+        disabled={false}
+        draftStore={draftStore}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Active turn",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Admit before acknowledgement" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
+
+    await waitFor(() => expect(startTurn).toHaveBeenCalledTimes(1));
+    const request = startTurn.mock.calls[0]?.[0];
+    expect(request).toBeDefined();
+    if (!request) throw new Error("Expected a queued turn request.");
+    const scopeKey = "thread:codex:thread-1";
+    const queued = draftStore.getQueuedTurn(scopeKey);
+    expect(request.queueEntryId).toBe(queued?.id);
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/turnQueue/updated",
+          params: {
+            threadId: "thread-1",
+            queueEntryId: request.queueEntryId!,
+            queueEntryCreatedAt: 2_000,
+            origin: "manual",
+            status: "started",
+            turnId: "turn-2",
+          },
+        },
+      });
+    });
+    expect(draftStore.getQueuedTurn(scopeKey)).toBeUndefined();
+
+    await act(async () => {
+      startTurnDeferred.resolve({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: request.queueEntryId!,
+        queueStatus: "queued",
+        queueEntryId: request.queueEntryId!,
+        queueEntryCreatedAt: 2_000,
+      });
+      await startTurnDeferred.promise;
+    });
+
+    expect(draftStore.getQueuedTurn(scopeKey)).toBeUndefined();
+    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
   });
 
   it("keeps a delayed backend queue acknowledgement scoped to its thread", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -26,6 +26,8 @@ export type ComposerQueuedTurnSnapshot = {
   backendQueuePending?: boolean;
   /** Main-process FIFO entry once the renderer has handed off dispatch ownership. */
   queueEntryId?: string;
+  /** Owner-clock creation time used to reject older navigation snapshots. */
+  queueEntryCreatedAt?: number;
   /** Durable main-process scheduled action represented by this renderer chip. */
   scheduledActionId?: string;
   /** Terminal scheduled action converted into a locally recoverable draft. */

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnProjection.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnProjection.test.tsx
@@ -19,7 +19,7 @@ function buildThread(
 }
 
 describe("useQueuedTurnProjection", () => {
-  it("keeps an acknowledged local queue entry until a snapshot observes it", () => {
+  it("orders queue absence against the owner snapshot timestamp", () => {
     const { result: storeResult } = renderHook(() => useComposerDraftStore());
     const store = storeResult.current;
     const scopeKey = "thread:codex:thread-1";
@@ -27,6 +27,7 @@ describe("useQueuedTurnProjection", () => {
       {
         id: "local-acknowledged",
         queueEntryId: "entry-1",
+        queueEntryCreatedAt: 2_000,
         text: "wait for admission",
         imageAttachments: [],
         fileAttachments: [],
@@ -34,14 +35,19 @@ describe("useQueuedTurnProjection", () => {
     ]);
 
     const projection = renderHook(
-      (props: { threads: NavigationThreadSummary[] }) =>
+      (props: {
+        snapshotFetchedAt: number;
+        threads: NavigationThreadSummary[];
+      }) =>
         useQueuedTurnProjection({
           composerDraftStore: store,
+          snapshotFetchedAt: props.snapshotFetchedAt,
           threads: props.threads,
         }),
       {
         initialProps: {
           // This navigation snapshot predates the queue acknowledgement.
+          snapshotFetchedAt: 1_000,
           threads: [buildThread([])],
         },
       },
@@ -50,19 +56,9 @@ describe("useQueuedTurnProjection", () => {
     expect(store.getQueuedTurn(scopeKey)?.id).toBe("local-acknowledged");
 
     projection.rerender({
-      threads: [
-        buildThread([
-          {
-            queueEntryId: "entry-1",
-            origin: "manual",
-            displayText: "wait for admission",
-            createdAt: 1_000,
-            position: 0,
-          },
-        ]),
-      ],
+      snapshotFetchedAt: 3_000,
+      threads: [buildThread([])],
     });
-    projection.rerender({ threads: [buildThread([])] });
 
     expect(store.getQueuedTurn(scopeKey)).toBeUndefined();
   });
@@ -94,6 +90,7 @@ describe("useQueuedTurnProjection", () => {
       (props: { threads: NavigationThreadSummary[] }) =>
         useQueuedTurnProjection({
           composerDraftStore: store,
+          snapshotFetchedAt: 2_000,
           threads: props.threads,
         }),
       {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnProjection.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnProjection.test.tsx
@@ -19,6 +19,54 @@ function buildThread(
 }
 
 describe("useQueuedTurnProjection", () => {
+  it("keeps an acknowledged local queue entry until a snapshot observes it", () => {
+    const { result: storeResult } = renderHook(() => useComposerDraftStore());
+    const store = storeResult.current;
+    const scopeKey = "thread:codex:thread-1";
+    store.setQueuedTurns(scopeKey, [
+      {
+        id: "local-acknowledged",
+        queueEntryId: "entry-1",
+        text: "wait for admission",
+        imageAttachments: [],
+        fileAttachments: [],
+      },
+    ]);
+
+    const projection = renderHook(
+      (props: { threads: NavigationThreadSummary[] }) =>
+        useQueuedTurnProjection({
+          composerDraftStore: store,
+          threads: props.threads,
+        }),
+      {
+        initialProps: {
+          // This navigation snapshot predates the queue acknowledgement.
+          threads: [buildThread([])],
+        },
+      },
+    );
+
+    expect(store.getQueuedTurn(scopeKey)?.id).toBe("local-acknowledged");
+
+    projection.rerender({
+      threads: [
+        buildThread([
+          {
+            queueEntryId: "entry-1",
+            origin: "manual",
+            displayText: "wait for admission",
+            createdAt: 1_000,
+            position: 0,
+          },
+        ]),
+      ],
+    });
+    projection.rerender({ threads: [buildThread([])] });
+
+    expect(store.getQueuedTurn(scopeKey)).toBeUndefined();
+  });
+
   it("mirrors FIFO entries from the snapshot and prunes dispatched ones", () => {
     const { result: storeResult } = renderHook(() => useComposerDraftStore());
     const store = storeResult.current;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -6,6 +6,7 @@ import {
   shortenDerivedThreadTitle,
 } from "@pwragent/shared";
 import type {
+  AgentEvent,
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
   NavigationSnapshot,
@@ -8735,6 +8736,82 @@ describe("useThreadNavigation", () => {
     expect(
       result.current.selectedThread?.messagingBindings?.[0]?.platform,
     ).toBe("discord");
+  });
+
+  it("reconciles queued turns when the backend thread timestamp is unchanged", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    let navigationCallCount = 0;
+    const getNavigationSnapshot = vi.fn(async () => {
+      navigationCallCount += 1;
+      return {
+        backend: "all" as const,
+        fetchedAt: 1_000 + navigationCallCount,
+        unchanged: false,
+        inboxThreadKeys: [],
+        threads: [
+          {
+            id: "thread-1",
+            title: "Queued thread",
+            titleSource: "explicit" as const,
+            source: "codex" as const,
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+            updatedAt: 1_000,
+            queuedTurns: navigationCallCount === 1
+              ? undefined
+              : [
+                  {
+                    queueEntryId: "queue-1",
+                    origin: "manual" as const,
+                    displayText: "Queued reply",
+                    createdAt: 1_000,
+                    position: 0,
+                  },
+                ],
+          },
+        ],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      };
+    });
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => expect(result.current.selectedThread?.id).toBe("thread-1"));
+    expect(result.current.selectedThread?.queuedTurns).toBeUndefined();
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/turnQueue/updated",
+            params: {
+              threadId: "thread-1",
+              queueEntryId: "queue-1",
+              queueEntryCreatedAt: 1_000,
+              origin: "manual",
+              status: "queued",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.queuedTurns?.[0]?.queueEntryId).toBe(
+        "queue-1",
+      );
+    });
   });
 
   it("keeps the public refresh callback stable across navigation renders", async () => {

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnProjection.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnProjection.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type {
   ComposerDraftStore,
@@ -16,15 +16,18 @@ import type {
  * instead of relying on renderer-local memory. Entries this window
  * already tracks (matching queueEntryId, or still backendQueuePending
  * in-flight) are left alone so live submissions keep their richer local
- * state (attachments, review commands); backend-owned entries whose id
- * vanished from the snapshot are pruned — the FIFO dispatched or
- * cancelled them.
+ * state (attachments, review commands). A backend-owned entry is pruned
+ * after its id was positively observed in a snapshot and then vanished —
+ * the FIFO dispatched or cancelled it. Requiring that positive observation
+ * prevents an older navigation snapshot from pruning a just-acknowledged
+ * local submission before its queue lifecycle notification arrives.
  */
 export function useQueuedTurnProjection(params: {
   composerDraftStore: ComposerDraftStore;
   threads: readonly NavigationThreadSummary[];
 }): void {
   const { composerDraftStore, threads } = params;
+  const snapshotObservedQueueEntryKeysRef = useRef(new Set<string>());
   useEffect(() => {
     for (const thread of threads) {
       const scopeKey = `thread:${thread.source}:${thread.id}`;
@@ -32,6 +35,11 @@ export function useQueuedTurnProjection(params: {
       const snapshotIds = new Set(
         snapshotEntries.map((entry) => entry.queueEntryId),
       );
+      for (const queueEntryId of snapshotIds) {
+        snapshotObservedQueueEntryKeysRef.current.add(
+          `${scopeKey}:${queueEntryId}`,
+        );
+      }
       const current = composerDraftStore.getQueuedTurns(scopeKey);
       const knownIds = new Set(
         current
@@ -46,7 +54,10 @@ export function useQueuedTurnProjection(params: {
           // a snapshot that may predate them.
           !entry.queueEntryId
           || entry.backendQueuePending
-          || snapshotIds.has(entry.queueEntryId),
+          || snapshotIds.has(entry.queueEntryId)
+          || !snapshotObservedQueueEntryKeysRef.current.has(
+            `${scopeKey}:${entry.queueEntryId}`,
+          ),
       );
       const additions: ComposerQueuedTurnSnapshot[] = snapshotEntries
         .filter((entry) => !knownIds.has(entry.queueEntryId))
@@ -63,6 +74,17 @@ export function useQueuedTurnProjection(params: {
         || kept.length !== current.length
       ) {
         composerDraftStore.setQueuedTurns(scopeKey, [...kept, ...additions]);
+      }
+      for (const entry of current) {
+        if (
+          entry.queueEntryId
+          && !snapshotIds.has(entry.queueEntryId)
+          && !kept.includes(entry)
+        ) {
+          snapshotObservedQueueEntryKeysRef.current.delete(
+            `${scopeKey}:${entry.queueEntryId}`,
+          );
+        }
       }
     }
   }, [composerDraftStore, threads]);

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnProjection.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnProjection.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type {
   ComposerDraftStore,
@@ -16,18 +16,17 @@ import type {
  * instead of relying on renderer-local memory. Entries this window
  * already tracks (matching queueEntryId, or still backendQueuePending
  * in-flight) are left alone so live submissions keep their richer local
- * state (attachments, review commands). A backend-owned entry is pruned
- * after its id was positively observed in a snapshot and then vanished —
- * the FIFO dispatched or cancelled it. Requiring that positive observation
- * prevents an older navigation snapshot from pruning a just-acknowledged
- * local submission before its queue lifecycle notification arrives.
+ * state (attachments, review commands). A backend-owned entry is pruned when
+ * an owner snapshot taken after that entry was created omits it — the FIFO
+ * dispatched or cancelled it. Ordering in the owner's clock domain prevents
+ * an older navigation snapshot from pruning a just-acknowledged submission.
  */
 export function useQueuedTurnProjection(params: {
   composerDraftStore: ComposerDraftStore;
+  snapshotFetchedAt?: number;
   threads: readonly NavigationThreadSummary[];
 }): void {
-  const { composerDraftStore, threads } = params;
-  const snapshotObservedQueueEntryKeysRef = useRef(new Set<string>());
+  const { composerDraftStore, snapshotFetchedAt, threads } = params;
   useEffect(() => {
     for (const thread of threads) {
       const scopeKey = `thread:${thread.source}:${thread.id}`;
@@ -35,11 +34,6 @@ export function useQueuedTurnProjection(params: {
       const snapshotIds = new Set(
         snapshotEntries.map((entry) => entry.queueEntryId),
       );
-      for (const queueEntryId of snapshotIds) {
-        snapshotObservedQueueEntryKeysRef.current.add(
-          `${scopeKey}:${queueEntryId}`,
-        );
-      }
       const current = composerDraftStore.getQueuedTurns(scopeKey);
       const knownIds = new Set(
         current
@@ -55,15 +49,18 @@ export function useQueuedTurnProjection(params: {
           !entry.queueEntryId
           || entry.backendQueuePending
           || snapshotIds.has(entry.queueEntryId)
-          || !snapshotObservedQueueEntryKeysRef.current.has(
-            `${scopeKey}:${entry.queueEntryId}`,
-          ),
+          || typeof entry.queueEntryCreatedAt !== "number"
+          || typeof snapshotFetchedAt !== "number"
+          // Millisecond equality is ambiguous: the snapshot may have read the
+          // FIFO just before creation within the same clock tick.
+          || snapshotFetchedAt <= entry.queueEntryCreatedAt,
       );
       const additions: ComposerQueuedTurnSnapshot[] = snapshotEntries
         .filter((entry) => !knownIds.has(entry.queueEntryId))
         .map((entry) => ({
           id: `backend-queued:${entry.queueEntryId}`,
           queueEntryId: entry.queueEntryId,
+          queueEntryCreatedAt: entry.createdAt,
           text: entry.displayText,
           imageAttachments: [],
           fileAttachments: [],
@@ -75,17 +72,6 @@ export function useQueuedTurnProjection(params: {
       ) {
         composerDraftStore.setQueuedTurns(scopeKey, [...kept, ...additions]);
       }
-      for (const entry of current) {
-        if (
-          entry.queueEntryId
-          && !snapshotIds.has(entry.queueEntryId)
-          && !kept.includes(entry)
-        ) {
-          snapshotObservedQueueEntryKeysRef.current.delete(
-            `${scopeKey}:${entry.queueEntryId}`,
-          );
-        }
-      }
     }
-  }, [composerDraftStore, threads]);
+  }, [composerDraftStore, snapshotFetchedAt, threads]);
 }

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -730,6 +730,8 @@ function threadSummariesEqual(
     left.executionMode === right.executionMode &&
     left.queuedExecutionMode === right.queuedExecutionMode &&
     left.queuedExecutionModeAt === right.queuedExecutionModeAt &&
+    JSON.stringify(left.queuedTurns ?? []) ===
+      JSON.stringify(right.queuedTurns ?? []) &&
     left.model === right.model &&
     left.reasoningEffort === right.reasoningEffort &&
     left.serviceTier === right.serviceTier &&

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -240,6 +240,11 @@ export type StartTurnRequest = {
   backend: AppServerBackendKind;
   federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
+  /**
+   * Renderer-reserved FIFO identity. Lets queue lifecycle events correlate a
+   * locally projected draft even when admission races ahead of the IPC reply.
+   */
+  queueEntryId?: string;
   input: AppServerTurnInputItem[];
   executionMode?: ThreadExecutionMode;
   approvalPolicy?: string;
@@ -258,6 +263,8 @@ export type StartTurnResponse = {
   turnId: string;
   queueStatus?: "started" | "queued";
   queueEntryId?: string;
+  /** Owner-clock creation time for ordering queue state against snapshots. */
+  queueEntryCreatedAt?: number;
 };
 
 export type CancelQueuedTurnRequest = {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1589,6 +1589,8 @@ export type AppServerNotification =
       params: {
         threadId: string;
         queueEntryId: string;
+        /** Owner-clock creation time for ordering against navigation snapshots. */
+        queueEntryCreatedAt?: number;
         origin: "manual" | "automation" | "messaging" | "scheduled";
         status: "queued" | "started" | "failed" | "cancelled" | "terminal";
         /**


### PR DESCRIPTION
## Summary

- reserve the queue entry ID in the renderer before IPC so lifecycle events can match the local queue card even when dispatch wins the admission-response race
- order snapshot-based absence using the backend queue creation timestamp and the navigation snapshot fetch timestamp
- include queued-turn changes in thread-summary reconciliation so queue snapshots cannot be hidden behind an otherwise unchanged thread summary
- remove the process-lifetime observation set, eliminating retained queue IDs

## Root cause

The affected thread accepted the second message at 23:20:17 with `queueStatus=queued`, then emitted the backend start lifecycle at 23:24:38. The enqueue itself succeeded.

The original renderer projection could treat a navigation snapshot that predated admission as proof that the FIFO had already dispatched the entry. The first fix required positive snapshot observation, but that introduced a second race: dispatch could occur while `startTurn` was awaiting its queued response, before the renderer knew the backend queue ID. The lifecycle event then could not match the local draft, and the later response could leave a stale card. Its observation set also retained IDs removed by lifecycle handlers.

The renderer now creates the queue ID before admission and sends it to the owner FIFO. Early lifecycle events therefore match immediately. Snapshot absence is only authoritative when the owner snapshot was fetched strictly after the queue entry was created; explicit started, failed, cancelled, and terminal lifecycle events remain authoritative.

## User impact

Queued messages remain visible with Edit/Delete controls while admission is pending or an older snapshot omits them, and disappear promptly once the backend starts, cancels, or rejects them.

## Validation

- focused desktop queue, composer, navigation, IPC, and FIFO tests: 413 passed
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`