### PR TITLE
feat(desktop): add on-demand federation load status

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
@@ -3,6 +3,7 @@ import type {
   CreateInstanceThreadResult,
   FederationHealthStatus,
   FederationHostInfo,
+  FederationLoadStatus,
   ListFederationInstancesResult,
   ListInstanceProjectsResult,
   MaterializeDirectoryLaunchpadRequest,
@@ -220,6 +221,140 @@ describe("federation agent tools service", () => {
       ok: false,
       error: { code: "invalid_arguments" },
     });
+  });
+
+  it("attaches live load readings only to instances that answer includeLoad", async () => {
+    const localLoad: FederationLoadStatus = {
+      loadAvg1: 0.5,
+      loadAvg5: 0.4,
+      loadAvg15: 0.3,
+      availableMemoryBytes: 32_000_000_000,
+      freeDiskBytes: 400_000_000_000,
+      sampledAt: 1_000,
+    };
+    const studioLoad: FederationLoadStatus = {
+      loadAvg1: 6.5,
+      loadAvg5: 5.0,
+      loadAvg15: 4.25,
+      availableMemoryBytes: 2_000_000_000,
+      sampledAt: 1_050,
+    };
+    const remoteBackend = vi.fn(
+      (target: { instanceId: string }) =>
+        ({
+          getLoadStatus: async () => {
+            if (target.instanceId === "pwr_studio") {
+              return studioLoad;
+            }
+            throw new Error("Federation request timed out: backend.getLoadStatus");
+          },
+        }) as unknown as ReturnType<DesktopFederationRuntime["remoteBackend"]>,
+    );
+    const handler = createFederationAgentToolsHandler({
+      // Never let unit tests mint a machine-id in the real PwrAgent root.
+      collectHostInfo: async () => localHostInfo,
+      collectLoadStatus: async () => localLoad,
+      runtime: buildRuntime({
+        health: async () =>
+          buildHealth({
+            peers: [
+              {
+                id: "pwr_studio",
+                label: "Studio Mac",
+                role: "client",
+                status: "connected",
+                capabilities: ["thread_navigation"],
+              },
+              {
+                id: "pwr_slow",
+                label: "Slow Mini",
+                role: "client",
+                status: "connected",
+                capabilities: ["thread_navigation"],
+              },
+              {
+                id: "pwr_nocap",
+                label: "Locked-Down Box",
+                role: "client",
+                status: "connected",
+                capabilities: ["federated_search"],
+              },
+              {
+                id: "pwr_offline",
+                label: "Offline Mini",
+                role: "client",
+                status: "disconnected",
+                capabilities: ["thread_navigation"],
+              },
+            ],
+          }),
+        remoteBackend:
+          remoteBackend as unknown as DesktopFederationRuntime["remoteBackend"],
+      }),
+    });
+
+    const response = await handler({
+      operation: "list_federation_instances",
+      context,
+      args: { includeLoad: true },
+    });
+
+    expect(response.ok).toBe(true);
+    const data = (response as { ok: true; data: ListFederationInstancesResult })
+      .data;
+    const byId = new Map(
+      data.instances.map((instance) => [instance.instanceId, instance]),
+    );
+    expect(byId.get("pwr_local")?.load).toEqual(localLoad);
+    expect(byId.get("pwr_studio")?.load).toEqual(studioLoad);
+    // Timed-out, capability-less, and disconnected peers degrade to no
+    // load block — the listing itself never fails.
+    expect(byId.get("pwr_slow")?.load).toBeUndefined();
+    expect(byId.get("pwr_nocap")?.load).toBeUndefined();
+    expect(byId.get("pwr_offline")?.load).toBeUndefined();
+    // Only load-eligible peers are queried at all.
+    expect(remoteBackend.mock.calls.map(([target]) => target.instanceId).sort())
+      .toEqual(["pwr_slow", "pwr_studio"]);
+  });
+
+  it("does not fan out load queries unless includeLoad is set", async () => {
+    const remoteBackend = vi.fn();
+    const collectLoadStatus = vi.fn();
+    const handler = createFederationAgentToolsHandler({
+      // Never let unit tests mint a machine-id in the real PwrAgent root.
+      collectHostInfo: async () => localHostInfo,
+      collectLoadStatus,
+      runtime: buildRuntime({
+        health: async () =>
+          buildHealth({
+            peers: [
+              {
+                id: "pwr_studio",
+                label: "Studio Mac",
+                role: "client",
+                status: "connected",
+                capabilities: ["thread_navigation"],
+              },
+            ],
+          }),
+        remoteBackend:
+          remoteBackend as unknown as DesktopFederationRuntime["remoteBackend"],
+      }),
+    });
+
+    const response = await handler({
+      operation: "list_federation_instances",
+      context,
+      args: {},
+    });
+
+    expect(response.ok).toBe(true);
+    const data = (response as { ok: true; data: ListFederationInstancesResult })
+      .data;
+    expect(data.instances.every((instance) => instance.load === undefined))
+      .toBe(true);
+    expect(remoteBackend).not.toHaveBeenCalled();
+    expect(collectLoadStatus).not.toHaveBeenCalled();
   });
 
   it("rejects an unknown instance-list cursor", async () => {

--- a/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
@@ -229,7 +229,7 @@ describe("federation agent tools service", () => {
       loadAvg5: 0.4,
       loadAvg15: 0.3,
       availableMemoryBytes: 32_000_000_000,
-      freeDiskBytes: 400_000_000_000,
+      diskFreeBytes: 400_000_000_000,
       sampledAt: 1_000,
     };
     const studioLoad: FederationLoadStatus = {

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -8,6 +8,7 @@ import type {
 import {
   FEDERATION_BACKEND_METHODS,
   FEDERATION_BACKEND_METHOD_CAPABILITIES,
+  FEDERATION_LOAD_STATUS_TIMEOUT_MS,
   FederationRemoteBackendClient,
   registerFederationBackendHandlers,
   type FederationBackendOperations,
@@ -129,6 +130,56 @@ describe("federation backend bridge", () => {
     await expect(pending).resolves.toMatchObject({
       availability: "running",
       configured: true,
+    });
+  });
+
+  it("queries on-demand load through thread_navigation with a tight deadline", async () => {
+    const sent: FederationProtocolEnvelope[] = [];
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "viewer_one",
+      remoteInstanceId: "owner_one",
+      sendEnvelope: (envelope) => sent.push(envelope),
+      now: () => 1_000,
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+
+    const pending = client.getLoadStatus();
+    const request = sent.at(-1)!;
+    expect(request).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.getLoadStatus,
+      params: {},
+    });
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.getLoadStatus
+      ],
+    ).toBe("thread_navigation");
+    // Load queries carry the short leash, not the default 30s one —
+    // fleet fan-outs degrade on a slow peer instead of stalling.
+    expect(request.deadlineAt).toBe(1_000 + FEDERATION_LOAD_STATUS_TIMEOUT_MS);
+
+    rpc.receiveEnvelope({
+      id: "response-load",
+      kind: "response",
+      requestId: request.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_100,
+      result: {
+        loadAvg1: 2.5,
+        loadAvg5: 1.75,
+        loadAvg15: 1.5,
+        availableMemoryBytes: 8_000_000_000,
+        freeDiskBytes: 250_000_000_000,
+        sampledAt: 1_050,
+      },
+    });
+    await expect(pending).resolves.toMatchObject({
+      loadAvg1: 2.5,
+      availableMemoryBytes: 8_000_000_000,
+      sampledAt: 1_050,
     });
   });
 
@@ -2073,6 +2124,7 @@ describe("federation backend bridge", () => {
       trustCodexProject: vi.fn(),
       setCelestialIcon: vi.fn(),
       starMapIntake: vi.fn(),
+      getLoadStatus: vi.fn(),
     };
     const replies: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({
@@ -2345,6 +2397,7 @@ describe("federation backend bridge", () => {
         trustCodexProject: vi.fn(),
         setCelestialIcon: vi.fn(),
         starMapIntake: vi.fn(),
+        getLoadStatus: vi.fn(),
       } as FederationBackendOperations,
     });
 

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -172,7 +172,7 @@ describe("federation backend bridge", () => {
         loadAvg5: 1.75,
         loadAvg15: 1.5,
         availableMemoryBytes: 8_000_000_000,
-        freeDiskBytes: 250_000_000_000,
+        diskFreeBytes: 250_000_000_000,
         sampledAt: 1_050,
       },
     });

--- a/apps/desktop/src/main/__tests__/federation-host-info.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-host-info.test.ts
@@ -74,17 +74,17 @@ describe("federation host info", () => {
     expect(load.loadAvg5).toBeGreaterThanOrEqual(0);
     expect(load.loadAvg15).toBeGreaterThanOrEqual(0);
     expect(load.availableMemoryBytes).toBeGreaterThan(0);
-    expect(load.freeDiskBytes).toBeGreaterThan(0);
+    expect(load.diskFreeBytes).toBeGreaterThan(0);
     expect(load.sampledAt).toBeGreaterThanOrEqual(before);
     expect(load.sampledAt).toBeLessThanOrEqual(Date.now());
   });
 
-  it("omits freeDiskBytes when the root's volume cannot be read", async () => {
+  it("omits diskFreeBytes when the root's volume cannot be read", async () => {
     const load = await collectFederationLoadStatus({
       rootDir: path.join(makeRoot(), "does-not-exist"),
     });
 
-    expect(load.freeDiskBytes).toBeUndefined();
+    expect(load.diskFreeBytes).toBeUndefined();
     expect(load.availableMemoryBytes).toBeGreaterThan(0);
   });
 });

--- a/apps/desktop/src/main/__tests__/federation-host-info.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-host-info.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   collectFederationHostInfo,
+  collectFederationLoadStatus,
   readOrCreateFederationMachineId,
 } from "../federation/federation-host-info";
 
@@ -60,5 +61,30 @@ describe("federation host info", () => {
     expect((await collectFederationHostInfo({ rootDir })).machineId).toBe(
       host.machineId,
     );
+  });
+
+  it("samples a live load reading against the PwrAgent root's volume", async () => {
+    const rootDir = makeRoot();
+    const before = Date.now();
+
+    const load = await collectFederationLoadStatus({ rootDir });
+
+    // loadAvg* are 0 on Windows by Node contract, so only pin non-negative.
+    expect(load.loadAvg1).toBeGreaterThanOrEqual(0);
+    expect(load.loadAvg5).toBeGreaterThanOrEqual(0);
+    expect(load.loadAvg15).toBeGreaterThanOrEqual(0);
+    expect(load.availableMemoryBytes).toBeGreaterThan(0);
+    expect(load.freeDiskBytes).toBeGreaterThan(0);
+    expect(load.sampledAt).toBeGreaterThanOrEqual(before);
+    expect(load.sampledAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("omits freeDiskBytes when the root's volume cannot be read", async () => {
+    const load = await collectFederationLoadStatus({
+      rootDir: path.join(makeRoot(), "does-not-exist"),
+    });
+
+    expect(load.freeDiskBytes).toBeUndefined();
+    expect(load.availableMemoryBytes).toBeGreaterThan(0);
   });
 });

--- a/apps/desktop/src/main/__tests__/federation-load-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-load-ipc.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FederationLoadStatus } from "@pwragent/shared";
+import { FEDERATION_READ_INSTANCE_LOAD_CHANNEL } from "../../shared/ipc";
+
+const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn(
+      (channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+        handlers.set(channel, handler);
+      },
+    ),
+    removeHandler: vi.fn((channel: string) => {
+      handlers.delete(channel);
+    }),
+  },
+}));
+
+const runtime = {
+  health: vi.fn(),
+  localBackend: vi.fn(),
+  connectedPeerTargets: vi.fn(),
+  remoteBackend: vi.fn(),
+};
+
+vi.mock("../federation/federation-runtime", () => ({
+  getDesktopFederationRuntime: () => runtime,
+}));
+vi.mock("../federation/federation-tailscale", () => ({
+  getFederationTailscaleService: () => ({}),
+}));
+vi.mock("../federation/federation-window", () => ({
+  createFederationWindow: vi.fn(),
+}));
+
+const localLoad: FederationLoadStatus = {
+  loadAvg1: 0.5,
+  loadAvg5: 0.4,
+  loadAvg15: 0.3,
+  availableMemoryBytes: 16_000_000_000,
+  diskFreeBytes: 250_000_000_000,
+  sampledAt: 1_000,
+};
+
+const remoteLoad: FederationLoadStatus = {
+  loadAvg1: 7.5,
+  loadAvg5: 6.0,
+  loadAvg15: 4.5,
+  availableMemoryBytes: 1_000_000_000,
+  sampledAt: 1_100,
+};
+
+async function invokeReadInstanceLoad(request?: unknown): Promise<unknown> {
+  const { registerFederationIpcHandlers } = await import("../ipc/federation");
+  registerFederationIpcHandlers();
+  return await handlers.get(FEDERATION_READ_INSTANCE_LOAD_CHANNEL)!(
+    {},
+    request,
+  );
+}
+
+describe("federation read-instance-load ipc", () => {
+  beforeEach(() => {
+    handlers.clear();
+    runtime.health.mockReset().mockResolvedValue({ instanceId: "pwr_local" });
+    runtime.localBackend
+      .mockReset()
+      .mockReturnValue({ getLoadStatus: async () => localLoad });
+    runtime.connectedPeerTargets.mockReset().mockReturnValue([]);
+    runtime.remoteBackend.mockReset();
+  });
+
+  it("samples locally when no instance id is given", async () => {
+    await expect(invokeReadInstanceLoad()).resolves.toEqual({
+      load: localLoad,
+    });
+    expect(runtime.remoteBackend).not.toHaveBeenCalled();
+  });
+
+  it("samples locally for the local instance's own id", async () => {
+    await expect(
+      invokeReadInstanceLoad({ instanceId: "pwr_local" }),
+    ).resolves.toEqual({ load: localLoad });
+    expect(runtime.remoteBackend).not.toHaveBeenCalled();
+  });
+
+  it("queries a connected thread_navigation peer over the federation RPC", async () => {
+    runtime.connectedPeerTargets.mockReturnValue([
+      {
+        target: { scope: "remote", instanceId: "pwr_studio" },
+        label: "Studio Mac",
+        capabilities: ["thread_navigation"],
+      },
+    ]);
+    runtime.remoteBackend.mockReturnValue({
+      getLoadStatus: async () => remoteLoad,
+    });
+
+    await expect(
+      invokeReadInstanceLoad({ instanceId: "pwr_studio" }),
+    ).resolves.toEqual({ load: remoteLoad });
+    expect(runtime.remoteBackend).toHaveBeenCalledWith({
+      scope: "remote",
+      instanceId: "pwr_studio",
+    });
+  });
+
+  it("returns no load for a peer that is not connected", async () => {
+    await expect(
+      invokeReadInstanceLoad({ instanceId: "pwr_offline" }),
+    ).resolves.toEqual({});
+    expect(runtime.remoteBackend).not.toHaveBeenCalled();
+  });
+
+  it("returns no load for a peer without thread_navigation", async () => {
+    runtime.connectedPeerTargets.mockReturnValue([
+      {
+        target: { scope: "remote", instanceId: "pwr_locked" },
+        label: "Locked-Down Box",
+        capabilities: ["federated_search"],
+      },
+    ]);
+
+    await expect(
+      invokeReadInstanceLoad({ instanceId: "pwr_locked" }),
+    ).resolves.toEqual({});
+    expect(runtime.remoteBackend).not.toHaveBeenCalled();
+  });
+
+  it("degrades a failed remote query to no load, never an error", async () => {
+    runtime.connectedPeerTargets.mockReturnValue([
+      {
+        target: { scope: "remote", instanceId: "pwr_slow" },
+        label: "Slow Mini",
+        capabilities: ["thread_navigation"],
+      },
+    ]);
+    runtime.remoteBackend.mockReturnValue({
+      getLoadStatus: async () => {
+        throw new Error("Federation request timed out: backend.getLoadStatus");
+      },
+    });
+
+    await expect(
+      invokeReadInstanceLoad({ instanceId: "pwr_slow" }),
+    ).resolves.toEqual({});
+  });
+
+  it("rejects a malformed instance id before touching the runtime", async () => {
+    await expect(
+      invokeReadInstanceLoad({ instanceId: "not a valid id!" }),
+    ).rejects.toThrow("Invalid federation instance id");
+    expect(runtime.health).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-transfer-ledger.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transfer-ledger.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { FederationTransferLedger } from "../federation/federation-transfer-ledger";
+
+describe("federation transfer ledger", () => {
+  it("accumulates per-peer directional byte and envelope counts", () => {
+    const ledger = new FederationTransferLedger();
+
+    ledger.record({
+      peerId: "pwr_studio",
+      direction: "sent",
+      byteCount: 1_000,
+      at: 1_000,
+    });
+    ledger.record({
+      peerId: "pwr_studio",
+      direction: "received",
+      byteCount: 200_000_000,
+      at: 2_000,
+    });
+    ledger.record({
+      peerId: "pwr_studio",
+      direction: "received",
+      byteCount: 500,
+      at: 3_000,
+    });
+    ledger.record({
+      peerId: "pwr_rack",
+      direction: "sent",
+      byteCount: 42,
+      at: 4_000,
+    });
+
+    expect(ledger.snapshot("pwr_studio")).toEqual({
+      bytesSent: 1_000,
+      bytesReceived: 200_000_500,
+      envelopesSent: 1,
+      envelopesReceived: 2,
+      since: 1_000,
+      lastActivityAt: 3_000,
+    });
+    expect(ledger.snapshot("pwr_rack")).toEqual({
+      bytesSent: 42,
+      bytesReceived: 0,
+      envelopesSent: 1,
+      envelopesReceived: 0,
+      since: 4_000,
+      lastActivityAt: 4_000,
+    });
+  });
+
+  it("returns nothing for peers with no observed activity", () => {
+    const ledger = new FederationTransferLedger();
+
+    expect(ledger.snapshot("pwr_idle")).toBeUndefined();
+  });
+
+  it("hands out copies, not live counter objects", () => {
+    const ledger = new FederationTransferLedger();
+    ledger.record({
+      peerId: "pwr_studio",
+      direction: "sent",
+      byteCount: 10,
+      at: 1_000,
+    });
+
+    const snapshot = ledger.snapshot("pwr_studio")!;
+    snapshot.bytesSent = 999;
+
+    expect(ledger.snapshot("pwr_studio")?.bytesSent).toBe(10);
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -166,6 +166,104 @@ describe("federation transport", () => {
     expect(server?.closePeer("client_one")).toBe(false);
   });
 
+  it("reports envelope wire bytes to both ends' transfer taps", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const gatewayTransfers: Array<{
+      peerId: string;
+      direction: "sent" | "received";
+      byteCount: number;
+    }> = [];
+    const clientTransfers: Array<{
+      direction: "sent" | "received";
+      byteCount: number;
+    }> = [];
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-transfer",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      onEnvelope: (envelope, connection) => {
+        connection.sendEnvelope({
+          id: "response-transfer",
+          kind: "response",
+          requestId: envelope.id,
+          protocolVersion: 1,
+          sourceInstanceId: "gateway_one",
+          targetInstanceId: connection.peerId,
+          createdAt: 2_000,
+          result: { ok: true },
+        });
+      },
+      onEnvelopeTransfer: (info) => gatewayTransfers.push(info),
+    });
+    const { url } = await server.start();
+
+    const reply = new Promise<FederationProtocolEnvelope>((resolve) => {
+      void connectFederationClient({
+        url,
+        mode: "enroll",
+        gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+        peerInstanceId: "client_one",
+        privateKeyPem: clientKeyPair.privateKeyPem,
+        publicKeyPem: clientKeyPair.publicKeyPem,
+        capabilities: ["remote_window"],
+        inviteToken: invite.token,
+        label: "Client",
+        role: "client",
+        onEnvelope: resolve,
+        onEnvelopeTransfer: (info) => clientTransfers.push(info),
+      }).then((client) => {
+        client.sendEnvelope({
+          id: "request-transfer",
+          kind: "request",
+          method: "thread.list",
+          params: {},
+          protocolVersion: 1,
+          sourceInstanceId: "client_one",
+          targetInstanceId: "gateway_one",
+          createdAt: 1_000,
+        });
+      });
+    });
+    await expect(reply).resolves.toMatchObject({
+      kind: "response",
+      requestId: "request-transfer",
+    });
+
+    // Envelope frames only — the auth exchange fires no taps, so one
+    // round-trip is exactly two events per side.
+    expect(gatewayTransfers).toHaveLength(2);
+    expect(clientTransfers).toHaveLength(2);
+    const [gatewayReceived, gatewaySent] = gatewayTransfers;
+    const [clientSent, clientReceived] = clientTransfers;
+    expect(gatewayReceived).toMatchObject({
+      peerId: "client_one",
+      direction: "received",
+    });
+    expect(gatewaySent).toMatchObject({
+      peerId: "client_one",
+      direction: "sent",
+    });
+    expect(clientSent.direction).toBe("sent");
+    expect(clientReceived.direction).toBe("received");
+    // Both ends count the same wire frames, so the figures agree — the
+    // property that makes a local ledger a truthful transfer monitor.
+    expect(gatewayReceived.byteCount).toBe(clientSent.byteCount);
+    expect(clientReceived.byteCount).toBe(gatewaySent.byteCount);
+    expect(clientSent.byteCount).toBeGreaterThan(0);
+    expect(gatewaySent.byteCount).toBeGreaterThan(0);
+  });
+
   it("evicts a duplicated peer id with close code 4001 and audits the replacement", async () => {
     const clientKeyPair = generateFederationIdentityKeyPair();
     let firstClose: { code: number; reason: string } | undefined;

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts
@@ -26,6 +26,7 @@ describe("pwragent federation agent tools", () => {
                 query: expect.objectContaining({ type: "string" }),
                 limit: expect.objectContaining({ minimum: 1, maximum: 100 }),
                 cursor: expect.objectContaining({ type: "string" }),
+                includeLoad: expect.objectContaining({ type: "boolean" }),
               }),
             }),
           }),
@@ -212,7 +213,7 @@ describe("pwragent federation agent tools", () => {
         callId: "call-1",
         namespace: "pwragent",
         tool: "list_federation_instances",
-        arguments: { query: " linux ", limit: 10 },
+        arguments: { query: " linux ", limit: 10, includeLoad: true },
       },
     });
 
@@ -224,8 +225,28 @@ describe("pwragent federation agent tools", () => {
         callId: "call-1",
         turnId: "turn-1",
       },
-      args: { query: "linux", limit: 10 },
+      args: { query: "linux", limit: 10, includeLoad: true },
     });
