### PR TITLE
refactor(desktop): reduce directory activity counts to indicator + count

### DIFF
--- a/apps/desktop/e2e/thread-row-status.spec.ts
+++ b/apps/desktop/e2e/thread-row-status.spec.ts
@@ -243,17 +243,19 @@ test("shows initiated background turns as thinking, then unread once they finish
     });
     await expect(directoriesTab).toBeVisible();
     await directoriesTab.click();
+    // The counts are indicator + number now; the words moved into a hover
+    // tooltip, so the stable handle is the data attribute rather than `title`.
     await expect(
       app.window
         .locator(".directory-row__summary")
         .filter({ hasText: "Thread row status fixture" })
-        .getByTitle("1 active thread"),
+        .locator('[data-active-thread-count="1"]'),
     ).toBeVisible();
     await expect(
       app.window
         .locator(".directory-row__summary")
         .filter({ hasText: "Thread row status fixture" })
-        .getByTitle("1 thread to review"),
+        .locator("[data-review-thread-count]"),
     ).toHaveCount(0);
 
     await app.advance({ stepId: "turn-started-1" });
@@ -272,7 +274,7 @@ test("shows initiated background turns as thinking, then unread once they finish
       app.window
         .locator(".directory-row__summary")
         .filter({ hasText: "Thread row status fixture" })
-        .getByTitle("1 thread to review"),
+        .locator('[data-review-thread-count="1"]'),
     ).toBeVisible();
   } finally {
     await app.close();

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -39,6 +39,7 @@ import {
   type DropIndicatorState,
 } from "./drag-drop";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 import {
   getSubthreadDisclosureCount,
@@ -213,6 +214,56 @@ function getDirectoryRowLinkedDirectoryMode(
   // additional roots (and makes one root stand in for all of them). Reuse the
   // label chips from Updated/Created so every linked project stays visible.
   return thread.linkedDirectories.length > 1 ? "label" : "kind";
+}
+
+/**
+ * One activity count in a directory header: the indicator alone, then the
+ * number. The words ("active", "to review") moved into the tooltip — a
+ * directory row is a dense line already carrying a chevron, a folder glyph,
+ * an elided path, and a new-thread button, and two trailing phrases pushed
+ * the label it belongs to down to a few characters.
+ *
+ * The scanner and the orange cookie are the same marks the thread rows below
+ * use for the same two states, so the header reads as a summary of the rows
+ * rather than a second vocabulary. `useViewportTooltip` rather than `title`
+ * because the sidebar clips, and because a native tooltip is a
+ * browser-default control.
+ *
+ * The portal node is a sibling of the count, not a child of it. A React
+ * portal still propagates events through the React tree, and this count
+ * renders inside the directory summary `<button>` — so a tooltip nested here
+ * would route its events into that button's onClick. `.viewport-tooltip` sets
+ * `pointer-events: none` today, which masks it, but every other call site in
+ * the app keeps the node outside the interactive element and a structured
+ * hover card (which AGENTS.md contemplates) would not be inert.
+ */
+function DirectoryCount(props: {
+  activeCount?: number;
+  className: string;
+  count: number;
+  indicator: ReactElement;
+  reviewCount?: number;
+  tooltipText: string;
+}) {
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+
+  return (
+    <>
+      <span
+        className={props.className}
+        data-active-thread-count={props.activeCount}
+        data-review-thread-count={props.reviewCount}
+        onMouseEnter={(event) =>
+          tooltip.show(event.currentTarget, props.tooltipText)
+        }
+        onMouseLeave={tooltip.hide}
+      >
+        {props.indicator}
+        <span>{props.count}</span>
+      </span>
+      {tooltip.tooltipNode}
+    </>
+  );
 }
 
 export function DirectoriesList(props: DirectoriesListProps) {
@@ -1176,24 +1227,24 @@ export function DirectoriesList(props: DirectoriesListProps) {
 
             <span className="directory-row__summary-meta">
               {activeThreadCount > 0 ? (
-                <span
+                <DirectoryCount
+                  activeCount={activeThreadCount}
                   className="directory-row__active-count"
-                  data-active-thread-count={activeThreadCount}
-                  title={formatActiveThreadCount(activeThreadCount)}
-                >
-                  <ThinkingScanner compact />
-                  <span>{activeThreadCount} active</span>
-                </span>
+                  count={activeThreadCount}
+                  indicator={<ThinkingScanner compact />}
+                  tooltipText={formatActiveThreadCount(activeThreadCount)}
+                />
               ) : null}
               {reviewThreadCount > 0 ? (
-                <span
+                <DirectoryCount
                   className="directory-row__review-count"
-                  data-review-thread-count={reviewThreadCount}
-                  title={formatReviewThreadCount(reviewThreadCount)}
-                >
-                  <span aria-hidden="true" className="thread-row__status-cookie" />
-                  <span>{reviewThreadCount} to review</span>
-                </span>
+                  count={reviewThreadCount}
+                  indicator={
+                    <span aria-hidden="true" className="thread-row__status-cookie" />
+                  }
+                  reviewCount={reviewThreadCount}
+                  tooltipText={formatReviewThreadCount(reviewThreadCount)}
+                />
               ) : null}
             </span>
           </button>

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1976,7 +1976,7 @@ describe("Sidebar", () => {
     ).not.toBeNull();
   });
 
-  it("separates active and reviewable threads in directory counts", () => {
+  it("separates active and reviewable threads in directory counts", async () => {
     const backendActiveThread = {
       ...sharedThread,
       id: "thread-backend-active",
@@ -2039,12 +2039,25 @@ describe("Sidebar", () => {
       .getAllByRole("button", { name: /PwrAgent/i })
       .find((button) => button.hasAttribute("aria-expanded"));
     expect(summary).toBeDefined();
-    const activeCount = within(summary!).getByTitle("2 active threads");
+    // Indicator + bare count only: the words live in the hover tooltip, and
+    // the button's aria-label still spells both out for assistive tech.
+    const activeCount = summary!.querySelector("[data-active-thread-count]");
     expect(activeCount).toHaveAttribute("data-active-thread-count", "2");
-    expect(activeCount).toHaveTextContent("2 active");
-    const reviewCount = within(summary!).getByTitle("1 thread to review");
+    expect(activeCount).toHaveTextContent(/^2$/);
+    const reviewCount = summary!.querySelector("[data-review-thread-count]");
     expect(reviewCount).toHaveAttribute("data-review-thread-count", "1");
-    expect(reviewCount).toHaveTextContent("1 to review");
+    expect(reviewCount).toHaveTextContent(/^1$/);
+
+    fireEvent.mouseEnter(activeCount!);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "2 active threads",
+    );
+    fireEvent.mouseLeave(activeCount!);
+
+    fireEvent.mouseEnter(reviewCount!);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "1 thread to review",
+    );
   });
 
   it("shows an approval chip for threads waiting on an approval request", () => {


### PR DESCRIPTION
## Summary

- A directory header read `PwrAgent  ⟨scanner⟩ 3 active  ⟨cookie⟩ 3 to review`, which on a resizable sidebar left the directory label — the thing the row is actually named for — elided to a few characters.
- Dropped the words. The header now shows each indicator with its bare count; the phrase moves into a hover tooltip, and the summary button's `aria-label` already spelled both out for assistive tech.
- The scanner and the orange cookie are the same marks the thread rows below use for the same two states, so nothing new has to be learned to read the row.
- The tooltip goes through `useViewportTooltip` rather than the `title` attribute it replaces: the sidebar clips, and a native tooltip is a browser-default control (see the desktop non-negotiables).

Third of four stacked PRs. Based on #1426.

## Verification

- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors` — clean.
- Renderer + shared vitest suites pass.
- `sidebar.test.tsx` now asserts the bare counts, the `data-*-thread-count` attributes, and both tooltip strings on hover.
- Screenshot of the new header captured on the macOS lab guest.

## Notes

- The extracted `DirectoryCount` component keeps mounting `ThinkingScanner` behind the existing `activeThreadCount > 0` guard, so the scanner's mount-time animation sync (#1187) is unaffected.