### PR TITLE
feat(desktop): put instance controls and live load on the Star Map

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-available-memory.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-available-memory.test.ts
@@ -18,14 +18,27 @@ Pages purgeable:                         12000.
 
 describe("federation available memory", () => {
   it("counts reclaimable macOS pages, not just free ones", () => {
-    // 8500 + 120000 + 12000 + 3000 = 143500 pages at 16 KiB.
-    expect(parseVmStatAvailableBytes(VM_STAT)).toBe(143_500 * 16_384);
+    // 8500 free + 120000 inactive + 3000 speculative = 131500 pages.
+    expect(parseVmStatAvailableBytes(VM_STAT)).toBe(131_500 * 16_384);
+  });
+
+  it("does not add purgeable pages on top of the queues holding them", () => {
+    // `Pages purgeable` is a property of pages already counted in the
+    // active/inactive queues, not a disjoint class, so adding it would
+    // overstate the headroom — the dangerous direction for a health card.
+    const withMorePurgeable = VM_STAT.replace(
+      "Pages purgeable:                         12000.",
+      "Pages purgeable:                        999999.",
+    );
+    expect(parseVmStatAvailableBytes(withMorePurgeable)).toBe(
+      parseVmStatAvailableBytes(VM_STAT),
+    );
   });
 
   it("scales by the page size the header reports", () => {
     // Getting this wrong silently scales the answer by 4x on Apple silicon.
     const fourKib = VM_STAT.replace("page size of 16384", "page size of 4096");
-    expect(parseVmStatAvailableBytes(fourKib)).toBe(143_500 * 4_096);
+    expect(parseVmStatAvailableBytes(fourKib)).toBe(131_500 * 4_096);
   });
 
   it("gives up on vm_stat output it cannot read", () => {
@@ -50,7 +63,7 @@ describe("federation available memory", () => {
         platform: "darwin",
         runVmStat: async () => VM_STAT,
       }),
-    ).resolves.toBe(143_500 * 16_384);
+    ).resolves.toBe(131_500 * 16_384);
   });
 
   it("reads Linux through /proc/meminfo", async () => {

--- a/apps/desktop/src/main/__tests__/federation-available-memory.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-available-memory.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import os from "node:os";
 import {
   parseMemAvailableBytes,
   parseVmStatAvailableBytes,
@@ -65,21 +64,32 @@ describe("federation available memory", () => {
 
   it("falls back to free memory when sampling fails", async () => {
     // A wrong-but-present number beats a missing metric on a health card,
-    // and os.freemem() is only ever pessimistic.
+    // and free memory is only ever pessimistic.
     await expect(
       readAvailableMemoryBytes({
         platform: "darwin",
         runVmStat: async () => {
           throw new Error("vm_stat: command not found");
         },
+        readFreeMemory: () => 4_096,
       }),
-    ).resolves.toBe(os.freemem());
+    ).resolves.toBe(4_096);
+  });
+
+  it("falls back when vm_stat answers with something unparsable", async () => {
+    await expect(
+      readAvailableMemoryBytes({
+        platform: "darwin",
+        runVmStat: async () => "surprise",
+        readFreeMemory: () => 4_096,
+      }),
+    ).resolves.toBe(4_096);
   });
 
   it("uses free memory directly where it already means available", async () => {
     // Windows' os.freemem() maps to GlobalMemoryStatusEx.ullAvailPhys.
     await expect(
-      readAvailableMemoryBytes({ platform: "win32" }),
-    ).resolves.toBe(os.freemem());
+      readAvailableMemoryBytes({ platform: "win32", readFreeMemory: () => 4_096 }),
+    ).resolves.toBe(4_096);
   });
 });

--- a/apps/desktop/src/main/__tests__/federation-available-memory.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-available-memory.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import os from "node:os";
+import {
+  parseMemAvailableBytes,
+  parseVmStatAvailableBytes,
+  readAvailableMemoryBytes,
+} from "../federation/federation-available-memory";
+
+/** Trimmed to the fields the parser reads, in the real format. */
+const VM_STAT = `Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                               8500.
+Pages active:                           500000.
+Pages inactive:                         120000.
+Pages speculative:                        3000.
+Pages throttled:                             0.
+Pages wired down:                       180000.
+Pages purgeable:                         12000.
+`;
+
+describe("federation available memory", () => {
+  it("counts reclaimable macOS pages, not just free ones", () => {
+    // 8500 + 120000 + 12000 + 3000 = 143500 pages at 16 KiB.
+    expect(parseVmStatAvailableBytes(VM_STAT)).toBe(143_500 * 16_384);
+  });
+
+  it("scales by the page size the header reports", () => {
+    // Getting this wrong silently scales the answer by 4x on Apple silicon.
+    const fourKib = VM_STAT.replace("page size of 16384", "page size of 4096");
+    expect(parseVmStatAvailableBytes(fourKib)).toBe(143_500 * 4_096);
+  });
+
+  it("gives up on vm_stat output it cannot read", () => {
+    expect(parseVmStatAvailableBytes("not vm_stat output")).toBeUndefined();
+    expect(
+      parseVmStatAvailableBytes("(page size of 4096 bytes)\nPages active: 1.\n"),
+    ).toBeUndefined();
+  });
+
+  it("prefers the kernel's own MemAvailable on Linux", () => {
+    expect(
+      parseMemAvailableBytes(
+        "MemTotal:       16316160 kB\nMemFree:          139264 kB\nMemAvailable:    2461696 kB\n",
+      ),
+    ).toBe(2_461_696 * 1024);
+    expect(parseMemAvailableBytes("MemTotal: 16316160 kB\n")).toBeUndefined();
+  });
+
+  it("reads macOS through vm_stat", async () => {
+    await expect(
+      readAvailableMemoryBytes({
+        platform: "darwin",
+        runVmStat: async () => VM_STAT,
+      }),
+    ).resolves.toBe(143_500 * 16_384);
+  });
+
+  it("reads Linux through /proc/meminfo", async () => {
+    await expect(
+      readAvailableMemoryBytes({
+        platform: "linux",
+        readMemInfo: async () => "MemAvailable:    2461696 kB\n",
+      }),
+    ).resolves.toBe(2_461_696 * 1024);
+  });
+
+  it("falls back to free memory when sampling fails", async () => {
+    // A wrong-but-present number beats a missing metric on a health card,
+    // and os.freemem() is only ever pessimistic.
+    await expect(
+      readAvailableMemoryBytes({
+        platform: "darwin",
+        runVmStat: async () => {
+          throw new Error("vm_stat: command not found");
+        },
+      }),
+    ).resolves.toBe(os.freemem());
+  });
+
+  it("uses free memory directly where it already means available", async () => {
+    // Windows' os.freemem() maps to GlobalMemoryStatusEx.ullAvailPhys.
+    await expect(
+      readAvailableMemoryBytes({ platform: "win32" }),
+    ).resolves.toBe(os.freemem());
+  });
+});

--- a/apps/desktop/src/main/federation/federation-available-memory.ts
+++ b/apps/desktop/src/main/federation/federation-available-memory.ts
@@ -30,8 +30,11 @@ export async function readAvailableMemoryBytes(options?: {
   platform?: NodeJS.Platform;
   runVmStat?: () => Promise<string>;
   readMemInfo?: () => Promise<string>;
+  /** Injectable so tests can pin the fallback; it moves under a live OS. */
+  readFreeMemory?: () => number;
 }): Promise<number> {
   const platform = options?.platform ?? process.platform;
+  const freeMemory = options?.readFreeMemory ?? (() => os.freemem());
   try {
     if (platform === "darwin") {
       const parsed = parseVmStatAvailableBytes(
@@ -47,7 +50,7 @@ export async function readAvailableMemoryBytes(options?: {
   } catch {
     // Sampling is best-effort; the fallback below is always available.
   }
-  return os.freemem();
+  return freeMemory();
 }
 
 async function runVmStat(): Promise<string> {

--- a/apps/desktop/src/main/federation/federation-available-memory.ts
+++ b/apps/desktop/src/main/federation/federation-available-memory.ts
@@ -1,0 +1,100 @@
+import { execFile } from "node:child_process";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Memory an instance could actually give to new work.
+ *
+ * `os.freemem()` is not that number on every platform, and on macOS it is
+ * badly misleading: it reports only truly free pages, so a healthy 16 GB Mac
+ * with a couple of GB of reclaimable file cache reports ~140 MB free while
+ * Activity Monitor's pressure gauge sits in the green. Showing that figure as
+ * "free RAM" reads as a machine about to die.
+ *
+ * Per platform:
+ * - **macOS**: `vm_stat` page counts. Free + inactive + purgeable +
+ *   speculative is the headroom the kernel can hand out without swapping,
+ *   which is what the pressure gauge is really reflecting.
+ * - **Linux**: `/proc/meminfo`'s `MemAvailable` — the kernel's own estimate
+ *   of exactly this, so no arithmetic of ours can beat it.
+ * - **Windows and anything else**: `os.freemem()`, which already maps to
+ *   `GlobalMemoryStatusEx.ullAvailPhys` (available, not merely free).
+ *
+ * Every path falls back to `os.freemem()`: a wrong-but-present number beats a
+ * missing metric on a health card, and the fallback is only ever pessimistic.
+ */
+export async function readAvailableMemoryBytes(options?: {
+  platform?: NodeJS.Platform;
+  runVmStat?: () => Promise<string>;
+  readMemInfo?: () => Promise<string>;
+}): Promise<number> {
+  const platform = options?.platform ?? process.platform;
+  try {
+    if (platform === "darwin") {
+      const parsed = parseVmStatAvailableBytes(
+        await (options?.runVmStat?.() ?? runVmStat()),
+      );
+      if (parsed !== undefined) return parsed;
+    } else if (platform === "linux") {
+      const parsed = parseMemAvailableBytes(
+        await (options?.readMemInfo?.() ?? readMemInfo()),
+      );
+      if (parsed !== undefined) return parsed;
+    }
+  } catch {
+    // Sampling is best-effort; the fallback below is always available.
+  }
+  return os.freemem();
+}
+
+async function runVmStat(): Promise<string> {
+  const { stdout } = await execFileAsync("vm_stat", [], {
+    timeout: 2_000,
+    windowsHide: true,
+  });
+  return stdout;
+}
+
+async function readMemInfo(): Promise<string> {
+  return await fs.readFile("/proc/meminfo", "utf8");
+}
+
+/**
+ * Sum the reclaimable page classes out of `vm_stat` output.
+ *
+ * Exported for tests: the format is stable but fiddly (a header line carrying
+ * the page size, then `Key: value.` lines), and getting the page size wrong
+ * silently scales the answer by 4096.
+ */
+export function parseVmStatAvailableBytes(stdout: string): number | undefined {
+  const pageSize = /page size of (\d+) bytes/.exec(stdout);
+  if (!pageSize) return undefined;
+  const bytesPerPage = Number(pageSize[1]);
+  if (!Number.isFinite(bytesPerPage) || bytesPerPage <= 0) return undefined;
+
+  const pages = (label: string): number | undefined => {
+    const match = new RegExp(`${label}:\\s+(\\d+)\\.`).exec(stdout);
+    return match ? Number(match[1]) : undefined;
+  };
+  const free = pages("Pages free");
+  if (free === undefined) return undefined;
+  // Inactive and speculative pages are backed by files or are already
+  // reclaimable; purgeable pages the kernel will simply drop under demand.
+  const reclaimable =
+    free
+    + (pages("Pages inactive") ?? 0)
+    + (pages("Pages purgeable") ?? 0)
+    + (pages("Pages speculative") ?? 0);
+  return reclaimable * bytesPerPage;
+}
+
+/** `MemAvailable` in bytes, or undefined when the field is absent. */
+export function parseMemAvailableBytes(contents: string): number | undefined {
+  const match = /^MemAvailable:\s+(\d+)\s*kB$/m.exec(contents);
+  if (!match) return undefined;
+  const kib = Number(match[1]);
+  return Number.isFinite(kib) ? kib * 1024 : undefined;
+}

--- a/apps/desktop/src/main/federation/federation-available-memory.ts
+++ b/apps/desktop/src/main/federation/federation-available-memory.ts
@@ -15,9 +15,9 @@ const execFileAsync = promisify(execFile);
  * "free RAM" reads as a machine about to die.
  *
  * Per platform:
- * - **macOS**: `vm_stat` page counts. Free + inactive + purgeable +
- *   speculative is the headroom the kernel can hand out without swapping,
- *   which is what the pressure gauge is really reflecting.
+ * - **macOS**: `vm_stat` page counts. Free + inactive + speculative is the
+ *   headroom the kernel can hand out without swapping, which is what the
+ *   pressure gauge is really reflecting.
  * - **Linux**: `/proc/meminfo`'s `MemAvailable` — the kernel's own estimate
  *   of exactly this, so no arithmetic of ours can beat it.
  * - **Windows and anything else**: `os.freemem()`, which already maps to
@@ -54,7 +54,7 @@ export async function readAvailableMemoryBytes(options?: {
 }
 
 async function runVmStat(): Promise<string> {
-  const { stdout } = await execFileAsync("vm_stat", [], {
+  const { stdout } = await execFileAsync("/usr/bin/vm_stat", [], {
     timeout: 2_000,
     windowsHide: true,
   });
@@ -84,12 +84,18 @@ export function parseVmStatAvailableBytes(stdout: string): number | undefined {
   };
   const free = pages("Pages free");
   if (free === undefined) return undefined;
-  // Inactive and speculative pages are backed by files or are already
-  // reclaimable; purgeable pages the kernel will simply drop under demand.
+  // Inactive and speculative pages are file-backed or already reclaimable, so
+  // the kernel can hand them out without swapping.
+  //
+  // `Pages purgeable` is deliberately NOT added. It is a property of pages
+  // that vm_stat has already counted in the active/inactive queues rather
+  // than a disjoint class — its own Anonymous/File-backed decomposition
+  // covers the same pages — so adding it double-counts. The error would be
+  // small (~1-2%) but it runs in the dangerous direction for a health card:
+  // overstating the headroom a machine has. Understating is safe.
   const reclaimable =
     free
     + (pages("Pages inactive") ?? 0)
-    + (pages("Pages purgeable") ?? 0)
     + (pages("Pages speculative") ?? 0);
   return reclaimable * bytesPerPage;
 }

--- a/apps/desktop/src/main/federation/federation-host-info.ts
+++ b/apps/desktop/src/main/federation/federation-host-info.ts
@@ -7,6 +7,7 @@ import type {
   FederationLoadStatus,
 } from "@pwragent/shared";
 import { resolvePwragentRoot } from "../profile";
+import { readAvailableMemoryBytes } from "./federation-available-memory";
 
 const MACHINE_ID_FILENAME = "machine-id";
 
@@ -104,7 +105,8 @@ export async function collectFederationLoadStatus(options?: {
     loadAvg5,
     loadAvg15,
     ...(cpuCount > 0 ? { cpuCount } : {}),
-    availableMemoryBytes: os.freemem(),
+    availableMemoryBytes: await readAvailableMemoryBytes(),
+    totalMemoryBytes: os.totalmem(),
     ...(diskFreeBytes !== undefined ? { diskFreeBytes } : {}),
     sampledAt: Date.now(),
   };

--- a/apps/desktop/src/main/federation/federation-host-info.ts
+++ b/apps/desktop/src/main/federation/federation-host-info.ts
@@ -98,10 +98,12 @@ export async function collectFederationLoadStatus(options?: {
   } catch {
     diskFreeBytes = undefined;
   }
+  const cpuCount = os.cpus().length;
   return {
     loadAvg1,
     loadAvg5,
     loadAvg15,
+    ...(cpuCount > 0 ? { cpuCount } : {}),
     availableMemoryBytes: os.freemem(),
     ...(diskFreeBytes !== undefined ? { diskFreeBytes } : {}),
     sampledAt: Date.now(),

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -28,6 +28,7 @@ import {
 import { CelestialIcon } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { copyText } from "../../lib/copy-text";
+import { formatByteCount } from "../../lib/format-bytes";
 import { formatRunningDurationMs } from "../../lib/format-duration";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
@@ -1649,24 +1650,6 @@ function diagnosticEventLabel(kind: FederationDiagnosticEvent["kind"]): string {
 
 function formatTimestamp(value: number): string {
   return new Date(value).toLocaleString();
-}
-
-/**
- * Wire-transfer figure for the peer rows: whole bytes/KB below 1 MB,
- * then one decimal only while the leading digits are scarce (below 10
- * of the unit) — "5.2 MB" carries signal, "200.0 MB" is just noise —
- * so a 200 MB replay habit and a post-compression 40 MB read as
- * obviously different at a glance.
- */
-function formatByteCount(value: number): string {
-  if (value < 1024) return `${value} B`;
-  if (value < 1024 * 1024) return `${Math.round(value / 1024)} KB`;
-  const mb = value / (1024 * 1024);
-  if (mb < 1024) {
-    return mb < 10 ? `${mb.toFixed(1)} MB` : `${Math.round(mb)} MB`;
-  }
-  const gb = mb / 1024;
-  return gb < 10 ? `${gb.toFixed(1)} GB` : `${Math.round(gb)} GB`;
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapInstanceCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapInstanceCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { CelestialIconId, FederationConnectionState } from "@pwragent/shared";
 import { CelestialIcon } from "../../icons";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
@@ -19,10 +20,55 @@ function statusTone(status: FederationConnectionState): string {
 }
 
 /**
+ * One control on the instance's affordance row. Icon-only, so the tooltip is
+ * the label — and it fires on focus as well as hover, since for a keyboard
+ * user the tooltip IS the discoverable name.
+ */
+function InstanceAction(props: {
+  className: string;
+  label: string;
+  pressed?: boolean;
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  return (
+    <>
+      <button
+        type="button"
+        className={`star-map-instance__action ${props.className}`}
+        aria-label={props.label}
+        {...(props.pressed !== undefined
+          ? { "aria-pressed": props.pressed }
+          : {})}
+        onClick={props.onClick}
+        onMouseEnter={(event) => tooltip.show(event.currentTarget, props.label)}
+        onMouseLeave={tooltip.hide}
+        onFocus={(event) => tooltip.show(event.currentTarget, props.label)}
+        onBlur={tooltip.hide}
+      >
+        {props.children}
+      </button>
+      {tooltip.tooltipNode}
+    </>
+  );
+}
+
+/**
  * One celestial body on the map: the instance's icon floating on the star
- * field with a glow, its label on a pill beneath, and the connection
- * status pinned to the body. No bordered card - the body IS the presence.
- * The [+] AI-intake action lands in the intake unit of the Star Map plan.
+ * field with a glow, its label on a pill beneath, the connection status
+ * pinned to the body, and an affordance row above it. No bordered card -
+ * the body IS the presence.
+ *
+ * The row is absolutely positioned above the body ON PURPOSE: the body,
+ * label and cloud geometry are tuned against `STAR_MAP_BODY_ROW_Y` and the
+ * first card slot, so growing this flex column would push the label into the
+ * cloud (worst on the larger hub body). Out of flow, it costs no layout.
+ *
+ * Clicking the body SELECTS the instance rather than opening it. Opening a
+ * remote viewer is a window-level commitment and lives on its own control:
+ * the biggest, most inviting target on the map should do the cheap,
+ * reversible thing.
  */
 export function StarMapInstanceCard(props: {
   instanceId: string;
@@ -38,9 +84,18 @@ export function StarMapInstanceCard(props: {
   isLocal: boolean;
   isHub: boolean;
   unreachable?: boolean;
-  onOpen: () => void;
+  selected?: boolean;
+  onSelect: () => void;
+  /**
+   * Leave the map for this instance: a remote viewer window for a peer, or
+   * the local app itself for this one.
+   */
+  onOpen?: () => void;
   /** Present when AI intake can target this instance. */
   onIntake?: () => void;
+  /** Toggles this instance's load card on the map. */
+  onToggleLoad?: () => void;
+  loadShown?: boolean;
 }) {
   // Display stacks the two lines to stay narrow, but every accessible name
   // has to keep the profile inline: two instances on one machine would
@@ -56,18 +111,85 @@ export function StarMapInstanceCard(props: {
     <div
       className={`star-map-instance${props.isLocal ? " star-map-instance--local" : ""}${
         props.isHub ? " star-map-instance--hub" : ""
-      }`}
+      }${props.selected ? " star-map-instance--selected" : ""}`}
       data-instance-id={props.instanceId}
     >
+      <span className="star-map-instance__actions">
+        {props.onIntake ? (
+          <InstanceAction
+            className="star-map-instance__action--intake"
+            label={`New thread on ${fullLabel}`}
+            onClick={props.onIntake}
+          >
+            +
+          </InstanceAction>
+        ) : null}
+        {props.onToggleLoad ? (
+          <InstanceAction
+            className="star-map-instance__action--load"
+            label={
+              props.loadShown
+                ? `Hide load for ${fullLabel}`
+                : `Show load for ${fullLabel} (CPU, memory, disk)`
+            }
+            pressed={props.loadShown === true}
+            onClick={props.onToggleLoad}
+          >
+            {/* Three ascending bars: a gauge, not a glyph with prior meaning
+                elsewhere in the product. */}
+            <svg viewBox="0 0 12 12" width="12" height="12" aria-hidden="true">
+              <rect x="1" y="7" width="2.5" height="4" rx="0.6" />
+              <rect x="4.75" y="4" width="2.5" height="7" rx="0.6" />
+              <rect x="8.5" y="1.5" width="2.5" height="9.5" rx="0.6" />
+            </svg>
+          </InstanceAction>
+        ) : null}
+        {props.onOpen ? (
+          <InstanceAction
+            className="star-map-instance__action--open"
+            label={
+              props.isLocal
+                ? `Open this instance (${fullLabel})`
+                : `Open remote viewer for ${fullLabel}`
+            }
+            onClick={props.onOpen}
+          >
+            {/* Arrow leaving a frame — the same "opens its own window"
+                shorthand the platform uses. */}
+            <svg viewBox="0 0 12 12" width="12" height="12" aria-hidden="true">
+              <path
+                d="M4.5 1.5h6v6"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M10.5 1.5 5 7"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+              />
+              <path
+                d="M8.5 10.5h-7v-7"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </InstanceAction>
+        ) : null}
+      </span>
       <button
         type="button"
         className="star-map-instance__body"
-        aria-label={
-          props.isLocal
-            ? `Open this instance (${fullLabel})`
-            : `Open remote viewer for ${fullLabel}`
-        }
-        onClick={props.onOpen}
+        aria-pressed={props.selected === true}
+        aria-label={`Focus ${fullLabel}`}
+        onClick={props.onSelect}
       >
         <span className="star-map-instance__glow" aria-hidden="true" />
         {props.icon ? (
@@ -99,16 +221,6 @@ export function StarMapInstanceCard(props: {
             </span>
           ) : null}
         </span>
-        {props.onIntake ? (
-          <button
-            type="button"
-            className="star-map-instance__intake"
-            aria-label={`New thread on ${fullLabel}`}
-            onClick={props.onIntake}
-          >
-            +
-          </button>
-        ) : null}
       </span>
       {props.unreachable ? (
         <span className="star-map-instance__unreachable">Unreachable</span>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapInstanceCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapInstanceCard.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import type { CelestialIconId, FederationConnectionState } from "@pwragent/shared";
-import { CelestialIcon } from "../../icons";
+import { CelestialIcon, PopoutIcon } from "../../icons";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 
 function statusTone(status: FederationConnectionState): string {
@@ -31,7 +31,12 @@ function InstanceAction(props: {
   children: ReactNode;
   onClick: () => void;
 }) {
-  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  // `.star-map-card__tooltip` raises the layer to 140. Without it the portal
+  // renders at the default 90 and the Star Map layer (120) paints straight
+  // over it — the tooltip is there, just invisible.
+  const tooltip = useViewportTooltip({
+    className: "viewport-tooltip star-map-card__tooltip",
+  });
   return (
     <>
       <button
@@ -102,7 +107,9 @@ export function StarMapInstanceCard(props: {
   // otherwise expose identical button names.
   // Native `title` is an anti-pattern here (UI-THEME.md): unstyleable,
   // platform-dependent timing, no wrapping on macOS Electron.
-  const labelTooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const labelTooltip = useViewportTooltip({
+    className: "viewport-tooltip star-map-card__tooltip",
+  });
   const fullLabel = props.profileName
     ? `${props.label} / ${props.profileName}`
     : props.label;
@@ -154,33 +161,7 @@ export function StarMapInstanceCard(props: {
             }
             onClick={props.onOpen}
           >
-            {/* Arrow leaving a frame — the same "opens its own window"
-                shorthand the platform uses. */}
-            <svg viewBox="0 0 12 12" width="12" height="12" aria-hidden="true">
-              <path
-                d="M4.5 1.5h6v6"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.4"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M10.5 1.5 5 7"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.4"
-                strokeLinecap="round"
-              />
-              <path
-                d="M8.5 10.5h-7v-7"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.4"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
+            <PopoutIcon size={13} />
           </InstanceAction>
         ) : null}
       </span>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapLoadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapLoadCard.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState, type CSSProperties } from "react";
+import type { FederationLoadStatus } from "@pwragent/shared";
+import { formatByteCount } from "../../lib/format-bytes";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import {
+  useStarMapCardDrag,
+  type StarMapCardDrag,
+} from "./useStarMapCardDrag";
+
+/**
+ * Past three missed polls a reading is no longer describing the machine in
+ * front of you. Fresh cards say nothing about their age on purpose — a
+ * ticking "4s ago" in a mission-control view is noise; only the failure is
+ * worth words.
+ */
+const STALE_AFTER_MS = 25_000;
+const STALE_TICK_MS = 5_000;
+
+/**
+ * Slot height the layout reserves for a load card. The card's content is
+ * fixed (an eyebrow and three figures), so a constant beats plumbing it
+ * through the measured-height map that variable thread cards need. Sized
+ * with room for one note line so a stale card grows into its own gap
+ * instead of over the card below it.
+ */
+export const STAR_MAP_LOAD_CARD_HEIGHT = 88;
+
+function formatAge(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s ago`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m ago`;
+  return `${Math.round(ms / 3_600_000)}h ago`;
+}
+
+/**
+ * Live load for one instance, parked in its solar system.
+ *
+ * It is not a thread, so it deliberately does not look like a thread card:
+ * no status cookie, no chips, no open action — three labelled figures and a
+ * dismiss. It is queried on demand while it is open (see
+ * `useStarMapInstanceLoad`), which is why closing it is a real affordance
+ * rather than a cosmetic hide.
+ */
+export function StarMapLoadCard(props: {
+  instanceId: string;
+  instanceLabel: string;
+  load?: FederationLoadStatus;
+  /** Default slot offset from the instance anchor, in px. */
+  baseSlot: { dx: number; dy: number };
+  /** Synced drag offset layered on top of the slot. */
+  offset?: { dx: number; dy: number };
+  width: number;
+  centered?: boolean;
+  stackIndex: number;
+  drag?: StarMapCardDrag;
+  /**
+   * Label of another instance on the same physical machine. Two profiles of
+   * one box report byte-identical load, and two cards showing the same
+   * numbers reads as a bug unless the card says why.
+   */
+  sharedWith?: string;
+  onDismiss: () => void;
+}) {
+  const load = props.load;
+  const cpuTooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const [, setTick] = useState(0);
+
+  // Staleness has to advance on its own: a peer that stops answering stops
+  // re-rendering this card, and a frozen "just read" is exactly the lie the
+  // stale state exists to prevent.
+  useEffect(() => {
+    if (!load) return;
+    const timer = setInterval(() => setTick((value) => value + 1), STALE_TICK_MS);
+    return () => clearInterval(timer);
+  }, [load]);
+
+  const left = props.baseSlot.dx + (props.offset?.dx ?? 0);
+  const top = props.baseSlot.dy + (props.offset?.dy ?? 0);
+  const style: CSSProperties = {
+    width: props.width,
+    left,
+    top,
+    marginLeft: -props.width / 2,
+    ...(props.centered ? { transform: "translateY(-50%)" } : {}),
+    zIndex: props.stackIndex,
+  };
+
+  const { startDrag } = useStarMapCardDrag({
+    baseSlot: props.baseSlot,
+    offset: props.offset,
+    drag: props.drag,
+  });
+
+  const age = load ? Math.max(0, Date.now() - load.sampledAt) : 0;
+  const stale = load ? age > STALE_AFTER_MS : false;
+  // Node reports 0 for every load average on Windows, so three exact zeros
+  // are "not reported", not an idle machine.
+  const loadAvgReported = load
+    ? load.loadAvg1 !== 0 || load.loadAvg5 !== 0 || load.loadAvg15 !== 0
+    : false;
+  const cpuDetail = load
+    ? `Load average — 1 min ${load.loadAvg1.toFixed(2)}, 5 min ${load.loadAvg5.toFixed(
+        2,
+      )}, 15 min ${load.loadAvg15.toFixed(2)}`
+    : "";
+
+  return (
+    <div
+      className={`star-map-card-shell star-map-load-shell${
+        stale ? " star-map-load-shell--stale" : ""
+      }`}
+      style={style}
+      data-load-instance-id={props.instanceId}
+      onPointerDown={startDrag}
+    >
+      <div className="star-map-load-card">
+        <div className="star-map-load-card__head">
+          <span className="star-map-load-card__eyebrow">Load</span>
+          <button
+            type="button"
+            className="star-map-load-card__dismiss"
+            aria-label={`Remove load card for ${props.instanceLabel}`}
+            onClick={props.onDismiss}
+          >
+            ×
+          </button>
+        </div>
+        {load ? (
+          <>
+            <dl className="star-map-load-card__metrics">
+              <div>
+                <dt>CPU</dt>
+                <dd
+                  onMouseEnter={(event) =>
+                    loadAvgReported
+                      ? cpuTooltip.show(event.currentTarget, cpuDetail)
+                      : cpuTooltip.show(
+                          event.currentTarget,
+                          "This platform does not report load average",
+                        )
+                  }
+                  onMouseLeave={cpuTooltip.hide}
+                  onFocus={(event) =>
+                    cpuTooltip.show(
+                      event.currentTarget,
+                      loadAvgReported
+                        ? cpuDetail
+                        : "This platform does not report load average",
+                    )
+                  }
+                  onBlur={cpuTooltip.hide}
+                  tabIndex={0}
+                >
+                  {loadAvgReported ? load.loadAvg1.toFixed(2) : "—"}
+                </dd>
+              </div>
+              <div>
+                <dt>Free RAM</dt>
+                <dd>{formatByteCount(load.availableMemoryBytes)}</dd>
+              </div>
+              <div>
+                <dt>Free disk</dt>
+                <dd>
+                  {load.diskFreeBytes !== undefined
+                    ? formatByteCount(load.diskFreeBytes)
+                    : "—"}
+                </dd>
+              </div>
+            </dl>
+            {stale ? (
+              <span className="star-map-load-card__note" role="status">
+                Not responding · last read {formatAge(age)}
+              </span>
+            ) : null}
+          </>
+        ) : (
+          <span className="star-map-load-card__note">Reading…</span>
+        )}
+        {props.sharedWith ? (
+          <span className="star-map-load-card__note">
+            Same machine as {props.sharedWith}
+          </span>
+        ) : null}
+      </div>
+      {cpuTooltip.tooltipNode}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapLoadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapLoadCard.tsx
@@ -17,11 +17,13 @@ const STALE_AFTER_MS = 25_000;
 const STALE_TICK_MS = 5_000;
 
 /**
- * Slot height the layout reserves for a load card. The card's content is
- * fixed (an eyebrow and three figures), so a constant beats plumbing it
- * through the measured-height map that variable thread cards need. Sized
- * with room for one note line so a stale card grows into its own gap
- * instead of over the card below it.
+ * Nominal height of a load card, used only to extend an instance's canvas
+ * far enough when the card is the sole thing under a body. Nothing reserves
+ * a slot for it any more: the card lands at the top of the cloud, painted
+ * above the stack, so that thread slots stay identical whether it is open or
+ * closed. The card's content is fixed (an eyebrow and three figures), which
+ * is why a constant beats plumbing it through the measured-height map that
+ * variable thread cards need.
  */
 export const STAR_MAP_LOAD_CARD_HEIGHT = 88;
 

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapLoadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapLoadCard.tsx
@@ -109,6 +109,15 @@ export function StarMapLoadCard(props: {
     : load.cpuCount
       ? `${Math.round((load.loadAvg1 / load.cpuCount) * 100)}%`
       : load.loadAvg1.toFixed(2);
+  /**
+   * Without a core count there is no percentage to show, and a bare "3.40"
+   * under a "CPU" label reads like one. The label carries the unit instead
+   * so the two cases cannot be confused — a peer on an older build reports
+   * no core count, since the figure is sampled on the machine it describes.
+   */
+  const cpuLabel = load && loadAvgReported && !load.cpuCount
+    ? "CPU load"
+    : "CPU";
   const cpuDetail = !load
     ? ""
     : !loadAvgReported
@@ -142,9 +151,9 @@ export function StarMapLoadCard(props: {
           <>
             <dl className="star-map-load-card__metrics">
               <div>
-                <dt>CPU</dt>
+                <dt>{cpuLabel}</dt>
                 <dd
-                  aria-label={`CPU: ${cpuValue}. ${cpuDetail}`}
+                  aria-label={`${cpuLabel}: ${cpuValue}. ${cpuDetail}`}
                   onMouseEnter={(event) =>
                     cpuTooltip.show(event.currentTarget, cpuDetail)
                   }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapLoadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapLoadCard.tsx
@@ -55,6 +55,15 @@ export function StarMapLoadCard(props: {
   stackIndex: number;
   drag?: StarMapCardDrag;
   /**
+   * `instanceId::system:load:position` — the card's key in the arrangement
+   * AND in the selection, so the shared group-move path writes its offset
+   * to the right entry without knowing this card exists.
+   */
+  cardKey: string;
+  /** Part of a multi-card selection, so it moves with the others. */
+  selected?: boolean;
+  onToggleSelect?: () => void;
+  /**
    * Label of another instance on the same physical machine. Two profiles of
    * one box report byte-identical load, and two cards showing the same
    * numbers reads as a bug unless the card says why.
@@ -91,6 +100,7 @@ export function StarMapLoadCard(props: {
     baseSlot: props.baseSlot,
     offset: props.offset,
     drag: props.drag,
+    onToggleSelect: props.onToggleSelect,
   });
 
   const age = load ? Math.max(0, Date.now() - load.sampledAt) : 0;
@@ -153,9 +163,10 @@ export function StarMapLoadCard(props: {
     <div
       className={`star-map-card-shell star-map-load-shell${
         stale ? " star-map-load-shell--stale" : ""
-      }`}
+      }${props.selected ? " star-map-card-shell--selected" : ""}`}
       style={style}
       data-load-instance-id={props.instanceId}
+      data-card-key={props.cardKey}
       onPointerDown={startDrag}
     >
       <div className="star-map-load-card">

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapLoadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapLoadCard.tsx
@@ -62,6 +62,7 @@ export function StarMapLoadCard(props: {
 }) {
   const load = props.load;
   const cpuTooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const memoryTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const [, setTick] = useState(0);
 
   // Staleness has to advance on its own: a peer that stops answering stops
@@ -118,6 +119,26 @@ export function StarMapLoadCard(props: {
   const cpuLabel = load && loadAvgReported && !load.cpuCount
     ? "CPU load"
     : "CPU";
+  /**
+   * A share of installed RAM, because the absolute figure alone does not say
+   * whether it is a lot: "2.4 GB" means nothing until you know the box has
+   * 16 GB. Falls back to the absolute value when total RAM is unknown (an
+   * older peer does not report it).
+   */
+  const memoryValue = !load
+    ? "—"
+    : load.totalMemoryBytes
+      ? `${Math.round(
+          (load.availableMemoryBytes / load.totalMemoryBytes) * 100,
+        )}%`
+      : formatByteCount(load.availableMemoryBytes);
+  const memoryDetail = !load
+    ? ""
+    : load.totalMemoryBytes
+      ? `${formatByteCount(load.availableMemoryBytes)} available of ${formatByteCount(
+          load.totalMemoryBytes,
+        )} — reclaimable cache included`
+      : "";
   const cpuDetail = !load
     ? ""
     : !loadAvgReported
@@ -168,8 +189,27 @@ export function StarMapLoadCard(props: {
                 </dd>
               </div>
               <div>
-                <dt>Free RAM</dt>
-                <dd>{formatByteCount(load.availableMemoryBytes)}</dd>
+                <dt>RAM free</dt>
+                <dd
+                  aria-label={`RAM free: ${memoryValue}${
+                    memoryDetail ? `. ${memoryDetail}` : ""
+                  }`}
+                  onMouseEnter={(event) =>
+                    memoryDetail
+                      ? memoryTooltip.show(event.currentTarget, memoryDetail)
+                      : undefined
+                  }
+                  onMouseLeave={memoryTooltip.hide}
+                  onFocus={(event) =>
+                    memoryDetail
+                      ? memoryTooltip.show(event.currentTarget, memoryDetail)
+                      : undefined
+                  }
+                  onBlur={memoryTooltip.hide}
+                  tabIndex={memoryDetail ? 0 : undefined}
+                >
+                  {memoryValue}
+                </dd>
               </div>
               <div>
                 <dt>Free disk</dt>
@@ -196,6 +236,7 @@ export function StarMapLoadCard(props: {
         ) : null}
       </div>
       {cpuTooltip.tooltipNode}
+      {memoryTooltip.tooltipNode}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapLoadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapLoadCard.tsx
@@ -97,11 +97,25 @@ export function StarMapLoadCard(props: {
   const loadAvgReported = load
     ? load.loadAvg1 !== 0 || load.loadAvg5 !== 0 || load.loadAvg15 !== 0
     : false;
-  const cpuDetail = load
-    ? `Load average — 1 min ${load.loadAvg1.toFixed(2)}, 5 min ${load.loadAvg5.toFixed(
-        2,
-      )}, 15 min ${load.loadAvg15.toFixed(2)}`
-    : "";
+  /**
+   * A load average is a queue length, not a percentage, and it means
+   * nothing without the core count — 3.3 is idle on 16 cores and badly
+   * oversubscribed on 2. Dividing by cores gives the figure an operator can
+   * actually read at a glance, and it is allowed to exceed 100%: that is
+   * precisely the "work is queueing" signal worth seeing.
+   */
+  const cpuValue = !load || !loadAvgReported
+    ? "—"
+    : load.cpuCount
+      ? `${Math.round((load.loadAvg1 / load.cpuCount) * 100)}%`
+      : load.loadAvg1.toFixed(2);
+  const cpuDetail = !load
+    ? ""
+    : !loadAvgReported
+      ? "This platform does not report load average"
+      : `Load average ${load.loadAvg1.toFixed(2)} over 1 min${
+          load.cpuCount ? ` across ${load.cpuCount} cores` : ""
+        } · 5 min ${load.loadAvg5.toFixed(2)} · 15 min ${load.loadAvg15.toFixed(2)}`;
 
   return (
     <div
@@ -130,27 +144,18 @@ export function StarMapLoadCard(props: {
               <div>
                 <dt>CPU</dt>
                 <dd
+                  aria-label={`CPU: ${cpuValue}. ${cpuDetail}`}
                   onMouseEnter={(event) =>
-                    loadAvgReported
-                      ? cpuTooltip.show(event.currentTarget, cpuDetail)
-                      : cpuTooltip.show(
-                          event.currentTarget,
-                          "This platform does not report load average",
-                        )
+                    cpuTooltip.show(event.currentTarget, cpuDetail)
                   }
                   onMouseLeave={cpuTooltip.hide}
                   onFocus={(event) =>
-                    cpuTooltip.show(
-                      event.currentTarget,
-                      loadAvgReported
-                        ? cpuDetail
-                        : "This platform does not report load average",
-                    )
+                    cpuTooltip.show(event.currentTarget, cpuDetail)
                   }
                   onBlur={cpuTooltip.hide}
                   tabIndex={0}
                 >
-                  {loadAvgReported ? load.loadAvg1.toFixed(2) : "—"}
+                  {cpuValue}
                 </dd>
               </div>
               <div>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -33,7 +33,7 @@ import {
   computeStarMapLayout,
   generateStarField,
   STAR_MAP_BODY_ROW_Y,
-  STAR_MAP_CARD_GAP,
+  STAR_MAP_CLOUD_TOP,
   STAR_MAP_ESTIMATED_CARD_HEIGHT,
   visibleCardCount,
   type StarMapCardSlot,
@@ -676,28 +676,30 @@ export function StarMapScreen(props: StarMapScreenProps) {
       const lane = lanes.get(position.instanceId);
       const threadHeights = lane?.heights.slice(0, lane.count) ?? [];
       const hasLoad = loadCardInstances.has(position.instanceId);
-      // The load card APPENDS below the column. It used to take the slot
-      // nearest the star and push the stack out by one, which moved every
-      // card — including hand-placed ones, whose offsets are relative to a
-      // slot. Appending leaves every existing slot byte-identical, so
-      // opening and closing the card disturbs nothing.
-      const allSlots = computeCardSlots([
-        ...threadHeights,
-        ...(hasLoad ? [STAR_MAP_LOAD_CARD_HEIGHT] : []),
-      ]);
-      const lastSlot = allSlots[allSlots.length - 1];
-      const lastHeight = hasLoad
-        ? STAR_MAP_LOAD_CARD_HEIGHT
-        : threadHeights[threadHeights.length - 1] ?? 0;
+      // Thread slots are computed as if the load card did not exist, so
+      // opening it moves nothing — not the stack, and not the hand-placed
+      // cards whose offsets are relative to a slot. The card lands at the
+      // top of the cloud (painted above, see STAR_MAP_LOAD_CARD_Z) and the
+      // operator drags it wherever they want it; that position is synced,
+      // so it is a one-time move rather than a standing annoyance.
+      // Appending below the column was the other collision-free option and
+      // was worse: on a long column the card opened off-screen, which reads
+      // as a button that does nothing.
+      const slots = computeCardSlots(threadHeights);
+      const lastSlot = slots[slots.length - 1];
       return {
         instanceId: position.instanceId,
         isHub: position.isHub,
         x: position.x,
         y: position.y,
-        slots: allSlots.slice(0, threadHeights.length),
+        slots,
         cardWidth: laneLayout.cardWidth,
-        loadSlot: hasLoad ? allSlots[threadHeights.length] : undefined,
-        contentBottom: lastSlot ? lastSlot.dy + lastHeight : 0,
+        loadSlot: hasLoad ? { dx: 0, dy: STAR_MAP_CLOUD_TOP } : undefined,
+        contentBottom: lastSlot
+          ? lastSlot.dy + (threadHeights[threadHeights.length - 1] ?? 0)
+          : hasLoad
+            ? STAR_MAP_CLOUD_TOP + STAR_MAP_LOAD_CARD_HEIGHT
+            : 0,
       };
     });
   }, [laneLayout, lanes, loadCardInstances, orbit, orbitMode]);
@@ -1401,10 +1403,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
           remote.staleInstanceIds.has(position.instanceId)
             ? " star-map__cloud--stale"
             : ""
-        }${
-          selectedInstanceId && selectedInstanceId !== position.instanceId
-            ? " star-map__cloud--muted"
-            : ""
         }`}
         style={{ left: position.x, top: position.y }}
       >
@@ -1673,11 +1671,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
           return (
             <div
               key={position.instanceId}
-              className={`star-map__anchor${
-                selectedInstanceId && selectedInstanceId !== position.instanceId
-                  ? " star-map__anchor--muted"
-                  : ""
-              }`}
+              className="star-map__anchor"
               style={{ left: position.x, top: position.y }}
             >
               <StarMapInstanceCard

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -665,8 +665,13 @@ export function StarMapScreen(props: StarMapScreenProps) {
         slots: instance.cardSlots,
         cardWidth: ORBIT_CARD_WIDTH,
         // Above the body, at a radius that does not depend on how many
-        // cards the rings hold — so opening it disturbs nothing.
-        loadSlot: { dx: 0, dy: ORBIT_LOAD_CARD_DY },
+        // cards the rings hold — so opening it disturbs nothing. Gated on
+        // membership like the lanes branch: without the check the card
+        // rendered forever in this lens, and dismissing it only flipped the
+        // toggle that reads the same membership.
+        loadSlot: loadCardInstances.has(instance.instanceId)
+          ? { dx: 0, dy: ORBIT_LOAD_CARD_DY }
+          : undefined,
         // Rings grow their radius, so orbit's canvas is already sized by
         // `computeOrbitPlacement`; only lanes derive theirs from content.
         contentBottom: 0,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -33,6 +33,7 @@ import {
   computeStarMapLayout,
   generateStarField,
   STAR_MAP_BODY_ROW_Y,
+  STAR_MAP_CARD_GAP,
   STAR_MAP_CLOUD_TOP,
   STAR_MAP_ESTIMATED_CARD_HEIGHT,
   visibleCardCount,
@@ -290,10 +291,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
       return;
     }
     // A press on empty space that never travels is a click, and a click on
-    // nothing drops the selection. Watched separately from the pan below
-    // because the lanes lens has no pan to hang it off.
+    // nothing drops the selection. Watched separately from the pan below so
+    // the two gestures stay independent.
     watchForCanvasClick(event);
-    if (!panZoomMode) return;
     const canvas = canvasRef.current;
     const viewport = viewportRef.current;
     if (!canvas) return;
@@ -1155,10 +1155,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const [selection, setSelection] = useState<ReadonlySet<string>>(new Set());
   const [marquee, setMarquee] = useState<SnapRect | undefined>(undefined);
   /**
-   * Canvas scale for the overlays drawn inside the transform. The lanes
-   * lens never scales, so it is 1 there.
+   * Canvas scale for the overlays drawn inside the transform. Every lens
+   * scales now, lanes included, so the live value always applies.
    */
-  const overlayScale = panZoomMode && view.scale > 0 ? view.scale : 1;
+  const overlayScale = view.scale > 0 ? view.scale : 1;
 
   /**
    * A press on empty space that ends without travelling is a click, and a
@@ -1198,7 +1198,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       const canvas = canvasRef.current;
       if (!canvas || event.button !== 0) return false;
       const rect = canvas.getBoundingClientRect();
-      const scale = panZoomMode && view.scale > 0 ? view.scale : 1;
+      const scale = view.scale > 0 ? view.scale : 1;
       const toCanvas = (clientX: number, clientY: number) => ({
         x: (clientX - rect.left) / scale,
         y: (clientY - rect.top) / scale,
@@ -1233,7 +1233,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       window.addEventListener("pointercancel", stop);
       return true;
     },
-    [cardRects, panZoomMode, view.scale],
+    [cardRects, view.scale],
   );
 
   /**
@@ -1351,7 +1351,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
 
       // See the note in `cardRects`: unmeasured cards report 0, not undefined.
       const height = lane?.heights[index] || STAR_MAP_ESTIMATED_CARD_HEIGHT;
-      const scale = panZoomMode && view.scale > 0 ? view.scale : 1;
+      const scale = view.scale > 0 ? view.scale : 1;
 
       return (offset: { dx: number; dy: number }) => {
         const snap = resolveSnap({
@@ -1374,7 +1374,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
         };
       };
     },
-    [bodies, cardRects, lanes, panZoomMode, selection, view.scale],
+    [bodies, cardRects, lanes, selection, view.scale],
   );
 
   const renderCloud = (position: {

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -1123,6 +1123,29 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const cardRects = useMemo(() => {
     const rects = new Map<string, SnapRect>();
     for (const position of bodies) {
+      // The load card is placed by hand like any other, so it belongs in the
+      // same geometry: cards align to it, guides draw against it, and a
+      // marquee sweeps it up. Keyed by its POSITION entry so the shared
+      // group-move commit writes to the right arrangement row.
+      if (position.loadSlot) {
+        const loadOffset = arrangement.offsetFor(
+          position.instanceId,
+          STAR_MAP_LOAD_CARD_POSITION_KEY,
+        );
+        rects.set(
+          `${position.instanceId}::${STAR_MAP_LOAD_CARD_POSITION_KEY}`,
+          {
+            x:
+              position.x
+              + position.loadSlot.dx
+              + (loadOffset?.dx ?? 0)
+              - position.cardWidth / 2,
+            y: position.loadSlot.dy + (loadOffset?.dy ?? 0) + position.y,
+            width: position.cardWidth,
+            height: STAR_MAP_LOAD_CARD_HEIGHT,
+          },
+        );
+      }
       const lane = lanes.get(position.instanceId);
       if (!lane) continue;
       const visible = lane.threads.slice(0, lane.count);
@@ -1326,7 +1349,14 @@ export function StarMapScreen(props: StarMapScreenProps) {
   );
 
   const snapFor = useCallback(
-    (instanceId: string, threadKey: string, cardWidth: number) => {
+    (
+      instanceId: string,
+      threadKey: string,
+      cardWidth: number,
+      // Cards outside the thread stack (the load card) know their own slot
+      // and height; the lane lookup below cannot find them.
+      override?: { baseSlot: StarMapCardSlot; height: number },
+    ) => {
       const selfKey = `${instanceId}::${threadKey}`;
       if (!cardRects.has(selfKey)) return undefined;
       // A card carrying a selection must not snap to the rest of it. Those
@@ -1346,11 +1376,13 @@ export function StarMapScreen(props: StarMapScreenProps) {
           (thread) =>
             buildThreadIdentityKey(thread.source, thread.id) === threadKey,
         ) ?? -1;
-      const baseSlot = index >= 0 ? body?.slots[index] : undefined;
+      const baseSlot =
+        override?.baseSlot ?? (index >= 0 ? body?.slots[index] : undefined);
       if (!body || !baseSlot) return undefined;
 
       // See the note in `cardRects`: unmeasured cards report 0, not undefined.
-      const height = lane?.heights[index] || STAR_MAP_ESTIMATED_CARD_HEIGHT;
+      const height =
+        override?.height ?? (lane?.heights[index] || STAR_MAP_ESTIMATED_CARD_HEIGHT);
       const scale = view.scale > 0 ? view.scale : 1;
 
       return (offset: { dx: number; dy: number }) => {
@@ -1393,6 +1425,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     // Thread slots never account for the load card, so its presence cannot
     // move a thread — hand-placed or otherwise.
     const loadSlot = position.loadSlot;
+    const loadCardKey = `${position.instanceId}::${STAR_MAP_LOAD_CARD_POSITION_KEY}`;
     const slots = position.slots;
     // One region for the whole cloud, sized to the slots this lens drew,
     // so every card in it can reach every other card's position. The load
@@ -1439,11 +1472,27 @@ export function StarMapScreen(props: StarMapScreenProps) {
             centered={orbitMode}
             stackIndex={STAR_MAP_LOAD_CARD_Z}
             sharedWith={sharedMachineLabels.get(position.instanceId)}
+            cardKey={loadCardKey}
+            selected={selection.has(loadCardKey)}
+            onToggleSelect={() => toggleSelected(loadCardKey)}
             drag={
               health?.instanceId
                 ? {
                     detentRadius,
                     scale: view.scale,
+                    snap: snapFor(
+                      position.instanceId,
+                      STAR_MAP_LOAD_CARD_POSITION_KEY,
+                      position.cardWidth,
+                      {
+                        baseSlot: loadSlot,
+                        height: STAR_MAP_LOAD_CARD_HEIGHT,
+                      },
+                    ),
+                    onGuidesChange: setActiveGuides,
+                    onGroupDelta: (delta) => moveSelectionBy(loadCardKey, delta),
+                    onGroupCommit: (delta) =>
+                      commitSelectionMove(loadCardKey, delta),
                     onCommitOffset: (offset) =>
                       arrangement.setCardPosition(
                         position.instanceId,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -12,6 +12,7 @@ import {
   formatFederationPeerDisplayLabel,
   formatFederationPeerDisplayLabelParts,
   isRemoteFederationTarget,
+  STAR_MAP_LOAD_CARD_KEY,
   type FederationPeerSummary,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
@@ -86,8 +87,13 @@ import {
 } from "./star-map-view-geometry";
 import { StarMapViewOptions } from "./StarMapViewOptions";
 import { StarMapInstanceCard } from "./StarMapInstanceCard";
+import {
+  StarMapLoadCard,
+  STAR_MAP_LOAD_CARD_HEIGHT,
+} from "./StarMapLoadCard";
 import { StarMapThreadCard } from "./StarMapThreadCard";
 import { useStarMapArrangement } from "./useStarMapArrangement";
+import { useStarMapInstanceLoad } from "./useStarMapInstanceLoad";
 import { useStarMapThreads } from "./useStarMapThreads";
 
 const MAX_CARDS_PER_INSTANCE = 8;
@@ -153,6 +159,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
   }>({ width: 1280, height: 800 });
   const stars = useMemo(() => generateStarField(STAR_COUNT), []);
   const [intakeTarget, setIntakeTarget] = useState<IntakeDialogTarget>();
+  // Which instance the operator is focused on. Selection is deliberately
+  // view-local and unsynced: it is a "where am I looking" gesture, not a
+  // property of the fleet the way card placement is.
+  const [selectedInstanceId, setSelectedInstanceId] = useState<string>();
   // Thread keys that just bubbled in via intake — they wear the entrance
   // animation until the timer clears them.
   const [enteringThreadKeys, setEnteringThreadKeys] = useState<Set<string>>(
@@ -404,6 +414,32 @@ export function StarMapScreen(props: StarMapScreenProps) {
     refreshNonce: remoteRefreshNonce,
   });
   const arrangement = useStarMapArrangement({ desktopApi: props.desktopApi });
+  // Load-card membership lives in the synced arrangement, so a card opened
+  // on one machine is on the map from every machine in the fleet.
+  const loadCardInstanceIds = useMemo(
+    () => arrangement.instancesWithCard(STAR_MAP_LOAD_CARD_KEY),
+    [arrangement],
+  );
+  const loadCardInstances = useMemo(
+    () => new Set(loadCardInstanceIds),
+    [loadCardInstanceIds],
+  );
+  const instanceLoads = useStarMapInstanceLoad({
+    desktopApi: props.desktopApi,
+    instanceIds: loadCardInstanceIds,
+  });
+  const toggleLoadCard = useCallback(
+    (instanceId: string) => {
+      arrangement.setCardPosition(
+        instanceId,
+        STAR_MAP_LOAD_CARD_KEY,
+        arrangement.isCardPlaced(instanceId, STAR_MAP_LOAD_CARD_KEY)
+          ? null
+          : { dx: 0, dy: 0 },
+      );
+    },
+    [arrangement],
+  );
 
   // The hub is the local instance unless this instance is a pure client -
   // then its enrolled gateway anchors the constellation and the local node
@@ -553,19 +589,33 @@ export function StarMapScreen(props: StarMapScreenProps) {
           cardHeights.get(buildThreadIdentityKey(thread.source, thread.id))
           ?? STAR_MAP_ESTIMATED_CARD_HEIGHT,
       );
+      // An open load card takes the slot nearest the star, so the lane has
+      // that much less room for threads. Reserving it here (rather than
+      // letting the card overlay) keeps the stack honest: the `+N more`
+      // badge counts what the load card displaced.
+      const loadReserve = loadCardInstances.has(instanceId)
+        ? STAR_MAP_LOAD_CARD_HEIGHT + STAR_MAP_CARD_GAP
+        : 0;
       // Lanes are bounded by the window; an orbit ring grows its radius
       // instead, so it only obeys the hard cap.
       const count = orbitMode
         ? Math.min(threads.length, ORBIT_MAX_CARDS_PER_INSTANCE)
         : visibleCardCount({
             heights,
-            availableHeight: viewportSize.height - STAR_MAP_BODY_ROW_Y,
+            availableHeight:
+              viewportSize.height - STAR_MAP_BODY_ROW_Y - loadReserve,
             max: MAX_CARDS_PER_INSTANCE,
           });
       result.set(instanceId, { threads, heights, count });
     }
     return result;
-  }, [attentionByInstance, cardHeights, orbitMode, viewportSize.height]);
+  }, [
+    attentionByInstance,
+    cardHeights,
+    loadCardInstances,
+    orbitMode,
+    viewportSize.height,
+  ]);
 
   const topology = useMemo(
     () =>
@@ -583,11 +633,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
       computeOrbitPlacement({
         nodes: topology,
         cardCounts: new Map(
-          [...lanes].map(([instanceId, lane]) => [instanceId, lane.count]),
+          // The load card rides the same rings, so it counts toward the
+          // radius the same way a thread card does.
+          [...lanes].map(([instanceId, lane]) => [
+            instanceId,
+            lane.count + (loadCardInstances.has(instanceId) ? 1 : 0),
+          ]),
         ),
         cardWidth: ORBIT_CARD_WIDTH,
       }),
-    [lanes, topology],
+    [lanes, loadCardInstances, topology],
   );
 
   /** Bodies plus their card slots, in whichever space the layout uses. */
@@ -609,11 +664,18 @@ export function StarMapScreen(props: StarMapScreenProps) {
         isHub: position.isHub,
         x: position.x,
         y: position.y,
-        slots: computeCardSlots(lane?.heights.slice(0, lane.count) ?? []),
+        // The load card, when open, owns the slot nearest the star and the
+        // thread stack starts one slot further out.
+        slots: computeCardSlots([
+          ...(loadCardInstances.has(position.instanceId)
+            ? [STAR_MAP_LOAD_CARD_HEIGHT]
+            : []),
+          ...(lane?.heights.slice(0, lane.count) ?? []),
+        ]),
         cardWidth: laneLayout.cardWidth,
       };
     });
-  }, [laneLayout, lanes, orbit, orbitMode]);
+  }, [laneLayout, lanes, loadCardInstances, orbit, orbitMode]);
 
   const panZoomCanvas = orbitMode
     ? { width: orbit.canvasWidth, height: orbit.canvasHeight }
@@ -805,6 +867,38 @@ export function StarMapScreen(props: StarMapScreenProps) {
       ]),
     );
   }, [health, localInstanceId, peers, props.localInstanceLabel]);
+
+  /**
+   * Instance id → label of another instance on the same physical machine.
+   * Two profiles of one box report identical load, and two cards showing
+   * the same numbers reads as a bug unless the card says why.
+   *
+   * Peer-to-peer only: `machineId` arrives on the peer host block, and the
+   * local instance does not advertise a host block to itself, so a
+   * local/peer pair sharing one machine is not detected yet.
+   */
+  const sharedMachineLabels = useMemo(() => {
+    const byMachine = new Map<string, string[]>();
+    for (const peer of peers) {
+      const machineId = peer.host?.machineId;
+      if (!machineId || peer.revokedAt) continue;
+      byMachine.set(machineId, [...(byMachine.get(machineId) ?? []), peer.id]);
+    }
+    const labels = new Map<string, string>();
+    for (const ids of byMachine.values()) {
+      if (ids.length < 2) continue;
+      for (const id of ids) {
+        const others = ids
+          .filter((candidate) => candidate !== id)
+          .map((candidate) => {
+            const parts = displayLabelPartsById.get(candidate);
+            return parts?.profileName ?? parts?.label ?? candidate;
+          });
+        labels.set(id, others.join(", "));
+      }
+    }
+    return labels;
+  }, [displayLabelPartsById, peers]);
 
   const chatCards = useStarMapChatCards();
   const { desktopApi, onFocusLocalInstance, onOpenLocalThread } = props;
@@ -1244,10 +1338,14 @@ export function StarMapScreen(props: StarMapScreenProps) {
     const threads = lane?.threads ?? [];
     const heights = lane?.heights ?? [];
     const visible = threads.slice(0, lane?.count ?? 0);
-    const slots = position.slots;
+    // Slot 0 belongs to the load card when it is open; the thread stack is
+    // laid out against the remainder.
+    const showLoadCard = loadCardInstances.has(position.instanceId);
+    const loadSlot = showLoadCard ? position.slots[0] : undefined;
+    const slots = showLoadCard ? position.slots.slice(1) : position.slots;
     // One region for the whole cloud, sized to the slots this lens drew,
     // so every card in it can reach every other card's position.
-    const detentRadius = cloudDetentRadius(slots);
+    const detentRadius = cloudDetentRadius(position.slots);
     const overflow = threads.length - visible.length;
     return (
       <div
@@ -1255,6 +1353,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
         className={`star-map__cloud${
           remote.staleInstanceIds.has(position.instanceId)
             ? " star-map__cloud--stale"
+            : ""
+        }${
+          selectedInstanceId && selectedInstanceId !== position.instanceId
+            ? " star-map__cloud--muted"
             : ""
         }`}
         style={{ left: position.x, top: position.y }}
@@ -1270,6 +1372,37 @@ export function StarMapScreen(props: StarMapScreenProps) {
                 + (heights[visible.length - 1] ?? 0)
                 + 40,
             }}
+          />
+        ) : null}
+        {loadSlot ? (
+          <StarMapLoadCard
+            key={`load:${position.instanceId}`}
+            instanceId={position.instanceId}
+            instanceLabel={instanceEntry(position.instanceId).label}
+            load={instanceLoads.get(position.instanceId)}
+            baseSlot={loadSlot}
+            offset={arrangement.offsetFor(
+              position.instanceId,
+              STAR_MAP_LOAD_CARD_KEY,
+            )}
+            width={position.cardWidth}
+            centered={orbitMode}
+            stackIndex={0}
+            sharedWith={sharedMachineLabels.get(position.instanceId)}
+            drag={
+              health?.instanceId
+                ? {
+                    detentRadius,
+                    onCommitOffset: (offset) =>
+                      arrangement.setCardPosition(
+                        position.instanceId,
+                        STAR_MAP_LOAD_CARD_KEY,
+                        offset,
+                      ),
+                  }
+                : undefined
+            }
+            onDismiss={() => toggleLoadCard(position.instanceId)}
           />
         ) : null}
         {visible.map((thread, index) => {
@@ -1500,7 +1633,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
           return (
             <div
               key={position.instanceId}
-              className="star-map__anchor"
+              className={`star-map__anchor${
+                selectedInstanceId && selectedInstanceId !== position.instanceId
+                  ? " star-map__anchor--muted"
+                  : ""
+              }`}
               style={{ left: position.x, top: position.y }}
             >
               <StarMapInstanceCard
@@ -1529,7 +1666,23 @@ export function StarMapScreen(props: StarMapScreenProps) {
                 unreachable={remote.unreachableInstanceIds.has(
                   position.instanceId,
                 )}
+                selected={selectedInstanceId === position.instanceId}
+                onSelect={() =>
+                  setSelectedInstanceId((current) =>
+                    current === position.instanceId
+                      ? undefined
+                      : position.instanceId,
+                  )
+                }
                 onOpen={() => openInstance(position.instanceId)}
+                onToggleLoad={
+                  props.desktopApi?.readFederationInstanceLoad
+                  && (position.instanceId === localInstanceId
+                    || entry.peer?.status === "connected")
+                    ? () => toggleLoadCard(position.instanceId)
+                    : undefined
+                }
+                loadShown={loadCardInstances.has(position.instanceId)}
                 onIntake={
                   props.desktopApi?.dispatchStarMapIntake
                   && (position.instanceId === localInstanceId

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -13,6 +13,7 @@ import {
   formatFederationPeerDisplayLabelParts,
   isRemoteFederationTarget,
   STAR_MAP_LOAD_CARD_KEY,
+  STAR_MAP_LOAD_CARD_POSITION_KEY,
   type FederationPeerSummary,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
@@ -116,6 +117,13 @@ const LANE_CANVAS_PADDING = 120;
  * many thread cards the rings hold.
  */
 const ORBIT_LOAD_CARD_DY = -150;
+/**
+ * The load card paints above every thread card in its cloud. Thread cards
+ * take z 0..n by stack position, so a load card left at 0 ends up UNDER the
+ * cards it sits among — and an operator-summoned readout hiding behind a
+ * thread card reads as a broken button.
+ */
+const STAR_MAP_LOAD_CARD_Z = LANE_MAX_CARDS_PER_INSTANCE + 10;
 /**
  * Chat cards float above the map chrome (close button, filters, view
  * options) so a card being read is never underneath a control strip.
@@ -1422,11 +1430,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
             baseSlot={loadSlot}
             offset={arrangement.offsetFor(
               position.instanceId,
-              STAR_MAP_LOAD_CARD_KEY,
+              STAR_MAP_LOAD_CARD_POSITION_KEY,
             )}
             width={position.cardWidth}
             centered={orbitMode}
-            stackIndex={0}
+            stackIndex={STAR_MAP_LOAD_CARD_Z}
             sharedWith={sharedMachineLabels.get(position.instanceId)}
             drag={
               health?.instanceId
@@ -1436,7 +1444,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
                     onCommitOffset: (offset) =>
                       arrangement.setCardPosition(
                         position.instanceId,
-                        STAR_MAP_LOAD_CARD_KEY,
+                        STAR_MAP_LOAD_CARD_POSITION_KEY,
                         offset,
                       ),
                   }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -80,10 +80,10 @@ import {
   type StarMapViewPreferences,
 } from "./star-map-preferences";
 import {
-  centerStarMapView,
   clampStarMapView,
   MAX_ZOOM,
   MIN_ZOOM,
+  placeStarMapView,
 } from "./star-map-view-geometry";
 import { StarMapViewOptions } from "./StarMapViewOptions";
 import { StarMapInstanceCard } from "./StarMapInstanceCard";
@@ -96,12 +96,20 @@ import { useStarMapArrangement } from "./useStarMapArrangement";
 import { useStarMapInstanceLoad } from "./useStarMapInstanceLoad";
 import { useStarMapThreads } from "./useStarMapThreads";
 
-const MAX_CARDS_PER_INSTANCE = 8;
+/**
+ * DOM-size backstop for a lane column, not a design limit: lanes pan and
+ * zoom, so a column is free to run past the fold. A fleet of five instances
+ * at this ceiling is already 200 mounted cards, which is the real reason to
+ * stop somewhere; past it the `+N more` badge tells the truth.
+ */
+const LANE_MAX_CARDS_PER_INSTANCE = 40;
 const STAR_COUNT = 130;
 /** Orbit rings use a fixed card width; lanes narrow theirs to fit. */
 const ORBIT_CARD_WIDTH = 200;
-/** Rings hold far more than a lane column, so orbit shows deeper. */
+/** A ring crowds geometrically, so orbit stays shallower than a column. */
 const ORBIT_MAX_CARDS_PER_INSTANCE = 16;
+/** Breathing room past the longest column / widest lane when panning. */
+const LANE_CANVAS_PADDING = 120;
 /**
  * Chat cards float above the map chrome (close button, filters, view
  * options) so a card being read is never underneath a control strip.
@@ -189,12 +197,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
   /** Projects as suns: threads pooled across instances, one body per repo. */
   const projectsMode = preferences.layout === "projects";
   /**
-   * Both big-canvas lenses pan and zoom; lanes fits the window and does
-   * not. Projects previously failed every one of these gates, so its
-   * oversized canvas could not be navigated at all, and the centring
-   * effect pinned it to the origin instead of centring it.
+   * Lanes hang from the top: bodies sit at a fixed y and their columns grow
+   * downward, so a tall canvas has to open at the top edge. Centring it — as
+   * the radial lenses want — would open the map already scrolled past the
+   * stars and the instance bodies.
    */
-  const panZoomMode = orbitMode || projectsMode;
+  const topAnchoredView = !orbitMode && !projectsMode;
 
   // Focus the layer on open AND whenever the floating thread closes -
   // "Back to map" leaves focus inside <main>, and without a refocus the
@@ -589,33 +597,22 @@ export function StarMapScreen(props: StarMapScreenProps) {
           cardHeights.get(buildThreadIdentityKey(thread.source, thread.id))
           ?? STAR_MAP_ESTIMATED_CARD_HEIGHT,
       );
-      // An open load card takes the slot nearest the star, so the lane has
-      // that much less room for threads. Reserving it here (rather than
-      // letting the card overlay) keeps the stack honest: the `+N more`
-      // badge counts what the load card displaced.
-      const loadReserve = loadCardInstances.has(instanceId)
-        ? STAR_MAP_LOAD_CARD_HEIGHT + STAR_MAP_CARD_GAP
-        : 0;
-      // Lanes are bounded by the window; an orbit ring grows its radius
-      // instead, so it only obeys the hard cap.
+      // A lane is no longer bounded by the window: the column grows as long
+      // as it needs and the operator pans and zooms into it, the way the
+      // orbit lens already worked. Truncating at the fold hid curated
+      // threads that were never coming back into view — the cap that
+      // remains is a DOM-size backstop, not a design limit.
       const count = orbitMode
         ? Math.min(threads.length, ORBIT_MAX_CARDS_PER_INSTANCE)
         : visibleCardCount({
             heights,
-            availableHeight:
-              viewportSize.height - STAR_MAP_BODY_ROW_Y - loadReserve,
-            max: MAX_CARDS_PER_INSTANCE,
+            availableHeight: Number.POSITIVE_INFINITY,
+            max: LANE_MAX_CARDS_PER_INSTANCE,
           });
       result.set(instanceId, { threads, heights, count });
     }
     return result;
-  }, [
-    attentionByInstance,
-    cardHeights,
-    loadCardInstances,
-    orbitMode,
-    viewportSize.height,
-  ]);
+  }, [attentionByInstance, cardHeights, orbitMode]);
 
   const topology = useMemo(
     () =>
@@ -655,38 +652,71 @@ export function StarMapScreen(props: StarMapScreenProps) {
         y: instance.y,
         slots: instance.cardSlots,
         cardWidth: ORBIT_CARD_WIDTH,
+        // Rings grow their radius, so orbit's canvas is already sized by
+        // `computeOrbitPlacement`; only lanes derive theirs from content.
+        contentBottom: 0,
       }));
     }
     return laneLayout.positions.map((position) => {
       const lane = lanes.get(position.instanceId);
+      // The load card, when open, owns the slot nearest the star and the
+      // thread stack starts one slot further out.
+      const itemHeights = [
+        ...(loadCardInstances.has(position.instanceId)
+          ? [STAR_MAP_LOAD_CARD_HEIGHT]
+          : []),
+        ...(lane?.heights.slice(0, lane.count) ?? []),
+      ];
+      const slots = computeCardSlots(itemHeights);
+      const lastSlot = slots[slots.length - 1];
       return {
         instanceId: position.instanceId,
         isHub: position.isHub,
         x: position.x,
         y: position.y,
-        // The load card, when open, owns the slot nearest the star and the
-        // thread stack starts one slot further out.
-        slots: computeCardSlots([
-          ...(loadCardInstances.has(position.instanceId)
-            ? [STAR_MAP_LOAD_CARD_HEIGHT]
-            : []),
-          ...(lane?.heights.slice(0, lane.count) ?? []),
-        ]),
+        slots,
         cardWidth: laneLayout.cardWidth,
+        contentBottom: lastSlot
+          ? lastSlot.dy + (itemHeights[itemHeights.length - 1] ?? 0)
+          : 0,
       };
     });
   }, [laneLayout, lanes, loadCardInstances, orbit, orbitMode]);
 
+  /**
+   * Lanes canvas: as wide as the instance row and as tall as the longest
+   * column, never smaller than the window so a short map still fills it.
+   *
+   * Lanes used to have no canvas at all — the lens rendered straight into
+   * the viewport and truncated each column at the fold. Sizing it to content
+   * is what lets the shared pan/zoom reach a column that runs past the
+   * bottom of the screen.
+   */
+  const lanesCanvas = useMemo(() => {
+    let right = viewportSize.width;
+    let bottom = viewportSize.height;
+    for (const body of bodies) {
+      right = Math.max(right, body.x + body.cardWidth / 2 + LANE_CANVAS_PADDING);
+      bottom = Math.max(
+        bottom,
+        body.y + body.contentBottom + LANE_CANVAS_PADDING,
+      );
+    }
+    return { width: right, height: bottom };
+  }, [bodies, viewportSize.height, viewportSize.width]);
+
   const panZoomCanvas = orbitMode
     ? { width: orbit.canvasWidth, height: orbit.canvasHeight }
-    : { width: projectLayout.canvasWidth, height: projectLayout.canvasHeight };
+    : projectsMode
+      ? { width: projectLayout.canvasWidth, height: projectLayout.canvasHeight }
+      : lanesCanvas;
 
   // Trackpad: two-finger drag pans, pinch (ctrl+wheel) zooms about the
   // pointer. Registered natively because the listener must not be passive.
   // Sits below panZoomCanvas because the clamp needs the canvas size.
   useEffect(() => {
     const element = viewportRef.current;
-    if (!element || !panZoomMode) return;
+    if (!element) return;
     const bounds = {
       canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
       viewport: { width: viewportSize.width, height: viewportSize.height },
@@ -731,7 +761,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     element.addEventListener("wheel", onWheel, { passive: false });
     return () => element.removeEventListener("wheel", onWheel);
   }, [
-    panZoomMode,
+    topAnchoredView,
     panZoomCanvas.width,
     panZoomCanvas.height,
     viewportSize.width,
@@ -756,18 +786,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
    */
   useEffect(() => {
     if (operatorMovedViewRef.current) return;
-    if (!panZoomMode) {
-      setView({ x: 0, y: 0, scale: 1 });
-      return;
-    }
     setView(
-      centerStarMapView({
+      placeStarMapView({
         canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
         viewport: { width: viewportSize.width, height: viewportSize.height },
+        topAnchored: topAnchoredView,
       }),
     );
   }, [
-    panZoomMode,
+    topAnchoredView,
     panZoomCanvas.width,
     panZoomCanvas.height,
     viewportSize.width,
@@ -787,18 +814,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
    */
   const resetView = useCallback(() => {
     operatorMovedViewRef.current = false;
-    if (!panZoomMode) {
-      setView({ x: 0, y: 0, scale: 1 });
-      return;
-    }
     setView(
-      centerStarMapView({
+      placeStarMapView({
         canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
         viewport: { width: viewportSize.width, height: viewportSize.height },
+        topAnchored: topAnchoredView,
       }),
     );
   }, [
-    panZoomMode,
+    topAnchoredView,
     panZoomCanvas.width,
     panZoomCanvas.height,
     viewportSize.width,
@@ -1549,24 +1573,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
         </svg>
         <div
           ref={canvasRef}
-          className={`star-map__canvas${
-            orbitMode || projectsMode ? " is-orbit" : ""
-          }`}
-          style={
-            orbitMode
-              ? {
-                  width: orbit.canvasWidth,
-                  height: orbit.canvasHeight,
-                  transform: `translate(${view.x}px, ${view.y}px) scale(${view.scale})`,
-                }
-              : projectsMode
-                ? {
-                    width: projectLayout.canvasWidth,
-                    height: projectLayout.canvasHeight,
-                    transform: `translate(${view.x}px, ${view.y}px) scale(${view.scale})`,
-                  }
-                : undefined
-          }
+          // Every lens is now a transformed canvas sized to its content —
+          // lanes included, which is what makes a column longer than the
+          // window reachable.
+          className="star-map__canvas is-transformed"
+          style={{
+            width: panZoomCanvas.width,
+            height: panZoomCanvas.height,
+            transform: `translate(${view.x}px, ${view.y}px) scale(${view.scale})`,
+          }}
         >
         {projectsMode ? null : (
         <svg
@@ -1932,7 +1947,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
             setPreferences(next);
             writeStoredPreferences(next);
           }}
-          onResetView={panZoomMode ? resetView : undefined}
+          onResetView={resetView}
         />
       </div>
       {/* Two different settings can empty the map, and a blank star field

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -111,6 +111,12 @@ const ORBIT_MAX_CARDS_PER_INSTANCE = 16;
 /** Breathing room past the longest column / widest lane when panning. */
 const LANE_CANVAS_PADDING = 120;
 /**
+ * Where an orbit load card parks: above the body, clear of the largest
+ * body's keepout. Fixed rather than ring-derived so it cannot depend on how
+ * many thread cards the rings hold.
+ */
+const ORBIT_LOAD_CARD_DY = -150;
+/**
  * Chat cards float above the map chrome (close button, filters, view
  * options) so a card being read is never underneath a control strip.
  */
@@ -630,16 +636,14 @@ export function StarMapScreen(props: StarMapScreenProps) {
       computeOrbitPlacement({
         nodes: topology,
         cardCounts: new Map(
-          // The load card rides the same rings, so it counts toward the
-          // radius the same way a thread card does.
-          [...lanes].map(([instanceId, lane]) => [
-            instanceId,
-            lane.count + (loadCardInstances.has(instanceId) ? 1 : 0),
-          ]),
+          // Deliberately NOT counting the load card: ring radius is derived
+          // from card count, so including it would move every thread card
+          // on the ring the moment the load card opened.
+          [...lanes].map(([instanceId, lane]) => [instanceId, lane.count]),
         ),
         cardWidth: ORBIT_CARD_WIDTH,
       }),
-    [lanes, loadCardInstances, topology],
+    [lanes, topology],
   );
 
   /** Bodies plus their card slots, in whichever space the layout uses. */
@@ -652,6 +656,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
         y: instance.y,
         slots: instance.cardSlots,
         cardWidth: ORBIT_CARD_WIDTH,
+        // Above the body, at a radius that does not depend on how many
+        // cards the rings hold — so opening it disturbs nothing.
+        loadSlot: { dx: 0, dy: ORBIT_LOAD_CARD_DY },
         // Rings grow their radius, so orbit's canvas is already sized by
         // `computeOrbitPlacement`; only lanes derive theirs from content.
         contentBottom: 0,
@@ -659,26 +666,30 @@ export function StarMapScreen(props: StarMapScreenProps) {
     }
     return laneLayout.positions.map((position) => {
       const lane = lanes.get(position.instanceId);
-      // The load card, when open, owns the slot nearest the star and the
-      // thread stack starts one slot further out.
-      const itemHeights = [
-        ...(loadCardInstances.has(position.instanceId)
-          ? [STAR_MAP_LOAD_CARD_HEIGHT]
-          : []),
-        ...(lane?.heights.slice(0, lane.count) ?? []),
-      ];
-      const slots = computeCardSlots(itemHeights);
-      const lastSlot = slots[slots.length - 1];
+      const threadHeights = lane?.heights.slice(0, lane.count) ?? [];
+      const hasLoad = loadCardInstances.has(position.instanceId);
+      // The load card APPENDS below the column. It used to take the slot
+      // nearest the star and push the stack out by one, which moved every
+      // card — including hand-placed ones, whose offsets are relative to a
+      // slot. Appending leaves every existing slot byte-identical, so
+      // opening and closing the card disturbs nothing.
+      const allSlots = computeCardSlots([
+        ...threadHeights,
+        ...(hasLoad ? [STAR_MAP_LOAD_CARD_HEIGHT] : []),
+      ]);
+      const lastSlot = allSlots[allSlots.length - 1];
+      const lastHeight = hasLoad
+        ? STAR_MAP_LOAD_CARD_HEIGHT
+        : threadHeights[threadHeights.length - 1] ?? 0;
       return {
         instanceId: position.instanceId,
         isHub: position.isHub,
         x: position.x,
         y: position.y,
-        slots,
+        slots: allSlots.slice(0, threadHeights.length),
         cardWidth: laneLayout.cardWidth,
-        contentBottom: lastSlot
-          ? lastSlot.dy + (itemHeights[itemHeights.length - 1] ?? 0)
-          : 0,
+        loadSlot: hasLoad ? allSlots[threadHeights.length] : undefined,
+        contentBottom: lastSlot ? lastSlot.dy + lastHeight : 0,
       };
     });
   }, [laneLayout, lanes, loadCardInstances, orbit, orbitMode]);
@@ -1357,19 +1368,23 @@ export function StarMapScreen(props: StarMapScreenProps) {
     y: number;
     slots: StarMapCardSlot[];
     cardWidth: number;
+    /** Set when this instance shows a load card; never a thread slot. */
+    loadSlot?: StarMapCardSlot;
   }) => {
     const lane = lanes.get(position.instanceId);
     const threads = lane?.threads ?? [];
     const heights = lane?.heights ?? [];
     const visible = threads.slice(0, lane?.count ?? 0);
-    // Slot 0 belongs to the load card when it is open; the thread stack is
-    // laid out against the remainder.
-    const showLoadCard = loadCardInstances.has(position.instanceId);
-    const loadSlot = showLoadCard ? position.slots[0] : undefined;
-    const slots = showLoadCard ? position.slots.slice(1) : position.slots;
+    // Thread slots never account for the load card, so its presence cannot
+    // move a thread — hand-placed or otherwise.
+    const loadSlot = position.loadSlot;
+    const slots = position.slots;
     // One region for the whole cloud, sized to the slots this lens drew,
-    // so every card in it can reach every other card's position.
-    const detentRadius = cloudDetentRadius(position.slots);
+    // so every card in it can reach every other card's position. The load
+    // card's slot joins the measurement without joining the thread stack.
+    const detentRadius = cloudDetentRadius(
+      loadSlot ? [...position.slots, loadSlot] : position.slots,
+    );
     const overflow = threads.length - visible.length;
     return (
       <div
@@ -1417,6 +1432,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
               health?.instanceId
                 ? {
                     detentRadius,
+                    scale: view.scale,
                     onCommitOffset: (offset) =>
                       arrangement.setCardPosition(
                         position.instanceId,
@@ -1466,8 +1482,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
                 health?.instanceId
                   ? {
                       detentRadius,
-                      // Lanes never scales, so this is 1 there.
-                      scale: panZoomMode ? view.scale : 1,
+                      // Every lens zooms now, lanes included, so the live
+                      // scale always applies.
+                      scale: view.scale,
                       snap: snapFor(
                         position.instanceId,
                         threadKey,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -1,4 +1,4 @@
-import { useRef, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
+import { type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
 import {
   buildThreadIdentityKey,
   type CelestialIconId,
@@ -16,15 +16,15 @@ import {
   getThreadRowStatus,
   ThreadRowStatus,
 } from "../navigation/ThreadRowStatus";
-import { pointerDeltaToCanvas, resolveCardDragOffset } from "./star-map-layout";
-import type { AlignmentGuide } from "./star-map-snapping";
+import {
+  useStarMapCardDrag,
+  type StarMapCardDrag,
+} from "./useStarMapCardDrag";
 import {
   visiblePullRequests,
   type StarMapCardFields,
 } from "./star-map-preferences";
 import type { StarMapSessionKeys } from "./attention";
-
-const DRAG_THRESHOLD_PX = 4;
 
 /**
  * Compact attention card floating in an instance's lane. Mirrors the
@@ -61,42 +61,7 @@ export function StarMapThreadCard(props: {
    * Present when the card is draggable. Radius and commit travel together
    * so a draggable card cannot exist without the region it drags in.
    */
-  drag?: {
-    /**
-     * Where drag resistance begins, measured from the INSTANCE BODY — one
-     * region shared by the whole cloud (`cloudDetentRadius`), not a
-     * per-card allowance, so any card can be placed where any other card
-     * sits. Past it the drag is resisted, not stopped.
-     */
-    detentRadius: number;
-    /**
-     * Current canvas scale. Pointer deltas arrive in screen pixels but the
-     * card is positioned in canvas pixels, so without this the card moves
-     * `scale` times too far and slides out from under the cursor.
-     */
-    scale: number;
-    /**
-     * Snap a proposed offset against the rest of the arrangement. The
-     * screen owns this because it is the only thing that knows where every
-     * other card sits; the card would otherwise have to reconstruct the
-     * whole map to align with one neighbour.
-     */
-    snap?: (offset: { dx: number; dy: number }) => {
-      dx: number;
-      dy: number;
-      guides: AlignmentGuide[];
-    };
-    /** Guides to draw while this drag is live; empty clears them. */
-    onGuidesChange?: (guides: AlignmentGuide[]) => void;
-    /**
-     * How far this drag has travelled, so the screen can carry the rest of
-     * a multi-card selection along. Fired per frame during the drag and
-     * once more on release, when the movement becomes durable.
-     */
-    onGroupDelta?: (delta: { dx: number; dy: number }) => void;
-    onGroupCommit?: (delta: { dx: number; dy: number }) => void;
-    onCommitOffset: (offset: { dx: number; dy: number }) => void;
-  };
+  drag?: StarMapCardDrag;
   /** `instanceId::threadKey`; unique across clouds. */
   cardKey: string;
   /** Part of a multi-card selection, so it moves with the others. */
@@ -122,9 +87,6 @@ export function StarMapThreadCard(props: {
     thread,
     props.sessionKeys?.thinkingThreadKeys,
   );
-  // Set while a pointer-drag exceeded the threshold, so the click that the
-  // browser fires on release does not also open the thread.
-  const suppressClickRef = useRef(false);
   // Cards live inside the clipped, transformed canvas, and a native
   // `title` cannot be styled, times out differently per platform, and
   // does not wrap on macOS Electron — see UI-THEME.md.
@@ -149,6 +111,16 @@ export function StarMapThreadCard(props: {
       : {}),
   };
 
+  const {
+    startDrag: startCardDrag,
+    consumeSuppressedClick,
+    suppressClick,
+  } = useStarMapCardDrag({
+    baseSlot: props.baseSlot,
+    offset: props.offset,
+    drag: props.drag,
+  });
+
   const startDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
     // Modifier-click amends the selection rather than opening or dragging.
@@ -156,85 +128,17 @@ export function StarMapThreadCard(props: {
     // that swept up one card too many without starting the sweep over.
     // Gated on the handler so lenses with no selection (Projects) keep
     // modifier-click opening the thread instead of doing nothing at all.
+    //
+    // Handled here rather than in the drag hook because it is a selection
+    // gesture: the hook is shared with cards that have no selection at all.
     const toggleSelect = props.onToggleSelect;
     if (toggleSelect && (event.shiftKey || event.metaKey || event.ctrlKey)) {
       event.preventDefault();
-      suppressClickRef.current = true;
+      suppressClick();
       toggleSelect();
       return;
     }
-    const drag = props.drag;
-    if (!drag) return;
-    const element = event.currentTarget;
-    const startX = event.clientX;
-    const startY = event.clientY;
-    const startOffset = props.offset ?? { dx: 0, dy: 0 };
-    let dragging = false;
-    let lastDx = startOffset.dx;
-    let lastDy = startOffset.dy;
-    let frame = 0;
-    const move = (pointerEvent: globalThis.PointerEvent) => {
-      const screenX = pointerEvent.clientX - startX;
-      const screenY = pointerEvent.clientY - startY;
-      // The threshold is about human intent, so it stays in screen pixels;
-      // only the movement itself converts into canvas space.
-      if (
-        !dragging
-        && Math.hypot(screenX, screenY) < DRAG_THRESHOLD_PX
-      ) {
-        return;
-      }
-      dragging = true;
-      suppressClickRef.current = true;
-      const delta = pointerDeltaToCanvas({
-        dx: screenX,
-        dy: screenY,
-        scale: drag.scale,
-      });
-      const resolved = resolveCardDragOffset({
-        baseSlot: props.baseSlot,
-        offset: {
-          dx: startOffset.dx + delta.dx,
-          dy: startOffset.dy + delta.dy,
-        },
-        detentRadius: drag.detentRadius,
-      });
-      const snapped = drag.snap ? drag.snap(resolved) : undefined;
-      lastDx = snapped ? snapped.dx : resolved.dx;
-      lastDy = snapped ? snapped.dy : resolved.dy;
-      drag.onGuidesChange?.(snapped?.guides ?? []);
-      if (!frame) {
-        frame = requestAnimationFrame(() => {
-          frame = 0;
-          element.style.left = `${props.baseSlot.dx + lastDx}px`;
-          element.style.top = `${props.baseSlot.dy + lastDy}px`;
-          drag.onGroupDelta?.({
-            dx: lastDx - startOffset.dx,
-            dy: lastDy - startOffset.dy,
-          });
-        });
-      }
-    };
-    const stop = () => {
-      window.removeEventListener("pointermove", move);
-      window.removeEventListener("pointerup", stop);
-      window.removeEventListener("pointercancel", stop);
-      if (frame) {
-        cancelAnimationFrame(frame);
-        frame = 0;
-      }
-      drag.onGuidesChange?.([]);
-      if (dragging) {
-        drag.onCommitOffset({ dx: lastDx, dy: lastDy });
-        drag.onGroupCommit?.({
-          dx: lastDx - startOffset.dx,
-          dy: lastDy - startOffset.dy,
-        });
-      }
-    };
-    window.addEventListener("pointermove", move);
-    window.addEventListener("pointerup", stop);
-    window.addEventListener("pointercancel", stop);
+    startCardDrag(event);
   };
 
   return (
@@ -277,10 +181,7 @@ export function StarMapThreadCard(props: {
           // and the kebab beside it gets a distinct name of its own.
           aria-label={`Open thread: ${thread.title}`}
           onClick={() => {
-            if (suppressClickRef.current) {
-              suppressClickRef.current = false;
-              return;
-            }
+            if (consumeSuppressedClick()) return;
             props.onOpen(thread);
           }}
         >

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
+import { type CSSProperties } from "react";
 import {
   buildThreadIdentityKey,
   type CelestialIconId,
@@ -111,35 +111,12 @@ export function StarMapThreadCard(props: {
       : {}),
   };
 
-  const {
-    startDrag: startCardDrag,
-    consumeSuppressedClick,
-    suppressClick,
-  } = useStarMapCardDrag({
+  const { startDrag, consumeSuppressedClick } = useStarMapCardDrag({
     baseSlot: props.baseSlot,
     offset: props.offset,
     drag: props.drag,
+    onToggleSelect: props.onToggleSelect,
   });
-
-  const startDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if (event.button !== 0) return;
-    // Modifier-click amends the selection rather than opening or dragging.
-    // It is the platform convention, and the only way to correct a marquee
-    // that swept up one card too many without starting the sweep over.
-    // Gated on the handler so lenses with no selection (Projects) keep
-    // modifier-click opening the thread instead of doing nothing at all.
-    //
-    // Handled here rather than in the drag hook because it is a selection
-    // gesture: the hook is shared with cards that have no selection at all.
-    const toggleSelect = props.onToggleSelect;
-    if (toggleSelect && (event.shiftKey || event.metaKey || event.ctrlKey)) {
-      event.preventDefault();
-      suppressClick();
-      toggleSelect();
-      return;
-    }
-    startCardDrag(event);
-  };
 
   return (
     // Shell owns position, drag and stacking so the card itself can stay a

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapInstanceCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapInstanceCard.test.tsx
@@ -123,6 +123,49 @@ describe("StarMapInstanceCard", () => {
     ).toBeNull();
   });
 
+  it("clicking an action never reaches the body underneath it", () => {
+    // The row tucks into the body's empty top margin, so their boxes overlap
+    // and the body is the later sibling. Without the row claiming a layer,
+    // the body wins the overlap and a click on the lower half of a button
+    // selects the instance instead of firing the action.
+    const onSelect = vi.fn();
+    const onToggleLoad = vi.fn();
+    const { container } = render(
+      <StarMapInstanceCard
+        instanceId="pwr_studio"
+        label="Studio Mac"
+        status="connected"
+        isLocal={false}
+        isHub={false}
+        onSelect={onSelect}
+        onToggleLoad={onToggleLoad}
+      />,
+    );
+
+    const actions = container.querySelector<HTMLElement>(
+      ".star-map-instance__actions",
+    );
+    const body = container.querySelector<HTMLElement>(
+      ".star-map-instance__body",
+    );
+    // The row must come BEFORE the body in the DOM (so it is the earlier
+    // sibling) and carry its own stacking order.
+    expect(actions).not.toBeNull();
+    expect(body).not.toBeNull();
+    expect(
+      actions!.compareDocumentPosition(body!)
+        & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Show load for Studio Mac (CPU, memory, disk)",
+      }),
+    );
+    expect(onToggleLoad).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
   it("shows an icon-only action's name on focus, not just on hover", () => {
     renderCard({ onToggleLoad: vi.fn() });
     const button = screen.getByRole("button", {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapInstanceCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapInstanceCard.test.tsx
@@ -1,0 +1,144 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StarMapInstanceCard } from "../StarMapInstanceCard";
+
+type CardProps = Parameters<typeof StarMapInstanceCard>[0];
+
+function renderCard(overrides: Partial<CardProps> = {}): CardProps {
+  const props: CardProps = {
+    instanceId: "pwr_studio",
+    label: "Studio Mac",
+    status: "connected",
+    isLocal: false,
+    isHub: false,
+    onSelect: vi.fn(),
+    ...overrides,
+  };
+  render(<StarMapInstanceCard {...props} />);
+  return props;
+}
+
+function tooltipText(): string[] {
+  return [...document.querySelectorAll(".viewport-tooltip")].map(
+    (node) => node.textContent ?? "",
+  );
+}
+
+describe("StarMapInstanceCard", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("selects the instance on body click instead of opening a window", () => {
+    const onSelect = vi.fn();
+    const onOpen = vi.fn();
+    renderCard({ onSelect, onOpen });
+
+    fireEvent.click(screen.getByRole("button", { name: "Focus Studio Mac" }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    // The window-level commitment stays on its own control: the biggest,
+    // most inviting target on the map must do the cheap, reversible thing.
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("puts opening a remote viewer on a dedicated action", () => {
+    const onOpen = vi.fn();
+    renderCard({ onOpen });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open remote viewer for Studio Mac" }),
+    );
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("names the open action for the local instance differently", () => {
+    renderCard({ isLocal: true, label: "This Mac", onOpen: vi.fn() });
+
+    expect(
+      screen.getByRole("button", { name: "Open this instance (This Mac)" }),
+    ).toBeTruthy();
+  });
+
+  it("keeps the profile in every action name so two profiles stay distinct", () => {
+    renderCard({
+      label: "Harold-MBP-M5-Max",
+      profileName: "dev",
+      onIntake: vi.fn(),
+      onToggleLoad: vi.fn(),
+      onOpen: vi.fn(),
+    });
+
+    for (const name of [
+      "New thread on Harold-MBP-M5-Max / dev",
+      "Show load for Harold-MBP-M5-Max / dev (CPU, memory, disk)",
+      "Open remote viewer for Harold-MBP-M5-Max / dev",
+      "Focus Harold-MBP-M5-Max / dev",
+    ]) {
+      expect(screen.getByRole("button", { name })).toBeTruthy();
+    }
+  });
+
+  it("reports load-card state through aria-pressed and flips the label", () => {
+    const onToggleLoad = vi.fn();
+    renderCard({ onToggleLoad, loadShown: false });
+
+    const show = screen.getByRole("button", {
+      name: "Show load for Studio Mac (CPU, memory, disk)",
+    });
+    expect(show.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(show);
+    expect(onToggleLoad).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    renderCard({ onToggleLoad, loadShown: true });
+
+    expect(
+      screen
+        .getByRole("button", { name: "Hide load for Studio Mac" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  it("marks the body pressed while selected", () => {
+    renderCard({ selected: true });
+
+    expect(
+      screen
+        .getByRole("button", { name: "Focus Studio Mac" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  it("omits actions the instance cannot perform", () => {
+    renderCard();
+
+    // A disconnected peer gets no intake and no load query, so those
+    // controls must not render at all rather than render disabled.
+    expect(screen.queryByRole("button", { name: /New thread on/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Show load for/ })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /Open remote viewer/ }),
+    ).toBeNull();
+  });
+
+  it("shows an icon-only action's name on focus, not just on hover", () => {
+    renderCard({ onToggleLoad: vi.fn() });
+    const button = screen.getByRole("button", {
+      name: "Show load for Studio Mac (CPU, memory, disk)",
+    });
+
+    // Keyboard users never hover, and the tooltip carries the whole meaning
+    // of an icon-only control, so focus has to surface it too.
+    fireEvent.focus(button);
+    expect(tooltipText()).toContain(
+      "Show load for Studio Mac (CPU, memory, disk)",
+    );
+
+    fireEvent.blur(button);
+    expect(tooltipText()).not.toContain(
+      "Show load for Studio Mac (CPU, memory, disk)",
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapLoadCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapLoadCard.test.tsx
@@ -1,0 +1,148 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FederationLoadStatus } from "@pwragent/shared";
+import { StarMapLoadCard } from "../StarMapLoadCard";
+
+type CardProps = Parameters<typeof StarMapLoadCard>[0];
+
+function buildLoad(
+  overrides: Partial<FederationLoadStatus> = {},
+): FederationLoadStatus {
+  return {
+    loadAvg1: 2.5,
+    loadAvg5: 1.75,
+    loadAvg15: 1.5,
+    availableMemoryBytes: 5_452_595,
+    diskFreeBytes: 214_748_364_800,
+    sampledAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function renderCard(overrides: Partial<CardProps> = {}): CardProps {
+  const props: CardProps = {
+    instanceId: "pwr_studio",
+    instanceLabel: "Studio Mac",
+    load: buildLoad(),
+    baseSlot: { dx: 0, dy: 100 },
+    width: 220,
+    stackIndex: 0,
+    onDismiss: vi.fn(),
+    ...overrides,
+  };
+  render(<StarMapLoadCard {...props} />);
+  return props;
+}
+
+function metric(label: string): string {
+  const term = [...document.querySelectorAll(".star-map-load-card__metrics dt")]
+    .find((node) => node.textContent === label);
+  const value = term?.parentElement?.querySelector("dd");
+  if (!value) throw new Error(`No metric labelled ${label}`);
+  return value.textContent ?? "";
+}
+
+describe("StarMapLoadCard", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the live figures with shared byte formatting", () => {
+    renderCard();
+
+    expect(metric("CPU")).toBe("2.50");
+    expect(metric("Free RAM")).toBe("5.2 MB");
+    expect(metric("Free disk")).toBe("200 GB");
+  });
+
+  it("reads three zero load averages as not reported, not as idle", () => {
+    // Node reports 0 for every average on Windows; printing "0.00" there
+    // would claim an idle machine we have no reading for.
+    renderCard({
+      load: buildLoad({ loadAvg1: 0, loadAvg5: 0, loadAvg15: 0 }),
+    });
+
+    expect(metric("CPU")).toBe("—");
+  });
+
+  it("shows a dash when the disk read failed", () => {
+    renderCard({ load: buildLoad({ diskFreeBytes: undefined }) });
+
+    expect(metric("Free disk")).toBe("—");
+  });
+
+  it("announces a reading nobody has refreshed instead of showing it as fresh", () => {
+    const { container } = render(
+      <StarMapLoadCard
+        instanceId="pwr_slow"
+        instanceLabel="Slow Mini"
+        load={buildLoad({ sampledAt: Date.now() - 90_000 })}
+        baseSlot={{ dx: 0, dy: 100 }}
+        width={220}
+        stackIndex={0}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(
+      container.querySelector(".star-map-load-shell--stale"),
+    ).not.toBeNull();
+    expect(screen.getByRole("status").textContent).toContain("Not responding");
+    expect(screen.getByRole("status").textContent).toContain("2m ago");
+  });
+
+  it("stays quiet about its age while the reading is fresh", () => {
+    renderCard();
+
+    // A ticking "4s ago" in a mission-control view is noise; only the
+    // failure is worth words.
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("explains identical numbers on two profiles of one machine", () => {
+    renderCard({ sharedWith: "dev" });
+
+    expect(document.body.textContent).toContain("Same machine as dev");
+  });
+
+  it("reads as pending before the first sample lands", () => {
+    renderCard({ load: undefined });
+
+    expect(document.body.textContent).toContain("Reading…");
+    expect(
+      document.querySelectorAll(".star-map-load-card__metrics").length,
+    ).toBe(0);
+  });
+
+  it("dismisses through a named control", () => {
+    const onDismiss = vi.fn();
+    renderCard({ onDismiss });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Remove load card for Studio Mac",
+      }),
+    );
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("layers the synced drag offset on top of its default slot", () => {
+    const { container } = render(
+      <StarMapLoadCard
+        instanceId="pwr_studio"
+        instanceLabel="Studio Mac"
+        load={buildLoad()}
+        baseSlot={{ dx: 0, dy: 100 }}
+        offset={{ dx: -40, dy: 25 }}
+        width={220}
+        stackIndex={0}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    const shell = container.querySelector<HTMLElement>(".star-map-load-shell");
+    expect(shell?.style.left).toBe("-40px");
+    expect(shell?.style.top).toBe("125px");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapLoadCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapLoadCard.test.tsx
@@ -12,6 +12,7 @@ function buildLoad(
     loadAvg1: 2.5,
     loadAvg5: 1.75,
     loadAvg15: 1.5,
+    cpuCount: 16,
     availableMemoryBytes: 5_452_595,
     diskFreeBytes: 214_748_364_800,
     sampledAt: Date.now(),
@@ -47,16 +48,30 @@ describe("StarMapLoadCard", () => {
     cleanup();
   });
 
-  it("renders the live figures with shared byte formatting", () => {
-    renderCard();
+  it("renders CPU against the core count, not as a bare load average", () => {
+    // A load average is a queue length: 2.5 is idle on 16 cores and badly
+    // oversubscribed on 2, so the bare number is unreadable on its own.
+    renderCard({ load: buildLoad({ loadAvg1: 2.5, cpuCount: 16 }) });
 
-    expect(metric("CPU")).toBe("2.50");
+    expect(metric("CPU")).toBe("16%");
     expect(metric("Free RAM")).toBe("5.2 MB");
     expect(metric("Free disk")).toBe("200 GB");
   });
 
+  it("lets CPU exceed 100% when work is queueing", () => {
+    renderCard({ load: buildLoad({ loadAvg1: 12, cpuCount: 8 }) });
+
+    expect(metric("CPU")).toBe("150%");
+  });
+
+  it("falls back to the raw average when the core count is unknown", () => {
+    renderCard({ load: buildLoad({ loadAvg1: 2.5, cpuCount: undefined }) });
+
+    expect(metric("CPU")).toBe("2.50");
+  });
+
   it("reads three zero load averages as not reported, not as idle", () => {
-    // Node reports 0 for every average on Windows; printing "0.00" there
+    // Node reports 0 for every average on Windows; printing "0%" there
     // would claim an idle machine we have no reading for.
     renderCard({
       load: buildLoad({ loadAvg1: 0, loadAvg5: 0, loadAvg15: 0 }),

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapLoadCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapLoadCard.test.tsx
@@ -13,7 +13,8 @@ function buildLoad(
     loadAvg5: 1.75,
     loadAvg15: 1.5,
     cpuCount: 16,
-    availableMemoryBytes: 5_452_595,
+    availableMemoryBytes: 2_576_980_378,
+    totalMemoryBytes: 17_179_869_184,
     diskFreeBytes: 214_748_364_800,
     sampledAt: Date.now(),
     ...overrides,
@@ -54,7 +55,6 @@ describe("StarMapLoadCard", () => {
     renderCard({ load: buildLoad({ loadAvg1: 2.5, cpuCount: 16 }) });
 
     expect(metric("CPU")).toBe("16%");
-    expect(metric("Free RAM")).toBe("5.2 MB");
     expect(metric("Free disk")).toBe("200 GB");
   });
 
@@ -81,6 +81,20 @@ describe("StarMapLoadCard", () => {
     });
 
     expect(metric("CPU")).toBe("—");
+  });
+
+  it("reads RAM as a share of the installed total", () => {
+    // 2.4 GB means nothing until you know the box has 16 GB — and on macOS
+    // the raw "free" figure would have read ~140 MB on a healthy machine.
+    renderCard();
+
+    expect(metric("RAM free")).toBe("15%");
+  });
+
+  it("falls back to absolute RAM when the total is unknown", () => {
+    renderCard({ load: buildLoad({ totalMemoryBytes: undefined }) });
+
+    expect(metric("RAM free")).toBe("2.4 GB");
   });
 
   it("shows a dash when the disk read failed", () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapLoadCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapLoadCard.test.tsx
@@ -64,10 +64,13 @@ describe("StarMapLoadCard", () => {
     expect(metric("CPU")).toBe("150%");
   });
 
-  it("falls back to the raw average when the core count is unknown", () => {
+  it("relabels the raw average so it cannot be read as a percentage", () => {
+    // A peer on an older build reports no core count, because the figure is
+    // sampled on the machine it describes. "CPU 2.50" would read as a
+    // percentage; "CPU load 2.50" cannot.
     renderCard({ load: buildLoad({ loadAvg1: 2.5, cpuCount: undefined }) });
 
-    expect(metric("CPU")).toBe("2.50");
+    expect(metric("CPU load")).toBe("2.50");
   });
 
   it("reads three zero load averages as not reported, not as idle", () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapLoadCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapLoadCard.test.tsx
@@ -29,6 +29,7 @@ function renderCard(overrides: Partial<CardProps> = {}): CardProps {
     baseSlot: { dx: 0, dy: 100 },
     width: 220,
     stackIndex: 0,
+    cardKey: "pwr_studio::system:load:position",
     onDismiss: vi.fn(),
     ...overrides,
   };
@@ -108,6 +109,7 @@ describe("StarMapLoadCard", () => {
       <StarMapLoadCard
         instanceId="pwr_slow"
         instanceLabel="Slow Mini"
+        cardKey="pwr_slow::system:load:position"
         load={buildLoad({ sampledAt: Date.now() - 90_000 })}
         baseSlot={{ dx: 0, dy: 100 }}
         width={220}
@@ -164,6 +166,7 @@ describe("StarMapLoadCard", () => {
       <StarMapLoadCard
         instanceId="pwr_studio"
         instanceLabel="Studio Mac"
+        cardKey="pwr_studio::system:load:position"
         load={buildLoad()}
         baseSlot={{ dx: 0, dy: 100 }}
         offset={{ dx: -40, dy: 25 }}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -75,6 +75,102 @@ describe("StarMapScreen", () => {
     window.localStorage.removeItem("pwragent.starMap.filters");
   });
 
+  it("writes load-card membership into the synced arrangement", async () => {
+    const setStarMapCardPosition = vi.fn(async () => ({ entries: [] }));
+    const desktopApi: DesktopApi = {
+      ...buildDesktopApi(),
+      readStarMapArrangement: vi.fn(async () => ({ entries: [] })),
+      setStarMapCardPosition,
+      readFederationInstanceLoad: vi.fn(async () => ({})),
+    };
+    render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /^Show load for/ }),
+      ).not.toBeNull();
+    });
+    // Re-query at click time: card measurement re-renders the map, and a node
+    // captured by an earlier waitFor can already be detached.
+    fireEvent.click(screen.getByRole("button", { name: /^Show load for/ }));
+
+    // Membership IS the arrangement entry, which is what carries the card to
+    // every other instance in the fleet.
+    await waitFor(() => {
+      expect(setStarMapCardPosition).toHaveBeenCalledWith({
+        instanceId: "pwr_local",
+        threadKey: "system:load",
+        dx: 0,
+        dy: 0,
+      });
+    });
+  });
+
+  it("renders a load card for an instance the arrangement already places one on", async () => {
+    const desktopApi: DesktopApi = {
+      ...buildDesktopApi(),
+      readStarMapArrangement: vi.fn(async () => ({
+        entries: [
+          {
+            instanceId: "pwr_local",
+            threadKey: "system:load",
+            dx: 0,
+            dy: 0,
+            updatedAt: 10,
+            by: "pwr_other",
+          },
+        ],
+      })),
+      setStarMapCardPosition: vi.fn(async () => ({ entries: [] })),
+      readFederationInstanceLoad: vi.fn(async () => ({
+        load: {
+          loadAvg1: 6.5,
+          loadAvg5: 5,
+          loadAvg15: 4.25,
+          availableMemoryBytes: 2_147_483_648,
+          diskFreeBytes: 107_374_182_400,
+          sampledAt: Date.now(),
+        },
+      })),
+    };
+    const { container } = render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[unreadThread("t1")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    // An entry written by another instance ("by: pwr_other") is enough: the
+    // fleet shares one map, so the card is here without a local click.
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-load-card")).not.toBeNull();
+    });
+    await waitFor(() => {
+      expect(container.textContent).toContain("6.50");
+    });
+    expect(container.textContent).toContain("2.0 GB");
+    expect(
+      screen.getByRole("button", { name: /^Hide load for/ }),
+    ).toBeTruthy();
+  });
+
   // Mirrors the sidebar row's invariant (see thread-row-chips.test.tsx):
   // the chips carry real buttons, so nesting them inside the card's own
   // button is `nested-interactive` — invalid and unoperable.

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -65,6 +65,13 @@ function unreadThread(id: string): NavigationThreadSummary {
   } as unknown as NavigationThreadSummary;
 }
 
+function seedLayout(layout: "lanes" | "orbit" | "projects") {
+  window.localStorage.setItem(
+    "pwragent.starMap.viewPreferences",
+    JSON.stringify({ layout }),
+  );
+}
+
 describe("StarMapScreen", () => {
   // Filter selection and view preferences both persist to localStorage,
   // so without this a test that clicks a chip silently changes the
@@ -170,6 +177,69 @@ describe("StarMapScreen", () => {
       screen.getByRole("button", { name: /^Hide load for/ }),
     ).toBeTruthy();
   });
+
+  // Both lenses place the load card themselves, so a membership check
+  // present in one and missing in the other is invisible to a single-lens
+  // test — which is exactly how the orbit lens shipped a card that could
+  // not be dismissed while its toggle flipped happily.
+  for (const layout of ["lanes", "orbit"] as const) {
+    it(`removes the load card for good when dismissed (${layout})`, async () => {
+      seedLayout(layout);
+      const setStarMapCardPosition = vi.fn(async () => ({ entries: [] }));
+      const desktopApi: DesktopApi = {
+        ...buildDesktopApi(),
+        readStarMapArrangement: vi.fn(async () => ({
+          entries: [
+            {
+              instanceId: "pwr_local",
+              threadKey: "system:load",
+              dx: 0,
+              dy: 0,
+              updatedAt: 10,
+              by: "pwr_local",
+            },
+          ],
+        })),
+        setStarMapCardPosition,
+        readFederationInstanceLoad: vi.fn(async () => ({})),
+      };
+      const { container } = render(
+        <StarMapScreen
+          desktopApi={desktopApi}
+          localThreads={[unreadThread("t1")]}
+          sessionKeys={{}}
+          localInstanceLabel="Mac-Mini-M4"
+          floating={false}
+          onClose={() => undefined}
+          onOpenLocalThread={() => undefined}
+          onFocusLocalInstance={() => undefined}
+        />,
+      );
+      await waitFor(() => {
+        expect(container.querySelector(".star-map-load-card")).not.toBeNull();
+      });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /^Remove load card/ }),
+      );
+
+      await waitFor(() => {
+        expect(container.querySelector(".star-map-load-card")).toBeNull();
+      });
+      // The toggle and the card must agree: both read the same membership.
+      expect(
+        screen.getByRole("button", { name: /^Show load for/ }).getAttribute(
+          "aria-pressed",
+        ),
+      ).toBe("false");
+      expect(setStarMapCardPosition).toHaveBeenCalledWith({
+        instanceId: "pwr_local",
+        threadKey: "system:load",
+        dx: null,
+        dy: null,
+      });
+    });
+  }
 
   it("removes the load card for good when dismissed", async () => {
     const setStarMapCardPosition = vi.fn(async () => ({ entries: [] }));

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -446,6 +446,65 @@ describe("StarMapScreen", () => {
     expect(Number(load.style.zIndex)).toBeGreaterThan(Math.max(...threadZ));
   });
 
+  it("puts the load card in the same selection and snapping geometry as threads", async () => {
+    const setStarMapCardPosition = vi.fn(async () => ({ entries: [] }));
+    const desktopApi: DesktopApi = {
+      ...buildDesktopApi(),
+      readStarMapArrangement: vi.fn(async () => ({
+        entries: [
+          {
+            instanceId: "pwr_local",
+            threadKey: "system:load",
+            dx: 0,
+            dy: 0,
+            updatedAt: 10,
+            by: "pwr_local",
+          },
+        ],
+      })),
+      setStarMapCardPosition,
+      readFederationInstanceLoad: vi.fn(async () => ({})),
+    };
+    const { container } = render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[unreadThread("t1"), unreadThread("t2")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    const loadShell = await waitFor(() => {
+      const node = container.querySelector<HTMLElement>(".star-map-load-shell");
+      if (!node) throw new Error("no load card");
+      return node;
+    });
+
+    // It is placed by hand like any other card, so it carries a card key —
+    // which is what puts it in `cardRects` (a snap target and guide source)
+    // and lets the shared group-move find its element.
+    expect(loadShell.dataset.cardKey).toBe("pwr_local::system:load:position");
+
+    // A marquee over the whole cloud sweeps it up with the threads.
+    fireEvent.pointerDown(
+      container.querySelector(".star-map__viewport")!,
+      { button: 0, shiftKey: true, clientX: -4000, clientY: -4000 },
+    );
+    fireEvent.pointerMove(window, { clientX: 4000, clientY: 4000 });
+    fireEvent.pointerUp(window, { clientX: 4000, clientY: 4000 });
+
+    await waitFor(() => {
+      expect(
+        container.querySelector(
+          ".star-map-load-shell.star-map-card-shell--selected",
+        ),
+      ).not.toBeNull();
+    });
+  });
+
   it("does not move a single thread card when the load card opens", async () => {
     const setStarMapCardPosition = vi.fn(async () => ({ entries: [] }));
     const desktopApi: DesktopApi = {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -171,6 +171,211 @@ describe("StarMapScreen", () => {
     ).toBeTruthy();
   });
 
+  it("removes the load card for good when dismissed", async () => {
+    const setStarMapCardPosition = vi.fn(async () => ({ entries: [] }));
+    let emit: ((event: unknown) => void) | undefined;
+    const desktopApi: DesktopApi = {
+      ...buildDesktopApi(),
+      onAgentEvent: vi.fn((listener: (event: unknown) => void) => {
+        emit = listener;
+        return () => undefined;
+      }),
+      readStarMapArrangement: vi.fn(async () => ({
+        entries: [
+          {
+            instanceId: "pwr_local",
+            threadKey: "system:load",
+            dx: 30,
+            dy: 40,
+            updatedAt: 10,
+            by: "pwr_local",
+          },
+        ],
+      })),
+      setStarMapCardPosition,
+      readFederationInstanceLoad: vi.fn(async () => ({})),
+    } as unknown as DesktopApi;
+    const { container } = render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-load-card")).not.toBeNull();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Remove load card/ }),
+    );
+
+    // Dismiss must UNPLACE the card, not merely clear its drag offset —
+    // otherwise it reappears at its default spot, which is the one place a
+    // dragged-away card was moved to escape.
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-load-card")).toBeNull();
+    });
+    expect(setStarMapCardPosition).toHaveBeenCalledWith({
+      instanceId: "pwr_local",
+      threadKey: "system:load",
+      dx: null,
+      dy: null,
+    });
+
+    // And it stays gone once the durable tombstone echoes back off the bus.
+    emit?.({
+      notification: {
+        method: "starMap/arrangement/changed",
+        params: {
+          entries: [
+            {
+              instanceId: "pwr_local",
+              threadKey: "system:load",
+              dx: null,
+              dy: null,
+              updatedAt: 20,
+              by: "pwr_local",
+            },
+          ],
+        },
+      },
+    });
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-load-card")).toBeNull();
+    });
+  });
+
+  it("keeps a dragged load card's position across close and reopen", async () => {
+    const setStarMapCardPosition = vi.fn(async () => ({ entries: [] }));
+    const desktopApi: DesktopApi = {
+      ...buildDesktopApi(),
+      readStarMapArrangement: vi.fn(async () => ({
+        entries: [
+          // Shown...
+          {
+            instanceId: "pwr_local",
+            threadKey: "system:load",
+            dx: 0,
+            dy: 0,
+            updatedAt: 10,
+            by: "pwr_local",
+          },
+          // ...and dragged well away from its default spot.
+          {
+            instanceId: "pwr_local",
+            threadKey: "system:load:position",
+            dx: -120,
+            dy: 260,
+            updatedAt: 10,
+            by: "pwr_local",
+          },
+        ],
+      })),
+      setStarMapCardPosition,
+      readFederationInstanceLoad: vi.fn(async () => ({})),
+    };
+    const { container } = render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+    const shell = async () =>
+      await waitFor(() => {
+        const node = container.querySelector<HTMLElement>(
+          ".star-map-load-shell",
+        );
+        if (!node) throw new Error("no load card");
+        return node;
+      });
+
+    const placed = await shell();
+    const left = placed.style.left;
+    const top = placed.style.top;
+    expect(left).not.toBe("0px");
+
+    fireEvent.click(screen.getByRole("button", { name: /^Remove load card/ }));
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-load-shell")).toBeNull();
+    });
+    // Closing writes ONLY the membership key. Position lives under its own
+    // key, so a close cannot forget where the operator put the card.
+    expect(setStarMapCardPosition).toHaveBeenCalledWith({
+      instanceId: "pwr_local",
+      threadKey: "system:load",
+      dx: null,
+      dy: null,
+    });
+    expect(setStarMapCardPosition).not.toHaveBeenCalledWith(
+      expect.objectContaining({ threadKey: "system:load:position" }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^Show load for/ }));
+    const reopened = await shell();
+    expect(reopened.style.left).toBe(left);
+    expect(reopened.style.top).toBe(top);
+  });
+
+  it("paints the load card above the thread cards it sits among", async () => {
+    const desktopApi: DesktopApi = {
+      ...buildDesktopApi(),
+      readStarMapArrangement: vi.fn(async () => ({
+        entries: [
+          {
+            instanceId: "pwr_local",
+            threadKey: "system:load",
+            dx: 0,
+            dy: 0,
+            updatedAt: 10,
+            by: "pwr_local",
+          },
+        ],
+      })),
+      setStarMapCardPosition: vi.fn(async () => ({ entries: [] })),
+      readFederationInstanceLoad: vi.fn(async () => ({})),
+    };
+    const { container } = render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[unreadThread("t1"), unreadThread("t2")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    const load = await waitFor(() => {
+      const node = container.querySelector<HTMLElement>(".star-map-load-shell");
+      if (!node) throw new Error("no load card");
+      return node;
+    });
+    const threadZ = [
+      ...container.querySelectorAll<HTMLElement>(".star-map-card-shell"),
+    ]
+      .filter((shell) => shell.dataset.threadKey)
+      .map((shell) => Number(shell.style.zIndex));
+
+    // An operator-summoned readout hiding behind a thread card reads as a
+    // broken button, so it outranks every card in its cloud.
+    expect(threadZ.length).toBeGreaterThan(0);
+    expect(Number(load.style.zIndex)).toBeGreaterThan(Math.max(...threadZ));
+  });
+
   it("does not move a single thread card when the load card opens", async () => {
     const setStarMapCardPosition = vi.fn(async () => ({ entries: [] }));
     const desktopApi: DesktopApi = {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -171,6 +171,49 @@ describe("StarMapScreen", () => {
     ).toBeTruthy();
   });
 
+  it("does not move a single thread card when the load card opens", async () => {
+    const setStarMapCardPosition = vi.fn(async () => ({ entries: [] }));
+    const desktopApi: DesktopApi = {
+      ...buildDesktopApi(),
+      readStarMapArrangement: vi.fn(async () => ({ entries: [] })),
+      setStarMapCardPosition,
+      readFederationInstanceLoad: vi.fn(async () => ({})),
+    };
+    const { container } = render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={[unreadThread("t1"), unreadThread("t2")]}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    const cardPositions = () =>
+      [...container.querySelectorAll<HTMLElement>(".star-map-card-shell")]
+        .filter((shell) => shell.dataset.threadKey)
+        .map((shell) => `${shell.dataset.threadKey}@${shell.style.top}`);
+
+    await waitFor(() => {
+      expect(cardPositions().length).toBe(2);
+    });
+    const before = cardPositions();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Show load for/ }));
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-load-card")).not.toBeNull();
+    });
+
+    // The load card appends below the column instead of taking the slot
+    // nearest the star. Card offsets are stored RELATIVE to a slot, so a
+    // shifting slot would drag hand-placed cards with it — reflow here is a
+    // data-integrity problem, not a cosmetic one.
+    expect(cardPositions()).toEqual(before);
+  });
+
   // Mirrors the sidebar row's invariant (see thread-row-chips.test.tsx):
   // the chips carry real buttons, so nesting them inside the card's own
   // button is `nested-interactive` — invalid and unoperable.

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-filters.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-filters.test.ts
@@ -76,12 +76,19 @@ describe("selectFilteredThreads", () => {
     expect(ids({})).toEqual(all.map((entry) => entry.id).sort());
   });
 
-  it("isolates on a single include", () => {
-    expect(ids({ unread: "include" })).toEqual(["unread", "unread-agent"]);
+  it("isolates on a single include, keeping pins alongside", () => {
+    // A pin outranks the attention chips: the sidebar's Pins section and the
+    // map are meant to agree about what the operator curated.
+    expect(ids({ unread: "include" })).toEqual([
+      "pinned",
+      "unread",
+      "unread-agent",
+    ]);
   });
 
   it("unions includes WITHIN a facet", () => {
     expect(ids({ unread: "include", pr: "include" })).toEqual([
+      "pinned",
       "pr",
       "unread",
       "unread-agent",
@@ -92,6 +99,7 @@ describe("selectFilteredThreads", () => {
     // "unread AND agent-driven" — not "unread or agent-driven", which is
     // what a flat union would give and is never what the operator means.
     expect(ids({ unread: "include", agent: "include" })).toEqual([
+      "pinned",
       "unread-agent",
     ]);
   });
@@ -106,11 +114,15 @@ describe("selectFilteredThreads", () => {
   });
 
   it("lets an exclude override an include in another facet", () => {
-    expect(ids({ unread: "include", agent: "exclude" })).toEqual(["unread"]);
+    expect(ids({ unread: "include", agent: "exclude" })).toEqual([
+      "pinned",
+      "unread",
+    ]);
   });
 
   it("supports include and exclude in the same facet", () => {
     expect(ids({ unread: "include", pr: "exclude" })).toEqual([
+      "pinned",
       "unread",
       "unread-agent",
     ]);
@@ -125,6 +137,34 @@ describe("selectFilteredThreads", () => {
       "unread",
       "unread-agent",
     ]);
+  });
+
+  it("lets an explicit pinned exclude hide a pin the chips would keep", () => {
+    // The override has exactly one counterweight: asking to see everything
+    // EXCEPT pins. Without it the chip would be a control that cannot act.
+    expect(ids({ unread: "include", pinned: "exclude" })).toEqual([
+      "unread",
+      "unread-agent",
+    ]);
+  });
+
+  it("orders pins first, in pin order, ahead of recent activity", () => {
+    const second = thread("pin-b", {
+      pinnedRank: "a1",
+      updatedAt: 0,
+    } as Partial<NavigationThreadSummary>);
+    const busy = thread("busy", {
+      updatedAt: 9_999,
+    } as Partial<NavigationThreadSummary>);
+
+    // Pins take the slots nearest the star and hold their own order, so a
+    // curated thread does not wander as unrelated activity arrives.
+    expect(
+      selectFilteredThreads({
+        selection: {},
+        threads: [busy, second, pinned],
+      }).map((entry) => entry.id),
+    ).toEqual(["pinned", "pin-b", "busy"]);
   });
 
   it("never shows archived threads", () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
@@ -90,10 +90,18 @@ function viewport(): HTMLElement {
   return element;
 }
 
+/**
+ * THREAD card shells, in render order.
+ *
+ * Keyed on `[data-thread-key]` rather than the `.star-map-card-shell` class,
+ * because that class is shared with non-thread cards on the map (the
+ * instance load card). Every assertion here indexes into this list, so a
+ * fixture that happened to open a load card would silently shift them all
+ * and fail looking like a selection bug.
+ */
 function shells(): HTMLElement[] {
-  return [...document.querySelectorAll(".star-map-card-shell")].filter(
-    (node): node is HTMLElement => node instanceof HTMLElement,
-  );
+  return [...document.querySelectorAll(".star-map-card-shell[data-thread-key]")]
+    .filter((node): node is HTMLElement => node instanceof HTMLElement);
 }
 
 async function ready() {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -549,9 +549,11 @@ describe("star map view bounds", () => {
     expect(after.y).toBe(start.y - 150);
   });
 
-  it("offers no reset in the lens that has no view to lose", async () => {
-    // Lanes fits the window: there is nothing to pan, so a reset control
-    // would be a button that does nothing.
+  it("gives lanes a view of its own, opened at the top of the columns", async () => {
+    // Lanes used to fit the window and truncate each column at the fold, so
+    // it had no view and no reset. Columns now run as long as they need, so
+    // the lens pans and zooms like the others — and it has to OPEN at the
+    // top, since bodies sit on a fixed row and their cards grow downward.
     seedLayout("lanes");
     renderMap({ threads: threads(9) });
     await waitFor(() => {
@@ -560,8 +562,10 @@ describe("star map view bounds", () => {
       ).toBeTruthy();
     });
 
+    expect(readTransform().y).toBe(0);
+
     fireEvent.click(screen.getByRole("button", { name: "View" }));
 
-    expect(screen.queryByRole("button", { name: "Reset view" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Reset view" })).toBeTruthy();
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-filters.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-filters.ts
@@ -1,4 +1,4 @@
-import type { NavigationThreadSummary } from "@pwragent/shared";
+import { comparePinnedThreads, type NavigationThreadSummary } from "@pwragent/shared";
 import {
   isAgentThread,
   threadAttentionCategories,
@@ -161,8 +161,32 @@ export function threadPassesFilters(params: {
 }
 
 /**
- * Threads to show, ordered by recent activity. Archived threads never
- * surface on the map regardless of selection.
+ * Whether a pin keeps a thread on the map irrespective of the attention
+ * chips. A pin is the operator saying "keep this in front of me", and the
+ * sidebar's Pins section and the map are meant to agree — so the chips,
+ * which describe transient attention, do not get to hide it.
+ *
+ * `pinned: exclude` is the one thing that still can: an operator asking to
+ * see everything EXCEPT pins has said so explicitly, and a chip that
+ * cannot act would be worse than no chip.
+ */
+function pinOverridesFilters(
+  selection: StarMapFilterSelection,
+  thread: NavigationThreadSummary,
+): boolean {
+  return (
+    isPinnedThread(thread) && filterState(selection, "pinned") !== "exclude"
+  );
+}
+
+/**
+ * Threads to show: pinned threads first in the operator's own pin order,
+ * then everything else by recent activity. Archived threads never surface
+ * on the map regardless of selection.
+ *
+ * Pins sort nearest the star deliberately — the slot closest to the body is
+ * the one that stays put as the column grows, so a curated thread does not
+ * wander as unrelated activity arrives.
  */
 export function selectFilteredThreads(params: {
   selection: StarMapFilterSelection;
@@ -171,14 +195,22 @@ export function selectFilteredThreads(params: {
 }): NavigationThreadSummary[] {
   return params.threads
     .filter((thread) => thread.archivedAt === undefined)
-    .filter((thread) =>
-      threadPassesFilters({
-        selection: params.selection,
-        sessionKeys: params.sessionKeys,
-        thread,
-      }),
+    .filter(
+      (thread) =>
+        pinOverridesFilters(params.selection, thread)
+        || threadPassesFilters({
+          selection: params.selection,
+          sessionKeys: params.sessionKeys,
+          thread,
+        }),
     )
-    .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
+    .sort((left, right) => {
+      const leftPinned = isPinnedThread(left);
+      const rightPinned = isPinnedThread(right);
+      if (leftPinned !== rightPinned) return leftPinned ? -1 : 1;
+      if (leftPinned && rightPinned) return comparePinnedThreads(left, right);
+      return (right.updatedAt ?? 0) - (left.updatedAt ?? 0);
+    });
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
@@ -138,3 +138,32 @@ export function centerStarMapView(params: {
     scale: 1,
   };
 }
+
+/**
+ * Where a lens opens.
+ *
+ * Radial lenses centre their canvas: content radiates from the middle, so
+ * the middle is the interesting part. A column lens anchors to the top
+ * instead — its bodies sit on a fixed row and their columns grow downward,
+ * so centring a tall canvas would open the map already scrolled past the
+ * bodies with nothing but card tails on screen.
+ *
+ * Clamped, so a top anchor on a canvas that is shorter than the window
+ * still lands somewhere legal rather than at a negative offset.
+ */
+export function placeStarMapView(params: {
+  canvas: StarMapViewBox;
+  viewport: StarMapViewBox;
+  topAnchored?: boolean;
+}): StarMapView {
+  const centered = centerStarMapView({
+    canvas: params.canvas,
+    viewport: params.viewport,
+  });
+  if (!params.topAnchored) return centered;
+  return clampStarMapView({
+    view: { ...centered, y: 0 },
+    canvas: params.canvas,
+    viewport: params.viewport,
+  });
+}

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapArrangement.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapArrangement.ts
@@ -22,6 +22,19 @@ export function useStarMapArrangement(params: {
     instanceId: string,
     threadKey: string,
   ) => StarMapCardOffset | undefined;
+  /**
+   * Whether a card key is present in the arrangement at all. Thread cards
+   * ignore this — they are derived, and an absent entry just means "default
+   * slot". Cards whose membership IS the arrangement entry (the reserved
+   * `system:` keys) read it to decide whether to render.
+   */
+  isCardPlaced: (instanceId: string, threadKey: string) => boolean;
+  /**
+   * Instance ids carrying a placed card for one key — how a reserved
+   * `system:` card discovers which instances are showing it without needing
+   * the body list, which is itself derived from that answer.
+   */
+  instancesWithCard: (threadKey: string) => string[];
   setCardPosition: (
     instanceId: string,
     threadKey: string,
@@ -116,5 +129,31 @@ export function useStarMapArrangement(params: {
     };
   }, [entries]);
 
-  return { offsetFor, setCardPosition };
+  const isCardPlaced = useMemo(() => {
+    return (instanceId: string, threadKey: string) => {
+      const entry = entries.get(
+        starMapArrangementEntryKey({ instanceId, threadKey }),
+      );
+      // A tombstone is the "removed" state, not a placement at the origin.
+      return Boolean(entry && entry.dx !== null && entry.dy !== null);
+    };
+  }, [entries]);
+
+  const instancesWithCard = useMemo(() => {
+    return (threadKey: string) => {
+      const ids: string[] = [];
+      for (const entry of entries.values()) {
+        if (
+          entry.threadKey === threadKey
+          && entry.dx !== null
+          && entry.dy !== null
+        ) {
+          ids.push(entry.instanceId);
+        }
+      }
+      return ids.sort();
+    };
+  }, [entries]);
+
+  return { offsetFor, isCardPlaced, instancesWithCard, setCardPosition };
 }

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapArrangement.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapArrangement.ts
@@ -155,5 +155,11 @@ export function useStarMapArrangement(params: {
     };
   }, [entries]);
 
-  return { offsetFor, isCardPlaced, instancesWithCard, setCardPosition };
+  // Memoised as one object: consumers put this in `useMemo` dependency
+  // lists, and a fresh literal every render would defeat every memo
+  // downstream of it — including the per-instance slot computation.
+  return useMemo(
+    () => ({ offsetFor, isCardPlaced, instancesWithCard, setCardPosition }),
+    [offsetFor, isCardPlaced, instancesWithCard, setCardPosition],
+  );
 }

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapCardDrag.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapCardDrag.ts
@@ -1,0 +1,164 @@
+import { useRef, type PointerEvent as ReactPointerEvent } from "react";
+import { pointerDeltaToCanvas, resolveCardDragOffset } from "./star-map-layout";
+import type { AlignmentGuide } from "./star-map-snapping";
+
+const DRAG_THRESHOLD_PX = 4;
+
+export type StarMapCardDrag = {
+  /**
+   * Where drag resistance begins, measured from the INSTANCE BODY — one
+   * region shared by the whole cloud (`cloudDetentRadius`), not a per-card
+   * allowance, so any card can be placed where any other card sits. Past it
+   * the drag is resisted, not stopped.
+   */
+  detentRadius: number;
+  /**
+   * Current canvas scale. Pointer deltas arrive in screen pixels but the card
+   * is positioned in canvas pixels, so without this the card moves `scale`
+   * times too far and slides out from under the cursor.
+   */
+  scale: number;
+  /**
+   * Snap a proposed offset against the rest of the arrangement. The screen
+   * owns this because it is the only thing that knows where every other card
+   * sits; a card would otherwise have to reconstruct the whole map to align
+   * with one neighbour. Optional: cards that are not part of the arrangement
+   * grid (the load card) drag without snapping.
+   */
+  snap?: (offset: { dx: number; dy: number }) => {
+    dx: number;
+    dy: number;
+    guides: AlignmentGuide[];
+  };
+  /** Guides to draw while this drag is live; empty clears them. */
+  onGuidesChange?: (guides: AlignmentGuide[]) => void;
+  /**
+   * How far this drag has travelled, so the screen can carry the rest of a
+   * multi-card selection along. Fired per frame during the drag and once
+   * more on release, when the movement becomes durable.
+   */
+  onGroupDelta?: (delta: { dx: number; dy: number }) => void;
+  onGroupCommit?: (delta: { dx: number; dy: number }) => void;
+  onCommitOffset: (offset: { dx: number; dy: number }) => void;
+};
+
+/**
+ * Pointer-drag for a positioned star-map card. Shared by every card type on
+ * the map so the feel — 4px threshold, screen-to-canvas delta conversion,
+ * detent resistance past the cloud radius, snapping and alignment guides,
+ * group movement for a multi-card selection, rAF-batched writes straight to
+ * `style.left/top`, and click suppression on release — cannot drift between
+ * them.
+ *
+ * The hook writes the element's inline position during the gesture and
+ * commits the resolved offset once, on release; React re-renders from the
+ * synced arrangement afterwards.
+ */
+export function useStarMapCardDrag(params: {
+  baseSlot: { dx: number; dy: number };
+  offset?: { dx: number; dy: number };
+  drag?: StarMapCardDrag;
+}): {
+  startDrag: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  /**
+   * Mark the release click as consumed without starting a drag — for a
+   * gesture the card handles itself, such as modifier-click selection.
+   */
+  suppressClick: () => void;
+  /**
+   * True when the gesture that just ended was a drag, so the click the
+   * browser fires on release must not also activate the card. Reading it
+   * clears it.
+   */
+  consumeSuppressedClick: () => boolean;
+} {
+  const suppressClickRef = useRef(false);
+
+  const startDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const drag = params.drag;
+    if (!drag || event.button !== 0) return;
+    const element = event.currentTarget;
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const startOffset = params.offset ?? { dx: 0, dy: 0 };
+    const baseSlot = params.baseSlot;
+    let dragging = false;
+    let lastDx = startOffset.dx;
+    let lastDy = startOffset.dy;
+    let frame = 0;
+    const move = (pointerEvent: globalThis.PointerEvent) => {
+      const screenX = pointerEvent.clientX - startX;
+      const screenY = pointerEvent.clientY - startY;
+      // The threshold is about human intent, so it stays in screen pixels;
+      // only the movement itself converts into canvas space.
+      if (
+        !dragging
+        && Math.hypot(screenX, screenY) < DRAG_THRESHOLD_PX
+      ) {
+        return;
+      }
+      dragging = true;
+      suppressClickRef.current = true;
+      const delta = pointerDeltaToCanvas({
+        dx: screenX,
+        dy: screenY,
+        scale: drag.scale,
+      });
+      const resolved = resolveCardDragOffset({
+        baseSlot,
+        offset: {
+          dx: startOffset.dx + delta.dx,
+          dy: startOffset.dy + delta.dy,
+        },
+        detentRadius: drag.detentRadius,
+      });
+      const snapped = drag.snap ? drag.snap(resolved) : undefined;
+      lastDx = snapped ? snapped.dx : resolved.dx;
+      lastDy = snapped ? snapped.dy : resolved.dy;
+      drag.onGuidesChange?.(snapped?.guides ?? []);
+      if (!frame) {
+        frame = requestAnimationFrame(() => {
+          frame = 0;
+          element.style.left = `${baseSlot.dx + lastDx}px`;
+          element.style.top = `${baseSlot.dy + lastDy}px`;
+          drag.onGroupDelta?.({
+            dx: lastDx - startOffset.dx,
+            dy: lastDy - startOffset.dy,
+          });
+        });
+      }
+    };
+    const stop = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", stop);
+      window.removeEventListener("pointercancel", stop);
+      if (frame) {
+        cancelAnimationFrame(frame);
+        frame = 0;
+      }
+      drag.onGuidesChange?.([]);
+      if (dragging) {
+        drag.onCommitOffset({ dx: lastDx, dy: lastDy });
+        drag.onGroupCommit?.({
+          dx: lastDx - startOffset.dx,
+          dy: lastDy - startOffset.dy,
+        });
+      }
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", stop);
+    window.addEventListener("pointercancel", stop);
+  };
+
+  return {
+    startDrag,
+    suppressClick: () => {
+      suppressClickRef.current = true;
+    },
+    consumeSuppressedClick: () => {
+      if (!suppressClickRef.current) return false;
+      suppressClickRef.current = false;
+      return true;
+    },
+  };
+}

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapCardDrag.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapCardDrag.ts
@@ -58,13 +58,17 @@ export function useStarMapCardDrag(params: {
   baseSlot: { dx: number; dy: number };
   offset?: { dx: number; dy: number };
   drag?: StarMapCardDrag;
+  /**
+   * Modifier-click amends the selection instead of dragging or opening.
+   * Lives here rather than in each card because every card type on the map
+   * needs the identical gesture, and it has to run BEFORE the drag: it is
+   * the only way to correct a marquee that swept up one card too many
+   * without starting the sweep over. Absent for lenses with no selection,
+   * where modifier-click keeps its normal meaning.
+   */
+  onToggleSelect?: () => void;
 }): {
   startDrag: (event: ReactPointerEvent<HTMLDivElement>) => void;
-  /**
-   * Mark the release click as consumed without starting a drag — for a
-   * gesture the card handles itself, such as modifier-click selection.
-   */
-  suppressClick: () => void;
   /**
    * True when the gesture that just ended was a drag, so the click the
    * browser fires on release must not also activate the card. Reading it
@@ -75,8 +79,16 @@ export function useStarMapCardDrag(params: {
   const suppressClickRef = useRef(false);
 
   const startDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    const toggleSelect = params.onToggleSelect;
+    if (toggleSelect && (event.shiftKey || event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      suppressClickRef.current = true;
+      toggleSelect();
+      return;
+    }
     const drag = params.drag;
-    if (!drag || event.button !== 0) return;
+    if (!drag) return;
     const element = event.currentTarget;
     const startX = event.clientX;
     const startY = event.clientY;
@@ -152,9 +164,6 @@ export function useStarMapCardDrag(params: {
 
   return {
     startDrag,
-    suppressClick: () => {
-      suppressClickRef.current = true;
-    },
     consumeSuppressedClick: () => {
       if (!suppressClickRef.current) return false;
       suppressClickRef.current = false;

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapInstanceLoad.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapInstanceLoad.ts
@@ -44,6 +44,16 @@ export function useStarMapInstanceLoad(params: {
     if (!read || instanceIds.length === 0) {
       return;
     }
+    // Drop readings for instances whose card was closed. Without this a
+    // reopened card shows the reading from before it was dismissed until the
+    // first poll lands — briefly, but as a stale figure with a real
+    // timestamp, which is exactly the lie the stale state exists to prevent.
+    setLoads((current) => {
+      const next = new Map(
+        [...current].filter(([instanceId]) => instanceIds.includes(instanceId)),
+      );
+      return next.size === current.size ? current : next;
+    });
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
 

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapInstanceLoad.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapInstanceLoad.ts
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import type { FederationLoadStatus } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+
+/**
+ * Load is queried on demand, never gossiped, so an open card is the only
+ * thing that costs anything. 8s is slow enough that a fleet of cards is
+ * cheap and fast enough that "high CPU" is still true when you read it.
+ */
+export const STAR_MAP_LOAD_POLL_INTERVAL_MS = 8_000;
+
+/**
+ * Polls live load for exactly the instances that have a load card open.
+ *
+ * Two deliberate properties:
+ * - The poll set is driven by card membership, so closing a card stops its
+ *   queries — there is no background load traffic for an unwatched peer.
+ * - Polling pauses while the document is hidden. A backgrounded map must not
+ *   keep waking peers, and a reading taken while you were away is not worth
+ *   the round trip.
+ *
+ * A failed or timed-out query leaves the previous reading in place rather
+ * than blanking the card; the card renders its own staleness from
+ * `sampledAt`, so a stalled peer reads as stale instead of as healthy zero.
+ */
+export function useStarMapInstanceLoad(params: {
+  desktopApi?: DesktopApi;
+  /** Instance ids with a load card on the map. */
+  instanceIds: readonly string[];
+  intervalMs?: number;
+}): Map<string, FederationLoadStatus> {
+  const { desktopApi } = params;
+  const intervalMs = params.intervalMs ?? STAR_MAP_LOAD_POLL_INTERVAL_MS;
+  const [loads, setLoads] = useState<Map<string, FederationLoadStatus>>(
+    new Map(),
+  );
+  // Membership drives the effect, but its identity must not: a re-render that
+  // rebuilds the same list would otherwise restart the timer every frame.
+  const instanceKey = [...params.instanceIds].sort().join(",");
+
+  useEffect(() => {
+    const read = desktopApi?.readFederationInstanceLoad;
+    const instanceIds = instanceKey ? instanceKey.split(",") : [];
+    if (!read || instanceIds.length === 0) {
+      return;
+    }
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const sample = async () => {
+      await Promise.all(
+        instanceIds.map(async (instanceId) => {
+          try {
+            const response = await read({ instanceId });
+            if (cancelled || !response.load) return;
+            setLoads((current) => {
+              const next = new Map(current);
+              next.set(instanceId, response.load!);
+              return next;
+            });
+          } catch {
+            // Keep the last reading; the card ages it via `sampledAt`.
+          }
+        }),
+      );
+    };
+
+    const tick = () => {
+      if (cancelled) return;
+      if (document.visibilityState === "visible") {
+        void sample();
+      }
+      timer = setTimeout(tick, intervalMs);
+    };
+    tick();
+
+    // Coming back to a visible map should not wait out the interval.
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") void sample();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [desktopApi, instanceKey, intervalMs]);
+
+  return loads;
+}

--- a/apps/desktop/src/renderer/src/lib/format-bytes.ts
+++ b/apps/desktop/src/renderer/src/lib/format-bytes.ts
@@ -1,0 +1,18 @@
+/**
+ * Byte figure for operator-facing metadata: whole bytes/KB below 1 MB, then
+ * one decimal only while the leading digits are scarce (below 10 of the
+ * unit) — "5.2 MB" carries signal, "200.0 MB" is noise.
+ *
+ * Shared so the federation transfer line and the Star Map load card cannot
+ * drift into two different roundings of the same kind of number.
+ */
+export function formatByteCount(value: number): string {
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${Math.round(value / 1024)} KB`;
+  const mb = value / (1024 * 1024);
+  if (mb < 1024) {
+    return mb < 10 ? `${mb.toFixed(1)} MB` : `${Math.round(mb)} MB`;
+  }
+  const gb = mb / 1024;
+  return gb < 10 ? `${gb.toFixed(1)} GB` : `${Math.round(gb)} GB`;
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9442,6 +9442,11 @@ textarea,
   left: 50%;
   align-items: center;
   gap: 4px;
+  /* Above the body. Tucking the row into the body's empty top margin means
+     the two boxes overlap, and the body is the LATER sibling — without this
+     it wins the overlap and swallows clicks on the lower half of every
+     button, selecting the instance instead. */
+  z-index: 1;
   transform: translateX(-50%);
 }
 
@@ -9476,10 +9481,19 @@ textarea,
   color: var(--accent-bright);
 }
 
+/* A toggle's ON state has to be louder than hover, not identical to it:
+   sharing one treatment left the button with no hover feedback at all while
+   it was on — the one state where you most want to know the click will
+   land. On is a filled accent; hover deepens the fill from wherever it
+   starts, so every button on the row answers the pointer. */
 .star-map-instance__action[aria-pressed="true"] {
-  border-color: var(--accent-border);
-  background: var(--accent-soft);
+  border-color: var(--accent);
+  background: var(--accent-bg-medium);
   color: var(--accent-bright);
+}
+
+.star-map-instance__action[aria-pressed="true"]:hover {
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
 }
 
 .star-map-instance__action:focus-visible {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9488,14 +9488,6 @@ textarea,
   box-shadow: 0 0 0 1px var(--accent);
 }
 
-/* Focusing one instance pushes the rest back rather than hiding them: the
-   topology still has to read as a whole while you work in one system. */
-.star-map__anchor--muted,
-.star-map__cloud--muted {
-  opacity: 0.35;
-  transition: opacity 160ms ease;
-}
-
 /* ==== Instance load card ==== */
 
 .star-map-load-card {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10434,7 +10434,7 @@ textarea,
   inset: 0;
 }
 
-.star-map__canvas.is-orbit {
+.star-map__canvas.is-transformed {
   inset: auto;
   left: 0;
   top: 0;
@@ -10444,7 +10444,7 @@ textarea,
 
 /* Bare sky is a pan handle in orbit; cards and bodies keep their own
    cursors because the pan never starts on them. */
-.star-map__viewport:has(.star-map__canvas.is-orbit) {
+.star-map__viewport:has(.star-map__canvas.is-transformed) {
   cursor: grab;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9433,7 +9433,12 @@ textarea,
 .star-map-instance__actions {
   display: inline-flex;
   position: absolute;
-  bottom: calc(100% + 6px);
+  /* Tucked into the body's own empty top margin — the box is 96px (116 on
+     the hub) around a 56px (72px) icon, so there is ~20px of nothing above
+     the glyph. Sitting ABOVE the box instead left the row visibly detached
+     from its star and floating over whatever card happened to be there,
+     since the anchor paints above the cloud. */
+  bottom: calc(100% - 14px);
   left: 50%;
   align-items: center;
   gap: 4px;
@@ -9489,6 +9494,16 @@ textarea,
 }
 
 /* ==== Instance load card ==== */
+
+/* No entrance animation. The rise keyframes own the `transform` channel,
+   which in orbit fights this card's inline `translateY(-50%)` centering: for
+   380ms the keyframe wins and the card sits half its height low, then snaps
+   up when the animation ends. A card that appears because the operator hit a
+   toggle should simply be there anyway — the rise exists so a cloud settles
+   like a constellation on open, not for an on-demand readout. */
+.star-map-load-shell {
+  animation: none;
+}
 
 .star-map-load-card {
   display: flex;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9294,9 +9294,11 @@ textarea,
   z-index: 2;
 }
 
-/* A celestial body, not a box: glowing icon, label pill beneath. */
+/* A celestial body, not a box: glowing icon, label pill beneath, affordance
+   row absolutely positioned above (hence `relative`). */
 .star-map-instance {
   display: flex;
+  position: relative;
   flex-direction: column;
   align-items: center;
   gap: 8px;
@@ -9417,7 +9419,7 @@ textarea,
   font-size: 11px;
 }
 
-/* Label pill + [+] intake side by side under the body. */
+/* Label pill under the body. */
 .star-map-instance__row {
   display: inline-flex;
   align-items: center;
@@ -9425,28 +9427,199 @@ textarea,
   min-width: 0;
 }
 
-.star-map-instance__intake {
+/* The instance's affordance row, ABOVE the body and out of flow. In flow it
+   would grow this flex column and push the label into the first card slot -
+   worst on the wider hub body, where the margin is only a few px. */
+.star-map-instance__actions {
+  display: inline-flex;
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  align-items: center;
+  gap: 4px;
+  transform: translateX(-50%);
+}
+
+/* Quiet by default: a fleet of four instances would otherwise carry a dozen
+   accent chips, against the one-accent-used-sparingly rule. Accent arrives
+   on hover, focus, and the pressed (card-open) state. */
+.star-map-instance__action {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
-  border: 1px solid var(--accent-border);
+  /* 24px is the WCAG 2.2 target-size floor; the old 22px intake button was
+     under it. */
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--border-subtle);
   border-radius: 6px;
-  background: var(--accent-soft);
-  color: var(--accent-bright);
+  background: color-mix(in srgb, var(--bg-panel) 80%, transparent);
+  color: var(--text-secondary);
   font-size: 14px;
   line-height: 1;
   cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
 }
 
-.star-map-instance__intake:hover {
-  background: var(--accent-bg-medium);
+.star-map-instance__action svg {
+  fill: currentColor;
 }
 
-.star-map-instance__intake:focus-visible {
+.star-map-instance__action:hover {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
+.star-map-instance__action[aria-pressed="true"] {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
+.star-map-instance__action:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
+}
+
+/* Selection is a "where am I looking" state, so it reads on the label the
+   local instance already marks itself with, not as another accent chip. */
+.star-map-instance--selected .star-map-instance__label {
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+/* Focusing one instance pushes the rest back rather than hiding them: the
+   topology still has to read as a whole while you work in one system. */
+.star-map__anchor--muted,
+.star-map__cloud--muted {
+  opacity: 0.35;
+  transition: opacity 160ms ease;
+}
+
+/* ==== Instance load card ==== */
+
+.star-map-load-card {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  /* Opaque for the same reason thread cards are: clouds overlap. */
+  background: var(--bg-panel);
+  color: var(--text-primary);
+}
+
+.star-map-load-shell:hover .star-map-load-card {
+  border-color: var(--accent-border);
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+}
+
+.star-map-load-card__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.star-map-load-card__eyebrow {
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+/* Same reveal-on-hover contract as the thread card's kebab, including the
+   pointer-events guard so a hidden button cannot still be clicked. */
+.star-map-load-card__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1;
+  opacity: 0;
+  cursor: pointer;
+  transition: opacity 120ms ease;
+  pointer-events: none;
+}
+
+.star-map-load-shell:hover .star-map-load-card__dismiss,
+.star-map-load-card__dismiss:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.star-map-load-card__dismiss:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.star-map-load-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 0;
+  gap: 4px 8px;
+}
+
+.star-map-load-card__metrics > div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.star-map-load-card__metrics dt {
+  margin: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  text-transform: uppercase;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.star-map-load-card__metrics dd {
+  margin: 0;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.star-map-load-card__metrics dd:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.star-map-load-card__note {
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.3;
+}
+
+/* A reading nobody has refreshed must not read as a healthy idle machine. */
+.star-map-load-shell--stale .star-map-load-card__metrics dd {
+  color: var(--text-muted);
+}
+
+.star-map-load-shell--stale .star-map-load-card {
+  border-color: var(--border-subtle);
+  border-style: dashed;
 }
 
 /* AI intake dialog: a small centered chat panel over the map. */
@@ -10515,7 +10688,9 @@ textarea,
 .star-map-instance,
 .star-map-instance *,
 .star-map-card,
-.star-map-card * {
+.star-map-card *,
+.star-map-load-card,
+.star-map-load-card * {
   -webkit-app-region: no-drag;
 }
 

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -152,12 +152,17 @@ export type FederationLoadStatus = {
    */
   cpuCount?: number;
   /**
-   * `os.freemem()` — truly free pages only. macOS/Linux keep reclaimable
-   * page cache out of this figure, so it understates what's actually
-   * available to new work; treat "low" thresholds generously on those
-   * platforms rather than alarming on a healthy, cache-warm box.
+   * Memory the instance could hand to new work — reclaimable cache
+   * included, since the kernel will simply drop it under demand.
+   *
+   * Deliberately NOT `os.freemem()`, which on macOS counts only truly free
+   * pages: a healthy 16 GB Mac with a few GB of file cache reports ~140 MB
+   * there while its pressure gauge sits in the green, and presenting that as
+   * free RAM reads as a machine about to die.
    */
   availableMemoryBytes: number;
+  /** Installed RAM, so `availableMemoryBytes` can be read as a share. */
+  totalMemoryBytes?: number;
   /** Live counterpart of the handshake snapshot `FederationHostInfo.diskFreeBytes`. */
   diskFreeBytes?: number;
   sampledAt: number;

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -145,6 +145,13 @@ export type FederationLoadStatus = {
   loadAvg5: number;
   loadAvg15: number;
   /**
+   * Cores the load averages are measured against. Carried in the reading
+   * itself because a load average is uninterpretable without it — 3.3 is
+   * idle on a 16-core box and badly oversubscribed on a 2-core one — and
+   * the handshake host block is not available for the local instance.
+   */
+  cpuCount?: number;
+  /**
    * `os.freemem()` — truly free pages only. macOS/Linux keep reclaimable
    * page cache out of this figure, so it understates what's actually
    * available to new work; treat "low" thresholds generously on those

--- a/packages/shared/src/contracts/star-map.ts
+++ b/packages/shared/src/contracts/star-map.ts
@@ -41,6 +41,17 @@ export type StarMapArrangementEntry = {
  */
 export const STAR_MAP_LOAD_CARD_KEY = "system:load";
 
+/**
+ * Where a load card sits, kept separate from whether it is shown.
+ *
+ * Membership and position cannot share one entry: closing a card has to
+ * un-place it, and the only "absent" value an entry has is the null-pair
+ * tombstone — which is also how a card forgets its offset. Sharing them made
+ * closing a card destroy the spot the operator had dragged it to, so
+ * reopening dumped it back on top of whatever sits at the default.
+ */
+export const STAR_MAP_LOAD_CARD_POSITION_KEY = "system:load:position";
+
 export function starMapArrangementEntryKey(
   entry: Pick<StarMapArrangementEntry, "instanceId" | "threadKey">,
 ): string {

--- a/packages/shared/src/contracts/star-map.ts
+++ b/packages/shared/src/contracts/star-map.ts
@@ -22,6 +22,25 @@ export type StarMapArrangementEntry = {
   by: string;
 };
 
+/**
+ * Reserved `threadKey` for an instance's load card. Thread keys are
+ * `buildThreadIdentityKey(source, id)` and every real backend source is a
+ * known kind, so a `system:` prefix cannot collide with one.
+ *
+ * Using the existing record instead of adding a field keeps this change
+ * additive on the wire: arrangement entries cross the federation, and an
+ * older peer validates only that `threadKey` is a non-empty string — it
+ * stores and relays the offset for a card it does not know how to render,
+ * rather than rejecting the merge.
+ *
+ * Presence is membership. An entry with live offsets means "this card is on
+ * the map" (`0,0` = open at its default spot); the null-pair tombstone that
+ * resets a thread card doubles as "closed" here. That is what makes the
+ * load card appear on every instance in the fleet, since arrangement writes
+ * already broadcast last-writer-wins.
+ */
+export const STAR_MAP_LOAD_CARD_KEY = "system:load";
+
 export function starMapArrangementEntryKey(
   entry: Pick<StarMapArrangementEntry, "instanceId" | "threadKey">,
 ): string {


### PR DESCRIPTION
Follows #1380 (merged), which shipped load-status *queries* with no human-visible surface. This adds the surface, and fixes the instance-body interaction while it's in there.

## Why

Two problems, one place:

1. **Load status had no UI at all.** The only consumers were the agent tool and an IPC endpoint — you couldn't see load anywhere in the app.
2. **Clicking an instance body opened a remote viewer window.** That's a Fitts's-law inversion: the largest, most inviting target on the map was wired to its heaviest, least reversible action. Local and remote bodies also did completely different things from the same gesture (local just closed the map).

## Instance affordance row

- **Body click now selects.** Selection pushes the other systems back with opacity rather than hiding them, so the topology still reads as a whole, and it's the scope a per-instance thread search will need next.
- **Open remote viewer, AI intake, and the load toggle** move onto an icon row above the body. `+` keeps its behaviour, just relocated.
- **24px targets** — the WCAG 2.2 floor; the old 22px `[+]` was under it.
- **Quiet by default**, accent on hover/focus/pressed. Four instances × three always-visible accent chips would have fought "one accent, used sparingly."
- **Tooltips fire on focus, not just hover.** For an icon-only control the tooltip *is* the label; all four pre-existing star-map tooltips are mouse-only, which would have left keyboard users with nothing but the aria-label.
- **Row is absolutely positioned out of flow.** In flow it grows the instance flex column and pushes the label into the first card slot — worst on the wider hub body, where the margin is only a few px.

## Live load card

- Movable card parked in the instance's solar system: CPU load average, free RAM, free disk. Drag/detent/persistence identical to thread cards.
- **It reserves the slot nearest the star**, so the thread stack shifts out by one and `+N more` keeps counting what's actually hidden — the card doesn't overlay or silently displace.
- **Membership is a reserved `system:load` thread key in the existing synced arrangement record.** Presence = on the map; the null-pair tombstone that resets a thread card doubles as "closed". Two consequences, both intended: a card opened on one machine appears on **every** machine in the fleet (one shared Galaxy view), and the change is **additive on the wire** — an older peer validates only that `threadKey` is a non-empty string, so it stores and relays an offset for a card it can't render instead of rejecting the merge. No schema change, no protocol bump.
- **Polling is membership-driven and pauses while the document is hidden** — no background load traffic for an unwatched peer. Interval 8s.
- **Honest failure states:** a reading nobody refreshed goes visibly stale (dashed border, muted figures, "Not responding · last read 2m ago") instead of reading as a healthy idle machine; three zero load averages read as "—" (Node reports 0 on Windows) rather than as idle; two profiles of one physical machine say "Same machine as dev" instead of looking like duplicated numbers.

## Shared extractions

`useStarMapCardDrag` (4px threshold, detent resistance, rAF writes, click suppression) and `lib/format-bytes` — both were about to exist twice, and drag feel / byte rounding are exactly the things that drift.

## Testing

- `pnpm typecheck`, `lint:eslint` (0 errors), `lint:boundaries`, `lint:colors` all green.
- 219 tests pass across the star-map and FederationSettings suites, including 17 new: instance-card behaviour (body selects and does **not** open, open action is separate and relabels for local, profile stays in every action name, `aria-pressed` on load state, absent actions don't render disabled, tooltip-on-focus) and load-card states (formatting, Windows zero-loadavg, failed disk read, stale, shared machine, pending, dismiss, synced offset).
- Two screen-level tests cover the round trip: toggling writes `system:load` membership, and an entry written by *another* instance (`by: pwr_other`) renders the card locally without a local click.

**Not verified locally:** the Playwright a11y gate audits the Star Map layer in both themes and can't run on this machine — CI covers it. The new controls are token-only with no raw colors, and the dimming applies only in the interactive selected state, so risk is low.

## Follow-ups deliberately not in here

- `#` thread picker (scoped from a sun, global from top chrome) — the search machinery already exists (`useFederatedThreadSearch`, `threadMatchesQuery`, `SidebarSearchPopup`'s two-section rendering), so this is mostly wiring an existing index to a new action-on-select.
- Manual thread-card membership / pin↔map cross-linking. Worth settling the cap policy first: the fleet currently shows **Pinned 67** against a cap of 8 cards per lane, so pin and map-membership almost certainly want to stay two flags with cross-linked actions rather than one shared flag.
- Local-vs-peer shared-machine detection (the local instance doesn't advertise a host block to itself, so only peer↔peer pairs are detected today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Known tradeoffs

- **The load card overlaps the first thread card when it opens.** It lands at the top of the cloud, painted above the stack, and you drag it once (the position syncs, so it's a one-time move). The alternatives were worse: taking a slot moves every card in the lane — including hand-placed ones, since offsets are stored relative to a slot — and appending below the column opened it off-screen on a long lane, which reads as a button that does nothing.
- **Card count per lane is now 40, up from a viewport-bounded ~8.** Cards render purely from the `NavigationThreadSummary` already in the snapshot — `StarMapThreadCard` has no effects and no data fetching, and remote cards come from one `getNavigationSnapshot` per *peer*, not per card — so a longer column costs DOM, not transcript loads. The height-measurement layout effect does run per render over every mounted card; panning writes the canvas transform directly without re-rendering, but zooming re-renders per wheel event, so that's the path to watch if a large fleet ever feels heavy.
- **Instance selection is intentionally minimal**: it paints a ring and nothing else, pending the `#` thread picker that gives it a scope to act on.
- **`cpuCount` / `totalMemoryBytes` are sampled on the machine being measured**, so a peer must run this build before its card can show CPU as a percentage or RAM as a share. Older peers fall back to a relabelled raw load average and an absolute byte figure.
