### PR TITLE
fix(desktop): make PwrAgent review work end to end on Grok

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -1465,6 +1465,40 @@ describe("AcpSessionReplayNormalizer", () => {
     ]);
   });
 
+  it("hides a review context block split across two chunks", () => {
+    // Grok echoed the whole block in one chunk, but nothing in ACP guarantees
+    // that. A chunk carrying only the tail of the block would otherwise miss
+    // the open marker and render the artifact remnant plus the close marker.
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "user_message_chunk",
+        content:
+          "[PwrAgent review sub-agent results — context for this turn]\n\nNo blocking",
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "user_message_chunk",
+        content:
+          " findings.\n\n[End PwrAgent review sub-agent results]\n\nSummarize.",
+      },
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "message",
+        role: "user",
+        text: "Summarize.",
+      }),
+    ]);
+  });
+
   it("extracts the ACP session_info_update title", () => {
     // ACP's own session metadata update (SessionUpdate::SessionInfoUpdate)
     // carries `title` and `updatedAt` and nothing else. Grok Build sends it

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -4,6 +4,7 @@ import {
   inferAcpReplayTurns,
   readAcpTopicTitle,
 } from "../acp/acp-session-normalizer";
+import grokReviewSession from "./fixtures/grok-managed-review-session.json";
 
 describe("AcpSessionReplayNormalizer", () => {
   it("keeps inferred provider work inside user-message boundaries", () => {
@@ -1395,6 +1396,147 @@ describe("AcpSessionReplayNormalizer", () => {
     ).toBeUndefined();
   });
 
+  it("hides the injected managed-review context from the transcript", () => {
+    // A finished managed review is handed to the parent thread by prefixing
+    // the next prompt with a wrapped context block. Grok echoes every prompt
+    // back as a user_message_chunk, so without this the operator sees the
+    // whole review artifact rendered as something they supposedly typed.
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "user_message_chunk",
+        content: [
+          "[PwrAgent review sub-agent results — context for this turn]",
+          "",
+          '{"findings":[],"overall_correctness":"patch is correct"}',
+          "",
+          "[End PwrAgent review sub-agent results]",
+        ].join("\n"),
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "user_message_chunk",
+        content: "Can you summarize the review results for me?",
+      },
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "message",
+        role: "user",
+        text: "Can you summarize the review results for me?",
+      }),
+    ]);
+  });
+
+  it("keeps user text that shares a chunk with the review context block", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "user_message_chunk",
+        content: [
+          "[PwrAgent review sub-agent results — context for this turn]",
+          "",
+          "Review 1:",
+          "No blocking findings.",
+          "",
+          "[End PwrAgent review sub-agent results]",
+          "",
+          "Summarize that for me.",
+        ].join("\n"),
+      },
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "message",
+        role: "user",
+        text: "Summarize that for me.",
+      }),
+    ]);
+  });
+
+  it("extracts the ACP session_info_update title", () => {
+    // ACP's own session metadata update (SessionUpdate::SessionInfoUpdate)
+    // carries `title` and `updatedAt` and nothing else. Grok Build sends it
+    // whenever it settles on a durable session title, which is mid-turn on
+    // the first prompt.
+    expect(
+      readAcpTopicTitle({
+        sessionUpdate: "session_info_update",
+        title: "Summarize path normalization review findings",
+      }),
+    ).toBe("Summarize path normalization review findings");
+    // A title-less info update (timestamp refresh, or an explicit clear) is
+    // still metadata, but it names no topic.
+    expect(
+      readAcpTopicTitle({
+        sessionUpdate: "session_info_update",
+        updatedAt: "2026-08-08T19:44:20Z",
+      }),
+    ).toBeUndefined();
+    expect(
+      readAcpTopicTitle({ sessionUpdate: "session_info_update", title: null }),
+    ).toBeUndefined();
+  });
+
+  it("keeps session metadata updates out of a streaming assistant message", () => {
+    // Grok Build emits session_info_update and last_turn_summary in the
+    // middle of the final assistant stream. Both used to fall through to the
+    // unknown-update branch, which dropped an "ACP update: …" activity into
+    // the transcript AND cleared the active assistant bubble, splitting the
+    // message the operator was watching get written.
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { sessionUpdate: "agent_message_chunk", content: "Overall: " },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "session_info_update",
+        title: "Summarize path normalization review findings",
+      },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1002,
+      update: {
+        sessionUpdate: "last_turn_summary",
+        summary: "Summarized the review findings",
+        prompt_id: "919afcda-d40d-411e-a729-5a94b0ed94ae",
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1003,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: "the patch has issues.",
+      },
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "message",
+        role: "assistant",
+        text: "Overall: the patch has issues.",
+      }),
+    ]);
+  });
+
   it("ignores transient Grok interaction updates without splitting text", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 
@@ -1865,5 +2007,87 @@ describe("AcpSessionReplayNormalizer", () => {
       "activity",
       "assistant:turn-1:1:The build script is available.",
     ]);
+  });
+
+  // End-to-end replay of the captured Grok Build session that produced the
+  // bug report: a PwrAgent /review finishes, its artifact is prepended to the
+  // operator's follow-up prompt, and Grok streams the summary while emitting
+  // session_info_update and last_turn_summary mid-flight.
+  describe("captured Grok Build review follow-up turn", () => {
+    function replayCapturedParentSession() {
+      const normalizer = new AcpSessionReplayNormalizer({
+        surfaceThoughtsAsMessages: false,
+      });
+      let replay = normalizer.replay();
+      for (const record of grokReviewSession.parentUpdates) {
+        replay = normalizer.apply({
+          sessionId: record.params.sessionId,
+          receivedAt: record.params._meta.agentTimestampMs,
+          update: record.params.update as Record<string, unknown>,
+        });
+        // The two transient updates below never reach updates.jsonl, so the
+        // capture cannot place them; inject them where they landed live —
+        // between the assistant's first and last streamed chunks.
+        if (record.params.update.sessionUpdate === "agent_message_chunk") {
+          replay = normalizer.apply({
+            sessionId: record.params.sessionId,
+            receivedAt: record.params._meta.agentTimestampMs + 1,
+            update: grokReviewSession.liveOnlyUpdates.sessionInfoUpdate,
+          });
+          replay = normalizer.apply({
+            sessionId: record.params.sessionId,
+            receivedAt: record.params._meta.agentTimestampMs + 2,
+            update: grokReviewSession.liveOnlyUpdates.lastTurnSummary,
+          });
+        }
+      }
+      return replay;
+    }
+
+    it("shows the operator's prompt without the review artifact", () => {
+      const replay = replayCapturedParentSession();
+      const userTexts = replay.entries.flatMap((entry) =>
+        entry.type === "message" && entry.role === "user" ? [entry.text] : [],
+      );
+
+      // "/always-approve on" is the execution-mode control prompt PwrAgent
+      // sends over the same session; the renderer materializes it as the
+      // permission-transition marker rather than a user bubble.
+      expect(userTexts).toEqual([
+        "/always-approve on",
+        "Can you summarize the review results for me?",
+      ]);
+      expect(userTexts.join("\n")).not.toContain("PwrAgent review sub-agent");
+      expect(userTexts.join("\n")).not.toContain("overall_correctness");
+    });
+
+    it("keeps the streamed reply in a single assistant bubble", () => {
+      const replay = replayCapturedParentSession();
+      const assistantTexts = replay.entries.flatMap((entry) =>
+        entry.type === "message" && entry.role === "assistant"
+          ? [entry.text]
+          : [],
+      );
+
+      expect(assistantTexts).toHaveLength(1);
+      expect(assistantTexts[0]).toContain("## Review summary");
+      // The tail of the reply — everything that used to land in a second
+      // bubble once a metadata update reset the active message.
+      expect(assistantTexts[0]).toContain("path-separator helper");
+    });
+
+    it("leaves no unknown-update noise in the transcript", () => {
+      const replay = replayCapturedParentSession();
+
+      expect(
+        replay.entries.filter((entry) => entry.id.startsWith("unknown:")),
+      ).toEqual([]);
+    });
+
+    it("surfaces the session_info_update title as the thread topic", () => {
+      expect(
+        readAcpTopicTitle(grokReviewSession.liveOnlyUpdates.sessionInfoUpdate),
+      ).toBe("Summarize path normalization review findings");
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2106,6 +2106,9 @@ function createKimiAcpRegistry(options?: {
   gitWorkspaceHandoffService?: unknown;
   worktreeArchiveService?: WorktreeArchiveService;
   runtimeCapabilities?: BackendAcpRuntimeCapabilities;
+  threadTitleGenerationService?: NonNullable<
+    ConstructorParameters<typeof DesktopBackendRegistry>[0]
+  >["threadTitleGenerationService"];
   acpWorktreeRepositoryResolver?: (
     cwd: string,
   ) => Promise<LinkedDirectorySummary | undefined>;
@@ -2192,6 +2195,9 @@ function createKimiAcpRegistry(options?: {
       options?.gitWorkspaceHandoffService as never,
     worktreeArchiveService: options?.worktreeArchiveService,
     acpWorktreeRepositoryResolver: options?.acpWorktreeRepositoryResolver,
+    ...(options?.threadTitleGenerationService
+      ? { threadTitleGenerationService: options.threadTitleGenerationService }
+      : {}),
   });
   return {
     acpBackendId,
@@ -4536,6 +4542,187 @@ describe("DesktopBackendRegistry", () => {
 
     await registry.close();
     expect(acpClient.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays managed review entries when reading ACP threads", async () => {
+    // A managed review writes its "started" and "result" entries into the
+    // thread overlay, not into the provider's own rollout. readThread's Codex
+    // path merges them back into the transcript; the ACP path returned early
+    // and never did, so a Grok review left no trace in the thread at all.
+    const acpBackendId = "acp:grok" as AcpBackendId;
+    const threadId = "grok-review-parent";
+    const startedEntry = {
+      type: "review" as const,
+      id: "managed-review:review-turn-1:started",
+      review: "Review changes against main",
+      displayText: "Review changes against main",
+      createdAt: 2_000,
+      turn: {
+        id: "review-turn-1",
+        status: "in_progress" as const,
+        startedAt: 2_000,
+      },
+    };
+    const resultEntry = {
+      type: "review" as const,
+      id: "managed-review:review-turn-1:result",
+      review: "No blocking findings.\n\nNo findings.",
+      createdAt: 3_000,
+      output: {
+        findings: [],
+        overall_correctness: "patch is correct" as const,
+        overall_explanation: "No blocking findings.",
+        overall_confidence_score: 0.96,
+      },
+      turn: {
+        id: "review-turn-1",
+        status: "completed" as const,
+        completedAt: 3_000,
+      },
+    };
+    const usageActivity = {
+      type: "activity" as const,
+      id: "live-turn-usage-review-turn-1",
+      summary:
+        "Monitor usage: 50,310 uncached in · 509,952 cached · 9,959 out (8,762 reasoning) · $0.32 list price",
+      status: "completed" as const,
+      createdAt: 3_001,
+      turn: { id: "review-turn-1", status: "completed" as const },
+      details: [],
+    };
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          [`${acpBackendId}:${threadId}`]: {
+            backend: acpBackendId,
+            threadId,
+            executionMode: "default",
+            extraLinkedDirectories: [],
+            managedReviewEntries: [startedEntry, resultEntry],
+            immutableUsageActivities: [usageActivity],
+          },
+        },
+      }),
+      sessionId: threadId,
+      sessions: [
+        {
+          backendId: acpBackendId,
+          sessionId: threadId,
+          title: "ACP session",
+          createdAt: 1_000,
+          updatedAt: 4_000,
+          executionMode: "default",
+          status: "idle",
+        },
+      ],
+      replay: {
+        entries: [
+          {
+            type: "message",
+            id: "user-1",
+            role: "user",
+            text: "Can you summarize the review results for me?",
+            createdAt: 4_000,
+          },
+        ],
+        messages: [],
+        pagination: { supportsPagination: false, hasPreviousPage: false },
+        threadStatus: "idle",
+      },
+    });
+
+    const response = await registry.readThread({
+      backend: acpBackendId,
+      threadId,
+    });
+
+    expect(response.replay.entries.filter((entry) => entry.type === "review"))
+      .toEqual([startedEntry, resultEntry]);
+    expect(response.replay.entries.map((entry) => entry.id)).toEqual([
+      startedEntry.id,
+      resultEntry.id,
+      usageActivity.id,
+      "user-1",
+    ]);
+
+    await registry.close();
+  });
+
+  it("keeps managed review entries out of ACP pagination pages", async () => {
+    // Older pages are a window into durable provider history. Splicing the
+    // overlay's review entries into every page would duplicate them above
+    // whatever slice the operator scrolled back to.
+    const acpBackendId = "acp:grok" as AcpBackendId;
+    const threadId = "grok-review-parent-paged";
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          [`${acpBackendId}:${threadId}`]: {
+            backend: acpBackendId,
+            threadId,
+            executionMode: "default",
+            extraLinkedDirectories: [],
+            managedReviewEntries: [
+              {
+                type: "review",
+                id: "managed-review:review-turn-1:started",
+                review: "Review changes against main",
+                displayText: "Review changes against main",
+                createdAt: 2_000,
+              },
+            ],
+          },
+        },
+      }),
+      sessionId: threadId,
+      sessions: [
+        {
+          backendId: acpBackendId,
+          sessionId: threadId,
+          title: "ACP session",
+          createdAt: 1_000,
+          updatedAt: 4_000,
+          executionMode: "default",
+          status: "idle",
+        },
+      ],
+      replay: {
+        entries: [
+          {
+            type: "message",
+            id: "user-1",
+            role: "user",
+            text: "Older page entry",
+            createdAt: 1_500,
+          },
+        ],
+        messages: [],
+        pagination: { supportsPagination: true, hasPreviousPage: true },
+        threadStatus: "idle",
+      },
+    });
+
+    const paged = await registry.readThread({
+      backend: acpBackendId,
+      threadId,
+      before: "user-2",
+    });
+    const viewOnly = await registry.readThread({
+      backend: acpBackendId,
+      threadId,
+      includeTurns: false,
+    });
+
+    expect(paged.replay.entries.some((entry) => entry.type === "review")).toBe(
+      false,
+    );
+    expect(
+      viewOnly.replay.entries.some((entry) => entry.type === "review"),
+    ).toBe(false);
+
+    await registry.close();
   });
 
   it("includes persisted pricing when reading ACP threads", async () => {
@@ -11351,6 +11538,107 @@ command = "pnpm grok"
       fastMode: true,
       prAutoDispatchEnabled: true,
     });
