### PR TITLE
test(tests): prune redundant thread and package tests

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -510,7 +510,6 @@ describe("ThreadContextPanel", () => {
         name: "Open transcript",
       }),
     ).not.toBeInTheDocument();
-    expect(openSubAgentTranscriptWindow).not.toHaveBeenCalled();
   });
 
   it("does not offer a transcript for a detached review child", () => {
@@ -544,7 +543,6 @@ describe("ThreadContextPanel", () => {
         name: "Open transcript",
       }),
     ).not.toBeInTheDocument();
-    expect(openSubAgentTranscriptWindow).not.toHaveBeenCalled();
   });
 
   it("labels Codex native sub-agent usage separately from monitor usage", () => {
@@ -2930,7 +2928,6 @@ describe("ThreadContextPanel", () => {
     });
 
     expect(screen.queryByRole("button", { name: "Detach" })).not.toBeInTheDocument();
-    expect(detachDirectoryFromThread).not.toHaveBeenCalled();
   });
 
   it("shows regular and Spark rate limits together on the AI provider info tab", () => {
@@ -2954,7 +2951,6 @@ describe("ThreadContextPanel", () => {
     expect(
       screen.queryByRole("button", { name: "Mark as Agent" }),
     ).not.toBeInTheDocument();
-    expect(setThreadAgent).not.toHaveBeenCalled();
   });
 
   it("keeps existing Codex Agent metadata read-only", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
@@ -146,7 +146,6 @@ describe("TranscriptCommandOutput", () => {
     expect(
       screen.queryByRole("button", { name: "Open transcript" }),
     ).not.toBeInTheDocument();
-    expect(openSubAgentTranscriptWindow).not.toHaveBeenCalled();
   });
 
   it("renders structured ACP tool invocations without pretending they are shell commands", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
@@ -26,22 +26,6 @@ describe("buildTranscriptRenderItems", () => {
     expect(items[1]).toMatchObject({ type: "entry", entry: entries[3] });
   });
 
-  it("shows active commentary messages without an elider", () => {
-    const entries = [
-      commentary("c1", "First scan."),
-      commentary("c2", "Narrowing."),
-      commentary("c3", "Still working."),
-    ];
-
-    const items = buildTranscriptRenderItems({ entries, activeMessageId: "c3" });
-
-    expect(items).toEqual([
-      { type: "entry", entry: entries[0] },
-      { type: "entry", entry: entries[1] },
-      { type: "entry", entry: entries[2] },
-    ]);
-  });
-
   it("shows all active commentary messages without an elider", () => {
     const entries = [
       commentary("c1", "First scan."),

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/LinkedProjectsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/LinkedProjectsPanel.test.tsx
@@ -53,7 +53,5 @@ describe("LinkedProjectsPanel", () => {
       "data-tooltip",
       REMOTE_NATIVE_PICKER_TOOLTIP,
     );
-    expect(pickDirectoryFromDisk).not.toHaveBeenCalled();
-    expect(attachDirectoryToThread).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/src/styles/__tests__/chevron-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/chevron-contract.test.ts
@@ -76,6 +76,12 @@ const INLINE_CHEVRONS: Array<{ name: string; collapsed: string; expanded: string
   },
 ];
 
+const NON_ARIA_STATE_CHEVRONS = INLINE_CHEVRONS.filter(
+  ({ collapsed, expanded }) =>
+    !collapsed.includes("aria-expanded")
+    && !expanded.includes("aria-expanded"),
+);
+
 // The base element rule that paints each unfilled chevron's "V" shape.
 const UNFILLED_BASE_RULES = [
   ".transcript-activity__chevron",
@@ -157,24 +163,22 @@ function sweepStateRules(): SweptRule[] {
 }
 
 describe("chevron disclosure direction contract", () => {
-  it.each(INLINE_CHEVRONS)(
-    "$name points right when collapsed (rotate(-45deg))",
-    ({ collapsed }) => {
+  // The generic aria-expanded sweep below covers those state pairs. These
+  // two legacy state selectors do not use aria-expanded, so keep their
+  // direction contract explicit without re-running every swept pair.
+  it.each(NON_ARIA_STATE_CHEVRONS)(
+    "$name points right when collapsed and down when expanded",
+    ({ collapsed, expanded }) => {
       const body = ruleBody(collapsed);
       expect(body).toContain("rotate(-45deg)");
       // "rotate(-45deg)" never contains the substring "rotate(45deg)", so
       // this guards against an expanded value leaking into a collapsed rule.
       expect(body).not.toContain("rotate(45deg)");
-    }
-  );
 
-  it.each(INLINE_CHEVRONS)(
-    "$name points down when expanded (rotate(45deg))",
-    ({ expanded }) => {
-      const body = ruleBody(expanded);
-      expect(body).toContain("rotate(45deg)");
-      expect(body).not.toContain("rotate(-45deg)");
-    }
+      const expandedBody = ruleBody(expanded);
+      expect(expandedBody).toContain("rotate(45deg)");
+      expect(expandedBody).not.toContain("rotate(-45deg)");
+    },
   );
 
   it.each(UNFILLED_BASE_RULES)("%s is an unfilled border chevron", (selector) => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -426,11 +426,6 @@ describe("Tangerine Terminal theme contract", () => {
     expect(titleButtonRule).not.toMatch(/(?:^|\n)\s*width:\s*100%;/);
   });
 
-  it("uses the standard thread chrome instead of legacy launchpad chrome", () => {
-    expect(css).not.toContain(".thread-header--launchpad");
-    expect(css).not.toContain(".launchpad-panel");
-  });
-
   it("keeps launchpad setup output from shrinking the header summary", () => {
     const setupComposerRule = extractRuleBody(
       css,

--- a/packages/messaging/providers/line/src/__tests__/line-adapter.test.ts
+++ b/packages/messaging/providers/line/src/__tests__/line-adapter.test.ts
@@ -763,7 +763,7 @@ describe("LineAdapter", () => {
     );
   });
 
-  it("rejects attachments over the request download limit before fetching", async () => {
+  it("rejects attachments over request and provider download limits before fetching", async () => {
     const api = createApi();
     const adapter = new LineAdapter({
       api,
@@ -772,16 +772,24 @@ describe("LineAdapter", () => {
     });
     adapters.push(adapter);
 
-    await expect(adapter.downloadAttachment({
-      attachment: {
-        id: "123",
-        kind: "file",
-        name: "large.bin",
-        disposition: "available",
-        sizeBytes: 11,
-      },
-      maxBytes: 10,
-    })).rejects.toThrow(/download limit/);
+    for (const { maxBytes, sizeBytes } of [
+      { maxBytes: 10, sizeBytes: 11 },
+      // The request allows 300 MiB, so only LINE's advertised 200 MiB cap
+      // rejects this case. The previous 200 MiB request duplicated the first
+      // branch and did not actually distinguish the provider cap.
+      { maxBytes: 300 * 1024 * 1024, sizeBytes: 201 * 1024 * 1024 },
+    ]) {
+      await expect(adapter.downloadAttachment({
+        attachment: {
+          id: "123",
+          kind: "file",
+          name: "large.bin",
+          disposition: "available",
+          sizeBytes,
+        },
+        maxBytes,
+      })).rejects.toThrow(/download limit/);
+    }
     expect(api.downloadMessageContent).not.toHaveBeenCalled();
   });
 
@@ -830,28 +838,6 @@ describe("LineAdapter", () => {
       fileName: "small.bin",
       sizeBytes: 10,
     });
-  });
-
-  it("rejects attachments over the advertised download cap before fetching", async () => {
-    const api = createApi();
-    const adapter = new LineAdapter({
-      api,
-      callbackHandleStore: createCallbackStore(),
-      config: createConfig(),
-    });
-    adapters.push(adapter);
-
-    await expect(adapter.downloadAttachment({
-      attachment: {
-        id: "123",
-        kind: "file",
-        name: "large.bin",
-        disposition: "available",
-        sizeBytes: 201 * 1024 * 1024,
-      },
-      maxBytes: 200 * 1024 * 1024,
-    })).rejects.toThrow(/download limit/);
-    expect(api.downloadMessageContent).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/shared/src/contracts/__tests__/branch-drift.test.ts
+++ b/packages/shared/src/contracts/__tests__/branch-drift.test.ts
@@ -2,41 +2,30 @@ import { describe, expect, it } from "vitest";
 
 import { isBranchDrifted } from "../branch-drift";
 
+const BRANCH_DRIFT_CASES: Array<[
+  scenario: string,
+  expected: string | undefined,
+  observed: string | undefined,
+  drifted: boolean,
+]> = [
+  ["missing expected branch", undefined, "main", false],
+  ["missing observed branch", "main", undefined, false],
+  ["equal named branches", "main", "main", false],
+  [
+    "HEAD expected and a named branch observed",
+    "HEAD",
+    "fix/release-skill-squash-merge",
+    true,
+  ],
+  ["a named branch expected and HEAD observed", "main", "HEAD", true],
+  ["HEAD on both sides", "HEAD", "HEAD", false],
+  ["different named branches", "main", "feature/x", true],
+  ["an empty expected branch", "", "main", false],
+  ["an empty observed branch", "main", "", false],
+];
+
 describe("isBranchDrifted", () => {
-  it("returns false when both args are undefined", () => {
-    expect(isBranchDrifted(undefined, undefined)).toBe(false);
-  });
-
-  it("returns false when expected is undefined", () => {
-    expect(isBranchDrifted(undefined, "main")).toBe(false);
-  });
-
-  it("returns false when observed is undefined", () => {
-    expect(isBranchDrifted("main", undefined)).toBe(false);
-  });
-
-  it("returns false when both are equal named branches", () => {
-    expect(isBranchDrifted("main", "main")).toBe(false);
-  });
-
-  it("returns true when expected is HEAD and observed is a named branch", () => {
-    expect(isBranchDrifted("HEAD", "fix/release-skill-squash-merge")).toBe(true);
-  });
-
-  it("returns true when observed is HEAD and expected is a named branch", () => {
-    expect(isBranchDrifted("main", "HEAD")).toBe(true);
-  });
-
-  it("returns false when both are HEAD", () => {
-    expect(isBranchDrifted("HEAD", "HEAD")).toBe(false);
-  });
-
-  it("returns true when both are different named branches", () => {
-    expect(isBranchDrifted("main", "feature/x")).toBe(true);
-  });
-
-  it("treats empty strings as missing", () => {
-    expect(isBranchDrifted("", "main")).toBe(false);
-    expect(isBranchDrifted("main", "")).toBe(false);
+  it.each(BRANCH_DRIFT_CASES)("handles %s", (_scenario, expected, observed, drifted) => {
+    expect(isBranchDrifted(expected, observed)).toBe(drifted);
   });
 });


### PR DESCRIPTION
## Summary

- Audited all 112 test files in the owned thread-detail, renderer-style, messaging, and shared-package scope against production code and git history.
- Removed 17 redundant Vitest cases (1,360 → 1,343, -1.25%) while keeping every test file and all production code unchanged.
- Reduced the patch by 49 net lines (59 additions, 108 deletions) without changing dependency boundaries or product behavior.

## Evidence-backed changes

- **Chevron contracts (-14 cases):** replaced 16 duplicate per-row collapsed/expanded checks with two combined checks for the only non-`aria-expanded` selectors. The existing stylesheet-wide direction, state-transition, and non-vacuity sweeps continue to cover all six `aria-expanded` rows.
- **Active commentary rendering (-1 case):** removed the three-entry no-elider case because the adjacent five-entry pure-render test exercises the same branch, and `TranscriptList` independently retains the integration assertion that all active commentary stays visible.
- **Legacy launchpad CSS (-1 case):** removed a negative-only check for two selectors absent from production. The positive thread-view regression still verifies standard launchpad navigation chrome and no legacy summary card.
- **LINE download limits (-1 case):** consolidated request-limit and provider-limit rejection into one matrix. The provider row now requests 300 MiB while LINE advertises 200 MiB, so its 201 MiB attachment is genuinely rejected by provider capability rather than duplicating the request-limit branch.
- **Branch drift (no runner-count change):** converted handwritten cases to a typed table, removed the redundant both-undefined combination, and kept distinct missing-side, named-branch, `HEAD`, and empty-string behavior.
- **Vacuous callback assertions (7 assertions, no runner-count change):** removed no-call checks from six tests where no interactive control exists or the remote add-directory control is disabled. The meaningful absence, disabled-state, and tooltip assertions remain.

Security/auth/input-validation coverage, provider callback semantics, transcript parsing edge cases, serialization/migration compatibility, malformed-input behavior, accessibility/theme contracts, and issue-linked regressions were intentionally retained.

## Measurement

Matched single local runs of:

`pnpm test apps/desktop/src/renderer/src/features/thread-detail apps/desktop/src/renderer/src/styles packages/messaging packages/shared`

| | Test files | Tests | Vitest duration | Wall time |
| --- | ---: | ---: | ---: | ---: |
| `origin/main` before | 112 | 1,360 | 16.46s | 17.54s |
| Audit branch after | 112 | 1,343 | 18.78s | 20.00s |
| Delta | 0 | -17 (-1.25%) | +2.32s | +2.46s |

Runtime is an adjacent single-run local measurement, not a benchmark claim. Shared-host load dominated the timings (earlier successful full runs varied materially), so the patch makes no speedup claim.

## Verification

- [x] Focused affected files: 8 files / 214 tests passed in 3.46s
- [x] Full owned scope after final `origin/main` rebase: 112 files / 1,343 tests passed in 18.78s (20.00s wall)
- [x] Preserved Discord identifier fuzz regression: 5 tests passed in 2.97s after one saturated full run hit its unchanged 5s timeout
- [x] ESLint on all eight changed files
- [x] `pnpm typecheck`
- [x] `pnpm lint:eslint`
- [x] `pnpm lint:boundaries`

## Notes

- Test-only change; no production source, E2E, desktop-main tests, historical decision docs, or protocol captures were modified.
- Six new upstream transcript-window regressions landed during the audit; they exercise distinct windowing, pagination, and ownership behavior and were retained.
- No formatter was run.
