### PR TITLE
feat(desktop): show managed review tool activity in the transcript

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -17622,6 +17622,128 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("mirrors managed review tool activity onto the reviewed thread", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+      startThreadResult: { threadId: "managed-review-child" },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-parent": {
+          backend: "codex",
+          threadId: "thread-parent",
+        } as ThreadOverlayState,
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+      resolveManagedReviewEnabled: () => true,
+    });
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+
+    await emit({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "managed-review-child",
+          turnId: "turn-1",
+          item: { id: "item-9", type: "commandExecution" },
+        },
+      },
+    } as AgentEvent);
+
+    const forwarded = events.filter(
+      (event) =>
+        (event.notification.params as { threadId?: string }).threadId
+        === "thread-parent",
+    );
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0]?.notification.params).toMatchObject({
+      threadId: "thread-parent",
+      turnId: "turn-1",
+      // Namespaced so a forwarded item cannot collide with a real one.
+      item: { id: "managed-review:item-9", type: "commandExecution" },
+    });
+
+    await registry.close();
+  });
+
+  it("never mirrors the review sub-agent's own prose onto the reviewed thread", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+      startThreadResult: { threadId: "managed-review-child" },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-parent": {
+          backend: "codex",
+          threadId: "thread-parent",
+        } as ThreadOverlayState,
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+      resolveManagedReviewEnabled: () => true,
+    });
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+
+    // The child's final assistant message is the raw JSON findings blob and
+    // its reasoning is model prose. Either one reaching the parent would
+    // render as a message in the reviewed thread's transcript.
+    for (const type of ["agentMessage", "reasoning", "userMessage"]) {
+      await emit({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "managed-review-child",
+            turnId: "turn-1",
+            item: { id: `item-${type}`, type, text: "should not appear" },
+          },
+        },
+      } as AgentEvent);
+    }
+
+    expect(
+      events.filter(
+        (event) =>
+          (event.notification.params as { threadId?: string }).threadId
+          === "thread-parent",
+      ),
+    ).toHaveLength(0);
+
+    await registry.close();
+  });
+
   it("runs the managed review experiment as one child turn and attributes usage to it", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -17683,6 +17683,82 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("mirrors command output without double-counting tool accounting", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+      startThreadResult: { threadId: "managed-review-child" },
+    });
+    const upsertThreadToolInvocation = vi.fn(
+      async (params: { invocation: unknown }) => params.invocation,
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock({
+        overlays: {
+          "codex:thread-parent": {
+            backend: "codex",
+            threadId: "thread-parent",
+          } as ThreadOverlayState,
+        },
+      }),
+      upsertThreadToolInvocation,
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: overlayStore as never,
+      resolveManagedReviewEnabled: () => true,
+    });
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+    upsertThreadToolInvocation.mockClear();
+
+    await (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit({
+      backend: "codex",
+      notification: {
+        method: "item/commandExecution/outputDelta",
+        params: {
+          threadId: "managed-review-child",
+          turnId: "turn-1",
+          itemId: "cmd-1",
+          delta: "hello from the reviewer\n",
+        },
+      },
+    } as AgentEvent);
+
+    // Streaming refinements reach the parent so the row animates, with the
+    // item reference namespaced like the envelope that introduced it.
+    const forwarded = events.filter(
+      (event) =>
+        (event.notification.params as { threadId?: string }).threadId
+        === "thread-parent",
+    );
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0]?.notification.params).toMatchObject({
+      threadId: "thread-parent",
+      itemId: "managed-review:cmd-1",
+    });
+
+    // The forwarded copy is a view of activity the child already recorded.
+    // Running it back through the pipeline would bill the same command twice
+    // and write a second sqlite row per streamed chunk.
+    expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(1);
+    expect(upsertThreadToolInvocation.mock.calls[0]?.[0]).toMatchObject({
+      invocation: { threadId: "managed-review-child" },
+    });
+
+    await registry.close();
+  });
+
   it("never mirrors the review sub-agent's own prose onto the reviewed thread", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },
@@ -18291,6 +18367,86 @@ command = "pnpm dev"
         delivery: "inline",
       }),
     ).rejects.toThrow("Selected backend does not support review/start");
