### PR TITLE
fix(desktop): show thread creation time in info panel

### DIFF
--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.png
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a85e52284174195bdbc9338e6c289e8f7d917ff5b45c11f12e37dac4c3b7da46
-size 148118
+oid sha256:a64af1760d3f1fea0d5de1bc22dbbb6cf83aafdadfc599977c27ca3e80fe7176
+size 149884

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -254,6 +254,41 @@ describe("ThreadContextPanel", () => {
     expect(panel).toHaveAttribute("aria-labelledby", activeTab.id);
   });
 
+  it("shows the thread creation and update timestamps in Thread info", () => {
+    const createdAt = new Date(2026, 6, 8, 9, 15).getTime();
+    const updatedAt = new Date(2026, 6, 9, 10, 41).getTime();
+    renderPanel({
+      pinned: true,
+      thread: {
+        ...baseThread,
+        createdAt,
+        updatedAt,
+      },
+    });
+
+    const executionContext = screen
+      .getByRole("heading", { level: 3, name: "Execution context" })
+      .closest("section");
+    expect(executionContext).not.toBeNull();
+    const context = within(executionContext!);
+    expect(context.getByText("Created").nextElementSibling).toHaveTextContent(
+      new Intl.DateTimeFormat(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      }).format(createdAt),
+    );
+    expect(context.getByText("Updated").nextElementSibling).toHaveTextContent(
+      new Intl.DateTimeFormat(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      }).format(updatedAt),
+    );
+  });
+
   it("renders persisted sub-agent cards with monitor usage", () => {
     vi.useFakeTimers();
     vi.setSystemTime(3_000);

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ThreadInfoPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ThreadInfoPanel.tsx
@@ -165,6 +165,12 @@ export function ThreadInfoPanel(props: ThreadInfoPanelProps) {
             </dd>
           </div>
           <div>
+            <dt>Created</dt>
+            <dd>
+              {props.thread.createdAt ? formatTimestamp(props.thread.createdAt) : "Unknown"}
+            </dd>
+          </div>
+          <div>
             <dt>Updated</dt>
             <dd>
               {props.thread.updatedAt ? formatTimestamp(props.thread.updatedAt) : "Unknown"}


### PR DESCRIPTION
## Summary

- add the thread creation date and time to the Thread info execution context
- preserve the existing Unknown fallback when a provider does not expose createdAt
- cover creation and update timestamp rendering with a focused renderer test

## Root cause

The navigation thread summary already carries createdAt, but the original execution-context UI rendered only updatedAt. The later tabbed context-rail refactor preserved that omission.

## User impact

Operators can now see both when a thread was created and when it was last updated from the (i) tab.

## Validation

- pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx (70 passed)
- pnpm lint:eslint
- git diff --check
