### PR TITLE
fix(desktop): keep the transcript live region out of the list role

### DIFF
--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -208,20 +208,12 @@ for (const theme of AUDIT_THEMES) {
     // carrying all three chip flavours: a worktree directory, a local one,
     // and a branch.
     //
-    // Its own fixture, deliberately, on two counts. STAR_MAP_FIXTURE
-    // carries directories now, but its threads are
-    // `threadStatus: "active"`, so the thread view renders its
-    // `.transcript-list__pending` live region — a `role="status"` sibling
-    // of the `role="listitem"` entries inside `.transcript-list__items`,
-    // which is a `role="list"`. That trips `aria-required-children`,
-    // pre-existing transcript debt unrelated to the chips. (The map blocks
-    // below miss it only because the map layer covers the thread view.)
-    // Borrowing another spec's fixture would work too, but this gate's
-    // coverage would then hinge on a file it does not own: drop a directory
-    // there and this block goes quiet with no failure anywhere. An idle
-    // thread also keeps the scan UNSCOPED — narrowing it with `include` is
-    // the cheap way out and would stop this block catching anything outside
-    // the sidebar.
+    // Its own fixture, deliberately: borrowing another spec's would work
+    // too, but this gate's coverage would then hinge on a file it does not
+    // own — drop a directory there and this block goes quiet with no
+    // failure anywhere. Keeping the scan UNSCOPED matters for the same
+    // reason; narrowing it with `include` is the cheap way out and would
+    // stop this block catching anything outside the sidebar.
     test("sidebar rows carrying copy chips have no violations", async () => {
       const app = await launchAuditApp({
         theme,
@@ -268,6 +260,38 @@ for (const theme of AUDIT_THEMES) {
         // window-wide and the scoping stopped being needed.)
         await expect(
           app.window.locator(".thread-view__primary .celestial-watermark"),
+        ).toHaveCount(1);
+        await runAxe(app.window);
+      } finally {
+        await app.close();
+      }
+    });
+
+    // The block above opens the smoke fixture's thread, which is idle, so
+    // the transcript renders nothing but its `role="listitem"` entries.
+    // An ACTIVE thread additionally renders `.transcript-list__pending`,
+    // the `role="status"` thinking line — and role="status" is not a
+    // permitted owned element of the `role="list"` scroll container, so
+    // for as long as it sat there bare every active thread failed
+    // `aria-required-children` (critical) with nothing to catch it: the
+    // idle fixture never renders the live region, and the Star Map blocks
+    // do use an active fixture but the map layer covers the thread view.
+    // It now renders inside a listitem wrapper. This block is the gate on
+    // that, so keep the fixture active and the scan unscoped.
+    test("open thread view with an active thread has no violations", async () => {
+      const app = await launchAuditApp({ fixturePath: STAR_MAP_FIXTURE, theme });
+      try {
+        await app.window
+          .getByRole("button", { name: /Star map attention thread/i })
+          .first()
+          .click();
+        await expect(app.window.getByText("The star map is live.")).toBeVisible();
+        // Assert the live region is actually painted. Without this the
+        // block keeps passing if the fixture's threads stop being active
+        // (or the thinking line stops rendering), having quietly stopped
+        // auditing the thing it exists for.
+        await expect(
+          app.window.locator(".transcript-list__pending"),
         ).toHaveCount(1);
         await runAxe(app.window);
       } finally {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -1452,14 +1452,30 @@ export function TranscriptList(props: TranscriptListProps) {
             );
           })}
           {props.pendingStatusText || props.runningTurnUsageText ? (
-            <div className="transcript-list__pending" role="status">
-              {props.pendingStatusText ? <ThinkingScanner /> : null}
-              {props.pendingStatusText ? <span>{props.pendingStatusText}</span> : null}
-              {props.runningTurnUsageText ? (
-                <span className="transcript-list__pending-usage">
-                  {props.runningTurnUsageText}
-                </span>
-              ) : null}
+            /*
+              The thinking line is a live region (role="status"), and
+              role="status" is not a permitted owned child of the
+              role="list" above — axe's aria-required-children fails the
+              whole list when it sits here bare. The listitem wrapper is
+              the same `display: contents` shim the entries use, so the
+              pending element stays a direct flex child of
+              .transcript-list__content for layout, keeps its position in
+              the DOM (the `:has(...:last-child)` bottom-padding rule in
+              app.css keys off the wrapper), and keeps announcing.
+            */
+            <div
+              className="transcript-list__item transcript-list__pending-item"
+              role="listitem"
+            >
+              <div className="transcript-list__pending" role="status">
+                {props.pendingStatusText ? <ThinkingScanner /> : null}
+                {props.pendingStatusText ? <span>{props.pendingStatusText}</span> : null}
+                {props.runningTurnUsageText ? (
+                  <span className="transcript-list__pending-usage">
+                    {props.runningTurnUsageText}
+                  </span>
+                ) : null}
+              </div>
             </div>
           ) : null}
           {props.pendingUserInput ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1674,11 +1674,55 @@ describe("TranscriptList", () => {
     // sit inside a listitem wrapper, and that wrapper is what the
     // bottom-padding rule in app.css keys off, so it also has to be the
     // last child of the content wrapper when nothing follows it.
-    const pendingItem = screen.getByRole("status").parentElement;
-    expect(pendingItem).toHaveAttribute("role", "listitem");
+    const pendingItem = screen.getByRole("status").closest('[role="listitem"]');
     expect(pendingItem).toHaveClass("transcript-list__pending-item");
     expect(pendingItem).toBe(
       document.querySelector(".transcript-list__content")?.lastElementChild
+    );
+  });
+
+  // The other half of that contract. `.transcript-list__pending-item` is what
+  // the bottom-padding override in app.css tests for `:last-child`, and the
+  // wrapper made the pre-wrapper `.transcript-list__pending:last-child` form
+  // unusable: the pending element is always the only child of its wrapper, so
+  // that selector would have trimmed the over-scroll reserve even with an
+  // approval card sitting below the thinking line. Assert the wrapper stops
+  // being last-of-content as soon as something follows it, or nothing catches
+  // a regression back to a selector that matches unconditionally.
+  it("keeps the pending wrapper off the content tail when an approval follows", () => {
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "What can this skill do?"
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingStatusText="Waiting for the app server…"
+        pendingRequest={{
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "approval-1",
+            command: "node --version",
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const pendingItem = screen.getByRole("status").closest('[role="listitem"]');
+    expect(pendingItem).toHaveClass("transcript-list__pending-item");
+    const contentTail =
+      document.querySelector(".transcript-list__content")?.lastElementChild;
+    expect(contentTail).not.toBe(pendingItem);
+    expect(contentTail).toBe(
+      screen.getByRole("group", { name: "Pending approval" })
     );
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1667,6 +1667,19 @@ describe("TranscriptList", () => {
       "Usage so far: 1,100 uncached in · 1,900 cached · 50 out"
     );
     expect(screen.getByRole("status").querySelector(".thinking-scanner")).not.toBeNull();
+    // The scroll container is a role="list", and role="status" is not a
+    // permitted owned element of a list — bare, it fails axe's
+    // aria-required-children for the whole transcript (the a11y gate's
+    // active-thread block covers it end to end). The live region has to
+    // sit inside a listitem wrapper, and that wrapper is what the
+    // bottom-padding rule in app.css keys off, so it also has to be the
+    // last child of the content wrapper when nothing follows it.
+    const pendingItem = screen.getByRole("status").parentElement;
+    expect(pendingItem).toHaveAttribute("role", "listitem");
+    expect(pendingItem).toHaveClass("transcript-list__pending-item");
+    expect(pendingItem).toBe(
+      document.querySelector(".transcript-list__content")?.lastElementChild
+    );
   });
 
   it("renders replayed plan progress inline in the transcript", () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -207,13 +207,21 @@ describe("Tangerine Terminal theme contract", () => {
     // that the bottom value stays at 24 (the over-scroll feel above
     // the last message / thinking indicator) and that the pending
     // override still drops to 4px.
+    //
+    // The override keys off `.transcript-list__pending-item`, the
+    // role="listitem" wrapper the thinking line now renders inside (a
+    // bare role="status" child of the role="list" scroller trips
+    // aria-required-children). The pending element is always the last
+    // child of that wrapper, so the pre-wrapper
+    // `.transcript-list__pending:last-child` form would fire even when a
+    // questionnaire / approval card follows it.
     const itemsRule = css.match(/\.transcript-list__items\s*\{[\s\S]*?\}/)?.[0];
     expect(itemsRule).toBeDefined();
     expect(itemsRule).toMatch(
       /padding-bottom:\s*24px;|padding:\s*\S+\s+\S+\s+24px(?:\s+\S+)?;/,
     );
     expect(css).toMatch(
-      /\.transcript-list__items:has\(\.transcript-list__pending:last-child\)\s*\{[\s\S]*?padding-bottom:\s*4px;[\s\S]*?\}/
+      /\.transcript-list__items:has\(\.transcript-list__pending-item:last-child\)\s*\{[\s\S]*?padding-bottom:\s*4px;[\s\S]*?\}/
     );
     // Negative regex stays — guard against accidental large bottom
     // values (>= 40px) regardless of which form is used.

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11542,7 +11542,14 @@ textarea,
   outline: none;
 }
 
-.transcript-list__items:has(.transcript-list__pending:last-child) {
+/* Trim the bottom over-scroll reserve when the thinking line is the last
+   thing in the transcript. The hook is the listitem wrapper, not
+   `.transcript-list__pending` itself: the pending element is always the
+   only (and therefore last) child of that wrapper, so testing it directly
+   would match even when a questionnaire / MCP prompt / approval card
+   follows. The wrapper is last-of-content in exactly the cases the bare
+   selector used to match. */
+.transcript-list__items:has(.transcript-list__pending-item:last-child) {
   padding-bottom: 4px;
 }
 


### PR DESCRIPTION
## Summary

- The transcript's thinking line renders as `role="status"`, and it sat as a direct owned child of the scroll container's `role="list"`. `status` is not a permitted owned element of `list`, so **every ACTIVE thread failed axe-core's `aria-required-children` (critical, WCAG)** on `.transcript-list__items`. Pre-existing debt, not a regression.
- Wrap the live region in the same `display: contents` `role="listitem"` shim the transcript entries already use. It keeps its DOM position, its layout box as a direct flex child of `.transcript-list__content`, and its announcement behavior. The alternative — hoisting it out of `.transcript-list__items` — would take it out of the scroller entirely: no longer scrolls with the transcript, loses the bottom-glue anchoring, and needs the content column's max-width/padding re-created by hand.
- Move the bottom-reserve rule in `app.css` onto the wrapper (`.transcript-list__pending-item:last-child`). This is load-bearing, not cosmetic: the pending element is always the last child of its own wrapper, so leaving `.transcript-list__pending:last-child` would have started matching even when a questionnaire / MCP prompt / approval card follows the thinking line. The wrapper is last-of-content in exactly the cases the old selector matched. The `theme-contract` lock is updated in the same commit, per the repo rule about deliberate chrome changes.
- Gate it. The a11y suite audited the thread view only on the idle smoke fixture (which never renders the live region) and used the active fixture only behind the Star Map layer (which covers the thread view), so nothing covered this. New block audits the thread view at rest on the active fixture, asserts the live region is actually painted, then runs an **unscoped** `runAxe`. No `KNOWN_VIOLATIONS` entry — that list works via `AxeBuilder.exclude()` and would drop the whole transcript list from the scan.
- Deleted the paragraph in the copy-chip block that documented this as unfixed debt.

## Verification

Desktop E2E ran on the macOS lab guest, both directions:

| Run | Result |
|---|---|
| `e2e/a11y.spec.ts` on this branch | **18/18 passed** (9 surfaces × 2 themes), including the new block |
| Same spec on a temp commit that unwraps the live region | **2 failed** — the new block in each theme, `aria-required-children (critical)` on `.transcript-list__items`; the other 16 passed |

The negative run is the point: it proves the new block catches this specific regression, and the other 16 passing on the unwrapped build re-confirms that nothing else covered active-thread transcripts.

Locally: 617 renderer tests across `thread-detail` + `styles`, `pnpm typecheck`, `pnpm lint:colors`, `pnpm lint:eslint` (0 errors).

I also confirmed the rule behavior directly against axe-core 4.12.1 (the engine the gate runs) in a throwaway jsdom test before touching the lab — the rendered component with the wrapper reports 0 `aria-required-children` violations, a control snippet in the pre-fix shape reports exactly 1. That scratch file is not part of this branch.

## Notes

- Screen-reader trade-off, deliberate: the thinking line now counts toward the list's item count, so "list, N items" includes a transient status row. Keeping the live region outside the list avoids that but costs the scroll anchoring described above; shipping a critical WCAG violation is worse than an extra counted item.
- No visual change. The wrapper is `display: contents`, so the pending element's box, position, and flex parent are identical.
- `.transcript-list__pending-item` has no styling of its own — it's a selector hook plus the shared `.transcript-list__item` shim.
- The turn-anchor lookups (`[data-turn-id]` in `ThreadView`/`ThreadFindBar`) don't see the new wrapper: it carries no `data-turn-id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
