### PR TITLE
fix(desktop): clamp the composer # thread picker rows

### DIFF
--- a/apps/desktop/e2e/composer-chip-alignment.spec.ts
+++ b/apps/desktop/e2e/composer-chip-alignment.spec.ts
@@ -33,10 +33,57 @@ import { launchElectronApp } from "./fixtures/electron-app";
  * carrying an attached PR, and no E2E fixture seeds one today.
  */
 const specDir = path.dirname(fileURLToPath(import.meta.url));
-const fixturePath = path.resolve(
+const sharedFixturePath = path.resolve(
   specDir,
   "fixtures/skill-autocomplete-interactions/replay.fixture.json",
 );
+
+/**
+ * The shared fixture holds exactly one thread, and the `#` picker leaves
+ * the thread you are writing in out of its own results — so on that
+ * fixture the popover has nothing to offer and never opens. This spec
+ * needs a second thread; the other two specs on that fixture do not, and
+ * one of them (`docs-site-screenshots.inspect.spec.ts`) captures the
+ * sidebar, where an extra row would change a committed PNG.
+ *
+ * The Inbox lens shows every thread regardless of `inbox.inInbox` (which
+ * `buildNavigationSnapshot` recomputes anyway), so there is no way to add
+ * a thread to the fixture and keep it out of that capture. Derive a
+ * two-thread copy here instead, and leave the shared fixture alone.
+ */
+async function writeTwoThreadFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const { mkdtemp, readFile, rm, writeFile } = await import("node:fs/promises");
+  const os = await import("node:os");
+
+  const fixture = JSON.parse(await readFile(sharedFixturePath, "utf8"));
+  const threadList = fixture.steps.find(
+    (step: { method?: string }) => step.method === "thread/list",
+  );
+  if (!threadList || !Array.isArray(threadList.result)) {
+    throw new Error("shared fixture no longer has a thread/list step");
+  }
+  threadList.result.push({
+    ...threadList.result[0],
+    id: "thread-hash-reference-target",
+    title: "Hash reference target",
+    summary: "Referenceable sibling for the composer # picker",
+    // Older than the thread under test, so candidate order is fixed.
+    updatedAt: 1759000000000,
+  });
+
+  const tmpRoot = await mkdtemp(
+    path.join(os.tmpdir(), "pwragent-chip-alignment-"),
+  );
+  const fixturePath = path.join(tmpRoot, "replay.fixture.json");
+  await writeFile(fixturePath, JSON.stringify(fixture));
+  return {
+    cleanup: () => rm(tmpRoot, { force: true, recursive: true }),
+    fixturePath,
+  };
+}
 
 /** Chips must agree this closely on where they sit within their line. */
 const OFFSET_TOLERANCE_PX = 0.5;
@@ -118,8 +165,9 @@ async function composerMetrics(paragraph: Locator): Promise<ComposerMetrics> {
 }
 
 test("composer chips of every structure sit at one height in the prose", async () => {
+  const fixture = await writeTwoThreadFixture();
   const app = await launchElectronApp({
-    fixturePath,
+    fixturePath: fixture.fixturePath,
     windowSize: {
       width: 1180,
       height: 760,
@@ -217,5 +265,6 @@ test("composer chips of every structure sit at one height in the prose", async (
     ).toBeLessThanOrEqual(HEIGHT_TOLERANCE_PX);
   } finally {
     await app.close();
+    await fixture.cleanup();
   }
 });

--- a/apps/desktop/e2e/fixtures/skill-autocomplete-interactions/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/skill-autocomplete-interactions/replay.fixture.json
@@ -47,6 +47,26 @@
             "reason": "new-thread"
           },
           "updatedAt": 1760000000000
+        },
+        {
+          "id": "thread-hash-reference-target",
+          "title": "Hash reference target",
+          "titleSource": "explicit",
+          "summary": "Referenceable sibling for the composer # picker, which leaves the thread you are writing in out of its own results. Kept out of the inbox so the sidebar renders exactly as before.",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [
+            {
+              "id": "pwragent-fixture",
+              "label": "PwrAgent",
+              "path": "/Users/huntharo/github/PwrAgent",
+              "kind": "local"
+            }
+          ],
+          "inbox": {
+            "inInbox": false
+          },
+          "updatedAt": 1759000000000
         }
       ]
     },

--- a/apps/desktop/e2e/fixtures/skill-autocomplete-interactions/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/skill-autocomplete-interactions/replay.fixture.json
@@ -47,26 +47,6 @@
             "reason": "new-thread"
           },
           "updatedAt": 1760000000000
