### PR TITLE
fix(desktop): bound what a star map chat card loads and mounts

### DIFF
--- a/apps/desktop/e2e/fixtures/federation-gateway.ts
+++ b/apps/desktop/e2e/fixtures/federation-gateway.ts
@@ -54,7 +54,35 @@ export type GatewayThreadSeed = {
   source?: AppServerBackendKind;
   executionMode?: AppServerThreadSummary["executionMode"];
   linkedDirectories?: LinkedDirectorySummary[];
+  /**
+   * Needed to reach a Star Map lane: a thread with no attention category
+   * is not on the map at all, and an idle thread with no PR and no
+   * unpushed commits matches none. Same reason `fixtures/star-map/` marks
+   * its threads active.
+   */
+  threadStatus?: "active" | "idle";
+  /**
+   * Serve a large, genuinely paged transcript for this thread instead of
+   * the one-line default. Entries are generated on demand from the
+   * request's `limit` / `before`, so the gateway can answer "how much did
+   * the client actually ask for" rather than only "what did we send".
+   */
+  transcript?: {
+    entryCount: number;
+    /** Padding per entry; entryCount * bytesPerEntry is the notional size. */
+    bytesPerEntry: number;
+  };
 };
+
+/** Entries the fake backend serves per requested turn. */
+const GATEWAY_ENTRIES_PER_TURN = 4;
+
+/**
+ * Ceiling on a single response, so a client that regresses to asking for
+ * everything fails the assertion instead of materialising ~120 MB inside
+ * the Playwright process and taking the runner down with it.
+ */
+const GATEWAY_MAX_RESPONSE_ENTRIES = 400;
 
 export type GatewayDirectorySeed = {
   key: string;
@@ -72,6 +100,16 @@ export type InProcessFederationGateway = {
   url: string;
   /** Requests the canned backend has served, oldest first. */
   calls: { method: string; params: unknown }[];
+  /**
+   * What the paged-transcript backend actually handed over. `bytesServed`
+   * is the transcript payload alone; `unboundedRequests` counts reads that
+   * asked for the thread from its first message.
+   */
+  transcriptStats: {
+    bytesServed: number;
+    entriesServed: number;
+    unboundedRequests: number;
+  };
   /** Current pin rank per thread id (mutated by backend.setThreadPin). */
   pinnedRankByThreadId: Map<string, string | undefined>;
   /** Resolves when a client connection has completed enrollment/auth. */
@@ -118,6 +156,70 @@ export async function startInProcessFederationGateway(params: {
   const threads = [...params.threads];
 
   const calls: { method: string; params: unknown }[] = [];
+  const transcriptStats = {
+    bytesServed: 0,
+    entriesServed: 0,
+    unboundedRequests: 0,
+  };
+
+  /**
+   * A real paging backend over a synthetic transcript.
+   *
+   * Entries are numbered oldest-first; `before` is the index to read
+   * backwards from, and `limit` is in TURNS (what the desktop sends), so
+   * the window is `limit * GATEWAY_ENTRIES_PER_TURN` entries. A request
+   * with no `limit` means "the whole thread from its first message" —
+   * recorded, and clamped so it cannot exhaust the test process.
+   */
+  const servePagedTranscript = (params: {
+    request: AppServerReadThreadRequest;
+    transcript: NonNullable<GatewayThreadSeed["transcript"]>;
+  }): AppServerReadThreadResponse => {
+    const { request, transcript } = params;
+    const requested = (request as { limit?: number }).limit;
+    const before = (request as { before?: string }).before;
+    if (requested === undefined) transcriptStats.unboundedRequests += 1;
+
+    const end = before === undefined
+      ? transcript.entryCount
+      : Math.max(0, Math.min(transcript.entryCount, Number.parseInt(before, 10)));
+    const windowSize = Math.min(
+      requested === undefined
+        ? transcript.entryCount
+        : Math.max(1, requested) * GATEWAY_ENTRIES_PER_TURN,
+      GATEWAY_MAX_RESPONSE_ENTRIES,
+    );
+    const start = Math.max(0, end - windowSize);
+
+    const padding = "x".repeat(Math.max(1, transcript.bytesPerEntry));
+    const entries = [];
+    for (let index = start; index < end; index += 1) {
+      const text = `entry ${index} ${padding}`;
+      transcriptStats.bytesServed += text.length;
+      transcriptStats.entriesServed += 1;
+      entries.push({
+        type: "message" as const,
+        id: `${request.threadId}-e-${index}`,
+        role: "assistant" as const,
+        text,
+      });
+    }
+
+    return {
+      backend: "codex",
+      fetchedAt: Date.now(),
+      threadId: request.threadId,
+      replay: {
+        entries,
+        messages: [],
+        pagination: {
+          supportsPagination: true,
+          hasPreviousPage: start > 0,
+          previousCursor: String(start),
+        },
+      },
+    } as AppServerReadThreadResponse;
+  };
   const pinnedRankByThreadId = new Map<string, string | undefined>(
     threads.map((thread) => [thread.id, thread.pinnedRank]),
   );
@@ -141,6 +243,7 @@ export async function startInProcessFederationGateway(params: {
           : []),
       updatedAt: thread.updatedAt,
       createdAt: thread.updatedAt,
+      ...(thread.threadStatus ? { threadStatus: thread.threadStatus } : {}),
       ...(pinnedRankByThreadId.get(thread.id) !== undefined
         ? { pinnedRank: pinnedRankByThreadId.get(thread.id) }
         : {}),
@@ -196,6 +299,10 @@ export async function startInProcessFederationGateway(params: {
     ): Promise<AppServerReadThreadResponse> {
       calls.push({ method: "readThread", params: request });
       const thread = threads.find((entry) => entry.id === request.threadId);
+      const transcript = thread?.transcript;
+      if (transcript) {
+        return servePagedTranscript({ request, transcript });
+      }
       const text = `Remote transcript for ${thread?.title ?? request.threadId}.`;
       return {
         backend: thread?.source ?? request.backend ?? "codex",
@@ -514,6 +621,7 @@ export async function startInProcessFederationGateway(params: {
     instanceLabel,
     url,
     calls,
+    transcriptStats,
     pinnedRankByThreadId,
     waitForConnection: async (timeoutMs = 15_000) => {
       await waitForConnectionCount(1, timeoutMs);

--- a/apps/desktop/e2e/star-map-chat-card-history.spec.ts
+++ b/apps/desktop/e2e/star-map-chat-card-history.spec.ts
@@ -188,13 +188,22 @@ test.describe("star map chat card history", () => {
     // 4. It opened at the NEWEST message. This is the one the CSS-contract
     //    unit test can only approximate: jsdom does no layout, so nothing
     //    else in the suite can tell a working scroller from a dead one.
-    const atBottom = await scroller.evaluate((element) => {
-      const distance =
-        element.scrollHeight - element.clientHeight - element.scrollTop;
-      return { distance, scrollHeight: element.scrollHeight };
-    });
-    // The scroller must genuinely overflow, or "at the bottom" is vacuous.
-    expect(atBottom.scrollHeight).toBeGreaterThan(0);
+    const atBottom = await scroller.evaluate((element) => ({
+      clientHeight: element.clientHeight,
+      distance:
+        element.scrollHeight - element.clientHeight - element.scrollTop,
+      scrollHeight: element.scrollHeight,
+      scrollTop: element.scrollTop,
+    }));
+    // The scroller must genuinely OVERFLOW, not merely exist. In the
+    // broken state the items box grew to its full content height and
+    // scrollHeight === clientHeight, which makes `distance` 0 and
+    // "scrolled to the bottom" true of a box that cannot scroll at all —
+    // the exact defect this test exists to catch, passing itself.
+    expect(atBottom.clientHeight).toBeGreaterThan(0);
+    expect(atBottom.scrollHeight).toBeGreaterThan(atBottom.clientHeight + 200);
+    // And it must have been moved there, not left at the top.
+    expect(atBottom.scrollTop).toBeGreaterThan(0);
     expect(atBottom.distance).toBeLessThan(80);
 
     // 5. Scrolling up fetches a BOUNDED page, not the rest of the thread.

--- a/apps/desktop/e2e/star-map-chat-card-history.spec.ts
+++ b/apps/desktop/e2e/star-map-chat-card-history.spec.ts
@@ -1,0 +1,226 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+import {
+  startInProcessFederationGateway,
+  type InProcessFederationGateway,
+} from "./fixtures/federation-gateway";
+
+/**
+ * A Star Map chat card must not read or mount a whole large thread.
+ *
+ * This is the regression that shipped: the card opened on a ~135 MB Codex
+ * thread pulled the transcript from its first message and mounted every
+ * entry, landing the operator at the OLDEST message. Three separate
+ * defects produced it, and NONE of them were catchable in jsdom — one was
+ * pure CSS (a wrapper stealing the scroller's overflow, which silently
+ * disabled scroll-to-bottom, glue, and paging), and the other two only
+ * show up against a backend that reports what it was actually asked for.
+ *
+ * So the gateway here is a real paging backend over a synthetic ~120 MB
+ * transcript: it honours `limit`/`before`, counts the bytes it hands over,
+ * and records any read that asked for the thread from the beginning. The
+ * assertions are about behaviour a user would notice — how much crossed
+ * the wire, how many nodes mounted, where the view landed, and whether
+ * scrolling up fetches a BOUNDED page rather than the rest of the thread.
+ */
+
+const THREAD_TITLE = "Huge remote transcript";
+const ENTRY_COUNT = 20_000;
+const BYTES_PER_ENTRY = 6_000;
+/** ~120 MB — what a client asking for everything would be served. */
+const TOTAL_TRANSCRIPT_BYTES = ENTRY_COUNT * BYTES_PER_ENTRY;
+
+/**
+ * Generous on purpose. The point is the ORDER OF MAGNITUDE: a card that
+ * mounts the whole thread is in the tens of thousands of nodes, and one
+ * that windows correctly is in the hundreds. A threshold this loose still
+ * fails hard on the regression without being brittle about how many
+ * elements a message bubble happens to render.
+ */
+const MAX_TRANSCRIPT_NODES = 4_000;
+/** Likewise: a bounded open is well under a megabyte. */
+const MAX_OPEN_BYTES = 4_000_000;
+
+async function createLocalControlFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(
+    path.join(os.tmpdir(), "pwragent-chat-card-history-e2e-"),
+  );
+  const fixturePath = path.join(rootDir, "local.fixture.json");
+  await writeFile(
+    fixturePath,
+    JSON.stringify({
+      metadata: { backend: "codex", scenario: "chat-card-history-control" },
+      steps: [
+        {
+          id: "initialize-1",
+          kind: "response",
+          method: "initialize",
+          result: {
+            serverInfo: { name: "Replay Codex", version: "1.0.0" },
+            methods: ["thread/list", "thread/read", "skills/list", "turn/start"],
+          },
+        },
+        {
+          id: "thread-list-1",
+          kind: "response",
+          method: "thread/list",
+          result: [],
+        },
+      ],
+    }),
+    "utf8",
+  );
+  return {
+    cleanup: () => rm(rootDir, { recursive: true, force: true }),
+    fixturePath,
+  };
+}
+
+test.describe("star map chat card history", () => {
+  let gateway: InProcessFederationGateway | undefined;
+  let fixture: { cleanup: () => Promise<void>; fixturePath: string } | undefined;
+  let app: Awaited<ReturnType<typeof launchElectronApp>> | undefined;
+
+  test.afterEach(async () => {
+    await app?.close();
+    await gateway?.close();
+    await fixture?.cleanup();
+    app = undefined;
+    gateway = undefined;
+    fixture = undefined;
+  });
+
+  test("opens a huge remote thread bounded, at the bottom, and pages on scroll", async () => {
+    test.slow();
+    gateway = await startInProcessFederationGateway({
+      threads: [
+        {
+          id: "huge-thread",
+          title: THREAD_TITLE,
+          updatedAt: Date.now(),
+          // Without this the thread matches no attention category and
+          // never reaches a lane, so the card would never be clickable.
+          threadStatus: "active",
+          transcript: {
+            entryCount: ENTRY_COUNT,
+            bytesPerEntry: BYTES_PER_ENTRY,
+          },
+        },
+      ],
+    });
+    fixture = await createLocalControlFixture();
+
+    app = await launchElectronApp({
+      fixturePath: fixture.fixturePath,
+      secretStorage: "memory",
+    });
+    const { window } = app;
+
+    // Enroll into the peer through the real Settings flow.
+    await window.getByRole("button", { name: "Open settings" }).click();
+    await window
+      .getByRole("navigation", { name: "Settings sections" })
+      .getByRole("button", { name: "Federation" })
+      .click();
+    await window.getByLabel("Import invite").fill(gateway.invite);
+    await window.getByRole("button", { name: "Import invite" }).click();
+    await gateway.waitForConnection(30_000);
+    await expect(
+      window
+        .getByRole("region", { name: "Connection" })
+        .getByText("Connected", { exact: true }),
+    ).toBeVisible({ timeout: 30_000 });
+    await window.getByRole("button", { name: "Exit Settings" }).click();
+
+    // Open the map and the peer's thread as a floating chat card.
+    await window.getByRole("button", { name: "Open Star Map" }).click();
+    const starMap = window.getByRole("region", {
+      name: "Star Map",
+      exact: true,
+    });
+    await expect(starMap).toBeVisible();
+
+    const card = starMap.getByRole("button", {
+      name: `Open thread: ${THREAD_TITLE}`,
+    });
+    await expect(card).toBeVisible({ timeout: 30_000 });
+    await card.click();
+
+    const chatCard = window.getByRole("region", {
+      name: `Chat: ${THREAD_TITLE}`,
+    });
+    await expect(chatCard).toBeVisible();
+    const scroller = chatCard.locator(".transcript-list__items");
+    await expect(scroller).toBeVisible();
+    // Wait for the transcript to actually populate before measuring —
+    // every assertion below is vacuous against an empty card.
+    await expect
+      .poll(() => gateway?.transcriptStats.entriesServed ?? 0, {
+        timeout: 30_000,
+      })
+      .toBeGreaterThan(0);
+    await expect(scroller.getByText(/^entry \d+ x+/).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // 1. It never asked for the thread from its first message.
+    expect(gateway.transcriptStats.unboundedRequests).toBe(0);
+
+    // 2. What crossed the wire is a rounding error against the thread.
+    const openBytes = gateway.transcriptStats.bytesServed;
+    expect(openBytes).toBeGreaterThan(0);
+    expect(openBytes).toBeLessThan(MAX_OPEN_BYTES);
+    expect(openBytes).toBeLessThan(TOTAL_TRANSCRIPT_BYTES / 20);
+
+    // 3. It did not mount tens of thousands of nodes.
+    const nodeCount = await chatCard
+      .locator(".star-map-chat-card__transcript")
+      .evaluate((element) => element.querySelectorAll("*").length);
+    expect(nodeCount).toBeGreaterThan(0);
+    expect(nodeCount).toBeLessThan(MAX_TRANSCRIPT_NODES);
+
+    // 4. It opened at the NEWEST message. This is the one the CSS-contract
+    //    unit test can only approximate: jsdom does no layout, so nothing
+    //    else in the suite can tell a working scroller from a dead one.
+    const atBottom = await scroller.evaluate((element) => {
+      const distance =
+        element.scrollHeight - element.clientHeight - element.scrollTop;
+      return { distance, scrollHeight: element.scrollHeight };
+    });
+    // The scroller must genuinely overflow, or "at the bottom" is vacuous.
+    expect(atBottom.scrollHeight).toBeGreaterThan(0);
+    expect(atBottom.distance).toBeLessThan(80);
+
+    // 5. Scrolling up fetches a BOUNDED page, not the rest of the thread.
+    const bytesBeforeScroll = gateway.transcriptStats.bytesServed;
+    const readsBeforeScroll = gateway.calls.filter(
+      (call) => call.method === "readThread",
+    ).length;
+    await scroller.evaluate((element) => {
+      element.scrollTop = 0;
+      element.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+
+    await expect
+      .poll(
+        () => gateway?.calls.filter((call) => call.method === "readThread").length ?? 0,
+        { timeout: 30_000 },
+      )
+      .toBeGreaterThan(readsBeforeScroll);
+
+    const scrollBytes = gateway.transcriptStats.bytesServed - bytesBeforeScroll;
+    expect(scrollBytes).toBeLessThan(MAX_OPEN_BYTES);
+
+    // Every read the card ever issued carried a limit.
+    const reads = gateway.calls.filter((call) => call.method === "readThread");
+    for (const read of reads) {
+      expect((read.params as { limit?: number }).limit).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -7,9 +7,10 @@ import {
   type CSSProperties,
   type PointerEvent as ReactPointerEvent,
 } from "react";
-import type {
-  CelestialIconId,
-  NavigationThreadSummary,
+import {
+  buildThreadIdentityKey,
+  type CelestialIconId,
+  type NavigationThreadSummary,
 } from "@pwragent/shared";
 import { CelestialIcon } from "../../icons";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
@@ -95,7 +96,10 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     onLimitChange: session.setRenderedTranscriptEntryLimit,
     onLoadOlder: session.loadOlder,
     pagination: session.response?.replay.pagination,
-    threadKey: thread.id,
+    // The canonical key, not a bare id: an ACP backend's kind ("acp:grok")
+    // already contains a colon, so `${source}:${id}` is ambiguous and a
+    // bare id is worse. Same key ThreadView keys its window by.
+    threadKey: buildThreadIdentityKey(thread.source, thread.id),
   });
 
   const federationTarget =

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -18,6 +18,8 @@ import {
   type CompactComposerAction,
 } from "../composer/CompactComposer";
 import { TranscriptList } from "../thread-detail/TranscriptList";
+import { useTranscriptWindow } from "../thread-detail/useTranscriptWindow";
+import { DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT } from "../../lib/thread-history-limits";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { useThreadSessionState } from "../../lib/useThreadSessionState";
@@ -75,7 +77,26 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   // UI-THEME.md rules it out regardless.
   const titleTooltip = useViewportTooltip({ className: "viewport-tooltip" });
 
-  const session = useThreadSessionState({ desktopApi, thread });
+  // Without a limit `readThread` returns the thread from its first message.
+  // On a large thread that is the entire transcript — hundreds of MB over
+  // the bridge before the card can paint. The main window has always asked
+  // for the last few turns and scrolled back on demand; so does this.
+  const session = useThreadSessionState({
+    desktopApi,
+    initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+    thread,
+  });
+
+  // Cap what actually mounts. Same window the full thread view uses, so a
+  // card over a long thread holds tens of entries rather than thousands.
+  const transcriptWindow = useTranscriptWindow({
+    entries: session.entries,
+    limit: session.renderedTranscriptEntryLimit,
+    onLimitChange: session.setRenderedTranscriptEntryLimit,
+    onLoadOlder: session.loadOlder,
+    pagination: session.response?.replay.pagination,
+    threadKey: thread.id,
+  });
 
   const federationTarget =
     thread.federation?.ref.target ?? readRendererFederationTarget();
@@ -329,11 +350,12 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           activeTurnId={session.activeTurnId}
           activeTurnStartedAt={session.activeTurnStartedAt}
           desktopApi={desktopApi}
-          entries={session.entries}
+          entries={transcriptWindow.visibleEntries}
           error={session.error}
           loading={session.loading}
           loadingMore={session.loadingMore}
-          onLoadOlder={session.loadOlder}
+          onLoadOlder={transcriptWindow.loadOlder}
+          pagination={transcriptWindow.visiblePagination}
           parentThreadId={thread.id}
           pendingAssistantMessage={session.pendingAssistantMessage}
           pendingMcpInteraction={session.pendingMcpInteraction}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -3,6 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { StarMapChatCard } from "../StarMapChatCard";
+import {
+  DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+  DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT,
+} from "../../../lib/thread-history-limits";
 
 const RECT = { left: 40, top: 40, width: 420, height: 520 };
 
@@ -85,6 +89,54 @@ async function typeAndSend(title: string, text: string) {
   fireEvent.keyDown(input, { key: "Enter" });
   return input as HTMLTextAreaElement;
 }
+
+describe("StarMapChatCard transcript loading", () => {
+  it("asks for the last few turns rather than the whole thread", async () => {
+    const desktopApi = buildApi();
+    renderCard({ desktopApi, thread: remoteThread() });
+
+    // No limit means `readThread` replays from the thread's first message.
+    // On a 135 MB thread that is the entire transcript over the bridge.
+    await waitFor(() => {
+      expect(desktopApi.readThread).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+        }),
+      );
+    });
+  });
+
+  it("mounts only the newest entries of a long transcript", async () => {
+    const entries = Array.from({ length: 200 }, (_, index) => ({
+      type: "message" as const,
+      id: `m-${index}`,
+      role: "assistant" as const,
+      text: `entry ${index}`,
+    }));
+    const desktopApi = buildApi({
+      readThread: vi.fn(async () => ({
+        backend: "codex",
+        threadId: "t",
+        replay: {
+          entries,
+          messages: [],
+          pagination: { supportsPagination: false, hasPreviousPage: false },
+        },
+      })),
+    } as unknown as Partial<DesktopApi>);
+    renderCard({ desktopApi, thread: remoteThread() });
+
+    // The tail is mounted; the head is held back until the operator scrolls
+    // for it. Rendering all 200 is what makes a big thread unresponsive.
+    await waitFor(() => {
+      expect(screen.getByText("entry 199")).toBeTruthy();
+    });
+    expect(screen.queryByText("entry 0")).toBeNull();
+    expect(
+      screen.queryByText(`entry ${200 - DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT}`),
+    ).toBeTruthy();
+  });
+});
 
 describe("StarMapChatCard federation routing", () => {
   it("hydrates a peer's thread against that peer", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/chat-card-transcript-layout.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/chat-card-transcript-layout.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(
+  path.resolve(testDir, "../../../styles/app.css"),
+  "utf8",
+);
+
+function ruleFor(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(new RegExp(`${escaped}\\s*\\{[\\s\\S]*?\\n\\}`));
+  if (!match) throw new Error(`app.css has no rule for ${selector}`);
+  return match[0];
+}
+
+/**
+ * The chat card's transcript box must NOT be a scroll container.
+ *
+ * TranscriptList owns a scroller (`.transcript-list__items`) and writes
+ * scroll position, glue-to-bottom, and its load-older trigger against it.
+ * That box only becomes a scroller when every ancestor down to it is a
+ * flex column that can shrink; give the card's wrapper its own overflow
+ * instead and the items box grows to full content height, so the writes
+ * land on an element that cannot scroll and silently do nothing — the card
+ * opens at the oldest message and never follows or pages.
+ *
+ * jsdom does no layout, so nothing else in the suite can catch this.
+ */
+describe("star map chat card transcript layout", () => {
+  const rule = ruleFor(".star-map-chat-card__transcript");
+
+  it("is a flex column so the transcript's own scroller resolves", () => {
+    expect(rule).toMatch(/display:\s*flex;/);
+    expect(rule).toMatch(/flex-direction:\s*column;/);
+  });
+
+  it("can shrink below its content", () => {
+    // Without this the items box never has a bounded height to scroll in.
+    expect(rule).toMatch(/min-height:\s*0;/);
+  });
+
+  it("does not take the overflow for itself", () => {
+    expect(rule).not.toMatch(/overflow[^:]*:\s*[^;]*(auto|scroll)/);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -65,10 +65,7 @@ import type {
 } from "../../lib/useIntegratedTerminals";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import type { PendingForkEnvironmentSetup } from "../../lib/useThreadNavigation";
-import {
-  DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT,
-  THREAD_HISTORY_PAGE_LIMIT,
-} from "../../lib/thread-history-limits";
+import { useTranscriptWindow } from "./useTranscriptWindow";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { resolvePreferredEditor } from "../../lib/preferred-application";
 import { Composer } from "../composer/Composer";
@@ -1247,12 +1244,6 @@ export function ThreadView(props: ThreadViewProps) {
   const [expandedImage, setExpandedImage] = useState<AppServerThreadImagePart>();
   const [contextRailResizing, setContextRailResizing] = useState(false);
   const [transcriptReglueRequestKey, setTranscriptReglueRequestKey] = useState(0);
-  // App supplies a session-owned limit in production. Keep a local fallback
-  // for isolated renderers/tests that intentionally omit the owner callbacks.
-  const [
-    uncontrolledTranscriptEntryLimits,
-    setUncontrolledTranscriptEntryLimits,
-  ] = useState(() => new Map<string, number>());
   const [pendingTranscriptTurnTarget, setPendingTranscriptTurnTarget] =
     useState<PendingTranscriptTurnTarget>();
   const transcriptTurnPageLoadsRef = useRef(0);
@@ -1411,98 +1402,30 @@ export function ThreadView(props: ThreadViewProps) {
   const selectedThreadKey = selectedThread
     ? buildThreadIdentityKey(selectedThread.source, selectedThread.id)
     : undefined;
-  const transcriptEntryLimit = selectedThreadKey
-    ? props.renderedTranscriptEntryLimit
-      ?? uncontrolledTranscriptEntryLimits.get(selectedThreadKey)
-      ?? DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT
-    : DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT;
-  const visibleTranscriptEntries = useMemo(
-    () => props.transcriptEntries.slice(-transcriptEntryLimit),
-    [props.transcriptEntries, transcriptEntryLimit],
-  );
   const transcriptEntryCount = props.transcriptEntries.length;
   const onLoadOlder = props.onLoadOlder;
   const onRenderedTranscriptEntryLimitChange =
     props.onRenderedTranscriptEntryLimitChange;
-  const hiddenTranscriptEntryCount =
-    transcriptEntryCount - visibleTranscriptEntries.length;
-  const canLoadServerTranscriptHistory = Boolean(
-    props.transcriptPagination?.supportsPagination
-    && props.transcriptPagination.hasPreviousPage,
-  );
-  const hasMoreTranscriptHistory =
-    hiddenTranscriptEntryCount > 0 || canLoadServerTranscriptHistory;
-  const visibleTranscriptPagination = useMemo<
-    AppServerThreadReplayPagination | undefined
-  >(
-    () =>
-      hiddenTranscriptEntryCount > 0
-        ? {
-            ...(props.transcriptPagination ?? {}),
-            hasPreviousPage: true,
-            supportsPagination: true,
-          }
-        : props.transcriptPagination,
-    [hiddenTranscriptEntryCount, props.transcriptPagination],
-  );
-  const expandTranscriptEntryLimit = useCallback(
-    (minimumLimit: number) => {
-      if (!selectedThreadKey) {
-        return;
-      }
-      const nextLimit = Math.max(transcriptEntryLimit, minimumLimit);
-      if (nextLimit === transcriptEntryLimit) {
-        return;
-      }
-      if (onRenderedTranscriptEntryLimitChange) {
-        onRenderedTranscriptEntryLimitChange(nextLimit);
-        return;
-      }
-      setUncontrolledTranscriptEntryLimits((current) => {
-        const currentLimit =
-          current.get(selectedThreadKey)
-          ?? DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT;
-        if (currentLimit >= minimumLimit) {
-          return current;
-        }
-        const next = new Map(current);
-        next.set(selectedThreadKey, minimumLimit);
-        return next;
-      });
-    },
-    [
-      onRenderedTranscriptEntryLimitChange,
-      selectedThreadKey,
-      transcriptEntryLimit,
-    ],
-  );
-  const loadOlderTranscript = useCallback(async () => {
-    if (hiddenTranscriptEntryCount > 0) {
-      expandTranscriptEntryLimit(
-        Math.min(
-          transcriptEntryCount,
-          transcriptEntryLimit + THREAD_HISTORY_PAGE_LIMIT,
-        ),
-      );
-      return;
-    }
-    if (canLoadServerTranscriptHistory) {
-      // Reserve renderer capacity before the response prepends its page.
-      // Otherwise the newly loaded entries would remain hidden behind the
-      // existing tail window until a second upward scroll.
-      expandTranscriptEntryLimit(
-        transcriptEntryLimit + THREAD_HISTORY_PAGE_LIMIT,
-      );
-    }
-    await onLoadOlder();
-  }, [
-    canLoadServerTranscriptHistory,
-    expandTranscriptEntryLimit,
-    hiddenTranscriptEntryCount,
+  // Shared with the Star Map's chat cards, which mount the same transcript
+  // on a much smaller surface — see useTranscriptWindow.
+  const transcriptWindow = useTranscriptWindow({
+    entries: props.transcriptEntries,
+    limit: props.renderedTranscriptEntryLimit,
+    onLimitChange: onRenderedTranscriptEntryLimitChange,
     onLoadOlder,
-    transcriptEntryCount,
-    transcriptEntryLimit,
-  ]);
+    pagination: props.transcriptPagination,
+    threadKey: selectedThreadKey,
+  });
+  const {
+    canLoadFromServer: canLoadServerTranscriptHistory,
+    expandLimit: expandTranscriptEntryLimit,
+    hasMoreHistory: hasMoreTranscriptHistory,
+    hiddenCount: hiddenTranscriptEntryCount,
+    limit: transcriptEntryLimit,
+    loadOlder: loadOlderTranscript,
+    visibleEntries: visibleTranscriptEntries,
+    visiblePagination: visibleTranscriptPagination,
+  } = transcriptWindow;
   useEffect(() => {
     const target = pendingTranscriptTurnTarget;
     if (!target) {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/use-transcript-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/use-transcript-window.test.tsx
@@ -1,0 +1,142 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT,
+  THREAD_HISTORY_PAGE_LIMIT,
+} from "../../../lib/thread-history-limits";
+import { useTranscriptWindow } from "../useTranscriptWindow";
+
+function entries(count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `e${index}`);
+}
+
+const SERVER_HAS_MORE = {
+  supportsPagination: true,
+  hasPreviousPage: true,
+  previousCursor: "cursor-1",
+};
+
+describe("useTranscriptWindow", () => {
+  it("mounts only the newest entries", () => {
+    const { result } = renderHook(() =>
+      useTranscriptWindow({
+        entries: entries(200),
+        onLoadOlder: vi.fn(),
+        threadKey: "t",
+      }),
+    );
+
+    expect(result.current.visibleEntries).toHaveLength(
+      DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT,
+    );
+    // The TAIL, not the head: a transcript opens at its newest message.
+    expect(result.current.visibleEntries.at(-1)).toBe("e199");
+    expect(result.current.hiddenCount).toBe(
+      200 - DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT,
+    );
+  });
+
+  it("leaves a short transcript whole", () => {
+    const { result } = renderHook(() =>
+      useTranscriptWindow({
+        entries: entries(3),
+        onLoadOlder: vi.fn(),
+        threadKey: "t",
+      }),
+    );
+
+    expect(result.current.visibleEntries).toHaveLength(3);
+    expect(result.current.hiddenCount).toBe(0);
+    expect(result.current.hasMoreHistory).toBe(false);
+  });
+
+  it("claims a previous page while entries are held back locally", () => {
+    const { result } = renderHook(() =>
+      useTranscriptWindow({
+        entries: entries(200),
+        onLoadOlder: vi.fn(),
+        threadKey: "t",
+      }),
+    );
+
+    // The server has nothing more, but we do — without this the transcript
+    // hides its load-older affordance over entries it already holds.
+    expect(result.current.visiblePagination).toMatchObject({
+      hasPreviousPage: true,
+      supportsPagination: true,
+    });
+    expect(result.current.hasMoreHistory).toBe(true);
+  });
+
+  it("widens the window before it goes back to the server", async () => {
+    const onLoadOlder = vi.fn();
+    const onLimitChange = vi.fn();
+    const { result } = renderHook(() =>
+      useTranscriptWindow({
+        entries: entries(200),
+        limit: DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT,
+        onLimitChange,
+        onLoadOlder,
+        pagination: SERVER_HAS_MORE,
+        threadKey: "t",
+      }),
+    );
+
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    expect(onLimitChange).toHaveBeenCalledWith(
+      DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT + THREAD_HISTORY_PAGE_LIMIT,
+    );
+    // Nothing fetched: the entries it just revealed were already here.
+    expect(onLoadOlder).not.toHaveBeenCalled();
+  });
+
+  it("fetches once the window has caught up with what was fetched", async () => {
+    const onLoadOlder = vi.fn();
+    const onLimitChange = vi.fn();
+    const { result } = renderHook(() =>
+      useTranscriptWindow({
+        entries: entries(10),
+        limit: DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT,
+        onLimitChange,
+        onLoadOlder,
+        pagination: SERVER_HAS_MORE,
+        threadKey: "t",
+      }),
+    );
+
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    expect(onLoadOlder).toHaveBeenCalledTimes(1);
+    // Capacity is reserved first, or the prepended page stays hidden behind
+    // the existing tail window until a second upward scroll.
+    expect(onLimitChange).toHaveBeenCalledWith(
+      DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT + THREAD_HISTORY_PAGE_LIMIT,
+    );
+  });
+
+  it("owns the limit itself when nobody else does", async () => {
+    const { result, rerender } = renderHook(
+      (props: { entries: string[] }) =>
+        useTranscriptWindow({
+          entries: props.entries,
+          onLoadOlder: vi.fn(),
+          threadKey: "t",
+        }),
+      { initialProps: { entries: entries(200) } },
+    );
+
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+    rerender({ entries: entries(200) });
+
+    expect(result.current.visibleEntries).toHaveLength(
+      DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT + THREAD_HISTORY_PAGE_LIMIT,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/useTranscriptWindow.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/useTranscriptWindow.ts
@@ -1,0 +1,144 @@
+import { useCallback, useMemo, useState } from "react";
+import type { AppServerThreadReplayPagination } from "@pwragent/shared";
+import {
+  DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT,
+  THREAD_HISTORY_PAGE_LIMIT,
+} from "../../lib/thread-history-limits";
+
+/**
+ * How much of a transcript is actually mounted.
+ *
+ * A thread's entry list can run to tens of thousands of items, and mounting
+ * all of them is what turns a large thread into an unresponsive surface. Only
+ * the newest `limit` entries render; scrolling up grows the window, and only
+ * once the window has caught up with everything already fetched does an
+ * upward scroll go back to the server for another page.
+ *
+ * This lived inside ThreadView, which is why the Star Map's chat cards — the
+ * one other surface that mounts a transcript — rendered every entry they were
+ * handed. It is a hook rather than a prop bag so both callers get the same
+ * behaviour instead of a second implementation drifting away from this one.
+ */
+export type TranscriptWindow<Entry> = {
+  /** The newest `limit` entries: what the transcript should mount. */
+  visibleEntries: Entry[];
+  /**
+   * Pagination as the transcript should see it. When entries are being held
+   * back locally there IS a previous page to reach, even on a thread whose
+   * server-side history is already fully fetched — otherwise the transcript
+   * hides its load-older affordance over entries it already has.
+   */
+  visiblePagination?: AppServerThreadReplayPagination;
+  /** The server still holds a page we have not fetched. */
+  canLoadFromServer: boolean;
+  hasMoreHistory: boolean;
+  hiddenCount: number;
+  limit: number;
+  /** Grow the window to at least `minimumLimit` entries. */
+  expandLimit: (minimumLimit: number) => void;
+  /** Widen the window first; go back to the server only when it is caught up. */
+  loadOlder: () => Promise<void>;
+};
+
+export function useTranscriptWindow<Entry>(params: {
+  entries: readonly Entry[];
+  /**
+   * Owner-controlled limit. Omit — along with `onLimitChange` — to let this
+   * hook own it, which is what isolated renderers and tests do.
+   */
+  limit?: number;
+  onLimitChange?: (limit: number) => void;
+  onLoadOlder: () => Promise<void> | void;
+  pagination?: AppServerThreadReplayPagination;
+  /** Limits are per thread, so switching threads starts from the default. */
+  threadKey?: string;
+}): TranscriptWindow<Entry> {
+  const { entries, onLimitChange, onLoadOlder, pagination, threadKey } = params;
+  const [uncontrolledLimits, setUncontrolledLimits] = useState(
+    () => new Map<string, number>(),
+  );
+
+  const limit = threadKey
+    ? params.limit
+      ?? uncontrolledLimits.get(threadKey)
+      ?? DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT
+    : DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT;
+
+  const visibleEntries = useMemo(
+    () => entries.slice(-limit),
+    [entries, limit],
+  );
+  const entryCount = entries.length;
+  const hiddenCount = entryCount - visibleEntries.length;
+  const canLoadFromServer = Boolean(
+    pagination?.supportsPagination && pagination.hasPreviousPage,
+  );
+  const hasMoreHistory = hiddenCount > 0 || canLoadFromServer;
+
+  const visiblePagination = useMemo<
+    AppServerThreadReplayPagination | undefined
+  >(
+    () =>
+      hiddenCount > 0
+        ? {
+            ...(pagination ?? {}),
+            hasPreviousPage: true,
+            supportsPagination: true,
+          }
+        : pagination,
+    [hiddenCount, pagination],
+  );
+
+  const expandLimit = useCallback(
+    (minimumLimit: number) => {
+      if (!threadKey) return;
+      const nextLimit = Math.max(limit, minimumLimit);
+      if (nextLimit === limit) return;
+      if (onLimitChange) {
+        onLimitChange(nextLimit);
+        return;
+      }
+      setUncontrolledLimits((current) => {
+        const currentLimit =
+          current.get(threadKey) ?? DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT;
+        if (currentLimit >= minimumLimit) return current;
+        const next = new Map(current);
+        next.set(threadKey, minimumLimit);
+        return next;
+      });
+    },
+    [limit, onLimitChange, threadKey],
+  );
+
+  const loadOlder = useCallback(async () => {
+    if (hiddenCount > 0) {
+      expandLimit(Math.min(entryCount, limit + THREAD_HISTORY_PAGE_LIMIT));
+      return;
+    }
+    if (canLoadFromServer) {
+      // Reserve renderer capacity before the response prepends its page.
+      // Otherwise the newly loaded entries would remain hidden behind the
+      // existing tail window until a second upward scroll.
+      expandLimit(limit + THREAD_HISTORY_PAGE_LIMIT);
+    }
+    await onLoadOlder();
+  }, [
+    canLoadFromServer,
+    entryCount,
+    expandLimit,
+    hiddenCount,
+    limit,
+    onLoadOlder,
+  ]);
+
+  return {
+    canLoadFromServer,
+    expandLimit,
+    hasMoreHistory,
+    hiddenCount,
+    limit,
+    loadOlder,
+    visibleEntries,
+    visiblePagination,
+  };
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10873,10 +10873,27 @@ textarea,
   color: var(--text-primary);
 }
 
+/* A flex column that does NOT scroll. `.transcript-list__items` inside it
+   is the scroller, and it only becomes one if this box is a flex container
+   with `min-height: 0` — otherwise `.transcript-list`'s own `flex: 1` never
+   resolves, the items box grows to its full content height, and the
+   overflow lands here instead.
+
+   That is not cosmetic. TranscriptList writes scroll position, glue-to-
+   bottom and its load-older trigger against the items box, so when the
+   overflow moved up here every one of them silently did nothing: the card
+   opened at the OLDEST message, never followed new ones, and never paged.
+   Padding lives on the items box for the same reason it does in the main
+   window — the scroll fades have to overlay it, and the bottom reserve
+   keeps room for the thinking indicator. So no padding here, and no
+   override of the items rule either: the card takes the transcript's own
+   spacing rather than restating it. */
 .star-map-chat-card__transcript {
+  display: flex;
   flex: 1 1 auto;
-  overflow: hidden auto;
-  padding: 8px 10px;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .star-map-chat-card__error {


### PR DESCRIPTION
Opening a floating chat card on a ~135 MB Codex thread pulled and rendered the whole transcript, and left the operator looking at the **oldest** message.

Three independent causes, all the same shape: **the card did not pass what the main window passes.**

### 1. Fetch — it really did ask for everything

`useThreadSessionState` sends `limit` to `readThread` only when given an `initialHistoryLimit`. Without it the backend replays from the thread's first message. `App.tsx` has always passed `DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT`; the card passed nothing.

So the answer to the open question in the report is *both* — it fetched everything **and** rendered everything. The card now asks for the same last few turns and pages back on demand.

### 2. Mount — the tail window lived in the wrong place

The windowing logic (slice to the newest N, synthesize a previous page while entries are held back locally, reserve capacity before fetching) was inline in `ThreadView`. The one other surface that mounts a transcript therefore had none of it.

Extracted to `useTranscriptWindow` and used by both, rather than growing a second implementation. **`ThreadView` is a pure refactor** — its 534 tests pass untouched.

### 3. Scroll — a double scroll container

`.star-map-chat-card__transcript` declared `overflow: hidden auto` while being a plain block box. So `.transcript-list`'s `flex: 1; min-height: 0` never resolved, `.transcript-list__items` grew to its full content height, and the card's wrapper quietly took the overflow instead.

`TranscriptList` writes scroll position, glue-to-bottom, and its load-older trigger against the items box — so all three silently did nothing. That single CSS declaration is why the card opened at the top, never followed new messages, and never paged on upward scroll.

Making the wrapper a shrinkable flex column hands the scroll back to the element that manages it. Open-at-bottom, stick-to-bottom, the scroll-to-bottom affordance, and scroll-triggered paging all come back with it — no new implementation, which is what the report asked for.

The card also now passes `pagination`; without it the load-older affordance stayed hidden.

## Tests

- `useTranscriptWindow` — 6 unit tests covering the tail window, the locally-held previous page, and widen-before-fetch
- `StarMapChatCard` — bounded request, and only the newest entries mounting out of 200. Both verified to fail without their fix
- A CSS-contract test pins the three properties that make the inner scroller resolve. **jsdom does no layout, so nothing else in the suite can catch this class of bug** — it is pinned in the style of `theme-contract`

862 tests green across star-map, thread-detail, and styles; 2366 across the full renderer. ESLint 0 errors, colors and boundaries clean.

## Note for review

While mocking `readThread` I found the existing card tests omit `replay.messages`, which makes the transcript throw and render an error instead of content. They passed because they only assert on calls, never on what rendered. The new tests supply it; the older ones are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Behaviour change worth knowing: the card now pages until it fills

Passing `pagination` flips `canLoadOlder` true for the first time, which also arms `requestOlderPageIfUnderflowing`. A chat card is small, so 40 short entries may not fill it — the card now pages backwards until its content overflows the box. This is intended (confirmed with the author): a half-empty card with no indication there is more to see is worse than one that fills itself.

Where it stops:

- as soon as content overflows; a history-signature ref prevents re-requesting identical state, so it cannot spin
- while walking the **local** window it costs no fetch at all — it only raises the mount cap over entries already in memory
- only once those are exhausted does it go to the server, one bounded page at a time
- resizing the card taller re-triggers it, which is consistent: bigger window, more content
- a zero-height (collapsed) card returns early and pages not at all

The E2E measures this rather than leaving it to inspection: it asserts the open cost stays under 5% of the transcript and that the post-scroll fetch is bounded, so "fill the card" degrading into "walk the whole thread" fails the test.

## E2E verification

`e2e/star-map-chat-card-history.spec.ts` runs against a real in-process federation gateway serving a synthetic ~120 MB transcript with genuine `limit`/`before` paging, byte accounting, and a record of any read that asked for the thread from its first message.

One correction applied after the first green run: the open-at-bottom assertion was originally `scrollHeight - clientHeight - scrollTop < 80`, which is **trivially true of a box that cannot scroll** — the exact broken state the test exists to catch. It now requires the scroller to genuinely overflow and to have been moved off the top.
