### PR TITLE
fix(desktop): preserve remote primary project

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2278,6 +2278,112 @@ describe("app server ipc", () => {
     );
   });
 
+  it("keeps a pinned remote thread in its owner's primary project", async () => {
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const { buildFederatedThreadRef } = await import("@pwragent/shared");
+
+    reconcileNavigationSnapshot.mockImplementationOnce(async (params: unknown) => ({
+      backend: (params as { backend: "all" | "codex" | "acp:grok" }).backend,
+      fetchedAt: 1234,
+      unchanged: false,
+      threads: (params as { threads: object[] }).threads.map((thread) => ({
+        inbox: { inInbox: false },
+        ...thread,
+      })),
+      inboxThreadKeys: [],
+      directories: [
+        {
+          key: "directory:/repo/PwrAgent",
+          kind: "directory" as const,
+          label: "PwrAgent",
+          path: "/repo/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          latestUpdatedAt: 2000,
+        },
+        {
+          key: "directory:/repo/PwrSuiteLab",
+          kind: "directory" as const,
+          label: "PwrSuiteLab",
+          path: "/repo/PwrSuiteLab",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          latestUpdatedAt: 2000,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const ref = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "peer-laptop",
+      threadId: "remote-primary-project",
+    });
+    listRemoteThreadPins.mockResolvedValueOnce([
+      { ref, addedAt: 1_000, instanceLabel: "Laptop" },
+    ]);
+    federationMock.remoteThreadSummaries.resolvePinnedThreads.mockResolvedValueOnce({
+      threads: [
+        {
+          source: "codex" as const,
+          id: "remote-primary-project",
+          title: "Review #1317: bind remote threads",
+          titleSource: "explicit" as const,
+          // This is the owner's authoritative project. The PwrSuiteLab link
+          // was added later by a composer @-reference and must not re-home
+          // the pinned row in this viewer's Directories lens.
+          projectKey: "/peer/.codex/worktrees/federated-bind/PwrAgent",
+          linkedDirectories: [
+            {
+              id: "pwragent",
+              label: "PwrAgent",
+              path: "/peer/pwrdrvr/PwrAgent",
+              worktreePath: "/peer/.codex/worktrees/federated-bind/PwrAgent",
+              kind: "worktree" as const,
+            },
+            {
+              id: "pwrsuitelab",
+              label: "PwrSuiteLab",
+              path: "/peer/pwrdrvr/PwrSuiteLab",
+              kind: "local" as const,
+            },
+          ],
+          inbox: { inInbox: false },
+          federation: {
+            ref,
+            instanceLabel: "Laptop",
+            peerStatus: "connected" as const,
+            capabilities: [],
+          },
+        },
+      ],
+      refreshed: [],
+      archived: [],
+    });
+
+    registerAppServerIpcHandlers();
+
+    const response = (await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.(
+      {},
+      {} satisfies GetNavigationSnapshotRequest,
+    )) as {
+      directories: Array<{ key: string; threadKeys: string[] }>;
+    };
+
+    const byKey = new Map(
+      response.directories.map((directory) => [directory.key, directory]),
+    );
+    expect(byKey.get("directory:/repo/PwrAgent")?.threadKeys).toContain(
+      "codex:remote-primary-project",
+    );
+    expect(byKey.get("directory:/repo/PwrSuiteLab")?.threadKeys).not.toContain(
+      "codex:remote-primary-project",
+    );
+  });
+
   it("stamps the viewer-owned local rank onto merged remote rows", async () => {
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
     const { buildFederatedThreadRef } = await import("@pwragent/shared");

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2335,13 +2335,13 @@ describe("app server ipc", () => {
           // This is the owner's authoritative project. The PwrSuiteLab link
           // was added later by a composer @-reference and must not re-home
           // the pinned row in this viewer's Directories lens.
-          projectKey: "/peer/.codex/worktrees/federated-bind/PwrAgent",
+          projectKey: "C:\\peer\\.codex\\worktrees\\federated-bind\\PwrAgent",
           linkedDirectories: [
             {
               id: "pwragent",
               label: "PwrAgent",
               path: "/peer/pwrdrvr/PwrAgent",
-              worktreePath: "/peer/.codex/worktrees/federated-bind/PwrAgent",
+              worktreePath: "C:/peer/.codex/worktrees/federated-bind/PwrAgent",
               kind: "worktree" as const,
             },
             {
@@ -2381,6 +2381,51 @@ describe("app server ipc", () => {
     );
     expect(byKey.get("directory:/repo/PwrSuiteLab")?.threadKeys).not.toContain(
       "codex:remote-primary-project",
+    );
+  });
+
+  it("keeps a partial remote pin summary ungrouped", async () => {
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const { buildFederatedThreadRef } = await import("@pwragent/shared");
+
+    const ref = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "peer-laptop",
+      threadId: "remote-partial-summary",
+    });
+    listRemoteThreadPins.mockResolvedValueOnce([
+      { ref, addedAt: 1_000, instanceLabel: "Laptop" },
+    ]);
+    federationMock.remoteThreadSummaries.resolvePinnedThreads.mockResolvedValueOnce({
+      // Cached pin payloads are untrusted JSON. A partial record must stay
+      // visible in Updated / Created rather than throwing during projection.
+      threads: [{
+        source: "codex" as const,
+        id: "remote-partial-summary",
+        title: "Partial remote summary",
+        titleSource: "explicit" as const,
+        projectKey: "/peer/.codex/worktrees/partial/PwrAgent",
+        inbox: { inInbox: false },
+        federation: {
+          ref,
+          instanceLabel: "Laptop",
+          peerStatus: "disconnected" as const,
+          capabilities: [],
+        },
+      }],
+      refreshed: [],
+      archived: [],
+    });
+
+    registerAppServerIpcHandlers();
+
+    const response = (await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.(
+      {},
+      {} satisfies GetNavigationSnapshotRequest,
+    )) as { threads: Array<{ id: string }> };
+
+    expect(response.threads).toContainEqual(
+      expect.objectContaining({ id: "remote-partial-summary" }),
     );
   });
 

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -568,14 +568,15 @@ function findRemoteHomeDirectoryIndex(
     }
   });
   const projectKey = thread.projectKey;
+  const linkedDirectories = thread.linkedDirectories ?? [];
   const primaryProjectDirectory = projectKey
-    ? thread.linkedDirectories.find((directory) =>
+    ? linkedDirectories.find((directory) =>
         linkedDirectoryMatchesProjectKey(directory, projectKey)
       )
     : undefined;
   const linkedByHomePreference = primaryProjectDirectory
     ? [primaryProjectDirectory]
-    : [...thread.linkedDirectories].sort((left, right) => {
+    : [...linkedDirectories].sort((left, right) => {
       if (left.kind !== right.kind) {
         return left.kind === "worktree" ? 1 : -1;
       }
@@ -609,7 +610,7 @@ function linkedDirectoryMatchesProjectKey(
 }
 
 function normalizeFederatedPath(value: string | undefined): string | undefined {
-  const normalized = value?.trim().replace(/\\\\/g, "/").replace(/\/+$/, "");
+  const normalized = value?.trim().replace(/\\/g, "/").replace(/\/+$/, "");
   return normalized || undefined;
 }
 

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -534,9 +534,9 @@ async function renderExplicitComposerPdfPreview(
  * group — its home directory — never every group it can match. Duplicating
  * the row made selection "jump" groups, because `selectedDirectory` resolves
  * to the first directory containing the key, which is whichever sorts first,
- * not the group the user clicked in. Home preference matches
- * `pickHomeDirectory`: repo checkouts (`kind: "local"`) before worktrees,
- * then the owner's linked-directory order.
+ * not the group the user clicked in. The owner's `projectKey` is authoritative
+ * when it identifies a linked directory; fallback preference is a local
+ * checkout before a worktree, then linked-directory order.
  *
  * Remote threads whose project has no local counterpart stay ungrouped and
  * surface only in the Updated / Created lenses.
@@ -544,12 +544,15 @@ async function renderExplicitComposerPdfPreview(
 /**
  * The single local directory group a remote thread belongs to, by project
  * identity (directory label / path basename — peer paths never match viewer
- * paths). Home preference mirrors `pickHomeDirectory`: repo checkouts
- * (`kind: "local"`) before worktree links, then the owner's linked order.
+ * paths). When the owner's projectKey identifies one of its linked
+ * directories, that primary project wins even if a secondary @-referenced
+ * directory is a local checkout. Otherwise, home preference mirrors
+ * `pickHomeDirectory`: repo checkouts (`kind: "local"`) before worktree
+ * links, then the owner's linked order.
  */
 function findRemoteHomeDirectoryIndex(
   directories: ReadonlyArray<{ label: string; path?: string }>,
-  linkedDirectories: NavigationThreadSummary["linkedDirectories"] | undefined,
+  thread: Pick<NavigationThreadSummary, "linkedDirectories" | "projectKey">,
 ): number | undefined {
   const directoryIndexByName = new Map<string, number>();
   directories.forEach((directory, index) => {
@@ -564,14 +567,20 @@ function findRemoteHomeDirectoryIndex(
       }
     }
   });
-  const linkedByHomePreference = [...(linkedDirectories ?? [])].sort(
-    (left, right) => {
+  const projectKey = thread.projectKey;
+  const primaryProjectDirectory = projectKey
+    ? thread.linkedDirectories.find((directory) =>
+        linkedDirectoryMatchesProjectKey(directory, projectKey)
+      )
+    : undefined;
+  const linkedByHomePreference = primaryProjectDirectory
+    ? [primaryProjectDirectory]
+    : [...thread.linkedDirectories].sort((left, right) => {
       if (left.kind !== right.kind) {
         return left.kind === "worktree" ? 1 : -1;
       }
       return 0;
-    },
-  );
+    });
   for (const linked of linkedByHomePreference) {
     const names = [linked.label, path.basename(linked.path)]
       .map((name) => (name ?? "").trim().toLowerCase())
@@ -584,6 +593,24 @@ function findRemoteHomeDirectoryIndex(
     }
   }
   return undefined;
+}
+
+function linkedDirectoryMatchesProjectKey(
+  directory: Pick<LinkedDirectorySummary, "path" | "worktreePath">,
+  projectKey: string,
+): boolean {
+  const normalizedProjectKey = normalizeFederatedPath(projectKey);
+  if (!normalizedProjectKey) {
+    return false;
+  }
+  return [directory.path, directory.worktreePath].some(
+    (candidate) => normalizeFederatedPath(candidate) === normalizedProjectKey,
+  );
+}
+
+function normalizeFederatedPath(value: string | undefined): string | undefined {
+  const normalized = value?.trim().replace(/\\\\/g, "/").replace(/\/+$/, "");
+  return normalized || undefined;
 }
 
 function attachRemoteThreadsToLocalDirectories(
@@ -601,7 +628,7 @@ function attachRemoteThreadsToLocalDirectories(
     const threadKey = buildThreadIdentityKey(thread.source, thread.id);
     const homeIndex = findRemoteHomeDirectoryIndex(
       directories,
-      thread.linkedDirectories,
+      thread,
     );
     if (homeIndex === undefined) {
       continue;
@@ -5978,7 +6005,7 @@ class DesktopAppServerService {
       const directories = [...this.lastDirectoriesByKey.values()];
       const homeIndex = findRemoteHomeDirectoryIndex(
         directories,
-        targetSummary?.linkedDirectories,
+        targetSummary ?? { linkedDirectories: [] },
       );
       const home = homeIndex === undefined ? undefined : directories[homeIndex];
       if (!home?.directoryThreadsCollapsed) {


### PR DESCRIPTION
## What changed

Pinned remote threads now use the owning instance's `projectKey` to choose their one sidebar directory group when that project matches a linked directory.

## Why

A remote thread whose primary workspace is a PwrAgent worktree could also carry a secondary PwrSuiteLab `@` reference. The viewer previously preferred any `local` linked directory over a `worktree`, so it projected the thread under PwrSuiteLab instead of its owner-selected PwrAgent project.

## Impact

Remote rows remain under their primary project in the Directories lens. Secondary linked directories remain visible as references but no longer re-home the sidebar row.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with existing warnings)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`

The regression reproduces the reported shape: a remote PwrAgent worktree identified by `projectKey`, plus a later local PwrSuiteLab reference.
