### PR TITLE
fix(desktop): quiet dev diagnostics

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -34,6 +34,12 @@ import type { ThreadTurnQueueSubmissionResult } from "../app-server/thread-turn-
 
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 const send = vi.fn();
+const mockAppServerLog = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
 // A second subscriber standing in for a federation (remote viewer)
 // window, so PR-authority fan-out can be asserted per window kind.
 const federationWindowSend = vi.fn();
@@ -382,10 +388,18 @@ vi.mock("../scheduled-actions/scheduled-thread-action-service", () => ({
   getScheduledThreadActionService: () => ({ create: vi.fn() }),
 }));
 
+vi.mock("../log", () => ({
+  getMainLogger: vi.fn(() => mockAppServerLog),
+}));
+
 describe("agent ipc", () => {
   beforeEach(() => {
     handlers.clear();
     send.mockReset();
+    mockAppServerLog.debug.mockClear();
+    mockAppServerLog.error.mockClear();
+    mockAppServerLog.info.mockClear();
+    mockAppServerLog.warn.mockClear();
     federationWindowSend.mockReset();
     registry.isPullRequestLocallyMonitored.mockClear();
     registry.isPullRequestLocallyMonitored.mockReturnValue(false);
@@ -1237,6 +1251,18 @@ describe("agent ipc", () => {
     expect(diff).toContain("$.notification.params.diff");
     expect(diff).toContain("protocol-tail");
     expect(diff).not.toContain("x".repeat(60_000));
+    expect(mockAppServerLog.debug).toHaveBeenCalledWith(
+      "agentEvent",
+      expect.objectContaining({
+        method: "turn/diff/updated",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      }),
+    );
+    expect(mockAppServerLog.info).not.toHaveBeenCalledWith(
+      "agentEvent",
+      expect.anything(),
+    );
 
     disposeAgentIpcHandlers();
   });

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -3779,7 +3779,7 @@ describe("app server ipc", () => {
 
     await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
 
-    expect(mockAppServerLog.info).toHaveBeenCalledWith(
+    expect(mockAppServerLog.debug).toHaveBeenCalledWith(
       "threadPullRequestsRefresh:requested",
       expect.objectContaining({
         branch: "fix/live-diff-activity-normalization",
@@ -3788,7 +3788,7 @@ describe("app server ipc", () => {
         trigger: "user",
       }),
     );
-    expect(mockAppServerLog.info).toHaveBeenCalledWith(
+    expect(mockAppServerLog.debug).toHaveBeenCalledWith(
       "threadPullRequestsRefresh:background-start",
       expect.objectContaining({
         previousPrIds: ["github.com/pwrdrvr/pwragent#845"],
@@ -3805,7 +3805,7 @@ describe("app server ipc", () => {
       });
     });
     await vi.waitFor(() => {
-      expect(mockAppServerLog.info).toHaveBeenCalledWith(
+      expect(mockAppServerLog.debug).toHaveBeenCalledWith(
         "threadPullRequestsRefresh:background-complete",
         expect.objectContaining({
           changedThreadCount: 1,
@@ -5631,7 +5631,7 @@ describe("app server ipc", () => {
         expect(detectPullRequestsForThread).toHaveBeenCalledTimes(1);
       });
       await vi.waitFor(() => {
-        expect(mockAppServerLog.info).toHaveBeenCalledWith(
+        expect(mockAppServerLog.debug).toHaveBeenCalledWith(
           "threadPullRequestsRefresh:background-complete",
           expect.objectContaining({
             fetchedPrIds: ["github.com/pwrdrvr/pwragent#434"],
@@ -5640,7 +5640,7 @@ describe("app server ipc", () => {
           }),
         );
       });
-      mockAppServerLog.info.mockClear();
+      mockAppServerLog.debug.mockClear();
 
       vi.setSystemTime(2_000_000 + 9_000);
       const cooldownResponse = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
@@ -5656,7 +5656,7 @@ describe("app server ipc", () => {
       });
       await Promise.resolve();
       expect(detectPullRequestsForThread).toHaveBeenCalledTimes(1);
-      expect(mockAppServerLog.info).toHaveBeenCalledWith(
+      expect(mockAppServerLog.debug).toHaveBeenCalledWith(
         "threadPullRequestsRefresh:skipped",
         expect.objectContaining({
           minIntervalMs: 10_000,

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -6,6 +6,13 @@
     "rowsChanged": 1080,
     "statements": 1080
   },
+  "live-thread-token-usage": {
+    "commits": 1,
+    "note": "one completed model request observed through thread token usage",
+    "observedWalBytes": 65920,
+    "rowsChanged": 3,
+    "statements": 3
+  },
   "streamed-command-output": {
     "commits": 2,
     "note": "500 streamed output deltas plus the completion for one command",

--- a/apps/desktop/src/main/__tests__/log-stdio.test.ts
+++ b/apps/desktop/src/main/__tests__/log-stdio.test.ts
@@ -95,7 +95,10 @@ describe("initializeMainLogger stdio handling", () => {
       throw makeBrokenPipeError();
     });
 
-    const { initializeMainLogger } = await import("../log");
+    const {
+      initializeMainLogger,
+      setMainLogDebugCollectionEnabled,
+    } = await import("../log");
     initializeMainLogger();
 
     mocks.consoleTransport.level = "silly";
@@ -104,8 +107,36 @@ describe("initializeMainLogger stdio handling", () => {
     expect(mocks.consoleWriteFn).toHaveBeenCalledTimes(1);
     expect(mocks.consoleTransport.level).toBe(false);
 
+    setMainLogDebugCollectionEnabled(true);
+    expect(mocks.consoleTransport.level).toBe(false);
+
     mocks.consoleTransport.writeFn(makeMessage());
     expect(mocks.consoleWriteFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the console at info unless debug collection is enabled", async () => {
+    const {
+      initializeMainLogger,
+      setMainLogDebugCollectionEnabled,
+    } = await import("../log");
+    // The log module disables its console transport when VITEST is present.
+    // Restore electron-log's normal runtime default so this test exercises
+    // initialization outside the unit-test guard.
+    mocks.consoleTransport.level = "silly";
+    initializeMainLogger();
+
+    expect(mocks.consoleTransport.level).toBe("info");
+    expect(mocks.fileTransport.level).toBe("info");
+
+    setMainLogDebugCollectionEnabled(true);
+
+    expect(mocks.consoleTransport.level).toBe("debug");
+    expect(mocks.fileTransport.level).toBe("debug");
+
+    setMainLogDebugCollectionEnabled(false);
+
+    expect(mocks.consoleTransport.level).toBe("info");
+    expect(mocks.fileTransport.level).toBe("info");
   });
 
   it("disables console logging when stdout emits an asynchronous broken-pipe error", async () => {

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -165,6 +165,50 @@ describe("sqlite write metrics", () => {
     await registry.close();
   });
 
+  it("holds one live token-usage observation to one commit", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+
+    const { writes } = await measureSqliteWrites(async () => {
+      await emit({
+        backend: "codex",
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            model: "gpt-5.5",
+            tokenUsage: {
+              total: {
+                inputTokens: 80_000,
+                cachedInputTokens: 72_000,
+                outputTokens: 1_000,
+              },
+              last: {
+                inputTokens: 80_000,
+                cachedInputTokens: 72_000,
+                outputTokens: 1_000,
+              },
+            },
+          },
+        },
+      } as AgentEvent);
+    });
+
+    expectSqliteWriteBudget({
+      note: "one completed model request observed through thread token usage",
+      scenario: "live-thread-token-usage",
+      writes,
+    });
+
+    await registry.close();
+  });
+
   it("holds an idle hour of heartbeats to its budget", async () => {
     // The floor the app pays for existing: the profile-runtime heartbeat and
     // the federation lease renewal both tick every 10s against a 45s TTL, each

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -131,7 +131,7 @@ function logDebug(event: string, payload: Record<string, unknown>): void {
     return;
   }
 
-  appServerLog.info(event, payload);
+  appServerLog.debug(event, payload);
 }
 
 function summarizeTurnInput(input: StartTurnRequest["input"]): Record<string, unknown> {
@@ -244,7 +244,7 @@ function logAgentEventSummary(summary: Record<string, unknown>): void {
 
   const key = coalescedAgentEventLogKey(summary);
   if (!key) {
-    appServerLog.info("agentEvent", summary);
+    appServerLog.debug("agentEvent", summary);
     return;
   }
 
@@ -258,7 +258,7 @@ function logAgentEventSummary(summary: Record<string, unknown>): void {
       latestSummary: summary,
       suppressedCount: 0,
     });
-    appServerLog.info("agentEvent", summary);
+    appServerLog.debug("agentEvent", summary);
     return;
   }
 

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -697,7 +697,7 @@ function logDebug(event: string, payload: Record<string, unknown>): void {
     return;
   }
 
-  appServerLog.info(event, payload);
+  appServerLog.debug(event, payload);
 }
 
 async function hydrateRetainedThreadOverlayData(

--- a/apps/desktop/src/main/log.ts
+++ b/apps/desktop/src/main/log.ts
@@ -36,6 +36,18 @@ function disableConsoleTransport(): void {
   electronLog.transports.console.level = false;
 }
 
+function configureConsoleTransport(): void {
+  const transport = electronLog.transports?.console;
+  if (!transport || transport.level === false) {
+    return;
+  }
+
+  // electron-log defaults this transport to "silly". Keep ordinary dev runs
+  // readable, then raise both live and persisted output when Help → Logs opts
+  // into debug collection.
+  transport.level = debugCollectionEnabled ? "debug" : "info";
+}
+
 function rethrowUnexpectedStdioError(error: unknown): void {
   queueMicrotask(() => {
     throw error;
@@ -99,6 +111,7 @@ export function initializeMainLogger(options?: { profileName?: string }): void {
   initialized = true;
   installStdioErrorHandlers();
   guardConsoleTransport();
+  configureConsoleTransport();
   if (options?.profileName) {
     electronLog.transports.file.fileName = resolveMainLogFileNameForProfile(
       options.profileName,
@@ -167,6 +180,7 @@ export function isMainLogDebugCollectionEnabled(): boolean {
 export function setMainLogDebugCollectionEnabled(enabled: boolean): void {
   debugCollectionEnabled = enabled;
   electronLog.transports.file.level = enabled ? "debug" : "info";
+  configureConsoleTransport();
 }
 
 type CompactField = {


### PR DESCRIPTION
## Summary

- default the main-process console transport to `info` instead of inheriting electron-log's `silly` default
- classify dev-only agent event and IPC diagnostics as `debug`, keeping them out of ordinary console output and the rotating info log
- let Help → Logs debug collection raise both console and file transports to `debug`
- pin live token-usage persistence with a checked-in SQLite write budget

## Root cause

`pnpm dev` did not intentionally enable debug logging. PwrAgent configured the file transport but left the console transport at electron-log's implicit `silly` default. In addition, two helpers named `logDebug` and the first copy of each agent event logged at `info`, so development diagnostics were synchronously appended to the normal persistent log even when debug collection was off.

The persistent log was already bounded to about 2 MiB per profile (1 MiB current plus 1 MiB old). The observed default-profile files accumulated roughly 2 MiB over 24.5 hours, so this was unnecessary churn and noise, not an SSD-endurance threat.

The nearby `contextReplay:classify` records reflect token-usage persistence rather than logging writes. A measured observation costs 1 commit, 3 statements/rows, and about 65.9 KiB of WAL. At the unusually busy sample rate of 12 observations in 25 seconds, that projects to about 2.55 GiB of WAL for 24 hours of continuous activity, or about 0.85 GiB over an 8-hour active day. This PR does not change that durability behavior; it records the exact commit/row budget so future amplification fails tests visibly.

## Impact

Ordinary `pnpm dev` output now shows operational `info` and above. Developers can opt back into the detailed diagnostics by enabling Debug in Help → Logs, which raises both live console output and persisted collection.

## Validation

- 145 focused desktop-main tests
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm lint:sql`
