### PR TITLE
fix(desktop): restore the standard disclosure chevron on unpublished commits

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -3071,6 +3071,65 @@ describe("ThreadContextPanel", () => {
     });
   });
 
+  // `.unpublished-commit__toggle` is a two-row grid — "chevron subject" over
+  // ".  sha" — which is what puts the chevron on the SUBJECT line instead of
+  // floating it between the two lines. Grid areas only resolve for DIRECT
+  // children, so wrapping subject + sha in an identity span (which is how this
+  // markup originally read) silently collapses both back onto one row with no
+  // other symptom. Nothing else in the suite would notice.
+  it("keeps the commit toggle's chevron, subject, and sha as direct grid children", async () => {
+    const listWorktreeUnpublishedCommits = vi.fn(async () => ({
+      commits: [
+        {
+          sha: "b6f2bd748f6d69e39a0aa388060dcb118640925f",
+          shortSha: "b6f2bd748",
+          subject: "test(desktop): vendor ACP SDK fix fixture",
+          additions: 19,
+          removals: 20,
+          files: [],
+          totalFiles: 0,
+          filesTruncated: false,
+        },
+      ],
+      totalCommits: 1,
+      truncated: false,
+      maxCommits: 20,
+      maxFilesPerCommit: 50,
+    }));
+
+    const { container } = renderPanel({
+      activeTab: "edits",
+      desktopApi: { listWorktreeUnpublishedCommits },
+      pinned: true,
+      thread: {
+        ...baseThread,
+        linkedDirectories: [
+          {
+            id: "linked-worktree",
+            kind: "worktree",
+            label: "PwrAgent",
+            path: "/repo",
+            worktreePath: "/repo/.worktrees/thread-1",
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector(".unpublished-commit__toggle")).not.toBeNull();
+    });
+
+    const toggle = container.querySelector(".unpublished-commit__toggle") as HTMLElement;
+    const children = [...toggle.children];
+    expect(children.map((child) => child.className)).toEqual([
+      "live-work-rail__chevron",
+      "unpublished-commit__subject",
+      "unpublished-commit__sha",
+    ]);
+    expect(children[1]?.textContent).toBe("test(desktop): vendor ACP SDK fix fixture");
+    expect(children[2]?.textContent).toBe("b6f2bd748");
+  });
+
   it("renders accumulated edit groups on the Edits tab and toggles the dock", () => {
     const groups = collectEditedFileGroups({
       entries: [

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -648,12 +648,13 @@ function UnpublishedCommitSection(props: {
           onClick={() => setExpanded((current) => !current)}
         >
           <span className="live-work-rail__chevron" aria-hidden="true" />
-          <span className="unpublished-commit__identity">
-            <span className="unpublished-commit__subject">
-              {props.commit.subject}
-            </span>
-            <span className="unpublished-commit__sha">{props.commit.shortSha}</span>
+          {/* Direct children of the toggle: it is a two-row grid that places
+              the chevron on the subject line and tucks the sha under it. An
+              identity wrapper here would collapse both back onto one row. */}
+          <span className="unpublished-commit__subject">
+            {props.commit.subject}
           </span>
+          <span className="unpublished-commit__sha">{props.commit.shortSha}</span>
         </button>
         <DiffStat
           additions={props.commit.additions}

--- a/apps/desktop/src/renderer/src/styles/__tests__/chevron-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/chevron-contract.test.ts
@@ -80,10 +80,81 @@ const INLINE_CHEVRONS: Array<{ name: string; collapsed: string; expanded: string
 const UNFILLED_BASE_RULES = [
   ".transcript-activity__chevron",
   ".transcript-work-phase-group__chevron",
+  ".transcript-monitor-result__chevron",
   ".directory-row__chevron",
   ".settings-section__chevron::before",
   ".live-work-rail__chevron",
 ];
+
+// Every chevron that sits DIRECTLY in a flex toggle needs a shrink guard: the
+// label beside it can only shrink so far, so past that the flex algorithm eats
+// the glyph itself. `.live-work-rail__chevron` shipped without one and
+// collapsed to 7.1px at a 240px rail and 5.4px at 200px, while the file rows
+// (a grid, immune to flex shrink) stayed 8px -- two sizes of chevron in one
+// column. `.settings-section__chevron` is the odd one out: the guard belongs on
+// that host span, a fixed 16x16 inline-flex box, and NOT on the ::before that
+// paints the V, which a fixed-size host can never squeeze.
+const SHRINK_GUARDED_CHEVRONS = [
+  ".transcript-activity__chevron",
+  ".transcript-work-phase-group__chevron",
+  ".transcript-monitor-result__chevron",
+  ".directory-row__chevron",
+  ".settings-section__chevron",
+  ".live-work-rail__chevron",
+];
+
+/** Collapse whitespace so a CSS selector wrapped across lines still compares. */
+function normalizeSelector(selector: string): string {
+  return selector.trim().replace(/\s+/g, " ");
+}
+
+/** The single rotate() a chevron rule applies, or undefined if it applies none. */
+function rotationOf(body: string): string | undefined {
+  const rotations = body.match(/rotate\([^)]*\)/g) ?? [];
+  return rotations.length === 1 ? rotations[0] : undefined;
+}
+
+type SweptRule = {
+  selector: string;
+  /** Selector with the state normalized out, so both states of one toggle pair up. */
+  pairKey: string;
+  state: "true" | "false";
+  /** The chevron class the rule targets, e.g. ".live-work-rail__chevron". */
+  chevron: string;
+  rotations: string[];
+};
+
+/**
+ * Every `aria-expanded` chevron rule in app.css that rotates its glyph,
+ * whether or not anyone remembered to enumerate it above. Matches rules
+ * nested inside `@media` / `@supports` too, since their selectors still
+ * start on their own line.
+ */
+function sweepStateRules(): SweptRule[] {
+  // Strip comments first: a rule's leading comment can otherwise carry
+  // "chevron" or a rotate() into the match and skew the selector.
+  const stripped = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  const swept: SweptRule[] = [];
+
+  for (const rule of stripped.matchAll(/(?:^|\n)([^{}\n][^{}]*?)\{([^{}]*)\}/g)) {
+    const selector = normalizeSelector(rule[1]);
+    const body = rule[2];
+    const state = selector.match(/aria-expanded="(true|false)"/);
+    if (!selector.includes("chevron") || !state || !/transform\s*:/.test(body)) {
+      continue;
+    }
+    const chevrons = selector.match(/\.[\w-]*chevron[\w-]*/g) ?? [];
+    swept.push({
+      selector,
+      pairKey: selector.replace(/aria-expanded="(true|false)"/, "aria-expanded"),
+      state: state[1] as "true" | "false",
+      chevron: chevrons[chevrons.length - 1] ?? "",
+      rotations: body.match(/rotate\([^)]*\)/g) ?? [],
+    });
+  }
+
+  return swept;
+}
 
 describe("chevron disclosure direction contract", () => {
   it.each(INLINE_CHEVRONS)(
@@ -122,37 +193,74 @@ describe("chevron disclosure direction contract", () => {
   // The list above only covers chevrons somebody remembered to add. The
   // unpublished-commit toggle shipped with rotate(0deg)/rotate(-90deg) — a
   // right-angle elbow rather than a chevron, in both states — precisely
-  // because it was never enumerated here. This sweep needs no maintenance:
-  // any aria-expanded chevron rule that rotates its glyph is held to the
-  // language whether or not it appears in INLINE_CHEVRONS.
-  it("holds EVERY aria-expanded chevron rule to -45/45, enumerated or not", () => {
-    // Strip comments first: a rule's leading comment can otherwise carry
-    // "chevron" or a rotate() into the match and skew the selector.
-    const stripped = css.replace(/\/\*[\s\S]*?\*\//g, "");
-    const rules = stripped.matchAll(/(?:^|\n)([^{}\n][^{}]*?)\{([^{}]*)\}/g);
-    const offenders: string[] = [];
-    let checked = 0;
+  // because it was never enumerated here. The two sweeps below need no
+  // per-selector maintenance.
+  it("points every aria-expanded chevron rule the right way, enumerated or not", () => {
+    const offenders = sweepStateRules()
+      .map((rule) => {
+        const want = rule.state === "true" ? "rotate(45deg)" : "rotate(-45deg)";
+        return rotationOf(rule.rotations.join(" ")) === want
+          ? undefined
+          : `${rule.selector} => ${rule.rotations.join(", ") || "(no rotate)"}, want ${want}`;
+      })
+      .filter(Boolean);
 
-    for (const rule of rules) {
-      const selector = rule[1].trim().replace(/\s+/g, " ");
-      const body = rule[2];
-      const state = selector.match(/aria-expanded="(true|false)"/);
-      if (!selector.includes("chevron") || !state || !/transform\s*:/.test(body)) {
-        continue;
+    expect(offenders).toEqual([]);
+  });
+
+  // Direction alone is not enough: a toggle can be pointed correctly in the
+  // one state it declares and still never MOVE, which is how the
+  // edited-file-groups header once sat stuck pointing down in both states
+  // (see the comment above its rotation hooks in app.css). Most chevrons
+  // declare only one state and inherit the other from the base rule, so the
+  // check is that base + declared covers both directions — not that both
+  // aria-expanded rules exist.
+  it("leaves no aria-expanded chevron stuck in one direction", () => {
+    const byPair = new Map<string, SweptRule[]>();
+    for (const rule of sweepStateRules()) {
+      byPair.set(rule.pairKey, [...(byPair.get(rule.pairKey) ?? []), rule]);
+    }
+
+    const stuck: string[] = [];
+    for (const [pairKey, rules] of byPair) {
+      const covered = new Set(
+        rules.map((rule) => rotationOf(rule.rotations.join(" "))).filter(Boolean)
+      );
+      // The state the toggle does not declare falls through to the base rule.
+      const base = rotationOf(ruleBody(rules[0].chevron));
+      if (base) {
+        covered.add(base);
       }
-      checked += 1;
-      const want = state[1] === "true" ? "rotate(45deg)" : "rotate(-45deg)";
-      const rotations = body.match(/rotate\([^)]*\)/g) ?? [];
-      if (rotations.length !== 1 || rotations[0] !== want) {
-        offenders.push(`${selector} => ${rotations.join(", ") || "(no rotate)"}, want ${want}`);
+      if (!covered.has("rotate(-45deg)") || !covered.has("rotate(45deg)")) {
+        stuck.push(`${pairKey} only ever reaches ${[...covered].join(", ") || "(nothing)"}`);
       }
     }
 
-    expect(offenders).toEqual([]);
-    // Guard the sweep itself: a regex that silently stops matching would
-    // otherwise pass vacuously forever. 11 such rules exist as of this
-    // commit; the floor only has to prove the scan still finds them.
-    expect(checked).toBeGreaterThanOrEqual(10);
+    expect(stuck).toEqual([]);
+  });
+
+  // Guards both sweeps against passing vacuously: a regex that silently stops
+  // matching would otherwise look green forever. Tied to the enumerated list
+  // rather than a hardcoded count, so it stays honest as rows come and go.
+  it("visits every aria-expanded selector the enumerated list names", () => {
+    const visited = new Set(sweepStateRules().map((rule) => rule.selector));
+    const enumerated = INLINE_CHEVRONS.flatMap(({ collapsed, expanded }) => [
+      collapsed,
+      expanded,
+    ])
+      .filter((selector) => selector.includes("aria-expanded"))
+      .map(normalizeSelector);
+
+    expect(enumerated.length).toBeGreaterThan(0);
+    expect([...visited]).toEqual(expect.arrayContaining(enumerated));
+  });
+
+  // A CSS-only sweep cannot see a toggle that has NO rotation rule at all —
+  // that lives in TSX. The render-side counterpart is
+  // features/thread-detail/__tests__/chevron-placement.test.tsx and the
+  // ThreadContextPanel commit-toggle structure test.
+  it.each(SHRINK_GUARDED_CHEVRONS)("%s cannot be squeezed by a flex toggle", (selector) => {
+    expect(ruleBody(selector)).toMatch(/flex:\s*0 0 auto/);
   });
 
   it("keeps the sidebar thread-tree as a deliberate FILLED-triangle exception", () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/chevron-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/chevron-contract.test.ts
@@ -69,6 +69,11 @@ const INLINE_CHEVRONS: Array<{ name: string; collapsed: string; expanded: string
     collapsed: '.live-work-rail__file-toggle[aria-expanded="false"] .live-work-rail__chevron',
     expanded: '.live-work-rail__file-toggle[aria-expanded="true"] .live-work-rail__chevron',
   },
+  {
+    name: "unpublished commit toggle",
+    collapsed: '.unpublished-commit__toggle[aria-expanded="false"] .live-work-rail__chevron',
+    expanded: '.unpublished-commit__toggle[aria-expanded="true"] .live-work-rail__chevron',
+  },
 ];
 
 // The base element rule that paints each unfilled chevron's "V" shape.
@@ -112,6 +117,42 @@ describe("chevron disclosure direction contract", () => {
     // rotate(225deg). The unified language never does; guard against it
     // creeping back in on any selector.
     expect(css).not.toContain("rotate(225deg)");
+  });
+
+  // The list above only covers chevrons somebody remembered to add. The
+  // unpublished-commit toggle shipped with rotate(0deg)/rotate(-90deg) — a
+  // right-angle elbow rather than a chevron, in both states — precisely
+  // because it was never enumerated here. This sweep needs no maintenance:
+  // any aria-expanded chevron rule that rotates its glyph is held to the
+  // language whether or not it appears in INLINE_CHEVRONS.
+  it("holds EVERY aria-expanded chevron rule to -45/45, enumerated or not", () => {
+    // Strip comments first: a rule's leading comment can otherwise carry
+    // "chevron" or a rotate() into the match and skew the selector.
+    const stripped = css.replace(/\/\*[\s\S]*?\*\//g, "");
+    const rules = stripped.matchAll(/(?:^|\n)([^{}\n][^{}]*?)\{([^{}]*)\}/g);
+    const offenders: string[] = [];
+    let checked = 0;
+
+    for (const rule of rules) {
+      const selector = rule[1].trim().replace(/\s+/g, " ");
+      const body = rule[2];
+      const state = selector.match(/aria-expanded="(true|false)"/);
+      if (!selector.includes("chevron") || !state || !/transform\s*:/.test(body)) {
+        continue;
+      }
+      checked += 1;
+      const want = state[1] === "true" ? "rotate(45deg)" : "rotate(-45deg)";
+      const rotations = body.match(/rotate\([^)]*\)/g) ?? [];
+      if (rotations.length !== 1 || rotations[0] !== want) {
+        offenders.push(`${selector} => ${rotations.join(", ") || "(no rotate)"}, want ${want}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+    // Guard the sweep itself: a regex that silently stops matching would
+    // otherwise pass vacuously forever. 11 such rules exist as of this
+    // commit; the floor only has to prove the scan still finds them.
+    expect(checked).toBeGreaterThanOrEqual(10);
   });
 
   it("keeps the sidebar thread-tree as a deliberate FILLED-triangle exception", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13362,6 +13362,14 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .live-work-rail__chevron {
   display: inline-block;
+  /* Never let a narrow rail squeeze the glyph: this chevron sits in flex
+     toggles whose label can only shrink so far, so without a shrink guard the
+     8px box collapsed (7.1px at a 240px rail, 5.4px at 200px) while the file
+     rows -- a grid, immune to flex shrink -- stayed 8px, leaving two sizes of
+     chevron stacked in one column. Every sibling chevron in the family
+     (.transcript-activity__chevron, .transcript-work-phase-group__chevron,
+     .directory-row__chevron) already carries this; the canonical one did not. */
+  flex: 0 0 auto;
   width: 8px;
   height: 8px;
   border-right: 1.5px solid currentColor;
@@ -13909,32 +13917,56 @@ a.transcript-message__messaging-origin:focus-visible {
   margin: 8px 0 10px;
 }
 
+/* Nested-child guide + indent, following `.subthread-list` (the app's other
+   nested-disclosure list): ONE continuous hairline for the whole list rather
+   than a segment per child, plus a real indent.
+   The 4px row gap used to chop a per-commit border into dashes, and the 4px
+   indent that came with it left the three disclosure levels 1px and 4px apart
+   -- visually flush, so the commits read as siblings of their own group
+   header. The indent below restores an even 14px (chevron 8px + toggle gap
+   6px) step per level, which is what puts a child's chevron directly under
+   its parent's label:
+     group chevron 18px -> commit chevron 32px -> file chevron 46px.
+   10px margin also drops the hairline on the group chevron's center (18 + 4),
+   so the guide descends from the control it belongs to. */
 .unpublished-commits__list {
   display: flex;
   flex-direction: column;
   gap: 4px;
   margin-top: 4px;
+  margin-left: 10px;
+  padding-left: 7px;
+  border-left: 1px solid var(--border-subtle);
 }
 
 .unpublished-commit {
   min-width: 0;
-  border-left: 1px solid var(--border-subtle);
-  padding-left: 4px;
 }
 
 .unpublished-commit__header {
   display: flex;
-  align-items: center;
+  /* Top-aligned, not centered: the toggle is two lines (subject over sha) and
+     the diff-stat belongs on the subject line, not floating between them. */
+  align-items: flex-start;
   gap: 6px;
   min-width: 0;
   padding: 4px 2px;
 }
 
+/* Two rows -- subject, then the sha indented under it -- so the chevron
+   centers on the SUBJECT line it discloses. As a two-line flex column this
+   centered the chevron across BOTH lines, leaving it aligned with neither.
+   Same summary-over-metadata shape as `.edited-file-groups__group-header`. */
 .unpublished-commit__toggle {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-areas:
+    "chevron subject"
+    ".       sha";
   flex: 1 1 auto;
   align-items: center;
-  gap: 6px;
+  column-gap: 6px;
+  row-gap: 1px;
   min-width: 0;
   padding: 0;
   border: 0;
@@ -13943,6 +13975,10 @@ a.transcript-message__messaging-origin:focus-visible {
   cursor: pointer;
   font: inherit;
   text-align: left;
+}
+
+.unpublished-commit__toggle .live-work-rail__chevron {
+  grid-area: chevron;
 }
 
 .unpublished-commit__toggle:hover {
@@ -13955,28 +13991,32 @@ a.transcript-message__messaging-origin:focus-visible {
   outline-offset: 1px;
 }
 
+/* Shared disclosure language (see .live-work-rail__chevron): right when
+   collapsed, down when expanded. These rotations were 0deg/-90deg, which
+   points the two borders of the glyph at a right angle instead of a chevron
+   -- an elbow, not an arrow -- and the two states were near-indistinguishable
+   at 8px, so the control read as decoration rather than as open/closed. */
 .unpublished-commit__toggle[aria-expanded="false"] .live-work-rail__chevron {
-  transform: rotate(-90deg);
+  transform: rotate(-45deg);
 }
 
 .unpublished-commit__toggle[aria-expanded="true"] .live-work-rail__chevron {
-  transform: rotate(0deg);
-}
-
-.unpublished-commit__identity {
-  display: flex;
-  flex: 1 1 auto;
-  flex-direction: column;
-  min-width: 0;
+  transform: rotate(45deg);
 }
 
 .unpublished-commit__subject {
+  grid-area: subject;
   overflow: hidden;
   color: var(--text-primary);
   font-size: 12px;
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.unpublished-commit__sha {
+  grid-area: sha;
+  justify-self: start;
 }
 
 .unpublished-commit__sha,
@@ -13990,8 +14030,12 @@ a.transcript-message__messaging-origin:focus-visible {
   flex: 0 0 auto;
 }
 
+/* One more 14px step, so a commit's files sit under its subject (chevron at
+   46px) instead of 4px off the commit's own chevron. 10px here + the file
+   toggle's own 6px inset = the step. */
 .unpublished-commit .live-work-rail__file-list {
   margin-top: 2px;
+  padding-left: 10px;
 }
 
 .other-changes__truncated,


### PR DESCRIPTION
## What

The Edits panel's per-commit toggle invented its own disclosure glyph. Where every other inline disclosure in the app rotates the shared chevron `-45deg` (collapsed) → `45deg` (expanded), this one used `0deg` / `-90deg`:

```css
.unpublished-commit__toggle[aria-expanded="false"] .live-work-rail__chevron {
  transform: rotate(-90deg);
}
.unpublished-commit__toggle[aria-expanded="true"] .live-work-rail__chevron {
  transform: rotate(0deg);
}
```

The glyph is a box with a right and a bottom border. At ±45° that's an arrow; at 0° / -90° it's a right-angle **elbow**. At 8px the two states are near-indistinguishable, so the control read as decoration rather than as open/closed.

## Why it happened

The elbow was standing in for an indent that was never there. Measured against the real stylesheet, the three disclosure levels sat **1px and 4px apart** — commits rendered flush with the group header they belong to, and a commit's files rendered flush with the commit:

| | before | after |
|---|---|---|
| group chevron | 18px | 18px |
| commit chevron | 19px | 32px |
| file chevron | 23px | 46px |
| step per level | 1px, 4px | **14px, 14px** |

14px is `chevron 8px + toggle gap 6px`, which is exactly what puts a child's chevron under its parent's label.

## Changes

- **Chevron rejoins the shared language** — `-45deg` / `45deg`.
- **Real indentation** at 14px per level, so the elbow no longer has a job to do.
- **The nesting hairline moves from each `.unpublished-commit` to the list**, so it's one continuous guide instead of segments chopped up by the 4px row gap, and it descends from the group chevron's center. Follows `.subthread-list`, the app's other nested-disclosure list.
- **The commit toggle becomes a two-row grid** (subject, then sha beneath it), matching the summary-over-badge shape of `.edited-file-groups__group-header`. As a two-line flex column it centered the chevron across *both* lines — 6px below the subject it discloses, aligned with neither.
- **`.live-work-rail__chevron` gains the flex shrink guard** its sibling chevrons already carry. Found while testing narrow widths: without it a narrow context rail squeezed the 8px glyph to **7.1px at a 240px rail and 5.4px at 200px** in flex toggles, while the file rows — a grid, immune to flex shrink — stayed 8px. Two sizes of chevron in one column. Pre-existing, affects every `.edited-file-groups` header.

## Why the contract test didn't catch it

`chevron-contract.test.ts` (#795) only checked chevrons somebody remembered to enumerate, and this one was never added to the list. It now carries three maintenance-free sweeps over `app.css`:

- **Direction** — every `aria-expanded` chevron rule is held to `-45/45`, enumerated or not. Also matches rules nested in `@media` / `@supports`.
- **Presence** — a toggle can point the right way in the one state it declares and still never *move*, which is what the edited-file-groups header shipped with. Most chevrons declare one state and inherit the other from the base rule, so the check is that base + declared covers **both** directions, not that both state rules exist.
- **Shrink guard** — asserted across all six chevrons in the family, not just the one fixed here. `.settings-section__chevron` is checked on the host span rather than the `::before`, since a fixed 16×16 inline-flex host can't squeeze its own pseudo-element.

Plus a render test locking the commit toggle's direct children (`chevron → subject → sha`). Grid areas only resolve for direct children, so re-wrapping subject + sha silently collapses the two-row layout with no other symptom.

## Testing

Each new guard was verified by mutation, not just by passing:

| Mutation | Caught by |
|---|---|
| restore `rotate(-90deg)` | direction sweep, naming the selector |
| delete the collapsed rule (chevron stuck down) | presence sweep |
| flip an **un-enumerated** chevron's base (`transcript-monitor-result`) | presence sweep |
| drop `flex: 0 0 auto` | shrink-guard check |
| re-wrap subject + sha in an identity span | ThreadContextPanel structure test |

- `chevron-contract.test.ts` — 33 pass.
- `styles/` + `thread-detail/` — 42 files, 630 tests pass.
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors, warning count unchanged at 133), `pnpm lint:colors` clean.

**Known limitation:** the geometry — 14px steps, continuous rail, shrink behavior — was measured by rendering the real `app.css` in a throwaway browser harness at 420px and 240px in both themes (chevron columns land at 18 / 32 / 46; all three chevrons stay 8px; commit chevron center sits on the subject line at 0.0px delta). jsdom cannot compute layout, and the repo's two visual-regression E2E snapshots already fail on a clean checkout, so **nothing in CI can re-verify those numbers**. The committed tests cover the rotation, presence, shrink-guard, and DOM-structure contracts; the pixel geometry is reviewed, not gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