+  });
+
+  it("rejects a non-boolean includeLoad before dispatching list_federation_instances", async () => {
+    const handler = vi.fn();
+    const router = buildPwrAgentFederationToolRouter(handler);
+
+    const response = await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "list_federation_instances",
+        arguments: { includeLoad: "yes" },
+      },
+    });
+
+    expect(response).toMatchObject({ success: false });
+    expect(handler).not.toHaveBeenCalled();
   });
 
   it("rejects an out-of-range limit before dispatching search_federation_threads", async () => {

--- a/apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts
@@ -93,7 +93,7 @@ function descriptionForOperation(
 ): string {
   switch (operation) {
     case "list_federation_instances":
-      return "List the PwrAgent instances this app can reach: the local instance plus any federated peers, each with its id, display label, celestial icon, operator-written purpose notes, connection status, capabilities, an isLocal flag, and host facts (OS platform/version, hostname, CPU architecture and count, total RAM, free disk, machineId). Use this first when the user wants work routed to a particular machine ('on the studio Mac', 'on the rack mini') or for 'find me a place to run this' requests — purpose notes describe intent, host facts describe capability. Instances sharing the same host.machineId are profiles on one physical machine and compete for the same CPUs/RAM — never sum their capacity. Disk/host figures are snapshots from the last handshake, not live readings. Results are paged: at most `limit` rows (default 25) per call, with nextCursor and totalCount when more remain; pass nextCursor back promptly (tokens expire after about a minute), or better, use `query` to filter by label, notes, profile, hostname, platform, or architecture instead of paging through a large fleet. Works with federation disabled too: the result is then just the local instance, so there is no need to check whether federation is configured before calling. Only instances with status connected (or the local instance) can accept new work.";
+      return "List the PwrAgent instances this app can reach: the local instance plus any federated peers, each with its id, display label, celestial icon, operator-written purpose notes, connection status, capabilities, an isLocal flag, and host facts (OS platform/version, hostname, CPU architecture and count, total RAM, free disk, machineId). Use this first when the user wants work routed to a particular machine ('on the studio Mac', 'on the rack mini') or for 'find me a place to run this' requests — purpose notes describe intent, host facts describe capability. Instances sharing the same host.machineId are profiles on one physical machine and compete for the same CPUs/RAM — never sum their capacity. Disk/host figures are snapshots from the last handshake, not live readings. For live readings, pass includeLoad: true to attach a `load` sibling next to `host` (1/5/15-minute CPU load averages, available RAM bytes, free disk bytes, sampledAt) fetched from each reachable instance with a short per-peer timeout — instances that fail to answer in time simply omit `load`. Load is per machine, not per instance: rows sharing host.machineId report the same underlying load, so dedupe by machineId when aggregating load for placement decisions. Results are paged: at most `limit` rows (default 25) per call, with nextCursor and totalCount when more remain; pass nextCursor back promptly (tokens expire after about a minute), or better, use `query` to filter by label, notes, profile, hostname, platform, or architecture instead of paging through a large fleet. Works with federation disabled too: the result is then just the local instance, so there is no need to check whether federation is configured before calling. Only instances with status connected (or the local instance) can accept new work.";
     case "list_instance_projects":
       return "List the projects/directories available on one PwrAgent instance, local or remote. Pass an instanceId from list_federation_instances. Each project row carries the key to pass to create_instance_thread as projectKey, plus its label, filesystem path, and whether a launchpad (per-project environment, model, and execution-mode presets) is configured. Use this to find the project the user is talking about on the chosen instance before creating a thread there.";
     case "create_instance_thread":
@@ -127,6 +127,11 @@ function inputSchemaForOperation(
             type: "string",
             description:
               "Continuation token from a previous truncated result. Tokens expire after about a minute; on an expired-cursor error, call again without a cursor.",
+          },
+          includeLoad: {
+            type: "boolean",
+            description:
+              "When true, attach a live `load` block (CPU load averages, available RAM, free disk, sampledAt) to each reachable instance via a short-timeout on-demand query. Instances that fail to answer in time omit `load`. Rows sharing host.machineId report the same underlying load — dedupe by machineId when aggregating.",
           },
         },
       };
@@ -263,7 +268,7 @@ function invalidArgumentsMessageForOperation(
 ): string {
   switch (operation) {
     case "list_federation_instances":
-      return "list_federation_instances accepts an optional non-empty query, an integer limit between 1 and 100, and an optional non-empty cursor.";
+      return "list_federation_instances accepts an optional non-empty query, an integer limit between 1 and 100, an optional non-empty cursor, and an optional boolean includeLoad.";
     case "list_instance_projects":
       return "list_instance_projects requires a non-empty instanceId string.";
     case "create_instance_thread":
@@ -293,12 +298,19 @@ function normalizeListFederationInstancesArgs(
     }
     limit = args.limit;
   }
+  if (
+    args.includeLoad !== undefined
+    && typeof args.includeLoad !== "boolean"
+  ) {
+    return undefined;
+  }
   const query = readTrimmedString(args.query);
   const cursor = readTrimmedString(args.cursor);
   return {
     ...(query ? { query } : {}),
     ...(limit !== undefined ? { limit } : {}),
     ...(cursor ? { cursor } : {}),
+    ...(args.includeLoad === true ? { includeLoad: true } : {}),
   };
 }
 

--- a/apps/desktop/src/main/federation/federation-agent-tools-service.ts
+++ b/apps/desktop/src/main/federation/federation-agent-tools-service.ts
@@ -6,6 +6,7 @@ import type {
   FederationHostInfo,
   FederationInstanceDescriptor,
   FederationInstanceId,
+  FederationLoadStatus,
   FederationRemoteTarget,
   FederationThreadSearchResultSummary,
   ListFederationInstancesResult,
@@ -32,7 +33,10 @@ import { getDesktopSettingsService } from "../settings/desktop-settings-singleto
 import type { RemoteThreadTargetStore } from "../state/remote-thread-target-store";
 import { FederatedSearchService } from "./federated-search-service";
 import type { FederationBackendOperations } from "./federation-backend-bridge";
-import { collectFederationHostInfo } from "./federation-host-info";
+import {
+  collectFederationHostInfo,
+  collectFederationLoadStatus,
+} from "./federation-host-info";
 import {
   defaultInstanceLabel,
   getDesktopFederationRuntime,
@@ -80,20 +84,24 @@ export function createFederationAgentToolsHandler(
   options: {
     runtime?: () => DesktopFederationRuntime;
     collectHostInfo?: () => Promise<FederationHostInfo>;
+    collectLoadStatus?: () => Promise<FederationLoadStatus>;
     targetStore?: RemoteThreadTargetStore;
   } = {},
 ): PwrAgentFederationHandler {
   const runtime = options.runtime ?? getDesktopFederationRuntime;
   const collectHostInfo = options.collectHostInfo ?? collectFederationHostInfo;
+  const collectLoadStatus =
+    options.collectLoadStatus ?? collectFederationLoadStatus;
   const cursors = new Map<string, InstanceListCursorEntry>();
   return async (request) => {
     try {
       if (request.operation === "list_federation_instances") {
-        return listFederationInstances(
+        return await listFederationInstances(
           runtime(),
           request.args,
           cursors,
           collectHostInfo,
+          collectLoadStatus,
         );
       }
       if (request.operation === "list_instance_projects") {
@@ -127,6 +135,7 @@ async function listFederationInstances(
   args: ListFederationInstancesToolArgs,
   cursors: Map<string, InstanceListCursorEntry>,
   collectHostInfo: () => Promise<FederationHostInfo>,
+  collectLoadStatus: () => Promise<FederationLoadStatus>,
 ): Promise<PwrAgentFederationResponse> {
   const limit = args.limit ?? DEFAULT_INSTANCE_PAGE_SIZE;
   pruneExpiredCursors(cursors);
@@ -167,6 +176,12 @@ async function listFederationInstances(
   const instances = [local, ...peers].filter((instance) =>
     matchesInstanceQuery(instance, args.query),
   );
+  // Loads are sampled once for the whole listing, so continuation pages
+  // serve readings at most one cursor TTL (~60s) old — the staleness a
+  // token-paged listing already accepts.
+  const listed = args.includeLoad
+    ? await attachInstanceLoads({ runtime, instances, collectLoadStatus })
+    : instances;
   return ok(
     pageInstances({
       cursors,
@@ -174,11 +189,63 @@ async function listFederationInstances(
         expiresAt: Date.now() + INSTANCE_CURSOR_TTL_MS,
         offset: 0,
         federationEnabled: health.enabled,
-        instances,
+        instances: listed,
       },
       limit,
     }),
   );
+}
+
+/**
+ * Fan the on-demand load query out concurrently: the local instance (a
+ * gateway answers for itself) samples directly, connected peers ride the
+ * short-timeout `backend.getLoadStatus` RPC — relayed peers included,
+ * through the same envelope relay as every backend RPC. Any instance
+ * that fails or times out just omits `load`; a slow peer must never
+ * fail the listing.
+ */
+async function attachInstanceLoads(params: {
+  runtime: DesktopFederationRuntime;
+  instances: FederationInstanceDescriptor[];
+  collectLoadStatus: () => Promise<FederationLoadStatus>;
+}): Promise<FederationInstanceDescriptor[]> {
+  return await Promise.all(
+    params.instances.map(async (instance) => {
+      const load = await queryInstanceLoad(params, instance);
+      return load ? { ...instance, load } : instance;
+    }),
+  );
+}
+
+async function queryInstanceLoad(
+  params: {
+    runtime: DesktopFederationRuntime;
+    collectLoadStatus: () => Promise<FederationLoadStatus>;
+  },
+  instance: FederationInstanceDescriptor,
+): Promise<FederationLoadStatus | undefined> {
+  if (
+    !instance.isLocal
+    && (
+      instance.status !== "connected"
+      || !instance.capabilities.includes("thread_navigation")
+    )
+  ) {
+    return undefined;
+  }
+  try {
+    return instance.isLocal
+      ? await params.collectLoadStatus()
+      : await params.runtime
+          .remoteBackend({ scope: "remote", instanceId: instance.instanceId })
+          .getLoadStatus();
+  } catch (error) {
+    log.debug("instance load query failed", {
+      instanceId: instance.instanceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
 }
 
 function pageInstances(params: {

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -25,6 +25,7 @@ import type {
   DetachThreadPullRequestRequest,
   DetachThreadPullRequestResponse,
   FederationCapability,
+  FederationLoadStatus,
   FederationRequestEnvelope,
   ForkThreadRequest,
   ForkThreadResponse,
@@ -128,6 +129,14 @@ import { FEDERATION_MAX_FRAME_BYTES } from "./federation-transport";
 
 const FEDERATION_RESPONSE_BYTE_BUDGET =
   FEDERATION_MAX_FRAME_BYTES - 64 * 1024;
+
+/**
+ * Load queries answer from in-memory OS counters plus one statfs, so a
+ * healthy peer replies well inside a second. Callers fan the query out
+ * across the fleet and degrade to "no load block" on timeout — a slow
+ * peer must cost seconds, not the default 30s RPC leash.
+ */
+export const FEDERATION_LOAD_STATUS_TIMEOUT_MS = 2_500;
 
 export type FederationReadTranscriptImageRequest = {
   url: string;
@@ -271,6 +280,7 @@ export const FEDERATION_BACKEND_METHODS = {
   openApplication: "backend.openApplication",
   readMessagingPlatformStatuses: "backend.readMessagingPlatformStatuses",
   readPwrSnapConnectionStatus: "backend.readPwrSnapConnectionStatus",
+  getLoadStatus: "backend.getLoadStatus",
   trustCodexProject: "backend.trustCodexProject",
   setCelestialIcon: "backend.setCelestialIcon",
   starMapIntake: "backend.starMapIntake",
@@ -360,6 +370,13 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   // messaging_route stays reserved for messaging-originated remote control.
   [FEDERATION_BACKEND_METHODS.readMessagingPlatformStatuses]: "remote_window",
   [FEDERATION_BACKEND_METHODS.readPwrSnapConnectionStatus]: "pwrsnap_connection",
+  // On-demand load readings (CPU load averages, available RAM, free
+  // disk) are read-only health facts at the same sensitivity tier as
+  // the browse-level grants, and the Star Map surface that polls them
+  // already rides thread_navigation for its event class. A dedicated
+  // capability would buy no isolation and cost every peer a handshake
+  // re-advertisement.
+  [FEDERATION_BACKEND_METHODS.getLoadStatus]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.trustCodexProject]: "environment_actions",
   // Celestial icon overrides are directed at the gateway (the assignment
   // coordinator). No dedicated capability exists for federation-level
@@ -525,6 +542,7 @@ export type FederationBackendOperations = {
   ): Promise<OpenDesktopApplicationResponse>;
   readMessagingPlatformStatuses(): Promise<MessagingPlatformStatus[]>;
   readPwrSnapConnectionStatus(): Promise<PwrSnapConnectionStatus>;
+  getLoadStatus(): Promise<FederationLoadStatus>;
   trustCodexProject(
     request: TrustCodexProjectRequest,
   ): Promise<TrustCodexProjectResponse>;
@@ -1010,6 +1028,10 @@ export function registerFederationBackendHandlers(params: {
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.readPwrSnapConnectionStatus,
     async () => await params.backend.readPwrSnapConnectionStatus(),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.getLoadStatus,
+    async () => await params.backend.getLoadStatus(),
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.openApplication,
@@ -1555,6 +1577,14 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
     return await this.rpc.request<PwrSnapConnectionStatus>({
       method: FEDERATION_BACKEND_METHODS.readPwrSnapConnectionStatus,
       params: {},
+    });
+  }
+
+  async getLoadStatus(): Promise<FederationLoadStatus> {
+    return await this.rpc.request<FederationLoadStatus>({
+      method: FEDERATION_BACKEND_METHODS.getLoadStatus,
+      params: {},
+      timeoutMs: FEDERATION_LOAD_STATUS_TIMEOUT_MS,
     });
   }
 

--- a/apps/desktop/src/main/federation/federation-host-info.ts
+++ b/apps/desktop/src/main/federation/federation-host-info.ts
@@ -82,7 +82,7 @@ export async function collectFederationHostInfo(options?: {
  * Live load reading, sampled at call time — the on-demand counterpart to
  * {@link collectFederationHostInfo}'s static facts. Served by the
  * `backend.getLoadStatus` federation RPC and never gossiped. `loadAvg*`
- * are 0 on Windows (Node's `os.loadavg()` contract); `freeDiskBytes`
+ * are 0 on Windows (Node's `os.loadavg()` contract); `diskFreeBytes`
  * measures the volume holding the PwrAgent root and is omitted when the
  * read fails.
  */
@@ -91,19 +91,19 @@ export async function collectFederationLoadStatus(options?: {
 }): Promise<FederationLoadStatus> {
   const rootDir = options?.rootDir ?? resolvePwragentRoot();
   const [loadAvg1, loadAvg5, loadAvg15] = os.loadavg();
-  let freeDiskBytes: number | undefined;
+  let diskFreeBytes: number | undefined;
   try {
     const stats = await fs.statfs(rootDir);
-    freeDiskBytes = stats.bavail * stats.bsize;
+    diskFreeBytes = stats.bavail * stats.bsize;
   } catch {
-    freeDiskBytes = undefined;
+    diskFreeBytes = undefined;
   }
   return {
     loadAvg1,
     loadAvg5,
     loadAvg15,
     availableMemoryBytes: os.freemem(),
-    ...(freeDiskBytes !== undefined ? { freeDiskBytes } : {}),
+    ...(diskFreeBytes !== undefined ? { diskFreeBytes } : {}),
     sampledAt: Date.now(),
   };
 }

--- a/apps/desktop/src/main/federation/federation-host-info.ts
+++ b/apps/desktop/src/main/federation/federation-host-info.ts
@@ -2,7 +2,10 @@ import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { FederationHostInfo } from "@pwragent/shared";
+import type {
+  FederationHostInfo,
+  FederationLoadStatus,
+} from "@pwragent/shared";
 import { resolvePwragentRoot } from "../profile";
 
 const MACHINE_ID_FILENAME = "machine-id";
@@ -72,5 +75,35 @@ export async function collectFederationHostInfo(options?: {
     memoryBytes: os.totalmem(),
     ...(diskFreeBytes !== undefined ? { diskFreeBytes } : {}),
     ...(machineId ? { machineId } : {}),
+  };
+}
+
+/**
+ * Live load reading, sampled at call time — the on-demand counterpart to
+ * {@link collectFederationHostInfo}'s static facts. Served by the
+ * `backend.getLoadStatus` federation RPC and never gossiped. `loadAvg*`
+ * are 0 on Windows (Node's `os.loadavg()` contract); `freeDiskBytes`
+ * measures the volume holding the PwrAgent root and is omitted when the
+ * read fails.
+ */
+export async function collectFederationLoadStatus(options?: {
+  rootDir?: string;
+}): Promise<FederationLoadStatus> {
+  const rootDir = options?.rootDir ?? resolvePwragentRoot();
+  const [loadAvg1, loadAvg5, loadAvg15] = os.loadavg();
+  let freeDiskBytes: number | undefined;
+  try {
+    const stats = await fs.statfs(rootDir);
+    freeDiskBytes = stats.bavail * stats.bsize;
+  } catch {
+    freeDiskBytes = undefined;
+  }
+  return {
+    loadAvg1,
+    loadAvg5,
+    loadAvg15,
+    availableMemoryBytes: os.freemem(),
+    ...(freeDiskBytes !== undefined ? { freeDiskBytes } : {}),
+    sampledAt: Date.now(),
   };
 }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -27,6 +27,7 @@ import type {
   FederationHostInfo,
   FederationInstanceId,
   FederationInstanceRole,
+  FederationLoadStatus,
   FederationPeerSummary,
   FederationPinDisposition,
   FederationProtocolEnvelope,
@@ -181,7 +182,10 @@ import {
   encodeFederationInvite,
 } from "./federation-enrollment";
 import { FederatedSearchService } from "./federated-search-service";
-import { collectFederationHostInfo } from "./federation-host-info";
+import {
+  collectFederationHostInfo,
+  collectFederationLoadStatus,
+} from "./federation-host-info";
 import { RemoteThreadSummaryCache } from "./remote-thread-summary-cache";
 import { hydrateFederatedThreadMessageOrigins } from "./federated-thread-origin-hydrator";
 import {
@@ -4296,6 +4300,9 @@ function localBackendOperations(): FederationBackendOperations {
     },
     async readPwrSnapConnectionStatus(): Promise<PwrSnapConnectionStatus> {
       return await getPwrSnapConnectionService().readStatus();
+    },
+    async getLoadStatus(): Promise<FederationLoadStatus> {
+      return await collectFederationLoadStatus();
     },
     async trustCodexProject(
       request: TrustCodexProjectRequest,

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -186,6 +186,7 @@ import {
   collectFederationHostInfo,
   collectFederationLoadStatus,
 } from "./federation-host-info";
+import { FederationTransferLedger } from "./federation-transfer-ledger";
 import { RemoteThreadSummaryCache } from "./remote-thread-summary-cache";
 import { hydrateFederatedThreadMessageOrigins } from "./federated-thread-origin-hydrator";
 import {
@@ -571,6 +572,12 @@ export class DesktopFederationRuntime {
     FederationInstanceId,
     number
   >();
+  /**
+   * Per-peer wire counters, fed by the transports' envelope taps.
+   * Deliberately a runtime-lifetime field (not reset in stop/restart):
+   * the operator's baseline-vs-optimized comparison spans reconnects.
+   */
+  private readonly transferLedger = new FederationTransferLedger();
   private gatewayListenerError?: string;
 
   setAgentEventPublisher(publisher: (event: AgentEvent) => void): void {
@@ -806,7 +813,13 @@ export class DesktopFederationRuntime {
     const settings = await getDesktopSettingsService().readSettings();
     const health = buildFederationHealthStatus({
       settings,
-      peers: this.visiblePeers(),
+      // Transfer counters attach here and only here — visiblePeers()
+      // feeds the gossiped peer directory too, and these numbers
+      // describe OUR socket with each peer, not facts about the peer.
+      peers: this.visiblePeers().map((peer) => {
+        const transfer = this.transferLedger.snapshot(peer.id);
+        return transfer ? { ...peer, transfer } : peer;
+      }),
       instanceId: this.ensureLocalInstanceId(),
       listenUrl: this.listenUrl,
       unavailableReason: this.gatewayListenerError,
@@ -1771,6 +1784,7 @@ export class DesktopFederationRuntime {
         },
         onEnvelope: (envelope, connection) =>
           void this.receiveEnvelope(envelope, connection.peerId),
+        onEnvelopeTransfer: (info) => this.transferLedger.record(info),
       });
       try {
         const started = await this.server.start();
@@ -1989,6 +2003,10 @@ export class DesktopFederationRuntime {
       // notes when the operator erases theirs (absent means "old client").
       notes: this.instanceNotes ?? settings.federation.instanceNotes.value.trim(),
       host: this.localHostInfo,
+      // All client traffic rides this one socket, so the counters land
+      // on the gateway's row — including relayed sibling traffic.
+      onEnvelopeTransfer: (info) =>
+        this.transferLedger.record({ ...info, peerId: gatewayInstanceId }),
       role: "client",
       headers: cloudflareAccessEnabled
         ? {

--- a/apps/desktop/src/main/federation/federation-transfer-ledger.ts
+++ b/apps/desktop/src/main/federation/federation-transfer-ledger.ts
@@ -1,0 +1,52 @@
+import type {
+  FederationInstanceId,
+  FederationTransferStats,
+} from "@pwragent/shared";
+
+/**
+ * Process-local wire-transfer accounting per directly connected peer.
+ * Fed by the transport's envelope-frame taps (post-encryption byte
+ * counts, so compression changes read as real wire savings) and read
+ * by the health surface. Counters accumulate across reconnects within
+ * one app run — the runtime keeps a single ledger across restarts of
+ * the federation stack — and are deliberately never persisted: they
+ * exist to answer "how much has this connection moved since launch",
+ * the baseline-vs-optimized comparison an operator actually runs.
+ */
+export class FederationTransferLedger {
+  private readonly byPeer = new Map<
+    FederationInstanceId,
+    FederationTransferStats
+  >();
+
+  record(params: {
+    peerId: FederationInstanceId;
+    direction: "sent" | "received";
+    byteCount: number;
+    at?: number;
+  }): void {
+    const at = params.at ?? Date.now();
+    const stats = this.byPeer.get(params.peerId) ?? {
+      bytesSent: 0,
+      bytesReceived: 0,
+      envelopesSent: 0,
+      envelopesReceived: 0,
+      since: at,
+      lastActivityAt: at,
+    };
+    if (params.direction === "sent") {
+      stats.bytesSent += params.byteCount;
+      stats.envelopesSent += 1;
+    } else {
+      stats.bytesReceived += params.byteCount;
+      stats.envelopesReceived += 1;
+    }
+    stats.lastActivityAt = at;
+    this.byPeer.set(params.peerId, stats);
+  }
+
+  snapshot(peerId: FederationInstanceId): FederationTransferStats | undefined {
+    const stats = this.byPeer.get(peerId);
+    return stats ? { ...stats } : undefined;
+  }
+}

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -276,6 +276,16 @@ export type FederationGatewayWebSocketServerOptions = {
     envelope: FederationProtocolEnvelope,
     connection: FederationGatewayConnection,
   ) => void;
+  /**
+   * Wire-byte tap for envelope frames only (handshake/auth frames and
+   * WebSocket keepalives are not reported). `byteCount` is the frame's
+   * post-encryption length — what actually crossed the wire.
+   */
+  onEnvelopeTransfer?: (info: {
+    peerId: FederationInstanceId;
+    direction: "sent" | "received";
+    byteCount: number;
+  }) => void;
 };
 
 export class FederationGatewayWebSocketServer {
@@ -551,7 +561,18 @@ export class FederationGatewayWebSocketServer {
       sessionId,
       capabilities: decision.capabilities,
       sendEnvelope: (envelope) => {
-        sendFrame(socket, { kind: "envelope", envelope }, transport);
+        const byteCount = sendFrame(
+          socket,
+          { kind: "envelope", envelope },
+          transport,
+        );
+        if (byteCount > 0) {
+          this.options.onEnvelopeTransfer?.({
+            peerId: decision.peer.id,
+            direction: "sent",
+            byteCount,
+          });
+        }
       },
       close: (code?: number, reason?: string) => socket.close(code, reason),
       terminate: () => socket.terminate(),
@@ -682,6 +703,11 @@ export class FederationGatewayWebSocketServer {
       }
       if (!next || next.kind !== "envelope") continue;
       this.sessions.heartbeat(sessionId, Date.now());
+      this.options.onEnvelopeTransfer?.({
+        peerId: connection.peerId,
+        direction: "received",
+        byteCount: frame.byteLength,
+      });
       this.options.onEnvelope?.(next.envelope, connection);
     }
   }
@@ -790,6 +816,15 @@ export async function connectFederationClient(params: {
   /** Pinned gateway Noise static public key (raw 32 bytes), from the invite. */
   gatewayNoisePublicKey?: Buffer;
   onEnvelope?: (envelope: FederationProtocolEnvelope) => void;
+  /**
+   * Wire-byte tap for envelope frames only, mirroring the gateway's
+   * `onEnvelopeTransfer`. The peer is implicitly the gateway this
+   * client dialed; the caller attributes accordingly.
+   */
+  onEnvelopeTransfer?: (info: {
+    direction: "sent" | "received";
+    byteCount: number;
+  }) => void;
   /**
    * Called once when the transport ends. `info` carries the WebSocket
    * close code/reason when the peer closed cleanly (e.g. 4001
@@ -1051,6 +1086,10 @@ async function establishFederationClient(
         return;
       }
       if (message?.kind === "envelope") {
+        params.onEnvelopeTransfer?.({
+          direction: "received",
+          byteCount: frame.byteLength,
+        });
         params.onEnvelope?.(message.envelope);
       }
     }
@@ -1063,7 +1102,10 @@ async function establishFederationClient(
     // granting a capability we predate is ignored, not fatal.
     capabilities: knownCapabilities(accepted.capabilities),
     sendEnvelope: (envelope) => {
-      sendFrame(socket, { kind: "envelope", envelope }, transport);
+      const byteCount = sendFrame(socket, { kind: "envelope", envelope }, transport);
+      if (byteCount > 0) {
+        params.onEnvelopeTransfer?.({ direction: "sent", byteCount });
+      }
     },
     close: () => socket.close(),
   };
@@ -1154,14 +1196,22 @@ function waitForOpen(socket: WebSocket): Promise<void> {
   });
 }
 
+/**
+ * Sends one frame and returns its wire byte length (post-encryption),
+ * 0 when the socket was not open. The return value feeds the transfer
+ * taps, which count what actually goes on the wire so payload-format
+ * changes (compression) read as real savings.
+ */
 function sendFrame(
   socket: WebSocket,
   message: FederationSocketMessage,
   transport?: NoiseTransport,
-): void {
-  if (socket.readyState !== WebSocket.OPEN) return;
+): number {
+  if (socket.readyState !== WebSocket.OPEN) return 0;
   const json = Buffer.from(JSON.stringify(message), "utf8");
-  socket.send(transport ? transport.encrypt(json) : json);
+  const wire = transport ? transport.encrypt(json) : json;
+  socket.send(wire);
+  return wire.byteLength;
 }
 
 function closeAfterFrameAuthenticationFailure(socket: WebSocket): void {

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -13,6 +13,8 @@ import type {
   ResetFederationEnrollmentResponse,
   ReadFederationHealthRequest,
   ReadFederationHealthResponse,
+  ReadFederationInstanceLoadRequest,
+  ReadFederationInstanceLoadResponse,
   ReadFederationDiagnosticsRequest,
   ReadFederationDiagnosticsResponse,
   ReadFederationPinImpactRequest,
@@ -35,6 +37,7 @@ import {
 import {
   FEDERATION_GET_HEALTH_CHANNEL,
   FEDERATION_GET_DIAGNOSTICS_CHANNEL,
+  FEDERATION_READ_INSTANCE_LOAD_CHANNEL,
   FEDERATION_GENERATE_INVITE_CHANNEL,
   FEDERATION_IMPORT_INVITE_CHANNEL,
   FEDERATION_OPEN_WINDOW_CHANNEL,
@@ -74,6 +77,7 @@ function peerAllowsEventClass(
 export function registerFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_OPEN_WINDOW_CHANNEL);
   ipcMain.removeHandler(FEDERATION_GET_HEALTH_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_READ_INSTANCE_LOAD_CHANNEL);
   ipcMain.removeHandler(FEDERATION_GET_DIAGNOSTICS_CHANNEL);
   ipcMain.removeHandler(FEDERATION_GENERATE_INVITE_CHANNEL);
   ipcMain.removeHandler(FEDERATION_IMPORT_INVITE_CHANNEL);
@@ -232,6 +236,39 @@ export function registerFederationIpcHandlers(): void {
     },
   );
   ipcMain.handle(
+    FEDERATION_READ_INSTANCE_LOAD_CHANNEL,
+    async (
+      _event,
+      request?: ReadFederationInstanceLoadRequest,
+    ): Promise<ReadFederationInstanceLoadResponse> => {
+      const instanceId = request?.instanceId;
+      if (instanceId !== undefined && !isFederationInstanceId(instanceId)) {
+        throw new Error("Invalid federation instance id");
+      }
+      const runtime = getDesktopFederationRuntime();
+      const health = await runtime.health();
+      try {
+        if (!instanceId || instanceId === health.instanceId) {
+          return { load: await runtime.localBackend().getLoadStatus() };
+        }
+        const peer = runtime.connectedPeerTargets().find(
+          (candidate) => candidate.target.instanceId === instanceId,
+        );
+        if (!peer || !peer.capabilities.includes("thread_navigation")) {
+          // Unreachable reads as "no load reading", never an error — a
+          // polling health surface wants a missing indicator, not a
+          // dialog, when a peer drops mid-poll.
+          return {};
+        }
+        return {
+          load: await runtime.remoteBackend(peer.target).getLoadStatus(),
+        };
+      } catch {
+        return {};
+      }
+    },
+  );
+  ipcMain.handle(
     FEDERATION_GENERATE_INVITE_CHANNEL,
     async (
       _event,
@@ -307,6 +344,7 @@ function readPinDisposition(value: unknown): FederationPinDisposition {
 export function disposeFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_OPEN_WINDOW_CHANNEL);
   ipcMain.removeHandler(FEDERATION_GET_HEALTH_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_READ_INSTANCE_LOAD_CHANNEL);
   ipcMain.removeHandler(FEDERATION_GET_DIAGNOSTICS_CHANNEL);
   ipcMain.removeHandler(FEDERATION_GENERATE_INVITE_CHANNEL);
   ipcMain.removeHandler(FEDERATION_IMPORT_INVITE_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -279,6 +279,8 @@ import type {
   OpenDesktopPwrAgentProfileResponse,
   ReadFederationHealthRequest,
   ReadFederationHealthResponse,
+  ReadFederationInstanceLoadRequest,
+  ReadFederationInstanceLoadResponse,
   ReadFederationDiagnosticsRequest,
   ReadFederationDiagnosticsResponse,
   ReadFederationPinImpactRequest,
@@ -474,6 +476,7 @@ import {
   PATH_REVEAL_CHANNEL,
   BACKEND_LIST_CHANNEL,
   FEDERATION_GET_HEALTH_CHANNEL,
+  FEDERATION_READ_INSTANCE_LOAD_CHANNEL,
   FEDERATION_GET_DIAGNOSTICS_CHANNEL,
   FEDERATION_GENERATE_INVITE_CHANNEL,
   FEDERATION_IMPORT_INVITE_CHANNEL,
@@ -900,6 +903,10 @@ const desktopApi = Object.freeze({
     request?: ReadFederationHealthRequest,
   ): Promise<ReadFederationHealthResponse> =>
     await ipcRenderer.invoke(FEDERATION_GET_HEALTH_CHANNEL, request),
+  readFederationInstanceLoad: async (
+    request?: ReadFederationInstanceLoadRequest,
+  ): Promise<ReadFederationInstanceLoadResponse> =>
+    await ipcRenderer.invoke(FEDERATION_READ_INSTANCE_LOAD_CHANNEL, request),
   readFederationDiagnostics: async (
     request?: ReadFederationDiagnosticsRequest,
   ): Promise<ReadFederationDiagnosticsResponse> =>

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -15,6 +15,7 @@ import type {
   FederationPinImpactScope,
   FederationTailscaleMode,
   FederationTailscaleStatus,
+  FederationTransferStats,
   ReadFederationPinImpactResponse,
 } from "@pwragent/shared";
 import {
@@ -28,6 +29,7 @@ import { CelestialIcon } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { copyText } from "../../lib/copy-text";
 import { formatRunningDurationMs } from "../../lib/format-duration";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
   SettingsField,
   SettingsPanelHead,
@@ -58,6 +60,7 @@ export function FederationSettings(props: FederationSettingsProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
   const [actionError, setActionError] = useState<string>();
+  const transferTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const [tailscaleStatus, setTailscaleStatus] = useState<FederationTailscaleStatus>();
   const [tailscaleLoading, setTailscaleLoading] = useState(false);
   const [tailscaleConfiguring, setTailscaleConfiguring] =
@@ -1065,12 +1068,23 @@ export function FederationSettings(props: FederationSettingsProps) {
                     <span>Last activity {formatTimestamp(peer.lastActivityAt)}</span>
                   ) : null}
                   {peer.transfer ? (
-                    <span>
+                    // role="img" + aria-label mirrors the sidebar's unpushed
+                    // chip: screen readers get worded directions instead of
+                    // "up arrow"; the hover tooltip carries the precise
+                    // envelope count and start time off the visible line.
+                    <span
+                      role="img"
+                      aria-label={formatTransferDetail(peer.transfer)}
+                      onMouseEnter={(event) =>
+                        transferTooltip.show(
+                          event.currentTarget,
+                          formatTransferDetail(peer.transfer!),
+                        )
+                      }
+                      onMouseLeave={transferTooltip.hide}
+                    >
                       Transferred ↑ {formatByteCount(peer.transfer.bytesSent)} ·
-                      ↓ {formatByteCount(peer.transfer.bytesReceived)} across{" "}
-                      {peer.transfer.envelopesSent
-                        + peer.transfer.envelopesReceived}{" "}
-                      envelopes since {formatTimestamp(peer.transfer.since)}
+                      ↓ {formatByteCount(peer.transfer.bytesReceived)}
                     </span>
                   ) : null}
                   <span>
@@ -1177,6 +1191,7 @@ export function FederationSettings(props: FederationSettingsProps) {
             ))}
           </dl>
         )}
+        {transferTooltip.tooltipNode}
       </SettingsSection>
 
       <SettingsSection
@@ -1625,16 +1640,35 @@ function formatTimestamp(value: number): string {
 
 /**
  * Wire-transfer figure for the peer rows: whole bytes/KB below 1 MB,
- * one decimal from MB up, so a 200 MB replay habit and a post-
- * compression 40 MB read as obviously different at a glance.
+ * then one decimal only while the leading digits are scarce (below 10
+ * of the unit) — "5.2 MB" carries signal, "200.0 MB" is just noise —
+ * so a 200 MB replay habit and a post-compression 40 MB read as
+ * obviously different at a glance.
  */
 function formatByteCount(value: number): string {
   if (value < 1024) return `${value} B`;
   if (value < 1024 * 1024) return `${Math.round(value / 1024)} KB`;
-  if (value < 1024 * 1024 * 1024) {
-    return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+  const mb = value / (1024 * 1024);
+  if (mb < 1024) {
+    return mb < 10 ? `${mb.toFixed(1)} MB` : `${Math.round(mb)} MB`;
   }
-  return `${(value / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  const gb = mb / 1024;
+  return gb < 10 ? `${gb.toFixed(1)} GB` : `${Math.round(gb)} GB`;
+}
+
+/**
+ * Worded long form for the transfer line's tooltip and aria-label:
+ * screen readers get "sent/received" instead of arrow glyphs, and the
+ * envelope count + counting start time live here instead of stretching
+ * the visible row.
+ */
+function formatTransferDetail(transfer: FederationTransferStats): string {
+  const envelopes = (
+    transfer.envelopesSent + transfer.envelopesReceived
+  ).toLocaleString();
+  return `Sent ${formatByteCount(transfer.bytesSent)}, received ${formatByteCount(
+    transfer.bytesReceived,
+  )} across ${envelopes} envelopes since ${formatTimestamp(transfer.since)}`;
 }
 
 function parseFederationListenPort(value: string): number {

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -1064,6 +1064,15 @@ export function FederationSettings(props: FederationSettingsProps) {
                   && peer.lastActivityAt !== peer.lastConnectedAt ? (
                     <span>Last activity {formatTimestamp(peer.lastActivityAt)}</span>
                   ) : null}
+                  {peer.transfer ? (
+                    <span>
+                      Transferred ↑ {formatByteCount(peer.transfer.bytesSent)} ·
+                      ↓ {formatByteCount(peer.transfer.bytesReceived)} across{" "}
+                      {peer.transfer.envelopesSent
+                        + peer.transfer.envelopesReceived}{" "}
+                      envelopes since {formatTimestamp(peer.transfer.since)}
+                    </span>
+                  ) : null}
                   <span>
                     Available: {formatFederationCapabilities(peer.capabilities)}
                   </span>
@@ -1612,6 +1621,20 @@ function diagnosticEventLabel(kind: FederationDiagnosticEvent["kind"]): string {
 
 function formatTimestamp(value: number): string {
   return new Date(value).toLocaleString();
+}
+
+/**
+ * Wire-transfer figure for the peer rows: whole bytes/KB below 1 MB,
+ * one decimal from MB up, so a 200 MB replay habit and a post-
+ * compression 40 MB read as obviously different at a glance.
+ */
+function formatByteCount(value: number): string {
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${Math.round(value / 1024)} KB`;
+  if (value < 1024 * 1024 * 1024) {
+    return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${(value / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }
 
 function parseFederationListenPort(value: string): number {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -145,6 +145,64 @@ describe("FederationSettings", () => {
     });
   });
 
+  it("shows locally counted wire transfer for peers that have moved bytes", async () => {
+    const health: FederationHealthStatus = {
+      enabled: true,
+      role: "gateway",
+      status: "listening",
+      peers: [
+        {
+          id: "pwr_studio",
+          label: "Studio Mac",
+          role: "client",
+          status: "connected",
+          capabilities: ["thread_navigation"],
+          transfer: {
+            bytesSent: 512_000,
+            bytesReceived: 209_715_200,
+            envelopesSent: 1_200,
+            envelopesReceived: 3_400,
+            since: Date.parse("2026-08-08T09:00:00.000Z"),
+            lastActivityAt: Date.parse("2026-08-08T09:45:00.000Z"),
+          },
+        },
+        {
+          id: "pwr_idle",
+          label: "Idle Mini",
+          role: "client",
+          status: "disconnected",
+          capabilities: [],
+        },
+      ],
+    };
+
+    render(
+      <FederationSettings
+        desktopApi={{
+          readFederationDiagnostics: vi.fn(async () => ({
+            health,
+            events: [],
+          })),
+        }}
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={vi.fn(async () => true)}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(
+      screen.getByText(/Transferred ↑ 500 KB · ↓ 200\.0 MB across 4600 envelopes/),
+    ).toBeInTheDocument();
+    // A peer with no observed traffic gets no transfer line at all.
+    expect(screen.getAllByText(/Transferred ↑/)).toHaveLength(1);
+  });
+
   it("saves the ordered gateway endpoint list", async () => {
     const onWriteConfig = vi.fn(async (_patch: DesktopSettingsConfigPatch) => true);
     render(

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -167,6 +167,21 @@ describe("FederationSettings", () => {
           },
         },
         {
+          id: "pwr_quiet",
+          label: "Quiet Mini",
+          role: "client",
+          status: "connected",
+          capabilities: ["thread_navigation"],
+          transfer: {
+            bytesSent: 900,
+            bytesReceived: 5_452_595,
+            envelopesSent: 4,
+            envelopesReceived: 9,
+            since: Date.parse("2026-08-08T09:30:00.000Z"),
+            lastActivityAt: Date.parse("2026-08-08T09:31:00.000Z"),
+          },
+        },
+        {
           id: "pwr_idle",
           label: "Idle Mini",
           role: "client",
@@ -196,11 +211,21 @@ describe("FederationSettings", () => {
     await act(async () => {
       await Promise.resolve();
     });
+    // Whole-number MB once the magnitude carries the signal...
     expect(
-      screen.getByText(/Transferred ↑ 500 KB · ↓ 200\.0 MB across 4600 envelopes/),
+      screen.getByText(/^Transferred ↑ 500 KB · ↓ 200 MB$/),
+    ).toBeInTheDocument();
+    // ...one decimal while leading digits are scarce.
+    expect(
+      screen.getByText(/^Transferred ↑ 900 B · ↓ 5\.2 MB$/),
+    ).toBeInTheDocument();
+    // Screen readers get worded directions, and the envelope count +
+    // counting start live in the long form instead of the visible row.
+    expect(
+      screen.getByLabelText(/^Sent 500 KB, received 200 MB across 4,600 envelopes since /),
     ).toBeInTheDocument();
     // A peer with no observed traffic gets no transfer line at all.
-    expect(screen.getAllByText(/Transferred ↑/)).toHaveLength(1);
+    expect(screen.getAllByText(/Transferred ↑/)).toHaveLength(2);
   });
 
   it("saves the ordered gateway endpoint list", async () => {

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -103,6 +103,8 @@ import type {
   OpenFederationWindowResponse,
   ReadFederationHealthRequest,
   ReadFederationHealthResponse,
+  ReadFederationInstanceLoadRequest,
+  ReadFederationInstanceLoadResponse,
   ReadFederationDiagnosticsRequest,
   ReadFederationDiagnosticsResponse,
   ReadFederationPinImpactRequest,
@@ -496,6 +498,14 @@ export type DesktopApi = {
   readFederationHealth?: (
     request?: ReadFederationHealthRequest,
   ) => Promise<ReadFederationHealthResponse>;
+  /** On-demand load poll for Star Map health indicators. Omitted or
+   *  local instanceId samples locally; a remote id rides the
+   *  short-timeout `backend.getLoadStatus` federation RPC. `load` is
+   *  absent when the instance did not answer — degrade to no
+   *  indicator, never an error. */
+  readFederationInstanceLoad?: (
+    request?: ReadFederationInstanceLoadRequest,
+  ) => Promise<ReadFederationInstanceLoadResponse>;
   readFederationDiagnostics?: (
     request?: ReadFederationDiagnosticsRequest,
   ) => Promise<ReadFederationDiagnosticsResponse>;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -2,6 +2,8 @@ export const APP_SERVER_LIST_THREADS_CHANNEL = "app-server:list-threads";
 export const THREAD_SEARCH_CHANNEL = "thread-search:search";
 export const FEDERATION_OPEN_WINDOW_CHANNEL = "federation:open-window";
 export const FEDERATION_GET_HEALTH_CHANNEL = "federation:get-health";
+export const FEDERATION_READ_INSTANCE_LOAD_CHANNEL =
+  "federation:read-instance-load";
 export const FEDERATION_GET_DIAGNOSTICS_CHANNEL = "federation:get-diagnostics";
 export const FEDERATION_GENERATE_INVITE_CHANNEL = "federation:generate-invite";
 export const FEDERATION_IMPORT_INVITE_CHANNEL = "federation:import-invite";

--- a/docs/plans/2026-08-08-001-feat-federation-load-status-plan.md
+++ b/docs/plans/2026-08-08-001-feat-federation-load-status-plan.md
@@ -32,7 +32,7 @@ One simple query RPC, no gossip, no caching layer:
     loadAvg5: number;
     loadAvg15: number;
     availableMemoryBytes: number; // os.freemem()
-    freeDiskBytes?: number;       // fs.statfs on the PwrAgent root; omitted on failure
+    diskFreeBytes?: number;       // fs.statfs on the PwrAgent root; omitted on failure
     sampledAt: number;
   };
   ```

--- a/docs/plans/2026-08-08-001-feat-federation-load-status-plan.md
+++ b/docs/plans/2026-08-08-001-feat-federation-load-status-plan.md
@@ -118,7 +118,10 @@ the protocol, not protocol fields** — nothing new crosses the wire:
   everything on the gateway's row because all its remote traffic rides
   that one socket.
 - Surface: the Settings → Federation peer rows render
-  "Transferred ↑ x · ↓ y across N envelopes since <t>".
+  "Transferred ↑ x · ↓ y"; the envelope count and counting start time
+  live in the row's hover tooltip + aria-label (the worded long form
+  also gives screen readers "sent/received" instead of arrow glyphs,
+  mirroring the sidebar's unpushed-commits chip pattern).
 
 ## Non-goals
 

--- a/docs/plans/2026-08-08-001-feat-federation-load-status-plan.md
+++ b/docs/plans/2026-08-08-001-feat-federation-load-status-plan.md
@@ -91,6 +91,35 @@ One simple query RPC, no gossip, no caching layer:
    dialog. The rendering side (indicator thresholds, visuals) lands on
    the Star Map branch; this branch provides the query surface only.
 
+## Addition (same branch): per-peer wire-transfer counters
+
+Decided with the operator after the load-status round landed: to
+baseline federation bandwidth before an envelope-compression change
+(and verify the change after), each instance counts its own wire
+traffic per directly connected peer. These are **local observations of
+the protocol, not protocol fields** — nothing new crosses the wire:
+
+- `sendFrame`/the envelope receive loops in `federation-transport.ts`
+  report each envelope frame's **post-encryption byte length** through
+  new `onEnvelopeTransfer` taps (gateway per-connection, client
+  per-socket). Handshake/auth frames and WebSocket keepalives are not
+  counted. Counting post-encryption means a compression PR moves these
+  numbers by exactly its real wire savings.
+- A process-local `FederationTransferLedger` in the runtime accumulates
+  `FederationTransferStats` (`bytesSent/bytesReceived`,
+  `envelopesSent/envelopesReceived`, `since`, `lastActivityAt`) per
+  peer, across reconnects, reset only on app restart. Never persisted.
+- `FederationPeerSummary.transfer` carries the snapshot on
+  health/diagnostics reads only — deliberately NOT attached in
+  `visiblePeers()`, which also feeds the gossiped peer directory; the
+  numbers describe the observer's socket, not the peer.
+- Attribution: a gateway sees true per-peer figures (relayed sibling
+  traffic counts on both legs, which is wire-truthful); a client sees
+  everything on the gateway's row because all its remote traffic rides
+  that one socket.
+- Surface: the Settings → Federation peer rows render
+  "Transferred ↑ x · ↓ y across N envelopes since <t>".
+
 ## Non-goals
 
 - No broadcast/gossip of load, no push events, no history/persistence.
@@ -127,4 +156,6 @@ One simple query RPC, no gossip, no caching layer:
 - [x] Sampler + bridge RPC + local backend operation
 - [x] `list_federation_instances` `includeLoad` fan-out
 - [x] Renderer IPC surface for Star Map polling
+- [x] Per-peer wire-transfer counters (transport taps, ledger, health,
+      Settings peer rows)
 - [x] Tests green (lint:eslint, typecheck, lint:boundaries, focused vitest)

--- a/docs/plans/2026-08-08-001-feat-federation-load-status-plan.md
+++ b/docs/plans/2026-08-08-001-feat-federation-load-status-plan.md
@@ -1,0 +1,130 @@
+# Federation on-demand load status
+
+- **Date:** 2026-08-08
+- **Type:** feat
+- **Scope:** desktop (federation), shared contracts
+- **Builds on:** PR #1248 / [2026-08-05-003-feat-federation-agent-tools-plan.md](2026-08-05-003-feat-federation-agent-tools-plan.md),
+  whose "Follow-up round" section deliberately deferred live load signals
+  to a query-on-demand follow-up and shaped `FederationHostInfo` so a
+  `load` sibling could join later. This is that follow-up.
+
+## Problem
+
+`FederationHostInfo` advertises static host facts (CPU count, total RAM,
+a disk-free snapshot) on handshake, but nothing answers "how busy is that
+instance *right now*?" Placement decisions ("find me a place to run
+this") and the Star Map's per-instance health indicators (low RAM, high
+CPU, low disk) need a live reading. Broadcasting it was rejected in the
+prior round: load changes constantly, so gossiping it either spams the
+mesh or serves stale numbers. It is a query-on-demand concern.
+
+## Decision
+
+One simple query RPC, no gossip, no caching layer:
+
+- **`backend.getLoadStatus`** joins `FEDERATION_BACKEND_METHODS` in
+  `federation-backend-bridge.ts`. Zero-argument request; the response is
+  a `FederationLoadStatus` sampled at answer time on the owning instance:
+
+  ```ts
+  type FederationLoadStatus = {
+    loadAvg1: number;   // os.loadavg() — 0 on Windows, by Node contract
+    loadAvg5: number;
+    loadAvg15: number;
+    availableMemoryBytes: number; // os.freemem()
+    freeDiskBytes?: number;       // fs.statfs on the PwrAgent root; omitted on failure
+    sampledAt: number;
+  };
+  ```
+
+  The type lives in `packages/shared/src/contracts/federation.ts` as a
+  **sibling** of `FederationHostInfo`, per the prior round's shaping —
+  host stays static facts, load stays live readings; neither extends the
+  other.
+
+- **Capability: `thread_navigation`.** A load reading is a read-only
+  health fact at the same sensitivity tier as the browse-level grants;
+  the Star Map's `star_map` event class already rides
+  `thread_navigation`, and `setCelestialIcon` set the precedent that
+  federation-level non-thread state uses the least-privileged grant
+  every browsing peer already holds. A new capability was considered and
+  rejected: it would buy no isolation (the data is less sensitive than
+  thread titles) and would cost a handshake-advertisement round for
+  every peer.
+
+- **Sampling** lives in `collectFederationLoadStatus` beside
+  `collectFederationHostInfo` in `federation-host-info.ts` — same
+  `fs.statfs`-on-the-PwrAgent-root pattern for disk, `os.loadavg()` +
+  `os.freemem()` for CPU/RAM. The local instance (including a gateway
+  answering for itself) samples directly via `localBackendOperations()`;
+  relayed peers are reached through the existing envelope relay exactly
+  like every other backend RPC — no special routing.
+
+- **Tight timeout, degrade to absence.** The remote client passes
+  `timeoutMs: 2_500` (`FEDERATION_LOAD_STATUS_TIMEOUT_MS`) instead of
+  the 30s default. Every caller treats a timeout/error as "no `load`
+  block", never as a failed listing.
+
+## Callers
+
+1. **`list_federation_instances`** gains `includeLoad?: boolean` —
+   additive optional input only, per the agent-tool contract rules in
+   `apps/desktop/src/main/agent-tools/AGENTS.md`. When true, the handler
+   fans `getLoadStatus` out concurrently to the local instance plus every
+   *connected* peer that granted `thread_navigation`, and attaches the
+   result as a `load` sibling next to each descriptor's `host` block.
+   Peers that fail or time out simply omit `load`. Continuation-cursor
+   pages serve the loads captured when the listing was built (bounded by
+   the existing ~60s cursor TTL, which is exactly the staleness budget a
+   token-paged listing already accepts). The tool description documents
+   the machineId rule: instances sharing `host.machineId` report the
+   same underlying load — dedupe by machineId when aggregating for
+   placement decisions, never sum.
+
+2. **Star Map health indicators** poll a new renderer-facing IPC
+   channel, `federation:read-instance-load`
+   (`readFederationInstanceLoad(request?: { instanceId? })` on
+   `desktopApi`). Omitted/local instanceId samples locally; a remote id
+   routes through `runtime.remoteBackend`. Not-connected peers,
+   missing capability, and RPC failures all return `{}` (no `load`) —
+   a polling health surface wants a missing indicator, not an error
+   dialog. The rendering side (indicator thresholds, visuals) lands on
+   the Star Map branch; this branch provides the query surface only.
+
+## Non-goals
+
+- No broadcast/gossip of load, no push events, no history/persistence.
+- No new federation capability.
+- No renderer UI in this branch.
+
+## Touched files
+
+- `packages/shared/src/contracts/federation.ts` — `FederationLoadStatus`,
+  `ReadFederationInstanceLoadRequest/Response`.
+- `packages/shared/src/contracts/federation-tools.ts` — `includeLoad`
+  arg, `load` on `FederationInstanceDescriptor`.
+- `apps/desktop/src/main/federation/federation-host-info.ts` — sampler.
+- `apps/desktop/src/main/federation/federation-backend-bridge.ts` —
+  method, capability, operations entry, handler, remote client + timeout.
+- `apps/desktop/src/main/federation/federation-runtime.ts` — local
+  backend operation.
+- `apps/desktop/src/main/federation/federation-agent-tools-service.ts` —
+  `includeLoad` fan-out.
+- `apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts`
+  — schema, normalization, description.
+- `apps/desktop/src/shared/ipc.ts`, `apps/desktop/src/main/ipc/federation.ts`,
+  `apps/desktop/src/preload/index.ts`,
+  `apps/desktop/src/renderer/src/lib/desktop-api.ts` — IPC surface.
+- Tests: `federation-host-info.test.ts`,
+  `federation-backend-bridge.test.ts`,
+  `federation-agent-tools-service.test.ts`,
+  `agent-tools/__tests__/pwragent-federation-agent-tools.test.ts`.
+
+## Progress
+
+- [x] Plan doc
+- [x] Shared contracts (`FederationLoadStatus`, tool args, IPC types)
+- [x] Sampler + bridge RPC + local backend operation
+- [x] `list_federation_instances` `includeLoad` fan-out
+- [x] Renderer IPC surface for Star Map polling
+- [x] Tests green (lint:eslint, typecheck, lint:boundaries, focused vitest)

--- a/packages/shared/src/contracts/federation-tools.ts
+++ b/packages/shared/src/contracts/federation-tools.ts
@@ -6,6 +6,7 @@ import type {
   FederationHostInfo,
   FederationInstanceId,
   FederationInstanceRole,
+  FederationLoadStatus,
 } from "./federation";
 import type {
   DirectorySummaryKind,
@@ -70,6 +71,13 @@ export type FederationInstanceDescriptor = {
    * capacity must not be summed.
    */
   host?: FederationHostInfo;
+  /**
+   * Live load reading, present only when the caller asked for it via
+   * `includeLoad` AND the instance answered within the short load-query
+   * timeout. Instances sharing `host.machineId` report the same
+   * underlying load — dedupe by machineId when aggregating.
+   */
+  load?: FederationLoadStatus;
   unavailableReason?: string;
 };
 
@@ -84,6 +92,14 @@ export type ListFederationInstancesToolArgs = {
   limit?: number;
   /** Continuation token from a previous truncated result. Short-lived. */
   cursor?: string;
+  /**
+   * When true, attach a live `load` block (CPU load averages, available
+   * RAM, free disk) to each reachable instance via a short-timeout
+   * on-demand query. Instances that fail to answer in time simply omit
+   * `load`. Continuation pages reuse the loads sampled when the listing
+   * was built.
+   */
+  includeLoad?: boolean;
 };
 
 export type ListFederationInstancesResult = {

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -137,15 +137,22 @@ export type FederationHostInfo = {
  * `FederationHostInfo.machineId` run on the same hardware and report the
  * same underlying load — dedupe by machineId when aggregating.
  * `loadAvg*` are 0 on Windows (Node's `os.loadavg()` contract);
- * `freeDiskBytes` measures the volume holding the PwrAgent root and is
+ * `diskFreeBytes` measures the volume holding the PwrAgent root and is
  * omitted when the read fails.
  */
 export type FederationLoadStatus = {
   loadAvg1: number;
   loadAvg5: number;
   loadAvg15: number;
+  /**
+   * `os.freemem()` — truly free pages only. macOS/Linux keep reclaimable
+   * page cache out of this figure, so it understates what's actually
+   * available to new work; treat "low" thresholds generously on those
+   * platforms rather than alarming on a healthy, cache-warm box.
+   */
   availableMemoryBytes: number;
-  freeDiskBytes?: number;
+  /** Live counterpart of the handshake snapshot `FederationHostInfo.diskFreeBytes`. */
+  diskFreeBytes?: number;
   sampledAt: number;
 };
 

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -129,6 +129,26 @@ export type FederationHostInfo = {
   machineId?: string;
 };
 
+/**
+ * Live load reading sampled on the owning instance at answer time.
+ * Deliberately a sibling of {@link FederationHostInfo}, not an extension:
+ * host facts are static and advertised on handshake, load is queried on
+ * demand (`backend.getLoadStatus`) and never gossiped. Instances sharing
+ * `FederationHostInfo.machineId` run on the same hardware and report the
+ * same underlying load — dedupe by machineId when aggregating.
+ * `loadAvg*` are 0 on Windows (Node's `os.loadavg()` contract);
+ * `freeDiskBytes` measures the volume holding the PwrAgent root and is
+ * omitted when the read fails.
+ */
+export type FederationLoadStatus = {
+  loadAvg1: number;
+  loadAvg5: number;
+  loadAvg15: number;
+  availableMemoryBytes: number;
+  freeDiskBytes?: number;
+  sampledAt: number;
+};
+
 export type FederationPeerSummary = {
   id: FederationPeerId;
   label: string;
@@ -310,6 +330,26 @@ export type ReadFederationHealthRequest = Record<string, never>;
 
 export type ReadFederationHealthResponse = {
   health: FederationHealthStatus;
+};
+
+/**
+ * Renderer poll for one instance's live load (Star Map health
+ * indicators). An omitted `instanceId` — or the local instance's own id —
+ * samples locally; a remote id rides the `backend.getLoadStatus`
+ * federation RPC.
+ */
+export type ReadFederationInstanceLoadRequest = {
+  instanceId?: FederationInstanceId;
+};
+
+/**
+ * `load` is absent when the peer is not connected, has not granted
+ * `thread_navigation`, or did not answer within the short load-query
+ * timeout. A polling health surface degrades to "no indicator" — this
+ * response never carries an error.
+ */
+export type ReadFederationInstanceLoadResponse = {
+  load?: FederationLoadStatus;
 };
 
 export type FederationTailscaleMode = "serve" | "funnel";

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -149,6 +149,31 @@ export type FederationLoadStatus = {
   sampledAt: number;
 };
 
+/**
+ * Locally observed wire-transfer counters for one directly connected
+ * peer socket. Not a protocol field — each side counts the envelope
+ * frames it sends and receives on its own transport (after encryption,
+ * so compression changes show up here as real wire savings), and the
+ * counters live only in the observing process: they start at first
+ * activity and reset on app restart, never persisted or gossiped.
+ *
+ * On a gateway the counters attribute per peer socket, including
+ * relayed sibling traffic on both legs. On a client, all remote
+ * traffic rides the single gateway socket and lands on the gateway's
+ * row. Handshake/auth frames and WebSocket keepalives are not counted.
+ */
+export type FederationTransferStats = {
+  /** Wire bytes of envelope frames sent to the peer. */
+  bytesSent: number;
+  /** Wire bytes of envelope frames received from the peer. */
+  bytesReceived: number;
+  envelopesSent: number;
+  envelopesReceived: number;
+  /** When counting began (first observed activity in this process). */
+  since: number;
+  lastActivityAt: number;
+};
+
 export type FederationPeerSummary = {
   id: FederationPeerId;
   label: string;
@@ -168,6 +193,13 @@ export type FederationPeerSummary = {
    */
   notes?: string;
   host?: FederationHostInfo;
+  /**
+   * This instance's locally counted wire transfer with the peer.
+   * Attached only on health/diagnostics reads — never advertised in
+   * the peer directory, because the numbers describe the observer's
+   * own socket, not the peer.
+   */
+  transfer?: FederationTransferStats;
   lastConnectedAt?: number;
   lastActivityAt?: number;
   revokedAt?: number;


### PR DESCRIPTION
## What

Adds a query-on-demand load reading to the federation layer, building on the federation agent-tool layer + `FederationHostInfo` host facts from #1248. This is the follow-up that plan's "Follow-up round" section explicitly reserved when it kept live load signals out of the handshake; the design is recorded in `docs/plans/2026-08-08-001-feat-federation-load-status-plan.md`.

- **New RPC `backend.getLoadStatus`** in `FEDERATION_BACKEND_METHODS`, returning a `FederationLoadStatus` sampled at answer time on the owning instance: `loadAvg1/5/15` (0 on Windows per Node's `os.loadavg()` contract), `availableMemoryBytes`, `freeDiskBytes` (statfs on the PwrAgent root's volume, omitted on failure), `sampledAt`. Nothing is broadcast or gossiped — load is a query-on-demand concern.
- **`FederationLoadStatus`** lands beside `FederationHostInfo` in `packages/shared/src/contracts/federation.ts` as a sibling, per the prior round's shaping — host stays static handshake facts, neither type extends the other.
- **Sampling** lives in `collectFederationLoadStatus` next to `collectFederationHostInfo`. The local instance (including a gateway answering for itself) samples directly via `localBackendOperations()`; relayed peers ride the existing envelope relay like every other backend RPC.
- **`list_federation_instances` gains `includeLoad?: boolean`** — additive optional input only, per the agent-tool contract rules. When set, the handler fans the query out concurrently to the local instance plus connected `thread_navigation`-capable peers and attaches `load` beside each descriptor's `host` block. Failures/timeouts omit `load`; the listing never fails on a slow peer. Continuation-cursor pages serve the loads sampled when the listing was built (bounded by the existing ~60s cursor TTL).
- **New `federation:read-instance-load` IPC channel** + `desktopApi.readFederationInstanceLoad({ instanceId? })` as the poll endpoint for the Star Map's per-instance health indicators. Unreachable/ineligible peers return `{}` (no `load`), never an error — a polling health surface wants a missing indicator, not a dialog. The rendering side lands on the Star Map branch; this PR provides the query surface only.

## Capability decision

`backend.getLoadStatus` is gated as **`thread_navigation`**: a load reading is a read-only health fact at the same sensitivity tier as the browse-level grants, the Star Map's `star_map` event class already rides `thread_navigation`, and `setCelestialIcon` set the precedent for federation-level non-thread state using the least-privileged grant every browsing peer already holds. A dedicated capability was considered and rejected — it would buy no isolation while costing every peer a handshake re-advertisement.

## Reviewer notes

- Remote load calls carry `timeoutMs: 2_500` (`FEDERATION_LOAD_STATUS_TIMEOUT_MS`) instead of the default 30s leash; the bridge test pins the deadline on the wire envelope.
- The tool description and `FederationLoadStatus` docs both carry the machine-sharing rule: instances sharing `host.machineId` report the same underlying load — dedupe by machineId when aggregating for placement decisions, never sum.
- No handshake, store, or gossip changes; older peers need nothing new to be queried.

## Testing

- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries`, `pnpm lint:sql`, `pnpm lint:codex-storage` all green.
- Focused vitest (63 tests passing): bridge capability + tight-deadline envelope test; agent-tools fan-out tests (load attached to local + answering peers; timed-out, capability-less, and disconnected peers omit it; no fan-out without `includeLoad`); host-info sampler tests including the statfs-failure path; tool-schema/normalization tests for `includeLoad`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Addition: per-peer wire-transfer counters (second commit)

To baseline federation bandwidth before an envelope-compression change (and verify the savings after it), each instance now counts its own wire traffic per directly connected peer. These are **local observations of the protocol, not protocol fields** — nothing new crosses the wire:

- `sendFrame` returns each frame's **post-encryption byte length**, and new `onEnvelopeTransfer` taps (gateway per-connection, client per-socket) report envelope frames only — handshake/auth frames and WebSocket keepalives are not counted. Counting after encryption means a compression PR moves these numbers by exactly its real wire savings.
- A process-local `FederationTransferLedger` accumulates `FederationTransferStats` (bytes/envelopes per direction, `since`, `lastActivityAt`) per peer across reconnects; reset only on app restart, never persisted.
- `FederationPeerSummary.transfer` carries the snapshot on health/diagnostics reads only — deliberately **not** attached in `visiblePeers()`, which also feeds the gossiped peer directory, because the numbers describe the observer's own socket, not the peer.
- Settings → Federation peer rows render "Transferred ↑ x · ↓ y across N envelopes since \<t\>". A gateway sees true per-peer figures (relay legs count on both sockets); a client sees all remote traffic on its gateway row, which is wire-truthful.
- New tests: a transport round-trip asserting both ends' taps report identical byte counts (and that the auth exchange fires none), ledger accounting unit tests, and a Settings rendering test. All gates re-run green (typecheck, ESLint 0 errors, boundaries; 99 tests across the touched suites).
