### PR TITLE
test(desktop): prune redundant renderer tests

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/CompactComposer.test.tsx
@@ -45,9 +45,13 @@ describe("CompactComposer", () => {
     expect(screen.getByText("gpt-5-codex · high · Full access")).toBeTruthy();
   });
 
-  it("omits the ambient strip when there is nothing to report", () => {
+  it("omits optional ambient and action chrome when unconfigured", () => {
     renderComposer();
+    expect(
+      screen.getByRole("textbox", { name: "Message Thread t1" }),
+    ).toBeTruthy();
     expect(screen.queryByText(/·/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "More actions" })).toBeNull();
   });
 
   it("swaps Send for Stop while a turn is running", () => {
@@ -56,11 +60,6 @@ describe("CompactComposer", () => {
     expect(screen.queryByRole("button", { name: "Send" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Stop" }));
     expect(onInterrupt).toHaveBeenCalledTimes(1);
-  });
-
-  it("hides the kebab when there are no secondary actions", () => {
-    renderComposer();
-    expect(screen.queryByRole("button", { name: "More actions" })).toBeNull();
   });
 
   it("runs a secondary action and closes the menu", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -3995,29 +3995,6 @@ describe("Sidebar", () => {
     expect(onArchiveThread).toHaveBeenCalledWith(sharedThread);
   });
 
-  it("renders directory rows without the raw chevron glyph affordance", () => {
-    render(
-      <Sidebar
-        backends={backends}
-        browseMode="directories"
-        createThreadError={undefined}
-        directories={directories}
-        inboxThreads={[sharedThread]}
-        launchpadError={undefined}
-        loading={false}
-        creatingThread={undefined}
-        selectedItemKey={undefined}
-        threads={[sharedThread]}
-        onBrowseModeChange={() => undefined}
-        onCreateThread={async () => undefined}
-        onOpenLaunchpad={async () => undefined}
-        onSelectThread={() => undefined}
-      />
-    );
-
-    expect(screen.queryByText("▾")).not.toBeInTheDocument();
-  });
-
   it("copies linked directory and branch metadata from recents chips", async () => {
     const copyText = vi.fn(async () => undefined);
     Object.defineProperty(window, "pwragent", {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1339,9 +1339,15 @@ describe("SettingsScreen", () => {
     });
   });
 
-  it("defaults live transcript event filtering off for stale snapshots", async () => {
-    const snapshot = createSnapshot() as any;
-    delete snapshot.experimental.liveTranscriptEventFiltering;
+  it("defaults missing experimental flags off and persists each when enabled", async () => {
+    const snapshot = createSnapshot();
+    const experimental = snapshot.experimental as Partial<
+      typeof snapshot.experimental
+    >;
+    delete experimental.liveTranscriptEventFiltering;
+    delete experimental.codexDefaultModeRequestUserInput;
+    delete experimental.lightweightNavigationRefresh;
+    delete experimental.markdownMathRendering;
     const settings = createSettingsState(snapshot);
 
     render(
@@ -1355,7 +1361,20 @@ describe("SettingsScreen", () => {
     const filteringSwitch = screen.getByRole("switch", {
       name: "Enable live transcript event filtering",
     });
+    const questionsSwitch = screen.getByRole("switch", {
+      name: "Enable Codex skill questions",
+    });
+    const refreshSwitch = screen.getByRole("switch", {
+      name: "Enable lightweight navigation refresh",
+    });
+    const mathSwitch = screen.getByRole("switch", {
+      name: "Enable Markdown math rendering",
+    });
+
     expect(filteringSwitch).toHaveAttribute("aria-checked", "false");
+    expect(questionsSwitch).toHaveAttribute("aria-checked", "false");
+    expect(refreshSwitch).toHaveAttribute("aria-checked", "false");
+    expect(mathSwitch).toHaveAttribute("aria-checked", "false");
 
     fireEvent.click(filteringSwitch);
     await waitFor(() => {
@@ -1363,24 +1382,6 @@ describe("SettingsScreen", () => {
         experimental: { liveTranscriptEventFiltering: true },
       });
     });
-  });
-
-  it("defaults Codex skill questions off for stale snapshots", async () => {
-    const snapshot = createSnapshot() as any;
-    delete snapshot.experimental.codexDefaultModeRequestUserInput;
-    const settings = createSettingsState(snapshot);
-
-    render(
-      <SettingsScreen
-        initialSection="experimental"
-        settings={settings}
-      />,
-    );
-
-    const questionsSwitch = screen.getByRole("switch", {
-      name: "Enable Codex skill questions",
-    });
-    expect(questionsSwitch).toHaveAttribute("aria-checked", "false");
 
     fireEvent.click(questionsSwitch);
     await waitFor(() => {
@@ -1388,24 +1389,6 @@ describe("SettingsScreen", () => {
         experimental: { codexDefaultModeRequestUserInput: true },
       });
     });
-  });
-
-  it("defaults lightweight navigation refresh off for stale snapshots", async () => {
-    const snapshot = createSnapshot() as any;
-    delete snapshot.experimental.lightweightNavigationRefresh;
-    const settings = createSettingsState(snapshot);
-
-    render(
-      <SettingsScreen
-        initialSection="experimental"
-        settings={settings}
-      />,
-    );
-
-    const refreshSwitch = screen.getByRole("switch", {
-      name: "Enable lightweight navigation refresh",
-    });
-    expect(refreshSwitch).toHaveAttribute("aria-checked", "false");
 
     fireEvent.click(refreshSwitch);
     await waitFor(() => {
@@ -1413,24 +1396,6 @@ describe("SettingsScreen", () => {
         experimental: { lightweightNavigationRefresh: true },
       });
     });
-  });
-
-  it("defaults Markdown math rendering off for stale snapshots", async () => {
-    const snapshot = createSnapshot() as any;
-    delete snapshot.experimental.markdownMathRendering;
-    const settings = createSettingsState(snapshot);
-
-    render(
-      <SettingsScreen
-        initialSection="experimental"
-        settings={settings}
-      />,
-    );
-
-    const mathSwitch = screen.getByRole("switch", {
-      name: "Enable Markdown math rendering",
-    });
-    expect(mathSwitch).toHaveAttribute("aria-checked", "false");
 
     fireEvent.click(mathSwitch);
     await waitFor(() => {
@@ -4168,7 +4133,7 @@ describe("SettingsScreen", () => {
     ).toHaveAttribute("aria-current", "page");
   });
 
-  it("places Exit Settings as the first row of the settings nav (NOT in the title bar)", () => {
+  it("keeps Exit, the General label, and section order in the settings nav", () => {
     // Regression lock for the design contract: Exit Settings lives
     // INSIDE `.settings-nav` (left column), not inside the title-bar
     // strip. Two prior attempts in this branch put it in the strip
@@ -4184,28 +4149,10 @@ describe("SettingsScreen", () => {
     expect(exit.closest(".settings-nav")).not.toBeNull();
     expect(exit.closest(".settings-titlebar")).toBeNull();
     expect(exit).toHaveClass("settings-nav__exit");
-  });
-
-  it("renders a 'General' group label between Exit Settings and the section list", () => {
-    render(
-      <SettingsScreen
-        settings={createSettingsState()}
-        onClose={() => undefined}
-      />,
-    );
 
     const label = document.querySelector(".settings-nav__group-label");
     expect(label).not.toBeNull();
     expect(label?.textContent?.toLowerCase()).toBe("general");
-  });
-
-  it("orders Git and worktree settings after the primary navigation group", () => {
-    render(
-      <SettingsScreen
-        settings={createSettingsState()}
-        onClose={() => undefined}
-      />,
-    );
 
     const nav = screen.getByRole("navigation", { name: "Settings sections" });
     const buttons = within(nav)

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-section-chevron.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-section-chevron.test.tsx
@@ -6,11 +6,11 @@ import { SettingsSection } from "../SettingsLayout";
 afterEach(cleanup);
 
 describe("settings section disclosure chevron placement", () => {
-  it("renders the chevron as the first child of the header, before the title block", () => {
+  it("renders its only chevron before the title block and outside header actions", () => {
     const { container } = render(
       <SettingsSection title="Telegram">
         <div>body</div>
-      </SettingsSection>
+      </SettingsSection>,
     );
 
     const header = container.querySelector(".settings-section__header-button");
@@ -19,16 +19,11 @@ describe("settings section disclosure chevron placement", () => {
     const children = [...(header as HTMLElement).children];
     expect(children[0]).toHaveClass("settings-section__chevron");
     expect(children[1]).toHaveClass("settings-section__header-main");
-  });
-
-  it("no longer renders the chevron inside the right-side header actions", () => {
-    const { container } = render(
-      <SettingsSection title="Telegram">
-        <div>body</div>
-      </SettingsSection>
-    );
-
+    expect(
+      header?.querySelectorAll(".settings-section__chevron"),
+    ).toHaveLength(1);
     const actions = container.querySelector(".settings-section__header-actions");
+    expect(actions).not.toBeNull();
     expect(actions?.querySelector(".settings-section__chevron")).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -153,10 +153,10 @@ describe("StarMapChatCard federation routing", () => {
     });
   });
 
-  it("starts a turn on the owning peer, not the viewer", async () => {
+  it("starts a turn on the owning peer and clears the sent draft", async () => {
     const desktopApi = buildApi();
     renderCard({ desktopApi, thread: remoteThread() });
-    await typeAndSend("Remote work", "ship it");
+    const input = await typeAndSend("Remote work", "ship it");
 
     await waitFor(() => {
       expect(desktopApi.startTurn).toHaveBeenCalledWith(
@@ -167,6 +167,9 @@ describe("StarMapChatCard federation routing", () => {
           input: [{ type: "text", text: "ship it" }],
         }),
       );
+    });
+    await waitFor(() => {
+      expect(input.value).toBe("");
     });
   });
 
@@ -187,7 +190,7 @@ describe("StarMapChatCard federation routing", () => {
 });
 
 describe("StarMapChatCard send failures", () => {
-  it("hands the text back to the input when the peer refuses", async () => {
+  it("restores the draft and rolls back its optimistic message when the peer refuses", async () => {
     const desktopApi = buildApi({
       startTurn: vi.fn(async () => {
         throw new Error("peer is offline");
@@ -200,6 +203,14 @@ describe("StarMapChatCard send failures", () => {
     // what they typed.
     await waitFor(() => {
       expect(input.value).toBe("do not lose me");
+    });
+    // The transcript must not keep a message for a turn that never ran.
+    // The composer is excluded because the restored draft lives there and
+    // text queries match textarea content.
+    await waitFor(() => {
+      expect(
+        screen.queryByText("do not lose me", { ignore: "textarea" }),
+      ).toBeNull();
     });
     expect((await screen.findByRole("alert")).textContent).toMatch(
       /peer is offline/,
@@ -220,38 +231,5 @@ describe("StarMapChatCard send failures", () => {
     expect(
       await screen.findByText("in flight", { ignore: "textarea" }),
     ).toBeTruthy();
-  });
-
-  it("rolls the optimistic message back when the turn never started", async () => {
-    const desktopApi = buildApi({
-      startTurn: vi.fn(async () => {
-        throw new Error("nope");
-      }),
-    } as unknown as Partial<DesktopApi>);
-    renderCard({ desktopApi, thread: remoteThread() });
-    await typeAndSend("Remote work", "rolled back");
-
-    // The transcript must not keep a message for a turn that never ran.
-    // The composer is excluded because the restored draft lives there and
-    // text queries match textarea content.
-    await waitFor(() => {
-      expect(
-        screen.queryByText("rolled back", { ignore: "textarea" }),
-      ).toBeNull();
-    });
-    expect((await screen.findByRole("alert")).textContent).toMatch(/nope/);
-  });
-
-  it("clears the draft when the send succeeds", async () => {
-    const desktopApi = buildApi();
-    renderCard({ desktopApi, thread: remoteThread() });
-    const input = await typeAndSend("Remote work", "sent for real");
-
-    await waitFor(() => {
-      expect(desktopApi.startTurn).toHaveBeenCalled();
-    });
-    await waitFor(() => {
-      expect(input.value).toBe("");
-    });
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapLoadCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapLoadCard.test.tsx
@@ -92,15 +92,15 @@ describe("StarMapLoadCard", () => {
     expect(metric("RAM free")).toBe("15%");
   });
 
-  it("falls back to absolute RAM when the total is unknown", () => {
-    renderCard({ load: buildLoad({ totalMemoryBytes: undefined }) });
+  it("falls back when memory total and disk readings are unavailable", () => {
+    renderCard({
+      load: buildLoad({
+        totalMemoryBytes: undefined,
+        diskFreeBytes: undefined,
+      }),
+    });
 
     expect(metric("RAM free")).toBe("2.4 GB");
-  });
-
-  it("shows a dash when the disk read failed", () => {
-    renderCard({ load: buildLoad({ diskFreeBytes: undefined }) });
-
     expect(metric("Free disk")).toBe("—");
   });
 

--- a/apps/desktop/src/renderer/src/features/update/__tests__/AppUpdateBanner.test.tsx
+++ b/apps/desktop/src/renderer/src/features/update/__tests__/AppUpdateBanner.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -44,11 +45,16 @@ describe("AppUpdateBanner", () => {
   });
 
   it("stays hidden before the update is ready to install", async () => {
-    renderBanner({ status: "available", version: "1.2.3" });
+    const { desktopApi, emit } = renderBanner({ status: "idle" });
 
     await waitFor(() => {
-      expect(screen.queryByText(/Restart to update/)).not.toBeInTheDocument();
+      expect(desktopApi.onAppUpdateStatus).toHaveBeenCalledTimes(1);
     });
+    act(() => {
+      emit({ status: "available", version: "1.2.3" });
+    });
+
+    expect(screen.queryByText(/Restart to update/)).not.toBeInTheDocument();
   });
 
   it("calls the restart install IPC action", async () => {

--- a/apps/desktop/src/renderer/src/icons/__tests__/celestial-icons.test.tsx
+++ b/apps/desktop/src/renderer/src/icons/__tests__/celestial-icons.test.tsx
@@ -31,9 +31,9 @@ const COLOR_LITERAL_RE = /#[0-9a-fA-F]{3,8}\b|\brgba?\(|\bhsla?\(|url\(#/;
 
 describe("celestial icon library", () => {
   it.each(CELESTIAL_ICONS)(
-    "%s renders an SVG with the shared filled-icon defaults",
+    "%s honors the shared filled-icon and accessibility contracts",
     (_name, Icon) => {
-      const { container } = render(<Icon />);
+      const { container, rerender } = render(<Icon />);
       const svg = container.querySelector("svg");
       expect(svg).toBeInTheDocument();
       expect(svg).toHaveAttribute("width", "16");
@@ -44,25 +44,13 @@ describe("celestial icon library", () => {
       expect(svg).not.toHaveAttribute("fill");
       // Decorative by default — no aria-label means hidden from AT.
       expect(svg).toHaveAttribute("aria-hidden", "true");
-    },
-  );
-
-  it.each(CELESTIAL_ICONS)(
-    "%s switches to role=img when an aria-label is supplied",
-    (_name, Icon) => {
-      const { container } = render(<Icon aria-label="Instance icon" />);
-      const svg = container.querySelector("svg");
-      expect(svg).toHaveAttribute("role", "img");
-      expect(svg).toHaveAttribute("aria-label", "Instance icon");
-      expect(svg).toHaveAttribute("aria-hidden", "false");
-    },
-  );
-
-  it.each(CELESTIAL_ICONS)(
-    "%s contains no color literals (currentColor + opacity only)",
-    (_name, Icon) => {
-      const { container } = render(<Icon />);
       expect(container.innerHTML).not.toMatch(COLOR_LITERAL_RE);
+
+      rerender(<Icon aria-label="Instance icon" />);
+      const labelledSvg = container.querySelector("svg");
+      expect(labelledSvg).toHaveAttribute("role", "img");
+      expect(labelledSvg).toHaveAttribute("aria-label", "Instance icon");
+      expect(labelledSvg).toHaveAttribute("aria-hidden", "false");
     },
   );
 
@@ -84,17 +72,20 @@ describe("celestial icon library", () => {
   });
 
   describe("CelestialIcon dispatcher", () => {
-    it.each(CELESTIAL_ICON_IDS)("renders an SVG for id %s", (icon) => {
-      const { container } = render(<CelestialIcon icon={icon} />);
-      const svg = container.querySelector("svg");
-      expect(svg).toBeInTheDocument();
-      expect(svg).toHaveAttribute("viewBox", "0 0 24 24");
-    });
-
-    it("renders a distinct markup per id", () => {
+    it("renders a distinct SVG for every id", () => {
       const markups = new Set<string>();
       for (const icon of CELESTIAL_ICON_IDS) {
         const { container } = render(<CelestialIcon icon={icon} />);
+        const svg = container.querySelector("svg");
+        expect({
+          icon,
+          rendered: svg !== null,
+          viewBox: svg?.getAttribute("viewBox"),
+        }).toEqual({
+          icon,
+          rendered: true,
+          viewBox: "0 0 24 24",
+        });
         markups.add(container.innerHTML);
         cleanup();
       }

--- a/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
+++ b/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
@@ -82,8 +82,8 @@ describe("icon library", () => {
   });
 
   describe("TelegramIcon", () => {
-    it("renders the official asset as an <img>", () => {
-      const { container } = render(<TelegramIcon />);
+    it("renders the official asset as an <img> and respects size overrides", () => {
+      const { container, rerender } = render(<TelegramIcon />);
       const img = container.querySelector("img");
       expect(img).toBeInTheDocument();
       expect(img).toHaveAttribute("width", "16");
@@ -91,19 +91,16 @@ describe("icon library", () => {
       expect(img).toHaveAttribute("alt", "");
       expect(img?.getAttribute("src") ?? "").toMatch(/svg|image/i);
       expect(container.querySelector("svg")).not.toBeInTheDocument();
-    });
-
-    it("respects size overrides", () => {
-      const { container } = render(<TelegramIcon size={28} />);
-      const img = container.querySelector("img");
-      expect(img).toHaveAttribute("width", "28");
-      expect(img).toHaveAttribute("height", "28");
+      rerender(<TelegramIcon size={28} />);
+      const resizedImg = container.querySelector("img");
+      expect(resizedImg).toHaveAttribute("width", "28");
+      expect(resizedImg).toHaveAttribute("height", "28");
     });
   });
 
   describe("DiscordIcon", () => {
-    it("renders the official asset as an <img>", () => {
-      const { container } = render(<DiscordIcon />);
+    it("renders the official asset as an <img> and respects size overrides", () => {
+      const { container, rerender } = render(<DiscordIcon />);
       const img = container.querySelector("img");
       expect(img).toBeInTheDocument();
       expect(img).toHaveAttribute("width", "16");
@@ -111,6 +108,10 @@ describe("icon library", () => {
       expect(img).toHaveAttribute("alt", "");
       expect(img?.getAttribute("src") ?? "").toMatch(/svg|image/i);
       expect(container.querySelector("svg")).not.toBeInTheDocument();
+      rerender(<DiscordIcon size={28} />);
+      const resizedImg = container.querySelector("img");
+      expect(resizedImg).toHaveAttribute("width", "28");
+      expect(resizedImg).toHaveAttribute("height", "28");
     });
 
     it("renders distinct sources for each variant", () => {
@@ -124,13 +125,6 @@ describe("icon library", () => {
       }
       expect(sources.size).toBe(3);
     });
-
-    it("respects size overrides", () => {
-      const { container } = render(<DiscordIcon size={28} />);
-      const img = container.querySelector("img");
-      expect(img).toHaveAttribute("width", "28");
-      expect(img).toHaveAttribute("height", "28");
-    });
   });
 
   describe("MattermostIcon", () => {
@@ -139,7 +133,7 @@ describe("icon library", () => {
     // asset files verbatim and render them via <img>. The variant prop
     // selects which published colorway the surface needs.
     it("renders an <img> at the requested size", () => {
-      const { container } = render(<MattermostIcon />);
+      const { container, rerender } = render(<MattermostIcon />);
       const img = container.querySelector("img");
       expect(img).toBeInTheDocument();
       expect(img).toHaveAttribute("width", "16");
@@ -149,6 +143,10 @@ describe("icon library", () => {
       const src = img?.getAttribute("src") ?? "";
       expect(src.length).toBeGreaterThan(0);
       expect(src).toMatch(/svg|image/i);
+      rerender(<MattermostIcon size={28} />);
+      const resizedImg = container.querySelector("img");
+      expect(resizedImg).toHaveAttribute("width", "28");
+      expect(resizedImg).toHaveAttribute("height", "28");
     });
 
     it("renders distinct sources for each variant", () => {
@@ -162,13 +160,6 @@ describe("icon library", () => {
       }
       // Three variants → three distinct asset URLs.
       expect(sources.size).toBe(3);
-    });
-
-    it("respects size overrides", () => {
-      const { container } = render(<MattermostIcon size={28} />);
-      const img = container.querySelector("img");
-      expect(img).toHaveAttribute("width", "28");
-      expect(img).toHaveAttribute("height", "28");
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/hash-references.test.ts
@@ -105,12 +105,16 @@ describe("hashReferenceAnchorKey", () => {
   });
 });
 
-describe("formatHashReferenceThreadLabel", () => {
-  it("keeps a short title verbatim and falls back to the id when it is blank", () => {
+describe("hash reference thread formatting", () => {
+  it("keeps ordinary titles and id fallbacks in labels and tooltips", () => {
     expect(
       formatHashReferenceThreadLabel(thread("id-1", "Bob's Best Thread 3000")),
     ).toBe("Bob's Best Thread 3000");
     expect(formatHashReferenceThreadLabel(thread("id-1", "   "))).toBe("id-1");
+    expect(
+      formatHashReferenceThreadTooltip(thread("id-1", "Bob's\nBest Thread")),
+    ).toBe("Bob's Best Thread");
+    expect(formatHashReferenceThreadTooltip(thread("id-1", ""))).toBe("id-1");
   });
 
   it("collapses a multi-line prompt title onto one truncated line", () => {
@@ -134,9 +138,6 @@ describe("formatHashReferenceThreadLabel", () => {
     const label = formatHashReferenceThreadLabel(thread("id-1", "x".repeat(200)));
     expect(label).toBe(`${"x".repeat(72)}…`);
   });
-});
-
-describe("formatHashReferenceThreadTooltip", () => {
   it("recovers what the label's ellipsis hid without becoming a wall of text", () => {
     const long = `${"word ".repeat(200)}end`;
     const tooltip = formatHashReferenceThreadTooltip(thread("id-1", long));
@@ -147,13 +148,6 @@ describe("formatHashReferenceThreadTooltip", () => {
     expect(tooltip.length).toBeGreaterThan(
       formatHashReferenceThreadLabel(thread("id-1", long)).length,
     );
-  });
-
-  it("leaves an ordinary title alone and falls back to the id", () => {
-    expect(
-      formatHashReferenceThreadTooltip(thread("id-1", "Bob's\nBest Thread")),
-    ).toBe("Bob's Best Thread");
-    expect(formatHashReferenceThreadTooltip(thread("id-1", ""))).toBe("id-1");
   });
 });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/keyboard-accel.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/keyboard-accel.test.ts
@@ -30,22 +30,19 @@ describe("formatPrimaryAccel", () => {
     expect(formatPrimaryAccel("B", { alt: true })).toBe("⌘⌥B");
   });
 
-  it("renders Ctrl/Alt words on Windows", () => {
-    setPlatform("win32");
-    expect(formatPrimaryAccel("B")).toBe("Ctrl+B");
-    expect(formatPrimaryAccel("B", { alt: true })).toBe("Ctrl+Alt+B");
-  });
-
-  it("renders Ctrl/Alt words on Linux", () => {
-    setPlatform("linux");
-    expect(formatPrimaryAccel("B")).toBe("Ctrl+B");
-    expect(formatPrimaryAccel("B", { alt: true })).toBe("Ctrl+Alt+B");
-  });
-
-  it("falls back to the Ctrl form when the desktop bridge is unavailable", () => {
-    setPlatform(undefined);
-    expect(formatPrimaryAccel("B")).toBe("Ctrl+B");
-    expect(formatPrimaryAccel("B", { alt: true })).toBe("Ctrl+Alt+B");
+  it("renders the Ctrl form on Windows, Linux, and without the desktop bridge", () => {
+    for (const platform of ["win32", "linux", undefined]) {
+      setPlatform(platform);
+      expect({
+        platform: platform ?? "unavailable",
+        primary: formatPrimaryAccel("B"),
+        withAlt: formatPrimaryAccel("B", { alt: true }),
+      }).toEqual({
+        platform: platform ?? "unavailable",
+        primary: "Ctrl+B",
+        withAlt: "Ctrl+Alt+B",
+      });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Streamline renderer Vitest coverage in 11 owned test files without changing production code, thread-detail tests, styles tests, desktop-main/package/E2E tests, or historical docs.
- Remove 32 redundant runtime cases (1,762 -> 1,730) while retaining accessibility, keyboard, async lifecycle, malformed-state, transition, and issue-linked coverage.
- Harden the retained AppUpdateBanner `available` state boundary so it cannot pass before the tested state is actually applied.

## Removed / consolidated coverage and evidence

- **CompactComposer:** Combined `omits the ambient strip when there is nothing to report` and `hides the kebab when there are no secondary actions` into `omits optional ambient and action chrome when unconfigured`. Both used the identical default `renderComposer()` state. The combined test first proves the composer textbox mounted, then checks both optional surfaces are absent.
- **Sidebar:** Removed `renders directory rows without the raw chevron glyph affordance`. Current production renders CSS-only `.directory-row__chevron` spans, not the retired raw `▾` text. The old negative text query did not positively establish the glyph-bearing UI contract and duplicated the removed-control state. Directory expansion, selection, metadata, keyboard, and archive coverage remain.
- **Experimental settings:** Consolidated `defaults live transcript event filtering off for stale snapshots`, `defaults Codex skill questions off for stale snapshots`, `defaults lightweight navigation refresh off for stale snapshots`, and `defaults Markdown math rendering off for stale snapshots`. Production resolves each missing field through its own `?? DEFAULT_...` branch and uses the same write-handler shape. One malformed snapshot now omits all four keys, asserts all four named switches default off, and asserts every distinct persisted patch after interaction.
- **Settings navigation:** Consolidated `places Exit Settings as the first row of the settings nav (NOT in the title bar)`, `renders a 'General' group label between Exit Settings and the section list`, and `orders Git and worktree settings after the primary navigation group`. All rendered the same default SettingsScreen. The merged test retains the Exit location/class contract, General label, exact button sequence, and separator placement.
- **Settings section chevron:** Consolidated `renders the chevron as the first child of the header, before the title block` and `no longer renders the chevron inside the right-side header actions`. Both rendered the same section. The merged test proves the header and actions container exist, asserts one chevron, checks child order, and checks that actions do not own it.
- **StarMapChatCard success:** Folded `clears the draft when the send succeeds` into `starts a turn on the owning peer, not the viewer`. Both exercised the same successful `send` transition. The merged test retains exact peer routing and waits for the controlled draft to clear.
- **StarMapChatCard failure:** Folded `rolls the optimistic message back when the turn never started` into `hands the text back to the input when the peer refuses`. Both exercised the same rejected `send` transition. The merged test retains draft restoration, optimistic rollback, and alert text; the separate in-flight optimistic-message test remains.
- **StarMapLoadCard:** Combined `falls back to absolute RAM when the total is unknown` and `shows a dash when the disk read failed`. These are independent fallback branches over the same card fixture; one render now seeds both missing readings and keeps both labelled metric assertions.
- **AppUpdateBanner:** Retained and hardened `stays hidden before the update is ready to install`. Production exposes restart UI only for `downloaded`. The test now waits for listener registration, emits `available` inside `act`, and then asserts restart UI is absent, so the state-machine boundary cannot pass on the initial idle render.
- **Celestial icon contracts:** Consolidated the three five-icon matrices—`%s renders an SVG with the shared filled-icon defaults`, `%s switches to role=img when an aria-label is supplied`, and `%s contains no color literals (currentColor + opacity only)`—into one five-icon matrix. Each icon keeps its own failure title. A rerender checks decorative-to-labelled accessibility while default geometry/theme assertions remain explicit. This removes 10 repeated runtime cases.
- **CelestialIcon dispatcher:** Consolidated the five-case `renders an SVG for id %s` matrix and `renders a distinct markup per id` into one loop. Structured assertions include the failing icon id, retain SVG/viewBox checks for every id, and preserve pairwise-distinct dispatcher markup. This removes 5 cases.
- **Telegram / Discord / Mattermost icons:** Folded each separate `respects size overrides` test into its vendor asset test. Each test now verifies the default asset/accessibility dimensions, rerenders with size 28, requeries the live image, and verifies the controlled size update. Variant-source tests remain separate.
- **Hash references:** Consolidated `keeps a short title verbatim and falls back to the id when it is blank` and `leaves an ordinary title alone and falls back to the id`. One formatting test retains both label and tooltip ordinary/fallback branches; long-label truncation and long-tooltip recovery stay separate.
- **Keyboard accelerators:** Consolidated `renders Ctrl/Alt words on Windows`, `renders Ctrl/Alt words on Linux`, and `falls back to the Ctrl form when the desktop bridge is unavailable`. Production has one macOS branch and one shared non-mac/unknown branch. The loop's structured actual/expected object includes the platform identity and checks both primary and Alt forms. macOS glyph coverage remains separate.

Net diff: 11 test files, 118 insertions, 243 deletions (125 fewer lines).

## Verification

- Exact owned renderer baseline on `origin/main`, excluding `features/thread-detail/**` and `styles/**`: **105 files / 1,762 tests**, Vitest **59.80s**, wall **61.37s** with `--maxWorkers=4`.
- Audited suite, same command and worker cap: **105 files / 1,730 tests**, Vitest **50.19s**, wall **51.23s**.
- Delta: **-32 tests (-1.8%)**, **-9.61s Vitest duration (-16.1%)**, **-10.14s wall (-16.5%)** in the stable back-to-back comparison.
- Final rebased changed-suite run: **11 files / 270 tests passed**, Vitest **23.72s**, wall **24.81s**.
- Focused AppUpdateBanner run: **5/5 passed**.
- Focused CompactComposer run: **9/9 passed**.
- `pnpm exec eslint <11 changed files>`: passed with no warnings or errors.
- `pnpm --filter @pwragent/desktop typecheck`: passed.
- `pnpm lint:boundaries`: passed (1,339 modules / 4,291 dependencies).
- `git diff --check origin/main...HEAD`: passed.

## Notes

- The host was heavily contended during this audit (load averages ranged roughly 30-140), so comparisons use an explicit four-worker cap. A preliminary default-parallel run produced only timeout failures; no product assertions failed.
- After the final non-renderer rebase, the current-base full run passed all 1,762 tests in 79.51s. The immediately following branch retry passed 1,729/1,730 and hit one untouched `App > renders the live thread shell with transcript history` async-heading timeout in `app-shell.test.tsx`; the same isolated test also exhausted its Testing Library wait while the host was loaded. The earlier full 1,730-test branch run and the final 270-test changed-suite run are green. No timeout, retry, production, or app-shell change is included.
- Managed monitoring was attempted for the long checks, but its startup/completion callback was unavailable in this handoff thread; direct commands and durable outputs were used as the fallback.
