### PR TITLE
perf(desktop): coalesce streamed tool-invocation accounting writes

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18217,6 +18217,124 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("flushes buffered command output on the timer, without a lifecycle event", async () => {
+    // A command can stream for minutes before it completes. Nothing else in
+    // this suite exercises the timer — every other case flushes through
+    // `item/completed` or `close()` — so a broken schedule would leave the
+    // whole run green while accounting sat in memory until the command ended.
+    vi.useFakeTimers();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+    });
+    const upsertThreadToolInvocation = vi.fn(
+      async (params: { invocation: unknown }) => params.invocation,
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      upsertThreadToolInvocation,
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: overlayStore as never,
+    });
+
+    try {
+      const emit = (registry as unknown as {
+        emit(event: AgentEvent): Promise<void>;
+      }).emit.bind(registry);
+      const streamChunk = async (delta: string): Promise<void> => {
+        await emit({
+          backend: "codex",
+          notification: {
+            method: "item/commandExecution/outputDelta",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              itemId: "cmd-1",
+              delta,
+            },
+          },
+        } as AgentEvent);
+      };
+
+      await streamChunk("chunk one\n");
+      await streamChunk("chunk two\n");
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(1);
+      expect(upsertThreadToolInvocation.mock.calls[0]?.[0]).toMatchObject({
+        invocation: { itemId: "cmd-1", outputChars: 20, status: "in_progress" },
+      });
+
+      // The next window has to arm again, or a long command only ever records
+      // its first 250ms of output.
+      await streamChunk("chunk three\n");
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(2);
+      expect(upsertThreadToolInvocation.mock.calls[1]?.[0]).toMatchObject({
+        invocation: { itemId: "cmd-1", outputChars: 12 },
+      });
+
+      await registry.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries buffered command output when the accounting write fails", async () => {
+    vi.useFakeTimers();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+    });
+    const upsertThreadToolInvocation = vi.fn(
+      async (params: { invocation: unknown }) => params.invocation,
+    );
+    upsertThreadToolInvocation.mockRejectedValueOnce(new Error("disk full"));
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      upsertThreadToolInvocation,
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: overlayStore as never,
+    });
+
+    try {
+      const emit = (registry as unknown as {
+        emit(event: AgentEvent): Promise<void>;
+      }).emit.bind(registry);
+      await emit({
+        backend: "codex",
+        notification: {
+          method: "item/commandExecution/outputDelta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "cmd-1",
+            delta: "chunk one\n",
+          },
+        },
+      } as AgentEvent);
+
+      await vi.advanceTimersByTimeAsync(250);
+      expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(1);
+
+      // A coalesced record stands in for a whole window of chunks, so dropping
+      // it on a transient failure would lose far more than the per-chunk write
+      // it replaced. It goes back in the buffer and rides the next flush.
+      await vi.advanceTimersByTimeAsync(250);
+      expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(2);
+      expect(upsertThreadToolInvocation.mock.calls[1]?.[0]).toMatchObject({
+        invocation: { itemId: "cmd-1", outputChars: 10 },
+      });
+
+      await registry.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("never mirrors the review sub-agent's own prose onto the reviewed thread", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18129,12 +18129,89 @@ command = "pnpm dev"
       itemId: "managed-review:cmd-1",
     });
 
+    // Streamed accounting is coalesced, so nothing is written on the hot path.
+    expect(upsertThreadToolInvocation).not.toHaveBeenCalled();
+
+    await registry.close();
+
     // The forwarded copy is a view of activity the child already recorded.