-        },
-        {
-          "id": "thread-hash-reference-target",
-          "title": "Hash reference target",
-          "titleSource": "explicit",
-          "summary": "Referenceable sibling for the composer # picker, which leaves the thread you are writing in out of its own results. Kept out of the inbox so the sidebar renders exactly as before.",
-          "source": "codex",
-          "executionMode": "default",
-          "linkedDirectories": [
-            {
-              "id": "pwragent-fixture",
-              "label": "PwrAgent",
-              "path": "/Users/huntharo/github/PwrAgent",
-              "kind": "local"
-            }
-          ],
-          "inbox": {
-            "inInbox": false
-          },
-          "updatedAt": 1759000000000
         }
       ]
     },

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -101,8 +101,10 @@ import {
 } from "../../lib/directory-references";
 import { expandTildePath } from "../../lib/tildify-path";
 import {
+  collapseHashReferenceWhitespace,
   filterHashReferenceCandidates,
   findHashReferenceTrigger,
+  formatHashReferenceThreadLabel,
 } from "../../lib/hash-references";
 import { normalizeImageFile } from "../../lib/image-normalization";
 import {
@@ -1290,20 +1292,35 @@ function reviewSubmissionKey(command: {
   }
 }
 
+/**
+ * `matchAnywhere` is for populations the picker matches by substring —
+ * thread titles, where the query rarely starts the name. Prefix-ranked
+ * populations ($ skills, / commands, @ directories) keep the leading-run
+ * highlight so the emphasis always sits on what was typed.
+ */
 function HighlightedAutocompleteLabel(props: {
   label: string;
+  matchAnywhere?: boolean;
   query: string;
 }) {
-  if (!props.query || !props.label.toLowerCase().startsWith(props.query.toLowerCase())) {
+  const matchIndex = !props.query
+    ? -1
+    : props.matchAnywhere
+      ? props.label.toLowerCase().indexOf(props.query.toLowerCase())
+      : props.label.toLowerCase().startsWith(props.query.toLowerCase())
+        ? 0
+        : -1;
+  if (matchIndex < 0) {
     return <span>{props.label}</span>;
   }
 
   return (
     <span>
+      {props.label.slice(0, matchIndex)}
       <span className="composer__autocomplete-match">
-        {props.label.slice(0, props.query.length)}
+        {props.label.slice(matchIndex, matchIndex + props.query.length)}
       </span>
-      {props.label.slice(props.query.length)}
+      {props.label.slice(matchIndex + props.query.length)}
     </span>
   );
 }
@@ -1413,7 +1430,11 @@ function resolveThreadSummaryReference(
       ? { instanceId: federationTarget.instanceId }
       : {}),
     threadId: thread.id,
-    title: thread.title,
+    // The chip, its tooltip, and the `[title](pwragent://…)` markdown the
+    // agent receives all read this. A title that is really a whole pasted
+    // prompt would otherwise become a composer-wide chip and a link label
+    // hundreds of characters long; the url still carries the identity.
+    title: formatHashReferenceThreadLabel(thread),
     titleSource: thread.titleSource,
     gitBranch: thread.gitBranch,
     linkedDirectories: thread.linkedDirectories,
@@ -4443,8 +4464,17 @@ export function Composer(props: ComposerProps) {
     if (!hashReferenceTrigger) {
       return [];
     }
+    // Referencing the thread you are writing in tells the agent nothing it
+    // does not already have, and on a bare `#` the current thread is the
+    // most recently updated one — so it would otherwise take the first row.
+    const currentThreadKey = props.thread
+      ? buildThreadIdentityKey(props.thread.source, props.thread.id)
+      : undefined;
+    const isCurrentThread = (thread: NavigationThreadSummary): boolean =>
+      currentThreadKey !== undefined
+      && buildThreadIdentityKey(thread.source, thread.id) === currentThreadKey;
     const localCandidates = filterHashReferenceCandidates(
-      props.threads ?? [],
+      (props.threads ?? []).filter((thread) => !isCurrentThread(thread)),
       hashReferenceTrigger.query,
     );
     const localThreadKeys = new Set(
@@ -4456,6 +4486,7 @@ export function Composer(props: ComposerProps) {
       federatedHashSearchResults.filter(
         (thread) =>
           thread.federation?.ref.target.scope === "remote"
+          && !isCurrentThread(thread)
           && !localThreadKeys.has(
             buildThreadIdentityKey(thread.source, thread.id),
           ),
@@ -4492,7 +4523,13 @@ export function Composer(props: ComposerProps) {
           remote: true,
         })),
     ];
-  }, [federatedHashSearchResults, hashReferenceTrigger, props.threads]);
+  }, [
+    federatedHashSearchResults,
+    hashReferenceTrigger,
+    props.thread?.id,
+    props.thread?.source,
+    props.threads,
+  ]);
   const hashReferenceCount = filteredHashReferenceOptions.length;
   const availableAutocompleteKind: AutocompleteKind | undefined = trigger && filteredSkills.length > 0
     ? "skills"
