### PR TITLE
fix(desktop): handle multiline PwrSnap MCP errors

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -8174,11 +8174,11 @@ script = "echo setup"
     await registry.close();
   });
 
-  it("explains rejected PwrSnap MCP transports without implying PwrSnap was down", async () => {
+  it("explains Codex's rejected PwrSnap MCP transport without implying PwrSnap was down", async () => {
     const codexClient = new MockBackendClient({ threads: [] });
     vi.spyOn(codexClient, "startThread").mockRejectedValueOnce(
       new Error(
-        "json-rpc error (-32600): failed to load configuration: invalid transport in mcp_servers.pwragent_pwrsnap",
+        "json-rpc error (-32600): failed to load configuration: invalid transport\nin `mcp_servers.pwragent_pwrsnap`",
       ),
     );
     const registry = new DesktopBackendRegistry({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5855,7 +5855,7 @@ function userActionablePwrSnapMcpConfigError(
   if (
     !registrations.some(({ server }) => server.name === PWRSNAP_MCP_CONNECTION_ID)
     || !(error instanceof Error)
-    || !error.message.includes("invalid transport in mcp_servers.")
+    || !/invalid transport\s+in\s+`?mcp_servers\./.test(error.message)
   ) {
     return error;
   }


### PR DESCRIPTION
## What changed

Recognizes Codex's newline/backtick-formatted `invalid transport` error when a PwrSnap MCP connection is selected, preserving PwrAgent's actionable message that PwrSnap was not contacted.

## Why

Codex CLI 0.146 reports this configuration failure as `invalid transport\nin \`mcp_servers…\``. The prior matcher accepted only the one-line spelling, so the error escaped unannotated.

## Impact

The P1 transportless-alias fix remains intact, and any residual transport validation failure now explains the local configuration cause instead of suggesting PwrSnap was unavailable.

## Validation

- Disposable Codex-home app-server probe: an inherited `pwrsnap` HTTP MCP server plus PwrAgent's disabled alias and stdio bridge is accepted.
- Disposable Codex-home negative probe: confirmed the actual multiline invalid-transport error shape.
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm typecheck`
- `pnpm --filter @pwragent/desktop build`
- `pnpm lint:eslint` (passes with existing warning baseline)
