### PR TITLE
fix(desktop): add focus indicator to Star Map layout options

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -633,6 +633,30 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).not.toMatch(/\.star-map-card:focus-visible\s*\{/);
   });
 
+  // The three focusable controls in the Star Map "View" popover: the chip that
+  // opens it, each button of the layout switch, and the "Reset view" action.
+  // They are ordinary `<button>`s, so they are tab-reachable whether or not
+  // anyone styles the focused state — the layout switch shipped without a
+  // `:focus-visible` rule at all and keyboard users simply had no idea where
+  // focus was. Nothing automated caught it: axe cannot evaluate focus
+  // visibility (it is not a computable property of the resting DOM), so the
+  // a11y gate was green the whole time. This assertion IS the guard.
+  //
+  // All three name `--focus-ring` at 1px, matching the star-map card ring
+  // above. Dropping one, or drifting a token/offset, is a design decision —
+  // change this test in the same commit so it is reviewed, not accidental.
+  it("draws every Star Map view-popover focus ring from the focus-ring token", () => {
+    for (const selector of [
+      ".star-map__filter-chip:focus-visible",
+      ".star-map__layout-option:focus-visible",
+      ".star-map__view-action:focus-visible",
+    ]) {
+      const ring = extractRuleBody(css, selector);
+      expect(ring).toContain("outline: 2px solid var(--focus-ring);");
+      expect(ring).toContain("outline-offset: 1px;");
+    }
+  });
+
   it("keeps long directory names from crowding the count and expand control", () => {
     const summaryRule = extractRuleBody(css, ".directory-row__summary");
     const summaryMetaRule = extractRuleBody(css, ".directory-row__summary-meta");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9999,6 +9999,14 @@ textarea,
   cursor: pointer;
 }
 
+.star-map__layout-option:hover {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+/* After :hover so the selected option keeps its own resting style while the
+   pointer is over a sibling. The two rules happen to agree on border and
+   text colour, so the order only matters if either ever diverges. */
 .star-map__layout-option.is-on {
   border-color: var(--accent-border);
   background: var(--accent-soft);
@@ -10006,7 +10014,7 @@ textarea,
 }
 
 .star-map__layout-option:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 1px;
 }
 
@@ -10029,7 +10037,7 @@ textarea,
 }
 
 .star-map__view-action:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 1px;
 }
 
@@ -10104,8 +10112,13 @@ textarea,
   text-decoration: none;
 }
 
+/* All three focusable controls in the View popover — the chip that opens it,
+   the layout switch, and the action row — name `--focus-ring` rather than
+   `--accent`. It resolves to `var(--accent)` in both themes, so this is the
+   same pixel it always painted, and it matches both the rest of this file
+   and the star-map card ring above. Offset stays at the Star Map's 1px. */
 .star-map__filter-chip:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 1px;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10005,6 +10005,11 @@ textarea,
   color: var(--text-primary);
 }
 
+.star-map__layout-option:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
 /* Action row in the View popover ("Reset view"). Reads as the layout
    switch's sibling rather than a new control species. */
 .star-map__view-action {


### PR DESCRIPTION
## Summary

The `Lanes` / `Orbit` / `Projects` buttons in the Star Map's **View** popover (`.star-map__layout-option`) had no `:focus-visible` rule, so keyboard users got no focus indicator when tabbing onto them. They are ordinary `<button>`s and always were tab-reachable — only the focused state was invisible.

- **Adds `.star-map__layout-option:focus-visible`** — `outline: 2px solid var(--focus-ring); outline-offset: 1px;`, the Star Map's established ring.
- **Adds `.star-map__layout-option:hover`**, matching its closest sibling `.star-map__view-action:hover`. These buttons had no hover feedback either, so mouse users got no affordance. Ordered before `.is-on` so the selected option keeps its resting style.
- **Migrates all three View-popover focus rules** (filter chip, layout option, view action) from `var(--accent)` to `var(--focus-ring)`. The semantic token is defined as `var(--accent)` in both theme blocks, so this paints the identical pixel — but it matches the rest of `app.css` (58 focus rules name `--focus-ring`, 22 name `--accent`) and the star-map card ring directly above, whose comment already documents this exact migration as deliberate.
- **Locks all three rings in `theme-contract.test.tsx`.**

No raw color literals; tokens only.

## Verification

- `pnpm lint:colors` — passed.
- `pnpm lint:eslint` — 0 errors (149 pre-existing warnings, unrelated).
- `pnpm test apps/desktop/src/renderer/src/features/star-map apps/desktop/src/renderer/src/styles` — 14 files, 260 tests passed.
- **Mutation-checked the new test**, since a CSS assertion that can't fail is worse than none: deleting `.star-map__layout-option:focus-visible` fails it (`Expected app.css to define …`), and drifting one rule's token to `--accent-bright` fails it. Both restored after.

## Notes

- **The new test is the only automated guard these rings can have.** axe cannot evaluate focus visibility — it isn't a computable property of the resting DOM — so `e2e/a11y.spec.ts` was green for the entire life of this bug. A green a11y gate was never evidence the focus indicator existed.
- **Correction to this PR's original description:** it claimed the layout options already defined a `:hover` state. They did not — there were exactly three `.star-map__layout-option` rules and none was `:hover`. That gap is now fixed here, which is why the diff is larger than the one-rule change first described.
- **`.star-map__filter-chip` still has no `:hover` rule.** Left alone deliberately: it is a tri-state control (`--include` / `--exclude` / neutral) with its own background treatment, so a hover style there is a design decision rather than a consistency fix, and it does not belong in an a11y patch.
- Verified the ring is not clipped: neither `.star-map__view-panel` nor `.star-map__layout-switch` sets `overflow`, and the switch's `gap: 4px` clears the 1px offset so adjacent rings don't collide.
