### PR TITLE
fix(desktop): make Updated and Created pure sort orders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,11 +193,14 @@ accidental.
 
 - Threads are first-class and may exist without a directory.
 - Inbox, Recents, and Directories share the thread lens switch.
-- Inbox is the default browsing lens. Its thread population and ordering match
-  the former Recents behavior: all threads, user-curated Pins at the top, and
-  unpinned threads in recent-activity order.
-- Recents keeps the same pinned section, but unpinned threads sort by thread
-  creation time so active threads do not jump around.
+- Inbox is the default browsing lens: all threads in recent-activity order.
+- Recents shows all threads in thread-creation order so active threads do not
+  jump around.
+- Inbox and Recents are **pure sort orders** — they do not float pinned threads
+  into a section. A pinned thread appears in its natural position by
+  updated/created time. Pin *ordering* (drag, the ⌘⇧↑/↓ shortcut, and the
+  context menu's Move Up / Move Down) is offered only in Directories, the one
+  lens where pin order is visible.
 - Directories keep pinned threads first within each directory, then sort
   unpinned threads by thread creation time.
 - Unread state remains available as the orange cookie marker on thread rows

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -40,8 +40,9 @@ summary.
 
 - Inbox, Recents, and Directories live in one thread lens switch; Inbox is the
   default browsing lens.
-- User-curated Pins live as a scrollable section at the top of Inbox and
-  Recents.
+- User-curated Pins live as a scrollable section at the top of each directory
+  in the Directories lens. Inbox and Recents are pure sort orders and do not
+  float pins.
 - Unread state uses the orange cookie marker, not punctuation badges.
 - The sidebar is an information surface, not a stack of generic cards.
 - Do not use browser-default controls in shipped UI.

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -6,8 +6,6 @@ import type {
 } from "@pwragent/shared";
 import {
   buildThreadIdentityKey,
-  comparePinnedThreads,
-  isPinnedThread,
   moveThreadKey,
   parseThreadIdentityKey,
   resolveThreadParentKey,
@@ -53,7 +51,6 @@ type RecentsListProps = {
     thread: NavigationThreadSummary,
     pr: PrSummary,
   ) => void;
-  onReorderThreadPins?: (orderedThreadKeys: string[]) => Promise<void>;
   onUpdateSubthreadOrder?: (
     parent: NavigationThreadSummary,
     threadIds: string[],
@@ -83,11 +80,21 @@ type RecentsListProps = {
   ) => Promise<void>;
 };
 
+/**
+ * The Updated and Created lenses are pure sort orders: every top-level thread
+ * renders in the order the caller supplies, pinned or not. A pinned thread
+ * still appears — just in its natural position by updated/created time,
+ * instead of floating into a section that crowds out what the sort is for.
+ *
+ * Pin *ordering* is therefore not editable here. It lives in the Directories
+ * lens, which is the only place a pinned section still exists and which
+ * carries both the drag and the keyboard (`onMovePinnedThread`) paths against
+ * the same global pinned-key list.
+ */
 export function RecentsList(props: RecentsListProps) {
   const [dropIndicator, setDropIndicator] = useState<
     DropIndicatorState | undefined
   >(undefined);
-  const [dividerDropTarget, setDividerDropTarget] = useState(false);
   const [draggedThreadKey, setDraggedThreadKey] = useState<string | undefined>(
     undefined,
   );
@@ -111,42 +118,6 @@ export function RecentsList(props: RecentsListProps) {
     children.push(thread);
     childrenByParentKey.set(parentKey, children);
   }
-  const pinnedThreads = topLevelThreads
-    .filter(isPinnedThread)
-    .sort(comparePinnedThreads);
-  const pinnedThreadKeys = pinnedThreads.map((thread) =>
-    buildThreadIdentityKey(thread.source, thread.id),
-  );
-  const unpinnedThreads = topLevelThreads.filter((thread) => !isPinnedThread(thread));
-
-  // Pin order is global across backends, so reorder operates on the full
-  // pinned-thread key list and passes the complete new order through.
-  const reorderPins = (nextThreadKeys: string[]): void => {
-    void props.onReorderThreadPins?.(nextThreadKeys);
-  };
-
-  const movePinnedThreadByKeyboard = (
-    thread: NavigationThreadSummary,
-    direction: "up" | "down",
-  ): void => {
-    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-    const currentIndex = pinnedThreadKeys.indexOf(threadKey);
-    if (currentIndex === -1) return;
-
-    const targetIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
-    const targetKey = pinnedThreadKeys[targetIndex];
-    if (!targetKey) return;
-
-    reorderPins(
-      moveThreadKey(
-        pinnedThreadKeys,
-        threadKey,
-        targetKey,
-        direction === "up" ? "before" : "after",
-      ),
-    );
-  };
-
   const renderSubthreads = (parent: NavigationThreadSummary) => {
     const parentKey = buildThreadIdentityKey(parent.source, parent.id);
     const children = sortSubthreadSummaries(parent, childrenByParentKey.get(parentKey) ?? []);
@@ -275,33 +246,30 @@ export function RecentsList(props: RecentsListProps) {
   };
 
   // Shift selection follows the rows a person can actually see: parents and
-  // any expanded children, first in the pinned section and then in the recent
-  // section. Collapsed children are deliberately absent, just like Finder
-  // ranges do not reach into a closed disclosure.
-  const selectionOrder = [...pinnedThreads, ...unpinnedThreads].flatMap(
-    (thread) => {
-      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-      const children = sortSubthreadSummaries(
-        thread,
-        childrenByParentKey.get(threadKey) ?? [],
-      );
-      return [
-        threadKey,
-        ...(isSubthreadSectionCollapsed(thread)
-          ? []
-          : children.map((child) =>
-              buildThreadIdentityKey(child.source, child.id),
-            )),
-      ];
-    },
-  );
+  // any expanded children, in render order. Collapsed children are
+  // deliberately absent, just like Finder ranges do not reach into a closed
+  // disclosure.
+  const selectionOrder = topLevelThreads.flatMap((thread) => {
+    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    const children = sortSubthreadSummaries(
+      thread,
+      childrenByParentKey.get(threadKey) ?? [],
+    );
+    return [
+      threadKey,
+      ...(isSubthreadSectionCollapsed(thread)
+        ? []
+        : children.map((child) =>
+            buildThreadIdentityKey(child.source, child.id),
+          )),
+    ];
+  });
 
   const renderThreadGroup = (thread: NavigationThreadSummary) => {
     const key = buildThreadIdentityKey(thread.source, thread.id);
     const children = sortSubthreadSummaries(thread, childrenByParentKey.get(key) ?? []);
     const subthreadCount = getSubthreadDisclosureCount(thread, children.length);
     const subthreadsCollapsed = isSubthreadSectionCollapsed(thread);
-    const pinned = isPinnedThread(thread);
     return (
       <div key={key} className="thread-group">
         <ThreadRow
@@ -310,12 +278,6 @@ export function RecentsList(props: RecentsListProps) {
           inputRequestThreadKeys={props.inputRequestThreadKeys}
           queuedMessageThreadKeys={props.queuedMessageThreadKeys}
           composerSourceThreadKey={props.composerSourceThreadKey}
-          dropIndicator={
-            dropIndicator?.targetKey === key
-              ? dropIndicator.position
-              : undefined
-          }
-          draggable={pinned || pinnedThreads.length > 0}
           includeLinkedDirectories
           revealSelectedThreadRequest={props.revealSelectedThreadRequest}
           selectedThreadKey={props.selectedThreadKey}
@@ -333,72 +295,6 @@ export function RecentsList(props: RecentsListProps) {
                   )
               : undefined
           }
-          onDragOverThread={
-            pinned
-              ? (event) => {
-                  event.preventDefault();
-                  const draggedThread = draggedThreadKey
-                    ? threadByKey.get(draggedThreadKey)
-                    : undefined;
-                  if (
-                    !draggedThread ||
-                    draggedThread.source !== thread.source ||
-                    draggedThread.parentThreadId
-                  ) {
-                    event.dataTransfer.dropEffect = "none";
-                    setDropIndicator(undefined);
-                    return;
-                  }
-
-                  event.dataTransfer.dropEffect = "move";
-                  setDropIndicator({
-                    targetKey: key,
-                    position: getDropIndicatorPosition(event),
-                  });
-                  setDividerDropTarget(false);
-                }
-              : undefined
-          }
-          onDragStartThread={(event) => {
-            setDraggedThreadKey(key);
-            event.dataTransfer.effectAllowed = "move";
-            event.dataTransfer.setData("text/plain", key);
-          }}
-          onDragLeaveThread={(event) => {
-            if (didDragLeaveCurrentTarget(event)) {
-              setDropIndicator(undefined);
-            }
-          }}
-          onDragEndThread={() => {
-            setDraggedThreadKey(undefined);
-            setDropIndicator(undefined);
-            setDividerDropTarget(false);
-          }}
-          onDropOnThread={
-            pinned
-              ? (event) => {
-                  event.preventDefault();
-                  setDraggedThreadKey(undefined);
-                  setDropIndicator(undefined);
-                  setDividerDropTarget(false);
-                  const draggedKey = event.dataTransfer.getData("text/plain");
-                  if (!draggedKey) return;
-                  const draggedThread = threadByKey.get(draggedKey);
-                  if (!draggedThread || draggedThread.parentThreadId) return;
-                  const position = getDropIndicatorPosition(event);
-                  const nextKeys = pinnedThreadKeys.includes(draggedKey)
-                    ? moveThreadKey(pinnedThreadKeys, draggedKey, key, position)
-                    : moveThreadKey(
-                        [...pinnedThreadKeys, draggedKey],
-                        draggedKey,
-                        key,
-                        position,
-                      );
-                  reorderPins(nextKeys);
-                }
-              : undefined
-          }
-          onMovePinnedThread={pinned ? movePinnedThreadByKeyboard : undefined}
           onOpenContextMenu={props.onOpenThreadContextMenu}
           onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
           onDetachPullRequest={props.onDetachPullRequest}
@@ -419,53 +315,7 @@ export function RecentsList(props: RecentsListProps) {
 
   return (
     <div className="sidebar-list sidebar-list--dense" role="list">
-      {pinnedThreads.map((thread) => renderThreadGroup(thread))}
-      {pinnedThreads.length > 0 ? (
-        <div
-          className={`recents-pinned-divider${
-            dividerDropTarget ? " is-drop-target" : ""
-          }`}
-          role="separator"
-          aria-label="Unpinned threads"
-          onDragOver={(event) => {
-            event.preventDefault();
-            const draggedThread = draggedThreadKey
-              ? threadByKey.get(draggedThreadKey)
-              : undefined;
-            if (
-              !draggedThread ||
-              !draggedThreadKey ||
-              draggedThread.parentThreadId ||
-              pinnedThreadKeys.includes(draggedThreadKey)
-            ) {
-              event.dataTransfer.dropEffect = "none";
-              setDividerDropTarget(false);
-              return;
-            }
-
-            event.dataTransfer.dropEffect = "move";
-            setDropIndicator(undefined);
-            setDividerDropTarget(true);
-          }}
-          onDragLeave={(event) => {
-            if (didDragLeaveCurrentTarget(event)) {
-              setDividerDropTarget(false);
-            }
-          }}
-          onDrop={(event) => {
-            event.preventDefault();
-            setDraggedThreadKey(undefined);
-            setDividerDropTarget(false);
-            const draggedKey = event.dataTransfer.getData("text/plain");
-            const draggedThread = threadByKey.get(draggedKey);
-            if (!draggedThread || draggedThread.parentThreadId || pinnedThreadKeys.includes(draggedKey)) return;
-            reorderPins([...pinnedThreadKeys, draggedKey]);
-          }}
-        >
-          <span>Recent threads</span>
-        </div>
-      ) : null}
-      {unpinnedThreads.map((thread) => renderThreadGroup(thread))}
+      {topLevelThreads.map((thread) => renderThreadGroup(thread))}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1238,13 +1238,19 @@ export function Sidebar(props: SidebarProps) {
   /**
    * Move Up / Move Down show as menu items only when the target
    * thread is pinned (reorder only applies inside the pinned
-   * section) AND the reorder IPC is wired. Each item is then
-   * disabled when the thread is at the top / bottom of the global
-   * pinned section. We render the items even when disabled
-   * so the menu layout doesn't jump as the user walks the list.
+   * section), the reorder IPC is wired, AND the active lens actually
+   * renders a pinned section. Updated and Created are pure sort
+   * orders, so a reorder there would move a thread within a list whose
+   * order is invisible — the row would not budge and the menu's
+   * ⌘⇧↑/↓ hint would advertise a shortcut those rows don't carry.
+   * Each item is then disabled when the thread is at the top / bottom
+   * of the global pinned section. We render the items even when
+   * disabled so the menu layout doesn't jump as the user walks the
+   * list.
    */
   const contextMenuShowMoveItems = Boolean(
     !contextMenuIsBulk &&
+      browseMode === "directories" &&
       contextMenu?.thread.pinnedRank &&
       props.onReorderThreadPins,
   );
@@ -1648,7 +1654,6 @@ export function Sidebar(props: SidebarProps) {
                   props.onRevealSelectedThreadComplete
                 }
                 onDetachPullRequest={detachPullRequest}
-                onReorderThreadPins={props.onReorderThreadPins}
                 onUpdateSubthreadOrder={props.onUpdateSubthreadOrder}
                 onSetSubthreadsCollapsed={props.onSetSubthreadsCollapsed}
                 onSelectThread={selectThreadFromList}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2688,10 +2688,13 @@ describe("Sidebar", () => {
     render(
       <Sidebar
         backends={forkBackends}
-        browseMode="recents"
+        // Move Up / Move Down only surface where a pinned section is
+        // rendered, which is the Directories lens.
+        browseMode="directories"
         directories={directories}
         inboxThreads={[pinnedThread]}
         loading={false}
+        selectedItemKey="codex:thread-1"
         threads={[pinnedThread]}
         onArchiveThread={async () => undefined}
         onBrowseModeChange={() => undefined}
@@ -2826,7 +2829,7 @@ describe("Sidebar", () => {
     });
   });
 
-  it("pins from the row menu and renders pinned threads above recents", () => {
+  it("pins from the row menu and leaves pinned threads in sort order", () => {
     const onSetThreadPin = vi.fn(async () => undefined);
     const pinnedThread = {
       ...updatedSinceSeenThread,
@@ -2857,11 +2860,18 @@ describe("Sidebar", () => {
     const rows = within(browseSection as HTMLElement).getAllByRole("button", {
       name: /Cross-project cleanup|Updated thread/i,
     });
-    expect(rows[0]).toHaveTextContent("Updated thread");
+    // Created is a pure sort order: the pinned thread keeps the position the
+    // caller's ordering gave it instead of floating to a pinned section.
+    expect(rows.map((row) => row.textContent)).toEqual([
+      expect.stringContaining("Cross-project cleanup"),
+      expect.stringContaining("Updated thread"),
+    ]);
     expect(
-      within(threadCard(rows[0]!)).getByRole("button", { name: "Unpin thread" }),
+      within(threadCard(rows[1]!)).getByRole("button", { name: "Unpin thread" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("separator", { name: "Unpinned threads" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("separator", { name: "Unpinned threads" }),
+    ).not.toBeInTheDocument();
 
     const unpinnedRow = within(browseSection as HTMLElement).getByRole("button", {
       name: /Cross-project cleanup/i,
@@ -2897,14 +2907,19 @@ describe("Sidebar", () => {
     render(
       <Sidebar
         backends={backends}
-        browseMode="recents"
+        browseMode="directories"
         createThreadError={undefined}
-        directories={directories}
+        directories={[
+          {
+            ...directories[0]!,
+            threadKeys: ["codex:thread-top", "codex:thread-bottom"],
+          },
+        ]}
         inboxThreads={[]}
         launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
-        selectedItemKey={undefined}
+        selectedItemKey="codex:thread-top"
         threads={[pinnedTop, pinnedBottom]}
         onBrowseModeChange={() => undefined}
         onCreateThread={async () => undefined}
@@ -3300,7 +3315,10 @@ describe("Sidebar", () => {
     expect(onSetDirectoryThreadsCollapsed).not.toHaveBeenCalled();
   });
 
-  it("shows recents drop targets for row edges and the pin divider", () => {
+  it("shows directory drop targets for row edges and the pin divider", () => {
+    // Pin reorder-by-drag lives only where a pinned section is rendered, which
+    // after the Updated/Created lenses became pure sort orders means the
+    // Directories lens alone.
     const pinnedThread = {
       ...updatedSinceSeenThread,
       pinnedRank: "1024",
@@ -3309,9 +3327,14 @@ describe("Sidebar", () => {
     render(
       <Sidebar
         backends={backends}
-        browseMode="recents"
+        browseMode="directories"
         createThreadError={undefined}
-        directories={directories}
+        directories={[
+          {
+            ...directories[0]!,
+            threadKeys: ["codex:thread-1", "codex:thread-updated"],
+          },
+        ]}
         inboxThreads={[sharedThread]}
         launchpadError={undefined}
         loading={false}
@@ -3360,11 +3383,50 @@ describe("Sidebar", () => {
     });
     expect(pinnedRow).not.toHaveClass("is-drop-target-before");
 
-    const divider = screen.getByRole("separator", { name: "Unpinned threads" });
+    const divider = screen.getByRole("button", {
+      name: "Hide directory threads for PwrAgent",
+    });
     fireEvent.dragOver(divider, {
       dataTransfer,
     });
     expect(divider).toHaveClass("is-drop-target");
+  });
+
+  it("renders no pinned section or drag affordance in the Created lens", () => {
+    const pinnedThread = {
+      ...updatedSinceSeenThread,
+      pinnedRank: "1024",
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread, pinnedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onReorderThreadPins={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    expect(
+      screen.queryByRole("separator", { name: /Unpinned threads/ }),
+    ).not.toBeInTheDocument();
+    for (const title of [/Cross-project cleanup/i, /Updated thread/i]) {
+      const shell = screen
+        .getByRole("button", { name: title })
+        .closest(".thread-row-shell");
+      expect(shell).not.toHaveAttribute("draggable", "true");
+    }
   });
 
   it("ignores attempts to drop a thread on another directory pin divider", () => {
@@ -5164,6 +5226,17 @@ describe("Sidebar directory pinning", () => {
 });
 
 describe("Sidebar thread pinning Move items", () => {
+  // Move Up / Move Down only surface in the Directories lens — the only lens
+  // that still renders a pinned section, and therefore the only one where a
+  // reorder visibly moves the row. Updated and Created are pure sort orders.
+  const pinnedThreadsDirectory = (
+    threadKeys: string[],
+  ): NavigationDirectorySummary => ({
+    ...directories[0]!,
+    needsAttentionCount: 0,
+    threadKeys,
+  });
+
   it("moves a pin across backends — pin order is global, not per-backend", async () => {
     // Pin order is global across backends (mirrors directory pinning). The
     // top global pin can Move Down past another backend's pins, producing an
@@ -5195,14 +5268,20 @@ describe("Sidebar thread pinning Move items", () => {
     render(
       <Sidebar
         backends={backends}
-        browseMode="recents"
+        browseMode="directories"
         createThreadError={undefined}
-        directories={[]}
+        directories={[
+          pinnedThreadsDirectory([
+            "codex:codex-top",
+            "acp:grok:grok-middle",
+            "acp:grok:grok-bottom",
+          ]),
+        ]}
         inboxThreads={[]}
         launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
-        selectedItemKey={undefined}
+        selectedItemKey="codex:codex-top"
         threads={[codexTop, grokMiddle, grokBottom]}
         onBrowseModeChange={() => undefined}
         onCreateThread={async () => undefined}
@@ -5260,14 +5339,16 @@ describe("Sidebar thread pinning Move items", () => {
     render(
       <Sidebar
         backends={backends}
-        browseMode="recents"
+        browseMode="directories"
         createThreadError={undefined}
-        directories={[]}
+        directories={[
+          pinnedThreadsDirectory(["codex:thread-top", "codex:thread-bottom"]),
+        ]}
         inboxThreads={[]}
         launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
-        selectedItemKey={undefined}
+        selectedItemKey="codex:thread-top"
         threads={[pinnedTop, pinnedBottom]}
         onBrowseModeChange={() => undefined}
         onCreateThread={async () => undefined}

--- a/docs/design/desktop-style-guide.md
+++ b/docs/design/desktop-style-guide.md
@@ -181,10 +181,10 @@ The sidebar is a structured queue. It should contain:
 
 Rules:
 
-- Inbox is the default thread lens and should include user-curated Pins at the
-  top of its scrollable list
-- Recents keeps the pinned section but sorts unpinned rows by thread creation
-  time
+- Inbox is the default thread lens, sorted by recent activity
+- Recents sorts by thread creation time
+- Inbox and Recents are pure sort orders: no pinned section, no pinned-first
+  float. Pins float only inside a directory in the Directories lens
 - unread work is a row-local state shown with the orange cookie marker
 - section headers should be quiet, compact, and utility-first
 - rows should carry metadata inline


### PR DESCRIPTION
## Summary

- Both lenses floated pinned threads into a section at the top, which crowds out the thing the lens exists to show — enough that the operator had stopped using either one. A pinned thread now appears in its natural position by updated/created time.
- Pin *reordering* only makes sense against a visible pin order, so it moves rather than disappears:
  - Drag-to-reorder and the ⌘⇧↑/↓ row shortcut were `RecentsList`-local and are dropped there. Both already exist in `DirectoriesList` against the same global pinned-key list, so the capability is intact.
  - The context menu's Move Up / Move Down were lens-agnostic and are now gated to the Directories lens. Left ungated they would have offered a reorder that visibly does nothing, and advertised a ⌘⇧↑/↓ hint for a shortcut those rows no longer carry.

Second of four stacked PRs. Based on #1425.

## Verification

- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries` — clean.
- Renderer + shared vitest suites pass.
- The row-edge drop-indicator spec and both Move-item specs were **moved to the Directories lens** rather than deleted, so the reorder paths stay covered where they now live.
- New spec pins that Created renders no pinned section and no drag affordance.

## Notes

- Docs updated to match: "Current Product Direction" in the root `AGENTS.md`, the desktop non-negotiables, and `docs/design/desktop-style-guide.md` all said pins float in Inbox/Recents.
- Reviewer question worth a look: gating the context-menu Move items on `browseMode === "directories"` is the one behavior change here that is not purely subtractive.