### PR TITLE
test(desktop): prune redundant main-process tests A-F

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -321,26 +321,18 @@ describe("describeInstalledAcpBackend", () => {
     ]);
   });
 
-  it("falls back to hardcoded execution modes for Kimi with no runtime mode selector", () => {
+  it.each([
+    { registryId: "kimi", name: "Kimi Code CLI" },
+    { registryId: "grok", name: "Grok CLI" },
+  ])("falls back to hardcoded execution modes for $name with no runtime mode selector", ({
+    registryId,
+    name,
+  }) => {
     const backend = describeInstalledAcpBackend({
       ...buildInstalledAgent(),
-      backendId: "acp:kimi" as AcpBackendId,
-      registryId: "kimi",
-      name: "Kimi Code CLI",
-    });
-
-    expect(backend.executionModes.map((mode) => mode.mode)).toEqual([
-      "default",
-      "full-access",
-    ]);
-  });
-
-  it("keeps hardcoded execution modes for Grok (no runtime mode selector)", () => {
-    const backend = describeInstalledAcpBackend({
-      ...buildInstalledAgent(),
-      backendId: "acp:grok" as AcpBackendId,
-      registryId: "grok",
-      name: "Grok CLI",
+      backendId: `acp:${registryId}` as AcpBackendId,
+      registryId,
+      name,
     });
 
     expect(backend.executionModes.map((mode) => mode.mode)).toEqual([

--- a/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
@@ -987,7 +987,19 @@ describe("AutomationScheduler", () => {
     });
   });
 
-  it("maps terminal backend failure notifications to failed runs", async () => {
+  it.each([
+    {
+      terminalStatus: "turn/failed" as const,
+      runStatus: "failed" as const,
+    },
+    {
+      terminalStatus: "turn/cancelled" as const,
+      runStatus: "cancelled" as const,
+    },
+  ])("maps terminal backend $terminalStatus notifications to $runStatus runs", async ({
+    terminalStatus,
+    runStatus,
+  }) => {
     createIntervalAutomation();
     const scheduler = buildScheduler();
     now = 5 * 60 * 1000;
@@ -997,33 +1009,13 @@ describe("AutomationScheduler", () => {
     await scheduler.handleTurnQueueUpdate({
       automationRunId: run?.id,
       status: "terminal",
-      terminalStatus: "turn/failed",
+      terminalStatus,
       now: 6 * 60 * 1000,
     });
 
     expect(store.listRunsForAutomation("automation-1")[0]).toMatchObject({
-      status: "failed",
-      errorMessage: "turn/failed",
-    });
-  });
-
-  it("maps terminal backend cancellation notifications to cancelled runs", async () => {
-    createIntervalAutomation();
-    const scheduler = buildScheduler();
-    now = 5 * 60 * 1000;
-    await scheduler.evaluateDueAutomations();
-    const [run] = store.listRunsForAutomation("automation-1");
-
-    await scheduler.handleTurnQueueUpdate({
-      automationRunId: run?.id,
-      status: "terminal",
-      terminalStatus: "turn/cancelled",
-      now: 6 * 60 * 1000,
-    });
-
-    expect(store.listRunsForAutomation("automation-1")[0]).toMatchObject({
-      status: "cancelled",
-      errorMessage: "turn/cancelled",
+      status: runStatus,
+      errorMessage: terminalStatus,
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7329,7 +7329,6 @@ script = "echo setup"
       expect(sessions[0]?.executionMode).toBe("full-access");
     });
 
-    expect(sessions[0]?.executionMode).toBe("full-access");
     await expect(
       registry.listThreads({ backend: acpBackendId }),
     ).resolves.toEqual([
@@ -38573,46 +38572,37 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("surfaces the single-client startTurn error directly when default mode is explicitly requested", async () => {
+  it.each([
+    {
+      executionMode: "default" as const,
+      input: "This must not silently escalate",
+    },
+    {
+      executionMode: "full-access" as const,
+      input: "This must not silently downgrade",
+    },
+  ])("surfaces the single-client startTurn error directly when $executionMode mode is explicitly requested", async ({
+    executionMode,
+    input,
+  }) => {
+    const error = `thread not loaded on ${executionMode} instance`;
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
-      startTurnError: new Error("thread not loaded on default instance"),
+      startTurnError: new Error(error),
     });
     const registry = new DesktopBackendRegistry({
       codexClient,
-      overlayStore: createOverlayStoreMock({ executionMode: "default" }),
+      overlayStore: createOverlayStoreMock({ executionMode }),
     });
 
     await expect(
       registry.startTurn({
         backend: "codex",
         threadId: "thread-1",
-        executionMode: "default",
-        input: [{ type: "text", text: "This must not silently escalate" }],
+        executionMode,
+        input: [{ type: "text", text: input }],
       }),
-    ).rejects.toThrow("thread not loaded on default instance");
-
-    await registry.close();
-  });
-
-  it("surfaces the single-client startTurn error directly when full-access mode is explicitly requested", async () => {
-    const codexClient = new MockBackendClient({
-      initializeResult: { methods: ["turn/start"] },
-      startTurnError: new Error("thread not loaded on full-access instance"),
-    });
-    const registry = new DesktopBackendRegistry({
-      codexClient,
-      overlayStore: createOverlayStoreMock({ executionMode: "full-access" }),
-    });
-
-    await expect(
-      registry.startTurn({
-        backend: "codex",
-        threadId: "thread-1",
-        executionMode: "full-access",
-        input: [{ type: "text", text: "This must not silently downgrade" }],
-      }),
-    ).rejects.toThrow("thread not loaded on full-access instance");
+    ).rejects.toThrow(error);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
@@ -180,49 +180,40 @@ describe("DesktopNotificationService", () => {
     ]);
   });
 
-  it("does not emit notifications while app is focused", () => {
+  it.each([
+    {
+      kind: "terminal",
+      notify: (service: DesktopNotificationService) => service.notifyTerminal({
+        enabled: true,
+        title: "Turn completed",
+        body: "Done",
+      }),
+    },
+    {
+      kind: "attention",
+      notify: (service: DesktopNotificationService) => service.notifyAttention({
+        enabled: true,
+        key: "codex:thread-1:req-focused",
+        title: "Approval needed",
+        body: "Please approve",
+      }),
+    },
+    {
+      kind: "approval",
+      notify: (service: DesktopNotificationService) => service.notifyApproval({
+        enabled: true,
+        key: "codex:thread-1:req-focused-approval",
+        intent: approvalIntent(),
+        onDecision: vi.fn(),
+      }),
+    },
+  ])("does not emit $kind notifications while a window is focused", ({ notify }) => {
     const service = new DesktopNotificationService();
     getAllWindows.mockReturnValue([
       { isDestroyed: () => false, isFocused: () => true, isMinimized: () => false },
     ]);
 
-    service.notifyTerminal({
-      enabled: true,
-      title: "Turn completed",
-      body: "Done",
-    });
-
-    expect(shownNotifications).toEqual([]);
-  });
-
-  it("does not emit attention notifications while a window is focused", () => {
-    const service = new DesktopNotificationService();
-    getAllWindows.mockReturnValue([
-      { isDestroyed: () => false, isFocused: () => true, isMinimized: () => false },
-    ]);
-
-    service.notifyAttention({
-      enabled: true,
-      key: "codex:thread-1:req-focused",
-      title: "Approval needed",
-      body: "Please approve",
-    });
-
-    expect(shownNotifications).toEqual([]);
-  });
-
-  it("does not emit approval notifications while a window is focused", () => {
-    const service = new DesktopNotificationService();
-    getAllWindows.mockReturnValue([
-      { isDestroyed: () => false, isFocused: () => true, isMinimized: () => false },
-    ]);
-
-    service.notifyApproval({
-      enabled: true,
-      key: "codex:thread-1:req-focused-approval",
-      intent: approvalIntent(),
-      onDecision: vi.fn(),
-    });
+    notify(service);
 
     expect(shownNotifications).toEqual([]);
   });
@@ -567,29 +558,6 @@ describe("DesktopNotificationService", () => {
     expect(onDecision).not.toHaveBeenCalled();
 
     shownNotifications[0]?.instance.emitAction(0);
-    expect(onDecision).not.toHaveBeenCalled();
-    expect(onDecision).not.toHaveBeenCalledWith("accept");
-  });
-
-  it("focuses the approval thread when clicking the notification body", () => {
-    const service = new DesktopNotificationService();
-    const onDecision = vi.fn();
-    const onShow = vi.fn();
-    getAllWindows.mockReturnValue([
-      { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
-    ]);
-
-    service.notifyApproval({
-      enabled: true,
-      key: "codex:thread-1:req-click-show",
-      intent: approvalIntent(),
-      onDecision,
-      onShow,
-    });
-
-    shownNotifications[0]?.instance.emitClick();
-
-    expect(onShow).toHaveBeenCalledTimes(1);
     expect(onDecision).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- audit all 111 desktop main-process Vitest files whose basenames begin A through F
- remove one test that exactly repeats an approval-notification click path already covered in the same file
- consolidate four pairs/groups of structurally identical cases with `it.each` while preserving each diagnostic case and assertion outcome
- remove two immediately repeated assertions that add no state transition or stronger check
- touch no production source, fixtures, G-Z tests, renderer tests, packages, E2E tests, or historical artifacts

## Removed tests and assertions

- Removed `DesktopNotificationService > focuses the approval thread when clicking the notification body`. The earlier `renders approval intents with a native approve action and opens the thread on click` test creates the same inactive-window service state, calls `notifyApproval` with the same `approvalIntent`, emits the notification body click, and asserts exactly `onShow` once plus no `onDecision`. Git blame shows both blocks entered together in `63de8f522`, so the smaller test added no later regression boundary or distinct branch.
- Removed `not.toHaveBeenCalledWith("accept")` from `keeps approval notifications passive when the intent lacks details`. It immediately followed `not.toHaveBeenCalled()` after the same `emitAction(0)` with no intervening action; the retained assertion is strictly stronger.
- Removed the post-`waitFor` `sessions[0].executionMode === "full-access"` assertion from `queues Kimi ACP execution mode changes during active turns and flushes once`. The same assertion is already inside the immediately preceding `waitFor` and no state-changing operation occurs between them. The distinct `listThreads` projection assertion remains.

## Consolidated tests

- Consolidated `falls back to hardcoded execution modes for Kimi with no runtime mode selector` and `keeps hardcoded execution modes for Grok (no runtime mode selector)` into a two-row provider table. Both invoke `describeInstalledAcpBackend`, differ only by provider identity, and assert the identical hardcoded `default`/`full-access` fallback. Source inspection confirmed Kimi and Grok use the same no-selector fallback path; both provider rows remain separate Vitest cases.
- Consolidated `maps terminal backend failure notifications to failed runs` and `maps terminal backend cancellation notifications to cancelled runs` into a two-row terminal-status table. Setup, queue transition, and lookup were identical; only the production terminal status and its expected persisted status/error varied. Both `turn/failed` and `turn/cancelled` cases remain.
- Consolidated `surfaces the single-client startTurn error directly when default mode is explicitly requested` and its `full-access` counterpart into a two-row execution-mode table. Both use the same single-client path; mode, matching overlay, non-escalate/non-downgrade input, and expected error remain explicit per row.
- Consolidated the focused-window terminal, attention, and approval notification tests into a three-row notifier table. Source inspection showed all three reach the same focused-window suppression guard; each public notifier and payload remains a separately named Vitest case and still asserts zero shown notifications.

## Conservative audit evidence

- Used basename-bounded `rg` inventory, normalized callback comparisons, substantial-similarity review, production-source tracing, and `git blame`/history before deletion. Similar titles alone were not treated as duplicates.
- Retained distinct security, lifecycle, malformed-input, platform, migration/backward-compatibility, and issue-linked negatives, including the ACP empty-command-cache regression, issue #658 runtime-mode behavior, and separate federation override-versus-oldest-auto collision cases.
- No fixture became orphaned, so no fixture was removed.

## Counts and timing

Same root command and owned 111-file list, pinned to `--maxWorkers=2` for a clean comparison on this busy host:

| | Files | Tests | Vitest duration | Wall time |
|---|---:|---:|---:|---:|
| Before | 111 passed | 1,917 passed | 79.63s | 80.70s |
| After | 111 passed | 1,916 passed | 80.42s | 81.48s |

Net source diff: 74 insertions, 132 deletions (-58 lines). The sub-second timing delta is noise-level; the safe gain is less duplicated test code and one fewer redundant execution. Default/high concurrency produced unrelated 5-second timeout flakes on this shared machine, so both reportable measurements use the same passing two-worker configuration.

## Checks

- `pnpm test <111 owned A-F paths> --maxWorkers=2` — 111 files, 1,916 tests passed
- focused four-file run — 4 files, 575 tests passed in 39.42s (40.30s wall)
- `pnpm --filter @pwragent/desktop typecheck` — passed
- ESLint on all four changed files — 0 errors; one pre-existing `prefer-const` warning in an untouched backend-registry section
- `pnpm lint:boundaries` — passed, 0 violations across 1,334 modules and 4,269 dependencies
- `git diff --check` — passed