### PR TITLE
refactor(desktop): use process-owned runtime leases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,9 @@
   index the row moved (~4 KB/page, and a timestamp column in an index moves on
   every write). Two calibration points: tool accounting once wrote per streamed
   8 KiB chunk, costing 3,693 commits and 58 MB of WAL for one `find /`
-  (PR #1406); the idle heartbeats cost 720 commits and 2.7 MB/hour per running
-  instance, about 65 MB/day. **If the projection looks excessive, say so to the
+  (PR #1406); the former 10-second runtime lease heartbeats cost 720 commits
+  and 2.7 MB/hour per running instance, about 65 MB/day. PID-owned runtime
+  leases now cost zero sqlite commits while idle. **If the projection looks excessive, say so to the
   user rather than shipping it quietly — the right answer is often that the
   design constraint has to change** (batch into one transaction, debounce
   behind a flush window, accumulate in memory and persist on a boundary, or

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -90,7 +90,7 @@ pnpm dev
 ```
 
 - Do **not** override `HOME` or set `NODE_ENV` — the app needs the real user data directory to load saved threads and Keychain secrets.
-- Messaging adapters are guarded by a profile-scoped sqlite lease. A shared runtime lease manager records the owning PID once and checks whether that process is still alive when another instance challenges the lease. The first confirmed absence is persisted; after a one-minute reclaim grace, PID reuse cannot revive the dead owner. If another live instance already owns messaging for the active profile, this process stays usable but leaves messaging stopped.
+- Messaging adapters are guarded by a profile-scoped sqlite lease. A shared runtime lease manager records the owning PID, runtime instance ID, and start time once, then verifies that identity against the existing profile runtime marker when another instance challenges the lease. The first confirmed absence is persisted; after a one-minute reclaim grace, PID reuse cannot revive the dead owner. If another live instance already owns messaging for the active profile, this process stays usable but leaves messaging stopped.
 - The federation runtime asks the same lease manager for a parallel profile-scoped lease (lease key `profile-federation`, independent of the messaging lease). If another live instance already runs federation for the active profile, this process keeps its federation runtime stopped and reports the holder in federation health instead of fighting over the shared instance identity.
 - Use `pnpm dev:no-messaging` when you explicitly want to guarantee that this app process never starts messaging adapters.
 - For visual verification of UI changes, either command can show real threads in the sidebar and thread detail pane; prefer `dev:no-messaging` when the UI work does not need live messaging.
@@ -631,13 +631,14 @@ Numbers to compare a new write path against, all measured with this harness:
 | One replay E2E spec | ~28 commits across two Electron processes |
 
 The former idle figure came from two 10-second sqlite renewal loops. Runtime
-leases now register one process identity and check the recorded PID only when a
-challenger tries to acquire messaging or federation. A confirmed dead-owner
-observation is persisted and becomes reclaimable after one minute, even if the
-PID is reused in the meantime. Holding either lease adds no timer and no idle
-sqlite writes. A process that is alive but hung retains ownership; this
-deliberately favors preventing dual owners over preempting a possibly healthy
-process.
+leases now register one process identity and verify its PID, instance ID, and
+start time against the existing profile runtime marker only when a challenger
+tries to acquire messaging or federation. A confirmed dead-owner observation
+is persisted and becomes reclaimable after one minute, even if the PID is
+reused in the meantime. Holding either lease adds no sqlite timer and no idle
+sqlite writes. A process that is alive but hung retains ownership while its
+profile marker remains fresh; this deliberately favors preventing dual owners
+over preempting a possibly healthy process.
 
 ### Write budgets
 

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -90,7 +90,7 @@ pnpm dev
 ```
 
 - Do **not** override `HOME` or set `NODE_ENV` — the app needs the real user data directory to load saved threads and Keychain secrets.
-- Messaging adapters are guarded by a profile-scoped sqlite lease. A shared runtime lease manager records the owning PID once and checks whether that process is still alive when another instance challenges the lease. If another live instance already owns messaging for the active profile, this process stays usable but leaves messaging stopped.
+- Messaging adapters are guarded by a profile-scoped sqlite lease. A shared runtime lease manager records the owning PID once and checks whether that process is still alive when another instance challenges the lease. The first confirmed absence is persisted; after a one-minute reclaim grace, PID reuse cannot revive the dead owner. If another live instance already owns messaging for the active profile, this process stays usable but leaves messaging stopped.
 - The federation runtime asks the same lease manager for a parallel profile-scoped lease (lease key `profile-federation`, independent of the messaging lease). If another live instance already runs federation for the active profile, this process keeps its federation runtime stopped and reports the holder in federation health instead of fighting over the shared instance identity.
 - Use `pnpm dev:no-messaging` when you explicitly want to guarantee that this app process never starts messaging adapters.
 - For visual verification of UI changes, either command can show real threads in the sidebar and thread detail pane; prefer `dev:no-messaging` when the UI work does not need live messaging.
@@ -626,15 +626,18 @@ Numbers to compare a new write path against, all measured with this harness:
 | Former 10-second runtime lease heartbeats | 720 commits / 2.7 MB per hour (~65 MB/day) |
 | PID-owned messaging + federation leases, idle hour | 0 commits / 0 MB WAL |
 | PID-owned lease lifecycle (register, acquire/release both, exit) | 6 commits / ~93 KB WAL |
+| PID-owned dead-owner observation + takeover, both leases | 5 commits / ~72 KB WAL |
 | Whole vitest suite | 51 sources / ~3,000 commits / ~27 MB WAL |
 | One replay E2E spec | ~28 commits across two Electron processes |
 
 The former idle figure came from two 10-second sqlite renewal loops. Runtime
 leases now register one process identity and check the recorded PID only when a
-challenger tries to acquire messaging or federation. Holding either lease adds
-no timer and no idle sqlite writes. A process that is alive but hung retains
-ownership; this deliberately favors preventing dual owners over preempting a
-possibly healthy process.
+challenger tries to acquire messaging or federation. A confirmed dead-owner
+observation is persisted and becomes reclaimable after one minute, even if the
+PID is reused in the meantime. Holding either lease adds no timer and no idle
+sqlite writes. A process that is alive but hung retains ownership; this
+deliberately favors preventing dual owners over preempting a possibly healthy
+process.
 
 ### Write budgets
 

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -90,8 +90,8 @@ pnpm dev
 ```
 
 - Do **not** override `HOME` or set `NODE_ENV` — the app needs the real user data directory to load saved threads and Keychain secrets.
-- Messaging adapters are guarded by a profile-scoped sqlite lease. If another live instance already owns messaging for the active profile, this process stays usable but leaves messaging stopped.
-- The federation runtime is guarded by a parallel profile-scoped lease (lease key `profile-federation`, independent of the messaging lease). If another live instance already runs federation for the active profile, this process keeps its federation runtime stopped and reports the holder in federation health instead of fighting over the shared instance identity.
+- Messaging adapters are guarded by a profile-scoped sqlite lease. A shared runtime lease manager records the owning PID once and checks whether that process is still alive when another instance challenges the lease. If another live instance already owns messaging for the active profile, this process stays usable but leaves messaging stopped.
+- The federation runtime asks the same lease manager for a parallel profile-scoped lease (lease key `profile-federation`, independent of the messaging lease). If another live instance already runs federation for the active profile, this process keeps its federation runtime stopped and reports the holder in federation health instead of fighting over the shared instance identity.
 - Use `pnpm dev:no-messaging` when you explicitly want to guarantee that this app process never starts messaging adapters.
 - For visual verification of UI changes, either command can show real threads in the sidebar and thread detail pane; prefer `dev:no-messaging` when the UI work does not need live messaging.
 - If the app starts but shows no threads, you are likely running from the wrong directory or with overridden env vars.
@@ -623,15 +623,18 @@ Numbers to compare a new write path against, all measured with this harness:
 |---|---|
 | Streamed command output, per-chunk (pre-#1406) | 3,693 commits / 58 MB WAL for one `find /` |
 | Streamed command output, coalesced (today) | 34 commits / 0.54 MB for the same command |
-| Idle heartbeats, per running instance | 720 commits / 2.7 MB per hour (~65 MB/day) |
+| Former 10-second runtime lease heartbeats | 720 commits / 2.7 MB per hour (~65 MB/day) |
+| PID-owned messaging + federation leases, idle hour | 0 commits / 0 MB WAL |
+| PID-owned lease lifecycle (register, acquire/release both, exit) | 6 commits / ~93 KB WAL |
 | Whole vitest suite | 51 sources / ~3,000 commits / ~27 MB WAL |
 | One replay E2E spec | ~28 commits across two Electron processes |
 
-The idle figure is the profile-runtime heartbeat plus the federation lease
-renewal, both ticking every 10s against a 45s TTL, each taking its own commit.
-It is a floor the app pays for existing, and it is worth knowing before you add
-another ticker: a third 10s heartbeat is another ~24 MB/day per instance, and
-an operator may be running several profiles at once.
+The former idle figure came from two 10-second sqlite renewal loops. Runtime
+leases now register one process identity and check the recorded PID only when a
+challenger tries to acquire messaging or federation. Holding either lease adds
+no timer and no idle sqlite writes. A process that is alive but hung retains
+ownership; this deliberately favors preventing dual owners over preempting a
+possibly healthy process.
 
 ### Write budgets
 

--- a/apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts
+++ b/apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   AppRuntimeInstanceStore,
   hashCwd,
+  RUNTIME_LEASE_DEAD_OWNER_GRACE_MS,
 } from "../state/app-runtime-instance-store";
 import { StateDb } from "../state/state-db";
 
@@ -174,7 +175,7 @@ describe("AppRuntimeInstanceStore", () => {
     });
   });
 
-  it("lets another instance acquire after the previous holder exits", () => {
+  it("reclaims messaging one minute after the previous holder exits", () => {
     store.recordInstanceStart({
       instanceId: "instance-a",
       profileName: "dev",
@@ -197,17 +198,27 @@ describe("AppRuntimeInstanceStore", () => {
     });
     store.markInstanceExited({ instanceId: "instance-a", now: 2_000 });
 
-    const result = store.acquireMessagingLease({
+    const observedDead = store.acquireMessagingLease({
       instanceId: "instance-b",
       now: 40_000,
       isOwnerAlive: () => false,
     });
 
+    expect(observedDead).toMatchObject({
+      acquired: false,
+      holder: { expiresAt: 2_000 + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS },
+    });
+    const result = store.acquireMessagingLease({
+      instanceId: "instance-b",
+      now: 2_000 + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS,
+      isOwnerAlive: () => true,
+    });
+
     expect(result.acquired).toBe(true);
     expect(store.getMessagingLease()).toMatchObject({
       ownerInstanceId: "instance-b",
-      acquiredAt: 40_000,
-      heartbeatAt: 40_000,
+      acquiredAt: 2_000 + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS,
+      heartbeatAt: 2_000 + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS,
       expiresAt: Number.MAX_SAFE_INTEGER,
       status: "active",
     });
@@ -281,7 +292,7 @@ describe("AppRuntimeInstanceStore", () => {
     expect(row.disabled_reason).not.toContain("token-secret-value");
   });
 
-  it("preserves rows across database reopen and replaces a dead owner", () => {
+  it("persists dead-owner observation across database reopen", () => {
     const dbPath = path.join(tempDir, "state.db");
     store.recordInstanceStart({
       instanceId: "instance-a",
@@ -308,13 +319,21 @@ describe("AppRuntimeInstanceStore", () => {
       desiredMessagingEnabled: true,
     });
 
-    expect(
-      store.acquireMessagingLease({
-        instanceId: "instance-b",
-        now: 40_000,
-        isOwnerAlive: () => false,
-      }).acquired,
-    ).toBe(true);
+    expect(store.acquireMessagingLease({
+      instanceId: "instance-b",
+      now: 40_000,
+      isOwnerAlive: () => false,
+    })).toMatchObject({ acquired: false });
+    stateDb.close();
+
+    stateDb = StateDb.open(dbPath, { profileName: "dev" });
+    store = new AppRuntimeInstanceStore(stateDb);
+    expect(store.acquireMessagingLease({
+      instanceId: "instance-b",
+      now: 40_000 + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS,
+      // PID reuse after a persisted dead observation cannot revive the owner.
+      isOwnerAlive: () => true,
+    })).toMatchObject({ acquired: true });
     expect(store.getMessagingLease()).toMatchObject({
       ownerInstanceId: "instance-b",
       status: "active",
@@ -537,7 +556,7 @@ describe("AppRuntimeInstanceStore", () => {
     });
   });
 
-  it("lets another instance acquire the federation lease after the holder dies", () => {
+  it("reclaims federation one minute after observing the holder dead", () => {
     store.recordInstanceStart({
       instanceId: "instance-a",
       profileName: "dev",
@@ -559,17 +578,27 @@ describe("AppRuntimeInstanceStore", () => {
       now: 1_000,
     });
 
-    const result = store.acquireFederationLease({
+    const observedDead = store.acquireFederationLease({
       instanceId: "instance-b",
       now: 40_000,
       isOwnerAlive: () => false,
     });
 
+    expect(observedDead).toMatchObject({
+      acquired: false,
+      holder: { expiresAt: 40_000 + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS },
+    });
+    const result = store.acquireFederationLease({
+      instanceId: "instance-b",
+      now: 40_000 + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS,
+      isOwnerAlive: () => true,
+    });
+
     expect(result.acquired).toBe(true);
     expect(store.getFederationLease()).toMatchObject({
       ownerInstanceId: "instance-b",
-      acquiredAt: 40_000,
-      heartbeatAt: 40_000,
+      acquiredAt: 40_000 + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS,
+      heartbeatAt: 40_000 + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS,
       expiresAt: Number.MAX_SAFE_INTEGER,
       status: "active",
     });

--- a/apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts
+++ b/apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts
@@ -46,7 +46,6 @@ describe("AppRuntimeInstanceStore", () => {
     const result = store.acquireMessagingLease({
       instanceId: "instance-a",
       now: 1_000,
-      ttlMs: 30_000,
     });
 
     expect(result.acquired).toBe(true);
@@ -65,7 +64,7 @@ describe("AppRuntimeInstanceStore", () => {
       ownerInstanceId: "instance-a",
       acquiredAt: 1_000,
       heartbeatAt: 1_000,
-      expiresAt: 31_000,
+      expiresAt: Number.MAX_SAFE_INTEGER,
       status: "active",
     });
   });
@@ -93,7 +92,7 @@ describe("AppRuntimeInstanceStore", () => {
     );
   });
 
-  it("renews the current holder lease without changing the original acquisition time", () => {
+  it("keeps the current holder lease without rewriting its acquisition", () => {
     store.recordInstanceStart({
       instanceId: "instance-a",
       profileName: "dev",
@@ -106,23 +105,21 @@ describe("AppRuntimeInstanceStore", () => {
       store.acquireMessagingLease({
         instanceId: "instance-a",
         now: 1_000,
-        ttlMs: 30_000,
       }).acquired,
     ).toBe(true);
 
     expect(
-      store.renewMessagingLease({
+      store.acquireMessagingLease({
         instanceId: "instance-a",
         now: 11_000,
-        ttlMs: 30_000,
       }),
-    ).toBe(true);
+    ).toMatchObject({ acquired: true });
 
     expect(store.getMessagingLease()).toMatchObject({
       ownerInstanceId: "instance-a",
       acquiredAt: 1_000,
-      heartbeatAt: 11_000,
-      expiresAt: 41_000,
+      heartbeatAt: 1_000,
+      expiresAt: Number.MAX_SAFE_INTEGER,
       status: "active",
     });
     expect(store.getInstance("instance-a")).toMatchObject({
@@ -151,13 +148,11 @@ describe("AppRuntimeInstanceStore", () => {
     store.acquireMessagingLease({
       instanceId: "instance-a",
       now: 1_000,
-      ttlMs: 30_000,
     });
 
     const result = store.acquireMessagingLease({
       instanceId: "instance-b",
       now: 2_000,
-      ttlMs: 30_000,
     });
 
     expect(result).toMatchObject({
@@ -165,7 +160,7 @@ describe("AppRuntimeInstanceStore", () => {
       reason: "held",
       holder: {
         ownerInstanceId: "instance-a",
-        expiresAt: 31_000,
+        expiresAt: Number.MAX_SAFE_INTEGER,
       },
     });
     expect(store.getInstance("instance-b")).toMatchObject({
@@ -179,7 +174,7 @@ describe("AppRuntimeInstanceStore", () => {
     });
   });
 
-  it("lets another instance acquire after the previous holder expires", () => {
+  it("lets another instance acquire after the previous holder exits", () => {
     store.recordInstanceStart({
       instanceId: "instance-a",
       profileName: "dev",
@@ -199,13 +194,13 @@ describe("AppRuntimeInstanceStore", () => {
     store.acquireMessagingLease({
       instanceId: "instance-a",
       now: 1_000,
-      ttlMs: 30_000,
     });
+    store.markInstanceExited({ instanceId: "instance-a", now: 2_000 });
 
     const result = store.acquireMessagingLease({
       instanceId: "instance-b",
       now: 40_000,
-      ttlMs: 30_000,
+      isOwnerAlive: () => false,
     });
 
     expect(result.acquired).toBe(true);
@@ -213,7 +208,7 @@ describe("AppRuntimeInstanceStore", () => {
       ownerInstanceId: "instance-b",
       acquiredAt: 40_000,
       heartbeatAt: 40_000,
-      expiresAt: 70_000,
+      expiresAt: Number.MAX_SAFE_INTEGER,
       status: "active",
     });
     const instance = store.getInstance("instance-b");
@@ -243,7 +238,6 @@ describe("AppRuntimeInstanceStore", () => {
     store.acquireMessagingLease({
       instanceId: "instance-a",
       now: 1_000,
-      ttlMs: 30_000,
     });
 
     expect(
@@ -287,7 +281,7 @@ describe("AppRuntimeInstanceStore", () => {
     expect(row.disabled_reason).not.toContain("token-secret-value");
   });
 
-  it("preserves rows across database reopen and still uses expiry as authority", () => {
+  it("preserves rows across database reopen and replaces a dead owner", () => {
     const dbPath = path.join(tempDir, "state.db");
     store.recordInstanceStart({
       instanceId: "instance-a",
@@ -300,7 +294,6 @@ describe("AppRuntimeInstanceStore", () => {
     store.acquireMessagingLease({
       instanceId: "instance-a",
       now: 1_000,
-      ttlMs: 30_000,
     });
     stateDb.close();
 
@@ -319,7 +312,7 @@ describe("AppRuntimeInstanceStore", () => {
       store.acquireMessagingLease({
         instanceId: "instance-b",
         now: 40_000,
-        ttlMs: 30_000,
+        isOwnerAlive: () => false,
       }).acquired,
     ).toBe(true);
     expect(store.getMessagingLease()).toMatchObject({
@@ -400,7 +393,6 @@ describe("AppRuntimeInstanceStore", () => {
     const result = store.acquireFederationLease({
       instanceId: "instance-a",
       now: 1_000,
-      ttlMs: 30_000,
     });
 
     expect(result.acquired).toBe(true);
@@ -408,7 +400,7 @@ describe("AppRuntimeInstanceStore", () => {
       ownerInstanceId: "instance-a",
       acquiredAt: 1_000,
       heartbeatAt: 1_000,
-      expiresAt: 31_000,
+      expiresAt: Number.MAX_SAFE_INTEGER,
       status: "active",
     });
     // The federation lease must not flip the messaging desired/effective
@@ -442,7 +434,6 @@ describe("AppRuntimeInstanceStore", () => {
     store.acquireMessagingLease({
       instanceId: "instance-a",
       now: 1_000,
-      ttlMs: 30_000,
     });
 
     // Messaging is held by instance-a, but that must not block instance-b's
@@ -451,14 +442,12 @@ describe("AppRuntimeInstanceStore", () => {
       store.acquireFederationLease({
         instanceId: "instance-b",
         now: 2_000,
-        ttlMs: 30_000,
       }).acquired,
     ).toBe(true);
     expect(
       store.acquireFederationLease({
         instanceId: "instance-a",
         now: 2_000,
-        ttlMs: 30_000,
       }),
     ).toMatchObject({
       acquired: false,
@@ -469,7 +458,6 @@ describe("AppRuntimeInstanceStore", () => {
       store.acquireMessagingLease({
         instanceId: "instance-b",
         now: 2_000,
-        ttlMs: 30_000,
       }),
     ).toMatchObject({
       acquired: false,
@@ -498,13 +486,11 @@ describe("AppRuntimeInstanceStore", () => {
     store.acquireFederationLease({
       instanceId: "instance-a",
       now: 1_000,
-      ttlMs: 30_000,
     });
 
     const result = store.acquireFederationLease({
       instanceId: "instance-b",
       now: 2_000,
-      ttlMs: 30_000,
     });
 
     expect(result).toMatchObject({
@@ -512,7 +498,7 @@ describe("AppRuntimeInstanceStore", () => {
       reason: "held",
       holder: {
         ownerInstanceId: "instance-a",
-        expiresAt: 31_000,
+        expiresAt: Number.MAX_SAFE_INTEGER,
       },
     });
     expect(store.getFederationLease()).toMatchObject({
@@ -521,7 +507,7 @@ describe("AppRuntimeInstanceStore", () => {
     });
   });
 
-  it("renews the federation lease without changing the original acquisition time", () => {
+  it("keeps the current federation holder without rewriting its acquisition", () => {
     store.recordInstanceStart({
       instanceId: "instance-a",
       profileName: "dev",
@@ -533,27 +519,25 @@ describe("AppRuntimeInstanceStore", () => {
     store.acquireFederationLease({
       instanceId: "instance-a",
       now: 1_000,
-      ttlMs: 30_000,
     });
 
     expect(
-      store.renewFederationLease({
+      store.acquireFederationLease({
         instanceId: "instance-a",
         now: 11_000,
-        ttlMs: 30_000,
       }),
-    ).toBe(true);
+    ).toMatchObject({ acquired: true });
 
     expect(store.getFederationLease()).toMatchObject({
       ownerInstanceId: "instance-a",
       acquiredAt: 1_000,
-      heartbeatAt: 11_000,
-      expiresAt: 41_000,
+      heartbeatAt: 1_000,
+      expiresAt: Number.MAX_SAFE_INTEGER,
       status: "active",
     });
   });
 
-  it("lets another instance acquire the federation lease after the holder expires", () => {
+  it("lets another instance acquire the federation lease after the holder dies", () => {
     store.recordInstanceStart({
       instanceId: "instance-a",
       profileName: "dev",
@@ -573,13 +557,12 @@ describe("AppRuntimeInstanceStore", () => {
     store.acquireFederationLease({
       instanceId: "instance-a",
       now: 1_000,
-      ttlMs: 30_000,
     });
 
     const result = store.acquireFederationLease({
       instanceId: "instance-b",
       now: 40_000,
-      ttlMs: 30_000,
+      isOwnerAlive: () => false,
     });
 
     expect(result.acquired).toBe(true);
@@ -587,7 +570,7 @@ describe("AppRuntimeInstanceStore", () => {
       ownerInstanceId: "instance-b",
       acquiredAt: 40_000,
       heartbeatAt: 40_000,
-      expiresAt: 70_000,
+      expiresAt: Number.MAX_SAFE_INTEGER,
       status: "active",
     });
   });
@@ -612,7 +595,6 @@ describe("AppRuntimeInstanceStore", () => {
     store.acquireFederationLease({
       instanceId: "instance-a",
       now: 1_000,
-      ttlMs: 30_000,
     });
 
     expect(

--- a/apps/desktop/src/main/__tests__/federation-health.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-health.test.ts
@@ -129,7 +129,6 @@ describe("applyFederationLeaseSnapshot", () => {
           instanceId: "instance-a",
           processId: 123,
           cwdHint: "PwrAgnt-a",
-          expiresAt: 31_000,
         },
       }),
     );

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -7,11 +7,11 @@
     "statements": 0
   },
   "runtime-lease-dead-owner-takeover": {
-    "commits": 3,
-    "note": "register challenger and replace a dead owner for both runtime leases",
-    "observedWalBytes": 45320,
-    "rowsChanged": 4,
-    "statements": 4
+    "commits": 5,
+    "note": "observe one dead owner, wait one minute, replace both runtime leases",
+    "observedWalBytes": 74160,
+    "rowsChanged": 8,
+    "statements": 8
   },
   "runtime-lease-lifecycle": {
     "commits": 6,

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -1,10 +1,24 @@
 {
-  "idle-hour-heartbeats": {
-    "commits": 720,
-    "note": "one idle hour: 360 profile heartbeats + 360 federation lease renewals",
-    "observedWalBytes": 2851040,
-    "rowsChanged": 1080,
-    "statements": 1080
+  "idle-hour-runtime-leases": {
+    "commits": 0,
+    "note": "one idle hour: PID-owned messaging and federation leases",
+    "observedWalBytes": 0,
+    "rowsChanged": 0,
+    "statements": 0
+  },
+  "runtime-lease-dead-owner-takeover": {
+    "commits": 3,
+    "note": "register challenger and replace a dead owner for both runtime leases",
+    "observedWalBytes": 45320,
+    "rowsChanged": 4,
+    "statements": 4
+  },
+  "runtime-lease-lifecycle": {
+    "commits": 6,
+    "note": "register once, acquire and release both runtime leases, mark exited",
+    "observedWalBytes": 94760,
+    "rowsChanged": 8,
+    "statements": 8
   },
   "live-thread-token-usage": {
     "commits": 1,

--- a/apps/desktop/src/main/__tests__/profile.test.ts
+++ b/apps/desktop/src/main/__tests__/profile.test.ts
@@ -11,6 +11,7 @@ import {
   deleteProfile,
   ensureBootstrapProfileDir,
   ensureNamedProfileExists,
+  isProfileRuntimeIdentityLive,
   readProfileArg,
   readProfilesRegistry,
   requestProfileInstanceFocus,
@@ -193,6 +194,78 @@ describe("PwrAgent profiles", () => {
     expect(readProfilesRegistry({ env }).profiles).not.toContainEqual(
       expect.objectContaining({ name: "scratch" }),
     );
+  });
+
+  it("matches identity-aware runtime markers by PID, instance, and start time", () => {
+    const { env } = createRoot();
+    ensureNamedProfileExists("scratch", { env });
+    const identity = {
+      instanceId: "runtime-v2-owner",
+      processId: process.pid,
+      startedAt: 1_000,
+    };
+    const heartbeat = startProfileRuntimeHeartbeat("scratch", {
+      env,
+      instanceId: identity.instanceId,
+      intervalMs: 60_000,
+      now: () => 2_000,
+      processId: identity.processId,
+      startedAt: identity.startedAt,
+    });
+
+    try {
+      expect(isProfileRuntimeIdentityLive("scratch", identity, {
+        env,
+        now: 2_000,
+      })).toBe(true);
+      expect(isProfileRuntimeIdentityLive("scratch", {
+        ...identity,
+        startedAt: identity.startedAt + 1,
+      }, {
+        env,
+        now: 2_000,
+      })).toBe(false);
+      expect(isProfileRuntimeIdentityLive("scratch", {
+        ...identity,
+        instanceId: "runtime-v2-recycled",
+      }, {
+        env,
+        now: 2_000,
+      })).toBe(false);
+    } finally {
+      heartbeat.stop();
+    }
+  });
+
+  it("bounds legacy PID matching by the runtime marker lifetime", () => {
+    const { env } = createRoot();
+    ensureNamedProfileExists("scratch", { env });
+    const heartbeat = startProfileRuntimeHeartbeat("scratch", {
+      env,
+      instanceId: "legacy-marker-id",
+      intervalMs: 60_000,
+      now: () => 2_000,
+      processId: process.pid,
+      startedAt: 1_000,
+    });
+    const legacyIdentity = {
+      instanceId: "unrelated-legacy-db-id",
+      processId: process.pid,
+      startedAt: 500,
+    };
+
+    try {
+      expect(isProfileRuntimeIdentityLive("scratch", legacyIdentity, {
+        env,
+        now: 2_000,
+      })).toBe(true);
+      expect(isProfileRuntimeIdentityLive("scratch", legacyIdentity, {
+        env,
+        now: 47_001,
+      })).toBe(false);
+    } finally {
+      heartbeat.stop();
+    }
   });
 
   it("requests focus only for profiles with a live runtime heartbeat", () => {

--- a/apps/desktop/src/main/__tests__/runtime-federation-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-federation-lease.test.ts
@@ -13,11 +13,20 @@ import { StateDb } from "../state/state-db";
 let stateDb: StateDb;
 let store: AppRuntimeInstanceStore;
 let tempDir: string;
+const activeCoordinators: RuntimeFederationLeaseCoordinator[] = [];
 
 function createRuntime(): FederationLeaseRuntime {
   return {
     stop: vi.fn(async () => {}),
   };
+}
+
+function createCoordinator(
+  options: ConstructorParameters<typeof RuntimeFederationLeaseCoordinator>[0],
+): RuntimeFederationLeaseCoordinator {
+  const coordinator = new RuntimeFederationLeaseCoordinator(options);
+  activeCoordinators.push(coordinator);
+  return coordinator;
 }
 
 function recordInstance(
@@ -44,6 +53,16 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  // Stop heartbeats before closing the DB so a still-scheduled interval
+  // cannot renew against a closed better-sqlite3 connection and fail the
+  // suite with an unhandled exception after every assertion passed.
+  for (const coordinator of activeCoordinators.splice(0)) {
+    try {
+      coordinator.shutdownSync();
+    } catch {
+      // Ignore teardown races; the store may already be closed.
+    }
+  }
   stateDb.close();
   rmSync(tempDir, { recursive: true, force: true });
 });
@@ -56,7 +75,7 @@ describe("RuntimeFederationLeaseCoordinator", () => {
       cwd: "/tmp/PwrAgnt",
       startedAt: 1_000,
     });
-    const coordinator = new RuntimeFederationLeaseCoordinator({
+    const coordinator = createCoordinator({
       instanceId: "instance-a",
       now: () => 1_000,
       store,
@@ -81,7 +100,7 @@ describe("RuntimeFederationLeaseCoordinator", () => {
     "acquires the profile lease in %s mode",
     async (mode) => {
       const runtime = createRuntime();
-      const coordinator = new RuntimeFederationLeaseCoordinator({
+      const coordinator = createCoordinator({
         instanceId: "instance-a",
         now: () => 1_000,
         store,
@@ -101,7 +120,7 @@ describe("RuntimeFederationLeaseCoordinator", () => {
 
   it("never acquires the lease when federation is disabled", async () => {
     const runtime = createRuntime();
-    const coordinator = new RuntimeFederationLeaseCoordinator({
+    const coordinator = createCoordinator({
       instanceId: "instance-a",
       now: () => 1_000,
       store,
@@ -119,7 +138,7 @@ describe("RuntimeFederationLeaseCoordinator", () => {
 
   it("releases a held lease when federation is disabled", async () => {
     const runtime = createRuntime();
-    const coordinator = new RuntimeFederationLeaseCoordinator({
+    const coordinator = createCoordinator({
       instanceId: "instance-a",
       now: () => 1_000,
       store,
@@ -153,12 +172,12 @@ describe("RuntimeFederationLeaseCoordinator", () => {
       cwd: "/tmp/PwrAgnt-b",
       startedAt: 2_000,
     });
-    const first = new RuntimeFederationLeaseCoordinator({
+    const first = createCoordinator({
       instanceId: "instance-a",
       now: () => 1_000,
       store,
     });
-    const second = new RuntimeFederationLeaseCoordinator({
+    const second = createCoordinator({
       instanceId: "instance-b",
       now: () => 2_000,
       store,
@@ -195,12 +214,12 @@ describe("RuntimeFederationLeaseCoordinator", () => {
   it("re-acquires the lease after the holder releases it", async () => {
     const firstRuntime = createRuntime();
     const secondRuntime = createRuntime();
-    const first = new RuntimeFederationLeaseCoordinator({
+    const first = createCoordinator({
       instanceId: "instance-a",
       now: () => 1_000,
       store,
     });
-    const second = new RuntimeFederationLeaseCoordinator({
+    const second = createCoordinator({
       instanceId: "instance-b",
       now: () => 2_000,
       store,
@@ -228,12 +247,12 @@ describe("RuntimeFederationLeaseCoordinator", () => {
     let now = 1_000;
     const firstRuntime = createRuntime();
     const secondRuntime = createRuntime();
-    const first = new RuntimeFederationLeaseCoordinator({
+    const first = createCoordinator({
       instanceId: "instance-a",
       now: () => now,
       store,
     });
-    const second = new RuntimeFederationLeaseCoordinator({
+    const second = createCoordinator({
       instanceId: "instance-b",
       now: () => now,
       store,
@@ -258,12 +277,12 @@ describe("RuntimeFederationLeaseCoordinator", () => {
     let now = 1_000;
     const firstRuntime = createRuntime();
     const secondRuntime = createRuntime();
-    const first = new RuntimeFederationLeaseCoordinator({
+    const first = createCoordinator({
       instanceId: "instance-a",
       now: () => now,
       store,
     });
-    const second = new RuntimeFederationLeaseCoordinator({
+    const second = createCoordinator({
       instanceId: "instance-b",
       now: () => now,
       store,
@@ -292,7 +311,7 @@ describe("RuntimeFederationLeaseCoordinator", () => {
 
   it("releases the lease on shutdownSync", async () => {
     const runtime = createRuntime();
-    const coordinator = new RuntimeFederationLeaseCoordinator({
+    const coordinator = createCoordinator({
       instanceId: "instance-a",
       now: () => 1_000,
       store,
@@ -311,7 +330,7 @@ describe("RuntimeFederationLeaseCoordinator", () => {
   it("releases the lease and stops the heartbeat when post-acquisition startup fails", async () => {
     vi.useFakeTimers();
     const runtime = createRuntime();
-    const coordinator = new RuntimeFederationLeaseCoordinator({
+    const coordinator = createCoordinator({
       instanceId: "instance-a",
       now: () => 1_000,
       store,
@@ -352,12 +371,12 @@ describe("RuntimeFederationLeaseCoordinator", () => {
       cwd: "/tmp/PwrAgnt-b",
       startedAt: 2_000,
     });
-    const first = new RuntimeFederationLeaseCoordinator({
+    const first = createCoordinator({
       instanceId: "instance-a",
       now: () => 1_000,
       store,
     });
-    const second = new RuntimeFederationLeaseCoordinator({
+    const second = createCoordinator({
       instanceId: "instance-b",
       now: () => 2_000,
       store,
@@ -382,7 +401,7 @@ describe("RuntimeFederationLeaseCoordinator", () => {
         throw new Error("stop failed");
       }),
     };
-    const coordinator = new RuntimeFederationLeaseCoordinator({
+    const coordinator = createCoordinator({
       instanceId: "instance-a",
       now: () => 1_000,
       store,

--- a/apps/desktop/src/main/__tests__/runtime-federation-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-federation-lease.test.ts
@@ -6,7 +6,10 @@ import {
   RuntimeFederationLeaseCoordinator,
   type FederationLeaseRuntime,
 } from "../runtime-federation-lease";
-import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
+import {
+  AppRuntimeInstanceStore,
+  RUNTIME_LEASE_DEAD_OWNER_GRACE_MS,
+} from "../state/app-runtime-instance-store";
 import { StateDb } from "../state/state-db";
 
 let stateDb: StateDb;
@@ -259,7 +262,7 @@ describe("RuntimeFederationLeaseCoordinator", () => {
     second.shutdownSync();
   });
 
-  it("re-acquires the lease after the holder process exits", async () => {
+  it("re-acquires one minute after observing the holder process exit", async () => {
     let now = 1_000;
     const firstRuntime = createRuntime();
     const secondRuntime = createRuntime();
@@ -278,17 +281,20 @@ describe("RuntimeFederationLeaseCoordinator", () => {
     liveProcessIds.delete(123);
     now = 40_000;
     await expect(second.applyMode(secondRuntime, "gateway")).resolves
+      .toMatchObject({ enabled: false, disabledReasonKind: "lease_held" });
+    now += RUNTIME_LEASE_DEAD_OWNER_GRACE_MS;
+    await expect(second.applyMode(secondRuntime, "gateway")).resolves
       .toMatchObject({ enabled: true });
 
     expect(store.getFederationLease()).toMatchObject({
       ownerInstanceId: "instance-b",
-      acquiredAt: 40_000,
+      acquiredAt: 40_000 + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS,
       status: "active",
     });
     second.shutdownSync();
   });
 
-  it("lets a live challenger replace a dead owner without waiting for a TTL", async () => {
+  it("does not let PID reuse revive a dead owner during reclaim grace", async () => {
     let now = 1_000;
     const firstRuntime = createRuntime();
     const secondRuntime = createRuntime();
@@ -306,6 +312,10 @@ describe("RuntimeFederationLeaseCoordinator", () => {
     await first.applyMode(firstRuntime, "client");
     liveProcessIds.delete(123);
     now = 2_000;
+    await expect(second.applyMode(secondRuntime, "client")).resolves
+      .toMatchObject({ enabled: false, disabledReasonKind: "lease_held" });
+    liveProcessIds.add(123);
+    now += RUNTIME_LEASE_DEAD_OWNER_GRACE_MS;
     await expect(second.applyMode(secondRuntime, "client")).resolves
       .toMatchObject({ enabled: true });
 

--- a/apps/desktop/src/main/__tests__/runtime-federation-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-federation-lease.test.ts
@@ -309,6 +309,33 @@ describe("RuntimeFederationLeaseCoordinator", () => {
     second.shutdownSync();
   });
 
+  it("stops the runtime when lease renewal throws", async () => {
+    vi.useFakeTimers();
+    const runtime = createRuntime();
+    const coordinator = createCoordinator({
+      instanceId: "instance-a",
+      now: () => 1_000,
+      store,
+    });
+    const renewLease = vi
+      .spyOn(store, "renewFederationLease")
+      .mockImplementationOnce(() => {
+        throw new Error("database is busy");
+      });
+
+    await coordinator.applyMode(runtime, "client");
+    await vi.advanceTimersByTimeAsync(FEDERATION_LEASE_HEARTBEAT_MS);
+
+    expect(runtime.stop).toHaveBeenCalledTimes(1);
+    expect(coordinator.snapshot()).toMatchObject({
+      leaseHeld: false,
+      disabledReasonKind: "runtime_stopped",
+    });
+
+    await vi.advanceTimersByTimeAsync(FEDERATION_LEASE_HEARTBEAT_MS * 3);
+    expect(renewLease).toHaveBeenCalledTimes(1);
+  });
+
   it("releases the lease on shutdownSync", async () => {
     const runtime = createRuntime();
     const coordinator = createCoordinator({

--- a/apps/desktop/src/main/__tests__/runtime-federation-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-federation-lease.test.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  FEDERATION_LEASE_HEARTBEAT_MS,
   RuntimeFederationLeaseCoordinator,
   type FederationLeaseRuntime,
 } from "../runtime-federation-lease";
@@ -13,6 +12,7 @@ import { StateDb } from "../state/state-db";
 let stateDb: StateDb;
 let store: AppRuntimeInstanceStore;
 let tempDir: string;
+let liveProcessIds: Set<number>;
 const activeCoordinators: RuntimeFederationLeaseCoordinator[] = [];
 
 function createRuntime(): FederationLeaseRuntime {
@@ -22,9 +22,26 @@ function createRuntime(): FederationLeaseRuntime {
 }
 
 function createCoordinator(
-  options: ConstructorParameters<typeof RuntimeFederationLeaseCoordinator>[0],
+  options: NonNullable<
+    ConstructorParameters<typeof RuntimeFederationLeaseCoordinator>[0]
+  >,
 ): RuntimeFederationLeaseCoordinator {
-  const coordinator = new RuntimeFederationLeaseCoordinator(options);
+  const processId =
+    options.processId
+    ?? (options.instanceId === "instance-b" ? 456 : 123);
+  liveProcessIds.add(processId);
+  const coordinator = new RuntimeFederationLeaseCoordinator({
+    profileName: "dev",
+    processId,
+    cwd:
+      options.cwd
+      ?? (options.instanceId === "instance-b"
+        ? "/tmp/PwrAgnt-b"
+        : "/tmp/PwrAgnt-a"),
+    processIsAlive: (candidateProcessId) =>
+      liveProcessIds.has(candidateProcessId),
+    ...options,
+  });
   activeCoordinators.push(coordinator);
   return coordinator;
 }
@@ -44,6 +61,7 @@ function recordInstance(
 }
 
 beforeEach(() => {
+  liveProcessIds = new Set<number>();
   tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-federation-lease-"));
   stateDb = StateDb.open(path.join(tempDir, "state.db"), {
     profileName: "dev",
@@ -53,9 +71,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
-  // Stop heartbeats before closing the DB so a still-scheduled interval
-  // cannot renew against a closed better-sqlite3 connection and fail the
-  // suite with an unhandled exception after every assertion passed.
+  // Release ownership before closing the shared test database.
   for (const coordinator of activeCoordinators.splice(0)) {
     try {
       coordinator.shutdownSync();
@@ -243,7 +259,7 @@ describe("RuntimeFederationLeaseCoordinator", () => {
     second.shutdownSync();
   });
 
-  it("re-acquires the lease after the holder's lease expires", async () => {
+  it("re-acquires the lease after the holder process exits", async () => {
     let now = 1_000;
     const firstRuntime = createRuntime();
     const secondRuntime = createRuntime();
@@ -259,6 +275,7 @@ describe("RuntimeFederationLeaseCoordinator", () => {
     });
 
     await first.applyMode(firstRuntime, "gateway");
+    liveProcessIds.delete(123);
     now = 40_000;
     await expect(second.applyMode(secondRuntime, "gateway")).resolves
       .toMatchObject({ enabled: true });
@@ -266,14 +283,12 @@ describe("RuntimeFederationLeaseCoordinator", () => {
     expect(store.getFederationLease()).toMatchObject({
       ownerInstanceId: "instance-b",
       acquiredAt: 40_000,
-      expiresAt: 70_000,
       status: "active",
     });
     second.shutdownSync();
   });
 
-  it("stops the runtime when the heartbeat loses the lease", async () => {
-    vi.useFakeTimers();
+  it("lets a live challenger replace a dead owner without waiting for a TTL", async () => {
     let now = 1_000;
     const firstRuntime = createRuntime();
     const secondRuntime = createRuntime();
@@ -289,17 +304,14 @@ describe("RuntimeFederationLeaseCoordinator", () => {
     });
 
     await first.applyMode(firstRuntime, "client");
-    // The first instance stops renewing (busy event loop, debugger pause,
-    // OS sleep) and the second takes the lease once it expires.
-    now = 32_000;
-    await second.applyMode(secondRuntime, "client");
-    now = 33_000;
-    await vi.advanceTimersByTimeAsync(FEDERATION_LEASE_HEARTBEAT_MS);
+    liveProcessIds.delete(123);
+    now = 2_000;
+    await expect(second.applyMode(secondRuntime, "client")).resolves
+      .toMatchObject({ enabled: true });
 
-    expect(firstRuntime.stop).toHaveBeenCalledTimes(1);
+    expect(firstRuntime.stop).not.toHaveBeenCalled();
     expect(first.snapshot()).toMatchObject({
       leaseHeld: false,
-      disabledReasonKind: "lease_held",
       leaseHolder: { instanceId: "instance-b" },
     });
     expect(store.getFederationLease()).toMatchObject({
@@ -309,7 +321,7 @@ describe("RuntimeFederationLeaseCoordinator", () => {
     second.shutdownSync();
   });
 
-  it("stops the runtime when lease renewal throws", async () => {
+  it("does not renew a PID-owned lease on a timer", async () => {
     vi.useFakeTimers();
     const runtime = createRuntime();
     const coordinator = createCoordinator({
@@ -317,23 +329,16 @@ describe("RuntimeFederationLeaseCoordinator", () => {
       now: () => 1_000,
       store,
     });
-    const renewLease = vi
-      .spyOn(store, "renewFederationLease")
-      .mockImplementationOnce(() => {
-        throw new Error("database is busy");
-      });
 
     await coordinator.applyMode(runtime, "client");
-    await vi.advanceTimersByTimeAsync(FEDERATION_LEASE_HEARTBEAT_MS);
+    const acquiredLease = store.getFederationLease();
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1_000);
 
-    expect(runtime.stop).toHaveBeenCalledTimes(1);
+    expect(store.getFederationLease()).toEqual(acquiredLease);
+    expect(runtime.stop).not.toHaveBeenCalled();
     expect(coordinator.snapshot()).toMatchObject({
-      leaseHeld: false,
-      disabledReasonKind: "runtime_stopped",
+      leaseHeld: true,
     });
-
-    await vi.advanceTimersByTimeAsync(FEDERATION_LEASE_HEARTBEAT_MS * 3);
-    expect(renewLease).toHaveBeenCalledTimes(1);
   });
 
   it("releases the lease on shutdownSync", async () => {
@@ -354,8 +359,7 @@ describe("RuntimeFederationLeaseCoordinator", () => {
     });
   });
 
-  it("releases the lease and stops the heartbeat when post-acquisition startup fails", async () => {
-    vi.useFakeTimers();
+  it("releases the lease when post-acquisition startup fails", async () => {
     const runtime = createRuntime();
     const coordinator = createCoordinator({
       instanceId: "instance-a",
@@ -377,8 +381,6 @@ describe("RuntimeFederationLeaseCoordinator", () => {
       disabledReasonKind: "startup_error",
     });
 
-    // The heartbeat must be stopped too: nothing may re-activate the lease.
-    await vi.advanceTimersByTimeAsync(FEDERATION_LEASE_HEARTBEAT_MS * 3);
     expect(store.getFederationLease()).toMatchObject({
       status: "released",
       releasedAt: 1_000,

--- a/apps/desktop/src/main/__tests__/runtime-lease-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-lease-manager.test.ts
@@ -3,7 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RuntimeLeaseManager } from "../runtime-lease-manager";
-import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
+import {
+  AppRuntimeInstanceStore,
+  RUNTIME_LEASE_DEAD_OWNER_GRACE_MS,
+} from "../state/app-runtime-instance-store";
 import { StateDb } from "../state/state-db";
 
 let stateDb: StateDb;
@@ -85,25 +88,44 @@ describe("RuntimeLeaseManager", () => {
     });
   });
 
-  it("atomically replaces a lease whose registered owner PID is dead", () => {
+  it("persists a dead observation before reclaiming a recycled PID", () => {
+    let now = 2_000;
     const owner = createManager({ instanceId: "instance-a", processId: 123 });
     const challenger = createManager({
       instanceId: "instance-b",
       processId: 456,
-      now: () => 2_000,
+      now: () => now,
     });
     owner.acquire("federation");
     liveProcessIds.delete(123);
 
+    expect(challenger.acquire("federation")).toMatchObject({
+      acquired: false,
+      holder: { instanceId: "instance-a", processId: 123 },
+    });
+    expect(store.getInstance("instance-a")).toMatchObject({ exitedAt: 2_000 });
+    expect(store.getFederationLease()).toMatchObject({
+      expiresAt: 2_000 + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS,
+      ownerInstanceId: "instance-a",
+      status: "active",
+    });
+
+    // A different process may reuse the PID during the grace period. The
+    // durable dead observation remains authoritative, so it cannot revive the
+    // original owner after the reclaim deadline.
+    liveProcessIds.add(123);
+    now = 2_000 + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS - 1;
+    expect(challenger.acquire("federation")).toMatchObject({ acquired: false });
+    now += 1;
     expect(challenger.acquire("federation")).toEqual({ acquired: true });
     expect(store.getFederationLease()).toMatchObject({
-      acquiredAt: 2_000,
       ownerInstanceId: "instance-b",
       status: "active",
     });
   });
 
-  it("does not let a recycled current PID preserve another instance's lease", () => {
+  it("reclaims a stale instance that used the current process PID", () => {
+    let now = 2_000;
     const staleOwner = createManager({
       instanceId: "instance-a",
       processId: 123,
@@ -113,9 +135,13 @@ describe("RuntimeLeaseManager", () => {
     const currentProcess = createManager({
       instanceId: "instance-b",
       processId: 123,
-      now: () => 2_000,
+      now: () => now,
     });
 
+    expect(currentProcess.acquire("messaging")).toMatchObject({
+      acquired: false,
+    });
+    now += RUNTIME_LEASE_DEAD_OWNER_GRACE_MS;
     expect(currentProcess.acquire("messaging")).toEqual({ acquired: true });
     expect(store.getMessagingLease()).toMatchObject({
       ownerInstanceId: "instance-b",

--- a/apps/desktop/src/main/__tests__/runtime-lease-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-lease-manager.test.ts
@@ -1,0 +1,125 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RuntimeLeaseManager } from "../runtime-lease-manager";
+import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: AppRuntimeInstanceStore;
+let tempDir: string;
+let liveProcessIds: Set<number>;
+
+function createManager(params: {
+  instanceId: string;
+  processId: number;
+  now?: () => number;
+}): RuntimeLeaseManager {
+  liveProcessIds.add(params.processId);
+  return new RuntimeLeaseManager({
+    cwd: `/tmp/${params.instanceId}`,
+    instanceId: params.instanceId,
+    now: params.now ?? (() => 1_000),
+    processId: params.processId,
+    processIsAlive: (processId) => liveProcessIds.has(processId),
+    profileName: "dev",
+    store,
+  });
+}
+
+beforeEach(() => {
+  liveProcessIds = new Set<number>();
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-runtime-leases-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"), {
+    profileName: "dev",
+  });
+  store = new AppRuntimeInstanceStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("RuntimeLeaseManager", () => {
+  it("uses one process registration for messaging and federation", () => {
+    const manager = createManager({
+      instanceId: "instance-a",
+      processId: 123,
+    });
+
+    expect(manager.acquire("messaging")).toEqual({ acquired: true });
+    expect(manager.acquire("federation")).toEqual({ acquired: true });
+
+    expect(store.getInstance("instance-a")).toMatchObject({
+      instanceId: "instance-a",
+      processId: 123,
+    });
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      status: "active",
+    });
+    expect(store.getFederationLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      status: "active",
+    });
+  });
+
+  it("denies both leases while their registered owner PID is alive", () => {
+    const owner = createManager({ instanceId: "instance-a", processId: 123 });
+    const challenger = createManager({
+      instanceId: "instance-b",
+      processId: 456,
+    });
+    owner.acquire("messaging");
+    owner.acquire("federation");
+
+    expect(challenger.acquire("messaging")).toMatchObject({
+      acquired: false,
+      holder: { instanceId: "instance-a", processId: 123 },
+    });
+    expect(challenger.acquire("federation")).toMatchObject({
+      acquired: false,
+      holder: { instanceId: "instance-a", processId: 123 },
+    });
+  });
+
+  it("atomically replaces a lease whose registered owner PID is dead", () => {
+    const owner = createManager({ instanceId: "instance-a", processId: 123 });
+    const challenger = createManager({
+      instanceId: "instance-b",
+      processId: 456,
+      now: () => 2_000,
+    });
+    owner.acquire("federation");
+    liveProcessIds.delete(123);
+
+    expect(challenger.acquire("federation")).toEqual({ acquired: true });
+    expect(store.getFederationLease()).toMatchObject({
+      acquiredAt: 2_000,
+      ownerInstanceId: "instance-b",
+      status: "active",
+    });
+  });
+
+  it("does not let a recycled current PID preserve another instance's lease", () => {
+    const staleOwner = createManager({
+      instanceId: "instance-a",
+      processId: 123,
+    });
+    staleOwner.acquire("messaging");
+
+    const currentProcess = createManager({
+      instanceId: "instance-b",
+      processId: 123,
+      now: () => 2_000,
+    });
+
+    expect(currentProcess.acquire("messaging")).toEqual({ acquired: true });
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-b",
+      status: "active",
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/runtime-lease-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-lease-manager.test.ts
@@ -12,27 +12,42 @@ import { StateDb } from "../state/state-db";
 let stateDb: StateDb;
 let store: AppRuntimeInstanceStore;
 let tempDir: string;
-let liveProcessIds: Set<number>;
+let liveRuntimeIdentities: Map<number, string>;
+
+function runtimeIdentityKey(params: {
+  instanceId: string;
+  startedAt: number;
+}): string {
+  return `${params.instanceId}:${params.startedAt}`;
+}
 
 function createManager(params: {
   instanceId: string;
   processId: number;
   now?: () => number;
 }): RuntimeLeaseManager {
-  liveProcessIds.add(params.processId);
+  const now = params.now ?? (() => 1_000);
+  const startedAt = now();
+  liveRuntimeIdentities.set(
+    params.processId,
+    runtimeIdentityKey({ instanceId: params.instanceId, startedAt }),
+  );
   return new RuntimeLeaseManager({
     cwd: `/tmp/${params.instanceId}`,
     instanceId: params.instanceId,
-    now: params.now ?? (() => 1_000),
+    now,
     processId: params.processId,
-    processIsAlive: (processId) => liveProcessIds.has(processId),
     profileName: "dev",
+    runtimeIdentityIsAlive: (owner) =>
+      liveRuntimeIdentities.get(owner.processId)
+      === runtimeIdentityKey(owner),
+    startedAt,
     store,
   });
 }
 
 beforeEach(() => {
-  liveProcessIds = new Set<number>();
+  liveRuntimeIdentities = new Map<number, string>();
   tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-runtime-leases-"));
   stateDb = StateDb.open(path.join(tempDir, "state.db"), {
     profileName: "dev",
@@ -69,7 +84,7 @@ describe("RuntimeLeaseManager", () => {
     });
   });
 
-  it("denies both leases while their registered owner PID is alive", () => {
+  it("denies both leases while their registered owner identity is alive", () => {
     const owner = createManager({ instanceId: "instance-a", processId: 123 });
     const challenger = createManager({
       instanceId: "instance-b",
@@ -97,7 +112,7 @@ describe("RuntimeLeaseManager", () => {
       now: () => now,
     });
     owner.acquire("federation");
-    liveProcessIds.delete(123);
+    liveRuntimeIdentities.delete(123);
 
     expect(challenger.acquire("federation")).toMatchObject({
       acquired: false,
@@ -113,7 +128,7 @@ describe("RuntimeLeaseManager", () => {
     // A different process may reuse the PID during the grace period. The
     // durable dead observation remains authoritative, so it cannot revive the
     // original owner after the reclaim deadline.
-    liveProcessIds.add(123);
+    liveRuntimeIdentities.set(123, "unrelated-process:3_000");
     now = 2_000 + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS - 1;
     expect(challenger.acquire("federation")).toMatchObject({ acquired: false });
     now += 1;
@@ -122,6 +137,27 @@ describe("RuntimeLeaseManager", () => {
       ownerInstanceId: "instance-b",
       status: "active",
     });
+  });
+
+  it("starts reclaim grace when a PID was recycled before observation", () => {
+    let now = 2_000;
+    const owner = createManager({ instanceId: "instance-a", processId: 123 });
+    const challenger = createManager({
+      instanceId: "instance-b",
+      processId: 456,
+      now: () => now,
+    });
+    owner.acquire("messaging");
+
+    // The original owner crashes and an unrelated process receives its PID
+    // before any challenger observes an empty PID slot.
+    liveRuntimeIdentities.set(123, "unrelated-process:1_500");
+
+    expect(challenger.acquire("messaging")).toMatchObject({ acquired: false });
+    expect(store.getInstance("instance-a")).toMatchObject({ exitedAt: 2_000 });
+
+    now += RUNTIME_LEASE_DEAD_OWNER_GRACE_MS;
+    expect(challenger.acquire("messaging")).toEqual({ acquired: true });
   });
 
   it("reclaims a stale instance that used the current process PID", () => {

--- a/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   AppRuntimeInstanceStore,
   hashCwd,
+  RUNTIME_LEASE_DEAD_OWNER_GRACE_MS,
 } from "../state/app-runtime-instance-store";
 import { StateDb } from "../state/state-db";
 import type { DesktopMessagingConfig } from "../messaging/messaging-config";
@@ -272,7 +273,7 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
     first.shutdownSync();
   });
 
-  it("stops runtime after a dead owner is replaced", async () => {
+  it("stops runtime after the dead-owner grace permits replacement", async () => {
     let now = 1_000;
     const firstRuntime = createRuntime();
     const secondRuntime = createRuntime();
@@ -309,8 +310,12 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
     await first.applyResolvedConfig(firstRuntime, config);
     liveProcessIds.delete(123);
     now = 2_000;
-    await second.applyResolvedConfig(secondRuntime, config);
-    now = 3_000;
+    await expect(second.applyResolvedConfig(secondRuntime, config)).resolves
+      .toMatchObject({ enabled: false, disabledReasonKind: "lease_held" });
+    now += RUNTIME_LEASE_DEAD_OWNER_GRACE_MS;
+    await expect(second.applyResolvedConfig(secondRuntime, config)).resolves
+      .toMatchObject({ enabled: true });
+    now += 1_000;
     await expect(first.applyResolvedConfig(firstRuntime, config)).resolves
       .toMatchObject({
         enabled: false,

--- a/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  MESSAGING_LEASE_HEARTBEAT_MS,
   PWRAGENT_INSTANCE_ROOT_ENV,
   RuntimeMessagingLeaseCoordinator,
 } from "../runtime-messaging-lease";
@@ -18,6 +17,7 @@ import type { DesktopMessagingRuntime } from "../messaging/messaging-runtime";
 let stateDb: StateDb;
 let store: AppRuntimeInstanceStore;
 let tempDir: string;
+let liveProcessIds: Set<number>;
 
 function createRuntime(options: { failApply?: boolean } = {}): DesktopMessagingRuntime {
   let enabled = false;
@@ -33,12 +33,27 @@ function createRuntime(options: { failApply?: boolean } = {}): DesktopMessagingR
   } as unknown as DesktopMessagingRuntime;
 }
 
+function createCoordinator(
+  options: NonNullable<
+    ConstructorParameters<typeof RuntimeMessagingLeaseCoordinator>[0]
+  >,
+): RuntimeMessagingLeaseCoordinator {
+  const processId = options.processId ?? process.pid;
+  liveProcessIds.add(processId);
+  return new RuntimeMessagingLeaseCoordinator({
+    ...options,
+    processId,
+    processIsAlive: (candidate) => liveProcessIds.has(candidate),
+  });
+}
+
 beforeEach(() => {
   tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-lease-coordinator-"));
   stateDb = StateDb.open(path.join(tempDir, "state.db"), {
     profileName: "dev",
   });
   store = new AppRuntimeInstanceStore(stateDb);
+  liveProcessIds = new Set();
 });
 
 afterEach(() => {
@@ -62,7 +77,7 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
         authorizedSupergroupIds: [],
       },
     }));
-    const coordinator = new RuntimeMessagingLeaseCoordinator({
+    const coordinator = createCoordinator({
       instanceId: "instance-a",
       profileName: "dev",
       processId: 123,
@@ -89,7 +104,7 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
 
   it("uses the launch root env var for lease owner identity", async () => {
     const runtime = createRuntime();
-    const coordinator = new RuntimeMessagingLeaseCoordinator({
+    const coordinator = createCoordinator({
       instanceId: "instance-a",
       profileName: "dev",
       processId: 123,
@@ -130,7 +145,7 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
 
   it("does not claim the lease when no adapters are runnable", async () => {
     const runtime = createRuntime();
-    const coordinator = new RuntimeMessagingLeaseCoordinator({
+    const coordinator = createCoordinator({
       instanceId: "instance-a",
       profileName: "dev",
       processId: 123,
@@ -162,7 +177,7 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
 
   it("treats Feishu-only config as runnable", async () => {
     const runtime = createRuntime();
-    const coordinator = new RuntimeMessagingLeaseCoordinator({
+    const coordinator = createCoordinator({
       instanceId: "instance-a",
       profileName: "dev",
       processId: 123,
@@ -205,7 +220,7 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
   it("starts runtime only for the profile lease holder", async () => {
     const firstRuntime = createRuntime();
     const secondRuntime = createRuntime();
-    const first = new RuntimeMessagingLeaseCoordinator({
+    const first = createCoordinator({
       instanceId: "instance-a",
       profileName: "dev",
       processId: 123,
@@ -213,7 +228,7 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
       now: () => 1_000,
       store,
     });
-    const second = new RuntimeMessagingLeaseCoordinator({
+    const second = createCoordinator({
       instanceId: "instance-b",
       profileName: "dev",
       processId: 456,
@@ -257,7 +272,7 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
     first.shutdownSync();
   });
 
-  it("stops runtime when another live instance holds the lease", async () => {
+  it("stops runtime after a dead owner is replaced", async () => {
     let now = 1_000;
     const firstRuntime = createRuntime();
     const secondRuntime = createRuntime();
@@ -274,7 +289,7 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
         authorizedSupergroupIds: [],
       },
     };
-    const first = new RuntimeMessagingLeaseCoordinator({
+    const first = createCoordinator({
       instanceId: "instance-a",
       profileName: "dev",
       processId: 123,
@@ -282,7 +297,7 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
       now: () => now,
       store,
     });
-    const second = new RuntimeMessagingLeaseCoordinator({
+    const second = createCoordinator({
       instanceId: "instance-b",
       profileName: "dev",
       processId: 456,
@@ -292,9 +307,10 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
     });
 
     await first.applyResolvedConfig(firstRuntime, config);
-    now = 32_000;
+    liveProcessIds.delete(123);
+    now = 2_000;
     await second.applyResolvedConfig(secondRuntime, config);
-    now = 33_000;
+    now = 3_000;
     await expect(first.applyResolvedConfig(firstRuntime, config)).resolves
       .toMatchObject({
         enabled: false,
@@ -311,11 +327,9 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
     second.shutdownSync();
   });
 
-  it("stops runtime when the heartbeat loses the lease", async () => {
-    vi.useFakeTimers();
+  it("does not renew a PID-owned lease on a timer", async () => {
     let now = 1_000;
-    const firstRuntime = createRuntime();
-    const secondRuntime = createRuntime();
+    const runtime = createRuntime();
     const config: DesktopMessagingConfig = {
       enabled: true,
       inputDebounceMs: 500,
@@ -329,7 +343,7 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
         authorizedSupergroupIds: [],
       },
     };
-    const first = new RuntimeMessagingLeaseCoordinator({
+    const coordinator = createCoordinator({
       instanceId: "instance-a",
       profileName: "dev",
       processId: 123,
@@ -337,38 +351,26 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
       now: () => now,
       store,
     });
-    const second = new RuntimeMessagingLeaseCoordinator({
-      instanceId: "instance-b",
-      profileName: "dev",
-      processId: 456,
-      cwd: "/tmp/PwrAgnt-b",
-      now: () => now,
-      store,
-    });
 
-    await first.applyResolvedConfig(firstRuntime, config);
-    now = 32_000;
-    await second.applyResolvedConfig(secondRuntime, config);
-    now = 33_000;
-    await vi.advanceTimersByTimeAsync(MESSAGING_LEASE_HEARTBEAT_MS);
+    await coordinator.applyResolvedConfig(runtime, config);
+    now = 60 * 60 * 1000;
 
-    expect(firstRuntime.stop).toHaveBeenCalledTimes(1);
-    expect(firstRuntime.isEnabled()).toBe(false);
-    expect(store.getInstance("instance-a")).toMatchObject({
-      desiredMessagingEnabled: true,
-      effectiveMessagingEnabled: false,
-      disabledReason: "lease_held",
+    expect(runtime.stop).not.toHaveBeenCalled();
+    expect(coordinator.snapshot()).toMatchObject({
+      leaseHeld: true,
+      effectiveMessagingEnabled: true,
     });
     expect(store.getMessagingLease()).toMatchObject({
-      ownerInstanceId: "instance-b",
+      ownerInstanceId: "instance-a",
+      heartbeatAt: 1_000,
       status: "active",
     });
-    second.shutdownSync();
+    coordinator.shutdownSync();
   });
 
   it("releases the lease when runtime startup fails", async () => {
     const runtime = createRuntime({ failApply: true });
-    const coordinator = new RuntimeMessagingLeaseCoordinator({
+    const coordinator = createCoordinator({
       instanceId: "instance-a",
       profileName: "dev",
       processId: 123,
@@ -411,7 +413,7 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
 
   it("releases the lease when the session disables messaging", async () => {
     const runtime = createRuntime();
-    const coordinator = new RuntimeMessagingLeaseCoordinator({
+    const coordinator = createCoordinator({
       instanceId: "instance-a",
       profileName: "dev",
       processId: 123,

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -5,7 +5,10 @@ import type { AgentEvent } from "@pwragent/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
 import { RuntimeLeaseManager } from "../runtime-lease-manager";
-import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
+import {
+  AppRuntimeInstanceStore,
+  RUNTIME_LEASE_DEAD_OWNER_GRACE_MS,
+} from "../state/app-runtime-instance-store";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import {
   measureSqliteWrites,
@@ -265,6 +268,7 @@ describe("sqlite write metrics", () => {
   });
 
   it("holds dead-process takeover of both runtime leases to its budget", async () => {
+    let now = 1_800_000_001_000;
     const instances = new AppRuntimeInstanceStore(stateDb);
     const owner = new RuntimeLeaseManager({
       cwd: "/tmp/PwrAgnt-a",
@@ -280,7 +284,7 @@ describe("sqlite write metrics", () => {
     const challenger = new RuntimeLeaseManager({
       cwd: "/tmp/PwrAgnt-b",
       instanceId: "instance-b",
-      now: () => 1_800_000_001_000,
+      now: () => now,
       processId: 5678,
       processIsAlive: () => false,
       profileName: "default",
@@ -290,10 +294,13 @@ describe("sqlite write metrics", () => {
     const { writes } = await measureSqliteWrites(() => {
       challenger.acquire("messaging");
       challenger.acquire("federation");
+      now += RUNTIME_LEASE_DEAD_OWNER_GRACE_MS;
+      challenger.acquire("messaging");
+      challenger.acquire("federation");
     });
 
     expectSqliteWriteBudget({
-      note: "register challenger and replace a dead owner for both runtime leases",
+      note: "observe one dead owner, wait one minute, replace both runtime leases",
       scenario: "runtime-lease-dead-owner-takeover",
       writes,
     });

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { AgentEvent } from "@pwragent/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
+import { RuntimeLeaseManager } from "../runtime-lease-manager";
 import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import {
@@ -209,40 +210,91 @@ describe("sqlite write metrics", () => {
     await registry.close();
   });
 
-  it("holds an idle hour of heartbeats to its budget", async () => {
-    // The floor the app pays for existing: the profile-runtime heartbeat and
-    // the federation lease renewal both tick every 10s against a 45s TTL, each
-    // taking its own commit. Budgeted so a third ticker, or a shortened
-    // interval, has to be a deliberate line in a diff.
+  it("holds messaging and federation for an idle hour without sqlite writes", async () => {
     const instances = new AppRuntimeInstanceStore(stateDb);
-    instances.recordInstanceStart({
+    const leases = new RuntimeLeaseManager({
+      cwd: "/tmp/PwrAgnt",
       instanceId: "instance-1",
+      now: () => 1_800_000_000_000,
       profileName: "default",
       processId: 1234,
-      startedAt: 1_800_000_000_000,
-      desiredMessagingEnabled: false,
+      processIsAlive: () => true,
+      store: instances,
     });
-    instances.acquireFederationLease({
-      instanceId: "instance-1",
-      now: 1_800_000_000_000,
-      ttlMs: 45_000,
-    });
+    leases.acquire("messaging");
+    leases.acquire("federation");
 
     const { writes } = await measureSqliteWrites(() => {
       for (let tick = 0; tick < 360; tick += 1) {
-        const now = 1_800_000_000_000 + tick * 10_000;
-        instances.heartbeatInstance({ instanceId: "instance-1", now });
-        instances.renewFederationLease({
-          instanceId: "instance-1",
-          now,
-          ttlMs: 45_000,
-        });
+        leases.snapshot("messaging");
+        leases.snapshot("federation");
       }
     });
 
     expectSqliteWriteBudget({
-      note: "one idle hour: 360 profile heartbeats + 360 federation lease renewals",
-      scenario: "idle-hour-heartbeats",
+      note: "one idle hour: PID-owned messaging and federation leases",
+      scenario: "idle-hour-runtime-leases",
+      writes,
+    });
+  });
+
+  it("holds runtime lease acquisition and release to its budget", async () => {
+    const leases = new RuntimeLeaseManager({
+      cwd: "/tmp/PwrAgnt",
+      instanceId: "instance-1",
+      now: () => 1_800_000_000_000,
+      processId: 1234,
+      processIsAlive: () => true,
+      profileName: "default",
+      store: new AppRuntimeInstanceStore(stateDb),
+    });
+
+    const { writes } = await measureSqliteWrites(() => {
+      leases.acquire("messaging");
+      leases.acquire("federation");
+      leases.release("federation");
+      leases.release("messaging");
+      leases.markExited();
+    });
+
+    expectSqliteWriteBudget({
+      note: "register once, acquire and release both runtime leases, mark exited",
+      scenario: "runtime-lease-lifecycle",
+      writes,
+    });
+  });
+
+  it("holds dead-process takeover of both runtime leases to its budget", async () => {
+    const instances = new AppRuntimeInstanceStore(stateDb);
+    const owner = new RuntimeLeaseManager({
+      cwd: "/tmp/PwrAgnt-a",
+      instanceId: "instance-a",
+      now: () => 1_800_000_000_000,
+      processId: 1234,
+      processIsAlive: () => true,
+      profileName: "default",
+      store: instances,
+    });
+    owner.acquire("messaging");
+    owner.acquire("federation");
+    const challenger = new RuntimeLeaseManager({
+      cwd: "/tmp/PwrAgnt-b",
+      instanceId: "instance-b",
+      now: () => 1_800_000_001_000,
+      processId: 5678,
+      processIsAlive: () => false,
+      profileName: "default",
+      store: instances,
+    });
+
+    const { writes } = await measureSqliteWrites(() => {
+      challenger.acquire("messaging");
+      challenger.acquire("federation");
+    });
+
+    expectSqliteWriteBudget({
+      note: "register challenger and replace a dead owner for both runtime leases",
+      scenario: "runtime-lease-dead-owner-takeover",
       writes,
     });
   });

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -1735,8 +1735,8 @@ export class DesktopFederationRuntime {
         await this.startAfterLeaseAcquired(mode, settings);
       } catch (error) {
         // A startup failure after acquisition (e.g. unreadable federation
-        // key material) must not keep renewing the profile lease with no
-        // runtime behind it: release so another instance can take over,
+        // key material) must not keep the profile lease with no runtime
+        // behind it: release so another instance can take over,
         // mirroring the messaging lease's startup-failure cleanup.
         await leaseCoordinator.releaseAfterStartupFailure(this);
         throw error;
@@ -1754,10 +1754,9 @@ export class DesktopFederationRuntime {
     settings: DesktopSettingsSnapshot,
   ): Promise<void> {
     this.stopping = false;
-    // Startup fence: losing the profile lease mid-startup makes the
-    // heartbeat stop this runtime, which flips `stopping` and bumps
-    // `walkEpoch`. A stale startup continuation must not create or publish
-    // sockets afterwards (the same guard connectToGateway uses per attempt).
+    // Startup fence: a concurrent stop flips `stopping` and bumps `walkEpoch`.
+    // A stale startup continuation must not create or publish sockets
+    // afterwards (the same guard connectToGateway uses per attempt).
     const startupEpoch = this.walkEpoch;
     const startupAborted = (): boolean =>
       this.stopping || this.walkEpoch !== startupEpoch;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -136,6 +136,7 @@ import {
   getExistingRuntimeMessagingLeaseCoordinator,
   getRuntimeMessagingLeaseCoordinator,
 } from "./runtime-messaging-lease";
+import { getExistingRuntimeLeaseManager } from "./runtime-lease-manager";
 import {
   getExistingRuntimeFederationLeaseCoordinator,
   getRuntimeFederationLeaseCoordinator,
@@ -460,10 +461,14 @@ function disposeMainProcessResourcesSync(options?: {
   // ahead of the mainProcessResourcesDisposed early-return so the
   // will-quit/process-exit fallback still fires when the barrier's
   // federation phase rejected or timed out before its own release.
-  if (options?.releaseFederationLease ?? true) {
+  const releaseFederationLease = options?.releaseFederationLease ?? true;
+  if (releaseFederationLease) {
     releaseFederationLeaseSync();
   }
   if (mainProcessResourcesDisposed) {
+    if (releaseFederationLease) {
+      getExistingRuntimeLeaseManager()?.markExited();
+    }
     return;
   }
   mainProcessResourcesDisposed = true;
@@ -506,6 +511,9 @@ function disposeMainProcessResourcesSync(options?: {
     getExistingRuntimeMessagingLeaseCoordinator() ??
     (isAppStateInitialized() ? getRuntimeMessagingLeaseCoordinator() : null);
   runtimeMessagingLeaseCoordinator?.shutdownSync();
+  if (releaseFederationLease) {
+    getExistingRuntimeLeaseManager()?.markExited();
+  }
 }
 
 async function closeRendererWindowsBeforeResourceShutdown(
@@ -647,6 +655,7 @@ async function disposeMainProcessResources(source: string): Promise<void> {
     // A queued registry entry can otherwise start after its durable lease was
     // released, leaving the next process free to dispatch the same action.
     disposeScheduledThreadActionService();
+    getExistingRuntimeLeaseManager()?.markExited();
     disposeAppState();
     mainProcessShutdownComplete = true;
   })();

--- a/apps/desktop/src/main/profile.ts
+++ b/apps/desktop/src/main/profile.ts
@@ -28,6 +28,7 @@ export const PWRAGENT_PROFILE_AUTO_CREATE_ENV = "PWRAGENT_PROFILE_AUTO_CREATE";
 
 const PROFILE_RUNTIME_HEARTBEAT_INTERVAL_MS = 10_000;
 const PROFILE_RUNTIME_HEARTBEAT_TTL_MS = 45_000;
+const PROFILE_RUNTIME_IDENTITY_PREFIX = "runtime-v2-";
 
 /**
  * Disk location for the throwaway "bootstrap" profile the wizard
@@ -83,7 +84,23 @@ export type ProfileRuntimeMarker = {
   heartbeatAt: number;
 };
 
+export type ProfileRuntimeIdentity = Pick<
+  ProfileRuntimeMarker,
+  "instanceId" | "processId" | "startedAt"
+>;
+
 let cachedProcessActiveProfileName: string | undefined;
+let processRuntimeIdentity: Omit<ProfileRuntimeIdentity, "processId"> | undefined;
+
+export function getProcessRuntimeIdentity(): Omit<ProfileRuntimeIdentity, "processId"> {
+  if (!processRuntimeIdentity) {
+    processRuntimeIdentity = {
+      instanceId: `${PROFILE_RUNTIME_IDENTITY_PREFIX}${randomUUID()}`,
+      startedAt: Date.now(),
+    };
+  }
+  return processRuntimeIdentity;
+}
 
 export function isValidProfileName(name: string): boolean {
   return isCanonicalProfileName(name);
@@ -620,6 +637,7 @@ export function startProfileRuntimeHeartbeat(
     intervalMs?: number;
     now?: () => number;
     processId?: number;
+    startedAt?: number;
   },
 ): ProfileRuntimeHeartbeat {
   const normalizedProfileName = normalizeProfileName(profileName);
@@ -632,7 +650,7 @@ export function startProfileRuntimeHeartbeat(
     instanceId: options?.instanceId ?? randomUUID(),
     processId,
     profileName: normalizedProfileName,
-    startedAt: now(),
+    startedAt: options?.startedAt ?? now(),
     heartbeatAt: now(),
   };
   const markerDir = resolveProfileRuntimeMarkerDir(normalizedProfileName, options);
@@ -710,6 +728,27 @@ export function findLiveProfileRuntimeMarkers(
     markers.push(marker);
   }
   return markers;
+}
+
+export function isProfileRuntimeIdentityLive(
+  profileName: string,
+  identity: ProfileRuntimeIdentity,
+  options?: { env?: NodeJS.ProcessEnv; homeDir?: string; now?: number },
+): boolean {
+  const markers = findLiveProfileRuntimeMarkers(profileName, options);
+  if (!identity.instanceId.startsWith(PROFILE_RUNTIME_IDENTITY_PREFIX)) {
+    // Runtime rows written before identity-aware leases used an unrelated
+    // random ID for the profile marker. A fresh PwrAgent marker at the same
+    // PID remains a bounded compatibility signal: after a crash it expires
+    // even if the OS has already reassigned that PID to another process.
+    return markers.some((marker) => marker.processId === identity.processId);
+  }
+  return markers.some(
+    (marker) =>
+      marker.instanceId === identity.instanceId
+      && marker.processId === identity.processId
+      && marker.startedAt === identity.startedAt,
+  );
 }
 
 export function requestProfileInstanceFocus(

--- a/apps/desktop/src/main/profile.ts
+++ b/apps/desktop/src/main/profile.ts
@@ -918,7 +918,7 @@ function writeJsonAtomic(filePath: string, value: unknown): void {
   fs.renameSync(tmpPath, filePath);
 }
 
-function isProcessAlive(processId: number): boolean {
+export function isProcessAlive(processId: number): boolean {
   if (!Number.isInteger(processId) || processId <= 0) {
     return false;
   }

--- a/apps/desktop/src/main/runtime-federation-lease.ts
+++ b/apps/desktop/src/main/runtime-federation-lease.ts
@@ -1,11 +1,10 @@
 import type { DesktopFederationMode } from "@pwragent/shared";
-import { getAppRuntimeInstanceStore } from "./state/app-state";
-import type {
-  AppRuntimeInstanceStore,
-  FederationRuntimeLeaseRecord,
-} from "./state/app-runtime-instance-store";
-import { getRuntimeMessagingLeaseCoordinator } from "./runtime-messaging-lease";
 import { getMainLogger } from "./log";
+import {
+  getRuntimeLeaseManager,
+  RuntimeLeaseManager,
+  type RuntimeLeaseManagerOptions,
+} from "./runtime-lease-manager";
 
 /**
  * The slice of DesktopFederationRuntime the coordinator drives. Structural
@@ -15,9 +14,6 @@ import { getMainLogger } from "./log";
 export type FederationLeaseRuntime = {
   stop(): Promise<void>;
 };
-
-export const FEDERATION_LEASE_TTL_MS = 30_000;
-export const FEDERATION_LEASE_HEARTBEAT_MS = 10_000;
 
 const leaseLog = getMainLogger("pwragent:federation-lease");
 
@@ -32,7 +28,6 @@ export type RuntimeFederationLeaseHolder = {
   processId?: number;
   cwdHint?: string;
   startedAt?: number;
-  expiresAt: number;
 };
 
 export type RuntimeFederationLeaseSnapshot = {
@@ -50,10 +45,8 @@ export type RuntimeFederationLeaseApplyResult = {
   leaseHolder?: RuntimeFederationLeaseHolder;
 };
 
-type RuntimeFederationLeaseCoordinatorOptions = {
-  instanceId?: string;
-  now?: () => number;
-  store?: AppRuntimeInstanceStore;
+type RuntimeFederationLeaseCoordinatorOptions = RuntimeLeaseManagerOptions & {
+  leaseManager?: RuntimeLeaseManager;
 };
 
 /**
@@ -64,25 +57,19 @@ type RuntimeFederationLeaseCoordinatorOptions = {
  * them run federation for the profile at a time.
  */
 export class RuntimeFederationLeaseCoordinator {
-  private readonly instanceId: string;
-  private readonly now: () => number;
-  private readonly store: AppRuntimeInstanceStore;
-  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
-  private leaseHeld = false;
+  private readonly leaseManager: RuntimeLeaseManager;
   private disabledReasonKind: RuntimeFederationDisabledReasonKind | undefined;
 
   constructor(options: RuntimeFederationLeaseCoordinatorOptions = {}) {
-    // Share the messaging lease's owner identity so one app process owns one
-    // app_runtime_instances row and lease-holder lookups resolve to that
-    // row's pid/cwd hint regardless of which lease is being described.
-    this.instanceId =
-      options.instanceId ?? getRuntimeMessagingLeaseCoordinator().id;
-    this.now = options.now ?? Date.now;
-    this.store = options.store ?? getAppRuntimeInstanceStore();
+    this.leaseManager =
+      options.leaseManager
+      ?? (hasCustomLeaseManagerOptions(options)
+        ? new RuntimeLeaseManager(options)
+        : getRuntimeLeaseManager());
   }
 
   get id(): string {
-    return this.instanceId;
+    return this.leaseManager.id;
   }
 
   /**
@@ -94,16 +81,11 @@ export class RuntimeFederationLeaseCoordinator {
    * adapter gate: the federation mode is the whole ladder.
    */
   async applyMode(
-    runtime: FederationLeaseRuntime,
+    _runtime: FederationLeaseRuntime,
     mode: DesktopFederationMode,
   ): Promise<RuntimeFederationLeaseApplyResult> {
-    const now = this.now();
     if (mode === "disabled") {
-      this.stopHeartbeat();
-      if (this.leaseHeld) {
-        this.store.releaseFederationLease({ instanceId: this.instanceId, now });
-      }
-      this.leaseHeld = false;
+      this.leaseManager.release("federation");
       this.disabledReasonKind = "saved_disabled";
       return {
         enabled: false,
@@ -112,42 +94,30 @@ export class RuntimeFederationLeaseCoordinator {
       };
     }
 
-    const acquire = this.store.acquireFederationLease({
-      instanceId: this.instanceId,
-      now,
-      ttlMs: FEDERATION_LEASE_TTL_MS,
-    });
+    const acquire = this.leaseManager.acquire("federation");
     if (!acquire.acquired) {
-      this.stopHeartbeat();
-      this.leaseHeld = false;
       this.disabledReasonKind = "lease_held";
-      const leaseHolder = this.describeLeaseHolder(acquire.holder);
       return {
         enabled: false,
         disabledReasonKind: "lease_held",
         disabledReason:
           "Federation is already active in another PwrAgent instance for this profile.",
-        ...(leaseHolder ? { leaseHolder } : {}),
+        leaseHolder: acquire.holder,
       };
     }
 
-    this.leaseHeld = true;
     this.disabledReasonKind = undefined;
-    this.startHeartbeat(runtime);
     return { enabled: true };
   }
 
   /**
    * Post-acquisition startup failure cleanup, mirroring the messaging
-   * coordinator: stop the heartbeat, tear down any partially started
-   * runtime, and release the lease so another instance can take over the
-   * profile instead of this process renewing it with no runtime behind it.
+   * coordinator: tear down any partially started runtime and release the
+   * lease so another instance can take over the profile.
    */
   async releaseAfterStartupFailure(
     runtime: FederationLeaseRuntime,
   ): Promise<void> {
-    const now = this.now();
-    this.stopHeartbeat();
     try {
       await runtime.stop();
     } catch (error) {
@@ -155,35 +125,20 @@ export class RuntimeFederationLeaseCoordinator {
         error: error instanceof Error ? error.message : String(error),
       });
     } finally {
-      if (this.leaseHeld) {
-        this.store.releaseFederationLease({ instanceId: this.instanceId, now });
-      }
-      this.leaseHeld = false;
+      this.leaseManager.release("federation");
       this.disabledReasonKind = "startup_error";
     }
   }
 
   shutdownSync(): void {
-    const now = this.now();
-    this.stopHeartbeat();
-    if (this.leaseHeld) {
-      this.store.releaseFederationLease({ instanceId: this.instanceId, now });
-    }
-    this.leaseHeld = false;
+    this.leaseManager.release("federation");
   }
 
   snapshot(): RuntimeFederationLeaseSnapshot {
-    const lease = this.store.getFederationLease();
-    const leaseHolder =
-      lease
-      && lease.status === "active"
-      && lease.ownerInstanceId !== this.instanceId
-      && lease.expiresAt > this.now()
-        ? this.describeLeaseHolder(lease)
-        : undefined;
+    const lease = this.leaseManager.snapshot("federation");
     return {
-      instanceId: this.instanceId,
-      leaseHeld: this.leaseHeld,
+      instanceId: lease.instanceId,
+      leaseHeld: lease.leaseHeld,
       ...(this.disabledReasonKind
         ? {
             disabledReasonKind: this.disabledReasonKind,
@@ -192,77 +147,23 @@ export class RuntimeFederationLeaseCoordinator {
             ),
           }
         : {}),
-      ...(leaseHolder ? { leaseHolder } : {}),
+      ...(lease.leaseHolder ? { leaseHolder: lease.leaseHolder } : {}),
     };
   }
+}
 
-  private startHeartbeat(runtime: FederationLeaseRuntime): void {
-    if (this.heartbeatTimer) return;
-    this.heartbeatTimer = setInterval(() => {
-      // Heartbeat must never throw out of the timer callback. A closed
-      // state DB during process/test teardown would otherwise surface as an
-      // unhandled exception after every assertion already passed.
-      let renewed = false;
-      try {
-        renewed = this.store.renewFederationLease({
-          instanceId: this.instanceId,
-          now: this.now(),
-          ttlMs: FEDERATION_LEASE_TTL_MS,
-        });
-      } catch (error) {
-        leaseLog.warn("federation lease heartbeat failed", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-      if (!renewed) {
-        void this.stopRuntimeAfterLeaseLoss(runtime).catch((error) => {
-          leaseLog.error("federation runtime stop failed after lease loss", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        });
-      }
-    }, FEDERATION_LEASE_HEARTBEAT_MS);
-    if (this.heartbeatTimer.unref) this.heartbeatTimer.unref();
-  }
-
-  private async stopRuntimeAfterLeaseLoss(
-    runtime: FederationLeaseRuntime,
-  ): Promise<void> {
-    const now = this.now();
-    this.stopHeartbeat();
-    this.leaseHeld = false;
-    try {
-      await runtime.stop();
-    } finally {
-      const lease = this.store.getFederationLease();
-      this.disabledReasonKind =
-        lease
-        && lease.status === "active"
-        && lease.ownerInstanceId !== this.instanceId
-        && lease.expiresAt > now
-          ? "lease_held"
-          : "runtime_stopped";
-    }
-  }
-
-  private stopHeartbeat(): void {
-    if (!this.heartbeatTimer) return;
-    clearInterval(this.heartbeatTimer);
-    this.heartbeatTimer = null;
-  }
-
-  private describeLeaseHolder(
-    lease: FederationRuntimeLeaseRecord,
-  ): RuntimeFederationLeaseHolder {
-    const holder = this.store.getInstance(lease.ownerInstanceId);
-    return {
-      instanceId: lease.ownerInstanceId,
-      ...(holder?.processId ? { processId: holder.processId } : {}),
-      ...(holder?.cwdHint ? { cwdHint: holder.cwdHint } : {}),
-      ...(holder?.startedAt ? { startedAt: holder.startedAt } : {}),
-      expiresAt: lease.expiresAt,
-    };
-  }
+function hasCustomLeaseManagerOptions(
+  options: RuntimeFederationLeaseCoordinatorOptions,
+): boolean {
+  return Boolean(
+    options.instanceId
+    || options.profileName
+    || options.processId
+    || options.cwd
+    || options.now
+    || options.store
+    || options.processIsAlive,
+  );
 }
 
 let coordinator: RuntimeFederationLeaseCoordinator | null = null;

--- a/apps/desktop/src/main/runtime-federation-lease.ts
+++ b/apps/desktop/src/main/runtime-federation-lease.ts
@@ -210,11 +210,9 @@ export class RuntimeFederationLeaseCoordinator {
           ttlMs: FEDERATION_LEASE_TTL_MS,
         });
       } catch (error) {
-        this.stopHeartbeat();
         leaseLog.warn("federation lease heartbeat failed", {
           error: error instanceof Error ? error.message : String(error),
         });
-        return;
       }
       if (!renewed) {
         void this.stopRuntimeAfterLeaseLoss(runtime).catch((error) => {

--- a/apps/desktop/src/main/runtime-federation-lease.ts
+++ b/apps/desktop/src/main/runtime-federation-lease.ts
@@ -159,10 +159,12 @@ function hasCustomLeaseManagerOptions(
     options.instanceId
     || options.profileName
     || options.processId
+    || options.startedAt
     || options.cwd
     || options.now
     || options.store
-    || options.processIsAlive,
+    || options.processIsAlive
+    || options.runtimeIdentityIsAlive,
   );
 }
 

--- a/apps/desktop/src/main/runtime-federation-lease.ts
+++ b/apps/desktop/src/main/runtime-federation-lease.ts
@@ -199,11 +199,23 @@ export class RuntimeFederationLeaseCoordinator {
   private startHeartbeat(runtime: FederationLeaseRuntime): void {
     if (this.heartbeatTimer) return;
     this.heartbeatTimer = setInterval(() => {
-      const renewed = this.store.renewFederationLease({
-        instanceId: this.instanceId,
-        now: this.now(),
-        ttlMs: FEDERATION_LEASE_TTL_MS,
-      });
+      // Heartbeat must never throw out of the timer callback. A closed
+      // state DB during process/test teardown would otherwise surface as an
+      // unhandled exception after every assertion already passed.
+      let renewed = false;
+      try {
+        renewed = this.store.renewFederationLease({
+          instanceId: this.instanceId,
+          now: this.now(),
+          ttlMs: FEDERATION_LEASE_TTL_MS,
+        });
+      } catch (error) {
+        this.stopHeartbeat();
+        leaseLog.warn("federation lease heartbeat failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return;
+      }
       if (!renewed) {
         void this.stopRuntimeAfterLeaseLoss(runtime).catch((error) => {
           leaseLog.error("federation runtime stop failed after lease loss", {

--- a/apps/desktop/src/main/runtime-lease-manager.ts
+++ b/apps/desktop/src/main/runtime-lease-manager.ts
@@ -1,0 +1,245 @@
+import { randomUUID } from "node:crypto";
+import {
+  isProcessAlive,
+  resolveActiveProfileName,
+} from "./profile";
+import { getAppRuntimeInstanceStore } from "./state/app-state";
+import type {
+  AppRuntimeInstanceRecord,
+  AppRuntimeInstanceStore,
+  AppRuntimeMessagingDisabledReason,
+  MessagingRuntimeLeaseRecord,
+} from "./state/app-runtime-instance-store";
+
+export const PWRAGENT_INSTANCE_ROOT_ENV = "PWRAGENT_INSTANCE_ROOT";
+
+export type RuntimeLeaseKind = "messaging" | "federation";
+
+export type RuntimeLeaseHolder = {
+  instanceId: string;
+  processId?: number;
+  cwdHint?: string;
+  startedAt?: number;
+};
+
+export type RuntimeLeaseAcquireResult =
+  | { acquired: true }
+  | { acquired: false; holder: RuntimeLeaseHolder };
+
+export type RuntimeLeaseSnapshot = {
+  instanceId: string;
+  leaseHeld: boolean;
+  leaseHolder?: RuntimeLeaseHolder;
+};
+
+export type RuntimeLeaseManagerOptions = {
+  instanceId?: string;
+  profileName?: string;
+  processId?: number;
+  cwd?: string;
+  now?: () => number;
+  store?: AppRuntimeInstanceStore;
+  env?: NodeJS.ProcessEnv;
+  processIsAlive?: (processId: number) => boolean;
+};
+
+/**
+ * One process-level owner for every profile-scoped runtime lease.
+ *
+ * Ownership is registered once in sqlite and remains valid while the owning
+ * PID exists. A challenger may replace a dead owner inside the store's atomic
+ * acquisition transaction. This deliberately favors single-owner safety over
+ * taking work away from a process that is alive but temporarily hung.
+ */
+export class RuntimeLeaseManager {
+  private readonly instanceId: string;
+  private readonly profileName: string;
+  private readonly processId: number;
+  private readonly cwd: string;
+  private readonly now: () => number;
+  private readonly store: AppRuntimeInstanceStore;
+  private readonly processIsAlive: (processId: number) => boolean;
+  private readonly heldLeases = new Set<RuntimeLeaseKind>();
+  private instanceRecorded = false;
+  private instanceExited = false;
+
+  constructor(options: RuntimeLeaseManagerOptions = {}) {
+    this.instanceId = options.instanceId ?? randomUUID();
+    this.profileName = options.profileName ?? resolveActiveProfileName();
+    this.processId = options.processId ?? process.pid;
+    this.cwd =
+      options.cwd
+      ?? options.env?.[PWRAGENT_INSTANCE_ROOT_ENV]
+      ?? process.env[PWRAGENT_INSTANCE_ROOT_ENV]
+      ?? process.cwd();
+    this.now = options.now ?? Date.now;
+    this.store = options.store ?? getAppRuntimeInstanceStore();
+    this.processIsAlive = options.processIsAlive ?? isProcessAlive;
+  }
+
+  get id(): string {
+    return this.instanceId;
+  }
+
+  recordMessagingState(params: {
+    desiredMessagingEnabled: boolean;
+    effectiveMessagingEnabled: boolean;
+    disabledReason?: AppRuntimeMessagingDisabledReason;
+  }): void {
+    const now = this.now();
+    if (!this.instanceRecorded) {
+      this.store.recordInstanceStart({
+        instanceId: this.instanceId,
+        profileName: this.profileName,
+        processId: this.processId,
+        cwd: this.cwd,
+        startedAt: now,
+        desiredMessagingEnabled: params.desiredMessagingEnabled,
+        effectiveMessagingEnabled: params.effectiveMessagingEnabled,
+        disabledReason: params.disabledReason,
+      });
+      this.instanceRecorded = true;
+      return;
+    }
+    this.store.markDesiredMessaging({
+      instanceId: this.instanceId,
+      desiredMessagingEnabled: params.desiredMessagingEnabled,
+      effectiveMessagingEnabled: params.effectiveMessagingEnabled,
+      disabledReason: params.disabledReason,
+      now,
+    });
+  }
+
+  acquire(kind: RuntimeLeaseKind): RuntimeLeaseAcquireResult {
+    this.ensureInstanceRecorded();
+    const params = {
+      instanceId: this.instanceId,
+      isOwnerAlive: (owner: AppRuntimeInstanceRecord) =>
+        this.isOwnerAlive(owner),
+      now: this.now(),
+    };
+    const result =
+      kind === "messaging"
+        ? this.store.acquireMessagingLease(params)
+        : this.store.acquireFederationLease(params);
+    if (result.acquired) {
+      this.heldLeases.add(kind);
+      return { acquired: true };
+    }
+    this.heldLeases.delete(kind);
+    return {
+      acquired: false,
+      holder: this.describeLeaseHolder(result.holder),
+    };
+  }
+
+  release(kind: RuntimeLeaseKind): boolean {
+    const now = this.now();
+    const released =
+      kind === "messaging"
+        ? this.store.releaseMessagingLease({
+            instanceId: this.instanceId,
+            now,
+          })
+        : this.store.releaseFederationLease({
+            instanceId: this.instanceId,
+            now,
+          });
+    this.heldLeases.delete(kind);
+    return released;
+  }
+
+  snapshot(kind: RuntimeLeaseKind): RuntimeLeaseSnapshot {
+    const lease = this.readLease(kind);
+    const leaseHeld =
+      lease?.status === "active"
+      && lease.ownerInstanceId === this.instanceId
+      && this.heldLeases.has(kind);
+    if (!leaseHeld) {
+      this.heldLeases.delete(kind);
+    }
+    const leaseHolder =
+      lease
+      && lease.status === "active"
+      && lease.ownerInstanceId !== this.instanceId
+        ? this.describeLeaseHolder(lease)
+        : undefined;
+    return {
+      instanceId: this.instanceId,
+      leaseHeld,
+      ...(leaseHolder ? { leaseHolder } : {}),
+    };
+  }
+
+  getInstance(): AppRuntimeInstanceRecord | undefined {
+    return this.store.getInstance(this.instanceId);
+  }
+
+  markExited(): void {
+    if (!this.instanceRecorded || this.instanceExited) {
+      return;
+    }
+    this.instanceExited = true;
+    this.store.markInstanceExited({
+      instanceId: this.instanceId,
+      now: this.now(),
+    });
+  }
+
+  private ensureInstanceRecorded(): void {
+    if (this.instanceRecorded) {
+      return;
+    }
+    this.recordMessagingState({
+      desiredMessagingEnabled: false,
+      effectiveMessagingEnabled: false,
+    });
+  }
+
+  private isOwnerAlive(owner: AppRuntimeInstanceRecord): boolean {
+    if (owner.exitedAt !== undefined) {
+      return false;
+    }
+    if (owner.processId === this.processId) {
+      return owner.instanceId === this.instanceId;
+    }
+    return this.processIsAlive(owner.processId);
+  }
+
+  private readLease(kind: RuntimeLeaseKind): MessagingRuntimeLeaseRecord | undefined {
+    return kind === "messaging"
+      ? this.store.getMessagingLease()
+      : this.store.getFederationLease();
+  }
+
+  private describeLeaseHolder(
+    lease: MessagingRuntimeLeaseRecord,
+  ): RuntimeLeaseHolder {
+    const holder = this.store.getInstance(lease.ownerInstanceId);
+    return {
+      instanceId: lease.ownerInstanceId,
+      ...(holder?.processId ? { processId: holder.processId } : {}),
+      ...(holder?.cwdHint ? { cwdHint: holder.cwdHint } : {}),
+      ...(holder?.startedAt ? { startedAt: holder.startedAt } : {}),
+    };
+  }
+}
+
+let manager: RuntimeLeaseManager | null = null;
+
+export function getRuntimeLeaseManager(): RuntimeLeaseManager {
+  if (!manager) {
+    manager = new RuntimeLeaseManager();
+  }
+  return manager;
+}
+
+export function getExistingRuntimeLeaseManager(): RuntimeLeaseManager | null {
+  return manager;
+}
+
+export function setRuntimeLeaseManagerForTests(
+  next: RuntimeLeaseManager | null,
+): void {
+  manager = next;
+}

--- a/apps/desktop/src/main/runtime-lease-manager.ts
+++ b/apps/desktop/src/main/runtime-lease-manager.ts
@@ -47,9 +47,12 @@ export type RuntimeLeaseManagerOptions = {
  * One process-level owner for every profile-scoped runtime lease.
  *
  * Ownership is registered once in sqlite and remains valid while the owning
- * PID exists. A challenger may replace a dead owner inside the store's atomic
- * acquisition transaction. This deliberately favors single-owner safety over
- * taking work away from a process that is alive but temporarily hung.
+ * PID exists. The first challenger that observes the PID absent persists that
+ * fact; after a one-minute safety grace, a challenger may replace the dead
+ * owner inside the store's atomic acquisition transaction. A recycled PID
+ * cannot revive an owner already observed dead. This deliberately favors
+ * single-owner safety over taking work away from a process that is alive but
+ * temporarily hung.
  */
 export class RuntimeLeaseManager {
   private readonly instanceId: string;

--- a/apps/desktop/src/main/runtime-lease-manager.ts
+++ b/apps/desktop/src/main/runtime-lease-manager.ts
@@ -1,6 +1,6 @@
-import { randomUUID } from "node:crypto";
 import {
-  isProcessAlive,
+  getProcessRuntimeIdentity,
+  isProfileRuntimeIdentityLive,
   resolveActiveProfileName,
 } from "./profile";
 import { getAppRuntimeInstanceStore } from "./state/app-state";
@@ -36,48 +36,69 @@ export type RuntimeLeaseManagerOptions = {
   instanceId?: string;
   profileName?: string;
   processId?: number;
+  startedAt?: number;
   cwd?: string;
   now?: () => number;
   store?: AppRuntimeInstanceStore;
   env?: NodeJS.ProcessEnv;
   processIsAlive?: (processId: number) => boolean;
+  runtimeIdentityIsAlive?: (owner: AppRuntimeInstanceRecord) => boolean;
 };
 
 /**
  * One process-level owner for every profile-scoped runtime lease.
  *
  * Ownership is registered once in sqlite and remains valid while the owning
- * PID exists. The first challenger that observes the PID absent persists that
+ * process has a fresh profile marker matching its PID, instance ID, and start
+ * time. The first challenger that observes the identity absent persists that
  * fact; after a one-minute safety grace, a challenger may replace the dead
- * owner inside the store's atomic acquisition transaction. A recycled PID
- * cannot revive an owner already observed dead. This deliberately favors
- * single-owner safety over taking work away from a process that is alive but
- * temporarily hung.
+ * owner inside the store's atomic acquisition transaction. This deliberately
+ * favors single-owner safety over taking work away from a process that is
+ * alive but temporarily hung.
  */
 export class RuntimeLeaseManager {
   private readonly instanceId: string;
   private readonly profileName: string;
   private readonly processId: number;
+  private readonly startedAt: number;
   private readonly cwd: string;
   private readonly now: () => number;
   private readonly store: AppRuntimeInstanceStore;
-  private readonly processIsAlive: (processId: number) => boolean;
+  private readonly runtimeIdentityIsAlive: (
+    owner: AppRuntimeInstanceRecord,
+  ) => boolean;
   private readonly heldLeases = new Set<RuntimeLeaseKind>();
   private instanceRecorded = false;
   private instanceExited = false;
 
   constructor(options: RuntimeLeaseManagerOptions = {}) {
-    this.instanceId = options.instanceId ?? randomUUID();
+    this.now = options.now ?? Date.now;
+    const processIdentity = getProcessRuntimeIdentity();
+    this.instanceId = options.instanceId ?? processIdentity.instanceId;
     this.profileName = options.profileName ?? resolveActiveProfileName();
     this.processId = options.processId ?? process.pid;
+    this.startedAt =
+      options.startedAt
+      ?? (options.instanceId ? this.now() : processIdentity.startedAt);
     this.cwd =
       options.cwd
       ?? options.env?.[PWRAGENT_INSTANCE_ROOT_ENV]
       ?? process.env[PWRAGENT_INSTANCE_ROOT_ENV]
       ?? process.cwd();
-    this.now = options.now ?? Date.now;
     this.store = options.store ?? getAppRuntimeInstanceStore();
-    this.processIsAlive = options.processIsAlive ?? isProcessAlive;
+    this.runtimeIdentityIsAlive =
+      options.runtimeIdentityIsAlive
+      ?? (options.processIsAlive
+        ? (owner) => options.processIsAlive!(owner.processId)
+        : (owner) =>
+            isProfileRuntimeIdentityLive(
+              owner.profileName,
+              owner,
+              {
+                env: options.env,
+                now: this.now(),
+              },
+            ));
   }
 
   get id(): string {
@@ -96,7 +117,7 @@ export class RuntimeLeaseManager {
         profileName: this.profileName,
         processId: this.processId,
         cwd: this.cwd,
-        startedAt: now,
+        startedAt: this.startedAt,
         desiredMessagingEnabled: params.desiredMessagingEnabled,
         effectiveMessagingEnabled: params.effectiveMessagingEnabled,
         disabledReason: params.disabledReason,
@@ -206,7 +227,7 @@ export class RuntimeLeaseManager {
     if (owner.processId === this.processId) {
       return owner.instanceId === this.instanceId;
     }
-    return this.processIsAlive(owner.processId);
+    return this.runtimeIdentityIsAlive(owner);
   }
 
   private readLease(kind: RuntimeLeaseKind): MessagingRuntimeLeaseRecord | undefined {

--- a/apps/desktop/src/main/runtime-messaging-lease.ts
+++ b/apps/desktop/src/main/runtime-messaging-lease.ts
@@ -1,12 +1,5 @@
-import { randomUUID } from "node:crypto";
-import {
-  resolveActiveProfileName,
-} from "./profile";
-import { getAppRuntimeInstanceStore } from "./state/app-state";
 import type {
   AppRuntimeMessagingDisabledReason,
-  AppRuntimeInstanceStore,
-  MessagingRuntimeLeaseRecord,
 } from "./state/app-runtime-instance-store";
 import type {
   DesktopMessagingConfig,
@@ -21,10 +14,14 @@ import type {
 } from "./messaging/messaging-runtime";
 import { resolveRuntimeMessagingOverride } from "./runtime-flags";
 import { getMainLogger } from "./log";
+import {
+  getRuntimeLeaseManager,
+  PWRAGENT_INSTANCE_ROOT_ENV,
+  RuntimeLeaseManager,
+  type RuntimeLeaseManagerOptions,
+} from "./runtime-lease-manager";
 
-export const MESSAGING_LEASE_TTL_MS = 30_000;
-export const MESSAGING_LEASE_HEARTBEAT_MS = 10_000;
-export const PWRAGENT_INSTANCE_ROOT_ENV = "PWRAGENT_INSTANCE_ROOT";
+export { PWRAGENT_INSTANCE_ROOT_ENV };
 
 const leaseLog = getMainLogger("pwragent:messaging-lease");
 
@@ -43,7 +40,6 @@ export type RuntimeMessagingLeaseSnapshot = {
     processId?: number;
     cwdHint?: string;
     startedAt?: number;
-    expiresAt: number;
   };
 };
 
@@ -54,47 +50,29 @@ export type RuntimeMessagingLeaseApplyResult = {
   leaseHolder?: RuntimeMessagingLeaseSnapshot["leaseHolder"];
 };
 
-type RuntimeMessagingLeaseCoordinatorOptions = {
-  instanceId?: string;
-  profileName?: string;
-  processId?: number;
-  cwd?: string;
-  now?: () => number;
-  store?: AppRuntimeInstanceStore;
+type RuntimeMessagingLeaseCoordinatorOptions = RuntimeLeaseManagerOptions & {
+  leaseManager?: RuntimeLeaseManager;
   env?: NodeJS.ProcessEnv;
   argv?: readonly string[];
 };
 
 export class RuntimeMessagingLeaseCoordinator {
-  private readonly instanceId: string;
-  private readonly profileName: string;
-  private readonly processId: number;
-  private readonly cwd: string;
-  private readonly now: () => number;
-  private readonly store: AppRuntimeInstanceStore;
+  private readonly leaseManager: RuntimeLeaseManager;
   private readonly env?: NodeJS.ProcessEnv;
   private readonly argv?: readonly string[];
-  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
-  private startedRecorded = false;
-  private leaseHeld = false;
 
   constructor(options: RuntimeMessagingLeaseCoordinatorOptions = {}) {
-    this.instanceId = options.instanceId ?? randomUUID();
-    this.profileName = options.profileName ?? resolveActiveProfileName();
-    this.processId = options.processId ?? process.pid;
-    this.cwd =
-      options.cwd
-      ?? options.env?.[PWRAGENT_INSTANCE_ROOT_ENV]
-      ?? process.env[PWRAGENT_INSTANCE_ROOT_ENV]
-      ?? process.cwd();
-    this.now = options.now ?? Date.now;
-    this.store = options.store ?? getAppRuntimeInstanceStore();
+    this.leaseManager =
+      options.leaseManager
+      ?? (hasCustomLeaseManagerOptions(options)
+        ? new RuntimeLeaseManager(options)
+        : getRuntimeLeaseManager());
     this.env = options.env;
     this.argv = options.argv;
   }
 
   get id(): string {
-    return this.instanceId;
+    return this.leaseManager.id;
   }
 
   async start(
@@ -141,7 +119,6 @@ export class RuntimeMessagingLeaseCoordinator {
     config: DesktopMessagingConfig,
     options: { allowStart?: boolean } = {},
   ): Promise<RuntimeMessagingLeaseApplyResult> {
-    const now = this.now();
     const desiredMessagingEnabled = config.enabled !== false;
     this.recordStart({
       desiredMessagingEnabled,
@@ -150,7 +127,7 @@ export class RuntimeMessagingLeaseCoordinator {
     });
 
     if (config.enabled === false) {
-      await this.stopRuntimeAndRelease(runtime, now, "runtime_stopped");
+      await this.stopRuntimeAndRelease(runtime, "runtime_stopped");
       return {
         enabled: false,
         disabledReasonKind: "saved_disabled",
@@ -159,7 +136,7 @@ export class RuntimeMessagingLeaseCoordinator {
     }
 
     if (!desktopMessagingConfigHasRunnableAdapters(config)) {
-      await this.stopRuntimeAndRelease(runtime, now, "no_runnable_adapters");
+      await this.stopRuntimeAndRelease(runtime, "no_runnable_adapters");
       return {
         enabled: false,
         disabledReasonKind: "no_runnable_adapters",
@@ -167,13 +144,15 @@ export class RuntimeMessagingLeaseCoordinator {
       };
     }
 
-    if (options.allowStart === false && !this.leaseHeld && !runtime.isEnabled()) {
-      this.store.markDesiredMessaging({
-        instanceId: this.instanceId,
+    if (
+      options.allowStart === false
+      && !this.leaseManager.snapshot("messaging").leaseHeld
+      && !runtime.isEnabled()
+    ) {
+      this.leaseManager.recordMessagingState({
         desiredMessagingEnabled: true,
         effectiveMessagingEnabled: false,
         disabledReason: "runtime_stopped",
-        now,
       });
       return {
         enabled: false,
@@ -182,30 +161,21 @@ export class RuntimeMessagingLeaseCoordinator {
       };
     }
 
-    const acquire = this.store.acquireMessagingLease({
-      instanceId: this.instanceId,
-      now,
-      ttlMs: MESSAGING_LEASE_TTL_MS,
-    });
+    const acquire = this.leaseManager.acquire("messaging");
     if (!acquire.acquired) {
-      this.stopHeartbeat();
       await runtime.stop();
-      this.leaseHeld = false;
-      const leaseHolder = this.describeLeaseHolder(acquire.holder);
       return {
         enabled: false,
         disabledReasonKind: "lease_held",
         disabledReason: "Messaging is already active in another PwrAgent instance for this profile.",
-        ...(leaseHolder ? { leaseHolder } : {}),
+        leaseHolder: acquire.holder,
       };
     }
 
-    this.leaseHeld = true;
-    this.startHeartbeat(runtime);
     try {
       await runtime.applyConfig(config, { allowStart: true });
     } catch (error) {
-      await this.releaseAfterStartupFailure(runtime, now);
+      await this.releaseAfterStartupFailure(runtime);
       throw error;
     }
     return { enabled: runtime.isEnabled() };
@@ -214,8 +184,7 @@ export class RuntimeMessagingLeaseCoordinator {
   async disableForSession(
     runtime: DesktopMessagingRuntime,
   ): Promise<RuntimeMessagingLeaseApplyResult> {
-    const now = this.now();
-    await this.stopRuntimeAndRelease(runtime, now, "runtime_stopped");
+    await this.stopRuntimeAndRelease(runtime, "runtime_stopped");
     return {
       enabled: false,
       disabledReasonKind: "runtime_stopped",
@@ -224,40 +193,25 @@ export class RuntimeMessagingLeaseCoordinator {
   }
 
   async shutdown(runtime: DesktopMessagingRuntime): Promise<void> {
-    const now = this.now();
-    await this.stopRuntimeAndRelease(runtime, now, "runtime_stopped");
-    this.store.markInstanceExited({ instanceId: this.instanceId, now });
+    await this.stopRuntimeAndRelease(runtime, "runtime_stopped");
   }
 
   shutdownSync(): void {
-    const now = this.now();
-    this.stopHeartbeat();
-    if (this.leaseHeld) {
-      this.store.releaseMessagingLease({ instanceId: this.instanceId, now });
-    }
-    this.store.markInstanceExited({ instanceId: this.instanceId, now });
-    this.leaseHeld = false;
+    this.leaseManager.release("messaging");
   }
 
   snapshot(): RuntimeMessagingLeaseSnapshot {
-    const instance = this.store.getInstance(this.instanceId);
-    const lease = this.store.getMessagingLease();
-    const leaseHolder =
-      lease
-      && lease.status === "active"
-      && lease.ownerInstanceId !== this.instanceId
-      && lease.expiresAt > this.now()
-        ? this.describeLeaseHolder(lease)
-        : undefined;
+    const instance = this.leaseManager.getInstance();
+    const lease = this.leaseManager.snapshot("messaging");
     return {
-      instanceId: this.instanceId,
+      instanceId: lease.instanceId,
       effectiveMessagingEnabled: instance?.effectiveMessagingEnabled ?? false,
       disabledReasonKind: instance?.disabledReason,
       ...(instance?.disabledReason
         ? { disabledReason: runtimeDisabledReasonMessage(instance.disabledReason) }
         : {}),
-      leaseHeld: this.leaseHeld,
-      ...(leaseHolder ? { leaseHolder } : {}),
+      leaseHeld: lease.leaseHeld,
+      ...(lease.leaseHolder ? { leaseHolder: lease.leaseHolder } : {}),
     };
   }
 
@@ -266,74 +220,25 @@ export class RuntimeMessagingLeaseCoordinator {
     effectiveMessagingEnabled: boolean;
     disabledReason?: AppRuntimeMessagingDisabledReason;
   }): void {
-    const now = this.now();
-    if (this.startedRecorded) {
-      this.store.markDesiredMessaging({
-        instanceId: this.instanceId,
-        desiredMessagingEnabled: params.desiredMessagingEnabled,
-        effectiveMessagingEnabled: params.effectiveMessagingEnabled,
-        disabledReason: params.disabledReason,
-        now,
-      });
-      return;
-    }
-    this.store.recordInstanceStart({
-      instanceId: this.instanceId,
-      profileName: this.profileName,
-      processId: this.processId,
-      cwd: this.cwd,
-      startedAt: now,
-      desiredMessagingEnabled: params.desiredMessagingEnabled,
-      effectiveMessagingEnabled: params.effectiveMessagingEnabled,
-      disabledReason: params.disabledReason,
-    });
-    this.startedRecorded = true;
+    this.leaseManager.recordMessagingState(params);
   }
 
   private async stopRuntimeAndRelease(
     runtime: DesktopMessagingRuntime,
-    now: number,
     disabledReason: AppRuntimeMessagingDisabledReason,
   ): Promise<void> {
-    this.stopHeartbeat();
     await runtime.stop();
-    if (this.leaseHeld) {
-      this.store.releaseMessagingLease({ instanceId: this.instanceId, now });
-    }
-    this.store.markDesiredMessaging({
-      instanceId: this.instanceId,
+    this.leaseManager.release("messaging");
+    this.leaseManager.recordMessagingState({
       desiredMessagingEnabled: disabledReason !== "runtime_stopped",
       effectiveMessagingEnabled: false,
       disabledReason,
-      now,
     });
-    this.leaseHeld = false;
-  }
-
-  private startHeartbeat(runtime: DesktopMessagingRuntime): void {
-    if (this.heartbeatTimer) return;
-    this.heartbeatTimer = setInterval(() => {
-      const renewed = this.store.renewMessagingLease({
-        instanceId: this.instanceId,
-        now: this.now(),
-        ttlMs: MESSAGING_LEASE_TTL_MS,
-      });
-      if (!renewed) {
-        void this.stopRuntimeAfterLeaseLoss(runtime).catch((error) => {
-          leaseLog.error("messaging runtime stop failed after lease loss", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        });
-      }
-    }, MESSAGING_LEASE_HEARTBEAT_MS);
-    if (this.heartbeatTimer.unref) this.heartbeatTimer.unref();
   }
 
   private async releaseAfterStartupFailure(
     runtime: DesktopMessagingRuntime,
-    now: number,
   ): Promise<void> {
-    this.stopHeartbeat();
     try {
       await runtime.stop({ preserveStartupFailures: true });
     } catch (error) {
@@ -341,63 +246,28 @@ export class RuntimeMessagingLeaseCoordinator {
         error: error instanceof Error ? error.message : String(error),
       });
     } finally {
-      if (this.leaseHeld) {
-        this.store.releaseMessagingLease({ instanceId: this.instanceId, now });
-      }
-      this.store.markDesiredMessaging({
-        instanceId: this.instanceId,
+      this.leaseManager.release("messaging");
+      this.leaseManager.recordMessagingState({
         desiredMessagingEnabled: true,
         effectiveMessagingEnabled: false,
         disabledReason: "startup_error",
-        now,
-      });
-      this.leaseHeld = false;
-    }
-  }
-
-  private async stopRuntimeAfterLeaseLoss(
-    runtime: DesktopMessagingRuntime,
-  ): Promise<void> {
-    const now = this.now();
-    this.stopHeartbeat();
-    this.leaseHeld = false;
-    try {
-      await runtime.stop();
-    } finally {
-      const lease = this.store.getMessagingLease();
-      const heldByAnotherInstance =
-        lease
-        && lease.status === "active"
-        && lease.ownerInstanceId !== this.instanceId
-        && lease.expiresAt > now;
-      this.store.markDesiredMessaging({
-        instanceId: this.instanceId,
-        desiredMessagingEnabled: true,
-        effectiveMessagingEnabled: false,
-        disabledReason: heldByAnotherInstance ? "lease_held" : "runtime_stopped",
-        now,
       });
     }
   }
+}
 
-  private stopHeartbeat(): void {
-    if (!this.heartbeatTimer) return;
-    clearInterval(this.heartbeatTimer);
-    this.heartbeatTimer = null;
-  }
-
-  private describeLeaseHolder(
-    lease: MessagingRuntimeLeaseRecord,
-  ): RuntimeMessagingLeaseSnapshot["leaseHolder"] {
-    const holder = this.store.getInstance(lease.ownerInstanceId);
-    return {
-      instanceId: lease.ownerInstanceId,
-      ...(holder?.processId ? { processId: holder.processId } : {}),
-      ...(holder?.cwdHint ? { cwdHint: holder.cwdHint } : {}),
-      ...(holder?.startedAt ? { startedAt: holder.startedAt } : {}),
-      expiresAt: lease.expiresAt,
-    };
-  }
+function hasCustomLeaseManagerOptions(
+  options: RuntimeMessagingLeaseCoordinatorOptions,
+): boolean {
+  return Boolean(
+    options.instanceId
+    || options.profileName
+    || options.processId
+    || options.cwd
+    || options.now
+    || options.store
+    || options.processIsAlive,
+  );
 }
 
 let coordinator: RuntimeMessagingLeaseCoordinator | null = null;

--- a/apps/desktop/src/main/runtime-messaging-lease.ts
+++ b/apps/desktop/src/main/runtime-messaging-lease.ts
@@ -263,10 +263,12 @@ function hasCustomLeaseManagerOptions(
     options.instanceId
     || options.profileName
     || options.processId
+    || options.startedAt
     || options.cwd
     || options.now
     || options.store
-    || options.processIsAlive,
+    || options.processIsAlive
+    || options.runtimeIdentityIsAlive,
   );
 }
 

--- a/apps/desktop/src/main/state/app-runtime-instance-store.ts
+++ b/apps/desktop/src/main/state/app-runtime-instance-store.ts
@@ -5,6 +5,7 @@ import type { StateDb } from "./state-db.js";
 const MESSAGING_LEASE_KEY = "profile-messaging";
 const FEDERATION_LEASE_KEY = "profile-federation";
 const PID_OWNED_LEASE_EXPIRES_AT = Number.MAX_SAFE_INTEGER;
+export const RUNTIME_LEASE_DEAD_OWNER_GRACE_MS = 60_000;
 
 export type AppRuntimeMessagingDisabledReason =
   | "explicit_override"
@@ -234,13 +235,41 @@ export class AppRuntimeInstanceStore {
         && existing.ownerInstanceId !== params.instanceId
       ) {
         const owner = this.getInstance(existing.ownerInstanceId);
-        if (owner && (params.isOwnerAlive?.(owner) ?? true)) {
-          params.onHeld?.();
-          return {
-            acquired: false as const,
-            reason: "held" as const,
-            holder: existing,
-          };
+        if (owner?.exitedAt !== undefined) {
+          const reclaimAt = owner.exitedAt + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS;
+          if (existing.expiresAt !== reclaimAt) {
+            this.setLeaseExpiry({
+              leaseKey: params.leaseKey,
+              ownerInstanceId: existing.ownerInstanceId,
+              expiresAt: reclaimAt,
+            });
+          }
+          if (params.now < reclaimAt) {
+            return this.heldResult(params, this.readLease(params.leaseKey)!);
+          }
+        } else if (owner && (params.isOwnerAlive?.(owner) ?? true)) {
+          return this.heldResult(params, existing);
+        } else if (
+          !owner
+          && existing.expiresAt !== PID_OWNED_LEASE_EXPIRES_AT
+        ) {
+          if (params.now < existing.expiresAt) {
+            return this.heldResult(params, existing);
+          }
+        } else {
+          const reclaimAt = params.now + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS;
+          if (owner) {
+            this.markInstanceExited({
+              instanceId: owner.instanceId,
+              now: params.now,
+            });
+          }
+          this.setLeaseExpiry({
+            leaseKey: params.leaseKey,
+            ownerInstanceId: existing.ownerInstanceId,
+            expiresAt: reclaimAt,
+          });
+          return this.heldResult(params, this.readLease(params.leaseKey)!);
         }
       }
 
@@ -262,9 +291,35 @@ export class AppRuntimeInstanceStore {
       params.onAcquired?.();
       return { acquired: true as const, lease };
     });
-    // Serialize the read/liveness-check/replace decision so two challengers
-    // cannot both observe one dead owner and claim the same lease.
+    // Serialize liveness observation, grace-deadline persistence, and eventual
+    // replacement so challengers cannot disagree about or both claim an owner.
     return acquire.immediate();
+  }
+
+  private heldResult(
+    params: { onHeld?: () => void },
+    holder: MessagingRuntimeLeaseRecord,
+  ): MessagingLeaseAcquireResult {
+    params.onHeld?.();
+    return {
+      acquired: false,
+      reason: "held",
+      holder,
+    };
+  }
+
+  private setLeaseExpiry(params: {
+    leaseKey: string;
+    ownerInstanceId: string;
+    expiresAt: number;
+  }): void {
+    this.stateDb.raw
+      .prepare(
+        `UPDATE messaging_runtime_lease
+         SET expires_at = ?
+         WHERE lease_key = ? AND owner_instance_id = ? AND status = 'active'`,
+      )
+      .run(params.expiresAt, params.leaseKey, params.ownerInstanceId);
   }
 
   private releaseLease(params: {

--- a/apps/desktop/src/main/state/app-runtime-instance-store.ts
+++ b/apps/desktop/src/main/state/app-runtime-instance-store.ts
@@ -4,6 +4,7 @@ import type { StateDb } from "./state-db.js";
 
 const MESSAGING_LEASE_KEY = "profile-messaging";
 const FEDERATION_LEASE_KEY = "profile-federation";
+const PID_OWNED_LEASE_EXPIRES_AT = Number.MAX_SAFE_INTEGER;
 
 export type AppRuntimeMessagingDisabledReason =
   | "explicit_override"
@@ -146,14 +147,6 @@ export class AppRuntimeInstanceStore {
       );
   }
 
-  heartbeatInstance(params: { instanceId: string; now: number }): void {
-    this.stateDb.raw
-      .prepare(
-        "UPDATE app_runtime_instances SET heartbeat_at = ? WHERE instance_id = ?",
-      )
-      .run(params.now, params.instanceId);
-  }
-
   markInstanceExited(params: { instanceId: string; now: number }): void {
     this.stateDb.raw
       .prepare(
@@ -166,8 +159,8 @@ export class AppRuntimeInstanceStore {
 
   acquireMessagingLease(params: {
     instanceId: string;
+    isOwnerAlive?: (owner: AppRuntimeInstanceRecord) => boolean;
     now: number;
-    ttlMs: number;
   }): MessagingLeaseAcquireResult {
     return this.acquireLease({
       leaseKey: MESSAGING_LEASE_KEY,
@@ -192,36 +185,10 @@ export class AppRuntimeInstanceStore {
 
   acquireFederationLease(params: {
     instanceId: string;
+    isOwnerAlive?: (owner: AppRuntimeInstanceRecord) => boolean;
     now: number;
-    ttlMs: number;
   }): FederationLeaseAcquireResult {
     return this.acquireLease({ leaseKey: FEDERATION_LEASE_KEY, ...params });
-  }
-
-  renewMessagingLease(params: {
-    instanceId: string;
-    now: number;
-    ttlMs: number;
-  }): boolean {
-    return this.renewLease({
-      leaseKey: MESSAGING_LEASE_KEY,
-      ...params,
-      onRenewed: () =>
-        this.markDesiredMessaging({
-          instanceId: params.instanceId,
-          desiredMessagingEnabled: true,
-          effectiveMessagingEnabled: true,
-          now: params.now,
-        }),
-    });
-  }
-
-  renewFederationLease(params: {
-    instanceId: string;
-    now: number;
-    ttlMs: number;
-  }): boolean {
-    return this.renewLease({ leaseKey: FEDERATION_LEASE_KEY, ...params });
   }
 
   releaseMessagingLease(params: { instanceId: string; now: number }): boolean {
@@ -254,68 +221,50 @@ export class AppRuntimeInstanceStore {
   private acquireLease(params: {
     leaseKey: string;
     instanceId: string;
+    isOwnerAlive?: (owner: AppRuntimeInstanceRecord) => boolean;
     now: number;
-    ttlMs: number;
     onHeld?: () => void;
     onAcquired?: () => void;
   }): MessagingLeaseAcquireResult {
-    return this.stateDb.raw.transaction(() => {
+    const acquire = this.stateDb.raw.transaction(() => {
       const existing = this.readLease(params.leaseKey);
       if (
         existing
         && existing.status === "active"
         && existing.ownerInstanceId !== params.instanceId
-        && existing.expiresAt > params.now
       ) {
-        params.onHeld?.();
-        return { acquired: false as const, reason: "held" as const, holder: existing };
+        const owner = this.getInstance(existing.ownerInstanceId);
+        if (owner && (params.isOwnerAlive?.(owner) ?? true)) {
+          params.onHeld?.();
+          return {
+            acquired: false as const,
+            reason: "held" as const,
+            holder: existing,
+          };
+        }
       }
 
-      const acquiredAt =
-        existing?.status === "active"
+      if (
+        existing
+        && existing.status === "active"
         && existing.ownerInstanceId === params.instanceId
-        && existing.expiresAt > params.now
-          ? existing.acquiredAt
-          : params.now;
+      ) {
+        params.onAcquired?.();
+        return { acquired: true as const, lease: existing };
+      }
+
       const lease = this.upsertActiveLease({
         leaseKey: params.leaseKey,
         instanceId: params.instanceId,
-        acquiredAt,
+        acquiredAt: params.now,
         now: params.now,
-        ttlMs: params.ttlMs,
       });
       params.onAcquired?.();
       return { acquired: true as const, lease };
-    })();
-  }
-
-  private renewLease(params: {
-    leaseKey: string;
-    instanceId: string;
-    now: number;
-    ttlMs: number;
-    onRenewed?: () => void;
-  }): boolean {
-    return this.stateDb.raw.transaction(() => {
-      const existing = this.readLease(params.leaseKey);
-      if (
-        !existing
-        || existing.status !== "active"
-        || existing.ownerInstanceId !== params.instanceId
-      ) {
-        return false;
-      }
-
-      this.upsertActiveLease({
-        leaseKey: params.leaseKey,
-        instanceId: params.instanceId,
-        acquiredAt: existing.acquiredAt,
-        now: params.now,
-        ttlMs: params.ttlMs,
-      });
-      params.onRenewed?.();
-      return true;
-    })();
+    });
+    // Serialize the read/liveness-check/replace decision so two challengers
+    // cannot both observe one dead owner and claim the same lease.
+    return acquire.immediate();
   }
 
   private releaseLease(params: {
@@ -358,7 +307,6 @@ export class AppRuntimeInstanceStore {
     instanceId: string;
     acquiredAt: number;
     now: number;
-    ttlMs: number;
   }): MessagingRuntimeLeaseRecord {
     this.stateDb.raw
       .prepare(
@@ -379,9 +327,8 @@ export class AppRuntimeInstanceStore {
         params.instanceId,
         params.acquiredAt,
         params.now,
-        params.now + params.ttlMs,
+        PID_OWNED_LEASE_EXPIRES_AT,
       );
-    this.heartbeatInstance({ instanceId: params.instanceId, now: params.now });
     return this.readLease(params.leaseKey)!;
   }
 }

--- a/apps/desktop/src/main/state/app-state.ts
+++ b/apps/desktop/src/main/state/app-state.ts
@@ -1,6 +1,7 @@
 import {
   ensureBootstrapProfileDir,
   ensureProfileExists,
+  getProcessRuntimeIdentity,
   resolveActiveProfilePath,
   resolveBootstrapProfilePath,
   startProfileRuntimeHeartbeat,
@@ -111,7 +112,11 @@ export function initializeAppState(
     stateDb.startGc();
 
     updateLastUsed(profileName);
-    profileRuntimeHeartbeat = startProfileRuntimeHeartbeat(profileName);
+    const processIdentity = getProcessRuntimeIdentity();
+    profileRuntimeHeartbeat = startProfileRuntimeHeartbeat(profileName, {
+      instanceId: processIdentity.instanceId,
+      startedAt: processIdentity.startedAt,
+    });
   }
 
   messagingStore = new SqliteMessagingStore(stateDb);

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -1025,7 +1025,7 @@ export function FederationSettings(props: FederationSettingsProps) {
           ) : null}
           {effectiveHealth.leaseHolder ? (
             <p className="federation-security-note">
-              {`Federation is off here because another PwrAgent instance holds this profile's federation lease${leaseHolderLabel ? ` (${leaseHolderLabel})` : ""}. Close that instance or wait for its lease to expire, then change a federation setting to try again.`}
+              {`Federation is off here because another PwrAgent instance holds this profile's federation lease${leaseHolderLabel ? ` (${leaseHolderLabel})` : ""}. Close that instance, then change a federation setting to try again.`}
             </p>
           ) : null}
           {connectionRemediation ? (

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -203,7 +203,7 @@ export function MessagingSettings(props: {
       : "Messaging disabled for this app instance";
   const runtimeWarningBody =
     runtimeMessaging.disabledReasonKind === "lease_held"
-      ? `Messaging is off here because another PwrAgent instance holds this profile's messaging lease${leaseHolderLabel ? ` (${leaseHolderLabel})` : ""}. Close that instance or wait for its lease to expire, then flip the master toggle to try again.`
+      ? `Messaging is off here because another PwrAgent instance holds this profile's messaging lease${leaseHolderLabel ? ` (${leaseHolderLabel})` : ""}. Close that instance, then flip the master toggle to try again.`
       : "Messaging is off because the app was launched with the no-messaging flag. You can override this for the current session by flipping the master toggle below, but make sure messaging is off in any other PwrAgent instances first. The override applies to this session only; the saved default is unchanged.";
   const configuredRoutePlatforms = configuredMessagingRoutePlatforms(
     props.snapshot,

--- a/docs/state-layout.md
+++ b/docs/state-layout.md
@@ -107,12 +107,15 @@ Multiple desktop instances can share the same profile's `state.db` safely. sqlit
 Messaging adapters and federation are each single-holder per profile. One
 runtime lease manager records the desktop process in `app_runtime_instances`;
 both capabilities ask it to acquire their independent row in
-`messaging_runtime_lease`. A challenger checks whether the recorded owner PID
-still exists inside an immediate sqlite transaction. The first confirmed
-absence is persisted on the runtime instance and gives the lease a one-minute
-reclaim deadline; after that deadline a recycled PID cannot revive the old
-owner. Clean shutdown releases both rows. There is no renewal timer, so an
-alive-but-hung owner is not preempted. These leases coordinate
+`messaging_runtime_lease`. A challenger verifies the recorded owner PID,
+runtime instance ID, and start time against its fresh profile runtime marker
+inside an immediate sqlite transaction. The first confirmed absence is
+persisted on the runtime instance and gives the lease a one-minute reclaim
+deadline; after that deadline a recycled PID cannot revive the old owner.
+Rows from older builds use a bounded same-PID marker check until that marker
+expires. Clean shutdown releases both rows. There is no sqlite renewal timer,
+so an alive-but-hung owner is not preempted while its marker remains fresh.
+These leases coordinate
 local processes that share the same profile database; they are not a
 cross-machine distributed lock for two different profile directories or two
 external deployments using the same credentials or identity.

--- a/docs/state-layout.md
+++ b/docs/state-layout.md
@@ -97,21 +97,23 @@ Single database containing all persistent state. Opened with WAL mode, `synchron
 | `directory_launchpads` | Per-directory launchpad drafts and settings |
 | `threads` | Thread overlay state (seen timestamps, git branch, linked dirs) |
 | `secrets` | `safeStorage`-encrypted secrets (bot tokens, API keys) |
-| `app_runtime_instances` | Per-process startup/heartbeat records for instances using this profile |
-| `messaging_runtime_lease` | Singleton profile lease that allows only one live instance to run messaging adapters |
+| `app_runtime_instances` | Per-process identity and runtime-state records for instances using this profile |
+| `messaging_runtime_lease` | Profile runtime leases, keyed independently for messaging and federation |
 
 ## Multi-Instance Access
 
 Multiple desktop instances can share the same profile's `state.db` safely. sqlite WAL mode serializes writes automatically. No external lockfile is required for normal state access.
 
-Messaging adapters are single-holder per profile. Each desktop process records
-an `app_runtime_instances` heartbeat, and only the process holding the
-`messaging_runtime_lease` starts provider adapters. If the holder exits cleanly,
-it releases the lease during shutdown. If it crashes or is killed, the lease
-expires after missed heartbeats and another instance can acquire it. This lease
-coordinates local processes that share the same profile database; it is not a
+Messaging adapters and federation are each single-holder per profile. One
+runtime lease manager records the desktop process in `app_runtime_instances`;
+both capabilities ask it to acquire their independent row in
+`messaging_runtime_lease`. A challenger checks whether the recorded owner PID
+still exists inside the same immediate sqlite transaction that replaces a dead
+owner. Clean shutdown releases both rows. There is no renewal timer or expiry
+window, so an alive-but-hung owner is not preempted. These leases coordinate
+local processes that share the same profile database; they are not a
 cross-machine distributed lock for two different profile directories or two
-external bot deployments using the same token.
+external deployments using the same credentials or identity.
 
 ## Migration
 

--- a/docs/state-layout.md
+++ b/docs/state-layout.md
@@ -108,9 +108,11 @@ Messaging adapters and federation are each single-holder per profile. One
 runtime lease manager records the desktop process in `app_runtime_instances`;
 both capabilities ask it to acquire their independent row in
 `messaging_runtime_lease`. A challenger checks whether the recorded owner PID
-still exists inside the same immediate sqlite transaction that replaces a dead
-owner. Clean shutdown releases both rows. There is no renewal timer or expiry
-window, so an alive-but-hung owner is not preempted. These leases coordinate
+still exists inside an immediate sqlite transaction. The first confirmed
+absence is persisted on the runtime instance and gives the lease a one-minute
+reclaim deadline; after that deadline a recycled PID cannot revive the old
+owner. Clean shutdown releases both rows. There is no renewal timer, so an
+alive-but-hung owner is not preempted. These leases coordinate
 local processes that share the same profile database; they are not a
 cross-machine distributed lock for two different profile directories or two
 external deployments using the same credentials or identity.

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -385,7 +385,6 @@ export type FederationHealthStatus = {
     processId?: number;
     cwdHint?: string;
     startedAt?: number;
-    expiresAt: number;
   };
   peers: FederationPeerSummary[];
   clientEnrollment?: FederationClientEnrollment;

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -434,7 +434,6 @@ export type SetMessagingEnabledResponse = {
     processId?: number;
     cwdHint?: string;
     startedAt?: number;
-    expiresAt: number;
   };
 };
 

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -600,7 +600,6 @@ export type DesktopSettingsSnapshot = {
         processId?: number;
         cwdHint?: string;
         startedAt?: number;
-        expiresAt: number;
       };
     };
   };


### PR DESCRIPTION
## Summary

- add one process-level runtime lease manager shared by messaging and federation
- replace 10-second SQLite renewal loops with acquisition-time process identity checks
- bind new lease rows to the existing profile runtime marker using PID, runtime instance ID, and start time
- preserve bounded compatibility for older rows through a fresh same-PID PwrAgent marker
- persist the first confirmed dead-owner observation and impose a one-minute reclaim grace
- preserve graceful release ordering and centralize holder identity reporting
- update live state documentation, regression tests, and exact SQLite write budgets

## Why

The heartbeat design created two recurring SQLite transactions every 10 seconds and depended on renewal error handling to prevent dual owners. A renewal exception could stop the timer while leaving federation running, which is the original P1 failure.

A bare PID check also was not sufficient because the OS can recycle a crashed owner PID before any challenger observes it absent. The unrelated process would then appear alive indefinitely. New rows now share the exact identity already written to the profile runtime marker: PID, a versioned runtime instance ID, and process start time. A recycled PID cannot reproduce or refresh that marker identity.

## Behavior and compatibility

Messaging and federation remain independent leases, but both use one registered process identity and one manager. A challenger verifies the owner against the fresh profile runtime marker. When the identity is absent, the same immediate SQLite transaction records `exited_at` and changes `expires_at` to a one-minute reclaim deadline. A subsequent acquisition at or after the deadline replaces the owner.

Rows written by older builds used unrelated random IDs for the database row and marker. They therefore use a bounded same-PID PwrAgent marker check: a live older build remains recognized, while its marker expires after a crash even if an unrelated process has recycled the PID. Historical plan artifacts were not modified.

## SQLite impact

- idle hour holding both leases: 0 commits, down from 720 commits and about 2.7 MB WAL
- full lifecycle for both leases: 6 commits and 8 changed rows
- dead-owner observation plus takeover for both leases: 5 commits and 8 changed rows

The identity fix adds no SQLite statements, and these values remain pinned in the checked-in write budgets.

## Validation

- 83 focused profile, lease-manager, coordinator, store, and SQLite write-budget tests passed after rebase
- `pnpm typecheck`
- `pnpm lint:eslint` (existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`
