### PR TITLE
feat(agent-core): add experimental Claude ACP support

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -129,6 +129,37 @@ describe("describeInstalledAcpBackend", () => {
     expect(gemini.capabilities.steerTurn).toBe(false);
   });
 
+  it("identifies Claude credentials as local to the owning federation instance", () => {
+    const backend = describeInstalledAcpBackend({
+      ...buildInstalledAgent(),
+      backendId: "acp:claude-acp" as AcpBackendId,
+      registryId: "claude-acp",
+      name: "Claude Agent",
+      version: "0.60.0",
+      distributionKind: "npx",
+      authStatus: "authenticated",
+      allowlistRuleId: "managed-claude-agent-acp-0.60.0",
+    });
+
+    expect(backend).toMatchObject({
+      kind: "acp:claude-acp",
+      label: "Claude Agent",
+      available: true,
+      acp: {
+        credentialScope: "owning-instance",
+        authStatus: "authenticated",
+        supportLevel: "experimental",
+      },
+      capabilities: {
+        startReview: false,
+        multiDirectoryThreads: true,
+      },
+    });
+    expect(JSON.stringify(backend)).not.toMatch(
+      /ANTHROPIC_API_KEY|auth login|accessToken|refreshToken/i,
+    );
+  });
+
   it("advertises Grok 4.5 reasoning efforts in launchpad options", () => {
     const backend = describeInstalledAcpBackend({
       ...buildInstalledAgent(),
@@ -4202,6 +4233,150 @@ describe("AcpBackendAdapter", () => {
         incompatibleInstances: diagnostic.incompatibleInstances,
       }),
     );
+
+    await adapter.close();
+  });
+
+  it("requires a verified managed runtime before launching cached Claude", async () => {
+    const backendId = "acp:claude-acp" as AcpBackendId;
+    const cached: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "claude-acp",
+      name: "Claude Agent",
+      version: "0.60.0",
+      distributionKind: "npx",
+      distributionSource: "@agentclientprotocol/claude-agent-acp@0.60.0",
+      authStatus: "authenticated",
+      verificationStatus: "verified",
+      allowlistRuleId: "managed-claude-agent-acp-0.60.0",
+      launchDescriptor: {
+        backendId,
+        registryId: "claude-acp",
+        distributionKind: "npx",
+        command: "/stale/node",
+        args: ["/stale/claude-agent-acp.js"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => cached,
+        listInstalledAgents: () => [cached],
+        upsertInstalledAgent: vi.fn(),
+      },
+      captureStores: [],
+      discoverLocalAcpAgents: async () => [],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+      isAcpAgentEnabled: () => true,
+      isClaudeAcpExperimentalEnabled: () => true,
+    });
+
+    await expect(adapter.describeInstalledBackends()).resolves.toEqual([
+      expect.objectContaining({
+        kind: backendId,
+        available: false,
+        unavailableReason: expect.stringContaining("failed verification"),
+        acp: expect.objectContaining({
+          installStatus: "unavailable",
+          authStatus: "required",
+          credentialScope: "owning-instance",
+        }),
+      }),
+    ]);
+    await expect(adapter.resolveInstalledAgent(backendId)).rejects.toThrow(
+      `ACP backend is not installed: ${backendId}`,
+    );
+
+    await adapter.close();
+  });
+
+  it("does not advertise or launch Claude when its Experimental opt-in is off", async () => {
+    const backendId = "acp:claude-acp" as AcpBackendId;
+    const cached: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "claude-acp",
+      name: "Claude Agent",
+      version: "0.60.0",
+      distributionKind: "npx",
+      authStatus: "authenticated",
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => cached,
+        listInstalledAgents: () => [cached],
+        upsertInstalledAgent: vi.fn(),
+      },
+      captureStores: [],
+      discoverLocalAcpAgents: async () => [cached],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+      isAcpAgentEnabled: () => true,
+      isClaudeAcpExperimentalEnabled: () => false,
+    });
+
+    await expect(adapter.describeInstalledBackends()).resolves.toEqual([]);
+    await expect(adapter.resolveInstalledAgent(backendId)).rejects.toThrow(
+      "experimental and is not enabled",
+    );
+    await expect(adapter.getClient(backendId)).rejects.toThrow(
+      "experimental and is not enabled",
+    );
+
+    await adapter.close();
+  });
+
+  it("preserves readiness only when Claude discovery verifies the pinned runtime", async () => {
+    const backendId = "acp:claude-acp" as AcpBackendId;
+    const cached: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "claude-acp",
+      name: "Claude Agent",
+      version: "0.60.0",
+      distributionKind: "npx",
+      distributionSource: "@agentclientprotocol/claude-agent-acp@0.60.0",
+      authStatus: "authenticated",
+      verificationStatus: "verified",
+      allowlistRuleId: "managed-claude-agent-acp-0.60.0",
+    };
+    const discovered: AcpInstalledAgentRecord = {
+      ...cached,
+      authStatus: "required",
+      launchDescriptor: {
+        backendId,
+        registryId: "claude-acp",
+        distributionKind: "npx",
+        command: "/verified/node",
+        args: ["/verified/claude-agent-acp.js"],
+        env: {},
+      },
+    };
+    const upsertInstalledAgent = vi.fn();
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => cached,
+        listInstalledAgents: () => [cached],
+        upsertInstalledAgent,
+      },
+      captureStores: [],
+      discoverLocalAcpAgents: async () => [discovered],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+      isAcpAgentEnabled: () => true,
+      isClaudeAcpExperimentalEnabled: () => true,
+    });
+
+    await expect(adapter.resolveInstalledAgent(backendId)).resolves.toMatchObject({
+      authStatus: "authenticated",
+      launchDescriptor: {
+        command: "/verified/node",
+      },
+    });
+    await adapter.describeInstalledBackends();
+    expect(upsertInstalledAgent).not.toHaveBeenCalled();
 
     await adapter.close();
   });

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -152,6 +152,7 @@ describe("describeInstalledAcpBackend", () => {
       },
       capabilities: {
         startReview: false,
+        steerTurn: false,
         multiDirectoryThreads: true,
       },
     });
@@ -898,6 +899,130 @@ describe("AcpBackendAdapter", () => {
                 output_tokens: 50,
                 reasoning_output_tokens: 10,
                 total_tokens: 1_250,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    await adapter.close();
+  });
+
+  it("publishes Claude prompt usage and context-window updates", async () => {
+    const backendId = "acp:claude-acp" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": {
+        stopReason: "end_turn",
+        usage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          cachedReadTokens: 900,
+          cachedWriteTokens: 50,
+          totalTokens: 1_070,
+        },
+      },
+    });
+    const events: AgentEvent[] = [];
+    const sessions: AcpSessionMetadata[] = [];
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "claude-acp",
+      name: "Claude Agent",
+      version: "0.60.0",
+      distributionKind: "npx",
+      authStatus: "authenticated",
+      launchDescriptor: {
+        backendId,
+        registryId: "claude-acp",
+        distributionKind: "npx",
+        command: process.execPath,
+        args: ["/verified/claude-agent-acp.js"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => sessions,
+        getSession: (_backendId, sessionId) =>
+          sessions.find((session) => session.sessionId === sessionId),
+        upsertSession: (metadata) => {
+          const index = sessions.findIndex(
+            (session) => session.sessionId === metadata.sessionId,
+          );
+          if (index >= 0) {
+            sessions[index] = metadata;
+          } else {
+            sessions.push(metadata);
+          }
+        },
+      },
+      captureStores: [],
+      createAcpTransport: () => transport,
+      discoverLocalAcpAgents: async () => [],
+      discoverManagedClaudeAcpAgent: async () => agent,
+      emit: async (event) => {
+        events.push(event);
+      },
+      handleServerRequest: async () => ({ decision: "accept" }),
+      isAcpAgentEnabled: () => true,
+      isClaudeAcpExperimentalEnabled: () => true,
+    });
+
+    await adapter.discoverAvailableAgents(
+      issueProviderDiscoveryPermit("settings-user-action"),
+    );
+    const client = await adapter.getClient(backendId);
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Answer briefly",
+      turnId: "turn-claude",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "Done." },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "usage_update",
+      used: 96_000,
+      size: 200_000,
+    });
+
+    await vi.waitFor(() => {
+      expect(events).toContainEqual({
+        backend: backendId,
+        notification: {
+          method: "thread/contextWindow/updated",
+          params: {
+            threadId: session.sessionId,
+            usedTokens: 96_000,
+            modelContextWindow: 200_000,
+          },
+        },
+      });
+      expect(events).toContainEqual({
+        backend: backendId,
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: session.sessionId,
+            turnId: "turn-claude",
+            tokenUsage: {
+              last_token_usage: {
+                input_tokens: 1_050,
+                cached_input_tokens: 900,
+                output_tokens: 20,
+                total_tokens: 1_070,
               },
             },
           },
@@ -4267,6 +4392,7 @@ describe("AcpBackendAdapter", () => {
       },
       captureStores: [],
       discoverLocalAcpAgents: async () => [],
+      discoverManagedClaudeAcpAgent: async () => undefined,
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
       isAcpAgentEnabled: () => true,
@@ -4303,6 +4429,7 @@ describe("AcpBackendAdapter", () => {
       distributionKind: "npx",
       authStatus: "authenticated",
     };
+    const discoverManagedClaudeAcpAgent = vi.fn(async () => cached);
     const adapter = new AcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => cached,
@@ -4310,7 +4437,8 @@ describe("AcpBackendAdapter", () => {
         upsertInstalledAgent: vi.fn(),
       },
       captureStores: [],
-      discoverLocalAcpAgents: async () => [cached],
+      discoverLocalAcpAgents: async () => [],
+      discoverManagedClaudeAcpAgent,
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
       isAcpAgentEnabled: () => true,
@@ -4324,6 +4452,7 @@ describe("AcpBackendAdapter", () => {
     await expect(adapter.getClient(backendId)).rejects.toThrow(
       "experimental and is not enabled",
     );
+    expect(discoverManagedClaudeAcpAgent).not.toHaveBeenCalled();
 
     await adapter.close();
   });
@@ -4362,13 +4491,17 @@ describe("AcpBackendAdapter", () => {
         upsertInstalledAgent,
       },
       captureStores: [],
-      discoverLocalAcpAgents: async () => [discovered],
+      discoverLocalAcpAgents: async () => [],
+      discoverManagedClaudeAcpAgent: async () => discovered,
       emit: vi.fn(async () => undefined),
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
       isAcpAgentEnabled: () => true,
       isClaudeAcpExperimentalEnabled: () => true,
     });
 
+    await adapter.discoverAvailableAgents(
+      issueProviderDiscoveryPermit("settings-user-action"),
+    );
     await expect(adapter.resolveInstalledAgent(backendId)).resolves.toMatchObject({
       authStatus: "authenticated",
       launchDescriptor: {
@@ -4377,6 +4510,137 @@ describe("AcpBackendAdapter", () => {
     });
     await adapter.describeInstalledBackends();
     expect(upsertInstalledAgent).not.toHaveBeenCalled();
+
+    await adapter.close();
+  });
+
+  it("keeps managed Claude available when generic ACP discovery fails", async () => {
+    const backendId = "acp:claude-acp" as AcpBackendId;
+    const cached: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "claude-acp",
+      name: "Claude Agent",
+      version: "0.60.0",
+      distributionKind: "npx",
+      distributionSource: "@agentclientprotocol/claude-agent-acp@0.60.0",
+      authStatus: "authenticated",
+      verificationStatus: "verified",
+      allowlistRuleId: "managed-claude-agent-acp-0.60.0",
+    };
+    const discovered: AcpInstalledAgentRecord = {
+      ...cached,
+      authStatus: "required",
+      launchDescriptor: {
+        backendId,
+        registryId: "claude-acp",
+        distributionKind: "npx",
+        command: "/verified/node",
+        args: ["/verified/claude-agent-acp.js"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => cached,
+        listInstalledAgents: () => [cached],
+        upsertInstalledAgent: vi.fn(),
+      },
+      captureStores: [],
+      discoverLocalAcpAgents: async () => {
+        throw new Error("Gemini probe failed");
+      },
+      discoverManagedClaudeAcpAgent: async () => discovered,
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+      isAcpAgentEnabled: () => true,
+      isClaudeAcpExperimentalEnabled: () => true,
+    });
+
+    await adapter.discoverAvailableAgents(
+      issueProviderDiscoveryPermit("settings-user-action"),
+    );
+    await expect(adapter.resolveInstalledAgent(backendId)).resolves.toMatchObject({
+      authStatus: "authenticated",
+      launchDescriptor: { command: "/verified/node" },
+    });
+
+    await adapter.close();
+  });
+
+  it("restarts invalidated managed Claude discovery before persisting it", async () => {
+    const backendId = "acp:claude-acp" as AcpBackendId;
+    const buildClaudeAgent = (command: string): AcpInstalledAgentRecord => ({
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "claude-acp",
+      name: "Claude Agent",
+      version: "0.60.0",
+      distributionKind: "npx",
+      distributionSource: "@agentclientprotocol/claude-agent-acp@0.60.0",
+      authStatus: "required",
+      verificationStatus: "verified",
+      allowlistRuleId: "managed-claude-agent-acp-0.60.0",
+      launchDescriptor: {
+        backendId,
+        registryId: "claude-acp",
+        distributionKind: "npx",
+        command,
+        args: ["/verified/claude-agent-acp.js"],
+        env: {},
+      },
+    });
+    const staleAgent = buildClaudeAgent("/stale/node");
+    const currentAgent = buildClaudeAgent("/current/node");
+    const discoveries: Array<{
+      resolve: (agent: AcpInstalledAgentRecord) => void;
+      promise: Promise<AcpInstalledAgentRecord>;
+    }> = [];
+    const discoverManagedClaudeAcpAgent = vi.fn(() => {
+      let resolve!: (agent: AcpInstalledAgentRecord) => void;
+      const promise = new Promise<AcpInstalledAgentRecord>((done) => {
+        resolve = done;
+      });
+      discoveries.push({ promise, resolve });
+      return promise;
+    });
+    const upsertInstalledAgent = vi.fn();
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => undefined,
+        listInstalledAgents: () => [],
+        upsertInstalledAgent,
+      },
+      captureStores: [],
+      discoverLocalAcpAgents: async () => [],
+      discoverManagedClaudeAcpAgent,
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+      isClaudeAcpExperimentalEnabled: () => true,
+    });
+
+    const preInvalidationListing = adapter.discoverAvailableAgents(
+      issueProviderDiscoveryPermit("settings-user-action"),
+    );
+    await vi.waitFor(() => expect(discoveries).toHaveLength(1));
+    adapter.invalidateLocalAgentDiscovery();
+    const postInvalidationListing = adapter.discoverAvailableAgents(
+      issueProviderDiscoveryPermit("settings-user-action"),
+    );
+    await vi.waitFor(() => expect(discoveries).toHaveLength(2));
+
+    discoveries[0]!.resolve(staleAgent);
+    await Promise.resolve();
+    expect(upsertInstalledAgent).not.toHaveBeenCalled();
+
+    discoveries[1]!.resolve(currentAgent);
+    await expect(preInvalidationListing).resolves.toEqual([currentAgent]);
+    await expect(postInvalidationListing).resolves.toEqual([currentAgent]);
+    expect(upsertInstalledAgent).toHaveBeenCalled();
+    expect(upsertInstalledAgent).not.toHaveBeenCalledWith(staleAgent);
+    for (const [persisted] of upsertInstalledAgent.mock.calls) {
+      expect(persisted).toEqual(currentAgent);
+    }
 
     await adapter.close();
   });

--- a/apps/desktop/src/main/__tests__/acp-registry-service.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-registry-service.test.ts
@@ -310,6 +310,53 @@ describe("AcpRegistryService", () => {
     });
   });
 
