### PR TITLE
fix(desktop): skip hidden directory thread rendering work

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -49,9 +49,12 @@ import { ThreadRow } from "./ThreadRow";
 import {
   formatActiveThreadCount,
   formatReviewThreadCount,
-  isThreadActive,
-  isThreadAwaitingReview,
 } from "./ThreadRowStatus";
+import {
+  buildDirectoryThreadRenderModel,
+  DIRECTORY_UNPINNED_THREAD_CAP,
+  type ExpandedDirectoryThreadRenderModel,
+} from "./directory-thread-render-model";
 
 type DirectoriesListProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
@@ -160,6 +163,18 @@ function buildLaunchpadSelectionKey(directoryKey: string): string {
  */
 const POST_DRAG_CLICK_SUPPRESS_MS = 150;
 
+const EMPTY_EXPANDED_DIRECTORY_THREAD_MODEL: ExpandedDirectoryThreadRenderModel = {
+  cappedUnpinnedThreads: [],
+  childThreadsByParentKey: new Map(),
+  directoryPinnedThreads: [],
+  directoryThreadsCollapsed: false,
+  directoryUnpinnedThreadCount: 0,
+  hiddenUnpinnedCount: 0,
+  overflowUnpinnedThreads: [],
+  selectionOrder: [],
+  unpinnedExpanded: false,
+};
+
 /**
  * The user can pin both `kind: "directory"` and `kind: "workspace"`
  * entries — both are named entries they click in the sidebar. Only
@@ -195,15 +210,6 @@ function hasPendingLaunchpadState(directory: NavigationDirectorySummary): boolea
     (launchpad.imageAttachments?.length ?? 0) > 0
   );
 }
-
-/**
- * Cap on how many *unpinned* threads a directory renders before the
- * rest collapse behind a "Show N more" toggle. Pinned threads are never
- * capped — they're user-curated and finite. Without this, a directory
- * with dozens of threads pushes every directory below it off-screen,
- * making the Directories lens slow to scroll past active projects.
- */
-const UNPINNED_THREAD_CAP = 10;
 
 function getDirectoryRowLinkedDirectoryMode(
   thread: NavigationThreadSummary,
@@ -580,7 +586,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
         (thread) =>
           buildThreadIdentityKey(thread.source, thread.id) ===
           topLevelThreadKey,
-      ) >= UNPINNED_THREAD_CAP
+      ) >= DIRECTORY_UNPINNED_THREAD_CAP
     ) {
       setUnpinnedExpandedByKey((current) => ({
         ...current,
@@ -633,20 +639,19 @@ export function DirectoriesList(props: DirectoriesListProps) {
     const expanded =
       expandedByKey[directory.key] ??
       (selectedLaunchpad || selectedThreadInDirectory);
-    const visibleThreads = directory.threadKeys
-      .map((threadKey) => threadsByKey.get(threadKey))
-      .filter((thread): thread is NavigationThreadSummary => Boolean(thread));
-    const activeThreadCount = visibleThreads.filter((thread) =>
-      isThreadActive(thread, props.thinkingThreadKeys),
-    ).length;
-    // A live turn can also be in the Inbox after emitting new output. Keep it
-    // in the activity count only, so a directory never reports the same thread
-    // as both active and waiting to be reviewed.
-    const reviewThreadCount = visibleThreads.filter(
-      (thread) =>
-        isThreadAwaitingReview(thread)
-        && !isThreadActive(thread, props.thinkingThreadKeys),
-    ).length;
+    const threadModel = buildDirectoryThreadRenderModel({
+      directory,
+      expanded,
+      selectedItemKey: props.selectedItemKey,
+      thinkingThreadKeys: props.thinkingThreadKeys,
+      threadsByKey,
+      unpinnedExpanded: unpinnedExpandedByKey[directory.key],
+    });
+    const {
+      activeThreadCount,
+      reviewThreadCount,
+      visibleThreadCount,
+    } = threadModel;
     const directorySummaryLabel = [
       directory.label,
       activeThreadCount > 0 ? formatActiveThreadCount(activeThreadCount) : undefined,
@@ -654,23 +659,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
     ]
       .filter((label): label is string => Boolean(label))
       .join(", ");
-    const directoryThreadKeys = new Set(
-      visibleThreads.map((thread) => buildThreadIdentityKey(thread.source, thread.id)),
-    );
-    const childThreadsByParentKey = new Map<string, NavigationThreadSummary[]>();
-    for (const thread of visibleThreads) {
-      if (!thread.parentThreadId) continue;
-      const parentKey = resolveThreadParentKey(thread, threadsByKey);
-      if (!parentKey || !directoryThreadKeys.has(parentKey)) continue;
-      const children = childThreadsByParentKey.get(parentKey) ?? [];
-      children.push(thread);
-      childThreadsByParentKey.set(parentKey, children);
-    }
-    const topLevelVisibleThreads = visibleThreads.filter((thread) => {
-      if (!thread.parentThreadId) return true;
-      const parentKey = resolveThreadParentKey(thread, threadsByKey);
-      return !parentKey || !directoryThreadKeys.has(parentKey);
-    });
+    const expandedThreadModel =
+      threadModel.expanded ?? EMPTY_EXPANDED_DIRECTORY_THREAD_MODEL;
+    const { childThreadsByParentKey } = expandedThreadModel;
     const renderStaticSubthreads = (parent: NavigationThreadSummary): ReactElement | null => {
       const parentKey = buildThreadIdentityKey(parent.source, parent.id);
       const children = sortSubthreadSummaries(parent, childThreadsByParentKey.get(parentKey) ?? []);
@@ -809,64 +800,16 @@ export function DirectoriesList(props: DirectoriesListProps) {
         </div>
       );
     };
-    const directoryPinnedThreads = topLevelVisibleThreads
-      .filter(isPinnedThread)
-      .sort(comparePinnedThreads);
-    const directoryUnpinnedThreads = topLevelVisibleThreads.filter(
-      (thread) => !isPinnedThread(thread),
-    );
-    const cappedUnpinnedThreads = directoryUnpinnedThreads.slice(
-      0,
-      UNPINNED_THREAD_CAP,
-    );
-    const overflowUnpinnedThreads =
-      directoryUnpinnedThreads.slice(UNPINNED_THREAD_CAP);
-    const hiddenUnpinnedCount = overflowUnpinnedThreads.length;
-    // Keep a selected thread visible even when it falls in the collapsed
-    // overflow — otherwise selecting it from another lens and switching to
-    // Directories would leave it hidden with no highlight. An explicit
-    // toggle still wins (`??`), so the user can deliberately collapse.
-    const selectedUnpinnedInOverflow = overflowUnpinnedThreads.some(
-      (thread) =>
-        buildThreadIdentityKey(thread.source, thread.id) ===
-        props.selectedItemKey,
-    );
-    const unpinnedExpanded =
-      unpinnedExpandedByKey[directory.key] ?? selectedUnpinnedInOverflow;
-    // This preference applies only when there is a pinned section to
-    // preserve. Without pinned threads, hiding every row would make an
-    // expanded directory look empty and remove the disclosure control.
-    const directoryThreadsCollapsed =
-      directoryPinnedThreads.length > 0 &&
-      directory.directoryThreadsCollapsed === true;
-    const visibleUnpinnedThreads = directoryThreadsCollapsed
-      ? []
-      : [
-          ...cappedUnpinnedThreads,
-          ...(unpinnedExpanded ? overflowUnpinnedThreads : []),
-        ];
-    // A directory can repeat a thread that is linked to more than one project,
-    // so a Shift range is intentionally scoped to the expanded directory the
-    // user clicked. That makes its extent obvious and excludes hidden rows
-    // behind the directory, pinned/unpinned, and "Show more" disclosures.
-    const selectionOrder = [
-      ...directoryPinnedThreads,
-      ...visibleUnpinnedThreads,
-    ].flatMap((thread) => {
-      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-      const children = sortSubthreadSummaries(
-        thread,
-        childThreadsByParentKey.get(threadKey) ?? [],
-      );
-      return [
-        threadKey,
-        ...(thread.subthreadsCollapsed
-          ? []
-          : children.map((child) =>
-              buildThreadIdentityKey(child.source, child.id),
-            )),
-      ];
-    });
+    const {
+      cappedUnpinnedThreads,
+      directoryPinnedThreads,
+      directoryThreadsCollapsed,
+      directoryUnpinnedThreadCount,
+      hiddenUnpinnedCount,
+      overflowUnpinnedThreads,
+      selectionOrder,
+      unpinnedExpanded,
+    } = expandedThreadModel;
     // Render one unpinned thread row. Shared by the always-shown capped
     // slice and the overflow slice so the "Show more / Show less" toggle
     // sits at a fixed pivot between them — collapsing never makes the
@@ -1214,7 +1157,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
 
             {expanded ? (
               <div className="directory-row__details">
-                {visibleThreads.length > 0 ? (
+                {visibleThreadCount > 0 ? (
                   <div className="sidebar-list sidebar-list--compact directory-row__threads">
                     {directoryPinnedThreads.map((thread) => {
 	                      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
@@ -1342,7 +1285,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                     })}
 
                     {directoryPinnedThreads.length > 0 &&
-                    directoryUnpinnedThreads.length > 0 ? (
+                    directoryUnpinnedThreadCount > 0 ? (
                       <button
                         type="button"
                         className={`recents-pinned-divider directory-row__thread-divider${
@@ -1408,7 +1351,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           <span>Directory threads</span>
                           {directoryThreadsCollapsed ? (
                             <span className="directory-row__thread-divider-count">
-                              {directoryUnpinnedThreads.length}
+                              {directoryUnpinnedThreadCount}
                             </span>
                           ) : null}
                         </span>

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/directories-list-performance.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/directories-list-performance.test.tsx
@@ -1,0 +1,80 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { buildThreadIdentityKey } from "@pwragent/shared";
+import { DirectoriesList } from "../DirectoriesList";
+import { buildLargeDirectoryFixture } from "./fixtures/directory-performance";
+
+const threadRowRender = vi.hoisted(() => vi.fn());
+
+vi.mock("../ThreadRow", () => ({
+  ThreadRow: (props: { thread: NavigationThreadSummary }) => {
+    threadRowRender(props.thread.id);
+    return <div data-testid="fixture-thread-row">{props.thread.title}</div>;
+  },
+}));
+
+afterEach(() => {
+  threadRowRender.mockClear();
+  cleanup();
+});
+
+function renderDirectories(
+  fixture: ReturnType<typeof buildLargeDirectoryFixture>,
+  selectedItemKey?: string,
+) {
+  return render(
+    <DirectoriesList
+      directories={fixture.directories}
+      selectedItemKey={selectedItemKey}
+      threads={fixture.threads}
+      onOpenLaunchpad={async () => undefined}
+      onOpenThreadContextMenu={() => undefined}
+      onSelectThread={() => undefined}
+    />,
+  );
+}
+
+describe("large collapsed directory rendering", () => {
+  it("mounts no thread rows for twelve collapsed three-digit projects", () => {
+    const fixture = buildLargeDirectoryFixture({
+      directoryCount: 12,
+      pinnedThreadsPerDirectory: 1,
+      unpinnedThreadsPerDirectory: 107,
+    });
+
+    renderDirectories(fixture);
+
+    expect(
+      screen.getAllByRole("button", { name: /^Project \d+$/ }),
+    ).toHaveLength(12);
+    expect(threadRowRender).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("fixture-thread-row")).not.toBeInTheDocument();
+  });
+
+  it("mounts only the pinned row above a minimized population of 107", () => {
+    const fixture = buildLargeDirectoryFixture({
+      pinnedThreadsPerDirectory: 1,
+      unpinnedThreadsPerDirectory: 107,
+      directoryThreadsCollapsed: true,
+    });
+    const pinned = fixture.threads[0]!;
+
+    renderDirectories(
+      fixture,
+      buildThreadIdentityKey(pinned.source, pinned.id),
+    );
+
+    expect(screen.getByText(pinned.title)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Show directory threads for Project 1",
+      }),
+    ).toHaveTextContent("107");
+    expect(screen.getAllByTestId("fixture-thread-row")).toHaveLength(1);
+    expect(
+      threadRowRender.mock.calls.every(([threadId]) => threadId === pinned.id),
+    ).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/directory-thread-render-model.test.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/directory-thread-render-model.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildDirectoryThreadRenderModel } from "../directory-thread-render-model";
+import { buildLargeDirectoryFixture } from "./fixtures/directory-performance";
+
+describe("large directory thread render model", () => {
+  it("does not prepare hidden thread structure for collapsed project folders", () => {
+    const fixture = buildLargeDirectoryFixture({
+      directoryCount: 12,
+      pinnedThreadsPerDirectory: 1,
+      unpinnedThreadsPerDirectory: 107,
+    });
+
+    const models = fixture.directories.map((directory) =>
+      buildDirectoryThreadRenderModel({
+        directory,
+        expanded: false,
+        threadsByKey: fixture.threadsByKey,
+      }),
+    );
+
+    expect(fixture.threads).toHaveLength(1_296);
+    expect(models.every((model) => model.expanded === undefined)).toBe(true);
+    expect(
+      models.reduce((count, model) => count + model.visibleThreadCount, 0),
+    ).toBe(1_296);
+  });
+
+  it("keeps 107 minimized directory threads out of the visible row model", () => {
+    const fixture = buildLargeDirectoryFixture({
+      pinnedThreadsPerDirectory: 1,
+      unpinnedThreadsPerDirectory: 107,
+      directoryThreadsCollapsed: true,
+    });
+    const model = buildDirectoryThreadRenderModel({
+      directory: fixture.directories[0]!,
+      expanded: true,
+      threadsByKey: fixture.threadsByKey,
+    });
+
+    expect(model.expanded?.directoryPinnedThreads).toHaveLength(1);
+    expect(model.expanded?.directoryUnpinnedThreadCount).toBe(107);
+    expect(model.expanded?.cappedUnpinnedThreads).toHaveLength(0);
+    expect(model.expanded?.overflowUnpinnedThreads).toHaveLength(0);
+    expect(model.expanded?.hiddenUnpinnedCount).toBe(107);
+    expect(model.expanded?.directoryThreadsCollapsed).toBe(true);
+    expect(model.expanded?.selectionOrder).toHaveLength(1);
+  });
+
+  it("prepares only the ten-row window while Show more is collapsed", () => {
+    const fixture = buildLargeDirectoryFixture({
+      pinnedThreadsPerDirectory: 0,
+      unpinnedThreadsPerDirectory: 107,
+      directoryThreadsCollapsed: false,
+    });
+    const model = buildDirectoryThreadRenderModel({
+      directory: fixture.directories[0]!,
+      expanded: true,
+      threadsByKey: fixture.threadsByKey,
+    });
+
+    expect(model.expanded?.directoryThreadsCollapsed).toBe(false);
+    expect(model.expanded?.cappedUnpinnedThreads).toHaveLength(10);
+    expect(model.expanded?.overflowUnpinnedThreads).toHaveLength(97);
+    expect(model.expanded?.selectionOrder).toHaveLength(10);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/fixtures/directory-performance.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/fixtures/directory-performance.ts
@@ -1,0 +1,92 @@
+import type {
+  NavigationDirectorySummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import { buildThreadIdentityKey } from "@pwragent/shared";
+
+export type LargeDirectoryFixture = {
+  directories: NavigationDirectorySummary[];
+  threads: NavigationThreadSummary[];
+  threadsByKey: Map<string, NavigationThreadSummary>;
+};
+
+/**
+ * Reproduces the operator shape that exposed the renderer cost: a small number
+ * of project headers, each backed by a three-digit thread population. Callers
+ * choose whether each project has a pinned row so they can exercise both the
+ * sticky "Directory threads" disclosure and the ordinary Show more cap.
+ */
+export function buildLargeDirectoryFixture(options: {
+  directoryCount?: number;
+  pinnedThreadsPerDirectory?: number;
+  unpinnedThreadsPerDirectory?: number;
+  directoryThreadsCollapsed?: boolean;
+} = {}): LargeDirectoryFixture {
+  const directoryCount = options.directoryCount ?? 1;
+  const pinnedThreadsPerDirectory =
+    options.pinnedThreadsPerDirectory ?? 1;
+  const unpinnedThreadsPerDirectory =
+    options.unpinnedThreadsPerDirectory ?? 107;
+  const threads: NavigationThreadSummary[] = [];
+  const directories: NavigationDirectorySummary[] = [];
+
+  for (let directoryIndex = 0; directoryIndex < directoryCount; directoryIndex += 1) {
+    const directoryNumber = directoryIndex + 1;
+    const directoryPath = `/fixture/project-${directoryNumber}`;
+    const directoryThreads: NavigationThreadSummary[] = [];
+    const totalThreads =
+      pinnedThreadsPerDirectory + unpinnedThreadsPerDirectory;
+
+    for (let threadIndex = 0; threadIndex < totalThreads; threadIndex += 1) {
+      const threadNumber = threadIndex + 1;
+      const pinned = threadIndex < pinnedThreadsPerDirectory;
+      directoryThreads.push({
+        id: `project-${directoryNumber}-thread-${threadNumber}`,
+        title: pinned
+          ? `Pinned project ${directoryNumber} thread ${threadNumber}`
+          : `Project ${directoryNumber} thread ${threadNumber}`,
+        titleSource: "explicit",
+        source: "codex",
+        executionMode: "default",
+        updatedAt: 1_800_000_000_000 - threadIndex,
+        linkedDirectories: [
+          {
+            id: directoryPath,
+            kind: "local",
+            label: `Project ${directoryNumber}`,
+            path: directoryPath,
+          },
+        ],
+        inbox: {
+          inInbox: false,
+        },
+        ...(pinned ? { pinnedRank: String(threadNumber * 1024) } : {}),
+      });
+    }
+
+    threads.push(...directoryThreads);
+    directories.push({
+      key: `directory:${directoryPath}`,
+      kind: "directory",
+      label: `Project ${directoryNumber}`,
+      path: directoryPath,
+      threadKeys: directoryThreads.map((thread) =>
+        buildThreadIdentityKey(thread.source, thread.id),
+      ),
+      needsAttentionCount: 0,
+      directoryThreadsCollapsed:
+        options.directoryThreadsCollapsed ?? true,
+    });
+  }
+
+  return {
+    directories,
+    threads,
+    threadsByKey: new Map(
+      threads.map((thread) => [
+        buildThreadIdentityKey(thread.source, thread.id),
+        thread,
+      ]),
+    ),
+  };
+}

--- a/apps/desktop/src/renderer/src/features/navigation/directory-thread-render-model.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/directory-thread-render-model.ts
@@ -1,0 +1,183 @@
+import type {
+  NavigationDirectorySummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import {
+  buildThreadIdentityKey,
+  comparePinnedThreads,
+  isPinnedThread,
+  resolveThreadParentKey,
+  sortSubthreadSummaries,
+} from "@pwragent/shared";
+import {
+  isThreadActive,
+  isThreadAwaitingReview,
+} from "./ThreadRowStatus";
+
+/**
+ * Cap on how many unpinned threads an expanded directory renders before the
+ * rest sit behind its Show more disclosure.
+ */
+export const DIRECTORY_UNPINNED_THREAD_CAP = 10;
+
+export type ExpandedDirectoryThreadRenderModel = {
+  cappedUnpinnedThreads: NavigationThreadSummary[];
+  childThreadsByParentKey: Map<string, NavigationThreadSummary[]>;
+  directoryPinnedThreads: NavigationThreadSummary[];
+  directoryThreadsCollapsed: boolean;
+  directoryUnpinnedThreadCount: number;
+  hiddenUnpinnedCount: number;
+  overflowUnpinnedThreads: NavigationThreadSummary[];
+  selectionOrder: string[];
+  unpinnedExpanded: boolean;
+};
+
+export type DirectoryThreadRenderModel = {
+  activeThreadCount: number;
+  reviewThreadCount: number;
+  visibleThreadCount: number;
+  /**
+   * Absent for a collapsed project row. Keeping this boundary explicit stops
+   * a closed directory from building parent maps, sorting pins, slicing its
+   * overflow, and deriving selection order for UI that cannot render.
+   */
+  expanded?: ExpandedDirectoryThreadRenderModel;
+};
+
+export function buildDirectoryThreadRenderModel(params: {
+  directory: NavigationDirectorySummary;
+  expanded: boolean;
+  selectedItemKey?: string;
+  thinkingThreadKeys?: Record<string, boolean>;
+  threadsByKey: ReadonlyMap<string, NavigationThreadSummary>;
+  unpinnedExpanded?: boolean;
+}): DirectoryThreadRenderModel {
+  let activeThreadCount = 0;
+  let reviewThreadCount = 0;
+  let visibleThreadCount = 0;
+  const directoryThreadKeys = params.expanded
+    ? new Set(params.directory.threadKeys)
+    : undefined;
+  const topLevelVisibleThreads: NavigationThreadSummary[] = [];
+  const childThreadCandidates: NavigationThreadSummary[] = [];
+  for (const threadKey of params.directory.threadKeys) {
+    const thread = params.threadsByKey.get(threadKey);
+    if (!thread) continue;
+    visibleThreadCount += 1;
+    if (isThreadActive(thread, params.thinkingThreadKeys)) {
+      activeThreadCount += 1;
+    } else if (isThreadAwaitingReview(thread)) {
+      // A live turn can also be in the Inbox after emitting new output. Keep
+      // it in the activity count only, so a directory never reports the same
+      // thread as both active and waiting to be reviewed.
+      reviewThreadCount += 1;
+    }
+    if (!directoryThreadKeys) continue;
+    if (!thread.parentThreadId) {
+      topLevelVisibleThreads.push(thread);
+      continue;
+    }
+    const parentKey = resolveThreadParentKey(thread, params.threadsByKey);
+    if (parentKey && directoryThreadKeys.has(parentKey)) {
+      childThreadCandidates.push(thread);
+    } else {
+      topLevelVisibleThreads.push(thread);
+    }
+  }
+
+  if (!params.expanded) {
+    return {
+      activeThreadCount,
+      reviewThreadCount,
+      visibleThreadCount,
+    };
+  }
+
+  const directoryPinnedThreads = topLevelVisibleThreads
+    .filter(isPinnedThread)
+    .sort(comparePinnedThreads);
+  const directoryUnpinnedThreadCount =
+    topLevelVisibleThreads.length - directoryPinnedThreads.length;
+  const directoryThreadsCollapsed =
+    directoryPinnedThreads.length > 0
+    && params.directory.directoryThreadsCollapsed === true;
+  // A sticky Directory threads collapse only renders pins. Keep its large
+  // hidden population as a count instead of allocating and slicing three
+  // arrays that no JSX will consume.
+  const unpinnedThreads = directoryThreadsCollapsed
+    ? []
+    : topLevelVisibleThreads.filter((thread) => !isPinnedThread(thread));
+  const cappedUnpinnedThreads = directoryThreadsCollapsed
+    ? []
+    : unpinnedThreads.slice(0, DIRECTORY_UNPINNED_THREAD_CAP);
+  const overflowUnpinnedThreads = directoryThreadsCollapsed
+    ? []
+    : unpinnedThreads.slice(DIRECTORY_UNPINNED_THREAD_CAP);
+  const hiddenUnpinnedCount = directoryThreadsCollapsed
+    ? directoryUnpinnedThreadCount
+    : overflowUnpinnedThreads.length;
+  const selectedUnpinnedInOverflow = overflowUnpinnedThreads.some(
+    (thread) =>
+      buildThreadIdentityKey(thread.source, thread.id) ===
+      params.selectedItemKey,
+  );
+  const unpinnedExpanded =
+    params.unpinnedExpanded ?? selectedUnpinnedInOverflow;
+  const visibleUnpinnedThreads = directoryThreadsCollapsed
+    ? []
+    : [
+        ...cappedUnpinnedThreads,
+        ...(unpinnedExpanded ? overflowUnpinnedThreads : []),
+      ];
+  const renderedParentKeys = new Set(
+    [...directoryPinnedThreads, ...visibleUnpinnedThreads].map((thread) =>
+      buildThreadIdentityKey(thread.source, thread.id),
+    ),
+  );
+  const childThreadsByParentKey = new Map<
+    string,
+    NavigationThreadSummary[]
+  >();
+  for (const thread of childThreadCandidates) {
+    const parentKey = resolveThreadParentKey(thread, params.threadsByKey);
+    if (!parentKey || !renderedParentKeys.has(parentKey)) continue;
+    const children = childThreadsByParentKey.get(parentKey) ?? [];
+    children.push(thread);
+    childThreadsByParentKey.set(parentKey, children);
+  }
+  const selectionOrder = [
+    ...directoryPinnedThreads,
+    ...visibleUnpinnedThreads,
+  ].flatMap((thread) => {
+    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    const children = sortSubthreadSummaries(
+      thread,
+      childThreadsByParentKey.get(threadKey) ?? [],
+    );
+    return [
+      threadKey,
+      ...(thread.subthreadsCollapsed
+        ? []
+        : children.map((child) =>
+            buildThreadIdentityKey(child.source, child.id),
+          )),
+    ];
+  });
+
+  return {
+    activeThreadCount,
+    reviewThreadCount,
+    visibleThreadCount,
+    expanded: {
+      cappedUnpinnedThreads,
+      childThreadsByParentKey,
+      directoryPinnedThreads,
+      directoryThreadsCollapsed,
+      directoryUnpinnedThreadCount,
+      hiddenUnpinnedCount,
+      overflowUnpinnedThreads,
+      selectionOrder,
+      unpinnedExpanded,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add large-directory fixtures covering twelve collapsed projects with 1,296 threads and the observed one-pinned-plus-107-hidden shape
- extract directory thread derivation into a focused render model
- skip parent maps, pin sorting, overflow slicing, and selection-order construction for collapsed project folders
- keep minimized unpinned directory populations as a count and build child maps only for rows that can render

## Root cause

Collapsed directory rows were not mounting every hidden `ThreadRow`, but `DirectoriesList` still derived the complete hidden structure on each render. Large navigation snapshots therefore paid for repeated array construction, filtering, sorting, slicing, parent mapping, and selection-order work even when the project or its unpinned section could not render those rows.

This was observed while investigating renderer CPU profiles from an operator instance with roughly 1,088 threads. The experimental lightweight navigation refresh would reduce provider polling work, but it still merges recent results into the complete cached snapshot, and thread creation continues to trigger full navigation refreshes. Reducing renderer work remains necessary.

## Impact

Collapsed project folders now perform the status/count scan needed by their header without preparing expanded thread structures. A minimized `Directory threads` section renders its pinned rows and retains the hidden population as a count without allocating capped or overflow lists.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/directory-thread-render-model.test.ts apps/desktop/src/renderer/src/features/navigation/__tests__/directories-list-performance.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx` — 109 tests passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — zero errors; existing warning baseline only
- `pnpm lint:boundaries`
- `git diff --check`
