### PR TITLE
feat(desktop): snapping, alignment guides, and marquee multi-select

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -108,6 +108,11 @@ const STAR_MAP_CHAT_CARD_BASE_Z = 40;
  * operator was not aiming at.
  */
 const SNAP_THRESHOLD_PX = 6;
+/**
+ * How far a press on empty canvas may travel and still count as a click
+ * that clears the selection, rather than a pan the operator abandoned.
+ */
+const CANVAS_CLICK_SLOP_PX = 4;
 
 type StarMapScreenProps = {
   desktopApi?: DesktopApi;
@@ -242,11 +247,20 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const startCanvasPan = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
     if (!shouldStartCanvasPan(event.target)) return;
-    // Shift claims the gesture for selection; everything else pans.
+    // Shift sweeps a fresh selection, Cmd/Ctrl extends the one already
+    // there; everything else pans.
     if (event.shiftKey) {
-      startMarquee(event);
+      startMarquee(event, "replace");
       return;
     }
+    if (event.metaKey || event.ctrlKey) {
+      startMarquee(event, "add");
+      return;
+    }
+    // A press on empty space that never travels is a click, and a click on
+    // nothing drops the selection. Watched separately from the pan below
+    // because the lanes lens has no pan to hang it off.
+    watchForCanvasClick(event);
     if (!panZoomMode) return;
     const canvas = canvasRef.current;
     const viewport = viewportRef.current;
@@ -996,14 +1010,47 @@ export function StarMapScreen(props: StarMapScreenProps) {
    */
   const [selection, setSelection] = useState<ReadonlySet<string>>(new Set());
   const [marquee, setMarquee] = useState<SnapRect | undefined>(undefined);
+  /**
+   * Canvas scale for the overlays drawn inside the transform. The lanes
+   * lens never scales, so it is 1 there.
+   */
+  const overlayScale = panZoomMode && view.scale > 0 ? view.scale : 1;
+
+  /**
+   * A press on empty space that ends without travelling is a click, and a
+   * click on nothing clears the selection. The slop is what separates it
+   * from a pan the operator started and thought better of.
+   */
+  const watchForCanvasClick = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const startX = event.clientX;
+      const startY = event.clientY;
+      const stop = (pointerEvent: globalThis.PointerEvent) => {
+        window.removeEventListener("pointerup", stop);
+        window.removeEventListener("pointercancel", stop);
+        const travelled = Math.hypot(
+          pointerEvent.clientX - startX,
+          pointerEvent.clientY - startY,
+        );
+        if (travelled <= CANVAS_CLICK_SLOP_PX) setSelection(new Set());
+      };
+      window.addEventListener("pointerup", stop);
+      window.addEventListener("pointercancel", stop);
+    },
+    [],
+  );
 
   /**
    * Shift-drag draws a marquee; a plain drag still pans. Both are
    * click-drag on empty space, so one of them had to take a modifier, and
-   * panning is the far more frequent gesture.
+   * panning is the far more frequent gesture. Cmd/Ctrl-drag runs the same
+   * sweep in `add` mode, so a selection can be built out of several.
    */
   const startMarquee = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
+    (
+      event: ReactPointerEvent<HTMLDivElement>,
+      mode: "replace" | "add",
+    ) => {
       const canvas = canvasRef.current;
       if (!canvas || event.button !== 0) return false;
       const rect = canvas.getBoundingClientRect();
@@ -1028,11 +1075,13 @@ export function StarMapScreen(props: StarMapScreenProps) {
           origin,
           toCanvas(pointerEvent.clientX, pointerEvent.clientY),
         );
-        const hits = new Set<string>();
-        for (const [key, cardRect] of cardRects) {
-          if (rectIntersects(cardRect, box)) hits.add(key);
-        }
-        setSelection(hits);
+        setSelection((current) => {
+          const hits = mode === "add" ? new Set(current) : new Set<string>();
+          for (const [key, cardRect] of cardRects) {
+            if (rectIntersects(cardRect, box)) hits.add(key);
+          }
+          return hits;
+        });
         setMarquee(undefined);
       };
       window.addEventListener("pointermove", move);
@@ -1090,6 +1139,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
     [selection, shellsByKey],
   );
 
+  /** Modifier-click on a card: in if it was out, out if it was in. */
+  const toggleSelected = useCallback((key: string) => {
+    setSelection((current) => {
+      const next = new Set(current);
+      if (!next.delete(key)) next.add(key);
+      return next;
+    });
+  }, []);
+
   const commitSelectionMove = useCallback(
     (draggedKey: string, delta: { dx: number; dy: number }) => {
       if (!selection.has(draggedKey)) return;
@@ -1097,10 +1155,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
       for (const key of selection) {
         if (key === draggedKey) continue;
         const shell = shells.get(key);
-        if (shell) {
-          delete shell.dataset.dragOriginLeft;
-          delete shell.dataset.dragOriginTop;
-        }
+        // No shell means the card is not on the map right now — filtered
+        // out, or on an instance that dropped. It keeps its place in the
+        // selection, because an instance that flaps for twenty seconds
+        // should not silently cost the operator every card it owns; but a
+        // card that is not there does not move, because the offset would
+        // land invisibly and only surface later.
+        if (!shell) continue;
+        delete shell.dataset.dragOriginLeft;
+        delete shell.dataset.dragOriginTop;
         const separator = key.indexOf("::");
         if (separator < 0) continue;
         const instanceId = key.slice(0, separator);
@@ -1122,8 +1185,13 @@ export function StarMapScreen(props: StarMapScreenProps) {
     (instanceId: string, threadKey: string, cardWidth: number) => {
       const selfKey = `${instanceId}::${threadKey}`;
       if (!cardRects.has(selfKey)) return undefined;
+      // A card carrying a selection must not snap to the rest of it. Those
+      // cards travel rigidly with this one, so their relative offset never
+      // changes and every "alignment" against them is a false latch at
+      // whatever spacing the group already had.
+      const passengers = selection.has(selfKey) ? selection : undefined;
       const others = [...cardRects.entries()]
-        .filter(([key]) => key !== selfKey)
+        .filter(([key]) => key !== selfKey && !passengers?.has(key))
         .map(([, rect]) => rect);
       if (others.length === 0) return undefined;
 
@@ -1162,7 +1230,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
         };
       };
     },
-    [bodies, cardRects, lanes, panZoomMode, view.scale],
+    [bodies, cardRects, lanes, panZoomMode, selection, view.scale],
   );
 
   const renderCloud = (position: {
@@ -1230,6 +1298,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
               stackIndex={index}
               cardKey={`${position.instanceId}::${threadKey}`}
               selected={selection.has(`${position.instanceId}::${threadKey}`)}
+              onToggleSelect={() =>
+                toggleSelected(`${position.instanceId}::${threadKey}`)
+              }
               cardFields={preferences.cardFields}
               menuActions={cardMenuActions(thread, position.instanceId)}
               drag={
@@ -1310,6 +1381,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
       onKeyDown={(event) => {
         if (event.key === "Escape") {
           event.stopPropagation();
+          // Escape unwinds one layer at a time: drop the selection first,
+          // and only close the map once there is nothing left to drop.
+          if (selection.size > 0) {
+            setSelection(new Set());
+            return;
+          }
           props.onClose();
         }
       }}
@@ -1489,6 +1566,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
               top: marquee.y,
               width: marquee.width,
               height: marquee.height,
+              // Drawn inside the zoomed canvas, so its edge is sized in
+              // canvas units to land at a constant thickness on screen.
+              borderWidth: 1 / overlayScale,
+              borderRadius: 4 / overlayScale,
             }}
           />
         ) : null}
@@ -1503,6 +1584,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
               <line
                 className="star-map__guide"
                 key={index}
+                // Same reason as the marquee's border: the canvas scale is
+                // a CSS transform on an ancestor, so the stroke has to be
+                // divided by it by hand.
+                strokeWidth={1 / overlayScale}
+                strokeDasharray={`${3 / overlayScale} ${3 / overlayScale}`}
                 x1={guide.axis === "x" ? guide.at : guide.start}
                 x2={guide.axis === "x" ? guide.at : guide.end}
                 y1={guide.axis === "x" ? guide.start : guide.at}
@@ -1735,6 +1821,26 @@ export function StarMapScreen(props: StarMapScreenProps) {
               </button>
             ) : null}
           </span>