+
+    await registry.close();
+  });
+
+  it("names a thread launched straight into a review", async () => {
+    // A /review launch never calls startTurn, so the thread was born with no
+    // user prompt for the title generator to work from and kept its fallback
+    // name forever. Synthesize a prompt from what the review already knows:
+    // the repository, the branch, and the review target.
+    const titleService = {
+      generateTitle: vi.fn(async (_params: { userPrompt: string }) => ({
+        status: "generated" as const,
+        title: "Review app against main",
+      })),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["thread/start", "thread/name/set", "review/start"],
+      },
+      threads: [],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.materializeDirectoryLaunchpad({
+      directoryKey: "directory:/repo/app",
+      reviewTarget: { type: "baseBranch", branch: "main" },
+      launchpad: {
+        directoryKey: "directory:/repo/app",
+        directoryKind: "directory",
+        directoryLabel: "app",
+        directoryPath: "/repo/app",
+        branchName: "agent/fix-remote-thread-project-home",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "/review main",
+        workMode: "local",
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+    });
+
+    await waitForCondition(() => codexClient.lastRenameThreadParams !== undefined);
+    expect(titleService.generateTitle).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      userPrompt: expect.stringContaining("Review changes against main"),
+    });
+    const userPrompt =
+      titleService.generateTitle.mock.calls[0]?.[0].userPrompt ?? "";
+    expect(userPrompt).toContain("app");
+    expect(userPrompt).toContain("agent/fix-remote-thread-project-home");
+    expect(codexClient.lastRenameThreadParams).toEqual({
+      threadId: "thread-1",
+      name: "Review app against main",
+    });
+
+    await registry.close();
+  });
+
+  it("names a Grok thread launched straight into a managed review", async () => {
+    const acpBackendId = "acp:grok" as AcpBackendId;
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Review commit abc1234",
+      })),
+    };
+    const { registry, sessions } = createKimiAcpRegistry({
+      acpBackendId,
+      sessionId: "grok-review-launch",
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.materializeDirectoryLaunchpad({
+      directoryKey: "directory:/repo/PwrAgnt",
+      reviewTarget: { type: "commit", sha: "abc1234", title: "Fix homing" },
+      launchpad: {
+        directoryKey: "directory:/repo/PwrAgnt",
+        directoryKind: "directory",
+        directoryLabel: "PwrAgnt",
+        directoryPath: "/repo/PwrAgnt",
+        backend: acpBackendId,
+        executionMode: "default",
+        prompt: "/review --commit abc1234",
+        workMode: "local",
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+    });
+
+    await waitForCondition(() => titleService.generateTitle.mock.calls.length > 0);
+    expect(titleService.generateTitle).toHaveBeenCalledWith({
+      backend: acpBackendId,
+      threadId: "grok-review-launch",
+      userPrompt: expect.stringContaining("Review commit abc1234 (Fix homing)"),
+    });
+    expect(sessions.some((session) => session.hidden)).toBe(true);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4580,14 +4580,36 @@ describe("DesktopBackendRegistry", () => {
         completedAt: 3_000,
       },
     };
-    const usageActivity = {
+    const monitorUsageActivity = {
       type: "activity" as const,
-      id: "live-turn-usage-review-turn-1",
+      id: "monitor-usage-review-turn-1",
       summary:
         "Monitor usage: 50,310 uncached in · 509,952 cached · 9,959 out (8,762 reasoning) · $0.32 list price",
       status: "completed" as const,
       createdAt: 3_001,
       turn: { id: "review-turn-1", status: "completed" as const },
+      details: [],
+    };
+    // Turn-scope usage is persisted for ACP threads too. Merging it would
+    // also drag in the supersede rule that removes each turn's "Latest
+    // request usage" line, which is a transcript change for every ACP thread
+    // and not part of making managed review work.
+    const turnUsageActivity = {
+      type: "activity" as const,
+      id: "live-turn-usage-chat-turn-9",
+      summary: "Turn usage: 1,000 uncached in · 0 cached · 10 out",
+      status: "completed" as const,
+      createdAt: 3_500,
+      turn: { id: "chat-turn-9", status: "completed" as const },
+      details: [],
+    };
+    const latestRequestActivity = {
+      type: "activity" as const,
+      id: "live-token-usage-chat-turn-9",
+      summary: "Latest request usage: 1,000 uncached in · 0 cached · 10 out",
+      status: "completed" as const,
+      createdAt: 3_600,
+      turn: { id: "chat-turn-9", status: "completed" as const },
       details: [],
     };
     const { registry } = createKimiAcpRegistry({
@@ -4600,7 +4622,10 @@ describe("DesktopBackendRegistry", () => {
             executionMode: "default",
             extraLinkedDirectories: [],
             managedReviewEntries: [startedEntry, resultEntry],
-            immutableUsageActivities: [usageActivity],
+            immutableUsageActivities: [
+              monitorUsageActivity,
+              turnUsageActivity,
+            ],
           },
         },
       }),
@@ -4625,6 +4650,7 @@ describe("DesktopBackendRegistry", () => {
             text: "Can you summarize the review results for me?",
             createdAt: 4_000,
           },
+          latestRequestActivity,
         ],
         messages: [],
         pagination: { supportsPagination: false, hasPreviousPage: false },
@@ -4642,8 +4668,11 @@ describe("DesktopBackendRegistry", () => {
     expect(response.replay.entries.map((entry) => entry.id)).toEqual([
       startedEntry.id,
       resultEntry.id,
-      usageActivity.id,
+      monitorUsageActivity.id,
       "user-1",
+      // Untouched: no turn-scope usage spliced in, and the turn's live
+      // "Latest request usage" line is not superseded away.
+      latestRequestActivity.id,
     ]);
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/fixtures/grok-managed-review-session.json
+++ b/apps/desktop/src/main/__tests__/fixtures/grok-managed-review-session.json
@@ -1,0 +1,219 @@
+{
+  "source": "Captured from a live Grok Build (grok-4.5-build) PwrAgent /review run on 2026-08-08. Absolute paths and the operator home directory are rewritten; no credentials were present in the capture.",
+  "parentSessionId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9",
+  "reviewSessionId": "019fe2e2-4146-7561-b3cc-321d736935e8",
+  "reviewPrompt": "Perform a code review. Focus on concrete correctness regressions introduced by the requested changes. Do not modify files.\n\nReview the current checkout against base branch 'main'. Find the merge base and inspect the resulting diff.\n\nReturn only one JSON object with this exact top-level shape:\n{\"findings\":[],\"overall_correctness\":\"patch is correct\",\"overall_explanation\":\"...\",\"overall_confidence_score\":0.0}\nEach finding must contain title, body, confidence_score, optional priority (0-3), and code_location with absolute_file_path plus line_range.start/end.\nDo not wrap the JSON in Markdown fences and do not include prose outside it.",
+  "reviewAgentMessageChunks": [
+    "I'll review this branch against `main` by finding the merge base and inspecting the full diff for correctness regressions.",
+    "I'll inspect path normalization, call sites, and how `projectKey` / `linkedDirectories` are typed and used.",
+    "Checking one more edge case: whether `projectKey` is ever separator-normalized before matching.",
+    "{\"findings\":[{\"title\":\"Path separator normalization is wrong and can skip primary-project matching\",\"body\":\"normalizeFederatedPath uses replace(/\\\\\\\\/g, \\\"/\\\"), which only rewrites double-backslash sequences. Single Windows separators (\\\\) are left intact. The intended helper (and the near-identical normalizePath in backend-registry) uses replace(/\\\\/g, \\\"/\\\").\\n\\nlinkedDirectoryMatchesProjectKey relies on this normalization to decide whether projectKey identifies a linked directory. If projectKey and path/worktreePath differ only by separator style (common when one side was previously normalized with /\\\\/g and the other still carries raw Windows paths), the primary match fails, primaryProjectDirectory stays undefined, and the code falls back to local-before-worktree ordering—the exact mis-homing this patch is meant to fix. Equal same-separator paths still match, so the regression is conditional, but the helper as written does not implement the normalization it claims.\",\"confidence_score\":0.93,\"priority\":1,\"code_location\":{\"absolute_file_path\":\"/workspaces/wt/PwrAgnt/apps/desktop/src/main/ipc/app-server.ts\",\"line_range\":{\"start\":611,\"end\":614}}},{\"title\":\"findRemoteHomeDirectoryIndex lost null-safe linkedDirectories handling\",\"body\":\"Previously the second argument was linkedDirectories | undefined and was always expanded as [...(linkedDirectories ?? [])]. The new path reads thread.linkedDirectories with no fallback before .find and the spread/sort.\\n\\nNavigationThreadSummary types require linkedDirectories, but pin payloads are JSON-cast summaries (targetPin.summary / request.summary). A partial or older cached summary with projectKey set and missing linkedDirectories now throws TypeError inside findRemoteHomeDirectoryIndex instead of returning undefined. That can break addRemoteThreadPin visibility ranking (and attachRemoteThreadsToLocalDirectories if a remote row is similarly incomplete) where the old code degraded safely.\",\"confidence_score\":0.72,\"priority\":2,\"code_location\":{\"absolute_file_path\":\"/workspaces/wt/PwrAgnt/apps/desktop/src/main/ipc/app-server.ts\",\"line_range\":{\"start\":570,\"end\":583}}}],\"overall_correctness\":\"patch has issues\",\"overall_explanation\":\"The core fix is sound for the reported bug: when projectKey identifies a linked directory, that primary project is preferred over local-kind secondary links, and the new unit test covers the PwrAgent worktree + PwrSuiteLab local case. No broader architectural regressions stand out in the small diff. However, the new path-equality helper uses an incorrect backslash regex, so primary-project selection can silently fall back to the old wrong ordering when separators differ; null-safety around linkedDirectories was also weakened relative to the previous ?? [] path.\",\"overall_confidence_score\":0.86}"
+  ],
+  "reviewTurnCompleted": {
+    "sessionUpdate": "turn_completed",
+    "prompt_id": "82d073ef-3244-4a06-92eb-5012cc89cecd",
+    "stop_reason": "end_turn",
+    "usage": {
+      "inputTokens": 560262,
+      "outputTokens": 9959,
+      "totalTokens": 570221,
+      "cachedReadTokens": 509952,
+      "cacheCreationTokens": 0,
+      "reasoningTokens": 8762,
+      "modelCalls": 13,
+      "apiDurationMs": 162306,
+      "costUsdTicks": 3133596000,
+      "modelUsage": {
+        "grok-4.5-build": {
+          "inputTokens": 560262,
+          "outputTokens": 9959,
+          "totalTokens": 570221,
+          "cachedReadTokens": 509952,
+          "cacheCreationTokens": 0,
+          "reasoningTokens": 8762,
+          "modelCalls": 13,
+          "apiDurationMs": 162306,
+          "costUsdTicks": 3133596000
+        }
+      },
+      "numTurns": 13
+    }
+  },
+  "parentUpdates": [
+    {
+      "method": "_x.ai/session/update",
+      "params": {
+        "sessionId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9",
+        "update": {
+          "sessionUpdate": "turn_completed",
+          "prompt_id": "919afcda-d40d-411e-a729-5a94b0ed94ae",
+          "stop_reason": "end_turn"
+        },
+        "_meta": {
+          "eventId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9-5792",
+          "agentTimestampMs": 1786217906438
+        }
+      }
+    },
+    {
+      "method": "session/update",
+      "params": {
+        "sessionId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9",
+        "update": {
+          "sessionUpdate": "user_message_chunk",
+          "content": {
+            "type": "text",
+            "text": "/always-approve on"
+          },
+          "_meta": {
+            "hostTurn": true
+          }
+        },
+        "_meta": {
+          "eventId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9-5791",
+          "agentTimestampMs": 1786217906438
+        }
+      }
+    },
+    {
+      "method": "session/update",
+      "params": {
+        "sessionId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9",
+        "update": {
+          "sessionUpdate": "user_message_chunk",
+          "content": {
+            "type": "text",
+            "text": "[PwrAgent review sub-agent results — context for this turn]\n\nI'll review this branch against `main` by finding the merge base and inspecting the full diff for correctness regressions.I'll inspect path normalization, call sites, and how `projectKey` / `linkedDirectories` are typed and used.Checking one more edge case: whether `projectKey` is ever separator-normalized before matching.{\"findings\":[{\"title\":\"Path separator normalization is wrong and can skip primary-project matching\",\"body\":\"normalizeFederatedPath uses replace(/\\\\\\\\/g, \\\"/\\\"), which only rewrites double-backslash sequences. Single Windows separators (\\\\) are left intact. The intended helper (and the near-identical normalizePath in backend-registry) uses replace(/\\\\/g, \\\"/\\\").\\n\\nlinkedDirectoryMatchesProjectKey relies on this normalization to decide whether projectKey identifies a linked directory. If projectKey and path/worktreePath differ only by separator style (common when one side was previously normalized with /\\\\/g and the other still carries raw Windows paths), the primary match fails, primaryProjectDirectory stays undefined, and the code falls back to local-before-worktree ordering—the exact mis-homing this patch is meant to fix. Equal same-separator paths still match, so the regression is conditional, but the helper as written does not implement the normalization it claims.\",\"confidence_score\":0.93,\"priority\":1,\"code_location\":{\"absolute_file_path\":\"/workspaces/wt/PwrAgnt/apps/desktop/src/main/ipc/app-server.ts\",\"line_range\":{\"start\":611,\"end\":614}}},{\"title\":\"findRemoteHomeDirectoryIndex lost null-safe linkedDirectories handling\",\"body\":\"Previously the second argument was linkedDirectories | undefined and was always expanded as [...(linkedDirectories ?? [])]. The new path reads thread.linkedDirectories with no fallback before .find and the spread/sort.\\n\\nNavigationThreadSummary types require linkedDirectories, but pin payloads are JSON-cast summaries (targetPin.summary / request.summary). A partial or older cached summary with projectKey set and missing linkedDirectories now throws TypeError inside findRemoteHomeDirectoryIndex instead of returning undefined. That can break addRemoteThreadPin visibility ranking (and attachRemoteThreadsToLocalDirectories if a remote row is similarly incomplete) where the old code degraded safely.\",\"confidence_score\":0.72,\"priority\":2,\"code_location\":{\"absolute_file_path\":\"/workspaces/wt/PwrAgnt/apps/desktop/src/main/ipc/app-server.ts\",\"line_range\":{\"start\":570,\"end\":583}}}],\"overall_correctness\":\"patch has issues\",\"overall_explanation\":\"The core fix is sound for the reported bug: when projectKey identifies a linked directory, that primary project is preferred over local-kind secondary links, and the new unit test covers the PwrAgent worktree + PwrSuiteLab local case. No broader architectural regressions stand out in the small diff. However, the new path-equality helper uses an incorrect backslash regex, so primary-project selection can silently fall back to the old wrong ordering when separators differ; null-safety around linkedDirectories was also weakened relative to the previous ?? [] path.\",\"overall_confidence_score\":0.86}\n\n[End PwrAgent review sub-agent results]"
+          },
+          "_meta": {
+            "modelId": "grok-4.5",
+            "promptIndex": 0
+          }
+        },
+        "_meta": {
+          "eventId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9-6915",
+          "agentTimestampMs": 1786218260077
+        }
+      }
+    },
+    {
+      "method": "session/update",
+      "params": {
+        "sessionId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9",
+        "update": {
+          "sessionUpdate": "user_message_chunk",
+          "content": {
+            "type": "text",
+            "text": "Can you summarize the review results for me?"
+          },
+          "_meta": {
+            "modelId": "grok-4.5",
+            "promptIndex": 0
+          }
+        },
+        "_meta": {
+          "eventId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9-6916",
+          "agentTimestampMs": 1786218260077
+        }
+      }
+    },
+    {
+      "method": "session/update",
+      "params": {
+        "sessionId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9",
+        "update": {
+          "sessionUpdate": "agent_thought_chunk",
+          "content": {
+            "type": "text",
+            "text": "The user wants me to summarize the review results that were provided in the message. This is a straightforward summarization task - I don't need to dig into the code or make changes. Let me synthesize..."
+          }
+        },
+        "_meta": {
+          "totalTokens": 9785,
+          "eventId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9-6958",
+          "agentTimestampMs": 1786218261445,
+          "promptId": "fa8b29ac-a5ab-4c03-8758-1263662f5335",
+          "streamStartMs": 1786218260523,
+          "turnStartMs": 1786218260122,
+          "updateType": "AgentThoughtChunk",
+          "chunkId": 39
+        }
+      }
+    },
+    {
+      "method": "session/update",
+      "params": {
+        "sessionId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9",
+        "update": {
+          "sessionUpdate": "agent_message_chunk",
+          "content": {
+            "type": "text",
+            "text": "## Review summary\n\n**Overall:** The patch is directionally right for the remote-thread home bug, but the reviewer marked it as **having issues** (confidence ~0.86). The main risk is a broken path-separator helper that can undo the fix on Windows-style paths.\n\n### What’s solid\n- Preferring the **primary project** (`projectKey`) over local-kind secondary links is the right approach.\n- The unit test covers the intended case (PwrAgent worktree + PwrSuiteLab local).\n- No broader architectural problems in the small diff.\n\n### Finding 1 — Path normalization is wrong (priority 1, high confidence)\nIn `app-server.ts`, `normalizeFederatedPath` uses `replace(/\\\\\\\\/g, \"/\")`, which only rewrites **double** backslashes. It should use `replace(/\\\\/g, \"/\")` (single `\\`), matching the existing `normalizePath` in backend-registry.\n\n**Impact:** If `projectKey` and a linked path differ only by separator style (`\\` vs `/`), primary matching fails, `primaryProjectDirectory` stays undefined, and the code falls back to the old local-before-worktree order — the bug this branch is meant to fix.\n\n### Finding 2 — Weaker null-safety on `linkedDirectories` (priority 2, medium confidence)\n`findRemoteHomeDirectoryIndex` now reads `thread.linkedDirectories` without a `?? []` fallback.\n\n**Impact:** Typed summaries always have the field, but pin/attach payloads are JSON-cast. A partial summary with `projectKey` and missing `linkedDirectories` can throw instead of degrading safely, which could break pin ranking / attach paths.\n\n### Bottom line\nFix the regex (must-do). Restore optional `linkedDirectories` handling (should-do). After that, the core primary-project preference looks good."
+          }
+        },
+        "_meta": {
+          "totalTokens": 9785,
+          "eventId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9-7389",
+          "agentTimestampMs": 1786218266523,
+          "promptId": "fa8b29ac-a5ab-4c03-8758-1263662f5335",
+          "streamStartMs": 1786218260523,
+          "turnStartMs": 1786218260122,
+          "updateType": "AgentMessageChunk",
+          "chunkId": 427
+        }
+      }
+    },
+    {
+      "method": "_x.ai/session/update",
+      "params": {
+        "sessionId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9",
+        "update": {
+          "sessionUpdate": "turn_completed",
+          "prompt_id": "fa8b29ac-a5ab-4c03-8758-1263662f5335",
+          "stop_reason": "end_turn",
+          "usage": {
+            "inputTokens": 19988,
+            "outputTokens": 445,
+            "totalTokens": 20433,
+            "cachedReadTokens": 11264,
+            "cacheCreationTokens": 0,
+            "reasoningTokens": 53,
+            "modelCalls": 1,
+            "apiDurationMs": 6435,
+            "costUsdTicks": 234972000,
+            "modelUsage": {
+              "grok-4.5-build": {
+                "inputTokens": 19988,
+                "outputTokens": 445,
+                "totalTokens": 20433,
+                "cachedReadTokens": 11264,
+                "cacheCreationTokens": 0,
+                "reasoningTokens": 53,
+                "modelCalls": 1,
+                "apiDurationMs": 6435,
+                "costUsdTicks": 234972000
+              }
+            },
+            "numTurns": 1
+          }
+        },
+        "_meta": {
+          "eventId": "019fe2e2-3c86-7a50-b806-7f689c7b48b9-7391",
+          "agentTimestampMs": 1786218266561
+        }
+      }
+    }
+  ],
+  "liveOnlyUpdates": {
+    "note": "Grok marks these transient — they reach the client over the wire but are never written to updates.jsonl, so they are reconstructed here from the grok-build shapes (xai-grok-shell session/summary.rs and extensions/notification.rs) that produced the transcript entries in the bug report.",
+    "sessionInfoUpdate": {
+      "sessionUpdate": "session_info_update",
+      "title": "Summarize path normalization review findings"
+    },
+    "lastTurnSummary": {
+      "sessionUpdate": "last_turn_summary",
+      "summary": "Summarized the review findings",
+      "prompt_id": "919afcda-d40d-411e-a729-5a94b0ed94ae"
+    }
+  }
+}

--- a/apps/desktop/src/main/__tests__/managed-review.test.ts
+++ b/apps/desktop/src/main/__tests__/managed-review.test.ts
@@ -101,6 +101,73 @@ describe("managed review", () => {
     });
   });
 
+  describe("overall_correctness paraphrases", () => {
+    function parseWith(params: {
+      correctness: unknown;
+      withFinding?: boolean;
+    }) {
+      return parseManagedReviewOutput(JSON.stringify({
+        findings: params.withFinding
+          ? [{
+              title: "Off-by-one",
+              body: "The loop reads one past the end.",
+              confidence_score: 0.8,
+              code_location: {
+                absolute_file_path: "/repo/loop.ts",
+                line_range: { start: 1, end: 2 },
+              },
+            }]
+          : [],
+        overall_correctness: params.correctness,
+        overall_explanation: "…",
+        overall_confidence_score: 0.5,
+      }));
+    }
+
+    // The renderer paints anything that is not "patch is correct" as a red
+    // "Patch needs work" badge, so a clean review paraphrased as "no issues
+    // found" must not collapse to incorrect — that badge next to "0 findings"
+    // is worse than no structured output at all.
+    it.each([
+      "patch is correct",
+      "Patch Is Correct",
+      "correct",
+      "looks correct",
+      "no issues found",
+    ])("reads %j as correct", (correctness) => {
+      expect(parseWith({ correctness })?.overall_correctness).toBe(
+        "patch is correct",
+      );
+    });
+
+    it.each([
+      "patch is incorrect",
+      "patch has issues",
+      "incorrect",
+      "there are problems with this patch",
+      "patch is not correct",
+    ])("reads %j as incorrect", (correctness) => {
+      expect(parseWith({ correctness })?.overall_correctness).toBe(
+        "patch is incorrect",
+      );
+    });
+
+    it("breaks an unreadable phrase on whether findings were reported", () => {
+      expect(parseWith({ correctness: "¯\\_(ツ)_/¯" })?.overall_correctness)
+        .toBe("patch is correct");
+      expect(
+        parseWith({ correctness: "¯\\_(ツ)_/¯", withFinding: true })
+          ?.overall_correctness,
+      ).toBe("patch is incorrect");
+    });
+
+    it("still rejects an artifact with no correctness verdict at all", () => {
+      expect(parseWith({ correctness: undefined })).toBeUndefined();
+      expect(parseWith({ correctness: "   " })).toBeUndefined();
+      expect(parseWith({ correctness: 3 })).toBeUndefined();
+    });
+  });
+
   it("names the accepted overall_correctness values in the prompt", () => {
     const prompt = buildManagedReviewPrompt({ type: "uncommittedChanges" });
 

--- a/apps/desktop/src/main/__tests__/managed-review.test.ts
+++ b/apps/desktop/src/main/__tests__/managed-review.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   buildManagedReviewPrompt,
+  formatManagedReviewOutput,
   parseManagedReviewOutput,
 } from "../app-server/managed-review";
+import grokReviewSession from "./fixtures/grok-managed-review-session.json";
 
 describe("managed review", () => {
   it.each([
@@ -55,5 +57,54 @@ describe("managed review", () => {
       }],
       overall_correctness: "patch is incorrect",
     });
+  });
+
+  // Grok Build ignores "do not include prose outside it" and streams three
+  // narration chunks before the JSON object, then reports a third correctness
+  // phrase the original enum check rejected outright. Rejecting the artifact
+  // means the raw prose+JSON blob becomes the review text and gets replayed
+  // into the parent thread as a giant user message.
+  describe("Grok Build managed review artifact", () => {
+    const output = grokReviewSession.reviewAgentMessageChunks.join("\n\n");
+
+    it("keeps the prose narration Grok emits before the JSON object", () => {
+      expect(output).toContain("I'll review this branch against");
+      expect(output).toContain('"overall_correctness":"patch has issues"');
+    });
+
+    it("parses the artifact out of the surrounding narration", () => {
+      const parsed = parseManagedReviewOutput(output);
+
+      expect(parsed).toBeDefined();
+      expect(parsed?.overall_correctness).toBe("patch is incorrect");
+      expect(parsed?.overall_confidence_score).toBeCloseTo(0.86);
+      expect(parsed?.findings).toHaveLength(2);
+      expect(parsed?.findings[0]).toMatchObject({
+        priority: 1,
+        code_location: {
+          absolute_file_path:
+            "/workspaces/wt/PwrAgnt/apps/desktop/src/main/ipc/app-server.ts",
+          line_range: { start: 611, end: 614 },
+        },
+      });
+    });
+
+    it("formats the parsed artifact instead of replaying raw model output", () => {
+      const parsed = parseManagedReviewOutput(output);
+      const formatted = formatManagedReviewOutput(parsed!);
+
+      expect(formatted).not.toContain("I'll review this branch against");
+      expect(formatted).not.toContain('"findings"');
+      expect(formatted).toContain(
+        "[P1] Path separator normalization is wrong",
+      );
+    });
+  });
+
+  it("names the accepted overall_correctness values in the prompt", () => {
+    const prompt = buildManagedReviewPrompt({ type: "uncommittedChanges" });
+
+    expect(prompt).toContain('"patch is correct"');
+    expect(prompt).toContain('"patch is incorrect"');
   });
 });

--- a/apps/desktop/src/main/acp/acp-rollout-store.ts
+++ b/apps/desktop/src/main/acp/acp-rollout-store.ts
@@ -6,7 +6,9 @@ import {
 } from "@pwragent/shared";
 import {
   AcpSessionReplayNormalizer,
+  isAcpSessionMetadataUpdateKind,
   isAcpUserBoilerplateMessage,
+  isGrokTransientUpdateKind,
   readAcpContentText,
   readAcpTopicTitle,
   shouldSurfaceAcpThoughtsAsMessages,
@@ -260,6 +262,12 @@ function shouldPersistUpdate(update: Record<string, unknown>): boolean {
     kind === "current_mode_update" ||
     kind === "model_changed"
   ) {
+    return false;
+  }
+  // Session metadata and the provider's own transient bookkeeping describe the
+  // session, not the conversation. A title-less session_info_update carries no
+  // topic for the check below to catch, so match on the kind as well.
+  if (isAcpSessionMetadataUpdateKind(kind) || isGrokTransientUpdateKind(kind)) {
     return false;
   }
   if (readAcpTopicTitle(update)) {

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -10,6 +10,7 @@ import type {
   AppServerThreadTurnStatus,
   AppServerTranscriptPhase,
 } from "@pwragent/shared";
+import { stripManagedReviewContextBlock } from "../../shared/review-command.js";
 import {
   isGenericShellToolTitle,
   readAcpCodeSearch,
@@ -51,6 +52,18 @@ export function isGrokTransientUpdateKind(kind: string | undefined): boolean {
     // session metadata. It is not a second lifecycle event or transcript item.
     || kind === "last_turn_summary"
   );
+}
+
+/**
+ * ACP session metadata (`SessionUpdate::SessionInfoUpdate`) carries a session
+ * title and an activity timestamp — thread metadata, never transcript content.
+ * Grok Build sends it mid-turn, so treating it as an unknown update both
+ * littered the transcript and split the assistant message being streamed.
+ */
+export function isAcpSessionMetadataUpdateKind(
+  kind: string | undefined,
+): boolean {
+  return kind === "session_info_update";
 }
 
 export function readAcpToolCallId(
@@ -356,6 +369,9 @@ export class AcpSessionReplayNormalizer {
       // Grok emits these transient xAI extension updates in addition to the
       // canonical ACP tool calls and permission requests. They are transport
       // state, not transcript entries, and must not split assistant bubbles.
+    } else if (isAcpSessionMetadataUpdateKind(kind)) {
+      // Session title/timestamp metadata. The title is consumed by
+      // readAcpTopicTitle on the acp-client side.
     } else if (kind === "turn_completed") {
       // Grok persists this as a durable replay terminal, but emits it before
       // the live session/prompt request resolves. The client defers the live
@@ -462,10 +478,18 @@ export class AcpSessionReplayNormalizer {
   }
 
   private applyUserMessageChunk(update: AcpSessionUpdate, createdAt: number): void {
-    const text =
+    // PwrAgent prepends the finished managed-review artifact to the next
+    // prompt so the agent can reason about it. The transcript already shows
+    // that review as its own entry, so strip the block back out of the echo
+    // rather than rendering it as something the operator typed.
+    const text = stripManagedReviewContextBlock(
       readContentText(update.update, "content") ??
-      readString(update.update, "text") ??
-      "";
+        readString(update.update, "text") ??
+        "",
+    );
+    if (!text) {
+      return;
+    }
     if (isAcpUserBoilerplateMessage(text)) {
       // Gemini re-emits its <session_context> environment block (date, OS,
       // workspace dir, directory tree) as a user_message_chunk on session/load.
@@ -774,6 +798,15 @@ export function readAcpTopicTitle(
       readString(update, "sessionSummary")
     )?.trim();
     return summary || undefined;
+  }
+
+  // Standard ACP session metadata:
+  //   { sessionUpdate: "session_info_update", title?: string | null,
+  //     updatedAt?: string | null }
+  // `title` is a tri-state (absent / null-to-clear / string). Only a non-empty
+  // string names a topic; the other two carry no title to adopt.
+  if (isAcpSessionMetadataUpdateKind(sessionUpdate)) {
+    return readString(update, "title")?.trim() || undefined;
   }
 
   const kind = readString(update, "kind");

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8079,10 +8079,17 @@ export class DesktopBackendRegistry {
       threadId: request.threadId,
     });
     // A managed review runs in a hidden child session, so its transcript
-    // entries and usage activities live in this thread's overlay rather than
-    // in the provider's rollout. Splice them back in on the same terms as the
+    // entries and its usage line live in this thread's overlay rather than in
+    // the provider's rollout. Splice them back in on the same terms as the
     // Codex path: only for a live, turn-bearing read, never into an older
     // pagination page.
+    //
+    // Only monitor-scope usage is merged here. Turn-scope usage is persisted
+    // for ACP threads too, but merging it would also apply the Codex
+    // supersede rule that drops each turn's "Latest request usage" line — a
+    // transcript change for every ACP thread, well beyond managed review.
+    // Replaying turn-scope usage for ACP is worth doing deliberately, with
+    // its own tests; it is not this change.
     const appendTranscriptOverlays =
       !request.before && request.includeTurns !== false;
     const replayWithTranscriptOverlays = appendTranscriptOverlays
@@ -8091,7 +8098,9 @@ export class DesktopBackendRegistry {
             replay,
             entries: overlay?.managedReviewEntries,
           }),
-          activities: overlay?.immutableUsageActivities,
+          activities: overlay?.immutableUsageActivities?.filter(
+            (activity) => usageActivityScope(activity) === "monitor",
+          ),
         })
       : replay;
     const messageIds = [

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2348,6 +2348,38 @@ function reviewTaskLabel(target: StartReviewRequest["target"]): string {
   }
 }
 
+/**
+ * A thread launched straight from `/review` never runs a user turn, so the
+ * title generator has no prompt to name it from and the thread keeps its
+ * backend fallback ("ACP session", "New thread") forever. Synthesize the
+ * prompt from what the launch already knows — the review target plus the
+ * repository and branch it runs against — so the generated name reads like
+ * "Review remote thread homing against main" rather than a generic placeholder.
+ */
+function reviewThreadTitlePrompt(params: {
+  branchName?: string;
+  directoryLabel?: string;
+  target: StartReviewRequest["target"];
+}): string {
+  const target = params.target;
+  const lines = [
+    `Starting a code review: ${
+      target.type === "commit"
+        ? `Review commit ${target.sha}${target.title ? ` (${target.title})` : ""}`
+        : reviewTaskLabel(target)
+    }.`,
+  ];
+  const repository = params.directoryLabel?.trim();
+  if (repository) {
+    lines.push(`Repository: ${repository}.`);
+  }
+  const branch = params.branchName?.trim();
+  if (branch) {
+    lines.push(`Working branch: ${branch}.`);
+  }
+  return lines.join(" ");
+}
+
 function parseThreadTurnKeyBody(
   body: string,
 ): { threadId: string; turnId: string } | undefined {
@@ -8046,11 +8078,27 @@ export class DesktopBackendRegistry {
       backend,
       threadId: request.threadId,
     });
+    // A managed review runs in a hidden child session, so its transcript
+    // entries and usage activities live in this thread's overlay rather than
+    // in the provider's rollout. Splice them back in on the same terms as the
+    // Codex path: only for a live, turn-bearing read, never into an older
+    // pagination page.
+    const appendTranscriptOverlays =
+      !request.before && request.includeTurns !== false;
+    const replayWithTranscriptOverlays = appendTranscriptOverlays
+      ? mergeImmutableUsageActivities({
+          replay: mergeManagedReviewEntries({
+            replay,
+            entries: overlay?.managedReviewEntries,
+          }),
+          activities: overlay?.immutableUsageActivities,
+        })
+      : replay;
     const messageIds = [
-      ...replay.entries.flatMap((entry) =>
+      ...replayWithTranscriptOverlays.entries.flatMap((entry) =>
         entry.type === "message" && entry.role === "user" ? [entry.id] : [],
       ),
-      ...replay.messages.flatMap((message) =>
+      ...replayWithTranscriptOverlays.messages.flatMap((message) =>
         message.role === "user" ? [message.id] : [],
       ),
     ];
@@ -8064,11 +8112,11 @@ export class DesktopBackendRegistry {
         : {};
     const messageOrigins = inferLegacyTaskMonitorMessageOrigins({
       origins: persistedMessageOrigins,
-      replay,
+      replay: replayWithTranscriptOverlays,
       subAgents: overlay?.subAgents,
     });
     const replayWithMessageOrigins = mergeThreadMessageOrigins(
-      replay,
+      replayWithTranscriptOverlays,
       messageOrigins,
     );
     const pricing =
@@ -16091,7 +16139,16 @@ export class DesktopBackendRegistry {
         this.scheduleThreadTitleGeneration({
           backend: launchpad.backend,
           threadId: startThreadResponse.threadId,
-          input,
+          input: request.reviewTarget
+            ? [{
+                type: "text",
+                text: reviewThreadTitlePrompt({
+                  branchName: launchpad.branchName,
+                  directoryLabel: launchpad.directoryLabel,
+                  target: request.reviewTarget,
+                }),
+              }]
+            : input,
         });
       } catch (error) {
         await this.overlayStore.setThreadScheduledStart({
@@ -16118,6 +16175,20 @@ export class DesktopBackendRegistry {
           fastMode: launchpad.backend === "codex" ? launchpad.fastMode : undefined,
         });
         turnId = reviewResponse.turnId;
+        // A review is the thread's whole first turn. Nothing else will supply
+        // a prompt to name it from, so name it from the review target here.
+        this.scheduleThreadTitleGeneration({
+          backend: launchpad.backend,
+          threadId: startThreadResponse.threadId,
+          input: [{
+            type: "text",
+            text: reviewThreadTitlePrompt({
+              branchName: launchpad.branchName,
+              directoryLabel: launchpad.directoryLabel,
+              target: request.reviewTarget,
+            }),
+          }],
+        });
       } catch (error) {
         turnStartFailure = {
           message: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/app-server/managed-review.ts
+++ b/apps/desktop/src/main/app-server/managed-review.ts
@@ -59,12 +59,10 @@ export function parseManagedReviewOutput(
   if (!record) {
     return undefined;
   }
-  const overallCorrectness = normalizeOverallCorrectness(
-    record.overall_correctness,
-  );
   if (
     !Array.isArray(record.findings)
-    || overallCorrectness === undefined
+    || typeof record.overall_correctness !== "string"
+    || !record.overall_correctness.trim()
     || typeof record.overall_explanation !== "string"
     || typeof record.overall_confidence_score !== "number"
   ) {
@@ -109,7 +107,10 @@ export function parseManagedReviewOutput(
 
   return {
     findings,
-    overall_correctness: overallCorrectness,
+    overall_correctness: normalizeOverallCorrectness(
+      record.overall_correctness,
+      findings,
+    ),
     overall_explanation: record.overall_explanation,
     overall_confidence_score: record.overall_confidence_score,
   };
@@ -146,22 +147,37 @@ function readReviewArtifactObject(
 /**
  * Codex review/start answers with exactly the two documented phrases. Other
  * agents paraphrase — Grok Build reports "patch has issues" — and an artifact
- * with real findings is worth more than the exact wording, so anything that is
- * not an affirmative "correct" reading collapses to "patch is incorrect".
+ * with real findings is worth more than the exact wording.
+ *
+ * Both directions have to be read, not just the negative one: the renderer
+ * paints anything that is not "patch is correct" as a red "Patch needs work"
+ * badge, so mapping an unrecognized-but-clean verdict to incorrect puts that
+ * badge next to a "0 findings" badge. When the wording says nothing either
+ * way, the findings list is the more trustworthy signal.
  */
 function normalizeOverallCorrectness(
-  value: unknown,
-): AppServerReviewOutput["overall_correctness"] | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
+  value: string,
+  findings: AppServerReviewOutput["findings"],
+): AppServerReviewOutput["overall_correctness"] {
   const normalized = value.trim().toLowerCase();
-  if (!normalized) {
-    return undefined;
+  const negation = String.raw`\b(no|not|without|zero|free of)\b[^.]{0,20}?`;
+  const fault = String.raw`\b(incorrect|issues?|problems?|bugs?|defects?)\b`;
+  const clean = String.raw`\b(correct|fine|good|ok|okay)\b`;
+  // "no issues found" names the fault word to deny it; "not correct" does the
+  // same to the clean word. Check both denials before either bare match.
+  if (new RegExp(negation + fault).test(normalized)) {
+    return "patch is correct";
   }
-  return normalized === "patch is correct"
-    ? "patch is correct"
-    : "patch is incorrect";
+  if (new RegExp(negation + clean).test(normalized)) {
+    return "patch is incorrect";
+  }
+  if (new RegExp(fault).test(normalized)) {
+    return "patch is incorrect";
+  }
+  if (new RegExp(clean).test(normalized)) {
+    return "patch is correct";
+  }
+  return findings.length > 0 ? "patch is incorrect" : "patch is correct";
 }
 
 export function formatManagedReviewOutput(

--- a/apps/desktop/src/main/app-server/managed-review.ts
+++ b/apps/desktop/src/main/app-server/managed-review.ts
@@ -2,10 +2,15 @@ import type {
   AppServerReviewOutput,
   AppServerReviewTarget,
 } from "@pwragent/shared";
+import {
+  MANAGED_REVIEW_CONTEXT_CLOSE_MARKER,
+  MANAGED_REVIEW_CONTEXT_OPEN_MARKER,
+} from "../../shared/review-command";
 
 const REVIEW_OUTPUT_INSTRUCTIONS = [
   "Return only one JSON object with this exact top-level shape:",
   '{"findings":[],"overall_correctness":"patch is correct","overall_explanation":"...","overall_confidence_score":0.0}',
+  'overall_correctness must be exactly "patch is correct" or "patch is incorrect" — no other wording.',
   "Each finding must contain title, body, confidence_score, optional priority (0-3), and code_location with absolute_file_path plus line_range.start/end.",
   "Do not wrap the JSON in Markdown fences and do not include prose outside it.",
 ].join("\n");
@@ -22,12 +27,12 @@ export function buildManagedReviewPrompt(
 
 export function buildManagedReviewContextInput(outputs: string[]): string {
   return [
-    "[PwrAgent review sub-agent results — context for this turn]",
+    MANAGED_REVIEW_CONTEXT_OPEN_MARKER,
     ...outputs.map((output, index) => [
       outputs.length > 1 ? `Review ${index + 1}:` : undefined,
       output.trim(),
     ].filter((line): line is string => Boolean(line)).join("\n")),
-    "[End PwrAgent review sub-agent results]",
+    MANAGED_REVIEW_CONTEXT_CLOSE_MARKER,
   ].join("\n\n");
 }
 
@@ -50,23 +55,16 @@ export function parseManagedReviewOutput(
   if (!text?.trim()) {
     return undefined;
   }
-  const source = unwrapJsonFence(text.trim());
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(source);
-  } catch {
+  const record = readReviewArtifactObject(text.trim());
+  if (!record) {
     return undefined;
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return undefined;
-  }
-  const record = parsed as Record<string, unknown>;
+  const overallCorrectness = normalizeOverallCorrectness(
+    record.overall_correctness,
+  );
   if (
     !Array.isArray(record.findings)
-    || (
-      record.overall_correctness !== "patch is correct"
-      && record.overall_correctness !== "patch is incorrect"
-    )
+    || overallCorrectness === undefined
     || typeof record.overall_explanation !== "string"
     || typeof record.overall_confidence_score !== "number"
   ) {
@@ -111,10 +109,59 @@ export function parseManagedReviewOutput(
 
   return {
     findings,
-    overall_correctness: record.overall_correctness,
+    overall_correctness: overallCorrectness,
     overall_explanation: record.overall_explanation,
     overall_confidence_score: record.overall_confidence_score,
   };
+}
+
+/**
+ * The prompt asks for a bare JSON object and nothing else. Grok Build streams
+ * two or three narration sentences first ("I'll review this branch against
+ * `main`…") and only then the object, so the artifact has to be recovered from
+ * the surrounding prose. Failing that recovery is not cosmetic: the unparsed
+ * blob becomes the review text and is replayed verbatim into the parent thread
+ * as the next turn's context.
+ */
+function readReviewArtifactObject(
+  text: string,
+): Record<string, unknown> | undefined {
+  for (const candidate of [unwrapJsonFence(text), extractJsonObject(text)]) {
+    if (!candidate) {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Codex review/start answers with exactly the two documented phrases. Other
+ * agents paraphrase — Grok Build reports "patch has issues" — and an artifact
+ * with real findings is worth more than the exact wording, so anything that is
+ * not an affirmative "correct" reading collapses to "patch is incorrect".
+ */
+function normalizeOverallCorrectness(
+  value: unknown,
+): AppServerReviewOutput["overall_correctness"] | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized === "patch is correct"
+    ? "patch is correct"
+    : "patch is incorrect";
 }
 
 export function formatManagedReviewOutput(
@@ -143,6 +190,12 @@ export function formatManagedReviewOutput(
 function unwrapJsonFence(value: string): string {
   const match = value.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
   return match?.[1]?.trim() ?? value;
+}
+
+function extractJsonObject(value: string): string {
+  const start = value.indexOf("{");
+  const end = value.lastIndexOf("}");
+  return start === -1 || end <= start ? "" : value.slice(start, end + 1);
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/apps/desktop/src/shared/review-command.ts
+++ b/apps/desktop/src/shared/review-command.ts
@@ -18,6 +18,40 @@ export function formatReviewCommand(target: AppServerReviewTarget): string {
   return `/review --custom ${target.instructions}`;
 }
 
+/**
+ * Delimiters wrapping the managed-review artifact that PwrAgent prepends to the
+ * next prompt after a review finishes. The agent needs the text in its context
+ * window; the operator does not need to read it in the transcript, and ACP
+ * agents echo every prompt back as a `user_message_chunk`. Both the writer
+ * (`buildManagedReviewContextInput`) and the transcript filter
+ * (`stripManagedReviewContextBlock`) key off these exact strings — change one
+ * and the block starts rendering as a user message again.
+ */
+export const MANAGED_REVIEW_CONTEXT_OPEN_MARKER =
+  "[PwrAgent review sub-agent results — context for this turn]";
+export const MANAGED_REVIEW_CONTEXT_CLOSE_MARKER =
+  "[End PwrAgent review sub-agent results]";
+
+/**
+ * Removes the wrapped review-context block from prompt text meant for display.
+ * Returns the remaining operator-authored text, or an empty string when the
+ * block was the whole message.
+ */
+export function stripManagedReviewContextBlock(value: string): string {
+  const start = value.indexOf(MANAGED_REVIEW_CONTEXT_OPEN_MARKER);
+  if (start === -1) {
+    return value;
+  }
+  const closeAt = value.indexOf(MANAGED_REVIEW_CONTEXT_CLOSE_MARKER, start);
+  // An unterminated block means the whole tail is review context — a truncated
+  // or still-streaming echo. Dropping it beats rendering half an artifact.
+  const end =
+    closeAt === -1
+      ? value.length
+      : closeAt + MANAGED_REVIEW_CONTEXT_CLOSE_MARKER.length;
+  return `${value.slice(0, start)}${value.slice(end)}`.trim();
+}
+
 export function normalizeReviewDisplayText(value: string): string {
   const normalized = value.trim().replace(/\s+/g, " ");
   if (!normalized) {

--- a/apps/desktop/src/shared/review-command.ts
+++ b/apps/desktop/src/shared/review-command.ts
@@ -36,13 +36,23 @@ export const MANAGED_REVIEW_CONTEXT_CLOSE_MARKER =
  * Removes the wrapped review-context block from prompt text meant for display.
  * Returns the remaining operator-authored text, or an empty string when the
  * block was the whole message.
+ *
+ * Handles a block split across streamed chunks in either direction: a chunk
+ * holding only the opening half drops its whole tail, and a chunk holding only
+ * the closing half drops everything up to and including the close marker.
+ * Without the second case the artifact's tail renders as a user message.
  */
 export function stripManagedReviewContextBlock(value: string): string {
   const start = value.indexOf(MANAGED_REVIEW_CONTEXT_OPEN_MARKER);
+  const closeAt = value.indexOf(
+    MANAGED_REVIEW_CONTEXT_CLOSE_MARKER,
+    start === -1 ? 0 : start,
+  );
   if (start === -1) {
-    return value;
+    return closeAt === -1
+      ? value
+      : value.slice(closeAt + MANAGED_REVIEW_CONTEXT_CLOSE_MARKER.length).trim();
   }
-  const closeAt = value.indexOf(MANAGED_REVIEW_CONTEXT_CLOSE_MARKER, start);
   // An unterminated block means the whole tail is review context — a truncated
   // or still-streaming echo. Dropping it beats rendering half an artifact.
   const end =


### PR DESCRIPTION
Enabling `managedReview` for Grok (#1386) was a one-line capability flip that turned on a review pipeline which had only ever run against Codex. Every stage after "start the review" was broken.

I captured the live Grok Build `/review` run from the bug report and drove each fix from it. The sanitized capture ships as [`grok-managed-review-session.json`](apps/desktop/src/main/__tests__/fixtures/grok-managed-review-session.json) (paths and the operator home rewritten; no credentials were in the capture) and backs an end-to-end replay test of the failing turn.

## What was broken

### `session_info_update` broke the transcript

Grok emits ACP's own `SessionUpdate::SessionInfoUpdate` mid-turn. The normalizer had no branch for it, so the unknown-update fallback both dropped an `ACP update: session_info_update` / "Unknown ACP session update" activity into the transcript **and** cleared `activeAssistantMessageId` — splitting the reply the operator was watching get written into two bubbles.

It carries `title` and `updatedAt` and nothing else: thread metadata, never transcript content. It is now handled as metadata, and its title flows through `readAcpTopicTitle` the same way Grok's `session_summary_generated` does. Grok's transient `last_turn_summary` (its own dashboard-row recap) was hitting the same fallback and got the same treatment. Neither is persisted to the rollout any more.

> One correction to the report: `session_info_update` is not the Context Usage payload. ACP's context-window/cost update is the separate unstable `usage_update` variant, and grok-build does not emit it.

### The review artifact never parsed

`parseManagedReviewOutput` required a bare JSON object and one of exactly two `overall_correctness` phrases. Grok streams three narration sentences before the object and answered `"patch has issues"`. Both checks failed, so the raw prose+JSON blob became the review text — which is what got replayed into the parent thread.

The artifact is now recovered from surrounding prose, non-canonical correctness phrasing collapses to `"patch is incorrect"`, and the prompt explicitly names the two accepted values.

### The review left no trace in the thread

`readThread` short-circuits to `readAcpThread` for ACP backends, and that path never merged the overlay's `managedReviewEntries` or `immutableUsageActivities`. The "Starting review" entry and the result entry were written to the overlay correctly and then thrown away on every read. `readAcpThread` now merges them on the same terms as the Codex path — live, turn-bearing reads only, never spliced into an older pagination page.

### The injected review context rendered as a giant user message

The finished artifact is prepended to the next prompt so the agent can reason about it, and Grok echoes every prompt back as a `user_message_chunk`. The wrapper's delimiters move to `shared/review-command` alongside a `stripManagedReviewContextBlock` helper, and the normalizer strips the block out of the echo. Text the operator typed in the same chunk is preserved.

### A `/review` launch never named its thread

`materializeDirectoryLaunchpad` calls `startReview` and returns; nothing scheduled title generation, so a review-launched thread kept its backend fallback (`ACP session`) forever. It now synthesizes a naming prompt from the review target plus the repository and branch, on both the immediate and scheduled paths.

## Testing

- `pnpm test` — 491 files, 6920 passed, 2 skipped
- `pnpm --filter @pwragent/desktop typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries` (no violations)

Each fix landed test-first; the new tests were confirmed failing against the current behavior before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)