### PR TITLE
test(desktop): reduce onboarding and accessibility launches

### DIFF
--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -6,13 +6,17 @@
 // We intentionally use the actual Electron renderer (not a jsdom render
 // of individual components) so that real styling from app.css — focus
 // rings, contrast, sticky-header layout — gets audited as it actually
-// ships. The cost is one Electron launch per surface; the coverage is
-// what a screen-reader / keyboard-only operator actually encounters.
+// ships. Surfaces that share a fixture and theme reuse one Electron
+// launch, with named steps and explicit state resets keeping failures
+// attributable and preventing overlays from leaking into the next scan.
+// The coverage is what a screen-reader / keyboard-only operator actually
+// encounters.
 //
-// To extend: add another entry to SURFACES below, or a separate
-// `test(...)` block that drives the renderer into a state (open a
-// dialog, switch a tab) and then calls `runAxe(window)`. Launch via
-// `launchAuditApp({ theme })` so the surface is audited at rest (see below).
+// To extend: add a named `test.step(...)` to the matching fixture group,
+// or add a grouped `test(...)` when the surface needs a different fixture.
+// Drive the renderer into the state, call `runAxe(window, surface)`, and
+// reset any stateful layer before the next step. Launch via
+// `launchAuditApp({ theme })` so every surface is audited at rest (see below).
 //
 // Every surface is audited in BOTH themes. The gate ran dark-only for
 // its whole life, which is exactly why three light-theme token-level
