### PR TITLE
fix(desktop): populate ACP slash commands on unborn threads

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-available-commands-store.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-available-commands-store.test.ts
@@ -70,7 +70,33 @@ describe("AcpAvailableCommandsStore", () => {
     });
   });
 
-  it("adds its table to a profile database that predates it", () => {
+  it("prunes rows for repositories nothing has re-observed", () => {
+    const now = Date.UTC(2026, 7, 8);
+    const retentionMs = 90 * 24 * 60 * 60 * 1000;
+    store.upsert({
+      backendId: "acp:grok",
+      repositoryPath: "/stale-repo",
+      commands: COMMANDS,
+      observedAt: now - retentionMs - 1,
+    });
+    store.upsert({
+      backendId: "acp:grok",
+      repositoryPath: "/live-repo",
+      commands: COMMANDS,
+      observedAt: now - retentionMs + 1,
+    });
+
+    stateDb.cleanupExpired(now);
+
+    expect(store.get("acp:grok", "/stale-repo")).toBeUndefined();
+    expect(store.get("acp:grok", "/live-repo")?.commands).toEqual(COMMANDS);
+  });
+
+  // The v50 migration block is belt-and-braces: `ensureCurrentSchema` runs
+  // ahead of it on every open and already carries this table's DDL. What is
+  // worth pinning is the observable outcome — an older profile database gains
+  // the table and lands on the current user_version.
+  it("converges an older profile database onto the current schema", () => {
     const dbPath = path.join(tempDir, "migrated.db");
     const seeded = StateDb.open(dbPath);
     seeded.raw.exec("DROP TABLE acp_available_commands");

--- a/apps/desktop/src/main/__tests__/acp-available-commands-store.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-available-commands-store.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AppServerAvailableCommandSummary } from "@pwragent/shared";
+import { AcpAvailableCommandsStore } from "../acp/acp-available-commands-store";
+import { CURRENT_STATE_DB_USER_VERSION, StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let tempDir: string;
+let store: AcpAvailableCommandsStore;
+
+const COMMANDS: AppServerAvailableCommandSummary[] = [
+  {
+    name: "compact",
+    description: "Compact this thread's context.",
+    backend: "acp:grok",
+    scope: "session",
+    source: "provider",
+  },
+];
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-acp-commands-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new AcpAvailableCommandsStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("AcpAvailableCommandsStore", () => {
+  it("round-trips commands for an agent and repository", () => {
+    store.upsert({
+      backendId: "acp:grok",
+      repositoryPath: "/repo",
+      commands: COMMANDS,
+      observedAt: 1234,
+    });
+
+    expect(store.get("acp:grok", "/repo")).toEqual({
+      backendId: "acp:grok",
+      repositoryPath: "/repo",
+      commands: COMMANDS,
+      observedAt: 1234,
+    });
+  });
+
+  it("keeps one row per agent and repository, newest write winning", () => {
+    store.upsert({
+      backendId: "acp:grok",
+      repositoryPath: "/repo",
+      commands: COMMANDS,
+      observedAt: 1000,
+    });
+    store.upsert({
+      backendId: "acp:grok",
+      repositoryPath: "/repo",
+      commands: [],
+      observedAt: 2000,
+    });
+
+    expect(store.get("acp:grok", "/repo")).toEqual({
+      backendId: "acp:grok",
+      repositoryPath: "/repo",
+      commands: [],
+      observedAt: 2000,
+    });
+  });
+
+  it("adds its table to a profile database that predates it", () => {
+    const dbPath = path.join(tempDir, "migrated.db");
+    const seeded = StateDb.open(dbPath);
+    seeded.raw.exec("DROP TABLE acp_available_commands");
+    seeded.raw.pragma("user_version = 49");
+    seeded.close();
+
+    const migrated = StateDb.open(dbPath);
+    try {
+      expect(migrated.raw.pragma("user_version", { simple: true })).toBe(
+        CURRENT_STATE_DB_USER_VERSION,
+      );
+      const migratedStore = new AcpAvailableCommandsStore(migrated);
+      migratedStore.upsert({
+        backendId: "acp:grok",
+        repositoryPath: "/repo",
+        commands: COMMANDS,
+        observedAt: 1000,
+      });
+      expect(migratedStore.get("acp:grok", "/repo")?.commands).toEqual(COMMANDS);
+    } finally {
+      migrated.close();
+    }
+  });
+
+  it("scopes rows by agent and by repository", () => {
+    store.upsert({
+      backendId: "acp:grok",
+      repositoryPath: "/repo",
+      commands: COMMANDS,
+      observedAt: 1000,
+    });
+
+    expect(store.get("acp:kimi", "/repo")).toBeUndefined();
+    expect(store.get("acp:grok", "/other-repo")).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -70,6 +70,7 @@ import {
   DesktopBackendRegistry,
   getCodexFastModeMismatchWarning,
 } from "../app-server/backend-registry";
+import type { AcpAvailableCommandsRecord } from "../acp/acp-available-commands-store";
 import {
   CodexEnvironmentCommandError,
   type CodexEnvironmentCommandRunner,
@@ -2112,6 +2113,11 @@ function createKimiAcpRegistry(options?: {
   acpWorktreeRepositoryResolver?: (
     cwd: string,
   ) => Promise<LinkedDirectorySummary | undefined>;
+  acpAvailableCommandsStore?: ReturnType<
+    typeof createAcpAvailableCommandsStoreMock
+  > | null;
+  acpAvailableCommandProbeTimeoutMs?: number;
+  availableCommandsOnSessionStart?: AppServerAvailableCommandSummary[];
 }) {
   const acpBackendId =
     options?.installedAgent?.backendId
@@ -2161,6 +2167,11 @@ function createKimiAcpRegistry(options?: {
         executionMode: params.executionMode,
         ...(params.acpRuntime ? { acpRuntime: params.acpRuntime } : {}),
         ...(params.hidden ? { hidden: true } : {}),
+        // Agents advertise their commands over `session/update`, which can
+        // land while `session/new` is still resolving.
+        ...(options?.availableCommandsOnSessionStart
+          ? { availableCommands: options.availableCommandsOnSessionStart }
+          : {}),
         status: "idle",
       };
       sessions.push(metadata);
@@ -2198,6 +2209,9 @@ function createKimiAcpRegistry(options?: {
     ...(options?.threadTitleGenerationService
       ? { threadTitleGenerationService: options.threadTitleGenerationService }
       : {}),
+    acpAvailableCommandsStore: options?.acpAvailableCommandsStore,
+    acpAvailableCommandProbeTimeoutMs:
+      options?.acpAvailableCommandProbeTimeoutMs,
   });
   return {
     acpBackendId,
@@ -2206,6 +2220,42 @@ function createKimiAcpRegistry(options?: {
     sendControlPrompt,
     sessions,
     startPrompt,
+  };
+}
+
+/**
+ * Match how the registry keys the ACP command cache: an absolute, forward-
+ * slashed path. `path.resolve` differs per platform, so tests must not hardcode
+ * the POSIX form of a repo root.
+ */
+function toTestRepositoryPath(value: string): string {
+  return path.resolve(value).replace(/\\/g, "/");
+}
+
+function createAcpAvailableCommandsStoreMock(
+  records: AcpAvailableCommandsRecord[] = [],
+) {
+  return {
+    records,
+    get: vi.fn((backendId: string, repositoryPath: string) =>
+      records.find(
+        (record) =>
+          record.backendId === backendId
+          && record.repositoryPath === repositoryPath,
+      ),
+    ),
+    upsert: vi.fn((record: AcpAvailableCommandsRecord) => {
+      const index = records.findIndex(
+        (candidate) =>
+          candidate.backendId === record.backendId
+          && candidate.repositoryPath === record.repositoryPath,
+      );
+      if (index === -1) {
+        records.push(record);
+      } else {
+        records[index] = record;
+      }
+    }),
   };
 }
 
@@ -3143,6 +3193,290 @@ describe("DesktopBackendRegistry", () => {
         },
       ],
     });
+  });
+
+  it("serves cached ACP provider commands to a launchpad draft with no thread", async () => {
+    const repositoryPath = toTestRepositoryPath("/repo");
+    const commands: AppServerAvailableCommandSummary[] = [
+      {
+        name: "compact",
+        description: "Compact this thread's context.",
+        backend: "acp:grok",
+        scope: "session",
+        source: "provider",
+      },
+    ];
+    const acpAvailableCommandsStore = createAcpAvailableCommandsStoreMock([
+      {
+        backendId: "acp:grok",
+        repositoryPath,
+        commands,
+        observedAt: 1000,
+      },
+    ]);
+    const { registry, acpClient } = createKimiAcpRegistry({
+      acpBackendId: "acp:grok" as AcpBackendId,
+      acpAvailableCommandsStore,
+    });
+
+    await expect(
+      registry.listSkills({
+        backend: "acp:grok" as AppServerBackendKind,
+        cwd: "/repo",
+        cwds: ["/repo"],
+      }),
+    ).resolves.toEqual({
+      data: [{ skills: [], commands }],
+    });
+    // Cache hit — no throwaway session, so no agent process spawn.
+    expect(acpClient.startSession).not.toHaveBeenCalled();
+  });
+
+  it("keys ACP launchpad commands on the repository behind a worktree cwd", async () => {
+    // A born thread running in a worktree and a draft sitting on the checkout
+    // must resolve to the same cache row: commands belong to the repo, and a
+    // `workMode: "worktree"` draft's directoryPath is the source checkout the
+    // worktree has not been cut from yet.
+    const repositoryPath = toTestRepositoryPath("/repo");
+    const worktreePath = toTestRepositoryPath("/worktrees/ab12/repo");
+    const commands: AppServerAvailableCommandSummary[] = [
+      {
+        name: "review",
+        backend: "acp:grok",
+        scope: "session",
+        source: "provider",
+      },
+    ];
+    const acpAvailableCommandsStore = createAcpAvailableCommandsStoreMock([
+      {
+        backendId: "acp:grok",
+        repositoryPath,
+        commands,
+        observedAt: 1000,
+      },
+    ]);
+    const { registry, acpClient } = createKimiAcpRegistry({
+      acpBackendId: "acp:grok" as AcpBackendId,
+      acpAvailableCommandsStore,
+      acpWorktreeRepositoryResolver: async (cwd) =>
+        path.resolve(cwd) === path.resolve(worktreePath)
+          ? {
+              id: repositoryPath,
+              path: repositoryPath,
+              worktreePath,
+              label: "repo",
+              kind: "worktree",
+            }
+          : undefined,
+    });
+
+    await expect(
+      registry.listSkills({
+        backend: "acp:grok" as AppServerBackendKind,
+        cwd: worktreePath,
+        cwds: [worktreePath],
+      }),
+    ).resolves.toEqual({
+      data: [{ skills: [], commands }],
+    });
+    expect(acpClient.startSession).not.toHaveBeenCalled();
+  });
+
+  it("probes once for an ACP repo it has never observed commands for", async () => {
+    const repositoryPath = toTestRepositoryPath("/repo");
+    const availableCommands: AppServerAvailableCommandSummary[] = [
+      {
+        name: "compact",
+        backend: "acp:grok",
+        scope: "session",
+        source: "provider",
+      },
+    ];
+    const acpAvailableCommandsStore = createAcpAvailableCommandsStoreMock();
+    const { registry, acpClient, sessions } = createKimiAcpRegistry({
+      acpBackendId: "acp:grok" as AcpBackendId,
+      acpAvailableCommandsStore,
+      availableCommandsOnSessionStart: availableCommands,
+    });
+
+    // A burst of composer keystrokes, all before the first probe resolves.
+    const responses = await Promise.all([
+      registry.listSkills({
+        backend: "acp:grok" as AppServerBackendKind,
+        cwd: "/repo",
+        cwds: ["/repo"],
+      }),
+      registry.listSkills({
+        backend: "acp:grok" as AppServerBackendKind,
+        cwd: "/repo",
+        cwds: ["/repo"],
+      }),
+    ]);
+
+    for (const response of responses) {
+      expect(response).toEqual({
+        data: [{ skills: [], commands: availableCommands }],
+      });
+    }
+    expect(acpClient.startSession).toHaveBeenCalledTimes(1);
+    expect(acpClient.startSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: repositoryPath,
+        hidden: true,
+        mcpServers: "none",
+      }),
+    );
+    // The throwaway session stays out of every thread list.
+    expect(sessions.every((session) => session.hidden)).toBe(true);
+
+    // Cached now, so a later draft in the same repo costs nothing.
+    await expect(
+      registry.listSkills({
+        backend: "acp:grok" as AppServerBackendKind,
+        cwd: "/repo",
+        cwds: ["/repo"],
+      }),
+    ).resolves.toEqual({
+      data: [{ skills: [], commands: availableCommands }],
+    });
+    expect(acpClient.startSession).toHaveBeenCalledTimes(1);
+    expect(acpAvailableCommandsStore.records).toEqual([
+      expect.objectContaining({
+        backendId: "acp:grok",
+        repositoryPath,
+        commands: availableCommands,
+      }),
+    ]);
+  });
+
+  it("records an ACP agent that advertises nothing instead of re-probing it", async () => {
+    const repositoryPath = toTestRepositoryPath("/repo");
+    const acpAvailableCommandsStore = createAcpAvailableCommandsStoreMock();
+    const { registry, acpClient } = createKimiAcpRegistry({
+      acpBackendId: "acp:grok" as AcpBackendId,
+      acpAvailableCommandsStore,
+      acpAvailableCommandProbeTimeoutMs: 1,
+    });
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await expect(
+        registry.listSkills({
+          backend: "acp:grok" as AppServerBackendKind,
+          cwd: "/repo",
+          cwds: ["/repo"],
+        }),
+      ).resolves.toEqual({ data: [{ skills: [], commands: [] }] });
+    }
+
+    expect(acpClient.startSession).toHaveBeenCalledTimes(1);
+    expect(acpAvailableCommandsStore.records).toEqual([
+      expect.objectContaining({ repositoryPath, commands: [] }),
+    ]);
+  });
+
+  it("backs off ACP command probes with no cache to remember the miss", async () => {
+    const { registry, acpClient } = createKimiAcpRegistry({
+      acpBackendId: "acp:grok" as AcpBackendId,
+      acpAvailableCommandsStore: null,
+      acpAvailableCommandProbeTimeoutMs: 1,
+    });
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await expect(
+        registry.listSkills({
+          backend: "acp:grok" as AppServerBackendKind,
+          cwd: "/repo",
+          cwds: ["/repo"],
+        }),
+      ).resolves.toEqual({ data: [{ skills: [], commands: [] }] });
+    }
+
+    expect(acpClient.startSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches ACP commands reported by a live session under its repository", async () => {
+    const repositoryPath = toTestRepositoryPath("/repo");
+    const worktreePath = toTestRepositoryPath("/worktrees/ab12/repo");
+    const commands: AppServerAvailableCommandSummary[] = [
+      {
+        name: "compact",
+        backend: "acp:grok",
+        scope: "session",
+        source: "provider",
+      },
+    ];
+    const acpAvailableCommandsStore = createAcpAvailableCommandsStoreMock();
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId: "acp:grok" as AcpBackendId,
+      acpAvailableCommandsStore,
+      sessionId: "grok-session-1",
+      sessions: [
+        {
+          backendId: "acp:grok" as AcpBackendId,
+          sessionId: "grok-session-1",
+          title: "Grok session",
+          cwd: worktreePath,
+          createdAt: 1000,
+          updatedAt: 1000,
+          executionMode: "default",
+          status: "idle",
+        },
+      ],
+      acpWorktreeRepositoryResolver: async (cwd) =>
+        path.resolve(cwd) === path.resolve(worktreePath)
+          ? {
+              id: repositoryPath,
+              path: repositoryPath,
+              worktreePath,
+              label: "repo",
+              kind: "worktree",
+            }
+          : undefined,
+    });
+
+    (
+      registry as unknown as {
+        rememberAcpAvailableCommands(event: AgentEvent): void;
+      }
+    ).rememberAcpAvailableCommands({
+      backend: "acp:grok" as AppServerBackendKind,
+      notification: {
+        method: "thread/availableCommands/updated",
+        params: { threadId: "grok-session-1", commands },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(acpAvailableCommandsStore.records).toEqual([
+        expect.objectContaining({ repositoryPath, commands }),
+      ]);
+    });
+
+    // The draft on the checkout now answers from what the worktree session saw.
+    await expect(
+      registry.listSkills({
+        backend: "acp:grok" as AppServerBackendKind,
+        cwd: "/repo",
+        cwds: ["/repo"],
+      }),
+    ).resolves.toEqual({ data: [{ skills: [], commands }] });
+  });
+
+  it("leaves Codex launchpad skill requests on the Codex client path", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["skills/list"] },
+      skills: [{ cwd: "/repo", skills: [] }],
+    });
+    const acpAvailableCommandsStore = createAcpAvailableCommandsStoreMock();
+    const { registry, acpClient } = createKimiAcpRegistry({
+      codexClient,
+      acpAvailableCommandsStore,
+    });
+
+    await expect(
+      registry.listSkills({ backend: "codex", cwd: "/repo", cwds: ["/repo"] }),
+    ).resolves.toEqual({ data: [{ cwd: "/repo", skills: [] }] });
+    expect(acpClient.startSession).not.toHaveBeenCalled();
+    expect(acpAvailableCommandsStore.get).not.toHaveBeenCalled();
   });
 
   it("adds Codex compact app-server command to listSkills", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2083,6 +2083,14 @@ type KimiSendControlPrompt = (params: {
   prompt: string;
 }) => Promise<{ text: string }>;
 
+type KimiStartSession = (params: {
+  acpRuntime?: BackendAcpSessionRuntimeState;
+  cwd?: string;
+  executionMode: "default" | "full-access";
+  hidden?: boolean;
+  title?: string;
+}) => Promise<AcpSessionMetadata>;
+
 type KimiStartPrompt = (params: {
   sessionId: string;
   prompt: string;
@@ -2117,7 +2125,9 @@ function createKimiAcpRegistry(options?: {
     typeof createAcpAvailableCommandsStoreMock
   > | null;
   acpAvailableCommandProbeTimeoutMs?: number;
+  acpAvailableCommandProbeBudgetMs?: number;
   availableCommandsOnSessionStart?: AppServerAvailableCommandSummary[];
+  startSession?: KimiStartSession;
 }) {
   const acpBackendId =
     options?.installedAgent?.backendId
@@ -2154,6 +2164,9 @@ function createKimiAcpRegistry(options?: {
       hidden?: boolean;
       title?: string;
     }) => {
+      if (options?.startSession) {
+        return await options.startSession(params);
+      }
       const resolvedSessionId = params.hidden
         ? `${sessionId}:title-helper:${sessions.length + 1}`
         : sessionId;
@@ -2212,6 +2225,7 @@ function createKimiAcpRegistry(options?: {
     acpAvailableCommandsStore: options?.acpAvailableCommandsStore,
     acpAvailableCommandProbeTimeoutMs:
       options?.acpAvailableCommandProbeTimeoutMs,
+    acpAvailableCommandProbeBudgetMs: options?.acpAvailableCommandProbeBudgetMs,
   });
   return {
     acpBackendId,
@@ -3372,6 +3386,39 @@ describe("DesktopBackendRegistry", () => {
     expect(acpAvailableCommandsStore.records).toEqual([
       expect.objectContaining({ repositoryPath, commands: [] }),
     ]);
+  });
+
+  it("gives up on an ACP probe whose session never opens", async () => {
+    // `session/new` inherits the transport's ten-minute default request
+    // timeout and `getClient` awaits an unbounded `initialize()`, so a wedged
+    // agent must not be able to hold `listSkills` open: the renderer skips any
+    // request while one is in flight, which would strand the `/` menu on
+    // PwrAgent's own commands with no way to retry.
+    const { registry, acpClient } = createKimiAcpRegistry({
+      acpBackendId: "acp:grok" as AcpBackendId,
+      acpAvailableCommandsStore: null,
+      acpAvailableCommandProbeBudgetMs: 5,
+      startSession: () => new Promise<AcpSessionMetadata>(() => {}),
+    });
+
+    await expect(
+      registry.listSkills({
+        backend: "acp:grok" as AppServerBackendKind,
+        cwd: "/repo",
+        cwds: ["/repo"],
+      }),
+    ).resolves.toEqual({ data: [{ skills: [], commands: [] }] });
+
+    // The stuck attempt is still running; the next request must resolve from
+    // it rather than start a second probe alongside it.
+    await expect(
+      registry.listSkills({
+        backend: "acp:grok" as AppServerBackendKind,
+        cwd: "/repo",
+        cwds: ["/repo"],
+      }),
+    ).resolves.toEqual({ data: [{ skills: [], commands: [] }] });
+    expect(acpClient.startSession).toHaveBeenCalledTimes(1);
   });
 
   it("backs off ACP command probes with no cache to remember the miss", async () => {

--- a/apps/desktop/src/main/acp/acp-available-commands-store.ts
+++ b/apps/desktop/src/main/acp/acp-available-commands-store.ts
@@ -1,0 +1,99 @@
+import type {
+  AcpBackendId,
+  AppServerAvailableCommandSummary,
+} from "@pwragent/shared";
+import type { StateDb } from "../state/state-db.js";
+
+export type AcpAvailableCommandsRecord = {
+  backendId: AcpBackendId;
+  repositoryPath: string;
+  commands: AppServerAvailableCommandSummary[];
+  observedAt: number;
+};
+
+/**
+ * Durable last-observed slash-command list per (ACP agent, repository root).
+ *
+ * ACP advertises `availableCommands` only through `session/update` on a live
+ * session, so a launchpad draft — no thread, no session — cannot ask for them.
+ * Live sessions write through here as they report, and launchpad requests read
+ * back the repo's last-known list. Rows are keyed by repository root rather
+ * than by cwd so every worktree of a checkout shares one entry.
+ */
+export type AcpAvailableCommandsStoreLike = {
+  get(
+    backendId: AcpBackendId,
+    repositoryPath: string,
+  ): AcpAvailableCommandsRecord | undefined;
+  upsert(record: AcpAvailableCommandsRecord): void;
+};
+
+export class AcpAvailableCommandsStore implements AcpAvailableCommandsStoreLike {
+  constructor(private readonly stateDb: StateDb) {}
+
+  get(
+    backendId: AcpBackendId,
+    repositoryPath: string,
+  ): AcpAvailableCommandsRecord | undefined {
+    const row = this.stateDb.raw
+      .prepare(
+        `SELECT observed_at, payload FROM acp_available_commands
+         WHERE backend_id = ? AND repository_path = ?`,
+      )
+      .get(backendId, repositoryPath) as
+      | { observed_at: number; payload: string }
+      | undefined;
+    if (!row) {
+      return undefined;
+    }
+
+    const commands = parseCommands(row.payload);
+    return commands
+      ? {
+          backendId,
+          repositoryPath,
+          commands,
+          observedAt: row.observed_at,
+        }
+      : undefined;
+  }
+
+  upsert(record: AcpAvailableCommandsRecord): void {
+    this.stateDb.raw
+      .prepare(
+        `INSERT OR REPLACE INTO acp_available_commands(
+           backend_id,
+           repository_path,
+           observed_at,
+           payload
+         )
+         VALUES (?, ?, ?, ?)`,
+      )
+      .run(
+        record.backendId,
+        record.repositoryPath,
+        record.observedAt,
+        JSON.stringify(record.commands),
+      );
+  }
+}
+
+function parseCommands(
+  payload: string,
+): AppServerAvailableCommandSummary[] | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payload);
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(parsed)) {
+    return undefined;
+  }
+  return parsed.filter(
+    (entry): entry is AppServerAvailableCommandSummary =>
+      Boolean(entry)
+      && typeof entry === "object"
+      && typeof (entry as { name?: unknown }).name === "string",
+  );
+}

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6189,12 +6189,23 @@ const MAX_ACCEPTED_THREAD_CONTROL_REQUESTS = 512;
 
 /**
  * How long a command-discovery probe waits for the agent's
- * `available_commands_update` after `session/new` before giving up. Agents that
- * advertise commands do so as part of session setup, so this only has to cover
- * one notification hop — the (much slower) agent process spawn is already
- * awaited inside `session/new`.
+ * `available_commands_update` once its session is open. Agents that advertise
+ * commands do so as part of session setup, so this only has to cover one
+ * notification hop.
  */
 const ACP_AVAILABLE_COMMAND_PROBE_TIMEOUT_MS = 5_000;
+/**
+ * Ceiling on a whole probe attempt, spawn included.
+ *
+ * Nothing under `startSession` is bounded on a timescale a composer can wait
+ * on: `getClient` awaits an unbounded `initialize()`, and `session/new` inherits
+ * the ACP stdio transport's ten-minute default request timeout. A wedged agent
+ * would otherwise leave `listSkills` unresolved — and because the renderer
+ * skips any request while one is in flight, the `/` menu would sit on
+ * PwrAgent's own commands with no way to retry. Generous enough for a cold
+ * agent process spawn, short enough that a stuck one is a blip.
+ */
+const ACP_AVAILABLE_COMMAND_PROBE_BUDGET_MS = 15_000;
 /**
  * Backoff after a probe that produced nothing (agent unavailable, auth
  * required, or an agent that simply advertises no commands). Without it every
@@ -6339,6 +6350,7 @@ export class DesktopBackendRegistry {
   // `rememberAcpAvailableCommands` for the write-through.
   private readonly acpAvailableCommandsStore?: AcpAvailableCommandsStoreLike;
   private readonly acpAvailableCommandProbeTimeoutMs: number;
+  private readonly acpAvailableCommandProbeBudgetMs: number;
   private readonly acpAvailableCommandProbes = new Map<
     string,
     Promise<AppServerAvailableCommandSummary[]>
@@ -6692,6 +6704,7 @@ export class DesktopBackendRegistry {
     acpSessionStore?: AcpSessionStoreLike | null;
     acpAvailableCommandsStore?: AcpAvailableCommandsStoreLike | null;
     acpAvailableCommandProbeTimeoutMs?: number;
+    acpAvailableCommandProbeBudgetMs?: number;
     discoverLocalAcpAgents?: LocalAcpDiscovery;
     isAcpAgentEnabled?: (registryId: string) => boolean;
     createAcpClient?: AcpClientFactory;
@@ -6891,6 +6904,9 @@ export class DesktopBackendRegistry {
     this.acpAvailableCommandProbeTimeoutMs =
       options?.acpAvailableCommandProbeTimeoutMs
       ?? ACP_AVAILABLE_COMMAND_PROBE_TIMEOUT_MS;
+    this.acpAvailableCommandProbeBudgetMs =
+      options?.acpAvailableCommandProbeBudgetMs
+      ?? ACP_AVAILABLE_COMMAND_PROBE_BUDGET_MS;
     this.overlayStore = options?.overlayStore ?? getDesktopOverlayStore();
     this.gitDirectoryService =
       options?.gitDirectoryService ??
@@ -8070,11 +8086,56 @@ export class DesktopBackendRegistry {
       return [];
     }
 
-    const probe = this.runAcpAvailableCommandProbe(params).finally(() => {
+    const attempt = this.runAcpAvailableCommandProbe(params);
+    const probe = this.withAcpAvailableCommandProbeDeadline(params, attempt);
+    this.acpAvailableCommandProbes.set(probeKey, probe);
+    // Cleanup follows the attempt rather than the deadline. Clearing the entry
+    // when the deadline fires would let the next request start a second probe
+    // alongside the stuck one; leaving it means later requests resolve
+    // instantly from the already-settled deadline, and the pair only reopens
+    // once the attempt itself finally gives up.
+    void attempt.finally(() => {
       this.acpAvailableCommandProbes.delete(probeKey);
     });
-    this.acpAvailableCommandProbes.set(probeKey, probe);
     return await probe;
+  }
+
+  /**
+   * Bound a probe attempt so a wedged agent cannot hold `listSkills` open.
+   *
+   * The attempt is not cancelled — ACP has no way to abandon an in-flight
+   * `session/new`, and there is nothing to clean up: the session is hidden, so
+   * a late arrival costs nothing and still writes its commands through to the
+   * cache for the next request.
+   */
+  private async withAcpAvailableCommandProbeDeadline(
+    params: { backend: AcpBackendId; repositoryPath: string },
+    attempt: Promise<AppServerAvailableCommandSummary[]>,
+  ): Promise<AppServerAvailableCommandSummary[]> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<AppServerAvailableCommandSummary[]>(
+      (resolve) => {
+        timer = setTimeout(() => {
+          backendRegistryLog.warn("ACP available-command probe exceeded budget", {
+            backend: params.backend,
+            budgetMs: this.acpAvailableCommandProbeBudgetMs,
+            repositoryPath: params.repositoryPath,
+          });
+          this.acpAvailableCommandProbeCooldowns.set(
+            `${params.backend}:${params.repositoryPath}`,
+            Date.now() + ACP_AVAILABLE_COMMAND_PROBE_COOLDOWN_MS,
+          );
+          resolve([]);
+        }, this.acpAvailableCommandProbeBudgetMs);
+        timer.unref?.();
+      },
+    );
+
+    try {
+      return await Promise.race([attempt, deadline]);
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   private async runAcpAvailableCommandProbe(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -401,6 +401,10 @@ import type {
   WorktreeWorkingStateEntry,
 } from "./git-working-state-service";
 import { resolveWorktreeRepositoryDirectory } from "./thread-directory-enricher";
+import {
+  AcpAvailableCommandsStore,
+  type AcpAvailableCommandsStoreLike,
+} from "../acp/acp-available-commands-store";
 import { GitWorkspaceHandoffService } from "./git-workspace-handoff-service";
 import { WorktreeArchiveService } from "./worktree-archive-service";
 import { getDesktopMessagingStore } from "../messaging/desktop-messaging-store";
@@ -6183,6 +6187,31 @@ class ActiveTurnControlPreconditionError extends Error {
 
 const MAX_ACCEPTED_THREAD_CONTROL_REQUESTS = 512;
 
+/**
+ * How long a command-discovery probe waits for the agent's
+ * `available_commands_update` after `session/new` before giving up. Agents that
+ * advertise commands do so as part of session setup, so this only has to cover
+ * one notification hop — the (much slower) agent process spawn is already
+ * awaited inside `session/new`.
+ */
+const ACP_AVAILABLE_COMMAND_PROBE_TIMEOUT_MS = 5_000;
+/**
+ * Backoff after a probe that produced nothing (agent unavailable, auth
+ * required, or an agent that simply advertises no commands). Without it every
+ * composer focus in that repo would re-spawn the agent to learn the same
+ * nothing.
+ */
+const ACP_AVAILABLE_COMMAND_PROBE_COOLDOWN_MS = 300_000;
+
+/**
+ * Match the forward-slashed directory identifiers
+ * `resolveWorktreeRepositoryDirectory` returns, so a Windows repo keys the same
+ * whether we resolved it through a worktree link or straight from its own path.
+ */
+function toForwardSlashes(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
 function buildSteerRequestKey(params: SteerTurnRequest): string {
   return [
     params.backend,
@@ -6304,6 +6333,21 @@ export class DesktopBackendRegistry {
   private readonly acpWorktreeRepositoryResolver: (
     cwd: string,
   ) => Promise<LinkedDirectorySummary | undefined>;
+  // Launchpad drafts have no ACP session to ask for `availableCommands`, so the
+  // repo's last-observed list is cached here and replayed for them. See
+  // `resolveAcpAvailableCommands` for the read path and
+  // `rememberAcpAvailableCommands` for the write-through.
+  private readonly acpAvailableCommandsStore?: AcpAvailableCommandsStoreLike;
+  private readonly acpAvailableCommandProbeTimeoutMs: number;
+  private readonly acpAvailableCommandProbes = new Map<
+    string,
+    Promise<AppServerAvailableCommandSummary[]>
+  >();
+  private readonly acpAvailableCommandProbeCooldowns = new Map<string, number>();
+  private readonly acpAvailableCommandWaiters = new Map<
+    string,
+    Set<(commands: AppServerAvailableCommandSummary[]) => void>
+  >();
   private readonly messagingStore?: MessagingArchiveCleanupStore | null;
   private messagingArchiveCleaner?: MessagingArchiveCleaner | null;
   private readonly archivedMessagingCleanupInFlight = new Map<
@@ -6646,6 +6690,8 @@ export class DesktopBackendRegistry {
     acpAgentStore?: AcpBackendAdapterOptions["acpAgentStore"];
     acpRolloutStore?: AcpBackendAdapterOptions["acpRolloutStore"];
     acpSessionStore?: AcpSessionStoreLike | null;
+    acpAvailableCommandsStore?: AcpAvailableCommandsStoreLike | null;
+    acpAvailableCommandProbeTimeoutMs?: number;
     discoverLocalAcpAgents?: LocalAcpDiscovery;
     isAcpAgentEnabled?: (registryId: string) => boolean;
     createAcpClient?: AcpClientFactory;
@@ -6835,6 +6881,16 @@ export class DesktopBackendRegistry {
     this.acpWorktreeRepositoryResolver =
       options?.acpWorktreeRepositoryResolver ??
       resolveWorktreeRepositoryDirectory;
+    this.acpAvailableCommandsStore =
+      options?.acpAvailableCommandsStore === null
+        ? undefined
+        : options?.acpAvailableCommandsStore ??
+          (isAppStateInitialized()
+            ? new AcpAvailableCommandsStore(getAppStateDb())
+            : undefined);
+    this.acpAvailableCommandProbeTimeoutMs =
+      options?.acpAvailableCommandProbeTimeoutMs
+      ?? ACP_AVAILABLE_COMMAND_PROBE_TIMEOUT_MS;
     this.overlayStore = options?.overlayStore ?? getDesktopOverlayStore();
     this.gitDirectoryService =
       options?.gitDirectoryService ??
@@ -6898,7 +6954,10 @@ export class DesktopBackendRegistry {
         ? async () => await settingsService.resolveTerminalSpawnEnvAsync()
         : undefined,
       isAcpAgentEnabled: options?.isAcpAgentEnabled,
-      emit: async (event) => await this.emit(event),
+      emit: async (event) => {
+        this.rememberAcpAvailableCommands(event);
+        await this.emit(event);
+      },
       handleServerRequest: async (backend, request) =>
         await this.handleServerRequest(backend, request),
       resolveMcpConnectionServers: async ({ backendId, sessionId }) => {
@@ -7887,6 +7946,289 @@ export class DesktopBackendRegistry {
     }
   }
 
+  /**
+   * Repository key an ACP cwd's commands are cached under.
+   *
+   * A worktree resolves to the checkout it was cut from, so a launchpad sitting
+   * on `/repo` and a born thread running in `/worktrees/ab12/repo` share one
+   * cache row — commands come from the repo's command files, not from the
+   * worktree. `resolveWorktreeRepositoryDirectory` is filesystem-only and never
+   * spawns git; a plain checkout (or an unreadable path) resolves to itself.
+   *
+   * A `workMode: "worktree"` draft is not a special case here: the draft's
+   * `directoryPath` is the *source* checkout it will be cut from, and the
+   * worktree itself is only created later by `prepareLaunchpadWorkspace`. So
+   * the path handed to us already exists and already is the base repo (or a
+   * worktree of it, which resolves back to the base).
+   */
+  private async resolveAcpCommandRepositoryPath(
+    cwd: string,
+  ): Promise<string | undefined> {
+    const trimmed = cwd.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+
+    const resolved = path.resolve(trimmed);
+    try {
+      const directory = await this.acpWorktreeRepositoryResolver(resolved);
+      if (directory?.path) {
+        return directory.path;
+      }
+    } catch (error) {
+      backendRegistryLog.warn("ACP command cache repository resolution failed", {
+        cwd: resolved,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return toForwardSlashes(resolved);
+  }
+
+  private async resolveAcpCommandRepositoryPaths(
+    cwds: Array<string | undefined>,
+  ): Promise<string[]> {
+    const resolved: string[] = [];
+    for (const cwd of cwds) {
+      if (!cwd?.trim()) {
+        continue;
+      }
+      const repositoryPath = await this.resolveAcpCommandRepositoryPath(cwd);
+      if (repositoryPath && !resolved.includes(repositoryPath)) {
+        resolved.push(repositoryPath);
+      }
+    }
+    return resolved;
+  }
+
+  /**
+   * Serve an ACP agent's slash commands for a request with no session behind
+   * it. Cache first (free, and kept fresh by every real session's
+   * write-through); a probe only runs when this agent has never reported
+   * commands for this repo.
+   */
+  private async resolveAcpAvailableCommands(params: {
+    backend: AcpBackendId;
+    cwds: Array<string | undefined>;
+  }): Promise<AppServerAvailableCommandSummary[]> {
+    const repositoryPaths = await this.resolveAcpCommandRepositoryPaths(
+      params.cwds,
+    );
+    let observedRepository = false;
+    for (const repositoryPath of repositoryPaths) {
+      const cached = this.acpAvailableCommandsStore?.get(
+        params.backend,
+        repositoryPath,
+      );
+      if (!cached) {
+        continue;
+      }
+      observedRepository = true;
+      if (cached.commands.length > 0) {
+        return cached.commands;
+      }
+    }
+    if (observedRepository) {
+      // We have watched this agent in this repo and it advertised nothing.
+      // Re-probing would spawn the agent to relearn the same nothing; a real
+      // session's write-through is what corrects this if that ever changes.
+      return [];
+    }
+
+    const probeTarget = repositoryPaths[0];
+    if (!probeTarget) {
+      return [];
+    }
+    return await this.probeAcpAvailableCommands({
+      backend: params.backend,
+      repositoryPath: probeTarget,
+    });
+  }
+
+  /**
+   * Learn an agent's commands for a repo by opening a throwaway session purely
+   * to receive its `available_commands_update`.
+   *
+   * Deduped per (agent, repo) by an in-flight promise, and backed off after an
+   * empty result, so a burst of composer keystrokes can never turn into a burst
+   * of agent process spawns. The renderer's own request dedupe
+   * (`useThreadSkills`) is the first line of defense; this is the second, and
+   * the one that holds across windows.
+   */
+  private async probeAcpAvailableCommands(params: {
+    backend: AcpBackendId;
+    repositoryPath: string;
+  }): Promise<AppServerAvailableCommandSummary[]> {
+    const probeKey = `${params.backend}:${params.repositoryPath}`;
+    const inFlight = this.acpAvailableCommandProbes.get(probeKey);
+    if (inFlight) {
+      return await inFlight;
+    }
+
+    const cooldownUntil =
+      this.acpAvailableCommandProbeCooldowns.get(probeKey) ?? 0;
+    if (this.closed || Date.now() < cooldownUntil) {
+      return [];
+    }
+
+    const probe = this.runAcpAvailableCommandProbe(params).finally(() => {
+      this.acpAvailableCommandProbes.delete(probeKey);
+    });
+    this.acpAvailableCommandProbes.set(probeKey, probe);
+    return await probe;
+  }
+
+  private async runAcpAvailableCommandProbe(params: {
+    backend: AcpBackendId;
+    repositoryPath: string;
+  }): Promise<AppServerAvailableCommandSummary[]> {
+    const probeKey = `${params.backend}:${params.repositoryPath}`;
+    try {
+      const client = await this.acpBackend.getClient(params.backend);
+      const session = await client.startSession({
+        cwd: params.repositoryPath,
+        executionMode: "default",
+        // Hidden keeps the throwaway session out of every thread list, exactly
+        // like the managed review child. `mcpServers: "none"` keeps the probe
+        // from standing up the agent-tool MCP surface for a session that will
+        // never take a prompt.
+        hidden: true,
+        mcpServers: "none",
+        title: "Command discovery",
+      });
+      const commands = await this.awaitAcpAvailableCommands({
+        backend: params.backend,
+        threadId: session.sessionId,
+      });
+      // Persist either outcome. On a hit, the write-through for the same
+      // notification normally already did this, but recording it here keeps the
+      // probe self-contained rather than dependent on that ordering. On a miss,
+      // "this agent advertises nothing here" is itself the answer, and storing
+      // it is what stops the next composer focus from spawning the agent again.
+      this.acpAvailableCommandsStore?.upsert({
+        backendId: params.backend,
+        repositoryPath: params.repositoryPath,
+        commands,
+        observedAt: Date.now(),
+      });
+      if (commands.length > 0) {
+        return commands;
+      }
+    } catch (error) {
+      backendRegistryLog.warn("ACP available-command probe failed", {
+        backend: params.backend,
+        repositoryPath: params.repositoryPath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    this.acpAvailableCommandProbeCooldowns.set(
+      probeKey,
+      Date.now() + ACP_AVAILABLE_COMMAND_PROBE_COOLDOWN_MS,
+    );
+    return [];
+  }
+
+  private async awaitAcpAvailableCommands(params: {
+    backend: AcpBackendId;
+    threadId: string;
+  }): Promise<AppServerAvailableCommandSummary[]> {
+    const waiterKey = `${params.backend}:${params.threadId}`;
+    return await new Promise<AppServerAvailableCommandSummary[]>((resolve) => {
+      let settled = false;
+      const settle = (
+        commands: AppServerAvailableCommandSummary[],
+      ): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        const waiters = this.acpAvailableCommandWaiters.get(waiterKey);
+        waiters?.delete(settle);
+        if (waiters && waiters.size === 0) {
+          this.acpAvailableCommandWaiters.delete(waiterKey);
+        }
+        resolve(commands);
+      };
+      const timer = setTimeout(
+        () => settle([]),
+        this.acpAvailableCommandProbeTimeoutMs,
+      );
+      timer.unref?.();
+
+      const waiters =
+        this.acpAvailableCommandWaiters.get(waiterKey) ?? new Set();
+      waiters.add(settle);
+      this.acpAvailableCommandWaiters.set(waiterKey, waiters);
+
+      // The update can land while `session/new` is still resolving, in which
+      // case it is already in the session store and no notification is coming.
+      const observed = this.acpBackend.getSession(
+        params.backend,
+        params.threadId,
+      )?.availableCommands;
+      if (observed?.length) {
+        settle(observed);
+      }
+    });
+  }
+
+  /**
+   * Write-through for every ACP session that reports its slash commands, so a
+   * later launchpad draft in the same repo can be answered without a session.
+   * Fire-and-forget: a cache miss costs a probe, never a failed request.
+   */
+  private rememberAcpAvailableCommands(event: AgentEvent): void {
+    if (
+      event.notification.method !== "thread/availableCommands/updated"
+      || !isAcpBackendId(event.backend)
+    ) {
+      return;
+    }
+
+    const backend = event.backend;
+    const { commands, threadId } = event.notification.params;
+    // An empty update is treated as "no news", not as "this repo has no
+    // commands": agents emit one during session setup before their command
+    // registry is populated, and letting that clobber a good cache would empty
+    // the launchpad menu until the next real session. The probe is the only
+    // path that records an empty list, and only after waiting one out.
+    if (!Array.isArray(commands) || commands.length === 0) {
+      return;
+    }
+
+    for (const waiter of [
+      ...(this.acpAvailableCommandWaiters.get(`${backend}:${threadId}`) ?? []),
+    ]) {
+      waiter(commands);
+    }
+
+    const cwd = this.acpBackend.getSession(backend, threadId)?.cwd;
+    if (!cwd) {
+      return;
+    }
+
+    void this.resolveAcpCommandRepositoryPath(cwd)
+      .then((repositoryPath) => {
+        if (!repositoryPath) {
+          return;
+        }
+        this.acpAvailableCommandsStore?.upsert({
+          backendId: backend,
+          repositoryPath,
+          commands,
+          observedAt: Date.now(),
+        });
+      })
+      .catch((error) => {
+        backendRegistryLog.warn("ACP available-command cache write failed", {
+          backend,
+          threadId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+  }
+
   async listSkills(params: {
     backend?: AppServerBackendKind;
     cwd?: string;
@@ -7895,18 +8237,23 @@ export class DesktopBackendRegistry {
   } = {}): Promise<Pick<AppServerListSkillsResponse, "data">> {
     const backend = params.backend ?? "codex";
     if (isAcpBackendId(backend)) {
-      if (!params.threadId) {
-        return { data: [] };
+      const session = params.threadId
+        ? this.acpBackend.getSession(backend, params.threadId)
+        : undefined;
+      const sessionCommands = session?.availableCommands ?? [];
+      if (sessionCommands.length > 0) {
+        return { data: [{ commands: sessionCommands, skills: [] }] };
       }
-      const session = this.acpBackend.getSession(backend, params.threadId);
-      return {
-        data: [
-          {
-            commands: session?.availableCommands ?? [],
-            skills: [],
-          },
-        ],
-      };
+
+      // No live session has reported commands for this request — either it is a
+      // launchpad draft (no thread id at all) or a session that has not yet
+      // advertised. Fall back to what the repo last told us, and probe for it
+      // when we have never seen this repo/agent pair.
+      const commands = await this.resolveAcpAvailableCommands({
+        backend,
+        cwds: [session?.cwd, params.cwd, ...(params.cwds ?? [])],
+      });
+      return { data: [{ commands, skills: [] }] };
     }
 
     const client = this.getClient(backend);

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -999,6 +999,14 @@ CREATE INDEX IF NOT EXISTS idx_federation_session_audit_session_created
   ON federation_session_audit(session_id, created_at DESC);
 `;
 
+/**
+ * Cached ACP slash commands are keyed by (agent, repository root), so a row
+ * outlives the repo it describes — a deleted checkout, a worktree root that
+ * moved, an agent the operator uninstalled. Nothing reads a row this old: a
+ * repo still in use is re-observed by every session that reports commands, and
+ * one that is not gets re-probed for the price of a single hidden session.
+ */
+const ACP_AVAILABLE_COMMANDS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const APP_RUNTIME_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
@@ -1473,6 +1481,9 @@ LEFT JOIN federation_peers
       this.db
         .prepare("DELETE FROM deliveries WHERE created_at < ?")
         .run(now - DELIVERIES_RETENTION_MS);
+      this.db
+        .prepare("DELETE FROM acp_available_commands WHERE observed_at < ?")
+        .run(now - ACP_AVAILABLE_COMMANDS_RETENTION_MS);
       this.db
         .prepare(
           "DELETE FROM bindings WHERE revoked_at IS NOT NULL AND revoked_at < ?",

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -10,7 +10,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 49;
+export const CURRENT_STATE_DB_USER_VERSION = 50;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -360,6 +360,28 @@ CREATE TABLE IF NOT EXISTS acp_sessions (
 );
 CREATE INDEX IF NOT EXISTS idx_acp_sessions_backend_updated
   ON acp_sessions(backend_id, updated_at DESC);
+`;
+
+/**
+ * Last-observed ACP `availableCommands` per (agent, repository root).
+ *
+ * ACP agents only advertise their slash commands over a live session, so a
+ * launchpad draft — which has no session and no thread id — has nothing to ask.
+ * Every session that reports commands writes through here keyed by the repo
+ * root behind its cwd, and launchpad requests read it back. Keying on the
+ * repository (not the worktree) is deliberate: commands are a property of the
+ * checkout's command files, so every worktree of a repo shares one row.
+ */
+const ACP_AVAILABLE_COMMANDS_SCHEMA = `
+CREATE TABLE IF NOT EXISTS acp_available_commands (
+  backend_id      TEXT NOT NULL,
+  repository_path TEXT NOT NULL,
+  observed_at     INTEGER NOT NULL,
+  payload         TEXT NOT NULL,
+  PRIMARY KEY (backend_id, repository_path)
+);
+CREATE INDEX IF NOT EXISTS idx_acp_available_commands_observed
+  ON acp_available_commands(observed_at DESC);
 `;
 
 const AUTOMATION_SCHEMA = `
@@ -1383,6 +1405,14 @@ LEFT JOIN federation_peers
     if ((db.pragma("user_version", { simple: true }) as number) < 49) {
       db.transaction(() => {
         migrateRawThreadIdentityKeysToLegacyStorage(db);
+        db.pragma("user_version = 49");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 50) {
+      db.transaction(() => {
+        // Additive table, no data migration; the same DDL also lives in
+        // `ensureCurrentSchema` so re-instantiated dbs converge.
+        db.exec(ACP_AVAILABLE_COMMANDS_SCHEMA);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1715,6 +1745,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     db.exec(MESSAGING_TOPIC_MANAGEMENT_SCHEMA);
     db.exec(ACP_AGENT_SCHEMA);
     db.exec(ACP_SESSION_SCHEMA);
+    db.exec(ACP_AVAILABLE_COMMANDS_SCHEMA);
     db.exec(AUTOMATION_SCHEMA);
     db.exec(SCHEDULED_THREAD_ACTION_SCHEMA);
     ensureScheduledThreadActionMetadataColumns(db);

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSkills.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSkills.test.tsx
@@ -81,6 +81,148 @@ describe("useThreadSkills", () => {
     });
   });
 
+  it.each([
+    { backend: "acp:grok" as const, directoryPath: "/Users/huntharo/pwrdrvr/PwrAgent" },
+    { backend: "acp:kimi" as const, directoryPath: "/Users/huntharo/pwrdrvr/PwrAgent" },
+    { backend: "codex" as const, directoryPath: "/Users/huntharo/pwrdrvr/PwrAgent" },
+  ])(
+    "loads provider commands for an unborn $backend launchpad draft",
+    async ({ backend, directoryPath }) => {
+      const listSkills = vi.fn(async () => ({
+        backend,
+        fetchedAt: Date.now(),
+        data: [
+          {
+            skills: [],
+            commands: [
+              {
+                name: "compact",
+                description: "Compact this thread's context.",
+                backend,
+                scope: "session" as const,
+                source: "provider" as const,
+              },
+            ],
+          },
+        ],
+      }));
+
+      const { result } = renderHook(() =>
+        useThreadSkills({
+          desktopApi: { listSkills },
+          launchpad: {
+            directoryKey: `directory:${directoryPath}`,
+            directoryKind: "directory",
+            directoryLabel: "PwrAgent",
+            directoryPath,
+            backend,
+            executionMode: "default",
+            prompt: "",
+            workMode: "local",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        })
+      );
+
+      await act(async () => {
+        await result.current.ensureLoaded();
+      });
+
+      expect(listSkills).toHaveBeenCalledWith({
+        backend,
+        cwd: directoryPath,
+        cwds: [directoryPath],
+      });
+
+      await waitFor(() => {
+        expect(result.current.providerCommands.map((command) => command.name)).toEqual([
+          "compact",
+        ]);
+      });
+    },
+  );
+
+  it("requests the base repository path for a worktree-mode launchpad draft", async () => {
+    // `workMode: "worktree"` drafts carry the *source* checkout in
+    // `directoryPath` — the worktree itself does not exist until launch — so
+    // the hook must forward that path unchanged rather than invent one.
+    const listSkills = vi.fn(async () => ({
+      backend: "acp:grok" as const,
+      fetchedAt: Date.now(),
+      data: [{ skills: [], commands: [] }],
+    }));
+
+    const { result } = renderHook(() =>
+      useThreadSkills({
+        desktopApi: { listSkills },
+        launchpad: {
+          directoryKey: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgent",
+          backend: "acp:grok",
+          executionMode: "default",
+          prompt: "",
+          workMode: "worktree",
+          branchName: "feature/x",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      })
+    );
+
+    await act(async () => {
+      await result.current.ensureLoaded();
+    });
+
+    expect(listSkills).toHaveBeenCalledWith({
+      backend: "acp:grok",
+      cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+      cwds: ["/Users/huntharo/pwrdrvr/PwrAgent"],
+    });
+  });
+
+  it("issues one launchpad skills request across a burst of composer triggers", async () => {
+    const listSkills = vi.fn(async () => ({
+      backend: "acp:grok" as const,
+      fetchedAt: Date.now(),
+      data: [{ skills: [], commands: [] }],
+    }));
+
+    const { result } = renderHook(() =>
+      useThreadSkills({
+        desktopApi: { listSkills },
+        launchpad: {
+          directoryKey: "directory:/repo",
+          directoryKind: "directory",
+          directoryLabel: "repo",
+          directoryPath: "/repo",
+          backend: "acp:grok",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      })
+    );
+
+    // The composer calls `onEnsureSkillsLoaded` on every keystroke after `/`.
+    await act(async () => {
+      await Promise.all([
+        result.current.ensureLoaded(),
+        result.current.ensureLoaded(),
+        result.current.ensureLoaded(),
+      ]);
+    });
+    await act(async () => {
+      await result.current.ensureLoaded();
+    });
+
+    expect(listSkills).toHaveBeenCalledTimes(1);
+  });
+
   it("loads provider commands for an ACP thread session", async () => {
     const listSkills = vi.fn(async () => ({
       backend: "acp:kimi" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
@@ -58,7 +58,11 @@ export function useThreadSkills(params: {
       };
     }
 
-    if (launchpad?.backend === "codex") {
+    // Every backend, not just Codex: an ACP agent's slash commands are served
+    // from the repo's last-observed list (see the registry's ACP branch of
+    // `listSkills`), so a draft that has never been launched still populates
+    // the `/` menu instead of falling back to PwrAgent's own commands alone.
+    if (launchpad) {
       const cwds = launchpad.directoryPath?.trim() ? [launchpad.directoryPath.trim()] : [];
       return {
         backend: launchpad.backend,
@@ -77,6 +81,23 @@ export function useThreadSkills(params: {
     stateByThreadKeyRef.current = stateByThreadKey;
   }, [stateByThreadKey]);
 
+  // Writes the ref and the React state together. The in-flight guard below is
+  // read synchronously, and the composer fires `ensureLoaded` once per
+  // keystroke after `/` — leaving the ref to catch up in an effect let a burst
+  // of keystrokes issue one request each.
+  const commitState = useCallback(
+    (
+      updater: (
+        current: Record<string, SkillState>,
+      ) => Record<string, SkillState>,
+    ): void => {
+      const next = updater(stateByThreadKeyRef.current);
+      stateByThreadKeyRef.current = next;
+      setStateByThreadKey(next);
+    },
+    [],
+  );
+
   const loadTarget = useCallback(
     async (options: { force?: boolean } = {}): Promise<void> => {
       if (!skillTarget) {
@@ -84,7 +105,7 @@ export function useThreadSkills(params: {
       }
 
       if (!desktopApi?.listSkills) {
-        setStateByThreadKey((current) => ({
+        commitState((current) => ({
           ...current,
           [skillTarget.key]: {
             error: "Desktop bridge is missing listSkills().",
@@ -105,7 +126,7 @@ export function useThreadSkills(params: {
       requestVersionsRef.current[skillTarget.key] = requestVersion;
       const cwds = skillTarget.cwds;
 
-      setStateByThreadKey((current) => ({
+      commitState((current) => ({
         ...current,
         [skillTarget.key]: {
           ...createEmptySkillState(),
@@ -128,7 +149,7 @@ export function useThreadSkills(params: {
           return;
         }
 
-        setStateByThreadKey((current) => ({
+        commitState((current) => ({
           ...current,
           [skillTarget.key]: {
             error: undefined,
@@ -141,7 +162,7 @@ export function useThreadSkills(params: {
           return;
         }
 
-        setStateByThreadKey((current) => ({
+        commitState((current) => ({
           ...current,
           [skillTarget.key]: {
             error: error instanceof Error ? error.message : String(error),
@@ -151,7 +172,7 @@ export function useThreadSkills(params: {
         }));
       }
     },
-    [desktopApi, skillTarget],
+    [commitState, desktopApi, skillTarget],
   );
 
   useEffect(() => {
@@ -212,7 +233,7 @@ export function useThreadSkills(params: {
         : [];
       requestVersionsRef.current[key] =
         (requestVersionsRef.current[key] ?? 0) + 1;
-      setStateByThreadKey((current) => ({
+      commitState((current) => ({
         ...current,
         [key]: {
           error: undefined,
@@ -230,7 +251,7 @@ export function useThreadSkills(params: {
         },
       }));
     });
-  }, [desktopApi, loadTarget, skillTarget, thread]);
+  }, [commitState, desktopApi, loadTarget, skillTarget, thread]);
 
   const ensureLoaded = useCallback(async (): Promise<void> => {
     await loadTarget();


### PR DESCRIPTION
## The bug

A launchpad draft on an ACP backend (Grok, Kimi) showed only PwrAgent's built-in `/review` in the `/` autocomplete. A **born** thread on the same backend in the same repo showed the provider's full command list.

Two independent layers were responsible.

**Layer 1 — the renderer never asked.** `useThreadSkills`'s launchpad branch was hardcoded to `backend === "codex"`, so every ACP draft produced an undefined skill target, `loadTarget` returned early, and `providerCommands` resolved to `[]`. `Composer` then rendered `SLASH_COMMANDS` alone.

**Layer 2 — the main process had nothing to return anyway.** ACP `availableCommands` arrive only over `session/update` on a live session (confirmed against the ACP schema: `session/new`'s response carries no commands). A draft has no session and no thread id, so the registry returned `{ data: [] }` by construction. This is exactly why born threads worked and unborn ones didn't.

## Layer 2: cache-first, probe on cold start

Picking between the two options in the issue:

- **Every ACP session that reports commands writes through** to a new `acp_available_commands` table keyed by *(agent, repository root)*. Normal use keeps this fresh for free, and a repo the operator has already run the agent in answers instantly.
- **A repo/agent pair never observed is probed once** — a hidden, MCP-less throwaway session opened purely to receive one `available_commands_update`. `hidden: true` keeps it out of every thread list, the same way `startManagedReviewChild` already does; `mcpServers: "none"` keeps it from standing up the agent-tool MCP surface for a session that will never take a prompt.

`listSkills` awaits the cold probe rather than refreshing in the background. Serving stale-then-refreshing would need a new invalidation event to reach the launchpad — the existing `thread/availableCommands/updated` handler in `useThreadSkills` is gated on `!thread || !threadId` and cannot fire for a draft. One request returning one correct answer is a smaller surface than that choreography, and the composer already renders a loading state.

**Probing on every composer focus was rejected**: it costs an agent process spawn to relearn a list that is stable per repo, and the write-through already keeps the cache honest.

## Repo, not worktree

Cache keys are repository roots. Commands come from the repo's command files, so a worktree and its checkout share one row — which is what makes "a born Grok thread in a worktree" and "a new draft on the checkout" agree.

Resolution reuses the existing `acpWorktreeRepositoryResolver`, which follows the worktree's `.git` link on the filesystem and **never spawns git**.

On the worktree caveat: I checked what `NavigationLaunchpadDraft.directoryPath` actually holds before assuming. A `workMode: "worktree"` draft carries the **source checkout** it will be cut from — `selectThreadWorkspace` sets it from the existing directory, and the worktree is only created later by `prepareLaunchpadWorkspace`. So the path handed to `listSkills` already exists, and already is the base repo (or a worktree of it, which resolves back to the base). No fallback needed, and a test pins it.

## No spawn per keystroke

Three layers, because the composer fires `onEnsureSkillsLoaded` on every keystroke after `/`:

1. **`useThreadSkills` now commits in-flight state to its ref synchronously.** This was a real pre-existing gap: the dedupe guard read a ref that only synced in a `useEffect`, so same-tick `ensureLoaded` calls each saw a stale `undefined` and issued their own request. A test pins one request per burst.
2. **The registry dedupes probes per (agent, repo)** on an in-flight promise, so concurrent requests share one session. This is the layer that holds across windows.
3. **A probe that finds nothing records the empty result**, so composer focus never re-spawns an agent to relearn the same nothing. Without a cache to remember the miss, a cooldown backs it off instead.

An empty `available_commands_update` is treated as "no news" rather than "this repo has no commands" — agents emit one during session setup, and letting it clobber a good cache would empty the menu until the next real session. Only the probe records an empty list, and only after waiting one out.

## Codex is untouched

Its branch of `listSkills` is unchanged. A test pins that a Codex launchpad request never reaches the ACP cache or a probe.

## Coverage

- `useThreadSkills`: launchpad `skillTarget` across `acp:grok` / `acp:kimi` / `codex`; a worktree-mode draft forwarding the base path; one request per keystroke burst.
- `backend-registry`: cache hit serves a draft with no thread; a worktree cwd hits the checkout's row; a cold repo probes exactly once under concurrent requests, then never again; an agent that advertises nothing is recorded rather than re-probed; the cooldown path with no store; a live session's report caches under its repository; Codex stays on the Codex client path.
- `AcpAvailableCommandsStore`: round-trip, last-write-wins, scoping, and a pre-v50 profile database gaining the table on open.

## Verification

`pnpm test` (492 files, 6935 passed), `pnpm typecheck`, `pnpm lint:eslint` (0 errors, no new warnings), `pnpm lint:boundaries`, `pnpm lint:sql`, `pnpm lint:codex-storage` all pass.

Not verified by a live agent run — I have no Grok/Kimi CLI session here, so the probe's real `session/new` → `available_commands_update` round trip is covered by tests against the ACP client seam rather than against a running agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
