### PR TITLE
fix(desktop): adopt ACP branch changes after turns

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2120,6 +2120,7 @@ function createKimiAcpRegistry(options?: {
   startPrompt?: KimiStartPrompt;
   overlayStore?: ReturnType<typeof createOverlayStoreMock>;
   codexClient?: MockBackendClient;
+  grokClient?: MockBackendClient;
   codexEnvironmentCommandRunner?: CodexEnvironmentCommandRunner;
   gitDirectoryService?: unknown;
   gitWorkspaceHandoffService?: unknown;
@@ -2197,7 +2198,7 @@ function createKimiAcpRegistry(options?: {
   };
   const registry = new DesktopBackendRegistry({
     codexClient: options?.codexClient ?? new MockBackendClient({ threads: [] }),
-    grokClient: new MockBackendClient({ threads: [] }),
+    grokClient: options?.grokClient ?? new MockBackendClient({ threads: [] }),
     overlayStore: options?.overlayStore ?? createOverlayStoreMock(),
     acpAgentStore: createAcpAgentStoreMock([
       options?.installedAgent
@@ -38183,6 +38184,130 @@ script = "printf setup"
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   });
+
+  it.each(["terminal", "idle"] as const)(
+    "adopts a named branch change from an ACP turn at the %s boundary",
+    async (boundary) => {
+      const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-acp-turn-branch-"));
+      const repo = path.join(root, "app");
+      await mkdir(repo, { recursive: true });
+      await git(repo, ["init", "-b", "feature/old"]);
+      await git(repo, [
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=Test User",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "init",
+      ]);
+
+      const acpBackendId = "acp:kimi" as AcpBackendId;
+      const overlayStore = createOverlayStoreMock({
+        overlays: {
+          "acp:kimi:thread-branch": {
+            backend: acpBackendId,
+            threadId: "thread-branch",
+            executionMode: "default",
+            gitBranch: "feature/old",
+            observedGitBranch: "feature/old",
+            extraLinkedDirectories: [],
+          },
+        },
+      });
+      const grokClient = new MockBackendClient({ threads: [] });
+      const { registry } = createKimiAcpRegistry({
+        acpBackendId,
+        sessionId: "thread-branch",
+        sessions: [
+          {
+            backendId: acpBackendId,
+            sessionId: "thread-branch",
+            title: "Active ACP branch turn",
+            cwd: repo,
+            createdAt: 1_000,
+            updatedAt: 2_000,
+            executionMode: "default",
+            status: "idle",
+          },
+        ],
+        grokClient,
+        overlayStore,
+      });
+      const eventMethods: string[] = [];
+      const unsubscribe = registry.onEvent((event) => {
+        eventMethods.push(event.notification.method);
+      });
+
+      try {
+        await registry.publishLocalEvent({
+          backend: acpBackendId,
+          notification: {
+            method: "turn/started",
+            params: {
+              threadId: "thread-branch",
+              turnId: "pending:started-turn",
+              turn: {
+                id: "pending:started-turn",
+                status: "in_progress",
+              },
+            },
+          },
+        });
+        await git(repo, ["switch", "-c", "fix/acp-branch-adoption"]);
+
+        if (boundary === "terminal") {
+          await registry.publishLocalEvent({
+            backend: acpBackendId,
+            notification: {
+              method: "turn/completed",
+              params: {
+                threadId: "thread-branch",
+                turnId: "pending:terminal-turn",
+                turn: {
+                  id: "pending:terminal-turn",
+                  status: "completed",
+                  output: [],
+                },
+              },
+            },
+          });
+        } else {
+          await registry.publishLocalEvent({
+            backend: acpBackendId,
+            notification: {
+              method: "thread/status/changed",
+              params: {
+                threadId: "thread-branch",
+                status: { type: "idle" },
+              },
+            },
+          });
+        }
+
+        await expect(
+          overlayStore.getThreadOverlayState({
+            backend: acpBackendId,
+            threadId: "thread-branch",
+          }),
+        ).resolves.toMatchObject({
+          gitBranch: "fix/acp-branch-adoption",
+          observedGitBranch: "fix/acp-branch-adoption",
+        });
+        expect(eventMethods).toEqual([
+          "turn/started",
+          "thread/branch/updated",
+          boundary === "terminal" ? "turn/completed" : "thread/status/changed",
+        ]);
+        expect(grokClient.lastUpdateThreadMetadataParams).toBeUndefined();
+      } finally {
+        unsubscribe();
+        await registry.close();
+        await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      }
+    },
+  );
 
   it("notifies listeners when the renderer adopts a new expected branch", async () => {
     const overlayStore = createOverlayStoreMock();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -21185,7 +21185,7 @@ export class DesktopBackendRegistry {
         await this.withCodexThreadClient(params.threadId, async (client) => {
           await updateWithClient(client);
         });
-      } else {
+      } else if (params.backend === "grok") {
         await updateWithClient(this.grokClient);
       }
     } catch (error) {
@@ -27715,10 +27715,23 @@ export class DesktopBackendRegistry {
           record: managedReview,
         });
       }
+      const genericActiveTurnKeyPrefix =
+        `${event.backend}:${notification.params.threadId}:`;
+      const hadGenericActiveTurn = Array.from(this.activeTurnKeys).some((key) =>
+        key.startsWith(genericActiveTurnKeyPrefix),
+      );
       if (turnId) {
-        this.activeTurnKeys.delete(
-          buildActiveTurnKey(event.backend, notification.params.threadId, turnId),
-        );
+        if (isAcpBackendId(event.backend)) {
+          for (const key of Array.from(this.activeTurnKeys)) {
+            if (key.startsWith(genericActiveTurnKeyPrefix)) {
+              this.activeTurnKeys.delete(key);
+            }
+          }
+        } else {
+          this.activeTurnKeys.delete(
+            buildActiveTurnKey(event.backend, notification.params.threadId, turnId),
+          );
+        }
         const steerKeyPrefix = buildSteerTurnKeyPrefix({
           backend: event.backend,
           threadId: notification.params.threadId,
@@ -27729,6 +27742,12 @@ export class DesktopBackendRegistry {
             this.acceptedSteerRequests.delete(key);
           }
         }
+      }
+      if (isAcpBackendId(event.backend) && hadGenericActiveTurn) {
+        await this.adoptThreadBranchChangeFromActiveTurn({
+          backend: event.backend,
+          threadId: notification.params.threadId,
+        });
       }
       if (event.backend === "codex" && turnId) {
         const activeTurnModeKey = buildActiveTurnModeKey(
@@ -27884,6 +27903,7 @@ export class DesktopBackendRegistry {
         this.threadHasActiveCodexReviewTurn(threadId);
       const endedTurnIds = new Set<string>();
       const genericKeyPrefix = `${event.backend}:${event.notification.params.threadId}:`;
+      let hadGenericActiveTurn = false;
       for (const key of Array.from(this.activeTurnKeys)) {
         if (key.startsWith(genericKeyPrefix)) {
           const parsed = parseActiveTurnKey(key);
@@ -27896,6 +27916,7 @@ export class DesktopBackendRegistry {
           ) {
             continue;
           }
+          hadGenericActiveTurn = true;
           if (parsed?.turnId && !parsed.turnId.startsWith("pending:")) {
             endedTurnIds.add(parsed.turnId);
           }
@@ -27904,6 +27925,12 @@ export class DesktopBackendRegistry {
       }
       if (event.backend !== "codex") {
         if (isAcpBackendId(event.backend)) {
+          if (hadGenericActiveTurn) {
+            await this.adoptThreadBranchChangeFromActiveTurn({
+              backend: event.backend,
+              threadId: event.notification.params.threadId,
+            });
+          }
           if (this.usesSlashControlledAcpExecutionModes(event.backend)) {
             await this.flushQueuedExecutionModeIfPresent(
               event.notification.params.threadId,


### PR DESCRIPTION
## What changed

- adopt named Git branch changes for ACP threads at both terminal-turn and idle-status boundaries
- use generic active-turn tracking for ACP, including stable `pending:` turn IDs and start/terminal ID drift
- clear drifted ACP active-turn keys at terminal events
- stop routing ACP branch metadata updates through the legacy AgentCore/Grok client
- add regression coverage for both ACP boundary shapes and preserve the existing Codex path

## Why

Branch adoption was gated to Codex's exact, non-pending turn-mode tracking. ACP turn IDs remain `pending:`-prefixed and may change between `turn/started` and the terminal notification, so detached worktrees switched to a named branch during an ACP turn were left at `HEAD`. The generic active-turn set already tracks every backend and is the correct signal for ACP.

This is the behavioral prerequisite for a stacked follow-up that removes the legacy in-repo AgentCore/Grok backend entirely.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` (476 passed)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`

No headed E2E was run on the host.