-    // Running it back through the pipeline would bill the same command twice
-    // and write a second sqlite row per streamed chunk.
+    // Running it back through the pipeline would bill the same command twice,
+    // so the flush writes the child's row and only the child's row.
     expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(1);
     expect(upsertThreadToolInvocation.mock.calls[0]?.[0]).toMatchObject({
       invocation: { threadId: "managed-review-child" },
+    });
+  });
+
+  it("coalesces streamed command output into one accounting write", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+    });
+    const upsertThreadToolInvocation = vi.fn(
+      async (params: { invocation: unknown }) => params.invocation,
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      upsertThreadToolInvocation,
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: overlayStore as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+
+    const deltas = ["first chunk\n", "second chunk\n", "third chunk\n"];
+    for (const delta of deltas) {
+      await emit({
+        backend: "codex",
+        notification: {
+          method: "item/commandExecution/outputDelta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "cmd-1",
+            delta,
+          },
+        },
+      } as AgentEvent);
+    }
+
+    // Codex streams 8 KiB chunks at hundreds per second; none of them may cost
+    // a sqlite read+write inline in the event pipeline.
+    expect(upsertThreadToolInvocation).not.toHaveBeenCalled();
+
+    await emit({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "cmd-1",
+            type: "commandExecution",
+            command: "find / -xdev",
+            status: "completed",
+            exitCode: 0,
+          },
+        },
+      },
+    } as AgentEvent);
+
+    // The accumulated stream lands first: the store stops summing once a row
+    // is terminal, so a delta written after the completion is under-counted.
+    expect(upsertThreadToolInvocation).toHaveBeenCalledTimes(2);
+    expect(upsertThreadToolInvocation.mock.calls[0]?.[0]).toMatchObject({
+      invocation: {
+        itemId: "cmd-1",
+        outputChars: deltas.reduce((sum, delta) => sum + delta.length, 0),
+        status: "in_progress",
+      },
+    });
+    expect(upsertThreadToolInvocation.mock.calls[1]?.[0]).toMatchObject({
+      invocation: { itemId: "cmd-1", status: "completed" },
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
@@ -6,6 +6,10 @@ import type {
   ThreadToolInvocationRecord,
 } from "@pwragent/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  mergeStreamedToolInvocationDeltas,
+  toolInvocationFromNotification,
+} from "../app-server/tool-invocation-accounting";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import { StateDb } from "../state/state-db";
 
@@ -143,6 +147,77 @@ describe("SqliteOverlayStore tool invocation accounting", () => {
       status: "completed",
       warningLines: 3,
     });
+  });
+
+  it("records coalesced output deltas identically to per-chunk writes", async () => {
+    // Codex streams fixed 8 KiB chunks; the registry folds them in memory and
+    // writes once per flush window. The stored totals have to match what a
+    // write per chunk produced, or the coalescing quietly changes accounting.
+    const deltas = [
+      "warning: slow step\nbuilding module a\n",
+      "error: module b failed\nretrying\n",
+      "info: done\n",
+    ];
+    const records = deltas.map((delta, index) =>
+      toolInvocationFromNotification({
+        backend: "codex",
+        notification: {
+          method: "item/commandExecution/outputDelta",
+          params: {
+            delta,
+            itemId: "cmd-1",
+            threadId: "thread-per-chunk",
+            turnId: "turn-1",
+          },
+        },
+        now: 1_800_000_000_000 + index * 10,
+      })!,
+    );
+
+    for (const record of records) {
+      await store.upsertThreadToolInvocation({ invocation: record });
+    }
+
+    const coalesced = records
+      .slice(1)
+      .reduce(
+        (accumulated, record) =>
+          mergeStreamedToolInvocationDeltas(accumulated, record),
+        records[0]!,
+      );
+    await store.upsertThreadToolInvocation({
+      invocation: {
+        ...coalesced,
+        invocationId: "coalesced",
+        itemId: "coalesced",
+        threadId: "thread-coalesced",
+      },
+    });
+
+    const perChunk = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-per-chunk",
+    });
+    const single = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-coalesced",
+    });
+
+    expect(perChunk.invocations).toHaveLength(1);
+    expect(single.invocations).toHaveLength(1);
+    expect(single.invocations[0]).toMatchObject({
+      debugLines: perChunk.invocations[0]!.debugLines,
+      errorLines: perChunk.invocations[0]!.errorLines,
+      estimatedOutputTokens: perChunk.invocations[0]!.estimatedOutputTokens,
+      infoLines: perChunk.invocations[0]!.infoLines,
+      observedAt: perChunk.invocations[0]!.observedAt,
+      outputChars: perChunk.invocations[0]!.outputChars,
+      outputLines: perChunk.invocations[0]!.outputLines,
+      warningLines: perChunk.invocations[0]!.warningLines,
+    });
+    expect(single.invocations[0]?.outputChars).toBe(
+      deltas.reduce((sum, delta) => sum + delta.length, 0),
+    );
   });
 });
 

