### PR TITLE
fix(desktop): report ACP token usage while a turn is still running

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -265,6 +265,42 @@ pnpm --filter @pwragent/desktop exec tsx \
 Works for 2+ frames; the indicator scales horizontally with frame
 count.
 
+## Capturing ACP Protocol Transcripts
+
+`scripts/capture-acp-transcript.mjs` drives a real ACP agent over stdio the
+way `AcpAgentClient` does — same `initialize` params, `session/new`, one
+`session/prompt` — and writes every JSON-RPC frame in both directions to
+stdout:
+
+```bash
+node apps/desktop/scripts/capture-acp-transcript.mjs \
+  --cmd ~/.kimi-code/bin/kimi --args acp \
+  --cwd /tmp/acp-scratch \
+  --prompt "tell me your favorite breakfast cereal" > capture.json
+```
+
+Flags: `--cmd` (required), `--args` (comma-separated), `--cwd`, `--prompt`,
+`--quiet-ms` (drain window after the prompt resolves), `--timeout-ms`,
+`--allow-tools`. Exit code is 0 only on a completed capture.
+
+Reach for this whenever a question about an agent's wire behavior would
+otherwise be answered by reading its source or guessing. **The committed
+`__tests__/fixtures/acp-transcripts/*-build.json` fixtures cannot answer
+turn-end questions** — they are normalizer-parity captures containing no
+completed turn, so grepping them for usage, stop reasons, or totals returns a
+confident wrong answer. That mistake is why
+`kimi-code-0-31-cereal.json` exists: a full captured turn establishing that
+Kimi Code 0.31.1 puts no token usage on the ACP wire.
+
+Two things to know before running it:
+
+- **Permission requests are denied by default.** Pass `--allow-tools` only
+  when tool traffic is the point, and point `--cwd` somewhere disposable when
+  you do — the harness answers on your behalf and the agent acts for real.
+- **Output is raw protocol.** The operator home directory and the capture cwd
+  are rewritten, but an agent can echo anything it read into a transcript.
+  Read a capture before committing it as a fixture.
+
 ## Accessibility
 
 The renderer is audited against WCAG 2.0 / 2.1 / 2.2 Level AA via

--- a/apps/desktop/scripts/capture-acp-transcript.mjs
+++ b/apps/desktop/scripts/capture-acp-transcript.mjs
@@ -13,9 +13,14 @@
 //     --cwd /tmp/scratch \
 //     --prompt "tell me your favorite breakfast cereal" > capture.json
 //
-// Pick a prompt that needs no tools unless tool traffic is the point: the
-// harness auto-approves permission requests so a tool call cannot wedge the
-// run, which is convenient but means it will happily let an agent act.
+// Permission requests are DENIED by default, so a capture cannot make an agent
+// act on the machine by accident. Pass `--allow-tools` when tool traffic is
+// what you are trying to capture, and point `--cwd` somewhere disposable when
+// you do.
+//
+// Output is raw protocol. It is rewritten for the operator's home directory
+// and the capture cwd, but read it before committing it as a fixture — an
+// agent can echo anything it read into a transcript.
 import { spawn } from "node:child_process";
 import os from "node:os";
 
@@ -34,6 +39,7 @@ const CWD = flag("cwd", os.tmpdir());
 const PROMPT = flag("prompt", "tell me your favorite breakfast cereal");
 const QUIET_MS = Number(flag("quiet-ms", "6000"));
 const HARD_TIMEOUT_MS = Number(flag("timeout-ms", "180000"));
+const ALLOW_TOOLS = process.argv.includes("--allow-tools");
 
 const child = spawn(COMMAND, ARGS, {
   stdio: ["pipe", "pipe", "pipe"],
@@ -44,6 +50,7 @@ const log = [];
 let nextId = 1;
 const pending = new Map();
 let lastActivityAt = Date.now();
+let promptCompleted = false;
 
 function send(method, params) {
   const id = nextId++;
@@ -73,43 +80,116 @@ child.stdout.on("data", (chunk) => {
       continue;
     }
     log.push({ dir: "in", frame });
+    // Route on `method`, not on `id`. JSON-RPC numbers each direction
+    // independently, so an agent counting its own requests from 1 collides
+    // with ours as a matter of course — and matching a request against
+    // `pending` resolves our in-flight call with `undefined` and drops the
+    // real response when it arrives. A frame carrying `method` is a request;
+    // one without is a response.
+    if (frame.method) {
+      respondToAgentRequest(frame);
+      continue;
+    }
     if (frame.id !== undefined && pending.has(frame.id)) {
       const entry = pending.get(frame.id);
       pending.delete(frame.id);
       if (frame.error) entry.reject(new Error(JSON.stringify(frame.error)));
       else entry.resolve(frame.result);
     }
-    // Answer agent->client requests permissively so a tool call cannot wedge
-    // the capture. This prompt should not trigger any.
-    if (frame.id !== undefined && frame.method) {
-      const response = {
-        jsonrpc: "2.0",
-        id: frame.id,
-        result: frame.method === "session/request_permission"
-          ? { outcome: { outcome: "selected", optionId: "allow" } }
-          : {},
-      };
-      log.push({ dir: "out", frame: response });
-      child.stdin.write(`${JSON.stringify(response)}\n`);
-    }
   }
 });
+
+function respondToAgentRequest(frame) {
+  if (frame.id === undefined) {
+    return; // A notification. Recorded above; nothing to answer.
+  }
+  if (frame.method === "session/request_permission" && !ALLOW_TOOLS) {
+    const response = {
+      jsonrpc: "2.0",
+      id: frame.id,
+      result: { outcome: { outcome: "selected", optionId: "reject" } },
+    };
+    log.push({ dir: "out", frame: response, note: "denied (no --allow-tools)" });
+    child.stdin.write(`${JSON.stringify(response)}\n`);
+    return;
+  }
+  if (frame.method === "session/request_permission") {
+    const response = {
+      jsonrpc: "2.0",
+      id: frame.id,
+      result: { outcome: { outcome: "selected", optionId: "allow" } },
+    };
+    log.push({ dir: "out", frame: response });
+    child.stdin.write(`${JSON.stringify(response)}\n`);
+    return;
+  }
+  // Anything else is a method this harness does not implement. Answering `{}`
+  // would be a malformed result for most of them, so refuse explicitly and
+  // let the capture show the agent's reaction.
+  const response = {
+    jsonrpc: "2.0",
+    id: frame.id,
+    error: { code: -32601, message: `capture harness does not implement ${frame.method}` },
+  };
+  log.push({ dir: "out", frame: response });
+  child.stdin.write(`${JSON.stringify(response)}\n`);
+}
 
 const stderr = [];
 child.stderr.on("data", (chunk) => {
   stderr.push(chunk.toString("utf8"));
 });
 
+// Without these, an agent that fails to launch or dies mid-capture leaves the
+// top-level await unsettled, and Node exits 13 with no output at all — no
+// status, no stderr, nothing to debug from. The hard timeout cannot cover it
+// because it is unref'd.
+child.on("error", (error) => {
+  finish("spawn-failed", error instanceof Error ? error.message : String(error));
+});
+child.on("exit", (code, signal) => {
+  // An agent that exits once it has answered has given us the whole capture —
+  // no more frames can arrive down a closed pipe, so stop draining and call it
+  // done. Exiting before the prompt resolved is a real failure.
+  if (promptCompleted) {
+    finish("ok");
+    return;
+  }
+  finish("agent-exited", `agent exited before answering (code ${code}, signal ${signal})`);
+});
+
+// Rewrite the two paths every capture on a developer machine carries. This is
+// a convenience, not a guarantee: an agent can put anything it read into a
+// transcript, so a capture still needs reading before it becomes a fixture.
+function redact(value) {
+  return JSON.parse(
+    JSON.stringify(value)
+      .split(CWD).join("/workspaces/scratch")
+      .split(os.homedir()).join("/home/operator"),
+  );
+}
+
+let finished = false;
 function finish(status, detail) {
+  if (finished) {
+    return;
+  }
+  finished = true;
   try {
     child.kill("SIGTERM");
   } catch {
     // already gone
   }
   process.stdout.write(
-    `${JSON.stringify({ status, detail, stderr: stderr.join(""), log }, null, 1)}\n`,
+    `${JSON.stringify(
+      redact({ status, detail, stderr: stderr.join(""), log }),
+      null,
+      1,
+    )}\n`,
   );
-  process.exit(0);
+  // Exit code carries the outcome so a scripted caller does not have to parse
+  // `status` to notice the run never completed.
+  process.exit(status === "ok" ? 0 : 1);
 }
 
 setTimeout(() => finish("hard-timeout"), HARD_TIMEOUT_MS).unref();
@@ -130,6 +210,7 @@ try {
     sessionId,
     prompt: [{ type: "text", text: PROMPT }],
   });
