### PR TITLE
chore(desktop): upgrade agent ACP to 0.13.0

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -25,7 +25,7 @@ Dependency Summary
 
 Apache-2.0
 ~~~~~~~~~~
-- @agentclientprotocol/sdk@0.4.5 | https://github.com/agentclientprotocol/agent-client-protocol
+- @agentclientprotocol/sdk@1.3.0 | https://github.com/agentclientprotocol/typescript-sdk
 - detect-libc@2.1.2 | https://github.com/lovell/detect-libc
 - pdfjs-dist@5.7.284 | https://github.com/mozilla/pdf.js
 - tunnel-agent@0.6.0 | https://github.com/mikeal/tunnel-agent
@@ -89,7 +89,7 @@ MIT
 - @octokit/request@10.0.11 | github:octokit/request.js
 - @octokit/request-error@7.1.0 | github:octokit/request-error.js
 - @octokit/types@16.0.0 | github:octokit/types.ts
-- @pwrdrvr/agent-acp@0.12.3 | https://github.com/pwrdrvr/agent-kit
+- @pwrdrvr/agent-acp@0.13.0 | https://github.com/pwrdrvr/agent-kit
 - @pwrdrvr/agent-client@0.6.1 | https://github.com/pwrdrvr/agent-kit
 - @pwrdrvr/agent-core@0.2.0 | https://github.com/pwrdrvr/agent-kit
 - @pwrdrvr/agent-transport@0.1.6 | https://github.com/pwrdrvr/agent-kit
@@ -405,7 +405,6 @@ MIT
 - web-namespaces@2.0.1 | wooorm/web-namespaces
 - whatwg-url@5.0.0 | jsdom/whatwg-url
 - ws@8.21.0 | https://github.com/websockets/ws
-- zod@3.25.76 | https://github.com/colinhacks/zod
 - zod@4.3.6 | https://github.com/colinhacks/zod
 - zwitch@2.0.4 | wooorm/zwitch
 
@@ -416,52 +415,27 @@ Python-2.0
 License Texts
 -------------
 
-@agentclientprotocol/sdk@0.4.5 (Apache-2.0)
+@agentclientprotocol/sdk@1.3.0 (Apache-2.0)
 -------------------------------------------
 
 Applies to:
-- @agentclientprotocol/sdk@0.4.5 (Apache-2.0)
+- @agentclientprotocol/sdk@1.3.0 (Apache-2.0)
 
-Representative file: @agentclientprotocol/sdk@0.4.5/LICENSE-APACHE
-
-Copyright 2025 Zed Industries, Inc.
-
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
-
+Representative file: @agentclientprotocol/sdk@1.3.0/LICENSE
 
 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
-
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-
    1. Definitions.
-
 
       "License" shall mean the terms and conditions for use, reproduction,
       and distribution as defined by Sections 1 through 9 of this document.
 
-
       "Licensor" shall mean the copyright owner or entity authorized by
       the copyright owner that is granting the License.
-
 
       "Legal Entity" shall mean the union of the acting entity and all
       other entities that control, are controlled by, or are under common
@@ -471,27 +445,22 @@ Apache License
       otherwise, or (ii) ownership of fifty percent (50%) or more of the
       outstanding shares, or (iii) beneficial ownership of such entity.
 
-
       "You" (or "Your") shall mean an individual or Legal Entity
       exercising permissions granted by this License.
-
 
       "Source" form shall mean the preferred form for making modifications,
       including but not limited to software source code, documentation
       source, and configuration files.
-
 
       "Object" form shall mean any form resulting from mechanical
       transformation or translation of a Source form, including but
       not limited to compiled object code, generated documentation,
       and conversions to other media types.
 
-
       "Work" shall mean the work of authorship, whether in Source or
       Object form, made available under the License, as indicated by a
       copyright notice that is included in or attached to the work
       (an example is provided in the Appendix below).
-
 
       "Derivative Works" shall mean any work, whether in Source or Object
       form, that is based on (or derived from) the Work and for which the
@@ -500,7 +469,6 @@ Apache License
       of this License, Derivative Works shall not include works that remain
       separable from, or merely link (or bind by name) to the interfaces of,
       the Work and Derivative Works thereof.
-
 
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
@@ -516,11 +484,9 @@ Apache License
       excluding communication that is conspicuously marked or otherwise
       designated in writing by the copyright owner as "Not a Contribution."
 
