### PR TITLE
fix(desktop): restore pending input after reload

### DIFF
--- a/apps/desktop/e2e/request-user-input.spec.ts
+++ b/apps/desktop/e2e/request-user-input.spec.ts
@@ -71,3 +71,23 @@ test("answers request_user_input questionnaires with back and next navigation", 
     await app.close();
   }
 });
+
+test("restores a pending questionnaire after the renderer reloads", async () => {
+  const app = await openRequestUserInputReplay();
+
+  try {
+    await app.window.reload();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Request user input replay"
+      })
+    ).toBeVisible();
+    await expect(app.window.getByRole("group", { name: "Pending input" })).toBeVisible();
+    await expect(app.window.getByText("Question 1 of 2")).toBeVisible();
+    await expect(app.window.getByRole("status")).toContainText("Waiting for input");
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1697,6 +1697,8 @@ function normalizePositivePullRequestNumber(value: unknown): number | undefined 
 }
 
 type PendingServerRequest = {
+  backend: AppServerBackendKind;
+  notification: AppServerPendingRequestNotification;
   resolve: (response: SubmitServerRequestRequest["response"]) => void;
   reject: (error: Error) => void;
 };
@@ -8232,11 +8234,16 @@ export class DesktopBackendRegistry {
             threadId: request.threadId,
           })
         : { lines: [], summaries: [] };
+    const pendingRequest = this.pendingServerRequestForThread({
+      backend,
+      threadId: request.threadId,
+    });
     return {
       backend,
       fetchedAt: Date.now(),
       pricing,
       threadId: request.threadId,
+      ...(pendingRequest ? { pendingRequest } : {}),
       ...(replayWithMessageOrigins.threadStatus
         ? { threadStatus: replayWithMessageOrigins.threadStatus }
         : {}),
@@ -9965,6 +9972,10 @@ export class DesktopBackendRegistry {
             threadId: request.threadId,
           })
         : undefined;