--- a/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
@@ -153,6 +153,13 @@ describe("SqliteOverlayStore tool invocation accounting", () => {
     // Codex streams fixed 8 KiB chunks; the registry folds them in memory and
     // writes once per flush window. The stored totals have to match what a
     // write per chunk produced, or the coalescing quietly changes accounting.
+    //
+    // This asserts equality with the old behavior, not correctness of the
+    // counters themselves. `outputLines` in particular over-counts, because a
+    // fixed-size chunk boundary lands mid-line and both halves count as lines.
+    // That is pre-existing and deliberately preserved here — if you set out to
+    // fix the line count, this test is measuring the wrong thing for you and
+    // should change with it.
     const deltas = [
       "warning: slow step\nbuilding module a\n",
       "error: module b failed\nretrying\n",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -230,6 +230,7 @@ import {
   type ThreadOverlayState,
   type ThreadWorkspaceHandoffStrategy,
   type ThreadSubAgentSummary,
+  type ThreadToolInvocationRecord,
   type ThreadUsageLineRecord,
   type PrSummary,
   type WorktreeSnapshotSummary,
@@ -414,6 +415,7 @@ import {
 } from "./protocol-log-observer";
 import {
   detectNoisyPolling,
+  mergeStreamedToolInvocationDeltas,
   toolAccountingLookbackSince,
   toolInvocationFromNotification,
 } from "./tool-invocation-accounting";
@@ -6298,6 +6300,16 @@ type PendingCodexInvalidIdRecovery = CodexRetryableTurnStart & {
 
 const CODEX_INVALID_ID_RECOVERY_COOLDOWN_MS = 5 * 60 * 1000;
 
+// How long streamed command-output accounting is held in memory before it is
+// written. Measured against `codex app-server`: a `find / -xdev` turn produced
+// 3,693 fixed 8 KiB `item/commandExecution/outputDelta` notifications over
+// 8.3s — ~444/second, 30 MB of output. One sqlite read+write per delta cost
+// 50-120ms of blocking main-process time per second of streaming, awaited
+// inline in `emit()` before any listener saw the event. Folding into a single
+// write per 250ms window (~110 deltas) drops that to under ~12ms/s and takes
+// it off the hot path entirely.
+const TOOL_INVOCATION_DELTA_FLUSH_INTERVAL_MS = 250;
+
 function isCodexInvalidIdRecoveryCooldownActive(
   attemptedAt: number,
   now: number,
@@ -6517,6 +6529,24 @@ export class DesktopBackendRegistry {
     TaskMonitorDelegationRecord
   >();
   private readonly taskMonitorWatchdogTimer?: NodeJS.Timeout;
+  /**
+   * Streamed command-output accounting waiting to be written, keyed by
+   * invocation id. Deltas fold together here instead of each one paying a
+   * sqlite read+write on the event hot path; see
+   * `TOOL_INVOCATION_DELTA_FLUSH_INTERVAL_MS`.
+   */
+  private readonly pendingToolInvocationDeltas = new Map<
+    string,
+    ThreadToolInvocationRecord
+  >();
+  private pendingToolInvocationDeltaTimer: NodeJS.Timeout | undefined;
+  /**
+   * Serializes every flush so a timer-driven write can never land after the
+   * `item/completed` write it accumulated before — the store keeps the
+   * terminal status and stops summing once a row is terminal, so an
+   * out-of-order delta flush would silently under-count the command's output.
+   */
+  private toolInvocationDeltaFlushChain: Promise<void> = Promise.resolve();
   /**
    * Best-effort cache of thread labels keyed by `buildThreadIdentityKey`, used
    * only to label native attention/terminal notifications so multiple
@@ -16794,6 +16824,13 @@ export class DesktopBackendRegistry {
     if (this.taskMonitorWatchdogTimer) {
       clearInterval(this.taskMonitorWatchdogTimer);
     }
+    if (this.pendingToolInvocationDeltaTimer) {
+      clearTimeout(this.pendingToolInvocationDeltaTimer);
+      this.pendingToolInvocationDeltaTimer = undefined;
+    }
+    // A command streaming at quit time has accounting worth up to one flush
+    // window sitting in memory; write it before the store goes away.
+    await this.flushStreamedToolInvocationDeltas();
     for (const reconciliation of this.codexNativeSubAgentReconciliations.values()) {
       if (reconciliation.timer) {
         clearTimeout(reconciliation.timer);
@@ -20690,6 +20727,21 @@ export class DesktopBackendRegistry {
       return;
     }
 
+    if (event.notification.method === "item/commandExecution/outputDelta") {
+      // Streamed output never notifies anyone (`shouldNotify` stays false for
+      // deltas) and never triggers noisy-polling detection (that only looks at
+      // `write_stdin`), so nothing downstream needs this write to have landed
+      // before the event reaches listeners. Accumulate and let the flush timer
+      // write it.
+      this.bufferStreamedToolInvocationDelta(invocation);
+      return;
+    }
+
+    // Land accumulated stream output before the lifecycle row: the store stops
+    // summing once a row is terminal, so a delta flushed after `item/completed`
+    // would be dropped down to a MAX() and under-count the command.
+    await this.flushStreamedToolInvocationDeltas();
+
     const stored = await this.overlayStore.upsertThreadToolInvocation({
       invocation,
     });
@@ -20732,6 +20784,65 @@ export class DesktopBackendRegistry {
         backend: stored.backend,
         threadId: stored.threadId,
       });
+    }
+  }
+
+  private bufferStreamedToolInvocationDelta(
+    invocation: ThreadToolInvocationRecord,
+  ): void {
+    const accumulated = this.pendingToolInvocationDeltas.get(
+      invocation.invocationId,
+    );
+    this.pendingToolInvocationDeltas.set(
+      invocation.invocationId,
+      accumulated
+        ? mergeStreamedToolInvocationDeltas(accumulated, invocation)
+        : invocation,
+    );
+
+    if (this.pendingToolInvocationDeltaTimer) {
+      return;
+    }
+    this.pendingToolInvocationDeltaTimer = setTimeout(() => {
+      this.pendingToolInvocationDeltaTimer = undefined;
+      void this.flushStreamedToolInvocationDeltas();
+    }, TOOL_INVOCATION_DELTA_FLUSH_INTERVAL_MS);
+    this.pendingToolInvocationDeltaTimer.unref?.();
+  }
+
+  /**
+   * Write every accumulated stream-output record. Callers get a promise for
+   * their own flush *and* for any flush already in flight, so the terminal
+   * `item/completed` write always follows the deltas it came after.
+   */
+  private flushStreamedToolInvocationDeltas(): Promise<void> {
+    const flushed = this.toolInvocationDeltaFlushChain.then(() =>
+      this.writePendingToolInvocationDeltas(),
+    );
+    this.toolInvocationDeltaFlushChain = flushed.catch(() => undefined);
+    return flushed;
+  }
+
+  private async writePendingToolInvocationDeltas(): Promise<void> {
+    if (
+      this.pendingToolInvocationDeltas.size === 0
+      || typeof this.overlayStore.upsertThreadToolInvocation !== "function"
+    ) {
+      return;
+    }
+    const pending = [...this.pendingToolInvocationDeltas.values()];
+    this.pendingToolInvocationDeltas.clear();
+    for (const invocation of pending) {
+      try {
+        await this.overlayStore.upsertThreadToolInvocation({ invocation });
+      } catch (error) {
+        backendRegistryLog.warn("tool invocation output accounting write failed", {
+          backend: invocation.backend,
+          error: error instanceof Error ? error.message : String(error),
+          invocationId: invocation.invocationId,
+          threadId: invocation.threadId,
+        });
+      }
     }
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -16824,12 +16824,9 @@ export class DesktopBackendRegistry {
     if (this.taskMonitorWatchdogTimer) {
       clearInterval(this.taskMonitorWatchdogTimer);
     }
-    if (this.pendingToolInvocationDeltaTimer) {
-      clearTimeout(this.pendingToolInvocationDeltaTimer);
-      this.pendingToolInvocationDeltaTimer = undefined;
-    }
     // A command streaming at quit time has accounting worth up to one flush
-    // window sitting in memory; write it before the store goes away.
+    // window sitting in memory; write it before the store goes away. The flush
+    // owns the timer, and `closed` above stops anything re-arming it.
     await this.flushStreamedToolInvocationDeltas();
     for (const reconciliation of this.codexNativeSubAgentReconciliations.values()) {
       if (reconciliation.timer) {
@@ -20799,8 +20796,11 @@ export class DesktopBackendRegistry {
         ? mergeStreamedToolInvocationDeltas(accumulated, invocation)
         : invocation,
     );
+    this.scheduleStreamedToolInvocationFlush();
+  }
 
-    if (this.pendingToolInvocationDeltaTimer) {
+  private scheduleStreamedToolInvocationFlush(): void {
+    if (this.pendingToolInvocationDeltaTimer || this.closed) {
       return;
     }
     this.pendingToolInvocationDeltaTimer = setTimeout(() => {
@@ -20824,6 +20824,12 @@ export class DesktopBackendRegistry {
   }
 
   private async writePendingToolInvocationDeltas(): Promise<void> {
+    // Whoever reached here is draining now, so a timer armed for this batch has
+    // nothing left to do.
+    if (this.pendingToolInvocationDeltaTimer) {
+      clearTimeout(this.pendingToolInvocationDeltaTimer);
+      this.pendingToolInvocationDeltaTimer = undefined;
+    }
     if (
       this.pendingToolInvocationDeltas.size === 0
       || typeof this.overlayStore.upsertThreadToolInvocation !== "function"
@@ -20836,6 +20842,12 @@ export class DesktopBackendRegistry {
       try {
         await this.overlayStore.upsertThreadToolInvocation({ invocation });
       } catch (error) {
+        // Unlike the lifecycle write in `recordToolInvocationAccounting`, this
+        // one has no caller to reject: most flushes run from a timer, where
+        // throwing would only produce an unhandled rejection. Put the record
+        // back instead, so a transient store failure costs a retry rather than
+        // the whole accumulated window, and let the next flush carry it.
+        this.requeueFailedToolInvocationDelta(invocation);
         backendRegistryLog.warn("tool invocation output accounting write failed", {
           backend: invocation.backend,
           error: error instanceof Error ? error.message : String(error),
@@ -20844,6 +20856,24 @@ export class DesktopBackendRegistry {
         });
       }
     }
+  }
+
+  private requeueFailedToolInvocationDelta(
+    invocation: ThreadToolInvocationRecord,
+  ): void {
+    if (this.closed) {
+      // Shutdown already took its one flush attempt; retrying would only queue
+      // work against a store that is going away.
+      return;
+    }
+    const newer = this.pendingToolInvocationDeltas.get(invocation.invocationId);
+    this.pendingToolInvocationDeltas.set(
+      invocation.invocationId,
+      newer
+        ? mergeStreamedToolInvocationDeltas(invocation, newer)
+        : invocation,
+    );
+    this.scheduleStreamedToolInvocationFlush();
   }
 
   private async describeSingleBackend(

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -208,6 +208,48 @@ export function buildToolOutputMetrics(
   };
 }
 
+/**
+ * Fold one streamed `item/commandExecution/outputDelta` record into the
+ * running accumulator for the same invocation.
+ *
+ * Codex emits fixed 8 KiB output deltas — a `find /` style command measured at
+ * ~444 deltas/second — and each one used to become its own sqlite read+write
+ * on the main process, inline in the event pipeline. Accumulating in memory
+ * and writing once per flush window keeps the totals identical while turning
+ * thousands of writes into a handful.
+ *
+ * The summing rules mirror `mergeThreadToolInvocationForUpsert` in
+ * `overlay-store-sqlite.ts` for the in-progress case, so a coalesced record
+ * merges onto the stored row exactly as the individual deltas would have.
+ */
+export function mergeStreamedToolInvocationDeltas(
+  accumulated: ThreadToolInvocationRecord,
+  incoming: ThreadToolInvocationRecord,
+): ThreadToolInvocationRecord {
+  const outputChars = accumulated.outputChars + incoming.outputChars;
+  return {
+    ...incoming,
+    debugLines: accumulated.debugLines + incoming.debugLines,
+    errorLines: accumulated.errorLines + incoming.errorLines,
+    estimatedOutputTokens: Math.ceil(outputChars / OUTPUT_TOKEN_CHAR_RATIO),
+    infoLines: accumulated.infoLines + incoming.infoLines,
+    observedAt: Math.max(accumulated.observedAt, incoming.observedAt),
+    outputChars,
+    outputLines: accumulated.outputLines + incoming.outputLines,
+    outputTruncated: accumulated.outputTruncated || incoming.outputTruncated,
+    ...(accumulated.startedAt !== undefined || incoming.startedAt !== undefined
+      ? {
+          startedAt: Math.min(
+            accumulated.startedAt ?? accumulated.observedAt,
+            incoming.startedAt ?? incoming.observedAt,
+          ),
+        }
+      : {}),
+    updatedAt: Math.max(accumulated.updatedAt, incoming.updatedAt),
+    warningLines: accumulated.warningLines + incoming.warningLines,
+  };
+}
+
 export function normalizeToolInvocationCommand(params: {
   args?: Record<string, unknown>;
   command?: string;

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -221,6 +221,13 @@ export function buildToolOutputMetrics(
  * The summing rules mirror `mergeThreadToolInvocationForUpsert` in
  * `overlay-store-sqlite.ts` for the in-progress case, so a coalesced record
  * merges onto the stored row exactly as the individual deltas would have.
+ *
+ * BOTH arguments must come from the `item/commandExecution/outputDelta` branch
+ * of `toolInvocationFromNotification`, and `incoming` must be the newer of the
+ * two. Only counters are combined; every other field is taken from `incoming`,
+ * so passing a lifecycle record here would drop the other one's `exitCode`,
+ * `completedAt`, `normalizedCommand`, and `sessionId`. Delta records carry
+ * none of those, which is what makes the wholesale take safe.
  */
 export function mergeStreamedToolInvocationDeltas(
   accumulated: ThreadToolInvocationRecord,
@@ -237,14 +244,6 @@ export function mergeStreamedToolInvocationDeltas(
     outputChars,
     outputLines: accumulated.outputLines + incoming.outputLines,
     outputTruncated: accumulated.outputTruncated || incoming.outputTruncated,
-    ...(accumulated.startedAt !== undefined || incoming.startedAt !== undefined
-      ? {
-          startedAt: Math.min(
-            accumulated.startedAt ?? accumulated.observedAt,
-            incoming.startedAt ?? incoming.observedAt,
-          ),
-        }
-      : {}),
     updatedAt: Math.max(accumulated.updatedAt, incoming.updatedAt),
     warningLines: accumulated.warningLines + incoming.warningLines,
   };


### PR DESCRIPTION
## Summary

- Tool-invocation accounting ran **one sqlite read + write per streamed command-output chunk**, awaited inline in `BackendRegistry.emit` before any listener saw the event. `toolInvocationFromNotification` has always handled `item/commandExecution/outputDelta` alongside `item/started` / `item/completed`, building a full invocation record from each chunk.
- Measured against `codex app-server`: a `find / -xdev -print` turn emits **fixed 8 KiB output deltas — 3,693 of them over 8.3s (~444/second, 30 MB of output)**. At **0.11–0.22 ms/chunk** for build + `upsertThreadToolInvocation` against a realistically sized table (26k rows), that is **50–120 ms of blocking main-process work per second of streaming**, on every command on every thread. The live `default` profile already holds a single invocation with **81.8 MB** of output — ~10,000 chunks in one command, ~2.7s of blocking work.
- Deltas are now folded in memory per invocation and written once per 250 ms window: **34 writes instead of 3,693, and 8–12 ms/s** of main-process work, none of it on the event hot path.

### Disk writes

CPU is not the worst of it. Each upsert is its own implicit transaction, and `observed_at` changes on every one, so all three indexes on `thread_tool_invocations` move too. Measured WAL growth for that single `find` command (auto-checkpoint disabled so the WAL size *is* the bytes appended):

| | Transactions | WAL written | Per transaction |
|---|---|---|---|
| Before | 3,693 | **58.05 MB** | 16.1 KB (4 × 4 KB pages) |
| After | 34 | **0.54 MB** | 16.2 KB |

**107× less.** That is 58 MB of SSD writes to persist ~19 integer counters, and it is WAL only — checkpointing later copies the same pages into the main DB file, so real write volume is roughly double. The 81.8 MB invocation already in the live profile would have cost ~160 MB of WAL by itself.

Worth being explicit about what this table holds, since the write rate makes it sound like transcript storage: it stores **counters only** — `output_chars`, `output_lines`, `warning_lines`/`error_lines`/`info_lines`/`debug_lines`, `estimated_output_tokens`, status, exit code, timestamps, plus the redacted `normalized_command`. No output text, no message content. That is unchanged here and stays consistent with [docs/thread-history-persistence.md](../blob/main/docs/thread-history-persistence.md). The bug was the write *frequency*, not the payload.

Accounting totals are preserved:

- New `mergeStreamedToolInvocationDeltas` mirrors the in-progress branch of `mergeThreadToolInvocationForUpsert`, so a coalesced record merges onto the stored row exactly as the individual deltas would have.
- Any non-delta accounting event flushes first — the store keeps the terminal status and stops summing once a row is terminal, so a delta landing after `item/completed` would degrade to a `MAX()` and under-count the command.
- All flushes run through one promise chain so a timer-driven write cannot overtake that ordering, and `close()` clears the timer and awaits a final flush.

Deltas were already the one accounting path that never notified anyone (`shouldNotify` stays false) and never fed noisy-polling detection (that only inspects `write_stdin`), so nothing downstream needed the write to have landed before fan-out.

## Verification

- `pnpm lint:eslint` — 0 errors (134 pre-existing warnings, unchanged; the only `backend-registry.ts` warning is a pre-existing `prefer-const` at line 16421).
- `pnpm lint:sql`, `pnpm lint:boundaries`, `pnpm typecheck` — clean.
- `pnpm test` — 7,012 passed. One failure, `acp-backend-adapter.test.ts > reads Gemini history from rollout`, is the known full-suite-load 5s timeout flake; the file passes on its own (39/39).
- New coverage:
  - `overlay-store-tool-accounting.test.ts` — equivalence test asserting coalesced deltas store byte-for-byte the same totals as per-chunk writes.
  - `backend-registry.test.ts` — asserts no write happens on the hot path, and that the accumulated stream lands *before* the `item/completed` row.
  - The existing managed-review double-counting test now asserts the same "child's row and only the child's row" invariant across the flush.
- Benchmarks were run from throwaway vitest files (real `StateDb`, real chunk shape, 26k-row table; WAL volume measured with `wal_autocheckpoint = 0` after a `wal_checkpoint(TRUNCATE)` of the seed) and deleted; no bench code ships.

## Notes

- **Pre-existing, not caused by #1399.** Found while reviewing that PR — its initial forwarding replayed events through `emit` and doubled these writes, which is what surfaced the underlying per-chunk cost. #1399 fixed the doubling by fanning forwarded copies straight to listeners and deliberately left this alone.
- Durability trade: a hard kill mid-command can lose up to 250 ms of one in-progress command's output accounting. `item/completed` carries the aggregate and largely re-establishes it. Normal quit flushes via `close()`.
- Not addressed here: `SqliteOverlayStore` re-`prepare()`s every statement on every call (~0.008–0.014 ms of SQL compile per call). That is a broad change across a 6,000-line file, and coalescing already removes 99% of these calls.
- Short high-volume commands (`seq 1 400000`, sub-second) emit **no** deltas at all — only `item/started` / `item/completed` — so this only ever affected commands that genuinely stream for seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
