### PR TITLE
perf(desktop): batch live token usage writes

### DIFF
--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -13,6 +13,13 @@
     "rowsChanged": 30,
     "statements": 30
   },
+  "live-thread-token-usage-timer-windows": {
+    "commits": 10,
+    "note": "10 cumulative live-usage observations separated by full one-second timer windows",
+    "observedWalBytes": 547960,
+    "rowsChanged": 30,
+    "statements": 30
+  },
   "streamed-command-output": {
     "commits": 2,
     "note": "500 streamed output deltas plus the completion for one command",

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -8,10 +8,10 @@
   },
   "live-thread-token-usage": {
     "commits": 1,
-    "note": "one completed model request observed through thread token usage",
+    "note": "500 cumulative usage observations across 10 turns, then one terminal flush",
     "observedWalBytes": 65920,
-    "rowsChanged": 3,
-    "statements": 3
+    "rowsChanged": 30,
+    "statements": 30
   },
   "streamed-command-output": {
     "commits": 2,

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -220,6 +220,167 @@ describe("sqlite write metrics", () => {
     }
   });
 
+  it("waits for earlier live usage before crossing a terminal durability boundary", async () => {
+    const overlayLookupStarted = createDeferred();
+    const releaseOverlayLookup = createDeferred();
+    const readOverlay = store.getThreadOverlayState.bind(store);
+    vi.spyOn(store, "getThreadOverlayState").mockImplementationOnce(
+      async (params) => {
+        overlayLookupStarted.resolve();
+        await releaseOverlayLookup.promise;
+        return await readOverlay(params);
+      },
+    );
+    const batchWrite = vi.spyOn(store, "upsertThreadUsageLines");
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+    let usageEmit = Promise.resolve();
+    let terminalEmit = Promise.resolve();
+    let terminalDelivered = false;
+    registry.onEvent((event) => {
+      if (event.notification.method === "turn/completed") {
+        terminalDelivered = true;
+      }
+    });
+
+    try {
+      usageEmit = emit(buildLiveUsageEvent({
+        inputTokens: 1_000,
+        threadId: "thread-terminal-race",
+        turnId: "turn-terminal-race",
+      }));
+      await overlayLookupStarted.promise;
+
+      terminalEmit = emit(
+        buildTurnCompletedEvent("thread-terminal-race", "turn-terminal-race"),
+      );
+      await waitForAsyncWork();
+
+      expect(terminalDelivered).toBe(false);
+      expect(batchWrite).not.toHaveBeenCalled();
+
+      releaseOverlayLookup.resolve();
+      await Promise.all([usageEmit, terminalEmit]);
+
+      expect(batchWrite).toHaveBeenCalledTimes(1);
+      expect(
+        (await store.readThreadPricing({
+          backend: "codex",
+          threadId: "thread-terminal-race",
+        })).lines[0],
+      ).toMatchObject({ inputTokens: 1_000 });
+    } finally {
+      releaseOverlayLookup.resolve();
+      await Promise.allSettled([usageEmit, terminalEmit]);
+      await registry.close();
+    }
+  });
+
+  it("persists pre-close live usage after a delayed lookup and ignores new usage", async () => {
+    const overlayLookupStarted = createDeferred();
+    const releaseOverlayLookup = createDeferred();
+    const readOverlay = store.getThreadOverlayState.bind(store);
+    const overlayLookup = vi
+      .spyOn(store, "getThreadOverlayState")
+      .mockImplementationOnce(async (params) => {
+        overlayLookupStarted.resolve();
+        await releaseOverlayLookup.promise;
+        return await readOverlay(params);
+      });
+    const batchWrite = vi.spyOn(store, "upsertThreadUsageLines");
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+    let usageEmit = Promise.resolve();
+    let postCloseEmit = Promise.resolve();
+    let closePromise: Promise<void> | undefined;
+    let closeSettled = false;
+
+    try {
+      usageEmit = emit(buildLiveUsageEvent({
+        inputTokens: 1_000,
+        threadId: "thread-close-race",
+        turnId: "turn-close-race",
+      }));
+      await overlayLookupStarted.promise;
+
+      closePromise = registry.close().finally(() => {
+        closeSettled = true;
+      });
+      postCloseEmit = emit(buildLiveUsageEvent({
+        inputTokens: 2_000,
+        threadId: "thread-close-race",
+        turnId: "turn-close-race",
+      }));
+      await postCloseEmit;
+      await waitForAsyncWork();
+
+      expect(closeSettled).toBe(false);
+      expect(overlayLookup).toHaveBeenCalledTimes(1);
+      expect(batchWrite).not.toHaveBeenCalled();
+
+      releaseOverlayLookup.resolve();
+      await Promise.all([usageEmit, closePromise]);
+
+      expect(batchWrite).toHaveBeenCalledTimes(1);
+      expect(
+        (await store.readThreadPricing({
+          backend: "codex",
+          threadId: "thread-close-race",
+        })).lines[0],
+      ).toMatchObject({ inputTokens: 1_000 });
+    } finally {
+      releaseOverlayLookup.resolve();
+      closePromise ??= registry.close();
+      await Promise.allSettled([usageEmit, postCloseEmit, closePromise]);
+    }
+  });
+
+  it("releases the terminal barrier when earlier live usage derivation fails", async () => {
+    vi.spyOn(store, "getThreadOverlayState").mockRejectedValueOnce(
+      new Error("overlay unavailable"),
+    );
+    const batchWrite = vi.spyOn(store, "upsertThreadUsageLines");
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+
+    try {
+      const usageEmit = emit(buildLiveUsageEvent({
+        inputTokens: 1_000,
+        threadId: "thread-usage-error",
+        turnId: "turn-usage-error",
+      }));
+      const usageRejected = expect(usageEmit).rejects.toThrow(
+        "overlay unavailable",
+      );
+      const terminalEmit = emit(
+        buildTurnCompletedEvent("thread-usage-error", "turn-usage-error"),
+      );
+
+      await Promise.all([
+        usageRejected,
+        expect(terminalEmit).resolves.toBeUndefined(),
+      ]);
+      expect(batchWrite).not.toHaveBeenCalled();
+    } finally {
+      await registry.close();
+    }
+  });
+
   it("flushes coalesced live usage on the bounded timer", async () => {
     vi.useFakeTimers();
     const batchWrite = vi.spyOn(store, "upsertThreadUsageLines");
@@ -493,6 +654,10 @@ function createDeferred(): {
     resolve = promiseResolve;
   });
   return { promise, resolve };
+}
+
+async function waitForAsyncWork(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
 function buildInvocation(invocationId: string) {

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -1,7 +1,11 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { AgentEvent } from "@pwragent/shared";
+import type {
+  AgentEvent,
+  AppServerThreadReplay,
+  ThreadUsageLineRecord,
+} from "@pwragent/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
 import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
@@ -214,6 +218,91 @@ describe("sqlite write metrics", () => {
           turnId: `turn-${turnIndex}`,
         });
       }
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("budgets recurring live usage timer windows", async () => {
+    vi.useFakeTimers({
+      toFake: ["Date", "clearTimeout", "setTimeout"],
+    });
+    const batchWrite = vi.spyOn(store, "upsertThreadUsageLines");
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+
+    try {
+      const { writes } = await measureSqliteWrites(async () => {
+        // Ten consecutive one-second windows, each with a fresh cumulative
+        // observation. Unlike the burst budget, this pins the recurring
+        // commit cadence paid when observations do not share a window.
+        for (let window = 1; window <= 10; window += 1) {
+          await emit(buildLiveUsageEvent({
+            inputTokens: window * 1_000,
+            threadId: "timer-thread",
+            turnId: "timer-turn",
+          }));
+          await vi.advanceTimersByTimeAsync(1_000);
+        }
+      });
+
+      expect(batchWrite).toHaveBeenCalledTimes(10);
+      expectSqliteWriteBudget({
+        note:
+          "10 cumulative live-usage observations separated by full one-second timer windows",
+        scenario: "live-thread-token-usage-timer-windows",
+        writes,
+      });
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes pending live usage before replay hydration supersedes it", async () => {
+    vi.useFakeTimers();
+    const threadId = "thread-hydration-race";
+    const turnId = "turn-hydration-race";
+    const batchWrite = vi.spyOn(store, "upsertThreadUsageLines");
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient({
+        replay: buildHydratedUsageReplay({ threadId, turnId }),
+      }),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+
+    try {
+      await emit(buildLiveUsageEvent({
+        inputTokens: 1_000,
+        threadId,
+        turnId,
+      }));
+      expect(batchWrite).not.toHaveBeenCalled();
+
+      await registry.readThread({ backend: "codex", threadId });
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      const pricing = await store.readThreadPricing({
+        backend: "codex",
+        threadId,
+      });
+      expect(pricing.lines).toHaveLength(1);
+      expect(pricing.lines[0]).toMatchObject({
+        source: "hydration",
+        status: "finalized",
+        turnId,
+        usageLineId: `codex:${threadId}:${turnId}:hydration`,
+      });
+      expect(pricing.summaries[0]?.usageLineCount).toBe(1);
     } finally {
       await registry.close();
       vi.useRealTimers();
@@ -645,6 +734,60 @@ function buildTurnCompletedEvent(threadId: string, turnId: string): AgentEvent {
   } as AgentEvent;
 }
 
+function buildHydratedUsageReplay(params: {
+  threadId: string;
+  turnId: string;
+}): AppServerThreadReplay {
+  const usageLine: ThreadUsageLineRecord = {
+    backend: "codex",
+    cachedInputCostMicros: 0,
+    cachedInputTokens: 1_200,
+    completedAt: 2_000,
+    createdAt: 2_000,
+    currency: "USD",
+    inputTokens: 1_500,
+    model: "gpt-5.5",
+    outputCostMicros: 0,
+    outputTokens: 150,
+    priceStatus: "unpriced",
+    provider: "openai",
+    reasoningOutputTokens: 0,
+    scope: "turn",
+    source: "hydration",
+    sourceItemId: "hydrated-usage",
+    status: "finalized",
+    threadId: params.threadId,
+    totalCostMicros: 0,
+    totalTokens: 1_650,
+    turnId: params.turnId,
+    uncachedInputCostMicros: 0,
+    uncachedInputTokens: 300,
+    usageLineId: `codex:${params.threadId}:${params.turnId}:hydration`,
+  };
+  return {
+    entries: [
+      {
+        type: "activity",
+        id: "hydrated-usage",
+        summary: "Turn usage: hydrated",
+        status: "completed",
+        createdAt: 2_000,
+        details: [],
+        turn: {
+          id: params.turnId,
+          status: "completed",
+        },
+        usageLine,
+      },
+    ],
+    messages: [],
+    pagination: {
+      hasPreviousPage: false,
+      supportsPagination: false,
+    },
+  };
+}
+
 function createDeferred(): {
   promise: Promise<void>;
   resolve: () => void;
@@ -683,11 +826,24 @@ function buildInvocation(invocationId: string) {
   };
 }
 
-function createStubBackendClient() {
+function createStubBackendClient(options?: {
+  replay?: AppServerThreadReplay;
+}) {
   return {
     close: async () => {},
-    getInitializeResult: async () => ({ methods: [] }),
+    getInitializeResult: async () => ({
+      methods: options?.replay ? ["thread/read"] : [],
+    }),
     onNotification: () => () => {},
     onPendingRequest: () => () => {},
+    readThread: async () =>
+      options?.replay ?? {
+        entries: [],
+        messages: [],
+        pagination: {
+          hasPreviousPage: false,
+          supportsPagination: false,
+        },
+      },
   } as never;
 }

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { AgentEvent } from "@pwragent/shared";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
 import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
@@ -165,7 +165,8 @@ describe("sqlite write metrics", () => {
     await registry.close();
   });
 
-  it("holds one live token-usage observation to one commit", async () => {
+  it("holds a burst of live token usage to one commit", async () => {
+    vi.useFakeTimers();
     const registry = new DesktopBackendRegistry({
       codexClient: createStubBackendClient(),
       overlayStore: store as never,
@@ -174,39 +175,225 @@ describe("sqlite write metrics", () => {
       emit(event: AgentEvent): Promise<void>;
     }).emit.bind(registry);
 
-    const { writes } = await measureSqliteWrites(async () => {
-      await emit({
-        backend: "codex",
-        notification: {
-          method: "thread/tokenUsage/updated",
-          params: {
-            threadId: "thread-1",
-            turnId: "turn-1",
-            model: "gpt-5.5",
-            tokenUsage: {
-              total: {
-                inputTokens: 80_000,
-                cachedInputTokens: 72_000,
-                outputTokens: 1_000,
-              },
-              last: {
-                inputTokens: 80_000,
-                cachedInputTokens: 72_000,
-                outputTokens: 1_000,
-              },
-            },
+    try {
+      const { writes } = await measureSqliteWrites(async () => {
+        // Fifty cumulative snapshots for each of ten concurrently active
+        // turns. Only the last snapshot per usageLineId belongs in sqlite.
+        for (let index = 0; index < 500; index += 1) {
+          const turnIndex = index % 10;
+          const observation = Math.floor(index / 10) + 1;
+          const inputTokens = observation * 1_000 + turnIndex;
+          await emit(buildLiveUsageEvent({
+            inputTokens,
+            threadId: `thread-${turnIndex}`,
+            turnId: `turn-${turnIndex}`,
+          }));
+        }
+
+        // A terminal notification is an explicit durability boundary. It
+        // drains every pending turn, not only the terminal event's own turn.
+        await emit(buildTurnCompletedEvent("thread-0", "turn-0"));
+      });
+
+      expectSqliteWriteBudget({
+        note:
+          "500 cumulative usage observations across 10 turns, then one terminal flush",
+        scenario: "live-thread-token-usage",
+        writes,
+      });
+
+      for (let turnIndex = 0; turnIndex < 10; turnIndex += 1) {
+        const pricing = await store.readThreadPricing({
+          backend: "codex",
+          threadId: `thread-${turnIndex}`,
+        });
+        expect(pricing.lines).toHaveLength(1);
+        expect(pricing.lines[0]).toMatchObject({
+          inputTokens: 50_000 + turnIndex,
+          threadId: `thread-${turnIndex}`,
+          turnId: `turn-${turnIndex}`,
+        });
+      }
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes coalesced live usage on the bounded timer", async () => {
+    vi.useFakeTimers();
+    const batchWrite = vi.spyOn(store, "upsertThreadUsageLines");
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+    const pricingEvents: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      if (event.notification.method === "thread/pricing/updated") {
+        pricingEvents.push(event);
+      }
+    });
+
+    try {
+      await emit(buildLiveUsageEvent({
+        inputTokens: 1_000,
+        threadId: "thread-timer",
+        turnId: "turn-timer",
+      }));
+      await emit(buildLiveUsageEvent({
+        inputTokens: 2_000,
+        threadId: "thread-timer",
+        turnId: "turn-timer",
+      }));
+
+      expect(batchWrite).not.toHaveBeenCalled();
+      expect(
+        (await store.readThreadPricing({
+          backend: "codex",
+          threadId: "thread-timer",
+        })).lines,
+      ).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(batchWrite).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(batchWrite).toHaveBeenCalledTimes(1);
+      expect(batchWrite.mock.calls[0]?.[0].lines).toHaveLength(1);
+      expect(batchWrite.mock.calls[0]?.[0].lines[0]).toMatchObject({
+        inputTokens: 2_000,
+        usageLineId: "codex:thread-timer:turn-timer:live-token-usage",
+      });
+      expect(pricingEvents).toHaveLength(1);
+      expect(pricingEvents[0]?.notification).toMatchObject({
+        method: "thread/pricing/updated",
+        params: {
+          pricing: {
+            lines: [expect.objectContaining({ inputTokens: 2_000 })],
           },
+          threadId: "thread-timer",
         },
-      } as AgentEvent);
-    });
+      });
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
 
-    expectSqliteWriteBudget({
-      note: "one completed model request observed through thread token usage",
-      scenario: "live-thread-token-usage",
-      writes,
+  it("retries a failed batch without overwriting a newer observation", async () => {
+    vi.useFakeTimers();
+    const firstWriteStarted = createDeferred();
+    const releaseFirstWrite = createDeferred();
+    const originalBatchWrite = store.upsertThreadUsageLines.bind(store);
+    const batchWrite = vi
+      .spyOn(store, "upsertThreadUsageLines")
+      .mockImplementationOnce(async () => {
+        firstWriteStarted.resolve();
+        await releaseFirstWrite.promise;
+        throw new Error("disk busy");
+      })
+      .mockImplementation(async (params) => await originalBatchWrite(params));
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
     });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+    const flush = (registry as unknown as {
+      flushLiveThreadUsageLines(): Promise<void>;
+    }).flushLiveThreadUsageLines.bind(registry);
 
-    await registry.close();
+    try {
+      await emit(buildLiveUsageEvent({
+        inputTokens: 1_000,
+        threadId: "thread-retry",
+        turnId: "turn-retry",
+      }));
+      const firstFlush = flush();
+      await firstWriteStarted.promise;
+
+      // This newer cumulative snapshot arrives while the older batch is in
+      // flight. Requeueing the failed batch must not put 1,000 back on top.
+      await emit(buildLiveUsageEvent({
+        inputTokens: 2_000,
+        threadId: "thread-retry",
+        turnId: "turn-retry",
+      }));
+      releaseFirstWrite.resolve();
+      await firstFlush;
+      await flush();
+
+      expect(batchWrite).toHaveBeenCalledTimes(2);
+      expect(batchWrite.mock.calls[1]?.[0].lines).toHaveLength(1);
+      expect(batchWrite.mock.calls[1]?.[0].lines[0]).toMatchObject({
+        inputTokens: 2_000,
+      });
+      expect(
+        (await store.readThreadPricing({
+          backend: "codex",
+          threadId: "thread-retry",
+        })).lines[0],
+      ).toMatchObject({ inputTokens: 2_000 });
+    } finally {
+      releaseFirstWrite.resolve();
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes live usage on close and ignores post-close writes", async () => {
+    vi.useFakeTimers();
+    const batchWrite = vi.spyOn(store, "upsertThreadUsageLines");
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient(),
+      overlayStore: store as never,
+    });
+    const emit = (registry as unknown as {
+      emit(event: AgentEvent): Promise<void>;
+    }).emit.bind(registry);
+    let closed = false;
+
+    try {
+      await emit(buildLiveUsageEvent({
+        inputTokens: 1_000,
+        threadId: "thread-close",
+        turnId: "turn-close",
+      }));
+      expect(batchWrite).not.toHaveBeenCalled();
+
+      await registry.close();
+      closed = true;
+      expect(batchWrite).toHaveBeenCalledTimes(1);
+      expect(
+        (await store.readThreadPricing({
+          backend: "codex",
+          threadId: "thread-close",
+        })).lines[0],
+      ).toMatchObject({ inputTokens: 1_000 });
+
+      await emit(buildLiveUsageEvent({
+        inputTokens: 2_000,
+        threadId: "thread-close",
+        turnId: "turn-close",
+      }));
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(batchWrite).toHaveBeenCalledTimes(1);
+      expect(
+        (await store.readThreadPricing({
+          backend: "codex",
+          threadId: "thread-close",
+        })).lines[0],
+      ).toMatchObject({ inputTokens: 1_000 });
+    } finally {
+      if (!closed) {
+        await registry.close();
+      }
+      vi.useRealTimers();
+    }
   });
 
   it("holds an idle hour of heartbeats to its budget", async () => {
@@ -247,6 +434,66 @@ describe("sqlite write metrics", () => {
     });
   });
 });
+
+function buildLiveUsageEvent(params: {
+  inputTokens: number;
+  threadId: string;
+  turnId: string;
+}): AgentEvent {
+  const cachedInputTokens = Math.max(0, params.inputTokens - 100);
+  return {
+    backend: "codex",
+    notification: {
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: params.threadId,
+        turnId: params.turnId,
+        model: "gpt-5.5",
+        tokenUsage: {
+          total: {
+            inputTokens: params.inputTokens,
+            cachedInputTokens,
+            outputTokens: 100,
+          },
+          last: {
+            inputTokens: params.inputTokens,
+            cachedInputTokens,
+            outputTokens: 100,
+          },
+        },
+      },
+    },
+  } as AgentEvent;
+}
+
+function buildTurnCompletedEvent(threadId: string, turnId: string): AgentEvent {
+  return {
+    backend: "codex",
+    notification: {
+      method: "turn/completed",
+      params: {
+        threadId,
+        turnId,
+        turn: {
+          id: turnId,
+          status: "completed",
+          output: [],
+        },
+      },
+    },
+  } as AgentEvent;
+}
+
+function createDeferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
 
 function buildInvocation(invocationId: string) {
   return {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6287,6 +6287,7 @@ type BackendRegistryOverlayStoreLike = OverlayStoreLike & Partial<
   Pick<
     SqliteOverlayStore,
     | "readThreadGitWorkingStateCache"
+    | "upsertThreadUsageLines"
     | "writeThreadGitWorkingStateCacheEntry"
   >
 >;
@@ -6318,6 +6319,21 @@ const CODEX_INVALID_ID_RECOVERY_COOLDOWN_MS = 5 * 60 * 1000;
 // write per 250ms window (~110 deltas) drops that to under ~12ms/s and takes
 // it off the hot path entirely.
 const TOOL_INVOCATION_DELTA_FLUSH_INTERVAL_MS = 250;
+
+// Token-usage updates are cumulative snapshots, so repeated observations for
+// one turn replace each other in memory. The write budget measures ~64 KiB of
+// WAL for a ten-turn batch: at this one-second ceiling, a pathological nonstop
+// stream is capped near 225 MiB/hour instead of ~900 MiB/hour at 250ms. In
+// practice app-server emits usage at model-request boundaries, not per token,
+// and turn terminals flush immediately; one second keeps pricing UI responsive
+// while allowing concurrent turns to share one sqlite transaction.
+const LIVE_THREAD_USAGE_FLUSH_INTERVAL_MS = 1_000;
+
+type PendingLiveThreadUsageLine = {
+  backend: AppServerBackendKind;
+  line: ThreadUsageLineRecord;
+  observationSequence: number;
+};
 
 function isCodexInvalidIdRecoveryCooldownActive(
   attemptedAt: number,
@@ -6532,6 +6548,22 @@ export class DesktopBackendRegistry {
     string,
     ObservedContextReplayCursor
   >();
+  /**
+   * Cumulative live usage waiting for one bulk sqlite transaction. The
+   * observation sequence preserves event arrival order even if an older
+   * event's overlay lookup resolves after a newer event's lookup.
+   */
+  private readonly pendingLiveThreadUsageLines = new Map<
+    string,
+    PendingLiveThreadUsageLine
+  >();
+  private liveThreadUsageObservationSequence = 0;
+  private pendingLiveThreadUsageTimer: NodeJS.Timeout | undefined;
+  /**
+   * Serializes timer, terminal, retry, and shutdown drains. A caller awaiting
+   * a flush therefore also waits for any batch that was already in flight.
+   */
+  private liveThreadUsageFlushChain: Promise<void> = Promise.resolve();
   private readonly taskMonitorDelegations = new Map<
     string,
     TaskMonitorDelegationRecord
@@ -16853,6 +16885,10 @@ export class DesktopBackendRegistry {
     if (this.taskMonitorWatchdogTimer) {
       clearInterval(this.taskMonitorWatchdogTimer);
     }
+    // Live usage and command output may each have one bounded window sitting
+    // in memory. `closed` prevents either drain from re-arming its timer; the
+    // serialized flush chains ensure no write survives close().
+    await this.flushLiveThreadUsageLines();
     // A command streaming at quit time has accounting worth up to one flush
     // window sitting in memory; write it before the store goes away. The flush
     // owns the timer, and `closed` above stops anything re-arming it.
@@ -19343,11 +19379,19 @@ export class DesktopBackendRegistry {
     );
   }
 
-  private async recordLiveThreadUsage(event: AgentEvent): Promise<void> {
+  private async recordLiveThreadUsage(
+    event: AgentEvent,
+    observationSequence?: number,
+  ): Promise<void> {
     const notification = event.notification;
     if (notification.method !== "thread/tokenUsage/updated") {
       return;
     }
+    if (this.closed) {
+      return;
+    }
+    const resolvedObservationSequence =
+      observationSequence ?? ++this.liveThreadUsageObservationSequence;
     const threadId = notification.params.threadId;
     if (!threadId) {
       return;
@@ -19436,9 +19480,17 @@ export class DesktopBackendRegistry {
     }
     if (typeof this.overlayStore.upsertThreadUsageLine === "function") {
       logUnpricedThreadUsageLine(line);
-      await this.overlayStore.upsertThreadUsageLine({ line });
+      const batchesLiveUsage =
+        typeof this.overlayStore.upsertThreadUsageLines === "function";
+      if (!batchesLiveUsage) {
+        if (this.closed) {
+          return;
+        }
+        await this.overlayStore.upsertThreadUsageLine({ line });
+      }
       // Best-effort: a failure here must never block the load-bearing pricing
-      // push below (the turn line is already persisted).
+      // write/notification path. The bulk path prepares the rare fork baseline
+      // before arming its timer, so the later pricing event includes both.
       try {
         await this.captureForkBaselineUsageLine({
           backend: event.backend,
@@ -19458,11 +19510,143 @@ export class DesktopBackendRegistry {
           error: error instanceof Error ? error.message : String(error),
         });
       }
+      if (batchesLiveUsage) {
+        this.bufferLiveThreadUsageLine({
+          backend: event.backend,
+          line,
+          observationSequence: resolvedObservationSequence,
+        });
+        return;
+      }
       await this.emitThreadPricingUpdated({
         backend: event.backend,
         threadId: line.parentThreadId ?? line.threadId,
       });
     }
+  }
+
+  private bufferLiveThreadUsageLine(
+    pending: PendingLiveThreadUsageLine,
+  ): void {
+    if (this.closed) {
+      return;
+    }
+    const existing = this.pendingLiveThreadUsageLines.get(
+      pending.line.usageLineId,
+    );
+    if (
+      !existing
+      || pending.observationSequence > existing.observationSequence
+    ) {
+      this.pendingLiveThreadUsageLines.set(
+        pending.line.usageLineId,
+        pending,
+      );
+    }
+    this.scheduleLiveThreadUsageFlush();
+  }
+
+  private scheduleLiveThreadUsageFlush(): void {
+    if (this.pendingLiveThreadUsageTimer || this.closed) {
+      return;
+    }
+    this.pendingLiveThreadUsageTimer = setTimeout(() => {
+      this.pendingLiveThreadUsageTimer = undefined;
+      void this.flushLiveThreadUsageLines();
+    }, LIVE_THREAD_USAGE_FLUSH_INTERVAL_MS);
+    this.pendingLiveThreadUsageTimer.unref?.();
+  }
+
+  private flushLiveThreadUsageLines(): Promise<void> {
+    const flushed = this.liveThreadUsageFlushChain.then(() =>
+      this.writePendingLiveThreadUsageLines(),
+    );
+    this.liveThreadUsageFlushChain = flushed.catch(() => undefined);
+    return flushed;
+  }
+
+  private async writePendingLiveThreadUsageLines(): Promise<void> {
+    if (this.pendingLiveThreadUsageTimer) {
+      clearTimeout(this.pendingLiveThreadUsageTimer);
+      this.pendingLiveThreadUsageTimer = undefined;
+    }
+    if (
+      this.pendingLiveThreadUsageLines.size === 0
+      || typeof this.overlayStore.upsertThreadUsageLines !== "function"
+    ) {
+      return;
+    }
+
+    const pending = [...this.pendingLiveThreadUsageLines.values()];
+    this.pendingLiveThreadUsageLines.clear();
+    try {
+      await this.overlayStore.upsertThreadUsageLines({
+        lines: pending.map((entry) => entry.line),
+      });
+    } catch (error) {
+      for (const entry of pending) {
+        this.requeueFailedLiveThreadUsageLine(entry);
+      }
+      backendRegistryLog.warn("live thread usage batch write failed", {
+        error: error instanceof Error ? error.message : String(error),
+        lineCount: pending.length,
+        usageLineIds: pending
+          .slice(0, 10)
+          .map((entry) => entry.line.usageLineId),
+      });
+      return;
+    }
+
+    const pricingTargets = new Map<
+      string,
+      { backend: AppServerBackendKind; threadId: string }
+    >();
+    for (const { backend, line } of pending) {
+      const target = {
+        backend,
+        threadId: line.parentThreadId ?? line.threadId,
+      };
+      pricingTargets.set(
+        JSON.stringify([target.backend, target.threadId]),
+        target,
+      );
+    }
+    for (const target of pricingTargets.values()) {
+      try {
+        // The notification embeds a fresh store read, so observers can never
+        // receive pricing for a usage line that has not committed yet.
+        await this.emitThreadPricingUpdated(target);
+      } catch (error) {
+        backendRegistryLog.warn("live thread pricing update failed", {
+          backend: target.backend,
+          error: error instanceof Error ? error.message : String(error),
+          threadId: target.threadId,
+        });
+      }
+    }
+  }
+
+  private requeueFailedLiveThreadUsageLine(
+    pending: PendingLiveThreadUsageLine,
+  ): void {
+    if (this.closed) {
+      // Shutdown already made its one durability attempt. Re-arming here would
+      // let a timer write against a store after the registry has closed.
+      return;
+    }
+    const newer = this.pendingLiveThreadUsageLines.get(
+      pending.line.usageLineId,
+    );
+    if (
+      !newer
+      || pending.observationSequence > newer.observationSequence
+    ) {
+      this.pendingLiveThreadUsageLines.set(
+        pending.line.usageLineId,
+        pending,
+      );
+    }
+    this.scheduleLiveThreadUsageFlush();
   }
 
   /**
@@ -28241,6 +28425,10 @@ export class DesktopBackendRegistry {
   }
 
   private async emit(event: AgentEvent): Promise<void> {
+    const liveThreadUsageObservationSequence =
+      event.notification.method === "thread/tokenUsage/updated"
+        ? ++this.liveThreadUsageObservationSequence
+        : undefined;
     await this.forwardManagedReviewActivity(event);
     event = await this.withThreadMessageContext(event);
     this.rememberFileChangeApprovalContext(event);
@@ -28336,6 +28524,10 @@ export class DesktopBackendRegistry {
       event.notification.method === "turn/failed" ||
       event.notification.method === "turn/cancelled"
     ) {
+      // A terminal event is the turn's explicit durability boundary. Flush all
+      // coalesced turns in one transaction before terminal state reaches any
+      // listener, even when several turns were active concurrently.
+      await this.flushLiveThreadUsageLines();
       const notification = event.notification as {
         params: {
           threadId: string;
@@ -28695,7 +28887,10 @@ export class DesktopBackendRegistry {
       }
     }
 
-    await this.recordLiveThreadUsage(event);
+    await this.recordLiveThreadUsage(
+      event,
+      liveThreadUsageObservationSequence,
+    );
     await this.recordToolInvocationAccounting(event);
     this.forgetCompletedTurnReplayObservations(event);
     await this.recordCodexNativeSubAgentActivity(event);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6336,9 +6336,11 @@ type PendingLiveThreadUsageLine = {
 };
 
 type LiveThreadUsageEmitWork = {
+  backend: AppServerBackendKind;
   observationSequence: number;
   settled: Promise<void>;
   settle: () => void;
+  threadId: string;
 };
 
 function isCodexInvalidIdRecoveryCooldownActive(
@@ -10354,6 +10356,17 @@ export class DesktopBackendRegistry {
       messageOrigins,
     );
     if (!request.viewOnly && !request.before && shouldAppendTranscriptOverlays) {
+      // Hydration supersedes live rows for the same turn in sqlite. Preserve
+      // that ordering now that live observations are delayed in memory: first
+      // let every already-arrived usage emit derive and buffer its row, then
+      // flush the batch before hydration marks those rows superseded. Without
+      // this boundary, the delayed live insert lands afterward and both rows
+      // remain active in pricing.
+      await this.waitForLiveThreadUsageEmitWork({
+        backend,
+        threadId: request.threadId,
+      });
+      await this.flushLiveThreadUsageLines();
       await this.persistReplayUsageLines(replayWithEnvironment);
     }
     const pricing =
@@ -19397,15 +19410,20 @@ export class DesktopBackendRegistry {
     );
   }
 
-  private registerLiveThreadUsageEmitWork(): LiveThreadUsageEmitWork {
+  private registerLiveThreadUsageEmitWork(
+    backend: AppServerBackendKind,
+    threadId: string,
+  ): LiveThreadUsageEmitWork {
     let settle!: () => void;
     const settled = new Promise<void>((resolve) => {
       settle = resolve;
     });
     const work = {
+      backend,
       observationSequence: ++this.liveThreadUsageObservationSequence,
       settled,
       settle,
+      threadId,
     };
     this.liveThreadUsageEmitWork.add(work);
     return work;
@@ -19420,11 +19438,17 @@ export class DesktopBackendRegistry {
     work.settle();
   }
 
-  private async waitForLiveThreadUsageEmitWork(): Promise<void> {
-    const pending = Array.from(
-      this.liveThreadUsageEmitWork,
-      (work) => work.settled,
-    );
+  private async waitForLiveThreadUsageEmitWork(params?: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<void> {
+    const pending = [...this.liveThreadUsageEmitWork]
+      .filter(
+        (work) =>
+          !params
+          || (work.backend === params.backend && work.threadId === params.threadId),
+      )
+      .map((work) => work.settled);
     await Promise.all(pending);
   }
 
@@ -28471,9 +28495,13 @@ export class DesktopBackendRegistry {
     if (isLiveThreadUsage && this.closed) {
       return Promise.resolve();
     }
-    const liveThreadUsageWork = isLiveThreadUsage
-      ? this.registerLiveThreadUsageEmitWork()
-      : undefined;
+    const liveThreadUsageWork =
+      event.notification.method === "thread/tokenUsage/updated"
+        ? this.registerLiveThreadUsageEmitWork(
+            event.backend,
+            event.notification.params.threadId,
+          )
+        : undefined;
     const method = event.notification.method;
     const precedingLiveThreadUsageBarrier =
       method === "turn/completed"

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6335,6 +6335,12 @@ type PendingLiveThreadUsageLine = {
   observationSequence: number;
 };
 
+type LiveThreadUsageEmitWork = {
+  observationSequence: number;
+  settled: Promise<void>;
+  settle: () => void;
+};
+
 function isCodexInvalidIdRecoveryCooldownActive(
   attemptedAt: number,
   now: number,
@@ -6558,6 +6564,12 @@ export class DesktopBackendRegistry {
     PendingLiveThreadUsageLine
   >();
   private liveThreadUsageObservationSequence = 0;
+  /**
+   * Usage notifications overlap at the JSON-RPC transport. Register each one
+   * before `emit` first yields so a later terminal event or close can capture
+   * an exact arrival-ordered durability barrier.
+   */
+  private readonly liveThreadUsageEmitWork = new Set<LiveThreadUsageEmitWork>();
   private pendingLiveThreadUsageTimer: NodeJS.Timeout | undefined;
   /**
    * Serializes timer, terminal, retry, and shutdown drains. A caller awaiting
@@ -16877,6 +16889,11 @@ export class DesktopBackendRegistry {
 
   async close(): Promise<void> {
     this.closed = true;
+    // `closed` rejects observations that enter from this point forward. The
+    // snapshot was registered synchronously at each earlier usage emit's
+    // entry, so waiting it cannot miss work still deriving its sqlite row.
+    const liveThreadUsageEmitBarrier =
+      this.waitForLiveThreadUsageEmitWork();
     this.acceptedSteerRequests.clear();
     this.acceptedThreadControlRequests.clear();
     this.acceptedActiveTurnControlRequests.clear();
@@ -16888,6 +16905,7 @@ export class DesktopBackendRegistry {
     // Live usage and command output may each have one bounded window sitting
     // in memory. `closed` prevents either drain from re-arming its timer; the
     // serialized flush chains ensure no write survives close().
+    await liveThreadUsageEmitBarrier;
     await this.flushLiveThreadUsageLines();
     // A command streaming at quit time has accounting worth up to one flush
     // window sitting in memory; write it before the store goes away. The flush
@@ -19379,19 +19397,48 @@ export class DesktopBackendRegistry {
     );
   }
 
+  private registerLiveThreadUsageEmitWork(): LiveThreadUsageEmitWork {
+    let settle!: () => void;
+    const settled = new Promise<void>((resolve) => {
+      settle = resolve;
+    });
+    const work = {
+      observationSequence: ++this.liveThreadUsageObservationSequence,
+      settled,
+      settle,
+    };
+    this.liveThreadUsageEmitWork.add(work);
+    return work;
+  }
+
+  private finishLiveThreadUsageEmitWork(
+    work: LiveThreadUsageEmitWork,
+  ): void {
+    if (!this.liveThreadUsageEmitWork.delete(work)) {
+      return;
+    }
+    work.settle();
+  }
+
+  private async waitForLiveThreadUsageEmitWork(): Promise<void> {
+    const pending = Array.from(
+      this.liveThreadUsageEmitWork,
+      (work) => work.settled,
+    );
+    await Promise.all(pending);
+  }
+
   private async recordLiveThreadUsage(
     event: AgentEvent,
     observationSequence?: number,
   ): Promise<void> {
     const notification = event.notification;
-    if (notification.method !== "thread/tokenUsage/updated") {
+    if (
+      notification.method !== "thread/tokenUsage/updated"
+      || observationSequence === undefined
+    ) {
       return;
     }
-    if (this.closed) {
-      return;
-    }
-    const resolvedObservationSequence =
-      observationSequence ?? ++this.liveThreadUsageObservationSequence;
     const threadId = notification.params.threadId;
     if (!threadId) {
       return;
@@ -19483,9 +19530,6 @@ export class DesktopBackendRegistry {
       const batchesLiveUsage =
         typeof this.overlayStore.upsertThreadUsageLines === "function";
       if (!batchesLiveUsage) {
-        if (this.closed) {
-          return;
-        }
         await this.overlayStore.upsertThreadUsageLine({ line });
       }
       // Best-effort: a failure here must never block the load-bearing pricing
@@ -19514,7 +19558,7 @@ export class DesktopBackendRegistry {
         this.bufferLiveThreadUsageLine({
           backend: event.backend,
           line,
-          observationSequence: resolvedObservationSequence,
+          observationSequence,
         });
         return;
       }
@@ -19528,9 +19572,6 @@ export class DesktopBackendRegistry {
   private bufferLiveThreadUsageLine(
     pending: PendingLiveThreadUsageLine,
   ): void {
-    if (this.closed) {
-      return;
-    }
     const existing = this.pendingLiveThreadUsageLines.get(
       pending.line.usageLineId,
     );
@@ -28424,11 +28465,42 @@ export class DesktopBackendRegistry {
     } as AgentEvent);
   }
 
-  private async emit(event: AgentEvent): Promise<void> {
-    const liveThreadUsageObservationSequence =
-      event.notification.method === "thread/tokenUsage/updated"
-        ? ++this.liveThreadUsageObservationSequence
+  private emit(event: AgentEvent): Promise<void> {
+    const isLiveThreadUsage =
+      event.notification.method === "thread/tokenUsage/updated";
+    if (isLiveThreadUsage && this.closed) {
+      return Promise.resolve();
+    }
+    const liveThreadUsageWork = isLiveThreadUsage
+      ? this.registerLiveThreadUsageEmitWork()
+      : undefined;
+    const method = event.notification.method;
+    const precedingLiveThreadUsageBarrier =
+      method === "turn/completed"
+      || method === "turn/failed"
+      || method === "turn/cancelled"
+        ? this.waitForLiveThreadUsageEmitWork()
         : undefined;
+    const emitted = this.emitAfterLiveThreadUsageRegistration(
+      event,
+      liveThreadUsageWork,
+      precedingLiveThreadUsageBarrier,
+    );
+    return liveThreadUsageWork
+      ? emitted.finally(() => {
+          // Earlier pipeline stages may reject before usage derivation. Always
+          // release the terminal/close barrier; the successful path finishes
+          // before listener fan-out to avoid a listener-driven close deadlock.
+          this.finishLiveThreadUsageEmitWork(liveThreadUsageWork);
+        })
+      : emitted;
+  }
+
+  private async emitAfterLiveThreadUsageRegistration(
+    event: AgentEvent,
+    liveThreadUsageWork: LiveThreadUsageEmitWork | undefined,
+    precedingLiveThreadUsageBarrier: Promise<void> | undefined,
+  ): Promise<void> {
     await this.forwardManagedReviewActivity(event);
     event = await this.withThreadMessageContext(event);
     this.rememberFileChangeApprovalContext(event);
@@ -28527,6 +28599,7 @@ export class DesktopBackendRegistry {
       // A terminal event is the turn's explicit durability boundary. Flush all
       // coalesced turns in one transaction before terminal state reaches any
       // listener, even when several turns were active concurrently.
+      await precedingLiveThreadUsageBarrier;
       await this.flushLiveThreadUsageLines();
       const notification = event.notification as {
         params: {
@@ -28889,7 +28962,7 @@ export class DesktopBackendRegistry {
 
     await this.recordLiveThreadUsage(
       event,
-      liveThreadUsageObservationSequence,
+      liveThreadUsageWork?.observationSequence,
     );
     await this.recordToolInvocationAccounting(event);
     this.forgetCompletedTurnReplayObservations(event);
@@ -28902,6 +28975,9 @@ export class DesktopBackendRegistry {
     this.notifyForAttentionRequired(event);
     await this.notifyForTerminalOutcome(event);
 
+    if (liveThreadUsageWork) {
+      this.finishLiveThreadUsageEmitWork(liveThreadUsageWork);
+    }
     await this.emitToListeners(event);
   }
 

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1000,9 +1000,82 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
   async upsertThreadUsageLine(params: {
     line: ThreadUsageLineRecord;
   }): Promise<{ line: ThreadUsageLineRecord; summary: ThreadPricingSummary }> {
+    const { lines, summaries } = await this.upsertThreadUsageLines({
+      lines: [params.line],
+    });
+    const line = lines[0];
+    if (!line) {
+      throw new Error("Thread usage line batch did not persist its input");
+    }
+    const summary = summaries.find(
+      (candidate) =>
+        candidate.backend === line.backend
+        && candidate.currency === line.currency
+        && candidate.provider === line.provider
+        && candidate.threadId === (line.parentThreadId ?? line.threadId),
+    );
+    if (!summary) {
+      throw new Error(
+        `Thread usage line ${line.usageLineId} did not produce a pricing summary`,
+      );
+    }
+    return { line, summary };
+  }
+
+  /**
+   * Persist the latest value for every distinct usage line under one sqlite
+   * transaction. Callers may pass repeated ids; later entries win before any
+   * statement runs, and affected pricing summaries are recomputed once each.
+   */
+  async upsertThreadUsageLines(params: {
+    lines: ThreadUsageLineRecord[];
+  }): Promise<{
+    lines: ThreadUsageLineRecord[];
+    summaries: ThreadPricingSummary[];
+  }> {
+    const latestLinesById = new Map<string, ThreadUsageLineRecord>();
+    for (const line of params.lines) {
+      latestLinesById.set(line.usageLineId, line);
+    }
+    if (latestLinesById.size === 0) {
+      return { lines: [], summaries: [] };
+    }
+
     const now = Date.now();
-    let line = repriceTokenUsageLine(normalizeThreadUsageLine(params.line, now));
-    const upsert = this.stateDb.raw.transaction(() => {
+    const lines = [...latestLinesById.values()].map((line) =>
+      repriceTokenUsageLine(normalizeThreadUsageLine(line, now)),
+    );
+    const summaryTargets = new Map<
+      string,
+      {
+        backend: string;
+        currency: string;
+        provider: string;
+        threadId: string;
+        updatedAt: number;
+      }
+    >();
+    const queueSummary = (target: {
+      backend: string;
+      currency: string;
+      provider: string;
+      threadId: string;
+      updatedAt: number;
+    }): void => {
+      summaryTargets.set(
+        JSON.stringify([
+          target.provider,
+          target.backend,
+          target.threadId,
+          target.currency,
+        ]),
+        target,
+      );
+    };
+    const upsertLine = (
+      inputLine: ThreadUsageLineRecord,
+    ): ThreadUsageLineRecord => {
+      let line = inputLine;
       const existing = this.readThreadUsageLineSync(line.usageLineId);
       if (existing) {
         line = mergeThreadUsageLineForUpsert(line, existing);
@@ -1280,7 +1353,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           existingRollupThreadId !== nextRollupThreadId ||
           existing.currency !== line.currency
         ) {
-          this.recomputeThreadPricingSummarySync({
+          queueSummary({
             backend: existing.backend,
             currency: existing.currency,
             provider: existing.provider,
@@ -1290,16 +1363,27 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
         }
       }
 
-      return this.recomputeThreadPricingSummarySync({
+      queueSummary({
         backend: line.backend,
         currency: line.currency,
         provider: line.provider,
         threadId: line.parentThreadId ?? line.threadId,
         updatedAt: now,
       });
+      return line;
+    };
+
+    const upsert = this.stateDb.raw.transaction(() => {
+      for (let index = 0; index < lines.length; index += 1) {
+        lines[index] = upsertLine(lines[index]!);
+      }
+
+      return [...summaryTargets.values()].map((target) =>
+        this.recomputeThreadPricingSummarySync(target),
+      );
     });
 
-    return { line, summary: upsert() };
+    return { lines, summaries: upsert() };
   }
 
   async readThreadPricing(params: {


### PR DESCRIPTION
## Summary

- coalesce cumulative live token-usage observations by `usageLineId`, retaining only the newest observation for each active turn
- flush all pending usage rows through one SQLite transaction on a bounded one-second window, turn-terminal boundaries, full replay hydration, and registry shutdown
- serialize flushes and safely requeue failed batches without allowing older observations to overwrite newer ones
- order terminal, hydration, and shutdown durability barriers around concurrently processed notifications
- replace the one-observation write budget with both burst and recurring-timer stress scenarios

## Root cause

Every `thread/tokenUsage/updated` notification called the single-row usage upsert, and that method opened its own transaction. Each observation therefore committed updates to `thread_usage_turns`, `thread_usage_lines`, and `thread_pricing_summaries` separately.

The app-server transport also processes notifications concurrently. A naive delayed flush could let a terminal event or shutdown overtake an earlier usage notification that was still resolving its overlay state. The registry now registers accepted usage work synchronously at `emit` entry, waits for the exact preceding work set at durability boundaries, and rejects only observations that arrive after close begins.

Full `readThread` hydration also has ordering semantics: hydration rows supersede live rows for the same turn. Full hydration now waits for already-arrived usage work for that backend/thread and flushes it before persisting replay usage, preventing a delayed live row from becoming active after hydration.

## Write budgets and impact

The burst budget drives 500 cumulative observations across 10 turns, then crosses a terminal durability boundary:

- **1 SQLite commit**
- **30 write statements / 30 affected rows**
- **65,920 bytes of observed WAL growth**

The prior implementation scaled directly to 500 commits for that burst.

The recurring budget drives 10 observations separated by complete one-second timer windows:

- **10 SQLite commits**
- **30 write statements / 30 affected rows**
- **547,960 bytes of observed WAL growth**

That is 54,796 observed WAL bytes per timer commit. At the pathological global ceiling of one fresh observation every second, it projects to 197,265,600 bytes/hour, approximately 188 MiB/hour or 4.4 GiB/day. Real updates occur at model-request boundaries, repeated observations for one turn collapse in memory, and terminal events flush immediately. The checked budget makes any future timer-cadence change reviewable.

Pricing notifications are emitted only after successful persistence. Pre-close observations are drained before shutdown returns, while post-close observations are ignored.

This is a follow-up to the logging fix merged in #1415.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts` — 14/14 passed
- combined SQLite/pricing focused run — 39/39 passed
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` — 498/498 passed
- targeted hydration/timer review regressions — 2/2 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors (existing warning baseline only)
- `pnpm lint:sql`
- `pnpm lint:boundaries`
- `git diff --check`
