### PR TITLE
feat(tests): report sqlite write volume for a run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ These are **dev-only escape hatches**. They are silently ignored in packaged pro
 
 - `PWRAGENT_PROFILE_AUTO_CREATE=1` — Bypass the onboarding wizard's "set up profile" prompt for missing-named-profile boots. Used by E2E fixtures and replay harnesses that need a profile dir materialized without operator interaction. Production launches MUST go through the wizard so an operator never gets a silently-created profile mapped to a Codex auth profile they didn't ask for (see issue #524).
 - `PWRAGENT_DEV_DISABLE_SECRET_STORAGE=1` — Skip `safeStorage` operations entirely. Wizard typed secrets are SILENTLY DROPPED; settings-screen secret pills report "unavailable." Workaround for unsigned dev Electron builds on macOS that surface a confusing "Keychain Not Found" dialog because the binary lacks a stable code-signed identity (signed release builds don't have this problem). Operator re-enters secrets in Settings → Models on a real build afterwards.
+- `PWRAGENT_DEV_SQLITE_WRITE_METRICS=1` — Count sqlite write volume (commits, write statements, rows, WAL growth, per table) for the process. Wraps the database in `StateDb.open` after schema setup. Paired with `PWRAGENT_DEV_SQLITE_WRITE_METRICS_FILE=<path>`, which appends one JSON line of totals per source. See "Sqlite Write-Volume Instrumentation" in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md).
 
 ## Frontend and Desktop UI
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,24 @@
 - For manual screenshots of the branch-drift dialog, run `pnpm --filter @pwragent/desktop inspect:e2e:branch-drift`; it opens a replay-backed Electron fixture and waits until you close the app.
 - To regenerate the README screenshots under `docs/assets/screenshots/`, run `pnpm --filter @pwragent/desktop screenshot:readme`. The full walkthrough (spec, fixtures, state-seeding helpers, native capture utilities) lives in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md) under "Capturing README Screenshots". macOS Screen Recording permission is required for whichever terminal/IDE runs the spec.
 - When focusing root Vitest runs through `pnpm test`, pass file paths or filters directly, for example `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`. Do not insert a standalone `--` before the focus args; `pnpm test -- apps/...` makes Vitest run the full workspace suite.
+- **Any new sqlite write that fires per command, per turn, per item, per
+  streamed event, or on a timer must be measured before it ships, and covered
+  by a measurement spec.** Do the arithmetic out loud: writes/second × commit
+  cost × how long a real session runs → MB/day. Sqlite commits are the unit,
+  not statements — each implicit transaction flushes its dirty pages plus every
+  index the row moved (~4 KB/page, and a timestamp column in an index moves on
+  every write). Two calibration points: tool accounting once wrote per streamed
+  8 KiB chunk, costing 3,693 commits and 58 MB of WAL for one `find /`
+  (PR #1406); the idle heartbeats cost 720 commits and 2.7 MB/hour per running
+  instance, about 65 MB/day. **If the projection looks excessive, say so to the
+  user rather than shipping it quietly — the right answer is often that the
+  design constraint has to change** (batch into one transaction, debounce
+  behind a flush window, accumulate in memory and persist on a boundary, or
+  not persist at all), and that is their call to make. Measure with
+  `pnpm test:sqlite-writes`; assert the *shape* of the write pattern (commits
+  do not scale with events) rather than a wall-clock number, so the spec means
+  the same thing on a loaded CI box. See "Sqlite Write-Volume Instrumentation"
+  in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md).
 
 ## Code Formatting & Linting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,8 @@
 - To regenerate the README screenshots under `docs/assets/screenshots/`, run `pnpm --filter @pwragent/desktop screenshot:readme`. The full walkthrough (spec, fixtures, state-seeding helpers, native capture utilities) lives in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md) under "Capturing README Screenshots". macOS Screen Recording permission is required for whichever terminal/IDE runs the spec.
 - When focusing root Vitest runs through `pnpm test`, pass file paths or filters directly, for example `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`. Do not insert a standalone `--` before the focus args; `pnpm test -- apps/...` makes Vitest run the full workspace suite.
 - **Any new sqlite write that fires per command, per turn, per item, per
-  streamed event, or on a timer must be measured before it ships, and covered
-  by a measurement spec.** Do the arithmetic out loud: writes/second × commit
+  streamed event, or on a timer must be measured before it ships, and pinned
+  by a checked-in write budget** that fails the suite when it moves. Do the arithmetic out loud: writes/second × commit
   cost × how long a real session runs → MB/day. Sqlite commits are the unit,
   not statements — each implicit transaction flushes its dirty pages plus every
   index the row moved (~4 KB/page, and a timestamp column in an index moves on
@@ -61,11 +61,13 @@
   user rather than shipping it quietly — the right answer is often that the
   design constraint has to change** (batch into one transaction, debounce
   behind a flush window, accumulate in memory and persist on a boundary, or
-  not persist at all), and that is their call to make. Measure with
-  `pnpm test:sqlite-writes`; assert the *shape* of the write pattern (commits
-  do not scale with events) rather than a wall-clock number, so the spec means
-  the same thing on a loaded CI box. See "Sqlite Write-Volume Instrumentation"
-  in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md).
+  not persist at all), and that is their call to make. Budgets live in
+  `apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json`; wrap the
+  feature (not its setup) in `measureSqliteWrites` and record with
+  `UPDATE_SQLITE_WRITE_BUDGETS=1`, so a write-cost change lands as a reviewable
+  line in the diff instead of never surfacing. Survey a whole run with
+  `pnpm test:sqlite-writes`. See "Sqlite Write-Volume Instrumentation" in
+  [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md).
 
 ## Code Formatting & Linting
 

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -525,6 +525,70 @@ The desktop app sits at the **top** of the dependency hierarchy and may import a
 
 Enforcement runs via `pnpm lint:boundaries` and fails CI on any violation.
 
+## Sqlite Write-Volume Instrumentation
+
+PR #1406 fixed tool accounting running one implicit transaction per streamed
+8 KiB command-output chunk: **3,693 commits and 58 MB of WAL growth** for a
+single `find /`, to persist about nineteen integer counters. The whole suite
+passed either way. It had to be found by hand.
+
+The reason nothing caught it is worth internalizing before you reach for a
+unit test here: **the main-process suites mock the overlay store.**
+`backend-registry.test.ts` alone constructs `createOverlayStoreMock` in 450+
+places, so no sqlite is involved and no assertion about write behavior is
+possible. The code path that writes for real only runs in the app — which the
+E2E harness does exercise, against a real `state.db` under a temp
+`PWRAGENT_HOME`.
+
+So the instrumentation lives on the database, in
+[`src/main/state/sqlite-write-metrics.ts`](src/main/state/sqlite-write-metrics.ts),
+and covers vitest, E2E, and dev runs from one place.
+
+**Measure commits, not statements.** Each implicit transaction flushes its
+dirty pages, and a row update drags along every index it moved — in #1406's
+case four 4 KB pages per write, because `observed_at` sits in all three
+indexes on `thread_tool_invocations`. Ranking by statements would call a
+batched migration expensive and a per-event write loop cheap.
+
+### Running it
+
+```bash
+pnpm test:sqlite-writes                       # whole suite, then the ranking
+pnpm test:sqlite-writes apps/desktop/src/main/__tests__/state-db.test.ts
+```
+
+Every desktop E2E run reports automatically — the harness is the only place
+the real write path executes, the overhead is a `statSync` per commit against
+a run that launches Electron, and the ranking prints at teardown into the run
+log (`e2e.log` on the lab guest). Opt out with
+`PWRAGENT_DEV_SQLITE_WRITE_METRICS=0`.
+
+### Things that will bite you
+
+- **Attach after migrations, not before.** Schema migrations commit once per
+  version on a fresh database. A suite that opens a temp db per test would
+  otherwise rank whichever file opened the most databases as the heaviest
+  writer — the first version of this reported 164 commits for 16 statements.
+- **Instrumentation must be invisible to the code it measures.**
+  better-sqlite3 hangs `.default` / `.deferred` / `.immediate` / `.exclusive`
+  off the callable `transaction()` returns, and they are **not enumerable**.
+  Copying with `Object.assign` drops them and every `tx.immediate(...)` caller
+  dies with "is not a function"; `pr-auto-dispatch.test.ts` is what caught it.
+- **A zero is not a clean bill of health.** A test file that mocks its store
+  reports zero writes no matter what it does in production. Read the ranking
+  as "of the code that touched real sqlite, here is the order", never as
+  coverage.
+
+### The regression guard
+
+[`src/main/__tests__/sqlite-write-metrics.test.ts`](src/main/__tests__/sqlite-write-metrics.test.ts)
+drives the real registry into a real store and asserts streamed command output
+stays at one commit per flush window instead of one per chunk. Reverting the
+#1406 coalescing fails it with `expected 501 to be less than or equal to 4`.
+It asserts the *shape* of the write pattern, not a wall-clock number, so it
+means the same thing on a loaded CI box as on a fast laptop. Prefer that style
+for any new budget you add here.
+
 ## SQLite Query Rules
 
 - Never interpolate user-sourced values into SQL strings. Always use

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -579,6 +579,24 @@ log (`e2e.log` on the lab guest). Opt out with
   as "of the code that touched real sqlite, here is the order", never as
   coverage.
 