-
       "Contributor" shall mean Licensor and any individual or Legal Entity
       on behalf of whom a Contribution has been received by Licensor and
       subsequently incorporated within the Work.
-
 
    2. Grant of Copyright License. Subject to the terms and conditions of
       this License, each Contributor hereby grants to You a perpetual,
@@ -528,7 +494,6 @@ Apache License
       copyright license to reproduce, prepare Derivative Works of,
       publicly display, publicly perform, sublicense, and distribute the
       Work and such Derivative Works in Source or Object form.
-
 
    3. Grant of Patent License. Subject to the terms and conditions of
       this License, each Contributor hereby grants to You a perpetual,
@@ -546,27 +511,22 @@ Apache License
       granted to You under this License for that Work shall terminate
       as of the date such litigation is filed.
 
-
    4. Redistribution. You may reproduce and distribute copies of the
       Work or Derivative Works thereof in any medium, with or without
       modifications, and in Source or Object form, provided that You
       meet the following conditions:
 
-
       (a) You must give any other recipients of the Work or
           Derivative Works a copy of this License; and
 
-
       (b) You must cause any modified files to carry prominent notices
           stating that You changed the files; and
-
 
       (c) You must retain, in the Source form of any Derivative Works
           that You distribute, all copyright, patent, trademark, and
           attribution notices from the Source form of the Work,
           excluding those notices that do not pertain to any part of
           the Derivative Works; and
-
 
       (d) If the Work includes a "NOTICE" text file as part of its
           distribution, then any Derivative Works that You distribute must
@@ -585,14 +545,12 @@ Apache License
           that such additional attribution notices cannot be construed
           as modifying the License.
 
-
       You may add Your own copyright statement to Your modifications and
       may provide additional or different license terms and conditions
       for use, reproduction, or distribution of Your modifications, or
       for any such Derivative Works as a whole, provided Your use,
       reproduction, and distribution of the Work otherwise complies with
       the conditions stated in this License.
-
 
    5. Submission of Contributions. Unless You explicitly state otherwise,
       any Contribution intentionally submitted for inclusion in the Work
@@ -602,12 +560,10 @@ Apache License
       the terms of any separate license agreement you may have executed
       with Licensor regarding such Contributions.
 
-
    6. Trademarks. This License does not grant permission to use the trade
       names, trademarks, service marks, or product names of the Licensor,
       except as required for reasonable and customary use in describing the
       origin of the Work and reproducing the content of the NOTICE file.
-
 
    7. Disclaimer of Warranty. Unless required by applicable law or
       agreed to in writing, Licensor provides the Work (and each
@@ -618,7 +574,6 @@ Apache License
       PARTICULAR PURPOSE. You are solely responsible for determining the
       appropriateness of using or redistributing the Work and assume any
       risks associated with Your exercise of permissions under this License.
-
 
    8. Limitation of Liability. In no event and under no legal theory,
       whether in tort (including negligence), contract, or otherwise,
@@ -632,7 +587,6 @@ Apache License
       other commercial damages or losses), even if such Contributor
       has been advised of the possibility of such damages.
 
-
    9. Accepting Warranty or Additional Liability. While redistributing
       the Work or Derivative Works thereof, You may choose to offer,
       and charge a fee for, acceptance of support, warranty, indemnity,
@@ -644,8 +598,21 @@ Apache License
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
 
-
    END OF TERMS AND CONDITIONS
+
+   Copyright 2025 Zed Industries, Inc. and contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 
 @floating-ui/core@1.8.0 (MIT)
 -----------------------------