+    const pendingRequest = this.pendingServerRequestForThread({
+      backend,
+      threadId: request.threadId,
+    });
 
     return {
       backend,
@@ -9972,6 +9983,7 @@ export class DesktopBackendRegistry {
       threadId: request.threadId,
       pricing,
       ...(toolAccounting ? { toolAccounting } : {}),
+      ...(pendingRequest ? { pendingRequest } : {}),
       ...(replayWithMessageOrigins.threadStatus
         ? { threadStatus: replayWithMessageOrigins.threadStatus }
         : {}),
@@ -14986,6 +14998,22 @@ export class DesktopBackendRegistry {
     };
   }
 
+  private pendingServerRequestForThread(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): AppServerPendingRequestNotification | undefined {
+    let pendingRequest: AppServerPendingRequestNotification | undefined;
+    for (const pending of this.pendingServerRequests.values()) {
+      if (
+        pending.backend === params.backend
+        && pending.notification.params.threadId === params.threadId
+      ) {
+        pendingRequest = pending.notification;
+      }
+    }
+    return pendingRequest;
+  }
+
   private async requestHandoffCwdTrustConfirmation(params: {
     backend: AppServerBackendKind;
     cwd: string;
@@ -15003,44 +15031,50 @@ export class DesktopBackendRegistry {
       threadId: params.threadId,
       requestId,
     });
+    const notification: AppServerPendingRequestNotification = {
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: params.threadId,
+        ...(params.turnId ? { turnId: params.turnId } : {}),
+        ...(params.itemId ? { itemId: params.itemId } : {}),
+        requestId,
+        questions: [
+          {
+            id: HANDOFF_CWD_TRUST_QUESTION_ID,
+            header: "Trust directory",
+            question: `Trust ${normalizedCwd} and allow Default Access agent threads to read, write, and delete files in it?`,
+            isOther: false,
+            isSecret: false,
+            options: [
+              {
+                label: HANDOFF_CWD_TRUST_APPROVE_LABEL,
+                description:
+                  "Trust this directory for future Default Access agent work.",
+              },
+              {
+                label: params.cancelLabel ?? "Cancel handoff",
+                description:
+                  params.cancelDescription ??
+                  "Do not add this directory or start the handoff.",
+              },
+            ],
+          },
+        ],
+      },
+    };
 
     const response = await new Promise<SubmitServerRequestRequest["response"]>(
       (resolve, reject) => {
-        this.pendingServerRequests.set(key, { resolve, reject });
+        this.pendingServerRequests.set(key, {
+          backend: params.backend,
+          notification,
+          resolve,
+          reject,
+        });
 
         void this.emit({
           backend: params.backend,
-          notification: {
-            method: "item/tool/requestUserInput",
-            params: {
-              threadId: params.threadId,
-              ...(params.turnId ? { turnId: params.turnId } : {}),
-              ...(params.itemId ? { itemId: params.itemId } : {}),
-              requestId,
-              questions: [
-                {
-                  id: HANDOFF_CWD_TRUST_QUESTION_ID,
-                  header: "Trust directory",
-                  question: `Trust ${normalizedCwd} and allow Default Access agent threads to read, write, and delete files in it?`,
-                  isOther: false,
-                  isSecret: false,
-                  options: [
-                    {
-                      label: HANDOFF_CWD_TRUST_APPROVE_LABEL,
-                      description:
-                        "Trust this directory for future Default Access agent work.",
-                    },
-                    {
-                      label: params.cancelLabel ?? "Cancel handoff",
-                      description:
-                        params.cancelDescription ??
-                        "Do not add this directory or start the handoff.",
-                    },
-                  ],
-                },
-              ],
-            },
-          },
+          notification,
         }).catch((error) => {
           backendRegistryLog.error(
             "failed to publish handoff cwd trust request; keeping request pending",
@@ -22036,7 +22070,12 @@ export class DesktopBackendRegistry {
     });
 
     return await new Promise<SubmitServerRequestRequest["response"]>((resolve, reject) => {
-      this.pendingServerRequests.set(key, { resolve, reject });
+      this.pendingServerRequests.set(key, {
+        backend,
+        notification: routedRequest,
+        resolve,
+        reject,
+      });
 
       void this.emit({
         backend,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -3,6 +3,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import type {
   AppServerBackendKind,
   AppServerReadThreadResponse,
+  AppServerToolRequestUserInputNotification,
   AppServerThreadActivityEntry,
   AppServerThreadEntry,
   AppServerThreadMessage,
@@ -8091,6 +8092,68 @@ describe("useThreadSessionState", () => {
     expect(result.current.pendingUserInput).toBeUndefined();
     expect(result.current.inputRequestThreadKeys).toEqual({});
     expect(result.current.pendingStatusText).toBe("Thinking");
+  });
+
+  it("recovers pending user input from thread hydration after a renderer restart", async () => {
+    const pendingRequest: AppServerToolRequestUserInputNotification = {
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "input-1",
+        requestId: "input-request-1",
+        questions: [
+          {
+            id: "approach",
+            header: "Approach",
+            question: "Which path should I take?",
+            isOther: false,
+            isSecret: false,
+            options: [
+              {
+                label: "Small patch (Recommended)",
+                description: "Keep this scoped.",
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const desktopApi: DesktopApi = {
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        pendingRequest,
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    expect(result.current.activeTurnId).toBe("turn-1");
+    expect(result.current.pendingStatusText).toBe("Waiting for input");
+    expect(result.current.inputRequestThreadKeys).toEqual({
+      "codex:thread-1": true,
+    });
+    expect(result.current.pendingUserInput).toMatchObject({
+      requestId: "input-request-1",
+      questions: [{ id: "approach" }],
+    });
   });
 
   it("does not reintroduce thinking when a request resolves after turn completion", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3829,6 +3829,27 @@ export function useThreadSessionState(params: {
             current.response,
             current.loadedOlderHistory
           );
+          const hydratedPendingRequest = response.pendingRequest;
+          const hydratedPendingUserInput =
+            hydratedPendingRequest && isRequestUserInputNotification(hydratedPendingRequest)
+              ? createQuestionnaireState(hydratedPendingRequest)
+              : undefined;
+          const hydratedPendingMcpInteraction =
+            hydratedPendingRequest && isMcpElicitationNotification(hydratedPendingRequest)
+              ? createMcpElicitationState(hydratedPendingRequest)
+              : undefined;
+          const hydratedApprovalRequest =
+            hydratedPendingRequest && isApprovalRequestNotification(hydratedPendingRequest)
+              ? hydratedPendingRequest
+              : undefined;
+          const hydratedPendingInteraction = Boolean(
+            hydratedPendingUserInput
+            || hydratedPendingMcpInteraction
+            || hydratedApprovalRequest
+          );
+          const hydratedPendingTurnId = hydratedPendingRequest
+            ? readNotificationTurnId(hydratedPendingRequest)
+            : undefined;
           const hydratedCompletedTurn = didHydrateCompletedTurn(
             current.response,
             responseWithLoadedHistory
@@ -3871,6 +3892,7 @@ export function useThreadSessionState(params: {
             responseThreadStatus === "idle"
             && thinkingReasons.length > 0
             && !hasPendingInteraction(current)
+            && !hydratedPendingInteraction
             && !ownUpdateStillSettling
             && !reviewUpdateStillSettling
             && !responseHasInProgressTurn(
@@ -3911,12 +3933,16 @@ export function useThreadSessionState(params: {
 
           return {
             ...currentAfterStaleThinking,
-            activeTurnId: shouldClearStaleThinking
+            activeTurnId: hydratedPendingTurnId ?? (shouldClearStaleThinking
               ? undefined
               : shouldAdoptHydratedTurn
                 ? trailingInProgressTurn.id
-                : current.activeTurnId,
-            activeTurnStartedAt: shouldClearStaleThinking
+                : current.activeTurnId),
+            activeTurnStartedAt: hydratedPendingTurnId
+              ? current.activeTurnId === hydratedPendingTurnId
+                ? current.activeTurnStartedAt
+                : undefined
+              : shouldClearStaleThinking
               ? undefined
               : shouldAdoptHydratedTurn
                 ? trailingInProgressTurn.startedAt
@@ -3924,7 +3950,7 @@ export function useThreadSessionState(params: {
                     ? current.activeTurnStartedAt
                     : undefined)
                 : current.activeTurnStartedAt,
-            backendReportedActive,
+            backendReportedActive: hydratedPendingInteraction || backendReportedActive,
             error: undefined,
             expectOwnUpdate: false,
             failedHydrationVersion: undefined,
@@ -3944,9 +3970,24 @@ export function useThreadSessionState(params: {
             pendingAssistantMessage: shouldClearStaleThinking
               ? undefined
               : current.pendingAssistantMessage,
-            pendingStatusText: shouldClearStaleThinking
-              ? undefined
-              : current.pendingStatusText,
+            pendingMcpInteraction: hydratedPendingInteraction
+              ? hydratedPendingMcpInteraction
+              : current.pendingMcpInteraction,
+            pendingRequest: hydratedPendingInteraction
+              ? hydratedApprovalRequest
+              : current.pendingRequest,
+            pendingStatusText: hydratedPendingUserInput
+              ? "Waiting for input"
+              : hydratedPendingMcpInteraction
+                ? "Waiting for MCP approval"
+                : hydratedApprovalRequest
+                  ? "Waiting for approval"
+                  : shouldClearStaleThinking
+                    ? undefined
+                    : current.pendingStatusText,
+            pendingUserInput: hydratedPendingInteraction
+              ? hydratedPendingUserInput
+              : current.pendingUserInput,
             response: responseWithLoadedHistory,
             staleThinkingRecheckAt:
               ownUpdateStillSettling || reviewUpdateStillSettling

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -876,6 +876,12 @@ export type AppServerReadThreadResponse = {
   fetchedAt: number;
   threadId: ThreadIdentifier;
   replay: AppServerThreadReplay;
+  /**
+   * A server request still awaiting an operator response. This lets a freshly
+   * loaded renderer recover an input or approval prompt that arrived while it
+   * was restarting or disconnected from main-process events.
+   */
+  pendingRequest?: AppServerPendingRequestNotification;
   pricing?: {
     lines: ThreadUsageLineRecord[];
     summaries: ThreadPricingSummary[];


### PR DESCRIPTION
## Summary
- hydrate outstanding input, approval, and MCP requests when a thread view reloads
- retain pending request payloads in the main-process registry
- cover renderer restart and Electron reload recovery

## Root cause
Pending request UI state lived only in renderer memory. A reload or missed main-process event left the active turn displaying “Thinking” even though main was still waiting for the operator’s questionnaire response.

## Validation
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm --filter @pwragent/desktop test:e2e e2e/request-user-input.spec.ts`
- `pnpm lint:eslint`
- `pnpm typecheck`
- `pnpm lint:boundaries`