### PR TITLE
fix(desktop): isolate remote directory disclosure state

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -334,6 +334,24 @@ const setThreadPinOverlay = vi.fn(
     pinnedRank: params.pinnedRank ?? undefined,
   }),
 );
+const setDirectoryThreadsCollapsedOverlay = vi.fn(async (params: {
+  directoryKey: string;
+  collapsed: boolean;
+}) => ({
+  directoryKey: params.directoryKey,
+  directoryThreadsCollapsed: params.collapsed,
+}));
+const setRemoteDirectoryThreadsCollapsedOverlay = vi.fn(async (params: {
+  instanceId: string;
+  directoryKey: string;
+  collapsed: boolean;
+}) => ({
+  directoryKey: params.directoryKey,
+  directoryThreadsCollapsed: params.collapsed,
+}));
+const readRemoteDirectoryOverlays = vi.fn(async (): Promise<
+  Record<string, { directoryKey: string; directoryThreadsCollapsed?: boolean }>
+> => ({}));
 const listPinnedThreadOverlayRanks = vi.fn(
   async (): Promise<Array<{ pinnedRank: string; parentThreadId?: string }>> => [],
 );
@@ -801,6 +819,10 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     setRemoteThreadLocalPin,
     setThreadReaction: setThreadReactionOverlay,
     setThreadPin: setThreadPinOverlay,
+    setDirectoryThreadsCollapsed: setDirectoryThreadsCollapsedOverlay,
+    setRemoteDirectoryThreadsCollapsed:
+      setRemoteDirectoryThreadsCollapsedOverlay,
+    readRemoteDirectoryOverlays,
     listPinnedThreadOverlayRanks,
     reorderThreadPins: reorderThreadPinsStore,
   }),
@@ -964,6 +986,10 @@ describe("app server ipc", () => {
     ensureDirectoryLaunchpad.mockClear();
     markThreadSeen.mockClear();
     setThreadReactionOverlay.mockClear();
+    setDirectoryThreadsCollapsedOverlay.mockClear();
+    setRemoteDirectoryThreadsCollapsedOverlay.mockClear();
+    readRemoteDirectoryOverlays.mockReset();
+    readRemoteDirectoryOverlays.mockResolvedValue({});
     registerDirectoryFromDiskService.mockClear();
     addLinkedDirectory.mockClear();
     removeLinkedDirectory.mockClear();
@@ -1744,6 +1770,87 @@ describe("app server ipc", () => {
         federation: { peerStatus: "disconnected" },
       }],
     });
