### PR TITLE
fix(desktop): preserve remote child environments

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -744,7 +744,7 @@ test.describe("federation remote window", () => {
     }
   });
 
-  test("preserves a Codex environment when a Kimi child is born through a remote viewer", async () => {
+  test("preserves a Codex environment when a Kimi child is born through a remote viewer", async ({ browserName: _browserName }, testInfo) => {
     test.setTimeout(300_000);
 
     const fixtureRoot = await mkdtemp(
@@ -1055,8 +1055,7 @@ test.describe("federation remote window", () => {
         }, { timeout: 30_000 })
         .toBe(true);
 
-      // Durable protocol capture: thread/start saw the setup marker, and
-      // review/start followed initialize + thread/start.
+      // Durable protocol capture: thread/start saw the setup marker.
       await expect
         .poll(async () => {
           const entries = await readFakeCodexRequestLog(requestLogPath);
@@ -1064,15 +1063,9 @@ test.describe("federation remote window", () => {
         }, { timeout: 30_000 })
         .toBeGreaterThan(0);
 
-      const protocol = await readFakeCodexRequestLog(requestLogPath);
-      const initialize = findFakeCodexRequest(protocol, "initialize");
-      const threadStart = findFakeCodexRequest(protocol, "thread/start");
-      const reviewStart = findFakeCodexRequest(protocol, "review/start");
-      expect(initialize).toBeTruthy();
+      let protocol = await readFakeCodexRequestLog(requestLogPath);
+      let threadStart = findFakeCodexRequest(protocol, "thread/start");
       expect(threadStart).toBeTruthy();
-      expect(reviewStart).toBeTruthy();
-      expect(initialize!.at).toBeLessThanOrEqual(threadStart!.at);
-      expect(threadStart!.at).toBeLessThanOrEqual(reviewStart!.at + 1_000);
 
       // Exact failure assertion: when fake Codex received thread/start, the
       // environment setup marker already existed in the requested cwd.
@@ -1081,7 +1074,33 @@ test.describe("federation remote window", () => {
       // Filesystem clock corroboration (allow small FS timestamp skew).
       const setupMtimeMs = statSync(setupMarkerPath).mtimeMs;
       expect(setupMtimeMs).toBeLessThanOrEqual(threadStart!.at + 5_000);
+
+      // Starting a native review continues asynchronously after child
+      // materialization. Wait for the durable request instead of assuming it
+      // has arrived as soon as thread/start is observable on a slower VM.
+      await expect
+        .poll(async () => {
+          const entries = await readFakeCodexRequestLog(requestLogPath);
+          return findAllFakeCodexRequests(entries, "review/start").length;
+        }, { timeout: 30_000 })
+        .toBeGreaterThan(0);
+
+      protocol = await readFakeCodexRequestLog(requestLogPath);
+      const initialize = findFakeCodexRequest(protocol, "initialize");
+      threadStart = findFakeCodexRequest(protocol, "thread/start");
+      const reviewStart = findFakeCodexRequest(protocol, "review/start");
+      expect(initialize).toBeTruthy();
+      expect(threadStart).toBeTruthy();
+      expect(reviewStart).toBeTruthy();
+      expect(initialize!.at).toBeLessThanOrEqual(threadStart!.at);
+      expect(threadStart!.at).toBeLessThanOrEqual(reviewStart!.at);
     } finally {
+      if (existsSync(requestLogPath)) {
+        await testInfo.attach("fake-codex-protocol", {
+          path: requestLogPath,
+          contentType: "application/x-ndjson",
+        });
+      }
       await viewer?.close();
       await owner?.close();
       await rm(fixtureRoot, { force: true, recursive: true });

--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -1,9 +1,21 @@
-import { existsSync } from "node:fs";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
+import {
+  buildFakeAgentConfigToml,
+  FEDERATION_CHILD_ENVIRONMENT_MARKER,
+  findAllFakeCodexRequests,
+  findFakeCodexRequest,
+  readFakeCodexRequestLog,
+  seedFakeCodexExecutable,
+  seedFakeKimiExecutable,
+  seedInstalledKimiParent,
+} from "./fixtures/fake-agent-executables";
 import {
   startInProcessFederationGateway,
   type InProcessFederationGateway,
@@ -17,6 +29,9 @@ import {
  * the gateway's router, so invite redemption, the auth handshake, remote
  * navigation snapshots, and pin routing all exercise production code on
  * both ends of the wire.
+ *
+ * The environment-loss repro below uses a second, fully real owner app
+ * with executable-backed Kimi + Codex fakes (no Codex replay fixture).
  */
 
 async function createLocalControlFixture(): Promise<{
@@ -41,7 +56,14 @@ async function createLocalControlFixture(): Promise<{
           method: "initialize",
           result: {
             serverInfo: { name: "Replay Codex", version: "1.0.0" },
-            methods: ["thread/list", "thread/read", "skills/list", "turn/start"],
+            methods: [
+              "thread/list",
+              "thread/read",
+              "skills/list",
+              "thread/start",
+              "turn/start",
+              "review/start",
+            ],
           },
         },
         {
@@ -87,6 +109,24 @@ async function createLocalControlFixture(): Promise<{
             },
           },
         },
+        {
+          id: "thread-start-1",
+          kind: "response",
+          method: "thread/start",
+          result: {
+            threadId: "federated-environment-child",
+          },
+        },
+        {
+          id: "review-start-1",
+          kind: "response",
+          method: "review/start",
+          result: {
+            threadId: "federated-environment-child",
+            reviewThreadId: "federated-environment-child",
+            turnId: "federated-environment-review",
+          },
+        },
       ],
     }),
   );
@@ -96,6 +136,74 @@ async function createLocalControlFixture(): Promise<{
     },
     fixturePath,
   };
+}
+
+async function reserveLoopbackPort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Expected a loopback TCP port for federation E2E");
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+  return address.port;
+}
+
+async function seedFixtureGitRepo(params: {
+  repoDir: string;
+  environmentSetupScript: string;
+  commitMessage?: string;
+  /**
+   * When false, skip `git init` / branch creation (for already-materialized
+   * worktrees). Defaults to true.
+   */
+  initializeGit?: boolean;
+}): Promise<void> {
+  await mkdir(path.join(params.repoDir, ".codex", "environments"), {
+    recursive: true,
+  });
+  if (params.initializeGit !== false) {
+    execFileSync("git", ["init"], { cwd: params.repoDir, stdio: "ignore" });
+    execFileSync("git", ["checkout", "-B", "main"], {
+      cwd: params.repoDir,
+      stdio: "ignore",
+    });
+  }
+  await writeFile(
+    path.join(params.repoDir, ".codex", "environments", "environment.toml"),
+    [
+      "version = 1",
+      'name = "PwrAgent"',
+      "",
+      "[setup]",
+      `script = ${JSON.stringify(params.environmentSetupScript)}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  execFileSync("git", ["add", ".codex/environments/environment.toml"], {
+    cwd: params.repoDir,
+    stdio: "ignore",
+  });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=pwragent-tests@example.invalid",
+      "commit",
+      "-m",
+      params.commitMessage ?? "Seed fixture repo",
+    ],
+    { cwd: params.repoDir, stdio: "ignore" },
+  );
 }
 
 test.describe("federation remote window", () => {
@@ -109,6 +217,12 @@ test.describe("federation remote window", () => {
     const ownerPtyCwd = await mkdtemp(
       path.join(os.tmpdir(), "pwragent-federation-e2e-pty-"),
     );
+    const fixtureRepo = path.join(ownerPtyCwd, "FixtureRepo");
+    await seedFixtureGitRepo({
+      repoDir: fixtureRepo,
+      environmentSetupScript: "printf federation-child-environment",
+      commitMessage: "Seed fixture repo",
+    });
     let app: Awaited<ReturnType<typeof launchElectronApp>> | undefined;
     try {
       gateway = await startInProcessFederationGateway({
@@ -119,6 +233,13 @@ test.describe("federation remote window", () => {
             key: "directory:/remote/FixtureRepo",
             label: "FixtureRepo",
             path: "/remote/FixtureRepo",
+            threadIds: ["remote-thread-1", "remote-thread-2"],
+          },
+          {
+            key: `directory:${fixtureRepo}`,
+            label: "EnvironmentRepo",
+            path: fixtureRepo,
+            threadIds: ["remote-kimi-parent"],
           },
         ],
         threads: [
@@ -132,6 +253,22 @@ test.describe("federation remote window", () => {
             title: "Remote gateway thread two",
             updatedAt: 1_000,
           },
+          {
+            id: "remote-kimi-parent",
+            title: "Remote Kimi parent",
+            updatedAt: 1_500,
+            source: "acp:kimi",
+            executionMode: "default",
+            linkedDirectories: [
+              {
+                id: fixtureRepo,
+                label: "EnvironmentRepo",
+                path: fixtureRepo,
+                worktreePath: fixtureRepo,
+                kind: "worktree",
+              },
+            ],
+          },
         ],
       });
 
@@ -139,6 +276,27 @@ test.describe("federation remote window", () => {
       app = await launchElectronApp({
         fixturePath: fixture.fixturePath,
         secretStorage: "memory",
+        preLaunchHook: async (homeRoot) => {
+          const { executablePath: fakeKimiPath } =
+            await seedFakeKimiExecutable(homeRoot);
+          const configPath = path.join(
+            homeRoot,
+            ".pwragent",
+            "profiles",
+            "default",
+            "config.toml",
+          );
+          await mkdir(path.dirname(configPath), { recursive: true });
+          await writeFile(
+            configPath,
+            [
+              "[acp_agents.kimi]",
+              `cli_path = ${JSON.stringify(fakeKimiPath)}`,
+              "",
+            ].join("\n"),
+            "utf8",
+          );
+        },
       });
       const { electronApp, window } = app;
 
@@ -462,6 +620,74 @@ test.describe("federation remote window", () => {
       await expect(
         remote.getByTestId("composer-tiptap-input"),
       ).toHaveAttribute("data-value", "");
+
+      // A child launchpad inherits the Kimi parent first. Switching it to
+      // OpenAI and choosing a Codex environment must preserve that environment
+      // through remote materialization, including the review-command path.
+      await remote
+        .getByRole("button", { name: "EnvironmentRepo, 1 thread to review" })
+        .click();
+      const remoteKimiParent = remote.getByRole("button", {
+        name: "Remote Kimi parent",
+      });
+      await expect(remoteKimiParent).toBeVisible();
+      await remoteKimiParent.click({ button: "right" });
+      await remote
+        .getByRole("menuitem", { name: "Sub-thread in Same Worktree" })
+        .click();
+
+      const childPrompt = remote.getByRole("textbox", { name: "New thread" });
+      await expect(childPrompt).toBeVisible();
+      const childSettings = remote.getByLabel("New thread settings");
+      const childProvider = childSettings.getByRole("button", {
+        name: "Provider",
+        exact: true,
+      });
+      await expect(childProvider).toContainText("Kimi");
+      await childProvider.click();
+      await remote.getByRole("option", { name: "OpenAI", exact: true }).click();
+      await expect(childProvider).toContainText("OpenAI");
+
+      const childTools = remote.getByLabel("Composer tools");
+      const childEnvironment = childTools.getByRole("button", {
+        name: "Environment",
+        exact: true,
+      });
+      await expect(childEnvironment).toBeVisible();
+      await childEnvironment.click();
+      await remote.getByRole("option", { name: "PwrAgent", exact: true }).click();
+      await expect(childEnvironment).toContainText("PwrAgent");
+
+      await childPrompt.fill("/review");
+      await remote.getByRole("button", { name: "Start thread" }).click();
+      const reviewTarget = remote.getByRole("group", { name: "Review target" });
+      await expect(reviewTarget).toBeVisible();
+      await reviewTarget.getByRole("combobox", { name: "Base branch" }).click();
+      await reviewTarget.getByRole("option", { name: "main", exact: true }).click();
+      await reviewTarget.getByRole("button", { name: "Start review" }).click();
+
+      await expect
+        .poll(
+          () => gateway!.calls.filter(
+            (call) => call.method === "materializeDirectoryLaunchpad",
+          ).length,
+          { timeout: 30_000 },
+        )
+        .toBe(2);
+      const childMaterializeCall = gateway.calls.filter(
+        (call) => call.method === "materializeDirectoryLaunchpad",
+      ).at(-1);
+      expect(childMaterializeCall?.params).toMatchObject({
+        parentThreadId: "remote-kimi-parent",
+        reviewTarget: { type: "baseBranch", branch: "main" },
+        launchpad: {
+          backend: "codex",
+          codexEnvironmentId: "environment",
+          codexEnvironmentExecutionTarget: "local",
+          directoryPath: fixtureRepo,
+        },
+      });
+
       await remoteRowOne.click();
       const remoteReply = remote.getByRole("textbox", { name: "Reply" });
       const recoveryDraft = "Keep this draft while the gateway reconnects";
@@ -515,6 +741,350 @@ test.describe("federation remote window", () => {
       await gateway?.close();
       await fixture.cleanup();
       await rm(ownerPtyCwd, { force: true, recursive: true });
+    }
+  });
+
+  test("preserves a Codex environment when a Kimi child is born through a remote viewer", async () => {
+    test.setTimeout(300_000);
+
+    const fixtureRoot = await mkdtemp(
+      path.join(os.tmpdir(), "pwragent-federation-environment-owner-"),
+    );
+    const sourceRepo = path.join(fixtureRoot, "source");
+    const fixtureRepo = path.join(
+      fixtureRoot,
+      ".pwragent",
+      "worktrees",
+      "federation-environment-repro",
+      "FixtureRepo",
+    );
+    const setupMarkerPath = path.join(
+      fixtureRepo,
+      FEDERATION_CHILD_ENVIRONMENT_MARKER,
+    );
+    const federationPort = await reserveLoopbackPort();
+
+    await mkdir(sourceRepo, { recursive: true });
+    execFileSync("git", ["init"], { cwd: sourceRepo, stdio: "ignore" });
+    execFileSync("git", ["checkout", "-B", "main"], {
+      cwd: sourceRepo,
+      stdio: "ignore",
+    });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=PwrAgent Tests",
+        "-c",
+        "user.email=pwragent-tests@example.invalid",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "Seed federation source repo",
+      ],
+      { cwd: sourceRepo, stdio: "ignore" },
+    );
+    execFileSync(
+      "git",
+      ["worktree", "add", "-b", "federation-environment-repro", fixtureRepo, "main"],
+      { cwd: sourceRepo, stdio: "ignore" },
+    );
+    await seedFixtureGitRepo({
+      repoDir: fixtureRepo,
+      environmentSetupScript: `touch ${FEDERATION_CHILD_ENVIRONMENT_MARKER}`,
+      commitMessage: "Seed federation environment fixture",
+      initializeGit: false,
+    });
+
+    const protocolDir = path.join(fixtureRoot, "protocol");
+    const requestLogPath = path.join(protocolDir, "fake-codex.protocol.jsonl");
+    const launchMarkerPath = path.join(protocolDir, "fake-codex.launched");
+    await mkdir(protocolDir, { recursive: true });
+
+    let owner: Awaited<ReturnType<typeof launchElectronApp>> | undefined;
+    let viewer: Awaited<ReturnType<typeof launchElectronApp>> | undefined;
+    try {
+      // Real owner: executable-backed Kimi + Codex via production settings.
+      // No PWRAGENT_REPLAY_FIXTURE_PATH — Codex discovery spawns fake-codex.
+      owner = await launchElectronApp({
+        requiresReplayDriver: false,
+        secretStorage: "memory",
+        preLaunchHook: async (homeRoot) => {
+          const { executablePath: fakeKimiPath } =
+            await seedFakeKimiExecutable(homeRoot);
+          const { executablePath: fakeCodexPath } =
+            await seedFakeCodexExecutable({
+              homeRoot,
+              requestLogPath,
+              launchMarkerPath,
+            });
+          await seedInstalledKimiParent({
+            directoryPath: fixtureRepo,
+            homeRoot,
+            fakeKimiPath,
+          });
+          const configPath = path.join(
+            homeRoot,
+            ".pwragent",
+            "profiles",
+            "default",
+            "config.toml",
+          );
+          await mkdir(path.dirname(configPath), { recursive: true });
+          await writeFile(
+            configPath,
+            buildFakeAgentConfigToml({
+              fakeKimiPath,
+              fakeCodexPath,
+              extraToml: [
+                "[federation]",
+                'mode = "gateway"',
+                'instance_label = "Federation Environment Owner"',
+                'listen_host = "127.0.0.1"',
+                `listen_port = ${federationPort}`,
+                `public_url = "ws://127.0.0.1:${federationPort}"`,
+                "",
+              ].join("\n"),
+            }),
+            "utf8",
+          );
+        },
+      });
+
+      await expect
+        .poll(
+          async () => await owner!.window.evaluate(async () => {
+            const api = (window as typeof window & {
+              pwragent?: {
+                listBackends?: () => Promise<{
+                  backends: Array<{ available: boolean; kind: string }>;
+                }>;
+              };
+            }).pwragent;
+            const response = await api?.listBackends?.();
+            const kimiReady = response?.backends.some(
+              (backend) => backend.kind === "acp:kimi" && backend.available,
+            ) ?? false;
+            const codexReady = response?.backends.some(
+              (backend) => backend.kind === "codex" && backend.available,
+            ) ?? false;
+            return kimiReady && codexReady;
+          }),
+          { timeout: 60_000 },
+        )
+        .toBe(true);
+
+      const parent = {
+        backend: "acp:kimi",
+        threadId: "federated-kimi-parent",
+      };
+
+      const invite = await owner.window.evaluate(async () => {
+        const api = (window as typeof window & {
+          pwragent?: {
+            generateFederationInvite?: () => Promise<{ invite: string }>;
+          };
+        }).pwragent;
+        if (!api?.generateFederationInvite) {
+          throw new Error("Owner invite API is unavailable");
+        }
+        return (await api.generateFederationInvite()).invite;
+      });
+
+      viewer = await launchElectronApp({
+        requiresReplayDriver: false,
+        secretStorage: "memory",
+      });
+      await expect
+        .poll(
+          async () => await viewer!.window.evaluate(async () => {
+            const api = (window as typeof window & {
+              pwragent?: {
+                readFederationHealth?: () => Promise<{
+                  health: { enabled: boolean };
+                }>;
+              };
+            }).pwragent;
+            return (await api?.readFederationHealth?.())?.health.enabled;
+          }),
+          { timeout: 30_000 },
+        )
+        .toBe(false);
+      // The renderer can become ready while the fire-and-forget federation
+      // startup restart is still unwinding. Importing during that narrow boot
+      // window coalesces with the disabled-mode restart instead of dialing the
+      // newly enrolled gateway, which is not representative of a viewer the
+      // operator is already using.
+      await viewer.window.waitForTimeout(1_000);
+      const enrollment = await viewer.window.evaluate(async (encodedInvite) => {
+        const api = (window as typeof window & {
+          pwragent?: {
+            importFederationInvite?: (request: { invite: string }) => Promise<{
+              gatewayInstanceId: string;
+            }>;
+          };
+        }).pwragent;
+        if (!api?.importFederationInvite) {
+          throw new Error("Viewer invite API is unavailable");
+        }
+        return await api.importFederationInvite({ invite: encodedInvite });
+      }, invite);
+
+      await expect
+        .poll(
+          async () => await viewer!.window.evaluate(async () => {
+            const api = (window as typeof window & {
+              pwragent?: {
+                readFederationHealth?: () => Promise<{
+                  health: { status?: string };
+                }>;
+              };
+            }).pwragent;
+            return JSON.stringify((await api?.readFederationHealth?.())?.health);
+          }),
+          { timeout: 30_000 },
+        )
+        .toContain('"status":"connected"');
+
+      const remoteWindowPromise = viewer.electronApp.waitForEvent("window");
+      await viewer.window.evaluate(async (instanceId) => {
+        const api = (window as typeof window & {
+          pwragent?: {
+            openFederationWindow?: (request: unknown) => Promise<unknown>;
+          };
+        }).pwragent;
+        if (!api?.openFederationWindow) {
+          throw new Error("Viewer remote-window API is unavailable");
+        }
+        await api.openFederationWindow({
+          target: { scope: "remote", instanceId },
+        });
+      }, enrollment.gatewayInstanceId);
+      const remote = await remoteWindowPromise;
+      await remote.waitForLoadState("domcontentloaded");
+
+      const remoteKimiParent = remote.getByRole("button", {
+        name: "Remote Kimi parent",
+      });
+      await expect(remoteKimiParent).toBeVisible({ timeout: 30_000 });
+      await remoteKimiParent.click({ button: "right" });
+      await remote
+        .getByRole("menuitem", { name: "Sub-thread in Same Worktree" })
+        .click();
+
+      const childSettings = remote.getByLabel("New thread settings");
+      const childProvider = childSettings.getByRole("button", {
+        name: "Provider",
+        exact: true,
+      });
+      await expect(childProvider).toContainText("Kimi");
+      await childProvider.click();
+      await remote.getByRole("option", { name: "OpenAI", exact: true }).click();
+      await expect(childProvider).toContainText("OpenAI");
+
+      const childAccessMode = childSettings.getByLabel("Access mode");
+      if (await childAccessMode.getAttribute("data-value") !== "full-access") {
+        await childAccessMode.click();
+        await remote.getByRole("option", { name: "Full Access" }).click();
+        await remote
+          .getByRole("dialog", { name: "Enable Full Access?" })
+          .getByRole("button", { name: "I Understand and Accept the Risks" })
+          .click();
+      }
+      await expect(childAccessMode).toHaveAttribute("data-value", "full-access");
+
+      const childEnvironment = remote
+        .getByLabel("Composer tools")
+        .getByRole("button", { name: "Environment", exact: true });
+      await expect(childEnvironment).toBeVisible();
+      await childEnvironment.click();
+      await remote.getByRole("option", { name: "PwrAgent", exact: true }).click();
+      await expect(childEnvironment).toContainText("PwrAgent");
+
+      await remote.getByRole("textbox", { name: "New thread" }).fill("/review");
+      await remote.getByRole("button", { name: "Start thread" }).click();
+      const reviewTarget = remote.getByRole("group", { name: "Review target" });
+      await expect(reviewTarget).toBeVisible();
+      await reviewTarget.getByRole("combobox", { name: "Base branch" }).click();
+      await reviewTarget.getByRole("option", { name: "main", exact: true }).click();
+      await reviewTarget.getByRole("button", { name: "Start review" }).click();
+
+      // Owner retains environmentId=environment on the materialized child.
+      await expect
+        .poll(
+          async () => await owner!.window.evaluate(
+            async ({ parentThreadId }) => {
+              const api = (window as typeof window & {
+                pwragent?: {
+                  getNavigationSnapshot?: (request: unknown) => Promise<{
+                    threads: Array<{
+                      codexEnvironmentRuntime?: { environmentId?: string };
+                      parentThreadId?: string;
+                      source: string;
+                    }>;
+                  }>;
+                };
+              }).pwragent;
+              const snapshot = await api?.getNavigationSnapshot?.({ backend: "all" });
+              return snapshot?.threads.find(
+                (thread) =>
+                  thread.source === "codex"
+                  && thread.parentThreadId === parentThreadId,
+              )?.codexEnvironmentRuntime?.environmentId;
+            },
+            { parentThreadId: parent.threadId },
+          ),
+          { timeout: 60_000 },
+        )
+        .toBe("environment");
+
+      // Setup marker proves environment setup actually ran on the owner worktree.
+      await expect
+        .poll(() => existsSync(setupMarkerPath), { timeout: 30_000 })
+        .toBe(true);
+
+      // Fake Codex must have been launched through production discovery.
+      await expect
+        .poll(() => {
+          try {
+            const raw = statSync(launchMarkerPath);
+            return raw.size > 0;
+          } catch {
+            return false;
+          }
+        }, { timeout: 30_000 })
+        .toBe(true);
+
+      // Durable protocol capture: thread/start saw the setup marker, and
+      // review/start followed initialize + thread/start.
+      await expect
+        .poll(async () => {
+          const entries = await readFakeCodexRequestLog(requestLogPath);
+          return findAllFakeCodexRequests(entries, "thread/start").length;
+        }, { timeout: 30_000 })
+        .toBeGreaterThan(0);
+
+      const protocol = await readFakeCodexRequestLog(requestLogPath);
+      const initialize = findFakeCodexRequest(protocol, "initialize");
+      const threadStart = findFakeCodexRequest(protocol, "thread/start");
+      const reviewStart = findFakeCodexRequest(protocol, "review/start");
+      expect(initialize).toBeTruthy();
+      expect(threadStart).toBeTruthy();
+      expect(reviewStart).toBeTruthy();
+      expect(initialize!.at).toBeLessThanOrEqual(threadStart!.at);
+      expect(threadStart!.at).toBeLessThanOrEqual(reviewStart!.at + 1_000);
+
+      // Exact failure assertion: when fake Codex received thread/start, the
+      // environment setup marker already existed in the requested cwd.
+      expect(threadStart!.setupMarkerPresent).toBe(true);
+
+      // Filesystem clock corroboration (allow small FS timestamp skew).
+      const setupMtimeMs = statSync(setupMarkerPath).mtimeMs;
+      expect(setupMtimeMs).toBeLessThanOrEqual(threadStart!.at + 5_000);
+    } finally {
+      await viewer?.close();
+      await owner?.close();
+      await rm(fixtureRoot, { force: true, recursive: true });
     }
   });
 });

--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -218,6 +218,12 @@ test.describe("federation remote window", () => {
       path.join(os.tmpdir(), "pwragent-federation-e2e-pty-"),
     );
     const fixtureRepo = path.join(ownerPtyCwd, "FixtureRepo");
+    const ownerOnlyEnvironmentRepo = path.posix.join(
+      "/owner-only",
+      path.basename(ownerPtyCwd),
+      "EnvironmentRepo",
+    );
+    expect(existsSync(ownerOnlyEnvironmentRepo)).toBe(false);
     await seedFixtureGitRepo({
       repoDir: fixtureRepo,
       environmentSetupScript: "printf federation-child-environment",
@@ -236,16 +242,16 @@ test.describe("federation remote window", () => {
             threadIds: ["remote-thread-1", "remote-thread-2"],
           },
           {
-            key: `directory:${fixtureRepo}`,
+            key: `directory:${ownerOnlyEnvironmentRepo}`,
             label: "EnvironmentRepo",
-            path: fixtureRepo,
+            path: ownerOnlyEnvironmentRepo,
             threadIds: ["remote-kimi-parent"],
             codexEnvironmentOptions: [
               {
                 id: "environment",
                 name: "PwrAgent",
                 sourcePath: path.join(
-                  fixtureRepo,
+                  ownerOnlyEnvironmentRepo,
                   ".codex",
                   "environments",
                   "environment.toml",
@@ -275,10 +281,10 @@ test.describe("federation remote window", () => {
             executionMode: "default",
             linkedDirectories: [
               {
-                id: fixtureRepo,
+                id: ownerOnlyEnvironmentRepo,
                 label: "EnvironmentRepo",
-                path: fixtureRepo,
-                worktreePath: fixtureRepo,
+                path: ownerOnlyEnvironmentRepo,
+                worktreePath: ownerOnlyEnvironmentRepo,
                 kind: "worktree",
               },
             ],
@@ -698,7 +704,7 @@ test.describe("federation remote window", () => {
           backend: "codex",
           codexEnvironmentId: "environment",
           codexEnvironmentExecutionTarget: "local",
-          directoryPath: fixtureRepo,
+          directoryPath: ownerOnlyEnvironmentRepo,
         },
       });
 

--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -240,6 +240,20 @@ test.describe("federation remote window", () => {
             label: "EnvironmentRepo",
             path: fixtureRepo,
             threadIds: ["remote-kimi-parent"],
+            codexEnvironmentOptions: [
+              {
+                id: "environment",
+                name: "PwrAgent",
+                sourcePath: path.join(
+                  fixtureRepo,
+                  ".codex",
+                  "environments",
+                  "environment.toml",
+                ),
+                setupScript: "printf federation-child-environment",
+                actions: [],
+              },
+            ],
           },
         ],
         threads: [

--- a/apps/desktop/e2e/fixtures/fake-agent-executables.ts
+++ b/apps/desktop/e2e/fixtures/fake-agent-executables.ts
@@ -1,0 +1,602 @@
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { AcpBackendId } from "@pwragent/shared";
+import { AcpAgentStore } from "../../src/main/acp/acp-agent-store";
+import { AcpSessionStore } from "../../src/main/acp/acp-session-store";
+import { StateDb } from "../../src/main/state/state-db";
+
+/**
+ * Durable executable-backed fakes for desktop E2E.
+ *
+ * Codex is configured through production settings (`[models.codex].path`) and
+ * discovery — never through `PWRAGENT_REPLAY_FIXTURE_PATH`. Kimi is configured
+ * through `[acp_agents.kimi].cli_path` plus an installed-agent / session seed
+ * when a parent ACP thread must already exist.
+ *
+ * The fake Codex app-server appends every JSON-RPC request to a durable
+ * protocol log so specs can assert exact materialization order (environment
+ * setup marker before thread/start, review/start, etc.).
+ */
+
+export const FAKE_CODEX_PROTOCOL_LOG_ENV = "PWRAGENT_FAKE_CODEX_PROTOCOL_LOG";
+export const FAKE_CODEX_LAUNCH_MARKER_ENV = "PWRAGENT_FAKE_CODEX_LAUNCH_MARKER";
+// Stay below the generated model/list contract (0.144.0) so the minimal
+// legacy list shape is accepted. Discovery still requires >= 0.125.0.
+export const FAKE_CODEX_VERSION = "0.130.0";
+export const FEDERATION_CHILD_ENVIRONMENT_MARKER =
+  ".federation-child-environment-ran";
+
+export type FakeCodexProtocolRequest = {
+  at: number;
+  method: string;
+  id?: string | number | null;
+  params?: unknown;
+  /** Present on `thread/start` when the fake can inspect the requested cwd. */
+  setupMarkerPresent?: boolean;
+  setupMarkerPath?: string;
+};
+
+export async function writeFakeKimiExecutable(
+  targetPath: string,
+): Promise<string> {
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  // Major 0.x so discovery does not treat this as legacy Python kimi-cli (1.x).
+  await writeFile(
+    targetPath,
+    `#!/usr/bin/env node
+if (process.argv.includes("--version")) {
+  process.stdout.write("kimi-code 0.1.0\\n");
+  process.exit(0);
+}
+const readline = require("node:readline");
+const input = readline.createInterface({ input: process.stdin });
+input.on("line", (line) => {
+  let request;
+  try {
+    request = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (request == null || request.id === undefined) {
+    return;
+  }
+  let result = {};
+  if (request.method === "initialize") {
+    result = { protocolVersion: 1 };
+  } else if (request.method === "session/new") {
+    result = { sessionId: "fake-kimi-session" };
+  } else if (request.method === "session/load") {
+    result = { updates: [] };
+  } else if (request.method === "session/prompt") {
+    result = { turnId: "fake-kimi-turn" };
+  } else if (request.method === "session/cancel") {
+    result = {};
+  }
+  process.stdout.write(
+    JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\\n",
+  );
+});
+`,
+    "utf8",
+  );
+  await chmod(targetPath, 0o755);
+  return targetPath;
+}
+
+export async function writeFakeCodexExecutable(params: {
+  targetPath: string;
+  protocolLogPath: string;
+  launchMarkerPath: string;
+}): Promise<string> {
+  await mkdir(path.dirname(params.targetPath), { recursive: true });
+  await mkdir(path.dirname(params.protocolLogPath), { recursive: true });
+  await mkdir(path.dirname(params.launchMarkerPath), { recursive: true });
+
+  // Bake absolute paths into the script so protocol capture still works if the
+  // spawn path only partially inherits the Electron process env.
+  const protocolLogLiteral = JSON.stringify(params.protocolLogPath);
+  const launchMarkerLiteral = JSON.stringify(params.launchMarkerPath);
+  const setupMarkerNameLiteral = JSON.stringify(
+    FEDERATION_CHILD_ENVIRONMENT_MARKER,
+  );
+  const versionLiteral = JSON.stringify(FAKE_CODEX_VERSION);
+  const protocolLogEnvLiteral = JSON.stringify(FAKE_CODEX_PROTOCOL_LOG_ENV);
+  const launchMarkerEnvLiteral = JSON.stringify(FAKE_CODEX_LAUNCH_MARKER_ENV);
+
+  await writeFile(
+    params.targetPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const readline = require("node:readline");
+const os = require("node:os");
+
+const BAKED_PROTOCOL_LOG = ${protocolLogLiteral};
+const BAKED_LAUNCH_MARKER = ${launchMarkerLiteral};
+const PROTOCOL_LOG =
+  process.env[${protocolLogEnvLiteral}] || BAKED_PROTOCOL_LOG;
+const LAUNCH_MARKER =
+  process.env[${launchMarkerEnvLiteral}] || BAKED_LAUNCH_MARKER;
+const SETUP_MARKER_NAME = ${setupMarkerNameLiteral};
+const VERSION = ${versionLiteral};
+
+function appendProtocol(entry) {
+  try {
+    fs.mkdirSync(path.dirname(PROTOCOL_LOG), { recursive: true });
+    fs.appendFileSync(PROTOCOL_LOG, JSON.stringify(entry) + "\\n");
+  } catch {
+    // Best-effort; the E2E will fail if assertions cannot read the log.
+  }
+}
+
+if (process.argv.includes("--version")) {
+  process.stdout.write("codex-cli " + VERSION + "\\n");
+  process.exit(0);
+}
+
+if (!process.argv.includes("app-server")) {
+  process.stderr.write("fake-codex: expected app-server mode\\n");
+  process.exit(2);
+}
+
+try {
+  fs.mkdirSync(path.dirname(LAUNCH_MARKER), { recursive: true });
+  fs.writeFileSync(
+    LAUNCH_MARKER,
+    JSON.stringify({ at: Date.now(), pid: process.pid, argv: process.argv }) + "\\n",
+  );
+} catch {
+  // ignore
+}
+appendProtocol({
+  at: Date.now(),
+  method: "__launch__",
+  params: { argv: process.argv.slice(1), pid: process.pid },
+});
+
+let threadCounter = 0;
+let turnCounter = 0;
+
+function platformFamily() {
+  return process.platform === "win32" ? "windows" : "unix";
+}
+
+function platformOs() {
+  if (process.platform === "darwin") return "macos";
+  if (process.platform === "win32") return "windows";
+  return "linux";
+}
+
+function nextThreadId() {
+  threadCounter += 1;
+  return "fake-codex-thread-" + threadCounter;
+}
+
+function nextTurnId() {
+  turnCounter += 1;
+  return "fake-codex-turn-" + turnCounter;
+}
+
+function minimalThread(id, params) {
+  const now = Math.floor(Date.now() / 1000);
+  const cwd =
+    typeof params?.cwd === "string" && params.cwd.trim()
+      ? params.cwd.trim()
+      : process.cwd();
+  return {
+    id,
+    sessionId: id,
+    forkedFromId: null,
+    parentThreadId: null,
+    preview: "",
+    ephemeral: false,
+    historyMode: "default",
+    modelProvider: "openai",
+    createdAt: now,
+    updatedAt: now,
+    recencyAt: now,
+    status: { type: "idle" },
+    path: null,
+    cwd,
+    cliVersion: VERSION,
+    source: { type: "cli" },
+    gitInfo: null,
+    extra: null,
+    turns: [],
+  };
+}
+
+function minimalTurn(id) {
+  return {
+    id,
+    items: [],
+    itemsView: "complete",
+    status: "completed",
+    error: null,
+    startedAt: null,
+    completedAt: null,
+    durationMs: null,
+  };
+}
+
+function handleRequest(request) {
+  const method = request.method;
+  const params = request.params ?? {};
+  if (method === "initialize") {
+    const codexHome =
+      process.env.CODEX_HOME
+      || path.join(process.env.HOME || os.tmpdir(), ".codex");
+    return {
+      userAgent: "codex_app_server_fake/" + VERSION,
+      codexHome,
+      platformFamily: platformFamily(),
+      platformOs: platformOs(),
+    };
+  }
+  if (method === "thread/list") {
+    return { data: [], nextCursor: null, backwardsCursor: null };
+  }
+  if (method === "thread/read") {
+    const threadId =
+      typeof params.threadId === "string" ? params.threadId : nextThreadId();
+    return { thread: minimalThread(threadId, params) };
+  }
+  if (method === "thread/start") {
+    const threadId = nextThreadId();
+    return {
+      thread: minimalThread(threadId, params),
+      model: "gpt-5",
+      modelProvider: "openai",
+      serviceTier: null,
+      cwd:
+        typeof params.cwd === "string" && params.cwd.trim()
+          ? params.cwd.trim()
+          : process.cwd(),
+      runtimeWorkspaceRoots: [],
+      instructionSources: [],
+      approvalPolicy: "never",
+      approvalsReviewer: "user",
+      sandbox: { type: "danger-full-access" },
+      activePermissionProfile: null,
+      reasoningEffort: null,
+      multiAgentMode: "explicitRequestOnly",
+    };
+  }
+  if (method === "thread/resume" || method === "thread/fork") {
+    const threadId =
+      typeof params.threadId === "string" ? params.threadId : nextThreadId();
+    return { thread: minimalThread(threadId, params) };
+  }
+  if (method === "thread/name/set" || method === "thread/settings/update") {
+    return {};
+  }
+  if (method === "turn/start") {
+    return { turn: minimalTurn(nextTurnId()) };
+  }
+  if (method === "review/start") {
+    const threadId =
+      typeof params.threadId === "string" ? params.threadId : nextThreadId();
+    return {
+      turn: minimalTurn(nextTurnId()),
+      reviewThreadId: threadId,
+    };
+  }
+  if (method === "skills/list") {
+    return { data: [] };
+  }
+  if (method === "model/list") {
+    return {
+      data: [
+        {
+          id: "gpt-5",
+          model: "gpt-5",
+          isDefault: true,
+          default: true,
+          supportsReasoning: true,
+        },
+      ],
+      nextCursor: null,
+    };
+  }
+  if (method === "account/read") {
+    return {
+      account: {
+        type: "apiKey",
+        email: "fake-codex@example.invalid",
+        planType: "plus",
+      },
+      requiresOpenaiAuth: false,
+    };
+  }
+  if (method === "account/rateLimits/read") {
+    return { rateLimits: [] };
+  }
+  if (method === "config/read") {
+    return { config: {}, origins: {}, layers: null };
+  }
+  if (method === "config/value/write" || method === "thread/inject_items") {
+    return {};
+  }
+  return {};
+}
+
+const input = readline.createInterface({ input: process.stdin });
+input.on("line", (line) => {
+  let request;
+  try {
+    request = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (request == null || typeof request !== "object") {
+    return;
+  }
+  if (request.id === undefined) {
+    appendProtocol({
+      at: Date.now(),
+      method: request.method ?? "notification",
+      params: request.params,
+    });
+    return;
+  }
+  const entry = {
+    at: Date.now(),
+    method: request.method,
+    id: request.id,
+    params: request.params,
+  };
+  if (request.method === "thread/start") {
+    const cwd =
+      typeof request.params?.cwd === "string" ? request.params.cwd.trim() : "";
+    if (cwd) {
+      const markerPath = path.join(cwd, SETUP_MARKER_NAME);
+      entry.setupMarkerPath = markerPath;
+      try {
+        entry.setupMarkerPresent = fs.existsSync(markerPath);
+      } catch {
+        entry.setupMarkerPresent = false;
+      }
+    }
+  }
+  appendProtocol(entry);
+  let result;
+  try {
+    result = handleRequest(request);
+  } catch (error) {
+    process.stdout.write(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: request.id,
+        error: {
+          code: -32000,
+          message: error instanceof Error ? error.message : String(error),
+        },
+      }) + "\\n",
+    );
+    return;
+  }
+  process.stdout.write(
+    JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\\n",
+  );
+});
+`,
+    "utf8",
+  );
+  await chmod(params.targetPath, 0o755);
+  return params.targetPath;
+}
+
+export async function readFakeCodexProtocolLog(
+  protocolLogPath: string,
+): Promise<FakeCodexProtocolRequest[]> {
+  try {
+    const raw = await readFile(protocolLogPath, "utf8");
+    return raw
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .flatMap((line) => {
+        try {
+          return [JSON.parse(line) as FakeCodexProtocolRequest];
+        } catch {
+          return [];
+        }
+      });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export function findFakeCodexRequests(
+  log: readonly FakeCodexProtocolRequest[],
+  method: string,
+): FakeCodexProtocolRequest[] {
+  return log.filter((entry) => entry.method === method);
+}
+
+/**
+ * Seed production config so discovery resolves the fake binaries the same
+ * way a real operator path override would.
+ */
+export function buildFakeAgentConfigToml(params: {
+  fakeKimiPath: string;
+  fakeCodexPath: string;
+  extraSections?: string[];
+  extraToml?: string;
+}): string {
+  const extra =
+    params.extraToml?.trim()
+    || (params.extraSections?.length
+      ? params.extraSections.join("\n").trim()
+      : "");
+  return [
+    "[models.codex]",
+    `path = ${JSON.stringify(params.fakeCodexPath)}`,
+    "",
+    "[acp_agents.kimi]",
+    `cli_path = ${JSON.stringify(params.fakeKimiPath)}`,
+    "",
+    extra ? `${extra}\n` : "",
+  ].join("\n");
+}
+
+export async function writeOwnerProfileConfig(params: {
+  homeRoot: string;
+  contents: string;
+}): Promise<string> {
+  const configPath = path.join(
+    params.homeRoot,
+    ".pwragent",
+    "profiles",
+    "default",
+    "config.toml",
+  );
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(configPath, params.contents, "utf8");
+  return configPath;
+}
+
+/**
+ * Persist a Kimi parent session + installed-agent row so the owner already
+ * has the managed-worktree parent the Remote Viewer right-clicks.
+ */
+export async function seedKimiParentSession(params: {
+  directoryPath: string;
+  homeRoot: string;
+  fakeKimiPath: string;
+  sessionId?: string;
+  title?: string;
+}): Promise<{ backendId: AcpBackendId; sessionId: string }> {
+  const backendId = "acp:kimi" as AcpBackendId;
+  const sessionId = params.sessionId ?? "federated-kimi-parent";
+  const seededAt = Date.now();
+  const dbPath = path.join(
+    params.homeRoot,
+    ".pwragent",
+    "profiles",
+    "default",
+    "state",
+    "state.db",
+  );
+  await mkdir(path.dirname(dbPath), { recursive: true });
+  const stateDb = StateDb.open(dbPath, { profileName: "default" });
+  try {
+    new AcpAgentStore(stateDb).upsertInstalledAgent({
+      backendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      distributionKind: "local",
+      distributionSource: params.fakeKimiPath,
+      installStatus: "installed",
+      authStatus: "not-required",
+      verificationStatus: "not-applicable",
+      allowlistRuleId: "e2e-kimi",
+      installedAt: seededAt,
+      updatedAt: seededAt,
+      launchDescriptor: {
+        backendId,
+        registryId: "kimi",
+        distributionKind: "local",
+        command: params.fakeKimiPath,
+        args: [],
+        env: {},
+      },
+    });
+    new AcpSessionStore(stateDb).upsertSession({
+      backendId,
+      sessionId,
+      agentSessionId: "fake-kimi-session",
+      title: params.title ?? "Remote Kimi parent",
+      titleSource: "explicit",
+      cwd: params.directoryPath,
+      createdAt: seededAt,
+      updatedAt: seededAt,
+      executionMode: "full-access",
+      status: "idle",
+      hasConversationHistory: true,
+    });
+  } finally {
+    stateDb.close();
+  }
+  return { backendId, sessionId };
+}
+
+export async function installOwnerFakeAgents(params: {
+  homeRoot: string;
+  binDir?: string;
+}): Promise<{
+  fakeKimiPath: string;
+  fakeCodexPath: string;
+  protocolLogPath: string;
+  launchMarkerPath: string;
+}> {
+  const binDir = params.binDir ?? path.join(params.homeRoot, "bin");
+  const fakeKimiPath = path.join(binDir, "fake-kimi");
+  const fakeCodexPath = path.join(binDir, "fake-codex");
+  const protocolLogPath = path.join(binDir, "fake-codex.protocol.jsonl");
+  const launchMarkerPath = path.join(binDir, "fake-codex.launched");
+  await writeFakeKimiExecutable(fakeKimiPath);
+  await writeFakeCodexExecutable({
+    targetPath: fakeCodexPath,
+    protocolLogPath,
+    launchMarkerPath,
+  });
+  return {
+    fakeKimiPath,
+    fakeCodexPath,
+    protocolLogPath,
+    launchMarkerPath,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Aliases kept for call-site clarity / future fixtures
+// ---------------------------------------------------------------------------
+
+export const seedFakeKimiExecutable = async (
+  homeRoot: string,
+): Promise<{ executablePath: string }> => ({
+  executablePath: await writeFakeKimiExecutable(
+    path.join(homeRoot, "bin", "fake-kimi"),
+  ),
+});
+
+export async function seedFakeCodexExecutable(params: {
+  homeRoot: string;
+  requestLogPath: string;
+  launchMarkerPath: string;
+}): Promise<{ executablePath: string }> {
+  const executablePath = path.join(params.homeRoot, "bin", "fake-codex");
+  await writeFakeCodexExecutable({
+    targetPath: executablePath,
+    protocolLogPath: params.requestLogPath,
+    launchMarkerPath: params.launchMarkerPath,
+  });
+  return { executablePath };
+}
+
+export const seedInstalledKimiParent = seedKimiParentSession;
+
+export const readFakeCodexRequestLog = readFakeCodexProtocolLog;
+
+export function findFakeCodexRequest(
+  entries: readonly FakeCodexProtocolRequest[],
+  method: string,
+): FakeCodexProtocolRequest | undefined {
+  return findFakeCodexRequests(entries, method)[0];
+}
+
+export const findAllFakeCodexRequests = findFakeCodexRequests;
+
+export function fakeCodexEnv(params: {
+  requestLogPath: string;
+  launchMarkerPath: string;
+}): Record<string, string> {
+  return {
+    [FAKE_CODEX_PROTOCOL_LOG_ENV]: params.requestLogPath,
+    [FAKE_CODEX_LAUNCH_MARKER_ENV]: params.launchMarkerPath,
+  };
+}

--- a/apps/desktop/e2e/fixtures/fake-agent-executables.ts
+++ b/apps/desktop/e2e/fixtures/fake-agent-executables.ts
@@ -245,7 +245,10 @@ function handleRequest(request) {
     const threadId = nextThreadId();
     return {
       thread: minimalThread(threadId, params),
-      model: "gpt-5",
+      model:
+        typeof params.model === "string" && params.model.trim()
+          ? params.model.trim()
+          : "gpt-5.5",
       modelProvider: "openai",
       serviceTier: null,
       cwd:
@@ -285,13 +288,24 @@ function handleRequest(request) {
     return { data: [] };
   }
   if (method === "model/list") {
+    // The desktop can carry its current Codex launchpad default into the new
+    // thread, then validates that same model again before review/start. Keep
+    // the fake catalog aligned with the production default while retaining a
+    // legacy option for tests that select it explicitly.
     return {
       data: [
         {
-          id: "gpt-5",
-          model: "gpt-5",
+          id: "gpt-5.5",
+          model: "gpt-5.5",
           isDefault: true,
           default: true,
+          supportsReasoning: true,
+        },
+        {
+          id: "gpt-5",
+          model: "gpt-5",
+          isDefault: false,
+          default: false,
           supportsReasoning: true,
         },
       ],

--- a/apps/desktop/e2e/fixtures/federation-gateway.ts
+++ b/apps/desktop/e2e/fixtures/federation-gateway.ts
@@ -3,11 +3,13 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type {
+  AppServerBackendKind,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
   AppServerThreadSummary,
   EnsureDirectoryLaunchpadRequest,
   EnsureDirectoryLaunchpadResponse,
+  LinkedDirectorySummary,
   ListBackendsResponse,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
@@ -16,6 +18,7 @@ import type {
   SetThreadPinResponse,
 } from "@pwragent/shared";
 import {
+  buildThreadIdentityKey,
   FEDERATION_INVITE_VERSION,
   FEDERATION_PROTOCOL_VERSION,
 } from "@pwragent/shared";
@@ -47,12 +50,16 @@ export type GatewayThreadSeed = {
   title: string;
   updatedAt: number;
   pinnedRank?: string;
+  source?: AppServerBackendKind;
+  executionMode?: AppServerThreadSummary["executionMode"];
+  linkedDirectories?: LinkedDirectorySummary[];
 };
 
 export type GatewayDirectorySeed = {
   key: string;
   label: string;
   path: string;
+  threadIds?: string[];
 };
 
 export type InProcessFederationGateway = {
@@ -118,15 +125,18 @@ export async function startInProcessFederationGateway(params: {
       id: thread.id,
       title: thread.title,
       titleSource: "explicit" as const,
-      source: "codex" as const,
-      linkedDirectories: directories[0]
-        ? [{
-            id: directories[0].path,
-            label: directories[0].label,
-            path: directories[0].path,
-            kind: "local" as const,
-          }]
-        : [],
+      source: thread.source ?? "codex",
+      executionMode: thread.executionMode,
+      linkedDirectories:
+        thread.linkedDirectories ??
+        (directories[0]
+          ? [{
+              id: directories[0].path,
+              label: directories[0].label,
+              path: directories[0].path,
+              kind: "local" as const,
+            }]
+          : []),
       updatedAt: thread.updatedAt,
       createdAt: thread.updatedAt,
       ...(pinnedRankByThreadId.get(thread.id) !== undefined
@@ -142,13 +152,22 @@ export async function startInProcessFederationGateway(params: {
       ...thread,
       inbox: { inInbox: true },
     })),
-    inboxThreadKeys: threads.map((thread) => `codex:${thread.id}`),
+    inboxThreadKeys: threads.map(
+      (thread) => buildThreadIdentityKey(thread.source ?? "codex", thread.id),
+    ),
     directories: directories.map((directory) => ({
       key: directory.key,
       kind: "directory" as const,
       label: directory.label,
       path: directory.path,
-      threadKeys: threads.map((thread) => `codex:${thread.id}`),
+      threadKeys: threads
+        .filter(
+          (thread) =>
+            !directory.threadIds || directory.threadIds.includes(thread.id),
+        )
+        .map((thread) =>
+          buildThreadIdentityKey(thread.source ?? "codex", thread.id),
+        ),
       needsAttentionCount: 0,
     })),
     launchpadDefaults: {
@@ -177,7 +196,7 @@ export async function startInProcessFederationGateway(params: {
       const thread = threads.find((entry) => entry.id === request.threadId);
       const text = `Remote transcript for ${thread?.title ?? request.threadId}.`;
       return {
-        backend: "codex",
+        backend: thread?.source ?? request.backend ?? "codex",
         fetchedAt: Date.now(),
         threadId: request.threadId,
         replay: {
@@ -216,6 +235,34 @@ export async function startInProcessFederationGateway(params: {
           {
             kind: "codex",
             label: "OpenAI",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start"],
+            capabilities: {
+              listThreads: true,
+              createThread: true,
+              resumeThread: true,
+              renameThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: true,
+              steerTurn: false,
+              transcriptPagination: false,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          },
+          {
+            kind: "acp:kimi",
+            label: "Kimi Code",
             available: true,
             methods: ["thread/list", "thread/read", "turn/start"],
             capabilities: {
@@ -315,6 +362,7 @@ export async function startInProcessFederationGateway(params: {
         id: threadId,
         title: prompt || "Remote created thread",
         updatedAt: Date.now(),
+        source: request.launchpad?.backend ?? "codex",
       });
       return {
         backend: request.launchpad?.backend ?? "codex",

--- a/apps/desktop/e2e/fixtures/federation-gateway.ts
+++ b/apps/desktop/e2e/fixtures/federation-gateway.ts
@@ -7,6 +7,7 @@ import type {
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
   AppServerThreadSummary,
+  CodexEnvironmentOption,
   EnsureDirectoryLaunchpadRequest,
   EnsureDirectoryLaunchpadResponse,
   LinkedDirectorySummary,
@@ -60,6 +61,7 @@ export type GatewayDirectorySeed = {
   label: string;
   path: string;
   threadIds?: string[];
+  codexEnvironmentOptions?: CodexEnvironmentOption[];
 };
 
 export type InProcessFederationGateway = {
@@ -335,6 +337,7 @@ export async function startInProcessFederationGateway(params: {
           prompt: "",
           workMode: "local",
           branchName: "main",
+          codexEnvironmentOptions: directory?.codexEnvironmentOptions,
           createdAt: now,
           updatedAt: now,
         },

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -5283,6 +5283,48 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("keeps launchpad updates stable across remote viewer rerenders", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "owner-instance",
+    };
+    (window as unknown as {
+      __pwragentFederationTarget?: typeof federationTarget;
+    }).__pwragentFederationTarget = federationTarget;
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot: vi.fn(async () => ({
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        federationTarget,
+        inboxThreadKeys: [],
+        threads: [],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      })),
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result, rerender } = renderHook(() =>
+      useThreadNavigation(desktopApi)
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    const initialUpdateDirectoryLaunchpad =
+      result.current.updateDirectoryLaunchpad;
+
+    rerender();
+
+    expect(result.current.updateDirectoryLaunchpad).toBe(
+      initialUpdateDirectoryLaunchpad,
+    );
+  });
+
   it("keeps server-confirmed settingsTouchedAt after sticky launchpad updates", async () => {
     const defaults: NavigationLaunchpadDefaults = {
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -5188,6 +5188,101 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("keeps owner environment metadata after remote viewer environment updates", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "owner-instance",
+    };
+    (window as unknown as {
+      __pwragentFederationTarget?: typeof federationTarget;
+    }).__pwragentFederationTarget = federationTarget;
+    const defaults = {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    };
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/owner-only/PwrAgent",
+      directoryKind: "directory",
+      directoryLabel: "PwrAgent",
+      directoryPath: "/owner-only/PwrAgent",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "",
+      workMode: "local",
+      codexEnvironmentOptions: [
+        {
+          id: "environment",
+          name: "PwrAgent",
+          sourcePath: "/owner-only/PwrAgent/.codex/environments/environment.toml",
+          setupScript: "pnpm install",
+          actions: [],
+        },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const updateDirectoryLaunchpad = vi.fn(async () => ({
+      defaults,
+      launchpad: {
+        ...launchpad,
+        codexEnvironmentId: undefined,
+        codexEnvironmentExecutionTarget: undefined,
+        codexEnvironmentOptions: [],
+        updatedAt: 2,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot: vi.fn(async () => ({
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        federationTarget,
+        inboxThreadKeys: [],
+        threads: [],
+        directories: [
+          {
+            key: launchpad.directoryKey,
+            kind: "directory" as const,
+            label: launchpad.directoryLabel,
+            path: launchpad.directoryPath,
+            threadKeys: [],
+            needsAttentionCount: 0,
+            launchpad,
+          },
+        ],
+        launchpadDefaults: defaults,
+      })),
+      onAgentEvent: () => () => undefined,
+      updateDirectoryLaunchpad,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedLaunchpad?.directoryKey).toBe(
+        launchpad.directoryKey,
+      );
+    });
+
+    await act(async () => {
+      await result.current.updateDirectoryLaunchpad(launchpad.directoryKey, {
+        codexEnvironmentId: "environment",
+        codexEnvironmentExecutionTarget: "local",
+      });
+    });
+
+    expect(result.current.selectedLaunchpad).toMatchObject({
+      codexEnvironmentId: "environment",
+      codexEnvironmentExecutionTarget: "local",
+      codexEnvironmentOptions: [
+        expect.objectContaining({
+          id: "environment",
+          name: "PwrAgent",
+        }),
+      ],
+    });
+  });
+
   it("keeps server-confirmed settingsTouchedAt after sticky launchpad updates", async () => {
     const defaults: NavigationLaunchpadDefaults = {
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2143,6 +2143,9 @@ function mergeLaunchpadUpdateResponse(
   current: NavigationLaunchpadDraft | undefined,
   next: NavigationLaunchpadDraft,
   patch: Parameters<NonNullable<DesktopApi["updateDirectoryLaunchpad"]>>[0]["patch"],
+  options?: {
+    preserveOwnerCodexEnvironmentMetadata?: boolean;
+  },
 ): NavigationLaunchpadDraft {
   if (!current || current.directoryKey !== next.directoryKey) {
     return next;
@@ -2185,6 +2188,20 @@ function mergeLaunchpadUpdateResponse(
   preserveEnvironment("codexEnvironmentExecutionTarget");
   preserveEnvironment("codexEnvironmentActionId");
   preserveEnvironment("codexEnvironmentOptions");
+
+  if (options?.preserveOwnerCodexEnvironmentMetadata) {
+    // Remote launchpad drafts are persisted on the viewer, but environment
+    // discovery belongs to the owner. The viewer-side update response may
+    // legitimately contain an empty environment list because the owner's
+    // absolute project path does not exist on this machine. Keep the
+    // owner-sourced metadata already held by the renderer while accepting the
+    // viewer's persisted settings response for every other field.
+    merged.codexEnvironmentId = current.codexEnvironmentId;
+    merged.codexEnvironmentExecutionTarget =
+      current.codexEnvironmentExecutionTarget;
+    merged.codexEnvironmentActionId = current.codexEnvironmentActionId;
+    merged.codexEnvironmentOptions = current.codexEnvironmentOptions;
+  }
 
   return merged;
 }
@@ -4982,8 +4999,27 @@ export function useThreadNavigation(
             directoryKey,
             patch,
           });
+          const optimisticLaunchpad = {
+            ...applyNavigationLaunchpadProviderSettingsPatch<NavigationLaunchpadDraft>(
+              launchpad,
+              patch,
+            ),
+            parentThreadId: groupRoot.id,
+            parentThreadBackend: groupRoot.source,
+            parentThreadTitle: groupRoot.title,
+            sourceThreadId: parent.id,
+          };
           launchpad = {
-            ...updated.launchpad,
+            ...mergeLaunchpadUpdateResponse(
+              optimisticLaunchpad,
+              updated.launchpad,
+              patch,
+              {
+                preserveOwnerCodexEnvironmentMetadata: Boolean(
+                  parent.federation || rendererFederationTarget,
+                ),
+              },
+            ),
             parentThreadId: groupRoot.id,
             parentThreadBackend: groupRoot.source,
             parentThreadTitle: groupRoot.title,
@@ -5562,6 +5598,11 @@ export function useThreadNavigation(
                   current[directoryKey],
                   response.launchpad,
                   patch,
+                  {
+                    preserveOwnerCodexEnvironmentMetadata: Boolean(
+                      rendererFederationTarget,
+                    ),
+                  },
                 ),
               }
             : current
@@ -5576,6 +5617,11 @@ export function useThreadNavigation(
               )?.launchpad,
               response.launchpad,
               patch,
+              {
+                preserveOwnerCodexEnvironmentMetadata: Boolean(
+                  rendererFederationTarget,
+                ),
+              },
             ),
             response.defaults
           ),
@@ -5589,6 +5635,11 @@ export function useThreadNavigation(
               nextPendingPickedLaunchpad,
               response.launchpad,
               patch,
+              {
+                preserveOwnerCodexEnvironmentMetadata: Boolean(
+                  rendererFederationTarget,
+                ),
+              },
             ),
           );
         }
@@ -5599,7 +5650,7 @@ export function useThreadNavigation(
         setLaunchpadError(error instanceof Error ? error.message : String(error));
       }
     },
-    [desktopApi]
+    [desktopApi, rendererFederationTarget]
   );
 
   const resetDirectoryLaunchpad = useCallback(

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2773,6 +2773,7 @@ export function useThreadNavigation(
   const setNavigationBrowseModeRequest = desktopApi?.setNavigationBrowseMode;
   const enabled = options.enabled ?? true;
   const rendererFederationTarget = readRendererFederationTarget();
+  const isRendererFederationWindow = Boolean(rendererFederationTarget);
   const lightweightNavigationRefresh = options.lightweightNavigationRefresh ?? false;
   const threadViewVisible = options.threadViewVisible ?? true;
   const [browseMode, setBrowseMode] = useState<BrowseMode>(readBridgedBrowseMode);
@@ -5599,9 +5600,8 @@ export function useThreadNavigation(
                   response.launchpad,
                   patch,
                   {
-                    preserveOwnerCodexEnvironmentMetadata: Boolean(
-                      rendererFederationTarget,
-                    ),
+                    preserveOwnerCodexEnvironmentMetadata:
+                      isRendererFederationWindow,
                   },
                 ),
               }
@@ -5618,9 +5618,8 @@ export function useThreadNavigation(
               response.launchpad,
               patch,
               {
-                preserveOwnerCodexEnvironmentMetadata: Boolean(
-                  rendererFederationTarget,
-                ),
+                preserveOwnerCodexEnvironmentMetadata:
+                  isRendererFederationWindow,
               },
             ),
             response.defaults
@@ -5636,9 +5635,8 @@ export function useThreadNavigation(
               response.launchpad,
               patch,
               {
-                preserveOwnerCodexEnvironmentMetadata: Boolean(
-                  rendererFederationTarget,
-                ),
+                preserveOwnerCodexEnvironmentMetadata:
+                  isRendererFederationWindow,
               },
             ),
           );
@@ -5650,7 +5648,7 @@ export function useThreadNavigation(
         setLaunchpadError(error instanceof Error ? error.message : String(error));
       }
     },
-    [desktopApi, rendererFederationTarget]
+    [desktopApi, isRendererFederationWindow]
   );
 
   const resetDirectoryLaunchpad = useCallback(


### PR DESCRIPTION
## Summary

- preserve owner-sourced Codex environment metadata while a Federation Remote Viewer persists child launchpad changes locally
- add executable fake Kimi ACP and fake Codex app-server backends for durable protocol-level coverage
- cover Kimi parent → OpenAI child → same worktree → PwrAgent environment → `/review`

## Root cause

Remote launchpad discovery came from the owner, but subsequent launchpad updates were persisted on the viewer. The update response re-ran Codex environment discovery against the owner's absolute directory path on the viewer. On a different machine that path does not exist, so the viewer returned no environment options and cleared the selected environment. The earlier same-host E2E masked this because the owner path happened to exist locally.

## Fix

When a remote viewer merges a locally persisted launchpad update, retain the owner-sourced Codex environment id, setup action, execution target, and environment options from the optimistic/current renderer state. The owner still validates and executes the selected environment during remote materialization.

The canned Federation regression now uses an owner-only path that is asserted absent on the viewer, so it fails without the production fix. The executable-backed real-owner regression verifies the environment setup completes before Codex starts the review.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` — 113 passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/desktop build`
- `pnpm lint:eslint` — 0 errors
- local `federation-remote-window.spec.ts` — 2 passed
- isolated Tart dual-instance run `pwragent-e2e-20260809-103830-3a1a98f9-1d180bca` at `3a1a98f95754db2c0db2fbf3ed89417985b7ac0a` — focused regression passed
- executable protocol order verified: `initialize` → `thread/start` with `setupMarkerPresent=true` → `review/start`