@@ -122,6 +126,7 @@ const KNOWN_VIOLATIONS: ReadonlyArray<{
 
 async function runAxe(
   window: Page,
+  surface: string,
   options?: {
     /**
      * Narrow the scan to one subtree. Use it only when the test is about
@@ -179,22 +184,104 @@ async function runAxe(
       })
       .join("\n");
     throw new Error(
-      `axe-core found ${results.violations.length} WCAG2 AA violation(s):\n${summary}`,
+      `axe-core found ${results.violations.length} WCAG2 AA violation(s) on ${surface}:\n${summary}`,
     );
   }
 }
 
 for (const theme of AUDIT_THEMES) {
   test.describe(`desktop renderer accessibility (WCAG2 AA, ${theme} theme)`, () => {
-    test("sidebar + empty-thread shell has no violations", async () => {
+    test("smoke fixture surfaces have no violations", async () => {
       const app = await launchAuditApp({ theme });
       try {
-        // Wait for first paint of the inbox lens — the "Replay smoke
-        // thread" row is the proxy for "renderer has hydrated".
-        await expect(
-          app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
-        ).toBeVisible();
-        await runAxe(app.window);
+        const smokeThread = app.window
+          .getByRole("button", { name: /Replay smoke thread/i })
+          .first();
+
+        await test.step("sidebar + empty-thread shell", async () => {
+          // The thread row is the proxy for "renderer has hydrated".
+          await expect(smokeThread).toBeVisible();
+          await runAxe(app.window, "sidebar + empty-thread shell");
+        });
+
+        await test.step("thread search", async () => {
+          // Before Search opens, the accessible name unambiguously belongs
+          // to the masthead button. The same name then moves to the
+          // autofocused textbox when the search view mounts.
+          await app.window
+            .getByRole("button", { name: "Search threads" })
+            .click();
+          const searchInput = app.window.getByRole("textbox", {
+            name: "Search threads",
+          });
+          await expect(searchInput).toBeVisible();
+          await runAxe(app.window, "thread search");
+
+          // Search is stateful main-view navigation. Close it before the
+          // settings scans so their unscoped audits see the empty shell
+          // behind the overlay, matching a clean launch.
+          await searchInput.press("Escape");
+          await expect(searchInput).toBeHidden();
+          await expect(smokeThread).toBeVisible();
+        });
+
+        await test.step("settings overlay", async () => {
+          await app.window.getByRole("button", { name: "Open settings" }).click();
+          const settingsNav = app.window.getByRole("navigation", {
+            name: "Settings sections",
+          });
+          await expect(settingsNav).toBeVisible();
+          await runAxe(app.window, "settings overlay");
+
+          await settingsNav
+            .getByRole("button", { name: /Exit Settings/i })
+            .click();
+          await expect(settingsNav).toBeHidden();
+          await expect(smokeThread).toBeVisible();
+        });
+
+        await test.step("settings → messaging", async () => {
+          await app.window.getByRole("button", { name: "Open settings" }).click();
+          const settingsNav = app.window.getByRole("navigation", {
+            name: "Settings sections",
+          });
+          await expect(settingsNav).toBeVisible();
+          await settingsNav
+            .getByRole("button", { name: /^Messaging$/ })
+            .click();
+          const messagingSettings = app.window.getByRole("region", {
+            name: "Messaging settings",
+          });
+          await expect(messagingSettings).toBeVisible();
+          await runAxe(app.window, "settings → messaging");
+
+          await settingsNav
+            .getByRole("button", { name: /Exit Settings/i })
+            .click();
+          await expect(messagingSettings).toBeHidden();
+          await expect(settingsNav).toBeHidden();
+          await expect(smokeThread).toBeVisible();
+        });
+
+        await test.step("open thread view", async () => {
+          await smokeThread.click();
+          await expect(
+            app.window.getByRole("heading", {
+              level: 2,
+              name: "Replay smoke thread",
+            }),
+          ).toBeVisible();
+          await expect(
+            app.window.getByText("The replay harness is live."),
+          ).toBeVisible();
+          // The celestial watermark is a real theme-dependent compositing
+          // input to every contrast pair in the transcript. Keep this
+          // assertion so the audit cannot go green by ceasing to render it.
+          await expect(
+            app.window.locator(".thread-view__primary .celestial-watermark"),
+          ).toHaveCount(1);
+          await runAxe(app.window, "open thread view");
+        });
       } finally {
         await app.close();
       }
@@ -214,61 +301,29 @@ for (const theme of AUDIT_THEMES) {
     // failure anywhere. Keeping the scan UNSCOPED matters for the same
     // reason; narrowing it with `include` is the cheap way out and would
     // stop this block catching anything outside the sidebar.
-    test("sidebar rows carrying copy chips have no violations", async () => {
+    test("sidebar copy-chip fixture surface has no violations", async () => {
       const app = await launchAuditApp({
         theme,
         fixturePath: COPY_CHIP_FIXTURE,
       });
       try {
-        // The branch chip renders last of the row's copy chips, so waiting
-        // on it means the linked-directory chips are up too.
-        await expect(
-          app.window.getByRole("button", {
-            name: "Copy branch feature/copy-chip-audit",
-          }),
-        ).toBeVisible();
-        await runAxe(app.window);
+        await test.step("sidebar rows carrying copy chips", async () => {
+          // The branch chip renders last of the row's copy chips, so waiting
+          // on it means the linked-directory chips are up too.
+          await expect(
+            app.window.getByRole("button", {
+              name: "Copy branch feature/copy-chip-audit",
+            }),
+          ).toBeVisible();
+          await runAxe(app.window, "sidebar rows carrying copy chips");
+        });
       } finally {
         await app.close();
       }
     });
 
-    test("open thread view has no violations", async () => {
-      const app = await launchAuditApp({ theme });
-      try {
-        await app.window
-          .getByRole("button", { name: /Replay smoke thread/i })
-          .first()
-          .click();
-        await expect(
-          app.window.getByRole("heading", {
-            level: 2,
-            name: "Replay smoke thread",
-          }),
-        ).toBeVisible();
-        await expect(app.window.getByText("The replay harness is live.")).toBeVisible();
-        // The celestial watermark paints the owning instance's mark behind
-        // the transcript at 0.05 opacity, tinted with `--text-muted`. That
-        // is a real compositing input to every contrast pair in the thread
-        // body, and it resolves differently per theme — a value harmless
-        // behind a dark surface can eat the margin on a light one. Assert
-        // it is actually painted, or the audit below keeps passing after a
-        // regression that stopped rendering it. It is aria-hidden, so it
-        // has no role to locate it by; the class IS the contract the a11y
-        // note in app.css points at. (Added by #1303 as its own scoped
-        // pair of blocks; folded in here once light theme went AA-clean
-        // window-wide and the scoping stopped being needed.)
-        await expect(
-          app.window.locator(".thread-view__primary .celestial-watermark"),
-        ).toHaveCount(1);
-        await runAxe(app.window);
-      } finally {
-        await app.close();
-      }
-    });
-
-    // The block above opens the smoke fixture's thread, which is idle, so
-    // the transcript renders nothing but its `role="listitem"` entries.
+    // The smoke fixture group opens an idle thread, so its transcript
+    // renders nothing but its `role="listitem"` entries.
     // An ACTIVE thread additionally renders `.transcript-list__pending`,
     // the `role="status"` thinking line — and role="status" is not a
     // permitted owned element of the `role="list"` scroll container, so
@@ -278,144 +333,79 @@ for (const theme of AUDIT_THEMES) {
     // do use an active fixture but the map layer covers the thread view.
     // It now renders inside a listitem wrapper. This block is the gate on
     // that, so keep the fixture active and the scan unscoped.
-    test("open thread view with an active thread has no violations", async () => {
+    test("star map fixture surfaces have no violations", async () => {
       const app = await launchAuditApp({ fixturePath: STAR_MAP_FIXTURE, theme });
       try {
-        await app.window
+        const attentionThread = app.window
           .getByRole("button", { name: /Star map attention thread/i })
-          .first()
-          .click();
-        await expect(app.window.getByText("The star map is live.")).toBeVisible();
-        // Assert the live region is actually painted. Without this the
-        // block keeps passing if the fixture's threads stop being active
-        // (or the thinking line stops rendering), having quietly stopped
-        // auditing the thing it exists for.
-        await expect(
-          app.window.locator(".transcript-list__pending"),
-        ).toHaveCount(1);
-        await runAxe(app.window);
-      } finally {
-        await app.close();
-      }
-    });
-
-    test("settings overlay has no violations", async () => {
-      const app = await launchAuditApp({ theme });
-      try {
-        await expect(
-          app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
-        ).toBeVisible();
-        await app.window.getByRole("button", { name: "Open settings" }).click();
-        // Settings sections nav is the stable signal that the overlay is
-        // hydrated (the overlay has no level-1 heading; see
-        // composer-draft-settings.spec.ts for the same anchor).
-        await expect(
-          app.window.getByRole("navigation", { name: "Settings sections" }),
-        ).toBeVisible();
-        await runAxe(app.window);
-      } finally {
-        await app.close();
-      }
-    });
-
-    test("thread search has no violations", async () => {
-      const app = await launchAuditApp({ theme });
-      try {
-        await expect(
-          app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
-        ).toBeVisible();
-        // Open Search from the sidebar masthead. Before it opens, "Search
-        // threads" is unambiguously the masthead button; the autofocused
-        // search field (same accessible name, but role=textbox) is the
-        // stable signal that the search view has mounted.
-        await app.window.getByRole("button", { name: "Search threads" }).click();
-        await expect(
-          app.window.getByRole("textbox", { name: "Search threads" }),
-        ).toBeVisible();
-        await runAxe(app.window);
-      } finally {
-        await app.close();
-      }
-    });
-
-    test("settings → messaging has no violations", async () => {
-      const app = await launchAuditApp({ theme });
-      try {
-        await expect(
-          app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
-        ).toBeVisible();
-        await app.window.getByRole("button", { name: "Open settings" }).click();
-        await expect(
-          app.window.getByRole("navigation", { name: "Settings sections" }),
-        ).toBeVisible();
-        await app.window
-          .getByRole("navigation", { name: "Settings sections" })
-          .getByRole("button", { name: /^Messaging$/ })
-          .click();
-        await runAxe(app.window);
-      } finally {
-        await app.close();
-      }
-    });
-
-    test("star map layer has no violations", async () => {
-      const app = await launchAuditApp({ fixturePath: STAR_MAP_FIXTURE, theme });
-      try {
-        await expect(
-          app.window
-            .getByRole("button", { name: /Star map attention thread/i })
-            .first(),
-        ).toBeVisible();
-        await app.window.getByRole("button", { name: "Open Star Map" }).click();
-        // `exact` because role-name matching is substring by default, and a
-        // chat card's "Chat: <title>" region can match "Star Map" too.
+          .first();
         const starMap = app.window.getByRole("region", {
           name: "Star Map",
           exact: true,
         });
-        await expect(starMap).toBeVisible();
-        // A single E2E instance means one body on the map. Gate on a card
-        // rather than the body: the lane populates from the navigation
-        // snapshot after the layer mounts, and auditing the empty layer
-        // would silently skip every card-borne contrast pair.
-        await expect(
-          starMap.getByRole("button", {
-            name: "Open thread: Star map attention thread",
-          }),
-        ).toBeVisible();
-        await runAxe(app.window);
-      } finally {
-        await app.close();
-      }
-    });
+        const starMapCard = starMap.getByRole("button", {
+          name: "Open thread: Star map attention thread",
+        });
 
-    test("star map intake dialog has no violations", async () => {
-      const app = await launchAuditApp({ fixturePath: STAR_MAP_FIXTURE, theme });
-      try {
-        await expect(
-          app.window
-            .getByRole("button", { name: /Star map attention thread/i })
-            .first(),
-        ).toBeVisible();
-        await app.window.getByRole("button", { name: "Open Star Map" }).click();
-        // `exact` because role-name matching is substring by default, and a
-        // chat card's "Chat: <title>" region can match "Star Map" too.
-        const starMap = app.window.getByRole("region", {
-          name: "Star Map",
-          exact: true,
+        await test.step("star map layer", async () => {
+          await expect(attentionThread).toBeVisible();
+          await app.window.getByRole("button", { name: "Open Star Map" }).click();
+          await expect(starMap).toBeVisible();
+          // Gate on a card rather than only the map body: the lane populates
+          // after the layer mounts, and an empty map skips the card contrast.
+          await expect(starMapCard).toBeVisible();
+          await runAxe(app.window, "star map layer");
+
+          await starMap
+            .getByRole("button", { name: "Close Star Map" })
+            .click();
+          await expect(starMap).toHaveCount(0);
+          await expect(
+            app.window.getByRole("button", { name: "Open Star Map" }),
+          ).toBeVisible();
         });
-        await expect(starMap).toBeVisible();
-        // The [+] beside the local body carries the machine label, which is
-        // the runner's hostname — match the copy, not the machine.
-        await starMap.getByRole("button", { name: /^New thread on / }).click();
-        const intake = app.window.getByRole("dialog", {
-          name: /^New thread on /,
+
+        await test.step("star map intake dialog", async () => {
+          await expect(
+            app.window.getByRole("button", { name: "Open Star Map" }),
+          ).toBeVisible();
+          await app.window.getByRole("button", { name: "Open Star Map" }).click();
+          await expect(starMap).toBeVisible();
+          await expect(starMapCard).toBeVisible();
+          // The [+] beside the local body carries the runner hostname, so
+          // match the stable copy rather than a machine-specific label.
+          await starMap.getByRole("button", { name: /^New thread on / }).click();
+          const intake = app.window.getByRole("dialog", {
+            name: /^New thread on /,
+          });
+          await expect(intake).toBeVisible();
+          await expect(
+            intake.getByRole("button", { name: "Start thread" }),
+          ).toBeVisible();
+          await runAxe(app.window, "star map intake dialog");
+
+          await intake
+            .getByRole("button", { name: "Close", exact: true })
+            .click();
+          await expect(intake).toHaveCount(0);
+          await starMap
+            .getByRole("button", { name: "Close Star Map" })
+            .click();
+          await expect(starMap).toHaveCount(0);
+          await expect(attentionThread).toBeVisible();
         });
-        await expect(intake).toBeVisible();
-        await expect(
-          intake.getByRole("button", { name: "Start thread" }),
-        ).toBeVisible();
-        await runAxe(app.window);
+
+        await test.step("open thread view with an active thread", async () => {
+          await attentionThread.click();
+          await expect(app.window.getByText("The star map is live.")).toBeVisible();
+          // Assert the live region is actually painted. Without this the
+          // scan keeps passing if the fixture stops being active and quietly
+          // stops auditing the role=status/list relationship it exists for.
+          await expect(
+            app.window.locator(".transcript-list__pending"),
+          ).toHaveCount(1);
+          await runAxe(app.window, "open thread view with an active thread");
+        });
       } finally {
         await app.close();
       }

--- a/apps/desktop/e2e/composer-markdown-paste.spec.ts
+++ b/apps/desktop/e2e/composer-markdown-paste.spec.ts
@@ -370,22 +370,41 @@ test("plain-text and text/html copies of one source paste to identical markdown"
 // HTML-authoritative guard still defers to the default paste when the clipboard
 // HTML already encodes the structure (a <pre>/<ul>/<ol>/<blockquote>/<hN>).
 
-async function pasteListAndReadValue(flavor: {
-  html?: string;
-  text: string;
-}): Promise<string | null> {
+async function pasteListsAndReadValues(
+  scenarios: ReadonlyArray<{
+    flavor: { html?: string; text: string };
+    listTag: "ol" | "ul";
+  }>,
+): Promise<Array<string | null>> {
   const fixture = await createPasteFixture();
   const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
   try {
     await openExistingThread(app);
     const tiptapInput = app.window.getByTestId("composer-tiptap-input");
-    await app.window.getByRole("textbox", { name: "Reply" }).focus();
-    await pasteIntoReply(app.window, flavor);
-    // Wait for the list to render before snapshotting the serialized value.
-    await expect(
-      tiptapInput.locator(".composer-tiptap-input__editor > ul > li"),
-    ).toHaveCount(2);
-    return await tiptapInput.getAttribute("data-value");
+    const textbox = app.window.getByRole("textbox", { name: "Reply" });
+    const values: Array<string | null> = [];
+
+    for (const [index, scenario] of scenarios.entries()) {
+      await textbox.focus();
+      if (index > 0) {
+        await app.window.keyboard.press(
+          process.platform === "darwin" ? "Meta+A" : "Control+A",
+        );
+        await app.window.keyboard.press("Delete");
+        await expect(tiptapInput).toHaveAttribute("data-value", "");
+      }
+
+      await pasteIntoReply(app.window, scenario.flavor);
+      // Wait for the list to render before snapshotting the serialized value.
+      await expect(
+        tiptapInput.locator(
+          `.composer-tiptap-input__editor > ${scenario.listTag} > li`,
+        ),
+      ).toHaveCount(2);
+      values.push(await tiptapInput.getAttribute("data-value"));
+    }
+
+    return values;
   } finally {
     await app.close();
     await fixture.cleanup();
@@ -438,21 +457,34 @@ test("pasted inline code renders as a styled pill, not bare text", async () => {
   }
 });
 
-test("a bullet list round-trips identically from text/plain and from list HTML", async () => {
-  const text = ["Steps:", "", "- First", "- Second"].join("\n");
-  const expected = "Steps:\n\n- First\n- Second";
+test("fence-free lists reconstruct and bullets round-trip identically from plain text and HTML", async () => {
+  const bulletText = ["Steps:", "", "- First", "- Second"].join("\n");
+  const bulletExpected = "Steps:\n\n- First\n- Second";
+  const orderedText = ["Order matters:", "", "1. Alpha", "2. Beta"].join("\n");
+  const orderedExpected = "Order matters:\n\n1. Alpha\n2. Beta";
 
-  // text/plain only → parser reconstructs the list.
-  const plain = await pasteListAndReadValue({ text });
+  // Each text/plain list independently triggers the block-markdown parser.
+  // Keeping the ordered-only clipboard free of bullets and fences ensures its
+  // detection cannot hitchhike on another block marker.
+  const [plainBullet, plainOrdered] = await pasteListsAndReadValues([
+    { flavor: { text: bulletText }, listTag: "ul" },
+    { flavor: { text: orderedText }, listTag: "ol" },
+  ]);
   // Rich HTML with a <ul> → the guard defers to the default paste, which
   // reconstructs from the HTML. Either flavor must serialize to the same markdown.
-  const html = await pasteListAndReadValue({
-    html: "<p>Steps:</p><ul><li>First</li><li>Second</li></ul>",
-    text,
-  });
+  const [htmlBullet] = await pasteListsAndReadValues([
+    {
+      flavor: {
+        html: "<p>Steps:</p><ul><li>First</li><li>Second</li></ul>",
+        text: bulletText,
+      },
+      listTag: "ul",
+    },
+  ]);
 
-  expect(plain).toBe(expected);
-  expect(html).toBe(plain);
+  expect(plainBullet).toBe(bulletExpected);
+  expect(htmlBullet).toBe(plainBullet);
+  expect(plainOrdered).toBe(orderedExpected);
 });
 
 // --- Nested language fences: the composer must agree with the transcript ---

--- a/apps/desktop/e2e/composer-markdown-paste.spec.ts
+++ b/apps/desktop/e2e/composer-markdown-paste.spec.ts
@@ -215,34 +215,6 @@ test("a trailing code block does not collapse the paragraph separators above it"
   }
 });
 
-test("a pasted code fence still becomes a code block when the clipboard is plain-text only", async () => {
-  const fixture = await createPasteFixture();
-  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
-
-  try {
-    await openExistingThread(app);
-    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
-    await app.window.getByRole("textbox", { name: "Reply" }).focus();
-
-    // No text/html: text/plain is the authoritative markdown source, so the
-    // custom fence parse must still run and form the code block.
-    await pasteIntoReply(app.window, {
-      text: ["Intro paragraph.", "", "Body paragraph.", "", CODE_PLAIN].join("\n"),
-    });
-
-    await expect(tiptapInput).toHaveAttribute(
-      "data-value",
-      `Intro paragraph.\n\nBody paragraph.\n\n${EXPECTED_CODE_VALUE}`,
-    );
-    await expect(
-      tiptapInput.locator(".composer-tiptap-input__editor > pre"),
-    ).toHaveCount(1);
-  } finally {
-    await app.close();
-    await fixture.cleanup();
-  }
-});
-
 test("a code fence is upgraded from text/plain even when HTML is present but has no code block", async () => {
   const fixture = await createPasteFixture();
   const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
@@ -419,58 +391,6 @@ async function pasteListAndReadValue(flavor: {
     await fixture.cleanup();
   }
 }
-
-test("a pasted bullet list is reconstructed as a list (text/plain only)", async () => {
-  const fixture = await createPasteFixture();
-  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
-
-  try {
-    await openExistingThread(app);
-    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
-    await app.window.getByRole("textbox", { name: "Reply" }).focus();
-
-    await pasteIntoReply(app.window, {
-      text: ["Here are the steps:", "", "- First item", "- Second item", "- Third item"].join("\n"),
-    });
-
-    await expect(
-      tiptapInput.locator(".composer-tiptap-input__editor > ul > li"),
-    ).toHaveCount(3);
-    await expect(tiptapInput).toHaveAttribute(
-      "data-value",
-      "Here are the steps:\n\n- First item\n- Second item\n- Third item",
-    );
-  } finally {
-    await app.close();
-    await fixture.cleanup();
-  }
-});
-
-test("a pasted ordered list is reconstructed as a list (text/plain only)", async () => {
-  const fixture = await createPasteFixture();
-  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
-
-  try {
-    await openExistingThread(app);
-    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
-    await app.window.getByRole("textbox", { name: "Reply" }).focus();
-
-    await pasteIntoReply(app.window, {
-      text: ["Order matters:", "", "1. Alpha", "2. Beta", "3. Gamma"].join("\n"),
-    });
-
-    await expect(
-      tiptapInput.locator(".composer-tiptap-input__editor > ol > li"),
-    ).toHaveCount(3);
-    await expect(tiptapInput).toHaveAttribute(
-      "data-value",
-      "Order matters:\n\n1. Alpha\n2. Beta\n3. Gamma",
-    );
-  } finally {
-    await app.close();
-    await fixture.cleanup();
-  }
-});
 
 test("pasted inline code renders as a styled pill, not bare text", async () => {
   const fixture = await createPasteFixture();

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -612,46 +612,6 @@ test("directory launchpad Tiptap WYSIWYG composer serializes markdown blocks", a
   }
 });
 
-test("directory launchpad Tiptap composer preserves pasted paragraph breaks", async () => {
-  const fixture = await createDirectoryLaunchpadSkillsFixture();
-  const app = await launchElectronApp({    fixturePath: fixture.fixturePath,
-  });
-
-  try {
-    await openDirectoryLaunchpad(app);
-
-    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
-    const textbox = app.window.getByRole("textbox", { name: "New thread" });
-    await textbox.focus();
-    await textbox.evaluate((element) => {
-      const dataTransfer = new DataTransfer();
-      dataTransfer.setData(
-        "text/html",
-        "<p>first paragraph</p><p>second paragraph</p>",
-      );
-      dataTransfer.setData("text/plain", "first paragraph\nsecond paragraph");
-      element.dispatchEvent(
-        new ClipboardEvent("paste", {
-          bubbles: true,
-          cancelable: true,
-          clipboardData: dataTransfer,
-        }),
-      );
-    });
-
-    await expect(
-      tiptapInput.locator(".composer-tiptap-input__editor p"),
-    ).toHaveCount(2);
-    await expect(tiptapInput).toHaveAttribute(
-      "data-value",
-      "first paragraph\n\nsecond paragraph",
-    );
-  } finally {
-    await app.close();
-    await fixture.cleanup();
-  }
-});
-
 test("directory launchpad skill autocomplete honors markdown offsets after formatted blocks", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({    fixturePath: fixture.fixturePath,

--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -179,39 +179,6 @@ async function expectFakeProvidersFound(
 }
 
 test.describe("Onboarding wizard", () => {
-  test("Get started and Back buttons are clickable", async () => {
-    const app = await launchElectronApp(wizardLaunchOptions);
-    try {
-      await expect(
-        app.window.getByRole("heading", {
-          name: /A few short choices/i,
-        }),
-      ).toBeVisible();
-
-      const getStarted = app.window.getByRole("button", { name: /Get started/i });
-      await expect(getStarted).toBeVisible();
-      await getStarted.click();
-
-      await expect(
-        app.window.getByRole("heading", {
-          name: /Pick your appearance and thread density/i,
-        }),
-      ).toBeVisible();
-
-      const back = app.window.getByRole("button", { name: /^← Back/i });
-      await expect(back).toBeVisible();
-      await back.click();
-
-      await expect(
-        app.window.getByRole("heading", {
-          name: /A few short choices/i,
-        }),
-      ).toBeVisible();
-    } finally {
-      await app.close();
-    }
-  });
-
   test("fires on a fresh PWRAGENT_HOME and walks Welcome → Done in Shared mode", async () => {
     const app = await launchElectronApp(wizardLaunchOptions);
     try {
@@ -287,7 +254,7 @@ test.describe("Onboarding wizard", () => {
     }
   });
 
-  test("messaging-safety gate: locked Continue flashes the ack card, checking it unlocks", async () => {
+  test("messaging-safety gate flashes once, resets on re-entry, and unlocks after acknowledgement", async () => {
     const app = await launchElectronApp(wizardLaunchOptions);
     try {
       // Walk to the messaging-safety step (same path as the Shared walk).
@@ -329,6 +296,17 @@ test.describe("Onboarding wizard", () => {
       ).toBeVisible();
       await expect(flash).toHaveCount(1);
 
+      // Leaving and returning clears the one-shot attention ring without
+      // replaying it. The acknowledgement remains unchecked and the gate
+      // remains locked until the operator acts again.
+      await app.window.getByRole("button", { name: /^← Back/i }).click();
+      await app.window.getByRole("button", { name: /^Continue/i }).click();
+      await expect(
+        app.window.getByRole("heading", { name: /Messaging is optional/i }),
+      ).toBeVisible();
+      await expect(flash).toHaveCount(0);
+      await expect(continueBtn).toHaveAttribute("aria-disabled", "true");
+
       // Tick the acknowledgement card → Continue unlocks.
       await app.window.locator(".onboarding-wizard__safety-ack").click();
       await expect(continueBtn).not.toHaveAttribute("aria-disabled", "true");
@@ -350,58 +328,25 @@ test.describe("Onboarding wizard", () => {
     }
   });
 
-  test("messaging-safety flash does not replay when navigating back to the step", async () => {
-    const app = await launchElectronApp(wizardLaunchOptions);
-    try {
-      // Walk to the messaging-safety step (same Shared-mode path).
-      await app.window.getByRole("button", { name: /Get started/i }).click();
-      await app.window.getByRole("button", { name: /^Continue/i }).click();
-      await app.window.getByRole("button", { name: /^Continue/i }).click();
-      await app.window
-        .getByText("Reuse your existing Codex login", { exact: false })
-        .click();
-      await app.window.getByRole("button", { name: /^Continue/i }).click();
-      await app.window
-        .getByRole("button", { name: /I.ll log in later/i })
-        .click();
-      await app.window.getByRole("button", { name: /^Continue/i }).click();
-
-      await expect(
-        app.window.getByRole("heading", { name: /Messaging is optional/i }),
-      ).toBeVisible();
-
-      const continueBtn = app.window.getByRole("button", {
-        name: /Continue with messaging/i,
-      });
-      const flash = app.window.locator(".onboarding-wizard__safety-ack-flash");
-
-      // Force a flash (box still unchecked), then leave and return.
-      await continueBtn.click({ force: true });
-      await expect(flash).toHaveCount(1);
-
-      // Anchored like the other call sites: the loose /Back/i also matches
-      // the title-bar history Back button in the shell behind the wizard.
-      await app.window.getByRole("button", { name: /^← Back/i }).click();
-      // Back lands on the shared Codex login step (login already deferred,
-      // so its Continue is live); Continue returns to messaging-safety.
-      await app.window.getByRole("button", { name: /^Continue/i }).click();
-      await expect(
-        app.window.getByRole("heading", { name: /Messaging is optional/i }),
-      ).toBeVisible();
-
-      // Re-entry must NOT replay the ring — the box is still unchecked and
-      // the operator never re-clicked the locked button.
-      await expect(flash).toHaveCount(0);
-      await expect(continueBtn).toHaveAttribute("aria-disabled", "true");
-    } finally {
-      await app.close();
-    }
-  });
-
-  test("back navigation preserves density selection across Thread presentation ↔ Models", async () => {
+  test("back navigation preserves the Welcome round trip and density selection across Thread presentation ↔ Models", async () => {
     const app = await launchElectronApp(wizardLaunchOptions);
     try {
       // Welcome → Thread presentation.
+      await app.window.getByRole("button", { name: /Get started/i }).click();
+      await expect(
+        app.window.getByRole("heading", {
+          name: /Pick your appearance and thread density/i,
+        }),
+      ).toBeVisible();
+
+      // The first Back round trip returns to Welcome and can re-enter the
+      // presentation step without losing the navigation path.
+      await app.window.getByRole("button", { name: /^← Back/i }).click();
+      await expect(
+        app.window.getByRole("heading", {
+          name: /A few short choices/i,
+        }),
+      ).toBeVisible();
       await app.window.getByRole("button", { name: /Get started/i }).click();
       await expect(
         app.window.getByRole("heading", {
@@ -467,14 +412,6 @@ test.describe("Onboarding wizard", () => {
           name: /A few short choices/i,
         }),
       ).toBeVisible();
-
-      // Back from Welcome returns to the confirmation (because that's
-      // where this session entered).
-      // (No-op visual check — the Back button is hidden on Welcome,
-      // matching the "no back from first-impression screen" UX rule.)
-      await expect(
-        app.window.getByRole("button", { name: /^← Back/i }),
-      ).toHaveCount(0);
     } finally {
       await app.close();
     }
@@ -664,7 +601,6 @@ test.describe("Onboarding wizard", () => {
       await expect(app.window.getByText(/brew install qwen-code/i)).toBeVisible();
       await app.window.getByRole("tab", { name: /Grok Build/i }).click();
       await expect(app.window.getByText(/x\.ai\/cli\/install\.sh/i)).toBeVisible();
-      await expect(app.window.getByText(/xAI API key/i)).toHaveCount(0);
     } finally {
       await app.close();
     }


### PR DESCRIPTION
## Summary

- fold the basic onboarding Get started/Back round trip into the existing navigation scenario
- combine the repeated messaging-safety walks while preserving the one-shot flash and acknowledgement gate coverage
- remove narrowly redundant composer and launchpad paste scenarios while retaining stronger round-trip and single-newline regression coverage
- retain an ordered-only plain-text list trigger in the existing two-launch list scenario, so ordered-list detection cannot hitchhike on a bullet or fence
- group accessibility surfaces by fixture and theme, with named steps, surface-specific axe errors, and explicit Search, Settings, Star Map, and intake teardown

## Why

These specs repeated coverage in fresh Electron processes. Consolidating equivalent paths reduces suite startup cost without dropping the stronger behavioral assertions or any accessibility surface/theme scan.

## Coverage impact

- Playwright tests: 57 → 39
- logical Electron launches across the four specs: 59 → 41
- accessibility launches: 18 → 6
- accessibility axe scans: 18 → 18
- no production code or fixture changes

Positive Grok Build install instructions and custom-PATH/well-known discovery coverage remain. The obsolete xAI API-key absence check is removed.

## Validation

- PwrSuiteLab macOS Tart guest, exact four-spec selection at commit `b9d88f95a`: 39 passed, 0 failed in 2.3 minutes; artifact collection complete
- `pnpm --filter @pwragent/desktop typecheck`
- focused ESLint on the four changed specs: 0 errors; 2 pre-existing warnings on unchanged lines
- `pnpm lint:boundaries`
- focused Search, Settings, Star Map, and intake renderer units: 4 files, 116 tests passed

## Isolation caveat

Each accessibility fixture/theme group now shares one renderer/profile process. Explicit close/reset assertions prevent stateful UI layers from leaking between scans, but the steps no longer have full process isolation: a failure in an earlier step stops later scans in that group until the test is retried or rerun.
