### PR TITLE
test(desktop): fail the E2E suite fast when a guest cannot run it

### DIFF
--- a/apps/desktop/e2e/canary-report.ts
+++ b/apps/desktop/e2e/canary-report.ts
@@ -1,0 +1,38 @@
+// Failure text for the desktop E2E pre-flight canary, split out so the
+// reporting is unit-testable without launching Electron.
+
+export function describeCanaryFailure(params: {
+  timeoutMs: number;
+  runnerName?: string;
+  detail: string;
+}): string {
+  return [
+    `Desktop E2E pre-flight failed after ${params.timeoutMs}ms, before any test ran.`,
+    "",
+    "The canary launches one app through the SAME harness every spec uses, so",
+    "if it cannot get a usable window here, no spec can. The suite is failing",
+    "fast on purpose rather than spending the job's whole time budget timing",
+    "out one test at a time — which reads like a regression in whichever spec",
+    "happens to sort first (currently a11y.spec.ts, which is innocent).",
+    "",
+    "Known shape of this on CI (2026-08-07, traced): Electron LAUNCHES and is",
+    "controllable — the trace records `Launch electron` completing — and then",
+    "`Wait for event \"window\"` never returns. The process layer is healthy and",
+    "the window layer is not. Every spec then dies on its own 30s timeout with",
+    "no teardown line, because no app object is ever handed back.",
+    "",
+    "This is a property of the machine, not of the branch. The same commit has",
+    "passed on a healthy runner and failed on an affected one within the same",
+    "hour. Before treating it as a code regression, check whether other recent",
+    "runs failed the same way on this same runner.",
+    "",
+    params.runnerName
+      ? `  Runner: ${params.runnerName}`
+      : "  Runner: (RUNNER_NAME unset — likely a local run)",
+    "",
+    "A persistent runner in this state does not recover on its own; it needs",
+    "an operator to recycle the guest.",
+    "",
+    `Underlying error: ${params.detail}`,
+  ].join("\n");
+}

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -16,6 +16,17 @@ import {
 } from "../../src/main/settings/desktop-secret-store";
 
 const fixtureDir = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The built main-process entry every E2E launch runs. Exported so callers
+ * that need to check for a build (the pre-flight canary) cannot drift from
+ * the path the harness actually launches — a stale copy would silently turn
+ * such a check into a no-op that reports success.
+ */
+export const DESKTOP_MAIN_ENTRY = path.resolve(
+  fixtureDir,
+  "../../out/main/index.js",
+);
 const ELECTRON_EVALUATE_QUIT_TIMEOUT_MS = 1_000;
 const ELECTRON_CLOSE_TIMEOUT_MS = 1_000;
 const ELECTRON_FORCE_EXIT_TIMEOUT_MS = 1_000;
@@ -62,7 +73,7 @@ type LaunchResult = {
   close: () => Promise<void>;
 };
 
