### PR TITLE
fix(desktop): keep tool accounting on ACP threads after a turn ends

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -56,6 +56,7 @@ import type {
   TaskMonitorResponse,
   ThreadExecutionMode,
   ThreadOverlayState,
+  ThreadToolAccounting,
   ThreadUsageLineRecord,
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
@@ -326,7 +327,13 @@ function createOverlayStoreMock(params?: {
   executionMode?: "default" | "full-access";
   launchpadDefaults?: NavigationLaunchpadDefaults;
   overlays?: Record<string, ThreadOverlayState>;
+  toolAccounting?: ThreadToolAccounting;
 }) {
+  const toolAccounting: ThreadToolAccounting = params?.toolAccounting ?? {
+    alerts: [],
+    invocations: [],
+    summaries: [],
+  };
   const initialOverlay = params?.executionMode
     ? {
         backend: "codex" as const,
@@ -420,6 +427,7 @@ function createOverlayStoreMock(params?: {
       ),
       summaries: [],
     }),
+    readThreadToolAccounting: async () => toolAccounting,
     upsertThreadMessageOrigin,
     readThreadMessageOrigins: async ({
       backend,
@@ -5171,6 +5179,84 @@ describe("DesktopBackendRegistry", () => {
     expect(
       viewOnly.replay.entries.some((entry) => entry.type === "review"),
     ).toBe(false);
+
+    await registry.close();
+  });
+
+  it("includes persisted tool accounting when reading ACP threads", async () => {
+    // The Pricing panel's "Tool output" section renders
+    // `response.toolAccounting`. Live `thread/toolAccounting/updated` events
+    // patch it into the session while a turn runs, and any readThread replaces
+    // the whole response — so a read that omits the field erases the section.
+    // On an ACP thread that is exactly what the operator sees: tool output
+    // during the turn, gone the moment it ends. The Codex read path has always
+    // returned this; the ACP path did not.
+    const acpBackendId = "acp:grok" as AcpBackendId;
+    const threadId = "grok-tool-accounting";
+    const toolAccounting: ThreadToolAccounting = {
+      alerts: [],
+      invocations: [
+        {
+          backend: acpBackendId,
+          threadId,
+          itemId: "item-1",
+          invocationId: "inv-1",
+          toolName: "shell",
+          category: "shell",
+          status: "completed",
+          observedAt: 3_000,
+          updatedAt: 3_000,
+          outputChars: 2_200,
+          outputLines: 23,
+          estimatedOutputTokens: 550,
+          warningLines: 0,
+          errorLines: 0,
+          infoLines: 1,
+          debugLines: 0,
+          outputTruncated: false,
+          noisy: false,
+        },
+      ],
+      summaries: [
+        {
+          category: "shell",
+          toolName: "shell",
+          invocationCount: 11,
+          outputChars: 36_000,
+          outputLines: 606,
+          estimatedOutputTokens: 8_974,
+          warningLines: 0,
+          errorLines: 0,
+          infoLines: 1,
+          debugLines: 0,
+          noisyInvocationCount: 0,
+          lastObservedAt: 3_000,
+        },
+      ],
+    };
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      overlayStore: createOverlayStoreMock({ toolAccounting }),
+      sessionId: threadId,
+      sessions: [
+        {
+          backendId: acpBackendId,
+          sessionId: threadId,
+          title: "ACP session",
+          createdAt: 1_000,
+          updatedAt: 4_000,
+          executionMode: "default",
+          status: "idle",
+        },
+      ],
+    });
+
+    const response = await registry.readThread({
+      backend: acpBackendId,
+      threadId,
+    });
+
+    expect(response.toolAccounting).toEqual(toolAccounting);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8595,6 +8595,20 @@ export class DesktopBackendRegistry {
             threadId: request.threadId,
           })
         : { lines: [], summaries: [] };
+    // Tool accounting is durable, but the response replaces the renderer's
+    // whole session snapshot — so omitting it here does not just leave the
+    // field stale, it erases whatever the live
+    // `thread/toolAccounting/updated` events had already patched in. On an
+    // ACP thread that read lands as the turn ends, which is why the Pricing
+    // panel's "Tool output" section used to appear during a turn and vanish
+    // the moment it finished.
+    const toolAccounting =
+      typeof this.overlayStore.readThreadToolAccounting === "function"
+        ? await this.overlayStore.readThreadToolAccounting({
+            backend,
+            threadId: request.threadId,
+          })
+        : undefined;
     const pendingRequest = this.pendingServerRequestForThread({
       backend,
       threadId: request.threadId,
@@ -8604,6 +8618,7 @@ export class DesktopBackendRegistry {
       fetchedAt: Date.now(),
       pricing,
       threadId: request.threadId,
+      ...(toolAccounting ? { toolAccounting } : {}),
       ...(pendingRequest ? { pendingRequest } : {}),
       ...(replayWithMessageOrigins.threadStatus
         ? { threadStatus: replayWithMessageOrigins.threadStatus }


### PR DESCRIPTION
With the tool-accounting experiment enabled, an ACP (Grok) thread shows the Pricing panel's **Tool output** section while a turn runs, then loses it the instant the turn ends. A Codex thread keeps it — that asymmetry is the bug.

## Cause

`readAcpThread` never returned `toolAccounting`. The Codex `readThread` path always has.

The field is durable in sqlite, so the omission looks harmless at a glance. It isn't, because the read response **replaces the renderer's whole session snapshot**:

- during a turn, `thread/toolAccounting/updated` events patch `session.response.toolAccounting` and the section renders
- the next `readThread` returns a response with no `toolAccounting` and the section is erased

And the read that lands right as a turn ends is what makes it vanish exactly then.

This is the same defect as the two fields fixed in #1394. That change restored `managedReviewEntries` and `immutableUsageActivities` to this exact return statement and missed the third one sitting next to them.

## Fix

Read `toolAccounting` from the overlay store and include it, mirroring the Codex path.

## Testing

Test-first — confirmed returning `undefined` before the change:

```
expect(response.toolAccounting).toEqual(toolAccounting)
+ Received: undefined
```

`createOverlayStoreMock` gains a `toolAccounting` option and a `readThreadToolAccounting` implementation, so the ACP read path is exercised with realistic `ThreadToolInvocationRecord` / `ThreadToolInvocationSummary` rows.

- `pnpm test` — 7034 passed, 2 skipped. Three failures under full-suite load (`logs-window.test.tsx`, two in `acp-backend-adapter.test.ts`) are the known load-dependent flake family; all pass in isolation (54/54), and this change touches neither the logs window nor session/load replay.
- `pnpm --filter @pwragent/desktop typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries` (no violations).

## Note

Independent of #1398 — different file region, no overlap, either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)