### PR TITLE
fix(desktop): stop an empty ACP probe from poisoning the command cache

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-available-commands-store.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-available-commands-store.test.ts
@@ -96,6 +96,28 @@ describe("AcpAvailableCommandsStore", () => {
   // ahead of it on every open and already carries this table's DDL. What is
   // worth pinning is the observable outcome — an older profile database gains
   // the table and lands on the current user_version.
+  it("purges empty rows left by a build that recorded failed probes", () => {
+    // Nothing writes these any more; the read path already ignores them so a
+    // probe can re-run. This is the sweep that gets them off disk.
+    store.upsert({
+      backendId: "acp:kimi",
+      repositoryPath: "/repo",
+      commands: [],
+      observedAt: 1000,
+    });
+    store.upsert({
+      backendId: "acp:grok",
+      repositoryPath: "/repo",
+      commands: COMMANDS,
+      observedAt: 1000,
+    });
+
+    stateDb.cleanupExpired(2000);
+
+    expect(store.get("acp:kimi", "/repo")).toBeUndefined();
+    expect(store.get("acp:grok", "/repo")?.commands).toEqual(COMMANDS);
+  });
+
   it("converges an older profile database onto the current schema", () => {
     const dbPath = path.join(tempDir, "migrated.db");
     const seeded = StateDb.open(dbPath);

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3363,8 +3363,10 @@ describe("DesktopBackendRegistry", () => {
     ]);
   });
 
-  it("records an ACP agent that advertises nothing instead of re-probing it", async () => {
-    const repositoryPath = toTestRepositoryPath("/repo");
+  it("never persists an empty ACP command probe result", async () => {
+    // A probe that came up empty because the agent was slow is
+    // indistinguishable from one whose agent has no commands. Storing that
+    // guess is what left an operator with a permanently empty `/` menu.
     const acpAvailableCommandsStore = createAcpAvailableCommandsStoreMock();
     const { registry, acpClient } = createKimiAcpRegistry({
       acpBackendId: "acp:grok" as AcpBackendId,
@@ -3382,9 +3384,50 @@ describe("DesktopBackendRegistry", () => {
       ).resolves.toEqual({ data: [{ skills: [], commands: [] }] });
     }
 
+    // Backed off in memory rather than written down.
     expect(acpClient.startSession).toHaveBeenCalledTimes(1);
+    expect(acpAvailableCommandsStore.records).toEqual([]);
+    expect(acpAvailableCommandsStore.upsert).not.toHaveBeenCalled();
+  });
+
+  it("re-probes past an empty ACP cache row left by an older build", async () => {
+    // Regression: builds before this fix persisted `[]` for a probe that timed
+    // out, and that row then suppressed every future probe. Profiles carrying
+    // one must heal on the next request rather than stay empty forever.
+    const repositoryPath = toTestRepositoryPath("/repo");
+    const availableCommands: AppServerAvailableCommandSummary[] = [
+      {
+        name: "compact",
+        backend: "acp:grok",
+        scope: "session",
+        source: "provider",
+      },
+    ];
+    const acpAvailableCommandsStore = createAcpAvailableCommandsStoreMock([
+      {
+        backendId: "acp:grok",
+        repositoryPath,
+        commands: [],
+        observedAt: 1000,
+      },
+    ]);
+    const { registry, acpClient } = createKimiAcpRegistry({
+      acpBackendId: "acp:grok" as AcpBackendId,
+      acpAvailableCommandsStore,
+      availableCommandsOnSessionStart: availableCommands,
+    });
+
+    await expect(
+      registry.listSkills({
+        backend: "acp:grok" as AppServerBackendKind,
+        cwd: "/repo",
+        cwds: ["/repo"],
+      }),
+    ).resolves.toEqual({ data: [{ skills: [], commands: availableCommands }] });
+    expect(acpClient.startSession).toHaveBeenCalledTimes(1);
+    // The poisoned row is replaced by the real observation.
     expect(acpAvailableCommandsStore.records).toEqual([
-      expect.objectContaining({ repositoryPath, commands: [] }),
+      expect.objectContaining({ repositoryPath, commands: availableCommands }),
     ]);
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2124,7 +2124,6 @@ function createKimiAcpRegistry(options?: {
   acpAvailableCommandsStore?: ReturnType<
     typeof createAcpAvailableCommandsStoreMock
   > | null;
-  acpAvailableCommandProbeTimeoutMs?: number;
   acpAvailableCommandProbeBudgetMs?: number;
   availableCommandsOnSessionStart?: AppServerAvailableCommandSummary[];
   startSession?: KimiStartSession;
@@ -2223,8 +2222,6 @@ function createKimiAcpRegistry(options?: {
       ? { threadTitleGenerationService: options.threadTitleGenerationService }
       : {}),
     acpAvailableCommandsStore: options?.acpAvailableCommandsStore,
-    acpAvailableCommandProbeTimeoutMs:
-      options?.acpAvailableCommandProbeTimeoutMs,
     acpAvailableCommandProbeBudgetMs: options?.acpAvailableCommandProbeBudgetMs,
   });
   return {
@@ -3371,7 +3368,7 @@ describe("DesktopBackendRegistry", () => {
     const { registry, acpClient } = createKimiAcpRegistry({
       acpBackendId: "acp:grok" as AcpBackendId,
       acpAvailableCommandsStore,
-      acpAvailableCommandProbeTimeoutMs: 1,
+      acpAvailableCommandProbeBudgetMs: 5,
     });
 
     for (let attempt = 0; attempt < 3; attempt += 1) {
@@ -3468,7 +3465,7 @@ describe("DesktopBackendRegistry", () => {
     const { registry, acpClient } = createKimiAcpRegistry({
       acpBackendId: "acp:grok" as AcpBackendId,
       acpAvailableCommandsStore: null,
-      acpAvailableCommandProbeTimeoutMs: 1,
+      acpAvailableCommandProbeBudgetMs: 5,
     });
 
     for (let attempt = 0; attempt < 3; attempt += 1) {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6189,11 +6189,15 @@ const MAX_ACCEPTED_THREAD_CONTROL_REQUESTS = 512;
 
 /**
  * How long a command-discovery probe waits for the agent's
- * `available_commands_update` once its session is open. Agents that advertise
- * commands do so as part of session setup, so this only has to cover one
- * notification hop.
+ * `available_commands_update` once its session is open.
+ *
+ * Agents advertise commands as part of session setup, so in principle this
+ * covers one notification hop — but a cold agent can take several seconds to
+ * get there, and the first cut at 5s was short enough that Kimi routinely lost
+ * the race. Overshooting costs a slower first `/` in a repo; undershooting used
+ * to cost a wrong answer, and now costs a wasted probe.
  */
-const ACP_AVAILABLE_COMMAND_PROBE_TIMEOUT_MS = 5_000;
+const ACP_AVAILABLE_COMMAND_PROBE_TIMEOUT_MS = 12_000;
 /**
  * Ceiling on a whole probe attempt, spawn included.
  *
@@ -6203,9 +6207,11 @@ const ACP_AVAILABLE_COMMAND_PROBE_TIMEOUT_MS = 5_000;
  * would otherwise leave `listSkills` unresolved — and because the renderer
  * skips any request while one is in flight, the `/` menu would sit on
  * PwrAgent's own commands with no way to retry. Generous enough for a cold
- * agent process spawn, short enough that a stuck one is a blip.
+ * agent process spawn, short enough that a stuck one is a blip. Must stay
+ * comfortably above {@link ACP_AVAILABLE_COMMAND_PROBE_TIMEOUT_MS} or the
+ * budget would cut the notification wait short instead of bounding the spawn.
  */
-const ACP_AVAILABLE_COMMAND_PROBE_BUDGET_MS = 15_000;
+const ACP_AVAILABLE_COMMAND_PROBE_BUDGET_MS = 25_000;
 /**
  * Backoff after a probe that produced nothing (agent unavailable, auth
  * required, or an agent that simply advertises no commands). Without it every
@@ -8021,6 +8027,13 @@ export class DesktopBackendRegistry {
    * it. Cache first (free, and kept fresh by every real session's
    * write-through); a probe only runs when this agent has never reported
    * commands for this repo.
+   *
+   * An empty stored row counts as *no answer*, not as "this agent has no
+   * commands". Treating it as an answer is what turned one slow probe into a
+   * permanently empty `/` menu: the row suppressed every later probe, and only
+   * a real session in that repo could dislodge it. Nothing writes empty rows
+   * any more, and ignoring the ones already on disk lets an affected profile
+   * heal on the next request.
    */
   private async resolveAcpAvailableCommands(params: {
     backend: AcpBackendId;
@@ -8029,25 +8042,14 @@ export class DesktopBackendRegistry {
     const repositoryPaths = await this.resolveAcpCommandRepositoryPaths(
       params.cwds,
     );
-    let observedRepository = false;
     for (const repositoryPath of repositoryPaths) {
       const cached = this.acpAvailableCommandsStore?.get(
         params.backend,
         repositoryPath,
       );
-      if (!cached) {
-        continue;
-      }
-      observedRepository = true;
-      if (cached.commands.length > 0) {
+      if (cached && cached.commands.length > 0) {
         return cached.commands;
       }
-    }
-    if (observedRepository) {
-      // We have watched this agent in this repo and it advertised nothing.
-      // Re-probing would spawn the agent to relearn the same nothing; a real
-      // session's write-through is what corrects this if that ever changes.
-      return [];
     }
 
     const probeTarget = repositoryPaths[0];
@@ -8160,18 +8162,21 @@ export class DesktopBackendRegistry {
         backend: params.backend,
         threadId: session.sessionId,
       });
-      // Persist either outcome. On a hit, the write-through for the same
-      // notification normally already did this, but recording it here keeps the
-      // probe self-contained rather than dependent on that ordering. On a miss,
-      // "this agent advertises nothing here" is itself the answer, and storing
-      // it is what stops the next composer focus from spawning the agent again.
-      this.acpAvailableCommandsStore?.upsert({
-        backendId: params.backend,
-        repositoryPath: params.repositoryPath,
-        commands,
-        observedAt: Date.now(),
-      });
       if (commands.length > 0) {
+        // Only a positive observation is durable. The write-through for the
+        // same notification normally already did this, but recording it here
+        // keeps the probe self-contained rather than dependent on that
+        // ordering. An empty result is never persisted — a probe that came up
+        // empty because the agent was slow is indistinguishable from one whose
+        // agent has no commands, and guessing wrong costs the operator a
+        // permanently empty menu. The in-memory cooldown below is what keeps
+        // an empty result from re-spawning the agent on the next keystroke.
+        this.acpAvailableCommandsStore?.upsert({
+          backendId: params.backend,
+          repositoryPath: params.repositoryPath,
+          commands,
+          observedAt: Date.now(),
+        });
         return commands;
       }
     } catch (error) {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6188,37 +6188,40 @@ class ActiveTurnControlPreconditionError extends Error {
 const MAX_ACCEPTED_THREAD_CONTROL_REQUESTS = 512;
 
 /**
- * How long a command-discovery probe waits for the agent's
- * `available_commands_update` once its session is open.
+ * Ceiling on a whole command-discovery probe: spawn, `initialize`,
+ * `session/new`, and the wait for `available_commands_update`, together.
  *
- * Agents advertise commands as part of session setup, so in principle this
- * covers one notification hop — but a cold agent can take several seconds to
- * get there, and the first cut at 5s was short enough that Kimi routinely lost
- * the race. Overshooting costs a slower first `/` in a repo; undershooting used
- * to cost a wrong answer, and now costs a wasted probe.
- */
-const ACP_AVAILABLE_COMMAND_PROBE_TIMEOUT_MS = 12_000;
-/**
- * Ceiling on a whole probe attempt, spawn included.
+ * One budget rather than a per-stage timeout, because the stages trade against
+ * each other. Nothing under `startSession` is bounded on a timescale a composer
+ * can wait on — `getClient` awaits an unbounded `initialize()`, and
+ * `session/new` inherits the ACP stdio transport's ten-minute default request
+ * timeout — so the probe needs a hard stop regardless. Splitting that stop into
+ * "spawn budget" and "notification budget" only invents an invariant between
+ * two constants: set the notification wait too close to the total and the
+ * deadline truncates it, reproducing the false-empty this whole path exists to
+ * avoid. Letting the wait consume whatever the spawn did not means a fast agent
+ * gets nearly the entire budget to advertise, and a slow one still cannot hold
+ * `listSkills` past this number.
  *
- * Nothing under `startSession` is bounded on a timescale a composer can wait
- * on: `getClient` awaits an unbounded `initialize()`, and `session/new` inherits
- * the ACP stdio transport's ten-minute default request timeout. A wedged agent
- * would otherwise leave `listSkills` unresolved — and because the renderer
- * skips any request while one is in flight, the `/` menu would sit on
- * PwrAgent's own commands with no way to retry. Generous enough for a cold
- * agent process spawn, short enough that a stuck one is a blip. Must stay
- * comfortably above {@link ACP_AVAILABLE_COMMAND_PROBE_TIMEOUT_MS} or the
- * budget would cut the notification wait short instead of bounding the spawn.
+ * The value is a judgement call, not a measurement: the 5s notification wait
+ * this replaced was demonstrably too short for a cold Kimi, but nobody has
+ * timed how long these agents actually take. While it runs the `/` menu is
+ * usable — PwrAgent's own commands render immediately and provider commands
+ * fill in — so overshooting costs a late-arriving section, not a blocked menu.
  */
-const ACP_AVAILABLE_COMMAND_PROBE_BUDGET_MS = 25_000;
+const ACP_AVAILABLE_COMMAND_PROBE_BUDGET_MS = 20_000;
 /**
  * Backoff after a probe that produced nothing (agent unavailable, auth
- * required, or an agent that simply advertises no commands). Without it every
- * composer focus in that repo would re-spawn the agent to learn the same
- * nothing.
+ * required, or an agent that simply advertises no commands).
+ *
+ * This is the *only* backstop against re-probing such an agent — empty results
+ * are deliberately never persisted — so it is deliberately long. Whether an
+ * agent ships slash commands does not change on a five-minute timescale, and
+ * every expiry costs another operator-visible probe. It still lives in memory
+ * and resets on restart, so a genuinely changed agent is never more than one
+ * relaunch away.
  */
-const ACP_AVAILABLE_COMMAND_PROBE_COOLDOWN_MS = 300_000;
+const ACP_AVAILABLE_COMMAND_PROBE_COOLDOWN_MS = 1_800_000;
 
 /**
  * Match the forward-slashed directory identifiers
@@ -6355,7 +6358,6 @@ export class DesktopBackendRegistry {
   // `resolveAcpAvailableCommands` for the read path and
   // `rememberAcpAvailableCommands` for the write-through.
   private readonly acpAvailableCommandsStore?: AcpAvailableCommandsStoreLike;
-  private readonly acpAvailableCommandProbeTimeoutMs: number;
   private readonly acpAvailableCommandProbeBudgetMs: number;
   private readonly acpAvailableCommandProbes = new Map<
     string,
@@ -6709,7 +6711,6 @@ export class DesktopBackendRegistry {
     acpRolloutStore?: AcpBackendAdapterOptions["acpRolloutStore"];
     acpSessionStore?: AcpSessionStoreLike | null;
     acpAvailableCommandsStore?: AcpAvailableCommandsStoreLike | null;
-    acpAvailableCommandProbeTimeoutMs?: number;
     acpAvailableCommandProbeBudgetMs?: number;
     discoverLocalAcpAgents?: LocalAcpDiscovery;
     isAcpAgentEnabled?: (registryId: string) => boolean;
@@ -6907,9 +6908,6 @@ export class DesktopBackendRegistry {
           (isAppStateInitialized()
             ? new AcpAvailableCommandsStore(getAppStateDb())
             : undefined);
-    this.acpAvailableCommandProbeTimeoutMs =
-      options?.acpAvailableCommandProbeTimeoutMs
-      ?? ACP_AVAILABLE_COMMAND_PROBE_TIMEOUT_MS;
     this.acpAvailableCommandProbeBudgetMs =
       options?.acpAvailableCommandProbeBudgetMs
       ?? ACP_AVAILABLE_COMMAND_PROBE_BUDGET_MS;
@@ -8088,7 +8086,12 @@ export class DesktopBackendRegistry {
       return [];
     }
 
-    const attempt = this.runAcpAvailableCommandProbe(params);
+    // One clock for the whole attempt. `runAcpAvailableCommandProbe` spends
+    // what it needs on the spawn and hands the remainder to the notification
+    // wait; the race below is the hard stop for the stages that can hang
+    // before the wait is ever reached.
+    const deadlineAt = Date.now() + this.acpAvailableCommandProbeBudgetMs;
+    const attempt = this.runAcpAvailableCommandProbe({ ...params, deadlineAt });
     const probe = this.withAcpAvailableCommandProbeDeadline(params, attempt);
     this.acpAvailableCommandProbes.set(probeKey, probe);
     // Cleanup follows the attempt rather than the deadline. Clearing the entry
@@ -8142,6 +8145,7 @@ export class DesktopBackendRegistry {
 
   private async runAcpAvailableCommandProbe(params: {
     backend: AcpBackendId;
+    deadlineAt: number;
     repositoryPath: string;
   }): Promise<AppServerAvailableCommandSummary[]> {
     const probeKey = `${params.backend}:${params.repositoryPath}`;
@@ -8160,6 +8164,7 @@ export class DesktopBackendRegistry {
       });
       const commands = await this.awaitAcpAvailableCommands({
         backend: params.backend,
+        deadlineAt: params.deadlineAt,
         threadId: session.sessionId,
       });
       if (commands.length > 0) {
@@ -8194,11 +8199,18 @@ export class DesktopBackendRegistry {
     return [];
   }
 
+  /**
+   * Wait for the agent to advertise, for whatever is left of the probe budget
+   * after the spawn. A fast agent gets nearly all of it; a slow one still
+   * cannot push the caller past the deadline.
+   */
   private async awaitAcpAvailableCommands(params: {
     backend: AcpBackendId;
+    deadlineAt: number;
     threadId: string;
   }): Promise<AppServerAvailableCommandSummary[]> {
     const waiterKey = `${params.backend}:${params.threadId}`;
+    const remainingMs = Math.max(0, params.deadlineAt - Date.now());
     return await new Promise<AppServerAvailableCommandSummary[]>((resolve) => {
       let settled = false;
       const settle = (
@@ -8216,10 +8228,7 @@ export class DesktopBackendRegistry {
         }
         resolve(commands);
       };
-      const timer = setTimeout(
-        () => settle([]),
-        this.acpAvailableCommandProbeTimeoutMs,
-      );
+      const timer = setTimeout(() => settle([]), remainingMs);
       timer.unref?.();
 
       const waiters =

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -1484,6 +1484,14 @@ LEFT JOIN federation_peers
       this.db
         .prepare("DELETE FROM acp_available_commands WHERE observed_at < ?")
         .run(now - ACP_AVAILABLE_COMMANDS_RETENTION_MS);
+      // Empty rows are inert — the read path ignores them so a probe can
+      // re-run — but they are never written any more, so any still on disk
+      // came from a build that mistook a timed-out probe for "this agent has
+      // no commands". `upsert` always writes `JSON.stringify(commands)`, so
+      // the empty array is exactly this literal.
+      this.db
+        .prepare("DELETE FROM acp_available_commands WHERE payload = '[]'")
+        .run();
       this.db
         .prepare(
           "DELETE FROM bindings WHERE revoked_at IS NOT NULL AND revoked_at < ?",


### PR DESCRIPTION
Fixes the "launchpad still shows only `/review`" report against #1396. The bug was mine, introduced in that PR's review pass.

## Root cause

#1396's probe wrote **every** outcome to `acp_available_commands`, including an empty one, and the read path treated any stored row as an authoritative answer:

```ts
observedRepository = true;
if (cached.commands.length > 0) return cached.commands;
...
if (observedRepository) return [];   // never probes again
```

So a single probe that timed out left the `/` menu on PwrAgent's own commands **permanently**. No later probe could run; only a real session in that exact repo could overwrite the row.

I added that "record the empty result" behaviour deliberately during the review pass, to stop repeat probes from accumulating rows. It traded a bounded cost for an unbounded one.

## Evidence

A live profile told the whole story:

| agent | repository | payload | written |
|---|---|---|---|
| `acp:kimi` | `/Users/huntharo/pwrdrvr/PwrAgnt` | `[]` | 01:23:01 |
| `acp:grok` | `/Users/huntharo/pwrdrvr/PwrAgnt` | 42 commands | 01:32:27 |

Kimi was poisoned and stayed broken. Grok was poisoned too, then **self-healed** at 01:32 when a real session's write-through replaced the row — which is exactly why Grok looked like it worked "sometimes" and Kimi never did.

Ruled out first, so the diagnosis isn't a guess:

- **Cache key derivation is correct.** Ran the real `resolveWorktreeRepositoryDirectory` against the actual paths: both `/Users/huntharo/pwrdrvr/PwrAgnt` and a worktree under `~/.codex/worktrees/…/PwrAgnt` resolve to the same key, which matches the stored row.
- **The main process read path is correct.** Simulated `listSkills` against a copy of the real DB — returns all 42 Grok commands for both the checkout and the worktree cwd.
- **The renderer and preload are correct.** Verified in the running app: Grok's warm cache renders 42 commands in an unborn launchpad, and Kimi's cold cache probes successfully and renders its list.

## The fix

- **Never persist an empty probe result.** A probe that timed out on a cold agent is indistinguishable from one whose agent genuinely has no commands, and guessing wrong costs a permanently empty menu. The existing in-memory cooldown already stops an empty result from re-spawning the agent on the next keystroke — and unlike a row, it expires.
- **Ignore empty rows on read**, so a profile carrying one from an older build heals on its next request rather than needing manual repair.
- **Raise the notification wait 5s → 12s** (overall budget 15s → 25s). 5s was short enough that Kimi routinely lost the race, which is what produced the empty result to begin with.

## Verification

Verified in the running app, not just in tests:

1. Poisoned a dev profile with the same `[]` Kimi row → launchpad `/` menu showed **only `/review`**. Bug reproduced exactly as reported.
2. Applied the fix, restarted against **the same poisoned row** → full Kimi command list (`/check-kimi-code-docs`, `/compact`, `/custom-theme`, …), and the row healed itself on disk (2 bytes → 7668).
3. Grok, whose cache was already good, rendered 42 commands throughout.

Two regression tests: an empty probe result must never reach the store, and an empty row left by an older build must not suppress the probe.

`pnpm test` (493 files, 7008 passed), typecheck, ESLint (0 errors, no new warnings), boundaries, and SQL lint all pass.

## Note for anyone already affected

No action needed — the read-path change heals a poisoned profile on the next `/` in that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