@@ -7576,7 +7613,18 @@ export function Composer(props: ComposerProps) {
     if (!inputRef.current) {
       return;
     }
-    inputRef.current.insertMentionToken(createComposerThreadToken(thread, 0));
+    inputRef.current.insertMentionToken(
+      createComposerThreadToken(
+        {
+          ...thread,
+          title: formatHashReferenceThreadLabel({
+            id: thread.threadId,
+            title: thread.title,
+          }),
+        },
+        0,
+      ),
+    );
   };
 
   const applyHashReference = (
@@ -10628,6 +10676,9 @@ export function Composer(props: ComposerProps) {
                 && !filteredHashReferenceOptions[index - 1]?.remote;
               if (option.kind === "thread") {
                 const thread = option.thread;
+                const threadLabel = formatHashReferenceThreadLabel(thread);
+                const threadTitle =
+                  collapseHashReferenceWhitespace(thread.title) || thread.id;
                 const key = thread.federation
                   ? federatedThreadIdentityKey(thread.federation.ref)
                   : buildThreadIdentityKey(thread.source, thread.id);
@@ -10650,6 +10701,9 @@ export function Composer(props: ComposerProps) {
                       aria-selected={index === activeHashReferenceIndex}
                       className={`composer__autocomplete-option${index === activeHashReferenceIndex ? " is-active" : ""}`}
                       tabIndex={index === activeHashReferenceIndex ? 0 : -1}
+                      // The visible label is one clamped line; hovering the
+                      // row still gives the operator the whole title.
+                      title={threadTitle}
                       type="button"
                       onMouseDown={(event) => {
                         event.preventDefault();
@@ -10675,14 +10729,13 @@ export function Composer(props: ComposerProps) {
                     >
                       <span className="composer__autocomplete-title">
                         <ThreadIcon size={13} aria-hidden="true" />
-                        <HighlightedAutocompleteLabel
-                          label={`#${thread.title.replace(/^#/, "")}`}
-                          query={
-                            hashReferenceTrigger?.query
-                              ? `#${hashReferenceTrigger.query}`
-                              : "#"
-                          }
-                        />
+                        <span className="composer__autocomplete-label">
+                          <HighlightedAutocompleteLabel
+                            label={`#${threadLabel.replace(/^#/, "")}`}
+                            matchAnywhere
+                            query={hashReferenceTrigger?.query.trim() ?? ""}
+                          />
+                        </span>
                         <span className="composer__autocomplete-source composer__autocomplete-source--pwragent">
                           Thread
                         </span>
@@ -10695,7 +10748,7 @@ export function Composer(props: ComposerProps) {
                             label={thread.federation.instanceLabel}
                           />
                         ) : null}
-                        <span>
+                        <span className="composer__autocomplete-label">
                           {describeHashReferenceThread(
                             thread,
                             hashReferenceTrigger?.query ?? "",
@@ -10727,6 +10780,7 @@ export function Composer(props: ComposerProps) {
                     aria-selected={index === activeHashReferenceIndex}
                     className={`composer__autocomplete-option${index === activeHashReferenceIndex ? " is-active" : ""}`}
                     tabIndex={index === activeHashReferenceIndex ? 0 : -1}
+                    title={pullRequest.title || pullRequest.url}
                     type="button"
                     onMouseDown={(event) => {
                       event.preventDefault();
@@ -10746,12 +10800,14 @@ export function Composer(props: ComposerProps) {
                   >
                     <span className="composer__autocomplete-title">
                       <PullRequestIcon size={13} aria-hidden="true" />
-                      <span>{`${pullRequest.org}/${pullRequest.repo}#${pullRequest.number}`}</span>
+                      <span className="composer__autocomplete-label">
+                        {`${pullRequest.org}/${pullRequest.repo}#${pullRequest.number}`}
+                      </span>
                       <span className="composer__autocomplete-source composer__autocomplete-source--provider">
                         Pull request
                       </span>
                     </span>
-                    <span className="composer__autocomplete-meta">
+                    <span className="composer__autocomplete-meta composer__autocomplete-meta--single-line">
                       {pullRequest.title || pullRequest.url}
                     </span>
                   </button>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -105,6 +105,7 @@ import {
   filterHashReferenceCandidates,
   findHashReferenceTrigger,
   formatHashReferenceThreadLabel,
+  formatHashReferenceThreadTooltip,
 } from "../../lib/hash-references";
 import { normalizeImageFile } from "../../lib/image-normalization";
 import {
@@ -1345,7 +1346,13 @@ function describeHashReferenceThread(
   if (directory?.label) {
     parts.push(directory.label);
   }
-  return parts.join(" · ") || thread.id;
+  if (parts.length > 0) {
+    return parts.join(" · ");
+  }
+  // The id is the last-resort disambiguator between same-named threads. A
+  // thread with no title is already showing that same id as its label, so
+  // repeating it here would just print the uuid twice.
+  return collapseHashReferenceWhitespace(thread.title) ? thread.id : "";
 }
 
 function createComposerSkillToken(
@@ -1398,7 +1405,15 @@ function createComposerThreadToken(
   });
   return {
     kind: "thread",
-    name: thread.title.trim() || thread.threadId,
+    // Every thread chip is minted here — picker, pasted url, and the draft
+    // rehydrate that rebuilds tokens from the live thread summary rather
+    // than from the saved link text. Formatting at the choke point is what
+    // makes the clamp survive a restore, and it makes the round trip
+    // converge: `format` of an already-formatted title is itself.
+    name: formatHashReferenceThreadLabel({
+      id: thread.threadId,
+      title: thread.title,
+    }),
     path,
     id: `${path}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
     index,
@@ -1430,11 +1445,7 @@ function resolveThreadSummaryReference(
       ? { instanceId: federationTarget.instanceId }
       : {}),
     threadId: thread.id,
-    // The chip, its tooltip, and the `[title](pwragent://…)` markdown the
-    // agent receives all read this. A title that is really a whole pasted
-    // prompt would otherwise become a composer-wide chip and a link label
-    // hundreds of characters long; the url still carries the identity.
-    title: formatHashReferenceThreadLabel(thread),
+    title: thread.title,
     titleSource: thread.titleSource,
     gitBranch: thread.gitBranch,
     linkedDirectories: thread.linkedDirectories,
@@ -7613,18 +7624,7 @@ export function Composer(props: ComposerProps) {
     if (!inputRef.current) {
       return;
     }
-    inputRef.current.insertMentionToken(
-      createComposerThreadToken(
-        {
-          ...thread,
-          title: formatHashReferenceThreadLabel({
-            id: thread.threadId,
-            title: thread.title,
-          }),
-        },
-        0,
-      ),
-    );
+    inputRef.current.insertMentionToken(createComposerThreadToken(thread, 0));
   };
 
   const applyHashReference = (
@@ -10677,8 +10677,11 @@ export function Composer(props: ComposerProps) {
               if (option.kind === "thread") {
                 const thread = option.thread;
                 const threadLabel = formatHashReferenceThreadLabel(thread);
-                const threadTitle =
-                  collapseHashReferenceWhitespace(thread.title) || thread.id;
+                const threadTitle = formatHashReferenceThreadTooltip(thread);
+                const threadMeta = describeHashReferenceThread(
+                  thread,
+                  hashReferenceTrigger?.query ?? "",
+                );
                 const key = thread.federation
                   ? federatedThreadIdentityKey(thread.federation.ref)
                   : buildThreadIdentityKey(thread.source, thread.id);
@@ -10748,12 +10751,11 @@ export function Composer(props: ComposerProps) {
                             label={thread.federation.instanceLabel}
                           />
                         ) : null}
-                        <span className="composer__autocomplete-label">
-                          {describeHashReferenceThread(
-                            thread,
-                            hashReferenceTrigger?.query ?? "",
-                          )}
-                        </span>
+                        {threadMeta ? (
+                          <span className="composer__autocomplete-label">
+                            {threadMeta}
+                          </span>
+                        ) : null}
                       </span>
                     </button>
                   </Fragment>

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2137,6 +2137,131 @@ describe("Composer", () => {
     });
   });
 
+  it("clamps a prompt-length thread title and leaves the current thread out", async () => {
+    const promptTitle = [
+      "Apparently we don't allow cross-provider parent/child relationships?",
+      "We should… In this case we created a \"child\" thread that is stuck in",
+      "the unpinned section because it is a parent but we refuse to render it.",
+    ].join("\n");
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      updatedAt: 30,
+    };
+    const promptTitledThread: NavigationThreadSummary = {
+      id: "019fdf98-11fe-71f4-936f-bfde8d967939",
+      title: promptTitle,
+      titleSource: "derived",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      updatedAt: 20,
+    };
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: currentThread.id,
+      turnId: "turn-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={currentThread}
+        threads={[currentThread, promptTitledThread]}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    fireEvent.change(textbox, { target: { value: "Ask #" } });
+    const listbox = await screen.findByRole("listbox", {
+      name: "Threads and pull requests",
+    });
+
+    // Referencing the thread you are writing in is never useful, and on a
+    // bare `#` it would otherwise sort first as the most recent thread.
+    expect(
+      within(listbox).queryByRole("button", { name: /#Current thread/ }),
+    ).not.toBeInTheDocument();
+
+    const options = within(listbox).getAllByRole("button");
+    expect(options).toHaveLength(1);
+    const label = options[0]!.querySelector(".composer__autocomplete-label");
+    expect(label).toHaveTextContent(
+      "#Apparently we don't allow cross-provider parent/child relationships? We…",
+    );
+    expect(label?.textContent).not.toContain("refuse to render it");
+    // The untruncated title stays reachable on the row itself.
+    expect(options[0]).toHaveAttribute(
+      "title",
+      promptTitle.replace(/\s+/g, " "),
+    );
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    await clickButton("Send");
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: currentThread.id,
+        input: [
+          {
+            type: "text",
+            text: "Ask [Apparently we don't allow cross-provider parent/child relationships? We…](pwragent://thread/019fdf98-11fe-71f4-936f-bfde8d967939?backend=codex)",
+          },
+        ],
+      });
+    });
+  });
+
+  it("highlights a thread-title match that does not start the name", async () => {
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const targetThread: NavigationThreadSummary = {
+      id: "thread-target",
+      title: "Implement hash references",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+
+    render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        thread={currentThread}
+        threads={[currentThread, targetThread]}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    fireEvent.change(textbox, { target: { value: "Ask #hash refer" } });
+    const listbox = await screen.findByRole("listbox", {
+      name: "Threads and pull requests",
+    });
+    const option = within(listbox).getByRole("button", {
+      name: /#Implement hash references/,
+    });
+    expect(option.querySelector(".composer__autocomplete-match"))
+      .toHaveTextContent("hash refer");
+  });
+
   it("offers matching threads and a precise PR link for a numeric hash query", async () => {
     const earlierPullRequest = {
       provider: "github.com" as const,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2262,6 +2262,123 @@ describe("Composer", () => {
       .toHaveTextContent("hash refer");
   });
 
+  it("does not print a titleless thread's id on both of its rows", async () => {
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const untitledThread: NavigationThreadSummary = {
+      id: "019fdf98-11fe-71f4-936f-bfde8d967939",
+      title: "",
+      titleSource: "derived",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+
+    render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        thread={currentThread}
+        threads={[currentThread, untitledThread]}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    fireEvent.change(textbox, { target: { value: "Ask #" } });
+    const listbox = await screen.findByRole("listbox", {
+      name: "Threads and pull requests",
+    });
+
+    const option = within(listbox).getAllByRole("button")[0]!;
+    // The id is the label when there is no title; the meta row's own id
+    // fallback would only repeat it.
+    expect(option.querySelector(".composer__autocomplete-title"))
+      .toHaveTextContent(`#${untitledThread.id}`);
+    expect(option.querySelector(".composer__autocomplete-meta"))
+      .not.toHaveTextContent(untitledThread.id);
+  });
+
+  it("keeps a thread chip clamped when a draft is restored", async () => {
+    // The clamp has to live where tokens are minted, not only where the
+    // picker inserts them: a restore rebuilds thread tokens from the live
+    // thread summary and discards the saved link text, so formatting only
+    // at the picker is undone by the next restore.
+    const promptTitle =
+      "Apparently we don't allow cross-provider parent/child relationships? We should fix this, and the title runs on well past any reasonable label length.";
+    const targetThread: NavigationThreadSummary = {
+      id: "019fdf98-11fe-71f4-936f-bfde8d967939",
+      title: promptTitle,
+      titleSource: "derived",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const clampedLabel =
+      "Apparently we don't allow cross-provider parent/child relationships? We…";
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "Repo",
+      directoryPath: "/repo",
+      backend: "codex",
+      executionMode: "default",
+      prompt: `check [${clampedLabel}](pwragent://thread/${targetThread.id}?backend=codex) please`,
+      workMode: "local",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const onMaterializeLaunchpad = vi.fn(async () => undefined);
+
+    render(
+      <ThreadLinkProvider onShowThread={() => undefined} threads={[targetThread]}>
+        <Composer
+          backends={[backendSummary("codex")]}
+          directory={{
+            key: "directory:/repo",
+            kind: "directory",
+            label: "Repo",
+            path: "/repo",
+            threadKeys: [],
+            needsAttentionCount: 0,
+          }}
+          draftStore={createComposerDraftStore()}
+          launchpad={launchpad}
+          onMaterializeLaunchpad={onMaterializeLaunchpad}
+          onUpdateLaunchpad={async () => undefined}
+          skills={[]}
+        />
+      </ThreadLinkProvider>,
+    );
+
+    const richInput = screen.getByTestId("composer-tiptap-input");
+    const chip = await waitFor(() =>
+      within(richInput).getByText(`#${clampedLabel}`).closest("[data-mention-kind]"),
+    );
+    expect(chip).toHaveAttribute("data-mention-kind", "thread");
+    expect(chip?.textContent).not.toContain("reasonable label length");
+
+    // Re-serializing has to reproduce the draft it was restored from, or
+    // every restore rewrites the prompt the agent eventually receives.
+    await clickButton("Start thread");
+    await waitFor(() => {
+      expect(onMaterializeLaunchpad).toHaveBeenCalledWith(
+        "directory:/repo",
+        [{ type: "text", text: launchpad.prompt }],
+        undefined,
+        undefined,
+        [],
+      );
+    });
+  });
+
   it("offers matching threads and a precise PR link for a numeric hash query", async () => {
     const earlierPullRequest = {
       provider: "github.com" as const,
@@ -2329,9 +2446,20 @@ describe("Composer", () => {
       .toHaveTextContent("#123");
     expect(threadOption.querySelector(".composer__autocomplete-meta"))
       .not.toHaveTextContent("#44");
-    fireEvent.click(
-      within(listbox).getByRole("button", { name: /pwrdrvr\/PwrAgent#123/ }),
-    );
+
+    // The PR row's subject is clamped to one line like every other row,
+    // with the full text on the row for hover.
+    const pullRequestOption = within(listbox).getByRole("button", {
+      name: /pwrdrvr\/PwrAgent#123/,
+    });
+    expect(pullRequestOption).toHaveAttribute("title", pullRequest.title);
+    expect(
+      pullRequestOption.querySelector(
+        ".composer__autocomplete-meta--single-line",
+      ),
+    ).toHaveTextContent(pullRequest.title);
+
+    fireEvent.click(pullRequestOption);
 
     const chip = await waitFor(() =>
       within(textbox)

--- a/apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts
@@ -5,6 +5,7 @@ import {
   filterHashReferenceCandidates,
   findHashReferenceTrigger,
   formatHashReferenceThreadLabel,
+  formatHashReferenceThreadTooltip,
 } from "../hash-references";
 
 function pullRequest(
@@ -96,6 +97,27 @@ describe("formatHashReferenceThreadLabel", () => {
   it("breaks mid-token only when no word boundary is near the limit", () => {
     const label = formatHashReferenceThreadLabel(thread("id-1", "x".repeat(200)));
     expect(label).toBe(`${"x".repeat(72)}…`);
+  });
+});
+
+describe("formatHashReferenceThreadTooltip", () => {
+  it("recovers what the label's ellipsis hid without becoming a wall of text", () => {
+    const long = `${"word ".repeat(200)}end`;
+    const tooltip = formatHashReferenceThreadTooltip(thread("id-1", long));
+
+    expect(tooltip.length).toBeLessThanOrEqual(301);
+    expect(tooltip.endsWith("…")).toBe(true);
+    // Strictly more context than the row shows, which is the whole point.
+    expect(tooltip.length).toBeGreaterThan(
+      formatHashReferenceThreadLabel(thread("id-1", long)).length,
+    );
+  });
+
+  it("leaves an ordinary title alone and falls back to the id", () => {
+    expect(
+      formatHashReferenceThreadTooltip(thread("id-1", "Bob's\nBest Thread")),
+    ).toBe("Bob's Best Thread");
+    expect(formatHashReferenceThreadTooltip(thread("id-1", ""))).toBe("id-1");
   });
 });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { NavigationThreadSummary, PrSummary } from "@pwragent/shared";
 import {
+  collapseHashReferenceWhitespace,
   filterHashReferenceCandidates,
   findHashReferenceTrigger,
+  formatHashReferenceThreadLabel,
 } from "../hash-references";
 
 function pullRequest(
@@ -63,6 +65,46 @@ describe("findHashReferenceTrigger", () => {
     expect(
       findHashReferenceTrigger(continuingDraft, continuingDraft.length),
     ).toBeUndefined();
+  });
+});
+
+describe("formatHashReferenceThreadLabel", () => {
+  it("keeps a short title verbatim and falls back to the id when it is blank", () => {
+    expect(
+      formatHashReferenceThreadLabel(thread("id-1", "Bob's Best Thread 3000")),
+    ).toBe("Bob's Best Thread 3000");
+    expect(formatHashReferenceThreadLabel(thread("id-1", "   "))).toBe("id-1");
+  });
+
+  it("collapses a multi-line prompt title onto one truncated line", () => {
+    const promptTitle = [
+      "#Apparently we don't allow cross-provider parent/child relationships?",
+      "We should… In this case we created a \"child\" thread that is stuck in",
+      "the unpinned section because it is a parent but we refuse to render it.",
+    ].join("\n");
+
+    const label = formatHashReferenceThreadLabel(thread("id-1", promptTitle));
+
+    expect(label).not.toContain("\n");
+    expect(label.length).toBeLessThanOrEqual(73);
+    expect(label.endsWith("…")).toBe(true);
+    expect(label).toBe(
+      "#Apparently we don't allow cross-provider parent/child relationships? We…",
+    );
+  });
+
+  it("breaks mid-token only when no word boundary is near the limit", () => {
+    const label = formatHashReferenceThreadLabel(thread("id-1", "x".repeat(200)));
+    expect(label).toBe(`${"x".repeat(72)}…`);
+  });
+});
+
+describe("collapseHashReferenceWhitespace", () => {
+  it("folds every run of whitespace into a single space", () => {
+    expect(collapseHashReferenceWhitespace("  one\n\ntwo\tthree ")).toBe(
+      "one two three",
+    );
+    expect(collapseHashReferenceWhitespace(undefined)).toBe("");
   });
 });
 

--- a/apps/desktop/src/renderer/src/lib/hash-references.ts
+++ b/apps/desktop/src/renderer/src/lib/hash-references.ts
@@ -20,7 +20,7 @@ export type HashReferenceCandidates = {
 const THREAD_CANDIDATE_LIMIT = 8;
 const PULL_REQUEST_CANDIDATE_LIMIT = 6;
 const THREAD_LABEL_LENGTH_LIMIT = 72;
-const THREAD_LABEL_MIN_BREAK_INDEX = 36;
+const THREAD_TOOLTIP_LENGTH_LIMIT = 300;
 
 /** Collapse a free-text thread title onto one line. */
 export function collapseHashReferenceWhitespace(
@@ -29,14 +29,34 @@ export function collapseHashReferenceWhitespace(
   return (value ?? "").replace(/\s+/g, " ").trim();
 }
 
+function truncateAtWordBoundary(value: string, limit: number): string {
+  if (value.length <= limit) {
+    return value;
+  }
+
+  const breakWindow = value.slice(0, limit + 1);
+  const wordBreak = breakWindow.lastIndexOf(" ");
+  const truncated =
+    wordBreak >= Math.floor(limit / 2)
+      ? value.slice(0, wordBreak)
+      : value.slice(0, limit);
+  return `${truncated.replace(/[\s,;:.-]+$/, "")}…`;
+}
+
 /**
  * A thread title is free text, and nothing guarantees it is short: a
  * provider that never derived a name leaves the operator's entire first
  * prompt — paragraphs, newlines and all — as the title. The `#` popover
  * renders one row per candidate inside a ~320px list, so an unbounded
  * title wraps until it is the only row the operator can see. Collapse to
- * a single line and cut at a word boundary; callers keep the untruncated
- * title reachable through the row's `title` attribute.
+ * a single line and cut at a word boundary.
+ *
+ * This is the label for every surface that names a referenced thread —
+ * the popover row, the composer chip, and the `[title](pwragent://…)`
+ * markdown the agent receives. Apply it wherever a token is minted, not
+ * just at the picker: a draft restore rebuilds tokens from the live
+ * thread summary rather than from the saved link text, so a formatter
+ * that skips that path is undone by the next restore.
  */
 export function formatHashReferenceThreadLabel(
   thread: Pick<NavigationThreadSummary, "id" | "title">,
@@ -45,17 +65,23 @@ export function formatHashReferenceThreadLabel(
   if (!collapsed) {
     return thread.id;
   }
-  if (collapsed.length <= THREAD_LABEL_LENGTH_LIMIT) {
-    return collapsed;
-  }
+  return truncateAtWordBoundary(collapsed, THREAD_LABEL_LENGTH_LIMIT);
+}
 
-  const breakWindow = collapsed.slice(0, THREAD_LABEL_LENGTH_LIMIT + 1);
-  const wordBreak = breakWindow.lastIndexOf(" ");
-  const truncated =
-    wordBreak >= THREAD_LABEL_MIN_BREAK_INDEX
-      ? collapsed.slice(0, wordBreak)
-      : collapsed.slice(0, THREAD_LABEL_LENGTH_LIMIT);
-  return `${truncated.replace(/[\s,;:.-]+$/, "")}…`;
+/**
+ * The hover text behind a clamped row. Longer than the label — the point
+ * is to recover what the ellipsis hid — but still bounded, because a
+ * native tooltip carrying a whole pasted prompt is its own unreadable
+ * wall of text.
+ */
+export function formatHashReferenceThreadTooltip(
+  thread: Pick<NavigationThreadSummary, "id" | "title">,
+): string {
+  const collapsed = collapseHashReferenceWhitespace(thread.title);
+  if (!collapsed) {
+    return thread.id;
+  }
+  return truncateAtWordBoundary(collapsed, THREAD_TOOLTIP_LENGTH_LIMIT);
 }
 
 /**

--- a/apps/desktop/src/renderer/src/lib/hash-references.ts
+++ b/apps/desktop/src/renderer/src/lib/hash-references.ts
@@ -19,6 +19,44 @@ export type HashReferenceCandidates = {
 
 const THREAD_CANDIDATE_LIMIT = 8;
 const PULL_REQUEST_CANDIDATE_LIMIT = 6;
+const THREAD_LABEL_LENGTH_LIMIT = 72;
+const THREAD_LABEL_MIN_BREAK_INDEX = 36;
+
+/** Collapse a free-text thread title onto one line. */
+export function collapseHashReferenceWhitespace(
+  value: string | undefined,
+): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * A thread title is free text, and nothing guarantees it is short: a
+ * provider that never derived a name leaves the operator's entire first
+ * prompt — paragraphs, newlines and all — as the title. The `#` popover
+ * renders one row per candidate inside a ~320px list, so an unbounded
+ * title wraps until it is the only row the operator can see. Collapse to
+ * a single line and cut at a word boundary; callers keep the untruncated
+ * title reachable through the row's `title` attribute.
+ */
+export function formatHashReferenceThreadLabel(
+  thread: Pick<NavigationThreadSummary, "id" | "title">,
+): string {
+  const collapsed = collapseHashReferenceWhitespace(thread.title);
+  if (!collapsed) {
+    return thread.id;
+  }
+  if (collapsed.length <= THREAD_LABEL_LENGTH_LIMIT) {
+    return collapsed;
+  }
+
+  const breakWindow = collapsed.slice(0, THREAD_LABEL_LENGTH_LIMIT + 1);
+  const wordBreak = breakWindow.lastIndexOf(" ");
+  const truncated =
+    wordBreak >= THREAD_LABEL_MIN_BREAK_INDEX
+      ? collapsed.slice(0, wordBreak)
+      : collapsed.slice(0, THREAD_LABEL_LENGTH_LIMIT);
+  return `${truncated.replace(/[\s,;:.-]+$/, "")}…`;
+}
 
 /**
  * Match a composer `#` reference from the trigger through the caret. Thread

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -20125,6 +20125,12 @@ a.transcript-message__messaging-origin:focus-visible {
   width: min(100%, 440px);
 }
 
+/* The kind badge is the row's only classifier, so it never shrinks — the
+   title label absorbs the width instead. */
+.composer__autocomplete--hash-references .composer__autocomplete-source {
+  flex: none;
+}
+
 .composer__autocomplete--directories .composer__autocomplete-option:not(.composer__autocomplete-option--action) {
   display: grid;
   grid-template-columns: minmax(0, 160px) minmax(0, 1fr);
@@ -20227,6 +20233,25 @@ a.transcript-message__messaging-origin:focus-visible {
   min-width: 0;
 }
 
+/* Kind icons keep their intrinsic size so only the label absorbs the
+   row's shrinking. */
+.composer__autocomplete-title > svg {
+  flex: none;
+}
+
+/* Free-text names (thread titles, branches, PR subjects) get one line and
+   an ellipsis. A thread whose provider never derived a short name carries
+   the operator's whole first prompt as its title, and left to wrap that
+   single row fills the popover and hides every other candidate. The full
+   text stays on the row's `title` attribute. */
+.composer__autocomplete-label {
+  min-width: 0;
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .composer__autocomplete-match {
   color: var(--accent-bright);
 }
@@ -20286,6 +20311,12 @@ a.transcript-message__messaging-origin:focus-visible {
   overflow: hidden;
 }
 
+.composer__autocomplete-meta--single-line {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .composer__autocomplete-meta--thread .chip--instance {
   flex: none;
   height: 18px;
@@ -20302,6 +20333,15 @@ a.transcript-message__messaging-origin:focus-visible {
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+}
+
+/* An all-remote result set still names its section, but there is no local
+   group above it to rule off — the border would just sit against the
+   popover's own top edge. */
+.composer__autocomplete-section-divider:first-child {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
 }
 
 .composer__autocomplete-remote-loading {


### PR DESCRIPTION
## The degenerate case

A thread title is free text, and nothing guarantees it is short. When a provider never derives a name, the operator's entire first prompt — paragraphs and newlines included — stays on as the title. The `#` picker rendered that raw, so a single candidate wrapped to ~15 lines and filled the whole `max-height: clamp(180px, 34vh, 320px)` popover; every other match was pushed behind a scroll.


## What changed

Every row is now one title line plus one meta line, so the list stays scannable no matter what the titles look like.

- **Collapse and truncate the title** — new `formatHashReferenceThreadLabel` folds whitespace onto one line and cuts at a word boundary (72 chars). This also bounds the minted composer chip and the `[title](pwragent://…)` markdown the agent receives; the url still carries the thread identity, so nothing is lost but bytes.
- **Clamp with an ellipsis** — title, branch/directory meta, and PR subject each get `text-overflow: ellipsis` on one line, and the kind badge (`Thread` / `Pull request`) no longer shrinks. The untruncated title stays reachable on the row's `title` attribute.
- **Highlight the match wherever it lands** — the picker matches thread titles by substring, but `HighlightedAutocompleteLabel` only highlighted a leading run, so on a title match it almost never fired. `matchAnywhere` is opt-in; the prefix-ranked populations (`$` skills, `/` commands, `@` directories) keep the old behavior.
- **Leave the current thread out of its own picker** — referencing the thread you are writing in tells the agent nothing it does not already have, and on a bare `#` it took the first row as the most recently updated thread.
- **Drop the "Other instances" rule when it is the first row** — an all-remote result set still names its section, but there is no local group above it to rule off, so the border just sat against the popover's top edge.

## Verification

- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors`, `pnpm lint:boundaries` — all clean.
- New coverage: 4 cases in `hash-references.test.ts` (collapse, word-boundary cut, mid-token fallback, blank-title id fallback) and 2 in `composer.test.tsx` (clamped row + `title` attribute + current-thread exclusion + the truncated markdown that reaches the agent; substring highlight).
- Full renderer suite: `2 failed | 137 passed` files both before and after — the 42 failing tests are the pre-existing `star-map` `window.localStorage` teardown failures on a clean checkout, unchanged by this branch.
- Layout verified against the real `app.css` in a side-by-side harness in both the local-and-remote and all-remote states.

## Known, not addressed here

Tracked in #1374: all four composer autocomplete popovers (`$`, `/`, `@`, `#`) use `role="listbox"` with `<button>` children carrying `aria-selected`, which fails ARIA's `aria-required-children` and leaves the input's `aria-activedescendant` pointing at a non-option. It is pre-existing and uniform across the four, so fixing it in one place would just make them inconsistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Follow-ups applied on this branch

**`489624f4` — the clamp now survives a draft restore.** The first commit
formatted the label at the two insert sites but not in
`createComposerThreadToken`, to avoid destabilizing the draft round trip.
That was backwards: `hydrateComposerDraft` rebuilds thread tokens through
`resolveThreadHref` → `threadSummaryLink`, which passes the **live**
`thread.title` and discards the saved link text — so a restore resurrected
the untruncated title in both the chip and the markdown the agent receives,
and the round trip was already not text-stable. Formatting in the factory
fixes the restore and makes the round trip converge (formatting an
already-formatted title is a no-op), and both call-site wrappers go away.
Also from review: the row tooltip is capped at 300 chars, the meta row no
longer repeats a titleless thread's id under its own label, and the PR row's
tooltip and single-line subject are now covered.

**`500e5d3d` — the chip-alignment fixture is derived, not edited.**
`composer-chip-alignment.spec.ts` failed on both E2E lanes because its
fixture holds exactly one thread: excluding the thread you are writing in
left the `#` picker with nothing to offer, so the popover never opened. The
first attempt added a thread to the committed fixture with
`"inbox": {"inInbox": false}` to keep it out of the sidebar — but
`buildNavigationSnapshot` recomputes `inbox` via `deriveInboxState`, and the
Inbox lens is `props.inboxThreads ?? props.threads` (all threads), so the row
would have appeared anyway and changed a committed docs-site PNG on the next
regen. Three specs share that fixture and only this one needs a second
thread, so the spec now derives a two-thread copy into a temp file at test
time — the pattern `docs-site-screenshots.inspect.spec.ts` already uses — and
the committed fixture is byte-identical to `main`.
