### PR TITLE
test(desktop): stop narrowing the Windows Job startup contract in detach tests

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -11,6 +11,7 @@ import {
   startLocalCodexEnvironmentAction,
   stopCodexEnvironmentDetachedCommand,
 } from "../app-server/codex-environment-runtime";
+import { WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS } from "../windows-job-wrapper";
 import { resolveWindowsBashShell } from "../windows-shell";
 
 const mainLogEntries = vi.hoisted(
@@ -219,13 +220,17 @@ describe("codex environment runtime", () => {
         },
       );
 
+      // The run registers only after the Windows Job becomes ready, so this
+      // poll must honor the same cold-start allowance as the test timeout.
+      // The helper's 10s default would reintroduce the narrowed contract
+      // whenever this test is the first detach launch to pay the cold start.
       await expectEventually(async () => {
         const result = stopCodexEnvironmentDetachedCommand(runId, "stop");
         if (!result.found) {
           throw new Error("Detached process is not registered yet");
         }
         return result;
-      });
+      }, isWindows ? WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS : 10_000);
 
       if (isWindows) {
         const exit = await detachedExit;

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -52,6 +52,22 @@ function spawnableShell(posixShell: string): string {
   return isWindows ? resolveWindowsBashShell() : posixShell;
 }
 
+/**
+ * Detach-mode commands launch through the Windows Job wrapper on win32, whose
+ * cold start (first PowerShell host + per-launch C# helper compile) is allowed
+ * up to `WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS` (28s) by design — hosted CI has
+ * taken 16.7s to enter the wrapper and 7.1s to compile its helper while still
+ * making journaled forward progress (see
+ * docs/solutions/2026-08-06-windows-vitest-process-isolation.md). These tests'
+ * explicit 15s timeouts predate the wrapper: they widened POSIX's 5s default,
+ * but on Windows they silently narrowed the workspace's 30s test contract to
+ * half the documented startup allowance, so whichever detach test launched
+ * first paid the cold start and timed out. Grant the same 30s contract the
+ * wrapper's own live-launch tests use; POSIX has no job wrapper and keeps the
+ * snug 15s.
+ */
+const DETACHED_ACTION_TEST_TIMEOUT_MS = isWindows ? 30_000 : 15_000;
+
 describe("codex environment runtime", () => {
   afterEach(() => {
     mainLogEntries.length = 0;
@@ -121,7 +137,7 @@ describe("codex environment runtime", () => {
     } finally {
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
-  }, 15_000);
+  }, DETACHED_ACTION_TEST_TIMEOUT_MS);
 
   it("captures detached stdout and stderr in arrival order", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-output-order-"));
@@ -170,7 +186,7 @@ describe("codex environment runtime", () => {
     } finally {
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
-  }, 15_000);
+  }, DETACHED_ACTION_TEST_TIMEOUT_MS);
 
   it("stops a detached action process tree by run id", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-stop-"));
@@ -225,7 +241,7 @@ describe("codex environment runtime", () => {
     } finally {
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
-  }, 15_000);
+  }, DETACHED_ACTION_TEST_TIMEOUT_MS);
 
   /**
    * Regression: only the Run-button path passed an owner, so an action started
@@ -309,7 +325,7 @@ describe("codex environment runtime", () => {
       }
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
-  }, 15_000);
+  }, DETACHED_ACTION_TEST_TIMEOUT_MS);
 
   it("strips parent Electron runtime variables from detached actions", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-electron-"));
@@ -873,7 +889,7 @@ describe("codex environment runtime", () => {
     } finally {
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
-  }, 15_000);
+  }, DETACHED_ACTION_TEST_TIMEOUT_MS);
 
   it("reuses cached shell hydration when setup is disabled", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-cache-"));


### PR DESCRIPTION
## Summary

- Fixes the Windows-only flake on PR #1380's `Windows desktop-main` lane (run 31269307868, job 93132519181), where `codex-environment-runtime.test.ts` "runs detached actions with the provided hydrated environment" and "captures detached stdout and stderr in arrival order" both timed out at 15s.
- The CI timings prove the detached completion signal was **not** missed: the first two Windows Job launches in the file died at exactly 15008ms/15007ms, then the third detach launch in the same file completed in 2.9s and every later one in ~0.7–1.5s. That is the documented cold-start profile — first PowerShell host launch plus the per-launch `Add-Type` C# helper compile, recorded at 16.7s + 7.1s on hosted CI in [docs/solutions/2026-08-06-windows-vitest-process-isolation.md](../blob/main/docs/solutions/2026-08-06-windows-vitest-process-isolation.md). When test 1 timed out mid-compile, test 2's concurrent second compile also blew 15s; by test 3 everything was warm.
- The explicit `15_000` timeouts predate both the Windows port (#670) and the Job wrapper (#1259): `git blame` dates them to May 2026, written to *widen* POSIX's 5s default. Once #1259 routed Windows detach launches through the Job wrapper with its deliberately sized 28s ready allowance (`WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS`, designed "inside the existing 30-second Windows test contract"), those literals silently **narrowed** the Windows contract to half the documented startup allowance.
- Fix: a platform-aware `DETACHED_ACTION_TEST_TIMEOUT_MS` (`isWindows ? 30_000 : 15_000`) applied to all five detach-mode tests — whichever launches first pays the cold start, so fixing only the two that failed would just move the flake. Windows regains the same 30s contract it would have had with no explicit timeout at all (and that `windows-job-wrapper.test.ts`'s own live-launch tests already pass explicitly); POSIX behavior is unchanged.

## Verification

- Audited the detach launch/teardown path in `codex-environment-runtime.ts` (ready-file poll, close-handler resolve/reject, job registration ordering) for a genuine spawn/exit signaling gap per the solution doc's guidance — found none; the signal arrives, late but within the designed allowance.
- `pnpm test apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts` — 27/27 pass locally (macOS).
- ESLint clean on the changed file.

## Notes

- This is not the solution doc's forbidden "widen a timeout to hide an unowned process": the contended resource (cold PowerShell start + per-launch helper compile) was already identified by #1259's diagnostic and given a documented allowance; this change restores that contract for tests that predate it, rather than masking a new leak.
- Possible follow-up (deliberately not done here — it would need its own Windows-executed evidence and revisits a #1259 design choice): caching the compiled Job helper assembly to cut the cold start for production detached actions too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)