### PR TITLE
fix(desktop): drag star map cards in canvas space, not screen space

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -1004,6 +1004,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
                 health?.instanceId
                   ? {
                       detentRadius,
+                      // Lanes never scales, so this is 1 there.
+                      scale: panZoomMode ? view.scale : 1,
                       onCommitOffset: (offset) =>
                         arrangement.setCardPosition(
                           position.instanceId,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -16,7 +16,7 @@ import {
   getThreadRowStatus,
   ThreadRowStatus,
 } from "../navigation/ThreadRowStatus";
-import { resolveCardDragOffset } from "./star-map-layout";
+import { pointerDeltaToCanvas, resolveCardDragOffset } from "./star-map-layout";
 import {
   visiblePullRequests,
   type StarMapCardFields,
@@ -68,6 +68,12 @@ export function StarMapThreadCard(props: {
      * sits. Past it the drag is resisted, not stopped.
      */
     detentRadius: number;
+    /**
+     * Current canvas scale. Pointer deltas arrive in screen pixels but the
+     * card is positioned in canvas pixels, so without this the card moves
+     * `scale` times too far and slides out from under the cursor.
+     */
+    scale: number;
     onCommitOffset: (offset: { dx: number; dy: number }) => void;
   };
   onOpen: (thread: NavigationThreadSummary) => void;
@@ -124,21 +130,28 @@ export function StarMapThreadCard(props: {
     let lastDy = startOffset.dy;
     let frame = 0;
     const move = (pointerEvent: globalThis.PointerEvent) => {
-      const deltaX = pointerEvent.clientX - startX;
-      const deltaY = pointerEvent.clientY - startY;
+      const screenX = pointerEvent.clientX - startX;
+      const screenY = pointerEvent.clientY - startY;
+      // The threshold is about human intent, so it stays in screen pixels;
+      // only the movement itself converts into canvas space.
       if (
         !dragging
-        && Math.hypot(deltaX, deltaY) < DRAG_THRESHOLD_PX
+        && Math.hypot(screenX, screenY) < DRAG_THRESHOLD_PX
       ) {
         return;
       }
       dragging = true;
       suppressClickRef.current = true;
+      const delta = pointerDeltaToCanvas({
+        dx: screenX,
+        dy: screenY,
+        scale: drag.scale,
+      });
       const resolved = resolveCardDragOffset({
         baseSlot: props.baseSlot,
         offset: {
-          dx: startOffset.dx + deltaX,
-          dy: startOffset.dy + deltaY,
+          dx: startOffset.dx + delta.dx,
+          dy: startOffset.dy + delta.dy,
         },
         detentRadius: drag.detentRadius,
       });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-drag-scale.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-drag-scale.test.tsx
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { pointerDeltaToCanvas } from "../star-map-layout";
+
+/**
+ * Dragging a card while zoomed in moved the card further than the mouse,
+ * so it slid out from under the cursor mid-drag (the pointer ended up over
+ * the canvas, and the cursor flipped from the card's pointer back to the
+ * canvas grab hand). The delta was in screen pixels; the card lives inside
+ * a `scale()`-transformed canvas.
+ */
+describe("pointerDeltaToCanvas", () => {
+  it("passes the delta through unscaled at 1x", () => {
+    expect(pointerDeltaToCanvas({ dx: 40, dy: -25, scale: 1 })).toEqual({
+      dx: 40,
+      dy: -25,
+    });
+  });
+
+  it("shrinks the delta when zoomed IN so the card tracks the pointer", () => {
+    // At 2x, 40 screen px is only 20 canvas px — applying 40 would render
+    // as 80 on screen, which is the reported "card outruns the mouse".
+    expect(pointerDeltaToCanvas({ dx: 40, dy: 60, scale: 2 })).toEqual({
+      dx: 20,
+      dy: 30,
+    });
+  });
+
+  it("grows the delta when zoomed OUT", () => {
+    expect(pointerDeltaToCanvas({ dx: 25, dy: -10, scale: 0.5 })).toEqual({
+      dx: 50,
+      dy: -20,
+    });
+  });
+
+  it("keeps the card exactly under the pointer at any scale", () => {
+    // The invariant the bug broke: canvas movement, rendered back through
+    // the same scale, must equal the pointer movement.
+    for (const scale of [0.35, 0.5, 1, 1.4, 2]) {
+      const moved = pointerDeltaToCanvas({ dx: 120, dy: -75, scale });
+      expect(moved.dx * scale).toBeCloseTo(120, 6);
+      expect(moved.dy * scale).toBeCloseTo(-75, 6);
+    }
+  });
+
+  it("treats a nonsense scale as unscaled rather than dividing by zero", () => {
+    expect(pointerDeltaToCanvas({ dx: 10, dy: 10, scale: 0 })).toEqual({
+      dx: 10,
+      dy: 10,
+    });
+  });
+});
+
+describe("card drag under zoom", () => {
+  it("moves the card by the pointer distance in canvas space", async () => {
+    const { render, screen, fireEvent, waitFor, act } = await import(
+      "@testing-library/react"
+    );
+    const { StarMapScreen } = await import("../StarMapScreen");
+    const { vi } = await import("vitest");
+
+    window.localStorage.setItem(
+      "pwragent.starMap.viewPreferences",
+      JSON.stringify({ layout: "orbit" }),
+    );
+    try {
+      const desktopApi = {
+        readFederationHealth: vi.fn(async () => ({
+          health: {
+            enabled: false,
+            role: "client" as const,
+            status: "disabled" as const,
+            instanceId: "pwr_local",
+            localCelestialIcon: "sun" as const,
+            localLabel: "Harold-MBP-M5-Max",
+            localProfileName: "default",
+            peers: [],
+          },
+        })),
+        onAgentEvent: vi.fn(() => () => undefined),
+      } as never;
+
+      render(
+        <StarMapScreen
+          desktopApi={desktopApi}
+          localThreads={[
+            {
+              id: "t1",
+              title: "Thread t1",
+              titleSource: "generated",
+              linkedDirectories: [],
+              source: "codex",
+              inbox: { inInbox: true, reason: "updated-since-seen" },
+              updatedAt: 100,
+            } as never,
+          ]}
+          sessionKeys={{}}
+          localInstanceLabel="Mac-Mini-M4"
+          floating={false}
+          onClose={() => undefined}
+          onOpenLocalThread={() => undefined}
+          onFocusLocalInstance={() => undefined}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /Open this instance/ }),
+        ).toBeTruthy();
+      });
+
+      const shell = document.querySelector(".star-map-card-shell") as HTMLElement;
+      expect(shell).not.toBeNull();
+      const startLeft = Number.parseFloat(shell.style.left);
+
+      // Zoom in, then drag by a known screen distance.
+      const viewport = document.querySelector(".star-map__viewport")!;
+      fireEvent.wheel(viewport, {
+        deltaY: -240,
+        ctrlKey: true,
+        clientX: 400,
+        clientY: 300,
+      });
+      const canvas = document.querySelector(".star-map__canvas") as HTMLElement;
+      const scale = Number(
+        /scale\(([\d.]+)\)/.exec(canvas.style.transform)?.[1] ?? "1",
+      );
+      expect(scale).toBeGreaterThan(1);
+
+      const SCREEN_DX = 120;
+      fireEvent.pointerDown(shell, { button: 0, clientX: 500, clientY: 400 });
+      await act(async () => {
+        fireEvent.pointerMove(window, {
+          clientX: 500 + SCREEN_DX,
+          clientY: 400,
+        });
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+      });
+
+      // The card must travel SCREEN_DX / scale in canvas units so that,
+      // rendered back through the same scale, it lands exactly under the
+      // pointer. Applying the raw screen delta moved it `scale` times too
+      // far — the card outrunning the mouse.
+      const movedBy = Number.parseFloat(shell.style.left) - startLeft;
+      expect(movedBy).toBeCloseTo(SCREEN_DX / scale, 1);
+      fireEvent.pointerUp(window, { clientX: 500 + SCREEN_DX, clientY: 400 });
+    } finally {
+      window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    }
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
@@ -247,6 +247,26 @@ function detentTravel(distance: number, radius: number): number {
  * stored, so running it over a stored offset again would compress a card
  * that is deliberately parked out past the detent.
  */
+/**
+ * Convert a pointer movement into canvas movement.
+ *
+ * Cards live inside `.star-map__canvas`, which the orbit and projects
+ * lenses render under `scale(view.scale)`. A pointer that travels N screen
+ * pixels therefore crosses N / scale canvas pixels — and a card moved by a
+ * raw screen delta renders as delta * scale on screen, so zoomed in the
+ * card outruns the pointer and slides out from under the cursor. Lanes
+ * never scales, so there the conversion is the identity.
+ */
+export function pointerDeltaToCanvas(params: {
+  dx: number;
+  dy: number;
+  /** Current canvas scale; values <= 0 are treated as unscaled. */
+  scale: number;
+}): { dx: number; dy: number } {
+  const scale = params.scale > 0 ? params.scale : 1;
+  return { dx: params.dx / scale, dy: params.dy / scale };
+}
+
 export function resolveCardDragOffset(params: {
   baseSlot: StarMapCardSlot;
   offset: StarMapCardSlot;


### PR DESCRIPTION
Dragging a card while zoomed in moved the card **further than the mouse**, so it slid out from under the cursor mid-drag — and the pointer, now over the canvas rather than the card, flipped from the card's cursor back to the canvas grab hand. Zoomed out, it lagged behind instead.

## Cause

Cards are positioned in **canvas pixels** inside `.star-map__canvas`, which the orbit and projects lenses render under `scale(view.scale)`. The drag applied the **raw pointer delta**:

```ts
const deltaX = pointerEvent.clientX - startX;   // screen pixels
```

So the card moved `delta` canvas pixels and rendered as `delta × scale` on screen. At 2× it travelled twice as far as the hand holding it — which is exactly the reported symptom, in both directions.

## Fix

Pointer movement converts to canvas space before it reaches the offset. Two details worth stating:

- **The drag threshold stays in screen pixels.** It is about human intent — did the operator mean to drag or click — not about where the card lands.
- **Lanes passes a scale of 1**, because that lens never zooms.

## Tests

The conversion is a pure helper, so the invariant is pinned directly: *canvas movement rendered back through the same scale must equal the pointer movement*, checked across every zoom level the map allows (0.35 → 2). Plus a degenerate-scale guard so a nonsense value can't divide by zero.

There's also an integration test that zooms the real screen, drags a real card, and asserts it travelled `screenDelta / scale` — because the bug was in the *wiring* as much as the math, and a constant passed for `scale` would satisfy the unit tests alone.

## Not in scope

The projects lens has no card drag at all (documented in `StarMapScreen.tsx`: arrangements are keyed and synced per federation instance, and a project is not an instance), so this only affects the instance lenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## It also fixes the orbit-limit detent (found in review)

`cloudDetentRadius` is computed from slot coordinates — **canvas units** — and `resolveCardDragOffset` compares the accumulated drag offset against it. That offset was carrying **screen pixels**, so the resistance engaged at the wrong distance at every zoom except 1×: about half the intended radius at 2×, and nearly three times it at 0.35×.

Nothing in the diff targets the detent; it falls out of putting the offset in the units the radius was always expressed in. Recorded here so a future detent complaint bisects to a commit that explains itself.
