### PR TITLE
fix(desktop): link backend toasts to threads

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -613,6 +613,9 @@ function DesktopAppShell(props: {
       ) {
         return;
       }
+      const instanceId = event.federationTarget?.scope === "remote"
+        ? event.federationTarget.instanceId
+        : undefined;
       // Params are cast explicitly: the AppServerNotification union is too
       // wide for the discriminant to narrow `params` reliably here.
       if (event.notification.method === "turn/failed") {
@@ -634,6 +637,7 @@ function DesktopAppShell(props: {
             threadId: params.threadId ?? "unknown",
             turnId: params.turnId ?? "unknown",
             errorMessage,
+            ...(instanceId ? { instanceId } : {}),
             threadLabel: labelForThread(event.backend, params.threadId),
           },
         });
@@ -655,6 +659,7 @@ function DesktopAppShell(props: {
           signal: {
             kind: "codex-invalid-id-recovery",
             failureMessage: params.failureMessage,
+            ...(instanceId ? { instanceId } : {}),
             recoveryError: params.recoveryError,
             status: params.status,
             threadId: params.threadId,
@@ -677,6 +682,7 @@ function DesktopAppShell(props: {
           signal: {
             kind: "system-error",
             backend: event.backend,
+            ...(instanceId ? { instanceId } : {}),
             threadId: params.threadId ?? "unknown",
             threadLabel: labelForThread(event.backend, params.threadId),
           },

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -2240,6 +2240,7 @@ function DesktopAppShell(props: {
           desktopApi={desktopApi}
           durableNotices={appNotices.durable}
           onDismissDurable={dismissAppNotice}
+          onOpenThread={showThreadFromLink}
           transientNotices={[
             {
               notice: navigation.archiveThreadNotice,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -391,6 +391,7 @@ describe("App", () => {
     expected,
   }) => {
     const agentEventListeners = new Set<(event: AgentEvent) => void>();
+    const copyText = vi.fn(async () => undefined);
     if (rendererTarget) {
       (window as typeof window & {
         __pwragentFederationTarget?: unknown;
@@ -399,6 +400,7 @@ describe("App", () => {
     Object.defineProperty(window, "pwragent", {
       configurable: true,
       value: {
+        copyText,
         getNavigationSnapshot: async () => ({
           backend: "all" as const,
           fetchedAt: Date.now(),
@@ -443,6 +445,18 @@ describe("App", () => {
 
     expect(screen.getByText("Turn failed")).toBeInTheDocument();
     expect(screen.getByText("1 of 3")).toBeInTheDocument();
+    if (rendererTarget?.scope === "remote") {
+      fireEvent.contextMenu(screen.getByRole("button", {
+        name: "Open thread Codex thread",
+      }));
+      fireEvent.click(screen.getByRole("menuitem", {
+        name: "Copy Thread Link",
+      }));
+      expect(copyText).toHaveBeenCalledWith(
+        "pwragent://thread/turn-failure-thread?backend=codex"
+        + "&instanceId=remote-gateway",
+      );
+    }
     fireEvent.click(screen.getByRole("button", { name: "Next notice" }));
     expect(screen.getByText("Codex repair failed")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Next notice" }));

--- a/apps/desktop/src/renderer/src/features/chrome/ChipContextMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/ChipContextMenu.tsx
@@ -27,6 +27,7 @@ export type ChipContextMenuItem =
   | ChipContextMenuActionItem;
 
 type ChipContextMenuProps = {
+  className?: string;
   items: ChipContextMenuItem[];
   onClose: () => void;
   position: ChipContextMenuPosition;
@@ -90,7 +91,10 @@ export function ChipContextMenu(props: ChipContextMenuProps) {
   return createPortal(
     <div
       ref={menuRef}
-      className="thread-context-menu chip-context-menu"
+      className={[
+        "thread-context-menu chip-context-menu",
+        props.className,
+      ].filter(Boolean).join(" ")}
       role="menu"
       style={{ left: position.x, top: position.y }}
       onClick={(event) => event.stopPropagation()}

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeStack.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeStack.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { DesktopApi } from "../../lib/desktop-api";
+import type { ResolvedThreadLink } from "../../lib/thread-links";
 import { AppNoticeToast, type AppNoticeToastNotice } from "./AppNoticeToast";
 
 export function AppNoticeStack(props: {
@@ -7,6 +8,7 @@ export function AppNoticeStack(props: {
   desktopApi?: Pick<DesktopApi, "copyText">;
   durableNotices: readonly AppNoticeToastNotice[];
   onDismissDurable: (id: string) => void;
+  onOpenThread?: (link: ResolvedThreadLink) => void;
   transientNotices?: readonly {
     notice?: AppNoticeToastNotice;
     onDismiss: () => void;
@@ -53,12 +55,14 @@ export function AppNoticeStack(props: {
             desktopApi={props.desktopApi}
             notice={notice}
             onDismiss={onDismiss}
+            onOpenThread={props.onOpenThread}
           />
         ) : null
       )}
       <AppNoticeToast
         desktopApi={props.desktopApi}
         notice={activeNotice}
+        onOpenThread={props.onOpenThread}
         navigation={activeNotice && durableNotices.length > 1
           ? {
               current: activeIndex + 1,

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -7,6 +7,8 @@ import {
 } from "../../icons";
 import { copyText } from "../../lib/copy-text";
 import type { DesktopApi } from "../../lib/desktop-api";
+import type { ResolvedThreadLink } from "../../lib/thread-links";
+import { ThreadChip } from "../thread-detail/ThreadChip";
 
 const AUTO_DISMISS_MS = 9_000;
 
@@ -21,6 +23,7 @@ export type AppNoticeToastNotice = {
   title: string;
   message: string;
   detail?: string;
+  threadLink?: ResolvedThreadLink;
   copyText?: string;
   tone?: "neutral" | "warning" | "success" | "error";
   status?: {
@@ -41,6 +44,7 @@ export function AppNoticeToast(props: {
   };
   notice?: AppNoticeToastNotice;
   onDismiss: () => void;
+  onOpenThread?: (link: ResolvedThreadLink) => void;
 }) {
   const [paused, setPaused] = useState(false);
   const timeoutRef = useRef<number | undefined>(undefined);
@@ -126,7 +130,15 @@ export function AppNoticeToast(props: {
           </p>
         ) : null}
         <p className="app-notice-toast__message">{props.notice.message}</p>
-        {props.notice.detail ? (
+        {props.notice.threadLink && props.onOpenThread ? (
+          <div className="app-notice-toast__thread-link">
+            <ThreadChip
+              fallbackLabel={props.notice.detail}
+              link={props.notice.threadLink}
+              onOpen={props.onOpenThread}
+            />
+          </div>
+        ) : props.notice.detail ? (
           <p className="app-notice-toast__detail">{props.notice.detail}</p>
         ) : null}
       </div>

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -133,6 +133,7 @@ export function AppNoticeToast(props: {
         {props.notice.threadLink && props.onOpenThread ? (
           <div className="app-notice-toast__thread-link">
             <ThreadChip
+              contextMenuClassName="app-notice-toast__thread-menu"
               fallbackLabel={props.notice.detail}
               link={props.notice.threadLink}
               onOpen={props.onOpenThread}

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -97,6 +97,33 @@ describe("AppNoticeToast", () => {
     expect(onOpenThread).toHaveBeenCalledWith(threadLink);
   });
 
+  it("opens its thread-chip context menu above the toast layer", () => {
+    const threadLink = {
+      backend: "codex" as const,
+      threadId: "thread-1",
+      title: "Fix the flaky test",
+    };
+
+    render(
+      <AppNoticeToast
+        notice={{
+          ...notice,
+          detail: threadLink.title,
+          threadLink,
+        }}
+        onDismiss={vi.fn()}
+        onOpenThread={vi.fn()}
+      />,
+    );
+
+    fireEvent.contextMenu(
+      screen.getByRole("button", { name: "Open thread Fix the flaky test" }),
+    );
+    expect(screen.getByRole("menu")).toHaveClass(
+      "app-notice-toast__thread-menu",
+    );
+  });
+
   it("marks warning notices for high-contrast styling", () => {
     render(
       <AppNoticeToast

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -71,6 +71,32 @@ describe("AppNoticeToast", () => {
     );
   });
 
+  it("renders an originating thread as an actionable thread chip", () => {
+    const onOpenThread = vi.fn();
+    const threadLink = {
+      backend: "codex" as const,
+      threadId: "thread-1",
+      title: "Fix the flaky test",
+    };
+
+    render(
+      <AppNoticeToast
+        notice={{
+          ...notice,
+          detail: threadLink.title,
+          threadLink,
+        }}
+        onDismiss={vi.fn()}
+        onOpenThread={onOpenThread}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open thread Fix the flaky test" }),
+    );
+    expect(onOpenThread).toHaveBeenCalledWith(threadLink);
+  });
+
   it("marks warning notices for high-contrast styling", () => {
     render(
       <AppNoticeToast

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/backend-error-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/backend-error-notice.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { AppNoticeToastNotice } from "../AppNoticeToast";
-import { resolveBackendErrorNotice } from "../backend-error-notice";
+import {
+  resolveBackendErrorNotice,
+  type BackendErrorSignal,
+} from "../backend-error-notice";
 
 describe("resolveBackendErrorNotice", () => {
   const invalidIdFailure =
@@ -228,5 +231,39 @@ describe("resolveBackendErrorNotice", () => {
       undefined,
     );
     expect(a?.id).not.toBe(b?.id);
+  });
+
+  it("preserves remote federation identity for every backend error path", () => {
+    const base = {
+      instanceId: "remote-gateway",
+      threadId: "thread-1",
+      threadLabel: "Remote thread",
+    };
+    const signals: BackendErrorSignal[] = [
+      {
+        ...base,
+        kind: "turn-failed",
+        backend: "codex",
+        errorMessage: "turn failed",
+        turnId: "turn-1",
+      },
+      {
+        ...base,
+        kind: "codex-invalid-id-recovery",
+        failureMessage: invalidIdFailure,
+        status: "failed",
+        turnId: "turn-1",
+      },
+      {
+        ...base,
+        kind: "system-error",
+        backend: "codex",
+      },
+    ];
+
+    for (const signal of signals) {
+      expect(resolveBackendErrorNotice(signal, undefined)?.threadLink)
+        .toMatchObject({ instanceId: "remote-gateway" });
+    }
   });
 });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/backend-error-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/backend-error-notice.test.ts
@@ -32,6 +32,11 @@ describe("resolveBackendErrorNotice", () => {
       },
       title: "Known Codex issue",
       tone: "warning",
+      threadLink: {
+        backend: "codex",
+        threadId: "thread-1",
+        title: "Fix the flaky test",
+      },
     });
 
     const succeeded = resolveBackendErrorNotice(
@@ -102,6 +107,11 @@ describe("resolveBackendErrorNotice", () => {
       title: "Turn failed",
       message: "stream disconnected before completion",
       detail: "Fix the flaky test",
+      threadLink: {
+        backend: "codex",
+        threadId: "thread-1",
+        title: "Fix the flaky test",
+      },
       copyText: "stream disconnected before completion",
     });
   });
@@ -121,6 +131,11 @@ describe("resolveBackendErrorNotice", () => {
       id: "system-error:codex:thread-1",
       title: "Agent backend error",
       detail: "Codex thread",
+      threadLink: {
+        backend: "codex",
+        threadId: "thread-1",
+        title: "Codex thread",
+      },
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/notifications/backend-error-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/backend-error-notice.ts
@@ -1,4 +1,7 @@
-import type { AppServerBackendKind } from "@pwragent/shared";
+import type {
+  AppServerBackendKind,
+  FederationInstanceId,
+} from "@pwragent/shared";
 import type { AppNoticeToastNotice } from "./AppNoticeToast";
 
 /**
@@ -16,6 +19,7 @@ export type BackendErrorSignal =
       turnId: string;
       failureMessage: string;
       recoveryError?: string;
+      instanceId?: FederationInstanceId;
       threadLabel: string;
     }
   | {
@@ -24,11 +28,13 @@ export type BackendErrorSignal =
       threadId: string;
       turnId: string;
       errorMessage: string;
+      instanceId?: FederationInstanceId;
       threadLabel: string;
     }
   | {
       kind: "system-error";
       backend: AppServerBackendKind;
+      instanceId?: FederationInstanceId;
       threadId: string;
       threadLabel: string;
     };
@@ -56,6 +62,7 @@ export function resolveBackendErrorNotice(
       message: signal.failureMessage,
       threadLink: {
         backend: "codex" as const,
+        ...(signal.instanceId ? { instanceId: signal.instanceId } : {}),
         threadId: signal.threadId,
         title: signal.threadLabel,
       },
@@ -108,6 +115,7 @@ export function resolveBackendErrorNotice(
       detail: signal.threadLabel,
       threadLink: {
         backend: signal.backend,
+        ...(signal.instanceId ? { instanceId: signal.instanceId } : {}),
         threadId: signal.threadId,
         title: signal.threadLabel,
       },
@@ -142,6 +150,7 @@ export function resolveBackendErrorNotice(
     detail: signal.threadLabel,
     threadLink: {
       backend: signal.backend,
+      ...(signal.instanceId ? { instanceId: signal.instanceId } : {}),
       threadId: signal.threadId,
       title: signal.threadLabel,
     },

--- a/apps/desktop/src/renderer/src/features/notifications/backend-error-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/backend-error-notice.ts
@@ -1,3 +1,4 @@
+import type { AppServerBackendKind } from "@pwragent/shared";
 import type { AppNoticeToastNotice } from "./AppNoticeToast";
 
 /**
@@ -19,7 +20,7 @@ export type BackendErrorSignal =
     }
   | {
       kind: "turn-failed";
-      backend: string;
+      backend: AppServerBackendKind;
       threadId: string;
       turnId: string;
       errorMessage: string;
@@ -27,7 +28,7 @@ export type BackendErrorSignal =
     }
   | {
       kind: "system-error";
-      backend: string;
+      backend: AppServerBackendKind;
       threadId: string;
       threadLabel: string;
     };
@@ -53,6 +54,11 @@ export function resolveBackendErrorNotice(
       id:
         `codex-invalid-id-recovery:codex:${signal.threadId}:${signal.turnId}`,
       message: signal.failureMessage,
+      threadLink: {
+        backend: "codex" as const,
+        threadId: signal.threadId,
+        title: signal.threadLabel,
+      },
     };
     if (signal.status === "repairing") {
       return {
@@ -100,6 +106,11 @@ export function resolveBackendErrorNotice(
       title: "Turn failed",
       message: signal.errorMessage,
       detail: signal.threadLabel,
+      threadLink: {
+        backend: signal.backend,
+        threadId: signal.threadId,
+        title: signal.threadLabel,
+      },
       copyText: signal.errorMessage,
     };
   }
@@ -129,5 +140,10 @@ export function resolveBackendErrorNotice(
     message:
       "The agent backend reported a system error. The active turn may have stopped.",
     detail: signal.threadLabel,
+    threadLink: {
+      backend: signal.backend,
+      threadId: signal.threadId,
+      title: signal.threadLabel,
+    },
   };
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
@@ -19,6 +19,7 @@ type ThreadChipProps = {
    */
   fallbackLabel?: string;
   link: ResolvedThreadLink;
+  contextMenuClassName?: string;
   onOpen: (link: ResolvedThreadLink) => void;
 };
 
@@ -88,6 +89,7 @@ export function ThreadChip(props: ThreadChipProps) {
       {tooltipController.tooltipNode}
       {contextMenuPosition && contextMenuInvokerRef.current ? (
         <ChipContextMenu
+          className={props.contextMenuClassName}
           items={threadCopyTargets(link, label)}
           position={contextMenuPosition}
           returnFocusTo={contextMenuInvokerRef.current}

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -669,6 +669,20 @@ describe("Tangerine Terminal theme contract", () => {
     expect(disabledRule).toContain("color: var(--text-muted);");
   });
 
+  it("layers toast thread-chip menus above the toast stack", () => {
+    const toastStackRule = extractRuleBody(css, ".app-toast-stack");
+    const toastThreadMenuRule = extractRuleBody(
+      css,
+      ".app-notice-toast__thread-menu",
+    );
+    const readZIndex = (rule: string): number =>
+      Number(rule.match(/z-index:\s*(\d+);/)?.[1] ?? Number.NaN);
+
+    expect(readZIndex(toastThreadMenuRule)).toBeGreaterThan(
+      readZIndex(toastStackRule),
+    );
+  });
+
   it("right-aligns the keyboard shortcut hint chip on context menu items", () => {
     // The `__shortcut` chip is the discoverability surface for
     // the otherwise-invisible Cmd+(Shift+)Arrow reorder shortcut.

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5728,6 +5728,10 @@ textarea,
   margin-top: 8px;
 }
 
+.app-notice-toast__thread-menu {
+  z-index: 90;
+}
+
 .app-notice-toast__status {
   display: flex;
   align-items: flex-start;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5722,6 +5722,12 @@ textarea,
   color: var(--text-secondary);
 }
 
+.app-notice-toast__thread-link {
+  display: flex;
+  min-width: 0;
+  margin-top: 8px;
+}
+
 .app-notice-toast__status {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
## What changed

- Render the originating thread on backend-error toasts as the existing interactive thread chip.
- Route chip activation through the app's established thread navigation path.
- Preserve plain-text detail rendering for notices without thread metadata or navigation.
- Cover chip activation and backend notice metadata with focused tests.

## Why

Backend failure toasts identified the affected thread with inert text, which made it unnecessarily difficult to jump from an out-of-context failure to the thread that needs attention.

## Impact

Operators can click or keyboard-activate the thread chip at the bottom of a backend failure toast to open the affected thread. The chip also retains the existing live-title, tooltip, and context-menu behavior used by thread links elsewhere.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeStack.test.tsx apps/desktop/src/renderer/src/features/notifications/__tests__/backend-error-notice.test.ts`
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
