### PR TITLE
test(desktop): prune redundant main-process tests G-Z

### DIFF
--- a/apps/desktop/scripts/dev.test.mjs
+++ b/apps/desktop/scripts/dev.test.mjs
@@ -165,32 +165,26 @@ describe("dev launch wrapper", () => {
     expect(child.killCalls).toEqual(["SIGTERM"]);
   });
 
-  it("preserves nonzero status when the child exits by signal independently", async () => {
+  it.each([
+    ["signal", 6161, "SIGTERM", 143],
+    ["hangup", 6162, "SIGHUP", 129],
+  ])("preserves nonzero status when the child exits by %s independently", async (
+    _name,
+    pid,
+    signal,
+    exitStatus,
+  ) => {
     const fakeProcess = createFakeProcess();
-    const child = createFakeChild(6161);
+    const child = createFakeChild(pid);
     const promise = runLongLived("node", ["electron-vite", "dev"], {}, {
       platform: "darwin",
       process: fakeProcess,
       spawn: () => child
     });
 
-    child.emit("close", null, "SIGTERM");
+    child.emit("close", null, signal);
 
-    await expect(promise).resolves.toBe(143);
-  });
-
-  it("preserves nonzero status when the child exits by hangup independently", async () => {
-    const fakeProcess = createFakeProcess();
-    const child = createFakeChild(6162);
-    const promise = runLongLived("node", ["electron-vite", "dev"], {}, {
-      platform: "darwin",
-      process: fakeProcess,
-      spawn: () => child
-    });
-
-    child.emit("close", null, "SIGHUP");
-
-    await expect(promise).resolves.toBe(129);
+    await expect(promise).resolves.toBe(exitStatus);
   });
 
   it("forces the long-lived dev child down on a repeated terminal signal", async () => {

--- a/apps/desktop/src/main/__tests__/git-remote.test.ts
+++ b/apps/desktop/src/main/__tests__/git-remote.test.ts
@@ -24,34 +24,30 @@ describe("parseGitHubRemote", () => {
     });
   });
 
-  it("preserves owner/repo casing, since GitHub keys are case-preserving", () => {
-    expect(parseGitHubRemote("git@github.com:PwrDrvr/PwrAgent.git")).toEqual({
-      host: "github.com",
-      owner: "PwrDrvr",
-      repo: "PwrAgent",
-    });
-  });
-
-  it("parses scp-style SSH aliases without an explicit user", () => {
-    expect(parseGitHubRemote("github-work:pwrdrvr/PwrAgent.git")).toEqual({
-      host: "github-work",
-      owner: "pwrdrvr",
-      repo: "PwrAgent",
-    });
+  it.each([
+    [
+      "preserves owner/repo casing, since GitHub keys are case-preserving",
+      "git@github.com:PwrDrvr/PwrAgent.git",
+      { host: "github.com", owner: "PwrDrvr", repo: "PwrAgent" },
+    ],
+    [
+      "parses scp-style SSH aliases without an explicit user",
+      "github-work:pwrdrvr/PwrAgent.git",
+      { host: "github-work", owner: "pwrdrvr", repo: "PwrAgent" },
+    ],
+    [
+      "reports non-github hosts so the caller can skip them",
+      "git@gitlab.com:group/proj.git",
+      { host: "gitlab.com", owner: "group", repo: "proj" },
+    ],
+  ])("%s", (_name, remote, expected) => {
+    expect(parseGitHubRemote(remote)).toEqual(expected);
   });
 
   it("strips embedded credentials and keeps the host", () => {
     expect(
       parseGitHubRemote("https://user:token@github.com/pwrdrvr/PwrAgent.git"),
     ).toEqual({ host: "github.com", owner: "pwrdrvr", repo: "PwrAgent" });
-  });
-
-  it("reports non-github hosts so the caller can skip them", () => {
-    expect(parseGitHubRemote("git@gitlab.com:group/proj.git")).toEqual({
-      host: "gitlab.com",
-      owner: "group",
-      repo: "proj",
-    });
   });
 
   it("rejects remotes that are not a repo root", () => {

--- a/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
@@ -169,7 +169,38 @@ describe("derive PR states", () => {
     expect(deriveChipState(row)).toBe("passing");
   });
 
-  it("returns passing when all checks SUCCEEDED", () => {
+  it.each([
+    {
+      name: "returns passing when all checks SUCCEEDED",
+      firstName: "Lint",
+      firstStatus: "COMPLETED",
+      secondConclusion: "SUCCESS",
+      secondName: "Test",
+      secondStatus: "COMPLETED",
+    },
+    {
+      name: "returns passing when checks include SKIPPED / NEUTRAL",
+      firstName: "Lint",
+      firstStatus: "COMPLETED",
+      secondConclusion: "SKIPPED",
+      secondName: "Optional",
+      secondStatus: "COMPLETED",
+    },
+    {
+      name: "treats a successful conclusion as final even when gh reports stale progress status",
+      firstName: "Install Dependencies",
+      firstStatus: "IN_PROGRESS",
+      secondConclusion: "SUCCESS",
+      secondName: "Test",
+      secondStatus: "COMPLETED",
+    },
+  ] as const)("$name", ({
+    firstName,
+    firstStatus,
+    secondConclusion,
+    secondName,
+    secondStatus,
+  }) => {
     expect(
       deriveChipState({
         ...rawMergedPr(),
@@ -178,60 +209,14 @@ describe("derive PR states", () => {
           {
             __typename: "CheckRun",
             conclusion: "SUCCESS",
-            status: "COMPLETED",
-            name: "Lint",
+            status: firstStatus,
+            name: firstName,
           },
           {
             __typename: "CheckRun",
-            conclusion: "SUCCESS",
-            status: "COMPLETED",
-            name: "Test",
-          },
-        ],
-      }),
-    ).toBe("passing");
-  });
-
-  it("returns passing when checks include SKIPPED / NEUTRAL", () => {
-    expect(
-      deriveChipState({
-        ...rawMergedPr(),
-        state: "OPEN",
-        statusCheckRollup: [
-          {
-            __typename: "CheckRun",
-            conclusion: "SUCCESS",
-            status: "COMPLETED",
-            name: "Lint",
-          },
-          {
-            __typename: "CheckRun",
-            conclusion: "SKIPPED",
-            status: "COMPLETED",
-            name: "Optional",
-          },
-        ],
-      }),
-    ).toBe("passing");
-  });
-
-  it("treats a successful conclusion as final even when gh reports stale progress status", () => {
-    expect(
-      deriveChipState({
-        ...rawMergedPr(),
-        state: "OPEN",
-        statusCheckRollup: [
-          {
-            __typename: "CheckRun",
-            conclusion: "SUCCESS",
-            status: "IN_PROGRESS",
-            name: "Install Dependencies",
-          },
-          {
-            __typename: "CheckRun",
-            conclusion: "SUCCESS",
-            status: "COMPLETED",
-            name: "Test",
+            conclusion: secondConclusion,
+            status: secondStatus,
+            name: secondName,
           },
         ],
       }),

--- a/apps/desktop/src/main/__tests__/image-normalization-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/image-normalization-ipc.test.ts
@@ -129,44 +129,39 @@ describe("image normalization ipc", () => {
     expect(execFile).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects HEIC conversion without macOS fallback support", async () => {
+  it.each([
+    {
+      name: "rejects HEIC conversion without macOS fallback support",
+      fileName: "photo.heic",
+      mimeType: "image/heic",
+      platform: "linux" as const,
+      expectedError: "HEIC/HEIF conversion is only available on macOS",
+    },
+    {
+      name: "rejects non-HEIC fallback requests",
+      fileName: "photo.webp",
+      mimeType: "image/webp",
+      platform: "darwin" as const,
+      expectedError: "only supports HEIC/HEIF",
+    },
+  ])("$name", async ({ fileName, mimeType, platform, expectedError }) => {
     const { convertImageUploadFallback } = await import("../ipc/image-normalization");
 
     await expect(
       convertImageUploadFallback(
         {
           data: new Uint8Array([1]).buffer,
-          fileName: "photo.heic",
-          mimeType: "image/heic",
+          fileName,
+          mimeType,
         },
         {
           createImageFromBuffer: () =>
             fakeNativeImage({ empty: true }) as Electron.NativeImage,
           execFile: vi.fn(),
-          platform: "linux",
+          platform,
         },
       ),
-    ).rejects.toThrow("HEIC/HEIF conversion is only available on macOS");
-  });
-
-  it("rejects non-HEIC fallback requests", async () => {
-    const { convertImageUploadFallback } = await import("../ipc/image-normalization");
-
-    await expect(
-      convertImageUploadFallback(
-        {
-          data: new Uint8Array([1]).buffer,
-          fileName: "photo.webp",
-          mimeType: "image/webp",
-        },
-        {
-          createImageFromBuffer: () =>
-            fakeNativeImage({ empty: true }) as Electron.NativeImage,
-          execFile: vi.fn(),
-          platform: "darwin",
-        },
-      ),
-    ).rejects.toThrow("only supports HEIC/HEIF");
+    ).rejects.toThrow(expectedError);
   });
 
   it("cleans up temporary files when sips fails", async () => {

--- a/apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts
@@ -54,14 +54,6 @@ async function addTestReactions(target: SqliteOverlayStore, threadId = "thread-1
 }
 
 describe("SqliteOverlayStore — thread reactions", () => {
-  it("starts with no reactions on a thread that has never been touched", async () => {
-    const overlay = await store.getThreadOverlayState({
-      backend: "codex",
-      threadId: "thread-1",
-    });
-    expect(overlay).toBeUndefined();
-  });
-
   it("adds a reaction with present=true and surfaces it through getThreadOverlayState", async () => {
     const next = await store.setThreadReaction({
       backend: "codex",

--- a/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
@@ -93,132 +93,60 @@ describe("ThreadTitleGenerationService", () => {
     expect(codexGenerator.generateTitle).not.toHaveBeenCalled();
   });
 
-  it("accepts recognized issue and PR references in generated titles", async () => {
+  it.each([
+    {
+      name: "accepts recognized issue and PR references in generated titles",
+      generatedTitle: "PR 456 issue 123 followup",
+      userPrompt: "In issue 123 and PR 456, why does rename fail?",
+    },
+    {
+      name: "allows bare numbers to be omitted from generated titles",
+      generatedTitle: "Rename behavior",
+      userPrompt: "Can we inspect 456 for rename behavior?",
+    },
+    {
+      name: "does not treat arbitrary prompt numbers as ticket references",
+      generatedTitle: "Thread rename rejection",
+      userPrompt:
+        "At 19:36:47.622 thread title generation rejected a rename for thread 019dd673-a098-7021-a344-a09e4d8ec850.",
+    },
+    {
+      name: "accepts titles that drop ticket references from the prompt",
+      generatedTitle: "Checkout crash followup",
+      userPrompt: "PROJECT-123 investigate checkout crash",
+    },
+    {
+      name: "accepts titles that preserve only one of multiple references",
+      generatedTitle: "Issue 123 rename followup",
+      userPrompt: "In issue 123 and PR 456, why does rename fail?",
+    },
+    {
+      name: "accepts generated titles that omit GitHub PR references from quoted context",
+      generatedTitle: "PR attachment API mismatch",
+      userPrompt:
+        "> PRs created: > - #12998: https://github.com/Giphy/giphy-services/pull/12998 > - #12999 stacked on it: https://github.com/Giphy/giphy-services/pull/12999 Why could the agent not attach the PR to the thread?",
+    },
+    {
+      name: "accepts first-turn handoff titles with non-ticket task markers",
+      generatedTitle: "Dynamic subagent monitoring",
+      userPrompt:
+        "**Handoff Message: Dynamic Subagent Monitoring for Long-Running Tasks**\n\nTask #1: monitor the spawned agents.\nTask #2: report long-running tool calls.",
+    },
+  ])("$name", async ({ generatedTitle, userPrompt }) => {
     const service = new ThreadTitleGenerationService({
       generators: {
-        codex: makeGenerator({ title: "PR 456 issue 123 followup" }),
+        codex: makeGenerator({ title: generatedTitle }),
       },
     });
 
     await expect(
       service.generateTitle({
         backend: "codex",
-        userPrompt: "In issue 123 and PR 456, why does rename fail?",
+        userPrompt,
       })
     ).resolves.toMatchObject({
       status: "generated",
-      title: "PR 456 issue 123 followup",
-    });
-  });
-
-  it("allows bare numbers to be omitted from generated titles", async () => {
-    const service = new ThreadTitleGenerationService({
-      generators: {
-        codex: makeGenerator({ title: "Rename behavior" }),
-      },
-    });
-
-    await expect(
-      service.generateTitle({
-        backend: "codex",
-        userPrompt: "Can we inspect 456 for rename behavior?",
-      })
-    ).resolves.toMatchObject({
-      status: "generated",
-      title: "Rename behavior",
-    });
-  });
-
-  it("does not treat arbitrary prompt numbers as ticket references", async () => {
-    const service = new ThreadTitleGenerationService({
-      generators: {
-        codex: makeGenerator({ title: "Thread rename rejection" }),
-      },
-    });
-
-    await expect(
-      service.generateTitle({
-        backend: "codex",
-        userPrompt:
-          "At 19:36:47.622 thread title generation rejected a rename for thread 019dd673-a098-7021-a344-a09e4d8ec850.",
-      })
-    ).resolves.toMatchObject({
-      status: "generated",
-      title: "Thread rename rejection",
-    });
-  });
-
-  it("accepts titles that drop ticket references from the prompt", async () => {
-    const service = new ThreadTitleGenerationService({
-      generators: {
-        codex: makeGenerator({ title: "Checkout crash followup" }),
-      },
-    });
-
-    await expect(
-      service.generateTitle({
-        backend: "codex",
-        userPrompt: "PROJECT-123 investigate checkout crash",
-      })
-    ).resolves.toMatchObject({
-      status: "generated",
-      title: "Checkout crash followup",
-    });
-  });
-
-  it("accepts titles that preserve only one of multiple references", async () => {
-    const service = new ThreadTitleGenerationService({
-      generators: {
-        codex: makeGenerator({ title: "Issue 123 rename followup" }),
-      },
-    });
-
-    await expect(
-      service.generateTitle({
-        backend: "codex",
-        userPrompt: "In issue 123 and PR 456, why does rename fail?",
-      })
-    ).resolves.toMatchObject({
-      status: "generated",
-      title: "Issue 123 rename followup",
-    });
-  });
-
-  it("accepts generated titles that omit GitHub PR references from quoted context", async () => {
-    const service = new ThreadTitleGenerationService({
-      generators: {
-        codex: makeGenerator({ title: "PR attachment API mismatch" }),
-      },
-    });
-
-    await expect(
-      service.generateTitle({
-        backend: "codex",
-        userPrompt:
-          "> PRs created: > - #12998: https://github.com/Giphy/giphy-services/pull/12998 > - #12999 stacked on it: https://github.com/Giphy/giphy-services/pull/12999 Why could the agent not attach the PR to the thread?",
-      })
-    ).resolves.toMatchObject({
-      status: "generated",
-      title: "PR attachment API mismatch",
-    });
-  });
-
-  it("accepts first-turn handoff titles with non-ticket task markers", async () => {
-    const service = new ThreadTitleGenerationService({
-      generators: {
-        codex: makeGenerator({ title: "Dynamic subagent monitoring" }),
-      },
-    });
-
-    await expect(
-      service.generateTitle({
-        backend: "codex",
-        userPrompt:
-          "**Handoff Message: Dynamic Subagent Monitoring for Long-Running Tasks**\n\nTask #1: monitor the spawned agents.\nTask #2: report long-running tool calls.",
-      })
-    ).resolves.toMatchObject({
-      status: "generated",
-      title: "Dynamic subagent monitoring",
+      title: generatedTitle,
     });
   });
 

--- a/apps/desktop/src/main/__tests__/toml-editor.test.ts
+++ b/apps/desktop/src/main/__tests__/toml-editor.test.ts
@@ -378,23 +378,6 @@ describe("applyTomlEdits", () => {
     expect(result).toBe("[s]\nexisting = 1\na = 1\nb = 2\n");
   });
 
-  it("parses sources only once regardless of edit count (single-pass)", () => {
-    // Spy via a side channel: count regex.exec invocations on a hot path
-    // would be too invasive. Instead, this is a behavior smoke check —
-    // 50 edits to a small section produce a stable result quickly.
-    const lines = ["[s]", "x = 0"];
-    const source = lines.join("\n") + "\n";
-    const edits = Array.from({ length: 50 }, (_, i) => ({
-      op: "set" as const,
-      path: ["s", `k${i}`],
-      value: i,
-    }));
-    const result = applyTomlEdits(source, edits);
-    for (let i = 0; i < 50; i += 1) {
-      expect(result).toContain(`k${i} = ${i}`);
-    }
-  });
-
   it("applies multiple edits in order", () => {
     const source = [
       "[messaging.telegram]",

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts
@@ -110,27 +110,42 @@ describe("pwragent federation agent tools", () => {
     });
   });
 
-  it("rejects a blank instanceId before dispatching list_instance_projects", async () => {
-    const handler = vi.fn();
-    const router = buildPwrAgentFederationToolRouter(handler);
-
-    const response = await router.handleDynamicToolCall({
-      backend: "codex",
-      call: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: "pwragent",
-        tool: "list_instance_projects",
-        arguments: { instanceId: "   " },
+  it.each([
+    {
+      name: "rejects a blank instanceId before dispatching list_instance_projects",
+      tool: "list_instance_projects",
+      arguments: { instanceId: "   " },
+    },
+    {
+      name: "rejects an unknown workMode before dispatching create_instance_thread",
+      tool: "create_instance_thread",
+      arguments: {
+        instanceId: "pwr_studio",
+        projectKey: "dir:/repo",
+        workMode: "container",
       },
-    });
-
-    expect(response).toMatchObject({ success: false });
-    expect(handler).not.toHaveBeenCalled();
-  });
-
-  it("rejects an unknown workMode before dispatching create_instance_thread", async () => {
+    },
+    {
+      name: "rejects an unknown scope before dispatching search_federation_threads",
+      tool: "search_federation_threads",
+      arguments: { query: "recorder crash", scope: "nearby" },
+    },
+    {
+      name: "rejects an out-of-range list limit before dispatching list_federation_instances",
+      tool: "list_federation_instances",
+      arguments: { limit: 500 },
+    },
+    {
+      name: "rejects a non-boolean includeLoad before dispatching list_federation_instances",
+      tool: "list_federation_instances",
+      arguments: { includeLoad: "yes" },
+    },
+    {
+      name: "rejects an out-of-range limit before dispatching search_federation_threads",
+      tool: "search_federation_threads",
+      arguments: { query: "recorder crash", limit: 500 },
+    },
+  ] as const)("$name", async ({ tool, arguments: callArguments }) => {
     const handler = vi.fn();
     const router = buildPwrAgentFederationToolRouter(handler);
 
@@ -141,52 +156,8 @@ describe("pwragent federation agent tools", () => {
         turnId: "turn-1",
         callId: "call-1",
         namespace: "pwragent",
-        tool: "create_instance_thread",
-        arguments: {
-          instanceId: "pwr_studio",
-          projectKey: "dir:/repo",
-          workMode: "container",
-        },
-      },
-    });
-
-    expect(response).toMatchObject({ success: false });
-    expect(handler).not.toHaveBeenCalled();
-  });
-
-  it("rejects an unknown scope before dispatching search_federation_threads", async () => {
-    const handler = vi.fn();
-    const router = buildPwrAgentFederationToolRouter(handler);
-
-    const response = await router.handleDynamicToolCall({
-      backend: "codex",
-      call: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: "pwragent",
-        tool: "search_federation_threads",
-        arguments: { query: "recorder crash", scope: "nearby" },
-      },
-    });
-
-    expect(response).toMatchObject({ success: false });
-    expect(handler).not.toHaveBeenCalled();
-  });
-
-  it("rejects an out-of-range list limit before dispatching list_federation_instances", async () => {
-    const handler = vi.fn();
-    const router = buildPwrAgentFederationToolRouter(handler);
-
-    const response = await router.handleDynamicToolCall({
-      backend: "codex",
-      call: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: "pwragent",
-        tool: "list_federation_instances",
-        arguments: { limit: 500 },
+        tool,
+        arguments: callArguments,
       },
     });
 
@@ -227,46 +198,6 @@ describe("pwragent federation agent tools", () => {
       },
       args: { query: "linux", limit: 10, includeLoad: true },
     });
-  });
-
-  it("rejects a non-boolean includeLoad before dispatching list_federation_instances", async () => {
-    const handler = vi.fn();
-    const router = buildPwrAgentFederationToolRouter(handler);
-
-    const response = await router.handleDynamicToolCall({
-      backend: "codex",
-      call: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: "pwragent",
-        tool: "list_federation_instances",
-        arguments: { includeLoad: "yes" },
-      },
-    });
-
-    expect(response).toMatchObject({ success: false });
-    expect(handler).not.toHaveBeenCalled();
-  });
-
-  it("rejects an out-of-range limit before dispatching search_federation_threads", async () => {
-    const handler = vi.fn();
-    const router = buildPwrAgentFederationToolRouter(handler);
-
-    const response = await router.handleDynamicToolCall({
-      backend: "codex",
-      call: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: "pwragent",
-        tool: "search_federation_threads",
-        arguments: { query: "recorder crash", limit: 500 },
-      },
-    });
-
-    expect(response).toMatchObject({ success: false });
-    expect(handler).not.toHaveBeenCalled();
   });
 
   it("normalizes create_instance_thread args before dispatch", async () => {


### PR DESCRIPTION
## Summary

- Remove two non-protective tests: one exact untouched-overlay duplicate and one TOML performance claim that never observed parse count or runtime.
- Convert six repeated test matrices to table-driven coverage while retaining every named behavioral row.
- Keep production code, fixtures, Windows/process-ownership coverage, renderer tests, and all tests outside the assigned G–Z/unit-test lane unchanged.

## Deletions and proof

- `overlay-store-reactions.test.ts`: remove the untouched-thread absence test. AST callback hashing found it byte-for-byte identical to the retained generic store-absence test in `overlay-store-prs.test.ts`; both were introduced together in `63de8f522`. The reactions copy never seeded, set, or read a reaction, so it provided no reaction-specific behavior.
- `toml-editor.test.ts`: remove the claimed “single-pass” performance test. Its own comment says it does not observe parser invocations, and it has no timing or call-count assertion; it only repeats already-covered ordered multi-edit result behavior. It therefore could not fail if the claimed parse-once property regressed.

## Consolidations and retained behavior

- `apps/desktop/scripts/dev.test.mjs`: table-drive the independent child-signal exit statuses; both SIGTERM → 143 and SIGHUP → 129 still execute separately.
- `git-remote.test.ts`: table-drive three structurally identical parse cases while retaining case preservation, SSH aliases, and non-GitHub host reporting.
- `github-pr-fetcher.test.ts`: table-drive passing-check rollups while retaining all-success, skipped-optional, and stale-IN_PROGRESS-with-success-conclusion behavior.
- `image-normalization-ipc.test.ts`: table-drive both rejection branches while retaining Linux HEIC/macOS-only and Darwin non-HEIC/HEIC-only errors.
- `thread-title-generation-service.test.ts`: table-drive all seven issue-linked reference-acceptance regressions. History for #75, #708, and #959 was reviewed; every original prompt/title pair remains separately named and executed.
- `pwragent-federation-agent-tools.test.ts`: table-drive six pre-dispatch validation branches while retaining blank instance IDs, unknown work modes/scopes, invalid list/search limits, and non-boolean `includeLoad`, including the no-dispatch assertion for every row.

An after-edit AST callback-hash scan found no remaining exact duplicate callback groups across the 169 owned files.

## Counts and timing

- Before: 169 files, 2,092 tests — 2,076 passed, 14 failed, 2 skipped; Vitest 146.33s, 152.06s wall.
- After: 169 files, 2,090 tests — 2,088 passed, 2 skipped; Vitest 22.57s, 23.63s wall.
- Changed suites: 8 files, 165 tests passed; Vitest 1.43s, 2.35s wall.
- Net diff: 167 insertions, 363 deletions (196 lines removed).

The before run was cold/load-contended and tripped existing 5-second timeouts in git-directory-service, index, MCP connections, messaging config/runtime, and PDF agent tools; one timeout caused a follow-on mock assertion. The warm after run was green. The timing difference is recorded, but should not be attributed to deleting two tiny tests.

## Validation

- `pnpm test <all 169 owned paths>`
- `pnpm test <8 changed test paths>`
- `pnpm exec eslint <7 changed TypeScript test paths>`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
