### PR TITLE
feat(desktop): move tool call tracking to dedicated tab

### DIFF
--- a/apps/desktop/e2e/thread-pricing-panel.spec.ts
+++ b/apps/desktop/e2e/thread-pricing-panel.spec.ts
@@ -49,7 +49,12 @@ test("hydrates provider-scoped pricing totals in the context rail", async () => 
       contextRail.getByRole("heading", { level: 3, name: "Pricing" }),
     ).toBeVisible();
     await expect(contextRail.getByText("$0.018", { exact: true })).toBeVisible();
-    await expect(contextRail.getByText("3 (2 priced, 1 unpriced)")).toBeVisible();
+    await expect(contextRail.getByText("Pricing summary")).toBeVisible();
+    await expect(contextRail.getByText("3 rows")).toBeVisible();
+    await expect(
+      contextRail.getByText(/2 priced · 1 unpriced ·/),
+    ).toBeVisible();
+    await expect(contextRail.getByText("Token volume")).toBeVisible();
     await expect(
       contextRail.getByText("1 usage row could not be priced."),
     ).toBeVisible();

--- a/apps/desktop/e2e/transcript-command-output.spec.ts
+++ b/apps/desktop/e2e/transcript-command-output.spec.ts
@@ -50,7 +50,9 @@ test("captured command output is inspectable from transcript work", async () => 
     await expect(commandActivity).toHaveCount(1);
     await commandActivity.click();
 
-    await expect(transcript.getByText("$ npm view dive")).toBeVisible();
+    await expect(
+      transcript.getByText("$ /bin/zsh -lc 'npm view dive'"),
+    ).toBeVisible();
     await expect(transcript.getByText(/dive@0\.5\.0 \| Proprietary/)).toBeVisible();
     await expect(transcript.getByText(/https:\/\/github\.com\/pvorb\/node-dive#readme/)).toBeVisible();
     await expect(transcript.getByText("Success · ran for 373ms")).toBeVisible();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5184,10 +5184,10 @@ describe("DesktopBackendRegistry", () => {
   });
 
   it("includes persisted tool accounting when reading ACP threads", async () => {
-    // The Pricing panel's "Tool output" section renders
+    // The Tool calls tab renders
     // `response.toolAccounting`. Live `thread/toolAccounting/updated` events
     // patch it into the session while a turn runs, and any readThread replaces
-    // the whole response — so a read that omits the field erases the section.
+    // the whole response — so a read that omits the field erases the tab data.
     // On an ACP thread that is exactly what the operator sees: tool output
     // during the turn, gone the moment it ends. The Codex read path has always
     // returned this; the ACP path did not.

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8646,7 +8646,7 @@ export class DesktopBackendRegistry {
     // field stale, it erases whatever the live
     // `thread/toolAccounting/updated` events had already patched in. On an
     // ACP thread that read lands as the turn ends, which is why the Pricing
-    // panel's "Tool output" section used to appear during a turn and vanish
+    // Tool calls tab used to appear during a turn and vanish
     // the moment it finished.
     const toolAccounting =
       typeof this.overlayStore.readThreadToolAccounting === "function"

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1396,6 +1396,8 @@ function DesktopAppShell(props: {
       settings.snapshot?.experimental.threadToolAccounting?.value === true
         ? session.response?.toolAccounting
         : undefined,
+    threadToolAccountingEnabled:
+      settings.snapshot?.experimental.threadToolAccounting?.value === true,
     threadPricingSummaryEnabled:
       settings.snapshot?.experimental.threadPricingSummary?.value ?? true,
     pricingDisplayOptions: {

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -34,11 +34,6 @@ const DEFAULT_MANAGED_REVIEW = {
   source: "default" as const,
 };
 
-const DEFAULT_THREAD_PRICING_SUMMARY = {
-  value: true,
-  source: "default" as const,
-};
-
 const DEFAULT_THREAD_TOOL_ACCOUNTING = {
   value: false,
   source: "default" as const,
@@ -67,9 +62,6 @@ export function ExperimentalSettings(props: {
   const markdownMathRendering =
     props.snapshot.experimental.markdownMathRendering ??
     DEFAULT_MARKDOWN_MATH_RENDERING;
-  const threadPricingSummary =
-    props.snapshot.experimental.threadPricingSummary ??
-    DEFAULT_THREAD_PRICING_SUMMARY;
   const threadToolAccounting =
     props.snapshot.experimental.threadToolAccounting ??
     DEFAULT_THREAD_TOOL_ACCOUNTING;
@@ -92,22 +84,22 @@ export function ExperimentalSettings(props: {
 
       <SettingsSection
         eyebrow="Experimental"
-        title="Tool Output Accounting"
-        description="Show tool-output volume and noisy-polling alerts inside the released Pricing panel."
+        title="Tool Call Tracking"
+        description="Show tool-call volume, command instances, output, and noisy-polling alerts in a dedicated thread panel."
         chip={threadToolAccounting.value ? "On" : "Off"}
         chipKind={threadToolAccounting.value ? "ok" : "default"}
       >
         <div className="settings-fields">
           <SettingsField
-            label="Display tool output accounting"
-            sub="Show experimental tool-output volume and noisy-polling alerts."
-            help="Collection stays on either way; this only controls the operator-facing section. Requires thread pricing under Settings → Usage & Pricing."
+            label="Display tool call tracking"
+            sub="Show the experimental Tool calls tab in the thread context rail."
+            help="Collection stays on either way; this only controls the operator-facing tab."
             source={sourceBadge(threadToolAccounting)}
             control={
               <SettingsSwitch
                 checked={threadToolAccounting.value}
-                disabled={props.saving || !threadPricingSummary.value}
-                label="Display tool output accounting"
+                disabled={props.saving}
+                label="Display tool call tracking"
                 onChange={(enabled) => {
                   void props.onThreadToolAccountingChange(enabled);
                 }}

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -874,7 +874,7 @@ describe("SettingsScreen", () => {
     });
 
     expect(
-      screen.getByRole("switch", { name: "Display tool output accounting" }),
+      screen.getByRole("switch", { name: "Display tool call tracking" }),
     ).not.toBeDisabled();
     expect(
       screen.queryByRole("heading", { name: "Thread pricing" }),
@@ -1259,7 +1259,7 @@ describe("SettingsScreen", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Experimental" }));
     fireEvent.click(
-      screen.getByRole("switch", { name: "Display tool output accounting" }),
+      screen.getByRole("switch", { name: "Display tool call tracking" }),
     );
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
@@ -1268,7 +1268,7 @@ describe("SettingsScreen", () => {
     });
   });
 
-  it("disables thread pricing display chips when summary is off", () => {
+  it("disables pricing units but keeps tool accounting independent", () => {
     const baseSnapshot = createSnapshot();
     const settings = createSettingsState(
       createSnapshot({
@@ -1293,8 +1293,8 @@ describe("SettingsScreen", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Experimental" }));
     expect(
-      screen.getByRole("switch", { name: "Display tool output accounting" }),
-    ).toBeDisabled();
+      screen.getByRole("switch", { name: "Display tool call tracking" }),
+    ).toBeEnabled();
   });
 
   it("saves hot CPU profiling delay and trigger mode presets", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { createPortal } from "react-dom";
 import type {
   BackendSummary,
+  AppServerThreadEntry,
   DesktopApplicationDiscoveryCandidate,
   EditGroupCommitState,
   NavigationThreadSummary,
@@ -32,6 +33,7 @@ import {
   ServerIcon,
   SubAgentsIcon,
   TerminalIcon,
+  ToolCallsIcon,
   type IconProps,
 } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
@@ -44,6 +46,7 @@ import { PullRequestsPanel } from "./context-panels/PullRequestsPanel";
 import { LinkedProjectsPanel } from "./context-panels/LinkedProjectsPanel";
 import { EditsPanel } from "./context-panels/EditsPanel";
 import { PricingPanel } from "./context-panels/PricingPanel";
+import { ToolCallsPanel } from "./context-panels/ToolCallsPanel";
 import { ActionRunsPanel } from "./context-panels/ActionRunsPanel";
 import { buildRailTooltipText } from "./context-panels/context-rail-shared";
 import type {
@@ -71,6 +74,7 @@ const CONTEXT_TABS: ContextTab[] = [
   { id: "info", label: "Thread info", Icon: InfoIcon },
   { id: "edits", label: "Edits", Icon: EditsIcon },
   { id: "pricing", label: "Pricing", Icon: PricingIcon },
+  { id: "tool-calls", label: "Tool calls", Icon: ToolCallsIcon },
   { id: "actions", label: "Actions", Icon: TerminalIcon },
   { id: "subagents", label: "Sub-agents", Icon: SubAgentsIcon },
   { id: "automations", label: "Automations", Icon: AutomationsIcon },
@@ -106,11 +110,13 @@ type ThreadContextPanelProps = {
     summaries: ThreadPricingSummary[];
   };
   toolAccounting?: ThreadToolAccounting;
+  toolCallEntries?: AppServerThreadEntry[];
   pricingDisplayOptions?: {
     codexCredits: boolean;
     usd: boolean;
   };
   threadPricingSummaryEnabled?: boolean;
+  threadToolAccountingEnabled?: boolean;
   /** Absent on the new-thread launchpad, where only provider context applies. */
   thread?: NavigationThreadSummary;
   worktreeArchiveError?: string;
@@ -181,15 +187,19 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const lastMousePositionRef = useRef<{ x: number; y: number } | undefined>(undefined);
   const outsideRailSinceRef = useRef<number | undefined>(undefined);
   const threadPricingSummaryEnabled = props.threadPricingSummaryEnabled ?? true;
+  const threadToolAccountingEnabled = props.threadToolAccountingEnabled ?? false;
 
   const activeTab = !props.thread
     ? "providers"
     : props.activeTab === "pricing" && !threadPricingSummaryEnabled
       ? "info"
+      : props.activeTab === "tool-calls" && !threadToolAccountingEnabled
+        ? "info"
       : props.activeTab;
   const visibleTabs = CONTEXT_TABS.filter((tab) =>
     props.thread
-      ? tab.id !== "pricing" || threadPricingSummaryEnabled
+      ? (tab.id !== "pricing" || threadPricingSummaryEnabled)
+        && (tab.id !== "tool-calls" || threadToolAccountingEnabled)
       : tab.id === "providers",
   );
   const topTabs = visibleTabs.filter((tab) => !tab.bottom);
@@ -727,11 +737,19 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           <PricingPanel
             activeTurnId={props.activeTurnId}
             pricing={props.pricing}
-            toolAccounting={props.toolAccounting}
             displayOptions={props.pricingDisplayOptions}
             onScrollToTurn={props.onScrollToTurn}
             subAgents={props.thread.subAgents}
             threadReasoningEffort={props.thread.reasoningEffort}
+          />
+        );
+      case "tool-calls":
+        if (!props.thread) return null;
+        return (
+          <ToolCallsPanel
+            entries={props.toolCallEntries}
+            onScrollToTurn={props.onScrollToTurn}
+            toolAccounting={props.toolAccounting}
           />
         );
       case "actions":

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -20,6 +20,7 @@ import type {
   CodexEnvironmentActionRun,
   ThreadPricingSummary,
   ThreadToolAccounting,
+  ThreadToolInvocationRecord,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import type { WindowPointerSnapshot } from "../../../../shared/window-pointer";
@@ -111,6 +112,8 @@ type ThreadContextPanelProps = {
   };
   toolAccounting?: ThreadToolAccounting;
   toolCallEntries?: AppServerThreadEntry[];
+  loadingToolCallDetailItemId?: string;
+  onRequestToolCallDetails?: (invocation: ThreadToolInvocationRecord) => void;
   pricingDisplayOptions?: {
     codexCredits: boolean;
     usd: boolean;
@@ -748,6 +751,8 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
         return (
           <ToolCallsPanel
             entries={props.toolCallEntries}
+            loadingDetailItemId={props.loadingToolCallDetailItemId}
+            onRequestInvocationDetails={props.onRequestToolCallDetails}
             onScrollToTurn={props.onScrollToTurn}
             toolAccounting={props.toolAccounting}
           />

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -895,6 +895,7 @@ export type ThreadViewProps = {
     summaries: ThreadPricingSummary[];
   };
   toolAccounting?: ThreadToolAccounting;
+  threadToolAccountingEnabled?: boolean;
   pricingDisplayOptions?: {
     codexCredits: boolean;
     usd: boolean;
@@ -1277,8 +1278,10 @@ export function ThreadView(props: ThreadViewProps) {
   // threaded a value through yet, so the rail is discoverable.
   const contextRailPinned = props.contextRailPinned ?? true;
   const threadPricingSummaryEnabled = props.threadPricingSummaryEnabled ?? true;
+  const threadToolAccountingEnabled = props.threadToolAccountingEnabled ?? false;
   const activeContextTab =
-    !threadPricingSummaryEnabled && props.activeContextTab === "pricing"
+    (!threadPricingSummaryEnabled && props.activeContextTab === "pricing")
+    || (!threadToolAccountingEnabled && props.activeContextTab === "tool-calls")
       ? DEFAULT_CONTEXT_TAB
       : props.activeContextTab ?? DEFAULT_CONTEXT_TAB;
   const editedFilesDock = props.editedFilesDock ?? DEFAULT_EDITED_FILES_DOCK;
@@ -2045,6 +2048,18 @@ export function ThreadView(props: ThreadViewProps) {
     pendingActivityEntry && activityHasFileDiff(pendingActivityEntry)
       ? pendingActivityEntry
       : undefined;
+  const toolCallEntries = useMemo(
+    () => [
+      ...props.transcriptEntries,
+      ...(pendingActivityEntry ? [pendingActivityEntry] : []),
+      ...(pendingProtocolActivityEntry ? [pendingProtocolActivityEntry] : []),
+    ],
+    [
+      pendingActivityEntry,
+      pendingProtocolActivityEntry,
+      props.transcriptEntries,
+    ],
+  );
   const threadImageGallery = useMemo(
     () =>
       collectThreadImageGallery([
@@ -3326,8 +3341,10 @@ export function ThreadView(props: ThreadViewProps) {
           thread={selectedThread!}
           pricing={props.pricing}
           toolAccounting={props.toolAccounting}
+          toolCallEntries={toolCallEntries}
           pricingDisplayOptions={props.pricingDisplayOptions}
           threadPricingSummaryEnabled={threadPricingSummaryEnabled}
+          threadToolAccountingEnabled={threadToolAccountingEnabled}
           worktreeArchiveError={props.worktreeArchiveError}
           onRestoreWorktree={props.onRestoreWorktree}
         />

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -109,6 +109,7 @@ import {
   readRendererSequence,
   summarizeActivityStatus,
 } from "./live-transcript-activity";
+import { findTranscriptCommandDetailEntryIndex } from "./tool-call-details";
 
 type LaunchpadEnvironmentSetupProgress = {
   command: string;
@@ -1450,11 +1451,16 @@ export function ThreadView(props: ThreadViewProps) {
       return;
     }
 
-    const targetIndex = findTranscriptTurnEntryIndex(
-      props.transcriptEntries,
-      target.turnId,
-      target.turnTimeMs,
-    );
+    const targetIndex = target.intent === "tool-detail"
+      ? findTranscriptCommandDetailEntryIndex(
+          props.transcriptEntries,
+          target.itemId,
+        )
+      : findTranscriptTurnEntryIndex(
+          props.transcriptEntries,
+          target.turnId,
+          target.turnTimeMs,
+        );
     if (targetIndex >= 0) {
       if (target.intent === "reveal") {
         expandTranscriptEntryLimit(props.transcriptEntries.length - targetIndex);
@@ -2231,10 +2237,9 @@ export function ThreadView(props: ThreadViewProps) {
       if (!invocation.turnId || !selectedThreadKey) {
         return;
       }
-      const targetIndex = findTranscriptTurnEntryIndex(
+      const targetIndex = findTranscriptCommandDetailEntryIndex(
         props.transcriptEntries,
-        invocation.turnId,
-        invocation.observedAt,
+        invocation.itemId,
       );
       if (targetIndex >= 0 || !canLoadServerTranscriptHistory) {
         return;

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -43,6 +43,7 @@ import type {
   ThreadExecutionMode,
   ThreadPricingSummary,
   ThreadToolAccounting,
+  ThreadToolInvocationRecord,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import {
@@ -1118,11 +1119,20 @@ type BranchDriftDialogState = {
   threadKey: string;
 };
 
-type PendingTranscriptTurnTarget = {
-  threadKey: string;
-  turnId: string;
-  turnTimeMs?: number;
-};
+type PendingTranscriptTurnTarget =
+  | {
+      intent: "reveal";
+      threadKey: string;
+      turnId: string;
+      turnTimeMs?: number;
+    }
+  | {
+      intent: "tool-detail";
+      itemId: string;
+      threadKey: string;
+      turnId: string;
+      turnTimeMs?: number;
+    };
 
 const MAX_TRANSCRIPT_TARGET_PAGE_LOADS = 60;
 
@@ -1446,32 +1456,38 @@ export function ThreadView(props: ThreadViewProps) {
       target.turnTimeMs,
     );
     if (targetIndex >= 0) {
-      expandTranscriptEntryLimit(props.transcriptEntries.length - targetIndex);
+      if (target.intent === "reveal") {
+        expandTranscriptEntryLimit(props.transcriptEntries.length - targetIndex);
+      }
       setPendingTranscriptTurnTarget(undefined);
       transcriptTurnPageLoadsRef.current = 0;
-      requestAnimationFrame(() => {
+      if (target.intent === "reveal") {
         requestAnimationFrame(() => {
-          const container = transcriptPanelRef.current;
-          if (container) {
-            scrollRenderedTranscriptToTurn(
-              container,
-              target.turnId,
-              target.turnTimeMs,
-            );
-          }
+          requestAnimationFrame(() => {
+            const container = transcriptPanelRef.current;
+            if (container) {
+              scrollRenderedTranscriptToTurn(
+                container,
+                target.turnId,
+                target.turnTimeMs,
+              );
+            }
+          });
         });
-      });
+      }
       return;
     }
 
     const finishAtNearestRenderedTurn = (): void => {
-      const container = transcriptPanelRef.current;
-      if (container) {
-        scrollRenderedTranscriptToTurn(
-          container,
-          target.turnId,
-          target.turnTimeMs,
-        );
+      if (target.intent === "reveal") {
+        const container = transcriptPanelRef.current;
+        if (container) {
+          scrollRenderedTranscriptToTurn(
+            container,
+            target.turnId,
+            target.turnTimeMs,
+          );
+        }
       }
       setPendingTranscriptTurnTarget(undefined);
       transcriptTurnPageLoadsRef.current = 0;
@@ -2192,6 +2208,7 @@ export function ThreadView(props: ThreadViewProps) {
       if (canLoadServerTranscriptHistory && selectedThreadKey) {
         transcriptTurnPageLoadsRef.current = 0;
         setPendingTranscriptTurnTarget({
+          intent: "reveal",
           threadKey: selectedThreadKey,
           turnId,
           turnTimeMs,
@@ -2204,6 +2221,34 @@ export function ThreadView(props: ThreadViewProps) {
     [
       canLoadServerTranscriptHistory,
       expandTranscriptEntryLimit,
+      props.transcriptEntries,
+      selectedThreadKey,
+    ],
+  );
+
+  const handleRequestToolCallDetails = useCallback(
+    (invocation: ThreadToolInvocationRecord) => {
+      if (!invocation.turnId || !selectedThreadKey) {
+        return;
+      }
+      const targetIndex = findTranscriptTurnEntryIndex(
+        props.transcriptEntries,
+        invocation.turnId,
+        invocation.observedAt,
+      );
+      if (targetIndex >= 0 || !canLoadServerTranscriptHistory) {
+        return;
+      }
+      transcriptTurnPageLoadsRef.current = 0;
+      setPendingTranscriptTurnTarget({
+        intent: "tool-detail",
+        itemId: invocation.itemId,
+        threadKey: selectedThreadKey,
+        turnId: invocation.turnId,
+        turnTimeMs: invocation.observedAt,
+      });
+    }, [
+      canLoadServerTranscriptHistory,
       props.transcriptEntries,
       selectedThreadKey,
     ],
@@ -3342,6 +3387,12 @@ export function ThreadView(props: ThreadViewProps) {
           pricing={props.pricing}
           toolAccounting={props.toolAccounting}
           toolCallEntries={toolCallEntries}
+          loadingToolCallDetailItemId={
+            pendingTranscriptTurnTarget?.intent === "tool-detail"
+              ? pendingTranscriptTurnTarget.itemId
+              : undefined
+          }
+          onRequestToolCallDetails={handleRequestToolCallDetails}
           pricingDisplayOptions={props.pricingDisplayOptions}
           threadPricingSummaryEnabled={threadPricingSummaryEnabled}
           threadToolAccountingEnabled={threadToolAccountingEnabled}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCommandOutput.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCommandOutput.tsx
@@ -37,6 +37,10 @@ function GenericTranscriptCommandOutput(props: TranscriptCommandOutputProps) {
     (isAgentCommand(command.rawCommand) ? "agent" : "shell");
   const sourceLabel =
     source === "agent" ? "Agent" : source === "tool" ? "Tool" : "Shell";
+  const fullCommand =
+    source === "shell"
+      ? command.rawCommand ?? command.displayCommand
+      : command.displayCommand;
   const displayCwd = command.cwd
     ? formatPathRelativeToDirectories(command.cwd, props.directoryPaths)
     : undefined;
@@ -54,7 +58,7 @@ function GenericTranscriptCommandOutput(props: TranscriptCommandOutputProps) {
           type="button"
           className="button button--ghost transcript-command__copy"
           onClick={() => {
-            void copyText(command.displayCommand);
+            void copyText(fullCommand);
           }}
         >
           {source === "tool" ? "Copy invocation" : "Copy command"}
@@ -78,7 +82,7 @@ function GenericTranscriptCommandOutput(props: TranscriptCommandOutputProps) {
       ) : null}
       <pre className="transcript-command__block">
         <code>
-          {source === "tool" ? command.displayCommand : `$ ${command.displayCommand}`}
+          {source === "tool" ? fullCommand : `$ ${fullCommand}`}
         </code>
       </pre>
       <div className="transcript-command__output" aria-label={`${props.detail.label} output`}>

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ComponentProps } from "react";
 import type {
   BackendSummary,
+  AppServerThreadEntry,
   NavigationThreadSummary,
   ThreadPricingSummary,
   ThreadToolAccounting,
@@ -158,8 +159,10 @@ type PanelOverrides = Partial<
     | "onEditedFilesDockChange"
     | "pricing"
     | "toolAccounting"
+    | "toolCallEntries"
     | "pricingDisplayOptions"
     | "threadPricingSummaryEnabled"
+    | "threadToolAccountingEnabled"
   >
 >;
 
@@ -734,7 +737,7 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByRole("tab", { name: "Thread info" })).toBeInTheDocument();
   });
 
-  it("renders tool output accounting and noisy polling alerts in Pricing", () => {
+  it("renders tool call groups and full command output in a dedicated tab", () => {
     const toolAccounting: ThreadToolAccounting = {
       alerts: [
         {
@@ -800,20 +803,66 @@ describe("ThreadContextPanel", () => {
         },
       ],
     };
+    const toolCallEntries: AppServerThreadEntry[] = [
+      {
+        type: "activity",
+        id: "activity-tool-1",
+        summary: "Ran 1 command",
+        details: [
+          {
+            id: "tool-1",
+            kind: "command",
+            label: "poll session 40500",
+            status: "completed",
+            command: {
+              displayCommand: "poll session 40500",
+              rawCommand: "write_stdin --session 40500 --yield-time-ms 30000",
+              output: "first line\nfull captured output",
+              exitCode: 0,
+            },
+          },
+        ],
+      },
+    ];
 
     renderPanel({
-      activeTab: "pricing",
+      activeTab: "tool-calls",
       pinned: true,
-      threadPricingSummaryEnabled: true,
+      threadToolAccountingEnabled: true,
       toolAccounting,
+      toolCallEntries,
     });
 
-    expect(screen.getByRole("heading", { level: 4, name: "Tool output" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 3, name: "Tool calls" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { level: 3, name: "Pricing" })).not.toBeInTheDocument();
     expect(screen.getByText("Noisy polling detected")).toBeInTheDocument();
     expect(screen.getByText(/Repeated write_stdin polling/)).toBeInTheDocument();
     expect(screen.getByText("write_stdin · polling")).toBeInTheDocument();
+    expect(screen.queryByText("poll session 40500")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
     expect(screen.getByText("poll session 40500")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+
+    expect(
+      screen.getByText("$ write_stdin --session 40500 --yield-time-ms 30000"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/full captured output/)).toBeInTheDocument();
     expect(screen.getAllByText(/6,000/).length).toBeGreaterThan(0);
+  });
+
+  it("hides the Tool calls tab while its experimental flag is off", () => {
+    renderPanel({
+      activeTab: "tool-calls",
+      pinned: true,
+      threadToolAccountingEnabled: false,
+    });
+
+    expect(screen.queryByRole("tab", { name: "Tool calls" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { level: 3, name: "Tool calls" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Thread info" })).toBeInTheDocument();
   });
 
   it("renders cached pricing totals and per-turn model settings", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -835,6 +835,10 @@ describe("ThreadContextPanel", () => {
 
     expect(screen.getByRole("heading", { level: 3, name: "Tool calls" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { level: 3, name: "Pricing" })).not.toBeInTheDocument();
+    expect(screen.getByText("Tool output")).toBeInTheDocument();
+    expect(screen.getByText("3 invocations")).toBeInTheDocument();
+    expect(screen.getByText("6k est. tokens")).toBeInTheDocument();
+    expect(screen.getByText("Diagnostics")).toBeInTheDocument();
     expect(screen.getByText("Noisy polling detected")).toBeInTheDocument();
     expect(screen.getByText(/Repeated write_stdin polling/)).toBeInTheDocument();
     expect(screen.getByText("write_stdin · polling")).toBeInTheDocument();
@@ -930,6 +934,9 @@ describe("ThreadContextPanel", () => {
     });
 
     expect(screen.getByRole("heading", { level: 3, name: "Pricing" })).toBeInTheDocument();
+    expect(screen.getByText("Pricing summary")).toBeInTheDocument();
+    expect(screen.getByText("1 row")).toBeInTheDocument();
+    expect(screen.getByText("Token volume")).toBeInTheDocument();
     expect(screen.getByText("$0.010")).toBeInTheDocument();
     expect(screen.getByText("OpenAI")).toBeInTheDocument();
     expect(screen.getByText("gpt-5.5 · high · Fast")).toBeInTheDocument();
@@ -1170,10 +1177,10 @@ describe("ThreadContextPanel", () => {
 
     expect(screen.getByText("$56.98 · 1,424 Codex Credits estimated")).toBeInTheDocument();
     expect(screen.queryByText("$21.44 · 1,423 Codex Credits")).not.toBeInTheDocument();
-    expect(
-      screen.getByText("2,807,703 uncached, 70,606,976 cached"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("222,825 (37,085 reasoning)")).toBeInTheDocument();
+    expect(document.body).toHaveTextContent("Uncached input2.8M");
+    expect(document.body).toHaveTextContent("Cached input70.6M");
+    expect(document.body).toHaveTextContent("Output222.8k");
+    expect(document.body).toHaveTextContent("Reasoning37.1k");
     expect(screen.getByText("Historical usage estimate")).toBeInTheDocument();
     expect(
       screen.getByText("$56.23 estimated list price · 1,406 Codex Credits estimated"),
@@ -1335,10 +1342,9 @@ describe("ThreadContextPanel", () => {
         "1,172,721 uncached in · 17,628,672 cached · 46,199 out (9,979 reasoning)",
       ),
     ).toBeInTheDocument();
-    // INPUT reflects the full context, including inherited tokens.
-    expect(
-      screen.getByText("1,328,248 uncached, 17,792,768 cached"),
-    ).toBeInTheDocument();
+    // The summary reflects the full context, including inherited tokens.
+    expect(document.body).toHaveTextContent("Uncached input1.3M");
+    expect(document.body).toHaveTextContent("Cached input17.8M");
     // No fabricated cost for the inherited history anywhere in the panel.
     expect(screen.queryByText(/estimated list price/)).not.toBeInTheDocument();
     expect(screen.queryByText(/includes estimates/)).not.toBeInTheDocument();
@@ -1443,7 +1449,8 @@ describe("ThreadContextPanel", () => {
     });
 
     expect(screen.getByText("$0.032 · 0.4 Codex Credits estimated")).toBeInTheDocument();
-    expect(document.body).toHaveTextContent("4 (4 priced, 0 unpriced)");
+    expect(document.body).toHaveTextContent("4 rows$0.032");
+    expect(document.body).toHaveTextContent("4 priced · 0 unpriced");
     expect(screen.getAllByText("Historical usage estimate")).toHaveLength(2);
     expect(screen.getByText("1,000 uncached in · 2,000 cached · 100 out (20 reasoning)")).toBeInTheDocument();
     expect(screen.getByText("500 uncached in · 1,000 cached · 50 out")).toBeInTheDocument();
@@ -2418,7 +2425,8 @@ describe("ThreadContextPanel", () => {
 
     expect(screen.queryByText("No usage pricing recorded yet.")).not.toBeInTheDocument();
     expect(screen.getAllByText("$0.002")[0]).toBeInTheDocument();
-    expect(document.body).toHaveTextContent("1 (1 priced, 0 unpriced)");
+    expect(document.body).toHaveTextContent("1 row$0.002");
+    expect(document.body).toHaveTextContent("1 priced · 0 unpriced");
     expect(screen.getByText("Sub-agent usage")).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -810,7 +810,7 @@ describe("ThreadContextPanel", () => {
         summary: "Ran 1 command",
         details: [
           {
-            id: "tool-1",
+            id: "tool-1-1",
             kind: "command",
             label: "poll session 40500",
             status: "completed",
@@ -853,6 +853,87 @@ describe("ThreadContextPanel", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/full captured output/)).toBeInTheDocument();
     expect(screen.getAllByText(/6,000/).length).toBeGreaterThan(0);
+  });
+
+  it("matches ACP transcript command details to their accounting item", () => {
+    const toolAccounting: ThreadToolAccounting = {
+      alerts: [],
+      invocations: [
+        {
+          backend: "acp:grok",
+          category: "search",
+          debugLines: 0,
+          errorLines: 0,
+          estimatedOutputTokens: 25,
+          infoLines: 1,
+          invocationId: "invocation-acp-1",
+          itemId: "tool-acp-1",
+          noisy: false,
+          normalizedCommand: "search source tree",
+          observedAt: 1_800_000_060_000,
+          outputChars: 100,
+          outputLines: 1,
+          outputTruncated: false,
+          status: "completed",
+          threadId: "thread-1",
+          toolName: "code_search",
+          turnId: "turn-1",
+          updatedAt: 1_800_000_060_000,
+          warningLines: 0,
+        },
+      ],
+      summaries: [
+        {
+          category: "search",
+          debugLines: 0,
+          errorLines: 0,
+          estimatedOutputTokens: 25,
+          infoLines: 1,
+          invocationCount: 1,
+          lastObservedAt: 1_800_000_060_000,
+          noisyInvocationCount: 0,
+          outputChars: 100,
+          outputLines: 1,
+          toolName: "code_search",
+          warningLines: 0,
+        },
+      ],
+    };
+    const toolCallEntries: AppServerThreadEntry[] = [
+      {
+        type: "activity",
+        id: "tool-acp-1",
+        summary: "Searched code",
+        details: [
+          {
+            id: "tool-acp-1:detail",
+            kind: "read",
+            label: "Searched code",
+            command: {
+              displayCommand: "search source tree",
+              source: "tool",
+              output: "ACP captured output",
+              exitCode: 0,
+            },
+          },
+        ],
+      },
+    ];
+
+    renderPanel({
+      activeTab: "tool-calls",
+      pinned: true,
+      threadToolAccountingEnabled: true,
+      toolAccounting,
+      toolCallEntries,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+    const instances = screen.getByRole("list", { name: "Command instances" });
+    fireEvent.click(within(instances).getByRole("button", { name: "Details" }));
+
+    expect(screen.getByText(/ACP captured output/)).toBeInTheDocument();
+    expect(screen.queryByText(/unavailable in transcript history/)).not.toBeInTheDocument();
   });
 
   it("hides the Tool calls tab while its experimental flag is off", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -7,12 +7,14 @@ import type {
   AppServerBackendKind,
   AppServerNotification,
   AppServerThreadActivityEntry,
+  AppServerThreadEntry,
   AppServerPendingRequestNotification,
   MessagingPlatformStatus,
   NavigationDirectorySummary,
   NavigationLaunchpadDraft,
   NavigationThreadSummary,
   StartReviewRequest,
+  ThreadToolAccounting,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
@@ -895,6 +897,161 @@ describe("ThreadView", () => {
     await waitFor(() => {
       expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
     });
+  });
+
+  it("loads older transcript pages before showing historical tool output", async () => {
+    const targetTime = 1_800_000_000_000;
+    const loadOlder = vi.fn();
+    let loadedPageCount = 0;
+    const recentEntries = Array.from({ length: 5 }, (_, index) => ({
+      type: "message" as const,
+      id: `recent-message-${index}`,
+      role: "assistant" as const,
+      text: `Recent history ${index}`,
+      turn: {
+        id: `turn-recent-${index}`,
+        status: "completed" as const,
+        completedAt: targetTime + index + 1,
+      },
+    }));
+    const selectedThread = buildTimestampTargetThread(
+      "thread-tool-history",
+      "Historical tool output",
+    );
+    const toolAccounting: ThreadToolAccounting = {
+      alerts: [],
+      invocations: [
+        {
+          backend: "codex",
+          category: "shell",
+          debugLines: 0,
+          errorLines: 0,
+          estimatedOutputTokens: 50,
+          infoLines: 2,
+          invocationId: "invocation-old-1",
+          itemId: "tool-old-1",
+          noisy: false,
+          normalizedCommand: "old historical command",
+          observedAt: targetTime,
+          outputChars: 200,
+          outputLines: 2,
+          outputTruncated: false,
+          status: "completed",
+          threadId: selectedThread.id,
+          toolName: "commandExecution",
+          turnId: "turn-target",
+          updatedAt: targetTime,
+          warningLines: 0,
+        },
+      ],
+      summaries: [
+        {
+          category: "shell",
+          debugLines: 0,
+          errorLines: 0,
+          estimatedOutputTokens: 50,
+          infoLines: 2,
+          invocationCount: 1,
+          lastObservedAt: targetTime,
+          noisyInvocationCount: 0,
+          outputChars: 200,
+          outputLines: 2,
+          toolName: "commandExecution",
+          warningLines: 0,
+        },
+      ],
+    };
+
+    function Harness() {
+      const [entries, setEntries] = useState<AppServerThreadEntry[]>(recentEntries);
+      const [hasPreviousPage, setHasPreviousPage] = useState(true);
+      return (
+        <ThreadView
+          activeContextTab="tool-calls"
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[]}
+          clearPendingRequest={() => undefined}
+          composerDisabled={false}
+          contextRailPinned
+          desktopApi={{}}
+          loading={false}
+          loadingMore={false}
+          messageCount={entries.length}
+          onLoadOlder={async () => {
+            loadOlder();
+            loadedPageCount += 1;
+            if (loadedPageCount === 1) {
+              setEntries((current) => [
+                {
+                  type: "message",
+                  id: "message-intermediate",
+                  role: "assistant",
+                  text: "Intermediate older page",
+                  turn: {
+                    id: "turn-intermediate",
+                    status: "completed",
+                    completedAt: targetTime - 1,
+                  },
+                },
+                ...current,
+              ]);
+              return;
+            }
+            setEntries((current) => [
+              {
+                type: "activity",
+                id: "activity-tool-old-1",
+                summary: "Ran historical command",
+                details: [
+                  {
+                    id: "tool-old-1-1",
+                    kind: "command",
+                    label: "old historical command",
+                    command: {
+                      displayCommand: "old historical command",
+                      rawCommand: "/bin/zsh -lc 'old historical command'",
+                      output: "historical captured output",
+                      exitCode: 0,
+                    },
+                  },
+                ],
+                turn: {
+                  id: "turn-target",
+                  status: "completed",
+                  completedAt: targetTime,
+                },
+              },
+              ...current,
+            ]);
+            setHasPreviousPage(false);
+          }}
+          removeOptimisticMessage={(_id) => undefined}
+          selectedThread={selectedThread}
+          skills={[]}
+          threadToolAccountingEnabled
+          toolAccounting={toolAccounting}
+          transcriptEntries={entries}
+          transcriptPagination={{
+            supportsPagination: true,
+            hasPreviousPage,
+            previousCursor: hasPreviousPage ? "cursor-1" : undefined,
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+    const instances = screen.getByRole("list", { name: "Command instances" });
+    fireEvent.click(within(instances).getByRole("button", { name: "Details" }));
+
+    expect(screen.getByText("Loading captured output…")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(loadOlder).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText(/historical captured output/)).toBeInTheDocument();
+    expect(screen.queryByText(/unavailable in transcript history/)).not.toBeInTheDocument();
   });
 
   it("pages manual find through hidden in-memory transcript history", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -899,21 +899,36 @@ describe("ThreadView", () => {
     });
   });
 
-  it("loads older transcript pages before showing historical tool output", async () => {
+  it("pages past a same-turn usage overlay to load historical tool output", async () => {
     const targetTime = 1_800_000_000_000;
     const loadOlder = vi.fn();
     let loadedPageCount = 0;
-    const recentEntries = Array.from({ length: 5 }, (_, index) => ({
-      type: "message" as const,
-      id: `recent-message-${index}`,
-      role: "assistant" as const,
-      text: `Recent history ${index}`,
-      turn: {
-        id: `turn-recent-${index}`,
-        status: "completed" as const,
-        completedAt: targetTime + index + 1,
+    const recentEntries: AppServerThreadEntry[] = [
+      {
+        type: "activity",
+        id: "live-turn-usage-turn-target",
+        createdAt: targetTime,
+        details: [],
+        status: "completed",
+        summary: "Turn usage: 1,000 uncached in · 2,000 cached · 100 out",
+        turn: {
+          id: "turn-target",
+          status: "completed",
+          completedAt: targetTime,
+        },
       },
-    }));
+      ...Array.from({ length: 5 }, (_, index) => ({
+        type: "message" as const,
+        id: `recent-message-${index}`,
+        role: "assistant" as const,
+        text: `Recent history ${index}`,
+        turn: {
+          id: `turn-recent-${index}`,
+          status: "completed" as const,
+          completedAt: targetTime + index + 1,
+        },
+      })),
+    ];
     const selectedThread = buildTimestampTargetThread(
       "thread-tool-history",
       "Historical tool output",

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
@@ -28,7 +28,9 @@ describe("TranscriptCommandOutput", () => {
       />
     );
 
-    expect(screen.getByText("$ npm view dive")).toBeInTheDocument();
+    expect(
+      screen.getByText("$ /bin/zsh -lc 'npm view dive'"),
+    ).toBeInTheDocument();
     expect(screen.getByText("dive@0.5.0 | Proprietary | deps: none")).toBeInTheDocument();
     expect(screen.getByText("Shell")).toBeInTheDocument();
     expect(screen.getByText("Success · ran for 373ms")).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -23,7 +23,11 @@ import {
   isTerminalSubAgent,
   subAgentCompletedAt,
 } from "./subagent-format";
-import { formatTimestamp } from "./context-rail-shared";
+import {
+  formatCompactCount,
+  formatTimestamp,
+  RailSummaryRow,
+} from "./context-rail-shared";
 import { RailStatusChip } from "./RailStatusChip";
 import { subAgentPricingUsageTitle } from "./subagent-kind";
 import { RailCardTiming, useNowWhileActive } from "./RailCardTiming";
@@ -101,39 +105,51 @@ export function PricingPanel(props: PricingPanelProps) {
       <h3>Pricing</h3>
       {summary ? (
         <>
-          <dl className="context-grid">
-            <dt>Running total</dt>
-            <dd>
-              {formatSummaryEstimates({
-                codexCreditMicros: pricingTotals.totalCreditMicros,
-                displayOptions,
-                hasEstimates: pricingTotals.hasEstimatedRows,
-                summary,
-              })}
-            </dd>
-            <dt>Usage rows</dt>
-            <dd>
-              {summary.usageLineCount.toLocaleString()}{" "}
-              <span className="context-list__meta">
-                ({summary.pricedUsageLineCount.toLocaleString()} priced,{" "}
-                {summary.unpricedUsageLineCount.toLocaleString()} unpriced)
+          <div className="rail-summary-card pricing-summary-card">
+            <div className="rail-summary-card__header">
+              <span className="rail-summary-card__eyebrow">Pricing summary</span>
+              <span className="rail-summary-card__meta">
+                {summary.usageLineCount.toLocaleString()} row
+                {summary.usageLineCount === 1 ? "" : "s"}
               </span>
-            </dd>
-            <dt>Input</dt>
-            <dd>
-              {formatTokenCount(summary.uncachedInputTokens)} uncached,{" "}
-              {formatTokenCount(summary.cachedInputTokens)} cached
-            </dd>
-            <dt>Output</dt>
-            <dd>
-              {formatTokenCount(summary.outputTokens)}
-              {summary.reasoningOutputTokens > 0
-                ? ` (${formatTokenCount(summary.reasoningOutputTokens)} reasoning)`
-                : ""}
-            </dd>
-            <dt>Updated</dt>
-            <dd>{formatTimestamp(summary.updatedAt)}</dd>
-          </dl>
+            </div>
+            <div className="rail-summary-card__headline">
+              <span className="rail-summary-card__primary">
+                {formatSummaryEstimates({
+                  codexCreditMicros: pricingTotals.totalCreditMicros,
+                  displayOptions,
+                  hasEstimates: pricingTotals.hasEstimatedRows,
+                  summary,
+                })}
+              </span>
+            </div>
+            <div className="rail-summary-card__caption">
+              {summary.pricedUsageLineCount.toLocaleString()} priced ·{" "}
+              {summary.unpricedUsageLineCount.toLocaleString()} unpriced ·{" "}
+              {formatTimestamp(summary.updatedAt)}
+            </div>
+            <div className="rail-summary-card__section">
+              <span className="rail-summary-card__section-title">Token volume</span>
+              <RailSummaryRow
+                label="Uncached input"
+                value={formatCompactCount(summary.uncachedInputTokens)}
+              />
+              <RailSummaryRow
+                label="Cached input"
+                value={formatCompactCount(summary.cachedInputTokens)}
+              />
+              <RailSummaryRow
+                label="Output"
+                value={formatCompactCount(summary.outputTokens)}
+              />
+              {summary.reasoningOutputTokens > 0 ? (
+                <RailSummaryRow
+                  label="Reasoning"
+                  value={formatCompactCount(summary.reasoningOutputTokens)}
+                />
+              ) : null}
+            </div>
+          </div>
           {summary.unpricedUsageLineCount > 0 ? (
             <p className="context-empty context-empty--warning">
               {summary.unpricedUsageLineCount.toLocaleString()} usage row

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -2,9 +2,6 @@ import type {
   AppServerBackendKind,
   ThreadPricingSummary,
   ThreadSubAgentSummary,
-  ThreadToolAccounting,
-  ThreadToolInvocationRecord,
-  ThreadToolInvocationSummary,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import {
@@ -39,7 +36,6 @@ type PricingPanelProps = {
     lines: ThreadUsageLineRecord[];
     summaries: ThreadPricingSummary[];
   };
-  toolAccounting?: ThreadToolAccounting;
   /**
    * Durable sub-agent (task-monitor) summaries for this thread, joined to
    * monitor-scope usage rows by `monitorId` === the row's `sourceItemId`.
@@ -89,7 +85,6 @@ export function PricingPanel(props: PricingPanelProps) {
     aggregateSummaries(displaySummaries) ?? aggregateUsageLines(displayLines);
   const displayOptions = props.displayOptions ?? DEFAULT_PRICING_DISPLAY_OPTIONS;
   const pricingTotals = buildPricingRunningTotals(displayLines);
-  const toolTotals = aggregateToolAccounting(props.toolAccounting);
   const activeTurnId = props.activeTurnId;
   const subAgentsById = new Map(
     (props.subAgents ?? []).map((subAgent) => [subAgent.monitorId, subAgent]),
@@ -170,117 +165,6 @@ export function PricingPanel(props: PricingPanelProps) {
         </>
       ) : displayLines.length === 0 ? (
         <p className="context-empty">No usage pricing recorded yet.</p>
-      ) : null}
-
-      {toolTotals ? (
-        <div className="pricing-tool-output">
-          <h4>Tool output</h4>
-          <dl className="context-grid">
-            <dt>Estimated output tokens</dt>
-            <dd>{formatTokenCount(toolTotals.estimatedOutputTokens)}</dd>
-            <dt>Output volume</dt>
-            <dd>
-              {formatCharacterCount(toolTotals.outputChars)} ·{" "}
-              {toolTotals.outputLines.toLocaleString()} lines
-            </dd>
-            <dt>Invocations</dt>
-            <dd>
-              {toolTotals.invocationCount.toLocaleString()}
-              {toolTotals.noisyInvocationCount > 0 ? (
-                <span className="context-list__meta">
-                  {" "}
-                  ({toolTotals.noisyInvocationCount.toLocaleString()} noisy)
-                </span>
-              ) : null}
-            </dd>
-            <dt>Warnings / errors</dt>
-            <dd>
-              {toolTotals.warningLines.toLocaleString()} /{" "}
-              {toolTotals.errorLines.toLocaleString()}
-            </dd>
-          </dl>
-          {props.toolAccounting?.alerts.length ? (
-            <ul className="context-list context-list--cards pricing-tool-alert-list">
-              {props.toolAccounting.alerts.map((alert) => (
-                <li
-                  key={alert.alertId}
-                  className="rail-card pricing-tool-alert"
-                >
-                  <p className="rail-card__title">Noisy polling detected</p>
-                  <p className="rail-card__usage">{alert.message}</p>
-                  <p className="rail-card__usage">
-                    Suggested steering: {alert.suggestedPrompt}
-                  </p>
-                </li>
-              ))}
-            </ul>
-          ) : null}
-          {props.toolAccounting?.summaries.length ? (
-            <ul className="context-list context-list--cards pricing-tool-summary-list">
-              {props.toolAccounting.summaries.slice(0, 6).map((summary) => (
-                <li
-                  key={`${summary.category}:${summary.toolName}`}
-                  className="rail-card pricing-tool-summary-row"
-                >
-                  <p className="rail-card__title">
-                    {formatToolSummaryTitle(summary)}
-                  </p>
-                  <p className="rail-card__usage">
-                    {formatTokenCount(summary.estimatedOutputTokens)} est. output tokens ·{" "}
-                    {formatCharacterCount(summary.outputChars)}
-                  </p>
-                  <p className="rail-card__usage">
-                    {summary.invocationCount.toLocaleString()} invocation
-                    {summary.invocationCount === 1 ? "" : "s"} ·{" "}
-                    {summary.warningLines.toLocaleString()} warn ·{" "}
-                    {summary.errorLines.toLocaleString()} error ·{" "}
-                    {(summary.infoLines + summary.debugLines).toLocaleString()} info/debug
-                  </p>
-                </li>
-              ))}
-            </ul>
-          ) : null}
-          {props.toolAccounting?.invocations.length ? (
-            <ul className="context-list context-list--cards pricing-tool-invocation-list">
-              {props.toolAccounting.invocations.slice(0, 8).map((invocation) => (
-                <li
-                  key={invocation.invocationId}
-                  className={`rail-card pricing-tool-invocation-row${
-                    invocation.noisy ? " pricing-tool-invocation-row--noisy" : ""
-                  }`}
-                >
-                  <p className="rail-card__title">
-                    {invocation.normalizedCommand ?? invocation.toolName}
-                  </p>
-                  <p className="rail-card__model">
-                    {invocation.toolName} · {invocation.category} ·{" "}
-                    {invocation.status}
-                    {invocation.exitCode !== undefined
-                      ? ` · exit ${invocation.exitCode}`
-                      : ""}
-                  </p>
-                  <p className="rail-card__usage">
-                    {formatTokenCount(invocation.estimatedOutputTokens)} est. output tokens ·{" "}
-                    {formatCharacterCount(invocation.outputChars)} ·{" "}
-                    {invocation.outputLines.toLocaleString()} lines
-                    {invocation.outputTruncated ? " · truncated" : ""}
-                    {invocation.noisy ? " · noisy" : ""}
-                  </p>
-                  <p className="rail-card__usage">
-                    {invocation.warningLines.toLocaleString()} warn ·{" "}
-                    {invocation.errorLines.toLocaleString()} error ·{" "}
-                    {invocation.infoLines.toLocaleString()} info ·{" "}
-                    {invocation.debugLines.toLocaleString()} debug
-                  </p>
-                  <ToolInvocationTimestamp
-                    invocation={invocation}
-                    onScrollToTurn={props.onScrollToTurn}
-                  />
-                </li>
-              ))}
-            </ul>
-          ) : null}
-        </div>
       ) : null}
 
       {displayLines.length > 0 ? (
@@ -427,99 +311,6 @@ export function PricingPanel(props: PricingPanelProps) {
         </div>
       ) : null}
     </section>
-  );
-}
-
-type ToolAccountingTotals = {
-  debugLines: number;
-  errorLines: number;
-  estimatedOutputTokens: number;
-  infoLines: number;
-  invocationCount: number;
-  noisyInvocationCount: number;
-  outputChars: number;
-  outputLines: number;
-  warningLines: number;
-};
-
-function aggregateToolAccounting(
-  toolAccounting: ThreadToolAccounting | undefined,
-): ToolAccountingTotals | undefined {
-  if (!toolAccounting || toolAccounting.summaries.length === 0) {
-    return undefined;
-  }
-  return toolAccounting.summaries.reduce<ToolAccountingTotals>(
-    (totals, summary) => ({
-      debugLines: totals.debugLines + summary.debugLines,
-      errorLines: totals.errorLines + summary.errorLines,
-      estimatedOutputTokens:
-        totals.estimatedOutputTokens + summary.estimatedOutputTokens,
-      infoLines: totals.infoLines + summary.infoLines,
-      invocationCount: totals.invocationCount + summary.invocationCount,
-      noisyInvocationCount:
-        totals.noisyInvocationCount + summary.noisyInvocationCount,
-      outputChars: totals.outputChars + summary.outputChars,
-      outputLines: totals.outputLines + summary.outputLines,
-      warningLines: totals.warningLines + summary.warningLines,
-    }),
-    {
-      debugLines: 0,
-      errorLines: 0,
-      estimatedOutputTokens: 0,
-      infoLines: 0,
-      invocationCount: 0,
-      noisyInvocationCount: 0,
-      outputChars: 0,
-      outputLines: 0,
-      warningLines: 0,
-    },
-  );
-}
-
-function formatToolSummaryTitle(summary: ThreadToolInvocationSummary): string {
-  return `${summary.toolName} · ${summary.category}`;
-}
-
-function formatCharacterCount(chars: number): string {
-  if (chars >= 1_000_000) {
-    return `${(chars / 1_000_000).toFixed(chars >= 10_000_000 ? 0 : 1)}M chars`;
-  }
-  if (chars >= 1_000) {
-    return `${(chars / 1_000).toFixed(chars >= 10_000 ? 0 : 1)}k chars`;
-  }
-  return `${chars.toLocaleString()} chars`;
-}
-
-function ToolInvocationTimestamp(props: {
-  invocation: ThreadToolInvocationRecord;
-  onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
-}) {
-  const timestamp = formatTimestamp(props.invocation.observedAt);
-  const canScrollToTurn = Boolean(props.invocation.turnId && props.onScrollToTurn);
-
-  return (
-    <p className="rail-card__times">
-      {canScrollToTurn ? (
-        <button
-          type="button"
-          className="rail-card__time-button"
-          title="Scroll the transcript to this turn"
-          aria-label={`Scroll the transcript to this turn (${timestamp})`}
-          onClick={() =>
-            props.invocation.turnId &&
-            props.onScrollToTurn?.(
-              props.invocation.turnId,
-              props.invocation.observedAt,
-            )
-          }
-        >
-          {timestamp}
-        </button>
-      ) : (
-        timestamp
-      )}
-      {props.invocation.turnId ? ` · ${props.invocation.turnId}` : ""}
-    </p>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
@@ -7,6 +7,7 @@ import type {
   ThreadToolInvocationSummary,
 } from "@pwragent/shared";
 import { TranscriptCommandOutput } from "../TranscriptCommandOutput";
+import { detailMatchesInvocationItem } from "../tool-call-details";
 import { formatTokenCount } from "./subagent-format";
 import {
   formatCompactCount,
@@ -300,14 +301,6 @@ function collectCommandDetails(
     }
   }
   return detailsByItemId;
-}
-
-function detailMatchesInvocationItem(detailId: string, itemId: string): boolean {
-  return (
-    detailId === itemId
-    || detailId.startsWith(`${itemId}-`)
-    || detailId.startsWith(`${itemId}:`)
-  );
 }
 
 function aggregateToolAccounting(

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
@@ -16,6 +16,8 @@ import {
 
 type ToolCallsPanelProps = {
   entries?: AppServerThreadEntry[];
+  loadingDetailItemId?: string;
+  onRequestInvocationDetails?: (invocation: ThreadToolInvocationRecord) => void;
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
   toolAccounting?: ThreadToolAccounting;
 };
@@ -36,8 +38,11 @@ export function ToolCallsPanel(props: ToolCallsPanelProps) {
   const accounting = props.toolAccounting;
   const totals = aggregateToolAccounting(accounting);
   const detailsByItemId = useMemo(
-    () => collectCommandDetails(props.entries ?? []),
-    [props.entries],
+    () => collectCommandDetails(
+      props.entries ?? [],
+      accounting?.invocations ?? [],
+    ),
+    [accounting?.invocations, props.entries],
   );
 
   return (
@@ -146,7 +151,9 @@ export function ToolCallsPanel(props: ToolCallsPanelProps) {
                       detailsByItemId={detailsByItemId}
                       expandedInvocation={expandedInvocation}
                       invocations={invocations}
+                      loadingDetailItemId={props.loadingDetailItemId}
                       onExpandedInvocationChange={setExpandedInvocation}
+                      onRequestInvocationDetails={props.onRequestInvocationDetails}
                       onScrollToTurn={props.onScrollToTurn}
                       totalCount={summary.invocationCount}
                     />
@@ -165,7 +172,9 @@ function ToolInvocationList(props: {
   detailsByItemId: Map<string, AppServerThreadActivityDetail>;
   expandedInvocation?: string;
   invocations: ThreadToolInvocationRecord[];
+  loadingDetailItemId?: string;
   onExpandedInvocationChange: (invocationId: string | undefined) => void;
+  onRequestInvocationDetails?: (invocation: ThreadToolInvocationRecord) => void;
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
   totalCount: number;
 }) {
@@ -189,7 +198,8 @@ function ToolInvocationList(props: {
         {props.invocations.map((invocation) => {
           const expanded = props.expandedInvocation === invocation.invocationId;
           const transcriptDetail = props.detailsByItemId.get(invocation.itemId);
-          const detail = transcriptDetail ?? buildFallbackDetail(invocation);
+          const loadingDetail =
+            props.loadingDetailItemId === invocation.itemId;
           return (
             <li
               key={invocation.invocationId}
@@ -205,11 +215,14 @@ function ToolInvocationList(props: {
                   type="button"
                   className="button button--ghost tool-call-row__details"
                   aria-expanded={expanded}
-                  onClick={() =>
+                  onClick={() => {
+                    if (!expanded && !transcriptDetail) {
+                      props.onRequestInvocationDetails?.(invocation);
+                    }
                     props.onExpandedInvocationChange(
                       expanded ? undefined : invocation.invocationId,
-                    )
-                  }
+                    );
+                  }}
                 >
                   {expanded ? "Hide" : "Details"}
                 </button>
@@ -233,7 +246,18 @@ function ToolInvocationList(props: {
               />
               {expanded ? (
                 <div className="tool-call-instance__detail">
-                  <TranscriptCommandOutput detail={detail} />
+                  {transcriptDetail ? (
+                    <TranscriptCommandOutput detail={transcriptDetail} />
+                  ) : (
+                    <p
+                      className="tool-call-instance__detail-status"
+                      aria-live="polite"
+                    >
+                      {loadingDetail
+                        ? "Loading captured output…"
+                        : "Captured output is unavailable in transcript history."}
+                    </p>
+                  )}
                 </div>
               ) : null}
             </li>
@@ -246,38 +270,44 @@ function ToolInvocationList(props: {
 
 function collectCommandDetails(
   entries: AppServerThreadEntry[],
+  invocations: ThreadToolInvocationRecord[],
 ): Map<string, AppServerThreadActivityDetail> {
   const detailsByItemId = new Map<string, AppServerThreadActivityDetail>();
+  const itemIds = [...new Set(invocations.map((invocation) => invocation.itemId))]
+    .sort((left, right) => right.length - left.length);
   for (const entry of entries) {
     if (entry.type !== "activity") {
       continue;
     }
     for (const detail of entry.details) {
-      if (detail.kind === "command" && detail.command) {
-        detailsByItemId.set(detail.id, detail);
+      if (!detail.command) {
+        continue;
+      }
+      const itemId = itemIds.find((candidate) =>
+        detailMatchesInvocationItem(detail.id, candidate),
+      );
+      if (!itemId) {
+        continue;
+      }
+      const current = detailsByItemId.get(itemId);
+      if (
+        !current
+        || (current.command?.output === undefined
+          && detail.command.output !== undefined)
+      ) {
+        detailsByItemId.set(itemId, detail);
       }
     }
   }
   return detailsByItemId;
 }
 
-function buildFallbackDetail(
-  invocation: ThreadToolInvocationRecord,
-): AppServerThreadActivityDetail {
-  const command = invocation.normalizedCommand ?? invocation.toolName;
-  return {
-    id: invocation.itemId,
-    kind: "command",
-    label: command,
-    status: invocation.status === "pending" ? "in_progress" : invocation.status,
-    command: {
-      displayCommand: command,
-      rawCommand: command,
-      ...(invocation.exitCode !== undefined
-        ? { exitCode: invocation.exitCode }
-        : {}),
-    },
-  };
+function detailMatchesInvocationItem(detailId: string, itemId: string): boolean {
+  return (
+    detailId === itemId
+    || detailId.startsWith(`${itemId}-`)
+    || detailId.startsWith(`${itemId}:`)
+  );
 }
 
 function aggregateToolAccounting(

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
@@ -1,0 +1,340 @@
+import { useMemo, useState } from "react";
+import type {
+  AppServerThreadActivityDetail,
+  AppServerThreadEntry,
+  ThreadToolAccounting,
+  ThreadToolInvocationRecord,
+  ThreadToolInvocationSummary,
+} from "@pwragent/shared";
+import { TranscriptCommandOutput } from "../TranscriptCommandOutput";
+import { formatTokenCount } from "./subagent-format";
+import { formatTimestamp } from "./context-rail-shared";
+
+type ToolCallsPanelProps = {
+  entries?: AppServerThreadEntry[];
+  onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
+  toolAccounting?: ThreadToolAccounting;
+};
+
+type ToolAccountingTotals = {
+  errorLines: number;
+  estimatedOutputTokens: number;
+  invocationCount: number;
+  noisyInvocationCount: number;
+  outputChars: number;
+  outputLines: number;
+  warningLines: number;
+};
+
+export function ToolCallsPanel(props: ToolCallsPanelProps) {
+  const [expandedSummary, setExpandedSummary] = useState<string>();
+  const [expandedInvocation, setExpandedInvocation] = useState<string>();
+  const accounting = props.toolAccounting;
+  const totals = aggregateToolAccounting(accounting);
+  const detailsByItemId = useMemo(
+    () => collectCommandDetails(props.entries ?? []),
+    [props.entries],
+  );
+
+  return (
+    <section className="context-panel__section tool-calls-panel">
+      <h3>Tool calls</h3>
+      {totals ? (
+        <dl className="context-grid">
+          <dt>Estimated output tokens</dt>
+          <dd>{formatTokenCount(totals.estimatedOutputTokens)}</dd>
+          <dt>Output volume</dt>
+          <dd>
+            {formatCharacterCount(totals.outputChars)} ·{" "}
+            {totals.outputLines.toLocaleString()} lines
+          </dd>
+          <dt>Invocations</dt>
+          <dd>
+            {totals.invocationCount.toLocaleString()}
+            {totals.noisyInvocationCount > 0 ? (
+              <span className="context-list__meta">
+                {" "}
+                ({totals.noisyInvocationCount.toLocaleString()} noisy)
+              </span>
+            ) : null}
+          </dd>
+          <dt>Warnings / errors</dt>
+          <dd>
+            {totals.warningLines.toLocaleString()} /{" "}
+            {totals.errorLines.toLocaleString()}
+          </dd>
+        </dl>
+      ) : (
+        <p className="context-empty">No tool calls recorded yet.</p>
+      )}
+
+      {accounting?.alerts.length ? (
+        <ul className="context-list context-list--cards tool-call-alert-list">
+          {accounting.alerts.map((alert) => (
+            <li key={alert.alertId} className="rail-card tool-call-alert">
+              <p className="rail-card__title">Noisy polling detected</p>
+              <p className="rail-card__usage">{alert.message}</p>
+              <p className="rail-card__usage">
+                Suggested steering: {alert.suggestedPrompt}
+              </p>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {accounting?.summaries.length ? (
+        <div className="tool-call-groups">
+          <h4>Commands</h4>
+          <ul className="context-list context-list--cards tool-call-summary-list">
+            {accounting.summaries.map((summary) => {
+              const summaryKey = `${summary.category}:${summary.toolName}`;
+              const expanded = expandedSummary === summaryKey;
+              const invocations = accounting.invocations.filter(
+                (invocation) =>
+                  invocation.category === summary.category
+                  && invocation.toolName === summary.toolName,
+              );
+              return (
+                <li key={summaryKey} className="rail-card tool-call-summary-row">
+                  <div className="tool-call-row__header">
+                    <p className="rail-card__title">
+                      {formatToolSummaryTitle(summary)}
+                    </p>
+                    <button
+                      type="button"
+                      className="button button--ghost tool-call-row__details"
+                      aria-expanded={expanded}
+                      onClick={() => {
+                        setExpandedSummary(expanded ? undefined : summaryKey);
+                        setExpandedInvocation(undefined);
+                      }}
+                    >
+                      {expanded ? "Hide" : "Details"}
+                    </button>
+                  </div>
+                  <p className="rail-card__usage">
+                    {formatTokenCount(summary.estimatedOutputTokens)} est. output tokens ·{" "}
+                    {formatCharacterCount(summary.outputChars)}
+                  </p>
+                  <p className="rail-card__usage">
+                    {summary.invocationCount.toLocaleString()} invocation
+                    {summary.invocationCount === 1 ? "" : "s"} ·{" "}
+                    {summary.warningLines.toLocaleString()} warn ·{" "}
+                    {summary.errorLines.toLocaleString()} error ·{" "}
+                    {(summary.infoLines + summary.debugLines).toLocaleString()} info/debug
+                  </p>
+                  {expanded ? (
+                    <ToolInvocationList
+                      detailsByItemId={detailsByItemId}
+                      expandedInvocation={expandedInvocation}
+                      invocations={invocations}
+                      onExpandedInvocationChange={setExpandedInvocation}
+                      onScrollToTurn={props.onScrollToTurn}
+                      totalCount={summary.invocationCount}
+                    />
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function ToolInvocationList(props: {
+  detailsByItemId: Map<string, AppServerThreadActivityDetail>;
+  expandedInvocation?: string;
+  invocations: ThreadToolInvocationRecord[];
+  onExpandedInvocationChange: (invocationId: string | undefined) => void;
+  onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
+  totalCount: number;
+}) {
+  if (props.invocations.length === 0) {
+    return (
+      <p className="context-empty tool-call-instances__empty">
+        No instances available.
+      </p>
+    );
+  }
+
+  return (
+    <div className="tool-call-instances">
+      {props.invocations.length < props.totalCount ? (
+        <p className="tool-call-instances__status">
+          Showing latest {props.invocations.length.toLocaleString()} of{" "}
+          {props.totalCount.toLocaleString()} recorded instances.
+        </p>
+      ) : null}
+      <ul className="tool-call-instance-list" aria-label="Command instances">
+        {props.invocations.map((invocation) => {
+          const expanded = props.expandedInvocation === invocation.invocationId;
+          const transcriptDetail = props.detailsByItemId.get(invocation.itemId);
+          const detail = transcriptDetail ?? buildFallbackDetail(invocation);
+          return (
+            <li
+              key={invocation.invocationId}
+              className={`tool-call-instance${
+                invocation.noisy ? " tool-call-instance--noisy" : ""
+              }`}
+            >
+              <div className="tool-call-row__header">
+                <p className="tool-call-instance__command">
+                  {invocation.normalizedCommand ?? invocation.toolName}
+                </p>
+                <button
+                  type="button"
+                  className="button button--ghost tool-call-row__details"
+                  aria-expanded={expanded}
+                  onClick={() =>
+                    props.onExpandedInvocationChange(
+                      expanded ? undefined : invocation.invocationId,
+                    )
+                  }
+                >
+                  {expanded ? "Hide" : "Details"}
+                </button>
+              </div>
+              <p className="rail-card__model">
+                {invocation.status}
+                {invocation.exitCode !== undefined
+                  ? ` · exit ${invocation.exitCode}`
+                  : ""}
+                {invocation.outputTruncated ? " · accounting truncated" : ""}
+                {invocation.noisy ? " · noisy" : ""}
+              </p>
+              <p className="rail-card__usage">
+                {formatTokenCount(invocation.estimatedOutputTokens)} est. output tokens ·{" "}
+                {formatCharacterCount(invocation.outputChars)} ·{" "}
+                {invocation.outputLines.toLocaleString()} lines
+              </p>
+              <ToolInvocationTimestamp
+                invocation={invocation}
+                onScrollToTurn={props.onScrollToTurn}
+              />
+              {expanded ? (
+                <div className="tool-call-instance__detail">
+                  <TranscriptCommandOutput detail={detail} />
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function collectCommandDetails(
+  entries: AppServerThreadEntry[],
+): Map<string, AppServerThreadActivityDetail> {
+  const detailsByItemId = new Map<string, AppServerThreadActivityDetail>();
+  for (const entry of entries) {
+    if (entry.type !== "activity") {
+      continue;
+    }
+    for (const detail of entry.details) {
+      if (detail.kind === "command" && detail.command) {
+        detailsByItemId.set(detail.id, detail);
+      }
+    }
+  }
+  return detailsByItemId;
+}
+
+function buildFallbackDetail(
+  invocation: ThreadToolInvocationRecord,
+): AppServerThreadActivityDetail {
+  const command = invocation.normalizedCommand ?? invocation.toolName;
+  return {
+    id: invocation.itemId,
+    kind: "command",
+    label: command,
+    status: invocation.status === "pending" ? "in_progress" : invocation.status,
+    command: {
+      displayCommand: command,
+      rawCommand: command,
+      ...(invocation.exitCode !== undefined
+        ? { exitCode: invocation.exitCode }
+        : {}),
+    },
+  };
+}
+
+function aggregateToolAccounting(
+  toolAccounting: ThreadToolAccounting | undefined,
+): ToolAccountingTotals | undefined {
+  if (!toolAccounting || toolAccounting.summaries.length === 0) {
+    return undefined;
+  }
+  return toolAccounting.summaries.reduce<ToolAccountingTotals>(
+    (totals, summary) => ({
+      errorLines: totals.errorLines + summary.errorLines,
+      estimatedOutputTokens:
+        totals.estimatedOutputTokens + summary.estimatedOutputTokens,
+      invocationCount: totals.invocationCount + summary.invocationCount,
+      noisyInvocationCount:
+        totals.noisyInvocationCount + summary.noisyInvocationCount,
+      outputChars: totals.outputChars + summary.outputChars,
+      outputLines: totals.outputLines + summary.outputLines,
+      warningLines: totals.warningLines + summary.warningLines,
+    }),
+    {
+      errorLines: 0,
+      estimatedOutputTokens: 0,
+      invocationCount: 0,
+      noisyInvocationCount: 0,
+      outputChars: 0,
+      outputLines: 0,
+      warningLines: 0,
+    },
+  );
+}
+
+function formatToolSummaryTitle(summary: ThreadToolInvocationSummary): string {
+  return `${summary.toolName} · ${summary.category}`;
+}
+
+function formatCharacterCount(chars: number): string {
+  if (chars >= 1_000_000) {
+    return `${(chars / 1_000_000).toFixed(chars >= 10_000_000 ? 0 : 1)}M chars`;
+  }
+  if (chars >= 1_000) {
+    return `${(chars / 1_000).toFixed(chars >= 10_000 ? 0 : 1)}k chars`;
+  }
+  return `${chars.toLocaleString()} chars`;
+}
+
+function ToolInvocationTimestamp(props: {
+  invocation: ThreadToolInvocationRecord;
+  onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
+}) {
+  const timestamp = formatTimestamp(props.invocation.observedAt);
+  const canScrollToTurn = Boolean(props.invocation.turnId && props.onScrollToTurn);
+
+  return (
+    <p className="rail-card__times">
+      {canScrollToTurn ? (
+        <button
+          type="button"
+          className="rail-card__time-button"
+          title="Scroll the transcript to this turn"
+          aria-label={`Scroll the transcript to this turn (${timestamp})`}
+          onClick={() =>
+            props.invocation.turnId
+            && props.onScrollToTurn?.(
+              props.invocation.turnId,
+              props.invocation.observedAt,
+            )
+          }
+        >
+          {timestamp}
+        </button>
+      ) : (
+        timestamp
+      )}
+      {props.invocation.turnId ? ` · ${props.invocation.turnId}` : ""}
+    </p>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
@@ -8,7 +8,11 @@ import type {
 } from "@pwragent/shared";
 import { TranscriptCommandOutput } from "../TranscriptCommandOutput";
 import { formatTokenCount } from "./subagent-format";
-import { formatTimestamp } from "./context-rail-shared";
+import {
+  formatCompactCount,
+  formatTimestamp,
+  RailSummaryRow,
+} from "./context-rail-shared";
 
 type ToolCallsPanelProps = {
   entries?: AppServerThreadEntry[];
@@ -40,30 +44,44 @@ export function ToolCallsPanel(props: ToolCallsPanelProps) {
     <section className="context-panel__section tool-calls-panel">
       <h3>Tool calls</h3>
       {totals ? (
-        <dl className="context-grid">
-          <dt>Estimated output tokens</dt>
-          <dd>{formatTokenCount(totals.estimatedOutputTokens)}</dd>
-          <dt>Output volume</dt>
-          <dd>
-            {formatCharacterCount(totals.outputChars)} ·{" "}
-            {totals.outputLines.toLocaleString()} lines
-          </dd>
-          <dt>Invocations</dt>
-          <dd>
-            {totals.invocationCount.toLocaleString()}
+        <div className="rail-summary-card tool-call-summary-card">
+          <div className="rail-summary-card__header">
+            <span className="rail-summary-card__eyebrow">Tool output</span>
+            <span className="rail-summary-card__meta">
+              {totals.invocationCount.toLocaleString()} invocation
+              {totals.invocationCount === 1 ? "" : "s"}
+            </span>
+          </div>
+          <div className="rail-summary-card__headline">
+            <span className="rail-summary-card__primary">
+              {formatCompactCount(totals.estimatedOutputTokens)} est. tokens
+            </span>
+            <span className="rail-summary-card__secondary">
+              {formatCharacterCount(totals.outputChars)}
+            </span>
+          </div>
+          <div className="rail-summary-card__caption">
+            {totals.outputLines.toLocaleString()} output line
+            {totals.outputLines === 1 ? "" : "s"}
+          </div>
+          <div className="rail-summary-card__section">
+            <span className="rail-summary-card__section-title">Diagnostics</span>
+            <RailSummaryRow
+              label="Warnings"
+              value={totals.warningLines.toLocaleString()}
+            />
+            <RailSummaryRow
+              label="Errors"
+              value={totals.errorLines.toLocaleString()}
+            />
             {totals.noisyInvocationCount > 0 ? (
-              <span className="context-list__meta">
-                {" "}
-                ({totals.noisyInvocationCount.toLocaleString()} noisy)
-              </span>
+              <RailSummaryRow
+                label="Noisy calls"
+                value={totals.noisyInvocationCount.toLocaleString()}
+              />
             ) : null}
-          </dd>
-          <dt>Warnings / errors</dt>
-          <dd>
-            {totals.warningLines.toLocaleString()} /{" "}
-            {totals.errorLines.toLocaleString()}
-          </dd>
-        </dl>
+          </div>
+        </div>
       ) : (
         <p className="context-empty">No tool calls recorded yet.</p>
       )}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/context-rail-shared.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/context-rail-shared.tsx
@@ -84,6 +84,15 @@ export function TooltipValue(props: {
   );
 }
 
+export function RailSummaryRow(props: { label: string; value: string }) {
+  return (
+    <div className="rail-summary-card__row">
+      <span className="rail-summary-card__row-label">{props.label}</span>
+      <span className="rail-summary-card__row-value">{props.value}</span>
+    </div>
+  );
+}
+
 export async function handleCopyPath(
   event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>,
   path: string,
@@ -129,6 +138,16 @@ export function formatTimestamp(
     minute: "2-digit",
     ...(options?.includeSeconds ? { second: "2-digit" } : {}),
   }).format(timestamp);
+}
+
+export function formatCompactCount(value: number): string {
+  if (Math.abs(value) >= 1_000_000) {
+    return `${Math.round(value / 100_000) / 10}M`;
+  }
+  if (Math.abs(value) >= 1_000) {
+    return `${Math.round(value / 100) / 10}k`;
+  }
+  return Math.round(value).toLocaleString();
 }
 
 export function formatAgentInstructionSummary(lineCount: number): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/context-tab.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/context-tab.ts
@@ -7,6 +7,7 @@ export type ContextTabId =
   | "info"
   | "edits"
   | "pricing"
+  | "tool-calls"
   | "actions"
   | "subagents"
   | "automations"
@@ -18,6 +19,7 @@ export const CONTEXT_TAB_IDS: ContextTabId[] = [
   "info",
   "edits",
   "pricing",
+  "tool-calls",
   "actions",
   "subagents",
   "automations",

--- a/apps/desktop/src/renderer/src/features/thread-detail/tool-call-details.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/tool-call-details.ts
@@ -1,0 +1,32 @@
+import type { AppServerThreadEntry } from "@pwragent/shared";
+
+export function detailMatchesInvocationItem(
+  detailId: string,
+  itemId: string,
+): boolean {
+  return (
+    detailId === itemId
+    || detailId.startsWith(`${itemId}-`)
+    || detailId.startsWith(`${itemId}:`)
+  );
+}
+
+export function findTranscriptCommandDetailEntryIndex(
+  entries: AppServerThreadEntry[],
+  itemId: string,
+): number {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (
+      entry?.type === "activity"
+      && entry.details.some(
+        (detail) =>
+          Boolean(detail.command)
+          && detailMatchesInvocationItem(detail.id, itemId),
+      )
+    ) {
+      return index;
+    }
+  }
+  return -1;
+}

--- a/apps/desktop/src/renderer/src/icons/ToolCallsIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/ToolCallsIcon.tsx
@@ -1,0 +1,13 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+/** Tool calls: command prompt with captured output lines. */
+export function ToolCallsIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <polyline points="4 6.5 7 9.5 4 12.5" />
+      <line x1="10" y1="9.5" x2="14" y2="9.5" />
+      <line x1="4" y1="16" x2="20" y2="16" />
+      <line x1="4" y1="19.5" x2="16" y2="19.5" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -45,6 +45,7 @@ export { StarMapIcon } from "./StarMapIcon";
 export { SubAgentsIcon } from "./SubAgentsIcon";
 export { TelegramIcon } from "./TelegramIcon";
 export { TerminalIcon } from "./TerminalIcon";
+export { ToolCallsIcon } from "./ToolCallsIcon";
 export { ThreadIcon } from "./ThreadIcon";
 export { UnlinkedDotIcon } from "./UnlinkedDotIcon";
 export { WorkspaceIcon } from "./WorkspaceIcon";

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -17728,14 +17728,14 @@ a.transcript-message__messaging-origin:focus-visible {
   line-height: 1.35;
 }
 
-.pricing-tool-output {
+.tool-call-groups {
   display: flex;
   flex-direction: column;
   gap: 10px;
   margin-top: 14px;
 }
 
-.pricing-tool-output h4 {
+.tool-call-groups h4 {
   margin: 0;
   color: var(--text-secondary);
   font-size: 11px;
@@ -17744,14 +17744,85 @@ a.transcript-message__messaging-origin:focus-visible {
   text-transform: uppercase;
 }
 
-.pricing-tool-alert,
-.pricing-tool-invocation-row--noisy {
+.tool-call-alert,
+.tool-call-instance--noisy {
   border-color: color-mix(in srgb, var(--status-warning) 45%, var(--border-subtle));
   box-shadow: inset 2px 0 0 0 var(--status-warning);
 }
 
-.pricing-tool-alert .rail-card__title {
+.tool-call-alert .rail-card__title {
   color: var(--text-primary);
+}
+
+.tool-call-row__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.tool-call-row__header > :first-child {
+  min-width: 0;
+}
+
+.tool-call-row__details {
+  flex: 0 0 auto;
+  min-height: 24px;
+  padding: 2px 7px;
+  font-size: 11px;
+}
+
+.tool-call-instance-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 10px 0 0;
+  padding: 0;
+  border-top: 1px solid var(--border-subtle);
+  list-style: none;
+}
+
+.tool-call-instances__status {
+  margin: 10px 0 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.tool-call-instance {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.tool-call-instance:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.tool-call-instance__command {
+  margin: 0;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.tool-call-instance__detail {
+  margin-top: 4px;
+}
+
+.tool-call-instance__detail .transcript-command {
+  margin: 0;
+}
+
+.tool-call-instances__empty {
+  margin-top: 10px;
 }
 
 /* The in-progress turn: a calm accent left-stripe + slightly firmer border,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -17306,6 +17306,106 @@ a.transcript-message__messaging-origin:focus-visible {
   font-size: 14px;
 }
 
+/* Dense rail summaries share the hierarchy and measurements of the PR and
+   context-window popovers: a strong total, a quiet caption, then compact
+   key/value rows separated by one divider. */
+.rail-summary-card {
+  margin-top: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--surface-overlay-faint);
+  color: var(--text-primary);
+}
+
+.rail-summary-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.rail-summary-card__eyebrow,
+.rail-summary-card__section-title {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.rail-summary-card__meta {
+  color: var(--text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.rail-summary-card__headline {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 6px;
+}
+
+.rail-summary-card__primary {
+  min-width: 0;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 16px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+.rail-summary-card__secondary {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.rail-summary-card__caption {
+  margin-top: 6px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.rail-summary-card__section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.rail-summary-card__section-title {
+  margin-bottom: 2px;
+}
+
+.rail-summary-card__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.rail-summary-card__row-label {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.rail-summary-card__row-value {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
 .context-value-row {
   display: inline-flex;
   max-width: 100%;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -17921,6 +17921,13 @@ a.transcript-message__messaging-origin:focus-visible {
   margin: 0;
 }
 
+.tool-call-instance__detail-status {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
 .tool-call-instances__empty {
   margin-top: 10px;
 }

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -646,7 +646,7 @@ export type DesktopSettingsSnapshot = {
      */
     threadPricingDisplayCodexCredits?: DesktopSettingsValue<boolean>;
     /**
-     * Shows experimental tool-output accounting inside the thread Pricing tab.
+     * Shows the experimental Tool calls tab in the thread context rail.
      * The desktop app may still collect tool metrics while this is disabled;
      * this only gates the operator-facing panel and noisy-polling alerts.
      */


### PR DESCRIPTION
## Summary

- move experimental tool-call tracking out of the Pricing tab into a dedicated **Tool calls** context-rail tab
- add group-level Details controls that reveal the recorded command instances for each tool/category
- add instance-level Details controls that show the full hydrated command and captured output
- keep command output ephemeral by joining accounting records to provider transcript activity instead of persisting output in PwrAgent sqlite
- make the experimental tool-call setting independent from the released Pricing setting

## Why

Tool-call/output accounting is an operational diagnostic surface, not pricing data. Combining it with usage pricing made both concepts harder to scan and prevented operators from enabling diagnostics without also enabling Pricing.

## User impact

Operators who enable Experimental → Tool Call Tracking get a separate Tool calls rail tab. Pricing remains focused on token usage and cost. Details can be expanded from a command group down to an individual invocation's full command and output.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with the existing warning baseline)
- `pnpm lint:boundaries`
- `git diff --check`
