### PR TITLE
feat(desktop): enable managed Kimi reviews

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -60,6 +60,19 @@ describe("describeInstalledAcpBackend", () => {
     expect(backend.methods).toContain("session/load");
   });
 
+  it("advertises managed review for Kimi but not other ACP providers", () => {
+    const kimi = describeInstalledAcpBackend({
+      ...buildInstalledAgent(),
+      backendId: "acp:kimi" as AcpBackendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+    });
+    const gemini = describeInstalledAcpBackend(buildInstalledAgent());
+
+    expect(kimi.capabilities.startReview).toBe(true);
+    expect(gemini.capabilities.startReview).toBe(false);
+  });
+
   it("advertises Grok 4.5 reasoning efforts in launchpad options", () => {
     const backend = describeInstalledAcpBackend({
       ...buildInstalledAgent(),

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2093,6 +2093,7 @@ type KimiStartPrompt = (params: {
 
 function createKimiAcpRegistry(options?: {
   acpBackendId?: AcpBackendId;
+  installedAgent?: AcpInstalledAgentRecord;
   acpRolloutStore?: AcpRolloutStore;
   sessionId?: string;
   sessions?: AcpSessionMetadata[];
@@ -2109,7 +2110,10 @@ function createKimiAcpRegistry(options?: {
     cwd: string,
   ) => Promise<LinkedDirectorySummary | undefined>;
 }) {
-  const acpBackendId = options?.acpBackendId ?? ("acp:kimi" as AcpBackendId);
+  const acpBackendId =
+    options?.installedAgent?.backendId
+    ?? options?.acpBackendId
+    ?? ("acp:kimi" as AcpBackendId);
   const sessions = options?.sessions ?? [];
   const sessionId = options?.sessionId ?? "kimi-session-1";
   const sendControlPrompt: KimiSendControlPrompt =
@@ -2166,13 +2170,19 @@ function createKimiAcpRegistry(options?: {
     refreshSession: vi.fn(async () => undefined),
     cancelSession: vi.fn(),
     readReplay: vi.fn((): AppServerThreadReplay => replay),
+    setRuntimeOption: vi.fn(async (params: {
+      sessionId: string;
+    }): Promise<BackendAcpSessionRuntimeState> =>
+      sessions.find((session) => session.sessionId === params.sessionId)?.acpRuntime
+      ?? { updatedAt: 1000 }),
   };
   const registry = new DesktopBackendRegistry({
     codexClient: options?.codexClient ?? new MockBackendClient({ threads: [] }),
     grokClient: new MockBackendClient({ threads: [] }),
     overlayStore: options?.overlayStore ?? createOverlayStoreMock(),
     acpAgentStore: createAcpAgentStoreMock([
-      createKimiAgentRecord(acpBackendId, options?.runtimeCapabilities),
+      options?.installedAgent
+      ?? createKimiAgentRecord(acpBackendId, options?.runtimeCapabilities),
     ]),
     acpRolloutStore: options?.acpRolloutStore,
     acpSessionStore: createAcpSessionStoreMock(sessions),
@@ -18301,8 +18311,24 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("rejects review start for ACP backends instead of routing through built-in clients", async () => {
-    const { acpBackendId, registry } = createKimiAcpRegistry();
+  it("rejects managed review start for ACP providers without the capability", async () => {
+    const geminiBackendId = "acp:gemini" as AcpBackendId;
+    const { acpBackendId, registry } = createKimiAcpRegistry({
+      installedAgent: {
+        ...createKimiAgentRecord(geminiBackendId),
+        backendId: geminiBackendId,
+        registryId: "gemini",
+        name: "Gemini CLI",
+        launchDescriptor: {
+          backendId: geminiBackendId,
+          registryId: "gemini",
+          distributionKind: "local",
+          command: "gemini",
+          args: ["--experimental-acp"],
+          env: {},
+        },
+      },
+    });
 
     await expect(
       registry.startReview({
@@ -18312,6 +18338,139 @@ command = "pnpm dev"
         delivery: "inline",
       }),
     ).rejects.toThrow("Selected backend does not support review/start");
+
+    await registry.close();
+  });
+
+  it("runs Kimi review in a hidden child and injects its output into the next parent turn", async () => {
+    const acpBackendId = "acp:kimi" as AcpBackendId;
+    const parentThreadId = "kimi-parent";
+    const parentRuntime: BackendAcpSessionRuntimeState = {
+      currentModeId: "default",
+      currentModelId: "kimi-code/k3",
+      reasoningEffort: "high",
+      updatedAt: 1000,
+    };
+    const sessions: AcpSessionMetadata[] = [{
+      backendId: acpBackendId,
+      sessionId: parentThreadId,
+      title: "Kimi parent",
+      cwd: "/repo/worktree",
+      createdAt: 1000,
+      updatedAt: 1000,
+      executionMode: "full-access",
+      acpRuntime: parentRuntime,
+      status: "idle",
+    }];
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        [`${acpBackendId}:${parentThreadId}`]: {
+          backend: acpBackendId,
+          threadId: parentThreadId,
+          executionMode: "full-access",
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const startPrompt = vi.fn((params: Parameters<KimiStartPrompt>[0]) => ({
+      sessionId: params.sessionId,
+      turnId: params.turnId ?? `turn-${startPrompt.mock.calls.length}`,
+    }));
+    const { acpClient, registry } = createKimiAcpRegistry({
+      acpBackendId,
+      overlayStore,
+      sessionId: parentThreadId,
+      sessions,
+      startPrompt,
+    });
+
+    const response = await registry.startReview({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    expect(response).toMatchObject({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+      reviewThreadId: expect.stringContaining(":title-helper:"),
+      turnId: expect.stringContaining("pending:"),
+    });
+    expect(acpClient.startSession).toHaveBeenCalledWith(expect.objectContaining({
+      acpRuntime: parentRuntime,
+      cwd: "/repo/worktree",
+      executionMode: "default",
+      hidden: true,
+    }));
+    expect(acpClient.setRuntimeOption).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: response.reviewThreadId,
+      source: "model",
+      value: "kimi-code/k3",
+      reasoningEffort: "high",
+    }));
+    expect(startPrompt).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: response.reviewThreadId,
+      prompt: expect.stringContaining("against base branch 'main'"),
+    }));
+
+    const reviewOutput = JSON.stringify({
+      findings: [],
+      overall_correctness: "patch is correct",
+      overall_explanation: "No blocking findings.",
+      overall_confidence_score: 0.96,
+    });
+    await (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit({
+      backend: acpBackendId,
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: response.reviewThreadId,
+          turnId: response.turnId,
+          turn: {
+            id: response.turnId,
+            status: "completed",
+            output: [{ type: "text", text: reviewOutput }],
+          },
+        },
+      },
+    });
+
+    const nextTurn = await registry.startTurn({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+      input: [{ type: "text", text: "Continue after review" }],
+    });
+    const nextPrompt = startPrompt.mock.calls.at(-1)?.[0].prompt;
+    expect(nextPrompt).toContain("PwrAgent review sub-agent results");
+    expect(nextPrompt).toContain(reviewOutput);
+    expect(nextPrompt).toContain("Continue after review");
+
+    await (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit({
+      backend: acpBackendId,
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: parentThreadId,
+          turnId: nextTurn.turnId,
+          turn: {
+            id: nextTurn.turnId,
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    });
+    await registry.startTurn({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+      input: [{ type: "text", text: "One more turn" }],
+    });
+    expect(startPrompt.mock.calls.at(-1)?.[0].prompt).toBe("One more turn");
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -508,10 +508,12 @@ function createOverlayStoreMock(params?: {
       backend,
       threadId,
       entry,
+      pendingContext,
     }: {
-      backend: "codex" | "grok";
+      backend: AppServerBackendKind;
       threadId: string;
       entry: NonNullable<ThreadOverlayState["managedReviewEntries"]>[number];
+      pendingContext?: boolean;
     }) => {
       const key = `${backend}:${threadId}`;
       const current = overlays.get(key) ?? {
@@ -533,6 +535,37 @@ function createOverlayStoreMock(params?: {
       const next = {
         ...current,
         managedReviewEntries: nextEntries,
+        pendingManagedReviewContextEntryIds: pendingContext
+          ? [
+              ...(current.pendingManagedReviewContextEntryIds ?? []),
+              entry.id,
+            ].filter((id, index, ids) => ids.indexOf(id) === index)
+          : current.pendingManagedReviewContextEntryIds,
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
+    consumeManagedReviewContexts: async ({
+      backend,
+      threadId,
+      entryIds,
+    }: {
+      backend: AppServerBackendKind;
+      threadId: string;
+      entryIds: string[];
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key);
+      if (!current) {
+        return undefined;
+      }
+      const consumed = new Set(entryIds);
+      const remaining = (current.pendingManagedReviewContextEntryIds ?? [])
+        .filter((id) => !consumed.has(id));
+      const next = {
+        ...current,
+        pendingManagedReviewContextEntryIds:
+          remaining.length > 0 ? remaining : undefined,
       } as ThreadOverlayState;
       overlays.set(key, next);
       return next;
@@ -18354,7 +18387,8 @@ command = "pnpm dev"
     const sessions: AcpSessionMetadata[] = [{
       backendId: acpBackendId,
       sessionId: parentThreadId,
-      title: "Kimi parent",
+      title: "ACP session",
+      titleSource: "fallback",
       cwd: "/repo/worktree",
       createdAt: 1000,
       updatedAt: 1000,
@@ -18376,13 +18410,14 @@ command = "pnpm dev"
       sessionId: params.sessionId,
       turnId: params.turnId ?? `turn-${startPrompt.mock.calls.length}`,
     }));
-    const { acpClient, registry } = createKimiAcpRegistry({
+    const firstRegistry = createKimiAcpRegistry({
       acpBackendId,
       overlayStore,
       sessionId: parentThreadId,
       sessions,
       startPrompt,
     });
+    const { acpClient, registry } = firstRegistry;
 
     const response = await registry.startReview({
       backend: acpBackendId,
@@ -18438,17 +18473,62 @@ command = "pnpm dev"
       },
     });
 
-    const nextTurn = await registry.startTurn({
+    const completedOverlay = await overlayStore.getThreadOverlayState({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+    });
+    expect(completedOverlay?.pendingManagedReviewContextEntryIds).toEqual([
+      `managed-review:${response.turnId}:result`,
+    ]);
+    await registry.close();
+
+    const followupStartPrompt = vi.fn(
+      (params: Parameters<KimiStartPrompt>[0]) => ({
+        sessionId: params.sessionId,
+        turnId: params.turnId ?? "followup-turn",
+      }),
+    );
+    const followup = createKimiAcpRegistry({
+      acpBackendId,
+      overlayStore,
+      sessionId: parentThreadId,
+      sessions,
+      startPrompt: followupStartPrompt,
+    });
+    const scheduleTitleGeneration = vi.spyOn(
+      followup.registry as unknown as {
+        scheduleThreadTitleGeneration(params: {
+          backend: AppServerBackendKind;
+          threadId: string;
+          input: AppServerTurnInputItem[];
+        }): void;
+      },
+      "scheduleThreadTitleGeneration",
+    );
+
+    const nextTurn = await followup.registry.startTurn({
       backend: acpBackendId,
       threadId: parentThreadId,
       input: [{ type: "text", text: "Continue after review" }],
     });
-    const nextPrompt = startPrompt.mock.calls.at(-1)?.[0].prompt;
+    const nextPrompt = followupStartPrompt.mock.calls.at(-1)?.[0].prompt;
     expect(nextPrompt).toContain("PwrAgent review sub-agent results");
     expect(nextPrompt).toContain(reviewOutput);
     expect(nextPrompt).toContain("Continue after review");
+    expect(scheduleTitleGeneration).toHaveBeenCalledWith({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+      input: [{ type: "text", text: "Continue after review" }],
+    });
+    const consumedOverlay = await overlayStore.getThreadOverlayState({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+    });
+    expect(
+      consumedOverlay?.pendingManagedReviewContextEntryIds,
+    ).toBeUndefined();
 
-    await (registry as unknown as {
+    await (followup.registry as unknown as {
       emit(event: AgentEvent): Promise<void>;
     }).emit({
       backend: acpBackendId,
@@ -18465,14 +18545,98 @@ command = "pnpm dev"
         },
       },
     });
-    await registry.startTurn({
+    await followup.registry.startTurn({
       backend: acpBackendId,
       threadId: parentThreadId,
       input: [{ type: "text", text: "One more turn" }],
     });
-    expect(startPrompt.mock.calls.at(-1)?.[0].prompt).toBe("One more turn");
+    expect(followupStartPrompt.mock.calls.at(-1)?.[0].prompt).toBe("One more turn");
 
+    await followup.registry.close();
+  });
+
+  it("routes direct and controlled Kimi review cancellation to the hidden child", async () => {
+    const acpBackendId = "acp:kimi" as AcpBackendId;
+    const parentThreadId = "kimi-review-parent";
+    const sessions: AcpSessionMetadata[] = [{
+      backendId: acpBackendId,
+      sessionId: parentThreadId,
+      title: "Kimi review parent",
+      cwd: "/repo/worktree",
+      createdAt: 1000,
+      updatedAt: 1000,
+      executionMode: "default",
+      status: "idle",
+    }];
+    const startPrompt = vi.fn((params: Parameters<KimiStartPrompt>[0]) => ({
+      sessionId: params.sessionId,
+      turnId: `review-turn-${startPrompt.mock.calls.length}`,
+    }));
+    const { acpClient, registry } = createKimiAcpRegistry({
+      acpBackendId,
+      sessionId: parentThreadId,
+      sessions,
+      startPrompt,
+    });
+
+    const directReview = await registry.startReview({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+      target: { type: "uncommittedChanges" },
+      delivery: "inline",
+    });
+    await registry.interruptTurn({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+      turnId: directReview.turnId,
+    });
+    expect(acpClient.cancelSession).toHaveBeenLastCalledWith(
+      directReview.reviewThreadId,
+    );
     await registry.close();
+
+    const controlledSessions: AcpSessionMetadata[] = [{
+      ...sessions[0]!,
+    }];
+    const controlledStartPrompt = vi.fn(
+      (params: Parameters<KimiStartPrompt>[0]) => ({
+        sessionId: params.sessionId,
+        turnId: "controlled-review-turn",
+      }),
+    );
+    const controlled = createKimiAcpRegistry({
+      acpBackendId,
+      sessionId: parentThreadId,
+      sessions: controlledSessions,
+      startPrompt: controlledStartPrompt,
+    });
+    const controlledReview = await controlled.registry.startReview({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+      target: { type: "uncommittedChanges" },
+      delivery: "inline",
+    });
+    await expect(controlled.registry.controlActiveTurn({
+      operation: "stop",
+      backend: acpBackendId,
+      threadId: parentThreadId,
+      requestId: "stop-kimi-review",
+      expectedTurnId: controlledReview.turnId,
+    })).resolves.toMatchObject({
+      ok: true,
+      backend: acpBackendId,
+      threadId: parentThreadId,
+      turnId: controlledReview.turnId,
+      disposition: "interrupted",
+    });
+    expect(controlled.acpClient.cancelSession).toHaveBeenLastCalledWith(
+      controlledReview.reviewThreadId,
+    );
+    expect(controlled.acpClient.cancelSession).not.toHaveBeenCalledWith(
+      parentThreadId,
+    );
+
+    await controlled.registry.close();
   });
 
   it("rejects Codex review start while the thread has an active turn", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -517,6 +517,30 @@ describe("MessagingController", () => {
     });
   });
 
+  it("submits reviews for Kimi when managed review is advertised", async () => {
+    const harness = await createHarness({
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [buildKimiRuntimeBackendSummary()],
+      }),
+    });
+    await bindThreadToBackend(harness, "acp:kimi");
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/review main"));
+
+    expect(harness.submitReview).toHaveBeenCalledWith({
+      backend: "acp:kimi",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Review started",
+    });
+  });
+
   it("rejects review when Codex does not advertise review/start", async () => {
     const harness = await createHarness({
       listBackends: async (): Promise<ListBackendsResponse> => ({

--- a/apps/desktop/src/main/__tests__/overlay-store-managed-reviews.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-managed-reviews.test.ts
@@ -85,9 +85,10 @@ describe("SqliteOverlayStore — managed review entries", () => {
         },
       });
       await store.upsertManagedReviewEntry({
-        backend: "codex",
+        backend: "acp:kimi",
         threadId: "thread-1",
         entry: result,
+        pendingContext: true,
       });
       stateDb.close();
 
@@ -95,10 +96,24 @@ describe("SqliteOverlayStore — managed review entries", () => {
       const reopenedStore = new SqliteOverlayStore(reopened);
       try {
         const overlay = await reopenedStore.getThreadOverlayState({
-          backend: "codex",
+          backend: "acp:kimi",
           threadId: "thread-1",
         });
         expect(overlay?.managedReviewEntries).toEqual([result]);
+        expect(overlay?.pendingManagedReviewContextEntryIds).toEqual([
+          result.id,
+        ]);
+
+        await reopenedStore.consumeManagedReviewContexts({
+          backend: "acp:kimi",
+          threadId: "thread-1",
+          entryIds: [result.id],
+        });
+        const consumed = await reopenedStore.getThreadOverlayState({
+          backend: "acp:kimi",
+          threadId: "thread-1",
+        });
+        expect(consumed?.pendingManagedReviewContextEntryIds).toBeUndefined();
       } finally {
         reopened.close();
       }

--- a/apps/desktop/src/main/acp/acp-agent-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-agent-capabilities.ts
@@ -1,23 +1,29 @@
 export type AcpAgentCapabilities = {
   liveWorkspaceHandoff: boolean;
+  managedReview: boolean;
 };
 
 const DEFAULT_ACP_AGENT_CAPABILITIES: AcpAgentCapabilities = {
   liveWorkspaceHandoff: false,
+  managedReview: false,
 };
 
 const ACP_AGENT_CAPABILITY_CATALOG: Record<string, AcpAgentCapabilities> = {
   gemini: {
     liveWorkspaceHandoff: false,
+    managedReview: false,
   },
   kimi: {
     liveWorkspaceHandoff: false,
+    managedReview: true,
   },
   grok: {
     liveWorkspaceHandoff: false,
+    managedReview: false,
   },
   qwen: {
     liveWorkspaceHandoff: false,
+    managedReview: false,
   },
 };
 

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -287,7 +287,9 @@ function hashString(value: string): string {
   return hash.toString(16);
 }
 
-export function buildAcpCapabilities(): BackendCapabilities {
+export function buildAcpCapabilities(
+  agentCapabilities?: AcpAgentCapabilities,
+): BackendCapabilities {
   return {
     listThreads: true,
     createThread: true,
@@ -299,7 +301,7 @@ export function buildAcpCapabilities(): BackendCapabilities {
     renameThread: true,
     readThread: true,
     startTurn: true,
-    startReview: false,
+    startReview: agentCapabilities?.managedReview === true,
     interruptTurn: true,
     steerTurn: false,
     transcriptPagination: false,
@@ -352,7 +354,7 @@ export function describeInstalledAcpBackend(
       "session/prompt",
       "session/cancel",
     ],
-    capabilities: buildAcpCapabilities(),
+    capabilities: buildAcpCapabilities(effectiveAcpAgentCapabilities(agent)),
     executionModes: buildAcpExecutionModes(agent, available, unavailableReason),
     launchpadOptions: buildAcpLaunchpadOptions(
       runtimeCapabilities,
@@ -401,9 +403,10 @@ function isLegacyKimiInstalledRecord(agent: AcpInstalledAgentRecord): boolean {
 function effectiveAcpAgentCapabilities(
   agent: AcpInstalledAgentRecord,
 ): AcpAgentCapabilities {
-  const configured =
-    agent.capabilities ??
-    acpAgentCapabilitiesForRegistryId(agent.registryId);
+  const configured = {
+    ...acpAgentCapabilitiesForRegistryId(agent.registryId),
+    ...agent.capabilities,
+  };
   return {
     ...configured,
     liveWorkspaceHandoff:
@@ -1525,6 +1528,11 @@ export class AcpBackendAdapter {
   async supportsLiveWorkspaceHandoff(backend: AcpBackendId): Promise<boolean> {
     const agent = await this.resolveInstalledAgent(backend);
     return effectiveAcpAgentCapabilities(agent).liveWorkspaceHandoff;
+  }
+
+  supportsManagedReview(backend: AcpBackendId): boolean {
+    const agent = this.getInstalledAgent(backend);
+    return Boolean(agent && effectiveAcpAgentCapabilities(agent).managedReview);
   }
 
   async listAvailableAgents(): Promise<AcpInstalledAgentRecord[]> {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -39,6 +39,7 @@ import {
   type PwrSnapConnectionService,
 } from "../mcp-connections/pwrsnap-connection-service";
 import {
+  buildManagedReviewContextInput,
   buildManagedReviewPrompt,
   formatManagedReviewOutput,
   parseManagedReviewOutput,
@@ -2601,7 +2602,7 @@ type TaskMonitorDelegationRecord = {
 };
 
 type ReviewSubAgentRecord = {
-  backend: Exclude<AppServerBackendKind, AcpBackendId>;
+  backend: AppServerBackendKind;
   createdAt: number;
   displayText: string;
   fastMode?: boolean;
@@ -6372,6 +6373,7 @@ export class DesktopBackendRegistry {
     string,
     ReviewSubAgentRecord
   >();
+  private readonly pendingManagedReviewContexts = new Map<string, string[]>();
   private readonly codexNativeSubAgentParents = new Map<string, string>();
   private readonly codexNativeSubAgentReconciliations = new Map<
     string,
@@ -8221,6 +8223,7 @@ export class DesktopBackendRegistry {
     acpRuntime?: BackendAcpSessionRuntimeState;
     reasoningEffort?: string;
     mcpRegistration?: AcpMcpServerRegistration;
+    hidden?: boolean;
   }): Promise<{ threadId: string }> {
     const client = await this.acpBackend.getClient(params.backend);
     const initialExecutionMode = this.usesSlashControlledAcpExecutionModes(
@@ -8233,6 +8236,7 @@ export class DesktopBackendRegistry {
       executionMode: initialExecutionMode,
       acpRuntime: params.acpRuntime,
       additionalMcpRegistration: params.mcpRegistration,
+      ...(params.hidden ? { hidden: true } : {}),
     });
     if (
       this.usesSlashControlledAcpExecutionModes(params.backend) &&
@@ -11230,6 +11234,13 @@ export class DesktopBackendRegistry {
     });
     const migrationApplied = migrationResult.status === "applied";
     if (isAcpBackendId(params.backend)) {
+      const managedReviewContextKey = buildThreadIdentityKey(
+        params.backend,
+        params.threadId,
+      );
+      const pendingManagedReviewContexts = [
+        ...(this.pendingManagedReviewContexts.get(managedReviewContextKey) ?? []),
+      ];
       const overlay = await this.overlayStore.getThreadOverlayState({
         backend: params.backend,
         threadId: params.threadId,
@@ -11260,9 +11271,20 @@ export class DesktopBackendRegistry {
           }),
           input: params.input,
         });
+        const inputWithManagedReviewContext = pendingManagedReviewContexts.length > 0
+          ? [
+              {
+                type: "text" as const,
+                text: buildManagedReviewContextInput(
+                  pendingManagedReviewContexts,
+                ),
+              },
+              ...preparedPdfInput.input,
+            ]
+          : preparedPdfInput.input;
         // ACP adapters already accept data-URL image parts. Keeping those
         // intact avoids changing their established image payload contract.
-        const input = await enrichLocalFileInputs(preparedPdfInput.input, {
+        const input = await enrichLocalFileInputs(inputWithManagedReviewContext, {
           privateStorageRoots: this.localFilePrivateStorageRoots,
         });
         if (this.usesSlashControlledAcpExecutionModes(params.backend)) {
@@ -11288,6 +11310,10 @@ export class DesktopBackendRegistry {
           input,
           model: modelSettings.model,
           reasoningEffort: modelSettings.reasoningEffort,
+        });
+        this.consumePendingManagedReviewContexts({
+          key: managedReviewContextKey,
+          consumed: pendingManagedReviewContexts,
         });
         this.pdfAttachmentStore.bindTurn(
           {
@@ -11928,17 +11954,29 @@ export class DesktopBackendRegistry {
 
   async startReview(params: StartReviewRequest): Promise<StartReviewResponse> {
     this.assertNotBootstrap("startReview");
-    if (isAcpBackendId(params.backend)) {
+    const acpManagedMode =
+      isAcpBackendId(params.backend)
+      && this.acpBackend.supportsManagedReview(params.backend);
+    if (isAcpBackendId(params.backend) && !acpManagedMode) {
       throw new Error("Selected backend does not support review/start");
     }
     const managedMode =
-      params.backend === "codex" && this.resolveManagedReviewEnabledFn();
+      acpManagedMode
+      || (params.backend === "codex" && this.resolveManagedReviewEnabledFn());
     const reserveCodexReviewStart = params.backend === "codex";
+    const acpReviewReservationKey = isAcpBackendId(params.backend)
+      ? buildTurnStartReservationKey(params.backend, params.threadId)
+      : undefined;
     if (reserveCodexReviewStart) {
       if (this.threadHasActiveTurn(params.threadId)) {
         throw new Error(`Thread already has an active turn in progress: ${params.threadId}`);
       }
       this.reservedCodexStartThreadIds.add(params.threadId);
+    } else if (acpReviewReservationKey) {
+      if (this.threadHasActiveTurn(params.threadId, params.backend)) {
+        throw new Error(`Thread already has an active turn in progress: ${params.threadId}`);
+      }
+      this.reservedAcpStartThreadKeys.add(acpReviewReservationKey);
     }
     let modelSettings: ModelSettings = {};
     let result: { threadId: string; reviewThreadId: string; turnId: string };
@@ -11948,14 +11986,13 @@ export class DesktopBackendRegistry {
       if (params.backend === "codex") {
         await this.flushQueuedExecutionModeIfPresent(params.threadId);
       }
-      overlay =
-        params.backend === "codex"
-          ? await this.overlayStore.getThreadOverlayState({
-              backend: params.backend,
-              threadId: params.threadId,
-            })
-          : undefined;
-      if (params.backend === "codex") {
+      overlay = managedMode || params.backend === "codex"
+        ? await this.overlayStore.getThreadOverlayState({
+            backend: params.backend,
+            threadId: params.threadId,
+          })
+        : undefined;
+      if (params.backend === "codex" || acpManagedMode) {
         cwd =
           params.cwd?.trim()
           || await this.resolveThreadEnvironmentCwd(
@@ -11999,6 +12036,7 @@ export class DesktopBackendRegistry {
 
       result = managedMode
         ? await this.startManagedReviewChild({
+            backend: params.backend,
             cwd,
             modelSettings,
             overlay,
@@ -12011,6 +12049,9 @@ export class DesktopBackendRegistry {
     } catch (error) {
       if (reserveCodexReviewStart) {
         this.reservedCodexStartThreadIds.delete(params.threadId);
+      }
+      if (acpReviewReservationKey) {
+        this.reservedAcpStartThreadKeys.delete(acpReviewReservationKey);
       }
       throw error;
     }
@@ -12041,9 +12082,11 @@ export class DesktopBackendRegistry {
       } finally {
         this.reservedCodexStartThreadIds.delete(params.threadId);
       }
+    } else if (acpReviewReservationKey) {
+      this.reservedAcpStartThreadKeys.delete(acpReviewReservationKey);
     }
     const reviewSubAgentRecord: ReviewSubAgentRecord = {
-      backend: params.backend as Exclude<AppServerBackendKind, AcpBackendId>,
+      backend: params.backend,
       createdAt: Date.now(),
       displayText: reviewTaskLabel(params.target),
       ...(modelSettings.fastMode !== undefined ? { fastMode: modelSettings.fastMode } : {}),
@@ -12089,12 +12132,47 @@ export class DesktopBackendRegistry {
   }
 
   private async startManagedReviewChild(params: {
+    backend: AppServerBackendKind;
     cwd?: string;
     modelSettings: ModelSettings;
     overlay?: ThreadOverlayState;
     parentThreadId: string;
     target: StartReviewRequest["target"];
   }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
+    if (isAcpBackendId(params.backend)) {
+      const parentSession = this.acpBackend.getSession(
+        params.backend,
+        params.parentThreadId,
+      );
+      const acpRuntime = parentSession?.acpRuntime;
+      const executionMode =
+        params.overlay?.executionMode
+        ?? parentSession?.executionMode
+        ?? "default";
+      const thread = await this.startAcpSession({
+        backend: params.backend,
+        cwd: params.cwd,
+        executionMode,
+        acpRuntime,
+        reasoningEffort:
+          params.modelSettings.reasoningEffort
+          ?? acpRuntime?.reasoningEffort,
+        hidden: true,
+      });
+      const turn = await this.startAcpTurn({
+        backend: params.backend,
+        threadId: thread.threadId,
+        input: [{ type: "text", text: buildManagedReviewPrompt(params.target) }],
+        model: params.modelSettings.model,
+        reasoningEffort: params.modelSettings.reasoningEffort,
+      });
+      return {
+        threadId: params.parentThreadId,
+        reviewThreadId: turn.threadId,
+        turnId: turn.turnId,
+      };
+    }
+
     const executionMode =
       params.overlay?.executionMode
       ?? await this.resolveCodexThreadExecutionModeForActiveTurn(
@@ -12223,6 +12301,14 @@ export class DesktopBackendRegistry {
       ?? (
         request.backend === "codex"
         && this.reservedCodexStartThreadIds.has(request.threadId)
+          ? `pending:${request.threadId}`
+          : undefined
+      )
+      ?? (
+        isAcpBackendId(request.backend)
+        && this.reservedAcpStartThreadKeys.has(
+          buildTurnStartReservationKey(request.backend, request.threadId),
+        )
           ? `pending:${request.threadId}`
           : undefined
       );
@@ -19758,6 +19844,28 @@ export class DesktopBackendRegistry {
     );
   }
 
+  private consumePendingManagedReviewContexts(params: {
+    consumed: string[];
+    key: string;
+  }): void {
+    if (params.consumed.length === 0) {
+      return;
+    }
+    const current = this.pendingManagedReviewContexts.get(params.key);
+    if (
+      !current
+      || !params.consumed.every((output, index) => current[index] === output)
+    ) {
+      return;
+    }
+    const remaining = current.slice(params.consumed.length);
+    if (remaining.length === 0) {
+      this.pendingManagedReviewContexts.delete(params.key);
+      return;
+    }
+    this.pendingManagedReviewContexts.set(params.key, remaining);
+  }
+
   private async publishManagedReviewTerminal(params: {
     method: "turn/completed" | "turn/failed" | "turn/cancelled";
     notification: Extract<
@@ -19780,6 +19888,17 @@ export class DesktopBackendRegistry {
       const review = parsed
         ? formatManagedReviewOutput(parsed)
         : output?.trim() || "Review completed without output.";
+      if (isAcpBackendId(params.record.backend)) {
+        const contextKey = buildThreadIdentityKey(
+          params.record.backend,
+          params.record.parentThreadId,
+        );
+        const pending = this.pendingManagedReviewContexts.get(contextKey) ?? [];
+        this.pendingManagedReviewContexts.set(contextKey, [
+          ...pending,
+          output?.trim() || review,
+        ]);
+      }
       const entry: AppServerThreadReviewEntry = {
         type: "review",
         id: `managed-review:${params.record.turnId}:result`,
@@ -21789,7 +21908,10 @@ export class DesktopBackendRegistry {
         "start_review must be invoked from a live turn on the thread being reviewed.",
       );
     }
-    if (isAcpBackendId(request.context.backend)) {
+    if (
+      isAcpBackendId(request.context.backend)
+      && !this.acpBackend.supportsManagedReview(request.context.backend)
+    ) {
       return threadOrchestrationFailure(
         "unsupported_backend",
         "Selected backend does not support review/start.",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6373,7 +6373,6 @@ export class DesktopBackendRegistry {
     string,
     ReviewSubAgentRecord
   >();
-  private readonly pendingManagedReviewContexts = new Map<string, string[]>();
   private readonly codexNativeSubAgentParents = new Map<string, string>();
   private readonly codexNativeSubAgentReconciliations = new Map<
     string,
@@ -11234,17 +11233,23 @@ export class DesktopBackendRegistry {
     });
     const migrationApplied = migrationResult.status === "applied";
     if (isAcpBackendId(params.backend)) {
-      const managedReviewContextKey = buildThreadIdentityKey(
-        params.backend,
-        params.threadId,
-      );
-      const pendingManagedReviewContexts = [
-        ...(this.pendingManagedReviewContexts.get(managedReviewContextKey) ?? []),
-      ];
       const overlay = await this.overlayStore.getThreadOverlayState({
         backend: params.backend,
         threadId: params.threadId,
       });
+      const pendingManagedReviewContextEntryIds =
+        overlay?.pendingManagedReviewContextEntryIds ?? [];
+      const managedReviewEntriesById = new Map(
+        (overlay?.managedReviewEntries ?? []).map((entry) => [entry.id, entry]),
+      );
+      const pendingManagedReviewContexts =
+        pendingManagedReviewContextEntryIds.flatMap((entryId) => {
+          const entry = managedReviewEntriesById.get(entryId);
+          if (!entry) {
+            return [];
+          }
+          return [entry.output ? JSON.stringify(entry.output) : entry.review];
+        });
       const modelSettings = await this.resolveModelSettings(params.backend, {
         model: migrationApplied
           ? overlay?.model
@@ -11271,7 +11276,12 @@ export class DesktopBackendRegistry {
           }),
           input: params.input,
         });
-        const inputWithManagedReviewContext = pendingManagedReviewContexts.length > 0
+        // ACP adapters already accept data-URL image parts. Keeping those
+        // intact avoids changing their established image payload contract.
+        const userInput = await enrichLocalFileInputs(preparedPdfInput.input, {
+          privateStorageRoots: this.localFilePrivateStorageRoots,
+        });
+        const input = pendingManagedReviewContexts.length > 0
           ? [
               {
                 type: "text" as const,
@@ -11279,14 +11289,9 @@ export class DesktopBackendRegistry {
                   pendingManagedReviewContexts,
                 ),
               },
-              ...preparedPdfInput.input,
+              ...userInput,
             ]
-          : preparedPdfInput.input;
-        // ACP adapters already accept data-URL image parts. Keeping those
-        // intact avoids changing their established image payload contract.
-        const input = await enrichLocalFileInputs(inputWithManagedReviewContext, {
-          privateStorageRoots: this.localFilePrivateStorageRoots,
-        });
+          : userInput;
         if (this.usesSlashControlledAcpExecutionModes(params.backend)) {
           await this.flushQueuedExecutionModeIfPresent(
             params.threadId,
@@ -11311,9 +11316,10 @@ export class DesktopBackendRegistry {
           model: modelSettings.model,
           reasoningEffort: modelSettings.reasoningEffort,
         });
-        this.consumePendingManagedReviewContexts({
-          key: managedReviewContextKey,
-          consumed: pendingManagedReviewContexts,
+        await this.overlayStore.consumeManagedReviewContexts({
+          backend: params.backend,
+          threadId: params.threadId,
+          entryIds: pendingManagedReviewContextEntryIds,
         });
         this.pdfAttachmentStore.bindTurn(
           {
@@ -11326,7 +11332,7 @@ export class DesktopBackendRegistry {
         this.scheduleThreadTitleGeneration({
           backend: params.backend,
           threadId: result.threadId,
-          input,
+          input: userInput,
         });
         this.bindPendingThreadMessageContext(
           pendingMessageContextId,
@@ -12674,8 +12680,18 @@ export class DesktopBackendRegistry {
 
       try {
         if (request.operation === "stop") {
-          const stopped = isAcpBackendId(request.backend)
-            ? await this.interruptAcpTurn(active, true)
+          const managedAcpReview = isAcpBackendId(request.backend)
+            ? this.findManagedReviewForParentTurn({
+                backend: request.backend,
+                parentThreadId: request.threadId,
+                turnId: active.turnId,
+              })
+            : undefined;
+          const stopped = isAcpBackendId(request.backend) && !managedAcpReview
+            ? await this.acpSessionPromptLocks.run(
+                lockKey,
+                async () => await this.interruptAcpTurn(active, true),
+              )
             : await this.interruptTurn(active);
           return {
             ok: true,
@@ -12737,13 +12753,7 @@ export class DesktopBackendRegistry {
       }
     };
 
-    return await this.activeTurnControlLocks.run(
-      lockKey,
-      async () =>
-        isAcpBackendId(request.backend)
-          ? await this.acpSessionPromptLocks.run(lockKey, perform)
-          : await perform(),
-    );
+    return await this.activeTurnControlLocks.run(lockKey, perform);
   }
 
   private async interruptAcpTurn(
@@ -12802,16 +12812,32 @@ export class DesktopBackendRegistry {
     threadId: string;
     turnId: string;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
-    if (isAcpBackendId(params.backend)) {
-      return await this.interruptAcpTurn(params);
-    }
-
     const managedReview = this.findManagedReviewForParentTurn({
       backend: params.backend,
       parentThreadId: params.threadId,
       turnId: params.turnId,
     });
     if (managedReview) {
+      if (isAcpBackendId(params.backend)) {
+        const childLockKey = executionModeQueueKey(
+          params.backend,
+          managedReview.reviewThreadId,
+        );
+        await this.acpSessionPromptLocks.run(
+          childLockKey,
+          async () => await this.interruptAcpTurn({
+            backend: params.backend,
+            threadId: managedReview.reviewThreadId,
+            turnId: managedReview.turnId,
+          }),
+        );
+        backendRegistryLog.info("managed ACP review interrupt requested", {
+          parentThreadId: managedReview.parentThreadId,
+          reviewThreadId: managedReview.reviewThreadId,
+          turnId: managedReview.turnId,
+        });
+        return params;
+      }
       const activeMode = this.activeCodexTurnModes.get(
         buildActiveTurnModeKey(
           managedReview.reviewThreadId,
@@ -12831,6 +12857,10 @@ export class DesktopBackendRegistry {
         turnId: managedReview.turnId,
       });
       return params;
+    }
+
+    if (isAcpBackendId(params.backend)) {
+      return await this.interruptAcpTurn(params);
     }
 
     const requestedCodexTurnModeKey =
@@ -19844,28 +19874,6 @@ export class DesktopBackendRegistry {
     );
   }
 
-  private consumePendingManagedReviewContexts(params: {
-    consumed: string[];
-    key: string;
-  }): void {
-    if (params.consumed.length === 0) {
-      return;
-    }
-    const current = this.pendingManagedReviewContexts.get(params.key);
-    if (
-      !current
-      || !params.consumed.every((output, index) => current[index] === output)
-    ) {
-      return;
-    }
-    const remaining = current.slice(params.consumed.length);
-    if (remaining.length === 0) {
-      this.pendingManagedReviewContexts.delete(params.key);
-      return;
-    }
-    this.pendingManagedReviewContexts.set(params.key, remaining);
-  }
-
   private async publishManagedReviewTerminal(params: {
     method: "turn/completed" | "turn/failed" | "turn/cancelled";
     notification: Extract<
@@ -19888,17 +19896,6 @@ export class DesktopBackendRegistry {
       const review = parsed
         ? formatManagedReviewOutput(parsed)
         : output?.trim() || "Review completed without output.";
-      if (isAcpBackendId(params.record.backend)) {
-        const contextKey = buildThreadIdentityKey(
-          params.record.backend,
-          params.record.parentThreadId,
-        );
-        const pending = this.pendingManagedReviewContexts.get(contextKey) ?? [];
-        this.pendingManagedReviewContexts.set(contextKey, [
-          ...pending,
-          output?.trim() || review,
-        ]);
-      }
       const entry: AppServerThreadReviewEntry = {
         type: "review",
         id: `managed-review:${params.record.turnId}:result`,
@@ -19915,6 +19912,7 @@ export class DesktopBackendRegistry {
         backend: params.record.backend,
         threadId: params.record.parentThreadId,
         entry,
+        pendingContext: isAcpBackendId(params.record.backend),
       });
       await this.emit({
         backend: params.record.backend,

--- a/apps/desktop/src/main/app-server/managed-review.ts
+++ b/apps/desktop/src/main/app-server/managed-review.ts
@@ -20,6 +20,17 @@ export function buildManagedReviewPrompt(
   ].join("\n\n");
 }
 
+export function buildManagedReviewContextInput(outputs: string[]): string {
+  return [
+    "[PwrAgent review sub-agent results — context for this turn]",
+    ...outputs.map((output, index) => [
+      outputs.length > 1 ? `Review ${index + 1}:` : undefined,
+      output.trim(),
+    ].filter((line): line is string => Boolean(line)).join("\n")),
+    "[End PwrAgent review sub-agent results]",
+  ].join("\n\n");
+}
+
 function reviewTargetInstructions(target: AppServerReviewTarget): string {
   switch (target.type) {
     case "baseBranch":

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -12966,7 +12966,7 @@ export class MessagingController {
   private async reviewSupportedForBinding(
     binding: MessagingBindingRecord,
   ): Promise<boolean> {
-    if (!this.options.backend.submitReview || isAcpBackendId(binding.backend)) {
+    if (!this.options.backend.submitReview) {
       return false;
     }
     try {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -592,6 +592,8 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           retainedBranchDriftPairs: current?.retainedBranchDriftPairs,
           immutableUsageActivities: current?.immutableUsageActivities,
           managedReviewEntries: current?.managedReviewEntries,
+          pendingManagedReviewContextEntryIds:
+            current?.pendingManagedReviewContextEntryIds,
           subAgents: current?.subAgents,
           handoffOrigin: current?.handoffOrigin,
           lastSeenAt: params.fetchedAt,
@@ -929,6 +931,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     backend: ThreadOverlayState["backend"];
     threadId: string;
     entry: NonNullable<ThreadOverlayState["managedReviewEntries"]>[number];
+    pendingContext?: boolean;
   }): Promise<ThreadOverlayState> {
     const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
     const current = this.getThread(threadKey) ?? {
@@ -950,6 +953,42 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     const nextState: ThreadOverlayState = {
       ...current,
       managedReviewEntries: nextEntries.slice(-MAX_MANAGED_REVIEW_ENTRIES),
+    };
+    const retainedEntryIds = new Set(
+      nextState.managedReviewEntries?.map((entry) => entry.id) ?? [],
+    );
+    const pendingContextEntryIds = [
+      ...(current.pendingManagedReviewContextEntryIds ?? []),
+      ...(params.pendingContext ? [params.entry.id] : []),
+    ].filter(
+      (id, index, ids) =>
+        retainedEntryIds.has(id) && ids.indexOf(id) === index,
+    );
+    nextState.pendingManagedReviewContextEntryIds =
+      pendingContextEntryIds.length > 0
+        ? pendingContextEntryIds
+        : undefined;
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
+  async consumeManagedReviewContexts(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    entryIds: string[];
+  }): Promise<ThreadOverlayState | undefined> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey);
+    if (!current || params.entryIds.length === 0) {
+      return current;
+    }
+    const consumed = new Set(params.entryIds);
+    const remaining = (current.pendingManagedReviewContextEntryIds ?? [])
+      .filter((id) => !consumed.has(id));
+    const nextState: ThreadOverlayState = {
+      ...current,
+      pendingManagedReviewContextEntryIds:
+        remaining.length > 0 ? remaining : undefined,
     };
     this.putThread(threadKey, nextState);
     return nextState;
@@ -6215,6 +6254,7 @@ export type OverlayStoreLike = Pick<
   | "setAcpWorktreeDirectory"
   | "persistThreadUsageActivity"
   | "upsertManagedReviewEntry"
+  | "consumeManagedReviewContexts"
   | "upsertThreadUsageLine"
   | "readThreadPricing"
   | "upsertThreadToolInvocation"

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1646,6 +1646,12 @@ export type ThreadOverlayState = {
    * threads are intentionally ephemeral.
    */
   managedReviewEntries?: AppServerThreadReviewEntry[];
+  /**
+   * Managed-review result entry ids that still need to be supplied to the
+   * parent ACP agent. The review text remains in `managedReviewEntries`; this
+   * list is only durable delivery metadata.
+   */
+  pendingManagedReviewContextEntryIds?: string[];
   /** Durable delegated sub-agent/task-monitor summaries for this thread. */
   subAgents?: ThreadSubAgentSummary[];
   /** Durable origin metadata for threads created by an Agent handoff tool. */


### PR DESCRIPTION
## Summary

- advertise managed review as the standard review implementation for Kimi, without the Codex experimental flag
- run each Kimi review in a hidden ACP child session that inherits the parent workspace, execution mode, runtime model, and reasoning settings
- publish the normal review artifact and inject the child output once into the parent’s next ACP prompt
- enable the existing review command through messaging and the agent orchestration tool while keeping other ACP providers gated

## Why

Kimi was hard-rejected by the review dispatcher and capability surface even though PwrAgent can run the review prompt in a managed child session. ACP-owned conversation history also means a synthetic replay item alone would not reach Kimi model context, so the completed review must be carried into the next parent prompt.

## Impact

Kimi threads can now use the same review surfaces as supported native backends. Review child sessions stay hidden, and completed findings are available to the parent model on its next turn without being replayed on later turns.

## Validation

- pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/managed-review.test.ts (889 tests)
- pnpm typecheck
- pnpm lint:eslint (0 errors; existing warning baseline only)
- pnpm lint:boundaries