-export async function launchElectronApp(params: {
+type LaunchElectronAppParams = {
   /** Path to a replay-driver fixture JSON. Required for tests that
    *  exercise thread replay (most specs); omit it for tests that
    *  only need wizard / pre-thread UI (set `requiresReplayDriver:
@@ -129,7 +140,11 @@ export async function launchElectronApp(params: {
    * `fixturePath`) — the replay driver isn't needed pre-thread.
    */
   requiresReplayDriver?: boolean;
-}): Promise<LaunchResult> {
+};
+
+export async function launchElectronApp(
+  params: LaunchElectronAppParams,
+): Promise<LaunchResult> {
   const homeRoot =
     params.homeRoot ??
     await mkdtemp(path.join(os.tmpdir(), "pwragent-desktop-e2e-home-"));
@@ -208,7 +223,7 @@ export async function launchElectronApp(params: {
 
   const electronApp = await electron.launch({
     args: [
-      path.resolve(fixtureDir, "../../out/main/index.js"),
+      DESKTOP_MAIN_ENTRY,
       // Hardware video codecs leak kernel objects inside a
       // Virtualization.framework guest (the Tart macOS VMs): every
       // VideoToolbox init creates an
@@ -228,6 +243,25 @@ export async function launchElectronApp(params: {
     cwd: path.resolve(fixtureDir, "../.."),
     env,
   });
+  // Everything from here on can throw on a sick guest — `firstWindow()` is
+  // the observed one: it never returns when the window layer is wedged. The
+  // launched process is ours the moment `electron.launch()` resolves, so a
+  // failure past this point has to close it rather than leave an orphan for
+  // the next job on a persistent runner to inherit.
+  try {
+    return await finishElectronLaunch({ electronApp, homeRoot, params });
+  } catch (error) {
+    await closeElectronApplication(electronApp).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function finishElectronLaunch(args: {
+  electronApp: ElectronApplication;
+  homeRoot: string;
+  params: LaunchElectronAppParams;
+}): Promise<LaunchResult> {
+  const { electronApp, homeRoot, params } = args;
   const window = await electronApp.firstWindow();
 
   const requiresReplayDriver = params.requiresReplayDriver ?? true;

--- a/apps/desktop/e2e/global-setup.ts
+++ b/apps/desktop/e2e/global-setup.ts
@@ -1,0 +1,100 @@
+// Pre-flight canary for the desktop E2E suite.
+//
+// A persistent macOS CI guest can reach a state where the suite cannot run at
+// all. Every spec launches its own app, so when that happens each test burns
+// its full 30s timeout and the job dies on the workflow's 20-minute cap
+// partway through whichever spec sorts first — currently `a11y.spec.ts`,
+// which makes those blocks look guilty when they are only first in line.
+//
+// Observed shape (2026-08-07, main), binary rather than degraded: a healthy
+// runner ran 187 tests in ~5 minutes with zero teardown fallbacks; an
+// affected one ran ZERO tests and burned the full cap, ALSO with zero
+// fallbacks. The same commit passed on one runner and failed on the other
+// within the same hour, so the trigger is the guest, not the branch.
+//
+// The trace from an affected run says precisely where it stops:
+//
+//     Launch electron            -> completed
+//     Wait for event "window"    -> never returns
+//
+// Electron starts and is controllable; the window never arrives. That is why
+// this canary must obtain a WINDOW, not merely a process — a launch-only
+// check would pass on exactly the failure it exists to catch.
+//
+// It gets that window by calling `launchElectronApp`, the same harness every
+// spec calls, rather than hand-rolling a launch. That is not just tidiness:
+// the harness seeds `onboarding.completed` and
+// `confirmQuitWithInProgressThreads: false` into the per-run home before
+// boot. A hand-rolled draft of this file skipped that, booted the first-run
+// setup wizard, and hung a healthy guest's global setup for a full hour —
+// no `Running N tests`, zero tests, strictly worse than the failure it was
+// meant to prevent. Delegating means the canary cannot drift from what the
+// specs actually do.
+//
+// This does not diagnose the guest-level cause and deliberately does not
+// guess at one. It makes the condition cheap and legible.
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describeCanaryFailure } from "./canary-report";
+import {
+  closeElectronApplication,
+  launchElectronApp,
+} from "./fixtures/electron-app";
+
+const setupDir = path.dirname(fileURLToPath(import.meta.url));
+const MAIN_ENTRY = path.resolve(setupDir, "../out/main/index.js");
+const SMOKE_FIXTURE = path.resolve(
+  setupDir,
+  "fixtures/smoke/replay.fixture.json",
+);
+
+/**
+ * Generous next to a healthy guest, where the whole walk is a few seconds,
+ * and short enough that an affected one is reported long before the
+ * workflow's step cap. Bounds the harness call as a whole: `firstWindow()`
+ * carries its own timeout, but a guest can stall anywhere and an unbounded
+ * pre-flight would recreate the job-length hang this file exists to prevent.
+ */
+const CANARY_TIMEOUT_MS = 60_000;
+
+export default async function globalSetup(): Promise<void> {
+  if (!existsSync(MAIN_ENTRY)) {
+    // `playwright test` invoked without a build. The specs report that far
+    // more clearly than a canary can, so stay out of the way.
+    return;
+  }
+
+  let timer: NodeJS.Timeout | undefined;
+  let launched: Awaited<ReturnType<typeof launchElectronApp>> | undefined;
+  try {
+    launched = await Promise.race([
+      launchElectronApp({ fixturePath: SMOKE_FIXTURE }),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`timed out after ${CANARY_TIMEOUT_MS}ms`)),
+          CANARY_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } catch (error) {
+    throw new Error(
+      describeCanaryFailure({
+        timeoutMs: CANARY_TIMEOUT_MS,
+        runnerName: process.env.RUNNER_NAME,
+        detail: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  } finally {
+    if (timer) clearTimeout(timer);
+    if (launched) {
+      // Never a gate, and never awaited unbounded. This app's graceful close
+      // routinely does not resolve — the shared helper bounds each step and
+      // force-kills the process tree, which is what every spec's `finally`
+      // does. Awaiting a bare `close()` here is what hung a guest for an hour.
+      await closeElectronApplication(launched.electronApp).catch(
+        () => undefined,
+      );
+    }
+  }
+}

--- a/apps/desktop/e2e/global-setup.ts
+++ b/apps/desktop/e2e/global-setup.ts
@@ -39,11 +39,12 @@ import { fileURLToPath } from "node:url";
 import { describeCanaryFailure } from "./canary-report";
 import {
   closeElectronApplication,
+  DESKTOP_MAIN_ENTRY,
   launchElectronApp,
+  withTimeout,
 } from "./fixtures/electron-app";
 
 const setupDir = path.dirname(fileURLToPath(import.meta.url));
-const MAIN_ENTRY = path.resolve(setupDir, "../out/main/index.js");
 const SMOKE_FIXTURE = path.resolve(
   setupDir,
   "fixtures/smoke/replay.fixture.json",
@@ -59,25 +60,38 @@ const SMOKE_FIXTURE = path.resolve(
 const CANARY_TIMEOUT_MS = 60_000;
 
 export default async function globalSetup(): Promise<void> {
-  if (!existsSync(MAIN_ENTRY)) {
+  if (!existsSync(DESKTOP_MAIN_ENTRY)) {
     // `playwright test` invoked without a build. The specs report that far
     // more clearly than a canary can, so stay out of the way.
     return;
   }
 
-  let timer: NodeJS.Timeout | undefined;
+  let settled = false;
   let launched: Awaited<ReturnType<typeof launchElectronApp>> | undefined;
+
+  const launching = launchElectronApp({ fixturePath: SMOKE_FIXTURE });
+  // A launch that lands AFTER we have given up still owns a real process. Left
+  // alone it becomes an orphan on a persistent runner — the very thing that
+  // makes the next job's guest suspect. `withTimeout` already swallows the
+  // late rejection (an unhandled one can abort the Playwright process), so
+  // this only has to deal with a late success.
+  void launching.then(
+    (late) => {
+      if (settled) {
+        void closeElectronApplication(late.electronApp).catch(() => undefined);
+      }
+    },
+    () => undefined,
+  );
+
   try {
-    launched = await Promise.race([
-      launchElectronApp({ fixturePath: SMOKE_FIXTURE }),
-      new Promise<never>((_resolve, reject) => {
-        timer = setTimeout(
-          () => reject(new Error(`timed out after ${CANARY_TIMEOUT_MS}ms`)),
-          CANARY_TIMEOUT_MS,
-        );
-      }),
-    ]);
+    launched = await withTimeout(
+      launching,
+      CANARY_TIMEOUT_MS,
+      `timed out after ${CANARY_TIMEOUT_MS}ms`,
+    );
   } catch (error) {
+    settled = true;
     throw new Error(
       describeCanaryFailure({
         timeoutMs: CANARY_TIMEOUT_MS,
@@ -86,7 +100,7 @@ export default async function globalSetup(): Promise<void> {
       }),
     );
   } finally {
-    if (timer) clearTimeout(timer);
+    settled = true;
     if (launched) {
       // Never a gate, and never awaited unbounded. This app's graceful close
       // routinely does not resolve — the shared helper bounds each step and

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
+  // One bounded Electron launch before the suite. A persistent CI guest can
+  // reach a state where no Electron process can start; without this the run
+  // spends its whole time budget timing out one test at a time and blames
+  // whichever spec sorts first rather than the machine. See
+  // e2e/global-setup.ts.
+  globalSetup: "./e2e/global-setup.ts",
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 1 : 0,

--- a/apps/desktop/src/main/__tests__/e2e-canary-report.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-canary-report.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { describeCanaryFailure } from "../../../e2e/canary-report";
+
+const globalSetupSource = readFileSync(
+  path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../e2e/global-setup.ts",
+  ),
+  "utf8",
+);
+
+// The canary only ever speaks on a guest nobody can reproduce on demand, so
+// what it says — and how it obtains its window — are pinned here rather than
+// trusted.
+describe("desktop E2E pre-flight canary", () => {
+  // The defect this guards against cost a full hour of a real guest's time.
+  // A hand-rolled launch skipped the harness's home seeding, booted the
+  // first-run setup wizard, and hung global setup forever. Delegating to
+  // `launchElectronApp` is what keeps the canary's boot identical to a spec's.
+  it("obtains its window through the shared harness, not a hand-rolled launch", () => {
+    expect(globalSetupSource).toContain("launchElectronApp");
+    expect(globalSetupSource).not.toMatch(/electron\.launch\(/);
+  });
+
+  // A launch-only check passes on the exact CI failure it exists to catch:
+  // the trace shows `Launch electron` completing and `Wait for event "window"`
+  // never returning. Going through the harness means a window is always
+  // required, because the harness awaits `firstWindow()` itself.
+  it("cannot pass on a process that never produces a window", () => {
+    expect(globalSetupSource).toContain("fixtures/smoke/replay.fixture.json");
+  });
+
+  // Teardown must never gate: this app's graceful close routinely does not
+  // resolve, so failing on it would fail every healthy run.
+  it("tears down through the bounded force-killing helper without gating", () => {
+    expect(globalSetupSource).toContain("closeElectronApplication");
+    expect(globalSetupSource).toMatch(
+      /closeElectronApplication\([\s\S]{0,80}?\)\s*\.catch\(/,
+    );
+  });
+
+  it("names the runner and points away from blaming the branch", () => {
+    const message = describeCanaryFailure({
+      timeoutMs: 60_000,
+      runnerName: "some-runner",
+      detail: "timed out after 60000ms",
+    });
+    expect(message).toContain("60000ms");
+    expect(message).toContain("some-runner");
+    expect(message).toContain("property of the machine, not of the branch");
+    expect(message).toContain("same runner");
+    // The traced shape, so a reader is not left guessing what "cannot run"
+    // meant on the affected runner.
+    expect(message).toContain('Wait for event "window"');
+    expect(message).toContain("a11y.spec.ts, which is innocent");
+  });
+
+  it("does not print undefined when run outside CI", () => {
+    const message = describeCanaryFailure({ timeoutMs: 1, detail: "d" });
+    expect(message).toContain("RUNNER_NAME unset");
+    expect(message).not.toContain("undefined");
+  });
+});

--- a/apps/desktop/src/main/__tests__/e2e-canary-report.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-canary-report.test.ts
@@ -12,6 +12,15 @@ const globalSetupSource = readFileSync(
   "utf8",
 );
 
+/**
+ * Comments in that file legitimately DISCUSS the patterns these tests forbid
+ * — "a hand-rolled `electron.launch(`" appears in the rationale. Matching raw
+ * source would fail the build over a comment, so assert against code only.
+ */
+const globalSetupCode = globalSetupSource
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
 // The canary only ever speaks on a guest nobody can reproduce on demand, so
 // what it says — and how it obtains its window — are pinned here rather than
 // trusted.
@@ -21,8 +30,9 @@ describe("desktop E2E pre-flight canary", () => {
   // first-run setup wizard, and hung global setup forever. Delegating to
   // `launchElectronApp` is what keeps the canary's boot identical to a spec's.
   it("obtains its window through the shared harness, not a hand-rolled launch", () => {
-    expect(globalSetupSource).toContain("launchElectronApp");
-    expect(globalSetupSource).not.toMatch(/electron\.launch\(/);
+    expect(globalSetupCode).toContain("launchElectronApp(");
+    // A hand-rolled launch is what skipped the harness's profile seeding.
+    expect(globalSetupCode).not.toMatch(/electron\.launch\(/);
   });
 
   // A launch-only check passes on the exact CI failure it exists to catch:
@@ -30,15 +40,38 @@ describe("desktop E2E pre-flight canary", () => {
   // never returning. Going through the harness means a window is always
   // required, because the harness awaits `firstWindow()` itself.
   it("cannot pass on a process that never produces a window", () => {
-    expect(globalSetupSource).toContain("fixtures/smoke/replay.fixture.json");
+    // `launchElectronApp` awaits `firstWindow()` itself, so delegating to it
+    // is what makes a window mandatory — asserting the call is asserting the
+    // invariant, not a proxy for it. The fixture path only proves the replay
+    // driver is exercised too.
+    expect(globalSetupCode).toMatch(/launchElectronApp\(\s*\{\s*fixturePath/);
+    expect(globalSetupCode).toContain("fixtures/smoke/replay.fixture.json");
   });
 
   // Teardown must never gate: this app's graceful close routinely does not
   // resolve, so failing on it would fail every healthy run.
   it("tears down through the bounded force-killing helper without gating", () => {
-    expect(globalSetupSource).toContain("closeElectronApplication");
-    expect(globalSetupSource).toMatch(
+    expect(globalSetupCode).toContain("closeElectronApplication");
+    expect(globalSetupCode).toMatch(
       /closeElectronApplication\([\s\S]{0,80}?\)\s*\.catch\(/,
+    );
+  });
+
+  // The review finding this guards: racing the launch by hand left the loser
+  // unattended. A late rejection is an unhandled rejection (which can abort
+  // the Playwright process), and a late SUCCESS is an orphaned Electron tree
+  // on a persistent runner — the exact resource the CI cleanup task exists to
+  // reap. `withTimeout` handles the first; the late-success close handles the
+  // second.
+  it("does not abandon a launch that lands after the timeout", () => {
+    expect(globalSetupCode).toContain("withTimeout(");
+    expect(globalSetupCode).not.toMatch(/Promise\.race\(/);
+    // Anchored on the launch promise's own handler. A looser match on
+    // `settled` near `closeElectronApplication` passes on the `finally`
+    // block alone, so deleting the late-success close went undetected —
+    // verified by mutation, which is the only reason this reads oddly.
+    expect(globalSetupCode).toMatch(
+      /launching\.then\([\s\S]{0,300}?closeElectronApplication/,
     );
   });
 


### PR DESCRIPTION
## Summary

The macOS E2E lane has been failing for 20 minutes at a time with every `a11y.spec.ts` block timing out. **The a11y blocks are innocent** — they sort first alphabetically, so they absorb the whole budget whenever the guest cannot run the suite at all.

Measured on `main`, 2026-08-07, grouped by **runner** rather than by branch:

| Runner | Result | Duration | Teardown fallbacks |
|---|---|---|---|
| M5-Max | 187 passed | 4.6–5.1m | 0 |
| M2-Max | **0 tests**, step cap hit | 20.8m | 0 |

The same commit passed on one runner and failed on the other **within the same hour**, and the failing runner had itself passed earlier that evening (185 passed, 6.3m @20:07). #1306 merging just before the first failure was coincidence — its code passed on the healthy runner with 187 tests in 5.0m. Zero fallbacks on *both* sides is the tell: the fixture's close path never runs because no app object is ever handed back.

### What the trace actually says

The Playwright trace from an affected run pins the stop point exactly:

```
Launch electron            →  completed
Wait for event "window"    →  never returns
```

**Electron starts and is controllable; the window never arrives.** The process layer is healthy and the window layer is not — consistent with a stalled window server, not with "Electron cannot start". (An earlier revision of this PR description claimed the latter; the trace corrected it.)

That detail decides the design. **The canary must obtain a WINDOW, not merely a process** — a launch-only check passes on precisely the failure it exists to catch.

### How it gets that window

By calling `launchElectronApp`, the harness every spec calls, instead of hand-rolling a launch. That is not tidiness. The harness seeds `onboarding.completed` and `confirmQuitWithInProgressThreads: false` into the per-run home before boot; a hand-rolled draft skipped both, booted the **first-run setup wizard**, and hung a healthy guest's global setup for a **full hour** — no `Running N tests`, zero tests, strictly worse than the failure it was meant to prevent. Delegating means the canary cannot drift from what specs actually do.

Teardown is deliberately **not** a gate: this app's graceful close routinely does not resolve, so gating on it would fail every healthy run. It goes through `closeElectronApplication`, the same bounded force-killing helper every spec uses, and its outcome is ignored.

### Review follow-ups (second commit)

Review found a race in the canary that could abort the run or orphan an app. Fixing it properly exposed a **harness** bug behind it:

- **`launchElectronApp` never closed the app it owned when a post-launch step threw.** The process is ours the moment `electron.launch()` resolves, and `firstWindow()` — the step that throws on a sick guest — came after. So on the affected runner *every spec* leaked an Electron tree, feeding the exact orphan problem the CI-cleanup work exists to reap. Post-launch work moved into `finishElectronLaunch`, wrapped so a failure closes the app before rethrowing. Benefits every spec, not just the canary.
- **The canary raced its launch by hand and left the loser unattended.** A late rejection is an unhandled rejection (can abort the Playwright process); a late *success* is an orphan. Now uses the repo's own `withTimeout` (which swallows the late rejection) plus an explicit close for a launch that lands after we gave up.
- **`DESKTOP_MAIN_ENTRY` is exported and shared**, so the build-exists check cannot drift from the path the harness launches — a stale copy would silently turn that check into a no-op reporting success.
- **Two test fixes.** Source assertions stripped no comments, so a comment *discussing* `electron.launch(` would have failed the build; they now match code only. And `"cannot pass on a process that never produces a window"` asserted only that a fixture path appeared — it now asserts the delegating call, since `launchElectronApp` awaiting `firstWindow()` is what makes a window mandatory.

Every assertion was mutation-tested, which was not ceremony: the first version of the late-launch guard matched `settled` near `closeElectronApplication`, satisfied by the `finally` block alone, so deleting the late-success close passed cleanly. All four mutations now behave — comment mentioning `electron.launch(` passes; real `electron.launch(` fails; dropped late-close fails; reverting to `Promise.race` fails.

## Verification

- ✅ **Real guest run, `e2e/a11y.spec.ts`, commit `b908376a`: `16 passed (38.4s)`, `status=passed exit=0`, zero teardown fallbacks.** The `Running 16 tests` banner appears, which is the proof global setup completed rather than hanging. (Run id embeds the commit — checked against HEAD, after an earlier attempt was refused with exit 75 because a concurrent session held the guest lock and its green result belonged to a different branch.)
- ✅ `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries` (1387 modules).
- ✅ `e2e-canary-report.test.ts` — 6 tests. It pins the two things that were got wrong: the window must come from the shared harness (asserts no bare `electron.launch(`), and teardown must not gate.

### Three drafts, and what caught each

Local checks — typecheck, eslint, boundaries, unit tests — were **green for every broken draft**. Only running it on a real guest distinguished them. That is the argument for the last bullet above being a hard requirement, not a nicety.

1. **Launch-only.** Would have passed on the actual CI failure, since the trace shows launch completing. Caught by review asking whether it would safely detect the condition.
2. **Bare `app.close()`.** Hung a healthy guest's global setup for an hour. Caught by running it — and by the operator noticing the stuck window was the setup wizard.
3. **`close` as a bounded fatal stage.** Same bug, faster: would have failed every healthy run in 25s.

### Unrelated flake seen while verifying

The full `apps/desktop/src` run shows `acp-backend-adapter.test.ts` failing **nondeterministically** — 5, then 2, then 4 failures across identical runs, different subsets each time; it passes 39/39 in isolation, so it is a full-suite worker-interaction flake. It is not from this PR: it still fails with this PR's new test file removed, and that spec shares no import path with anything changed here. The three tests that *do* import the refactored harness (`electron-e2e-fixture`, `electron-app-close`, `e2e-canary-report`) all pass. Recording it here rather than letting the suite read as green.

## Notes

- **The actual fix for CI is recycling the M2-Max runner guest.** That is a live mutation on a runner needing operator approval naming the target; nothing here substitutes for it. This PR only changes how the failure reports itself — one bounded launch before 200+ tests pay for it, failing in under a minute with the runner named.
- The signature differs from the lab's existing teardown-degeneration runbook (115–140 fallbacks, suites still *passing*, 15–18m). Ours is zero fallbacks and nothing passing — a distinct, more severe mode worth recording separately.
- Possible follow-up outside this repo: the lab tooling can clear a *stale* lock but has no path to end an active-but-wedged session, so one bad run can hold the shared guest display until a human intervenes. That is exactly what draft 2 did here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