+        </div>
+      ) : null}
+      {/* The only thing on the surface that admits a selection exists.
+          `role="status"` so the count is heard, not just seen — the cards
+          themselves carry no selected state to a screen reader. */}
+      {selection.size > 0 ? (
+        <div className="star-map__selection" role="status" aria-live="polite">
+          <span>
+            {selection.size === 1 ? "1 card selected" : `${selection.size} cards selected`}
+          </span>
+          <span className="star-map__selection-hint" aria-hidden="true">
+            drag to move · ⇧-click to amend
+          </span>
+          <button
+            type="button"
+            className="star-map__selection-clear"
+            onClick={() => setSelection(new Set())}
+          >
+            Clear
+          </button>
         </div>
       ) : null}
       <div className="star-map__filters" role="group" aria-label="Thread filters">

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -55,6 +55,8 @@ import {
   type StarMapFilterSelection,
 } from "./star-map-filters";
 import {
+  marqueeRect,
+  rectIntersects,
   resolveSnap,
   type AlignmentGuide,
   type SnapRect,
@@ -238,8 +240,14 @@ export function StarMapScreen(props: StarMapScreenProps) {
   });
 
   const startCanvasPan = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if (!panZoomMode || event.button !== 0) return;
+    if (event.button !== 0) return;
     if (!shouldStartCanvasPan(event.target)) return;
+    // Shift claims the gesture for selection; everything else pans.
+    if (event.shiftKey) {
+      startMarquee(event);
+      return;
+    }
+    if (!panZoomMode) return;
     const canvas = canvasRef.current;
     const viewport = viewportRef.current;
     if (!canvas) return;
@@ -965,7 +973,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
         if (!slot) return;
         const threadKey = buildThreadIdentityKey(thread.source, thread.id);
         const offset = arrangement.offsetFor(position.instanceId, threadKey);