+  });
+
+  it("overlays viewer-owned directory disclosure state on remote snapshots", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "peer_navigation_preferences",
+    };
+    const directoryKey = "directory:/Users/remote/repos/PwrAgent";
+    readRemoteDirectoryOverlays.mockResolvedValueOnce({
+      [directoryKey]: {
+        directoryKey,
+        directoryThreadsCollapsed: true,
+      },
+    });
+    federationMock.runtime.remoteNavigationSnapshot.mockResolvedValueOnce({
+      backend: "all",
+      fetchedAt: 1_000,
+      federationTarget,
+      unchanged: true,
+      threads: [],
+      inboxThreadKeys: [],
+      directories: [{
+        key: directoryKey,
+        kind: "directory",
+        label: "PwrAgent",
+        path: "/Users/remote/repos/PwrAgent",
+        threadKeys: [],
+        needsAttentionCount: 0,
+        directoryThreadsCollapsed: false,
+      }],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    });
+
+    registerAppServerIpcHandlers();
+    const snapshot = await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {
+      federationTarget,
+    }) as {
+      unchanged: boolean;
+      directories: Array<{ directoryThreadsCollapsed?: boolean }>;
+    };
+
+    expect(readRemoteDirectoryOverlays).toHaveBeenCalledWith({
+      instanceId: federationTarget.instanceId,
+    });
+    expect(snapshot.directories[0]?.directoryThreadsCollapsed).toBe(true);
+    expect(snapshot.unchanged).toBe(false);
+  });
+
+  it("stores a remote directory disclosure on the viewer without publishing it", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SET_DIRECTORY_THREADS_COLLAPSED_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "peer_navigation_preferences",
+    };
+    const directoryKey = "directory:/Users/remote/repos/PwrAgent";
+
+    registerAppServerIpcHandlers();
+    const response = await handlers.get(
+      NAVIGATION_SET_DIRECTORY_THREADS_COLLAPSED_CHANNEL,
+    )?.({}, {
+      directoryKey,
+      collapsed: true,
+      federationTarget,
+    });
+
+    expect(setRemoteDirectoryThreadsCollapsedOverlay).toHaveBeenCalledWith({
+      instanceId: federationTarget.instanceId,
+      directoryKey,
+      collapsed: true,
+    });
+    expect(setDirectoryThreadsCollapsedOverlay).not.toHaveBeenCalled();
+    expect(publishLocalEvent).not.toHaveBeenCalled();
+    expect(response).toEqual({ directoryKey, collapsed: true });
   });
 
   it("keeps unexpected remote navigation failures actionable", async () => {

--- a/apps/desktop/src/main/__tests__/overlay-store-directory-pins.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-directory-pins.test.ts
@@ -92,6 +92,37 @@ describe("SqliteOverlayStore — directory pins", () => {
     });
   });
 
