### PR TITLE
fix(desktop): eliminate Windows test lifecycle flakes

### DIFF
--- a/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
@@ -1,6 +1,3 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ThreadTurnQueueEntry } from "../app-server/thread-turn-queue";
 import { ThreadQueueAutomationRunner } from "../automations/automation-runner";
@@ -8,6 +5,7 @@ import { AutomationScheduler } from "../automations/automation-scheduler";
 import { AutomationStore } from "../automations/automation-store";
 import type { AutomationGateRunner } from "../automations/automation-gate-runner";
 import { StateDb } from "../state/state-db";
+import { openInMemoryStateDb } from "./sqlite-test-utils";
 
 class FakeQueue {
   active = false;
@@ -49,15 +47,13 @@ class FakeQueue {
   }
 }
 
-let tempDir: string;
 let stateDb: StateDb;
 let store: AutomationStore;
 let queue: FakeQueue;
 let now = 0;
 
 beforeEach(() => {
-  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-automation-scheduler-"));
-  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  stateDb = openInMemoryStateDb();
   store = new AutomationStore(stateDb);
   queue = new FakeQueue();
   now = 0;
@@ -65,7 +61,6 @@ beforeEach(() => {
 
 afterEach(() => {
   stateDb.close();
-  rmSync(tempDir, { recursive: true, force: true });
 });
 
 function createIntervalAutomation(

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1276,38 +1276,6 @@ function createOverlayStoreMock(params?: {
   } as unknown as OverlayStoreLike;
 }
 
-/**
- * Detach-mode env actions resolve on spawn and `unref()` the child, so the
- * spawned process (the shell plus any grandchild it launches) keeps holding
- * its `cwd` directory handle after `runCodexEnvironmentAction` returns. On
- * Windows that open handle blocks the temp-dir cleanup with
- * `EBUSY: resource busy or locked, rmdir` until the process fully exits —
- * POSIX can unlink a directory that still has open handles, Windows cannot.
- *
- * Waiting for the action's output *file* is not sufficient: it is written
- * while the child is still alive. The detached-exit handler flips the run's
- * status to a terminal value ("exited"/"failed") once the child's `close`
- * event fires, so gate temp-dir cleanup on that terminal status — the same
- * pattern the concurrent-runs test uses — to guarantee the process is gone
- * before we remove its working directory. The `rm` retry options remain as a
- * backstop for Windows' lazy post-exit handle release.
- */
-async function waitForDetachedActionRunToExit(
-  overlayStore: OverlayStoreLike,
-  params: { backend: "codex" | "grok"; threadId: string; actionId: string },
-): Promise<void> {
-  await expectEventually(async () => {
-    const overlay = await overlayStore.getThreadOverlayState({
-      backend: params.backend,
-      threadId: params.threadId,
-    });
-    const run = overlay?.codexEnvironmentRuntime?.actionRuns?.find(
-      (candidate) => candidate.actionId === params.actionId,
-    );
-    return run?.status === "exited" || run?.status === "failed";
-  }, true);
-}
-
 const TEST_TASK_MONITOR_MODELS: BackendModelOption[] = [
   {
     id: "gpt-5.6-luna",
@@ -12462,7 +12430,6 @@ command = '''${expectedActionCommand}'''
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-thread-env-worktree-"));
     const localPath = path.join(root, "local");
     const worktreePath = path.join(root, "worktree");
-    const outputPath = path.join(root, "action-cwd.txt");
     await mkdir(localPath, { recursive: true });
     await mkdir(worktreePath, { recursive: true });
 
@@ -12490,13 +12457,14 @@ command = '''${expectedActionCommand}'''
               {
                 id: "capture-cwd",
                 name: "Capture CWD",
-                command: `node -e "require('node:fs').writeFileSync(process.argv[1], process.cwd())" ${JSON.stringify(outputPath)}`,
+                command: "capture-cwd",
               },
             ],
           },
         },
       },
     });
+    let commandParams: Parameters<CodexEnvironmentCommandRunner>[0] | undefined;
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({
         initializeResult: { methods: ["thread/list"] },
@@ -12506,6 +12474,10 @@ command = '''${expectedActionCommand}'''
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
       overlayStore,
+      codexEnvironmentCommandRunner: vi.fn(async (params) => {
+        commandParams = params;
+        return { pid: 12345 };
+      }),
     });
 
     try {
@@ -12527,17 +12499,11 @@ command = '''${expectedActionCommand}'''
           ],
         },
       });
-      // The action writes process.cwd() (native separators on Windows). Compare
-      // both sides forward-slashed so a backslash/forward-slash difference
-      // doesn't fail the match — no-op on POSIX where there are no backslashes.
-      await expectEventually(
-        async () =>
-          (await realpath((await readFile(outputPath, "utf8")).trim())).replace(
-            /\\/g,
-            "/",
-          ),
-        (await realpath(worktreePath)).replace(/\\/g, "/"),
-      );
+      expect(commandParams).toMatchObject({
+        command: "capture-cwd",
+        cwd: worktreePath,
+        mode: "detach",
+      });
       await expect(
         overlayStore.getThreadOverlayState({
           backend: "codex",
@@ -12547,13 +12513,6 @@ command = '''${expectedActionCommand}'''
         codexEnvironmentRuntime: {
           cwd: worktreePath,
         },
-      });
-      // Gate cleanup on the detached child fully exiting (see helper) so the
-      // worktree dir it ran in is no longer locked when we remove it.
-      await waitForDetachedActionRunToExit(overlayStore, {
-        backend: "codex",
-        threadId: "thread-1",
-        actionId: "capture-cwd",
       });
     } finally {
       await registry.close();
@@ -12565,7 +12524,6 @@ command = '''${expectedActionCommand}'''
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-thread-env-local-"));
     const localPath = path.join(root, "local");
     const worktreePath = path.join(root, "worktree");
-    const outputPath = path.join(root, "action-cwd.txt");
     await mkdir(localPath, { recursive: true });
     await mkdir(worktreePath, { recursive: true });
 
@@ -12592,13 +12550,14 @@ command = '''${expectedActionCommand}'''
               {
                 id: "capture-cwd",
                 name: "Capture CWD",
-                command: `node -e "require('node:fs').writeFileSync(process.argv[1], process.cwd())" ${JSON.stringify(outputPath)}`,
+                command: "capture-cwd",
               },
             ],
           },
         },
       },
     });
