### PR TITLE
fix(desktop): support cross-provider parent-child grouping

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -390,8 +390,16 @@ function createOverlayStoreMock(params?: {
       backend: ThreadOverlayState["backend"];
       threadId: string;
     }) => overlays.get(`${backend}:${threadId}`),
-    getThreadOverlayStates: async ({ threadIds }: { threadIds: string[] }) =>
-      Object.fromEntries(threadIds.map((threadId) => [threadId, overlays.get(`codex:${threadId}`)])),
+    getThreadOverlayStates: async ({
+      backend,
+      threadIds,
+    }: {
+      backend: AppServerBackendKind;
+      threadIds: string[];
+    }) =>
+      Object.fromEntries(
+        threadIds.map((threadId) => [threadId, overlays.get(`${backend}:${threadId}`)]),
+      ),
     upsertThreadUsageLine: async ({ line }: { line: ThreadUsageLineRecord }) => {
       usageLines.set(line.usageLineId, line);
       return {
@@ -2107,6 +2115,7 @@ function createKimiAcpRegistry(options?: {
   codexEnvironmentCommandRunner?: CodexEnvironmentCommandRunner;
   gitDirectoryService?: unknown;
   gitWorkspaceHandoffService?: unknown;
+  worktreeArchiveService?: WorktreeArchiveService;
   runtimeCapabilities?: BackendAcpRuntimeCapabilities;
   acpWorktreeRepositoryResolver?: (
     cwd: string,
@@ -2184,6 +2193,7 @@ function createKimiAcpRegistry(options?: {
     gitDirectoryService: options?.gitDirectoryService as never,
     gitWorkspaceHandoffService:
       options?.gitWorkspaceHandoffService as never,
+    worktreeArchiveService: options?.worktreeArchiveService,
     acpWorktreeRepositoryResolver: options?.acpWorktreeRepositoryResolver,
   });
   return {
@@ -21740,6 +21750,142 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("persists the source backend on a trusted cross-provider handoff launchpad", async () => {
+    const root = await mkdtemp(
+      path.join(os.tmpdir(), "pwragent-cross-provider-trust-"),
+    );
+    const repoPath = path.join(root, "repo");
+    const worktreePath = path.join(root, "worktree");
+    await mkdir(repoPath, { recursive: true });
+    await mkdir(worktreePath, { recursive: true });
+    const parentDirectory: LinkedDirectorySummary = {
+      id: expectedDir(repoPath),
+      kind: "worktree",
+      label: "repo",
+      path: expectedDir(repoPath),
+      worktreePath: expectedDir(worktreePath),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "turn/start"] },
+      threads: [
+        {
+          id: "codex-parent",
+          title: "Codex parent",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [parentDirectory],
+          updatedAt: 1000,
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:codex-parent": {
+          backend: "codex",
+          threadId: "codex-parent",
+          executionMode: "default",
+          extraLinkedDirectories: [parentDirectory],
+        },
+      },
+    });
+    const { acpBackendId, registry } = createKimiAcpRegistry({
+      codexClient,
+      overlayStore,
+      sessionId: "kimi-child",
+      gitDirectoryService: {
+        inspectWorkspaceGit: vi.fn(async () => ({
+          kind: "local" as const,
+          branch: "main",
+          hasCommits: true,
+          headHasCommit: true,
+          worktreeCreationAvailable: true,
+        })),
+        resolvePrimaryWorkspacePath: vi.fn(async () => repoPath),
+      },
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+    try {
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "codex-parent",
+            turnId: "turn-1",
+            turn: { id: "turn-1" },
+          },
+        },
+      });
+
+      const responsePromise = codexClient.emitRequest({
+        method: "item/tool/call",
+        params: {
+          threadId: "codex-parent",
+          turnId: "turn-1",
+          callId: "call-1",
+          requestId: "call-1",
+          namespace: "pwragent",
+          tool: "handoff_task",
+          arguments: {
+            backend: acpBackendId,
+            task: "Investigate the migration race.",
+            groupingMode: "subthread",
+            workspaceMode: "project_local",
+            cwd: repoPath,
+          },
+        },
+      } as AppServerPendingRequestNotification);
+
+      await vi.waitFor(() => {
+        expect(
+          events.find(
+            (event) => event.notification.method === "item/tool/requestUserInput",
+          ),
+        ).toBeDefined();
+      });
+      const inputRequest = events.find(
+        (event): event is AgentEvent & {
+          notification: Extract<
+            AppServerNotification,
+            { method: "item/tool/requestUserInput" }
+          >;
+        } => event.notification.method === "item/tool/requestUserInput",
+      )!.notification;
+      await registry.submitServerRequest({
+        backend: "codex",
+        threadId: "codex-parent",
+        turnId: "turn-1",
+        requestId: inputRequest.params.requestId,
+        response: {
+          answers: {
+            trust_directory: {
+              answers: ["Trust directory (Recommended)"],
+            },
+          },
+        },
+      });
+
+      await expect(responsePromise).resolves.toMatchObject({ success: true });
+      const realRepoPath = expectedDir(await realpath(repoPath));
+      await expect(
+        overlayStore.getDirectoryLaunchpad({
+          directoryKey: `directory:${realRepoPath}`,
+        }),
+      ).resolves.toMatchObject({
+        backend: acpBackendId,
+        parentThreadId: "codex-parent",
+        parentThreadBackend: "codex",
+      });
+    } finally {
+      unsubscribe();
+      await registry.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("ignores subthread grouping when a handoff targets a different project", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-cross-project-"));
     const parentRepoPath = path.join(root, "PwrAgent");
@@ -34246,6 +34392,82 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("skips Codex parent worktree cleanup while an active ACP child shares it", async () => {
+    const worktreePath = "/repo/.worktrees/shared";
+    const parentThread: AppServerThreadSummary = {
+      id: "codex-parent",
+      title: "Codex parent",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          label: "app",
+          path: "/repo/app",
+          kind: "worktree",
+          worktreePath,
+        },
+      ],
+      source: "codex",
+      gitBranch: "codex/parent",
+      updatedAt: 1,
+    };
+    const childSession: AcpSessionMetadata = {
+      backendId: "acp:kimi" as AcpBackendId,
+      sessionId: "kimi-child",
+      title: "Kimi child",
+      cwd: worktreePath,
+      createdAt: 2,
+      updatedAt: 2,
+      executionMode: "default",
+      status: "idle",
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [parentThread],
+    });
+    const archiveWorktree = vi.fn(async () => ({
+      id: "snapshot-1",
+      backend: "codex" as const,
+      threadId: "codex-parent",
+      worktreePath,
+      repositoryPath: "/repo/app",
+      snapshotRef: "refs/pwragent/snapshots/snapshot-1",
+      snapshotCommit: "abc123",
+      sourceBranch: "codex/parent",
+      sourceHead: "def456",
+      createdAt: 1000,
+      archivedAt: 1000,
+      state: "archived" as const,
+      ignoredFilesExcluded: true,
+    }));
+    const { registry } = createKimiAcpRegistry({
+      codexClient,
+      sessions: [childSession],
+      worktreeArchiveService: {
+        archive: archiveWorktree,
+      } as unknown as WorktreeArchiveService,
+    });
+
+    const response = await registry.archiveThread({
+      backend: "codex",
+      threadId: "codex-parent",
+    });
+
+    expect(archiveWorktree).not.toHaveBeenCalled();
+    expect(response.cleanup).toEqual([
+      {
+        worktreePath,
+        branch: "codex/parent",
+        removedWorktree: false,
+        deletedBranch: false,
+        skippedReason:
+          "Worktree is still used by another active thread: kimi-child.",
+      },
+    ]);
+
+    await registry.close();
+  });
+
   it("ungroups active child threads when archiving only the parent", async () => {
     const parentThread: AppServerThreadSummary = {
       id: "thread-parent",
@@ -34298,6 +34520,115 @@ script = "printf setup"
     expect(setThreadParent).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-child",
+      parentThreadId: undefined,
+    });
+
+    await registry.close();
+  });
+
+  it("ungroups legacy cross-provider ACP children when archiving a Codex parent", async () => {
+    const parentThread: AppServerThreadSummary = {
+      id: "codex-parent",
+      title: "Codex parent",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 1,
+    };
+    const childSession: AcpSessionMetadata = {
+      backendId: "acp:kimi" as AcpBackendId,
+      sessionId: "kimi-child",
+      title: "Kimi child",
+      createdAt: 2,
+      updatedAt: 2,
+      executionMode: "default",
+      status: "idle",
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "acp:kimi:kimi-child": {
+          backend: "acp:kimi",
+          threadId: "kimi-child",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          parentThreadId: "codex-parent",
+        },
+      },
+    });
+    const setThreadParent = vi.spyOn(overlayStore, "setThreadParent");
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [parentThread],
+    });
+    const { registry } = createKimiAcpRegistry({
+      codexClient,
+      overlayStore,
+      sessions: [childSession],
+    });
+
+    await registry.archiveThread({
+      backend: "codex",
+      threadId: "codex-parent",
+    });
+
+    expect(setThreadParent).toHaveBeenCalledWith({
+      backend: "acp:kimi",
+      threadId: "kimi-child",
+      parentThreadId: undefined,
+    });
+
+    await registry.close();
+  });
+
+  it("ungroups active Codex children when archiving an ACP parent", async () => {
+    const parentSession: AcpSessionMetadata = {
+      backendId: "acp:kimi" as AcpBackendId,
+      sessionId: "kimi-parent",
+      title: "Kimi parent",
+      createdAt: 1,
+      updatedAt: 1,
+      executionMode: "default",
+      status: "idle",
+    };
+    const childThread: AppServerThreadSummary = {
+      id: "codex-child",
+      title: "Codex child",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:codex-child": {
+          backend: "codex",
+          threadId: "codex-child",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          parentThreadId: "kimi-parent",
+          parentThreadBackend: "acp:kimi",
+        },
+      },
+    });
+    const setThreadParent = vi.spyOn(overlayStore, "setThreadParent");
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [childThread],
+    });
+    const { registry } = createKimiAcpRegistry({
+      codexClient,
+      overlayStore,
+      sessions: [parentSession],
+    });
+
+    await registry.archiveThread({
+      backend: "acp:kimi",
+      threadId: "kimi-parent",
+    });
+
+    expect(setThreadParent).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "codex-child",
       parentThreadId: undefined,
     });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -719,10 +719,12 @@ function createOverlayStoreMock(params?: {
       backend,
       threadId,
       parentThreadId,
+      parentThreadBackend,
     }: {
-      backend: "codex" | "grok";
+      backend: AppServerBackendKind;
       threadId: string;
       parentThreadId?: string;
+      parentThreadBackend?: AppServerBackendKind;
     }) => {
       const key = `${backend}:${threadId}`;
       const current = overlays.get(key) ?? {
@@ -734,6 +736,7 @@ function createOverlayStoreMock(params?: {
       const next = {
         ...current,
         parentThreadId,
+        parentThreadBackend,
       } as ThreadOverlayState;
       overlays.set(key, next);
       return next;
@@ -743,7 +746,7 @@ function createOverlayStoreMock(params?: {
       threadId,
       pinnedRank,
     }: {
-      backend: "codex" | "grok";
+      backend: AppServerBackendKind;
       threadId: string;
       pinnedRank?: string | null;
     }) => {
@@ -766,7 +769,7 @@ function createOverlayStoreMock(params?: {
       threadId,
       scheduledStart,
     }: {
-      backend: "codex" | "grok";
+      backend: AppServerBackendKind;
       threadId: string;
       scheduledStart?: ThreadOverlayState["scheduledStart"];
     }) => {
@@ -21540,6 +21543,201 @@ command = "pnpm dev"
 
     await registry.close();
     await rm(root, { recursive: true, force: true });
+  });
+
+  it("groups an ACP handoff under a Codex parent", async () => {
+    const parentDirectory = {
+      id: expectedDir("/repo/app"),
+      kind: "local" as const,
+      label: "app",
+      path: expectedDir("/repo/app"),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "turn/start"] },
+      threads: [
+        {
+          id: "codex-parent",
+          title: "Codex parent",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [parentDirectory],
+          updatedAt: 1000,
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:codex-parent": {
+          backend: "codex",
+          threadId: "codex-parent",
+          executionMode: "default",
+          extraLinkedDirectories: [parentDirectory],
+        },
+      },
+    });
+    const { acpBackendId, registry } = createKimiAcpRegistry({
+      codexClient,
+      overlayStore,
+      sessionId: "kimi-child",
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "codex-parent",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "codex-parent",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          backend: acpBackendId,
+          task: "Investigate the migration race.",
+          title: "Migration race",
+          groupingMode: "subthread",
+          workspaceMode: "none",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload).toMatchObject({
+      backend: acpBackendId,
+      threadId: "kimi-child",
+      groupingMode: "subthread",
+      groupedUnderThreadId: "codex-parent",
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: acpBackendId,
+        threadId: "kimi-child",
+      }),
+    ).resolves.toMatchObject({
+      parentThreadId: "codex-parent",
+      parentThreadBackend: "codex",
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "codex-parent",
+      }),
+    ).resolves.toMatchObject({
+      subthreadOrder: ["kimi-child"],
+    });
+
+    await registry.close();
+  });
+
+  it("groups a Codex handoff under its Kimi parent", async () => {
+    const acpBackendId = "acp:kimi" as AcpBackendId;
+    const parentDirectory = {
+      id: expectedDir("/repo/app"),
+      kind: "local" as const,
+      label: "app",
+      path: expectedDir("/repo/app"),
+    };
+    const parentSession: AcpSessionMetadata = {
+      backendId: acpBackendId,
+      sessionId: "kimi-parent",
+      title: "Kimi parent",
+      cwd: "/repo/app",
+      createdAt: 1000,
+      updatedAt: 1000,
+      executionMode: "default",
+      status: "idle",
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "thread/list", "turn/start"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "acp:kimi:kimi-parent": {
+          backend: acpBackendId,
+          threadId: "kimi-parent",
+          executionMode: "default",
+          extraLinkedDirectories: [parentDirectory],
+        },
+      },
+    });
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      codexClient,
+      overlayStore,
+      sessions: [parentSession],
+    });
+    const turn = await registry.startTurn({
+      backend: acpBackendId,
+      threadId: "kimi-parent",
+      input: [{ type: "text", text: "Delegate the migration lock fix." }],
+    });
+    await registry.publishLocalEvent({
+      backend: acpBackendId,
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "kimi-parent",
+          turnId: turn.turnId,
+          turn: { id: turn.turnId },
+        },
+      },
+    });
+
+    const response = await callRegistryMcpTool({
+      registry,
+      backend: acpBackendId,
+      threadId: "kimi-parent",
+      turnId: turn.turnId,
+      tool: "handoff_task",
+      args: {
+        backend: "codex",
+        task: "Fix the migration lock race.",
+        title: "Migration lock",
+        groupingMode: "subthread",
+        workspaceMode: "none",
+      },
+    });
+
+    expect(response).toMatchObject({
+      structuredContent: {
+        backend: "codex",
+        threadId: "thread-1",
+        groupingMode: "subthread",
+        groupedUnderThreadId: "kimi-parent",
+      },
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      parentThreadId: "kimi-parent",
+      parentThreadBackend: acpBackendId,
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: acpBackendId,
+        threadId: "kimi-parent",
+      }),
+    ).resolves.toMatchObject({
+      subthreadOrder: ["thread-1"],
+    });
+
+    await registry.close();
   });
 
   it("ignores subthread grouping when a handoff targets a different project", async () => {

--- a/apps/desktop/src/main/__tests__/overlay-store-pins.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-pins.test.ts
@@ -201,4 +201,37 @@ describe("SqliteOverlayStore — thread pins", () => {
       store = new SqliteOverlayStore(stateDb);
     }
   });
+
+  it("stores cross-provider child order on the actual parent", async () => {
+    await store.setThreadParent({
+      backend: "codex",
+      threadId: "codex-child",
+      parentThreadId: "kimi-parent",
+      parentThreadBackend: "acp:kimi",
+    });
+
+    await expect(
+      store.getThreadOverlayState({
+        backend: "codex",
+        threadId: "codex-child",
+      }),
+    ).resolves.toMatchObject({
+      parentThreadId: "kimi-parent",
+      parentThreadBackend: "acp:kimi",
+    });
+    await expect(
+      store.getThreadOverlayState({
+        backend: "acp:kimi",
+        threadId: "kimi-parent",
+      }),
+    ).resolves.toMatchObject({
+      subthreadOrder: ["codex-child"],
+    });
+    await expect(
+      store.getThreadOverlayState({
+        backend: "codex",
+        threadId: "kimi-parent",
+      }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9095,6 +9095,19 @@ export class DesktopBackendRegistry {
     if (!session) {
       throw new Error(`ACP thread not found: ${params.threadId}`);
     }
+    let activeThreads: AppServerThreadSummary[] = [];
+    try {
+      activeThreads = await this.listThreads({
+        archived: false,
+        callerReason: "archive-cleanup",
+      });
+    } catch (error) {
+      backendRegistryLog.warn("ACP archive child lookup failed", {
+        backend: params.backend,
+        threadId: params.threadId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
     const archivedAt = Date.now();
     this.acpBackend.upsertSession({
       ...session,
@@ -9107,6 +9120,19 @@ export class DesktopBackendRegistry {
       threadId: params.threadId,
       origin: "thread-archive",
     });
+    try {
+      await this.ungroupChildrenOfArchivedThread({
+        backend: params.backend,
+        activeThreads,
+        parentThreadId: params.threadId,
+      });
+    } catch (error) {
+      backendRegistryLog.warn("ACP archive child ungrouping failed", {
+        backend: params.backend,
+        threadId: params.threadId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
     return {
       backend: params.backend,
       threadId: params.threadId,
@@ -14847,6 +14873,7 @@ export class DesktopBackendRegistry {
 
   private async ensureHandoffTrustedDirectoryLaunchpad(params: {
     cwd: string;
+    parentThreadBackend: AppServerBackendKind;
     preferredBackend: AppServerBackendKind;
     parentThreadId: string;
     parentThreadTitle?: string;
@@ -14861,6 +14888,7 @@ export class DesktopBackendRegistry {
       directoryPath,
       currentBranch: await readCurrentGitBranch(directoryPath).catch(() => undefined),
       parentThreadId: params.parentThreadId,
+      parentThreadBackend: params.parentThreadBackend,
       parentThreadTitle: params.parentThreadTitle,
       preferredBackend: params.preferredBackend,
       registeredAt: Date.now(),
@@ -14916,6 +14944,7 @@ export class DesktopBackendRegistry {
 
     await this.ensureHandoffTrustedDirectoryLaunchpad({
       cwd: params.cwd,
+      parentThreadBackend: params.backend,
       preferredBackend: params.backend,
       parentThreadId: params.sourceThreadId,
       parentThreadTitle: params.sourceThread?.title,
@@ -20201,11 +20230,13 @@ export class DesktopBackendRegistry {
     threadId: string;
   }): Promise<ArchiveCleanupMetadata> {
     const activeThreads = await this.listThreads({
-      backend: params.backend,
       archived: false,
       callerReason: "archive-cleanup",
     });
-    const activeThread = activeThreads.find((thread) => thread.id === params.threadId);
+    const activeThread = activeThreads.find(
+      (thread) =>
+        thread.source === params.backend && thread.id === params.threadId,
+    );
     let archivedThreads: AppServerThreadSummary[] = [];
     try {
       archivedThreads = await this.listThreads({
@@ -20616,25 +20647,59 @@ export class DesktopBackendRegistry {
       return;
     }
 
-    const activeThreadIds = params.activeThreads
-      .filter((thread) => thread.source === params.backend)
-      .map((thread) => thread.id);
-    const overlaysByThreadId = await this.overlayStore.getThreadOverlayStates({
-      backend: params.backend,
-      threadIds: activeThreadIds,
-    });
-    const childThreadIds = activeThreadIds.filter(
-      (threadId) =>
-        overlaysByThreadId[threadId]?.parentThreadId === params.parentThreadId,
+    const activeThreadsByBackend = new Map<
+      AppServerBackendKind,
+      AppServerThreadSummary[]
+    >();
+    for (const thread of params.activeThreads) {
+      const backendThreads = activeThreadsByBackend.get(thread.source) ?? [];
+      backendThreads.push(thread);
+      activeThreadsByBackend.set(thread.source, backendThreads);
+    }
+    const childThreads: Array<{
+      backend: AppServerBackendKind;
+      threadId: string;
+    }> = [];
+    const legacyParentMatches = params.activeThreads.filter(
+      (thread) => thread.id === params.parentThreadId,
     );
-    if (childThreadIds.length === 0) {
+    for (const [backend, threads] of activeThreadsByBackend) {
+      const threadIds = threads.map((thread) => thread.id);
+      const overlaysByThreadId = await this.overlayStore.getThreadOverlayStates({
+        backend,
+        threadIds,
+      });
+      for (const threadId of threadIds) {
+        const overlay = overlaysByThreadId[threadId];
+        if (overlay?.parentThreadId !== params.parentThreadId) {
+          continue;
+        }
+        if (overlay.parentThreadBackend) {
+          if (overlay.parentThreadBackend === params.backend) {
+            childThreads.push({ backend, threadId });
+          }
+          continue;
+        }
+        if (backend === params.backend) {
+          childThreads.push({ backend, threadId });
+          continue;
+        }
+        if (
+          legacyParentMatches.length === 1
+          && legacyParentMatches[0]?.source === params.backend
+        ) {
+          childThreads.push({ backend, threadId });
+        }
+      }
+    }
+    if (childThreads.length === 0) {
       return;
     }
 
     await Promise.all(
-      childThreadIds.map((threadId) =>
+      childThreads.map(({ backend, threadId }) =>
         setThreadParent.call(this.overlayStore, {
-          backend: params.backend,
+          backend,
           threadId,
           parentThreadId: undefined,
         }),
@@ -23525,6 +23590,7 @@ export class DesktopBackendRegistry {
       }
       await this.ensureHandoffTrustedDirectoryLaunchpad({
         cwd: requestedCwd,
+        parentThreadBackend: sourceBackend,
         preferredBackend: backend,
         parentThreadId: sourceThreadId,
         parentThreadTitle: sourceThread?.title,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10145,6 +10145,7 @@ export class DesktopBackendRegistry {
     branchName?: string;
     requiredWorkMode?: NavigationLaunchpadDraft["workMode"];
     parentThreadId?: string;
+    parentThreadBackend?: AppServerBackendKind;
     prAutoDispatchEnabled?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
     linkedDirectories?: LinkedDirectorySummary[];
@@ -10159,6 +10160,7 @@ export class DesktopBackendRegistry {
       branchName,
       requiredWorkMode,
       parentThreadId,
+      parentThreadBackend,
       prAutoDispatchEnabled,
       mcpConnectionIds,
       ...request
@@ -10514,6 +10516,7 @@ export class DesktopBackendRegistry {
         backend,
         threadId: result.threadId,
         parentThreadId,
+        parentThreadBackend,
       });
       await this.emit({
         backend,
@@ -10522,6 +10525,7 @@ export class DesktopBackendRegistry {
           params: {
             threadId: result.threadId,
             parentThreadId,
+            parentThreadBackend,
           },
         },
       });
@@ -10826,6 +10830,7 @@ export class DesktopBackendRegistry {
           backend,
           threadId: result.threadId,
           parentThreadId: request.parentThreadId,
+          parentThreadBackend: request.parentThreadBackend,
         });
         await this.emit({
           backend,
@@ -10834,6 +10839,7 @@ export class DesktopBackendRegistry {
             params: {
               threadId: result.threadId,
               parentThreadId: request.parentThreadId,
+              parentThreadBackend: request.parentThreadBackend,
             },
           },
         });
@@ -14950,6 +14956,8 @@ export class DesktopBackendRegistry {
       };
       const requestParentThreadId =
         request.parentThreadId ?? normalizedExisting.parentThreadId;
+      const requestParentThreadBackend =
+        request.parentThreadBackend ?? normalizedExisting.parentThreadBackend;
       const requestParentThreadTitle =
         request.parentThreadTitle ?? normalizedExisting.parentThreadTitle;
       const identityChanged =
@@ -14959,6 +14967,7 @@ export class DesktopBackendRegistry {
       const parentChanged =
         request.parentThreadId !== undefined &&
         (normalizedExisting.parentThreadId !== request.parentThreadId ||
+          normalizedExisting.parentThreadBackend !== request.parentThreadBackend ||
           normalizedExisting.parentThreadTitle !== request.parentThreadTitle);
 
       if (isEmptyDirectoryLaunchpadDraft(existing)) {
@@ -14979,6 +14988,7 @@ export class DesktopBackendRegistry {
           workMode: defaultLaunchpadWorkMode(request, defaults),
           branchName: existing.branchName ?? request.currentBranch,
           parentThreadId: requestParentThreadId,
+          parentThreadBackend: requestParentThreadBackend,
           parentThreadTitle: requestParentThreadTitle,
           registeredAt,
           updatedAt: Date.now(),
@@ -15011,6 +15021,7 @@ export class DesktopBackendRegistry {
               directoryLabel: request.directoryLabel,
               directoryPath: request.directoryPath,
               parentThreadId: requestParentThreadId,
+              parentThreadBackend: requestParentThreadBackend,
               parentThreadTitle: requestParentThreadTitle,
               registeredAt,
               updatedAt: Date.now(),
@@ -15046,6 +15057,7 @@ export class DesktopBackendRegistry {
       workMode: defaultLaunchpadWorkMode(request, defaults),
       branchName: request.currentBranch,
       parentThreadId: request.parentThreadId,
+      parentThreadBackend: request.parentThreadBackend,
       parentThreadTitle: request.parentThreadTitle,
       createdAt: Date.now(),
       updatedAt: Date.now(),
@@ -15834,7 +15846,9 @@ export class DesktopBackendRegistry {
       acpRuntime: launchpad.acpRuntime,
       codexEnvironmentRuntime,
       directoryKey: launchpad.directoryKey,
-      parentThreadId: request.parentThreadId,
+      parentThreadId: request.parentThreadId ?? launchpad.parentThreadId,
+      parentThreadBackend:
+        request.parentThreadBackend ?? launchpad.parentThreadBackend,
     });
     const linkedDirectory = linkedDirectories?.[0];
     if (linkedDirectory) {
@@ -21912,32 +21926,43 @@ export class DesktopBackendRegistry {
     }
   }
 
-  private async resolveHandoffGroupParentThreadId(params: {
+  private async resolveHandoffGroupParentThreadRef(params: {
     backend: AppServerBackendKind;
     sourceOverlay: ThreadOverlayState;
     sourceThreadId: string;
-  }): Promise<string> {
+  }): Promise<{ backend: AppServerBackendKind; threadId: string }> {
     const directParentThreadId = params.sourceOverlay.parentThreadId?.trim();
     if (!directParentThreadId) {
-      return params.sourceThreadId;
+      return { backend: params.backend, threadId: params.sourceThreadId };
     }
 
     let parentThreadId = directParentThreadId;
-    const seen = new Set([params.sourceThreadId]);
-    while (!seen.has(parentThreadId)) {
-      seen.add(parentThreadId);
+    let parentBackend =
+      params.sourceOverlay.parentThreadBackend ?? params.backend;
+    const directParentBackend = parentBackend;
+    const seen = new Set([
+      buildThreadIdentityKey(params.backend, params.sourceThreadId),
+    ]);
+    let parentKey = buildThreadIdentityKey(parentBackend, parentThreadId);
+    while (!seen.has(parentKey)) {
+      seen.add(parentKey);
       const parentOverlay = await this.overlayStore.getThreadOverlayState({
-        backend: params.backend,
+        backend: parentBackend,
         threadId: parentThreadId,
       });
       const nextParentThreadId = parentOverlay?.parentThreadId?.trim();
       if (!nextParentThreadId) {
-        return parentThreadId;
+        return { backend: parentBackend, threadId: parentThreadId };
       }
       parentThreadId = nextParentThreadId;
+      parentBackend = parentOverlay?.parentThreadBackend ?? parentBackend;
+      parentKey = buildThreadIdentityKey(parentBackend, parentThreadId);
     }
 
-    return directParentThreadId;
+    return {
+      backend: directParentBackend,
+      threadId: directParentThreadId,
+    };
   }
 
   private startPendingThreadWorkspaceMove(
@@ -23619,7 +23644,6 @@ export class DesktopBackendRegistry {
           });
     const groupingMode: HandoffTaskGroupingMode =
       requestedGroupingMode === "subthread" &&
-      backend === sourceBackend &&
       sameHandoffProjectBoundary(callerProjectBoundary, childProjectBoundary)
         ? "subthread"
         : "none";
@@ -23627,7 +23651,7 @@ export class DesktopBackendRegistry {
       this.updatePendingThreadHandoff(handoffId, {
         groupingMode,
         message:
-          "Requested subthread grouping crosses a backend or project boundary, so the child thread will be created ungrouped.",
+          "Requested subthread grouping crosses a project boundary, so the child thread will be created ungrouped.",
       });
       if (workspaceMode === "same_workspace") {
         const message =
@@ -23636,14 +23660,16 @@ export class DesktopBackendRegistry {
         return threadOrchestrationFailure("invalid_arguments", message);
       }
     }
-    const groupedParentThreadId =
+    const groupedParentThread =
       groupingMode === "subthread"
-        ? await this.resolveHandoffGroupParentThreadId({
+        ? await this.resolveHandoffGroupParentThreadRef({
             backend: sourceBackend,
             sourceOverlay,
             sourceThreadId,
           })
         : undefined;
+    const groupedParentThreadId = groupedParentThread?.threadId;
+    const groupedParentBackend = groupedParentThread?.backend;
 
     let threadId: string;
     let createdLinkedDirectory: LinkedDirectorySummary | undefined;
@@ -23668,7 +23694,10 @@ export class DesktopBackendRegistry {
           backend,
           sourceThreadId,
           ...(groupedParentThreadId
-            ? { parentThreadId: groupedParentThreadId }
+            ? {
+                parentThreadId: groupedParentThreadId,
+                parentThreadBackend: groupedParentBackend,
+              }
             : {}),
           executionMode,
           directoryLabel:
@@ -23715,6 +23744,7 @@ export class DesktopBackendRegistry {
           sandbox: inheritedSettings.sandbox,
           codexEnvironmentRuntime: inheritedSettings.codexEnvironmentRuntime,
           parentThreadId: groupedParentThreadId,
+          parentThreadBackend: groupedParentBackend,
         });
         threadId = started.threadId;
         this.updatePendingThreadHandoff(handoffId, { threadId });
@@ -23724,7 +23754,7 @@ export class DesktopBackendRegistry {
       }
       if (groupedParentThreadId && this.overlayStore.updateSubthreadOrder) {
         const parentOverlay = await this.overlayStore.getThreadOverlayState({
-          backend,
+          backend: groupedParentBackend ?? backend,
           threadId: groupedParentThreadId,
         });
         const nextOrder = insertSubthreadIdAfter(
@@ -23736,7 +23766,7 @@ export class DesktopBackendRegistry {
           threadId,
         );
         await this.overlayStore.updateSubthreadOrder({
-          backend,
+          backend: groupedParentBackend ?? backend,
           parentThreadId: groupedParentThreadId,
           threadIds: nextOrder,
         });

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -5792,12 +5792,20 @@ class DesktopAppServerService {
     instanceLabel: string,
   ): Promise<FederatedThreadRef | undefined> {
     const parentThreadId = request.summary?.parentThreadId;
-    if (!parentThreadId || parentThreadId === request.ref.threadId) {
+    const parentBackend =
+      request.summary?.parentThreadBackend ?? request.ref.backend;
+    if (
+      !parentThreadId
+      || (
+        parentThreadId === request.ref.threadId
+        && parentBackend === request.ref.backend
+      )
+    ) {
       return undefined;
     }
     try {
       const parentRef = buildFederatedThreadRef({
-        backend: request.ref.backend,
+        backend: parentBackend,
         instanceId,
         threadId: parentThreadId,
       });
@@ -5809,7 +5817,7 @@ class DesktopAppServerService {
         .remoteThreadSummaries()
         .threadFromPeer({
           target: { scope: "remote", instanceId },
-          backend: request.ref.backend,
+          backend: parentBackend,
           threadId: parentThreadId,
         });
       if (!parentSummary) {
@@ -5822,13 +5830,13 @@ class DesktopAppServerService {
         pinnedVia: "companion",
       });
       logDebug("addRemoteThreadPin:companion-parent", {
-        backend: request.ref.backend,
+        backend: parentBackend,
         instanceId,
         threadId: parentThreadId,
         childThreadId: request.ref.threadId,
       });
       await getDesktopBackendRegistry().publishLocalEvent({
-        backend: request.ref.backend,
+        backend: parentBackend,
         notification: {
           method: "navigation/remoteThreadPins/changed",
           params: {
@@ -6019,12 +6027,14 @@ class DesktopAppServerService {
       backend,
       threadId: request.threadId,
       parentThreadId: request.parentThreadId,
+      parentThreadBackend: request.parentThreadBackend,
     });
 
     logDebug("setThreadParent", {
       backend,
       threadId: request.threadId,
       parentThreadId: overlay.parentThreadId ?? null,
+      parentThreadBackend: overlay.parentThreadBackend ?? null,
     });
 
     await getDesktopBackendRegistry().publishLocalEvent({
@@ -6035,6 +6045,7 @@ class DesktopAppServerService {
             params: {
               threadId: request.threadId,
               parentThreadId: overlay.parentThreadId,
+              parentThreadBackend: overlay.parentThreadBackend,
             },
           }
         : {
@@ -6049,6 +6060,7 @@ class DesktopAppServerService {
       backend,
       threadId: request.threadId,
       parentThreadId: overlay.parentThreadId,
+      parentThreadBackend: overlay.parentThreadBackend,
     };
   }
 

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -600,6 +600,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           worktreeSnapshots: current?.worktreeSnapshots ?? [],
           pinnedRank: current?.pinnedRank,
           parentThreadId: current?.parentThreadId,
+          parentThreadBackend: current?.parentThreadBackend,
           subthreadOrder: current?.subthreadOrder,
           subthreadsCollapsed: current?.subthreadsCollapsed,
           permissionTransitionLog: current?.permissionTransitionLog,
@@ -2442,8 +2443,12 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     backend: ThreadOverlayState["backend"];
     threadId: string;
     parentThreadId?: string | null;
+    parentThreadBackend?: ThreadOverlayState["backend"] | null;
   }): Promise<ThreadOverlayState> {
-    if (params.parentThreadId === params.threadId) {
+    if (
+      params.parentThreadId === params.threadId
+      && (!params.parentThreadBackend || params.parentThreadBackend === params.backend)
+    ) {
       throw new Error("A thread cannot be its own parent.");
     }
     const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
@@ -2454,16 +2459,20 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       extraLinkedDirectories: [],
     };
     const parentThreadId = params.parentThreadId?.trim();
+    const parentThreadBackend = parentThreadId
+      ? params.parentThreadBackend ?? params.backend
+      : undefined;
     const nextState: ThreadOverlayState = {
       ...current,
       parentThreadId: parentThreadId || undefined,
+      parentThreadBackend,
       pinnedRank: parentThreadId ? undefined : current.pinnedRank,
     };
     this.putThread(threadKey, nextState);
     if (parentThreadId) {
-      const parentKey = buildThreadIdentityKey(params.backend, parentThreadId);
+      const parentKey = buildThreadIdentityKey(parentThreadBackend!, parentThreadId);
       const parent = this.getThread(parentKey) ?? {
-        backend: params.backend,
+        backend: parentThreadBackend!,
         threadId: parentThreadId,
         executionMode: "default" as const,
         extraLinkedDirectories: [],

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -24,6 +24,7 @@ import {
   moveDirectoryKey,
   moveThreadKey,
   parseThreadIdentityKey,
+  resolveThreadParentKey,
   sortSubthreadSummaries,
 } from "@pwragent/shared";
 import {
@@ -532,10 +533,10 @@ export function DirectoriesList(props: DirectoriesListProps) {
     let topLevelThread = selectedThread;
     const visited = new Set<string>();
     while (topLevelThread.parentThreadId) {
-      const parentKey = buildThreadIdentityKey(
-        topLevelThread.source,
-        topLevelThread.parentThreadId,
-      );
+      const parentKey = resolveThreadParentKey(topLevelThread, threadsByKey);
+      if (!parentKey) {
+        break;
+      }
       if (visited.has(parentKey) || !directoryThreadKeys.has(parentKey)) {
         break;
       }
@@ -566,9 +567,8 @@ export function DirectoriesList(props: DirectoriesListProps) {
         if (!thread.parentThreadId) {
           return true;
         }
-        return !directoryThreadKeys.has(
-          buildThreadIdentityKey(thread.source, thread.parentThreadId),
-        );
+        const parentKey = resolveThreadParentKey(thread, threadsByKey);
+        return !parentKey || !directoryThreadKeys.has(parentKey);
       })
       .filter((thread) => !isPinnedThread(thread));
     const topLevelThreadKey = buildThreadIdentityKey(
@@ -660,17 +660,16 @@ export function DirectoriesList(props: DirectoriesListProps) {
     const childThreadsByParentKey = new Map<string, NavigationThreadSummary[]>();
     for (const thread of visibleThreads) {
       if (!thread.parentThreadId) continue;
-      const parentKey = buildThreadIdentityKey(thread.source, thread.parentThreadId);
-      if (!directoryThreadKeys.has(parentKey)) continue;
+      const parentKey = resolveThreadParentKey(thread, threadsByKey);
+      if (!parentKey || !directoryThreadKeys.has(parentKey)) continue;
       const children = childThreadsByParentKey.get(parentKey) ?? [];
       children.push(thread);
       childThreadsByParentKey.set(parentKey, children);
     }
     const topLevelVisibleThreads = visibleThreads.filter((thread) => {
       if (!thread.parentThreadId) return true;
-      return !directoryThreadKeys.has(
-        buildThreadIdentityKey(thread.source, thread.parentThreadId),
-      );
+      const parentKey = resolveThreadParentKey(thread, threadsByKey);
+      return !parentKey || !directoryThreadKeys.has(parentKey);
     });
     const renderStaticSubthreads = (parent: NavigationThreadSummary): ReactElement | null => {
       const parentKey = buildThreadIdentityKey(parent.source, parent.id);
@@ -735,7 +734,10 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 const draggedThread = draggedSubthreadKey
                   ? threadsByKey.get(draggedSubthreadKey)
                   : undefined;
-                if (!draggedThread || draggedThread.parentThreadId !== parent.id) {
+                if (
+                  !draggedThread
+                  || resolveThreadParentKey(draggedThread, threadsByKey) !== parentKey
+                ) {
                   event.dataTransfer.dropEffect = "none";
                   setSubthreadDropIndicator(undefined);
                   return;
@@ -765,7 +767,10 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 const draggedThread = draggedKey
                   ? threadsByKey.get(draggedKey)
                   : undefined;
-                if (!draggedThread || draggedThread.parentThreadId !== parent.id) {
+                if (
+                  !draggedThread
+                  || resolveThreadParentKey(draggedThread, threadsByKey) !== parentKey
+                ) {
                   return;
                 }
                 const nextKeys = moveThreadKey(

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -10,6 +10,7 @@ import {
   isPinnedThread,
   moveThreadKey,
   parseThreadIdentityKey,
+  resolveThreadParentKey,
   sortSubthreadSummaries,
 } from "@pwragent/shared";
 import {
@@ -98,13 +99,14 @@ export function RecentsList(props: RecentsListProps) {
   );
   const topLevelThreads = props.threads.filter((thread) => {
     if (!thread.parentThreadId) return true;
-    return !threadByKey.has(buildThreadIdentityKey(thread.source, thread.parentThreadId));
+    const parentKey = resolveThreadParentKey(thread, threadByKey);
+    return !parentKey || !threadByKey.has(parentKey);
   });
   const childrenByParentKey = new Map<string, NavigationThreadSummary[]>();
   for (const thread of props.threads) {
     if (!thread.parentThreadId) continue;
-    const parentKey = buildThreadIdentityKey(thread.source, thread.parentThreadId);
-    if (!threadByKey.has(parentKey)) continue;
+    const parentKey = resolveThreadParentKey(thread, threadByKey);
+    if (!parentKey || !threadByKey.has(parentKey)) continue;
     const children = childrenByParentKey.get(parentKey) ?? [];
     children.push(thread);
     childrenByParentKey.set(parentKey, children);
@@ -157,7 +159,9 @@ export function RecentsList(props: RecentsListProps) {
       return null;
     }
 
-    const childIds = children.map((child) => child.id);
+    const childKeys = children.map((child) =>
+      buildThreadIdentityKey(child.source, child.id),
+    );
     return (
       <div className="subthread-list" role="list" aria-label={`Sub-threads of ${parent.title}`}>
         {children.map((child) => {
@@ -188,7 +192,10 @@ export function RecentsList(props: RecentsListProps) {
                 event.preventDefault();
                 const draggedKey = draggedThreadKey;
                 const draggedThread = draggedKey ? threadByKey.get(draggedKey) : undefined;
-                if (!draggedThread || draggedThread.parentThreadId !== parent.id) {
+                if (
+                  !draggedThread
+                  || resolveThreadParentKey(draggedThread, threadByKey) !== parentKey
+                ) {
                   event.dataTransfer.dropEffect = "none";
                   setDropIndicator(undefined);
                   return;
@@ -222,13 +229,16 @@ export function RecentsList(props: RecentsListProps) {
                   event.dataTransfer.getData("application/x-pwragent-subthread") ||
                   event.dataTransfer.getData("text/plain");
                 const draggedThread = threadByKey.get(draggedKey);
-                if (!draggedThread || draggedThread.parentThreadId !== parent.id) {
+                if (
+                  !draggedThread
+                  || resolveThreadParentKey(draggedThread, threadByKey) !== parentKey
+                ) {
                   return;
                 }
                 const draggedId = parseThreadIdentityKey(draggedKey)?.threadId;
                 if (!draggedId) return;
                 const nextKeys = moveThreadKey(
-                  childIds.map((threadId) => buildThreadIdentityKey(parent.source, threadId)),
+                  childKeys,
                   draggedKey,
                   childKey,
                   getDropIndicatorPosition(event),

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -24,6 +24,7 @@ import {
   isPinnedThread,
   moveDirectoryKey,
   moveThreadKey,
+  resolveThreadParentKey,
 } from "@pwragent/shared";
 import {
   readRendererFederationLabel,
@@ -372,6 +373,15 @@ export function Sidebar(props: SidebarProps) {
   const revealSelectedThreadRequest = props.revealSelectedThreadRequest;
   const selectedItemKey = props.selectedItemKey;
   const navigationThreads = props.threads;
+  const navigationThreadByKey = useMemo(
+    () => new Map(
+      navigationThreads.map((thread) => [
+        buildThreadIdentityKey(thread.source, thread.id),
+        thread,
+      ]),
+    ),
+    [navigationThreads],
+  );
   const setSubthreadsCollapsed = props.onSetSubthreadsCollapsed;
   const browseMode = props.browseMode;
 
@@ -563,13 +573,7 @@ export function Sidebar(props: SidebarProps) {
       return;
     }
 
-    const threadByKey = new Map(
-      navigationThreads.map((thread) => [
-        buildThreadIdentityKey(thread.source, thread.id),
-        thread,
-      ]),
-    );
-    const selectedThread = threadByKey.get(selectedItemKey);
+    const selectedThread = navigationThreadByKey.get(selectedItemKey);
     if (!selectedThread) {
       return;
     }
@@ -584,15 +588,15 @@ export function Sidebar(props: SidebarProps) {
     const visited = new Set<string>();
     let current = selectedThread;
     while (current.parentThreadId) {
-      const parentKey = buildThreadIdentityKey(
-        current.source,
-        current.parentThreadId,
-      );
+      const parentKey = resolveThreadParentKey(current, navigationThreadByKey);
+      if (!parentKey) {
+        break;
+      }
       if (visited.has(parentKey)) {
         break;
       }
       visited.add(parentKey);
-      const parent = threadByKey.get(parentKey);
+      const parent = navigationThreadByKey.get(parentKey);
       if (!parent) {
         break;
       }
@@ -603,7 +607,7 @@ export function Sidebar(props: SidebarProps) {
     }
   }, [
     browseMode,
-    navigationThreads,
+    navigationThreadByKey,
     revealSelectedThreadRequest,
     selectedItemKey,
     setSubthreadsCollapsed,
@@ -1160,8 +1164,11 @@ export function Sidebar(props: SidebarProps) {
   const contextMenuChildThreadCount = contextMenu && !contextMenuIsBulk
     ? props.threads.filter(
         (thread) =>
-          thread.source === contextMenu.thread.source &&
-          thread.parentThreadId === contextMenu.thread.id,
+          resolveThreadParentKey(thread, navigationThreadByKey)
+          === buildThreadIdentityKey(
+            contextMenu.thread.source,
+            contextMenu.thread.id,
+          ),
       ).length
     : 0;
   const contextMenuHasChildThreads = contextMenuChildThreadCount > 0;

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -952,6 +952,88 @@ describe("Sidebar", () => {
     expect(onSetSubthreadsCollapsed).toHaveBeenCalledWith(sharedThread, true);
   });
 
+  it("groups a Codex child under its pinned ACP parent in Inbox", () => {
+    const parentThread: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "kimi-parent",
+      title: "Federation migration parent",
+      source: "acp:kimi",
+      pinnedRank: "1024",
+    };
+    const childThread: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "codex-child",
+      title: "Federation migration child",
+      parentThreadId: parentThread.id,
+    };
+
+    const { container } = render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[childThread, parentThread]}
+        loading={false}
+        selectedItemKey="codex:codex-child"
+        threads={[childThread, parentThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    const childButton = screen.getByRole("button", {
+      name: "Federation migration child",
+    });
+    expect(container.querySelector(".subthread-list")).toContainElement(
+      threadCard(childButton),
+    );
+  });
+
+  it("groups a Codex child under its pinned ACP parent in Directories", () => {
+    const parentThread: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "kimi-parent",
+      title: "Federation directory parent",
+      source: "acp:kimi",
+      pinnedRank: "1024",
+    };
+    const childThread: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "codex-child",
+      title: "Federation directory child",
+      parentThreadId: parentThread.id,
+    };
+    const directory: NavigationDirectorySummary = {
+      ...directories[0]!,
+      threadKeys: ["acp%3Akimi:kimi-parent", "codex:codex-child"],
+    };
+
+    const { container } = render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        directories={[directory]}
+        inboxThreads={[childThread, parentThread]}
+        loading={false}
+        selectedItemKey="codex:codex-child"
+        threads={[childThread, parentThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    const childButton = screen.getByRole("button", {
+      name: "Federation directory child",
+    });
+    expect(container.querySelector(".subthread-list")).toContainElement(
+      threadCard(childButton),
+    );
+  });
+
   it("keeps native Codex workers in an on-demand sub-agent disclosure", () => {
     const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true }));
     Object.defineProperty(window, "pwragent", {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -6014,8 +6014,10 @@ describe("useThreadNavigation", () => {
 
     expect(forkThread).toHaveBeenCalledWith({
       backend: "codex",
+      federationTarget: undefined,
       sourceThreadId: "thread-parent",
       parentThreadId: "thread-parent",
+      parentThreadBackend: "codex",
       executionMode: "default",
       directoryKind: "directory",
       directoryLabel: "app",
@@ -6030,6 +6032,7 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedThread).toMatchObject({
       id: "thread-fork",
       parentThreadId: "thread-parent",
+      parentThreadBackend: "codex",
       gitBranch: "HEAD",
       observedGitBranch: "HEAD",
       linkedDirectories: [
@@ -6317,6 +6320,7 @@ describe("useThreadNavigation", () => {
       directoryPath: "/repo/app",
       gitStatusSourcePath: "/repo/app",
       parentThreadId: "thread-parent",
+      parentThreadBackend: "codex",
       parentThreadTitle: "Local parent",
       preferredBackend: "codex",
     });
@@ -6329,6 +6333,7 @@ describe("useThreadNavigation", () => {
         directoryLabel: "app",
         directoryPath: "/repo/app",
         parentThreadId: "thread-parent",
+        parentThreadBackend: "codex",
         parentThreadTitle: "Local parent",
       },
     });
@@ -6337,6 +6342,7 @@ describe("useThreadNavigation", () => {
     );
     expect(result.current.selectedLaunchpad).toMatchObject({
       parentThreadId: "thread-parent",
+      parentThreadBackend: "codex",
       parentThreadTitle: "Local parent",
     });
   });
@@ -7381,6 +7387,7 @@ describe("useThreadNavigation", () => {
       directoryPath: "/repo/app/.worktrees/parent/app",
       gitStatusSourcePath: "/repo/app",
       parentThreadId: "thread-parent",
+      parentThreadBackend: "codex",
       parentThreadTitle: "Worktree parent",
       preferredBackend: "codex",
     });
@@ -7391,6 +7398,7 @@ describe("useThreadNavigation", () => {
         directoryPath: "/repo/app/.worktrees/parent/app",
         branchName: "feature/parent",
         parentThreadId: "thread-parent",
+        parentThreadBackend: "codex",
       }),
     });
     expect(result.current.selectedLaunchpad).toMatchObject({
@@ -7398,6 +7406,7 @@ describe("useThreadNavigation", () => {
       workMode: "local",
       branchName: "feature/parent",
       parentThreadId: "thread-parent",
+      parentThreadBackend: "codex",
       parentThreadTitle: "Worktree parent",
     });
   });

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -36,6 +36,7 @@ import {
   insertSubthreadIdAfter,
   isRemoteFederationTarget,
   isSubthreadLaunchpadKey,
+  resolveThreadParentKey,
   shortenDerivedThreadTitle,
   sortSubthreadSummaries,
 } from "@pwragent/shared";
@@ -744,6 +745,7 @@ function threadSummariesEqual(
       JSON.stringify(right.workspaceHandoff ?? {}) &&
     left.pinnedRank === right.pinnedRank &&
     left.parentThreadId === right.parentThreadId &&
+    left.parentThreadBackend === right.parentThreadBackend &&
     JSON.stringify(left.subthreadOrder ?? []) ===
       JSON.stringify(right.subthreadOrder ?? []) &&
     left.subthreadsCollapsed === right.subthreadsCollapsed &&
@@ -1025,6 +1027,7 @@ function updateThreadParentInSnapshot(
     backend: AppServerBackendKind;
     threadId: string;
     parentThreadId?: string;
+    parentThreadBackend?: AppServerBackendKind;
   },
 ): NavigationSnapshot | undefined {
   if (!snapshot) {
@@ -1036,13 +1039,19 @@ function updateThreadParentInSnapshot(
     if (thread.source !== params.backend || thread.id !== params.threadId) {
       return thread;
     }
-    if (thread.parentThreadId === params.parentThreadId) {
+    if (
+      thread.parentThreadId === params.parentThreadId
+      && thread.parentThreadBackend === params.parentThreadBackend
+    ) {
       return thread;
     }
     changed = true;
     return {
       ...thread,
       parentThreadId: params.parentThreadId,
+      parentThreadBackend: params.parentThreadId
+        ? params.parentThreadBackend ?? params.backend
+        : undefined,
       pinnedRank: params.parentThreadId ? undefined : thread.pinnedRank,
     };
   });
@@ -1062,15 +1071,26 @@ function ungroupChildThreadsInSnapshot(
   }
 
   let changed = false;
+  const threadByKey = new Map(
+    snapshot.threads.map((thread) => [
+      buildThreadIdentityKey(thread.source, thread.id),
+      thread,
+    ]),
+  );
+  const parentKey = buildThreadIdentityKey(
+    params.backend,
+    params.parentThreadId,
+  );
   const threads = snapshot.threads.map((thread) => {
-    if (
-      thread.source !== params.backend ||
-      thread.parentThreadId !== params.parentThreadId
-    ) {
+    if (resolveThreadParentKey(thread, threadByKey) !== parentKey) {
       return thread;
     }
     changed = true;
-    return { ...thread, parentThreadId: undefined };
+    return {
+      ...thread,
+      parentThreadId: undefined,
+      parentThreadBackend: undefined,
+    };
   });
 
   return changed ? { ...snapshot, threads } : snapshot;
@@ -1081,10 +1101,15 @@ function collectDescendantThreads(
   parent: NavigationThreadSummary,
 ): NavigationThreadSummary[] {
   const descendants: NavigationThreadSummary[] = [];
+  const threadByKey = new Map(
+    threads.map((thread) => [
+      buildThreadIdentityKey(thread.source, thread.id),
+      thread,
+    ]),
+  );
+  const parentKey = buildThreadIdentityKey(parent.source, parent.id);
   const queue = threads.filter(
-    (thread) =>
-      thread.source === parent.source &&
-      thread.parentThreadId === parent.id,
+    (thread) => resolveThreadParentKey(thread, threadByKey) === parentKey,
   );
   const seen = new Set<string>();
 
@@ -1096,11 +1121,11 @@ function collectDescendantThreads(
     }
     seen.add(key);
     descendants.push(thread);
+    const currentKey = buildThreadIdentityKey(thread.source, thread.id);
     queue.push(
       ...threads.filter(
         (candidate) =>
-          candidate.source === thread.source &&
-          candidate.parentThreadId === thread.id,
+          resolveThreadParentKey(candidate, threadByKey) === currentKey,
       ),
     );
   }
@@ -2220,6 +2245,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
   optimisticUserMessage?: NavigationThreadSummary["optimisticUserMessage"];
   optimisticActiveTurn?: NavigationThreadSummary["optimisticActiveTurn"];
   parentThreadId?: string;
+  parentThreadBackend?: AppServerBackendKind;
   pinnedRank?: string;
   scheduledStart?: NavigationThreadSummary["scheduledStart"];
 }): NavigationThreadSummary {
@@ -2257,6 +2283,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
         }
       : {}),
     parentThreadId: params.parentThreadId,
+    parentThreadBackend: params.parentThreadBackend,
     pinnedRank: params.pinnedRank,
     acpRuntime: params.launchpad.acpRuntime,
     codexEnvironmentRuntime: params.codexEnvironmentRuntime,
@@ -3865,9 +3892,10 @@ export function useThreadNavigation(
       }
 
       if (method === "thread/parent/set") {
-        const { threadId, parentThreadId } = event.notification.params as {
+        const { threadId, parentThreadId, parentThreadBackend } = event.notification.params as {
           threadId: string;
           parentThreadId: string;
+          parentThreadBackend?: AppServerBackendKind;
         };
         setState((current) => ({
           ...current,
@@ -3875,6 +3903,7 @@ export function useThreadNavigation(
             backend: event.backend,
             threadId,
             parentThreadId,
+            parentThreadBackend,
           }),
         }));
         scheduleRefresh();
@@ -3891,6 +3920,7 @@ export function useThreadNavigation(
             backend: event.backend,
             threadId,
             parentThreadId: undefined,
+            parentThreadBackend: undefined,
           }),
         }));
         scheduleRefresh();
@@ -4589,11 +4619,15 @@ export function useThreadNavigation(
       if (!source.parentThreadId) {
         return source;
       }
-      const root = stateRef.current.response?.threads.find(
-        (thread) =>
-          thread.source === source.source &&
-          thread.id === source.parentThreadId,
+      const threads = stateRef.current.response?.threads ?? [];
+      const threadByKey = new Map(
+        threads.map((thread) => [
+          buildThreadIdentityKey(thread.source, thread.id),
+          thread,
+        ]),
       );
+      const parentKey = resolveThreadParentKey(source, threadByKey);
+      const root = parentKey ? threadByKey.get(parentKey) : undefined;
       return root ?? source;
     },
     [],
@@ -4608,7 +4642,7 @@ export function useThreadNavigation(
    */
   const insertSubthreadBelowSource = useCallback(
     async (
-      backend: AppServerBackendKind,
+      parentBackend: AppServerBackendKind,
       rootThreadId: string,
       sourceThreadId: string,
       newThreadId: string,
@@ -4617,15 +4651,18 @@ export function useThreadNavigation(
       if (!snapshot) {
         return;
       }
-      const root = snapshot.threads.find(
-        (thread) => thread.source === backend && thread.id === rootThreadId,
+      const threadByKey = new Map(
+        snapshot.threads.map((thread) => [
+          buildThreadIdentityKey(thread.source, thread.id),
+          thread,
+        ]),
       );
+      const rootKey = buildThreadIdentityKey(parentBackend, rootThreadId);
+      const root = threadByKey.get(rootKey);
       const currentChildIds = sortSubthreadSummaries(
         root ?? { subthreadOrder: undefined },
         snapshot.threads.filter(
-          (thread) =>
-            thread.source === backend &&
-            thread.parentThreadId === rootThreadId,
+          (thread) => resolveThreadParentKey(thread, threadByKey) === rootKey,
         ),
       ).map((child) => child.id);
       const nextOrder = insertSubthreadIdAfter(
@@ -4637,7 +4674,7 @@ export function useThreadNavigation(
       setState((current) => ({
         ...current,
         response: updateSubthreadOrderInSnapshot(current.response, {
-          backend,
+          backend: parentBackend,
           parentThreadId: rootThreadId,
           threadIds: nextOrder,
         }),
@@ -4649,7 +4686,7 @@ export function useThreadNavigation(
       if (persistOrder) {
         try {
           const result = await persistOrder({
-            backend,
+            backend: parentBackend,
             parentThreadId: rootThreadId,
             threadIds: nextOrder,
           });
@@ -4662,7 +4699,7 @@ export function useThreadNavigation(
             }),
           }));
         } catch {
-          await refresh(buildThreadIdentityKey(backend, rootThreadId));
+          await refresh(buildThreadIdentityKey(parentBackend, rootThreadId));
         }
       }
 
@@ -4670,13 +4707,13 @@ export function useThreadNavigation(
         setState((current) => ({
           ...current,
           response: updateSubthreadsCollapsedInSnapshot(current.response, {
-            backend,
+            backend: parentBackend,
             parentThreadId: rootThreadId,
             collapsed: false,
           }),
         }));
         void desktopApi?.setSubthreadsCollapsed?.({
-          backend,
+          backend: parentBackend,
           parentThreadId: rootThreadId,
           collapsed: false,
         }).catch(() => {});
@@ -4722,12 +4759,14 @@ export function useThreadNavigation(
           directoryPath: launchpadDirectoryPath,
           gitStatusSourcePath: directory.gitStatusSourcePath,
           parentThreadId: groupRoot.id,
+          parentThreadBackend: groupRoot.source,
           parentThreadTitle: groupRoot.title,
           preferredBackend: parent.source,
         });
         let launchpad: NavigationLaunchpadDraft = {
           ...response.launchpad,
           parentThreadId: groupRoot.id,
+          parentThreadBackend: groupRoot.source,
           parentThreadTitle: groupRoot.title,
           sourceThreadId: parent.id,
         };
@@ -4740,6 +4779,7 @@ export function useThreadNavigation(
           directoryPath: launchpadDirectoryPath,
           ...(directory.branchName ? { branchName: directory.branchName } : {}),
           parentThreadId: groupRoot.id,
+          parentThreadBackend: groupRoot.source,
           parentThreadTitle: groupRoot.title,
         };
         if (desktopApi.updateDirectoryLaunchpad) {
@@ -4750,6 +4790,7 @@ export function useThreadNavigation(
           launchpad = {
             ...updated.launchpad,
             parentThreadId: groupRoot.id,
+            parentThreadBackend: groupRoot.source,
             parentThreadTitle: groupRoot.title,
             sourceThreadId: parent.id,
           };
@@ -4820,6 +4861,7 @@ export function useThreadNavigation(
             readRendererFederationTarget(),
           sourceThreadId: parent.id,
           parentThreadId: groupRoot.id,
+          parentThreadBackend: groupRoot.source,
           executionMode,
           directoryKind: directory.directoryKind,
           directoryLabel: directory.directoryLabel,
@@ -4871,12 +4913,13 @@ export function useThreadNavigation(
           codexEnvironmentRuntime: response.codexEnvironmentRuntime,
           linkedDirectories,
           parentThreadId: groupRoot.id,
+          parentThreadBackend: groupRoot.source,
         };
         const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
         // Drop the fork directly below the card it was spawned from, and let
         // the order write land before the refresh below reads it back.
         await insertSubthreadBelowSource(
-          response.backend,
+          groupRoot.source,
           groupRoot.id,
           parent.id,
           response.threadId,
@@ -5498,6 +5541,8 @@ export function useThreadNavigation(
         parentThreadId ??
         launchpad.parentThreadId ??
         getParentThreadIdFromSubthreadLaunchpadKey(directoryKey);
+      const materializeParentThreadBackend =
+        launchpad.parentThreadBackend ?? launchpad.backend;
       const federationTarget = readRendererFederationTarget();
       let response: Awaited<ReturnType<NonNullable<DesktopApi["materializeDirectoryLaunchpad"]>>>;
       try {
@@ -5510,7 +5555,10 @@ export function useThreadNavigation(
           reviewTarget,
           scheduledFor,
           ...(materializeParentThreadId
-            ? { parentThreadId: materializeParentThreadId }
+            ? {
+                parentThreadId: materializeParentThreadId,
+                parentThreadBackend: materializeParentThreadBackend,
+              }
             : {}),
         });
       } catch (error) {
@@ -5558,6 +5606,9 @@ export function useThreadNavigation(
             }
           : undefined,
         parentThreadId: materializeParentThreadId,
+        parentThreadBackend: materializeParentThreadId
+          ? materializeParentThreadBackend
+          : undefined,
         pinnedRank: response.pinnedRank,
         scheduledStart: response.scheduledAction
           ? {
@@ -5573,7 +5624,7 @@ export function useThreadNavigation(
       // so the order write commits before the refresh below reads it back.
       if (materializeParentThreadId) {
         await insertSubthreadBelowSource(
-          response.backend,
+          materializeParentThreadBackend,
           materializeParentThreadId,
           launchpad.sourceThreadId ?? materializeParentThreadId,
           response.threadId,
@@ -6161,6 +6212,7 @@ export function useThreadNavigation(
     async (
       thread: NavigationThreadSummary,
       parentThreadId?: string,
+      parentThreadBackend?: AppServerBackendKind,
     ): Promise<void> => {
       if (!setThreadParentRequest) {
         return;
@@ -6172,6 +6224,7 @@ export function useThreadNavigation(
           backend: thread.source,
           threadId: thread.id,
           parentThreadId,
+          parentThreadBackend,
         }),
       }));
 
@@ -6180,6 +6233,7 @@ export function useThreadNavigation(
           backend: thread.source,
           threadId: thread.id,
           parentThreadId,
+          parentThreadBackend,
         });
         setState((current) => ({
           ...current,
@@ -6187,6 +6241,7 @@ export function useThreadNavigation(
             backend: result.backend,
             threadId: result.threadId,
             parentThreadId: result.parentThreadId,
+            parentThreadBackend: result.parentThreadBackend,
           }),
         }));
       } catch {

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -57,6 +57,34 @@ describe("materializeNavigationThreads — subthread grouping", () => {
       threads.find((thread) => thread.id === "nested-child")?.parentThreadId,
     ).toBe("root-thread");
   });
+
+  it("preserves an explicit cross-provider parent identity", () => {
+    const threads = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {
+        "codex:codex-child": {
+          backend: "codex",
+          threadId: "codex-child",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          parentThreadId: "kimi-parent",
+          parentThreadBackend: "acp:kimi",
+        },
+      },
+      previousKnownThreadKeys: [],
+      threads: [
+        buildThread({ id: "kimi-parent", source: "acp:kimi" }),
+        buildThread({ id: "codex-child" }),
+      ],
+    });
+
+    expect(
+      threads.find((thread) => thread.id === "codex-child"),
+    ).toMatchObject({
+      parentThreadId: "kimi-parent",
+      parentThreadBackend: "acp:kimi",
+    });
+  });
 });
 
 describe("buildDirectorySummaries", () => {

--- a/packages/agent-core/src/persistence/migrations.ts
+++ b/packages/agent-core/src/persistence/migrations.ts
@@ -11,7 +11,10 @@ import type {
   ThreadPermissionTransition,
   ThreadPermissionTransitionStatus,
 } from "@pwragent/shared";
-import { buildThreadIdentityKey } from "@pwragent/shared";
+import {
+  buildThreadIdentityKey,
+  isAppServerBackendKind,
+} from "@pwragent/shared";
 
 export const CURRENT_OVERLAY_STORE_VERSION = 6;
 
@@ -388,6 +391,19 @@ export function migrateOverlayStoreData(raw: unknown): OverlayStoreData {
               typeof launchpadRecord.branchName === "string"
                 ? launchpadRecord.branchName
                 : undefined,
+            parentThreadId:
+              typeof launchpadRecord.parentThreadId === "string"
+                ? launchpadRecord.parentThreadId
+                : undefined,
+            parentThreadBackend:
+              typeof launchpadRecord.parentThreadBackend === "string"
+              && isAppServerBackendKind(launchpadRecord.parentThreadBackend)
+                ? launchpadRecord.parentThreadBackend
+                : undefined,
+            parentThreadTitle:
+              typeof launchpadRecord.parentThreadTitle === "string"
+                ? launchpadRecord.parentThreadTitle
+                : undefined,
             model:
               typeof launchpadRecord.model === "string"
                 ? launchpadRecord.model
@@ -506,6 +522,15 @@ export function migrateOverlayStoreData(raw: unknown): OverlayStoreData {
               threadRecord.messagingBindingTransitionLog,
             ),
             reactions: migrateThreadReactions(threadRecord.reactions),
+            parentThreadId:
+              typeof threadRecord.parentThreadId === "string"
+                ? threadRecord.parentThreadId
+                : undefined,
+            parentThreadBackend:
+              typeof threadRecord.parentThreadBackend === "string"
+              && isAppServerBackendKind(threadRecord.parentThreadBackend)
+                ? threadRecord.parentThreadBackend
+                : undefined,
           } satisfies ThreadOverlayState,
         ];
       }),

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -73,6 +73,7 @@ export class OverlayStore {
             worktreeSnapshots: current?.worktreeSnapshots ?? [],
             pinnedRank: current?.pinnedRank,
             parentThreadId: current?.parentThreadId,
+            parentThreadBackend: current?.parentThreadBackend,
             subthreadOrder: current?.subthreadOrder,
             subthreadsCollapsed: current?.subthreadsCollapsed,
             permissionTransitionLog: current?.permissionTransitionLog,
@@ -592,9 +593,13 @@ export class OverlayStore {
     backend: ThreadOverlayState["backend"];
     threadId: string;
     parentThreadId?: string | null;
+    parentThreadBackend?: ThreadOverlayState["backend"] | null;
   }): Promise<ThreadOverlayState> {
     return await this.withData(async (data) => {
-      if (params.parentThreadId === params.threadId) {
+      if (
+        params.parentThreadId === params.threadId
+        && (!params.parentThreadBackend || params.parentThreadBackend === params.backend)
+      ) {
         throw new Error("A thread cannot be its own parent.");
       }
       const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
@@ -605,16 +610,20 @@ export class OverlayStore {
         extraLinkedDirectories: [],
       };
       const parentThreadId = params.parentThreadId?.trim();
+      const parentThreadBackend = parentThreadId
+        ? params.parentThreadBackend ?? params.backend
+        : undefined;
       const nextState: ThreadOverlayState = {
         ...current,
         parentThreadId: parentThreadId || undefined,
+        parentThreadBackend,
         pinnedRank: parentThreadId ? undefined : current.pinnedRank,
       };
       data.threads[threadKey] = nextState;
       if (parentThreadId) {
-        const parentKey = buildThreadIdentityKey(params.backend, parentThreadId);
+        const parentKey = buildThreadIdentityKey(parentThreadBackend!, parentThreadId);
         const parent = data.threads[parentKey] ?? {
-          backend: params.backend,
+          backend: parentThreadBackend!,
           threadId: parentThreadId,
           executionMode: "default" as const,
           extraLinkedDirectories: [],

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -54,6 +54,7 @@ export type StartThreadRequest = {
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   acpRuntime?: BackendAcpSessionRuntimeState;
   parentThreadId?: ThreadIdentifier;
+  parentThreadBackend?: AppServerBackendKind;
 };
 
 export type StartThreadResponse = {
@@ -81,6 +82,7 @@ export type ForkThreadRequest = {
   federationTarget?: FederationTarget;
   sourceThreadId: ThreadIdentifier;
   parentThreadId?: ThreadIdentifier;
+  parentThreadBackend?: AppServerBackendKind;
   executionMode?: ThreadExecutionMode;
   directoryKind?: DirectorySummaryKind;
   directoryLabel?: string;
@@ -660,6 +662,7 @@ export type EnsureDirectoryLaunchpadRequest = {
   gitStatusSourcePath?: string;
   currentBranch?: string;
   parentThreadId?: string;
+  parentThreadBackend?: AppServerBackendKind;
   parentThreadTitle?: string;
   preferredBackend?: AppServerBackendKind;
   registeredAt?: number;
@@ -697,6 +700,7 @@ export type UpdateDirectoryLaunchpadRequest = {
       | "workMode"
       | "branchName"
       | "parentThreadId"
+      | "parentThreadBackend"
       | "parentThreadTitle"
       | "codexEnvironmentId"
       | "codexEnvironmentExecutionTarget"
@@ -735,6 +739,7 @@ export type MaterializeDirectoryLaunchpadRequest = {
   collaborationMode?: AppServerCollaborationModeRequest;
   reviewTarget?: AppServerReviewTarget;
   parentThreadId?: ThreadIdentifier;
+  parentThreadBackend?: AppServerBackendKind;
   /**
    * Create the provider thread and prepare its workspace now, but defer the
    * first turn or review until this wall-clock time.

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -111,6 +111,8 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
    * agent thread; this only controls sidebar grouping.
    */
   parentThreadId?: ThreadIdentifier;
+  /** Provider that owns `parentThreadId`; defaults to this thread's provider. */
+  parentThreadBackend?: AppServerBackendKind;
   /**
    * Set only when this thread inherited copied context by forking another
    * thread. Renderer surfaces use this to distinguish fork baseline history
@@ -658,6 +660,7 @@ export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
   workMode: LaunchpadWorkMode;
   branchName?: string;
   parentThreadId?: string;
+  parentThreadBackend?: AppServerBackendKind;
   parentThreadTitle?: string;
   /**
    * The thread card this launchpad was spawned from. May differ from
@@ -1252,12 +1255,14 @@ export type SetThreadParentRequest = {
   backend?: AppServerBackendKind;
   threadId: ThreadIdentifier;
   parentThreadId?: ThreadIdentifier | null;
+  parentThreadBackend?: AppServerBackendKind | null;
 };
 
 export type SetThreadParentResponse = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   parentThreadId?: ThreadIdentifier;
+  parentThreadBackend?: AppServerBackendKind;
 };
 
 export type UpdateSubthreadOrderRequest = {
@@ -1589,6 +1594,8 @@ export type ThreadOverlayState = {
    * access to the parent transcript or state.
    */
   parentThreadId?: ThreadIdentifier;
+  /** Provider that owns `parentThreadId`; defaults to this thread's provider. */
+  parentThreadBackend?: AppServerBackendKind;
   /**
    * Set only when this thread was created by forking another thread
    * (`thread/fork`). Records the source thread the fork inherited its context

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1663,6 +1663,7 @@ export type AppServerNotification =
       params: {
         threadId: string;
         parentThreadId: string;
+        parentThreadBackend?: AppServerBackendKind;
       };
     }
   | {

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -162,33 +162,45 @@ function resolveNavigationExecutionMode(params: {
   );
 }
 
-function resolveNavigationParentThreadId(params: {
+function resolveNavigationParentThread(params: {
   overlay?: ThreadOverlayState;
   overlayByThreadKey: Record<string, ThreadOverlayState | undefined>;
   source: AppServerThreadSummary["source"];
   threadId: string;
-}): string | undefined {
+}): Pick<NavigationThreadSummary, "parentThreadBackend" | "parentThreadId"> {
   const directParentThreadId = params.overlay?.parentThreadId?.trim();
   if (!directParentThreadId) {
-    return undefined;
+    return {};
   }
 
   let parentThreadId = directParentThreadId;
-  const seen = new Set([params.threadId]);
-  while (!seen.has(parentThreadId)) {
-    seen.add(parentThreadId);
+  const directParentThreadBackend = params.overlay?.parentThreadBackend;
+  let parentThreadBackend = directParentThreadBackend ?? params.source;
+  const seen = new Set([buildThreadIdentityKey(params.source, params.threadId)]);
+  let parentKey = buildThreadIdentityKey(parentThreadBackend, parentThreadId);
+  while (!seen.has(parentKey)) {
+    seen.add(parentKey);
     const parentOverlay =
-      params.overlayByThreadKey[
-        buildThreadIdentityKey(params.source, parentThreadId)
-      ];
+      params.overlayByThreadKey[parentKey];
     const nextParentThreadId = parentOverlay?.parentThreadId?.trim();
     if (!nextParentThreadId) {
-      return parentThreadId;
+      return {
+        ...(directParentThreadBackend ? { parentThreadBackend } : {}),
+        parentThreadId,
+      };
     }
     parentThreadId = nextParentThreadId;
+    parentThreadBackend =
+      parentOverlay?.parentThreadBackend ?? parentThreadBackend;
+    parentKey = buildThreadIdentityKey(parentThreadBackend, parentThreadId);
   }
 
-  return directParentThreadId;
+  return {
+    ...(directParentThreadBackend
+      ? { parentThreadBackend: directParentThreadBackend }
+      : {}),
+    parentThreadId: directParentThreadId,
+  };
 }
 
 export function materializeNavigationThreads(params: {
@@ -217,7 +229,7 @@ export function materializeNavigationThreads(params: {
     ]);
     const gitBranch = resolveNavigationGitBranch({ overlay, thread });
     const observedGitBranch = resolveNavigationObservedBranch({ overlay, thread });
-    const parentThreadId = resolveNavigationParentThreadId({
+    const parentThread = resolveNavigationParentThread({
       overlay,
       overlayByThreadKey: params.overlayByThreadKey,
       source: thread.source,
@@ -256,7 +268,7 @@ export function materializeNavigationThreads(params: {
       subAgents: overlay?.subAgents ?? [],
       scheduledStart: overlay?.scheduledStart,
       pinnedRank: overlay?.pinnedRank,
-      parentThreadId,
+      ...parentThread,
       forkSourceThreadId: overlay?.forkSourceThreadId,
       subthreadOrder: overlay?.subthreadOrder,
       subthreadsCollapsed: overlay?.subthreadsCollapsed,
@@ -555,6 +567,7 @@ export function buildNavigationSnapshotHash(params: {
       reactions: thread.reactions ?? [],
       pinnedRank: thread.pinnedRank ?? null,
       parentThreadId: thread.parentThreadId ?? null,
+      parentThreadBackend: thread.parentThreadBackend ?? null,
       forkSourceThreadId: thread.forkSourceThreadId ?? null,
       subthreadOrder: thread.subthreadOrder ?? [],
       subthreadsCollapsed: thread.subthreadsCollapsed ?? null,

--- a/packages/shared/src/subthreads.ts
+++ b/packages/shared/src/subthreads.ts
@@ -1,7 +1,51 @@
-import type { NavigationThreadSummary } from "./contracts/navigation";
+import {
+  buildThreadIdentityKey,
+  type NavigationThreadSummary,
+} from "./contracts/navigation";
 
 type SubthreadParent = Pick<NavigationThreadSummary, "subthreadOrder">;
 type SubthreadChild = Pick<NavigationThreadSummary, "id" | "createdAt">;
+type ParentLinkedThread = Pick<
+  NavigationThreadSummary,
+  "id" | "parentThreadBackend" | "parentThreadId" | "source"
+>;
+
+/**
+ * Resolve a child's parent identity across providers. New relationships carry
+ * `parentThreadBackend`; older persisted cross-provider links only have the
+ * parent id, so they fall back to a unique id match after the historical
+ * same-provider lookup. An ambiguous legacy id stays top-level rather than
+ * attaching to the wrong provider's thread.
+ */
+export function resolveThreadParentKey<T extends ParentLinkedThread>(
+  thread: T,
+  threadsByKey: ReadonlyMap<string, T>,
+): string | undefined {
+  const parentThreadId = thread.parentThreadId?.trim();
+  if (!parentThreadId) {
+    return undefined;
+  }
+
+  const explicitKey = buildThreadIdentityKey(
+    thread.parentThreadBackend ?? thread.source,
+    parentThreadId,
+  );
+  if (threadsByKey.has(explicitKey) || thread.parentThreadBackend) {
+    return explicitKey;
+  }
+
+  let legacyMatch: string | undefined;
+  for (const [threadKey, candidate] of threadsByKey) {
+    if (candidate.id !== parentThreadId) {
+      continue;
+    }
+    if (legacyMatch) {
+      return undefined;
+    }
+    legacyMatch = threadKey;
+  }
+  return legacyMatch;
+}
 
 /**
  * Order a parent's child threads for display. Children explicitly listed in the


### PR DESCRIPTION
## Summary
- allow grouped handoffs across provider backends when they remain in the same project
- persist the parent backend and write subthread ordering onto the actual parent identity
- resolve legacy ID-only cross-provider links throughout navigation and pinning
- carry cross-provider roots through follow-on subthread and fork launchpads

## Root cause
The child backend was used to reconstruct the parent identity. For a Codex child of an ACP/Kimi parent, that produced a nonexistent Codex-flavored parent: the child could not render under the real parent, while its linked-child state still excluded it from normal pin behavior.

## User impact
The existing legacy Codex child linked to an `acp:kimi` parent renders beneath that parent without requiring an unlink/relink or state migration. New grouped handoffs persist the provider-qualified parent identity explicitly.

## Validation
- 750 focused tests passed across renderer navigation, thread navigation, overlay persistence, shared subthread helpers, directory navigation, and backend handoffs
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`