+  it("keeps remote-viewer disclosures separate from local and other peers", async () => {
+    const directoryKey = "directory:/Users/me/code/PwrAgent";
+    await store.setDirectoryThreadsCollapsed({
+      directoryKey,
+      collapsed: false,
+    });
+    await store.setRemoteDirectoryThreadsCollapsed({
+      instanceId: "peer-m2",
+      directoryKey,
+      collapsed: true,
+    });
+    await store.setRemoteDirectoryThreadsCollapsed({
+      instanceId: "peer-studio",
+      directoryKey,
+      collapsed: false,
+    });
+
+    await expect(store.getDirectoryOverlayState({ directoryKey }))
+      .resolves.toMatchObject({ directoryThreadsCollapsed: false });
+    await expect(
+      store.readRemoteDirectoryOverlays({ instanceId: "peer-m2" }),
+    ).resolves.toMatchObject({
+      [directoryKey]: { directoryThreadsCollapsed: true },
+    });
+    await expect(
+      store.readRemoteDirectoryOverlays({ instanceId: "peer-studio" }),
+    ).resolves.toMatchObject({
+      [directoryKey]: { directoryThreadsCollapsed: false },
+    });
+  });
+
   it("returns undefined for a directoryKey with no overlay row", async () => {
     await expect(
       store.getDirectoryOverlayState({

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1856,21 +1856,25 @@ class DesktopAppServerService {
     request: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot> {
     if (request.federationTarget && isRemoteFederationTarget(request.federationTarget)) {
+      const federationTarget = request.federationTarget;
       const cacheKey = getRemoteNavigationSnapshotCacheKey({
         ...request,
-        federationTarget: request.federationTarget,
+        federationTarget,
       });
       try {
         const snapshot = await getDesktopFederationRuntime()
           .remoteNavigationSnapshot(
-            request.federationTarget,
+            federationTarget,
             {
               backend: request.backend === "all" ? undefined : request.backend,
               filter: request.filter,
             },
           );
         this.remoteNavigationSnapshotCache.set(cacheKey, snapshot);
-        return snapshot;
+        return await this.applyRemoteDirectoryViewerOverlays(
+          snapshot,
+          federationTarget.instanceId,
+        );
       } catch (error) {
         if (!isFederationPeerUnavailableError(error)) {
           throw error;
@@ -1889,21 +1893,24 @@ class DesktopAppServerService {
             executionMode: "default",
           },
         };
-        return {
-          ...fallback,
-          unchanged: false,
-          threads: fallback.threads.map((thread) =>
-            thread.federation
-              ? {
-                  ...thread,
-                  federation: {
-                    ...thread.federation,
-                    peerStatus: "disconnected",
-                  },
-                }
-              : thread,
-          ),
-        };
+        return await this.applyRemoteDirectoryViewerOverlays(
+          {
+            ...fallback,
+            unchanged: false,
+            threads: fallback.threads.map((thread) =>
+              thread.federation
+                ? {
+                    ...thread,
+                    federation: {
+                      ...thread.federation,
+                      peerStatus: "disconnected",
+                    },
+                  }
+                : thread,
+            ),
+          },
+          federationTarget.instanceId,
+        );
       }
     }
     const backend: AppServerBackendScope = request.backend ?? "all";
@@ -2044,6 +2051,38 @@ class DesktopAppServerService {
         && !primaryGitRepositoriesChanged
         && !remotePins.changed,
     };
+  }
+
+  private async applyRemoteDirectoryViewerOverlays(
+    snapshot: NavigationSnapshot,
+    instanceId: string,
+  ): Promise<NavigationSnapshot> {
+    const overlays = await this.getOverlayStore().readRemoteDirectoryOverlays({
+      instanceId,
+    });
+    let changed = false;
+    const directories = snapshot.directories.map((directory) => {
+      const collapsed = overlays[directory.key]?.directoryThreadsCollapsed;
+      if (
+        collapsed === undefined
+        || directory.directoryThreadsCollapsed === collapsed
+      ) {
+        return directory;
+      }
+      changed = true;
+      return {
+        ...directory,
+        directoryThreadsCollapsed: collapsed,
+      };
+    });
+    return changed
+      ? {
+          ...snapshot,
+          directories,
+          // The owner's unchanged hash does not include viewer-local state.
+          unchanged: false,
+        }
+      : snapshot;
   }
 
   /**
@@ -6203,6 +6242,28 @@ class DesktopAppServerService {
     request: SetDirectoryThreadsCollapsedRequest,
   ): Promise<SetDirectoryThreadsCollapsedResponse> {
     rejectNonUserDirectoryKey(request.directoryKey);
+
+    if (
+      request.federationTarget
+      && isRemoteFederationTarget(request.federationTarget)
+    ) {
+      const overlay = await this.getOverlayStore()
+        .setRemoteDirectoryThreadsCollapsed({
+          instanceId: request.federationTarget.instanceId,
+          directoryKey: request.directoryKey,
+          collapsed: request.collapsed,
+        });
+      const collapsed = overlay.directoryThreadsCollapsed === true;
+      logDebug("setDirectoryThreadsCollapsed:remote-viewer", {
+        instanceId: request.federationTarget.instanceId,
+        directoryKey: request.directoryKey,
+        collapsed,
+      });
+      return {
+        directoryKey: request.directoryKey,
+        collapsed,
+      };
+    }
 
     const overlay = await this.getOverlayStore().setDirectoryThreadsCollapsed({
       directoryKey: request.directoryKey,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2580,6 +2580,62 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     return nextState;
   }
 
+  /**
+   * Persist a remote window's disclosure locally without changing either the
+   * owning instance's overlay or this viewer's same-path local directory.
+   */
+  async setRemoteDirectoryThreadsCollapsed(params: {
+    instanceId: string;
+    directoryKey: string;
+    collapsed: boolean;
+  }): Promise<DirectoryOverlayState> {
+    const current = this.stateDb.raw
+      .prepare(
+        `SELECT payload FROM remote_directory_overlay
+         WHERE instance_id = ? AND directory_key = ?`,
+      )
+      .get(params.instanceId, params.directoryKey) as
+        | { payload: string }
+        | undefined;
+    const nextState: DirectoryOverlayState = {
+      ...(current
+        ? JSON.parse(current.payload) as DirectoryOverlayState
+        : {}),
+      directoryKey: params.directoryKey,
+      directoryThreadsCollapsed: params.collapsed,
+    };
+    this.stateDb.raw
+      .prepare(
+        `INSERT OR REPLACE INTO remote_directory_overlay(
+           instance_id,
+           directory_key,
+           payload
+         ) VALUES (?, ?, ?)`,
+      )
+      .run(params.instanceId, params.directoryKey, JSON.stringify(nextState));
+    return nextState;
+  }
+
+  async readRemoteDirectoryOverlays(params: {
+    instanceId: string;
+  }): Promise<Record<string, DirectoryOverlayState>> {
+    const rows = this.stateDb.raw
+      .prepare(
+        `SELECT directory_key, payload FROM remote_directory_overlay
+         WHERE instance_id = ?`,
+      )
+      .all(params.instanceId) as Array<{
+        directory_key: string;
+        payload: string;
+      }>;
+    return Object.fromEntries(
+      rows.map((row) => [
+        row.directory_key,
+        JSON.parse(row.payload) as DirectoryOverlayState,
+      ]),
+    );
+  }
+
   async getDirectoryOverlayState(params: {
     directoryKey: string;
   }): Promise<DirectoryOverlayState | undefined> {
@@ -6237,6 +6293,8 @@ export type OverlayStoreLike = Pick<
   | "setDirectoryPin"
   | "reorderDirectoryPins"
   | "setDirectoryThreadsCollapsed"
+  | "setRemoteDirectoryThreadsCollapsed"
+  | "readRemoteDirectoryOverlays"
   | "getDirectoryOverlayState"
   | "readAllDirectoryOverlays"
   | "setThreadPullRequests"

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 46;
+export const CURRENT_STATE_DB_USER_VERSION = 47;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -210,6 +210,17 @@ const DIRECTORY_OVERLAY_SCHEMA = `
 CREATE TABLE IF NOT EXISTS directory_overlay (
   directory_key TEXT PRIMARY KEY,
   payload       TEXT NOT NULL
+);
+`;
+
+/* Viewer-owned directory display preferences for federation windows. The
+   owning instance's directory overlay remains untouched. */
+const REMOTE_DIRECTORY_OVERLAY_SCHEMA = `
+CREATE TABLE IF NOT EXISTS remote_directory_overlay (
+  instance_id   TEXT NOT NULL,
+  directory_key TEXT NOT NULL,
+  payload       TEXT NOT NULL,
+  PRIMARY KEY(instance_id, directory_key)
 );
 `;
 
@@ -1354,6 +1365,12 @@ FROM remote_thread_pins
 LEFT JOIN federation_peers
   ON federation_peers.peer_id = remote_thread_pins.instance_id
 `);
+        db.pragma("user_version = 46");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 47) {
+      db.transaction(() => {
+        db.exec(REMOTE_DIRECTORY_OVERLAY_SCHEMA);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1516,6 +1533,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     db.exec(DIRECTORY_GIT_STATUS_SCHEMA);
     db.exec(THREAD_GIT_WORKING_STATE_SCHEMA);
     db.exec(DIRECTORY_OVERLAY_SCHEMA);
+    db.exec(REMOTE_DIRECTORY_OVERLAY_SCHEMA);
     db.exec(COMPOSER_DRAFT_RECOVERY_SCHEMA);
     db.exec(MESSAGING_TOPIC_MANAGEMENT_SCHEMA);
     db.exec(ACP_AGENT_SCHEMA);

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -8954,6 +8954,90 @@ describe("useThreadNavigation", () => {
     expect(result.current.directories[0]?.directoryThreadsCollapsed).toBe(true);
   });
 
+  it("keeps a remote viewer's Directory threads disclosure independent of the owner", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = federationTarget;
+    const directory = {
+      key: "directory:/Users/remote/repos/PwrAgent",
+      kind: "directory" as const,
+      label: "PwrAgent",
+      path: "/Users/remote/repos/PwrAgent",
+      threadKeys: [],
+      needsAttentionCount: 0,
+      directoryThreadsCollapsed: false,
+    };
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      federationTarget,
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [directory],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const setDirectoryThreadsCollapsed: NonNullable<
+      DesktopApi["setDirectoryThreadsCollapsed"]
+    > = vi.fn(async (request) => ({
+      directoryKey: request.directoryKey,
+      collapsed: request.collapsed,
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (handler) => {
+        agentEventHandler = handler;
+        return () => undefined;
+      },
+      setDirectoryThreadsCollapsed,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.setDirectoryThreadsCollapsed(directory, true);
+    });
+
+    expect(setDirectoryThreadsCollapsed).toHaveBeenCalledWith({
+      directoryKey: directory.key,
+      collapsed: true,
+      federationTarget,
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        federationTarget,
+        notification: {
+          method: "directory/threadsCollapsed/updated",
+          params: {
+            directoryKey: directory.key,
+            collapsed: false,
+          },
+        },
+      });
+    });
+    expect(result.current.directories[0]?.directoryThreadsCollapsed).toBe(true);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.directories[0]?.directoryThreadsCollapsed).toBe(true);
+  });
+
   it("applies a peer's PR events to its pinned rows without touching local threads", async () => {
     // A pinned remote row is the only place a peer's PR chip is shown,
     // and the main window has no federation target, so these events do

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1248,6 +1248,28 @@ function updateDirectoryThreadsCollapsedInSnapshot(
   return changed ? { ...snapshot, directories } : snapshot;
 }
 
+function applyDirectoryThreadsCollapsedOverrides(
+  snapshot: NavigationSnapshot,
+  overrides: ReadonlyMap<string, boolean>,
+): NavigationSnapshot {
+  let changed = false;
+  const directories = snapshot.directories.map((directory) => {
+    const collapsed = overrides.get(directory.key);
+    if (
+      collapsed === undefined
+      || directory.directoryThreadsCollapsed === collapsed
+    ) {
+      return directory;
+    }
+    changed = true;
+    return {
+      ...directory,
+      directoryThreadsCollapsed: collapsed,
+    };
+  });
+  return changed ? { ...snapshot, directories, unchanged: false } : snapshot;
+}
+
 function markThreadsSeenInSnapshot(
   snapshot: NavigationSnapshot | undefined,
   params: Array<{
@@ -2696,6 +2718,9 @@ export function useThreadNavigation(
   const lastFocusRefreshCompletedAtRef = useRef(0);
   const remoteRecoveryAttemptRef = useRef(0);
   const remotePeerDisconnectedRef = useRef(false);
+  const remoteDirectoryThreadsCollapsedOverridesRef = useRef(
+    new Map<string, boolean>(),
+  );
   const lastNavigationActivityAtRef = useRef(Date.now());
   const backgroundRefreshIdleRef = useRef(false);
   const launchpadUpdateRevisionRef = useRef(new Map<string, number>());
@@ -2823,10 +2848,35 @@ export function useThreadNavigation(
           threadCount: snapshot.threads.length,
           unchanged: Boolean(snapshot.unchanged),
         });
-        const response = removeThreadKeysFromSnapshot(
+        const filteredResponse = removeThreadKeysFromSnapshot(
           snapshot,
           suppressedArchivedThreadKeysRef.current
         );
+        if (federationTarget && isRemoteFederationTarget(federationTarget)) {
+          // A remote window adopts its first snapshot as a baseline, then
+          // owns the disclosure for the rest of the window lifetime. This
+          // also seeds preferences restored by the viewer-side SQLite
+          // overlay before owner events can race them.
+          for (const directory of filteredResponse.directories) {
+            if (
+              !remoteDirectoryThreadsCollapsedOverridesRef.current.has(
+                directory.key,
+              )
+            ) {
+              remoteDirectoryThreadsCollapsedOverridesRef.current.set(
+                directory.key,
+                directory.directoryThreadsCollapsed === true,
+              );
+            }
+          }
+        }
+        const response = federationTarget
+          && isRemoteFederationTarget(federationTarget)
+          ? applyDirectoryThreadsCollapsedOverrides(
+              filteredResponse,
+              remoteDirectoryThreadsCollapsedOverridesRef.current,
+            )
+          : filteredResponse;
         const optimisticSelection = preferredOptimisticThread ?? optimisticThreadRef.current;
         const optimisticThreadKey = optimisticSelection
           ? buildThreadIdentityKey(optimisticSelection.source, optimisticSelection.id)
@@ -3980,13 +4030,17 @@ export function useThreadNavigation(
           directoryKey: string;
           collapsed: boolean;
         };
+        const viewerCollapsed = windowTarget
+          && isRemoteFederationTarget(windowTarget)
+          ? remoteDirectoryThreadsCollapsedOverridesRef.current.get(directoryKey)
+          : undefined;
         setState((current) => ({
           ...current,
           response: updateDirectoryThreadsCollapsedInSnapshot(
             current.response,
             {
               directoryKey,
-              collapsed,
+              collapsed: viewerCollapsed ?? collapsed,
             },
           ),
         }));
@@ -6395,6 +6449,14 @@ export function useThreadNavigation(
         return;
       }
 
+      const federationTarget = readRendererFederationTarget();
+      if (federationTarget && isRemoteFederationTarget(federationTarget)) {
+        remoteDirectoryThreadsCollapsedOverridesRef.current.set(
+          directory.key,
+          collapsed,
+        );
+      }
+
       setState((current) => ({
         ...current,
         response: updateDirectoryThreadsCollapsedInSnapshot(
@@ -6410,6 +6472,7 @@ export function useThreadNavigation(
         const result = await setDirectoryThreadsCollapsedRequest({
           directoryKey: directory.key,
           collapsed,
+          ...(federationTarget ? { federationTarget } : {}),
         });
         setState((current) => ({
           ...current,
@@ -6422,6 +6485,11 @@ export function useThreadNavigation(
           ),
         }));
       } catch {
+        if (federationTarget && isRemoteFederationTarget(federationTarget)) {
+          remoteDirectoryThreadsCollapsedOverridesRef.current.delete(
+            directory.key,
+          );
+        }
         await refresh();
       }
     },

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1315,6 +1315,11 @@ export type ReorderDirectoryPinsResponse = {
 export type SetDirectoryThreadsCollapsedRequest = {
   directoryKey: string;
   collapsed: boolean;
+  /**
+   * Remote-viewer disclosures are viewer-owned display state. The target
+   * namespaces the local preference; it is never routed to the owner.
+   */
+  federationTarget?: FederationTarget;
 };
 
 export type SetDirectoryThreadsCollapsedResponse = {


### PR DESCRIPTION
## What changed

- Added a regression test covering a remote viewer collapse surviving both an owner-side live event and a subsequent navigation refresh.
- Persisted remote Directory Threads disclosure preferences in viewer-owned SQLite state, scoped by federation instance and directory.
- Overlaid viewer preferences onto live and disconnected remote snapshots.
- Kept an in-window disclosure baseline so owner events and in-flight refreshes cannot overwrite the viewer's choice.

## Root cause

The renderer optimistically collapsed the section, but omitted the remote target from the write. The preference therefore landed in the viewer's unscoped local directory overlay, while later snapshots and live events continued applying the owning Mac's disclosure state.

## Impact

Collapsing or expanding Directory Threads in a remote viewer is now independent from the owning instance, from the viewer's same-path local directory, and from other remote peers. The choice persists across refreshes and app restarts.

## Validation

- 235 affected renderer/main/migration tests
- 38 state DB and directory-overlay tests
- workspace and desktop typechecks
- ESLint (0 errors; existing warning baseline only)
- SQL template lint
- dependency boundary lint
