### PR TITLE
fix(desktop): retire a # autocomplete anchor once it goes cold

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -108,6 +108,8 @@ import {
   findHashReferenceTrigger,
   formatHashReferenceThreadLabel,
   formatHashReferenceThreadTooltip,
+  hashReferenceAnchorKey,
+  HASH_ANCHOR_COLD_QUERY_LENGTH,
 } from "../../lib/hash-references";
 import { normalizeImageFile } from "../../lib/image-normalization";
 import {
@@ -4492,15 +4494,40 @@ export function Composer(props: ComposerProps) {
   const trigger = findSkillTrigger(draft, selectionStart);
   const slashTrigger = findSlashCommandTrigger(draft, selectionStart);
   const directoryRefTrigger = findDirectoryReferenceTrigger(draft, selectionStart);
-  const hashReferenceTrigger = findHashReferenceTrigger(draft, selectionStart);
+  // `#` is the one trigger whose query spans spaces — thread titles have
+  // spaces in them — so unlike `@` and `$` nothing retires it. Left alone,
+  // a `#` anywhere in a sentence keeps the picker armed and the federated
+  // search re-firing for the whole rest of the line. Anchors that have
+  // gone cold are remembered here and their `#` reads as prose again.
+  const [coldHashAnchors, setColdHashAnchors] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const rawHashReferenceTrigger = findHashReferenceTrigger(draft, selectionStart);
+  const rawHashReferenceQuery = rawHashReferenceTrigger?.query;
+  const hashReferenceTrigger =
+    rawHashReferenceTrigger
+    && !coldHashAnchors.has(hashReferenceAnchorKey(rawHashReferenceTrigger.query))
+      ? rawHashReferenceTrigger
+      : undefined;
   const {
+    available: federatedHashSearchAvailable,
     loading: federatedHashSearchLoading,
     results: federatedHashSearchResults,
+    settledQuery: federatedHashSearchSettledQuery,
   } = useFederatedThreadSearch({
     query: hashReferenceTrigger?.query ?? "",
     limit: FEDERATED_THREAD_SEARCH_LIMIT,
     search: props.desktopApi?.jumpSearchRemoteThreads,
   });
+  // Have the peers answered about *this* query? `loading` is set inside
+  // the hook's effect, so for one commit after a keystroke it still reads
+  // `false` while holding the previous query's results — long enough for
+  // a retirement check to mistake it for a settled empty answer and kill
+  // the anchor before the search ever left the building.
+  const federatedHashSearchSettled =
+    !federatedHashSearchAvailable
+    || (!federatedHashSearchLoading
+      && federatedHashSearchSettledQuery === (rawHashReferenceQuery ?? "").trim());
   const filteredSkills = useMemo(() => {
     if (!trigger) {
       return [];
@@ -5031,6 +5058,48 @@ export function Composer(props: ComposerProps) {
   useEffect(() => {
     setActiveHashReferenceIndex(0);
   }, [hashReferenceTrigger?.query, props.launchpad?.directoryKey, props.thread?.id]);
+
+  // Retire a `#` that has run long with nothing to show. Matching is
+  // monotonic (see HASH_ANCHOR_COLD_QUERY_LENGTH), so an empty result set
+  // past the threshold is terminal for this anchor, not a lull — every
+  // longer query is a subset of one that already matched nothing.
+  useEffect(() => {
+    if (
+      rawHashReferenceQuery === undefined
+      || rawHashReferenceQuery.length < HASH_ANCHOR_COLD_QUERY_LENGTH
+      // A slow peer must not retire a live anchor: "empty" only counts
+      // once the federated search has answered for this exact query,
+      // otherwise the anchor dies a beat before the remote rows land.
+      || !federatedHashSearchSettled
+      || filteredHashReferenceOptions.length > 0
+    ) {
+      return;
+    }
+
+    const key = hashReferenceAnchorKey(rawHashReferenceQuery);
+    setColdHashAnchors((current) =>
+      current.has(key) ? current : new Set(current).add(key),
+    );
+  }, [
+    federatedHashSearchSettled,
+    filteredHashReferenceOptions.length,
+    rawHashReferenceQuery,
+  ]);
+
+  // Cold anchors belong to one composing session. Forget them when the
+  // draft empties (sent or cleared) or the composer switches threads, so
+  // a run that matched nothing an hour ago cannot suppress a `#` against
+  // a thread list that has moved on since.
+  useEffect(() => {
+    if (draft.trim().length > 0) {
+      return;
+    }
+    setColdHashAnchors((current) => (current.size === 0 ? current : new Set()));
+  }, [draft]);
+
+  useEffect(() => {
+    setColdHashAnchors((current) => (current.size === 0 ? current : new Set()));
+  }, [props.launchpad?.directoryKey, props.thread?.id]);
 
   useEffect(() => {
     if (!dismissedAutocompleteKey) {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -30,6 +30,7 @@ import {
   DEFAULT_DESKTOP_AGENT_THREAD,
 } from "../../../lib/agent-thread";
 import { normalizeImageFile } from "../../../lib/image-normalization";
+import { FEDERATED_THREAD_SEARCH_DEBOUNCE_MS } from "../../../lib/useFederatedThreadSearch";
 import { ThreadLinkProvider } from "../../../lib/thread-links";
 import { Composer } from "../Composer";
 import { REMOTE_NATIVE_PICKER_TOOLTIP } from "../native-picker-boundary";
@@ -79,6 +80,21 @@ beforeAll(() => {
   Range.prototype.getClientRects ??= () => [] as unknown as DOMRectList;
   Range.prototype.getBoundingClientRect ??= () => emptyRect;
 });
+
+/**
+ * Drive the federated thread search past its debounce and let the
+ * resulting promise chain land.
+ *
+ * Requires `vi.useFakeTimers()` in the calling test. Proving a search
+ * did NOT fire means waiting out the debounce, and doing that on the
+ * wall clock costs real seconds per assertion; advancing fake timers
+ * makes the same proof instant and exact.
+ */
+async function settleFederatedSearch(): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(FEDERATED_THREAD_SEARCH_DEBOUNCE_MS * 2);
+  });
+}
 
 async function flushReactUpdates(): Promise<void> {
   await act(async () => {
@@ -2277,6 +2293,7 @@ describe("Composer", () => {
       inbox: { inInbox: false },
     };
     const jumpSearchRemoteThreads = vi.fn(async () => ({ results: [] }));
+    vi.useFakeTimers();
 
     render(
       <Composer
@@ -2296,27 +2313,182 @@ describe("Composer", () => {
 
     // Settles: local matched nothing and the peer answered nothing, past
     // the threshold, so the anchor is cold and the popover is gone.
+    await settleFederatedSearch();
+    expect(jumpSearchRemoteThreads).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("listbox", { name: "Threads and pull requests" }),
+    ).not.toBeInTheDocument();
+
+    // Now type the rest of the reported sentence one keystroke at a time.
+    // This is the actual bug: not "one more edit re-fires", but that the
+    // anchor stayed armed for every character to end of line.
+    let value = "Ask #validate acp";
+    for (const character of " sdk asdg asd asdg sdg sdg sadg sd gas dgsg") {
+      value += character;
+      fireEvent.change(textbox, { target: { value } });
+    }
+    await settleFederatedSearch();
+
+    // Still exactly the one search from before the anchor went cold.
+    expect(jumpSearchRemoteThreads).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("listbox", { name: "Threads and pull requests" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps a later `#` on the same line working after an earlier one retires", async () => {
+    // Retiring is per-anchor, not per-composer. A cold `#` earlier in the
+    // sentence must not swallow a genuine reference typed after it.
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const targetThread: NavigationThreadSummary = {
+      id: "019fbbbe-ad52-77c2-b7f7-28182d9a6f83",
+      title: "Bob's Best Thread 3000",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+
+    render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        thread={currentThread}
+        threads={[currentThread, targetThread]}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    fireEvent.change(textbox, { target: { value: "Ask #validate acp sdk" } });
     await waitFor(() => {
       expect(
         screen.queryByRole("listbox", { name: "Threads and pull requests" }),
       ).not.toBeInTheDocument();
     });
-    await waitFor(() => {
-      expect(jumpSearchRemoteThreads).toHaveBeenCalled();
-    });
 
-    const callsWhenCold = jumpSearchRemoteThreads.mock.calls.length;
     fireEvent.change(textbox, {
-      target: { value: "Ask #validate acp sdk asdg asd asdg sdg" },
+      target: { value: "Ask #validate acp sdk #Bob" },
     });
-    // Comfortably past FEDERATED_THREAD_SEARCH_DEBOUNCE_MS (200ms), so a
-    // still-armed anchor would have fired again by now.
-    await new Promise((resolve) => setTimeout(resolve, 400));
 
-    expect(jumpSearchRemoteThreads).toHaveBeenCalledTimes(callsWhenCold);
+    const listbox = await screen.findByRole("listbox", {
+      name: "Threads and pull requests",
+    });
     expect(
-      screen.queryByRole("listbox", { name: "Threads and pull requests" }),
-    ).not.toBeInTheDocument();
+      within(listbox).getByRole("button", { name: /#Bob's Best Thread 3000/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("forgets cold `#` anchors when the draft is cleared", async () => {
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const jumpSearchRemoteThreads = vi.fn(async () => ({ results: [] }));
+    vi.useFakeTimers();
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          jumpSearchRemoteThreads,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={currentThread}
+        threads={[currentThread]}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    fireEvent.change(textbox, { target: { value: "Ask #validate acp" } });
+    await settleFederatedSearch();
+    expect(jumpSearchRemoteThreads).toHaveBeenCalledTimes(1);
+
+    // Control. Without this step the assertion below passes even with
+    // retirement removed entirely — every keystroke would search, landing
+    // on the same final count for the wrong reason.
+    fireEvent.change(textbox, { target: { value: "Ask #validate acp sdk" } });
+    await settleFederatedSearch();
+    expect(jumpSearchRemoteThreads).toHaveBeenCalledTimes(1);
+
+    // Sending or clearing ends the composing session the cold set belongs
+    // to, so the same run is allowed to search again against a thread list
+    // that may well have moved on.
+    fireEvent.change(textbox, { target: { value: "" } });
+    await settleFederatedSearch();
+    fireEvent.change(textbox, { target: { value: "Ask #validate acp" } });
+    await settleFederatedSearch();
+
+    expect(jumpSearchRemoteThreads).toHaveBeenCalledTimes(2);
+  });
+
+  it("forgets cold `#` anchors when the composer switches threads", async () => {
+    const threadOne: NavigationThreadSummary = {
+      id: "thread-one",
+      title: "First thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const threadTwo: NavigationThreadSummary = {
+      id: "thread-two",
+      title: "Second thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const jumpSearchRemoteThreads = vi.fn(async () => ({ results: [] }));
+    vi.useFakeTimers();
+
+    const composer = (thread: NavigationThreadSummary) => (
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          jumpSearchRemoteThreads,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={thread}
+        threads={[threadOne, threadTwo]}
+      />
+    );
+    const { rerender } = render(composer(threadOne));
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Reply" }), {
+      target: { value: "Ask #validate acp" },
+    });
+    await settleFederatedSearch();
+    expect(jumpSearchRemoteThreads).toHaveBeenCalledTimes(1);
+
+    // Control, same reason as the draft-cleared case: without it the
+    // final count is reached whether or not retirement exists at all.
+    fireEvent.change(screen.getByRole("textbox", { name: "Reply" }), {
+      target: { value: "Ask #validate acp sdk" },
+    });
+    await settleFederatedSearch();
+    expect(jumpSearchRemoteThreads).toHaveBeenCalledTimes(1);
+
+    rerender(composer(threadTwo));
+    fireEvent.change(screen.getByRole("textbox", { name: "Reply" }), {
+      target: { value: "Ask #validate acp" },
+    });
+    await settleFederatedSearch();
+
+    expect(jumpSearchRemoteThreads).toHaveBeenCalledTimes(2);
   });
 
   it("re-arms a cold `#` anchor once the query is short again", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2263,6 +2263,104 @@ describe("Composer", () => {
     expect(screen.queryByText("No command")).not.toBeInTheDocument();
   });
 
+  it("retires a `#` anchor that runs long with nothing to match", async () => {
+    // `#` is the only trigger whose query spans spaces, so before this it
+    // stayed armed for the whole rest of the line: every keystroke after a
+    // `#` re-ran the federated search and the popover sat there showing
+    // "Searching other instances…" over ordinary prose.
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const jumpSearchRemoteThreads = vi.fn(async () => ({ results: [] }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          jumpSearchRemoteThreads,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={currentThread}
+        threads={[currentThread]}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    fireEvent.change(textbox, { target: { value: "Ask #validate acp" } });
+
+    // Settles: local matched nothing and the peer answered nothing, past
+    // the threshold, so the anchor is cold and the popover is gone.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("listbox", { name: "Threads and pull requests" }),
+      ).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(jumpSearchRemoteThreads).toHaveBeenCalled();
+    });
+
+    const callsWhenCold = jumpSearchRemoteThreads.mock.calls.length;
+    fireEvent.change(textbox, {
+      target: { value: "Ask #validate acp sdk asdg asd asdg sdg" },
+    });
+    // Comfortably past FEDERATED_THREAD_SEARCH_DEBOUNCE_MS (200ms), so a
+    // still-armed anchor would have fired again by now.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    expect(jumpSearchRemoteThreads).toHaveBeenCalledTimes(callsWhenCold);
+    expect(
+      screen.queryByRole("listbox", { name: "Threads and pull requests" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps a long multi-word `#` query armed while it still matches", async () => {
+    // The threshold must not punish a legitimate long title — the query
+    // spans spaces precisely because thread titles do.
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const targetThread: NavigationThreadSummary = {
+      id: "019fbbbe-ad52-77c2-b7f7-28182d9a6f83",
+      title: "Bob's Best Thread 3000",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+
+    render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        thread={currentThread}
+        threads={[currentThread, targetThread]}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    // 16 characters of query — twice the cold threshold — and still a match.
+    fireEvent.change(textbox, { target: { value: "Ask #Bob's Best Thread" } });
+
+    const listbox = await screen.findByRole("listbox", {
+      name: "Threads and pull requests",
+    });
+    expect(
+      within(listbox).getByRole("button", { name: /#Bob's Best Thread 3000/ }),
+    ).toBeInTheDocument();
+  });
+
   it("inserts a hash-prefixed thread chip from the inline thread picker", async () => {
     const currentThread: NavigationThreadSummary = {
       id: "thread-current",

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2319,6 +2319,58 @@ describe("Composer", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("re-arms a cold `#` anchor once the query is short again", async () => {
+    // The escape hatch. A retired anchor is keyed by the query's leading
+    // run, so deleting back past that run yields a different (shorter)
+    // key that was never retired — the same reason parking the caret
+    // right of the `#` re-arms it.
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const targetThread: NavigationThreadSummary = {
+      id: "019fbbbe-ad52-77c2-b7f7-28182d9a6f83",
+      title: "Bob's Best Thread 3000",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+
+    render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        thread={currentThread}
+        threads={[currentThread, targetThread]}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    // Mistyped past the threshold — the apostrophe means this matches
+    // nothing, so the anchor goes cold on key "bobs bes".
+    fireEvent.change(textbox, { target: { value: "Ask #Bobs Best Thrxxx" } });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("listbox", { name: "Threads and pull requests" }),
+      ).not.toBeInTheDocument();
+    });
+
+    fireEvent.change(textbox, { target: { value: "Ask #Bob" } });
+
+    const listbox = await screen.findByRole("listbox", {
+      name: "Threads and pull requests",
+    });
+    expect(
+      within(listbox).getByRole("button", { name: /#Bob's Best Thread 3000/ }),
+    ).toBeInTheDocument();
+  });
+
   it("keeps a long multi-word `#` query armed while it still matches", async () => {
     // The threshold must not punish a legitimate long title — the query
     // spans spaces precisely because thread titles do.

--- a/apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts
@@ -6,6 +6,8 @@ import {
   findHashReferenceTrigger,
   formatHashReferenceThreadLabel,
   formatHashReferenceThreadTooltip,
+  hashReferenceAnchorKey,
+  HASH_ANCHOR_COLD_QUERY_LENGTH,
 } from "../hash-references";
 
 function pullRequest(
@@ -66,6 +68,40 @@ describe("findHashReferenceTrigger", () => {
     expect(
       findHashReferenceTrigger(continuingDraft, continuingDraft.length),
     ).toBeUndefined();
+  });
+});
+
+describe("hashReferenceAnchorKey", () => {
+  it("stays put as the query grows to the right", () => {
+    // The whole point: `#validate` retiring must keep the anchor retired
+    // while the operator types the rest of the sentence after it. A key
+    // that moved with the query would retire nothing.
+    const key = hashReferenceAnchorKey("validate");
+    expect(hashReferenceAnchorKey("validate acp sdk")).toBe(key);
+    expect(hashReferenceAnchorKey("validate acp sdk asdg asd asdg")).toBe(key);
+  });
+
+  it("ignores case so retyping the same run does not re-arm a cold anchor", () => {
+    expect(hashReferenceAnchorKey("VaLiDaTe acp")).toBe(
+      hashReferenceAnchorKey("validate acp"),
+    );
+  });
+
+  it("separates anchors that differ inside the leading run", () => {
+    expect(hashReferenceAnchorKey("validate acp")).not.toBe(
+      hashReferenceAnchorKey("validxte acp"),
+    );
+  });
+
+  it("cannot key a query short enough to still be live", () => {
+    // A caret parked immediately right of the `#` yields an empty query,
+    // and retirement only ever fires at or past the threshold — so the
+    // re-arm gesture can never land on an already-cold key.
+    expect(hashReferenceAnchorKey("")).toBe("");
+    expect("".length).toBeLessThan(HASH_ANCHOR_COLD_QUERY_LENGTH);
+    expect(hashReferenceAnchorKey("short").length).toBeLessThan(
+      HASH_ANCHOR_COLD_QUERY_LENGTH,
+    );
   });
 });
 

--- a/apps/desktop/src/renderer/src/lib/hash-references.ts
+++ b/apps/desktop/src/renderer/src/lib/hash-references.ts
@@ -22,6 +22,39 @@ const PULL_REQUEST_CANDIDATE_LIMIT = 6;
 const THREAD_LABEL_LENGTH_LIMIT = 72;
 const THREAD_TOOLTIP_LENGTH_LIMIT = 300;
 
+/**
+ * How long a `#` query may get, with nothing to show for it, before the
+ * `#` stops being an autocomplete anchor and goes back to being prose.
+ *
+ * Zero results is safe to treat as *terminal* rather than transient
+ * because matching is monotonic: `threadMatchesQuery` is a set of
+ * `includes(needle)` tests over fixed haystacks (title, id, branch,
+ * agent metadata, PR numbers, directory labels), so extending a query
+ * can only ever narrow the result set. A query matching nothing at
+ * eight characters cannot start matching at nine. Without this, a `#`
+ * anywhere in a sentence keeps the picker armed — and the federated
+ * search re-firing — for the whole rest of the line.
+ */
+export const HASH_ANCHOR_COLD_QUERY_LENGTH = 8;
+
+/**
+ * Identity for a `#` anchor that has gone cold.
+ *
+ * This is the query's leading run, deliberately NOT the `#`'s offset in
+ * the document. An offset shifts the moment the operator edits anything
+ * earlier in the line, which would silently re-arm a retired anchor
+ * mid-sentence — the exact symptom being fixed. The leading run is
+ * stable both as the query grows to the right and as text before the
+ * `#` changes.
+ *
+ * Two anchors sharing a leading run collapse to one entry. That is
+ * harmless: by the monotonicity above, if the run matched nothing for
+ * one of them it matches nothing for the other.
+ */
+export function hashReferenceAnchorKey(query: string): string {
+  return query.slice(0, HASH_ANCHOR_COLD_QUERY_LENGTH).toLowerCase();
+}
+
 /** Collapse a free-text thread title onto one line. */
 export function collapseHashReferenceWhitespace(
   value: string | undefined,

--- a/apps/desktop/src/renderer/src/lib/useFederatedThreadSearch.ts
+++ b/apps/desktop/src/renderer/src/lib/useFederatedThreadSearch.ts
@@ -16,9 +16,21 @@ export function useFederatedThreadSearch(params: {
   available: boolean;
   loading: boolean;
   results: NavigationThreadSummary[];
+  /**
+   * The (trimmed) query `results` actually answer.
+   *
+   * `loading` alone cannot tell a caller "the peers have replied about
+   * *this* query": it is set from inside an effect, so for one commit
+   * after the query changes it still reads `false` while carrying the
+   * previous query's results. A caller that treats that frame as a
+   * settled empty answer acts on the wrong query. Compare against this
+   * instead.
+   */
+  settledQuery: string;
 } {
   const [results, setResults] = useState<NavigationThreadSummary[]>([]);
   const [loading, setLoading] = useState(false);
+  const [settledQuery, setSettledQuery] = useState("");
   const generationRef = useRef(0);
   const query = params.query.trim();
   const search = params.search ?? getDesktopApi()?.jumpSearchRemoteThreads;
@@ -34,6 +46,8 @@ export function useFederatedThreadSearch(params: {
     if (!query || !available || !search) {
       setResults([]);
       setLoading(false);
+      // Nothing to ask, so this query is answered the moment it arrives.
+      setSettledQuery(query);
       return;
     }
 
@@ -49,6 +63,7 @@ export function useFederatedThreadSearch(params: {
           }
           setResults(response.results);
           setLoading(false);
+          setSettledQuery(query);
         })
         .catch(() => {
           if (generationRef.current !== generation) {
@@ -56,10 +71,11 @@ export function useFederatedThreadSearch(params: {
           }
           setResults([]);
           setLoading(false);
+          setSettledQuery(query);
         });
     }, FEDERATED_THREAD_SEARCH_DEBOUNCE_MS);
     return () => clearTimeout(timer);
   }, [available, params.limit, query, search]);
 
-  return { available, loading, results };
+  return { available, loading, results, settledQuery };
 }


### PR DESCRIPTION
## Summary

- **`#` never let go.** It is the only composer trigger whose query spans spaces — thread titles have spaces, so `findHashReferenceTrigger` matches `[^\n#]*` to end of line — and nothing retired it. Typing `#validate acp sdk asdg asd…` kept the picker armed and the federated search re-firing for the whole rest of the line, with "Searching other instances…" parked over the composer while typing ordinary prose. `@` and `$` use character classes that exclude whitespace, so they self-terminate; untouched here.
- **An anchor now retires once its query passes 8 characters with nothing to show.** Zero results is safe to treat as *terminal* rather than transient because matching is monotonic: `threadMatchesQuery` is a set of `includes(needle)` tests over fixed haystacks, so extending a query can only narrow the result set. A query matching nothing at eight characters cannot start matching at nine.
- **Retired anchors are keyed by the query's leading run, not the `#`'s offset.** An offset shifts the moment you edit earlier in the line, which would silently re-arm a retired anchor mid-sentence — the exact symptom being fixed. The leading run is stable both as the query grows and as text before the `#` changes.
- **Re-arming falls out of the trigger already being caret-relative.** Parking the caret immediately right of the `#` makes the query empty, and retirement only fires at or past the threshold, so a caret-adjacent anchor can never be cold. Editing mid-range keeps the same leading run and stays retired — a `#` eight words back is prose, not a reference.
- **`useFederatedThreadSearch` gains `settledQuery`.** `loading` could not answer "have the peers replied about *this* query": it is set inside an effect, so for one commit after a keystroke it still reads `false` while holding the previous query's results.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/composer apps/desktop/src/renderer/src/lib` — 875 passed (40 files).
- `pnpm test apps/desktop/src/renderer/src/features/navigation` — 172 passed (`SidebarSearchPopup` is the other `useFederatedThreadSearch` consumer; the hook change is purely additive).
- Composer suite run 3× back to back — 392 passed each time, no flake.
- `pnpm typecheck` clean, `pnpm lint:boundaries` clean (1316 modules), `pnpm lint:eslint` 0 errors and **zero new warnings** (warning list diffed against the branch base — identical).
- **The new test was confirmed to fail without the fix**, both in isolation and in a full-file run: the remote search fires a second time (`expected 1 call, got 2`).

## Notes

- **The settled-query change came out of a real race, not a style preference.** The first version of this fix retired anchors using `loading`, which passed in isolation and failed under full-suite load — my retirement effect ran in the same commit as the hook's effect and saw the stale `loading === false`, killing the anchor *before* the search ever fired. `settledQuery` makes "the peers answered about this exact query" checkable, so a slow peer can no longer be mistaken for an empty answer.
- **Escape-dismissal is still keyed wrong and is deliberately not fixed here.** `dismissedAutocompleteKey` (`Composer.tsx`) is built as `hash-references:${start}:${end}:#${query}`; since `end` and `query` change every keystroke, an Escape dismissal is invalidated by the next character. That is a separate behavior change (should an explicit dismissal outlive the anchor?) and belongs in its own PR rather than riding along on a bug fix.
- **`applyHashReference` still uses the raw trigger** to compute the splice range when a row is picked. That is correct: a cold anchor renders no popover, so no row can be chosen, and the insertion path needs the true text range.
- The 8-character threshold is a constant (`HASH_ANCHOR_COLD_QUERY_LENGTH`) with the monotonicity argument written next to it, so retuning it is a one-line change with the reasoning in view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
