### PR TITLE
fix(desktop): stop unknown ACP updates from splitting assistant messages

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -1728,6 +1728,43 @@ describe("AcpSessionReplayNormalizer", () => {
     ]);
   });
 
+  it.each(["plan", "file", "terminal", "turn_started"])(
+    "keeps %s as an assistant message boundary",
+    (sessionUpdate) => {
+      // These kinds really do end the assistant's message. The clear that used
+      // to happen up front for everything now lives in each of their branches,
+      // so each one needs its own guard: the two tool-call tests above pin only
+      // the tool-call pair, and without this dropping any of the other calls is
+      // a silent regression.
+      const normalizer = new AcpSessionReplayNormalizer();
+
+      normalizer.apply({
+        sessionId: "session-1",
+        receivedAt: 1000,
+        update: { sessionUpdate: "agent_message_chunk", content: "Before" },
+      });
+      normalizer.apply({
+        sessionId: "session-1",
+        receivedAt: 1001,
+        update: { sessionUpdate, title: "Boundary", status: "completed" },
+      });
+      const replay = normalizer.apply({
+        sessionId: "session-1",
+        receivedAt: 1002,
+        update: { sessionUpdate: "agent_message_chunk", content: "After" },
+      });
+
+      expect(
+        replay.entries.flatMap((entry) =>
+          entry.type === "message" ? [`${entry.id}:${entry.text}`] : []
+        ),
+      ).toEqual([
+        "assistant:session-1:0:Before",
+        "assistant:session-1:1:After",
+      ]);
+    },
+  );
+
   it("treats Grok turn_completed as an idempotent turn finish", () => {
     const normalizer = new AcpSessionReplayNormalizer();
     normalizer.recordUserPrompt({
@@ -1852,6 +1889,53 @@ describe("AcpSessionReplayNormalizer", () => {
       type: "activity",
       summary: "ACP update: future_update",
     });
+  });
+
+  it("keeps distinct unknown kinds from colliding on one activity", () => {
+    // The breadcrumb is only useful if it names the kind that arrived. Two
+    // unrecognized kinds in the same millisecond used to share an id, and
+    // upsertActivity merges — so the second one vanished into the first.
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { sessionUpdate: "some_future_grok_update" },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { sessionUpdate: "another_future_update" },
+    });
+
+    expect(
+      replay.entries.flatMap((entry) =>
+        entry.type === "activity" ? [entry.summary] : []
+      ),
+    ).toEqual([
+      "ACP update: some_future_grok_update",
+      "ACP update: another_future_update",
+    ]);
+  });
+
+  it("dedupes a replayed unknown update onto one activity", () => {
+    // The id still has to collapse a re-applied update, which is what makes it
+    // safe to run the same session updates through the normalizer twice.
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    const update = {
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { sessionUpdate: "some_future_grok_update" },
+    };
+    normalizer.apply(update);
+    const replay = normalizer.apply(update);
+
+    expect(
+      replay.entries.flatMap((entry) =>
+        entry.type === "activity" ? [entry.summary] : []
+      ),
+    ).toEqual(["ACP update: some_future_grok_update"]);
   });
 
   it("omits model change notifications from transcript replay", () => {

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -1571,6 +1571,48 @@ describe("AcpSessionReplayNormalizer", () => {
     ]);
   });
 