+### Known baselines
+
+Numbers to compare a new write path against, all measured with this harness:
+
+| Path | Cost |
+|---|---|
+| Streamed command output, per-chunk (pre-#1406) | 3,693 commits / 58 MB WAL for one `find /` |
+| Streamed command output, coalesced (today) | 34 commits / 0.54 MB for the same command |
+| Idle heartbeats, per running instance | 720 commits / 2.7 MB per hour (~65 MB/day) |
+| Whole vitest suite | 51 sources / ~3,000 commits / ~27 MB WAL |
+| One replay E2E spec | ~28 commits across two Electron processes |
+
+The idle figure is the profile-runtime heartbeat plus the federation lease
+renewal, both ticking every 10s against a 45s TTL, each taking its own commit.
+It is a floor the app pays for existing, and it is worth knowing before you add
+another ticker: a third 10s heartbeat is another ~24 MB/day per instance, and
+an operator may be running several profiles at once.
+
 ### The regression guard
 
 [`src/main/__tests__/sqlite-write-metrics.test.ts`](src/main/__tests__/sqlite-write-metrics.test.ts)

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -597,15 +597,65 @@ It is a floor the app pays for existing, and it is worth knowing before you add
 another ticker: a third 10s heartbeat is another ~24 MB/day per instance, and
 an operator may be running several profiles at once.
 
-### The regression guard
+### Write budgets
 
-[`src/main/__tests__/sqlite-write-metrics.test.ts`](src/main/__tests__/sqlite-write-metrics.test.ts)
-drives the real registry into a real store and asserts streamed command output
-stays at one commit per flush window instead of one per chunk. Reverting the
-#1406 coalescing fails it with `expected 501 to be less than or equal to 4`.
-It asserts the *shape* of the write pattern, not a wall-clock number, so it
-means the same thing on a loaded CI box as on a fast laptop. Prefer that style
-for any new budget you add here.
+[`src/main/__tests__/fixtures/sqlite-write-budgets.json`](src/main/__tests__/fixtures/sqlite-write-budgets.json)
+records what each measured scenario costs, and
+`sqlite-write-metrics.test.ts` fails when one moves:
+
+```
+sqlite write budget "streamed-command-output" changed.
+  budget:   2 commits, 2 statements, 2 rows (~36 KB WAL)
+  measured: 501 commits, 501 statements, 501 rows (~2820 KB WAL)
+```
+
+That is the pre-#1406 write pattern being caught automatically. Note the
+budget: **2 commits for 501 streamed events**, because commits must not scale
+with events.
+
+**Setup is excluded by construction.** `measureSqliteWrites(fn)` measures only
+what the callback does, so opening the database, applying migrations, and
+seeding fixtures all sit outside it. A budget therefore tracks the feature and
+stays put when a test grows more setup — no classifying writes after the fact,
+no arguing about which INSERT was "arrange".
+
+**Only the deterministic counters are asserted.** Commits, write statements,
+and rows changed are a pure function of the code path — same operations, same
+numbers, on any machine under any load, which is what makes an exact assertion
+safe here rather than a tolerance. WAL bytes are *not* deterministic (page fill
+and checkpoint timing move them run to run), so `observedWalBytes` is recorded
+for humans to read and never asserted. Commits are the honest proxy for volume.
+
+Deviation fails in **both** directions. An increase is the regression this
+exists to catch; a decrease means the budget has gone stale and would stop
+catching anything, so lowering it is a deliberate act.
+
+### Adding a budget
+
+Any new write path that fires per command, per turn, per item, per streamed
+event, or on a timer gets one. Wrap the feature — not its setup — and name the
+scenario:
+
+```ts
+const { writes } = await measureSqliteWrites(async () => {
+  // drive the feature
+});
+expectSqliteWriteBudget({
+  note: "what one unit of work is, in words",
+  scenario: "my-feature",
+  writes,
+});
+```
+
+Then record it with `UPDATE_SQLITE_WRITE_BUDGETS=1 pnpm test <file>` and commit
+the JSON. Re-record the same way when a change moves a number **on purpose**,
+and say why in the commit message — the point of the file is that a write-cost
+change shows up as a reviewable line in a diff instead of never showing up at
+all.
+
+Before recording, do the projection: writes/second × how long a real session
+runs → MB/day. If it looks excessive, raise it rather than baking it in. A
+budget is a record of what a path costs, not permission for it to cost that.
 
 ## SQLite Query Rules
 

--- a/apps/desktop/e2e/global-teardown.ts
+++ b/apps/desktop/e2e/global-teardown.ts
@@ -1,0 +1,30 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Print the sqlite write-volume ranking for the run.
+ *
+ * The E2E harness is the only place the real write path executes — the
+ * main-process suites mock the overlay store — so this is where a per-event
+ * write regression like PR #1406's per-chunk tool accounting becomes visible.
+ * Output goes to stdout so it lands in the lab's `e2e.log` alongside the
+ * Playwright results.
+ */
+export default function globalTeardown(): void {
+  const metricsFile = process.env.PWRAGENT_DEV_SQLITE_WRITE_METRICS_FILE;
+  if (!metricsFile || !existsSync(metricsFile)) {
+    return;
+  }
+  const script = path.join(
+    import.meta.dirname,
+    "..",
+    "..",
+    "..",
+    "scripts",
+    "report-sqlite-writes.mjs",
+  );
+  spawnSync("node", [script, metricsFile], { stdio: "inherit" });
+  // The file is append-only across a run; a stale one would blend two runs.
+  rmSync(metricsFile, { force: true });
+}

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -1,4 +1,23 @@
+import path from "node:path";
 import { defineConfig } from "@playwright/test";
+
+// Every E2E run reports how much the app made sqlite write. This is the only
+// harness that drives the real write path — the main-process unit suites mock
+// the overlay store — so it is the one place a per-event write regression can
+// be seen. Cost is a statSync per commit against a run that launches Electron,
+// so it is on by default; set PWRAGENT_DEV_SQLITE_WRITE_METRICS=0 to skip it.
+// Assigned at config module scope so every Playwright worker, and therefore
+// every Electron child it launches, inherits the variables.
+if (process.env.PWRAGENT_DEV_SQLITE_WRITE_METRICS !== "0") {
+  process.env.PWRAGENT_DEV_SQLITE_WRITE_METRICS = "1";
+  // Not under `outputDir`: Playwright clears that directory for a run, and
+  // the app appends to this file while tests are executing.
+  process.env.PWRAGENT_DEV_SQLITE_WRITE_METRICS_FILE ??= path.join(
+    import.meta.dirname,
+    ".local",
+    "sqlite-write-metrics.jsonl",
+  );
+}
 
 export default defineConfig({
   testDir: "./e2e",
@@ -8,6 +27,8 @@ export default defineConfig({
   // whichever spec sorts first rather than the machine. See
   // e2e/global-setup.ts.
   globalSetup: "./e2e/global-setup.ts",
+  // Prints the sqlite write-volume ranking into the run log.
+  globalTeardown: "./e2e/global-teardown.ts",
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 1 : 0,

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budget.ts
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budget.ts
@@ -1,0 +1,110 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { expect } from "vitest";
+import type { SqliteWriteDelta } from "../../state/sqlite-write-metrics";
+
+/**
+ * Checked-in write budgets, asserted per scenario.
+ *
+ * A budget records what one feature costs sqlite, measured around the feature
+ * itself — `measureSqliteWrites` excludes database setup and fixture seeding
+ * by construction, so these numbers move when the *feature's* write pattern
+ * moves and stay put when a test grows more setup.
+ *
+ * **Only the deterministic counters are asserted.** Commits, write statements,
+ * and rows changed are a pure function of the code path: same operations, same
+ * numbers, on any machine under any load. WAL bytes are not — page fill and
+ * checkpoint timing move them run to run — so bytes are recorded for humans to
+ * read and never assert. Commits are the useful proxy for volume anyway, since
+ * each one flushes its dirty pages plus every index the row moved.
+ *
+ * To change a budget deliberately, run with `UPDATE_SQLITE_WRITE_BUDGETS=1`
+ * and commit the diff. A reviewer then sees the write cost change as a line in
+ * the PR instead of never seeing it at all.
+ */
+const BUDGETS_PATH = path.join(import.meta.dirname, "sqlite-write-budgets.json");
+
+type Budget = {
+  commits: number;
+  observedWalBytes: number;
+  note: string;
+  rowsChanged: number;
+  statements: number;
+};
+
+type BudgetFile = Record<string, Budget>;
+
+export function expectSqliteWriteBudget(params: {
+  note: string;
+  scenario: string;
+  writes: SqliteWriteDelta;
+}): void {
+  const budgets = readBudgets();
+  const measured: Budget = {
+    commits: params.writes.commits,
+    note: params.note,
+    observedWalBytes: params.writes.walBytes,
+    rowsChanged: params.writes.rowsChanged,
+    statements: params.writes.statements,
+  };
+
+  if (process.env.UPDATE_SQLITE_WRITE_BUDGETS) {
+    budgets[params.scenario] = measured;
+    writeFileSync(
+      BUDGETS_PATH,
+      `${JSON.stringify(sortKeys(budgets), null, 2)}\n`,
+    );
+    return;
+  }
+
+  const budget = budgets[params.scenario];
+  if (!budget) {
+    throw new Error(
+      `No sqlite write budget recorded for "${params.scenario}".\n`
+        + `Measured ${describe(measured)}.\n`
+        + "Record it with UPDATE_SQLITE_WRITE_BUDGETS=1 and commit the result.",
+    );
+  }
+
+  // Deviation in either direction fails. An increase is the regression this
+  // exists to catch; a decrease means the budget is stale and would stop
+  // catching anything, so it has to be lowered on purpose.
+  expect(
+    {
+      commits: measured.commits,
+      rowsChanged: measured.rowsChanged,
+      statements: measured.statements,
+    },
+    `sqlite write budget "${params.scenario}" changed.\n`
+      + `  budget:   ${describe(budget)}\n`
+      + `  measured: ${describe(measured)}\n`
+      + "If this is intended, re-record with UPDATE_SQLITE_WRITE_BUDGETS=1 and\n"
+      + "explain the change in the commit message. If it is not, you have added\n"
+      + "sqlite writes to a path that is measured for a reason.",
+  ).toEqual({
+    commits: budget.commits,
+    rowsChanged: budget.rowsChanged,
+    statements: budget.statements,
+  });
+}
+
+function describe(budget: Budget): string {
+  return (
+    `${budget.commits} commits, ${budget.statements} statements, `
+    + `${budget.rowsChanged} rows (~${(budget.observedWalBytes / 1024).toFixed(0)} KB WAL)`
+  );
+}
+
+function readBudgets(): BudgetFile {
+  try {
+    return JSON.parse(readFileSync(BUDGETS_PATH, "utf8")) as BudgetFile;
+  } catch {
+    return {};
+  }
+}
+
+function sortKeys(budgets: BudgetFile): BudgetFile {
+  return Object.fromEntries(
+    Object.entries(budgets).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -1,0 +1,16 @@
+{
+  "idle-hour-heartbeats": {
+    "commits": 720,
+    "note": "one idle hour: 360 profile heartbeats + 360 federation lease renewals",
+    "observedWalBytes": 2851040,
+    "rowsChanged": 1080,
+    "statements": 1080
+  },
+  "streamed-command-output": {
+    "commits": 2,
+    "note": "500 streamed output deltas plus the completion for one command",
+    "observedWalBytes": 37080,
+    "rowsChanged": 2,
+    "statements": 2
+  }
+}

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -1,0 +1,197 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AgentEvent } from "@pwragent/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DesktopBackendRegistry } from "../app-server/backend-registry";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import {
+  readSqliteWriteMetrics,
+  resetSqliteWriteMetrics,
+  SQLITE_WRITE_METRICS_ENV,
+} from "../state/sqlite-write-metrics";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: SqliteOverlayStore;
+let tempDir: string;
+
+beforeEach(() => {
+  process.env[SQLITE_WRITE_METRICS_ENV] = "1";
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-write-metrics-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new SqliteOverlayStore(stateDb);
+  // The collector is process-wide and this file asserts on exact counts, so
+  // each test starts from zero. Ordinary test files do not do this — the
+  // vitest setup resets once per file so the report attributes a whole file.
+  resetSqliteWriteMetrics();
+});
+
+afterEach(() => {
+  delete process.env[SQLITE_WRITE_METRICS_ENV];
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("sqlite write metrics", () => {
+  it("attributes commits and rows to the table that took them", async () => {
+    await store.upsertThreadToolInvocation({
+      invocation: buildInvocation("tool-1"),
+    });
+    await store.upsertThreadToolInvocation({
+      invocation: buildInvocation("tool-2"),
+    });
+
+    const metrics = readSqliteWriteMetrics();
+    expect(metrics?.commits).toBe(2);
+    expect(metrics?.rowsChanged).toBe(2);
+    expect(
+      metrics?.tables.find((table) => table.table === "thread_tool_invocations"),
+    ).toMatchObject({ commits: 2, rowsChanged: 2, statements: 2 });
+  });
+
+  it("counts a batched transaction as one commit, not one per statement", () => {
+    // Write amplification tracks commits, not statements: each implicit
+    // transaction flushes its dirty pages plus every index they moved. A
+    // report that counted statements would rank a batched migration as
+    // expensive and a per-event write loop as cheap — exactly backwards.
+    const insert = stateDb.raw.prepare(
+      "INSERT INTO thread_tool_invocation_alerts (alert_id, backend, thread_id, "
+        + "kind, severity, tool_name, message, suggested_prompt, invocation_count, "
+        + "total_output_chars, estimated_output_tokens, average_interval_ms, "
+        + "first_observed_at, last_observed_at, created_at, updated_at) "
+        + "VALUES (?, 'codex', 'thread-1', 'noisy-polling', 'warning', "
+        + "'write_stdin', 'm', 'p', 1, 1, 1, 1, 1, 1, 1, 1)",
+    );
+    stateDb.raw.transaction(() => {
+      for (let index = 0; index < 50; index += 1) {
+        insert.run(`batched-${index}`);
+      }
+    })();
+
+    const metrics = readSqliteWriteMetrics();
+    expect(metrics?.statements).toBe(50);
+    expect(metrics?.commits).toBe(1);
+  });
+
+  it("keeps the transaction variants callable and counted", () => {
+    // better-sqlite3 hangs .default/.deferred/.immediate/.exclusive off the
+    // callable it returns, and they are not enumerable. The first version of
+    // this wrapper copied with Object.assign and dropped them, so every
+    // `tx.immediate(...)` caller died with "is not a function". Instrumentation
+    // has to be invisible to the code it measures.
+    const insert = stateDb.raw.prepare(
+      "INSERT INTO thread_tool_invocations (invocation_id, backend, thread_id, "
+        + "item_id, tool_name, category, status, observed_at, updated_at, "
+        + "output_chars, output_lines, estimated_output_tokens, warning_lines, "
+        + "error_lines, info_lines, debug_lines, output_truncated, noisy) "
+        + "VALUES (?, 'codex', 't', 'i', 'commandExecution', 'shell', "
+        + "'completed', 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0)",
+    );
+    const transaction = stateDb.raw.transaction((id: string) => {
+      insert.run(id);
+    });
+
+    expect(typeof transaction.immediate).toBe("function");
+    expect(typeof transaction.deferred).toBe("function");
+    expect(typeof transaction.exclusive).toBe("function");
+
+    transaction("plain");
+    transaction.immediate("immediate");
+
+    const metrics = readSqliteWriteMetrics();
+    expect(metrics?.statements).toBe(2);
+    expect(metrics?.commits).toBe(2);
+  });
+
+  it("holds streamed command output to one commit per flush window", async () => {
+    // The regression guard for PR #1406. Tool accounting used to run one
+    // implicit transaction per streamed 8 KiB chunk — 3,693 commits and 58 MB
+    // of WAL for a single `find /`. Nothing caught it: every test over that
+    // path uses a mocked overlay store, so no sqlite was involved.
+    //
+    // This drives the real registry into a real store and asserts the shape of
+    // the write pattern rather than a wall-clock number, so it means the same
+    // thing on a loaded CI box as on a fast laptop.
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+
+    const chunks = 500;
+    for (let index = 0; index < chunks; index += 1) {
+      await emit({
+        backend: "codex",
+        notification: {
+          method: "item/commandExecution/outputDelta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "cmd-1",
+            delta: `line ${index}\n`,
+          },
+        },
+      } as AgentEvent);
+    }
+    await emit({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "cmd-1",
+            type: "commandExecution",
+            command: "find / -xdev",
+            status: "completed",
+            exitCode: 0,
+          },
+        },
+      },
+    } as AgentEvent);
+
+    const metrics = readSqliteWriteMetrics();
+    // One flush carrying every buffered chunk, plus the completion row. The
+    // point is that this does not scale with `chunks`.
+    expect(metrics?.commits).toBeLessThanOrEqual(4);
+    expect(metrics?.commits).toBeGreaterThan(0);
+
+    await registry.close();
+  });
+});
+
+function buildInvocation(invocationId: string) {
+  return {
+    backend: "codex" as const,
+    category: "shell" as const,
+    debugLines: 0,
+    errorLines: 0,
+    estimatedOutputTokens: 25,
+    infoLines: 0,
+    invocationId,
+    itemId: invocationId,
+    noisy: false,
+    observedAt: 1_800_000_000_000,
+    outputChars: 100,
+    outputLines: 4,
+    outputTruncated: false,
+    status: "completed" as const,
+    threadId: "thread-1",
+    toolName: "commandExecution",
+    updatedAt: 1_800_000_000_000,
+    warningLines: 0,
+  };
+}
+
+function createStubBackendClient() {
+  return {
+    close: async () => {},
+    getInitializeResult: async () => ({ methods: [] }),
+    onNotification: () => () => {},
+    onPendingRequest: () => () => {},
+  } as never;
+}

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -4,12 +4,15 @@ import path from "node:path";
 import type { AgentEvent } from "@pwragent/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
+import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import {
+  measureSqliteWrites,
   readSqliteWriteMetrics,
   resetSqliteWriteMetrics,
   SQLITE_WRITE_METRICS_ENV,
 } from "../state/sqlite-write-metrics";
+import { expectSqliteWriteBudget } from "./fixtures/sqlite-write-budget";
 import { StateDb } from "../state/state-db";
 
 let stateDb: StateDb;
@@ -109,10 +112,6 @@ describe("sqlite write metrics", () => {
     // implicit transaction per streamed 8 KiB chunk — 3,693 commits and 58 MB
     // of WAL for a single `find /`. Nothing caught it: every test over that
     // path uses a mocked overlay store, so no sqlite was involved.
-    //
-    // This drives the real registry into a real store and asserts the shape of
-    // the write pattern rather than a wall-clock number, so it means the same
-    // thing on a loaded CI box as on a fast laptop.
     const registry = new DesktopBackendRegistry({
       codexClient: createStubBackendClient(),
       overlayStore: store as never,
@@ -121,46 +120,87 @@ describe("sqlite write metrics", () => {
       emit(event: AgentEvent): Promise<void>;
     }).emit.bind(registry);
 
-    const chunks = 500;
-    for (let index = 0; index < chunks; index += 1) {
+    // Everything above is setup and sits outside the measured region, so the
+    // budget tracks the streaming path rather than the fixture.
+    const { writes } = await measureSqliteWrites(async () => {
+      for (let index = 0; index < 500; index += 1) {
+        await emit({
+          backend: "codex",
+          notification: {
+            method: "item/commandExecution/outputDelta",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              itemId: "cmd-1",
+              delta: `line ${index}\n`,
+            },
+          },
+        } as AgentEvent);
+      }
       await emit({
         backend: "codex",
         notification: {
-          method: "item/commandExecution/outputDelta",
+          method: "item/completed",
           params: {
             threadId: "thread-1",
             turnId: "turn-1",
-            itemId: "cmd-1",
-            delta: `line ${index}\n`,
+            item: {
+              id: "cmd-1",
+              type: "commandExecution",
+              command: "find / -xdev",
+              status: "completed",
+              exitCode: 0,
+            },
           },
         },
       } as AgentEvent);
-    }
-    await emit({
-      backend: "codex",
-      notification: {
-        method: "item/completed",
-        params: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          item: {
-            id: "cmd-1",
-            type: "commandExecution",
-            command: "find / -xdev",
-            status: "completed",
-            exitCode: 0,
-          },
-        },
-      },
-    } as AgentEvent);
+    });
 
-    const metrics = readSqliteWriteMetrics();
-    // One flush carrying every buffered chunk, plus the completion row. The
-    // point is that this does not scale with `chunks`.
-    expect(metrics?.commits).toBeLessThanOrEqual(4);
-    expect(metrics?.commits).toBeGreaterThan(0);
+    expectSqliteWriteBudget({
+      note: "500 streamed output deltas plus the completion for one command",
+      scenario: "streamed-command-output",
+      writes,
+    });
 
     await registry.close();
+  });
+
+  it("holds an idle hour of heartbeats to its budget", async () => {
+    // The floor the app pays for existing: the profile-runtime heartbeat and
+    // the federation lease renewal both tick every 10s against a 45s TTL, each
+    // taking its own commit. Budgeted so a third ticker, or a shortened
+    // interval, has to be a deliberate line in a diff.
+    const instances = new AppRuntimeInstanceStore(stateDb);
+    instances.recordInstanceStart({
+      instanceId: "instance-1",
+      profileName: "default",
+      processId: 1234,
+      startedAt: 1_800_000_000_000,
+      desiredMessagingEnabled: false,
+    });
+    instances.acquireFederationLease({
+      instanceId: "instance-1",
+      now: 1_800_000_000_000,
+      ttlMs: 45_000,
+    });
+
+    const { writes } = await measureSqliteWrites(() => {
+      for (let tick = 0; tick < 360; tick += 1) {
+        const now = 1_800_000_000_000 + tick * 10_000;
+        instances.heartbeatInstance({ instanceId: "instance-1", now });
+        instances.renewFederationLease({
+          instanceId: "instance-1",
+          now,
+          ttlMs: 45_000,
+        });
+      }
+    });
+
+    expectSqliteWriteBudget({
+      note: "one idle hour: 360 profile heartbeats + 360 federation lease renewals",
+      scenario: "idle-hour-heartbeats",
+      writes,
+    });
   });
 });
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -179,6 +179,10 @@ import {
 } from "./profile";
 import { SECRET_STORAGE_DISABLED_ENV } from "./settings/desktop-secret-store";
 import {
+  SQLITE_WRITE_METRICS_ENV,
+  SQLITE_WRITE_METRICS_FILE_ENV,
+} from "./state/sqlite-write-metrics";
+import {
   isUpdateInstallInProgress,
   isUpdateInstallUpdaterQuitReady,
   setUpdateInstallPreparationHandler,
@@ -951,6 +955,8 @@ function rejectDevOnlyEnvVarsInProduction(): void {
   const devOnlyVars = [
     PWRAGENT_PROFILE_AUTO_CREATE_ENV,
     SECRET_STORAGE_DISABLED_ENV,
+    SQLITE_WRITE_METRICS_ENV,
+    SQLITE_WRITE_METRICS_FILE_ENV,
   ];
   for (const name of devOnlyVars) {
     if (process.env[name] !== undefined) {

--- a/apps/desktop/src/main/state/sqlite-write-metrics-setup.ts
+++ b/apps/desktop/src/main/state/sqlite-write-metrics-setup.ts
@@ -1,0 +1,30 @@
+import { afterAll, beforeAll, expect } from "vitest";
+import {
+  flushSqliteWriteMetrics,
+  isSqliteWriteMetricsEnabled,
+  resetSqliteWriteMetrics,
+} from "./sqlite-write-metrics";
+
+/**
+ * Vitest setup that attributes sqlite write volume to the test file that
+ * caused it. Inert unless `PWRAGENT_DEV_SQLITE_WRITE_METRICS` is set, so a
+ * normal `pnpm test` pays nothing beyond this import.
+ *
+ * Vitest isolates the module graph per test file, so the collector is already
+ * per-file; this only has to name it and flush it. Drive it through
+ * `pnpm test:sqlite-writes`, which sets the env vars and prints the report.
+ *
+ * Note what this can and cannot see: it measures tests that open a real
+ * `StateDb`. The big main-process suites mock the overlay store, so they read
+ * as zero here no matter how they write in production. The E2E run is what
+ * covers those paths, through the same collector inside the real app.
+ */
+if (isSqliteWriteMetricsEnabled()) {
+  beforeAll(() => {
+    resetSqliteWriteMetrics();
+  });
+
+  afterAll(() => {
+    flushSqliteWriteMetrics(expect.getState().testPath ?? "unknown");
+  });
+}

--- a/apps/desktop/src/main/state/sqlite-write-metrics.ts
+++ b/apps/desktop/src/main/state/sqlite-write-metrics.ts
@@ -233,6 +233,65 @@ export function attachSqliteWriteMetrics(params: {
   }) as unknown as typeof db.transaction;
 }
 
+export type SqliteWriteDelta = {
+  commits: number;
+  rowsChanged: number;
+  statements: number;
+  tables: SqliteTableWriteMetrics[];
+  walBytes: number;
+};
+
+/**
+ * Measure only what `run` does.
+ *
+ * This is the seam that separates a scenario's cost from the cost of getting
+ * ready to run it. Opening a database, applying migrations, and seeding rows
+ * all happen outside the callback and are excluded by construction — no
+ * classifying of writes after the fact, no guessing which INSERT was "setup".
+ * A budget written against this therefore tracks the feature, and stays put
+ * when a test's fixtures grow.
+ */
+export async function measureSqliteWrites<T>(
+  run: () => T | Promise<T>,
+): Promise<{ result: T; writes: SqliteWriteDelta }> {
+  const before = collector?.snapshot("");
+  const result = await run();
+  const after = collector?.snapshot("");
+  return { result, writes: diffSnapshots(before, after) };
+}
+
+function diffSnapshots(
+  before: SqliteWriteMetricsSnapshot | undefined,
+  after: SqliteWriteMetricsSnapshot | undefined,
+): SqliteWriteDelta {
+  if (!after) {
+    return { commits: 0, rowsChanged: 0, statements: 0, tables: [], walBytes: 0 };
+  }
+  const baseline = new Map(
+    (before?.tables ?? []).map((table) => [table.table, table]),
+  );
+  const tables: SqliteTableWriteMetrics[] = [];
+  for (const table of after.tables) {
+    const start = baseline.get(table.table);
+    const delta = {
+      commits: table.commits - (start?.commits ?? 0),
+      rowsChanged: table.rowsChanged - (start?.rowsChanged ?? 0),
+      statements: table.statements - (start?.statements ?? 0),
+      table: table.table,
+    };
+    if (delta.statements > 0) {
+      tables.push(delta);
+    }
+  }
+  return {
+    commits: after.commits - (before?.commits ?? 0),
+    rowsChanged: after.rowsChanged - (before?.rowsChanged ?? 0),
+    statements: after.statements - (before?.statements ?? 0),
+    tables: tables.sort((left, right) => right.commits - left.commits),
+    walBytes: after.walBytes - (before?.walBytes ?? 0),
+  };
+}
+
 export function isSqliteWriteMetricsEnabled(): boolean {
   return Boolean(process.env[SQLITE_WRITE_METRICS_ENV]);
 }

--- a/apps/desktop/src/main/state/sqlite-write-metrics.ts
+++ b/apps/desktop/src/main/state/sqlite-write-metrics.ts
@@ -1,0 +1,308 @@
+import fs from "node:fs";
+import path from "node:path";
+import type BetterSqlite3 from "better-sqlite3";
+
+/**
+ * Opt-in accounting for how much a process makes sqlite write.
+ *
+ * This exists because PR #1406 shipped a bug nothing could see: tool
+ * accounting ran one implicit transaction per streamed 8 KiB command-output
+ * chunk, costing 3,693 commits and 58 MB of WAL growth for a single `find /`.
+ * The suite passed either way, because every test over that path uses a mocked
+ * overlay store — no sqlite is involved, so no assertion could have noticed.
+ *
+ * What does exercise the real write path is the app: the E2E harness boots
+ * Electron against a real `state.db` under a temp `PWRAGENT_HOME`. So the
+ * instrumentation lives here, on the database, rather than in a vitest helper
+ * — it then covers the E2E app process, dev runs, and the tests that do use a
+ * real store, all from one place.
+ *
+ * The signal that matters is **commits**, not statements. Each implicit
+ * transaction flushes its dirty pages, and a row update drags every index it
+ * moved along with it, so commits are what write volume is proportional to.
+ * Counting statements instead would rank a batched migration as expensive and
+ * a per-event write loop as cheap — exactly backwards.
+ */
+
+export type SqliteTableWriteMetrics = {
+  commits: number;
+  rowsChanged: number;
+  statements: number;
+  table: string;
+};
+
+export type SqliteWriteMetricsSnapshot = {
+  commits: number;
+  label: string;
+  rowsChanged: number;
+  statements: number;
+  tables: SqliteTableWriteMetrics[];
+  walBytes: number;
+};
+
+/**
+ * **Dev-only.** `rejectDevOnlyEnvVarsInProduction()` in `index.ts` clears this
+ * on packaged builds before any consumer reads it, so a shipped app never
+ * wraps its database in instrumentation.
+ */
+export const SQLITE_WRITE_METRICS_ENV = "PWRAGENT_DEV_SQLITE_WRITE_METRICS";
+
+/** Run-scoped JSONL sink that `report-sqlite-writes.mjs` ranks. */
+export const SQLITE_WRITE_METRICS_FILE_ENV =
+  "PWRAGENT_DEV_SQLITE_WRITE_METRICS_FILE";
+
+const WRITE_STATEMENT = /^\s*(?:INSERT|UPDATE|DELETE|REPLACE)\b/i;
+const TABLE_NAME =
+  /^\s*(?:INSERT(?:\s+OR\s+\w+)?\s+INTO|UPDATE|DELETE\s+FROM|REPLACE\s+INTO)\s+["'`[]?(\w+)/i;
+
+class SqliteWriteMetricsCollector {
+  private commits = 0;
+  private rowsChanged = 0;
+  private statements = 0;
+  private walBytes = 0;
+  private readonly tables = new Map<string, SqliteTableWriteMetrics>();
+  private readonly walSizes = new Map<string, number>();
+
+  record(params: {
+    changes: number;
+    committed: boolean;
+    table: string;
+    walPath: string | undefined;
+  }): void {
+    this.statements += 1;
+    this.rowsChanged += params.changes;
+    const table = this.tables.get(params.table) ?? {
+      commits: 0,
+      rowsChanged: 0,
+      statements: 0,
+      table: params.table,
+    };
+    table.statements += 1;
+    table.rowsChanged += params.changes;
+    if (params.committed) {
+      this.commits += 1;
+      table.commits += 1;
+      this.sampleWal(params.walPath);
+    }
+    this.tables.set(params.table, table);
+  }
+
+  recordExplicitCommit(walPath: string | undefined): void {
+    this.commits += 1;
+    this.sampleWal(walPath);
+  }
+
+  snapshot(label: string): SqliteWriteMetricsSnapshot {
+    return {
+      commits: this.commits,
+      label,
+      rowsChanged: this.rowsChanged,
+      statements: this.statements,
+      tables: [...this.tables.values()].sort(
+        (left, right) => right.commits - left.commits,
+      ),
+      walBytes: this.walBytes,
+    };
+  }
+
+  /** Seed a database's WAL baseline so pre-existing frames are not counted. */
+  observe(walPath: string | undefined): void {
+    if (walPath && !this.walSizes.has(walPath)) {
+      this.walSizes.set(walPath, readWalSize(walPath));
+    }
+  }
+
+  reset(): void {
+    this.commits = 0;
+    this.rowsChanged = 0;
+    this.statements = 0;
+    this.walBytes = 0;
+    this.tables.clear();
+    for (const walPath of [...this.walSizes.keys()]) {
+      this.walSizes.set(walPath, readWalSize(walPath));
+    }
+  }
+
+  private sampleWal(walPath: string | undefined): void {
+    if (!walPath) {
+      return;
+    }
+    const size = readWalSize(walPath);
+    // A checkpoint only ever shrinks the file, so counting growth alone
+    // survives one without double-counting the frames it folded into the db.
+    const previous = this.walSizes.get(walPath) ?? 0;
+    if (size > previous) {
+      this.walBytes += size - previous;
+    }
+    this.walSizes.set(walPath, size);
+  }
+}
+
+function readWalSize(walPath: string): number {
+  try {
+    return fs.statSync(walPath).size;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * One collector per process, shared by every attached database. A process
+ * opens several (the profile db, a federation fixture's, a test's temp dirs),
+ * and the question being asked is always "how much did this run write", not
+ * "which file did it land in".
+ */
+let collector: SqliteWriteMetricsCollector | undefined;
+
+/**
+ * Wrap a database so every write statement is counted. Called from
+ * `StateDb.open` only when metrics are enabled; a normal run patches nothing.
+ */
+export function attachSqliteWriteMetrics(params: {
+  db: BetterSqlite3.Database;
+  dbPath: string;
+}): void {
+  collector ??= new SqliteWriteMetricsCollector();
+  const active = collector;
+  registerProcessExitFlush();
+  const walPath =
+    params.dbPath === ":memory:" || params.dbPath === ""
+      ? undefined
+      : `${params.dbPath}-wal`;
+  active.observe(walPath);
+  const db = params.db;
+  const originalPrepare = db.prepare.bind(db);
+  const originalTransaction = db.transaction.bind(db);
+
+  db.prepare = ((source: string) => {
+    const statement = originalPrepare(source);
+    if (!WRITE_STATEMENT.test(source)) {
+      return statement;
+    }
+    const table = TABLE_NAME.exec(source)?.[1] ?? "unknown";
+    const originalRun = statement.run.bind(statement);
+    statement.run = ((...args: unknown[]) => {
+      const result = originalRun(...(args as never[]));
+      active.record({
+        changes: result.changes,
+        // Inside an explicit transaction the commit belongs to the
+        // transaction, not this statement; `transaction()` counts that one.
+        committed: !db.inTransaction,
+        table,
+        walPath,
+      });
+      return result;
+    }) as typeof statement.run;
+    return statement;
+  }) as typeof db.prepare;
+
+  // `transaction()` hands back a callable that also carries .default /
+  // .deferred / .immediate / .exclusive variants. They are NOT enumerable, so
+  // copying them with Object.assign silently loses them and every
+  // `tx.immediate(...)` caller dies with "is not a function" — which is how
+  // `pr-auto-dispatch.test.ts` caught the first version of this. Wrap each
+  // variant explicitly instead.
+  const countTransaction = <T extends (...args: unknown[]) => unknown>(
+    transactionFn: T,
+  ): T =>
+    ((...args: unknown[]) => {
+      const nested = db.inTransaction;
+      const result = transactionFn(...args);
+      if (!nested) {
+        active.recordExplicitCommit(walPath);
+      }
+      return result;
+    }) as T;
+
+  db.transaction = ((fn: (...args: unknown[]) => unknown) => {
+    const wrapped = originalTransaction(fn) as unknown as Record<string, unknown>;
+    const counted = countTransaction(
+      wrapped as unknown as (...args: unknown[]) => unknown,
+    ) as unknown as Record<string, unknown>;
+    for (const variant of ["default", "deferred", "immediate", "exclusive"]) {
+      const original = wrapped[variant];
+      if (typeof original === "function") {
+        Object.defineProperty(counted, variant, {
+          configurable: true,
+          value: countTransaction(original as (...args: unknown[]) => unknown),
+          writable: true,
+        });
+      }
+    }
+    return counted;
+  }) as unknown as typeof db.transaction;
+}
+
+export function isSqliteWriteMetricsEnabled(): boolean {
+  return Boolean(process.env[SQLITE_WRITE_METRICS_ENV]);
+}
+
+export function readSqliteWriteMetrics(
+  label = "current",
+): SqliteWriteMetricsSnapshot | undefined {
+  return collector?.snapshot(label);
+}
+
+export function resetSqliteWriteMetrics(): void {
+  collector?.reset();
+}
+
+/**
+ * Append the current totals as one JSON line. The vitest setup and the E2E
+ * harness both point `PWRAGENT_DEV_SQLITE_WRITE_METRICS_FILE` at a run-scoped
+ * file so `report-sqlite-writes.mjs` can rank whatever produced it.
+ */
+let flushedStatements = 0;
+let exitFlushRegistered = false;
+
+export function flushSqliteWriteMetrics(label: string): void {
+  const target = process.env[SQLITE_WRITE_METRICS_FILE_ENV];
+  const snapshot = collector?.snapshot(label);
+  if (!target || !snapshot || snapshot.statements === 0) {
+    return;
+  }
+  try {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.appendFileSync(target, `${JSON.stringify(snapshot)}\n`);
+    flushedStatements = snapshot.statements;
+  } catch {
+    // Instrumentation must never fail a run it is only observing.
+  }
+}
+
+/**
+ * The app never calls `flushSqliteWriteMetrics` itself — it has no idea when a
+ * "run" ends — so a process that opened an instrumented database writes its
+ * totals out as it exits. This is what makes an E2E run report at all: the
+ * Electron main process is the thing doing the writing, and Playwright's
+ * teardown only sees the file it leaves behind.
+ *
+ * `appendFileSync` is safe in an `exit` handler; async work there would not
+ * run. A process killed with SIGKILL reports nothing, which is the honest
+ * outcome — nothing can be flushed from a process that is already gone.
+ */
+function registerProcessExitFlush(): void {
+  if (exitFlushRegistered) {
+    return;
+  }
+  exitFlushRegistered = true;
+  process.once("exit", () => {
+    const snapshot = collector?.snapshot("");
+    // Skip when an explicit flush (the vitest setup) already reported these
+    // statements, so a worker's exit cannot double-count its own test file.
+    if (!snapshot || snapshot.statements <= flushedStatements) {
+      return;
+    }
+    flushSqliteWriteMetrics(resolveProcessLabel());
+  });
+}
+
+function resolveProcessLabel(): string {
+  const fixture = process.env.PWRAGENT_REPLAY_FIXTURE_PATH;
+  if (fixture) {
+    // One spec drives one replay fixture, so its directory names the run
+    // better than a pid does.
+    return `fixture:${path.basename(path.dirname(fixture))}`;
+  }
+  return `pid:${process.pid}`;
+}

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,6 +9,10 @@ import {
   type ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
+import {
+  attachSqliteWriteMetrics,
+  isSqliteWriteMetricsEnabled,
+} from "./sqlite-write-metrics.js";
 
 export const CURRENT_STATE_DB_USER_VERSION = 50;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
@@ -1427,6 +1431,18 @@ LEFT JOIN federation_peers
     // Keep current-version databases converged without asking pre-v36 profiles
     // to install the unique index before the migration above removes duplicates.
     db.exec(PR_AUTO_DISPATCH_GLOBAL_FINGERPRINT_INDEX);
+
+    // Dev-only write accounting, attached only after schema setup so the
+    // report ranks steady-state writes. Migrations commit once per version on
+    // a fresh database, which on a suite that opens a temp db per test would
+    // otherwise swamp the signal — the heaviest "writer" would just be
+    // whichever file opened the most databases. Off unless
+    // PWRAGENT_DEV_SQLITE_WRITE_METRICS is set, and
+    // `rejectDevOnlyEnvVarsInProduction` clears that variable on packaged
+    // builds before anything reads it, so a shipped app never patches its db.
+    if (isSqliteWriteMetricsEnabled()) {
+      attachSqliteWriteMetrics({ db, dbPath });
+    }
     return new StateDb(db);
   }
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eval:pdf": "pnpm --filter @pwragent/desktop eval:pdf",
     "eval:pdf:build": "pnpm --filter @pwragent/desktop prepare:eval-pdf && pnpm --filter @pwragent/desktop eval:pdf",
     "test": "vitest run --config vitest.workspace.ts",
+    "test:sqlite-writes": "node ./scripts/run-sqlite-write-report.mjs",
     "test:nice": "node ./scripts/nice-run.mjs pnpm test",
     "test:watch": "vitest --config vitest.workspace.ts",
     "typecheck": "pnpm -r --if-present typecheck"

--- a/scripts/report-sqlite-writes.mjs
+++ b/scripts/report-sqlite-writes.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Rank whatever produced the most sqlite write volume in a run.
+ *
+ * Reads the JSONL that `PWRAGENT_DEV_SQLITE_WRITE_METRICS_FILE` collected —
+ * one line per vitest file, or per app process in an E2E run — and prints the
+ * heaviest writers. Commits lead the ranking because write amplification
+ * tracks commits, not statements: every implicit transaction flushes its dirty
+ * pages plus every index they moved.
+ *
+ * Usage:
+ *   node scripts/report-sqlite-writes.mjs <metrics.jsonl> [--top N]
+ */
+import { readFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+const file = args.find((arg) => !arg.startsWith("--"));
+const topIndex = args.indexOf("--top");
+const top = topIndex >= 0 ? Number(args[topIndex + 1]) : 15;
+
+if (!file) {
+  console.error("usage: report-sqlite-writes.mjs <metrics.jsonl> [--top N]");
+  process.exit(64);
+}
+
+let lines = [];
+try {
+  lines = readFileSync(file, "utf8").split("\n").filter(Boolean);
+} catch {
+  console.error(`No metrics were recorded at ${file}.`);
+  console.error(
+    "Nothing opened a real StateDb, or the run was not started with PWRAGENT_DEV_SQLITE_WRITE_METRICS=1.",
+  );
+  process.exit(1);
+}
+
+const entries = [];
+for (const line of lines) {
+  try {
+    entries.push(JSON.parse(line));
+  } catch {
+    // A truncated final line from a killed run should not lose the rest.
+  }
+}
+
+if (entries.length === 0) {
+  console.error(`No usable metrics in ${file}.`);
+  process.exit(1);
+}
+
+entries.sort((left, right) => right.commits - left.commits);
+
+const totals = entries.reduce(
+  (sum, entry) => ({
+    commits: sum.commits + entry.commits,
+    rowsChanged: sum.rowsChanged + entry.rowsChanged,
+    statements: sum.statements + entry.statements,
+    walBytes: sum.walBytes + entry.walBytes,
+  }),
+  { commits: 0, rowsChanged: 0, statements: 0, walBytes: 0 },
+);
+
+const byTable = new Map();
+for (const entry of entries) {
+  for (const table of entry.tables) {
+    const current = byTable.get(table.table) ?? {
+      commits: 0,
+      statements: 0,
+      table: table.table,
+    };
+    current.commits += table.commits;
+    current.statements += table.statements;
+    byTable.set(table.table, current);
+  }
+}
+
+console.log("");
+console.log("sqlite write volume");
+console.log("===================");
+console.log(
+  `${entries.length} source(s) · ${fmt(totals.commits)} commits · `
+    + `${fmt(totals.statements)} write statements · ${fmt(totals.rowsChanged)} rows · `
+    + `${mb(totals.walBytes)} WAL`,
+);
+console.log("");
+console.log(`Top ${Math.min(top, entries.length)} by commits:`);
+for (const entry of entries.slice(0, top)) {
+  const hottest = entry.tables[0];
+  console.log(
+    `  ${pad(fmt(entry.commits), 8)} commits  ${pad(mb(entry.walBytes), 10)}  ${short(entry.label)}`
+      + (hottest ? `  [${hottest.table} ${fmt(hottest.commits)}]` : ""),
+  );
+}
+
+console.log("");
+// Statements are shown alongside because a table only ever written inside
+// explicit transactions has its commits attributed to the transaction, not to
+// any one table — it would otherwise look like it never writes at all.
+console.log("Top tables by commits:");
+for (const table of [...byTable.values()]
+  .sort((left, right) => right.commits - left.commits)
+  .slice(0, top)) {
+  console.log(
+    `  ${pad(fmt(table.commits), 8)} commits  ${pad(fmt(table.statements), 8)} stmts  ${table.table}`,
+  );
+}
+console.log("");
+
+function fmt(value) {
+  return value.toLocaleString("en-US");
+}
+
+function mb(bytes) {
+  if (bytes <= 0) return "0 MB";
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+}
+
+function pad(value, width) {
+  return String(value).padStart(width);
+}
+
+function short(label) {
+  const marker = "/apps/desktop/";
+  const index = label.indexOf(marker);
+  return index >= 0 ? label.slice(index + marker.length) : label;
+}

--- a/scripts/run-sqlite-write-report.mjs
+++ b/scripts/run-sqlite-write-report.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * Run the test suite with sqlite write accounting on, then print the ranked
+ * report. Any extra arguments are forwarded to vitest, so you can narrow the
+ * run the same way `pnpm test` does:
+ *
+ *   pnpm test:sqlite-writes
+ *   pnpm test:sqlite-writes apps/desktop/src/main/__tests__/state-db.test.ts
+ */
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const outDir = path.join(tmpdir(), "pwragent-sqlite-write-metrics");
+const metricsFile = path.join(outDir, `run-${process.pid}.jsonl`);
+
+rmSync(metricsFile, { force: true });
+mkdirSync(outDir, { recursive: true });
+
+const vitest = spawnSync(
+  "pnpm",
+  ["exec", "vitest", "run", "--config", "vitest.workspace.ts", ...process.argv.slice(2)],
+  {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PWRAGENT_DEV_SQLITE_WRITE_METRICS: "1",
+      PWRAGENT_DEV_SQLITE_WRITE_METRICS_FILE: metricsFile,
+    },
+    stdio: "inherit",
+  },
+);
+
+// Report regardless of suite outcome — a failing run still tells you where the
+// writes went, and that is often why you started the run.
+const report = spawnSync(
+  "node",
+  [path.join(repoRoot, "scripts", "report-sqlite-writes.mjs"), metricsFile],
+  { cwd: repoRoot, stdio: "inherit" },
+);
+
+process.exit(vitest.status ?? report.status ?? 0);

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -43,6 +43,9 @@ export default defineConfig({
             "apps/desktop/src/preload/__tests__/**/*.test.ts",
             "apps/desktop/src/shared/__tests__/**/*.test.ts"
           ],
+          // Inert unless PWRAGENT_DEV_SQLITE_WRITE_METRICS is set; see
+          // `pnpm test:sqlite-writes`.
+          setupFiles: ["apps/desktop/src/main/state/sqlite-write-metrics-setup.ts"],
           // Inline @pwrdrvr/codex-discovery so vitest transforms it. Without
           // this, the kit's bundled `import { spawn } from "child_process"`
           // is loaded raw by Node and bypasses the tests'


### PR DESCRIPTION
## Summary

Follow-up to #1406, which fixed tool accounting running **one implicit transaction per streamed 8 KiB command-output chunk** — 3,693 commits and 58 MB of WAL growth for a single `find /`, to persist about nineteen integer counters. The whole suite passed either way. It had to be found by hand.

**The card asked for a vitest-level hook. Investigating first showed that would not have caught the bug.** The main-process suites mock the overlay store — `backend-registry.test.ts` alone builds `createOverlayStoreMock` in 450+ places — so no sqlite is involved and no assertion about write behavior is possible there. What runs the real write path is the app, which the E2E harness drives against a real `state.db` under a temp `PWRAGENT_HOME`.

So the collector attaches to the database in `StateDb.open` and covers vitest, E2E, and dev runs from one place.

**Commits, not statements, are the ranked metric.** Each implicit transaction flushes its dirty pages plus every index they moved — four 4 KB pages per write in #1406's case, since `observed_at` sits in all three indexes on `thread_tool_invocations`. Ranking by statements would call a batched migration expensive and a per-event write loop cheap, exactly backwards.

### What you get

```bash
pnpm test:sqlite-writes                    # whole suite, then the ranking
pnpm test:sqlite-writes <vitest args>      # narrowed the same way as pnpm test
```

Whole-suite baseline today: **51 sources, 3,054 commits, 27 MB WAL**, ranked by file with the hottest table called out per row.

Every desktop E2E run reports automatically at teardown into the run log. The harness is the only place the real write path executes, and the cost is a `statSync` per commit against a run that launches Electron. `PWRAGENT_DEV_SQLITE_WRITE_METRICS=0` opts out.

### Write budgets (it fails, it does not just report)

Budgets live in a checked-in JSON and `sqlite-write-metrics.test.ts` fails when one moves:

```
sqlite write budget "streamed-command-output" changed.
  budget:   2 commits, 2 statements, 2 rows (~36 KB WAL)
  measured: 501 commits, 501 statements, 501 rows (~2820 KB WAL)
```

That is the pre-#1406 pattern caught automatically — verified by reverting the coalescing, not assumed. Note the budget itself: **2 commits for 501 streamed events**, because commits must not scale with events.

**Setup is separated from feature cost by construction.** `measureSqliteWrites(fn)` measures only what the callback does, so opening the database, applying migrations, and seeding fixtures all sit outside it. A budget tracks the feature and stays put when a test grows more setup — no classifying writes after the fact.

**Only the deterministic counters are asserted.** Commits, statements, and rows are a pure function of the code path — same operations, same numbers, on any machine under any load — which is what makes an exact assertion safe rather than a tolerance. WAL bytes are *not* deterministic (page fill, checkpoint timing), so `observedWalBytes` is recorded for humans to read and never asserted.

Deviation fails **both** ways: an increase is the regression; a decrease means the budget went stale and would stop catching anything. Re-record deliberately with `UPDATE_SQLITE_WRITE_BUDGETS=1`.

Two scenarios to start — streamed command output, and an idle hour of heartbeats (720 commits, the ~65 MB/day floor found while building this).

### Guidance

Root `AGENTS.md` now requires any new sqlite write firing per command, per turn, per item, per streamed event, or on a timer to be measured and pinned by a budget — including doing the MB/day projection out loud, and **raising it with the user when the projection looks excessive**, since the fix is usually a design-constraint change rather than a tweak.

## Verification

- `pnpm typecheck`, `lint:sql`, `lint:boundaries` clean; `lint:eslint` 0 errors (134 pre-existing warnings, unchanged).
- `pnpm test` — 7,076 passed. The one failure is the documented `acp-backend-adapter.test.ts` full-suite-load timeout flake; it passes alone (39/39), and it also passed in the metrics-enabled run of the same suite.
- `pnpm test:sqlite-writes` — **497/497 files pass with instrumentation on**, so the wrapper is transparent to the suite.
- **Validated on the PwrSuiteLab macOS guest**, since local desktop E2E is off-limits: `run-e2e.sh --workload pwragent e2e/thread-pricing-panel.spec.ts` passed and printed the ranking into `e2e.log`, attributing writes to two Electron processes by fixture:
  ```
  2 source(s) · 28 commits · 57 write statements · 21 rows · 0.30 MB WAL
        22 commits  0.29 MB  fixture:thread-pricing-panel  [app_runtime_instances 3]
         6 commits  0.01 MB  fixture:smoke                 [app_runtime_instances 1]
  ```

## Notes

Three things the first cut of this got wrong, each now covered by a test and written up in `apps/desktop/AGENTS.md`:

- **Attaching before migrations** made a fresh temp db's schema setup swamp the signal — 164 commits for 16 statements, so the "heaviest writer" was just whichever file opened the most databases. Attach happens after schema setup now.
- **`Object.assign` on the `transaction()` callable** dropped its non-enumerable `.default`/`.deferred`/`.immediate`/`.exclusive` variants, breaking 24 tests in `pr-auto-dispatch.test.ts` with "is not a function". Instrumentation has to be invisible to the code it measures; each variant is wrapped explicitly now.
- **Nothing flushed in the app.** The first lab run passed and reported nothing at all, because `flushSqliteWriteMetrics` was only ever called from the vitest setup — the Electron process collected in memory and exited. A process-exit flush fixes it; that is what makes E2E report.

Read a zero in the ranking as "this file touched no real sqlite", never as coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
