### PR TITLE
fix(desktop): preserve live thread status during refresh

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -193,6 +193,107 @@ describe("useThreadNavigation", () => {
     expect(result.current.threads[0]?.threadStatus).toBe("idle");
   });
 
+  it("does not let an in-flight remote snapshot overwrite a live status event", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "instance-m2-max",
+    };
+    (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = federationTarget;
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const snapshot = (threadStatus: "active" | "idle"): NavigationSnapshot => ({
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["acp:kimi:session-1"],
+      threads: [
+        {
+          id: "session-1",
+          title: "Remote Kimi thread",
+          titleSource: "explicit",
+          source: "acp:kimi",
+          threadStatus,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread",
+          },
+          federation: {
+            ref: {
+              backend: "acp:kimi",
+              target: federationTarget,
+              threadId: "session-1",
+            },
+            instanceLabel: "M2 Max",
+            peerStatus: "connected",
+            capabilities: ["thread_navigation"],
+          },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+      federationTarget,
+    });
+    const staleRefresh = createDeferred<NavigationSnapshot>();
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce(snapshot("idle"))
+      .mockReturnValueOnce(staleRefresh.promise)
+      .mockResolvedValueOnce(snapshot("idle"));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.threadStatus).toBe("idle");
+    });
+    let refresh!: Promise<void>;
+    act(() => {
+      refresh = result.current.refresh();
+    });
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "acp:kimi",
+        federationTarget,
+        notification: {
+          method: "thread/status/changed",
+          params: {
+            threadId: "session-1",
+            status: { type: "active" },
+          },
+        },
+      });
+    });
+    expect(result.current.threads[0]?.threadStatus).toBe("active");
+
+    await act(async () => {
+      staleRefresh.resolve(snapshot("idle"));
+      await refresh;
+    });
+    expect(result.current.threads[0]?.threadStatus).toBe("active");
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.threads[0]?.threadStatus).toBe("idle");
+  });
+
   it("clears a directory attention count after the selected thread is marked seen", async () => {
     const markThreadSeen = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -47,6 +47,7 @@ import { resolveThreadWorkingStatePath } from "./thread-working-state-path";
 import {
   agentEventThreadIdentityKey,
   federationTargetsEqual,
+  threadSummaryIdentityKey,
 } from "./federated-thread-events";
 import {
   buildSubthreadLaunchpadKey,
@@ -136,6 +137,11 @@ type NavigationState = {
 type NavigationRefreshOptions = {
   forceRefresh?: boolean;
   refreshMode?: "active-recent" | "full";
+};
+
+type ThreadStatusObservation = {
+  sequence: number;
+  threadStatus: AppServerThreadStatus;
 };
 
 type PrChipLocation = {
@@ -827,6 +833,30 @@ function reconcileNavigationSnapshot(
         : thread;
     }),
   };
+}
+
+function applyConcurrentThreadStatusObservations(
+  snapshot: NavigationSnapshot,
+  observations: ReadonlyMap<string, ThreadStatusObservation>,
+  sequenceAtRefreshStart: number,
+): NavigationSnapshot {
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    const observation = observations.get(threadSummaryIdentityKey(thread));
+    if (
+      !observation
+      || observation.sequence <= sequenceAtRefreshStart
+      || observation.threadStatus === thread.threadStatus
+    ) {
+      return thread;
+    }
+    changed = true;
+    return {
+      ...thread,
+      threadStatus: observation.threadStatus,
+    };
+  });
+  return changed ? { ...snapshot, threads } : snapshot;
 }
 
 function applyDirectoryGitStatusUpdate(
@@ -1565,6 +1595,7 @@ function applyThreadStatusUpdate(
   snapshot: NavigationSnapshot | undefined,
   params: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
     threadStatus: AppServerThreadStatus;
   }
@@ -1576,6 +1607,14 @@ function applyThreadStatusUpdate(
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
     if (thread.source !== params.backend || thread.id !== params.threadId) {
+      return thread;
+    }
+    if (
+      !federationTargetsEqual(
+        thread.federation?.ref.target,
+        params.federationTarget,
+      )
+    ) {
       return thread;
     }
     if (thread.threadStatus === params.threadStatus) {
@@ -2730,6 +2769,10 @@ export function useThreadNavigation(
   const pendingDirectoryGitStatusRef = useRef(
     new Map<string, NavigationDirectoryGitStatus | null>(),
   );
+  const threadStatusObservationSequenceRef = useRef(0);
+  const threadStatusObservationsRef = useRef(
+    new Map<string, ThreadStatusObservation>(),
+  );
   const setNavigationBrowseModeRequestRef = useRef(setNavigationBrowseModeRequest);
   const stateRef = useRef(state);
 
@@ -2840,6 +2883,8 @@ export function useThreadNavigation(
                 ...(federationTarget ? { federationTarget } : {}),
               }
             : undefined;
+        const threadStatusSequenceAtRefreshStart =
+          threadStatusObservationSequenceRef.current;
         const snapshot = snapshotRequest
           ? await desktopApi.getNavigationSnapshot(snapshotRequest)
           : await desktopApi.getNavigationSnapshot();
@@ -2869,7 +2914,16 @@ export function useThreadNavigation(
             };
           }
 
-          const nextResponse = reconcileNavigationSnapshot(current.response, response);
+          const responseWithConcurrentThreadStatuses =
+            applyConcurrentThreadStatusObservations(
+              response,
+              threadStatusObservationsRef.current,
+              threadStatusSequenceAtRefreshStart,
+            );
+          const nextResponse = reconcileNavigationSnapshot(
+            current.response,
+            responseWithConcurrentThreadStatuses,
+          );
           prChipLocationIndexRef.current = buildPrChipLocationIndex(nextResponse);
           return {
             loading: false,
@@ -3521,10 +3575,22 @@ export function useThreadNavigation(
           return;
         }
 
+        const observationSequence =
+          threadStatusObservationSequenceRef.current + 1;
+        threadStatusObservationSequenceRef.current = observationSequence;
+        threadStatusObservationsRef.current.set(
+          agentEventThreadIdentityKey(event, threadId),
+          {
+            sequence: observationSequence,
+            threadStatus,
+          },
+        );
+
         setState((current) => ({
           ...current,
           response: applyThreadStatusUpdate(current.response, {
             backend: event.backend,
+            federationTarget: event.federationTarget,
             threadId,
             threadStatus,
           }),


### PR DESCRIPTION
## Summary

- preserve live `thread/status/changed` observations that arrive while a navigation snapshot refresh is in flight
- scope status patches by federation target so identical backend/thread IDs from another origin cannot update the wrong row
- add a remote-viewer regression test covering the stale-idle snapshot ordering and a later authoritative idle refresh

## Root cause

A remote `getNavigationSnapshot()` request could start while the owner still reported the thread as idle. If `thread/status/changed(active)` arrived before that request completed, the event correctly patched the sidebar row, but the older snapshot was then reconciled wholesale and overwrote `threadStatus` back to idle. Repeated active events made the Thinking indicator reappear, producing the observed flicker while the transcript remained active.

M2 Max runtime evidence ruled out provider-side status flicker: the successful resumed Kimi turn ran from 08:33:47.170 to 08:36:46.407 EDT, and all 1,166 pre-terminal ACP updates normalized to `active`. The only actual transition to idle was the normal `turn_finished`.

## Checks

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (110 tests)
- `pnpm typecheck`
- `pnpm exec eslint "packages/**/*.{ts,tsx}" "apps/*/src/**/*.{ts,tsx}" --quiet`
- `pnpm lint:boundaries`
- `git diff --check`