+  it("keeps an unrecognized update from splitting a streaming assistant message", () => {
+    // Failing to classify an update is not evidence that it ended the
+    // assistant's message. session_info_update and last_turn_summary were two
+    // instances of this; the next extension kind a provider adds must not tear
+    // the reply the operator is watching stream into two bubbles.
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { sessionUpdate: "agent_message_chunk", content: "Overall: " },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: { sessionUpdate: "some_future_grok_update", detail: "opaque" },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1002,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: "the patch is fine.",
+      },
+    });
+
+    // The breadcrumb still lands — an unknown kind is worth surfacing — but it
+    // sorts after the completed message instead of running through it.
+    expect(
+      replay.entries.map((entry) =>
+        entry.type === "message"
+          ? `${entry.id}:${entry.text}`
+          : entry.type === "activity"
+            ? entry.summary
+            : entry.type
+      ),
+    ).toEqual([
+      "assistant:session-1:0:Overall: the patch is fine.",
+      "ACP update: some_future_grok_update",
+    ]);
+  });
+
   it("ignores transient Grok interaction updates without splitting text", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -444,6 +444,13 @@ export class AcpSessionReplayNormalizer {
         // stays open, so later chunks append to the existing (earlier) message
         // entry and this activity naturally sorts after the finished message
         // rather than through the middle of it.
+        //
+        // This trades one failure for a better one. If an unrecognized kind
+        // really was a boundary — a provider naming its tool call something we
+        // do not enumerate — the text after it merges into the earlier bubble
+        // instead of starting a new one. A reply that reads as one paragraph
+        // too many beats a reply torn in half around a placeholder, and the fix
+        // is to enumerate the kind above, which this breadcrumb is what surfaces.
         this.removeCurrentAgentWaitingActivity();
         this.upsertActivity(unknownActivity(update, kind, createdAt));
       }
@@ -1443,7 +1450,12 @@ function unknownActivity(
   kind: string,
   createdAt: number,
 ): AppServerThreadActivityEntry {
-  const id = `unknown:${update.sessionId}:${createdAt}`;
+  // The kind is part of the identity, not just the summary. Two different
+  // unrecognized kinds in the same millisecond used to collide on this id, and
+  // upsertActivity merges rather than appends — so the second kind's name was
+  // dropped and the breadcrumb reported only the first. Re-applying the same
+  // update still dedupes, which is what the id is for.
+  const id = `unknown:${update.sessionId}:${createdAt}:${kind}`;
   return {
     type: "activity",
     id,

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -383,35 +383,41 @@ export class AcpSessionReplayNormalizer {
       // Topic updates are thread metadata, not transcript entries.
     } else {
       const toolCallId = readAcpToolCallId(update.update);
-      const updatesKnownToolCall =
-        kind === "tool_call_update"
-        && toolCallId !== undefined
-        && this.knownToolCallIds.has(toolCallId);
       // A tool_call is the semantic boundary between assistant messages.
       // Updates for that known call may arrive while the provider is already
       // streaming the next message, so only those preserve the active bubble.
       // A standalone tool_call_update remains a boundary for providers that
       // use it as their only notification for a tool invocation.
-      if (!updatesKnownToolCall) {
-        this.activeAssistantMessageId = undefined;
-        this.activeAssistantMessagePhase = undefined;
-      }
+      const updatesKnownToolCall =
+        kind === "tool_call_update"
+        && toolCallId !== undefined
+        && this.knownToolCallIds.has(toolCallId);
       if (
         toolCallId
         && (kind === "tool_call" || kind === "tool_call_update")
       ) {
         this.knownToolCallIds.add(toolCallId);
       }
+      // Each branch below ends the active assistant bubble only if that update
+      // really is a message boundary. Doing it up front instead would also end
+      // it for kinds we failed to classify, and not recognizing a kind says
+      // nothing about whether the assistant finished speaking.
       if (kind === "plan") {
+        this.endActiveAssistantMessage();
         this.removeCurrentAgentWaitingActivity();
         this.upsertPlan(update, createdAt);
       } else if (kind === "tool_call" || kind === "tool_call_update") {
+        if (!updatesKnownToolCall) {
+          this.endActiveAssistantMessage();
+        }
         this.removeCurrentAgentWaitingActivity();
         this.upsertActivity(toolActivity(update, kind, createdAt));
       } else if (kind === "file" || kind === "terminal") {
+        this.endActiveAssistantMessage();
         this.removeCurrentAgentWaitingActivity();
         this.upsertActivity(toolActivity(update, kind, createdAt));
       } else if (kind === "turn_started") {
+        this.endActiveAssistantMessage();
         this.knownToolCallIds.clear();
         this.status = "active";
       } else if (kind === "turn_finished") {
@@ -433,6 +439,11 @@ export class AcpSessionReplayNormalizer {
           waitingForAgent: readBoolean(update.update, "waitingForAgent"),
         });
       } else {
+        // An unrecognized kind is worth a breadcrumb — it is how new protocol
+        // traffic gets spotted — but it must not be destructive. The bubble
+        // stays open, so later chunks append to the existing (earlier) message
+        // entry and this activity naturally sorts after the finished message
+        // rather than through the middle of it.
         this.removeCurrentAgentWaitingActivity();
         this.upsertActivity(unknownActivity(update, kind, createdAt));
       }
@@ -550,6 +561,16 @@ export class AcpSessionReplayNormalizer {
         `assistant:${this.currentTurnId ?? update.sessionId}:${this.assistantMessageSequence++}`;
     }
     return this.activeAssistantMessageId;
+  }
+
+  /**
+   * Close the assistant bubble currently being streamed, so the next text
+   * chunk starts a new message entry instead of appending to this one. Call
+   * this only for updates that are genuinely a message boundary.
+   */
+  private endActiveAssistantMessage(): void {
+    this.activeAssistantMessageId = undefined;
+    this.activeAssistantMessagePhase = undefined;
   }
 
   private resetAssistantMessageIfPhaseChanged(


### PR DESCRIPTION
## Problem

In `AcpSessionReplayNormalizer.apply()`, the final `else` fallback cleared `activeAssistantMessageId` / `activeAssistantMessagePhase` for **every** kind that reached it, *before* the inner if/else chain decided what the update actually was. Only `tool_call_update` for an already-known `toolCallId` was spared.

So any unrecognized session update split the assistant message being streamed in half and wedged an `ACP update: <kind>` placeholder between the halves. Probed against merged `main`, a made-up kind between two `agent_message_chunk`s produced:

```
{ type: "message",  text: "Overall: " }
{ type: "activity", text: "ACP update: some_future_grok_update" }
{ type: "message",  text: "the patch is fine." }
```

#1394 fixed two *instances* of this — `session_info_update` (routed to a metadata branch) and `last_turn_summary` (folded into `isGrokTransientUpdateKind`, also landed by #1389). Both were Grok Build, both mid-turn, and the second shipped a screenshot of a "Review summary" reply torn into two bubbles. The mechanism stayed live for the next extension update xAI adds, and for anything Gemini/Kimi/Qwen emits that is not enumerated.

## Fix

Move the bubble-clearing into the branches that have earned it rather than doing it up front:

- **Clears** — `plan`, `tool_call`, standalone `tool_call_update`, `file`, `terminal`, `turn_started`. These really are message boundaries.
- **Already cleared** — `turn_finished`, `pwragent_turn_failed`, `pwragent_user_prompt` clear via their `record*` methods; no change.
- **Preserved** — a `tool_call_update` for a known tool call keeps the bubble, exactly as before.
- **Now preserved** — an unrecognized kind falls through to `unknownActivity()` with the assistant message left intact. Failing to classify an update is not evidence that it ended the assistant's message.

The `unknownActivity` breadcrumb still lands — it is genuinely useful for spotting new protocol traffic, it just isn't destructive anymore. With the bubble left open, later chunks append to the existing (earlier) message entry, so the activity naturally sorts *after* the completed message rather than through it. That ordering consequence is commented in the code.

## Tests

Added `"keeps an unrecognized update from splitting a streaming assistant message"`, which feeds an unrecognized `sessionUpdate` between two `agent_message_chunk`s and asserts one assistant message plus a trailing activity. Confirmed it fails on the pre-fix normalizer with exactly the 3-entry split above.

The two tests pinning behavior that must NOT change stay green: `"splits assistant messages around a standalone tool update"` and `"updates known tool progress without splitting a streaming assistant message"`.

## Verification

- `pnpm test` — 6985 passed. The only failures were 5 load-dependent 5s timeouts in `acp-backend-adapter.test.ts` (known flake); that file re-run alone passes 39/39.
- `pnpm --filter @pwragent/desktop typecheck` — clean
- `pnpm lint:eslint` — 0 errors (134 pre-existing warnings)
- `pnpm lint:boundaries` — no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)