+
+    await registry.close();
+  });
+
+  it("mirrors an ACP review sub-agent's activity onto the reviewed thread", async () => {
+    const acpBackendId = "acp:kimi" as AcpBackendId;
+    const parentThreadId = "kimi-parent";
+    const sessions: AcpSessionMetadata[] = [{
+      backendId: acpBackendId,
+      sessionId: parentThreadId,
+      title: "ACP session",
+      titleSource: "fallback",
+      cwd: "/repo/worktree",
+      createdAt: 1000,
+      updatedAt: 1000,
+      executionMode: "default",
+      status: "idle",
+    }];
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        [`${acpBackendId}:${parentThreadId}`]: {
+          backend: acpBackendId,
+          threadId: parentThreadId,
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const startPrompt = vi.fn((params: Parameters<KimiStartPrompt>[0]) => ({
+      sessionId: params.sessionId,
+      turnId: params.turnId ?? `turn-${startPrompt.mock.calls.length}`,
+    }));
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      overlayStore,
+      sessionId: parentThreadId,
+      sessions,
+      startPrompt,
+    });
+
+    const response = await registry.startReview({
+      backend: acpBackendId,
+      threadId: parentThreadId,
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+    expect(response.reviewThreadId).not.toBe(parentThreadId);
+
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    // Forwarding is backend-agnostic, but ACP reaches the child through a
+    // hidden session rather than an ephemeral thread — pin that the record
+    // lookup still resolves it.
+    await (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit({
+      backend: acpBackendId,
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: response.reviewThreadId,
+          turnId: response.turnId,
+          item: { id: "acp-item-3", type: "commandExecution" },
+        },
+      },
+    } as AgentEvent);
+
+    const forwarded = events.filter(
+      (event) =>
+        (event.notification.params as { threadId?: string }).threadId
+        === parentThreadId,
+    );
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0]?.notification.params).toMatchObject({
+      threadId: parentThreadId,
+      turnId: response.turnId,
+      item: { id: "managed-review:acp-item-3", type: "commandExecution" },
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -27587,6 +27587,12 @@ export class DesktopBackendRegistry {
    * which `docs/thread-history-persistence.md` requires.
    */
   private async forwardManagedReviewActivity(event: AgentEvent): Promise<void> {
+    // Every emitted event reaches this method, including per-chunk streaming
+    // deltas on unrelated threads. Reviews are rare and short-lived, so settle
+    // the common case with a size check before touching the notification.
+    if (this.activeReviewSubAgents.size === 0) {
+      return;
+    }
     const method = event.notification.method;
     const isItemEnvelope =
       method === "item/started" || method === "item/completed";
@@ -27635,7 +27641,11 @@ export class DesktopBackendRegistry {
       typeof value === "string" ? `managed-review:${value}` : undefined;
     const forwardedItemId = namespaceId(params.item?.id);
     const forwardedRefId = namespaceId(params.itemId);
-    await this.emit({
+    // Straight to listeners, NOT back through `emit`. The forwarded copy is a
+    // view of activity the child thread already recorded; replaying it through
+    // the pipeline would write a second tool-invocation row per item and add
+    // parent-keyed entries to the file-change approval-context cache.
+    await this.emitToListeners({
       backend: event.backend,
       notification: {
         ...event.notification,
@@ -28119,6 +28129,18 @@ export class DesktopBackendRegistry {
     this.notifyForAttentionRequired(event);
     await this.notifyForTerminalOutcome(event);
 
+    await this.emitToListeners(event);
+  }
+
+  /**
+   * Fan an event out to subscribers without running any of `emit`'s recording
+   * stages. Only for events that are a *view* of something already recorded —
+   * a managed review's forwarded activity is the sole caller. Running those
+   * through `emit` would re-execute the whole pipeline against the parent
+   * thread id, which double-counts tool accounting (a sqlite write per item)
+   * and pollutes the file-change approval-context cache.
+   */
+  private async emitToListeners(event: AgentEvent): Promise<void> {
     for (const listener of this.eventListeners) {
       try {
         await listener(event);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -27542,7 +27542,118 @@ export class DesktopBackendRegistry {
     };
   }
 
+  /**
+   * Item types forwarded from a managed review's hidden child thread onto its
+   * parent transcript.
+   *
+   * An ALLOWLIST, deliberately. The child's final assistant message is the raw
+   * JSON findings blob and its reasoning is model prose; forwarding either
+   * would render them as parent-thread messages. A denylist would leak both the
+   * moment a provider adds a type. An unknown type going unforwarded costs a
+   * missing progress row, which is the far cheaper failure.
+   */
+  private static readonly MANAGED_REVIEW_FORWARDED_ITEM_TYPES = new Set([
+    "commandExecution",
+    "fileChange",
+    "mcpToolCall",
+    "patchApply",
+    "toolCall",
+    "webSearch",
+  ]);
+
+  /**
+   * Streaming refinements of an already-forwarded item. These carry no item
+   * envelope of their own, so they are matched by method and rewritten onto the
+   * parent unconditionally — they only ever refine an item the allowlist above
+   * already let through.
+   */
+  private static readonly MANAGED_REVIEW_FORWARDED_METHODS = new Set([
+    "item/commandExecution/outputDelta",
+    "item/fileChange/outputDelta",
+    "item/mcpToolCall/progress",
+  ]);
+
+  /**
+   * Mirror a managed review sub-agent's tool activity onto the thread being
+   * reviewed, so an in-flight review shows what it is doing instead of a silent
+   * gap between "started" and the findings.
+   *
+   * Deliberately transient: the forwarded copies are events only, never
+   * persisted. They live in the renderer's in-memory session state for as long
+   * as the thread stays loaded and vanish on reload or eviction. That is the
+   * intended lifetime — the review's *findings* are durable in the overlay via
+   * `upsertManagedReviewEntry`, so nothing an operator still needs to read is
+   * lost when the breadcrumb goes. It also keeps command output out of sqlite,
+   * which `docs/thread-history-persistence.md` requires.
+   */
+  private async forwardManagedReviewActivity(event: AgentEvent): Promise<void> {
+    const method = event.notification.method;
+    const isItemEnvelope =
+      method === "item/started" || method === "item/completed";
+    if (
+      !isItemEnvelope
+      && !DesktopBackendRegistry.MANAGED_REVIEW_FORWARDED_METHODS.has(method)
+    ) {
+      return;
+    }
+    const params = event.notification.params as {
+      threadId?: unknown;
+      turnId?: unknown;
+      itemId?: unknown;
+      item?: { id?: unknown; type?: unknown };
+    };
+    const childThreadId =
+      typeof params.threadId === "string" ? params.threadId : undefined;
+    if (!childThreadId) {
+      return;
+    }
+    const record = this.findManagedReviewForChildRequest({
+      backend: event.backend,
+      reviewThreadId: childThreadId,
+      ...(typeof params.turnId === "string" ? { turnId: params.turnId } : {}),
+    });
+    // Only a managed review child has a record here; a normal thread's own
+    // items never match, which is also what stops the forwarded copy (addressed
+    // to the parent) from being forwarded again.
+    if (!record || record.reviewThreadId === record.parentThreadId) {
+      return;
+    }
+    if (isItemEnvelope) {
+      const itemType =
+        typeof params.item?.type === "string" ? params.item.type : undefined;
+      if (
+        !itemType
+        || !DesktopBackendRegistry.MANAGED_REVIEW_FORWARDED_ITEM_TYPES.has(itemType)
+      ) {
+        return;
+      }
+    }
+    // Namespace every id so a forwarded item can never collide with a real
+    // item on the parent thread, and group it under the review's turn so it
+    // nests with the review entry rather than floating at the transcript tail.
+    const namespaceId = (value: unknown): string | undefined =>
+      typeof value === "string" ? `managed-review:${value}` : undefined;
+    const forwardedItemId = namespaceId(params.item?.id);
+    const forwardedRefId = namespaceId(params.itemId);
+    await this.emit({
+      backend: event.backend,
+      notification: {
+        ...event.notification,
+        params: {
+          ...(event.notification.params as Record<string, unknown>),
+          threadId: record.parentThreadId,
+          turnId: record.turnId,
+          ...(forwardedRefId ? { itemId: forwardedRefId } : {}),
+          ...(params.item && forwardedItemId
+            ? { item: { ...params.item, id: forwardedItemId } }
+            : {}),
+        },
+      },
+    } as AgentEvent);
+  }
+
   private async emit(event: AgentEvent): Promise<void> {
+    await this.forwardManagedReviewActivity(event);
     event = await this.withThreadMessageContext(event);
     this.rememberFileChangeApprovalContext(event);
     event = this.withEmbeddedFileChangeApprovalContext(event);


### PR DESCRIPTION
## Summary

- A PwrAgent-managed review showed nothing between "Review changes against `<target>`" and the findings — no way to tell whether it was working, stuck, or what it was reading. Codex's native `review/start` has always surfaced its tool calls; the managed path did not.
- The review sub-agent's tool items are now mirrored onto the reviewed thread, so an in-flight managed review shows the same `Explored 8 items · Used 7 tools` row a native turn does.
- #1391 made this matter much more: every cross-provider review takes the managed path, so the silent gap went from a flag-gated experiment to the normal case.

## Verification

- `pnpm test` — 6986 passing, 2 skipped. Two timeouts in `acp-backend-adapter.test.ts`; that file passes 39/39 in isolation and is a documented pre-existing flake on this machine (all failures are `Test timed out in 5000ms`, and the failing test *names* differ run to run — earlier runs of this same branch hit three different ones). Forwarding only activates when an active managed-review record exists, which those tests never create.
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries` (0 violations), `pnpm lint:codex-storage` (relevant here — the alternative designs involved reading rollout storage).
- Five registry tests, each verified load-bearing by breaking the code and watching them fail rather than assuming they covered the path.

## Notes

**Why the renderer is untouched.** `useThreadSessionState` already aggregates `item/started` / `item/completed` into an activity entry via `summarizeLiveActivity`. Rewriting the child's events onto the parent thread id means that existing pipeline builds the row, so a managed review's progress is assembled by the same code as a native turn's and reads identically. Items are grouped under the review's turn id so they nest with the review entry, and item ids are namespaced `managed-review:<id>` so a forwarded copy cannot collide with a real item on the parent.

**Forwarded copies bypass the emit pipeline — this is the load-bearing correctness decision.** The first revision called `this.emit()` for the rewritten copy, which ran all ~20 recording stages a second time against the parent thread id. Two of them act on tool items:

- `recordToolInvocationAccounting` billed the same tool call twice and wrote a second sqlite row per item — per *chunk*, for streamed command output.
- `rememberFileChangeApprovalContext` added parent-keyed entries to a cache capped at 500 with FIFO eviction, so a review touching many files could evict a pending approval context belonging to an unrelated thread and leave its approval dialog with no diff or path.

A forwarded copy is a *view* of activity the child thread already recorded, so it now goes straight to subscribers through `emitToListeners` (the fan-out loop lifted out of `emit` unchanged). A test pins the double-write and fails if the call is put back through `emit`.

**Allowlist, not denylist.** The child's final assistant message is the raw JSON findings blob and its reasoning is model prose; either reaching the parent renders as a *message* in the reviewed thread. A denylist leaks both the moment a provider adds an item type; an allowlist fails the other way, costing at most a missing progress row. A test asserts `agentMessage`, `reasoning`, and `userMessage` never cross over, confirmed to fail if the allowlist is widened. It also incidentally keeps `rememberManagedReviewOutput` from seeing a duplicate.

**Retention — in-memory, and that is the whole design.** The forwarded copies are events only, never persisted; they live in the renderer's session state while the thread stays loaded and vanish on reload or eviction.

"What if the operator never saw it?" is already answered elsewhere: the review's **findings** are durable in the overlay via `upsertManagedReviewEntry`, written at both start and terminal. A review that completed while the operator was in another thread still shows its result and verdict — only the breadcrumb of *how* it got there is ephemeral. That removes any need for unread tracking, an eviction policy, or a new store, and keeps command output out of sqlite as [docs/thread-history-persistence.md](docs/thread-history-persistence.md) requires. Two heavier designs were dropped: reading the ACP rollout JSONL (works for Kimi/Grok, impossible for Codex — that rollout is Codex-owned and off-limits), and a PwrAgent-owned activity sidecar (durable, but buys retention nobody needs and adds a store to prune).

**Coverage spans both backends.** Codex (ephemeral child thread) and ACP (hidden session) reach the child differently, which is where #1391 had a bug, so both are tested. The streaming-refinement branch (`outputDelta` / `progress`, which carry `params.itemId` instead of `params.item`) is covered too — it had none, and it is the branch that fires most often.

**Out of scope, carded separately:** `recordToolInvocationAccounting` runs on every `item/commandExecution/outputDelta`, so streamed command output already costs one synchronous sqlite read plus an INSERT per chunk, for every command on every thread. That is pre-existing — this PR's forwarding briefly doubled it, which is how it surfaced — and worth measuring before optimizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