@@ -873,11 +840,11 @@ The above copyright notice and this permission notice (including the next paragr
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-@pwrdrvr/agent-acp@0.12.3 (MIT)
+@pwrdrvr/agent-acp@0.13.0 (MIT)
 -------------------------------
 
 Applies to:
-- @pwrdrvr/agent-acp@0.12.3 (MIT)
+- @pwrdrvr/agent-acp@0.13.0 (MIT)
 - @pwrdrvr/agent-client@0.6.1 (MIT)
 - @pwrdrvr/agent-core@0.2.0 (MIT)
 - @pwrdrvr/agent-transport@0.1.6 (MIT)
@@ -885,7 +852,7 @@ Applies to:
 - @pwrdrvr/codex-app-server-protocol@0.144.0 (MIT)
 - @pwrdrvr/codex-discovery@0.1.4 (MIT)
 
-Representative file: @pwrdrvr/agent-acp@0.12.3/LICENSE
+Representative file: @pwrdrvr/agent-acp@0.13.0/LICENSE
 
 MIT License
 
@@ -6674,14 +6641,13 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-zod@3.25.76 (MIT)
------------------
+zod@4.3.6 (MIT)
+---------------
 
 Applies to:
-- zod@3.25.76 (MIT)
 - zod@4.3.6 (MIT)
 
-Representative file: zod@3.25.76/LICENSE
+Representative file: zod@4.3.6/LICENSE
 
 MIT License
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -61,7 +61,7 @@
     "@pwragent/messaging-provider-slack": "workspace:*",
     "@pwragent/messaging-provider-telegram": "workspace:*",
     "@pwragent/shared": "workspace:*",
-    "@pwrdrvr/agent-acp": "^0.12.0",
+    "@pwrdrvr/agent-acp": "^0.13.0",
     "@pwrdrvr/agent-client": "^0.6.1",
     "@pwrdrvr/agent-core": "^0.2.0",
     "@pwrdrvr/agent-transport": "^0.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       '@pwrdrvr/agent-acp':
-        specifier: ^0.12.0
-        version: 0.12.3
+        specifier: ^0.13.0
+        version: 0.13.0(zod@4.3.6)
       '@pwrdrvr/agent-client':
         specifier: ^0.6.1
         version: 0.6.1
@@ -341,8 +341,10 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@agentclientprotocol/sdk@0.4.5':
-    resolution: {integrity: sha512-1cKCZvy6xJ+9n7BkUzrgFfj+waJOj21HaiYvbE4elxBCT7WAHAk5zaQ5cQfmw876TZoEP062Vxy7qkYp1rzEfw==}
+  '@agentclientprotocol/sdk@1.3.0':
+    resolution: {integrity: sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -1051,8 +1053,8 @@ packages:
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
-  '@pwrdrvr/agent-acp@0.12.3':
-    resolution: {integrity: sha512-pjZLp3XKQYPkUNdrE9z2t+lMs3y64/KoANqQKAYcgzG4zdGt2NCCsk9hJo2kg7NMW6W4tKhbhn+TPG78XZLQlg==}
+  '@pwrdrvr/agent-acp@0.13.0':
+    resolution: {integrity: sha512-PHPLX++fnS1mWRruQV7eUJEDmcphKGCDUsVEcEmqYSObDbn6BqOKYAsmVaYJu3TnAdF0k5GJbmnbvALz/Jv3Lg==}
 
   '@pwrdrvr/agent-client@0.6.1':
     resolution: {integrity: sha512-Q8jyGN9c3BfGTW1ba3baFliaF0bWpabV2rYgKmgwZypB3BoPiraZ3qv4X4piHNKVHJ+XK8PdNtyGC78c6sLHNA==}
@@ -4407,9 +4409,6 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -4420,9 +4419,9 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@agentclientprotocol/sdk@0.4.5':
+  '@agentclientprotocol/sdk@1.3.0(zod@4.3.6)':
     dependencies:
-      zod: 3.25.76
+      zod: 4.3.6
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -5135,11 +5134,13 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
-  '@pwrdrvr/agent-acp@0.12.3':
+  '@pwrdrvr/agent-acp@0.13.0(zod@4.3.6)':
     dependencies:
-      '@agentclientprotocol/sdk': 0.4.5
+      '@agentclientprotocol/sdk': 1.3.0(zod@4.3.6)
       '@pwrdrvr/agent-core': 0.2.0
       '@pwrdrvr/agent-transport': 0.1.6
+    transitivePeerDependencies:
+      - zod
 
   '@pwrdrvr/agent-client@0.6.1':
     dependencies:
@@ -8938,8 +8939,6 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
-
-  zod@3.25.76: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
## What changed

- Updates the desktop dependency to published `@pwrdrvr/agent-acp@^0.13.0`.
- Locks its transitive `@agentclientprotocol/sdk@1.3.0` dependency.
- Removes the temporary local tarball fixture and its CI sparse-checkout support.
- Regenerates `THIRD_PARTY_LICENSES` from the published package.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm licenses:check`
- `pnpm --filter @pwragent/desktop typecheck`
- Full PwrSuiteLab macOS guest E2E was previously exercised with the identical agent-kit source fixture. The controller reached Playwright and collected artifacts; the 225-test suite finished with 191 passed, 32 skipped, and two unrelated UI failures (live-work rail geometry and a seven-pixel visual-regression diff).

This remains a draft pending a green full-suite result.