### PR TITLE
fix(desktop): filter Grok post-turn metadata

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildPendingRequestActions,
   buildPendingRequestResponse,
+  deriveInboxState,
 } from "@pwragent/shared";
 import { AcpAgentClient } from "../acp/acp-client";
 import { AcpRolloutStore } from "../acp/acp-rollout-store";
@@ -2922,6 +2923,65 @@ describe("AcpAgentClient", () => {
     // entries — the normalizer's readAcpTopicTitle fallthrough at line 118
     // routes them to thread metadata instead.
     expect(client.readReplay(session.sessionId).entries).toEqual([]);
+  });
+
+  it("does not mark a seen Grok thread unread for last_turn_summary metadata", async () => {
+    let now = 1000;
+    const transport = new FakeAcpAgentTransport();
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      store,
+      transport,
+      now: () => now,
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    now = 1100;
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "Finished the requested work." },
+    });
+    const seenUpdatedAt =
+      store.getSession("acp:grok", session.sessionId)?.updatedAt ?? 0;
+    expect(seenUpdatedAt).toBe(1100);
+
+    now = 1200;
+    transport.emitVendorNotification({
+      method: "_x.ai/session_notification",
+      sessionId: session.sessionId,
+      update: {
+        sessionUpdate: "last_turn_summary",
+        summary: "Requested work complete",
+      },
+    });
+
+    const metadata = store.getSession("acp:grok", session.sessionId);
+    expect(metadata?.updatedAt).toBe(seenUpdatedAt);
+    expect(
+      deriveInboxState({
+        firstSnapshot: false,
+        isNewThread: false,
+        overlay: {
+          backend: "acp:grok",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          lastSeenUpdatedAt: seenUpdatedAt,
+          threadId: session.sessionId,
+        },
+        thread: {
+          id: session.sessionId,
+          linkedDirectories: [],
+          source: "acp:grok",
+          title: "ACP session",
+          titleSource: "fallback",
+          updatedAt: metadata?.updatedAt,
+        },
+      }),
+    ).toMatchObject({ inInbox: false });
   });
 
   it("distinguishes known tool progress from standalone tool updates", async () => {

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -1534,6 +1534,34 @@ describe("AcpSessionReplayNormalizer", () => {
     ).toBe(false);
   });
 
+  it("keeps Grok last_turn_summary out of the transcript and turn lifecycle", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+    normalizer.recordUserPrompt({
+      sessionId: "session-1",
+      prompt: "Inspect this",
+      turnId: "turn-1",
+      receivedAt: 1000,
+      waitingForAgent: true,
+    });
+
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "last_turn_summary",
+        summary: "Inspection complete",
+      },
+    });
+
+    expect(replay.threadStatus).toBe("active");
+    expect(replay.entries).toHaveLength(2);
+    expect(
+      replay.entries.some(
+        (entry) => entry.type === "activity" && entry.summary.startsWith("ACP update:"),
+      ),
+    ).toBe(false);
+  });
+
   it("records thought chunks as assistant response messages", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -47,6 +47,9 @@ export function isGrokTransientUpdateKind(kind: string | undefined): boolean {
     || kind === "pending_interaction"
     || kind === "interaction_resolved"
     || kind === "response_completed"
+    // Grok publishes this after its canonical `turn_completed` update as
+    // session metadata. It is not a second lifecycle event or transcript item.
+    || kind === "last_turn_summary"
   );
 }
 


### PR DESCRIPTION
## Summary

- Treat Grok ACP `last_turn_summary` as post-turn session metadata rather than a transcript activity or lifecycle event.
- Preserve the raw provider notification in the durable ACP rollout so a later, deliberate UI can consume its summary and `prompt_id`.
- Preserve the current turn state until Grok's canonical completion path finishes the prompt.
- Cover the case where the final assistant message is already seen: the later metadata update does not advance `updatedAt` or re-add the thread to Inbox.

## Root cause

A new Grok vendor update was falling through to the unknown-ACP-activity renderer after the canonical `turn_completed` event. It is emitted after turn completion and does not represent new user-visible content.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts`
- `pnpm lint:eslint` (passes with the repository's existing warnings)
- `pnpm typecheck`