### PR TITLE
fix(tests): fail fast when the desktop E2E onboarding seed does not take

### DIFF
--- a/apps/desktop/e2e/canary-report.ts
+++ b/apps/desktop/e2e/canary-report.ts
@@ -5,34 +5,60 @@ export function describeCanaryFailure(params: {
   timeoutMs: number;
   runnerName?: string;
   detail: string;
+  /**
+   * Whether the canary gave up waiting, as opposed to the harness
+   * rejecting with a diagnosis of its own.
+   *
+   * The distinction decides which story gets told, and telling the wrong
+   * one is expensive. A hang means a sick guest, and the right response
+   * is to recycle it. A rejection means the harness already knows what
+   * is wrong — a missing onboarding seed, say — and recycling the guest
+   * would be a wasted trip that fixes nothing. Defaults to `true` to
+   * preserve the original behavior for callers that don't distinguish.
+   */
+  timedOut?: boolean;
 }): string {
-  return [
-    `Desktop E2E pre-flight failed after ${params.timeoutMs}ms, before any test ran.`,
-    "",
-    "The canary launches one app through the SAME harness every spec uses, so",
-    "if it cannot get a usable window here, no spec can. The suite is failing",
-    "fast on purpose rather than spending the job's whole time budget timing",
-    "out one test at a time — which reads like a regression in whichever spec",
-    "happens to sort first (currently a11y.spec.ts, which is innocent).",
-    "",
-    "Known shape of this on CI (2026-08-07, traced): Electron LAUNCHES and is",
-    "controllable — the trace records `Launch electron` completing — and then",
-    "`Wait for event \"window\"` never returns. The process layer is healthy and",
-    "the window layer is not. Every spec then dies on its own 30s timeout with",
-    "no teardown line, because no app object is ever handed back.",
-    "",
-    "This is a property of the machine, not of the branch. The same commit has",
-    "passed on a healthy runner and failed on an affected one within the same",
-    "hour. Before treating it as a code regression, check whether other recent",
-    "runs failed the same way on this same runner.",
-    "",
-    params.runnerName
-      ? `  Runner: ${params.runnerName}`
-      : "  Runner: (RUNNER_NAME unset — likely a local run)",
-    "",
-    "A persistent runner in this state does not recover on its own; it needs",
-    "an operator to recycle the guest.",
-    "",
-    `Underlying error: ${params.detail}`,
-  ].join("\n");
+  const timedOut = params.timedOut ?? true;
+  const preamble = timedOut
+    ? [
+      `Desktop E2E pre-flight timed out after ${params.timeoutMs}ms, before any test ran.`,
+      "",
+      "The canary launches one app through the SAME harness every spec uses, so",
+      "if it cannot get a usable window here, no spec can. The suite is failing",
+      "fast on purpose rather than spending the job's whole time budget timing",
+      "out one test at a time — which reads like a regression in whichever spec",
+      "happens to sort first (currently a11y.spec.ts, which is innocent).",
+      "",
+      "Known shape of this on CI (2026-08-07, traced): Electron LAUNCHES and is",
+      "controllable — the trace records `Launch electron` completing — and then",
+      "`Wait for event \"window\"` never returns. The process layer is healthy and",
+      "the window layer is not. Every spec then dies on its own 30s timeout with",
+      "no teardown line, because no app object is ever handed back.",
+      "",
+      "This is a property of the machine, not of the branch. The same commit has",
+      "passed on a healthy runner and failed on an affected one within the same",
+      "hour. Before treating it as a code regression, check whether other recent",
+      "runs failed the same way on this same runner.",
+      "",
+      params.runnerName
+        ? `  Runner: ${params.runnerName}`
+        : "  Runner: (RUNNER_NAME unset — likely a local run)",
+      "",
+      "A persistent runner in this state does not recover on its own; it needs",
+      "an operator to recycle the guest.",
+    ]
+    : [
+      "Desktop E2E pre-flight failed before any test ran.",
+      "",
+      "The canary launches one app through the SAME harness every spec uses, so",
+      "this would have failed every spec in turn. The harness rejected with a",
+      "specific diagnosis rather than hanging, so read the error below — it is",
+      "the actual problem, and it is NOT the guest needing to be recycled.",
+      "",
+      params.runnerName
+        ? `  Runner: ${params.runnerName}`
+        : "  Runner: (RUNNER_NAME unset — likely a local run)",
+    ];
+
+  return [...preamble, "", `Underlying error: ${params.detail}`].join("\n");
 }

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -10,6 +10,7 @@ import type {
 } from "@pwragent/shared";
 import { _electron as electron, expect, type ElectronApplication, type Page } from "@playwright/test";
 import {
+  assertUnreachableProfileBootDecision,
   bootstrapProfileExists,
   PWRAGENT_HOME_ENV,
   PWRAGENT_PROFILE_AUTO_CREATE_ENV,
@@ -44,13 +45,15 @@ const ELECTRON_EVALUATE_QUIT_TIMEOUT_MS = 1_000;
 const ELECTRON_CLOSE_TIMEOUT_MS = 1_000;
 const ELECTRON_FORCE_EXIT_TIMEOUT_MS = 1_000;
 /**
- * Hard ceiling on everything `close()` does. Playwright's own worker
- * teardown timeout is 30s and is NOT per-test — when it fires, the
- * reported error is `Worker teardown timeout of 30000ms exceeded` with
- * no hint of which app wedged, and the worker is recycled, so the next
- * spec pays a fresh Electron boot too. Bounding teardown here means a
- * single stuck app costs one warning line instead of cascading into
- * every subsequent test in the run.
+ * Hard ceiling on everything `close()` does.
+ *
+ * Specs call `close()` from their own `try`/`finally`, so it spends the
+ * test's budget, not a fixture's: an unbounded stall shows up as the
+ * test timing out at 30s, which replaces whatever the test actually
+ * found with a timeout that names nothing. (Playwright's separate 30s
+ * *worker* teardown timeout is what collects an Electron process no one
+ * closed at all — see the catch in `launchElectronApp`.) 15s leaves room
+ * for a slow force-kill plus `rm` while still failing inside one test.
  */
 const ELECTRON_TEARDOWN_TIMEOUT_MS = 15_000;
 
@@ -146,6 +149,13 @@ type LaunchElectronAppParams = {
    * `<homeRoot>/.pwragent/profiles/default/config.toml` or any other
    * on-disk state the app reads at startup. Everything underneath
    * `<homeRoot>/` is cleaned up on `close()`.
+   *
+   * `default` is right for every caller today, but it is hardcoded here
+   * while the onboarding seed resolves its profile from the launch env
+   * (see `resolveSeedConfigPath`). A spec that also passed
+   * `env.PWRAGENT_PROFILE` would have its hook and the seed writing to
+   * two different profiles — resolve the name the same way if you ever
+   * need that combination.
    */
   preLaunchHook?: (homeRoot: string) => void | Promise<void>;
   /**
@@ -179,13 +189,18 @@ type LaunchElectronAppParams = {
    */
   secretStorage?: "disabled" | "memory";
   /**
-   * Whether to seed `onboarding.completed = true` into the
-   * `default` profile's config.toml before launch. Defaults to
-   * `true` so the wizard doesn't intercept clicks in most specs.
+   * Whether to seed `onboarding.completed = true` into the config.toml
+   * of the profile this launch will actually open — resolved from the
+   * launch environment by `resolveSeedConfigPath`, not assumed to be
+   * `default`. Defaults to `true` so the wizard doesn't intercept
+   * clicks in most specs, and the seed is verified before launch (see
+   * `assertOnboardingSeedTook`).
+   *
    * Wizard specs pass `false` to let the wizard fire — combined
    * with NOT pre-creating any profile dir (skip the appearance
    * seed and any preLaunchHook profile-creation), this lets the
-   * boot decision return `no-profile-configured`.
+   * boot decision return `no-profile-configured`. Passing `false`
+   * also disables every onboarding assertion, pre- and post-launch.
    */
   suppressOnboarding?: boolean;
   /**
@@ -411,20 +426,22 @@ async function finishElectronLaunch(args: {
       // Bound the whole teardown. `closeElectronApplication` is already
       // internally bounded, but the profile-process sweep and the `rm`
       // both touch the filesystem, and on a degraded shared runner either
-      // can stall. Anything that outlives the budget here would otherwise
-      // be collected by Playwright's 30s worker teardown timeout, which
-      // reports as `Worker teardown timeout of 30000ms exceeded` against
-      // the test — hiding the test's real result and recycling the worker.
-      // A warning line keeps the actual failure legible.
-      try {
-        await withTimeout(
-          teardown(),
-          ELECTRON_TEARDOWN_TIMEOUT_MS,
-          `[pwragent-e2e-teardown] teardown exceeded ${ELECTRON_TEARDOWN_TIMEOUT_MS}ms for homeRoot=${homeRoot}`,
-        );
-      } catch (error) {
+      // can stall. Specs call this from their own `finally`, so an
+      // unbounded stall burns the rest of the 30s test budget and reports
+      // as the test timing out — which buries whatever the test actually
+      // found. Warning and moving on keeps that result legible.
+      //
+      // ONLY the timeout is swallowed. A teardown that *fails* — an `rm`
+      // hitting ENOTEMPTY because a spawned profile survived the sweep,
+      // say — still rejects, because that is a real leak and a warning is
+      // not enough to get it noticed.
+      const running = teardown();
+      if (await raceTeardownTimeout(running, ELECTRON_TEARDOWN_TIMEOUT_MS)) {
+        // Still in flight, and now unobserved: keep a late rejection from
+        // surfacing as an unhandled promise rejection mid-suite.
+        running.catch(() => undefined);
         console.warn(
-          error instanceof Error ? error.message : String(error),
+          `[pwragent-e2e-teardown] teardown exceeded ${ELECTRON_TEARDOWN_TIMEOUT_MS}ms for homeRoot=${homeRoot}`,
         );
       }
     },
@@ -461,9 +478,27 @@ async function finishElectronLaunch(args: {
  * `default`. A hardcoded path silently seeds the wrong directory the
  * moment a spec (or the ambient environment) moves either one, and the
  * only symptom is the first-run wizard taking over every surface.
+ *
+ * Following the resolvers means inheriting their production fallback:
+ * with no `PWRAGENT_HOME` and no `HOME`, `resolvePwragentRoot` lands on
+ * `os.homedir()` — the operator's REAL `~/.pwragent`, which the seed
+ * would then rewrite. Right for the app, catastrophic for a test
+ * fixture, so an absent `HOME` is refused rather than resolved.
  */
 export function resolveSeedConfigPath(env: Record<string, string>): string {
-  const resolverOptions = { argv: [], env, homeDir: env.HOME } as const;
+  const homeDir = env.HOME;
+  if (!homeDir) {
+    throw new Error(
+      [
+        "PwrAgent E2E launch environment has no HOME.",
+        "  The profile resolvers would fall back to os.homedir(), so the",
+        "  onboarding seed would be written into the operator's real",
+        "  ~/.pwragent profile. Pass `homeRoot`, or an explicit `env.HOME`,",
+        "  rather than deleting HOME from the launch environment.",
+      ].join("\n"),
+    );
+  }
+  const resolverOptions = { argv: [], env, homeDir } as const;
   const profileName = resolveActiveProfileName(resolverOptions);
   return path.join(
     resolveProfileDir(profileName, resolverOptions),
@@ -565,7 +600,7 @@ export function assertOnboardingSeedTook(params: {
  *    resolve before the renderer has mounted the overlay — which is why
  *    it is not the thing being relied on.
  */
-async function waitForRendererReady(params: {
+export async function waitForRendererReady(params: {
   electronApp: ElectronApplication;
   env: Record<string, string>;
   requiresReplayDriver: boolean;
@@ -687,8 +722,12 @@ function describeBootDecision(decision: ProfileBootDecision): string {
       return `missing-named-profile (${decision.requestedName} via ${decision.source})`;
     case "missing-default-profile":
       return `missing-default-profile (${decision.configuredName})`;
+    case "no-profile-configured":
+      return "no-profile-configured (fresh PWRAGENT_HOME, nothing to open)";
     default:
-      return decision.kind;
+      // A new `ProfileBootDecision` variant should be a compile error
+      // here, not a decision this harness silently describes by name.
+      assertUnreachableProfileBootDecision(decision);
   }
 }
 
@@ -866,6 +905,34 @@ export async function closeElectronApplication(
   await killProcessTree(child);
   await waitForProcessExit(child, ELECTRON_FORCE_EXIT_TIMEOUT_MS);
   await waitForClose(closePromise, ELECTRON_FORCE_EXIT_TIMEOUT_MS);
+}
+
+/**
+ * Resolve `true` when `running` is still pending after `timeoutMs`.
+ *
+ * Deliberately not `withTimeout`: that collapses "timed out" and "the
+ * work rejected" into one rejection, and teardown needs to tell them
+ * apart — one is a degraded runner to warn about, the other is a real
+ * cleanup failure that must fail the test. A rejection before the
+ * deadline propagates to the caller here.
+ */
+export async function raceTeardownTimeout(
+  running: Promise<void>,
+  timeoutMs: number,
+): Promise<boolean> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race<boolean>([
+      running.then(() => false),
+      new Promise<true>((resolve) => {
+        timeout = setTimeout(() => resolve(true), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
 }
 
 export async function withTimeout<T>(

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -9,7 +9,20 @@ import type {
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import { _electron as electron, expect, type ElectronApplication, type Page } from "@playwright/test";
-import { applyDesktopSettingsPatch } from "../../src/main/settings/desktop-config";
+import {
+  bootstrapProfileExists,
+  PWRAGENT_HOME_ENV,
+  PWRAGENT_PROFILE_AUTO_CREATE_ENV,
+  PWRAGENT_PROFILE_ENV,
+  resolveActiveProfileName,
+  resolveProfileBootDecision,
+  resolveProfileDir,
+  type ProfileBootDecision,
+} from "../../src/main/profile";
+import {
+  applyDesktopSettingsPatch,
+  readDesktopSettingsConfig,
+} from "../../src/main/settings/desktop-config";
 import {
   E2E_MEMORY_SECRET_STORAGE_ENV,
   SECRET_STORAGE_DISABLED_ENV,
@@ -30,6 +43,48 @@ export const DESKTOP_MAIN_ENTRY = path.resolve(
 const ELECTRON_EVALUATE_QUIT_TIMEOUT_MS = 1_000;
 const ELECTRON_CLOSE_TIMEOUT_MS = 1_000;
 const ELECTRON_FORCE_EXIT_TIMEOUT_MS = 1_000;
+/**
+ * Hard ceiling on everything `close()` does. Playwright's own worker
+ * teardown timeout is 30s and is NOT per-test — when it fires, the
+ * reported error is `Worker teardown timeout of 30000ms exceeded` with
+ * no hint of which app wedged, and the worker is recycled, so the next
+ * spec pays a fresh Electron boot too. Bounding teardown here means a
+ * single stuck app costs one warning line instead of cascading into
+ * every subsequent test in the run.
+ */
+const ELECTRON_TEARDOWN_TIMEOUT_MS = 15_000;
+
+/**
+ * Root element of the first-run wizard overlay (`OnboardingWizard.tsx`).
+ * It is also `role="dialog"` / `aria-label="First-run setup"`, but the
+ * class is the element the component itself roots on and does not move
+ * when the accessible name is reworded.
+ */
+const ONBOARDING_WIZARD_SELECTOR = ".onboarding-wizard-overlay";
+
+/**
+ * Upper bound on how long the wizard watcher stays armed. It only has to
+ * outlive a slow boot; expiring means the wizard never appeared, so the
+ * watcher goes quiet rather than failing.
+ */
+const ONBOARDING_WIZARD_WATCH_TIMEOUT_MS = 120_000;
+
+/**
+ * Env vars that redirect which PwrAgent root and profile the launched
+ * app opens into. The harness inherits the full ambient environment
+ * (below), so any of these left exported in the runner's shell — the
+ * `pwragent-dev-profile` skill exports `PWRAGENT_PROFILE`, for one —
+ * would silently point Electron at a different profile than the one the
+ * harness seeds `onboarding.completed = true` into. The wizard then
+ * fires over every spec. Strip them from the inherited copy BEFORE
+ * per-spec `params.env` is applied, so a spec that deliberately sets one
+ * (see `onboarding-wizard.spec.ts`) still gets it.
+ */
+const PROFILE_RESOLUTION_ENV_VARS = [
+  PWRAGENT_HOME_ENV,
+  PWRAGENT_PROFILE_ENV,
+  PWRAGENT_PROFILE_AUTO_CREATE_ENV,
+] as const;
 
 type ElectronChildProcess = ReturnType<ElectronApplication["process"]>;
 type CloseResult = "closed" | "rejected" | "timeout";
@@ -151,49 +206,19 @@ export async function launchElectronApp(
   if (params.preLaunchHook) {
     await params.preLaunchHook(homeRoot);
   }
-  // Seed `[general.appearance]` AFTER the preLaunchHook so hooks that
-  // write the whole config.toml don't clobber the appearance keys. The
-  // patch path edits the file in place, preserving anything the hook
-  // wrote, and creates the file if the hook didn't write one. Defaults
-  // to dark so color-assertion tests don't pick up the runner's OS
-  // theme through `theme: "system"`.
-  //
-  // The seed target follows whatever HOME the launched Electron process
-  // will actually use: tests may pass `env.HOME = <their own tmp>` to
-  // override the helper's `homeRoot`, in which case the appearance has
-  // to land in THEIR tmp dir, not the helper's. If both are unset, fall
-  // back to the helper's `homeRoot`.
-  const seedHomeRoot = params.env?.HOME ?? homeRoot;
-  const suppressOnboarding = params.suppressOnboarding ?? true;
-  if (suppressOnboarding) {
-    applyDesktopSettingsPatch(
-      path.join(seedHomeRoot, ".pwragent/profiles/default/config.toml"),
-      {
-        general: {
-          confirmQuitWithInProgressThreads: false,
-          appearance: {
-            theme: params.appearance?.theme ?? "dark",
-            density: params.appearance?.density ?? "mission-control",
-          },
-        },
-        // Suppress the first-run onboarding wizard for every replay-backed
-        // test. The wizard's modal scrim auto-fires on profiles with
-        // `onboarding.completed === false` (see App.tsx), and the per-test
-        // home root is always fresh, so without this seed the wizard would
-        // intercept clicks in every spec. Wizard specs explicitly pass
-        // `suppressOnboarding: false` to let the wizard fire.
-        onboarding: { completed: true },
-        ...(params.contextRailPinned !== undefined
-          ? { ui: { contextRailPinned: params.contextRailPinned } }
-          : {}),
-      },
-    );
-  }
+  // Build the launch environment BEFORE seeding config.toml. The seed
+  // has to land in the profile directory the launched process will
+  // actually open, and that is a function of the final environment
+  // (`PWRAGENT_HOME`, `PWRAGENT_PROFILE`, `HOME`), not of `homeRoot`
+  // alone — see `resolveSeedConfigPath` below.
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (value !== undefined) {
       env[key] = value;
     }
+  }
+  for (const key of PROFILE_RESOLUTION_ENV_VARS) {
+    delete env[key];
   }
   Object.assign(env, {
     HOME: homeRoot,
@@ -221,6 +246,40 @@ export async function launchElectronApp(
   // openDesktopPwrAgentProfile(), covering both Electron processes.
   configureElectronE2eSecretStorageEnv(env, params.secretStorage);
 
+  // Seed `[general.appearance]` AFTER the preLaunchHook so hooks that
+  // write the whole config.toml don't clobber the appearance keys. The
+  // patch path edits the file in place, preserving anything the hook
+  // wrote, and creates the file if the hook didn't write one. Defaults
+  // to dark so color-assertion tests don't pick up the runner's OS
+  // theme through `theme: "system"`.
+  const seedConfigPath = resolveSeedConfigPath(env);
+  const suppressOnboarding = params.suppressOnboarding ?? true;
+  if (suppressOnboarding) {
+    applyDesktopSettingsPatch(seedConfigPath, {
+      general: {
+        confirmQuitWithInProgressThreads: false,
+        appearance: {
+          theme: params.appearance?.theme ?? "dark",
+          density: params.appearance?.density ?? "mission-control",
+        },
+      },
+      // Suppress the first-run onboarding wizard for every replay-backed
+      // test. The wizard's modal scrim auto-fires on profiles with
+      // `onboarding.completed === false` (see App.tsx), and the per-test
+      // home root is always fresh, so without this seed the wizard would
+      // intercept clicks in every spec. Wizard specs explicitly pass
+      // `suppressOnboarding: false` to let the wizard fire.
+      onboarding: { completed: true },
+      ...(params.contextRailPinned !== undefined
+        ? { ui: { contextRailPinned: params.contextRailPinned } }
+        : {}),
+    });
+    // Prove the seed took before paying for an Electron boot. Both
+    // checks reuse the production resolvers/parser, so they cannot
+    // drift from what the launched process does with the same env.
+    assertOnboardingSeedTook({ env, seedConfigPath });
+  }
+
   const electronApp = await electron.launch({
     args: [
       DESKTOP_MAIN_ENTRY,
@@ -247,100 +306,61 @@ export async function launchElectronApp(
   // the observed one: it never returns when the window layer is wedged. The
   // launched process is ours the moment `electron.launch()` resolves, so a
   // failure past this point has to close it rather than leave an orphan for
-  // the next job on a persistent runner to inherit.
+  // the next job on a persistent runner to inherit. That now includes the
+  // onboarding-wizard check inside `finishElectronLaunch`, which throws by
+  // design.
   try {
-    return await finishElectronLaunch({ electronApp, homeRoot, params });
+    return await finishElectronLaunch({
+      electronApp,
+      env,
+      homeRoot,
+      params,
+      seedConfigPath,
+      suppressOnboarding,
+    });
   } catch (error) {
     await closeElectronApplication(electronApp).catch(() => undefined);
+    await killSpawnedProfileProcessesUnder(homeRoot).catch(() => undefined);
+    // Deliberately NOT removing `homeRoot`: on a launch failure the
+    // seeded config.toml and whatever profile state exists are the
+    // evidence, and the dir sits under the OS tmpdir either way.
     throw error;
   }
 }
 
 async function finishElectronLaunch(args: {
   electronApp: ElectronApplication;
+  env: Record<string, string>;
   homeRoot: string;
   params: LaunchElectronAppParams;
+  seedConfigPath: string;
+  suppressOnboarding: boolean;
 }): Promise<LaunchResult> {
-  const { electronApp, homeRoot, params } = args;
+  const {
+    electronApp,
+    env,
+    homeRoot,
+    params,
+    seedConfigPath,
+    suppressOnboarding,
+  } = args;
   const window = await electronApp.firstWindow();
 
-  const requiresReplayDriver = params.requiresReplayDriver ?? true;
-  if (requiresReplayDriver) {
-    await expect
-      .poll(async () =>
-        await electronApp.evaluate(() =>
-          Boolean(globalThis.__PWRAGENT_REPLAY_DRIVER__)
-        )
-      )
-      .toBe(true);
-  } else {
-    // Wizard specs: just wait for the renderer to mount. We don't
-    // care about the replay driver — there's no thread to replay.
-    await window.waitForLoadState("domcontentloaded");
-  }
+  await waitForRendererReady({
+    electronApp,
+    env,
+    requiresReplayDriver: params.requiresReplayDriver ?? true,
+    seedConfigPath,
+    suppressOnboarding,
+    window,
+  });
 
   if (params.windowSize) {
-    const targetSize = params.windowSize;
-    const windowId = await electronApp.evaluate(
-      ({ BrowserWindow }, size) => {
-        const window = BrowserWindow.getAllWindows()[0];
-        if (!window) {
-          throw new Error("Expected an Electron BrowserWindow for replay E2E sizing");
-        }
-
-        window.setMinimumSize(0, 0);
-        window.setContentSize(size.width, size.height);
-        return window.id;
-      },
-      targetSize
-    );
-
-    let attempt = 0;
-    let previousRequest: NativeContentSize | null = null;
-    await expect
-      .poll(async () => {
-        const observed = await window.evaluate(() => ({
-          innerHeight: globalThis.innerHeight,
-          innerWidth: globalThis.innerWidth,
-        }));
-        if (
-          observed.innerHeight === targetSize.height
-          && observed.innerWidth === targetSize.width
-        ) {
-          return observed;
-        }
-
-        const request = nextRendererViewportRequest({
-          attempt,
-          observed,
-          previousRequest,
-          target: targetSize,
-        });
-        previousRequest = request;
-        attempt += 1;
-
-        await electronApp.evaluate(
-          ({ BrowserWindow }, resize) => {
-            const window = BrowserWindow.fromId(resize.windowId);
-            if (!window || window.isDestroyed()) {
-              throw new Error(
-                "Expected the replay E2E BrowserWindow to remain live while resizing",
-              );
-            }
-            window.setContentSize(resize.request.width, resize.request.height);
-          },
-          { request, windowId },
-        );
-
-        return await window.evaluate(() => ({
-          innerHeight: globalThis.innerHeight,
-          innerWidth: globalThis.innerWidth,
-        }));
-      })
-      .toMatchObject({
-        innerHeight: targetSize.height,
-        innerWidth: targetSize.width,
-      });
+    await applyRendererViewport({
+      electronApp,
+      target: params.windowSize,
+      window,
+    });
   }
 
   return {
@@ -388,24 +408,356 @@ async function finishElectronLaunch(args: {
       }, requestParams);
     },
     close: async () => {
-      await closeElectronApplication(electronApp);
-      // The wizard's graduation path can spawn a detached child
-      // Electron process for the operator's chosen profile (see
-      // `openPwrAgentProfile` in `ipc/profiles.ts`). That child
-      // outlives the test's bootstrap Electron and keeps writing
-      // to `<homeRoot>/.pwragent/profiles/<name>/` (state.db
-      // heartbeats, Codex plugin clones, etc.). If we rm the
-      // tmpdir while the child is mid-write, rm races and ENOTEMPTYs.
-      //
-      // Find any live PwrAgent instances under this tmpdir via
-      // their runtime-instance heartbeat markers, kill them, then
-      // proceed with cleanup. Each marker file is a JSON blob
-      // containing the process's PID; the marker dir layout matches
-      // `startProfileRuntimeHeartbeat` in `main/profile.ts`.
-      await killSpawnedProfileProcessesUnder(homeRoot);
-      await rm(homeRoot, { recursive: true, force: true });
+      // Bound the whole teardown. `closeElectronApplication` is already
+      // internally bounded, but the profile-process sweep and the `rm`
+      // both touch the filesystem, and on a degraded shared runner either
+      // can stall. Anything that outlives the budget here would otherwise
+      // be collected by Playwright's 30s worker teardown timeout, which
+      // reports as `Worker teardown timeout of 30000ms exceeded` against
+      // the test — hiding the test's real result and recycling the worker.
+      // A warning line keeps the actual failure legible.
+      try {
+        await withTimeout(
+          teardown(),
+          ELECTRON_TEARDOWN_TIMEOUT_MS,
+          `[pwragent-e2e-teardown] teardown exceeded ${ELECTRON_TEARDOWN_TIMEOUT_MS}ms for homeRoot=${homeRoot}`,
+        );
+      } catch (error) {
+        console.warn(
+          error instanceof Error ? error.message : String(error),
+        );
+      }
     },
   };
+
+  async function teardown(): Promise<void> {
+    await closeElectronApplication(electronApp);
+    // The wizard's graduation path can spawn a detached child
+    // Electron process for the operator's chosen profile (see
+    // `openPwrAgentProfile` in `ipc/profiles.ts`). That child
+    // outlives the test's bootstrap Electron and keeps writing
+    // to `<homeRoot>/.pwragent/profiles/<name>/` (state.db
+    // heartbeats, Codex plugin clones, etc.). If we rm the
+    // tmpdir while the child is mid-write, rm races and ENOTEMPTYs.
+    //
+    // Find any live PwrAgent instances under this tmpdir via
+    // their runtime-instance heartbeat markers, kill them, then
+    // proceed with cleanup. Each marker file is a JSON blob
+    // containing the process's PID; the marker dir layout matches
+    // `startProfileRuntimeHeartbeat` in `main/profile.ts`.
+    await killSpawnedProfileProcessesUnder(homeRoot);
+    await rm(homeRoot, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Path of the `config.toml` the launched process will read, resolved
+ * through the SAME production resolvers the app uses at boot rather than
+ * a hand-built `<home>/.pwragent/profiles/default/` string.
+ *
+ * That distinction is the whole point. The app's root is
+ * `PWRAGENT_HOME` when set and `<HOME>/.pwragent` otherwise, and its
+ * profile is `PWRAGENT_PROFILE` → `profiles.toml::default_profile` →
+ * `default`. A hardcoded path silently seeds the wrong directory the
+ * moment a spec (or the ambient environment) moves either one, and the
+ * only symptom is the first-run wizard taking over every surface.
+ */
+export function resolveSeedConfigPath(env: Record<string, string>): string {
+  const resolverOptions = { argv: [], env, homeDir: env.HOME } as const;
+  const profileName = resolveActiveProfileName(resolverOptions);
+  return path.join(
+    resolveProfileDir(profileName, resolverOptions),
+    "config.toml",
+  );
+}
+
+/**
+ * Fail before paying for an Electron boot if the onboarding seed will
+ * not actually suppress the wizard.
+ *
+ * There are exactly two ways the wizard fires, and this covers both:
+ *
+ *  1. The boot decision is not `open` — no profile dir where the app
+ *     looks, or a named/registry profile that doesn't exist. The app
+ *     drops into bootstrap mode and runs the wizard before committing to
+ *     a profile (see `resolveProfileBootDecision`).
+ *  2. The profile opens, but `onboarding.completed` doesn't read back as
+ *     `true`. `App.tsx` auto-opens the wizard on the first snapshot
+ *     where it is `false`. (A malformed `config.toml` does NOT quietly
+ *     fall back to defaults here — `parseDesktopSettingsToml` is strict
+ *     and throws — but that throw says "Invalid TOML" and nothing about
+ *     onboarding, so it gets the same context attached below.)
+ *
+ * Both are checked with production code (`resolveProfileBootDecision`,
+ * `readDesktopSettingsConfig`) so the harness cannot drift from the app.
+ */
+export function assertOnboardingSeedTook(params: {
+  env: Record<string, string>;
+  seedConfigPath: string;
+}): void {
+  const decision = resolveProfileBootDecision({
+    argv: [],
+    env: params.env,
+    homeDir: params.env.HOME,
+  });
+  if (decision.kind !== "open") {
+    throw new Error(
+      [
+        "PwrAgent E2E launch would open the first-run onboarding wizard:",
+        `  boot decision:    ${describeBootDecision(decision)}`,
+        "  The app boots into bootstrap mode and the wizard's modal scrim",
+        "  intercepts every click, so no spec assertion can run.",
+        describeProfileEnvironment(params),
+      ].join("\n"),
+    );
+  }
+
+  let completed: boolean | undefined;
+  try {
+    completed = readDesktopSettingsConfig(params.seedConfigPath)
+      .onboarding?.completed;
+  } catch (error) {
+    throw new Error(
+      [
+        "PwrAgent E2E onboarding seed did not take: the seeded config.toml",
+        `  is unreadable — ${error instanceof Error ? error.message : String(error)}`,
+        describeProfileEnvironment(params),
+      ].join("\n"),
+      { cause: error },
+    );
+  }
+  if (completed !== true) {
+    throw new Error(
+      [
+        "PwrAgent E2E onboarding seed did not take:",
+        `  onboarding.completed read back as ${JSON.stringify(completed)},`,
+        "  expected true. The wizard auto-opens on the first settings",
+        "  snapshot where it is not true, and its scrim intercepts every",
+        "  click, so no spec assertion can run.",
+        describeProfileEnvironment(params),
+      ].join("\n"),
+    );
+  }
+}
+
+/**
+ * Wait for the launched app to be driveable, failing fast and by name if
+ * the first-run wizard takes the window instead.
+ *
+ * The wizard is worth catching by name because of how badly it presents
+ * otherwise. Its overlay is a SIBLING of the app shell, so the sidebar
+ * and its rows stay in the DOM: a spec either fails
+ * `expect(row).toBeVisible()` with a bare "element(s) not found", or
+ * watches a `.click()` retry against the scrim until the 30s Playwright
+ * test timeout. Neither mentions onboarding.
+ *
+ * Two checks, in order of certainty:
+ *
+ *  - `bootstrapProfileExists` is the deterministic one.
+ *    `initializeAppState("bootstrap")` materializes `<root>/.bootstrap/`
+ *    during `app.whenReady()`, before any BrowserWindow exists, so by
+ *    the time `firstWindow()` has resolved the directory is either there
+ *    or the app is not in bootstrap mode. No polling, no race.
+ *  - The overlay racer is a net for a wizard that opens some other way
+ *    (`onboarding.completed` flipping to false under a live profile).
+ *    It can lose — the replay driver installs from the `BackendRegistry`
+ *    constructor, which runs in bootstrap mode too, so readiness can
+ *    resolve before the renderer has mounted the overlay — which is why
+ *    it is not the thing being relied on.
+ */
+async function waitForRendererReady(params: {
+  electronApp: ElectronApplication;
+  env: Record<string, string>;
+  requiresReplayDriver: boolean;
+  seedConfigPath: string;
+  suppressOnboarding: boolean;
+  window: Page;
+}): Promise<void> {
+  if (
+    params.suppressOnboarding
+    && bootstrapProfileExists({
+      env: params.env,
+      homeDir: params.env.HOME,
+    })
+  ) {
+    throw onboardingWizardError({
+      ...params,
+      detail: "the app booted into bootstrap mode (`.bootstrap/` exists)",
+    });
+  }
+
+  const wizardWatch = params.suppressOnboarding
+    ? watchForOnboardingWizard(params.window, params)
+    : undefined;
+  try {
+    const ready = params.requiresReplayDriver
+      ? expect
+        .poll(async () =>
+          await params.electronApp.evaluate(() =>
+            Boolean(globalThis.__PWRAGENT_REPLAY_DRIVER__)
+          )
+        )
+        .toBe(true)
+      // Wizard specs: just wait for the renderer to mount. We don't
+      // care about the replay driver — there's no thread to replay.
+      : params.window.waitForLoadState("domcontentloaded");
+    await Promise.race(wizardWatch ? [ready, wizardWatch.detected] : [ready]);
+    if (wizardWatch) {
+      await wizardWatch.assertAbsent();
+    }
+  } finally {
+    wizardWatch?.disarm();
+  }
+}
+
+function watchForOnboardingWizard(
+  window: Page,
+  context: { env: Record<string, string>; seedConfigPath: string },
+): {
+  detected: Promise<never>;
+  assertAbsent: () => Promise<void>;
+  disarm: () => void;
+} {
+  let disarmed = false;
+  const overlay = window.locator(ONBOARDING_WIZARD_SELECTOR);
+  const never = new Promise<never>(() => undefined);
+  const detected = overlay
+    .waitFor({
+      state: "attached",
+      timeout: ONBOARDING_WIZARD_WATCH_TIMEOUT_MS,
+    })
+    .then(
+      () => (disarmed ? never : Promise.reject(onboardingWizardError(context))),
+      // Timed out, or the page went away because the launch failed for
+      // an unrelated reason. Either way this racer has nothing to say —
+      // never settle, and let the real result win the race.
+      () => never,
+    );
+  detected.catch(() => undefined);
+  return {
+    detected,
+    assertAbsent: async () => {
+      if (await overlay.count() > 0) {
+        throw onboardingWizardError(context);
+      }
+    },
+    disarm: () => {
+      disarmed = true;
+    },
+  };
+}
+
+function onboardingWizardError(context: {
+  detail?: string;
+  env: Record<string, string>;
+  seedConfigPath: string;
+}): Error {
+  return new Error(
+    [
+      "PwrAgent first-run onboarding wizard is showing, but this app was",
+      "launched with suppressOnboarding: true. Its modal scrim intercepts",
+      "every click, so no assertion in this spec can run.",
+      ...(context.detail ? [`Detected because ${context.detail}.`] : []),
+      "",
+      `The \`onboarding.completed = true\` seed at ${context.seedConfigPath}`,
+      "did not take effect for the profile this Electron process opened.",
+      describeProfileEnvironment(context),
+    ].join("\n"),
+  );
+}
+
+function describeProfileEnvironment(context: {
+  env: Record<string, string>;
+  seedConfigPath: string;
+}): string {
+  const show = (key: string): string => context.env[key] ?? "(unset)";
+  return [
+    `  seeded config:    ${context.seedConfigPath}`,
+    `  HOME:             ${show("HOME")}`,
+    `  ${PWRAGENT_HOME_ENV}:    ${show(PWRAGENT_HOME_ENV)}`,
+    `  ${PWRAGENT_PROFILE_ENV}: ${show(PWRAGENT_PROFILE_ENV)}`,
+  ].join("\n");
+}
+
+function describeBootDecision(decision: ProfileBootDecision): string {
+  switch (decision.kind) {
+    case "open":
+      return `open (${decision.profileName} via ${decision.source})`;
+    case "missing-named-profile":
+      return `missing-named-profile (${decision.requestedName} via ${decision.source})`;
+    case "missing-default-profile":
+      return `missing-default-profile (${decision.configuredName})`;
+    default:
+      return decision.kind;
+  }
+}
+
+async function applyRendererViewport(params: {
+  electronApp: ElectronApplication;
+  target: NativeContentSize;
+  window: Page;
+}): Promise<void> {
+  const { electronApp, target: targetSize, window } = params;
+  const windowId = await electronApp.evaluate(
+    ({ BrowserWindow }, size) => {
+      const window = BrowserWindow.getAllWindows()[0];
+      if (!window) {
+        throw new Error("Expected an Electron BrowserWindow for replay E2E sizing");
+      }
+
+      window.setMinimumSize(0, 0);
+      window.setContentSize(size.width, size.height);
+      return window.id;
+    },
+    targetSize
+  );
+
+  let attempt = 0;
+  let previousRequest: NativeContentSize | null = null;
+  await expect
+    .poll(async () => {
+      const observed = await window.evaluate(() => ({
+        innerHeight: globalThis.innerHeight,
+        innerWidth: globalThis.innerWidth,
+      }));
+      if (
+        observed.innerHeight === targetSize.height
+        && observed.innerWidth === targetSize.width
+      ) {
+        return observed;
+      }
+
+      const request = nextRendererViewportRequest({
+        attempt,
+        observed,
+        previousRequest,
+        target: targetSize,
+      });
+      previousRequest = request;
+      attempt += 1;
+
+      await electronApp.evaluate(
+        ({ BrowserWindow }, resize) => {
+          const window = BrowserWindow.fromId(resize.windowId);
+          if (!window || window.isDestroyed()) {
+            throw new Error(
+              "Expected the replay E2E BrowserWindow to remain live while resizing",
+            );
+          }
+          window.setContentSize(resize.request.width, resize.request.height);
+        },
+        { request, windowId },
+      );
+
+      return await window.evaluate(() => ({
+        innerHeight: globalThis.innerHeight,
+        innerWidth: globalThis.innerWidth,
+      }));
+    })
+    .toMatchObject({
+      innerHeight: targetSize.height,
+      innerWidth: targetSize.width,
+    });
 }
 
 /**

--- a/apps/desktop/e2e/global-setup.ts
+++ b/apps/desktop/e2e/global-setup.ts
@@ -84,19 +84,23 @@ export default async function globalSetup(): Promise<void> {
     () => undefined,
   );
 
+  // Distinguish "gave up waiting" from "the harness told us what is
+  // wrong". Only the former means a sick guest, and only the former
+  // should send an operator off to recycle one. The harness rejects with
+  // a real diagnosis for things like a missing onboarding seed, which
+  // recycling would not fix.
+  const timeoutMessage = `timed out after ${CANARY_TIMEOUT_MS}ms`;
   try {
-    launched = await withTimeout(
-      launching,
-      CANARY_TIMEOUT_MS,
-      `timed out after ${CANARY_TIMEOUT_MS}ms`,
-    );
+    launched = await withTimeout(launching, CANARY_TIMEOUT_MS, timeoutMessage);
   } catch (error) {
     settled = true;
+    const detail = error instanceof Error ? error.message : String(error);
     throw new Error(
       describeCanaryFailure({
         timeoutMs: CANARY_TIMEOUT_MS,
         runnerName: process.env.RUNNER_NAME,
-        detail: error instanceof Error ? error.message : String(error),
+        detail,
+        timedOut: detail === timeoutMessage,
       }),
     );
   } finally {

--- a/apps/desktop/src/main/__tests__/e2e-canary-report.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-canary-report.test.ts
@@ -96,4 +96,41 @@ describe("desktop E2E pre-flight canary", () => {
     expect(message).toContain("RUNNER_NAME unset");
     expect(message).not.toContain("undefined");
   });
+
+  // A hang and a diagnosed rejection need opposite responses, and the
+  // sick-guest narrative is actively misleading for the second: it sends an
+  // operator to recycle a healthy guest while the real cause — a missing
+  // onboarding seed, say — sits under "Underlying error:" twenty lines down.
+  it("drops the sick-guest narrative when the harness rejected with a diagnosis", () => {
+    const message = describeCanaryFailure({
+      timeoutMs: 60_000,
+      runnerName: "some-runner",
+      detail: "PwrAgent first-run onboarding wizard is showing",
+      timedOut: false,
+    });
+
+    expect(message).toContain("onboarding wizard is showing");
+    expect(message).toContain("NOT the guest needing to be recycled");
+    expect(message).toContain("some-runner");
+    expect(message).not.toContain("property of the machine");
+    expect(message).not.toContain("recycle the guest.");
+    // Reporting the budget as though it elapsed misreads an instant failure.
+    expect(message).not.toContain("60000ms");
+  });
+
+  it("keeps the timeout narrative when the canary gave up waiting", () => {
+    const message = describeCanaryFailure({
+      timeoutMs: 60_000,
+      detail: "timed out after 60000ms",
+      timedOut: true,
+    });
+    expect(message).toContain("timed out after 60000ms, before any test ran");
+    expect(message).toContain("property of the machine");
+  });
+
+  // The two branches are only useful if the caller can tell them apart.
+  it("classifies the canary rejection instead of assuming a timeout", () => {
+    expect(globalSetupCode).toContain("timedOut:");
+    expect(globalSetupCode).toMatch(/timedOut:\s*detail === timeoutMessage/);
+  });
 });

--- a/apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  assertOnboardingSeedTook,
   closeElectronApplication,
   configureElectronE2eSecretStorageEnv,
   nextRendererViewportRequest,
+  resolveSeedConfigPath,
 } from "../../../e2e/fixtures/electron-app";
+import { applyDesktopSettingsPatch } from "../settings/desktop-config";
 import {
   E2E_MEMORY_SECRET_STORAGE_ENV,
   SECRET_STORAGE_DISABLED_ENV,
@@ -69,5 +75,130 @@ describe("Electron E2E fixture teardown", () => {
         target: { width: 1440, height: 900 },
       }),
     ).toEqual({ width: 1441, height: 898 });
+  });
+});
+
+// A blocked onboarding wizard used to present as twenty identical
+// `Worker teardown timeout of 30000ms exceeded` lines and a 20-minute
+// job burn, with nothing in the output naming onboarding. These lock the
+// pre-launch checks that turn that into a one-second, self-describing
+// failure — and, just as importantly, that they stay quiet on the happy
+// path so no spec pays a false positive.
+describe("Electron E2E onboarding-suppression seed", () => {
+  const roots: string[] = [];
+
+  function makeHomeRoot(): string {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "pwragent-seed-assert-"),
+    );
+    roots.push(root);
+    return root;
+  }
+
+  function seed(configPath: string, completed: boolean): void {
+    applyDesktopSettingsPatch(configPath, {
+      general: { appearance: { theme: "dark" } },
+      onboarding: { completed },
+    });
+  }
+
+  afterEach(() => {
+    while (roots.length > 0) {
+      fs.rmSync(roots.pop() as string, { recursive: true, force: true });
+    }
+  });
+
+  it("follows PWRAGENT_HOME and PWRAGENT_PROFILE to the config the app will read", () => {
+    const pwragentRoot = makeHomeRoot();
+    const env = {
+      HOME: makeHomeRoot(),
+      PWRAGENT_HOME: pwragentRoot,
+      PWRAGENT_PROFILE: "ghost",
+    };
+
+    expect(resolveSeedConfigPath(env)).toBe(
+      path.join(pwragentRoot, "profiles", "ghost", "config.toml"),
+    );
+  });
+
+  it("passes once the seed has landed in that profile", () => {
+    const env = { HOME: makeHomeRoot() };
+    const seedConfigPath = resolveSeedConfigPath(env);
+    seed(seedConfigPath, true);
+
+    expect(() =>
+      assertOnboardingSeedTook({ env, seedConfigPath }),
+    ).not.toThrow();
+  });
+
+  it("names the wizard when no profile exists for the app to open", () => {
+    const env = { HOME: makeHomeRoot() };
+    const seedConfigPath = resolveSeedConfigPath(env);
+
+    expect(() => assertOnboardingSeedTook({ env, seedConfigPath })).toThrow(
+      /onboarding wizard[\s\S]*no-profile-configured/,
+    );
+  });
+
+  it("names the wizard when PWRAGENT_PROFILE points at a profile that was never created", () => {
+    const env = { HOME: makeHomeRoot(), PWRAGENT_PROFILE: "ghost" };
+    const seedConfigPath = resolveSeedConfigPath(env);
+    // The seed lands in `profiles/ghost/`, so the profile now exists and
+    // the boot decision is `open` — this is the case the old hardcoded
+    // `profiles/default/config.toml` path got wrong.
+    seed(seedConfigPath, true);
+
+    expect(() =>
+      assertOnboardingSeedTook({ env, seedConfigPath }),
+    ).not.toThrow();
+    expect(() =>
+      assertOnboardingSeedTook({
+        env,
+        seedConfigPath: path.join(
+          env.HOME,
+          ".pwragent/profiles/default/config.toml",
+        ),
+      }),
+    ).toThrow(/seed did not take[\s\S]*read back as undefined/);
+  });
+
+  it("names the seed when the profile opens but onboarding.completed is not true", () => {
+    const env = { HOME: makeHomeRoot() };
+    const seedConfigPath = resolveSeedConfigPath(env);
+    seed(seedConfigPath, false);
+
+    expect(() => assertOnboardingSeedTook({ env, seedConfigPath })).toThrow(
+      /seed did not take/,
+    );
+  });
+
+  // `parseDesktopSettingsToml` is strict — a truncated write throws
+  // rather than falling back to defaults — but a bare "Invalid TOML"
+  // says nothing about which harness step produced the file.
+  it("names the seed when a partially written config.toml fails to parse", () => {
+    const env = { HOME: makeHomeRoot() };
+    const seedConfigPath = resolveSeedConfigPath(env);
+    seed(seedConfigPath, true);
+    fs.writeFileSync(seedConfigPath, "[onboarding\ncompleted = tru", "utf8");
+
+    expect(() => assertOnboardingSeedTook({ env, seedConfigPath })).toThrow(
+      /seed did not take[\s\S]*Invalid TOML/,
+    );
+  });
+
+  it("reports the paths and env that decided the profile", () => {
+    const env = { HOME: makeHomeRoot() };
+    const seedConfigPath = resolveSeedConfigPath(env);
+
+    expect(() => assertOnboardingSeedTook({ env, seedConfigPath })).toThrow(
+      new RegExp(
+        [
+          `seeded config: +${seedConfigPath.replaceAll(/[$()*+.?[\\\]^{|}]/g, "\\$&")}`,
+          `HOME: +${env.HOME.replaceAll(/[$()*+.?[\\\]^{|}]/g, "\\$&")}`,
+          "PWRAGENT_HOME: +\\(unset\\)",
+          "PWRAGENT_PROFILE: +\\(unset\\)",
+        ].join("[\\s\\S]*"),
+      ),
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts
@@ -7,7 +7,9 @@ import {
   closeElectronApplication,
   configureElectronE2eSecretStorageEnv,
   nextRendererViewportRequest,
+  raceTeardownTimeout,
   resolveSeedConfigPath,
+  waitForRendererReady,
 } from "../../../e2e/fixtures/electron-app";
 import { applyDesktopSettingsPatch } from "../settings/desktop-config";
 import {
@@ -200,5 +202,148 @@ describe("Electron E2E onboarding-suppression seed", () => {
         ].join("[\\s\\S]*"),
       ),
     );
+  });
+
+  // Following the production resolvers means inheriting their fallback
+  // to `os.homedir()`. Right for the app; for a fixture it would seed
+  // the operator's real ~/.pwragent, so the harness refuses instead.
+  it("refuses to resolve a seed path when HOME is missing from the launch env", () => {
+    expect(() => resolveSeedConfigPath({} as Record<string, string>)).toThrow(
+      /no HOME[\s\S]*operator's real/,
+    );
+  });
+});
+
+// The pre-launch checks above are the deterministic gate, but they run
+// before Electron exists. These cover what happens once it does.
+describe("Electron E2E renderer readiness", () => {
+  const roots: string[] = [];
+
+  function makeHomeRoot(options?: { bootstrap?: boolean }): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "pwragent-ready-"));
+    roots.push(root);
+    if (options?.bootstrap) {
+      // Matches `resolveBootstrapProfileDir` — a sibling of `profiles/`.
+      fs.mkdirSync(path.join(root, ".pwragent", ".bootstrap", "state"), {
+        recursive: true,
+      });
+    }
+    return root;
+  }
+
+  /** Minimal stand-ins; `waitForRendererReady` only touches these. */
+  function makeWindow(options?: {
+    overlayAttaches?: boolean;
+    overlayCount?: number;
+  }): { window: Parameters<typeof waitForRendererReady>[0]["window"] } {
+    const pending = new Promise<void>(() => undefined);
+    const window = {
+      waitForLoadState: async () => undefined,
+      locator: () => ({
+        count: async () => options?.overlayCount ?? 0,
+        waitFor: async () =>
+          options?.overlayAttaches ? undefined : await pending,
+      }),
+    };
+    return { window: window as never };
+  }
+
+  function args(overrides: {
+    env: Record<string, string>;
+    window: Parameters<typeof waitForRendererReady>[0]["window"];
+    suppressOnboarding?: boolean;
+  }): Parameters<typeof waitForRendererReady>[0] {
+    return {
+      electronApp: {} as never,
+      env: overrides.env,
+      requiresReplayDriver: false,
+      seedConfigPath: path.join(overrides.env.HOME, "config.toml"),
+      suppressOnboarding: overrides.suppressOnboarding ?? true,
+      window: overrides.window,
+    };
+  }
+
+  afterEach(() => {
+    while (roots.length > 0) {
+      fs.rmSync(roots.pop() as string, { recursive: true, force: true });
+    }
+  });
+
+  // `initializeAppState("bootstrap")` creates `.bootstrap/` during
+  // `app.whenReady()`, before any BrowserWindow exists — which is what
+  // makes this check race-free where watching the DOM is not.
+  it("names the wizard when the app booted into bootstrap mode", async () => {
+    const env = { HOME: makeHomeRoot({ bootstrap: true }) };
+
+    await expect(
+      waitForRendererReady(args({ env, ...makeWindow() })),
+    ).rejects.toThrow(/onboarding wizard is showing[\s\S]*bootstrap mode/);
+  });
+
+  it("passes when no bootstrap profile exists and no overlay is present", async () => {
+    const env = { HOME: makeHomeRoot() };
+
+    await expect(
+      waitForRendererReady(args({ env, ...makeWindow() })),
+    ).resolves.toBeUndefined();
+  });
+
+  it("names the wizard when the overlay wins the race against readiness", async () => {
+    const env = { HOME: makeHomeRoot() };
+    const { window } = makeWindow({ overlayAttaches: true });
+    // Readiness never settles, so only the watcher can resolve this.
+    const stalled = {
+      ...(window as unknown as Record<string, unknown>),
+      waitForLoadState: () => new Promise<void>(() => undefined),
+    };
+
+    await expect(
+      waitForRendererReady(args({ env, window: stalled as never })),
+    ).rejects.toThrow(/onboarding wizard is showing/);
+  });
+
+  it("names the wizard when the overlay is already up once readiness settles", async () => {
+    const env = { HOME: makeHomeRoot() };
+
+    await expect(
+      waitForRendererReady(args({ env, ...makeWindow({ overlayCount: 1 }) })),
+    ).rejects.toThrow(/onboarding wizard is showing/);
+  });
+
+  // Wizard specs want the wizard. None of the above may fire for them.
+  it("skips every onboarding check when suppressOnboarding is false", async () => {
+    const env = { HOME: makeHomeRoot({ bootstrap: true }) };
+
+    await expect(
+      waitForRendererReady(
+        args({
+          env,
+          suppressOnboarding: false,
+          ...makeWindow({ overlayAttaches: true, overlayCount: 1 }),
+        }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+// `close()` warns past its budget but must not turn a real cleanup
+// failure into a warning nobody reads.
+describe("Electron E2E teardown budget", () => {
+  it("reports a still-pending teardown as timed out", async () => {
+    await expect(
+      raceTeardownTimeout(new Promise<void>(() => undefined), 5),
+    ).resolves.toBe(true);
+  });
+
+  it("reports a teardown that finished in time as not timed out", async () => {
+    await expect(raceTeardownTimeout(Promise.resolve(), 5_000)).resolves.toBe(
+      false,
+    );
+  });
+
+  it("propagates a teardown failure rather than reporting a timeout", async () => {
+    await expect(
+      raceTeardownTimeout(Promise.reject(new Error("ENOTEMPTY")), 5_000),
+    ).rejects.toThrow("ENOTEMPTY");
   });
 });


### PR DESCRIPTION
## Summary

The macOS Desktop E2E lane intermittently burned its full 20-minute budget producing twenty identical `Worker teardown timeout of 30000ms exceeded` lines, a trail of orphan Electron processes, and nothing in the output naming the cause. It has hit both PRs and unmodified `main`.

The blocking surface is the first-run onboarding wizard. When the `onboarding.completed = true` seed does not take, its modal scrim intercepts every click. It presents that badly because the wizard overlay is a **sibling** of the app shell, so sidebar rows stay in the DOM and `toBeVisible()` still passes — a spec either fails with a bare `element(s) not found` or watches a `.click()` retry against the scrim until Playwright's 30s test timeout. Neither mentions onboarding.

Changes to `apps/desktop/e2e/fixtures/electron-app.ts`:

- **Resolve the seed target the way the app does.** It was hardcoded to `<home>/.pwragent/profiles/default/config.toml`; it now goes through `resolveActiveProfileName` / `resolveProfileDir`, so it follows `PWRAGENT_HOME` and `PWRAGENT_PROFILE`. The old path silently seeded the wrong directory whenever either moved.
- **Strip `PWRAGENT_HOME` / `PWRAGENT_PROFILE` / `PWRAGENT_PROFILE_AUTO_CREATE` from the inherited environment**, before per-spec `params.env` overrides so `onboarding-wizard.spec.ts` still gets its deliberate `PWRAGENT_PROFILE`. The harness copies the whole ambient env, and the `pwragent-dev-profile` skill exports `PWRAGENT_PROFILE`.
- **Assert pre-launch** that the boot decision is `open` and that `onboarding.completed` reads back as `true`, using the production resolver and parser so the harness cannot drift from the app. This is the deterministic gate: it models both ways the wizard fires and costs nothing.
- **Assert post-launch via `bootstrapProfileExists()`.** `initializeAppState(\"bootstrap\")` materializes `<root>/.bootstrap/` during `app.whenReady()`, before any BrowserWindow exists, so by the time `firstWindow()` resolves the answer is settled — no polling, no race. An overlay racer sits behind it as a net for causes the checks don't model.
- **Close Electron when post-launch setup throws.** Previously the caller never received a `LaunchResult`, so `close()` could not run and the app leaked straight into worker teardown — the orphan processes observed at job end.
- **Bound `close()` at 15s** so one stuck app costs a warning line instead of Playwright's 30s worker teardown timeout and a recycled worker.

The resize block moved into an `applyRendererViewport` helper so the failure-cleanup `try` stays small; it is otherwise unchanged.

## Verification

Run on the PwrSuiteLab macOS guest (not the operator's Mac).

| Run | Result |
|---|---|
| Seed deliberately skipped, **before** the fix | 30.0s test timeout, `element(s) not found`; the captured a11y snapshot confirms `dialog \"First-run setup\"` was up |
| Seed deliberately skipped, **after** | **3.8s**, `PwrAgent first-run onboarding wizard is showing… Detected because the app booted into bootstrap mode`, with the config path, `HOME`, `PWRAGENT_HOME`, `PWRAGENT_PROFILE`. No orphans, no teardown timeouts. |
| `e2e/a11y.spec.ts` (the failing lane) | 16/16 passed, 54.2s |
| `e2e/onboarding-wizard.spec.ts` + `e2e/smoke.spec.ts` | 13/13 passed |
| `e2e/thread-branch-drift.spec.ts` + `e2e/provider-model-selectors.spec.ts` (the `env.HOME` + `preLaunchHook` shape) | 7/7 passed |

Plus 12 unit tests in `apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts` covering each pre-launch failure mode: env-driven seed-path resolution, missing profile, `completed !== true`, and an unparseable `config.toml`.

`pnpm --filter @pwragent/desktop typecheck`, `pnpm lint:eslint` (0 errors), and `pnpm lint:boundaries` are clean.

## Notes

- **This does not identify the CI root cause.** It closes two concrete holes — ambient env leakage and wrong-profile seeding — and makes any future occurrence self-identifying in about a second. But the intermittent CI failure itself was not reproduced, so I can't say which hole it was, or whether it's a third (a shared runner leaving a prior Electron alive is still plausible). The next red run should say so directly.
- The first watcher I wrote lost the race: the replay driver installs from the `BackendRegistry` constructor, which runs in bootstrap mode too, so readiness resolved before the overlay mounted. That is why the deterministic `.bootstrap/` check exists — the lab run caught it, not reasoning.
- One premise in the original report turned out to be wrong: a malformed `config.toml` does **not** make the reader fall back to defaults. `parseDesktopSettingsToml` is strict and throws `Invalid TOML`. That throw is now wrapped with the seed context, since the raw message names neither the harness step nor onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)