+  promptCompleted = true;
   // Drain trailing notifications until the stream goes quiet.
   await new Promise((resolve) => {
     const timer = setInterval(() => {

--- a/apps/desktop/scripts/capture-acp-transcript.mjs
+++ b/apps/desktop/scripts/capture-acp-transcript.mjs
@@ -1,0 +1,145 @@
+// Drive an ACP agent over stdio the way PwrAgent's AcpAgentClient does — same
+// initialize params, same session/new, one session/prompt — and record every
+// frame in both directions. Writes the whole JSON-RPC log to stdout on exit.
+//
+// This exists so a claim about what an agent puts on the wire can be answered
+// with a capture instead of a guess. The committed `acp-transcripts` fixtures
+// are parity captures that contain no completed turn, so they cannot answer
+// questions about usage, stop reasons, or anything else that only appears at
+// the end of a turn.
+//
+//   node apps/desktop/scripts/capture-acp-transcript.mjs \
+//     --cmd ~/.kimi-code/bin/kimi --args acp \
+//     --cwd /tmp/scratch \
+//     --prompt "tell me your favorite breakfast cereal" > capture.json
+//
+// Pick a prompt that needs no tools unless tool traffic is the point: the
+// harness auto-approves permission requests so a tool call cannot wedge the
+// run, which is convenient but means it will happily let an agent act.
+import { spawn } from "node:child_process";
+import os from "node:os";
+
+function flag(name, fallback) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index === -1 ? fallback : process.argv[index + 1];
+}
+
+const COMMAND = flag("cmd");
+if (!COMMAND) {
+  process.stderr.write("--cmd <agent binary> is required\n");
+  process.exit(2);
+}
+const ARGS = (flag("args") ?? "").split(",").filter(Boolean);
+const CWD = flag("cwd", os.tmpdir());
+const PROMPT = flag("prompt", "tell me your favorite breakfast cereal");
+const QUIET_MS = Number(flag("quiet-ms", "6000"));
+const HARD_TIMEOUT_MS = Number(flag("timeout-ms", "180000"));
+
+const child = spawn(COMMAND, ARGS, {
+  stdio: ["pipe", "pipe", "pipe"],
+  env: { ...process.env },
+});
+
+const log = [];
+let nextId = 1;
+const pending = new Map();
+let lastActivityAt = Date.now();
+
+function send(method, params) {
+  const id = nextId++;
+  const frame = { jsonrpc: "2.0", id, method, params };
+  log.push({ dir: "out", frame });
+  child.stdin.write(`${JSON.stringify(frame)}\n`);
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+  });
+}
+
+let buffer = "";
+child.stdout.on("data", (chunk) => {
+  lastActivityAt = Date.now();
+  buffer += chunk.toString("utf8");
+  let index = buffer.indexOf("\n");
+  while (index !== -1) {
+    const line = buffer.slice(0, index).trim();
+    buffer = buffer.slice(index + 1);
+    index = buffer.indexOf("\n");
+    if (!line) continue;
+    let frame;
+    try {
+      frame = JSON.parse(line);
+    } catch {
+      log.push({ dir: "in", unparsed: line });
+      continue;
+    }
+    log.push({ dir: "in", frame });
+    if (frame.id !== undefined && pending.has(frame.id)) {
+      const entry = pending.get(frame.id);
+      pending.delete(frame.id);
+      if (frame.error) entry.reject(new Error(JSON.stringify(frame.error)));
+      else entry.resolve(frame.result);
+    }
+    // Answer agent->client requests permissively so a tool call cannot wedge
+    // the capture. This prompt should not trigger any.
+    if (frame.id !== undefined && frame.method) {
+      const response = {
+        jsonrpc: "2.0",
+        id: frame.id,
+        result: frame.method === "session/request_permission"
+          ? { outcome: { outcome: "selected", optionId: "allow" } }
+          : {},
+      };
+      log.push({ dir: "out", frame: response });
+      child.stdin.write(`${JSON.stringify(response)}\n`);
+    }
+  }
+});
+
+const stderr = [];
+child.stderr.on("data", (chunk) => {
+  stderr.push(chunk.toString("utf8"));
+});
+
+function finish(status, detail) {
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    // already gone
+  }
+  process.stdout.write(
+    `${JSON.stringify({ status, detail, stderr: stderr.join(""), log }, null, 1)}\n`,
+  );
+  process.exit(0);
+}
+
+setTimeout(() => finish("hard-timeout"), HARD_TIMEOUT_MS).unref();
+
+try {
+  await send("initialize", {
+    protocolVersion: 1,
+    clientCapabilities: {
+      auth: { terminal: false },
+      fs: { readTextFile: false, writeTextFile: false },
+      terminal: false,
+    },
+    clientInfo: { name: "pwragent", title: "PwrAgent", version: "0.0.0" },
+  });
+  const session = await send("session/new", { cwd: CWD, mcpServers: [] });
+  const sessionId = session?.sessionId ?? session?.session_id;
+  await send("session/prompt", {
+    sessionId,
+    prompt: [{ type: "text", text: PROMPT }],
+  });
+  // Drain trailing notifications until the stream goes quiet.
+  await new Promise((resolve) => {
+    const timer = setInterval(() => {
+      if (Date.now() - lastActivityAt > QUIET_MS) {
+        clearInterval(timer);
+        resolve();
+      }
+    }, 500);
+  });
+  finish("ok");
+} catch (error) {
+  finish("error", error instanceof Error ? error.message : String(error));
+}

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1407,6 +1407,165 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
+  it("restarts the ACP running total on each turn", async () => {
+    // The running total is per turn, not per session: `liveTurnUsage` is keyed
+    // by turn and dropped at `turn_finished`. Pinning that here because the
+    // same field is session-cumulative on Codex, and consumers subtract
+    // against it — see the note on `AcpUsageEnvelope`. If a later change makes
+    // ACP cumulative, this test should fail loudly rather than the difference
+    // being discovered downstream.
+    const backendId = "acp:grok" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport();
+    const events: AgentEvent[] = [];
+    const sessions: AcpSessionMetadata[] = [];
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+      launchDescriptor: {
+        backendId,
+        registryId: "grok",
+        distributionKind: "local",
+        command: "grok",
+        args: ["acp"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => sessions,
+        getSession: (_backendId, sessionId) =>
+          sessions.find((session) => session.sessionId === sessionId),
+        upsertSession: (metadata) => {
+          const index = sessions.findIndex(
+            (session) => session.sessionId === metadata.sessionId,
+          );
+          if (index >= 0) {
+            sessions[index] = metadata;
+          } else {
+            sessions.push(metadata);
+          }
+        },
+      },
+      captureStores: [],
+      createAcpTransport: () => transport,
+      emit: async (event) => {
+        events.push(event);
+      },
+      handleServerRequest: async () => ({ decision: "accept" }),
+    });
+
+    const client = await adapter.getClient(backendId);
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "full-access",
+      acpRuntime: { currentModelId: "grok-4.5-build" },
+    });
+    const responseCompleted = (usage: Record<string, number>) => ({
+      sessionUpdate: "response_completed",
+      stop_reason: "tool_use",
+      usage: {
+        cache_creation_input_tokens: 0,
+        reasoning_tokens: 0,
+        ...usage,
+      },
+    });
+    const liveTotalsFor = (turnId: string) =>
+      events
+        .filter(
+          (event) =>
+            event.notification.method === "thread/tokenUsage/updated"
+            && "turnId" in event.notification.params
+            && event.notification.params.turnId === turnId,
+        )
+        .flatMap((event) => {
+          const usage = (
+            event.notification.params as {
+              tokenUsage?: Record<string, unknown>;
+            }
+          ).tokenUsage;
+          const total = usage?.total_token_usage as
+            | { input_tokens?: number }
+            | undefined;
+          return total ? [total.input_tokens] : [];
+        });
+
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "First turn",
+      turnId: "turn-one",
+    });
+    // Assistant text is what makes the prompt count as answered, which is what
+    // lets the turn finish cleanly. No `_meta.usage`, so it adds no envelope.
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "First answer." },
+    });
+    transport.emitSessionUpdate(
+      session.sessionId,
+      responseCompleted({
+        input_tokens: 100,
+        cache_read_input_tokens: 900,
+        output_tokens: 10,
+      }),
+    );
+    transport.emitSessionUpdate(
+      session.sessionId,
+      responseCompleted({
+        input_tokens: 200,
+        cache_read_input_tokens: 1_800,
+        output_tokens: 20,
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(liveTotalsFor("turn-one")).toEqual([1_000, 3_000]);
+    });
+    // The client ends its tracked turn when the `session/prompt` request
+    // resolves, which is also what makes the adapter emit `turn/completed`.
+    // Wait for that rather than firing a synthetic `turn_finished`, or the
+    // next prompt races the first turn's teardown.
+    await vi.waitFor(() => {
+      expect(
+        events.some(
+          (event) => event.notification.method === "turn/completed",
+        ),
+      ).toBe(true);
+    });
+
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Second turn",
+      turnId: "turn-two",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "Second answer." },
+    });
+    transport.emitSessionUpdate(
+      session.sessionId,
+      responseCompleted({
+        input_tokens: 50,
+        cache_read_input_tokens: 450,
+        output_tokens: 5,
+      }),
+    );
+
+    // Turn two starts from its own zero rather than continuing turn one's
+    // 3,000 — each turn's usage line reports that turn's spend.
+    await vi.waitFor(() => {
+      expect(liveTotalsFor("turn-two")).toEqual([500]);
+    });
+    expect(liveTotalsFor("turn-one")).toEqual([1_000, 3_000]);
+
+    await adapter.close();
+  });
+
   it("uses separate live assistant item ids for ACP text separated by tools", async () => {
     const backendId = "acp:kimi" as AcpBackendId;
     const transport = new FakeAcpAgentTransport();

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1408,8 +1408,8 @@ describe("AcpBackendAdapter", () => {
   });
 
   it("restarts the ACP running total on each turn", async () => {
-    // Per turn, not per session — the ACP convention, matching how both
-    // reporting agents emit (Grok per `response_completed`, Qwen per
+    // Per turn, not per session — the ACP convention, matching every agent
+    // known to report (Grok per `response_completed`, Qwen per
     // `agent_message_chunk._meta.usage`). Codex sends the same field meaning a
     // session-cumulative total, so consumers subtract against it; see the note
     // on `AcpUsageEnvelope`. Pinned here so a change to cumulative fails at

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1408,12 +1408,12 @@ describe("AcpBackendAdapter", () => {
   });
 
   it("restarts the ACP running total on each turn", async () => {
-    // The running total is per turn, not per session: `liveTurnUsage` is keyed
-    // by turn and dropped at `turn_finished`. Pinning that here because the
-    // same field is session-cumulative on Codex, and consumers subtract
-    // against it — see the note on `AcpUsageEnvelope`. If a later change makes
-    // ACP cumulative, this test should fail loudly rather than the difference
-    // being discovered downstream.
+    // Per turn, not per session — the ACP convention, matching how both
+    // reporting agents emit (Grok per `response_completed`, Qwen per
+    // `agent_message_chunk._meta.usage`). Codex sends the same field meaning a
+    // session-cumulative total, so consumers subtract against it; see the note
+    // on `AcpUsageEnvelope`. Pinned here so a change to cumulative fails at
+    // the seam that defines the convention rather than downstream.
     const backendId = "acp:grok" as AcpBackendId;
     const transport = new FakeAcpAgentTransport();
     const events: AgentEvent[] = [];

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1137,37 +1137,272 @@ describe("AcpBackendAdapter", () => {
       transport.emitSessionUpdate(session.sessionId, update);
     }
 
+    // One event per model call as it lands, then the authoritative turn total.
+    // Banking everything until `turn_finished` is what left long ACP turns —
+    // a managed review runs for minutes — reporting no usage at all while the
+    // operator watched them run.
     await vi.waitFor(() => {
       expect(
         events.filter(
           (event) =>
             event.notification.method === "thread/tokenUsage/updated",
         ),
-      ).toHaveLength(1);
+      ).toHaveLength(3);
     });
     const usageEvents = events.filter(
       (event) => event.notification.method === "thread/tokenUsage/updated",
     );
-    expect(usageEvents.at(-1)).toEqual({
-      backend: backendId,
-      notification: {
-        method: "thread/tokenUsage/updated",
-        params: {
-          threadId: session.sessionId,
-          turnId: "turn-usage",
-          model: "qwen3-coder-plus",
-          tokenUsage: {
-            last_token_usage: {
-              input_tokens: 48_851,
-              cached_input_tokens: 20_000,
-              output_tokens: 322,
-              reasoning_output_tokens: 49,
-              total_tokens: 49_173,
+    // Each live event carries this call's own usage plus the running turn
+    // total, which is the pair `deriveLiveThreadTokenUsage` needs to seed a
+    // per-turn baseline and report growth against it.
+    // Partitioned rather than positional: this harness fires the whole canned
+    // fixture without awaiting the adapter's async emit pipeline, so the
+    // interleaving between model calls and prompt resolution is a property of
+    // the test, not of the protocol.
+    //
+    // A live model-call event is the pair `deriveLiveThreadTokenUsage` needs —
+    // this call's own usage plus the running turn total — so it can seed a
+    // per-turn baseline and report growth against it.
+    const liveEvents = usageEvents.filter(
+      (event) =>
+        "tokenUsage" in event.notification.params
+        && Boolean(
+          (event.notification.params.tokenUsage as Record<string, unknown>)
+            .total_token_usage,
+        ),
+    );
+    expect(
+      liveEvents.map((event) => event.notification.params),
+    ).toEqual([
+      {
+        threadId: session.sessionId,
+        turnId: "turn-usage",
+        model: "qwen3-coder-plus",
+        tokenUsage: {
+          last_token_usage: {
+            input_tokens: 23_851,
+            cached_input_tokens: 0,
+            output_tokens: 222,
+            reasoning_output_tokens: 29,
+            total_tokens: 24_073,
+          },
+          total_token_usage: {
+            input_tokens: 23_851,
+            cached_input_tokens: 0,
+            output_tokens: 222,
+            reasoning_output_tokens: 29,
+            total_tokens: 24_073,
+          },
+        },
+      },
+      {
+        threadId: session.sessionId,
+        turnId: "turn-usage",
+        model: "qwen3-coder-plus",
+        tokenUsage: {
+          last_token_usage: {
+            input_tokens: 25_000,
+            cached_input_tokens: 20_000,
+            output_tokens: 100,
+            reasoning_output_tokens: 20,
+            total_tokens: 25_100,
+          },
+          total_token_usage: {
+            input_tokens: 48_851,
+            cached_input_tokens: 20_000,
+            output_tokens: 322,
+            reasoning_output_tokens: 49,
+            total_tokens: 49_173,
+          },
+        },
+      },
+    ]);
+    // The turn total stays authoritative and still arrives without a
+    // `total_token_usage` companion, so it overwrites the turn's line rather
+    // than folding onto it — and `foldObservedContextReplay` ignores it, which
+    // is what keeps the live events from being counted twice as replays.
+    expect(
+      usageEvents.filter((event) => !liveEvents.includes(event)),
+    ).toEqual([
+      {
+        backend: backendId,
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: session.sessionId,
+            turnId: "turn-usage",
+            model: "qwen3-coder-plus",
+            tokenUsage: {
+              last_token_usage: {
+                input_tokens: 48_851,
+                cached_input_tokens: 20_000,
+                output_tokens: 322,
+                reasoning_output_tokens: 49,
+                total_tokens: 49_173,
+              },
             },
           },
         },
       },
+    ]);
+
+    await adapter.close();
+  });
+
+  it("reports Grok model-call usage while a turn is still running", async () => {
+    // Grok Build reports usage only on `response_completed`, a transient
+    // extension update. It was read by nothing, so a long Grok turn produced
+    // no usage event at all until it finished — the reason a managed review's
+    // sub-agent card sat blank for minutes while Codex's showed live spend.
+    const backendId = "acp:grok" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport();
+    const events: AgentEvent[] = [];
+    const sessions: AcpSessionMetadata[] = [];
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+      launchDescriptor: {
+        backendId,
+        registryId: "grok",
+        distributionKind: "local",
+        command: "grok",
+        args: ["acp"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => sessions,
+        getSession: (_backendId, sessionId) =>
+          sessions.find((session) => session.sessionId === sessionId),
+        upsertSession: (metadata) => {
+          const index = sessions.findIndex(
+            (session) => session.sessionId === metadata.sessionId,
+          );
+          if (index >= 0) {
+            sessions[index] = metadata;
+          } else {
+            sessions.push(metadata);
+          }
+        },
+      },
+      captureStores: [],
+      createAcpTransport: () => transport,
+      emit: async (event) => {
+        events.push(event);
+      },
+      handleServerRequest: async () => ({ decision: "accept" }),
     });
+
+    const client = await adapter.getClient(backendId);
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "full-access",
+      acpRuntime: { currentModelId: "grok-4.5-build" },
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Review the current checkout against base branch 'main'.",
+      turnId: "review-turn",
+    });
+    // Two model calls of a still-running review. `input_tokens` is the
+    // uncached remainder; cached reads and cache creation are reported apart.
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "response_completed",
+      message_id: "msg_1",
+      stop_reason: "tool_use",
+      usage: {
+        input_tokens: 300,
+        cache_read_input_tokens: 900,
+        cache_creation_input_tokens: 100,
+        output_tokens: 40,
+        reasoning_tokens: 12,
+      },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "response_completed",
+      message_id: "msg_2",
+      stop_reason: "tool_use",
+      usage: {
+        input_tokens: 250,
+        cache_read_input_tokens: 1_800,
+        cache_creation_input_tokens: 0,
+        output_tokens: 60,
+        reasoning_tokens: 30,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        events.filter(
+          (event) => event.notification.method === "thread/tokenUsage/updated",
+        ).length,
+      ).toBeGreaterThanOrEqual(2);
+    });
+    const liveUsage = events
+      .filter(
+        (event) => event.notification.method === "thread/tokenUsage/updated",
+      )
+      .map((event) => event.notification.params)
+      .filter(
+        (params) =>
+          "tokenUsage" in params
+          && Boolean(
+            (params.tokenUsage as Record<string, unknown>).total_token_usage,
+          ),
+      );
+
+    expect(liveUsage).toEqual([
+      {
+        threadId: session.sessionId,
+        turnId: "review-turn",
+        model: "grok-4.5-build",
+        tokenUsage: {
+          last_token_usage: {
+            input_tokens: 1_300,
+            cached_input_tokens: 900,
+            output_tokens: 40,
+            reasoning_output_tokens: 12,
+            total_tokens: 1_340,
+          },
+          total_token_usage: {
+            input_tokens: 1_300,
+            cached_input_tokens: 900,
+            output_tokens: 40,
+            reasoning_output_tokens: 12,
+            total_tokens: 1_340,
+          },
+        },
+      },
+      {
+        threadId: session.sessionId,
+        turnId: "review-turn",
+        model: "grok-4.5-build",
+        tokenUsage: {
+          last_token_usage: {
+            input_tokens: 2_050,
+            cached_input_tokens: 1_800,
+            output_tokens: 60,
+            reasoning_output_tokens: 30,
+            total_tokens: 2_110,
+          },
+          total_token_usage: {
+            input_tokens: 3_350,
+            cached_input_tokens: 2_700,
+            output_tokens: 100,
+            reasoning_output_tokens: 42,
+            total_tokens: 3_450,
+          },
+        },
+      },
+    ]);
 
     await adapter.close();
   });

--- a/apps/desktop/src/main/__tests__/acp-usage.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-usage.test.ts
@@ -87,6 +87,103 @@ describe("ACP usage normalization", () => {
     });
   });
 
+  // Grok Build reports each model call on `response_completed`, a transient
+  // xAI extension update that never reaches updates.jsonl. It was the only
+  // mid-turn usage Grok emits and the parser ignored it outright, so a long
+  // turn reported nothing at all until it finished.
+  //
+  // Its shape is NOT the turn total's shape. `ResponseUsage` is snake_case and
+  // its `input_tokens` is the *uncached* prompt remainder
+  // (prompt − cache_read − cache_creation), whereas `turn_completed.usage` is
+  // camelCase with an `inputTokens` that includes both. Reading the field
+  // straight across would undercount every running total by the cached
+  // portion, then jump when the turn total landed.
+  describe("Grok response_completed model-call usage", () => {
+    function responseCompleted(usage: Record<string, number>) {
+      return readAcpUsageEnvelope({
+        sessionUpdate: "response_completed",
+        message_id: "msg_1",
+        stop_reason: "tool_use",
+        usage,
+      });
+    }
+
+    it("normalizes the uncached input remainder to an inclusive total", () => {
+      expect(
+        responseCompleted({
+          input_tokens: 300,
+          cache_read_input_tokens: 900,
+          cache_creation_input_tokens: 100,
+          output_tokens: 40,
+          reasoning_tokens: 12,
+        }),
+      ).toEqual({
+        scope: "model-call",
+        tokenUsage: {
+          cachedInputTokens: 900,
+          inputTokens: 1_300,
+          outputTokens: 40,
+          reasoningOutputTokens: 12,
+          totalTokens: 1_340,
+        },
+      });
+    });
+
+    it("ignores a response that carries no usage", () => {
+      expect(
+        readAcpUsageEnvelope({
+          sessionUpdate: "response_completed",
+          stop_reason: "end_turn",
+        }),
+      ).toBeUndefined();
+    });
+
+    it("accumulates to the same totals Grok reports at turn end", () => {
+      // Two model calls whose sums must match what turn_completed would say:
+      // prompt 1,300 + 2,050, of which 900 + 1,800 cached.
+      const folded = [
+        responseCompleted({
+          input_tokens: 300,
+          cache_read_input_tokens: 900,
+          cache_creation_input_tokens: 100,
+          output_tokens: 40,
+          reasoning_tokens: 12,
+        }),
+        responseCompleted({
+          input_tokens: 250,
+          cache_read_input_tokens: 1_800,
+          cache_creation_input_tokens: 0,
+          output_tokens: 60,
+          reasoning_tokens: 30,
+        }),
+      ].reduce<AcpTokenUsage | undefined>(
+        (total, envelope) =>
+          envelope ? foldAcpTurnUsage(total, envelope) : total,
+        undefined,
+      );
+
+      expect(folded).toEqual({
+        cachedInputTokens: 2_700,
+        inputTokens: 3_350,
+        outputTokens: 100,
+        reasoningOutputTokens: 42,
+        totalTokens: 3_450,
+      });
+      // The authoritative turn total still overwrites the running sum.
+      const turnTotal = readAcpUsageEnvelope({
+        sessionUpdate: "turn_completed",
+        usage: {
+          inputTokens: 3_350,
+          cachedReadTokens: 2_700,
+          outputTokens: 100,
+          reasoningTokens: 42,
+          totalTokens: 3_450,
+        },
+      });
+      expect(turnTotal && foldAcpTurnUsage(folded, turnTotal)).toEqual(folded);
+    });
+  });
+
   it("recovers the selected ACP model from session runtime state", () => {
     expect(
       readAcpSelectedModel({

--- a/apps/desktop/src/main/__tests__/acp-usage.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-usage.test.ts
@@ -9,10 +9,11 @@ import {
   type AcpTokenUsage,
 } from "../acp/acp-usage";
 
-const fixturePath = path.join(
+const fixtureDir = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
-  "fixtures/acp-transcripts/qwen-tool-usage.json",
+  "fixtures/acp-transcripts",
 );
+const fixturePath = path.join(fixtureDir, "qwen-tool-usage.json");
 
 describe("ACP usage normalization", () => {
   it("aggregates every Qwen model-call envelope in a tool-using turn", () => {
@@ -182,6 +183,43 @@ describe("ACP usage normalization", () => {
       });
       expect(turnTotal && foldAcpTurnUsage(folded, turnTotal)).toEqual(folded);
     });
+  });
+
+  // Whether Kimi reports usage was previously "unknown", and before that it
+  // was wrongly asserted to be "no" on the strength of a fixture that could
+  // not have shown usage either way. This is a purpose-made capture: a real
+  // `kimi acp` turn end to end, driven with a prompt chosen to need no tools
+  // ("tell me your favorite breakfast cereal"), recorded off the wire.
+  //
+  // Kimi Code 0.31.1 sends no usage anywhere in a complete turn. It tracks
+  // tokens internally — `/usage` is in its advertised command list — but does
+  // not put them on the ACP wire, so PwrAgent has nothing to price a Kimi
+  // thread from. Recapture and revisit when Kimi's ACP surface changes.
+  it("finds no token usage in a complete Kimi Code 0.31.1 turn", () => {
+    const updates = JSON.parse(
+      readFileSync(
+        path.join(fixtureDir, "kimi-code-0-31-cereal.json"),
+        "utf8",
+      ),
+    ) as Array<Record<string, unknown>>;
+
+    // A real turn: the agent thought, answered, and advertised its commands.
+    expect(updates.length).toBeGreaterThan(50);
+    expect(
+      new Set(updates.map((update) => update.sessionUpdate)),
+    ).toEqual(
+      new Set([
+        "available_commands_update",
+        "agent_thought_chunk",
+        "agent_message_chunk",
+      ]),
+    );
+    expect(
+      updates.flatMap((update) => {
+        const envelope = readAcpUsageEnvelope(update);
+        return envelope ? [envelope] : [];
+      }),
+    ).toEqual([]);
   });
 
   it("recovers the selected ACP model from session runtime state", () => {

--- a/apps/desktop/src/main/__tests__/acp-usage.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-usage.test.ts
@@ -203,8 +203,8 @@ describe("ACP usage normalization", () => {
       ),
     ) as Array<Record<string, unknown>>;
 
-    // A real turn: the agent thought, answered, and advertised its commands.
-    expect(updates.length).toBeGreaterThan(50);
+    // A real turn, not a stub: the agent thought, answered, and advertised
+    // its commands.
     expect(
       new Set(updates.map((update) => update.sessionUpdate)),
     ).toEqual(

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18353,6 +18353,73 @@ command = "pnpm dev"
     await followup.registry.close();
   });
 
+  it("keys an ACP managed review on the ids its usage notifications carry", async () => {
+    // Live sub-agent pricing depends on one join: recordTaskMonitorUsage looks
+    // the review up by (backend, notification.threadId, notification.turnId),
+    // and the ACP adapter stamps those as the child session id and its turn id
+    // (see "reports Grok model-call usage while a turn is still running" in
+    // acp-backend-adapter.test.ts). If startReview ever recorded the parent
+    // thread or a different turn id here, every usage event would miss the
+    // review record and the sub-agent card would silently stay blank again.
+    const acpBackendId = "acp:grok" as AcpBackendId;
+    const parentThreadId = "grok-usage-review-parent";
+    const sessions: AcpSessionMetadata[] = [{
+      backendId: acpBackendId,
+      sessionId: parentThreadId,
+      title: "Grok review parent",
+      cwd: "/repo/worktree",
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      executionMode: "default",
+      status: "idle",
+    }];
+    const startPrompt = vi.fn((params: Parameters<KimiStartPrompt>[0]) => ({
+      sessionId: params.sessionId,
+      turnId: "grok-review-turn",
+    }));
+    const overlayStore = createOverlayStoreMock();
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      overlayStore,
+      sessionId: parentThreadId,
+      sessions,
+      startPrompt,
+    });
+
+    const review = await registry.startReview({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    // The hidden child session the review actually runs in — not the parent.
+    const childSessionId = startPrompt.mock.calls.at(-1)?.[0].sessionId;
+    expect(childSessionId).toBeDefined();
+    expect(childSessionId).not.toBe(parentThreadId);
+    expect(review).toMatchObject({
+      threadId: parentThreadId,
+      reviewThreadId: childSessionId,
+      turnId: "grok-review-turn",
+    });
+
+    // And the sub-agent row the card renders is registered under that child,
+    // waiting for monitorUsage to arrive.
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+    });
+    expect(overlay?.subAgents?.[0]).toMatchObject({
+      monitorId: "review:grok-review-turn",
+      monitorThreadId: childSessionId,
+      monitorTurnId: "grok-review-turn",
+      status: "running",
+    });
+    expect(overlay?.subAgents?.[0]?.monitorUsage).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("routes direct and controlled Kimi review cancellation to the hidden child", async () => {
     const acpBackendId = "acp:kimi" as AcpBackendId;
     const parentThreadId = "kimi-review-parent";

--- a/apps/desktop/src/main/__tests__/fixtures/acp-transcripts/kimi-code-0-31-cereal.json
+++ b/apps/desktop/src/main/__tests__/fixtures/acp-transcripts/kimi-code-0-31-cereal.json
@@ -1,0 +1,782 @@
+[
+ {
+  "sessionUpdate": "available_commands_update",
+  "availableCommands": [
+   {
+    "name": "compact",
+    "description": "Compact the conversation context",
+    "input": {
+     "hint": "<optional custom summarization instructions>"
+    }
+   },
+   {
+    "name": "status",
+    "description": "Show current session status"
+   },
+   {
+    "name": "usage",
+    "description": "Show session token usage"
+   },
+   {
+    "name": "mcp",
+    "description": "Show MCP server status"
+   },
+   {
+    "name": "tasks",
+    "description": "List background tasks"
+   },
+   {
+    "name": "help",
+    "description": "Show available ACP commands"
+   },
+   {
+    "name": "check-kimi-code-docs",
+    "description": "Answer questions about the Kimi Code product using the official documentation — CLI usage, configuration, slash commands, features, membership and quota, API onboarding, third-party tool setup, and error codes. Use when the user asks how Kimi Code works, how to set something up, or what a Kimi Code error message means."
+   },
+   {
+    "name": "custom-theme",
+    "description": "Create or edit a kimi-code custom color theme — a JSON file under the resolved KIMI_CODE_HOME data directory that recolors the TUI. Use when the user wants their own theme, asks for a specific palette or mood, or wants to tweak an existing custom theme's colors."
+   },
+   {
+    "name": "import-from-cc-codex",
+    "description": "Import Claude Code and Codex instructions, skills, and MCP settings into Kimi Code."
+   },
+   {
+    "name": "mcp-config",
+    "description": "Configure MCP servers and handle MCP OAuth login."
+   },
+   {
+    "name": "sub-skill",
+    "description": "Discover and reorganize the skill inventory into hierarchical sub-skill bundles. Use when the user asks to review, group, or consolidate skills into a parent bundle."
+   },
+   {
+    "name": "sub-skill.consolidate",
+    "description": "Apply an approved sub-skill grouping by moving user-specified skills into a parent bundle, with timestamped backups of every modified directory."
+   },
+   {
+    "name": "sub-skill.review",
+    "description": "Analyze the available skill set and recommend candidate groups that could be consolidated into sub-skill bundles. Read-only — proposes a plan, does not move files."
+   },
+   {
+    "name": "update-config",
+    "description": "Inspect or edit kimi-code's own config — `config.toml` (model, provider, permission, hooks) and `tui.toml` (theme, editor, notifications, auto-update). Use when the user asks what a setting does or wants to change one."
+   },
+   {
+    "name": "write-goal",
+    "description": "Help the user craft a well-specified `/goal` objective for goal mode — turn a rough intention into a completion contract with a clear finish line, proof, boundaries, and stop rule. Use when the user asks for help writing, refining, or improving a goal."
+   },
+   {
+    "name": "skill:datadog-investigator",
+    "description": "Investigate Datadog alerts, incidents, and service behavior using a consistent evidence-first workflow. Use this when a user wants help triaging an alert, gathering logs and traces, or turning a Datadog signal into clear findings or follow-up actions."
+   },
+   {
+    "name": "skill:find-skills",
+    "description": "Helps users discover and install agent skills when they ask questions like \"how do I do X\", \"find a skill for X\", \"is there a skill that can...\", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill."
+   },
+   {
+    "name": "skill:slidev",
+    "description": "Create and present web-based slidedecks for developers using Slidev with Markdown, Vue components, code highlighting, animations, and interactive features. Use when building technical presentations, conference talks, code walkthroughs, teaching materials, or developer decks."
+   }
+  ]
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": "We"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " need"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " answer"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " simple"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " question"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": "."
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " Need"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " final"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " answer"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": "."
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " User"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " asks"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " favorite"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " breakfast"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " cereal"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": "."
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " As"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " AI"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " no"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " personal"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " preferences"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": ","
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " but"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " can"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " say"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " if"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " I"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " had"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " to"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " pick"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": ","
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " maybe"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " something"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": "."
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " Need"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " concise"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": "."
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " Could"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " mention"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " I"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " don't"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " eat"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": ","
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " but"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " a"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " solid"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " pick"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " is"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": "..."
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " Need"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " maybe"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " favorite"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": "?"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " Avoid"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " over"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": "expl"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": "aining"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": "."
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " Need"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " maybe"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " no"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " tools"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": "."
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " Final"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " in"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": " English"
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": "."
+  }
+ },
+ {
+  "sessionUpdate": "agent_thought_chunk",
+  "content": {
+   "type": "text",
+   "text": ""
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": "I"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " don"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": "’t"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " eat"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " breakfast"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": ","
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " but"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " if"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " I"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " had"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " to"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " pick"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " a"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " cereal"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " to"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " recommend"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": ":"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " plain"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " Cheer"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": "ios"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " —"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " dependable"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": ","
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " not"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " too"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " sweet"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": ","
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " and"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " good"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " with"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": " fruit"
+  }
+ },
+ {
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+   "type": "text",
+   "text": "."
+  }
+ }
+]

--- a/apps/desktop/src/main/acp/acp-usage.ts
+++ b/apps/desktop/src/main/acp/acp-usage.ts
@@ -25,15 +25,16 @@ export type AcpUsageEnvelope = {
  *
  * Every ACP agent known to report usage reports it per model call, which folds
  * to per turn: Grok on `response_completed`, Qwen on
- * `agent_message_chunk._meta.usage`. Whether Gemini or Kimi report anything is
- * untested — the `acp-transcripts` fixtures are normalizer-parity captures
- * with no completed turn in them, so they cannot answer it (grok-build.json
- * carries no usage either, and Grok certainly reports). Codex is the outlier
- * among what we do know: it sends this field meaning a session-cumulative
- * total, which is why `deriveLiveThreadTokenUsage` can read `total - last` as
- * "the context this turn inherited". For ACP that subtraction lands on zero on
- * a turn's first call, which is equally correct: the turn did start from
- * nothing.
+ * `agent_message_chunk._meta.usage`. Kimi Code 0.31.1 reports none at all —
+ * `kimi-code-0-31-cereal.json` is a full captured turn with no usage anywhere,
+ * so a Kimi thread cannot be priced. Gemini is still untested; the
+ * `acp-transcripts` parity captures cannot answer it, since they hold no
+ * completed turn (grok-build.json carries no usage either, and Grok certainly
+ * reports). Codex is the outlier among the reporters: it sends this field
+ * meaning a session-cumulative total, which is why
+ * `deriveLiveThreadTokenUsage` can read `total - last` as "the context this
+ * turn inherited". For ACP that subtraction lands on zero on a turn's first
+ * call, which is equally correct: the turn did start from nothing.
  *
  * If a future agent reports cumulative instead, do NOT quietly widen this
  * function to accept both. The shapes are indistinguishable from a single

--- a/apps/desktop/src/main/acp/acp-usage.ts
+++ b/apps/desktop/src/main/acp/acp-usage.ts
@@ -23,13 +23,17 @@ export type AcpUsageEnvelope = {
  * restarts at zero on every turn. That is the number it sends as
  * `total_token_usage` on `thread/tokenUsage/updated`.
  *
- * Both ACP agents that report usage today report per model call, which folds
+ * Every ACP agent known to report usage reports it per model call, which folds
  * to per turn: Grok on `response_completed`, Qwen on
- * `agent_message_chunk._meta.usage`. Gemini and Kimi report none. Codex is the
- * outlier — it sends the same field meaning a session-cumulative total, which
- * is why `deriveLiveThreadTokenUsage` can read `total - last` as "the context
- * this turn inherited". For ACP that subtraction lands on zero on a turn's
- * first call, which is equally correct: the turn did start from nothing.
+ * `agent_message_chunk._meta.usage`. Whether Gemini or Kimi report anything is
+ * untested — the `acp-transcripts` fixtures are normalizer-parity captures
+ * with no completed turn in them, so they cannot answer it (grok-build.json
+ * carries no usage either, and Grok certainly reports). Codex is the outlier
+ * among what we do know: it sends this field meaning a session-cumulative
+ * total, which is why `deriveLiveThreadTokenUsage` can read `total - last` as
+ * "the context this turn inherited". For ACP that subtraction lands on zero on
+ * a turn's first call, which is equally correct: the turn did start from
+ * nothing.
  *
  * If a future agent reports cumulative instead, do NOT quietly widen this
  * function to accept both. The shapes are indistinguishable from a single

--- a/apps/desktop/src/main/acp/acp-usage.ts
+++ b/apps/desktop/src/main/acp/acp-usage.ts
@@ -18,6 +18,9 @@ export function readAcpUsageEnvelope(
   update: Record<string, unknown>,
 ): AcpUsageEnvelope | undefined {
   const kind = readAcpUpdateKind(update);
+  if (kind === "response_completed") {
+    return readGrokResponseUsageEnvelope(readRecord(update.usage));
+  }
   const usage =
     kind === "turn_completed"
       ? readRecord(update.usage)
@@ -57,6 +60,70 @@ export function readAcpUsageEnvelope(
   return {
     ...(model ? { model } : {}),
     scope: kind === "turn_completed" ? "turn" : "model-call",
+    tokenUsage: {
+      ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
+      ...(inputTokens !== undefined ? { inputTokens } : {}),
+      ...(outputTokens !== undefined ? { outputTokens } : {}),
+      ...(reasoningOutputTokens !== undefined
+        ? { reasoningOutputTokens }
+        : {}),
+      ...(totalTokens !== undefined ? { totalTokens } : {}),
+    },
+  };
+}
+
+/**
+ * Grok Build's per-model-call usage, carried on the transient
+ * `response_completed` extension update. Its `ResponseUsage` struct is
+ * snake_case on the wire and reports the *uncached* prompt remainder:
+ *
+ *   input_tokens = prompt − cache_read_input_tokens − cache_creation_input_tokens
+ *
+ * `turn_completed.usage` is camelCase and its `inputTokens` is the whole
+ * prompt. Normalizing to the inclusive convention here is what lets a running
+ * sum of model calls land on the same numbers the turn total reports, instead
+ * of trailing it by the cached portion and jumping at the end of the turn.
+ */
+function readGrokResponseUsageEnvelope(
+  usage: Record<string, unknown> | undefined,
+): AcpUsageEnvelope | undefined {
+  if (!usage) {
+    return undefined;
+  }
+  const uncachedInputTokens = readFiniteNumber(usage.input_tokens);
+  const cachedInputTokens = readFiniteNumber(usage.cache_read_input_tokens);
+  const cacheCreationTokens = readFiniteNumber(
+    usage.cache_creation_input_tokens,
+  );
+  const outputTokens = readFiniteNumber(usage.output_tokens);
+  const reasoningOutputTokens = readFiniteNumber(usage.reasoning_tokens);
+  if (
+    uncachedInputTokens === undefined
+    && cachedInputTokens === undefined
+    && cacheCreationTokens === undefined
+    && outputTokens === undefined
+    && reasoningOutputTokens === undefined
+  ) {
+    return undefined;
+  }
+
+  const inputTokens =
+    uncachedInputTokens !== undefined
+    || cachedInputTokens !== undefined
+    || cacheCreationTokens !== undefined
+      ? (uncachedInputTokens ?? 0)
+        + (cachedInputTokens ?? 0)
+        + (cacheCreationTokens ?? 0)
+      : undefined;
+  // Grok's turn total reports totalTokens as prompt + completion, so derive
+  // the same sum per call rather than leaving it for a later consumer to
+  // guess at from a partially-populated envelope.
+  const totalTokens =
+    inputTokens !== undefined || outputTokens !== undefined
+      ? (inputTokens ?? 0) + (outputTokens ?? 0)
+      : undefined;
+  return {
+    scope: "model-call",
     tokenUsage: {
       ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
       ...(inputTokens !== undefined ? { inputTokens } : {}),

--- a/apps/desktop/src/main/acp/acp-usage.ts
+++ b/apps/desktop/src/main/acp/acp-usage.ts
@@ -14,6 +14,45 @@ export type AcpUsageEnvelope = {
   tokenUsage: AcpTokenUsage;
 };
 
+/**
+ * ACP running totals are PER TURN, not per session.
+ *
+ * `AcpBackendAdapter` folds these envelopes into a `liveTurnUsage` entry keyed
+ * by `(backend, session, turn)` and drops it at `turn_finished`, so the sum
+ * restarts at zero on every turn. That is the number it sends as
+ * `total_token_usage` on `thread/tokenUsage/updated`.
+ *
+ * Codex sends the same field meaning something else: a session-cumulative
+ * total, which is why `deriveLiveThreadTokenUsage` can read `total - last` as
+ * "the context this turn inherited". For ACP that subtraction lands on zero on
+ * a turn's first call, which is also correct — the turn did start from nothing
+ * — so every consumer traced today produces right answers from either shape.
+ *
+ * Two things follow that are NOT obvious from the field name, and one open
+ * question:
+ *
+ *  - `deriveTurnUsageBaseline` (renderer) prefers `contextWindow.cumulative*`
+ *    over `total - last` when a context window is known. Nothing populates a
+ *    context window from an ACP payload today, because these notifications
+ *    carry no `modelContextWindow`. Adding one — the obvious shape of a Grok
+ *    context-usage indicator — would feed a per-turn total into a baseline
+ *    that expects a session-cumulative one, and the live turn usage would
+ *    collapse toward zero. Settle the semantics before adding that field.
+ *  - `foldObservedContextReplay` keeps its cursor per THREAD and treats a
+ *    total at or below the cursor as a stale re-emission. Per-turn totals
+ *    restart below it, so after the first turn an ACP thread stops advancing
+ *    that cursor. It contributed nothing before this shape existed either (the
+ *    fold requires a total, and ACP sent none), so no observable count
+ *    regressed — but ACP does not meaningfully participate in replay
+ *    accounting, and a half-advanced cursor is easy to mistake for one that
+ *    works.
+ *
+ * Whether ACP should instead report a session-cumulative total is genuinely
+ * open. It would align both of the above with Codex, but it needs answers we
+ * do not have yet: what a resumed or compacted ACP session should report, and
+ * whether Grok's per-call usage is safe to accumulate across turns at all.
+ */
+
 export function readAcpUsageEnvelope(
   update: Record<string, unknown>,
 ): AcpUsageEnvelope | undefined {
@@ -107,6 +146,12 @@ function readGrokResponseUsageEnvelope(
     return undefined;
   }
 
+  // Cache-creation tokens land in `inputTokens` but not in
+  // `cachedInputTokens`, so downstream `inputTokens - cachedInputTokens`
+  // prices them as uncached input. That mirrors `turn_completed.usage`, whose
+  // `cacheCreationTokens` is a separate field this parser also folds nowhere
+  // — matching it is what keeps the running sum and the turn total in
+  // agreement. It is not a claim about how xAI bills cache writes.
   const inputTokens =
     uncachedInputTokens !== undefined
     || cachedInputTokens !== undefined

--- a/apps/desktop/src/main/acp/acp-usage.ts
+++ b/apps/desktop/src/main/acp/acp-usage.ts
@@ -15,21 +15,29 @@ export type AcpUsageEnvelope = {
 };
 
 /**
- * ACP running totals are PER TURN, not per session.
+ * ACP running totals are PER TURN, not per session. That is the convention for
+ * this transport, deliberately, not an accident of one provider.
  *
  * `AcpBackendAdapter` folds these envelopes into a `liveTurnUsage` entry keyed
  * by `(backend, session, turn)` and drops it at `turn_finished`, so the sum
  * restarts at zero on every turn. That is the number it sends as
  * `total_token_usage` on `thread/tokenUsage/updated`.
  *
- * Codex sends the same field meaning something else: a session-cumulative
- * total, which is why `deriveLiveThreadTokenUsage` can read `total - last` as
- * "the context this turn inherited". For ACP that subtraction lands on zero on
- * a turn's first call, which is also correct — the turn did start from nothing
- * — so every consumer traced today produces right answers from either shape.
+ * Both ACP agents that report usage today report per model call, which folds
+ * to per turn: Grok on `response_completed`, Qwen on
+ * `agent_message_chunk._meta.usage`. Gemini and Kimi report none. Codex is the
+ * outlier — it sends the same field meaning a session-cumulative total, which
+ * is why `deriveLiveThreadTokenUsage` can read `total - last` as "the context
+ * this turn inherited". For ACP that subtraction lands on zero on a turn's
+ * first call, which is equally correct: the turn did start from nothing.
  *
- * Two things follow that are NOT obvious from the field name, and one open
- * question:
+ * If a future agent reports cumulative instead, do NOT quietly widen this
+ * function to accept both. The shapes are indistinguishable from a single
+ * observation, so the reader would have to guess. Track which providers (and
+ * which versions) report which way, and normalize on that, keeping per-turn as
+ * the shape this layer hands downstream.
+ *
+ * Two consequences of per-turn that the field name hides:
  *
  *  - `deriveTurnUsageBaseline` (renderer) prefers `contextWindow.cumulative*`
  *    over `total - last` when a context window is known. Nothing populates a
@@ -37,20 +45,16 @@ export type AcpUsageEnvelope = {
  *    carry no `modelContextWindow`. Adding one — the obvious shape of a Grok
  *    context-usage indicator — would feed a per-turn total into a baseline
  *    that expects a session-cumulative one, and the live turn usage would
- *    collapse toward zero. Settle the semantics before adding that field.
+ *    collapse toward zero. Fix that baseline preference before adding the
+ *    field; committing to per-turn makes this the likelier trap, not a rarer
+ *    one.
  *  - `foldObservedContextReplay` keeps its cursor per THREAD and treats a
  *    total at or below the cursor as a stale re-emission. Per-turn totals
  *    restart below it, so after the first turn an ACP thread stops advancing
- *    that cursor. It contributed nothing before this shape existed either (the
- *    fold requires a total, and ACP sent none), so no observable count
- *    regressed — but ACP does not meaningfully participate in replay
- *    accounting, and a half-advanced cursor is easy to mistake for one that
- *    works.
- *
- * Whether ACP should instead report a session-cumulative total is genuinely
- * open. It would align both of the above with Codex, but it needs answers we
- * do not have yet: what a resumed or compacted ACP session should report, and
- * whether Grok's per-call usage is safe to accumulate across turns at all.
+ *    that cursor. Nothing regressed — the fold needs a total and ACP sent none
+ *    before — but the practical position is that ACP does not participate in
+ *    replay accounting, and a half-advanced cursor is easy to mistake for one
+ *    that works.
  */
 
 export function readAcpUsageEnvelope(

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -1857,9 +1857,9 @@ export class AcpBackendAdapter {
           //
           // `totalTokenUsage` here is the running total for THIS TURN, since
           // `liveTurnUsage` is keyed by turn and dropped at `turn_finished`.
-          // Codex sends a session-cumulative total in the same field; see the
-          // note on `AcpUsageEnvelope` for what that divergence does and does
-          // not affect before changing this payload's shape.
+          // That is the ACP convention; Codex sends a session-cumulative total
+          // in the same field. See the note on `AcpUsageEnvelope` before
+          // changing this payload's shape.
           if (usageEnvelope.scope === "model-call" && !fromSessionLoad) {
             liveUsageNotification = acpUsageNotification({
               envelope: {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -1854,6 +1854,12 @@ export class AcpBackendAdapter {
           // all while it runs, which is what leaves the review sub-agent card
           // blank next to Codex's live one. Session-load replay is excluded:
           // those envelopes are history, not new spend.
+          //
+          // `totalTokenUsage` here is the running total for THIS TURN, since
+          // `liveTurnUsage` is keyed by turn and dropped at `turn_finished`.
+          // Codex sends a session-cumulative total in the same field; see the
+          // note on `AcpUsageEnvelope` for what that divergence does and does
+          // not affect before changing this payload's shape.
           if (usageEnvelope.scope === "model-call" && !fromSessionLoad) {
             liveUsageNotification = acpUsageNotification({
               envelope: {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -1832,22 +1832,40 @@ export class AcpBackendAdapter {
       }) => {
         const updateKind = readAcpUpdateKind(update);
         const usageEnvelope = readAcpUsageEnvelope(update);
+        let liveUsageNotification: AppServerNotification | undefined;
         if (usageEnvelope && turnId) {
           const usageKey = [agent.backendId, sessionId, turnId].join(":");
           const previousUsage = this.liveTurnUsage.get(usageKey);
-          this.liveTurnUsage.set(usageKey, {
-            model:
-              usageEnvelope.model ??
-              previousUsage?.model ??
-              selectedAcpModel(
-                agent,
-                this.getSession(agent.backendId, sessionId),
-              ),
-            tokenUsage: foldAcpTurnUsage(
-              previousUsage?.tokenUsage,
-              usageEnvelope,
-            ),
-          });
+          const model =
+            usageEnvelope.model ??
+            previousUsage?.model ??
+            selectedAcpModel(
+              agent,
+              this.getSession(agent.backendId, sessionId),
+            );
+          const tokenUsage = foldAcpTurnUsage(
+            previousUsage?.tokenUsage,
+            usageEnvelope,
+          );
+          this.liveTurnUsage.set(usageKey, { model, tokenUsage });
+          // Publish each model call as it lands rather than banking the whole
+          // turn until `turn_finished`. A long turn — a managed review runs
+          // for minutes across a dozen calls — otherwise reports no usage at
+          // all while it runs, which is what leaves the review sub-agent card
+          // blank next to Codex's live one. Session-load replay is excluded:
+          // those envelopes are history, not new spend.
+          if (usageEnvelope.scope === "model-call" && !fromSessionLoad) {
+            liveUsageNotification = acpUsageNotification({
+              envelope: {
+                ...(model ? { model } : {}),
+                scope: "model-call",
+                tokenUsage: usageEnvelope.tokenUsage,
+              },
+              threadId: sessionId,
+              totalTokenUsage: tokenUsage,
+              turnId,
+            });
+          }
         }
         const completedUsage =
           updateKind === "turn_finished" && turnId
@@ -1868,7 +1886,7 @@ export class AcpBackendAdapter {
               totalTokenUsage: completedUsage.tokenUsage,
               turnId,
             })
-          : undefined;
+          : liveUsageNotification;
         const agentMessageDelta =
           updateKind === "agent_message_chunk"
             ? readAcpUpdateText(update)


### PR DESCRIPTION
Follow-up to #1394. A Grok managed review runs for minutes across a dozen model calls, and its sub-agent card showed no usage the whole time while Codex's showed live spend.

## 1. Grok's per-model-call usage was never read

Grok Build reports each model call on `response_completed.usage` — a transient xAI extension update never written to `updates.jsonl`. [`readAcpUsageEnvelope`](apps/desktop/src/main/acp/acp-usage.ts) read usage from exactly two kinds: `turn_completed.usage` and `agent_message_chunk._meta.usage`. Grok leaves that `_meta` null, so every per-call report was dropped.

**Its shape is not the turn total's shape.** From grok-build's `ResponseUsage` (snake_case, no `rename_all`):

```rust
input_tokens: prompt_tokens - cached_prompt_tokens - cache_creation_prompt_tokens
cache_read_input_tokens: cached_prompt_tokens
```

whereas `turn_completed.usage` is camelCase and its `inputTokens` is the whole prompt. Reading the field straight across would have undercounted every running total by the cached portion — on the captured review, ~510k of 560k input — then jumped when the turn total landed. The parser normalizes to the inclusive convention, with a test asserting a running sum lands exactly on what `turn_completed` reports.

## 2. Usage was banked until `turn_finished`

The adapter accumulated envelopes but only emitted `thread/tokenUsage/updated` at `turn_finished`. `recordTaskMonitorUsage` needs that notification to populate a review record's `latestUsage` → `subAgents[].monitorUsage`, which is what the card renders — so nothing arrived until the review was over.

Each model call is now published as it lands, carrying its own usage plus the running turn total. That pair is what `deriveLiveThreadTokenUsage` needs to seed a per-turn baseline and report growth against it, so repeated events overwrite the turn's line rather than accumulating. The authoritative turn total still arrives at `turn_finished` **without** a `total_token_usage` companion, which matters twice: it overwrites rather than folding, and `foldObservedContextReplay` requires both fields, so it isn't counted as an extra context replay.

**This reaches Qwen too**, which reports mid-turn usage via `agent_message_chunk._meta.usage` and was banked the same way.

## 3. Per-turn is now the documented ACP convention

`total_token_usage` means a **per-turn** running total on ACP and a **session-cumulative** one on Codex. Every consumer produces correct numbers from either shape today — the per-turn baseline derives to zero, which is right, since the turn did start from nothing — so this documents the divergence rather than changing it. Two consequences are written down where someone would hit them:

- `deriveTurnUsageBaseline` prefers a known context window over `total - last`. Nothing populates one from an ACP payload today. Adding `modelContextWindow` — the obvious shape of a Grok context-usage indicator — would feed a per-turn total into a baseline expecting a cumulative one and collapse live turn usage toward zero. **Fix that baseline preference before adding the field.**
- `foldObservedContextReplay` keeps a per-thread cursor and reads a total at or below it as stale, so per-turn totals stop advancing it after the first turn. Nothing regressed (the fold needs a total and ACP sent none before), but ACP does not participate in replay accounting.

If a future agent reports cumulative, the shapes are indistinguishable from a single observation — track it per provider/version and normalize, keeping per-turn as what this layer hands downstream.

## 4. A capture harness, and what it settled about Kimi

`scripts/capture-acp-transcript.mjs` drives a real ACP agent the way `AcpAgentClient` does and records every frame. It exists because a claim about an agent's wire behavior should be answered with a capture: the committed `*-build.json` fixtures are normalizer-parity captures with **no completed turn**, so grepping them for usage returns a confident wrong answer — which is exactly the mistake an earlier revision of this branch made and `002066e20` retracts.

Measured: **Kimi Code 0.31.1 puts no token usage on the ACP wire** — a full turn, 101 updates, nothing anywhere. It tracks tokens internally (`/usage` is in its command list) but does not surface them, so a Kimi thread cannot be priced. `kimi-code-0-31-cereal.json` is that capture; a test pins it.

The harness denies permission requests unless `--allow-tools` is passed, routes frames by `method` (ids are per-direction and collide), reports failures through its exit code, and rewrites the home directory and cwd on the way out. Documented in `apps/desktop/AGENTS.md`.

## Testing

- `pnpm test` — 6990 passed, 2 skipped. The one failure under full-suite load (`acp-backend-adapter.test.ts`) is the known load-dependent flake; passes in isolation (41/41).
- `pnpm --filter @pwragent/desktop typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries` (no violations).

New coverage: `response_completed` normalization and convergence with the turn total; a Grok turn emitting live usage mid-flight; the Qwen test updated to the new cadence; a multi-turn test pinning that the running total restarts per turn; the join between a managed review's ids and what the adapter stamps on notifications.

Independent of #1408 — no file overlap, either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)