+    let commandParams: Parameters<CodexEnvironmentCommandRunner>[0] | undefined;
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({
         initializeResult: { methods: ["thread/list"] },
@@ -12608,6 +12567,10 @@ command = '''${expectedActionCommand}'''
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
       overlayStore,
+      codexEnvironmentCommandRunner: vi.fn(async (params) => {
+        commandParams = params;
+        return { pid: 12345 };
+      }),
     });
 
     try {
@@ -12629,22 +12592,10 @@ command = '''${expectedActionCommand}'''
           ],
         },
       });
-      // Compare both sides forward-slashed so native Windows separators in the
-      // captured process.cwd() don't fail the match — no-op on POSIX.
-      await expectEventually(
-        async () =>
-          (await realpath((await readFile(outputPath, "utf8")).trim())).replace(
-            /\\/g,
-            "/",
-          ),
-        (await realpath(localPath)).replace(/\\/g, "/"),
-      );
-      // Gate cleanup on the detached child fully exiting (see helper) so the
-      // dir it ran in is no longer locked when we remove it.
-      await waitForDetachedActionRunToExit(overlayStore, {
-        backend: "codex",
-        threadId: "thread-1",
-        actionId: "capture-cwd",
+      expect(commandParams).toMatchObject({
+        command: "capture-cwd",
+        cwd: localPath,
+        mode: "detach",
       });
     } finally {
       await registry.close();
@@ -12850,24 +12801,21 @@ command = '''${expectedActionCommand}'''
             cwd: root,
             actions: [
               {
-                // Print a marker to stdout so the captured output (which
-                // gets attributed to the run via onDetachedExit) has a
-                // deterministic value to assert on. A small sleep makes
-                // the two children genuinely overlap in time.
                 id: "action-a",
                 name: "Action A",
-                command: "sleep 0.2 && printf 'A-output-marker'",
+                command: "action-a-command",
               },
               {
                 id: "action-b",
                 name: "Action B",
-                command: "sleep 0.2 && printf 'B-output-marker'",
+                command: "action-b-command",
               },
             ],
           },
         },
       },
     });