+  it("allowlists only PwrAgent's exact Claude adapter pin", () => {
+    const service = new AcpRegistryService();
+    const snapshot = {
+      fetchedAt: 1,
+      agents: normalizeRegistry({
+        agents: [
+          {
+            id: "claude-acp",
+            name: "Claude Agent",
+            version: "0.60.0",
+            license: "Apache-2.0",
+            distribution: {
+              npx: {
+                package: "@agentclientprotocol/claude-agent-acp@0.60.0",
+              },
+            },
+          },
+          {
+            id: "claude-acp",
+            name: "Claude Agent",
+            version: "0.66.0",
+            license: "Apache-2.0",
+            distribution: {
+              npx: {
+                package: "@agentclientprotocol/claude-agent-acp@0.66.0",
+              },
+            },
+          },
+        ],
+      }),
+      raw: {},
+    };
+
+    const entries = service.applyAllowlist(snapshot);
+    expect(entries[0]).toMatchObject({
+      installable: true,
+      allowlist: {
+        allowed: true,
+        ruleId: "managed-claude-agent-acp-0.60.0",
+      },
+    });
+    expect(entries[1]).toMatchObject({
+      installable: false,
+      allowlist: { allowed: false, reason: "allowlist-rule-mismatch" },
+    });
+  });
+
   it("rejects registry HTTP failures", async () => {
     const service = new AcpRegistryService({
       fetch: async () => ({

--- a/apps/desktop/src/main/__tests__/acp-runtime-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-runtime-discovery.test.ts
@@ -105,6 +105,80 @@ describe("discoverAcpRuntimeCapabilities", () => {
     expect(selectedModel).toBe("kimi-code/kimi-for-coding");
     expect(close).toHaveBeenCalledOnce();
   });
+
+  it("discovers Claude models and each model's effort levels", async () => {
+    let selectedModel = "claude-sonnet";
+    const request = vi.fn(
+      async (
+        method: string,
+        params?: Record<string, unknown>,
+      ): Promise<unknown> => {
+        if (method === "initialize") {
+          return {
+            protocolVersion: 1,
+            agentInfo: {
+              name: "Claude Agent ACP",
+              version: "0.60.0",
+            },
+          };
+        }
+        if (method === "session/new") {
+          return {
+            sessionId: "claude-session",
+            configOptions: buildClaudeConfigOptions(selectedModel),
+          };
+        }
+        if (method === "session/set_config_option") {
+          if (params?.configId === "model") {
+            selectedModel = String(params.value);
+          }
+          return {
+            configOptions: buildClaudeConfigOptions(selectedModel),
+          };
+        }
+        return {};
+      },
+    );
+    const close = vi.fn(async () => undefined);
+    const transport: AcpJsonRpcTransport = {
+      request,
+      close,
+      onNotification: () => () => undefined,
+    };
+
+    const result = await discoverAcpRuntimeCapabilities(
+      buildClaudeAgent(),
+      {
+        cwd: "/repo",
+        now: () => 1000,
+        transportFactory: () => transport,
+      },
+    );
+
+    expect(result.runtimeCapabilities?.models).toEqual({
+      currentModelId: "claude-sonnet",
+      availableModels: [
+        {
+          id: "claude-sonnet",
+          label: "Claude Sonnet",
+          current: true,
+          supportsReasoning: true,
+          reasoningEfforts: ["low", "medium", "high"],
+          defaultReasoningEffort: "medium",
+        },
+        {
+          id: "claude-opus",
+          label: "Claude Opus",
+          current: false,
+          supportsReasoning: true,
+          reasoningEfforts: ["medium", "high", "max"],
+          defaultReasoningEffort: "high",
+        },
+      ],
+    });
+    expect(selectedModel).toBe("claude-sonnet");
+    expect(close).toHaveBeenCalledOnce();
+  });
 });
 
 function buildKimiConfigOptions(selectedModel: string) {
@@ -169,6 +243,59 @@ function buildKimiAgent(): AcpInstalledAgentRecord {
       distributionKind: "local",
       command: "kimi",
       args: ["acp"],
+      env: {},
+    },
+  };
+}
+
+function buildClaudeConfigOptions(selectedModel: string) {
+  const efforts = selectedModel === "claude-opus"
+    ? ["medium", "high", "max"]
+    : ["low", "medium", "high"];
+  return [
+    {
+      type: "select",
+      id: "model",
+      name: "Model",
+      category: "model",
+      currentValue: selectedModel,
+      options: [
+        { value: "claude-sonnet", name: "Claude Sonnet" },
+        { value: "claude-opus", name: "Claude Opus" },
+      ],
+    },
+    {
+      type: "select",
+      id: "effort",
+      name: "Effort",
+      category: "thought_level",
+      currentValue: selectedModel === "claude-opus" ? "high" : "medium",
+      options: efforts.map((value) => ({ value, name: value })),
+    },
+  ];
+}
+
+function buildClaudeAgent(): AcpInstalledAgentRecord {
+  const backendId = "acp:claude-acp" as AcpBackendId;
+  return {
+    backendId,
+    registryId: "claude-acp",
+    name: "Claude Agent",
+    version: "0.60.0",
+    distributionKind: "npx",
+    distributionSource: "@agentclientprotocol/claude-agent-acp@0.60.0",
+    installStatus: "installed",
+    authStatus: "authenticated",
+    verificationStatus: "verified",
+    allowlistRuleId: "managed-claude-agent-acp-0.60.0",
+    installedAt: 1000,
+    updatedAt: 1000,
+    launchDescriptor: {
+      backendId,
+      registryId: "claude-acp",
+      distributionKind: "npx",
+      command: process.execPath,
+      args: ["/verified/claude-agent-acp.js"],
       env: {},
     },
   };

--- a/apps/desktop/src/main/__tests__/acp-usage.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-usage.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   foldAcpTurnUsage,
+  readAcpContextWindowUpdate,
   readAcpSelectedModel,
   readAcpUsageEnvelope,
   type AcpTokenUsage,
@@ -86,6 +87,36 @@ describe("ACP usage normalization", () => {
       reasoningOutputTokens: 10,
       totalTokens: 1_250,
     });
+  });
+
+  it("normalizes Claude prompt-response usage and context updates", () => {
+    expect(
+      readAcpUsageEnvelope({
+        kind: "turn_finished",
+        usage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          cachedReadTokens: 900,
+          cachedWriteTokens: 50,
+          totalTokens: 1_070,
+        },
+      }),
+    ).toEqual({
+      scope: "turn",
+      tokenUsage: {
+        cachedInputTokens: 900,
+        inputTokens: 1_050,
+        outputTokens: 20,
+        totalTokens: 1_070,
+      },
+    });
+    expect(
+      readAcpContextWindowUpdate({
+        sessionUpdate: "usage_update",
+        used: 96_000,
+        size: 200_000,
+      }),
+    ).toEqual({ used: 96_000, size: 200_000 });
   });
 
   // Grok Build reports each model call on `response_completed`, a transient

--- a/apps/desktop/src/main/__tests__/claude-acp-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/claude-acp-runtime.test.ts
@@ -22,6 +22,8 @@ import {
 } from "../acp/claude-acp-runtime";
 
 const temporaryDirectories: string[] = [];
+const TEST_PACKAGE_CONTENT_DIGEST =
+  "sha256-64o0mY8Wcu6Gu1V+70nzTHfuRs+Ot5OnqVUlNZPmWQI=";
 
 afterEach(async () => {
   await Promise.all(
@@ -66,6 +68,7 @@ describe("managed Claude ACP runtime", () => {
 
     const installed = await installManagedClaudeAcpRuntime({
       runtimeDirectory,
+      expectedPackageContentDigest: TEST_PACKAGE_CONTENT_DIGEST,
       installId: () => "test-install",
       now: () => 1234,
       resolveToolchain: async () => ({
@@ -100,6 +103,7 @@ describe("managed Claude ACP runtime", () => {
 
     const discovered = await discoverManagedClaudeAcpRuntime({
       runtimeDirectory,
+      expectedPackageContentDigest: TEST_PACKAGE_CONTENT_DIGEST,
       now: () => 5678,
     });
     expect(discovered).toMatchObject({
@@ -115,6 +119,7 @@ describe("managed Claude ACP runtime", () => {
     await expect(
       installManagedClaudeAcpRuntime({
         runtimeDirectory,
+        expectedPackageContentDigest: TEST_PACKAGE_CONTENT_DIGEST,
         installId: () => "bad-integrity",
         resolveToolchain: async () => ({
           nodeCommand: process.execPath,
@@ -149,6 +154,7 @@ describe("managed Claude ACP runtime", () => {
       await expect(
         installManagedClaudeAcpRuntime({
           runtimeDirectory,
+          expectedPackageContentDigest: TEST_PACKAGE_CONTENT_DIGEST,
           installId: () => "escaped-entrypoint",
           resolveToolchain: async () => ({
             nodeCommand: process.execPath,
@@ -172,6 +178,63 @@ describe("managed Claude ACP runtime", () => {
       ).rejects.toThrow("escapes its package");
     },
   );
+
+  it("rejects modified installed package bytes during rediscovery", async () => {
+    const runtimeDirectory = await temporaryRuntimeDirectory();
+    await installManagedClaudeAcpRuntime({
+      runtimeDirectory,
+      expectedPackageContentDigest: TEST_PACKAGE_CONTENT_DIGEST,
+      installId: () => "tamper-check",
+      resolveToolchain: async () => ({
+        nodeCommand: process.execPath,
+        npmCommand: "/usr/bin/npm",
+        npmArgsPrefix: [],
+      }),
+      runInstaller: async ({ cwd }) => {
+        await writePackageFixture(cwd, CLAUDE_ACP_PACKAGE_INTEGRITY);
+      },
+    });
+    await writeFile(
+      path.join(
+        runtimeDirectory,
+        "node_modules",
+        "@agentclientprotocol",
+        "claude-agent-acp",
+        "dist",
+        "index.js",
+      ),
+      "tampered",
+    );
+
+    await expect(
+      discoverManagedClaudeAcpRuntime({
+        runtimeDirectory,
+        expectedPackageContentDigest: TEST_PACKAGE_CONTENT_DIGEST,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("formats Windows authentication commands for PowerShell", () => {
+    const entrypoint =
+      "C:\\Program Files\\PwrAgent\\claude-agent-acp\\dist\\index.js";
+    const record = {
+      launchDescriptor: {
+        command: "C:\\Program Files\\nodejs\\node.exe",
+        args: [entrypoint],
+      },
+    } as Parameters<typeof claudeAcpManagedRuntimeSummary>[0];
+
+    const summary = claudeAcpManagedRuntimeSummary(record, {
+      platform: "win32",
+    });
+
+    expect(summary.subscriptionAuthCommand).toBe(
+      `& 'C:\\Program Files\\nodejs\\node.exe' '${entrypoint}' --cli auth login --claudeai`,
+    );
+    expect(summary.consoleAuthCommand).toBe(
+      `& 'C:\\Program Files\\nodejs\\node.exe' '${entrypoint}' --cli auth login --console`,
+    );
+  });
 
   it(
     "classifies local credential and blocked-subscription failures as auth setup",

--- a/apps/desktop/src/main/__tests__/claude-acp-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/claude-acp-runtime.test.ts
@@ -89,7 +89,7 @@ describe("managed Claude ACP runtime", () => {
       installedAt: 1234,
       launchDescriptor: {
         command: process.execPath,
-        args: [expect.stringContaining("dist/index.js")],
+        args: [expect.stringContaining(path.join("dist", "index.js"))],
       },
     });
     const summary = claudeAcpManagedRuntimeSummary(installed);

--- a/apps/desktop/src/main/__tests__/claude-acp-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/claude-acp-runtime.test.ts
@@ -1,0 +1,233 @@
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CLAUDE_ACP_PACKAGE_INTEGRITY,
+  CLAUDE_ACP_PACKAGE_NAME,
+  CLAUDE_ACP_PACKAGE_SPEC,
+  CLAUDE_ACP_VERSION,
+  claudeAcpManagedRuntimeSummary,
+  claudeAcpPlaceholderSettingsEntry,
+  discoverManagedClaudeAcpRuntime,
+  installManagedClaudeAcpRuntime,
+  isClaudeAcpAuthenticationError,
+} from "../acp/claude-acp-runtime";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, { force: true, recursive: true }),
+    ),
+  );
+});
+
+describe("managed Claude ACP runtime", () => {
+  it("publishes the exact managed package and credential policy", () => {
+    const entry = claudeAcpPlaceholderSettingsEntry();
+
+    expect(entry).toMatchObject({
+      backendId: "acp:claude-acp",
+      registryId: "claude-acp",
+      name: "Claude Agent",
+      version: "0.60.0",
+      distributionSource: CLAUDE_ACP_PACKAGE_SPEC,
+      installable: true,
+      installed: false,
+      verificationStatus: "verified",
+      managedRuntime: {
+        packageName: CLAUDE_ACP_PACKAGE_NAME,
+        pinnedVersion: CLAUDE_ACP_VERSION,
+        integrity: CLAUDE_ACP_PACKAGE_INTEGRITY,
+        credentialScope: "owning-instance",
+        supportLevel: "experimental",
+        authMethod: "local-terminal",
+        subscriptionAuthBlocked: false,
+      },
+    });
+  });
+
+  it("installs atomically, verifies integrity, and exposes local auth", async () => {
+    const runtimeDirectory = await temporaryRuntimeDirectory();
+    const runInstaller = vi.fn(
+      async (params: { cwd: string; args: string[] }) => {
+        await writePackageFixture(params.cwd, CLAUDE_ACP_PACKAGE_INTEGRITY);
+      },
+    );
+
+    const installed = await installManagedClaudeAcpRuntime({
+      runtimeDirectory,
+      installId: () => "test-install",
+      now: () => 1234,
+      resolveToolchain: async () => ({
+        nodeCommand: process.execPath,
+        npmCommand: "/usr/bin/npm",
+        npmArgsPrefix: [],
+      }),
+      runInstaller,
+    });
+
+    expect(runInstaller).toHaveBeenCalledOnce();
+    const args = runInstaller.mock.calls[0]?.[0].args ?? [];
+    expect(args).toContain("--ignore-scripts");
+    expect(args).toContain("--save-exact");
+    expect(args).toContain(CLAUDE_ACP_PACKAGE_SPEC);
+    expect(installed).toMatchObject({
+      backendId: "acp:claude-acp",
+      installStatus: "installed",
+      authStatus: "required",
+      verificationStatus: "verified",
+      installedAt: 1234,
+      launchDescriptor: {
+        command: process.execPath,
+        args: [expect.stringContaining("dist/index.js")],
+      },
+    });
+    const summary = claudeAcpManagedRuntimeSummary(installed);
+    expect(summary.consoleAuthCommand).toContain("--cli auth login --console");
+    expect(summary.subscriptionAuthCommand).toContain(
+      "--cli auth login --claudeai",
+    );
+
+    const discovered = await discoverManagedClaudeAcpRuntime({
+      runtimeDirectory,
+      now: () => 5678,
+    });
+    expect(discovered).toMatchObject({
+      version: CLAUDE_ACP_VERSION,
+      installedAt: 1234,
+      updatedAt: 5678,
+    });
+  });
+
+  it("rejects an integrity mismatch without promoting the staging directory", async () => {
+    const runtimeDirectory = await temporaryRuntimeDirectory();
+
+    await expect(
+      installManagedClaudeAcpRuntime({
+        runtimeDirectory,
+        installId: () => "bad-integrity",
+        resolveToolchain: async () => ({
+          nodeCommand: process.execPath,
+          npmCommand: "/usr/bin/npm",
+          npmArgsPrefix: [],
+        }),
+        runInstaller: async ({ cwd }) => {
+          await writePackageFixture(cwd, "sha512-not-the-pinned-package");
+        },
+      }),
+    ).rejects.toThrow("failed integrity verification");
+
+    await expect(readFile(runtimeDirectory, "utf8")).rejects.toThrow();
+    await expect(
+      readFile(
+        path.join(path.dirname(runtimeDirectory), ".install-bad-integrity"),
+        "utf8",
+      ),
+    ).rejects.toThrow();
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "rejects a package entrypoint symlink that escapes the managed runtime",
+    async () => {
+      const runtimeDirectory = await temporaryRuntimeDirectory();
+      const escapedEntrypoint = path.join(
+        path.dirname(runtimeDirectory),
+        "escaped-entrypoint.js",
+      );
+      await writeFile(escapedEntrypoint, "");
+
+      await expect(
+        installManagedClaudeAcpRuntime({
+          runtimeDirectory,
+          installId: () => "escaped-entrypoint",
+          resolveToolchain: async () => ({
+            nodeCommand: process.execPath,
+            npmCommand: "/usr/bin/npm",
+            npmArgsPrefix: [],
+          }),
+          runInstaller: async ({ cwd }) => {
+            await writePackageFixture(cwd, CLAUDE_ACP_PACKAGE_INTEGRITY);
+            const entrypoint = path.join(
+              cwd,
+              "node_modules",
+              "@agentclientprotocol",
+              "claude-agent-acp",
+              "dist",
+              "index.js",
+            );
+            await rm(entrypoint);
+            await symlink(escapedEntrypoint, entrypoint);
+          },
+        }),
+      ).rejects.toThrow("escapes its package");
+    },
+  );
+
+  it(
+    "classifies local credential and blocked-subscription failures as auth setup",
+    () => {
+      expect(
+        isClaudeAcpAuthenticationError(new Error("Authentication required")),
+      ).toBe(true);
+      expect(
+        isClaudeAcpAuthenticationError(
+          new Error(
+            "This integration does not support using claude.ai subscriptions",
+          ),
+        ),
+      ).toBe(true);
+      expect(
+        isClaudeAcpAuthenticationError(new Error("connection reset")),
+      ).toBe(false);
+    },
+  );
+});
+
+async function temporaryRuntimeDirectory(): Promise<string> {
+  const parent = await mkdtemp(path.join(os.tmpdir(), "pwragent-claude-acp-"));
+  temporaryDirectories.push(parent);
+  return path.join(parent, "runtime");
+}
+
+async function writePackageFixture(
+  runtimeDirectory: string,
+  integrity: string,
+): Promise<void> {
+  const packageDirectory = path.join(
+    runtimeDirectory,
+    "node_modules",
+    "@agentclientprotocol",
+    "claude-agent-acp",
+  );
+  await mkdir(path.join(packageDirectory, "dist"), { recursive: true });
+  await writeFile(
+    path.join(packageDirectory, "package.json"),
+    JSON.stringify({
+      name: CLAUDE_ACP_PACKAGE_NAME,
+      version: CLAUDE_ACP_VERSION,
+      bin: { "claude-agent-acp": "dist/index.js" },
+    }),
+  );
+  await writeFile(path.join(packageDirectory, "dist", "index.js"), "");
+  await writeFile(
+    path.join(runtimeDirectory, "package-lock.json"),
+    JSON.stringify({
+      packages: {
+        "../../resolved/profile/node_modules/@agentclientprotocol/claude-agent-acp": {
+          version: CLAUDE_ACP_VERSION,
+          integrity,
+        },
+      },
+    }),
+  );
+}

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -2531,17 +2531,23 @@ describe("DesktopSettingsService", () => {
     const initial = await service.readSettingsProjection();
     expect(initial.acpAgents.gemini.enabled).toBe(true);
     expect(initial.acpAgents.kimi.enabled).toBe(true);
+    expect(initial.acpAgents["claude-acp"]?.enabled).toBe(true);
 
     await service.writeConfigPatchTargeted({
-      acpAgents: { kimi: { enabled: false } },
+      acpAgents: {
+        kimi: { enabled: false },
+        "claude-acp": { enabled: false },
+      },
     });
 
     const tomlOnDisk = fs.readFileSync(configPath, "utf8");
     expect(tomlOnDisk).toContain("[acp_agents.kimi]");
     expect(tomlOnDisk).toContain("enabled = false");
+    expect(tomlOnDisk).toContain("[acp_agents.claude-acp]");
 
     const snapshot = await service.readSettingsProjection();
     expect(snapshot.acpAgents.kimi.enabled).toBe(false);
+    expect(snapshot.acpAgents["claude-acp"]?.enabled).toBe(false);
     // Untouched agents stay enabled.
     expect(snapshot.acpAgents.gemini.enabled).toBe(true);
   });
@@ -3927,6 +3933,35 @@ describe("DesktopSettingsService", () => {
     expect(written).toContain("# keep this operator comment");
     expect(written).toContain("thread_tool_accounting = true");
     expect(written).toContain("managed_review = true");
+  });
+
+  it("defaults experimental Claude ACP to off and persists an explicit opt-in", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    expect((await service.readSettings()).experimental.claudeAcp).toEqual({
+      value: false,
+      source: "default",
+    });
+    expect(service.resolveClaudeAcpExperimentalEnabled()).toBe(false);
+
+    await service.writeConfigPatch({
+      experimental: { claudeAcp: true },
+    });
+
+    expect((await service.readSettings()).experimental.claudeAcp).toEqual({
+      value: true,
+      source: "config",
+    });
+    expect(service.resolveClaudeAcpExperimentalEnabled()).toBe(true);
+    expect(fs.readFileSync(configPath, "utf8")).toContain(
+      "claude_acp = true",
+    );
   });
 
   it("preserves unknown sections written by other builds when saving a patch", async () => {

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -3944,17 +3944,17 @@ describe("DesktopSettingsService", () => {
       secretStore: new MemoryDesktopSecretStore(),
     });
 
-    expect((await service.readSettings()).experimental.claudeAcp).toEqual({
+    expect((await service.readSettingsProjection()).experimental.claudeAcp).toEqual({
       value: false,
       source: "default",
     });
     expect(service.resolveClaudeAcpExperimentalEnabled()).toBe(false);
 
-    await service.writeConfigPatch({
+    await service.writeConfigPatchTargeted({
       experimental: { claudeAcp: true },
     });
 
-    expect((await service.readSettings()).experimental.claudeAcp).toEqual({
+    expect((await service.readSettingsProjection()).experimental.claudeAcp).toEqual({
       value: true,
       source: "config",
     });

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -504,6 +504,90 @@ describe("federation backend bridge", () => {
     ]);
   });
 
+  it("federates Claude capability metadata without credential material", async () => {
+    const sent: FederationProtocolEnvelope[] = [];
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "viewer_one",
+      remoteInstanceId: "owner_one",
+      sendEnvelope: (envelope) => sent.push(envelope),
+      now: () => 1_000,
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+
+    const pending = client.listBackends();
+    const request = sent.at(-1)!;
+    expect(request).toMatchObject({
+      method: FEDERATION_BACKEND_METHODS.listBackends,
+      params: {},
+    });
+    expect(JSON.stringify(request)).not.toMatch(
+      /ANTHROPIC_API_KEY|accessToken|refreshToken|claude\.ai/i,
+    );
+
+    rpc.receiveEnvelope({
+      id: "backends-response",
+      kind: "response",
+      requestId: request.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_100,
+      result: {
+        fetchedAt: 1_050,
+        backends: [
+          {
+            kind: "acp:claude-acp",
+            source: "acp",
+            label: "Claude Agent",
+            available: true,
+            acp: {
+              registryId: "claude-acp",
+              version: "0.60.0",
+              distributionKinds: ["npx"],
+              installStatus: "installed",
+              authStatus: "authenticated",
+              verificationStatus: "verified",
+              credentialScope: "owning-instance",
+              supportLevel: "experimental",
+            },
+            methods: ["session/new", "session/prompt"],
+            capabilities: {
+              listThreads: true,
+              createThread: true,
+              resumeThread: true,
+              renameThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: true,
+              steerTurn: false,
+              transcriptPagination: false,
+              toolUse: true,
+              approvalRequests: true,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [],
+          },
+        ],
+      },
+    });
+
+    const result = await pending;
+    expect(result).toMatchObject({
+      backends: [
+        {
+          kind: "acp:claude-acp",
+          acp: {
+            credentialScope: "owning-instance",
+            supportLevel: "experimental",
+          },
+        },
+      ],
+    });
+    expect(JSON.stringify(result)).not.toMatch(
+      /ANTHROPIC_API_KEY|accessToken|refreshToken|auth login|--claudeai|--console/i,
+    );
+  });
+
   it("preserves encoded ACP navigation keys on the protocol-v1 wire", async () => {
     const backend = {
       getNavigationSnapshot: vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AcpAgentSettingsEntry } from "@pwragent/shared";
+import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
 import { DesktopSettingsService } from "../settings/desktop-settings-service";
 import { MemoryDesktopSecretStore } from "../settings/desktop-secret-store";
 
@@ -15,6 +16,7 @@ const listBackendsMock = vi.fn(async () => ({ backends: [], fetchedAt: 1 }));
 const invalidateAcpBackendDiscoveryMock = vi.fn();
 const getDesktopBackendRegistryMock = vi.fn(() => ({
   invalidateAcpBackendDiscovery: invalidateAcpBackendDiscoveryMock,
+  invalidateProviderRuntimeSelections: invalidateAcpBackendDiscoveryMock,
   listBackends: listBackendsMock,
   listThreads: listThreadsMock,
 }));
@@ -48,6 +50,10 @@ const localAcpDiscoveryMock = vi.hoisted(() => ({
 }));
 const acpRuntimeDiscoveryMock = vi.hoisted(() => ({
   discoverAcpRuntimeCapabilities: vi.fn(async () => ({} as unknown)),
+}));
+const claudeAcpRuntimeMock = vi.hoisted(() => ({
+  discoverManagedClaudeAcpRuntime: vi.fn(async () => undefined as unknown),
+  installManagedClaudeAcpRuntime: vi.fn(async () => undefined as unknown),
 }));
 const electronMocks = vi.hoisted(() => ({
   openExternal: vi.fn(async () => undefined),
@@ -169,6 +175,18 @@ vi.mock("child_process", () => ({
 
 vi.mock("../acp/acp-instance-discovery", () => localAcpDiscoveryMock);
 vi.mock("../acp/acp-runtime-discovery", () => acpRuntimeDiscoveryMock);
+vi.mock("../acp/claude-acp-runtime", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../acp/claude-acp-runtime")
+  >();
+  return {
+    ...actual,
+    discoverManagedClaudeAcpRuntime:
+      claudeAcpRuntimeMock.discoverManagedClaudeAcpRuntime,
+    installManagedClaudeAcpRuntime:
+      claudeAcpRuntimeMock.installManagedClaudeAcpRuntime,
+  };
+});
 
 vi.mock("../app-server/backend-registry", () => ({
   disposeDesktopBackendRegistry: disposeDesktopBackendRegistryMock,
@@ -263,6 +281,11 @@ describe("settings ipc", () => {
     localAcpDiscoveryMock.discoverLocalAcpAgentRecords.mockResolvedValue([]);
     acpRuntimeDiscoveryMock.discoverAcpRuntimeCapabilities.mockReset();
     acpRuntimeDiscoveryMock.discoverAcpRuntimeCapabilities.mockResolvedValue({});
+    claudeAcpRuntimeMock.discoverManagedClaudeAcpRuntime.mockReset();
+    claudeAcpRuntimeMock.discoverManagedClaudeAcpRuntime.mockResolvedValue(
+      undefined,
+    );
+    claudeAcpRuntimeMock.installManagedClaudeAcpRuntime.mockReset();
     electronMocks.openExternal.mockClear();
     childProcessMocks.execFile.mockImplementation(
       (
@@ -528,6 +551,18 @@ describe("settings ipc", () => {
         patch: {
           acpAgents: {
             gemini: {
+              enabled: false,
+            },
+          },
+        },
+      },
+    );
+    await handlers.get(SETTINGS_WRITE_CONFIG_CHANNEL)?.(
+      {},
+      {
+        patch: {
+          acpAgents: {
+            "claude-acp": {
               enabled: false,
             },
           },
@@ -1627,6 +1662,134 @@ describe("settings ipc", () => {
       // Following a build published for testing is not being held back by a
       // pin. Nothing here needs a person.
       expect(grok?.managedBuild?.pinnedBehind).toBeUndefined();
+    } finally {
+      disposeAppState();
+    }
+  });
+
+  it("installs only the pinned Claude runtime and preserves cached readiness", async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "pwragent-settings-ipc-"),
+    );
+    tempRoots.push(tempRoot);
+    vi.stubEnv("PWRAGENT_HOME", tempRoot);
+    const { initializeAppState, disposeAppState, getAppStateDb } = await import(
+      "../state/app-state"
+    );
+    const { AcpAgentStore } = await import("../acp/acp-agent-store");
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const { ACP_AGENT_INSTALL_CHANNEL } = await import("../../shared/ipc");
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+    vi.spyOn(service, "resolveTerminalSpawnEnvAsync").mockResolvedValue({
+      PATH: "/operator/bin:/usr/bin",
+    });
+    const installedRecord = {
+      backendId: "acp:claude-acp",
+      registryId: "claude-acp",
+      name: "Claude Agent",
+      version: "0.60.0",
+      distributionKind: "npx",
+      distributionSource: "@agentclientprotocol/claude-agent-acp@0.60.0",
+      installStatus: "installed",
+      authStatus: "required",
+      verificationStatus: "verified",
+      allowlistRuleId: "managed-claude-agent-acp-0.60.0",
+      installedAt: 1000,
+      updatedAt: 1000,
+      launchDescriptor: {
+        backendId: "acp:claude-acp",
+        registryId: "claude-acp",
+        distributionKind: "npx",
+        command: "/usr/bin/node",
+        args: ["/profile/runtime/dist/index.js"],
+        env: {},
+      },
+    } satisfies AcpInstalledAgentRecord;
+    claudeAcpRuntimeMock.installManagedClaudeAcpRuntime.mockResolvedValue(
+      installedRecord,
+    );
+
+    initializeAppState();
+    try {
+      new AcpAgentStore(getAppStateDb()).upsertInstalledAgent({
+        ...installedRecord,
+        authStatus: "authenticated",
+        installedAt: 500,
+        runtimeCapabilities: {
+          schemaVersion: 1,
+          status: "discovered",
+          discoveredAt: 900,
+          checkedAt: 900,
+          source: "session-new",
+        },
+      });
+      registerSettingsIpcHandlers(service);
+      await expect(
+        handlers.get(ACP_AGENT_INSTALL_CHANNEL)?.(
+          {},
+          { registryId: "claude-acp", expectedVersion: "0.60.0" },
+        ),
+      ).rejects.toThrow("Enable Experimental");
+      expect(
+        claudeAcpRuntimeMock.installManagedClaudeAcpRuntime,
+      ).not.toHaveBeenCalled();
+      await service.writeConfigPatchTargeted({
+        experimental: { claudeAcp: true },
+      });
+      const response = await handlers.get(ACP_AGENT_INSTALL_CHANNEL)?.(
+        {},
+        { registryId: "claude-acp", expectedVersion: "0.60.0" },
+      );
+
+      expect(
+        claudeAcpRuntimeMock.installManagedClaudeAcpRuntime,
+      ).toHaveBeenCalledWith({
+        env: { PATH: "/operator/bin:/usr/bin" },
+      });
+      expect(response).toMatchObject({
+        entry: {
+          backendId: "acp:claude-acp",
+          installed: true,
+          authStatus: "authenticated",
+          managedRuntime: {
+            pinnedVersion: "0.60.0",
+            credentialScope: "owning-instance",
+            supportLevel: "experimental",
+            subscriptionAuthBlocked: false,
+            consoleAuthCommand: expect.stringContaining(
+              "--cli auth login --console",
+            ),
+            subscriptionAuthCommand: expect.stringContaining(
+              "--cli auth login --claudeai",
+            ),
+          },
+        },
+      });
+      expect(
+        new AcpAgentStore(getAppStateDb()).getInstalledAgent("acp:claude-acp"),
+      ).toMatchObject({
+        installStatus: "installed",
+        authStatus: "authenticated",
+        installedAt: 500,
+        runtimeCapabilities: {
+          status: "discovered",
+          discoveredAt: 900,
+        },
+      });
+
+      await expect(
+        handlers.get(ACP_AGENT_INSTALL_CHANNEL)?.(
+          {},
+          { registryId: "claude-acp", expectedVersion: "0.66.0" },
+        ),
+      ).rejects.toThrow("only installs the allowlisted");
+      expect(
+        claudeAcpRuntimeMock.installManagedClaudeAcpRuntime,
+      ).toHaveBeenCalledTimes(1);
     } finally {
       disposeAppState();
     }

--- a/apps/desktop/src/main/acp/acp-agent-allowlist.ts
+++ b/apps/desktop/src/main/acp/acp-agent-allowlist.ts
@@ -40,6 +40,13 @@ const BANNED_ACP_REGISTRY_IDS = new Set(["codex-acp"]);
  */
 export const DEFAULT_ACP_AGENT_ALLOWLIST: AcpAgentAllowlistRule[] = [
   {
+    id: "managed-claude-agent-acp-0.60.0",
+    registryId: "claude-acp",
+    versions: ["0.60.0"],
+    distributionKinds: ["npx"],
+    allowedPackageNames: ["@agentclientprotocol/claude-agent-acp@0.60.0"],
+  },
+  {
     id: "local-grok-cli",
     registryId: "grok",
     distributionKinds: ["local"],

--- a/apps/desktop/src/main/acp/acp-agent-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-agent-capabilities.ts
@@ -34,6 +34,7 @@ const ACP_AGENT_CAPABILITY_CATALOG: Record<string, AcpAgentCapabilities> = {
   "claude-acp": {
     liveWorkspaceHandoff: false,
     managedReview: false,
+    steerTurn: false,
   },
 };
 

--- a/apps/desktop/src/main/acp/acp-agent-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-agent-capabilities.ts
@@ -31,6 +31,10 @@ const ACP_AGENT_CAPABILITY_CATALOG: Record<string, AcpAgentCapabilities> = {
     managedReview: false,
     steerTurn: false,
   },
+  "claude-acp": {
+    liveWorkspaceHandoff: false,
+    managedReview: false,
+  },
 };
 
 export function acpAgentCapabilitiesForRegistryId(

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -652,9 +652,11 @@ export class AcpAgentClient {
     }
     const finishedAt = this.now();
     this.finishTrackedTurn(params.sessionId, finishedAt);
+    const usage = asRecord(asRecord(result)?.usage);
     this.appendHistoryUpdate(params.sessionId, finishedAt, {
       kind: "turn_finished",
       turnId,
+      ...(usage ? { usage } : {}),
     });
     const record = asRecord(result);
     return {
@@ -794,19 +796,23 @@ export class AcpAgentClient {
         this.assertPromptProducedResponse(params.sessionId, result);
         const receivedAt = this.now();
         const finished = this.finishTrackedTurn(params.sessionId, receivedAt);
-        this.appendHistoryUpdate(params.sessionId, receivedAt, {
+        const usage = asRecord(asRecord(result)?.usage);
+        const turnFinishedUpdate = {
           kind: "turn_finished",
           ...(finished.turnId ? { turnId: finished.turnId } : {}),
           outputText: finished.assistantText,
-        });
+          ...(usage ? { usage } : {}),
+        };
+        this.appendHistoryUpdate(
+          params.sessionId,
+          receivedAt,
+          turnFinishedUpdate,
+        );
         void this.notifySessionUpdate({
           sessionId: params.sessionId,
           replay: finished.replay,
           turnId: finished.turnId,
-          update: {
-            kind: "turn_finished",
-            outputText: finished.assistantText,
-          },
+          update: turnFinishedUpdate,
         });
       })
       .catch((error) => {

--- a/apps/desktop/src/main/acp/acp-usage.ts
+++ b/apps/desktop/src/main/acp/acp-usage.ts
@@ -14,6 +14,11 @@ export type AcpUsageEnvelope = {
   tokenUsage: AcpTokenUsage;
 };
 
+export type AcpContextWindowUpdate = {
+  size: number;
+  used: number;
+};
+
 /**
  * ACP running totals are PER TURN, not per session. That is the convention for
  * this transport, deliberately, not an accident of one provider.
@@ -70,7 +75,7 @@ export function readAcpUsageEnvelope(
     return readGrokResponseUsageEnvelope(readRecord(update.usage));
   }
   const usage =
-    kind === "turn_completed"
+    kind === "turn_completed" || kind === "turn_finished"
       ? readRecord(update.usage)
       : kind === "agent_message_chunk"
         ? readRecord(readRecord(update._meta)?.usage)
@@ -79,10 +84,22 @@ export function readAcpUsageEnvelope(
     return undefined;
   }
 
-  const inputTokens = readFiniteNumber(usage.inputTokens);
+  const reportedInputTokens = readFiniteNumber(usage.inputTokens);
   const cachedInputTokens =
     readFiniteNumber(usage.cachedInputTokens) ??
     readFiniteNumber(usage.cachedReadTokens);
+  const cachedWriteTokens = readFiniteNumber(usage.cachedWriteTokens);
+  // ACP's unstable PromptResponse.usage shape reports cache reads and writes
+  // separately from inputTokens. Normalize that split shape to PwrAgent's
+  // inclusive input convention; cache writes remain uncached input for pricing.
+  // Existing agent_message_chunk and turn_completed producers that omit
+  // cachedWriteTokens retain their established input semantics.
+  const inputTokens =
+    cachedWriteTokens !== undefined
+      ? (reportedInputTokens ?? 0)
+        + (cachedInputTokens ?? 0)
+        + cachedWriteTokens
+      : reportedInputTokens;
   const outputTokens = readFiniteNumber(usage.outputTokens);
   const reasoningOutputTokens =
     readFiniteNumber(usage.reasoningOutputTokens) ??
@@ -107,7 +124,10 @@ export function readAcpUsageEnvelope(
     (modelUsage ? Object.keys(modelUsage)[0] : undefined);
   return {
     ...(model ? { model } : {}),
-    scope: kind === "turn_completed" ? "turn" : "model-call",
+    scope:
+      kind === "turn_completed" || kind === "turn_finished"
+        ? "turn"
+        : "model-call",
     tokenUsage: {
       ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
       ...(inputTokens !== undefined ? { inputTokens } : {}),
@@ -118,6 +138,19 @@ export function readAcpUsageEnvelope(
       ...(totalTokens !== undefined ? { totalTokens } : {}),
     },
   };
+}
+
+export function readAcpContextWindowUpdate(
+  update: Record<string, unknown>,
+): AcpContextWindowUpdate | undefined {
+  if (readAcpUpdateKind(update) !== "usage_update") {
+    return undefined;
+  }
+  const used = readFiniteNumber(update.used);
+  const size = readFiniteNumber(update.size);
+  return used !== undefined && used >= 0 && size !== undefined && size > 0
+    ? { size, used }
+    : undefined;
 }
 
 /**

--- a/apps/desktop/src/main/acp/claude-acp-runtime.ts
+++ b/apps/desktop/src/main/acp/claude-acp-runtime.ts
@@ -1,0 +1,682 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  access,
+  mkdir,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import type {
+  AcpAgentSettingsEntry,
+  AcpBackendId,
+} from "@pwragent/shared";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env.js";
+import { getAppStateMode } from "../state/app-state.js";
+import {
+  resolveActiveProfilePath,
+  resolveBootstrapProfilePath,
+} from "../profile.js";
+import { buildCommandDiscoveryCandidate } from "../settings/command-discovery.js";
+import { acpAgentCapabilitiesForRegistryId } from "./acp-agent-capabilities.js";
+import type {
+  AcpInstalledAgentRecord,
+  AcpRegistryAgent,
+} from "./acp-registry-types.js";
+
+const execFile = promisify(execFileCallback);
+
+export const CLAUDE_ACP_REGISTRY_ID = "claude-acp";
+export const CLAUDE_ACP_BACKEND_ID = "acp:claude-acp" as AcpBackendId;
+export const CLAUDE_ACP_NAME = "Claude Agent";
+export const CLAUDE_ACP_PACKAGE_NAME =
+  "@agentclientprotocol/claude-agent-acp";
+export const CLAUDE_ACP_VERSION = "0.60.0";
+export const CLAUDE_ACP_PACKAGE_SPEC =
+  `${CLAUDE_ACP_PACKAGE_NAME}@${CLAUDE_ACP_VERSION}`;
+export const CLAUDE_ACP_PACKAGE_INTEGRITY =
+  "sha512-+ZZCJukpKdEY+/O982UCtgGHOY+MKa/JPpZ34v25ITawRyQyg3cqqOGo3M+9TsA4D+T/NXb+kT3zUB1uQZhY+Q==";
+export const CLAUDE_ACP_ALLOWLIST_RULE_ID =
+  "managed-claude-agent-acp-0.60.0";
+export const CLAUDE_ACP_REPOSITORY_URL =
+  "https://github.com/agentclientprotocol/claude-agent-acp";
+
+const CLAUDE_ACP_RUNTIME_DIRECTORY =
+  `state/acp-runtimes/claude-agent-acp/${CLAUDE_ACP_VERSION}`;
+const CLAUDE_ACP_MARKER_FILE = "pwragent-runtime.json";
+const CLAUDE_ACP_PACKAGE_LOCK_KEY =
+  "node_modules/@agentclientprotocol/claude-agent-acp";
+const CLAUDE_ACP_BIN_NAME = "claude-agent-acp";
+const CLAUDE_ACP_MINIMUM_NODE_MAJOR = 22;
+const CLAUDE_ACP_INSTALL_TIMEOUT_MS = 10 * 60_000;
+
+type ClaudeAcpRuntimeMarker = {
+  schemaVersion: 1;
+  packageName: typeof CLAUDE_ACP_PACKAGE_NAME;
+  version: typeof CLAUDE_ACP_VERSION;
+  integrity: typeof CLAUDE_ACP_PACKAGE_INTEGRITY;
+  nodeCommand: string;
+  entrypoint: string;
+  installedAt: number;
+};
+
+type ClaudeAcpRuntimeToolchain = {
+  nodeCommand: string;
+  npmCommand: string;
+  npmArgsPrefix: string[];
+};
+
+export type ClaudeAcpRuntimeOptions = {
+  env?: NodeJS.ProcessEnv;
+  now?: () => number;
+  runtimeDirectory?: string;
+  installId?: () => string;
+  resolveToolchain?: (
+    env: NodeJS.ProcessEnv,
+  ) => Promise<ClaudeAcpRuntimeToolchain>;
+  runInstaller?: (params: {
+    command: string;
+    args: string[];
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+  }) => Promise<void>;
+};
+
+export function claudeAcpRuntimeDirectory(): string {
+  if (getAppStateMode() === "bootstrap") {
+    return resolveBootstrapProfilePath(CLAUDE_ACP_RUNTIME_DIRECTORY);
+  }
+  return resolveActiveProfilePath(CLAUDE_ACP_RUNTIME_DIRECTORY);
+}
+
+export function claudeAcpPlaceholderSettingsEntry(): AcpAgentSettingsEntry {
+  return {
+    backendId: CLAUDE_ACP_BACKEND_ID,
+    registryId: CLAUDE_ACP_REGISTRY_ID,
+    name: CLAUDE_ACP_NAME,
+    description:
+      "Experimental Claude support through the vetted Agent Client Protocol adapter managed by PwrAgent.",
+    version: CLAUDE_ACP_VERSION,
+    license: "Apache-2.0",
+    authors: ["Agent Client Protocol contributors"],
+    repositoryUrl: CLAUDE_ACP_REPOSITORY_URL,
+    distributionKind: "npx",
+    distributionSource: CLAUDE_ACP_PACKAGE_SPEC,
+    installable: true,
+    installed: false,
+    installStatus: "not-installed",
+    authStatus: "required",
+    verificationStatus: "verified",
+    allowlistRuleId: CLAUDE_ACP_ALLOWLIST_RULE_ID,
+    managedRuntime: claudeAcpManagedRuntimeSummary(),
+  };
+}
+
+export function claudeAcpManagedRuntimeSummary(
+  record?: AcpInstalledAgentRecord,
+): NonNullable<AcpAgentSettingsEntry["managedRuntime"]> {
+  const descriptor = record?.launchDescriptor;
+  return {
+    kind: "pwragent-managed",
+    packageName: CLAUDE_ACP_PACKAGE_NAME,
+    pinnedVersion: CLAUDE_ACP_VERSION,
+    integrity: CLAUDE_ACP_PACKAGE_INTEGRITY,
+    credentialScope: "owning-instance",
+    supportLevel: "experimental",
+    authMethod: "local-terminal",
+    subscriptionAuthBlocked: false,
+    ...(descriptor
+      ? {
+          consoleAuthCommand: formatLocalCommand(
+            descriptor.command,
+            [
+              descriptor.args[0] ?? "",
+              "--cli",
+              "auth",
+              "login",
+              "--console",
+            ].filter(Boolean),
+          ),
+          subscriptionAuthCommand: formatLocalCommand(
+            descriptor.command,
+            [
+              descriptor.args[0] ?? "",
+              "--cli",
+              "auth",
+              "login",
+              "--claudeai",
+            ].filter(Boolean),
+          ),
+        }
+      : {}),
+  };
+}
+
+export async function discoverManagedClaudeAcpRuntime(
+  options: ClaudeAcpRuntimeOptions = {},
+): Promise<AcpInstalledAgentRecord | undefined> {
+  const runtimeDirectory =
+    options.runtimeDirectory ?? claudeAcpRuntimeDirectory();
+  const marker = await readRuntimeMarker(runtimeDirectory);
+  if (!marker) {
+    return undefined;
+  }
+  const validated = await validateRuntimeInstallation(runtimeDirectory, marker);
+  if (!validated) {
+    return undefined;
+  }
+  return buildClaudeAcpInstalledRecord({
+    marker,
+    runtimeDirectory,
+    entrypoint: validated.entrypoint,
+    now: options.now?.() ?? Date.now(),
+  });
+}
+
+export async function installManagedClaudeAcpRuntime(
+  options: ClaudeAcpRuntimeOptions = {},
+): Promise<AcpInstalledAgentRecord> {
+  const runtimeDirectory =
+    options.runtimeDirectory ?? claudeAcpRuntimeDirectory();
+  const alreadyInstalled = await discoverManagedClaudeAcpRuntime({
+    ...options,
+    runtimeDirectory,
+  });
+  if (alreadyInstalled) {
+    return alreadyInstalled;
+  }
+
+  const env = options.env ?? process.env;
+  const resolveToolchain = options.resolveToolchain ?? resolveClaudeAcpToolchain;
+  const toolchain = await resolveToolchain(env);
+  const parentDirectory = path.dirname(runtimeDirectory);
+  const installId = options.installId?.() ?? randomUUID();
+  const stagingDirectory = path.join(parentDirectory, `.install-${installId}`);
+  const replacedDirectory = path.join(parentDirectory, `.replaced-${installId}`);
+  await mkdir(parentDirectory, { recursive: true });
+  await mkdir(stagingDirectory, { recursive: false });
+
+  const runInstaller = options.runInstaller ?? runNpmInstaller;
+  let movedExisting = false;
+  try {
+    await runInstaller({
+      command: toolchain.npmCommand,
+      args: [
+        ...toolchain.npmArgsPrefix,
+        "install",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+        "--package-lock=true",
+        "--save-exact",
+        "--prefix",
+        stagingDirectory,
+        CLAUDE_ACP_PACKAGE_SPEC,
+      ],
+      cwd: stagingDirectory,
+      env,
+    });
+
+    const packageRoot = path.join(
+      stagingDirectory,
+      "node_modules",
+      "@agentclientprotocol",
+      "claude-agent-acp",
+    );
+    const entrypoint = await validateInstalledPackage(
+      stagingDirectory,
+      packageRoot,
+    );
+    const installedAt = options.now?.() ?? Date.now();
+    const marker: ClaudeAcpRuntimeMarker = {
+      schemaVersion: 1,
+      packageName: CLAUDE_ACP_PACKAGE_NAME,
+      version: CLAUDE_ACP_VERSION,
+      integrity: CLAUDE_ACP_PACKAGE_INTEGRITY,
+      nodeCommand: toolchain.nodeCommand,
+      entrypoint: path.relative(stagingDirectory, entrypoint),
+      installedAt,
+    };
+    await writeRuntimeMarker(stagingDirectory, marker);
+
+    if (await pathExists(runtimeDirectory)) {
+      await rename(runtimeDirectory, replacedDirectory);
+      movedExisting = true;
+    }
+    try {
+      await rename(stagingDirectory, runtimeDirectory);
+    } catch (promotionError) {
+      // Several PwrAgent processes may share one profile. Another process can
+      // win the atomic promotion after our existence check; accept only a
+      // fully validated copy of the same pinned runtime in that case.
+      const racedInstallation = await discoverManagedClaudeAcpRuntime({
+        ...options,
+        runtimeDirectory,
+      });
+      if (racedInstallation) {
+        return racedInstallation;
+      }
+      throw promotionError;
+    }
+    if (movedExisting) {
+      try {
+        await removeScopedInstallDirectory(replacedDirectory, parentDirectory);
+        movedExisting = false;
+      } catch {
+        // The finally block retries this scoped cleanup.
+      }
+    }
+
+    const finalEntrypoint = path.join(runtimeDirectory, marker.entrypoint);
+    return buildClaudeAcpInstalledRecord({
+      marker,
+      runtimeDirectory,
+      entrypoint: finalEntrypoint,
+      now: installedAt,
+    });
+  } catch (error) {
+    if (movedExisting && !(await pathExists(runtimeDirectory))) {
+      await rename(replacedDirectory, runtimeDirectory).catch(() => undefined);
+      movedExisting = false;
+    }
+    throw normalizeInstallError(error);
+  } finally {
+    await removeScopedInstallDirectory(
+      stagingDirectory,
+      parentDirectory,
+    ).catch(() => undefined);
+    if (movedExisting) {
+      await removeScopedInstallDirectory(
+        replacedDirectory,
+        parentDirectory,
+      ).catch(() => undefined);
+    }
+  }
+}
+
+export function failedClaudeAcpInstallRecord(
+  error: unknown,
+  now = Date.now(),
+): AcpInstalledAgentRecord {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    backendId: CLAUDE_ACP_BACKEND_ID,
+    registryId: CLAUDE_ACP_REGISTRY_ID,
+    name: CLAUDE_ACP_NAME,
+    version: CLAUDE_ACP_VERSION,
+    distributionKind: "npx",
+    distributionSource: CLAUDE_ACP_PACKAGE_SPEC,
+    installStatus: "install-failed",
+    authStatus: "required",
+    verificationStatus: "verified",
+    allowlistRuleId: CLAUDE_ACP_ALLOWLIST_RULE_ID,
+    installedAt: now,
+    updatedAt: now,
+    lastError: message,
+    capabilities: acpAgentCapabilitiesForRegistryId(CLAUDE_ACP_REGISTRY_ID),
+    registryAgent: claudeAcpRegistryAgent(),
+  };
+}
+
+export function unavailableManagedClaudeAcpRuntime(
+  record: AcpInstalledAgentRecord,
+  now = Date.now(),
+): AcpInstalledAgentRecord {
+  const error =
+    "The managed Claude runtime is missing or failed verification. Reinstall the pinned adapter.";
+  return {
+    ...record,
+    name: CLAUDE_ACP_NAME,
+    version: CLAUDE_ACP_VERSION,
+    distributionKind: "npx",
+    distributionSource: CLAUDE_ACP_PACKAGE_SPEC,
+    installStatus: "unavailable",
+    authStatus: "required",
+    verificationStatus: "verified",
+    allowlistRuleId: CLAUDE_ACP_ALLOWLIST_RULE_ID,
+    updatedAt: Math.max(record.updatedAt, now),
+    launchDescriptor: undefined,
+    runtimeCapabilities: undefined,
+    lastDiscoveredAt: now,
+    lastDiscoveryError: error,
+    lastError: error,
+  };
+}
+
+export function isClaudeAcpAuthenticationError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /(?:auth(?:entication|orization)?|credential|api[ _-]?key|login|sign[ -]?in|subscription)/i.test(
+    message,
+  );
+}
+
+function buildClaudeAcpInstalledRecord(params: {
+  marker: ClaudeAcpRuntimeMarker;
+  runtimeDirectory: string;
+  entrypoint: string;
+  now: number;
+}): AcpInstalledAgentRecord {
+  return {
+    backendId: CLAUDE_ACP_BACKEND_ID,
+    registryId: CLAUDE_ACP_REGISTRY_ID,
+    name: CLAUDE_ACP_NAME,
+    version: CLAUDE_ACP_VERSION,
+    distributionKind: "npx",
+    distributionSource: CLAUDE_ACP_PACKAGE_SPEC,
+    installStatus: "installed",
+    authStatus: "required",
+    verificationStatus: "verified",
+    allowlistRuleId: CLAUDE_ACP_ALLOWLIST_RULE_ID,
+    installedAt: params.marker.installedAt,
+    updatedAt: params.now,
+    capabilities: acpAgentCapabilitiesForRegistryId(CLAUDE_ACP_REGISTRY_ID),
+    launchDescriptor: {
+      backendId: CLAUDE_ACP_BACKEND_ID,
+      registryId: CLAUDE_ACP_REGISTRY_ID,
+      distributionKind: "npx",
+      command: params.marker.nodeCommand,
+      args: [params.entrypoint],
+      env: {},
+      installPath: params.runtimeDirectory,
+    },
+    registryAgent: claudeAcpRegistryAgent(),
+  };
+}
+
+function claudeAcpRegistryAgent(): AcpRegistryAgent {
+  return {
+    id: CLAUDE_ACP_REGISTRY_ID,
+    backendId: CLAUDE_ACP_BACKEND_ID,
+    name: CLAUDE_ACP_NAME,
+    version: CLAUDE_ACP_VERSION,
+    description:
+      "Experimental Claude support through the external Agent Client Protocol adapter managed by PwrAgent.",
+    authors: ["Agent Client Protocol contributors"],
+    license: "Apache-2.0",
+    repositoryUrl: CLAUDE_ACP_REPOSITORY_URL,
+    distributions: [
+      {
+        kind: "npx",
+        packageName: CLAUDE_ACP_PACKAGE_SPEC,
+        args: [],
+        env: {},
+      },
+    ],
+    distributionKinds: ["npx"],
+    auth: { required: true, methods: ["terminal"] },
+    raw: {
+      source: "pwragent-managed",
+      credentialScope: "owning-instance",
+      supportLevel: "experimental",
+      subscriptionAuthBlocked: false,
+    },
+  };
+}
+
+async function resolveClaudeAcpToolchain(
+  env: NodeJS.ProcessEnv,
+): Promise<ClaudeAcpRuntimeToolchain> {
+  const node = await buildCommandDiscoveryCandidate(
+    { command: "node", source: "path" },
+    {
+      env,
+      parseVersion: parseCliVersion,
+      validateVersion: (version) => {
+        const major = Number.parseInt(version.split(".")[0] ?? "", 10);
+        return Number.isFinite(major) && major >= CLAUDE_ACP_MINIMUM_NODE_MAJOR
+          ? undefined
+          : `Node.js ${CLAUDE_ACP_MINIMUM_NODE_MAJOR} or newer is required`;
+      },
+    },
+  );
+  if (!node?.executable || !node.version) {
+    throw new Error(
+      `Claude setup requires Node.js ${CLAUDE_ACP_MINIMUM_NODE_MAJOR} or newer on the local PATH.`,
+    );
+  }
+  const npm = await buildCommandDiscoveryCandidate(
+    { command: "npm", source: "path" },
+    { env, parseVersion: parseCliVersion },
+  );
+  if (!npm?.executable) {
+    throw new Error("Claude setup requires npm on the local PATH.");
+  }
+
+  if ((process.platform as NodeJS.Platform) === "win32") {
+    const npmCli = await resolveWindowsNpmCli(npm.command, node.command);
+    if (!npmCli) {
+      throw new Error("PwrAgent could not resolve npm's local CLI entrypoint.");
+    }
+    return {
+      nodeCommand: node.command,
+      npmCommand: node.command,
+      npmArgsPrefix: [npmCli],
+    };
+  }
+  return {
+    nodeCommand: node.command,
+    npmCommand: npm.command,
+    npmArgsPrefix: [],
+  };
+}
+
+async function resolveWindowsNpmCli(
+  npmCommand: string,
+  nodeCommand: string,
+): Promise<string | undefined> {
+  const candidates = [
+    path.join(path.dirname(npmCommand), "node_modules", "npm", "bin", "npm-cli.js"),
+    path.join(path.dirname(nodeCommand), "node_modules", "npm", "bin", "npm-cli.js"),
+  ];
+  for (const candidate of candidates) {
+    if (await pathExists(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+async function runNpmInstaller(params: {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}): Promise<void> {
+  await execFile(params.command, params.args, {
+    cwd: params.cwd,
+    env: buildPwrAgentChildProcessEnv(params.env),
+    timeout: CLAUDE_ACP_INSTALL_TIMEOUT_MS,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+}
+
+async function validateInstalledPackage(
+  runtimeDirectory: string,
+  packageRoot: string,
+): Promise<string> {
+  const packageJson = await readJsonFile(path.join(packageRoot, "package.json"));
+  if (
+    packageJson.name !== CLAUDE_ACP_PACKAGE_NAME
+    || packageJson.version !== CLAUDE_ACP_VERSION
+  ) {
+    throw new Error("The downloaded Claude ACP package did not match its version pin.");
+  }
+  const packageLock = await readJsonFile(
+    path.join(runtimeDirectory, "package-lock.json"),
+  );
+  const lockPackages = asRecord(packageLock.packages);
+  const lockedPackage = Object.entries(lockPackages ?? {}).find(([lockPath]) => {
+    const normalized = lockPath.replace(/\\/g, "/");
+    return normalized === CLAUDE_ACP_PACKAGE_LOCK_KEY
+      || normalized.endsWith(`/${CLAUDE_ACP_PACKAGE_LOCK_KEY}`);
+  })?.[1];
+  const lockedPackageRecord = asRecord(lockedPackage);
+  if (
+    lockedPackageRecord?.version !== CLAUDE_ACP_VERSION
+    || lockedPackageRecord.integrity !== CLAUDE_ACP_PACKAGE_INTEGRITY
+  ) {
+    throw new Error("The downloaded Claude ACP package failed integrity verification.");
+  }
+  const bin = typeof packageJson.bin === "string"
+    ? packageJson.bin
+    : readString(asRecord(packageJson.bin)?.[CLAUDE_ACP_BIN_NAME]);
+  if (!bin) {
+    throw new Error("The downloaded Claude ACP package has no executable entrypoint.");
+  }
+  const entrypoint = path.resolve(packageRoot, bin);
+  if (!isPathInside(entrypoint, packageRoot) || !(await pathExists(entrypoint))) {
+    throw new Error("The Claude ACP executable entrypoint is invalid.");
+  }
+  const [resolvedRuntime, resolvedPackageRoot, resolvedEntrypoint] =
+    await Promise.all([
+      realpath(runtimeDirectory),
+      realpath(packageRoot),
+      realpath(entrypoint),
+    ]);
+  if (
+    !isPathInside(resolvedPackageRoot, resolvedRuntime)
+    || !isPathInside(resolvedEntrypoint, resolvedPackageRoot)
+  ) {
+    throw new Error("The Claude ACP executable entrypoint escapes its package.");
+  }
+  return entrypoint;
+}
+
+async function validateRuntimeInstallation(
+  runtimeDirectory: string,
+  marker: ClaudeAcpRuntimeMarker,
+): Promise<{ entrypoint: string } | undefined> {
+  if (!path.isAbsolute(marker.nodeCommand)) {
+    return undefined;
+  }
+  const entrypoint = path.resolve(runtimeDirectory, marker.entrypoint);
+  if (!isPathInside(entrypoint, runtimeDirectory)) {
+    return undefined;
+  }
+  try {
+    const validatedEntrypoint = await validateInstalledPackage(
+      runtimeDirectory,
+      path.join(
+        runtimeDirectory,
+        "node_modules",
+        "@agentclientprotocol",
+        "claude-agent-acp",
+      ),
+    );
+    if (validatedEntrypoint !== entrypoint) {
+      return undefined;
+    }
+    await access(marker.nodeCommand);
+    return { entrypoint };
+  } catch {
+    return undefined;
+  }
+}
+
+async function readRuntimeMarker(
+  runtimeDirectory: string,
+): Promise<ClaudeAcpRuntimeMarker | undefined> {
+  try {
+    const value = await readJsonFile(
+      path.join(runtimeDirectory, CLAUDE_ACP_MARKER_FILE),
+    );
+    if (
+      value.schemaVersion !== 1
+      || value.packageName !== CLAUDE_ACP_PACKAGE_NAME
+      || value.version !== CLAUDE_ACP_VERSION
+      || value.integrity !== CLAUDE_ACP_PACKAGE_INTEGRITY
+      || typeof value.nodeCommand !== "string"
+      || typeof value.entrypoint !== "string"
+      || typeof value.installedAt !== "number"
+    ) {
+      return undefined;
+    }
+    return value as ClaudeAcpRuntimeMarker;
+  } catch {
+    return undefined;
+  }
+}
+
+async function writeRuntimeMarker(
+  runtimeDirectory: string,
+  marker: ClaudeAcpRuntimeMarker,
+): Promise<void> {
+  await writeFile(
+    path.join(runtimeDirectory, CLAUDE_ACP_MARKER_FILE),
+    `${JSON.stringify(marker, null, 2)}\n`,
+    { encoding: "utf8", flag: "wx" },
+  );
+}
+
+async function readJsonFile(filePath: string): Promise<Record<string, unknown>> {
+  return asRecord(JSON.parse(await readFile(filePath, "utf8"))) ?? {};
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function removeScopedInstallDirectory(
+  directory: string,
+  parentDirectory: string,
+): Promise<void> {
+  if (
+    path.dirname(directory) !== parentDirectory
+    || !/^\.(?:install|replaced)-[a-zA-Z0-9-]+$/.test(path.basename(directory))
+  ) {
+    throw new Error("Refusing to remove an unexpected Claude ACP runtime path.");
+  }
+  await rm(directory, { force: true, recursive: true });
+}
+
+function parseCliVersion(output: string): string | undefined {
+  return /\bv?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\b/.exec(output)?.[1];
+}
+
+function normalizeInstallError(error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/Node\.js \d+ or newer is required/i.test(message)) {
+    return new Error(
+      `Claude setup requires Node.js ${CLAUDE_ACP_MINIMUM_NODE_MAJOR} or newer on the local PATH.`,
+    );
+  }
+  return new Error(`Claude ACP installation failed: ${message}`);
+}
+
+function isPathInside(candidate: string, parent: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function formatLocalCommand(command: string, args: string[]): string {
+  return [command, ...args].map(quoteCommandArgument).join(" ");
+}
+
+function quoteCommandArgument(value: string): string {
+  if (/^[a-zA-Z0-9_@%+=:,./\\-]+$/.test(value)) {
+    return value;
+  }
+  if (process.platform === "win32") {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}

--- a/apps/desktop/src/main/acp/claude-acp-runtime.ts
+++ b/apps/desktop/src/main/acp/claude-acp-runtime.ts
@@ -1,9 +1,10 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   access,
   mkdir,
   readFile,
+  readdir,
   realpath,
   rename,
   rm,
@@ -40,6 +41,8 @@ export const CLAUDE_ACP_PACKAGE_SPEC =
   `${CLAUDE_ACP_PACKAGE_NAME}@${CLAUDE_ACP_VERSION}`;
 export const CLAUDE_ACP_PACKAGE_INTEGRITY =
   "sha512-+ZZCJukpKdEY+/O982UCtgGHOY+MKa/JPpZ34v25ITawRyQyg3cqqOGo3M+9TsA4D+T/NXb+kT3zUB1uQZhY+Q==";
+export const CLAUDE_ACP_PACKAGE_CONTENT_DIGEST =
+  "sha256-Dh3T8+VIa3dxj9vVGCBtIk/LVoL2vKpE3wj4onixCq4=";
 export const CLAUDE_ACP_ALLOWLIST_RULE_ID =
   "managed-claude-agent-acp-0.60.0";
 export const CLAUDE_ACP_REPOSITORY_URL =
@@ -55,10 +58,11 @@ const CLAUDE_ACP_MINIMUM_NODE_MAJOR = 22;
 const CLAUDE_ACP_INSTALL_TIMEOUT_MS = 10 * 60_000;
 
 type ClaudeAcpRuntimeMarker = {
-  schemaVersion: 1;
+  schemaVersion: 2;
   packageName: typeof CLAUDE_ACP_PACKAGE_NAME;
   version: typeof CLAUDE_ACP_VERSION;
   integrity: typeof CLAUDE_ACP_PACKAGE_INTEGRITY;
+  contentDigest: string;
   nodeCommand: string;
   entrypoint: string;
   installedAt: number;
@@ -75,6 +79,7 @@ export type ClaudeAcpRuntimeOptions = {
   now?: () => number;
   runtimeDirectory?: string;
   installId?: () => string;
+  expectedPackageContentDigest?: string;
   resolveToolchain?: (
     env: NodeJS.ProcessEnv,
   ) => Promise<ClaudeAcpRuntimeToolchain>;
@@ -118,6 +123,7 @@ export function claudeAcpPlaceholderSettingsEntry(): AcpAgentSettingsEntry {
 
 export function claudeAcpManagedRuntimeSummary(
   record?: AcpInstalledAgentRecord,
+  options: { platform?: NodeJS.Platform } = {},
 ): NonNullable<AcpAgentSettingsEntry["managedRuntime"]> {
   const descriptor = record?.launchDescriptor;
   return {
@@ -140,6 +146,7 @@ export function claudeAcpManagedRuntimeSummary(
               "login",
               "--console",
             ].filter(Boolean),
+            options.platform,
           ),
           subscriptionAuthCommand: formatLocalCommand(
             descriptor.command,
@@ -150,6 +157,7 @@ export function claudeAcpManagedRuntimeSummary(
               "login",
               "--claudeai",
             ].filter(Boolean),
+            options.platform,
           ),
         }
       : {}),
@@ -161,11 +169,20 @@ export async function discoverManagedClaudeAcpRuntime(
 ): Promise<AcpInstalledAgentRecord | undefined> {
   const runtimeDirectory =
     options.runtimeDirectory ?? claudeAcpRuntimeDirectory();
-  const marker = await readRuntimeMarker(runtimeDirectory);
+  const expectedPackageContentDigest =
+    options.expectedPackageContentDigest ?? CLAUDE_ACP_PACKAGE_CONTENT_DIGEST;
+  const marker = await readRuntimeMarker(
+    runtimeDirectory,
+    expectedPackageContentDigest,
+  );
   if (!marker) {
     return undefined;
   }
-  const validated = await validateRuntimeInstallation(runtimeDirectory, marker);
+  const validated = await validateRuntimeInstallation(
+    runtimeDirectory,
+    marker,
+    expectedPackageContentDigest,
+  );
   if (!validated) {
     return undefined;
   }
@@ -201,6 +218,8 @@ export async function installManagedClaudeAcpRuntime(
   await mkdir(stagingDirectory, { recursive: false });
 
   const runInstaller = options.runInstaller ?? runNpmInstaller;
+  const expectedPackageContentDigest =
+    options.expectedPackageContentDigest ?? CLAUDE_ACP_PACKAGE_CONTENT_DIGEST;
   let movedExisting = false;
   try {
     await runInstaller({
@@ -230,13 +249,15 @@ export async function installManagedClaudeAcpRuntime(
     const entrypoint = await validateInstalledPackage(
       stagingDirectory,
       packageRoot,
+      expectedPackageContentDigest,
     );
     const installedAt = options.now?.() ?? Date.now();
     const marker: ClaudeAcpRuntimeMarker = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       packageName: CLAUDE_ACP_PACKAGE_NAME,
       version: CLAUDE_ACP_VERSION,
       integrity: CLAUDE_ACP_PACKAGE_INTEGRITY,
+      contentDigest: expectedPackageContentDigest,
       nodeCommand: toolchain.nodeCommand,
       entrypoint: path.relative(stagingDirectory, entrypoint),
       installedAt,
@@ -497,6 +518,7 @@ async function runNpmInstaller(params: {
 async function validateInstalledPackage(
   runtimeDirectory: string,
   packageRoot: string,
+  expectedPackageContentDigest: string,
 ): Promise<string> {
   const packageJson = await readJsonFile(path.join(packageRoot, "package.json"));
   if (
@@ -543,12 +565,19 @@ async function validateInstalledPackage(
   ) {
     throw new Error("The Claude ACP executable entrypoint escapes its package.");
   }
+  const contentDigest = await computePackageContentDigest(resolvedPackageRoot);
+  if (contentDigest !== expectedPackageContentDigest) {
+    throw new Error(
+      "The downloaded Claude ACP package failed installed-byte verification.",
+    );
+  }
   return entrypoint;
 }
 
 async function validateRuntimeInstallation(
   runtimeDirectory: string,
   marker: ClaudeAcpRuntimeMarker,
+  expectedPackageContentDigest: string,
 ): Promise<{ entrypoint: string } | undefined> {
   if (!path.isAbsolute(marker.nodeCommand)) {
     return undefined;
@@ -566,6 +595,7 @@ async function validateRuntimeInstallation(
         "@agentclientprotocol",
         "claude-agent-acp",
       ),
+      expectedPackageContentDigest,
     );
     if (validatedEntrypoint !== entrypoint) {
       return undefined;
@@ -579,16 +609,18 @@ async function validateRuntimeInstallation(
 
 async function readRuntimeMarker(
   runtimeDirectory: string,
+  expectedPackageContentDigest: string,
 ): Promise<ClaudeAcpRuntimeMarker | undefined> {
   try {
     const value = await readJsonFile(
       path.join(runtimeDirectory, CLAUDE_ACP_MARKER_FILE),
     );
     if (
-      value.schemaVersion !== 1
+      value.schemaVersion !== 2
       || value.packageName !== CLAUDE_ACP_PACKAGE_NAME
       || value.version !== CLAUDE_ACP_VERSION
       || value.integrity !== CLAUDE_ACP_PACKAGE_INTEGRITY
+      || value.contentDigest !== expectedPackageContentDigest
       || typeof value.nodeCommand !== "string"
       || typeof value.entrypoint !== "string"
       || typeof value.installedAt !== "number"
@@ -657,16 +689,67 @@ function isPathInside(candidate: string, parent: string): boolean {
   return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
 }
 
-function formatLocalCommand(command: string, args: string[]): string {
-  return [command, ...args].map(quoteCommandArgument).join(" ");
+async function computePackageContentDigest(packageRoot: string): Promise<string> {
+  const files = await collectPackageFiles(packageRoot);
+  const digest = createHash("sha256");
+  digest.update("pwragent-claude-acp-content-v1\0");
+  for (const relativePath of files) {
+    const contents = await readFile(
+      path.join(packageRoot, ...relativePath.split("/")),
+    );
+    digest.update(relativePath);
+    digest.update("\0");
+    digest.update(String(contents.byteLength));
+    digest.update("\0");
+    digest.update(contents);
+  }
+  return `sha256-${digest.digest("base64")}`;
 }
 
-function quoteCommandArgument(value: string): string {
+async function collectPackageFiles(
+  packageRoot: string,
+  directory = packageRoot,
+): Promise<string[]> {
+  const files: string[] = [];
+  const entries = (await readdir(directory, { withFileTypes: true }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await collectPackageFiles(packageRoot, entryPath));
+      continue;
+    }
+    if (!entry.isFile()) {
+      throw new Error(
+        "The downloaded Claude ACP package contains an unsupported file entry.",
+      );
+    }
+    files.push(path.relative(packageRoot, entryPath).split(path.sep).join("/"));
+  }
+  return files;
+}
+
+function formatLocalCommand(
+  command: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform === "win32") {
+    return `& ${[command, ...args].map(quotePowerShellArgument).join(" ")}`;
+  }
+  return [command, ...args].map(quotePosixCommandArgument).join(" ");
+}
+
+function quotePowerShellArgument(value: string): string {
   if (/^[a-zA-Z0-9_@%+=:,./\\-]+$/.test(value)) {
     return value;
   }
-  if (process.platform === "win32") {
-    return `"${value.replace(/"/g, '""')}"`;
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function quotePosixCommandArgument(value: string): string {
+  if (/^[a-zA-Z0-9_@%+=:,./\\-]+$/.test(value)) {
+    return value;
   }
   return `'${value.replace(/'/g, `'"'"'`)}'`;
 }

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -63,6 +63,11 @@ import {
   providerProjectionForRegistryId,
 } from "../settings/config-store/provider-runtime-config";
 import {
+  CLAUDE_ACP_BACKEND_ID,
+  CLAUDE_ACP_REGISTRY_ID,
+  unavailableManagedClaudeAcpRuntime,
+} from "../acp/claude-acp-runtime";
+import {
   AcpLiveToolUpdateResolver,
   acpToolUpdateNotifications,
   acpUsageNotification,
@@ -286,6 +291,7 @@ export type AcpBackendAdapterOptions = {
   resolveProviderDependencyFingerprint?: (
     registryId: string,
   ) => string | undefined;
+  isClaudeAcpExperimentalEnabled?: () => boolean;
   checkGrokCliUpdate?: typeof checkGrokCliUpdate | null;
   resolveMcpConnectionServers?: (context: {
     backendId: AcpBackendId;
@@ -462,6 +468,12 @@ export function describeInstalledAcpBackend(
       allowlistRuleId: agent.allowlistRuleId,
       license: agent.registryAgent?.license,
       runtime: runtimeCapabilities,
+      ...(agent.registryId === CLAUDE_ACP_REGISTRY_ID
+        ? {
+            credentialScope: "owning-instance" as const,
+            supportLevel: "experimental" as const,
+          }
+        : {}),
     },
     methods: [
       "session/new",
@@ -490,6 +502,9 @@ function formatAcpAgentDisplayName(agent: AcpInstalledAgentRecord): string {
   }
   if (agent.registryId === "qwen") {
     return "Qwen";
+  }
+  if (agent.registryId === CLAUDE_ACP_REGISTRY_ID) {
+    return "Claude Agent";
   }
   return agent.name;
 }
@@ -527,6 +542,48 @@ function acpAgentLaunchIdentity(agent: AcpInstalledAgentRecord): string {
       : undefined,
   });
 }
+
+function mergeCachedManagedClaudeAgent(
+  cached: AcpInstalledAgentRecord,
+  discovered: AcpInstalledAgentRecord | undefined,
+): AcpInstalledAgentRecord {
+  if (!discovered) {
+    return cached.installStatus === "installed"
+      ? unavailableManagedClaudeAcpRuntime(cached, cached.updatedAt)
+      : cached;
+  }
+  const sameRuntime = isSameVerifiedManagedClaudeRuntime(cached, discovered);
+  return {
+    ...discovered,
+    authStatus: sameRuntime ? cached.authStatus : discovered.authStatus,
+    installedAt: sameRuntime ? cached.installedAt : discovered.installedAt,
+    ...(sameRuntime && cached.runtimeCapabilities
+      ? { runtimeCapabilities: cached.runtimeCapabilities }
+      : {}),
+    ...(sameRuntime && cached.lastDiscoveredAt !== undefined
+      ? { lastDiscoveredAt: cached.lastDiscoveredAt }
+      : {}),
+    ...(sameRuntime && cached.lastDiscoveryError !== undefined
+      ? { lastDiscoveryError: cached.lastDiscoveryError }
+      : {}),
+  };
+}
+
+function isSameVerifiedManagedClaudeRuntime(
+  cached: AcpInstalledAgentRecord,
+  discovered: AcpInstalledAgentRecord,
+): boolean {
+  return (
+    cached.registryId === CLAUDE_ACP_REGISTRY_ID
+    && discovered.registryId === CLAUDE_ACP_REGISTRY_ID
+    && cached.installStatus === "installed"
+    && discovered.installStatus === "installed"
+    && discovered.verificationStatus === "verified"
+    && cached.version === discovered.version
+    && cached.allowlistRuleId === discovered.allowlistRuleId
+  );
+}
+
 function effectiveAcpAgentCapabilities(
   agent: AcpInstalledAgentRecord,
 ): AcpAgentCapabilities {
@@ -1094,6 +1151,7 @@ export class AcpBackendAdapter {
   private readonly resolveProviderDependencyFingerprint?: (
     registryId: string,
   ) => string | undefined;
+  private readonly isClaudeAcpExperimentalEnabled: () => boolean;
   private readonly resolveMcpConnectionServers?: AcpBackendAdapterOptions["resolveMcpConnectionServers"];
   private readonly emit: (event: AgentEvent) => Promise<void>;
   private readonly handleServerRequest: (
@@ -1168,6 +1226,8 @@ export class AcpBackendAdapter {
     this.isAcpAgentEnabled = options.isAcpAgentEnabled;
     this.resolveProviderDependencyFingerprint =
       options.resolveProviderDependencyFingerprint;
+    this.isClaudeAcpExperimentalEnabled =
+      options.isClaudeAcpExperimentalEnabled ?? (() => false);
     this.createAcpTransport = options.createAcpTransport;
     this.createAcpClient =
       options.createAcpClient ?? ((agent) => this.createDefaultClient(agent));
@@ -1176,6 +1236,11 @@ export class AcpBackendAdapter {
   async describeInstalledBackends(): Promise<BackendSummary[]> {
     const installedAgents = await this.listAvailableAgents();
     const enabledAgents = installedAgents
+      .filter(
+        (agent) =>
+          agent.registryId !== CLAUDE_ACP_REGISTRY_ID
+          || this.isClaudeAcpExperimentalEnabled(),
+      )
       .filter((agent) =>
         this.isAcpAgentEnabled
           ? this.isAcpAgentEnabled(agent.registryId)
@@ -1435,6 +1500,14 @@ export class AcpBackendAdapter {
     sessionId: string,
   ): Promise<AppServerThreadReplay> {
     const session = this.getSession(backend, sessionId);
+    if (
+      backend === CLAUDE_ACP_BACKEND_ID
+      && !this.isClaudeAcpExperimentalEnabled()
+    ) {
+      return session
+         ? this.readRolloutReplay(session, "rollout-claude-experimental-disabled")
+         : new AcpSessionReplayNormalizer().replay();
+    }
     const cachedClient = await (
       this.findSessionOwner(backend, sessionId) ?? this.acpClients.get(backend)
     )
@@ -1660,6 +1733,7 @@ export class AcpBackendAdapter {
     if (this.closed) {
       throw new Error("ACP backend adapter is closed");
     }
+    this.assertExperimentalBackendEnabled(backend);
     const resolving = this.acpClientResolutions.get(backend);
     if (resolving) {
       return await resolving;
@@ -1965,6 +2039,7 @@ export class AcpBackendAdapter {
   async resolveInstalledAgent(
     backend: AcpBackendId,
   ): Promise<AcpInstalledAgentRecord> {
+    this.assertExperimentalBackendEnabled(backend);
     const agent = (await this.listAvailableAgents()).find(
       (candidate) => candidate.backendId === backend,
     );
@@ -1991,6 +2066,17 @@ export class AcpBackendAdapter {
       throw new Error(`ACP backend authentication required: ${backend}`);
     }
     return agent;
+  }
+
+  private assertExperimentalBackendEnabled(backend: AcpBackendId): void {
+    if (
+      backend === CLAUDE_ACP_BACKEND_ID
+      && !this.isClaudeAcpExperimentalEnabled()
+    ) {
+      throw new Error(
+        "Claude ACP is experimental and is not enabled on this PwrAgent instance.",
+      );
+    }
   }
 
   async supportsLiveWorkspaceHandoff(backend: AcpBackendId): Promise<boolean> {
@@ -2072,6 +2158,23 @@ export class AcpBackendAdapter {
     const installedByBackendId = new Map(
       installedAgents.map((agent) => [agent.backendId, agent]),
     );
+    const discoveredManagedAgents = new Map(
+      discoveredAgents
+        .filter(
+          (agent) =>
+            agent.registryId === CLAUDE_ACP_REGISTRY_ID
+            && agent.installStatus === "installed",
+        )
+        .map((agent) => [agent.backendId, agent]),
+    );
+    const effectiveInstalledAgents = installedAgents.map((agent) =>
+      agent.registryId === CLAUDE_ACP_REGISTRY_ID
+        ? mergeCachedManagedClaudeAgent(
+            agent,
+            discoveredManagedAgents.get(agent.backendId),
+          )
+        : agent,
+    );
     const effectiveDiscoveredAgents = discoveredAgents.map((agent) => {
       const cached = installedByBackendId.get(agent.backendId);
       const sameRuntime =
@@ -2079,32 +2182,37 @@ export class AcpBackendAdapter {
         && cached?.installStatus === "installed"
         && cached.version === agent.version
         && acpAgentLaunchIdentity(cached) === acpAgentLaunchIdentity(agent);
+      const sameManagedClaudeRuntime = cached
+        ? isSameVerifiedManagedClaudeRuntime(cached, agent)
+        : false;
+      const preserveCachedMetadata = sameRuntime || sameManagedClaudeRuntime;
       return {
         ...agent,
+        authStatus: preserveCachedMetadata ? cached.authStatus : agent.authStatus,
         installedAt: cached?.installedAt ?? agent.installedAt,
         updatedAt:
-          sameRuntime && cached
+          preserveCachedMetadata && cached
             ? Math.max(agent.updatedAt, cached.updatedAt)
             : agent.updatedAt,
-        ...(sameRuntime && cached?.runtimeCapabilities
+        ...(preserveCachedMetadata && cached?.runtimeCapabilities
           ? { runtimeCapabilities: cached.runtimeCapabilities }
           : {}),
-        ...(sameRuntime && cached?.lastDiscoveredAt !== undefined
+        ...(preserveCachedMetadata && cached?.lastDiscoveredAt !== undefined
           ? { lastDiscoveredAt: cached.lastDiscoveredAt }
           : {}),
-        ...(sameRuntime && cached?.lastDiscoveryError !== undefined
+        ...(preserveCachedMetadata && cached?.lastDiscoveryError !== undefined
           ? { lastDiscoveryError: cached.lastDiscoveryError }
           : {}),
         // A PwrAgent-supplied Grok build follows the verified GitHub release
         // feed, so a cached vendor-updater result must not ride along with it.
         // Dropping it here keeps a status written while a vendor binary was
         // active from reappearing once the managed build becomes the runtime.
-        ...(sameRuntime
+        ...(preserveCachedMetadata
           && cached?.update !== undefined
           && !isPwrAgentOwnedGrokRuntime(agent)
           ? { update: cached.update }
           : {}),
-        ...(sameRuntime
+        ...(preserveCachedMetadata
           && cached?.updateCommand !== undefined
           && !isPwrAgentOwnedGrokRuntime(agent)
           ? { updateCommand: cached.updateCommand }
@@ -2113,9 +2221,17 @@ export class AcpBackendAdapter {
     });
     for (const agent of effectiveDiscoveredAgents) {
       const cached = installedByBackendId.get(agent.backendId);
-      if (!cached || JSON.stringify(cached) !== JSON.stringify(agent)) {
+      const sameManagedClaudeRuntime = cached
+        ? isSameVerifiedManagedClaudeRuntime(cached, agent)
+        : false;
+      if (
+        !sameManagedClaudeRuntime
+        && (!cached || JSON.stringify(cached) !== JSON.stringify(agent))
+      ) {
         // Fresh discovery owns launch selection. The durable record is a cache
         // of that result, never an authority that can suppress a new override.
+        // Managed Claude is verified independently and reuses its credential
+        // state without repeating this database write on every backend list.
         this.acpAgentStore?.upsertInstalledAgent(agent);
       }
     }
@@ -2124,7 +2240,7 @@ export class AcpBackendAdapter {
     );
     const merged = [
       ...effectiveDiscoveredAgents,
-      ...installedAgents.filter(
+      ...effectiveInstalledAgents.filter(
         (agent) => !discoveredBackendIds.has(agent.backendId),
       ),
     ];

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -65,6 +65,7 @@ import {
 import {
   CLAUDE_ACP_BACKEND_ID,
   CLAUDE_ACP_REGISTRY_ID,
+  discoverManagedClaudeAcpRuntime,
   unavailableManagedClaudeAcpRuntime,
 } from "../acp/claude-acp-runtime";
 import {
@@ -74,6 +75,7 @@ import {
 } from "../acp/acp-live-notifications";
 import {
   foldAcpTurnUsage,
+  readAcpContextWindowUpdate,
   readAcpSelectedModel,
   readAcpUsageEnvelope,
   type AcpTokenUsage,
@@ -168,6 +170,9 @@ export type AcpTransportFactory = (
   agent: AcpInstalledAgentRecord,
 ) => AcpJsonRpcTransport;
 export type LocalAcpDiscovery = () => Promise<AcpInstalledAgentRecord[]>;
+export type ManagedClaudeAcpDiscovery = () => Promise<
+  AcpInstalledAgentRecord | undefined
+>;
 
 /**
  * Real local ACP discovery, and the only discovery that reaches outside this
@@ -240,12 +245,31 @@ export function createLocalAcpAgentDiscovery(params: {
 }
 
 /**
+ * Real managed Claude discovery. Keep it separate from generic local-agent
+ * discovery so an unrelated CLI probe failure cannot hide a verified Claude
+ * runtime, while still requiring the production registry to opt into machine
+ * access explicitly.
+ */
+export function createManagedClaudeAcpDiscovery(params?: {
+  resolveEnv?: () => Promise<NodeJS.ProcessEnv>;
+}): ManagedClaudeAcpDiscovery {
+  return async () => {
+    const env = await params?.resolveEnv?.();
+    return await discoverManagedClaudeAcpRuntime({
+      ...(env ? { env } : {}),
+    });
+  };
+}
+
+/**
  * Inert discovery: reports no installed ACP agents and touches nothing outside
  * this process. This is what a `DesktopBackendRegistry` gets unless its caller
  * opts in to machine discovery, so a registry test that injects no stub fails
  * by finding no agents rather than by installing a Grok runtime.
  */
 export const noLocalAcpAgentDiscovery: LocalAcpDiscovery = async () => [];
+export const noManagedClaudeAcpDiscovery: ManagedClaudeAcpDiscovery =
+  async () => undefined;
 
 export type AcpSessionStoreLike =
   Pick<AcpSessionStoreContract, "getSession" | "listSessions"> &
@@ -287,6 +311,7 @@ export type AcpBackendAdapterOptions = {
    * Production passes `createLocalAcpAgentDiscovery(...)`; tests pass a stub.
    */
   discoverLocalAcpAgents: LocalAcpDiscovery;
+  discoverManagedClaudeAcpAgent?: ManagedClaudeAcpDiscovery;
   isAcpAgentEnabled?: (registryId: string) => boolean;
   resolveProviderDependencyFingerprint?: (
     registryId: string,
@@ -1147,6 +1172,7 @@ export class AcpBackendAdapter {
   private readonly createAcpClient: AcpClientFactory;
   private readonly createAcpTransport?: AcpTransportFactory;
   private readonly discoverLocalAcpAgents: LocalAcpDiscovery;
+  private readonly discoverManagedClaudeAcpAgent: ManagedClaudeAcpDiscovery;
   private readonly isAcpAgentEnabled?: (registryId: string) => boolean;
   private readonly resolveProviderDependencyFingerprint?: (
     registryId: string,
@@ -1185,6 +1211,9 @@ export class AcpBackendAdapter {
   private localAcpAgentsPromise?: Promise<AcpInstalledAgentRecord[]>;
   private localAgentSnapshot: AcpInstalledAgentRecord[] = [];
   private readonly invalidatedProviderRegistryIds = new Set<string>();
+  private managedClaudeAcpAgentPromise?: Promise<
+    AcpInstalledAgentRecord | undefined
+  >;
 
   constructor(options: AcpBackendAdapterOptions) {
     this.captureStores = options.captureStores;
@@ -1223,6 +1252,9 @@ export class AcpBackendAdapter {
             ? new AcpRolloutStore(resolveDefaultAcpRolloutRoot())
             : undefined);
     this.discoverLocalAcpAgents = options.discoverLocalAcpAgents;
+    this.discoverManagedClaudeAcpAgent =
+      options.discoverManagedClaudeAcpAgent
+      ?? noManagedClaudeAcpDiscovery;
     this.isAcpAgentEnabled = options.isAcpAgentEnabled;
     this.resolveProviderDependencyFingerprint =
       options.resolveProviderDependencyFingerprint;
@@ -1403,6 +1435,7 @@ export class AcpBackendAdapter {
   invalidateLocalAgentDiscovery(): void {
     this.localAcpAgentsRevision += 1;
     this.localAcpAgentsPromise = undefined;
+    this.managedClaudeAcpAgentPromise = undefined;
   }
 
   invalidateRuntimeSelections(registryIds: readonly string[]): void {
@@ -1505,8 +1538,8 @@ export class AcpBackendAdapter {
       && !this.isClaudeAcpExperimentalEnabled()
     ) {
       return session
-         ? this.readRolloutReplay(session, "rollout-claude-experimental-disabled")
-         : new AcpSessionReplayNormalizer().replay();
+        ? this.readRolloutReplay(session, "rollout-claude-experimental-disabled")
+        : new AcpSessionReplayNormalizer().replay();
     }
     const cachedClient = await (
       this.findSessionOwner(backend, sessionId) ?? this.acpClients.get(backend)
@@ -2090,9 +2123,26 @@ export class AcpBackendAdapter {
   }
 
   async listAvailableAgents(): Promise<AcpInstalledAgentRecord[]> {
+    const verifiedManagedClaudeBackends = new Set(
+      this.localAgentSnapshot
+        .filter(
+          (agent) =>
+            agent.registryId === CLAUDE_ACP_REGISTRY_ID
+            && agent.installStatus === "installed"
+            && agent.verificationStatus === "verified"
+            && agent.launchDescriptor !== undefined,
+        )
+        .map((agent) => agent.backendId),
+    );
     const durable = (this.acpAgentStore?.listInstalledAgents() ?? [])
       .map(normalizeInstalledAcpAgent)
-      .filter((agent) => !isBannedAcpRegistryId(agent.registryId));
+      .filter((agent) => !isBannedAcpRegistryId(agent.registryId))
+      .map((agent) =>
+        agent.registryId === CLAUDE_ACP_REGISTRY_ID
+        && !verifiedManagedClaudeBackends.has(agent.backendId)
+          ? unavailableManagedClaudeAcpRuntime(agent, agent.updatedAt)
+          : agent,
+      );
     if (this.localAgentSnapshot.length === 0) return durable;
     const durableByBackend = new Map(
       durable.map((agent) => [agent.backendId, agent]),
@@ -2123,14 +2173,32 @@ export class AcpBackendAdapter {
   ): Promise<AcpInstalledAgentRecord[]> {
     assertProviderDiscoveryPermit(permit);
     while (true) {
-      const discovery = await this.readLocalAgentsOnce();
-      if (discovery.revision !== this.localAcpAgentsRevision) {
+      const [localDiscovery, managedClaudeDiscovery] = await Promise.all([
+        this.readLocalAgentsOnce(),
+        this.isClaudeAcpExperimentalEnabled()
+          ? this.readManagedClaudeAcpAgentOnce()
+          : Promise.resolve({
+              agent: undefined,
+              revision: this.localAcpAgentsRevision,
+            }),
+      ]);
+      if (
+        localDiscovery.revision !== this.localAcpAgentsRevision
+        || managedClaudeDiscovery.revision !== this.localAcpAgentsRevision
+      ) {
         continue;
       }
       // Keep the revision check and all consumption synchronous. An
       // invalidation queued after discovery settles must run before this
       // point or after stale results have been fully merged and persisted.
-      const agents = this.mergeAndPersistDiscoveredAgents(discovery.agents);
+      const agents = this.mergeAndPersistDiscoveredAgents([
+        ...localDiscovery.agents.filter(
+          (agent) => agent.registryId !== CLAUDE_ACP_REGISTRY_ID,
+        ),
+        ...(managedClaudeDiscovery.agent
+          ? [managedClaudeDiscovery.agent]
+          : []),
+      ]);
       for (const agent of agents) {
         if (agent.registryId === "grok" && agent.installStatus === "installed") {
           this.refreshGrokUpdateStatusInBackground(agent);
@@ -2188,7 +2256,10 @@ export class AcpBackendAdapter {
       const preserveCachedMetadata = sameRuntime || sameManagedClaudeRuntime;
       return {
         ...agent,
-        authStatus: preserveCachedMetadata ? cached.authStatus : agent.authStatus,
+        authStatus:
+          preserveCachedMetadata && cached
+            ? cached.authStatus
+            : agent.authStatus,
         installedAt: cached?.installedAt ?? agent.installedAt,
         updatedAt:
           preserveCachedMetadata && cached
@@ -2401,6 +2472,24 @@ export class AcpBackendAdapter {
     };
   }
 
+  private async readManagedClaudeAcpAgentOnce(): Promise<{
+    agent: AcpInstalledAgentRecord | undefined;
+    revision: number;
+  }> {
+    const revision = this.localAcpAgentsRevision;
+    this.managedClaudeAcpAgentPromise ??=
+      this.discoverManagedClaudeAcpAgent().catch((error) => {
+        acpBackendAdapterLog.debug("managed_claude_acp_discovery_failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return undefined;
+      });
+    return {
+      agent: await this.managedClaudeAcpAgentPromise,
+      revision,
+    };
+  }
+
   private createDefaultClient(agent: AcpInstalledAgentRecord): AcpRuntimeClient {
     if (!agent.launchDescriptor) {
       throw new Error(`ACP backend ${agent.backendId} has no launch descriptor`);
@@ -2442,6 +2531,7 @@ export class AcpBackendAdapter {
         update,
       }) => {
         const updateKind = readAcpUpdateKind(update);
+        const contextWindowUpdate = readAcpContextWindowUpdate(update);
         const usageEnvelope = readAcpUsageEnvelope(update);
         let liveUsageNotification: AppServerNotification | undefined;
         if (usageEnvelope && turnId) {
@@ -2571,6 +2661,19 @@ export class AcpBackendAdapter {
                 commands:
                   this.getSession(agent.backendId, sessionId)?.availableCommands ??
                   [],
+              },
+            },
+          });
+        }
+        if (contextWindowUpdate) {
+          await this.emit({
+            backend: agent.backendId,
+            notification: {
+              method: "thread/contextWindow/updated",
+              params: {
+                threadId: sessionId,
+                usedTokens: contextWindowUpdate.used,
+                modelContextWindow: contextWindowUpdate.size,
               },
             },
           });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -346,6 +346,7 @@ import {
   acpSessionHasConversationHistory,
   acpSessionToThreadSummary,
   createLocalAcpAgentDiscovery,
+  createManagedClaudeAcpDiscovery,
   findAcpModelConfigOption,
   findAcpThoughtLevelConfigOption,
   formatAcpRuntimeLabel,
@@ -354,6 +355,7 @@ import {
   isAcpSessionMissingForProjectError,
   mergeAcpRuntimeState,
   noLocalAcpAgentDiscovery,
+  noManagedClaudeAcpDiscovery,
   readKimiYoloExecutionModeFromText,
   withAcpModelRuntimeSelection,
   type AcpBackendAdapterOptions,
@@ -362,6 +364,7 @@ import {
   type AcpSessionMetadata,
   type AcpSessionStoreLike,
   type LocalAcpDiscovery,
+  type ManagedClaudeAcpDiscovery,
 } from "./acp-backend-adapter";
 import {
   CodexAppServerClient,
@@ -8376,13 +8379,14 @@ export class DesktopBackendRegistry {
     providerThreadSnapshotStore?: ProviderThreadSnapshotStoreLike | null;
     acpAvailableCommandProbeBudgetMs?: number;
     discoverLocalAcpAgents?: LocalAcpDiscovery;
+    discoverManagedClaudeAcpAgent?: ManagedClaudeAcpDiscovery;
     /**
      * Opt in to real machine ACP discovery — scanning the operator's machine,
-     * and installing/probing a managed Grok build under the PwrAgent root.
-     * Only `getDesktopBackendRegistry()` sets this. Every other construction
-     * (all of them in tests) gets `noLocalAcpAgentDiscovery` unless it injects
-     * its own `discoverLocalAcpAgents`, so a test cannot reach the machine by
-     * forgetting an option.
+     * and installing/probing managed Grok and Claude builds under the PwrAgent
+     * root. Only `getDesktopBackendRegistry()` sets this. Every other
+     * construction (all of them in tests) gets inert local and managed-Claude
+     * discovery unless it injects its own seams, so a test cannot reach the
+     * machine by forgetting an option.
      */
     useMachineAcpDiscovery?: boolean;
     isAcpAgentEnabled?: (registryId: string) => boolean;
@@ -8964,6 +8968,18 @@ export class DesktopBackendRegistry {
               },
             )
           : noLocalAcpAgentDiscovery),
+      discoverManagedClaudeAcpAgent:
+        options?.discoverManagedClaudeAcpAgent
+        ?? (options?.useMachineAcpDiscovery
+          ? createManagedClaudeAcpDiscovery(
+              settingsService
+                ? {
+                    resolveEnv: async () =>
+                      await settingsService.resolveTerminalSpawnEnvAsync(),
+                  }
+                : undefined,
+            )
+          : noManagedClaudeAcpDiscovery),
       isAcpAgentEnabled:
         options?.isAcpAgentEnabled
         ?? (options?.configStore
@@ -8981,6 +8997,10 @@ export class DesktopBackendRegistry {
               registryId,
             )?.dependencyFingerprint
         : undefined,
+      isClaudeAcpExperimentalEnabled: options?.configStore
+        ? () =>
+            options.configStore!.read("experimental").claudeAcp === true
+        : () => false,
       emit: async (event) => {
         this.rememberAcpAvailableCommands(event);
         await this.emit(event);
@@ -38006,9 +38026,9 @@ export function getDesktopBackendRegistry(): DesktopBackendRegistry {
   if (!registry) {
     // The one construction that wants the operator's real machine. Every other
     // `new DesktopBackendRegistry(...)` in the tree is a test, and defaults to
-    // `noLocalAcpAgentDiscovery` — keeping the config read, the GitHub release
-    // fetch, the managed-Grok install, and the 5-16s binary probe out of the
-    // suite even when a test forgets to inject its own discovery stub.
+    // inert ACP discovery — keeping config reads, network fetches, managed
+    // installs, and binary probes out of the suite even when a test forgets to
+    // inject its own discovery stubs.
     registry = new DesktopBackendRegistry({
       configStore: getDesktopConfigStore(),
       useMachineAcpDiscovery: true,

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -26,6 +26,8 @@ import type {
   InspectDiscordThreadPermissionsResponse,
   ListDiscordThreadPermissionChannelsRequest,
   ListDiscordThreadPermissionChannelsResponse,
+  InstallAcpAgentRequest,
+  InstallAcpAgentResponse,
   ListAcpAgentSettingsRequest,
   ListAcpAgentSettingsResponse,
   ReadDesktopSettingsRequest,
@@ -59,6 +61,7 @@ import {
 import {
   ONBOARDING_COMPLETE_CODEX_BOOTSTRAP_CHANNEL,
   ACP_AGENTS_LIST_CHANNEL,
+  ACP_AGENT_INSTALL_CHANNEL,
   ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL,
   SETTINGS_CHECK_CODEX_AUTH_PROFILE_STATUS_CHANNEL,
   SETTINGS_CLEAR_SECRET_CHANNEL,
@@ -123,11 +126,26 @@ import {
 import { isSafeExternalOpenUrl } from "../external-url-policy";
 import { getMainLogger } from "../log";
 import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
-import { BUILT_IN_ACP_STRATEGIES, type AcpAgentStrategy } from "@pwrdrvr/agent-acp";
+import { BUILT_IN_ACP_STRATEGIES } from "@pwrdrvr/agent-acp";
 import { AcpAgentStore } from "../acp/acp-agent-store";
 import { isBannedAcpRegistryId } from "../acp/acp-agent-allowlist";
 import { discoverLocalAcpAgentRecords } from "../acp/acp-instance-discovery";
 import { discoverAcpRuntimeCapabilities } from "../acp/acp-runtime-discovery";
+import {
+  CLAUDE_ACP_BACKEND_ID,
+  CLAUDE_ACP_NAME,
+  CLAUDE_ACP_PACKAGE_NAME,
+  CLAUDE_ACP_REGISTRY_ID,
+  CLAUDE_ACP_REPOSITORY_URL,
+  CLAUDE_ACP_VERSION,
+  claudeAcpManagedRuntimeSummary,
+  claudeAcpPlaceholderSettingsEntry,
+  discoverManagedClaudeAcpRuntime,
+  failedClaudeAcpInstallRecord,
+  installManagedClaudeAcpRuntime,
+  isClaudeAcpAuthenticationError,
+  unavailableManagedClaudeAcpRuntime,
+} from "../acp/claude-acp-runtime";
 import { shouldReprobeAcpCapabilities } from "../acp/acp-capability-freshness";
 import { describeDistributionSource } from "../acp/acp-install-provenance";
 import { isPwrAgentOwnedGrokRuntime } from "../acp/grok-cli-update";
@@ -159,6 +177,17 @@ import {
 const settingsIpcLog = getMainLogger("pwragent:settings");
 const ACP_UPDATE_SNOOZE_MS = 24 * 60 * 60_000;
 const SLACK_APP_MANAGEMENT_URL = "https://api.slack.com/apps";
+const SUPPORTED_ACP_AGENT_CATALOG = [
+  ...BUILT_IN_ACP_STRATEGIES,
+  {
+    id: CLAUDE_ACP_REGISTRY_ID,
+    backendId: CLAUDE_ACP_BACKEND_ID,
+    displayName: CLAUDE_ACP_NAME,
+    authors: ["Agent Client Protocol contributors"],
+    license: "Apache-2.0",
+    repositoryUrl: CLAUDE_ACP_REPOSITORY_URL,
+  },
+] as const;
 // Codex profile login now runs through @pwrdrvr/codex-discovery's
 // CodexLoginManager (extracted from this file's inline flow). PwrAgnt owns the
 // instance so the Electron seam — `shell.openExternal` — is injected and the
@@ -176,7 +205,10 @@ function getService(service?: DesktopSettingsService): DesktopSettingsService {
 function invalidateAcpRefreshCacheAfterWrite(
   patch: WriteDesktopSettingsConfigRequest["patch"],
 ): void {
-  if (patch.acpAgents !== undefined) {
+  if (
+    patch.acpAgents !== undefined
+    || patch.experimental?.claudeAcp !== undefined
+  ) {
     recentAcpRefreshes.clear();
   }
   // A config write only invalidates normalized provider state. It is never
@@ -212,6 +244,7 @@ const recentAcpRefreshes = new Set<
 >();
 const ACP_REFRESH_REUSE_TTL_MS = 5_000;
 const USER_INITIATED_ACP_PROBE_TIMEOUT_MS = 10 * 60_000;
+let inFlightClaudeAcpInstall: Promise<InstallAcpAgentResponse> | undefined;
 
 function acpRefreshRegistryIds(
   request: ListAcpAgentSettingsRequest,
@@ -352,6 +385,8 @@ async function listAcpAgentSettingsImpl(
   service?: DesktopSettingsService,
   permit?: ProviderDiscoveryPermit,
 ): Promise<ListAcpAgentSettingsResponse> {
+  const claudeExperimental =
+    getService(service).resolveClaudeAcpExperimentalEnabled();
   const store = new AcpAgentStore(getAppStateDb());
   const settingsService = getService(service);
   const registryService = new AcpRegistryService();
@@ -390,6 +425,7 @@ async function listAcpAgentSettingsImpl(
     ...(permit ? { permit } : {}),
     providers: settingsService.readProvidersConfig(),
     refreshLocal: request.refresh === true,
+    claudeExperimental,
     ...(request.force === true ? { force: true } : {}),
     ...(request.probeCapabilities === false
       ? { probeCapabilities: false }
@@ -401,6 +437,10 @@ async function listAcpAgentSettingsImpl(
     ? registryService
         .applyAllowlist(snapshot)
         .filter((agent) => agent.allowlist.allowed)
+        .filter(
+          (agent) =>
+            agent.id !== CLAUDE_ACP_REGISTRY_ID || claudeExperimental,
+        )
         .flatMap((agent) => {
           const entry = acpAgentSettingsEntry({
             agent,
@@ -417,28 +457,33 @@ async function listAcpAgentSettingsImpl(
     }
   }
 
-  // Always present every supported provider (Gemini/Grok/Kimi/Qwen) as its own
+  // Always present every supported provider as its own
   // section, even when nothing was discovered for it — they are known providers
   // we support via ACP, so an undiscovered one shows a "Not installed" status
   // instead of vanishing. Fill a placeholder for any built-in strategy that
   // neither the registry nor local discovery produced an entry for. This makes
   // the screen independent of registry availability (offline / cold start).
   const presentBackendIds = new Set(entries.map((entry) => entry.backendId));
-  for (const strategy of BUILT_IN_ACP_STRATEGIES) {
+  for (const strategy of SUPPORTED_ACP_AGENT_CATALOG) {
     if (
       isBannedAcpRegistryId(strategy.id) ||
+      (strategy.id === CLAUDE_ACP_REGISTRY_ID && !claudeExperimental) ||
       presentBackendIds.has(`acp:${strategy.id}`)
     ) {
       continue;
     }
-    entries.push(placeholderAcpAgentSettingsEntry(strategy));
+    entries.push(
+      strategy.id === CLAUDE_ACP_REGISTRY_ID
+        ? claudeAcpPlaceholderSettingsEntry()
+        : placeholderAcpAgentSettingsEntry(strategy),
+    );
     presentBackendIds.add(`acp:${strategy.id}`);
   }
 
   // Stable, predictable order: the built-in catalog order first (Gemini, Grok,
   // Kimi, Qwen), any extra non-catalog entries after in their existing order.
   const catalogOrder = new Map(
-    BUILT_IN_ACP_STRATEGIES.map((strategy, index) => [
+    SUPPORTED_ACP_AGENT_CATALOG.map((strategy, index) => [
       strategy.backendId,
       index,
     ]),
@@ -470,6 +515,71 @@ async function listAcpAgentSettingsImpl(
     fetchedAt: snapshot?.fetchedAt ?? Date.now(),
     entries: orderedEntries,
     ...(error ? { error } : {}),
+  };
+}
+
+async function installAcpAgent(
+  request: InstallAcpAgentRequest,
+  service?: DesktopSettingsService,
+): Promise<InstallAcpAgentResponse> {
+  if (
+    !getService(service).resolveClaudeAcpExperimentalEnabled()
+  ) {
+    throw new Error(
+      "Enable Experimental → Claude Agent through ACP before installing this runtime.",
+    );
+  }
+  if (
+    request?.registryId !== CLAUDE_ACP_REGISTRY_ID
+    || request?.expectedVersion !== CLAUDE_ACP_VERSION
+  ) {
+    throw new Error(
+      `PwrAgent only installs the allowlisted ${CLAUDE_ACP_PACKAGE_NAME}@${CLAUDE_ACP_VERSION} runtime.`,
+    );
+  }
+  if (inFlightClaudeAcpInstall) {
+    return await inFlightClaudeAcpInstall;
+  }
+  const run = installAcpAgentImpl(service).finally(() => {
+    if (inFlightClaudeAcpInstall === run) {
+      inFlightClaudeAcpInstall = undefined;
+    }
+  });
+  inFlightClaudeAcpInstall = run;
+  return await run;
+}
+
+async function installAcpAgentImpl(
+  service?: DesktopSettingsService,
+): Promise<InstallAcpAgentResponse> {
+  const store = new AcpAgentStore(getAppStateDb());
+  const now = Date.now();
+  const previous = store.getInstalledAgent(CLAUDE_ACP_BACKEND_ID);
+  let record: AcpInstalledAgentRecord;
+  try {
+    const env = await getService(service).resolveTerminalSpawnEnvAsync();
+    record = await installManagedClaudeAcpRuntime({ env });
+    if (
+      previous?.installStatus === "installed"
+      && previous.version === record.version
+    ) {
+      record = {
+        ...record,
+        authStatus: previous.authStatus,
+        runtimeCapabilities: previous.runtimeCapabilities,
+        lastDiscoveredAt: previous.lastDiscoveredAt,
+        lastDiscoveryError: previous.lastDiscoveryError,
+        installedAt: previous.installedAt,
+      };
+    }
+  } catch (error) {
+    record = failedClaudeAcpInstallRecord(error, now);
+  }
+  store.upsertInstalledAgent(record);
+  getDesktopBackendRegistry().invalidateAcpBackendDiscovery();
+  return {
+    fetchedAt: now,
+    entry: installedAcpAgentSettingsEntry(record),
   };
 }
 
@@ -577,13 +687,19 @@ async function decorateManagedGrokBuild(
  * when the registry is unavailable.
  */
 function placeholderAcpAgentSettingsEntry(
-  strategy: AcpAgentStrategy,
+  strategy: {
+    id: string;
+    displayName: string;
+    authors: readonly string[];
+    license?: string;
+    repositoryUrl?: string;
+  },
 ): AcpAgentSettingsEntry {
   return {
     backendId: `acp:${strategy.id}`,
     registryId: strategy.id,
     name: strategy.displayName,
-    authors: strategy.authors,
+    authors: [...strategy.authors],
     ...(strategy.license ? { license: strategy.license } : {}),
     ...(strategy.repositoryUrl
       ? { repositoryUrl: strategy.repositoryUrl }
@@ -609,9 +725,15 @@ async function listInstalledAndLocalAcpAgents(
     probeCapabilities?: boolean;
     registryIds?: readonly string[];
     env?: NodeJS.ProcessEnv;
+    claudeExperimental?: boolean;
   },
 ): Promise<AcpInstalledAgentRecord[]> {
-  const installed = store.listInstalledAgents();
+  const claudeExperimental =
+    options?.claudeExperimental
+    ?? getDesktopConfigStore().read("experimental").claudeAcp === true;
+  const visible = (record: AcpInstalledAgentRecord): boolean =>
+    record.registryId !== CLAUDE_ACP_REGISTRY_ID || claudeExperimental;
+  const installed = store.listInstalledAgents().filter(visible);
   let discovered: AcpInstalledAgentRecord[] = [];
   if (options?.refreshLocal) {
     assertProviderDiscoveryPermit(options.permit, [
@@ -671,6 +793,21 @@ async function listInstalledAndLocalAcpAgents(
             : {}),
         };
       });
+      if (claudeExperimental) {
+        const managedClaude = await discoverManagedClaudeAcpRuntime({
+          ...(options?.env ? { env: options.env } : {}),
+        });
+        if (managedClaude) {
+          discovered.push(managedClaude);
+        } else {
+          const cachedClaude = store.getInstalledAgent(CLAUDE_ACP_BACKEND_ID);
+          if (cachedClaude?.installStatus === "installed") {
+            store.upsertInstalledAgent(
+              unavailableManagedClaudeAcpRuntime(cachedClaude),
+            );
+          }
+        }
+      }
       const discoveryCwd = await ensureAcpRuntimeDiscoveryWorkspace();
       const now = Date.now();
       for (const record of discovered) {
@@ -687,22 +824,41 @@ async function listInstalledAndLocalAcpAgents(
           && record.version !== undefined
           && current.version !== record.version;
         const pwrAgentOwnedGrok = isPwrAgentOwnedGrokRuntime(record);
+        const sameManagedClaudeRuntime =
+          record.registryId === CLAUDE_ACP_REGISTRY_ID
+          && current?.installStatus === "installed"
+          && current.version === record.version;
+        const preserveCachedRuntime =
+          !runtimeVersionChanged
+          && (
+            record.registryId !== CLAUDE_ACP_REGISTRY_ID
+            || sameManagedClaudeRuntime
+          );
         const nextRecord = {
           ...record,
-          runtimeCapabilities: runtimeVersionChanged
-            ? undefined
-            : current?.runtimeCapabilities,
+          authStatus:
+            sameManagedClaudeRuntime
+              ? current.authStatus
+              : record.authStatus,
+          runtimeCapabilities: preserveCachedRuntime
+            ? current?.runtimeCapabilities
+            : undefined,
           update: pwrAgentOwnedGrok ? undefined : current?.update,
           updateCommand: pwrAgentOwnedGrok
             ? undefined
             : current?.updateCommand,
-          lastDiscoveredAt: runtimeVersionChanged
-            ? undefined
-            : current?.lastDiscoveredAt,
-          lastDiscoveryError: runtimeVersionChanged
-            ? undefined
-            : current?.lastDiscoveryError,
-          installedAt: current?.installedAt ?? record.installedAt,
+          lastDiscoveredAt: preserveCachedRuntime
+            ? current?.lastDiscoveredAt
+            : undefined,
+          lastDiscoveryError: preserveCachedRuntime
+            ? current?.lastDiscoveryError
+            : undefined,
+          installedAt:
+            record.registryId === CLAUDE_ACP_REGISTRY_ID
+              ? preserveCachedRuntime
+                ? current?.installedAt ?? record.installedAt
+                : record.installedAt
+              : current?.installedAt ?? record.installedAt,
           updatedAt: Math.max(current?.updatedAt ?? 0, record.updatedAt),
         } satisfies AcpInstalledAgentRecord;
         if (
@@ -718,10 +874,17 @@ async function listInstalledAndLocalAcpAgents(
         // that are undiscovered, stale, or version-changed (or when forced).
         // Otherwise persist the merged record carrying the cached capabilities
         // without launching anything.
-        if (
-          shouldReprobeAcpCapabilities(current, record.version, now, {
+        const reprobeRequired = shouldReprobeAcpCapabilities(
+          current,
+          record.version,
+          now,
+          {
             ...(options?.force === true ? { force: true } : {}),
-          })
+          },
+        );
+        if (
+          acpAgentEnabledFor(config, record.registryId)
+          && reprobeRequired
         ) {
           store.upsertInstalledAgent(
             await refreshAcpRuntimeCapabilities(
@@ -746,7 +909,7 @@ async function listInstalledAndLocalAcpAgents(
     }
   }
   const refreshedInstalled = options?.refreshLocal
-    ? store.listInstalledAgents()
+    ? store.listInstalledAgents().filter(visible)
     : installed;
   const allowedInstalled = refreshedInstalled.filter(
     (record) => !isBannedAcpRegistryId(record.registryId),
@@ -759,6 +922,7 @@ async function listInstalledAndLocalAcpAgents(
     ...discovered.filter(
       (record) =>
         !installedBackendIds.has(record.backendId) &&
+        visible(record) &&
         !isBannedAcpRegistryId(record.registryId),
     ),
   ];
@@ -777,6 +941,9 @@ async function refreshAcpRuntimeCapabilities(
     });
     return {
       ...record,
+      ...(record.registryId === CLAUDE_ACP_REGISTRY_ID
+        ? { authStatus: "authenticated" as const }
+        : {}),
       ...(result.runtimeCapabilities
         ? {
             runtimeCapabilities: result.runtimeCapabilities,
@@ -791,6 +958,13 @@ async function refreshAcpRuntimeCapabilities(
   } catch (error) {
     return {
       ...record,
+      ...(record.registryId === CLAUDE_ACP_REGISTRY_ID
+        ? {
+            authStatus: isClaudeAcpAuthenticationError(error)
+              ? "required" as const
+              : "failed" as const,
+          }
+        : {}),
       lastDiscoveryError: error instanceof Error ? error.message : String(error),
       updatedAt: Math.max(record.updatedAt, now),
     };
@@ -900,7 +1074,7 @@ export function installedAcpAgentSettingsEntry(
     websiteUrl: agent?.websiteUrl,
     distributionKind: record.distributionKind,
     distributionSource: record.distributionSource,
-    installable: false,
+    installable: record.registryId === CLAUDE_ACP_REGISTRY_ID,
     installed: record.installStatus === "installed",
     installStatus: record.installStatus,
     authStatus: record.authStatus,
@@ -923,6 +1097,9 @@ export function installedAcpAgentSettingsEntry(
       : {}),
     ...(record.activeCommand !== undefined
       ? { activeCommand: record.activeCommand }
+      : {}),
+    ...(record.registryId === CLAUDE_ACP_REGISTRY_ID
+      ? { managedRuntime: claudeAcpManagedRuntimeSummary(record) }
       : {}),
   };
 }
@@ -1333,6 +1510,16 @@ export function registerSettingsIpcHandlers(
       request?: ListAcpAgentSettingsRequest,
     ): Promise<ListAcpAgentSettingsResponse> =>
       await listAcpAgentSettings(request, service),
+  );
+
+  ipcMain.removeHandler(ACP_AGENT_INSTALL_CHANNEL);
+  ipcMain.handle(
+    ACP_AGENT_INSTALL_CHANNEL,
+    async (
+      _event,
+      request: InstallAcpAgentRequest,
+    ): Promise<InstallAcpAgentResponse> =>
+      await installAcpAgent(request, service),
   );
 
   ipcMain.removeHandler(ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL);
@@ -1885,6 +2072,7 @@ export function disposeSettingsIpcHandlers(): void {
   codexLoginManager.dispose();
   recentAcpRefreshes.clear();
   ipcMain.removeHandler(ACP_AGENTS_LIST_CHANNEL);
+  ipcMain.removeHandler(ACP_AGENT_INSTALL_CHANNEL);
   ipcMain.removeHandler(ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL);
   ipcMain.removeHandler(SETTINGS_READ_CHANNEL);
   ipcMain.removeHandler(SETTINGS_READ_BOOTSTRAP_CHANNEL);

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -576,7 +576,11 @@ async function installAcpAgentImpl(
     record = failedClaudeAcpInstallRecord(error, now);
   }
   store.upsertInstalledAgent(record);
-  getDesktopBackendRegistry().invalidateAcpBackendDiscovery();
+  await getDesktopBackendRegistry().invalidateProviderRuntimeSelections({
+    acp: true,
+    acpRegistryIds: [CLAUDE_ACP_REGISTRY_ID],
+    codex: false,
+  });
   return {
     fetchedAt: now,
     entry: installedAcpAgentSettingsEntry(record),
@@ -883,7 +887,7 @@ async function listInstalledAndLocalAcpAgents(
           },
         );
         if (
-          acpAgentEnabledFor(config, record.registryId)
+          acpProviderEnabledFromSnapshot(providers, record.registryId)
           && reprobeRequired
         ) {
           store.upsertInstalledAgent(

--- a/apps/desktop/src/main/settings/config-store/config-domains.ts
+++ b/apps/desktop/src/main/settings/config-store/config-domains.ts
@@ -35,7 +35,14 @@ import {
 import type { DesktopSettingsConfig } from "../desktop-config";
 
 export const CONFIG_STORE_DURABLE_SCHEMA_VERSION = 1;
-export const PROVIDER_IDS = ["codex", "gemini", "grok", "kimi", "qwen"] as const;
+export const PROVIDER_IDS = [
+  "codex",
+  "gemini",
+  "grok",
+  "kimi",
+  "qwen",
+  "claude-acp",
+] as const;
 
 export type ProviderId = (typeof PROVIDER_IDS)[number];
 
@@ -170,7 +177,9 @@ export function normalizeConfigDomains(params: {
     PROVIDER_IDS.map((provider) => {
       const commandOverride = provider === "codex"
         ? config.models?.codex?.path?.trim() || undefined
-        : config.acpAgents?.[provider]?.cliPath?.trim() || undefined;
+        : provider === "claude-acp"
+          ? undefined
+          : config.acpAgents?.[provider]?.cliPath?.trim() || undefined;
       const enabled = provider === "codex"
         ? true
         : config.acpAgents?.[provider]?.enabled !== false;

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -132,6 +132,7 @@ export type DesktopSettingsConfig = {
     threadToolAccounting?: boolean;
     codexDefaultModeRequestUserInput?: boolean;
     managedReview?: boolean;
+    claudeAcp?: boolean;
     diffCondensation?: {
       enabled?: boolean;
     };
@@ -282,6 +283,9 @@ export type DesktopSettingsConfig = {
       cliPath?: string;
       enabled?: boolean;
     };
+    "claude-acp"?: {
+      enabled?: boolean;
+    };
   };
   git?: {
     backgroundPrPolling?: boolean;
@@ -380,14 +384,21 @@ export function acpCliPathOverrideFor(
 }
 
 /**
- * Whether an ACP agent is enabled, from an already-loaded config. Defaults to
- * **true** (agents are on unless explicitly disabled). Prefer this over
+ * Whether an ACP agent is enabled, from an already-loaded config. Ordinary
+ * agents default on unless explicitly disabled. Claude additionally requires
+ * its default-off Experimental gate. Prefer this over
  * {@link resolveAcpAgentEnabled} when resolving multiple agents.
  */
 export function acpAgentEnabledFor(
   config: DesktopSettingsConfig,
   registryId: string,
 ): boolean {
+  if (
+    registryId === "claude-acp"
+    && !claudeAcpExperimentalEnabledFor(config)
+  ) {
+    return false;
+  }
   const agents = config.acpAgents as
     | Record<string, { enabled?: boolean } | undefined>
     | undefined;
@@ -422,6 +433,14 @@ export function managedGrokBuildsEnabledForRuntime(
     return false;
   }
   return managedGrokBuildsEnabledFor(config, !options.isPackaged);
+}
+
+/** Claude's community ACP adapter is invisible and non-runnable unless the
+ * operator explicitly enables its dedicated Experimental feature. */
+export function claudeAcpExperimentalEnabledFor(
+  config: DesktopSettingsConfig,
+): boolean {
+  return config.experimental?.claudeAcp === true;
 }
 
 /**
@@ -763,6 +782,12 @@ export function desktopSettingsPatchToEdits(
     set(
       ["experimental", "managed_review"],
       patch.experimental.managedReview,
+    );
+  }
+  if (patch.experimental?.claudeAcp !== undefined) {
+    set(
+      ["experimental", "claude_acp"],
+      patch.experimental.claudeAcp,
     );
   }
   if (patch.general?.appearance?.theme !== undefined) {
@@ -1539,6 +1564,12 @@ export function desktopSettingsPatchToEdits(
   if (patch.acpAgents?.qwen?.enabled !== undefined) {
     set(["acp_agents", "qwen", "enabled"], patch.acpAgents.qwen.enabled);
   }
+  if (patch.acpAgents?.["claude-acp"]?.enabled !== undefined) {
+    set(
+      ["acp_agents", "claude-acp", "enabled"],
+      patch.acpAgents["claude-acp"].enabled,
+    );
+  }
 
   if (patch.git?.backgroundPrPolling !== undefined) {
     // `[experimental].background_pr_polling` was the pre-Git-settings shape.
@@ -1650,6 +1681,7 @@ function normalizeDesktopConfig(
   const acpAgentsGrok = tables["acp_agents.grok"];
   const acpAgentsKimi = tables["acp_agents.kimi"];
   const acpAgentsQwen = tables["acp_agents.qwen"];
+  const acpAgentsClaude = tables["acp_agents.claude-acp"];
   const git = tables["git"];
   const editor = tables["applications.editor"];
   const terminal = tables["applications.terminal"];
@@ -1767,6 +1799,7 @@ function normalizeDesktopConfig(
         experimental?.codex_default_mode_request_user_input,
       ),
       managedReview: readBoolean(experimental?.managed_review),
+      claudeAcp: readBoolean(experimental?.claude_acp),
       diffCondensation: {
         enabled: readBoolean(diffCondensation?.enabled),
       },
@@ -1999,6 +2032,9 @@ function normalizeDesktopConfig(
       qwen: {
         cliPath: readString(acpAgentsQwen?.cli_path),
         enabled: readBoolean(acpAgentsQwen?.enabled),
+      },
+      "claude-acp": {
+        enabled: readBoolean(acpAgentsClaude?.enabled),
       },
     },
     git: {
@@ -2296,11 +2332,13 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
   const acpAgentsGrok = config.acpAgents?.grok;
   const acpAgentsKimi = config.acpAgents?.kimi;
   const acpAgentsQwen = config.acpAgents?.qwen;
+  const acpAgentsClaude = config.acpAgents?.["claude-acp"];
   if (
-    (acpAgentsGemini && hasDefinedValue(acpAgentsGemini)) ||
-    (acpAgentsGrok && hasDefinedValue(acpAgentsGrok)) ||
-    (acpAgentsKimi && hasDefinedValue(acpAgentsKimi)) ||
-    (acpAgentsQwen && hasDefinedValue(acpAgentsQwen))
+    (acpAgentsGemini && hasDefinedValue(acpAgentsGemini))
+    || (acpAgentsGrok && hasDefinedValue(acpAgentsGrok))
+    || (acpAgentsKimi && hasDefinedValue(acpAgentsKimi))
+    || (acpAgentsQwen && hasDefinedValue(acpAgentsQwen))
+    || (acpAgentsClaude && hasDefinedValue(acpAgentsClaude))
   ) {
     pruned.acpAgents = {
       ...(acpAgentsGemini && hasDefinedValue(acpAgentsGemini)
@@ -2314,6 +2352,9 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
         : {}),
       ...(acpAgentsQwen && hasDefinedValue(acpAgentsQwen)
         ? { qwen: acpAgentsQwen }
+        : {}),
+      ...(acpAgentsClaude && hasDefinedValue(acpAgentsClaude)
+        ? { "claude-acp": acpAgentsClaude }
         : {}),
     };
   }

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -2723,6 +2723,7 @@ export class DesktopSettingsService {
           grok: providerConfigSection(providers.grok),
           kimi: providerConfigSection(providers.kimi),
           qwen: providerConfigSection(providers.qwen),
+          "claude-acp": providerConfigSection(providers["claude-acp"]),
         },
         applications: this.configStore.read("applications"),
         git: this.configStore.read("git"),

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -976,6 +976,10 @@ export class DesktopSettingsService {
           config.experimental?.managedReview,
           false,
         ),
+        claudeAcp: this.resolveConfigBoolean(
+          config.experimental?.claudeAcp,
+          false,
+        ),
         diffCondensation: {
           enabled: this.resolveDiffCondensationEnabled(
             config.experimental?.diffCondensation?.enabled,
@@ -1395,6 +1399,9 @@ export class DesktopSettingsService {
           ),
           enabled: config.acpAgents?.qwen?.enabled ?? true,
         },
+        "claude-acp": {
+          enabled: config.acpAgents?.["claude-acp"]?.enabled ?? true,
+        },
       },
       applications: {
         ...applications,
@@ -1779,6 +1786,13 @@ export class DesktopSettingsService {
   resolveManagedReviewEnabled(): boolean {
     return this.resolveConfigBoolean(
       this.readExperimentalConfig().managedReview,
+      false,
+    ).value;
+  }
+
+  resolveClaudeAcpExperimentalEnabled(): boolean {
+    return this.resolveConfigBoolean(
+      this.readConfig().config.experimental?.claudeAcp,
       false,
     ).value;
   }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -125,6 +125,8 @@ import type {
   HandoffThreadWorkspaceResponse,
   ListAcpAgentSettingsRequest,
   ListAcpAgentSettingsResponse,
+  InstallAcpAgentRequest,
+  InstallAcpAgentResponse,
   AcknowledgeAcpAgentUpdateRequest,
   AcknowledgeAcpAgentUpdateResponse,
   NavigationBrowseMode,
@@ -500,6 +502,7 @@ import {
   AGENT_TRUST_CODEX_PROJECT_CHANNEL,
   AGENT_UPDATE_THREAD_EXPECTED_BRANCH_CHANNEL,
   ACP_AGENTS_LIST_CHANNEL,
+  ACP_AGENT_INSTALL_CHANNEL,
   ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL,
   AUTOMATIONS_CREATE_CHANNEL,
   AUTOMATIONS_DELETE_CHANNEL,
@@ -1173,6 +1176,10 @@ const desktopApi = Object.freeze({
     request?: ListAcpAgentSettingsRequest,
   ): Promise<ListAcpAgentSettingsResponse> =>
     await ipcRenderer.invoke(ACP_AGENTS_LIST_CHANNEL, request),
+  installAcpAgent: async (
+    request: InstallAcpAgentRequest,
+  ): Promise<InstallAcpAgentResponse> =>
+    await ipcRenderer.invoke(ACP_AGENT_INSTALL_CHANNEL, request),
   acknowledgeAcpAgentUpdate: async (
     request: AcknowledgeAcpAgentUpdateRequest,
   ): Promise<AcknowledgeAcpAgentUpdateResponse> =>

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -17,6 +17,7 @@ import {
 } from "./SettingsLayout";
 import { SettingsCopyValue } from "./SettingsCopyValue";
 import { SettingsPathRow, type SettingsPathRowChip } from "./SettingsPathRow";
+import { SettingsSwitch } from "./SettingsSwitch";
 import {
   acpRelativeTime,
   acpStatusLabel,
@@ -105,10 +106,6 @@ export function AcpAgentsSettings(props: {
   const [error, setError] = useState<string | undefined>();
   const claudeExperimentalEnabled =
     props.snapshot?.experimental?.claudeAcp?.value ?? true;
-  const visibleEntries = entries.filter(
-    (entry) =>
-      entry.registryId !== "claude-acp" || claudeExperimentalEnabled,
-  );
 
   async function refresh(
     refreshRegistry = false,
@@ -209,9 +206,12 @@ export function AcpAgentsSettings(props: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.desktopApi]);
 
-  const visibleEntries = props.only
+  const visibleEntries = (props.only
     ? entries.filter((entry) => entry.registryId === props.only)
-    : displayOrderedAcpEntries(entries);
+    : displayOrderedAcpEntries(entries)).filter(
+      (entry) =>
+        entry.registryId !== "claude-acp" || claudeExperimentalEnabled,
+    );
 
   return (
     <>

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -101,7 +101,14 @@ export function AcpAgentsSettings(props: {
   const [entries, setEntries] = useState<AcpAgentSettingsEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [installingRegistryId, setInstallingRegistryId] = useState<string>();
   const [error, setError] = useState<string | undefined>();
+  const claudeExperimentalEnabled =
+    props.snapshot?.experimental?.claudeAcp?.value ?? true;
+  const visibleEntries = entries.filter(
+    (entry) =>
+      entry.registryId !== "claude-acp" || claudeExperimentalEnabled,
+  );
 
   async function refresh(
     refreshRegistry = false,
@@ -143,6 +150,47 @@ export function AcpAgentsSettings(props: {
     }
   }
 
+  async function install(entry: AcpAgentSettingsEntry): Promise<void> {
+    if (!props.desktopApi?.installAcpAgent || !entry.managedRuntime) {
+      setError("Managed ACP installation is unavailable in this build.");
+      return;
+    }
+    setInstallingRegistryId(entry.registryId);
+    setError(undefined);
+    try {
+      const response = await props.desktopApi.installAcpAgent({
+        registryId: entry.registryId,
+        expectedVersion: entry.managedRuntime.pinnedVersion,
+      });
+      setEntries((current) =>
+        current.map((candidate) =>
+          candidate.backendId === response.entry.backendId
+            ? response.entry
+            : candidate,
+        ),
+      );
+      window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
+    } catch (installError) {
+      const message = installError instanceof Error
+        ? installError.message
+        : String(installError);
+      setError(message);
+      setEntries((current) =>
+        current.map((candidate) =>
+          candidate.backendId === entry.backendId
+            ? {
+                ...candidate,
+                installStatus: "install-failed",
+                lastError: message,
+              }
+            : candidate,
+        ),
+      );
+    } finally {
+      setInstallingRegistryId(undefined);
+    }
+  }
+
   // Run the initial cache read exactly once. Mounting or focusing a provider
   // must never probe or launch it; the row's Refresh/Save actions own that
   // provider-scoped discovery budget. The ref only collapses StrictMode's
@@ -177,6 +225,7 @@ export function AcpAgentsSettings(props: {
             />
           ) : null}
           <AcpAgentSection
+            desktopApi={props.desktopApi}
             entry={entry}
             cliPathSnapshot={cliPathSnapshotFor(props.snapshot, entry.registryId)}
             enabled={acpAgentEnabledInSnapshot(props.snapshot, entry.registryId)}
@@ -186,6 +235,7 @@ export function AcpAgentsSettings(props: {
             }
             saving={props.saving}
             refreshing={refreshing || loading || props.catalogRefreshing}
+            installing={installingRegistryId === entry.registryId}
             onCliPathChange={
               props.onCliPathChange
                 ? async (registryId, cliPath) => {
@@ -214,6 +264,9 @@ export function AcpAgentsSettings(props: {
               props.onManagedGrokBuildChannelChange
             }
             onRefresh={() => refresh(true, true)}
+            onInstall={() => {
+              void install(entry);
+            }}
           />
         </Fragment>
       ))}
@@ -322,6 +375,7 @@ function LegacyKimiCompatibilityCard(props: {
 }
 
 function AcpAgentSection(props: {
+  desktopApi?: DesktopApi;
   entry: AcpAgentSettingsEntry;
   cliPathSnapshot: DesktopSettingsValue<string> | undefined;
   enabled: boolean;
@@ -330,6 +384,7 @@ function AcpAgentSection(props: {
   managedGrokBuildChannel?: DesktopUpdateChannel;
   saving?: boolean;
   refreshing?: boolean;
+  installing?: boolean;
   onCliPathChange?: (
     registryId: string,
     cliPath: string,
@@ -340,6 +395,7 @@ function AcpAgentSection(props: {
     channel: DesktopUpdateChannel,
   ) => Promise<boolean>;
   onRefresh: () => Promise<boolean>;
+  onInstall: () => void;
 }) {
   const { entry, enabled } = props;
   const managedBuild = entry.managedBuild;
@@ -352,6 +408,9 @@ function AcpAgentSection(props: {
   useEffect(() => {
     setDraft(savedPath);
   }, [savedPath]);
+  if (entry.managedRuntime) {
+    return <ManagedAcpAgentSection {...props} />;
+  }
 
   const detail =
     entry.lastDiscoveryError ?? entry.lastError ?? entry.unavailableReason;
@@ -871,4 +930,172 @@ function rejectedAcpInstanceLabel(
     default:
       return "ACP check failed";
   }
+}
+
+function ManagedAcpAgentSection(props: {
+  desktopApi?: DesktopApi;
+  entry: AcpAgentSettingsEntry;
+  enabled: boolean;
+  saving?: boolean;
+  refreshing?: boolean;
+  installing?: boolean;
+  onEnabledChange?: (registryId: string, enabled: boolean) => Promise<void>;
+  onInstall: () => void;
+  onRefresh: () => void;
+}) {
+  const { entry, enabled } = props;
+  const runtime = entry.managedRuntime;
+  if (!runtime) {
+    return null;
+  }
+  const ready = entry.installed && entry.authStatus === "authenticated";
+  const detail =
+    entry.lastDiscoveryError ?? entry.lastError ?? entry.unavailableReason;
+  let chip = "Not installed";
+  let chipKind: "muted" | "ok" | "warn" | "err" = "muted";
+  if (!enabled) {
+    chip = "Disabled";
+  } else if (ready) {
+    chip = "Ready";
+    chipKind = "ok";
+  } else if (entry.installStatus === "install-failed") {
+    chip = "Install failed";
+    chipKind = "err";
+  } else if (entry.authStatus === "failed") {
+    chip = "Readiness failed";
+    chipKind = "err";
+  } else if (entry.installed) {
+    chip = "Sign-in required";
+    chipKind = "warn";
+  }
+
+  return (
+    <SettingsSection
+      eyebrow="Experimental provider"
+      title={entry.name}
+      sectionId={`acp-${entry.registryId}`}
+      chip={chip}
+      chipKind={chipKind}
+    >
+      <div className="settings-fields">
+        {props.onEnabledChange ? (
+          <SettingsField
+            label="Enabled"
+            sub="Show Claude in the model picker after this instance is ready."
+            control={
+              <SettingsSwitch
+                checked={enabled}
+                disabled={props.saving}
+                label={`Enable ${entry.name}`}
+                onChange={(next) => {
+                  void props.onEnabledChange?.(entry.registryId, next);
+                }}
+              />
+            }
+          />
+        ) : null}
+
+        <SettingsField
+          label="Experimental support"
+          sub="This community-maintained ACP adapter and its authentication paths are not generally supported. Behavior, availability, and policy treatment may change or be removed."
+          source="Experimental"
+          control={
+            <p className="settings-empty">
+              Subscription use through a third-party product may require
+              separate authorization under Anthropic&apos;s terms.
+            </p>
+          }
+        />
+
+        <SettingsField
+          label="Managed runtime"
+          sub="PwrAgent installs this external Apache-2.0 adapter with npm lifecycle scripts disabled, then verifies the exact package version and integrity. Anthropic service terms still apply."
+          source={`Pinned v${runtime.pinnedVersion}`}
+          error={!entry.installed ? detail : undefined}
+          control={
+            <SettingsCopyValue
+              value={`${runtime.packageName}@${runtime.pinnedVersion}`}
+              desktopApi={props.desktopApi}
+              label="Claude ACP package pin"
+            />
+          }
+        />
+
+        {!entry.installed ? (
+          <SettingsField
+            label="Install"
+            sub="Requires Node.js 22 or newer and npm on this instance. Installation is local to the active PwrAgent profile."
+            control={
+              <div className="settings-inline-actions">
+                <button
+                  className="button button--secondary"
+                  disabled={props.installing || props.saving}
+                  type="button"
+                  onClick={props.onInstall}
+                >
+                  {props.installing
+                    ? "Installing…"
+                    : entry.installStatus === "install-failed"
+                      ? "Retry install"
+                      : "Install Claude adapter"}
+                </button>
+              </div>
+            }
+          />
+        ) : (
+          <SettingsField
+            label="Local authentication"
+            sub="Run one of these commands in a terminal on the owning instance, then check readiness. The adapter owns its local sign-in flow; PwrAgent does not collect or proxy the credential."
+            source={
+              ready
+                ? "Ready on this instance"
+                : entry.authStatus === "failed"
+                  ? "Readiness check failed"
+                  : "Local sign-in required"
+            }
+            error={detail}
+            control={
+              <div className="settings-fields">
+                {runtime.subscriptionAuthCommand ? (
+                  <SettingsCopyValue
+                    value={runtime.subscriptionAuthCommand}
+                    desktopApi={props.desktopApi}
+                    label="Claude subscription login command"
+                  />
+                ) : null}
+                {runtime.consoleAuthCommand ? (
+                  <SettingsCopyValue
+                    value={runtime.consoleAuthCommand}
+                    desktopApi={props.desktopApi}
+                    label="Anthropic Console login command"
+                  />
+                ) : null}
+                <div className="settings-inline-actions">
+                  <button
+                    className="button button--secondary"
+                    disabled={props.refreshing}
+                    type="button"
+                    onClick={props.onRefresh}
+                  >
+                    {props.refreshing ? "Checking…" : "Check readiness"}
+                  </button>
+                </div>
+              </div>
+            }
+          />
+        )}
+
+        <SettingsField
+          label="Credential boundary"
+          sub="The adapter process, workspace, and Anthropic credentials stay on the PwrAgent instance that owns the thread. Federation sends backend capability metadata and thread operations, never Claude credentials."
+          source="Owning instance only"
+          control={
+            <p className="settings-empty">
+              No credential material crosses the federation boundary.
+            </p>
+          }
+        />
+      </div>
+    </SettingsSection>
+  );
 }

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -35,6 +35,11 @@ const DEFAULT_MANAGED_REVIEW = {
   source: "default" as const,
 };
 
+const DEFAULT_CLAUDE_ACP = {
+  value: false,
+  source: "default" as const,
+};
+
 const DEFAULT_THREAD_TOOL_ACCOUNTING = {
   value: false,
   source: "default" as const,
@@ -64,6 +69,7 @@ export function ExperimentalSettings(props: {
     enabled: boolean,
   ) => Promise<void>;
   onManagedReviewChange: (enabled: boolean) => Promise<void>;
+  onClaudeAcpChange: (enabled: boolean) => Promise<void>;
 }) {
   const [tokenMiserWriteTarget, setTokenMiserWriteTarget] = useState<
     boolean | undefined
@@ -115,6 +121,8 @@ export function ExperimentalSettings(props: {
     DEFAULT_CODEX_DEFAULT_MODE_REQUEST_USER_INPUT;
   const managedReview =
     props.snapshot.experimental.managedReview ?? DEFAULT_MANAGED_REVIEW;
+  const claudeAcp =
+    props.snapshot.experimental.claudeAcp ?? DEFAULT_CLAUDE_ACP;
   const discontinuedEnabledCount =
     (condensation.enabled.value ? 1 : 0) +
     (liveTranscriptEventFiltering.value ? 1 : 0);
@@ -210,6 +218,33 @@ export function ExperimentalSettings(props: {
               }
             />
           ) : null}
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Experimental"
+        title="Claude Agent through ACP"
+        description="Expose the community-maintained Claude ACP adapter under AI Providers. This integration and its authentication paths are experimental and may change or be removed."
+        chip={claudeAcp.value ? "On" : "Off"}
+        chipKind={claudeAcp.value ? "ok" : "default"}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Enable experimental Claude ACP"
+            sub="Allow this PwrAgent instance to install and run the pinned Claude adapter with local credentials."
+            help="When off, Claude is absent from AI Providers, backend discovery, and federation capabilities. Subscription use through a third-party product may require separate authorization under Anthropic's terms."
+            source={sourceBadge(claudeAcp)}
+            control={
+              <SettingsSwitch
+                checked={claudeAcp.value}
+                disabled={props.saving}
+                label="Enable experimental Claude ACP"
+                onChange={(enabled) => {
+                  void props.onClaudeAcpChange(enabled);
+                }}
+              />
+            }
+          />
         </div>
       </SettingsSection>
 

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -8,6 +8,7 @@ import {
   SettingsSectionStack,
   ToggleField,
 } from "./SettingsLayout";
+import { SettingsSwitch } from "./SettingsSwitch";
 import { sourceBadge } from "./settings-fields";
 
 const DEFAULT_LIVE_TRANSCRIPT_EVENT_FILTERING = {

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -820,6 +820,11 @@ function SettingsSectionBody(props: {
             experimental: { managedReview: enabled },
           });
         }}
+        onClaudeAcpChange={async (enabled: boolean) => {
+          await props.settings.writeConfig({
+            experimental: { claudeAcp: enabled },
+          });
+        }}
       />
     );
   }

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -322,6 +322,102 @@ describe("AcpAgentsSettings", () => {
     );
   });
 
+  it("hides a stale Claude entry when its Experimental opt-in is off", async () => {
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [claudeEntry(false)],
+    }));
+    const snapshot = {
+      experimental: {
+        claudeAcp: { value: false, source: "default" },
+      },
+    } as DesktopSettingsSnapshot;
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        snapshot={snapshot}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listAcpAgents).toHaveBeenCalled();
+    });
+    expect(screen.queryByText("Claude Agent")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Install Claude adapter" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("installs the pinned Claude runtime and surfaces local auth choices", async () => {
+    const placeholder = claudeEntry(false);
+    const installed = claudeEntry(true);
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [placeholder],
+    }));
+    const installAcpAgent = vi.fn(async () => ({
+      fetchedAt: 2000,
+      entry: installed,
+    }));
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents, installAcpAgent } as DesktopApi}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Install Claude adapter" }),
+    );
+    await waitFor(() => {
+      expect(installAcpAgent).toHaveBeenCalledWith({
+        registryId: "claude-acp",
+        expectedVersion: "0.60.0",
+      });
+    });
+    expect(
+      await screen.findByText(/Subscription use through a third-party product/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/--cli auth login --console/)).toBeInTheDocument();
+    expect(screen.getByText(/--cli auth login --claudeai/)).toBeInTheDocument();
+    expect(screen.getByText("Owning instance only")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Check readiness" }));
+    await waitFor(() => {
+      expect(listAcpAgents).toHaveBeenCalledWith({ refresh: true, force: true });
+    });
+  });
+
+  it("surfaces an unexpected managed install failure as a retryable state", async () => {
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [claudeEntry(false)],
+    }));
+    const installAcpAgent = vi.fn(async () => {
+      throw new Error("npm registry unavailable");
+    });
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents, installAcpAgent } as DesktopApi}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Install Claude adapter" }),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Retry install" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("npm registry unavailable")).toHaveAttribute(
+      "role",
+      "alert",
+    );
+    expect(screen.getByText("Install failed")).toBeInTheDocument();
+  });
+
   it("keeps cached ACP agents visible while explicit discovery refreshes", async () => {
     const dispatchEvent = vi.spyOn(window, "dispatchEvent");
     let resolveRefresh:
@@ -1184,3 +1280,39 @@ describe("AcpAgentsSettings", () => {
     expect(headings).toEqual(["Grok", "Gemini CLI"]);
   });
 });
+
+function claudeEntry(installed: boolean): AcpAgentSettingsEntry {
+  return {
+    backendId: "acp:claude-acp",
+    registryId: "claude-acp",
+    name: "Claude Agent",
+    version: "0.60.0",
+    authors: ["Agent Client Protocol contributors"],
+    distributionKind: "npx",
+    distributionSource: "@agentclientprotocol/claude-agent-acp@0.60.0",
+    installable: true,
+    installed,
+    installStatus: installed ? "installed" : "not-installed",
+    authStatus: "required",
+    verificationStatus: "verified",
+    allowlistRuleId: "managed-claude-agent-acp-0.60.0",
+    managedRuntime: {
+      kind: "pwragent-managed",
+      packageName: "@agentclientprotocol/claude-agent-acp",
+      pinnedVersion: "0.60.0",
+      integrity: "sha512-test",
+      credentialScope: "owning-instance",
+      supportLevel: "experimental",
+      authMethod: "local-terminal",
+      subscriptionAuthBlocked: false,
+      ...(installed
+        ? {
+            consoleAuthCommand:
+              "/usr/bin/node /profile/claude-agent-acp/dist/index.js --cli auth login --console",
+            subscriptionAuthCommand:
+              "/usr/bin/node /profile/claude-agent-acp/dist/index.js --cli auth login --claudeai",
+          }
+        : {}),
+    },
+  };
+}

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -385,7 +385,11 @@ describe("AcpAgentsSettings", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Check readiness" }));
     await waitFor(() => {
-      expect(listAcpAgents).toHaveBeenCalledWith({ refresh: true, force: true });
+      expect(listAcpAgents).toHaveBeenCalledWith({
+        discoveryIntent: "settings-user-action",
+        refresh: true,
+        force: true,
+      });
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1424,6 +1424,17 @@ describe("SettingsScreen", () => {
       });
     });
 
+    const claudeAcpSwitch = screen.getByRole("switch", {
+      name: "Enable experimental Claude ACP",
+    });
+    expect(claudeAcpSwitch).toHaveAttribute("aria-checked", "false");
+    fireEvent.click(claudeAcpSwitch);
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        experimental: { claudeAcp: true },
+      });
+    });
+
     fireEvent.click(within(sections).getByRole("button", { name: "Messaging" }));
     expect(screen.getByRole("heading", { name: "General" })).toBeInTheDocument();
     const imageProfile = screen.getByRole("radiogroup", {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ProviderStatusPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ProviderStatusPanel.tsx
@@ -61,6 +61,18 @@ export function ProviderStatusPanel(props: ProviderStatusPanelProps) {
                           <dd>{formatAcpAuthStatus(backend.acp.authStatus)}</dd>
                         </div>
                       ) : null}
+                      {backend.acp?.credentialScope === "owning-instance" ? (
+                        <div>
+                          <dt>Credentials</dt>
+                          <dd>Owning instance only</dd>
+                        </div>
+                      ) : null}
+                      {backend.acp?.supportLevel === "experimental" ? (
+                        <div>
+                          <dt>Support</dt>
+                          <dd>Experimental</dd>
+                        </div>
+                      ) : null}
                       {backend.account ? (
                         <div>
                           <dt>Account</dt>

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/ProviderStatusPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/ProviderStatusPanel.test.tsx
@@ -147,6 +147,30 @@ describe("ProviderStatusPanel", () => {
     expect(screen.getByText("Managed by provider")).toBeInTheDocument();
   });
 
+  it("shows the owning-instance credential boundary for managed Claude", () => {
+    render(
+      <ProviderStatusPanel
+        backends={[
+          {
+            ...kimiBackend,
+            kind: "acp:claude-acp",
+            label: "Claude Agent",
+            acp: {
+              ...kimiBackend.acp!,
+              registryId: "claude-acp",
+              authStatus: "authenticated",
+              credentialScope: "owning-instance",
+              supportLevel: "experimental",
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Owning instance only")).toBeInTheDocument();
+    expect(screen.getByText("Experimental")).toBeInTheDocument();
+  });
+
   it("shows Grok subscription and included-credit usage from ACP billing", () => {
     render(<ProviderStatusPanel backends={[grokAcpBackend]} />);
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/backend-label.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/backend-label.test.ts
@@ -93,6 +93,7 @@ describe("formatBackendLabel", () => {
     expect(formatBackendLabel("acp:kimi")).toBe("Kimi");
     expect(formatBackendLabel("acp:grok")).toBe("Grok");
     expect(formatBackendLabel("acp:qwen")).toBe("Qwen");
+    expect(formatBackendLabel("acp:claude-acp")).toBe("Claude Agent");
     expect(formatBackendLabel("acp:unknown")).toBe("unknown");
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -27,6 +27,7 @@ import { readRendererSequence } from "../../features/thread-detail/live-transcri
 function buildThread(params: {
   codexEnvironmentRuntime?: NavigationThreadSummary["codexEnvironmentRuntime"];
   id: string;
+  source?: AppServerBackendKind;
   updatedAt: number;
 }): NavigationThreadSummary {
   return {
@@ -34,7 +35,7 @@ function buildThread(params: {
     title: `Thread ${params.id}`,
     titleSource: "explicit" as const,
     summary: `Summary for ${params.id}`,
-    source: "codex" as const,
+    source: params.source ?? "codex",
     linkedDirectories: [],
     inbox: {
       inInbox: false,
@@ -14008,6 +14009,66 @@ describe("useThreadSessionState", () => {
       totalTokens: 96_000,
       usedPercent: 75,
     });
+  });
+
+  it("applies ACP context-window updates without creating token usage", async () => {
+    let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: vi.fn(async ({ backend, threadId }) => ({
+        backend: backend ?? "acp:claude-acp",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({
+          id: "thread-1",
+          source: "acp:claude-acp",
+          updatedAt: 1_000,
+        }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(desktopApi.readThread).toHaveBeenCalled();
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "acp:claude-acp",
+        notification: {
+          method: "thread/contextWindow/updated",
+          params: {
+            threadId: "thread-1",
+            usedTokens: 96_000,
+            modelContextWindow: 200_000,
+          },
+        },
+      });
+    });
+
+    expect(result.current.contextWindow).toMatchObject({
+      modelContextWindow: 200_000,
+      remainingTokens: 104_000,
+      totalTokens: 96_000,
+      usedPercent: 48,
+    });
+    expect(result.current.entries).toEqual([]);
   });
 
   it("derives context window usage from captured input and output token breakdowns", async () => {

--- a/apps/desktop/src/renderer/src/lib/backend-label.ts
+++ b/apps/desktop/src/renderer/src/lib/backend-label.ts
@@ -39,6 +39,9 @@ export function formatBackendLabel(
   if (backend === "acp:qwen") {
     return "Qwen";
   }
+  if (backend === "acp:claude-acp") {
+    return "Claude Agent";
+  }
   const summary = summaries.find((candidate) => candidate.kind === backend);
   if (summary?.label) {
     return summary.label;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -124,6 +124,8 @@ import type {
   StartCodexMcpServerLoginResponse,
   ListAcpAgentSettingsRequest,
   ListAcpAgentSettingsResponse,
+  InstallAcpAgentRequest,
+  InstallAcpAgentResponse,
   AcknowledgeAcpAgentUpdateRequest,
   AcknowledgeAcpAgentUpdateResponse,
   ListDesktopPwrAgentProfilesResponse,
@@ -825,6 +827,9 @@ export type DesktopApi = {
   listAcpAgents?: (
     request?: ListAcpAgentSettingsRequest
   ) => Promise<ListAcpAgentSettingsResponse>;
+  installAcpAgent?: (
+    request: InstallAcpAgentRequest,
+  ) => Promise<InstallAcpAgentResponse>;
   acknowledgeAcpAgentUpdate?: (
     request: AcknowledgeAcpAgentUpdateRequest,
   ) => Promise<AcknowledgeAcpAgentUpdateResponse>;

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -2834,6 +2834,40 @@ function normalizeThreadContextWindowState(
   };
 }
 
+function contextWindowStateFromTotals(params: {
+  modelContextWindow: number;
+  totalTokens: number;
+}): ThreadContextWindowState {
+  const rawUsedPercent =
+    (params.totalTokens / params.modelContextWindow) * 100;
+  const usedPercent = Math.max(0, Math.min(100, rawUsedPercent));
+  const remainingTokens = Math.max(
+    0,
+    params.modelContextWindow - params.totalTokens
+  );
+  const remainingPercent = Math.max(
+    0,
+    Math.min(100, (remainingTokens / params.modelContextWindow) * 100)
+  );
+  return {
+    cachedInputTokens: undefined,
+    cumulativeCachedInputTokens: undefined,
+    cumulativeInputTokens: undefined,
+    cumulativeOutputTokens: undefined,
+    cumulativeReasoningOutputTokens: undefined,
+    cumulativeTotalTokens: undefined,
+    inputTokens: undefined,
+    modelContextWindow: params.modelContextWindow,
+    outputTokens: undefined,
+    phase: getContextWindowMoonPhase(rawUsedPercent),
+    reasoningOutputTokens: undefined,
+    remainingPercent,
+    remainingTokens,
+    totalTokens: params.totalTokens,
+    usedPercent,
+  };
+}
+
 function isContextCompactionItemNotification(
   notification: AppServerNotification
 ): boolean {
@@ -3218,6 +3252,7 @@ function isThreadLocalTranscriptNotification(
     notification.method === "item/mcpToolCall/progress" ||
     notification.method === "item/commandExecution/outputDelta" ||
     notification.method === "item/fileChange/outputDelta" ||
+    notification.method === "thread/contextWindow/updated" ||
     notification.method === "thread/tokenUsage/updated"
   );
 }
@@ -6661,6 +6696,18 @@ export function useThreadSessionState(params: {
                   toolAccounting: event.notification.params.toolAccounting,
                 }
               : current.response,
+          };
+        }
+
+        if (event.notification.method === "thread/contextWindow/updated") {
+          return {
+            ...current,
+            contextWindow: contextWindowStateFromTotals({
+              modelContextWindow:
+                event.notification.params.modelContextWindow,
+              totalTokens: event.notification.params.usedTokens,
+            }),
+            lastTouchedAt: nextLastTouchedAt,
           };
         }
 

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -83,6 +83,7 @@ export const THREAD_MIGRATION_RETRY_CHANNEL = "thread-migration:retry";
 export const FOCUSED_DIFF_ANALYZE_CHANNEL = "focused-diff:analyze";
 export const BACKEND_LIST_CHANNEL = "backend:list";
 export const ACP_AGENTS_LIST_CHANNEL = "acp-agents:list";
+export const ACP_AGENT_INSTALL_CHANNEL = "acp-agents:install";
 export const ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL =
   "acp-agents:acknowledge-update";
 export const AGENT_START_THREAD_CHANNEL = "agent:start-thread";

--- a/docs/acp-registry-backends.md
+++ b/docs/acp-registry-backends.md
@@ -99,13 +99,14 @@ the general local-CLI discovery path, not a new agent-kit strategy:
 - Installation requires Node.js 22 or newer plus npm on the owning instance.
   npm lifecycle scripts are disabled. Before an installation is promoted,
   PwrAgent verifies the package name, exact version, executable entrypoint, and
-  the checked-in npm SHA-512 integrity value.
+  the checked-in npm SHA-512 integrity value, then hashes the complete installed
+  package tree against a checked-in SHA-256 content digest.
 - Runtime launches go through PwrAgent's normal ACP stdio transport and owned
   process-tree shutdown. PwrAgent launches the adapter with no adapter-specific
   arguments, matching its normal local-authenticated behavior.
-- Cached readiness is reused only after the on-disk package and entrypoint pass
-  the same pin checks. A removed or altered runtime becomes unavailable and
-  must be reinstalled before PwrAgent will launch it.
+- Cached readiness is reused only after the on-disk package bytes and
+  entrypoint pass the same pin checks. A removed or altered runtime becomes
+  unavailable and must be reinstalled before PwrAgent will launch it.
 - Authentication is an explicit local setup step. Settings provides both the
   adapter's `--cli auth login --claudeai` subscription command and its
   `--cli auth login --console` command for the operator to run in a terminal,
@@ -113,6 +114,11 @@ the general local-CLI discovery path, not a new agent-kit strategy:
   ACP client does not advertise terminal-auth handling; these commands are the
   intentionally explicit local flow. PwrAgent does not receive, store, log, or
   transport the resulting credential.
+- An authenticated readiness probe discovers the account's available models
+  and the model-dependent effort choices advertised by the adapter. Prompt
+  results populate PwrAgent's turn token-usage and pricing state; ACP
+  `usage_update` notifications populate context-window occupancy separately so
+  cumulative context is never mispriced as per-turn spend.
 
 The package pin is deliberately independent of the moving public ACP registry.
 An upgrade requires updating the package version, integrity value, allowlist

--- a/docs/acp-registry-backends.md
+++ b/docs/acp-registry-backends.md
@@ -82,3 +82,81 @@ Ship with a narrow allowlist. Add new agents only after agent-specific smoke
 testing covers install, launch, session creation, prompt turn, cancellation,
 permission requests, rejection of unsupported reverse requests, auth/setup
 status, and registry-unavailable startup.
+
+## Managed Claude Runtime
+
+Claude is exposed as `acp:claude-acp`. It is a PwrAgent-managed exception to
+the general local-CLI discovery path, not a new agent-kit strategy:
+
+- Claude is Experimental and defaults off. It appears under AI Providers only
+  after the operator enables **Experimental → Claude Agent through ACP**. When
+  that flag is off, PwrAgent also blocks installation and launch and omits
+  Claude from local and federated backend capabilities.
+- PwrAgent installs the external
+  `@agentclientprotocol/claude-agent-acp@0.60.0` executable under the active
+  profile's `state/acp-runtimes/` directory. It is not a desktop-app or
+  agent-kit dependency.
+- Installation requires Node.js 22 or newer plus npm on the owning instance.
+  npm lifecycle scripts are disabled. Before an installation is promoted,
+  PwrAgent verifies the package name, exact version, executable entrypoint, and
+  the checked-in npm SHA-512 integrity value.
+- Runtime launches go through PwrAgent's normal ACP stdio transport and owned
+  process-tree shutdown. PwrAgent launches the adapter with no adapter-specific
+  arguments, matching its normal local-authenticated behavior.
+- Cached readiness is reused only after the on-disk package and entrypoint pass
+  the same pin checks. A removed or altered runtime becomes unavailable and
+  must be reinstalled before PwrAgent will launch it.
+- Authentication is an explicit local setup step. Settings provides both the
+  adapter's `--cli auth login --claudeai` subscription command and its
+  `--cli auth login --console` command for the operator to run in a terminal,
+  then uses an ACP session probe to mark the runtime ready. PwrAgent's generic
+  ACP client does not advertise terminal-auth handling; these commands are the
+  intentionally explicit local flow. PwrAgent does not receive, store, log, or
+  transport the resulting credential.
+
+The package pin is deliberately independent of the moving public ACP registry.
+An upgrade requires updating the package version, integrity value, allowlist
+rule, tests, and authenticated smoke-test evidence together.
+
+### Federation and credential ownership
+
+The thread's owning PwrAgent instance launches Claude beside the workspace and
+reads credentials from that instance's local Claude credential store. Remote
+instances may receive the backend's availability, version, capabilities, and
+the `owning-instance` credential-scope marker through the existing federation
+backend APIs. They never receive an Anthropic API key, OAuth token, credential
+file, or authentication command, and they never launch a second adapter for a
+remotely owned thread.
+
+### Anthropic policy boundary
+
+[Anthropic's Agent SDK documentation](https://code.claude.com/docs/en/agent-sdk)
+directs third-party products to use API key authentication through Anthropic
+Console or a supported cloud provider. Its
+[authentication policy](https://code.claude.com/docs/en/legal-and-compliance#authentication-and-credential-use)
+prohibits offering Claude.ai login or routing Free, Pro, or Max plan
+credentials on users' behalf. The community adapter supports local Claude.ai
+login, and other open-source ACP clients expose that flow, but no public
+evidence reviewed for this integration establishes Anthropic approval for
+PwrAgent to do so.
+
+PwrAgent therefore labels the entire provider Experimental, requires a
+specific opt-in, keeps authentication and execution on the owning instance,
+and shows the policy caveat beside the controls. Those mitigations do not
+resolve the underlying terms question. Subscription authentication should
+receive legal/policy review or explicit Anthropic approval before it is treated
+as generally supported or enabled by default.
+
+The adapter is Apache-2.0, but its bundled Anthropic Agent SDK and the service
+remain subject to Anthropic's commercial terms, usage policy, supported-region
+rules, and operator account agreement. PwrAgent does not make an independent
+claim that a particular enterprise gateway, cloud-provider credential flow, or
+resale/deployment model is authorized. Those paths remain operator-managed and
+should receive legal/policy review before PwrAgent adds first-class setup UI.
+
+The community adapter labels `--console` as Anthropic Console authentication
+with API usage billing. PwrAgent has not independently established that this
+interactive credential mechanism is contractually equivalent to the API-key
+authentication Anthropic prescribes for third-party products. Confirm that
+point with Anthropic before broad distribution; if it is not approved, replace
+the interactive command with an explicit local API-key setup flow.

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -133,6 +133,10 @@ export type BackendAcpSummary = {
   websiteUrl?: string;
   allowlistRuleId?: string;
   runtime?: BackendAcpRuntimeCapabilities;
+  /** Credentials are read only by the PwrAgent instance that owns and launches
+   *  this backend. Federation transports capability metadata, never secrets. */
+  credentialScope?: "owning-instance";
+  supportLevel?: "experimental";
 };
 
 export type BackendCapabilities = {
@@ -302,6 +306,22 @@ export type AcpAgentSettingsEntry = {
   managedBuild?: AcpManagedBuildStatus;
   enabled?: boolean;
   preference?: AcpAgentPreference;
+  managedRuntime?: AcpManagedRuntimeSettings;
+};
+
+/** PwrAgent-owned policy for an external ACP runtime. This is display and
+ *  control metadata only; it never contains tokens, cookies, or credentials. */
+export type AcpManagedRuntimeSettings = {
+  kind: "pwragent-managed";
+  packageName: string;
+  pinnedVersion: string;
+  integrity: string;
+  credentialScope: "owning-instance";
+  supportLevel: "experimental";
+  authMethod: "local-terminal";
+  subscriptionAuthBlocked: boolean;
+  consoleAuthCommand?: string;
+  subscriptionAuthCommand?: string;
 };
 
 /**
@@ -428,6 +448,16 @@ export type ListAcpAgentSettingsResponse = {
   fetchedAt: number;
   entries: AcpAgentSettingsEntry[];
   error?: string;
+};
+
+export type InstallAcpAgentRequest = {
+  registryId: string;
+  expectedVersion: string;
+};
+
+export type InstallAcpAgentResponse = {
+  fetchedAt: number;
+  entry: AcpAgentSettingsEntry;
 };
 
 export type AcknowledgeAcpAgentUpdateRequest = {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1689,6 +1689,14 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "thread/contextWindow/updated";
+      params: {
+        threadId: string;
+        usedTokens: number;
+        modelContextWindow: number;
+      };
+    }
+  | {
       method: "thread/pricing/updated";
       params: {
         threadId: string;

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -887,6 +887,12 @@ export type DesktopSettingsSnapshot = {
      */
     managedReview?: DesktopSettingsValue<boolean>;
     /**
+     * Exposes the experimental, community-maintained Claude ACP provider.
+     * Disabled by default; when off Claude is absent from provider discovery,
+     * installation, launch, and federation capability metadata.
+     */
+    claudeAcp?: DesktopSettingsValue<boolean>;
+    /**
      * Diff condensation (a.k.a. "diff eliding") gates whether the configured
      * backend may classify less-relevant diff hunks. When disabled, every diff
      * renders in full and no structured-generation request fires.
@@ -1082,6 +1088,12 @@ export type DesktopSettingsSnapshot = {
        */
       enabled: boolean;
     };
+    "claude-acp"?: {
+      /** Managed Claude runtimes have no operator-selectable executable path.
+       *  This secondary provider toggle only applies while the default-off
+       *  Experimental Claude gate is also enabled. */
+      enabled: boolean;
+    };
   };
   git: {
     /**
@@ -1153,6 +1165,7 @@ export type DesktopSettingsConfigPatch = {
     threadToolAccounting?: boolean;
     codexDefaultModeRequestUserInput?: boolean;
     managedReview?: boolean;
+    claudeAcp?: boolean;
     diffCondensation?: {
       enabled?: boolean;
     };
@@ -1301,6 +1314,9 @@ export type DesktopSettingsConfigPatch = {
     };
     qwen?: {
       cliPath?: string;
+      enabled?: boolean;
+    };
+    "claude-acp"?: {
       enabled?: boolean;
     };
   };


### PR DESCRIPTION
## Summary

- add a PwrAgent-owned, version-pinned Claude ACP runtime using the external `@agentclientprotocol/claude-agent-acp@0.60.0` executable
- verify the exact package/version/SHA-512 and entrypoint during an atomic local-profile install, with npm lifecycle scripts disabled
- gate Claude behind a new default-off Experimental setting across AI Providers, installation, discovery, launch, readiness, and federation capability advertisement
- launch the adapter with its normal zero-argument behavior and expose locally owned Claude subscription and Anthropic Console login commands inside the Experimental experience
- keep the adapter process, workspace, and credentials on the PwrAgent instance that owns the thread; federation receives only capability, support-level, and credential-scope metadata
- document the unresolved Anthropic policy/authorization concern explicitly

The current `@pwrdrvr/agent-acp@0.13.0` lock already consumes `@agentclientprotocol/sdk@1.3.0`, so this does not add the Claude adapter to PwrAgent or agent-kit dependencies.

## Product behavior

Claude is absent from AI Providers and non-runnable by default. Operators must enable **Experimental → Claude Agent through ACP** before PwrAgent will show, install, discover, launch, or federate the provider.

When enabled, PwrAgent installs the pinned external runtime under the active profile, provides local subscription and Console login commands, and probes ACP readiness. No credential material or authentication command crosses federation boundaries.

## Policy caveat

Anthropic's public Agent SDK authentication guidance directs third-party products toward Console/cloud credentials and raises a material concern around offering Claude.ai plan login. Other open-source ACP clients expose the adapter's local subscription flow, but this PR does not establish Anthropic approval for PwrAgent. The provider remains explicitly Experimental and default-off; legal/policy review or explicit Anthropic approval is still recommended before treating subscription auth as generally supported.

## Verification

- focused Vitest: 10 files, 267 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; 138 baseline warnings)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:colors`
- `pnpm licenses:check`
- `git diff --check`