-        const height = lane.heights[index] ?? STAR_MAP_ESTIMATED_CARD_HEIGHT;
+        // `||`, not `??`: an unmeasured card reports 0, and a zero-height
+        // rect is invisible to both snapping and selection.
+        const height = lane.heights[index] || STAR_MAP_ESTIMATED_CARD_HEIGHT;
         rects.set(`${position.instanceId}::${threadKey}`, {
           // Cards are centred on their slot horizontally (marginLeft is
           // -width/2), so the rect's left edge is half a card back.
@@ -984,6 +994,130 @@ export function StarMapScreen(props: StarMapScreenProps) {
    * feels the same at every zoom, then converted into the canvas units the
    * geometry works in — the same reasoning as the drag threshold.
    */
+  const [selection, setSelection] = useState<ReadonlySet<string>>(new Set());
+  const [marquee, setMarquee] = useState<SnapRect | undefined>(undefined);
+
+  /**
+   * Shift-drag draws a marquee; a plain drag still pans. Both are
+   * click-drag on empty space, so one of them had to take a modifier, and
+   * panning is the far more frequent gesture.
+   */
+  const startMarquee = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const canvas = canvasRef.current;
+      if (!canvas || event.button !== 0) return false;
+      const rect = canvas.getBoundingClientRect();
+      const scale = panZoomMode && view.scale > 0 ? view.scale : 1;
+      const toCanvas = (clientX: number, clientY: number) => ({
+        x: (clientX - rect.left) / scale,
+        y: (clientY - rect.top) / scale,
+      });
+      const origin = toCanvas(event.clientX, event.clientY);
+      event.preventDefault();
+
+      const move = (pointerEvent: globalThis.PointerEvent) => {
+        setMarquee(
+          marqueeRect(origin, toCanvas(pointerEvent.clientX, pointerEvent.clientY)),
+        );
+      };
+      const stop = (pointerEvent: globalThis.PointerEvent) => {
+        window.removeEventListener("pointermove", move);
+        window.removeEventListener("pointerup", stop);
+        window.removeEventListener("pointercancel", stop);
+        const box = marqueeRect(
+          origin,
+          toCanvas(pointerEvent.clientX, pointerEvent.clientY),
+        );
+        const hits = new Set<string>();
+        for (const [key, cardRect] of cardRects) {
+          if (rectIntersects(cardRect, box)) hits.add(key);
+        }
+        setSelection(hits);
+        setMarquee(undefined);
+      };
+      window.addEventListener("pointermove", move);
+      window.addEventListener("pointerup", stop);
+      window.addEventListener("pointercancel", stop);
+      return true;
+    },
+    [cardRects, panZoomMode, view.scale],
+  );
+
+  /**
+   * Card shells by key. Read from the DOM rather than a selector string:
+   * keys contain `:` and `::`, and escaping them for an attribute selector
+   * is the kind of detail that silently matches nothing.
+   */
+  const shellsByKey = useCallback((): Map<string, HTMLElement> => {
+    const shells = new Map<string, HTMLElement>();
+    for (const node of document.querySelectorAll("[data-card-key]")) {
+      if (!(node instanceof HTMLElement)) continue;
+      const key = node.dataset.cardKey;
+      if (key) shells.set(key, node);
+    }
+    return shells;
+  }, []);
+
+  /**
+   * Carry the rest of the selection along with the card under the pointer.
+   * The DOM is written directly, the same way the dragged card moves
+   * itself — a React state update per frame across N cards is exactly the
+   * cost this surface cannot pay mid-drag.
+   */
+  const moveSelectionBy = useCallback(
+    (draggedKey: string, delta: { dx: number; dy: number }) => {
+      if (!selection.has(draggedKey)) return;
+      const shells = shellsByKey();
+      for (const key of selection) {
+        if (key === draggedKey) continue;
+        const shell = shells.get(key);
+        if (!shell) continue;
+        const origin = shell.dataset.dragOriginLeft
+          ? {
+              left: Number(shell.dataset.dragOriginLeft),
+              top: Number(shell.dataset.dragOriginTop),
+            }
+          : {
+              left: Number.parseFloat(shell.style.left),
+              top: Number.parseFloat(shell.style.top),
+            };
+        shell.dataset.dragOriginLeft = String(origin.left);
+        shell.dataset.dragOriginTop = String(origin.top);
+        shell.style.left = `${origin.left + delta.dx}px`;
+        shell.style.top = `${origin.top + delta.dy}px`;
+      }
+    },
+    [selection, shellsByKey],
+  );
+
+  const commitSelectionMove = useCallback(
+    (draggedKey: string, delta: { dx: number; dy: number }) => {
+      if (!selection.has(draggedKey)) return;
+      const shells = shellsByKey();
+      for (const key of selection) {
+        if (key === draggedKey) continue;
+        const shell = shells.get(key);
+        if (shell) {
+          delete shell.dataset.dragOriginLeft;
+          delete shell.dataset.dragOriginTop;
+        }
+        const separator = key.indexOf("::");
+        if (separator < 0) continue;
+        const instanceId = key.slice(0, separator);
+        const threadKey = key.slice(separator + 2);
+        const current = arrangement.offsetFor(instanceId, threadKey) ?? {
+          dx: 0,
+          dy: 0,
+        };
+        arrangement.setCardPosition(instanceId, threadKey, {
+          dx: current.dx + delta.dx,
+          dy: current.dy + delta.dy,
+        });
+      }
+    },
+    [arrangement, selection, shellsByKey],
+  );
+
   const snapFor = useCallback(
     (instanceId: string, threadKey: string, cardWidth: number) => {
       const selfKey = `${instanceId}::${threadKey}`;
@@ -1003,7 +1137,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
       const baseSlot = index >= 0 ? body?.slots[index] : undefined;
       if (!body || !baseSlot) return undefined;
 
-      const height = lane?.heights[index] ?? STAR_MAP_ESTIMATED_CARD_HEIGHT;
+      // See the note in `cardRects`: unmeasured cards report 0, not undefined.
+      const height = lane?.heights[index] || STAR_MAP_ESTIMATED_CARD_HEIGHT;
       const scale = panZoomMode && view.scale > 0 ? view.scale : 1;
 
       return (offset: { dx: number; dy: number }) => {
@@ -1093,6 +1228,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
               width={position.cardWidth}
               centered={orbitMode}
               stackIndex={index}
+              cardKey={`${position.instanceId}::${threadKey}`}
+              selected={selection.has(`${position.instanceId}::${threadKey}`)}
               cardFields={preferences.cardFields}
               menuActions={cardMenuActions(thread, position.instanceId)}
               drag={
@@ -1109,6 +1246,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
                         position.cardWidth,
                       ),
                       onGuidesChange: setActiveGuides,
+                      onGroupDelta: (delta) =>
+                        moveSelectionBy(
+                          `${position.instanceId}::${threadKey}`,
+                          delta,
+                        ),
+                      onGroupCommit: (delta) =>
+                        commitSelectionMove(
+                          `${position.instanceId}::${threadKey}`,
+                          delta,
+                        ),
                       onCommitOffset: (offset) =>
                         arrangement.setCardPosition(
                           position.instanceId,
@@ -1334,6 +1481,17 @@ export function StarMapScreen(props: StarMapScreenProps) {
           );
         })}
         {(projectsMode ? [] : bodies).map((position) => renderCloud(position))}
+        {marquee ? (
+          <div
+            className="star-map__marquee"
+            style={{
+              left: marquee.x,
+              top: marquee.y,
+              width: marquee.width,
+              height: marquee.height,
+            }}
+          />
+        ) : null}
         {activeGuides.length > 0 ? (
           <svg
             className="star-map__guides"
@@ -1409,6 +1567,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
                         instanceIcon={celestialIcons.iconFor(
                           owner === localInstanceId ? undefined : owner,
                         )}
+                        cardKey={`${owner ?? "project"}::${buildThreadIdentityKey(
+                          thread.source,
+                          thread.id,
+                        )}`}
                         baseSlot={slots[index]}
                         // No drag here on purpose: arrangements are keyed
                         // and synced per federation instance, and a project

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -31,6 +31,7 @@ import {
   computeStarMapLayout,
   generateStarField,
   STAR_MAP_BODY_ROW_Y,
+  STAR_MAP_CARD_GAP,
   STAR_MAP_ESTIMATED_CARD_HEIGHT,
   visibleCardCount,
   type StarMapCardSlot,
@@ -53,6 +54,11 @@ import {
   type StarMapFilterKey,
   type StarMapFilterSelection,
 } from "./star-map-filters";
+import {
+  resolveSnap,
+  type AlignmentGuide,
+  type SnapRect,
+} from "./star-map-snapping";
 import { buildFederationTopology } from "./star-map-topology";
 import {
   groupThreadsByProject,
@@ -93,6 +99,13 @@ const ORBIT_MAX_CARDS_PER_INSTANCE = 16;
  * options) so a card being read is never underneath a control strip.
  */
 const STAR_MAP_CHAT_CARD_BASE_Z = 40;
+/**
+ * How close an edge has to come before it latches, in SCREEN pixels so the
+ * pull feels identical at every zoom. Wide enough to catch a deliberate
+ * near-miss, tight enough that a card never latches to something the
+ * operator was not aiming at.
+ */
+const SNAP_THRESHOLD_PX = 6;
 
 type StarMapScreenProps = {
   desktopApi?: DesktopApi;
@@ -933,6 +946,90 @@ export function StarMapScreen(props: StarMapScreenProps) {
     return status;
   };
 
+  const [activeGuides, setActiveGuides] = useState<AlignmentGuide[]>([]);
+
+  /**
+   * Every visible card as an absolute canvas rect, keyed so a dragging
+   * card can exclude itself. Absolute rather than cloud-local so cards
+   * belonging to different instances can still align with each other —
+   * the operator sees one map, not several coordinate systems.
+   */
+  const cardRects = useMemo(() => {
+    const rects = new Map<string, SnapRect>();
+    for (const position of bodies) {
+      const lane = lanes.get(position.instanceId);
+      if (!lane) continue;
+      const visible = lane.threads.slice(0, lane.count);
+      visible.forEach((thread, index) => {
+        const slot = position.slots[index];
+        if (!slot) return;
+        const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+        const offset = arrangement.offsetFor(position.instanceId, threadKey);
+        const height = lane.heights[index] ?? STAR_MAP_ESTIMATED_CARD_HEIGHT;
+        rects.set(`${position.instanceId}::${threadKey}`, {
+          // Cards are centred on their slot horizontally (marginLeft is
+          // -width/2), so the rect's left edge is half a card back.
+          x: position.x + slot.dx + (offset?.dx ?? 0) - position.cardWidth / 2,
+          y: position.y + slot.dy + (offset?.dy ?? 0),
+          width: position.cardWidth,
+          height,
+        });
+      });
+    }
+    return rects;
+  }, [arrangement, bodies, lanes]);
+
+  /**
+   * Build the snap for one card. Threshold is screen-space so the pull
+   * feels the same at every zoom, then converted into the canvas units the
+   * geometry works in — the same reasoning as the drag threshold.
+   */
+  const snapFor = useCallback(
+    (instanceId: string, threadKey: string, cardWidth: number) => {
+      const selfKey = `${instanceId}::${threadKey}`;
+      if (!cardRects.has(selfKey)) return undefined;
+      const others = [...cardRects.entries()]
+        .filter(([key]) => key !== selfKey)
+        .map(([, rect]) => rect);
+      if (others.length === 0) return undefined;
+
+      const body = bodies.find((entry) => entry.instanceId === instanceId);
+      const lane = lanes.get(instanceId);
+      const index =
+        lane?.threads.findIndex(
+          (thread) =>
+            buildThreadIdentityKey(thread.source, thread.id) === threadKey,
+        ) ?? -1;
+      const baseSlot = index >= 0 ? body?.slots[index] : undefined;
+      if (!body || !baseSlot) return undefined;
+
+      const height = lane?.heights[index] ?? STAR_MAP_ESTIMATED_CARD_HEIGHT;
+      const scale = panZoomMode && view.scale > 0 ? view.scale : 1;
+
+      return (offset: { dx: number; dy: number }) => {
+        const snap = resolveSnap({
+          defaultGap: STAR_MAP_CARD_GAP,
+          moving: {
+            // Cards are centred on their slot (marginLeft is -width/2), so
+            // the rect's left edge sits half a card back.
+            x: body.x + baseSlot.dx + offset.dx - cardWidth / 2,
+            y: body.y + baseSlot.dy + offset.dy,
+            width: cardWidth,
+            height,
+          },
+          others,
+          threshold: SNAP_THRESHOLD_PX / scale,
+        });
+        return {
+          dx: offset.dx + snap.dx,
+          dy: offset.dy + snap.dy,
+          guides: snap.guides,
+        };
+      };
+    },
+    [bodies, cardRects, lanes, panZoomMode, view.scale],
+  );
+
   const renderCloud = (position: {
     instanceId: string;
     x: number;
@@ -1006,6 +1103,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
                       detentRadius,
                       // Lanes never scales, so this is 1 there.
                       scale: panZoomMode ? view.scale : 1,
+                      snap: snapFor(
+                        position.instanceId,
+                        threadKey,
+                        position.cardWidth,
+                      ),
+                      onGuidesChange: setActiveGuides,
                       onCommitOffset: (offset) =>
                         arrangement.setCardPosition(
                           position.instanceId,
@@ -1231,6 +1334,25 @@ export function StarMapScreen(props: StarMapScreenProps) {
           );
         })}
         {(projectsMode ? [] : bodies).map((position) => renderCloud(position))}
+        {activeGuides.length > 0 ? (
+          <svg
+            className="star-map__guides"
+            width={panZoomCanvas.width || viewportSize.width}
+            height={panZoomCanvas.height || viewportSize.height}
+            aria-hidden="true"
+          >
+            {activeGuides.map((guide, index) => (
+              <line
+                className="star-map__guide"
+                key={index}
+                x1={guide.axis === "x" ? guide.at : guide.start}
+                x2={guide.axis === "x" ? guide.at : guide.end}
+                y1={guide.axis === "x" ? guide.start : guide.at}
+                y2={guide.axis === "x" ? guide.end : guide.at}
+              />
+            ))}
+          </svg>
+        ) : null}
         {projectsMode && projectLayout.arms.length > 0 ? (
           <svg
             className="star-map__arms"

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -88,8 +88,19 @@ export function StarMapThreadCard(props: {
     };
     /** Guides to draw while this drag is live; empty clears them. */
     onGuidesChange?: (guides: AlignmentGuide[]) => void;
+    /**
+     * How far this drag has travelled, so the screen can carry the rest of
+     * a multi-card selection along. Fired per frame during the drag and
+     * once more on release, when the movement becomes durable.
+     */
+    onGroupDelta?: (delta: { dx: number; dy: number }) => void;
+    onGroupCommit?: (delta: { dx: number; dy: number }) => void;
     onCommitOffset: (offset: { dx: number; dy: number }) => void;
   };
+  /** `instanceId::threadKey`; unique across clouds. */
+  cardKey: string;
+  /** Part of a multi-card selection, so it moves with the others. */
+  selected?: boolean;
   onOpen: (thread: NavigationThreadSummary) => void;
   /** Kebab entries; the kebab is hidden when empty. */
   menuActions?: StarMapCardMenuAction[];
@@ -178,6 +189,10 @@ export function StarMapThreadCard(props: {
           frame = 0;
           element.style.left = `${props.baseSlot.dx + lastDx}px`;
           element.style.top = `${props.baseSlot.dy + lastDy}px`;
+          drag.onGroupDelta?.({
+            dx: lastDx - startOffset.dx,
+            dy: lastDy - startOffset.dy,
+          });
         });
       }
     };
@@ -192,6 +207,10 @@ export function StarMapThreadCard(props: {
       drag.onGuidesChange?.([]);
       if (dragging) {
         drag.onCommitOffset({ dx: lastDx, dy: lastDy });
+        drag.onGroupCommit?.({
+          dx: lastDx - startOffset.dx,
+          dy: lastDy - startOffset.dy,
+        });
       }
     };
     window.addEventListener("pointermove", move);
@@ -207,9 +226,10 @@ export function StarMapThreadCard(props: {
     <div
       className={`star-map-card-shell${
         props.entering ? " star-map-card-shell--entering" : ""
-      }`}
+      }${props.selected ? " star-map-card-shell--selected" : ""}`}
       style={style}
       data-thread-key={threadKey}
+      data-card-key={props.cardKey}
       onPointerDown={startDrag}
     >
       {/* Top-right, and large: the next card covers this one's bottom, so

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -101,6 +101,12 @@ export function StarMapThreadCard(props: {
   cardKey: string;
   /** Part of a multi-card selection, so it moves with the others. */
   selected?: boolean;
+  /**
+   * Add or remove this card from the selection. Deliberately outside
+   * `drag`: amending a selection has to work before the durable instance
+   * id lands, which is the one thing that gates dragging.
+   */
+  onToggleSelect?: () => void;
   onOpen: (thread: NavigationThreadSummary) => void;
   /** Kebab entries; the kebab is hidden when empty. */
   menuActions?: StarMapCardMenuAction[];
@@ -144,8 +150,21 @@ export function StarMapThreadCard(props: {
   };
 
   const startDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    // Modifier-click amends the selection rather than opening or dragging.
+    // It is the platform convention, and the only way to correct a marquee
+    // that swept up one card too many without starting the sweep over.
+    // Gated on the handler so lenses with no selection (Projects) keep
+    // modifier-click opening the thread instead of doing nothing at all.
+    const toggleSelect = props.onToggleSelect;
+    if (toggleSelect && (event.shiftKey || event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      suppressClickRef.current = true;
+      toggleSelect();
+      return;
+    }
     const drag = props.drag;
-    if (!drag || event.button !== 0) return;
+    if (!drag) return;
     const element = event.currentTarget;
     const startX = event.clientX;
     const startY = event.clientY;

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -17,6 +17,7 @@ import {
   ThreadRowStatus,
 } from "../navigation/ThreadRowStatus";
 import { pointerDeltaToCanvas, resolveCardDragOffset } from "./star-map-layout";
+import type { AlignmentGuide } from "./star-map-snapping";
 import {
   visiblePullRequests,
   type StarMapCardFields,
@@ -74,6 +75,19 @@ export function StarMapThreadCard(props: {
      * `scale` times too far and slides out from under the cursor.
      */
     scale: number;
+    /**
+     * Snap a proposed offset against the rest of the arrangement. The
+     * screen owns this because it is the only thing that knows where every
+     * other card sits; the card would otherwise have to reconstruct the
+     * whole map to align with one neighbour.
+     */
+    snap?: (offset: { dx: number; dy: number }) => {
+      dx: number;
+      dy: number;
+      guides: AlignmentGuide[];
+    };
+    /** Guides to draw while this drag is live; empty clears them. */
+    onGuidesChange?: (guides: AlignmentGuide[]) => void;
     onCommitOffset: (offset: { dx: number; dy: number }) => void;
   };
   onOpen: (thread: NavigationThreadSummary) => void;
@@ -155,8 +169,10 @@ export function StarMapThreadCard(props: {
         },
         detentRadius: drag.detentRadius,
       });
-      lastDx = resolved.dx;
-      lastDy = resolved.dy;
+      const snapped = drag.snap ? drag.snap(resolved) : undefined;
+      lastDx = snapped ? snapped.dx : resolved.dx;
+      lastDy = snapped ? snapped.dy : resolved.dy;
+      drag.onGuidesChange?.(snapped?.guides ?? []);
       if (!frame) {
         frame = requestAnimationFrame(() => {
           frame = 0;
@@ -173,6 +189,7 @@ export function StarMapThreadCard(props: {
         cancelAnimationFrame(frame);
         frame = 0;
       }
+      drag.onGuidesChange?.([]);
       if (dragging) {
         drag.onCommitOffset({ dx: lastDx, dy: lastDy });
       }

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
@@ -1,0 +1,183 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { StarMapScreen } from "../StarMapScreen";
+
+/**
+ * Shift-drag selects; a plain drag still pans. Both are click-drag on
+ * empty space, so the modifier is what keeps them apart.
+ */
+
+function buildDesktopApi(): DesktopApi {
+  return {
+    readFederationHealth: vi.fn(async () => ({
+      health: {
+        enabled: false,
+        role: "client" as const,
+        status: "disabled" as const,
+        instanceId: "pwr_local",
+        localCelestialIcon: "sun" as const,
+        localLabel: "Harold-MBP-M5-Max",
+        localProfileName: "default",
+        peers: [],
+      },
+    })),
+    onAgentEvent: vi.fn(() => () => undefined),
+    readStarMapArrangement: vi.fn(async () => ({ entries: [] })),
+    setStarMapCardPosition: vi.fn(async () => undefined),
+  } as unknown as DesktopApi;
+}
+
+function thread(id: string): NavigationThreadSummary {
+  return {
+    id,
+    title: `Thread ${id}`,
+    titleSource: "generated",
+    linkedDirectories: [],
+    source: "codex",
+    inbox: { inInbox: true, reason: "updated-since-seen" },
+    updatedAt: 100,
+  } as unknown as NavigationThreadSummary;
+}
+
+function renderMap(count: number) {
+  return render(
+    <StarMapScreen
+      desktopApi={buildDesktopApi()}
+      localThreads={Array.from({ length: count }, (_, index) =>
+        thread(`t${index}`),
+      )}
+      sessionKeys={{}}
+      localInstanceLabel="Mac-Mini-M4"
+      floating={false}
+      onClose={() => undefined}
+      onOpenLocalThread={() => undefined}
+      onFocusLocalInstance={() => undefined}
+    />,
+  );
+}
+
+function viewport(): HTMLElement {
+  const element = document.querySelector(".star-map__viewport");
+  if (!(element instanceof HTMLElement)) throw new Error("no viewport");
+  return element;
+}
+
+function shells(): HTMLElement[] {
+  return [...document.querySelectorAll(".star-map-card-shell")].filter(
+    (node): node is HTMLElement => node instanceof HTMLElement,
+  );
+}
+
+async function ready() {
+  await waitFor(() => {
+    expect(
+      screen.getByRole("button", { name: /Open this instance/ }),
+    ).toBeTruthy();
+  });
+}
+
+describe("star map marquee selection", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+  });
+
+  it("selects the cards a shift-drag sweeps over", async () => {
+    renderMap(4);
+    await ready();
+    expect(document.querySelector(".star-map-card-shell--selected")).toBeNull();
+
+    // A sweep large enough to cover the whole cloud.
+    fireEvent.pointerDown(viewport(), {
+      button: 0,
+      shiftKey: true,
+      clientX: -4000,
+      clientY: -4000,
+    });
+    fireEvent.pointerMove(window, { clientX: 4000, clientY: 4000 });
+    fireEvent.pointerUp(window, { clientX: 4000, clientY: 4000 });
+
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll(".star-map-card-shell--selected").length,
+      ).toBeGreaterThan(1);
+    });
+  });
+
+  it("shows the marquee while the sweep is live and drops it after", async () => {
+    renderMap(3);
+    await ready();
+
+    fireEvent.pointerDown(viewport(), {
+      button: 0,
+      shiftKey: true,
+      clientX: 100,
+      clientY: 100,
+    });
+    fireEvent.pointerMove(window, { clientX: 400, clientY: 350 });
+    await waitFor(() => {
+      expect(document.querySelector(".star-map__marquee")).not.toBeNull();
+    });
+
+    fireEvent.pointerUp(window, { clientX: 400, clientY: 350 });
+    await waitFor(() => {
+      expect(document.querySelector(".star-map__marquee")).toBeNull();
+    });
+  });
+
+  it("leaves a plain drag panning rather than selecting", async () => {
+    renderMap(3);
+    await ready();
+
+    fireEvent.pointerDown(viewport(), { button: 0, clientX: -4000, clientY: -4000 });
+    fireEvent.pointerMove(window, { clientX: 4000, clientY: 4000 });
+    fireEvent.pointerUp(window, { clientX: 4000, clientY: 4000 });
+
+    expect(document.querySelector(".star-map__marquee")).toBeNull();
+    expect(document.querySelector(".star-map-card-shell--selected")).toBeNull();
+  });
+
+  it("carries the rest of the selection when one selected card is dragged", async () => {
+    renderMap(4);
+    await ready();
+
+    fireEvent.pointerDown(viewport(), {
+      button: 0,
+      shiftKey: true,
+      clientX: -4000,
+      clientY: -4000,
+    });
+    fireEvent.pointerMove(window, { clientX: 4000, clientY: 4000 });
+    fireEvent.pointerUp(window, { clientX: 4000, clientY: 4000 });
+
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll(".star-map-card-shell--selected").length,
+      ).toBeGreaterThan(1);
+    });
+
+    const selected = shells().filter((shell) =>
+      shell.className.includes("--selected"),
+    );
+    const dragged = selected[0];
+    const passenger = selected[1];
+    const passengerLeftBefore = Number.parseFloat(passenger.style.left);
+
+    fireEvent.pointerDown(dragged, { button: 0, clientX: 500, clientY: 400 });
+    await act(async () => {
+      fireEvent.pointerMove(window, { clientX: 560, clientY: 400 });
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    });
+
+    // The passenger travels with the card under the pointer; without the
+    // group hand-off it would sit still while its neighbour moved.
+    await waitFor(() => {
+      expect(Number.parseFloat(passenger.style.left)).not.toBe(
+        passengerLeftBefore,
+      );
+    });
+    fireEvent.pointerUp(window, { clientX: 560, clientY: 400 });
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
@@ -344,7 +344,9 @@ describe("star map selection is amendable", () => {
 
     // The absent cards take no offset. Committing one would land invisibly
     // and only surface when the card came back.
-    const moved = vi.mocked(desktopApi.setStarMapCardPosition).mock.calls;
+    const setCardPosition = desktopApi.setStarMapCardPosition;
+    if (!setCardPosition) throw new Error("no setStarMapCardPosition");
+    const moved = vi.mocked(setCardPosition).mock.calls;
     expect(moved.length).toBeGreaterThan(0);
     for (const call of moved) {
       expect(JSON.stringify(call)).not.toMatch(/t2|t3/);

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
@@ -41,21 +41,47 @@ function thread(id: string): NavigationThreadSummary {
   } as unknown as NavigationThreadSummary;
 }
 
-function renderMap(count: number) {
-  return render(
+function renderMap(
+  count: number,
+  overrides?: { desktopApi?: DesktopApi; onClose?: () => void },
+) {
+  const desktopApi = overrides?.desktopApi ?? buildDesktopApi();
+  const screenFor = (threadCount: number) => (
     <StarMapScreen
-      desktopApi={buildDesktopApi()}
-      localThreads={Array.from({ length: count }, (_, index) =>
+      desktopApi={desktopApi}
+      localThreads={Array.from({ length: threadCount }, (_, index) =>
         thread(`t${index}`),
       )}
       sessionKeys={{}}
       localInstanceLabel="Mac-Mini-M4"
       floating={false}
-      onClose={() => undefined}
+      onClose={overrides?.onClose ?? (() => undefined)}
       onOpenLocalThread={() => undefined}
       onFocusLocalInstance={() => undefined}
-    />,
+    />
   );
+  const result = render(screenFor(count));
+  return {
+    ...result,
+    /** Re-render with a different thread count, as a filter change would. */
+    showThreads: (next: number) => result.rerender(screenFor(next)),
+  };
+}
+
+/** Sweep the whole cloud, so every card lands in the selection. */
+function sweepEverything(modifier: "shiftKey" | "metaKey" = "shiftKey") {
+  fireEvent.pointerDown(viewport(), {
+    button: 0,
+    [modifier]: true,
+    clientX: -4000,
+    clientY: -4000,
+  });
+  fireEvent.pointerMove(window, { clientX: 4000, clientY: 4000 });
+  fireEvent.pointerUp(window, { clientX: 4000, clientY: 4000 });
+}
+
+function selectedShells(): HTMLElement[] {
+  return shells().filter((shell) => shell.className.includes("--selected"));
 }
 
 function viewport(): HTMLElement {
@@ -179,5 +205,149 @@ describe("star map marquee selection", () => {
       );
     });
     fireEvent.pointerUp(window, { clientX: 560, clientY: 400 });
+  });
+});
+
+describe("star map selection is amendable", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+  });
+
+  it("reports how many cards are selected", async () => {
+    renderMap(4);
+    await ready();
+    expect(screen.queryByText(/cards selected/)).toBeNull();
+
+    sweepEverything();
+    await waitFor(() => {
+      expect(screen.getByText(/\d+ cards selected/)).toBeTruthy();
+    });
+    expect(screen.getByText(`${selectedShells().length} cards selected`)).toBeTruthy();
+  });
+
+  it("clears the selection on a click on empty canvas", async () => {
+    renderMap(4);
+    await ready();
+    sweepEverything();
+    await waitFor(() => expect(selectedShells().length).toBeGreaterThan(1));
+
+    // Press and release in the same spot: a click, not an abandoned pan.
+    fireEvent.pointerDown(viewport(), { button: 0, clientX: 300, clientY: 300 });
+    fireEvent.pointerUp(window, { clientX: 300, clientY: 300 });
+
+    await waitFor(() => expect(selectedShells()).toHaveLength(0));
+  });
+
+  it("keeps the selection when a pan is released somewhere else", async () => {
+    renderMap(4);
+    await ready();
+    sweepEverything();
+    await waitFor(() => expect(selectedShells().length).toBeGreaterThan(1));
+    const before = selectedShells().length;
+
+    fireEvent.pointerDown(viewport(), { button: 0, clientX: 300, clientY: 300 });
+    fireEvent.pointerMove(window, { clientX: 460, clientY: 380 });
+    fireEvent.pointerUp(window, { clientX: 460, clientY: 380 });
+
+    expect(selectedShells()).toHaveLength(before);
+  });
+
+  it("drops the selection on Escape before it closes the map", async () => {
+    const onClose = vi.fn();
+    renderMap(4, { onClose });
+    await ready();
+    sweepEverything();
+    await waitFor(() => expect(selectedShells().length).toBeGreaterThan(1));
+
+    const layer = document.querySelector(".star-map");
+    if (!(layer instanceof HTMLElement)) throw new Error("no layer");
+    fireEvent.keyDown(layer, { key: "Escape" });
+
+    await waitFor(() => expect(selectedShells()).toHaveLength(0));
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Nothing left to unwind, so the second press closes.
+    fireEvent.keyDown(layer, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("takes a card back out of the selection on a modifier-click", async () => {
+    renderMap(4);
+    await ready();
+    sweepEverything();
+    await waitFor(() => expect(selectedShells().length).toBeGreaterThan(1));
+    const before = selectedShells().length;
+
+    fireEvent.pointerDown(selectedShells()[0], {
+      button: 0,
+      shiftKey: true,
+      clientX: 500,
+      clientY: 400,
+    });
+
+    await waitFor(() => expect(selectedShells()).toHaveLength(before - 1));
+  });
+
+  it("extends the selection on a Cmd-sweep and replaces it on a Shift-sweep", async () => {
+    renderMap(4);
+    await ready();
+    sweepEverything();
+    await waitFor(() => expect(selectedShells().length).toBeGreaterThan(1));
+    const before = selectedShells().length;
+
+    // A sweep over empty space. In add mode it takes nothing away...
+    fireEvent.pointerDown(viewport(), {
+      button: 0,
+      metaKey: true,
+      clientX: 6000,
+      clientY: 6000,
+    });
+    fireEvent.pointerMove(window, { clientX: 6200, clientY: 6200 });
+    fireEvent.pointerUp(window, { clientX: 6200, clientY: 6200 });
+    expect(selectedShells()).toHaveLength(before);
+
+    // ...while the same sweep in replace mode starts a fresh, empty one.
+    fireEvent.pointerDown(viewport(), {
+      button: 0,
+      shiftKey: true,
+      clientX: 6000,
+      clientY: 6000,
+    });
+    fireEvent.pointerMove(window, { clientX: 6200, clientY: 6200 });
+    fireEvent.pointerUp(window, { clientX: 6200, clientY: 6200 });
+    await waitFor(() => expect(selectedShells()).toHaveLength(0));
+  });
+
+  it("remembers cards that left the map but does not move them", async () => {
+    const desktopApi = buildDesktopApi();
+    const { showThreads } = renderMap(4, { desktopApi });
+    await ready();
+    sweepEverything();
+    await waitFor(() => expect(selectedShells().length).toBe(4));
+
+    // Two cards leave — a filter change, or the instance that owns them
+    // dropping for a moment.
+    showThreads(2);
+    await waitFor(() => expect(shells()).toHaveLength(2));
+    // Still remembered: an instance that flaps must not silently cost the
+    // operator every card it owns.
+    expect(screen.getByText("4 cards selected")).toBeTruthy();
+
+    const dragged = selectedShells()[0];
+    fireEvent.pointerDown(dragged, { button: 0, clientX: 500, clientY: 400 });
+    await act(async () => {
+      fireEvent.pointerMove(window, { clientX: 560, clientY: 400 });
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    });
+    fireEvent.pointerUp(window, { clientX: 560, clientY: 400 });
+
+    // The absent cards take no offset. Committing one would land invisibly
+    // and only surface when the card came back.
+    const moved = vi.mocked(desktopApi.setStarMapCardPosition).mock.calls;
+    expect(moved.length).toBeGreaterThan(0);
+    for (const call of moved) {
+      expect(JSON.stringify(call)).not.toMatch(/t2|t3/);
+    }
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-snapping.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-snapping.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import {
+  marqueeRect,
+  observedGaps,
+  rectIntersects,
+  resolveSnap,
+  type SnapRect,
+} from "../star-map-snapping";
+
+const CARD = { width: 200, height: 100 };
+
+function card(x: number, y: number): SnapRect {
+  return { x, y, ...CARD };
+}
+
+const SNAP = { defaultGap: 12, threshold: 8 };
+
+describe("resolveSnap alignment", () => {
+  it("does nothing when there is nothing to snap to", () => {
+    expect(resolveSnap({ ...SNAP, moving: card(0, 0), others: [] })).toEqual({
+      dx: 0,
+      dy: 0,
+      guides: [],
+    });
+  });
+
+  it("latches a near-miss left edge", () => {
+    // 5px off a shared left edge, inside the 8px tolerance.
+    const result = resolveSnap({
+      ...SNAP,
+      moving: card(105, 400),
+      others: [card(100, 0)],
+    });
+    expect(result.dx).toBe(-5);
+  });
+
+  it("leaves an edge alone once it is out of tolerance", () => {
+    const result = resolveSnap({
+      ...SNAP,
+      moving: card(120, 400),
+      others: [card(100, 0)],
+    });
+    expect(result.dx).toBe(0);
+  });
+
+  it("aligns centres, not just edges", () => {
+    // Moving centre 203, other centre 200 → pull left by 3.
+    const result = resolveSnap({
+      ...SNAP,
+      moving: card(103, 400),
+      others: [card(100, 0)],
+    });
+    expect(result.dx).toBe(-3);
+  });
+
+  it("aligns a right edge to another card's left edge", () => {
+    // Moving right edge 397 wants the neighbour's left edge at 400.
+    const result = resolveSnap({
+      ...SNAP,
+      moving: card(197, 0),
+      others: [card(400, 0)],
+    });
+    expect(result.dx).toBe(3);
+  });
+
+  it("prefers the smallest adjustment among competing neighbours", () => {
+    const result = resolveSnap({
+      ...SNAP,
+      moving: card(106, 400),
+      others: [card(100, 0), card(108, 900)],
+    });
+    expect(result.dx).toBe(2);
+  });
+
+  it("emits a guide spanning both cards so the snap is explainable", () => {
+    const result = resolveSnap({
+      ...SNAP,
+      moving: card(105, 400),
+      others: [card(100, 0)],
+    });
+    const guide = result.guides.find((entry) => entry.axis === "x");
+    expect(guide?.at).toBe(100);
+    // Spans from the topmost card's top to the bottom card's bottom.
+    expect(guide?.start).toBe(0);
+    expect(guide?.end).toBe(500);
+  });
+
+  it("snaps both axes independently", () => {
+    const result = resolveSnap({
+      ...SNAP,
+      moving: card(104, 603),
+      others: [card(100, 600)],
+    });
+    expect(result.dx).toBe(-4);
+    expect(result.dy).toBe(-3);
+  });
+});
+
+describe("observedGaps", () => {
+  it("reports the gap between two stacked cards", () => {
+    expect(observedGaps([card(0, 0), card(0, 130)], "y")).toEqual([30]);
+  });
+
+  it("ignores cards that do not overlap across the axis", () => {
+    // Side by side, so there is no vertical stack to measure.
+    expect(observedGaps([card(0, 0), card(500, 130)], "y")).toEqual([]);
+  });
+
+  it("ignores touching cards rather than reporting a zero interval", () => {
+    expect(observedGaps([card(0, 0), card(0, 100)], "y")).toEqual([]);
+  });
+
+  it("collects every distinct gap in the arrangement", () => {
+    const gaps = observedGaps(
+      [card(0, 0), card(0, 130), card(0, 250)],
+      "y",
+    );
+    // 30 between the first pair, 20 between the second, 150 end to end.
+    expect(gaps).toEqual([20, 30, 150]);
+  });
+});
+
+describe("resolveSnap spacing", () => {
+  it("matches a spacing the arrangement already uses", () => {
+    // Two cards 30px apart; a third dragged near that interval takes it.
+    const others = [card(0, 0), card(0, 130)];
+    const result = resolveSnap({
+      ...SNAP,
+      moving: card(0, 264),
+      others,
+    });
+    expect(result.dy).toBe(-4);
+    expect(result.spacing).toEqual({ axis: "y", gap: 30 });
+  });
+
+  it("offers the default gap when the arrangement has none of its own", () => {
+    const result = resolveSnap({
+      ...SNAP,
+      moving: card(0, 116),
+      others: [card(0, 0)],
+    });
+    expect(result.dy).toBe(-4);
+    expect(result.spacing).toEqual({ axis: "y", gap: 12 });
+  });
+
+  it("spaces above a neighbour as readily as below", () => {
+    const result = resolveSnap({
+      ...SNAP,
+      moving: card(0, -117),
+      others: [card(0, 0)],
+    });
+    expect(result.dy).toBe(5);
+  });
+
+  it("does not space against a card it is not stacked with", () => {
+    const result = resolveSnap({
+      ...SNAP,
+      moving: card(900, 116),
+      others: [card(0, 0)],
+    });
+    expect(result.dy).toBe(0);
+    expect(result.spacing).toBeUndefined();
+  });
+
+  it("lets alignment win an axis over spacing", () => {
+    // Tops are 3px apart AND a spacing candidate is nearby; the visible
+    // edge match is the stronger cue, so it takes the axis.
+    const result = resolveSnap({
+      ...SNAP,
+      moving: card(0, 3),
+      others: [card(0, 0)],
+    });
+    expect(result.dy).toBe(-3);
+    expect(result.spacing).toBeUndefined();
+  });
+
+  it("aligns one axis and spaces the other — the stacking case", () => {
+    // Dragged slightly off a shared left edge and slightly off the
+    // established 30px gap: X aligns, Y takes the spacing detent.
+    const result = resolveSnap({
+      ...SNAP,
+      moving: card(4, 264),
+      others: [card(0, 0), card(0, 130)],
+    });
+    expect(result.dx).toBe(-4);
+    expect(result.dy).toBe(-4);
+    expect(result.spacing).toEqual({ axis: "y", gap: 30 });
+  });
+});
+
+describe("marquee geometry", () => {
+  it("normalises a drag in any direction", () => {
+    expect(marqueeRect({ x: 100, y: 80 }, { x: 20, y: 10 })).toEqual({
+      x: 20,
+      y: 10,
+      width: 80,
+      height: 70,
+    });
+  });
+
+  it("selects a card the marquee touches", () => {
+    expect(rectIntersects(card(0, 0), marqueeRect({ x: 190, y: 90 }, { x: 300, y: 200 }))).toBe(
+      true,
+    );
+  });
+
+  it("leaves a card the marquee only approaches", () => {
+    expect(
+      rectIntersects(card(0, 0), marqueeRect({ x: 201, y: 101 }, { x: 300, y: 200 })),
+    ).toBe(false);
+  });
+
+  it("treats a zero-size marquee as selecting nothing", () => {
+    expect(
+      rectIntersects(card(0, 0), marqueeRect({ x: 50, y: 50 }, { x: 50, y: 50 })),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-snapping.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-snapping.ts
@@ -1,0 +1,263 @@
+/**
+ * Snapping for hand-arranged star map cards.
+ *
+ * Two kinds, both computed in absolute canvas coordinates so cards from
+ * different clouds can align with each other:
+ *
+ * - **Alignment** — a dragged card's left / centre / right (and top /
+ *   middle / bottom) latching onto the same edge of a nearby card.
+ * - **Spacing** — once cards are stacked, matching a gap that already
+ *   exists in the arrangement rather than a fixed ladder of pixel values.
+ *   An arbitrary 2/5/10px ladder fights the operator; a spacing they
+ *   already chose is one they meant.
+ */
+
+export type SnapRect = {
+  /** Top-left corner, absolute canvas coordinates. */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type SnapAxis = "x" | "y";
+
+/**
+ * A line to draw so the operator can see WHY the card latched. Without it
+ * a snap reads as the card sticking for no reason.
+ */
+export type AlignmentGuide = {
+  axis: SnapAxis;
+  /** Canvas coordinate of the line on its own axis. */
+  at: number;
+  /** Extent along the other axis, so the line spans both cards. */
+  start: number;
+  end: number;
+};
+
+export type SnapResult = {
+  dx: number;
+  dy: number;
+  guides: AlignmentGuide[];
+  /** Set when a spacing detent claimed an axis, for an optional readout. */
+  spacing?: { axis: SnapAxis; gap: number };
+};
+
+/** Gaps below this are treated as "touching" rather than a real interval. */
+const MIN_MEANINGFUL_GAP = 4;
+/** Two cards count as stacked when they overlap this much across the axis. */
+const CROSS_AXIS_OVERLAP = 8;
+
+function edgesFor(rect: SnapRect, axis: SnapAxis): number[] {
+  return axis === "x"
+    ? [rect.x, rect.x + rect.width / 2, rect.x + rect.width]
+    : [rect.y, rect.y + rect.height / 2, rect.y + rect.height];
+}
+
+function spanStart(rect: SnapRect, axis: SnapAxis): number {
+  return axis === "x" ? rect.y : rect.x;
+}
+
+function spanEnd(rect: SnapRect, axis: SnapAxis): number {
+  return axis === "x" ? rect.y + rect.height : rect.x + rect.width;
+}
+
+/**
+ * Best edge alignment on one axis: the smallest adjustment that brings any
+ * of the moving card's three edges onto any of a neighbour's three.
+ */
+function alignAxis(params: {
+  axis: SnapAxis;
+  moving: SnapRect;
+  others: readonly SnapRect[];
+  threshold: number;
+}): { delta: number; guide: AlignmentGuide } | undefined {
+  const movingEdges = edgesFor(params.moving, params.axis);
+  let best: { delta: number; guide: AlignmentGuide } | undefined;
+
+  for (const other of params.others) {
+    for (const otherEdge of edgesFor(other, params.axis)) {
+      for (const movingEdge of movingEdges) {
+        const delta = otherEdge - movingEdge;
+        if (Math.abs(delta) > params.threshold) continue;
+        if (best && Math.abs(delta) >= Math.abs(best.delta)) continue;
+        best = {
+          delta,
+          guide: {
+            axis: params.axis,
+            at: otherEdge,
+            start: Math.min(
+              spanStart(params.moving, params.axis),
+              spanStart(other, params.axis),
+            ),
+            end: Math.max(
+              spanEnd(params.moving, params.axis),
+              spanEnd(other, params.axis),
+            ),
+          },
+        };
+      }
+    }
+  }
+  return best;
+}
+
+/** Do two rects overlap enough across `axis` to be considered a stack? */
+function overlapsAcross(
+  a: SnapRect,
+  b: SnapRect,
+  axis: SnapAxis,
+): boolean {
+  const aStart = spanStart(a, axis);
+  const aEnd = spanEnd(a, axis);
+  const bStart = spanStart(b, axis);
+  const bEnd = spanEnd(b, axis);
+  return Math.min(aEnd, bEnd) - Math.max(aStart, bStart) >= CROSS_AXIS_OVERLAP;
+}
+
+/**
+ * Gaps the arrangement already contains along `axis`, between cards that
+ * are stacked on it. These become the detents, which is why the snapping
+ * gets tighter the more the operator has already arranged.
+ */
+export function observedGaps(
+  rects: readonly SnapRect[],
+  axis: SnapAxis,
+): number[] {
+  const gaps = new Set<number>();
+  for (let i = 0; i < rects.length; i += 1) {
+    for (let j = i + 1; j < rects.length; j += 1) {
+      const a = rects[i];
+      const b = rects[j];
+      if (!overlapsAcross(a, b, axis)) continue;
+      const aStart = axis === "x" ? a.x : a.y;
+      const aSize = axis === "x" ? a.width : a.height;
+      const bStart = axis === "x" ? b.x : b.y;
+      const bSize = axis === "x" ? b.width : b.height;
+      const gap =
+        aStart < bStart ? bStart - (aStart + aSize) : aStart - (bStart + bSize);
+      if (gap >= MIN_MEANINGFUL_GAP) gaps.add(Math.round(gap));
+    }
+  }
+  return [...gaps].sort((left, right) => left - right);
+}
+
+/**
+ * Snap the moving card so it sits a known gap from a stacked neighbour.
+ * Only considered on an axis alignment did not already claim.
+ */
+function spaceAxis(params: {
+  axis: SnapAxis;
+  defaultGap: number;
+  moving: SnapRect;
+  others: readonly SnapRect[];
+  threshold: number;
+}): { delta: number; gap: number } | undefined {
+  const gaps = [...observedGaps(params.others, params.axis)];
+  if (!gaps.includes(params.defaultGap)) gaps.push(params.defaultGap);
+
+  const movingStart = params.axis === "x" ? params.moving.x : params.moving.y;
+  const movingSize =
+    params.axis === "x" ? params.moving.width : params.moving.height;
+
+  let best: { delta: number; gap: number } | undefined;
+  for (const other of params.others) {
+    if (!overlapsAcross(params.moving, other, params.axis)) continue;
+    const otherStart = params.axis === "x" ? other.x : other.y;
+    const otherSize = params.axis === "x" ? other.width : other.height;
+    for (const gap of gaps) {
+      // Sitting after the neighbour, and sitting before it.
+      const candidates = [
+        otherStart + otherSize + gap,
+        otherStart - gap - movingSize,
+      ];
+      for (const candidate of candidates) {
+        const delta = candidate - movingStart;
+        if (Math.abs(delta) > params.threshold) continue;
+        if (best && Math.abs(delta) >= Math.abs(best.delta)) continue;
+        best = { delta, gap };
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Resolve a drag position into a snapped one.
+ *
+ * Alignment wins an axis over spacing: latching an edge is the stronger,
+ * more legible cue, and the two commonly apply to different axes anyway —
+ * stacking a card under another aligns X and spaces Y, which is exactly
+ * the arrangement this exists to make easy.
+ */
+export function resolveSnap(params: {
+  defaultGap: number;
+  moving: SnapRect;
+  others: readonly SnapRect[];
+  /** Canvas-space tolerance; callers convert from a screen-space value. */
+  threshold: number;
+}): SnapResult {
+  if (params.threshold <= 0 || params.others.length === 0) {
+    return { dx: 0, dy: 0, guides: [] };
+  }
+
+  const result: SnapResult = { dx: 0, dy: 0, guides: [] };
+  for (const axis of ["x", "y"] as const) {
+    const aligned = alignAxis({
+      axis,
+      moving: params.moving,
+      others: params.others,
+      threshold: params.threshold,
+    });
+    if (aligned) {
+      if (axis === "x") result.dx = aligned.delta;
+      else result.dy = aligned.delta;
+      result.guides.push(aligned.guide);
+      continue;
+    }
+    const spaced = spaceAxis({
+      axis,
+      defaultGap: params.defaultGap,
+      moving: params.moving,
+      others: params.others,
+      threshold: params.threshold,
+    });
+    if (!spaced) continue;
+    if (axis === "x") result.dx = spaced.delta;
+    else result.dy = spaced.delta;
+    result.spacing = { axis, gap: spaced.gap };
+  }
+  return result;
+}
+
+/**
+ * Whether a rect intersects a marquee, for rubber-band selection.
+ *
+ * An empty rect intersects nothing, so a marquee the operator never
+ * dragged out selects nothing — rather than quietly claiming whatever
+ * card happened to sit under the press.
+ */
+export function rectIntersects(a: SnapRect, b: SnapRect): boolean {
+  if (a.width <= 0 || a.height <= 0 || b.width <= 0 || b.height <= 0) {
+    return false;
+  }
+  return (
+    a.x < b.x + b.width
+    && a.x + a.width > b.x
+    && a.y < b.y + b.height
+    && a.y + a.height > b.y
+  );
+}
+
+/** Normalise a drag between two points into a positive-extent rect. */
+export function marqueeRect(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+): SnapRect {
+  return {
+    x: Math.min(from.x, to.x),
+    y: Math.min(from.y, to.y),
+    width: Math.abs(to.x - from.x),
+    height: Math.abs(to.y - from.y),
+  };
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9792,6 +9792,25 @@ textarea,
   cursor: default;
 }
 
+/* Alignment guides, drawn only while a card is being dragged. They exist
+   so a snap is explainable: without the line, a card latching reads as the
+   drag sticking for no reason. */
+.star-map__guides {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 6;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.star-map__guide {
+  stroke: var(--accent-bright);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+  opacity: 0.9;
+}
+
 /* Projects lens: projects seat along spiral arms, each the centre of its
    own little system. Deliberately quiet — a project is a place, not a
    star, and a field of bright orange discs reads as noise rather than as

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9792,6 +9792,22 @@ textarea,
   cursor: default;
 }
 
+/* Rubber-band selection. Shift-drag, because a plain drag already pans
+   and panning is the more frequent gesture. */
+.star-map__marquee {
+  position: absolute;
+  z-index: 7;
+  border: 1px solid var(--accent-border);
+  border-radius: 4px;
+  background: var(--accent-soft);
+  pointer-events: none;
+}
+
+.star-map-card-shell--selected .star-map-card {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 1px var(--accent-border);
+}
+
 /* Alignment guides, drawn only while a card is being dragged. They exist
    so a snap is explainable: without the line, a card latching reads as the
    drag sticking for no reason. */

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9793,19 +9793,94 @@ textarea,
 }
 
 /* Rubber-band selection. Shift-drag, because a plain drag already pans
-   and panning is the more frequent gesture. */
+   and panning is the more frequent gesture.
+
+   The band lives inside the zoomed canvas, so its border and radius are
+   written inline as `1 / scale` — a fixed 1px border renders at 0.35px
+   zoomed out, which is exactly when a sweep covers the most cards. */
 .star-map__marquee {
   position: absolute;
   z-index: 7;
-  border: 1px solid var(--accent-border);
-  border-radius: 4px;
+  border-style: solid;
+  border-color: var(--accent-border);
   background: var(--accent-soft);
   pointer-events: none;
 }
 
+/* Selection speaks the sidebar's language: the same tinted fill and accent
+   border as `.thread-row.is-selected`, and the same solid accent rail,
+   which is the part that actually reads. The previous 1px ring reused
+   `--accent-border` — the identical token the hover state puts on the
+   border — so a selected card and a hovered one were the same picture. */
 .star-map-card-shell--selected .star-map-card {
   border-color: var(--accent-border);
-  box-shadow: 0 0 0 1px var(--accent-border);
+  background: var(--bg-row-active);
+}
+
+.star-map-card-shell--selected .star-map-card::before {
+  position: absolute;
+  top: 6px;
+  bottom: 6px;
+  left: 3px;
+  z-index: 1;
+  width: 3px;
+  border-radius: 999px;
+  background: var(--accent);
+  content: "";
+  pointer-events: none;
+}
+
+/* Hover still elevates a selected card. Selection is carried by the rail,
+   so the pointer keeps its own feedback instead of the two fighting over
+   the background. */
+.star-map-card-shell--selected:hover .star-map-card {
+  background: var(--bg-panel-elevated);
+}
+
+/* Selection readout. Bottom-centre, clear of the top chrome, and the only
+   thing on the surface that admits a selection exists: it carries the
+   count, the way to drop it, and — by appearing at all — the hint that the
+   gesture is there to find. */
+.star-map__selection {
+  display: inline-flex;
+  position: absolute;
+  bottom: 18px;
+  left: 50%;
+  z-index: 8;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 6px 5px 12px;
+  transform: translateX(-50%);
+  border: 1px solid var(--accent-border);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg-panel) 92%, transparent);
+  color: var(--text-secondary);
+  font-size: 11px;
+  box-shadow: var(--shadow-popover);
+}
+
+.star-map__selection-hint {
+  color: var(--text-muted);
+}
+
+.star-map__selection-clear {
+  padding: 3px 8px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.star-map__selection-clear:hover {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.star-map__selection-clear:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
 }
 
 /* Alignment guides, drawn only while a card is being dragged. They exist
@@ -9820,10 +9895,13 @@ textarea,
   pointer-events: none;
 }
 
+/* Width and dash are written inline as `n / scale` rather than set here.
+   `vector-effect: non-scaling-stroke` would be the obvious answer, but it
+   only cancels transforms *inside* the SVG viewport, and the transform
+   here is a CSS `scale()` on the canvas div above it — so the guide would
+   still thin out to a sub-pixel dotted hairline at MIN_ZOOM. */
 .star-map__guide {
   stroke: var(--accent-bright);
-  stroke-width: 1;
-  stroke-dasharray: 3 3;
   opacity: 0.9;
 }
 


### PR DESCRIPTION
Three asks, built on top of the drag-scale fix that just landed.

## 1. Alignment guides

A dragged card latches onto a neighbour's **left / centre / right** (and **top / middle / bottom**), and draws the line it latched to. A snap without a visible reason reads as the drag sticking for no reason.

Two decisions carried over from the drag threshold, for the same reasons:

- **Tolerance is in screen pixels** (6px), converted to canvas units at the current zoom, so the pull feels identical however far in you are.
- **Geometry is absolute canvas coordinates**, not cloud-local, so cards on *different instances* align with each other. The operator sees one map, not several coordinate systems.

## 2. Spacing detents

Deliberately **not** a fixed 2/5/10px ladder. Once two cards sit a given distance apart, that distance becomes the target for the next one — the arrangement teaches the snapping what "correct" means here. An arbitrary ladder fights an operator who wanted 30px; a spacing they already chose is one they meant. A default gap seeds the first stack, before there's anything to learn from.

Alignment wins an axis over spacing (a visible edge is the stronger cue), and they usually claim different axes anyway: stacking a card under another aligns X and spaces Y, which is the exact arrangement this exists to make easy.

## 3. Marquee multi-select

**Shift-drag** sweeps a selection; plain drag still pans. Dragging any selected card carries the rest.

Movement writes the DOM directly, the same way the dragged card already moves itself — a React state update per frame across N cards is the one cost this surface can't pay mid-drag. The arrangement hears about it once, on release.

**No protocol work needed.** `setCardPosition` is already keyed per instance+thread and merges LWW per entry, so N cards is N independent writes. My earlier estimate that this needed a batch API was wrong.

## Two bugs this surfaced

- **Unmeasured cards had zero-height rects.** `heights[index] ?? FALLBACK` keeps a `0` because zero isn't nullish, so before the first measure pass cards were invisible to both snapping and selection. Caught by the empty-rect guard doing its job on data that should never have been empty.
- **`CSS.escape` inside a quoted attribute selector** over-escaped the `:` in every card key and matched nothing, so group drag silently moved only the card under the pointer. Shells are now found by scanning `data-card-key`.

## Tests

22 on the snapping geometry (edge alignment, centre alignment, competing neighbours, guide extents, observed gaps, spacing above and below, alignment-beats-spacing, marquee normalisation and hit-testing) and 4 at the screen level (sweep selects, marquee appears and clears, plain drag still pans, passengers travel with the dragged card).

Full suite green, typecheck / `lint:colors` / `lint:boundaries` / ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)