+    const commandParams: Array<Parameters<CodexEnvironmentCommandRunner>[0]> = [];
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({
         initializeResult: { methods: ["thread/list"] },
@@ -12877,6 +12825,10 @@ command = '''${expectedActionCommand}'''
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
       overlayStore,
+      codexEnvironmentCommandRunner: vi.fn(async (params) => {
+        commandParams.push(params);
+        return { pid: 12345 + commandParams.length };
+      }),
     });
 
     try {
@@ -12906,9 +12858,33 @@ command = '''${expectedActionCommand}'''
       expect(runIdB).toBeTruthy();
       expect(runIdA).not.toBe(runIdB);
 
-      // After both detached children exit, the overlay's actionRuns should
-      // contain both entries, each with its own captured output. Poll
-      // until the exit + output handlers have both fired and persisted.
+      const paramsA = commandParams.find(
+        (params) => params.command === "action-a-command",
+      );
+      const paramsB = commandParams.find(
+        (params) => params.command === "action-b-command",
+      );
+      expect(paramsA).toBeTruthy();
+      expect(paramsB).toBeTruthy();
+
+      // Interleave the injected lifecycle callbacks after both runs exist.
+      // This exercises run-id attribution without making a unit test launch
+      // competing Git Bash/PowerShell process trees.
+      paramsA?.onDetachedOutput?.({ output: "A-output-marker" });
+      paramsB?.onDetachedOutput?.({ output: "B-output-marker" });
+      paramsB?.onDetachedExit?.({
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 200,
+        output: "B-output-marker",
+      });
+      paramsA?.onDetachedExit?.({
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 250,
+        output: "A-output-marker",
+      });
+
       const deadline = Date.now() + 10_000;
       let lastSnapshot: ReadonlyArray<unknown> | undefined;
       let lastError: string | undefined;
@@ -12945,7 +12921,7 @@ command = '''${expectedActionCommand}'''
       await registry.close();
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
-  }, 15_000);
+  });
 
   it("cleans up prior-session env-action runs on startup", async () => {
     // Before the cleanup pass: an overlay row from a previous app launch

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -24573,26 +24573,20 @@ script = "printf setup"
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-task-cwd-"));
     const scratchPath = path.join(root, "scratch-workspace");
     const repoPath = path.join(root, "PwrAgnt");
+    const worktreePath = path.join(repoPath, ".worktrees", "handoff-task");
     try {
       await mkdir(scratchPath, { recursive: true });
-      await mkdir(repoPath, { recursive: true });
-      try {
-        await git(repoPath, ["init", "-b", "main"]);
-      } catch {
-        await git(repoPath, ["init"]);
-        await git(repoPath, ["checkout", "-b", "main"]);
-      }
-      await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
-      await git(repoPath, ["add", "README.md"]);
-      await git(repoPath, [
-        "-c",
-        "user.name=PwrAgent Tests",
-        "-c",
-        "user.email=tests@pwragent.local",
-        "commit",
-        "-m",
-        "initial",
-      ]);
+      await mkdir(worktreePath, { recursive: true });
+      const canonicalRepoPath = await realpath(repoPath);
+      const canonicalWorktreePath = await realpath(worktreePath);
+      const prepareLaunchpadWorkspace = vi.fn(async (_launchpad: {
+        directoryPath?: string;
+        workMode: "local" | "worktree";
+      }) => ({
+        cwd: canonicalWorktreePath,
+        repositoryPath: canonicalRepoPath,
+        workMode: "worktree" as const,
+      }));
 
       const scratchDirectory = {
         id: expectedDir(scratchPath),
@@ -24618,9 +24612,28 @@ script = "printf setup"
         grokClient: new MockBackendClient({
           initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
         }),
-        gitDirectoryService: new GitDirectoryService({
-          resolveWorktreeStorage: () => "in-repo",
-        }),
+        gitDirectoryService: {
+          inspectWorkspaceGit: vi.fn(async (cwd: string) => ({
+            kind: "worktree" as const,
+            branch: cwd === canonicalWorktreePath ? "HEAD" : "main",
+            hasCommits: true,
+            headHasCommit: true,
+            worktreeCreationAvailable: true,
+          })),
+          prepareLaunchpadWorkspace,
+          recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+          resolvePrimaryWorkspacePath: vi.fn(async (cwd?: string) => {
+            if (
+              cwd?.startsWith(worktreePath)
+              || cwd?.startsWith(canonicalWorktreePath)
+              || cwd?.startsWith(repoPath)
+              || cwd?.startsWith(canonicalRepoPath)
+            ) {
+              return canonicalRepoPath;
+            }
+            return cwd;
+          }),
+        } as never,
         overlayStore: createOverlayStoreMock({
           overlays: {
             "codex:ordinary-thread": {
@@ -24667,6 +24680,15 @@ script = "printf setup"
       } as AppServerPendingRequestNotification);
 
       expect(response).toMatchObject({ success: true });
+      expect(prepareLaunchpadWorkspace).toHaveBeenCalledOnce();
+      expect(prepareLaunchpadWorkspace.mock.calls[0]?.[0]).toMatchObject({
+        workMode: "worktree",
+      });
+      expect(
+        expectedDir(
+          prepareLaunchpadWorkspace.mock.calls[0]?.[0].directoryPath ?? "",
+        ),
+      ).toBe(expectedDir(repoPath));
       const handoffCwd = expectedDir(codexClient.lastStartThreadParams?.cwd ?? "");
       expect(handoffCwd).toContain(
         expectedDir(await realpath(path.join(repoPath, ".worktrees"))),
@@ -24851,27 +24873,21 @@ script = "printf setup"
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-fork-cwd-"));
     const parentPath = path.join(root, "parent-project");
     const repoPath = path.join(root, "other-project");
+    const worktreePath = path.join(repoPath, ".worktrees", "forked-child");
     try {
-      for (const repo of [parentPath, repoPath]) {
-        await mkdir(repo, { recursive: true });
-        try {
-          await git(repo, ["init", "-b", "main"]);
-        } catch {
-          await git(repo, ["init"]);
-          await git(repo, ["checkout", "-b", "main"]);
-        }
-        await writeFile(path.join(repo, "README.md"), "handoff\n", "utf8");
-        await git(repo, ["add", "README.md"]);
-        await git(repo, [
-          "-c",
-          "user.name=PwrAgent Tests",
-          "-c",
-          "user.email=tests@pwragent.local",
-          "commit",
-          "-m",
-          "initial",
-        ]);
-      }
+      await mkdir(parentPath, { recursive: true });
+      await mkdir(worktreePath, { recursive: true });
+      const canonicalParentPath = await realpath(parentPath);
+      const canonicalRepoPath = await realpath(repoPath);
+      const canonicalWorktreePath = await realpath(worktreePath);
+      const prepareLaunchpadWorkspace = vi.fn(async (_launchpad: {
+        directoryPath?: string;
+        workMode: "local" | "worktree";
+      }) => ({
+        cwd: canonicalWorktreePath,
+        repositoryPath: canonicalRepoPath,
+        workMode: "worktree" as const,
+      }));
 
       const parentRuntime: CodexThreadEnvironmentRuntime = {
         environmentId: "parent-env",
@@ -24904,9 +24920,34 @@ script = "printf setup"
         grokClient: new MockBackendClient({
           initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
         }),
-        gitDirectoryService: new GitDirectoryService({
-          resolveWorktreeStorage: () => "in-repo",
-        }),
+        gitDirectoryService: {
+          inspectWorkspaceGit: vi.fn(async (cwd: string) => ({
+            kind: "worktree" as const,
+            branch: cwd === canonicalWorktreePath ? "HEAD" : "main",
+            hasCommits: true,
+            headHasCommit: true,
+            worktreeCreationAvailable: true,
+          })),
+          prepareLaunchpadWorkspace,
+          recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+          resolvePrimaryWorkspacePath: vi.fn(async (cwd?: string) => {
+            if (
+              cwd?.startsWith(worktreePath)
+              || cwd?.startsWith(canonicalWorktreePath)
+              || cwd?.startsWith(repoPath)
+              || cwd?.startsWith(canonicalRepoPath)
+            ) {
+              return canonicalRepoPath;
+            }
+            if (
+              cwd?.startsWith(parentPath)
+              || cwd?.startsWith(canonicalParentPath)
+            ) {
+              return canonicalParentPath;
+            }
+            return cwd;
+          }),
+        } as never,
         overlayStore: createOverlayStoreMock({
           overlays: {
             "codex:ordinary-thread": {
@@ -24952,6 +24993,18 @@ script = "printf setup"
       } as AppServerPendingRequestNotification);
 
       expect(response).toMatchObject({ success: true });
+      expect(prepareLaunchpadWorkspace).toHaveBeenCalledOnce();
+      expect(prepareLaunchpadWorkspace.mock.calls[0]?.[0]).toMatchObject({
+        workMode: "worktree",
+      });
+      expect(
+        expectedDir(
+          prepareLaunchpadWorkspace.mock.calls[0]?.[0].directoryPath ?? "",
+        ),
+      ).toBe(expectedDir(repoPath));
+      expect(expectedDir(codexClient.lastForkThreadParams?.cwd ?? "")).toBe(
+        expectedDir(canonicalWorktreePath),
+      );
       expect(codexClient.lastForkThreadParams?.codexEnvironmentRuntime).toBeUndefined();
       const payload = JSON.parse(
         (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2698,8 +2698,16 @@ describe("MessagingController", () => {
 
   it("retracts a source stream that finishes while private delivery is in flight", async () => {
     let now = 1000;
+    let releaseSourceDeliveryRecord!: () => void;
     let releaseSourceStream!: () => void;
+    let resolveSourceDeliveryRecorded!: () => void;
     let resolveSourceStreamStarted!: () => void;
+    const sourceDeliveryRecorded = new Promise<void>((resolve) => {
+      resolveSourceDeliveryRecorded = resolve;
+    });
+    const sourceDeliveryRecordRelease = new Promise<void>((resolve) => {
+      releaseSourceDeliveryRecord = resolve;
+    });
     const sourceStreamStarted = new Promise<void>((resolve) => {
       resolveSourceStreamStarted = resolve;
     });
@@ -2733,6 +2741,15 @@ describe("MessagingController", () => {
         };
       },
     });
+    const recordDelivery = harness.store.recordDelivery.bind(harness.store);
+    vi.spyOn(harness.store, "recordDelivery").mockImplementation(async (delivery) => {
+      const recorded = await recordDelivery(delivery);
+      if (delivery.intentId?.startsWith("assistant-stream:")) {
+        resolveSourceDeliveryRecorded();
+        await sourceDeliveryRecordRelease;
+      }
+      return recorded;
+    });
 
     await harness.controller.handleBackendEvent({
       backend: "codex",
@@ -2760,6 +2777,8 @@ describe("MessagingController", () => {
       },
     } satisfies AgentEvent);
     await sourceStreamStarted;
+    releaseSourceStream();
+    await sourceDeliveryRecorded;
 
     let privateRequestSettled = false;
     const privateRequest = harness.controller.handlePwrAgentMessagingRequest({
@@ -2780,7 +2799,14 @@ describe("MessagingController", () => {
     });
     expect(privateRequestSettled).toBe(false);
 
-    releaseSourceStream();
+    // The stream adapter has returned and its delivery record is durable, so
+    // its first cancellation check has already passed. Let the private request
+    // cancel and begin awaiting that delivery before its caller receives the
+    // visible surface. This deterministically exercises the result-ownership
+    // gap that Windows load used to expose nondeterministically.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(privateRequestSettled).toBe(false);
+    releaseSourceDeliveryRecord();
     const [, response] = await Promise.all([sourceDelivery, privateRequest]);
 
     expect(response).toMatchObject({ ok: true });
@@ -2914,8 +2940,16 @@ describe("MessagingController", () => {
   });
 
   it("retracts an in-flight working update before private success", async () => {
+    let releaseWorkingUpdateRecord!: () => void;
     let releaseWorkingUpdate!: () => void;
+    let resolveWorkingUpdateRecorded!: () => void;
     let resolveWorkingUpdateStarted!: () => void;
+    const workingUpdateRecorded = new Promise<void>((resolve) => {
+      resolveWorkingUpdateRecorded = resolve;
+    });
+    const workingUpdateRecordRelease = new Promise<void>((resolve) => {
+      releaseWorkingUpdateRecord = resolve;
+    });
     const workingUpdateStarted = new Promise<void>((resolve) => {
       resolveWorkingUpdateStarted = resolve;
     });
@@ -2986,6 +3020,15 @@ describe("MessagingController", () => {
         };
       },
     });
+    const recordDelivery = harness.store.recordDelivery.bind(harness.store);
+    vi.spyOn(harness.store, "recordDelivery").mockImplementation(async (delivery) => {
+      const recorded = await recordDelivery(delivery);
+      if (delivery.intentId?.startsWith("tool-update:")) {
+        resolveWorkingUpdateRecorded();
+        await workingUpdateRecordRelease;
+      }
+      return recorded;
+    });
 
     const workingUpdate = harness.controller.handleBackendEvent({
       backend: "codex",
@@ -3004,6 +3047,8 @@ describe("MessagingController", () => {
       },
     } satisfies AgentEvent);
     await workingUpdateStarted;
+    releaseWorkingUpdate();
+    await workingUpdateRecorded;
 
     const privateRequest = harness.controller.handlePwrAgentMessagingRequest({
       operation: "send_private_response",
@@ -3025,7 +3070,8 @@ describe("MessagingController", () => {
         ),
       ).toBe(true);
     });
-    releaseWorkingUpdate();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    releaseWorkingUpdateRecord();
     const [, response] = await Promise.all([workingUpdate, privateRequest]);
 
     expect(response).toMatchObject({ ok: true });

--- a/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
+++ b/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
@@ -3,7 +3,7 @@ import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   formatWindowsJobStartupTelemetry,
   formatWindowsJobStartupTimeout,
@@ -140,16 +140,19 @@ describe("wrapCommandInWindowsJob", () => {
   });
 
   it("honors journaled progress inside the overall readiness bound", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-07T00:00:00.000Z"));
     const wrapped = wrapCommandInWindowsJob({
       args: ["/c", "exit 0"],
       command: "C:\\Windows\\System32\\cmd.exe",
       env: { SystemRoot: "C:\\Windows" },
     });
+    let readyPoll: ReturnType<typeof startWindowsJobReadyPoll> | undefined;
     try {
-      const telemetry = await new Promise<
+      const telemetryPromise = new Promise<
         ReturnType<typeof readWindowsJobStartupTelemetry>
       >((resolve, reject) => {
-        startWindowsJobReadyPoll({
+        readyPoll = startWindowsJobReadyPoll({
           launch: wrapped,
           onReady: resolve,
           onTimeout: ({ stage }) =>
@@ -158,29 +161,27 @@ describe("wrapCommandInWindowsJob", () => {
           powershellStartTimeoutMs: 200,
           progressTimeoutMs: 100,
         });
-        setTimeout(() => {
-          appendFileSync(
-            wrapped.startupStatusFilePath,
-            "150\tpowershell-started\t\n170\thelper-compile-started\t\n",
-          );
-        }, 150);
-        setTimeout(() => {
-          appendFileSync(
-            wrapped.startupStatusFilePath,
-            "240\thelper-ready\t\n",
-          );
-        }, 240);
-        setTimeout(() => {
-          appendFileSync(
-            wrapped.startupStatusFilePath,
-            "300\ttarget-assigned\t\n",
-          );
-        }, 300);
-        setTimeout(() => {
-          appendFileSync(wrapped.startupStatusFilePath, "320\tready\t\n");
-          writeFileSync(wrapped.readyFilePath, "ready", "utf8");
-        }, 320);
       });
+      await vi.advanceTimersByTimeAsync(150);
+      appendFileSync(
+        wrapped.startupStatusFilePath,
+        "150\tpowershell-started\t\n170\thelper-compile-started\t\n",
+      );
+      await vi.advanceTimersByTimeAsync(90);
+      appendFileSync(
+        wrapped.startupStatusFilePath,
+        "240\thelper-ready\t\n",
+      );
+      await vi.advanceTimersByTimeAsync(60);
+      appendFileSync(
+        wrapped.startupStatusFilePath,
+        "300\ttarget-assigned\t\n",
+      );
+      await vi.advanceTimersByTimeAsync(20);
+      appendFileSync(wrapped.startupStatusFilePath, "320\tready\t\n");
+      writeFileSync(wrapped.readyFilePath, "ready", "utf8");
+      await vi.advanceTimersByTimeAsync(5);
+      const telemetry = await telemetryPromise;
 
       expect(telemetry.phases.map(({ phase }) => phase)).toEqual([
         "wrapper-created",
@@ -194,7 +195,9 @@ describe("wrapCommandInWindowsJob", () => {
         "wrapper-created@0ms -> powershell-started@150ms -> helper-compile-started@170ms -> helper-ready@240ms -> target-assigned@300ms -> ready@320ms",
       );
     } finally {
+      readyPoll?.cancel();
       wrapped.cleanup();
+      vi.useRealTimers();
     }
   });
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -818,7 +818,10 @@ export class MessagingController {
   private readonly capabilityProfile: MessagingCapabilityProfile;
   private readonly deliveredAssistantMessageKeys = new Set<string>();
   private readonly assistantStreamBuffers = new Map<string, AssistantStreamBuffer>();
-  private readonly assistantStreamDeliveryQueues = new Map<string, Promise<void>>();
+  private readonly assistantStreamDeliveryQueues = new Map<
+    string,
+    Promise<MessagingDeliveryResult>
+  >();
   private readonly assistantStreamCancellationFailures = new Set<string>();
   private readonly assistantStreamCancellationSignals = new Map<
     string,
@@ -828,7 +831,10 @@ export class MessagingController {
     string,
     MessagingCancellationSignal
   >();
-  private readonly workingUpdateDeliveries = new Map<string, Set<Promise<void>>>();
+  private readonly workingUpdateDeliveries = new Map<
+    string,
+    Set<Promise<MessagingDeliveryResult>>
+  >();
   private readonly workingUpdateSurfaces = new Map<
     string,
     Map<string, MessagingSurfaceRef>
@@ -5709,7 +5715,9 @@ export class MessagingController {
   ): Promise<void> {
     const deliveries = this.assistantStreamBufferKeysForEvent(event, binding)
       .map((bufferKey) => this.assistantStreamDeliveryQueues.get(bufferKey))
-      .filter((delivery): delivery is Promise<void> => Boolean(delivery));
+      .filter(
+        (delivery): delivery is Promise<MessagingDeliveryResult> => Boolean(delivery),
+      );
     if (deliveries.length === 0) {
       return;
     }
@@ -5747,30 +5755,28 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     isFinal: boolean,
   ): Promise<MessagingDeliveryResult> {
-    let result: MessagingDeliveryResult | undefined;
     const previous = this.assistantStreamDeliveryQueues.get(bufferKey) ?? Promise.resolve();
     const delivery = previous
       .catch(() => undefined)
-      .then(async () => {
+      .then(async (): Promise<MessagingDeliveryResult> => {
         const latest = this.assistantStreamBuffers.get(bufferKey);
         if (!latest) {
-          return;
+          return {
+            channel: binding.channel.channel,
+            deliveredAt: this.now(),
+            outcome: "discarded",
+          };
         }
-        result = await this.deliverAssistantStreamBuffer(latest, binding, isFinal);
+        return await this.deliverAssistantStreamBuffer(latest, binding, isFinal);
       });
     this.assistantStreamDeliveryQueues.set(bufferKey, delivery);
     try {
-      await delivery;
+      return await delivery;
     } finally {
       if (this.assistantStreamDeliveryQueues.get(bufferKey) === delivery) {
         this.assistantStreamDeliveryQueues.delete(bufferKey);
       }
     }
-    return result ?? {
-      channel: binding.channel.channel,
-      deliveredAt: this.now(),
-      outcome: "discarded",
-    };
   }
 
   private async deliverAssistantStreamBuffer(
@@ -5903,7 +5909,7 @@ export class MessagingController {
     turnId: string,
   ): Promise<boolean> {
     const cancellationKey = this.turnProseKey(binding.id, turnId);
-    const deliveries = new Set<Promise<void>>();
+    const deliveries = new Set<Promise<MessagingDeliveryResult>>();
     const surfaces = new Map<string, MessagingSurfaceRef>();
     this.assistantStreamCancellationFailures.delete(cancellationKey);
     this.assistantStreamCancellationSignals.get(cancellationKey)?.cancel();
@@ -5922,11 +5928,25 @@ export class MessagingController {
         this.assistantStreamBuffers.delete(bufferKey);
       }
     }
-    await Promise.allSettled(deliveries);
+    const deliveryResults = await Promise.allSettled(deliveries);
+    for (const deliveryResult of deliveryResults) {
+      if (
+        deliveryResult.status === "fulfilled"
+        && deliveryResult.value.surface
+        && isVisibleAssistantStreamDelivery(deliveryResult.value)
+      ) {
+        surfaces.set(
+          messagingSurfaceKey(deliveryResult.value.surface),
+          deliveryResult.value.surface,
+        );
+      }
+    }
 
     // A delivery already awaiting its adapter can finish after the buffers are
-    // cleared. The delivery guard retracts a newly-created surface; make one
-    // final sweep for an existing surface before reporting private success.
+    // cleared. Retain the settled delivery result above so the cancellation
+    // path owns a surface created between the delivery guard's post-adapter
+    // check and the caller recording it, then make one final sweep for existing
+    // surfaces.
     for (const [bufferKey, buffer] of this.assistantStreamBuffers) {
       if (
         bufferKey.startsWith(`${binding.id}\0`)
@@ -6006,19 +6026,31 @@ export class MessagingController {
     const key = this.turnProseKey(binding.id, turnId);
     this.workingUpdateCancellationFailures.delete(key);
     this.workingUpdateCancellationSignals.get(key)?.cancel();
-    await Promise.allSettled(this.workingUpdateDeliveries.get(key) ?? []);
+    const deliveryResults = await Promise.allSettled(
+      this.workingUpdateDeliveries.get(key) ?? [],
+    );
 
-    const surfaces = this.workingUpdateSurfaces.get(key);
-    if (surfaces) {
-      for (const surface of surfaces.values()) {
-        const dismissed = await this.dismissTerminalPrivateResponseSurface(
-          binding,
-          turnId,
-          surface,
+    const surfaces = new Map(this.workingUpdateSurfaces.get(key) ?? []);
+    for (const deliveryResult of deliveryResults) {
+      if (
+        deliveryResult.status === "fulfilled"
+        && deliveryResult.value.surface
+        && isVisibleAssistantStreamDelivery(deliveryResult.value)
+      ) {
+        surfaces.set(
+          messagingSurfaceKey(deliveryResult.value.surface),
+          deliveryResult.value.surface,
         );
-        if (!dismissed) {
-          this.workingUpdateCancellationFailures.add(key);
-        }
+      }
+    }
+    for (const surface of surfaces.values()) {
+      const dismissed = await this.dismissTerminalPrivateResponseSurface(
+        binding,
+        turnId,
+        surface,
+      );
+      if (!dismissed) {
+        this.workingUpdateCancellationFailures.add(key);
       }
     }
 
@@ -15380,7 +15412,7 @@ export class MessagingController {
     );
     const guardedIsCancelled = () =>
       isTaskMonitorCancelled() || cancellation.isCancelled();
-    const deliveryPromise = (async () => {
+    const deliveryPromise = (async (): Promise<MessagingDeliveryResult> => {
       const result = await this.deliver(intent, binding, undefined, {
         isCancelled: guardedIsCancelled,
         whenCancelled: cancellation.whenCancelled,
@@ -15412,6 +15444,7 @@ export class MessagingController {
         }
         surfaces.set(messagingSurfaceKey(result.surface), result.surface);
       }
+      return result;
     })();
     let deliveries = this.workingUpdateDeliveries.get(cancellationKey);
     if (!deliveries) {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -99,6 +99,32 @@ function createDeferred<T>(): {
   return { promise, resolve, reject };
 }
 
+function createQueuedStartTurnController() {
+  const called = createDeferred<StartTurnRequest>();
+  const response = createDeferred<StartTurnResponse>();
+  const startTurn = vi.fn((request: StartTurnRequest) => {
+    called.resolve(request);
+    return response.promise;
+  });
+  return {
+    called: called.promise,
+    startTurn,
+    acknowledge: async () => {
+      const request = await called.promise;
+      await act(async () => {
+        response.resolve({
+          backend: request.backend,
+          threadId: request.threadId,
+          turnId: "queue-entry-1",
+          queueStatus: "queued",
+          queueEntryId: "queue-entry-1",
+        });
+        await response.promise;
+      });
+    },
+  };
+}
+
 afterEach(async () => {
   delete (window as unknown as {
     __pwragentFederationTarget?: unknown;
@@ -5431,6 +5457,7 @@ describe("Composer", () => {
       threadId: "thread-1",
       turnId: "turn-1",
     }));
+    const queuedStart = createQueuedStartTurnController();
     render(
       <Composer
         activeTurnId="turn-1"
@@ -5446,13 +5473,7 @@ describe("Composer", () => {
         desktopApi={{
           cancelQueuedTurn,
           onAgentEvent: () => () => undefined,
-          startTurn: vi.fn(async () => ({
-            backend: "codex" as const,
-            threadId: "thread-1",
-            turnId: "queue-entry-1",
-            queueStatus: "queued" as const,
-            queueEntryId: "queue-entry-1",
-          })),
+          startTurn: queuedStart.startTurn,
           steerTurn,
         }}
         disabled={false}
@@ -5481,14 +5502,16 @@ describe("Composer", () => {
     const textarea = screen.getByLabelText("Reply");
     fireEvent.change(textarea, { target: { value: "Steer remotely" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
+    await queuedStart.called;
+    await flushReactUpdates();
     await screen.findByLabelText("Queued message");
     const steerButton = screen.getByRole("button", { name: "Steer" });
     // The local projection renders immediately but remains disabled until the
     // owning peer returns its stable queue entry id. A click before that
     // acknowledgement is intentionally ignored.
-    await waitFor(() => {
-      expect(steerButton).toBeEnabled();
-    });
+    expect(steerButton).toBeDisabled();
+    await queuedStart.acknowledge();
+    expect(steerButton).toBeEnabled();
     fireEvent.click(steerButton);
 
     await waitFor(() => {
@@ -5520,6 +5543,7 @@ describe("Composer", () => {
       threadId: "thread-1",
       turnId: "turn-1",
     }));
+    const queuedStart = createQueuedStartTurnController();
     render(
       <Composer
         activeTurnId="turn-1"
@@ -5535,13 +5559,7 @@ describe("Composer", () => {
         desktopApi={{
           cancelQueuedTurn,
           onAgentEvent: () => () => undefined,
-          startTurn: vi.fn(async () => ({
-            backend: "codex" as const,
-            threadId: "thread-1",
-            turnId: "queue-entry-1",
-            queueStatus: "queued" as const,
-            queueEntryId: "queue-entry-1",
-          })),
+          startTurn: queuedStart.startTurn,
           steerTurn,
         }}
         disabled={false}
@@ -5570,12 +5588,11 @@ describe("Composer", () => {
     const textarea = screen.getByLabelText("Reply");
     fireEvent.change(textarea, { target: { value: "Already admitted once" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
+    await queuedStart.acknowledge();
     await screen.findByLabelText("Queued message");
 
     const steerButton = screen.getByRole("button", { name: "Steer" });
-    await waitFor(() => {
-      expect(steerButton).toBeEnabled();
-    });
+    expect(steerButton).toBeEnabled();
     fireEvent.click(steerButton);
 
     await waitFor(() => {
@@ -5622,6 +5639,7 @@ describe("Composer", () => {
       threadId: "thread-1",
       turnId: "turn-1",
     }));
+    const queuedStart = createQueuedStartTurnController();
     render(
       <Composer
         activeTurnId="turn-1"
@@ -5640,13 +5658,7 @@ describe("Composer", () => {
             agentEventHandler = callback as typeof agentEventHandler;
             return () => undefined;
           },
-          startTurn: vi.fn(async () => ({
-            backend: "codex" as const,
-            threadId: "thread-1",
-            turnId: "queue-entry-1",
-            queueStatus: "queued" as const,
-            queueEntryId: "queue-entry-1",
-          })),
+          startTurn: queuedStart.startTurn,
           steerTurn,
         }}
         disabled={false}
@@ -5676,12 +5688,11 @@ describe("Composer", () => {
     const textarea = screen.getByLabelText("Reply");
     fireEvent.change(textarea, { target: { value: "Preserve until admitted" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
+    await queuedStart.acknowledge();
     await screen.findByLabelText("Queued message");
 
     const steerButton = screen.getByRole("button", { name: "Steer" });
-    await waitFor(() => {
-      expect(steerButton).toBeEnabled();
-    });
+    expect(steerButton).toBeEnabled();
     fireEvent.click(steerButton);
 
     await waitFor(() => {

--- a/apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx
@@ -614,57 +614,57 @@ describe("LogsWindow", () => {
     expect(desktopApi.readAppLogSnapshot).toHaveBeenCalledTimes(2);
   });
 
-  it(
-    "marks the view as tail-only when the live renderer buffer wraps",
-    async () => {
-      let listener:
-        | Parameters<NonNullable<DesktopApi["onAppLogEntry"]>>[0]
-        | undefined;
-      const desktopApi = {
-        readAppLogSnapshot: vi.fn(async () => ({
-          kind: "log-snapshot",
-          title: "Logs",
-          debugCollectionEnabled: false,
-          entries: Array.from(
-            { length: MAX_RENDERED_LOG_ENTRIES },
-            (_, index) => ({
-              sequence: index + 1,
-              timestamp: Date.now(),
-              level: "info",
-              line:
-                index === 0
-                  ? "[2026-05-12 20:06:28.722] [info] (pwragent:main) oldest visible marker"
-                  : `[2026-05-12 20:06:28.722] [info] (pwragent:main) line ${index + 1}`,
-            }),
-          ),
-          readAt: Date.now(),
-          truncated: false,
-        })),
-        onAppLogEntry: vi.fn((callback) => {
-          listener = callback;
-          return () => undefined;
-        }),
-      } as unknown as DesktopApi;
-      (window as Window & { pwragent?: DesktopApi }).pwragent = desktopApi;
+  it("marks the view as tail-only when the live renderer buffer wraps", async () => {
+    let listener:
+      | Parameters<NonNullable<DesktopApi["onAppLogEntry"]>>[0]
+      | undefined;
+    const desktopApi = {
+      readAppLogSnapshot: vi.fn(async () => ({
+        kind: "log-snapshot",
+        title: "Logs",
+        debugCollectionEnabled: false,
+        entries: Array.from(
+          { length: MAX_RENDERED_LOG_ENTRIES },
+          (_, index) => ({
+            sequence: index + 1,
+            timestamp: Date.now(),
+            // Keep the ring full without asking jsdom to materialize 5,000
+            // visible log rows. Debug is filtered by default; the first
+            // entry remains visible so the live overwrite is still proven
+            // through the component boundary.
+            level: index === 0 ? "info" : "debug",
+            line:
+              index === 0
+                ? "[2026-05-12 20:06:28.722] [info] (pwragent:main) oldest visible marker"
+                : `[2026-05-12 20:06:28.722] [info] (pwragent:main) line ${index + 1}`,
+          }),
+        ),
+        readAt: Date.now(),
+        truncated: false,
+      })),
+      onAppLogEntry: vi.fn((callback) => {
+        listener = callback;
+        return () => undefined;
+      }),
+    } as unknown as DesktopApi;
+    (window as Window & { pwragent?: DesktopApi }).pwragent = desktopApi;
 
-      render(<LogsWindow />);
+    render(<LogsWindow />);
 
-      await screen.findByText(/oldest visible marker/);
-      expect(screen.queryByText("Showing tail")).not.toBeInTheDocument();
+    await screen.findByText(/oldest visible marker/);
+    expect(screen.queryByText("Showing tail")).not.toBeInTheDocument();
 
-      act(() => {
-        listener?.({
-          sequence: MAX_RENDERED_LOG_ENTRIES + 1,
-          timestamp: Date.now(),
-          level: "info",
-          line: "[2026-05-12 20:06:29.000] [info] (pwragent:main) wrapped line",
-        });
+    act(() => {
+      listener?.({
+        sequence: MAX_RENDERED_LOG_ENTRIES + 1,
+        timestamp: Date.now(),
+        level: "info",
+        line: "[2026-05-12 20:06:29.000] [info] (pwragent:main) wrapped line",
       });
+    });
 
-      expect(screen.getByText("Showing tail")).toBeInTheDocument();
-      expect(screen.queryByText(/oldest visible marker/)).not.toBeInTheDocument();
-      expect(screen.getByText(/wrapped line/)).toBeInTheDocument();
-    },
-    30_000,
-  );
+    expect(screen.getByText("Showing tail")).toBeInTheDocument();
+    expect(screen.queryByText(/oldest visible marker/)).not.toBeInTheDocument();
+    expect(screen.getByText(/wrapped line/)).toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -182,6 +182,11 @@ describe("ThreadMarkdown", () => {
   });
 
   it("stops typesetting immediately when experimental math rendering is disabled", async () => {
+    // This assertion is about the enabled -> disabled transition, not the
+    // latency of the provider's first lazy module fetch. Warm the same module
+    // before mounting so renderer load cannot consume waitFor's readiness
+    // window on a busy Windows worker.
+    await import("../../../lib/markdown-math-runtime");
     const text = String.raw`Toggle \(a=1\).`;
     const { container, rerender } = render(
       <MarkdownRenderingOptionsProvider mathEnabled>


### PR DESCRIPTION
## Summary

- isolate Windows-sensitive unit tests from real shell, Git, SQLite WAL, and renderer/module startup work that is outside each test's contract
- make synthetic Windows Job readiness tests use owned fake-time phase transitions instead of narrow real-timer margins
- retain in-flight messaging delivery results so terminal private-response cancellation cannot lose a surface created between adapter completion and caller bookkeeping
- make the queue, logs, and markdown regressions wait on or construct the exact lifecycle state they assert, without retries, worker reductions, serial lanes, or wider timeouts

## Root cause

The Windows lane was not leaking persistent processes. Repeated full-suite runs showed rotating single-test failures while every terminal residue sample was empty and Windows Job startup was healthy.

The failures came from several independent ownership gaps amplified by runner load:

- unit tests launched real Git Bash/PowerShell process trees or created/deleted WAL-backed SQLite state when their assertions only required an injected boundary
- a synthetic readiness test used 10 ms real-timer margins, then deleted its journal while delayed producers were still active
- renderer tests conflated cold lazy imports or large filtered DOM populations with the state under test
- terminal private-response cancellation awaited in-flight delivery promises that resolved as `void`, losing a newly created surface in the cancellation/bookkeeping gap
- two handoff tests spent nearly their whole local timeout creating real repositories and worktrees instead of using the existing Git service boundary

A representative public Windows failure is [this Windows build + test job](https://github.com/pwrdrvr/PwrAgent/actions/runs/31208012203/job/92963778413?pr=1315).

## Validation

All stress runs used zero retries.

- Windows full workspace: 10/10 passed; each iteration reported 516 passed and 2 skipped files, 6,913 passed and 21 skipped tests; no persistent processes
- Windows MessagingController: 20/20 passed after the delivery ownership fix, plus 10/10 on the final fixture patch; both terminal-private-response retraction regressions passed every iteration
- Windows backend-registry: 20/20 passed on the final fixture patch; 474/474 tests per iteration; no persistent processes
- focused local suite: 7/7 files, 1,196 passed and 2 skipped
- ESLint: 0 errors (144 existing warnings)
- workspace typecheck, dependency boundaries, Codex storage boundary, production build, and `git diff --check`: passed
- after the final non-conflicting main rebase: Composer 264/264 and desktop typecheck passed
