### PR TITLE
fix(deps): update js-yaml to 4.3.1

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -241,7 +241,7 @@ MIT
 - is-plain-obj@4.1.0 | sindresorhus/is-plain-obj
 - is-promise@4.0.0 | https://github.com/then/is-promise
 - jose@6.2.3 | panva/jose
-- js-yaml@4.3.0 | nodeca/js-yaml
+- js-yaml@4.3.1 | nodeca/js-yaml
 - json-schema-traverse@1.0.0 | https://github.com/epoberezkin/json-schema-traverse
 - json-with-bigint@3.5.8 | https://github.com/Ivan-Korolenko/json-with-bigint
 - jsonfile@6.2.1 | https://github.com/jprichardson/node-jsonfile
@@ -4026,13 +4026,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-js-yaml@4.3.0 (MIT)
+js-yaml@4.3.1 (MIT)
 -------------------
 
 Applies to:
-- js-yaml@4.3.0 (MIT)
+- js-yaml@4.3.1 (MIT)
 
-Representative file: js-yaml@4.3.0/LICENSE
+Representative file: js-yaml@4.3.1/LICENSE
 
 (The MIT License)
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
       "form-data": "4.0.6",
       "hono": "4.12.34",
       "ip-address": "10.3.1",
-      "js-yaml": "4.3.0",
+      "js-yaml": "4.3.1",
       "postcss": "8.5.23",
       "prosemirror-model": "1.25.9",
       "prosemirror-view": "1.41.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   form-data: 4.0.6
   hono: 4.12.34
   ip-address: 10.3.1
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   postcss: 8.5.23
   prosemirror-model: 1.25.9
   prosemirror-view: 1.41.9
@@ -2861,8 +2861,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -5928,7 +5928,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -6076,7 +6076,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -6324,7 +6324,7 @@ snapshots:
       app-builder-lib: 26.15.7(dmg-builder@26.15.7)(electron-builder-squirrel-windows@26.15.7)
       builder-util: 26.15.3
       fs-extra: 10.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
@@ -6402,7 +6402,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.7.0
       fs-extra: 10.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -7140,7 +7140,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary

- update the workspace `js-yaml` override from 4.3.0 to patched version 4.3.1
- refresh the pnpm lockfile so all transitive consumers resolve 4.3.1
- regenerate the third-party license notice for the updated package version

## Why

Dependabot alert [#76](https://github.com/pwrdrvr/PwrAgent/security/dependabot/76) reports GHSA-5p4m-2wfm-xmqj, a high-severity quadratic CPU consumption issue in `js-yaml` versions before 4.3.1. The existing workspace override pinned the vulnerable 4.3.0 release across Electron builder and updater dependency paths.

## Impact

All `js-yaml` consumers now resolve the patched 4.3.1 release. No application code or public API changes.

## Validation

- `pnpm install --frozen-lockfile`
- verified `pnpm why -r js-yaml` resolves exactly one version: 4.3.1
- `pnpm licenses:check`
- `pnpm lint`
- `git diff --check`
