### PR TITLE
feat(desktop): enable PwrAgent review for Grok

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -61,16 +61,23 @@ describe("describeInstalledAcpBackend", () => {
     expect(backend.methods).toContain("session/load");
   });
 
-  it("advertises managed review for Kimi but not other ACP providers", () => {
+  it("advertises managed review for Kimi and Grok but not other ACP providers", () => {
     const kimi = describeInstalledAcpBackend({
       ...buildInstalledAgent(),
       backendId: "acp:kimi" as AcpBackendId,
       registryId: "kimi",
       name: "Kimi Code CLI",
     });
+    const grok = describeInstalledAcpBackend({
+      ...buildInstalledAgent(),
+      backendId: "acp:grok" as AcpBackendId,
+      registryId: "grok",
+      name: "Grok",
+    });
     const gemini = describeInstalledAcpBackend(buildInstalledAgent());
 
     expect(kimi.capabilities.startReview).toBe(true);
+    expect(grok.capabilities.startReview).toBe(true);
     expect(gemini.capabilities.startReview).toBe(false);
   });
 

--- a/apps/desktop/src/main/acp/acp-agent-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-agent-capabilities.ts
@@ -19,7 +19,7 @@ const ACP_AGENT_CAPABILITY_CATALOG: Record<string, AcpAgentCapabilities> = {
   },
   grok: {
     liveWorkspaceHandoff: false,
-    managedReview: false,
+    managedReview: true,
   },
   qwen: {
     liveWorkspaceHandoff: false,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -11077,23 +11077,31 @@ describe("Composer", () => {
     expect(within(commands).getByRole("button", { name: /\/review/i })).toBeInTheDocument();
   });
 
-  it("keeps duplicate local and provider slash commands labeled by source", async () => {
+  it.each([
+    ["Codex", "codex", "OpenAI"],
+    ["Grok", "acp:grok", "Grok"],
+  ] as const)("keeps duplicate local and provider slash commands labeled by source for %s", async (
+    _providerName,
+    backend,
+    providerLabel,
+  ) => {
     render(
       <Composer
         desktopApi={{
           onAgentEvent: () => () => undefined,
           startTurn: async () => ({
-            backend: "codex",
+            backend,
             threadId: "thread-1",
             turnId: "turn-1",
           }),
         }}
+        backends={[{ ...backendSummary(backend), label: providerLabel }]}
         disabled={false}
         providerCommands={[
           {
             name: "review",
-            description: "Run a Codex code review.",
-            backend: "codex",
+            description: `Run a ${providerLabel} code review.`,
+            backend,
             scope: "backend",
             source: "provider",
           },
@@ -11103,7 +11111,7 @@ describe("Composer", () => {
           id: "thread-1",
           title: "Review thread",
           titleSource: "explicit",
-          source: "codex",
+          source: backend,
           executionMode: "default",
           linkedDirectories: [],
           inbox: { inInbox: false },
@@ -11117,7 +11125,7 @@ describe("Composer", () => {
     const commands = screen.getByRole("listbox", { name: "Commands" });
     expect(within(commands).getAllByRole("button", { name: /\/review/i })).toHaveLength(2);
     expect(within(commands).getByText("PwrAgent")).toBeInTheDocument();
-    expect(within(commands).getByText("OpenAI")).toBeInTheDocument();
+    expect(within(commands).getByText(providerLabel)).toBeInTheDocument();
   });
 
   it("routes Codex compact slash commands to thread compaction", async () => {


### PR DESCRIPTION
## Summary

Enable the PwrAgent-managed `/review` flow for the Grok ACP backend.

- Advertise managed review for Grok, matching Kimi.
- Show distinct PwrAgent and provider-native `/review` command sources for Grok.
- Preserve unsupported status for other ACP providers.

## Why

Grok exposed only its provider-native review command, leaving the PwrAgent review workflow unavailable and unattributed in the command palette.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (warnings only; no errors)
