### PR TITLE
fix(desktop): keep drag-and-scroll responsive

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -36,7 +36,7 @@ import {
 import {
   didDragLeaveCurrentTarget,
   getDropIndicatorPosition,
-  useDropIndicatorState,
+  useDropIndicatorController,
 } from "./drag-drop";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
@@ -279,10 +279,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
   const [unpinnedExpandedByKey, setUnpinnedExpandedByKey] = useState<
     Record<string, boolean>
   >({});
-  const [dropIndicator, setDropIndicator] = useDropIndicatorState();
-  const [dividerDropTarget, setDividerDropTarget] = useState<
-    string | undefined
-  >(undefined);
+  const dropIndicator = useDropIndicatorController();
   const [draggedThreadKey, setDraggedThreadKey] = useState<string | undefined>(
     undefined,
   );
@@ -294,8 +291,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
   const [draggedSubthreadKey, setDraggedSubthreadKey] = useState<
     string | undefined
   >(undefined);
-  const [subthreadDropIndicator, setSubthreadDropIndicator] =
-    useDropIndicatorState();
+  const subthreadDropIndicator = useDropIndicatorController();
   // Directory drag/drop state (plan 2026-05-09-002 Unit K). Mirrors
   // the per-thread state above but tracks directory keys rather
   // than thread keys. The `directoriesPinnedDividerDropTarget`
@@ -304,8 +300,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
   const [draggedDirectoryKey, setDraggedDirectoryKey] = useState<
     string | undefined
   >(undefined);
-  const [directoryDropIndicator, setDirectoryDropIndicator] =
-    useDropIndicatorState();
+  const directoryDropIndicator = useDropIndicatorController();
   const [directoriesPinnedDividerDropTarget, setDirectoriesPinnedDividerDropTarget] =
     useState(false);
   const previousSelectedItemKeyRef = useRef<string | undefined>(undefined);
@@ -673,9 +668,6 @@ export function DirectoriesList(props: DirectoriesListProps) {
       // directory is already pinned (matches the thread-pin pattern:
       // first pin lives via context menu, drag is reordering).
       (directoryPinned || pinnedDirectories.length > 0);
-    const isDirectoryDropTarget =
-      directoryDropIndicator?.targetKey === directory.key;
-
     const selectedLaunchpad =
       props.selectedItemKey === buildLaunchpadSelectionKey(directory.key);
     const selectedDirectory = selectedLaunchpad || Boolean(
@@ -746,11 +738,6 @@ export function DirectoriesList(props: DirectoriesListProps) {
               composerSourceThreadKey={props.composerSourceThreadKey}
               compact
               draggable={reorderable}
-              dropIndicator={
-                subthreadDropIndicator?.targetKey === rowDropKey
-                  ? subthreadDropIndicator.position
-                  : undefined
-              }
               includeLinkedDirectories
               linkedDirectoryMode={getDirectoryRowLinkedDirectoryMode(child)}
               nested
@@ -780,28 +767,28 @@ export function DirectoriesList(props: DirectoriesListProps) {
                   || resolveThreadParentKey(draggedThread, threadsByKey) !== parentKey
                 ) {
                   event.dataTransfer.dropEffect = "none";
-                  setSubthreadDropIndicator(undefined);
+                  subthreadDropIndicator.clear();
                   return;
                 }
                 event.dataTransfer.dropEffect = "move";
-                setSubthreadDropIndicator({
+                subthreadDropIndicator.show(event.currentTarget, {
                   targetKey: rowDropKey,
                   position: getDropIndicatorPosition(event),
                 });
               }}
               onDragLeaveThread={(event) => {
                 if (didDragLeaveCurrentTarget(event)) {
-                  setSubthreadDropIndicator(undefined);
+                  subthreadDropIndicator.clear();
                 }
               }}
               onDragEndThread={() => {
                 setDraggedSubthreadKey(undefined);
-                setSubthreadDropIndicator(undefined);
+                subthreadDropIndicator.clear();
               }}
               onDropOnThread={(event) => {
                 event.preventDefault();
                 setDraggedSubthreadKey(undefined);
-                setSubthreadDropIndicator(undefined);
+                subthreadDropIndicator.clear();
                 const draggedKey = event.dataTransfer.getData(
                   "application/x-pwragent-subthread",
                 );
@@ -860,6 +847,11 @@ export function DirectoriesList(props: DirectoriesListProps) {
       selectionOrder,
       unpinnedExpanded,
     } = expandedThreadModel;
+    const showPinnedAppendTarget = Boolean(
+      props.onReorderThreadPins
+      && draggedThreadKey
+      && directory.threadKeys.includes(draggedThreadKey)
+    );
     // Render one unpinned thread row. Shared by the always-shown capped
     // slice and the overflow slice so the "Show more / Show less" toggle
     // sits at a fixed pivot between them — collapsing never makes the
@@ -912,8 +904,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             }}
             onDragEndThread={() => {
               setDraggedThreadKey(undefined);
-              setDropIndicator(undefined);
-              setDividerDropTarget(undefined);
+              dropIndicator.clear();
             }}
             onOpenContextMenu={props.onOpenThreadContextMenu}
             onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
@@ -933,14 +924,10 @@ export function DirectoriesList(props: DirectoriesListProps) {
       );
     };
 
-    const dropIndicatorClass = isDirectoryDropTarget
-      ? ` is-drop-target-${directoryDropIndicator!.position}`
-      : "";
-
     return (
       <section
         key={directory.key}
-        className={`directory-row${dropIndicatorClass}`}
+        className="directory-row"
         onDragOver={
           directoryDragEnabled
             ? (event) => {
@@ -968,7 +955,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 }
                 event.preventDefault();
                 event.dataTransfer.dropEffect = "move";
-                setDirectoryDropIndicator({
+                directoryDropIndicator.show(event.currentTarget, {
                   targetKey: directory.key,
                   position: getDropIndicatorPosition(event),
                 });
@@ -980,7 +967,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
           directoryDragEnabled
             ? (event) => {
                 if (didDragLeaveCurrentTarget(event)) {
-                  setDirectoryDropIndicator(undefined);
+                  directoryDropIndicator.clear();
                 }
               }
             : undefined
@@ -1000,7 +987,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 }
                 event.preventDefault();
                 setDraggedDirectoryKey(undefined);
-                setDirectoryDropIndicator(undefined);
+                directoryDropIndicator.clear();
                 setDirectoriesPinnedDividerDropTarget(false);
                 lastDirectoryDragEndedAtRef.current = Date.now();
                 if (draggedKey === directory.key) {
@@ -1068,7 +1055,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             directoryDragEnabled
               ? () => {
                   setDraggedDirectoryKey(undefined);
-                  setDirectoryDropIndicator(undefined);
+                  directoryDropIndicator.clear();
                   setDirectoriesPinnedDividerDropTarget(false);
                   // Record drag-end so the summary button's click
                   // handler can suppress the synthetic post-release
@@ -1231,11 +1218,6 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           draftThreadKeys={props.draftThreadKeys}
                           composerSourceThreadKey={props.composerSourceThreadKey}
                           compact
-                          dropIndicator={
-                            dropIndicator?.targetKey === rowDropKey
-                              ? dropIndicator.position
-                              : undefined
-                          }
                           draggable={Boolean(props.onReorderThreadPins)}
                           includeLinkedDirectories
                           linkedDirectoryMode={getDirectoryRowLinkedDirectoryMode(thread)}
@@ -1269,16 +1251,15 @@ export function DirectoriesList(props: DirectoriesListProps) {
                               !directory.threadKeys.includes(draggedThreadKey)
                             ) {
                               event.dataTransfer.dropEffect = "none";
-                              setDropIndicator(undefined);
+                              dropIndicator.clear();
                               return;
                             }
 
                             event.dataTransfer.dropEffect = "move";
-                            setDropIndicator({
+                            dropIndicator.show(event.currentTarget, {
                               targetKey: rowDropKey,
                               position: getDropIndicatorPosition(event),
                             });
-                            setDividerDropTarget(undefined);
                           }}
                           onDragStartThread={(event) => {
                             setDraggedThreadKey(threadKey);
@@ -1287,19 +1268,17 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           }}
                           onDragLeaveThread={(event) => {
                             if (didDragLeaveCurrentTarget(event)) {
-                              setDropIndicator(undefined);
+                              dropIndicator.clear();
                             }
                           }}
                           onDragEndThread={() => {
                             setDraggedThreadKey(undefined);
-                            setDropIndicator(undefined);
-                            setDividerDropTarget(undefined);
+                            dropIndicator.clear();
                           }}
                           onDropOnThread={(event) => {
                             event.preventDefault();
                             setDraggedThreadKey(undefined);
-                            setDropIndicator(undefined);
-                            setDividerDropTarget(undefined);
+                            dropIndicator.clear();
                             const draggedKey = event.dataTransfer.getData("text/plain");
                             if (!draggedKey) return;
                             const position = getDropIndicatorPosition(event);
@@ -1337,15 +1316,51 @@ export function DirectoriesList(props: DirectoriesListProps) {
 	                      );
                     })}
 
+                    {showPinnedAppendTarget ? (
+                      <div
+                        aria-label={`Pin thread after pinned threads for ${directory.label}`}
+                        className="directory-row__pin-drop-slot"
+                        role="separator"
+                        onDragOver={(event) => {
+                          event.preventDefault();
+                          if (
+                            !draggedThreadKey
+                            || !directory.threadKeys.includes(draggedThreadKey)
+                          ) {
+                            event.dataTransfer.dropEffect = "none";
+                            dropIndicator.clear();
+                            return;
+                          }
+
+                          event.dataTransfer.dropEffect = "move";
+                          dropIndicator.show(event.currentTarget, {
+                            targetKey: `pinned-append:${directory.key}`,
+                            position: "before",
+                          });
+                        }}
+                        onDragLeave={(event) => {
+                          if (didDragLeaveCurrentTarget(event)) {
+                            dropIndicator.clear();
+                          }
+                        }}
+                        onDrop={(event) => {
+                          event.preventDefault();
+                          lastDirectoryThreadDropAtRef.current = Date.now();
+                          setDraggedThreadKey(undefined);
+                          dropIndicator.clear();
+                          dropThreadAfterDirectoryPins(
+                            directory,
+                            event.dataTransfer.getData("text/plain"),
+                          );
+                        }}
+                      />
+                    ) : null}
+
                     {directoryPinnedThreads.length > 0 &&
                     directoryUnpinnedThreadCount > 0 ? (
                       <button
                         type="button"
-                        className={`recents-pinned-divider directory-row__thread-divider${
-                          dividerDropTarget === directory.key
-                            ? " is-drop-target"
-                            : ""
-                        }`}
+                        className="recents-pinned-divider directory-row__thread-divider"
                         aria-expanded={!directoryThreadsCollapsed}
                         aria-label={`${
                           directoryThreadsCollapsed ? "Show" : "Hide"
@@ -1361,36 +1376,6 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           void props.onSetDirectoryThreadsCollapsed?.(
                             directory,
                             !directoryThreadsCollapsed,
-                          );
-                        }}
-                        onDragOver={(event) => {
-                          event.preventDefault();
-                          if (
-                            !draggedThreadKey ||
-                            !directory.threadKeys.includes(draggedThreadKey)
-                          ) {
-                            event.dataTransfer.dropEffect = "none";
-                            setDividerDropTarget(undefined);
-                            return;
-                          }
-
-                          event.dataTransfer.dropEffect = "move";
-                          setDropIndicator(undefined);
-                          setDividerDropTarget(directory.key);
-                        }}
-                        onDragLeave={(event) => {
-                          if (didDragLeaveCurrentTarget(event)) {
-                            setDividerDropTarget(undefined);
-                          }
-                        }}
-                        onDrop={(event) => {
-                          event.preventDefault();
-                          lastDirectoryThreadDropAtRef.current = Date.now();
-                          setDraggedThreadKey(undefined);
-                          setDividerDropTarget(undefined);
-                          dropThreadAfterDirectoryPins(
-                            directory,
-                            event.dataTransfer.getData("text/plain"),
                           );
                         }}
                       >
@@ -1474,7 +1459,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             }
             event.preventDefault();
             event.dataTransfer.dropEffect = "move";
-            setDirectoryDropIndicator(undefined);
+            directoryDropIndicator.clear();
             setDirectoriesPinnedDividerDropTarget(true);
           }}
           onDragLeave={(event) => {

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -215,11 +215,24 @@ function hasPendingLaunchpadState(directory: NavigationDirectorySummary): boolea
 }
 
 type ThreadPinDragSession = {
+  appendTargetElement?: HTMLDivElement;
   canceled: boolean;
   sourceElement: HTMLDivElement;
   sourceWasPinned: boolean;
   threadKey: string;
 };
+
+function setThreadPinAppendTargetActive(
+  session: ThreadPinDragSession,
+  active: boolean,
+): void {
+  session.appendTargetElement?.classList.toggle("is-drag-enabled", active);
+  if (active) {
+    session.appendTargetElement?.removeAttribute("aria-hidden");
+  } else {
+    session.appendTargetElement?.setAttribute("aria-hidden", "true");
+  }
+}
 
 function isPointInsideDragSource(
   session: ThreadPinDragSession,
@@ -306,9 +319,6 @@ export function DirectoriesList(props: DirectoriesListProps) {
     Record<string, boolean>
   >({});
   const dropIndicator = useDropIndicatorController();
-  const [draggedThreadKey, setDraggedThreadKey] = useState<string | undefined>(
-    undefined,
-  );
   // Sub-thread (child) drag/drop state — kept SEPARATE from the
   // pinned-thread / directory drag state above so a child reorder can
   // never cross-wire with a pin or directory drag. Child drags carry the
@@ -360,20 +370,29 @@ export function DirectoriesList(props: DirectoriesListProps) {
     threadKey: string,
     sourceWasPinned: boolean,
   ): void => {
-    threadPinDragSessionRef.current = {
+    const session: ThreadPinDragSession = {
+      appendTargetElement:
+        event.currentTarget
+          .closest(".directory-row")
+          ?.querySelector<HTMLDivElement>(".directory-row__pin-drop-slot")
+        ?? undefined,
       canceled: false,
       sourceElement: event.currentTarget,
       sourceWasPinned,
       threadKey,
     };
-    setDraggedThreadKey(threadKey);
+    threadPinDragSessionRef.current = session;
+    setThreadPinAppendTargetActive(session, true);
     event.dataTransfer.effectAllowed = "move";
     event.dataTransfer.setData("text/plain", threadKey);
   };
 
   const finishThreadPinDrag = (): void => {
+    const session = threadPinDragSessionRef.current;
+    if (session) {
+      setThreadPinAppendTargetActive(session, false);
+    }
     threadPinDragSessionRef.current = undefined;
-    setDraggedThreadKey(undefined);
     dropIndicator.clear();
   };
 
@@ -383,7 +402,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
       const session = threadPinDragSessionRef.current;
       if (!session) return;
       session.canceled = true;
-      setDraggedThreadKey(undefined);
+      setThreadPinAppendTargetActive(session, false);
       dropIndicator.clear();
     };
 
@@ -912,10 +931,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
       selectionOrder,
       unpinnedExpanded,
     } = expandedThreadModel;
-    const showPinnedAppendTarget = Boolean(
+    const renderPinnedAppendTarget = Boolean(
       props.onReorderThreadPins
-      && draggedThreadKey
-      && directory.threadKeys.includes(draggedThreadKey)
+      && directoryUnpinnedThreadCount > 0
     );
     // Render one unpinned thread row. Shared by the always-shown capped
     // slice and the overflow slice so the "Show more / Show less" toggle
@@ -1300,18 +1318,17 @@ export function DirectoriesList(props: DirectoriesListProps) {
                                   : undefined
                               }
                           onDragOverThread={(event) => {
-                            const draggedThread = draggedThreadKey
-                              ? threadsByKey.get(draggedThreadKey)
-                              : undefined;
                             const session = threadPinDragSessionRef.current;
+                            const draggedThread = session
+                              ? threadsByKey.get(session.threadKey)
+                              : undefined;
                             if (
-                              !draggedThreadKey ||
                               !draggedThread ||
                               !session ||
                               session.canceled ||
                               !session.sourceWasPinned ||
-                              draggedThreadKey === threadKey ||
-                              !directory.threadKeys.includes(draggedThreadKey)
+                              session.threadKey === threadKey ||
+                              !directory.threadKeys.includes(session.threadKey)
                             ) {
                               event.dataTransfer.dropEffect = "none";
                               dropIndicator.clear();
@@ -1380,20 +1397,19 @@ export function DirectoriesList(props: DirectoriesListProps) {
 	                      );
                     })}
 
-                    {showPinnedAppendTarget ? (
+                    {renderPinnedAppendTarget ? (
                       <div className="directory-row__pin-drop-boundary">
                         <div
                           aria-label={`Pin thread after pinned threads for ${directory.label}`}
+                          aria-hidden="true"
                           className="directory-row__pin-drop-slot"
                           role="separator"
                           onDragOver={(event) => {
                             const session = threadPinDragSessionRef.current;
                             if (
-                              !draggedThreadKey
-                              || !session
+                              !session
                               || session.canceled
-                              || session.threadKey !== draggedThreadKey
-                              || !directory.threadKeys.includes(draggedThreadKey)
+                              || !directory.threadKeys.includes(session.threadKey)
                               || isPointInsideDragSource(session, {
                                 x: event.clientX,
                                 y: event.clientY,

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -36,7 +36,7 @@ import {
 import {
   didDragLeaveCurrentTarget,
   getDropIndicatorPosition,
-  type DropIndicatorState,
+  useDropIndicatorState,
 } from "./drag-drop";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
@@ -279,9 +279,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
   const [unpinnedExpandedByKey, setUnpinnedExpandedByKey] = useState<
     Record<string, boolean>
   >({});
-  const [dropIndicator, setDropIndicator] = useState<
-    DropIndicatorState | undefined
-  >(undefined);
+  const [dropIndicator, setDropIndicator] = useDropIndicatorState();
   const [dividerDropTarget, setDividerDropTarget] = useState<
     string | undefined
   >(undefined);
@@ -296,9 +294,8 @@ export function DirectoriesList(props: DirectoriesListProps) {
   const [draggedSubthreadKey, setDraggedSubthreadKey] = useState<
     string | undefined
   >(undefined);
-  const [subthreadDropIndicator, setSubthreadDropIndicator] = useState<
-    DropIndicatorState | undefined
-  >(undefined);
+  const [subthreadDropIndicator, setSubthreadDropIndicator] =
+    useDropIndicatorState();
   // Directory drag/drop state (plan 2026-05-09-002 Unit K). Mirrors
   // the per-thread state above but tracks directory keys rather
   // than thread keys. The `directoriesPinnedDividerDropTarget`
@@ -307,9 +304,8 @@ export function DirectoriesList(props: DirectoriesListProps) {
   const [draggedDirectoryKey, setDraggedDirectoryKey] = useState<
     string | undefined
   >(undefined);
-  const [directoryDropIndicator, setDirectoryDropIndicator] = useState<
-    DropIndicatorState | undefined
-  >(undefined);
+  const [directoryDropIndicator, setDirectoryDropIndicator] =
+    useDropIndicatorState();
   const [directoriesPinnedDividerDropTarget, setDirectoriesPinnedDividerDropTarget] =
     useState(false);
   const previousSelectedItemKeyRef = useRef<string | undefined>(undefined);
@@ -780,6 +776,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                   : undefined;
                 if (
                   !draggedThread
+                  || draggedSubthreadKey === childKey
                   || resolveThreadParentKey(draggedThread, threadsByKey) !== parentKey
                 ) {
                   event.dataTransfer.dropEffect = "none";
@@ -1268,6 +1265,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                             if (
                               !draggedThreadKey ||
                               !draggedThread ||
+                              draggedThreadKey === threadKey ||
                               !directory.threadKeys.includes(draggedThreadKey)
                             ) {
                               event.dataTransfer.dropEffect = "none";

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type DragEvent,
   type ReactElement,
   type MouseEvent,
 } from "react";
@@ -213,6 +214,35 @@ function hasPendingLaunchpadState(directory: NavigationDirectorySummary): boolea
   );
 }
 
+type ThreadPinDragSession = {
+  canceled: boolean;
+  sourceWasPinned: boolean;
+  sourceBounds: {
+    bottom: number;
+    left: number;
+    right: number;
+    top: number;
+  };
+  threadKey: string;
+};
+
+function isPointInsideDragSource(
+  session: ThreadPinDragSession,
+  point: { x: number; y: number },
+): boolean {
+  if (
+    session.sourceBounds.right <= session.sourceBounds.left
+    || session.sourceBounds.bottom <= session.sourceBounds.top
+  ) {
+    return false;
+  }
+  return (
+    point.x >= session.sourceBounds.left
+    && point.x <= session.sourceBounds.right
+    && point.y >= session.sourceBounds.top
+    && point.y <= session.sourceBounds.bottom
+  );
+}
 function getDirectoryRowLinkedDirectoryMode(
   thread: NavigationThreadSummary,
 ): "kind" | "label" {
@@ -305,6 +335,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
     useState(false);
   const previousSelectedItemKeyRef = useRef<string | undefined>(undefined);
   const handledRevealRequestRef = useRef(0);
+  const threadPinDragSessionRef = useRef<ThreadPinDragSession | undefined>(
+    undefined,
+  );
   /**
    * Suppress the directory summary button's expand/collapse click
    * when the click is the trailing edge of a drag gesture. Browsers
@@ -325,6 +358,48 @@ export function DirectoriesList(props: DirectoriesListProps) {
   // Suppress the click browsers synthesize immediately after a drop so
   // pinning a thread never also minimizes the section.
   const lastDirectoryThreadDropAtRef = useRef(0);
+
+  const beginThreadPinDrag = (
+    event: DragEvent<HTMLDivElement>,
+    threadKey: string,
+    sourceWasPinned: boolean,
+  ): void => {
+    const sourceRect = event.currentTarget.getBoundingClientRect();
+    threadPinDragSessionRef.current = {
+      canceled: false,
+      sourceWasPinned,
+      sourceBounds: {
+        bottom: sourceRect.bottom,
+        left: sourceRect.left,
+        right: sourceRect.right,
+        top: sourceRect.top,
+      },
+      threadKey,
+    };
+    setDraggedThreadKey(threadKey);
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("text/plain", threadKey);
+  };
+
+  const finishThreadPinDrag = (): void => {
+    threadPinDragSessionRef.current = undefined;
+    setDraggedThreadKey(undefined);
+    dropIndicator.clear();
+  };
+
+  useEffect(() => {
+    const cancelThreadPinDrag = (event: KeyboardEvent): void => {
+      if (event.key !== "Escape") return;
+      const session = threadPinDragSessionRef.current;
+      if (!session) return;
+      session.canceled = true;
+      setDraggedThreadKey(undefined);
+      dropIndicator.clear();
+    };
+
+    window.addEventListener("keydown", cancelThreadPinDrag);
+    return () => window.removeEventListener("keydown", cancelThreadPinDrag);
+  }, [dropIndicator]);
   const threadsByKey = useMemo(
     () =>
       new Map(
@@ -898,14 +973,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 : undefined
             }
             onDragStartThread={(event) => {
-              setDraggedThreadKey(threadKey);
-              event.dataTransfer.effectAllowed = "move";
-              event.dataTransfer.setData("text/plain", threadKey);
+              beginThreadPinDrag(event, threadKey, false);
             }}
-            onDragEndThread={() => {
-              setDraggedThreadKey(undefined);
-              dropIndicator.clear();
-            }}
+            onDragEndThread={finishThreadPinDrag}
             onOpenContextMenu={props.onOpenThreadContextMenu}
             onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
             onDetachPullRequest={props.onDetachPullRequest}
@@ -1229,7 +1299,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                               subthreadCount={subthreadCount}
                               subthreadsCollapsed={subthreadsCollapsed}
 	                          thinkingThreadKeys={props.thinkingThreadKeys}
-	                          thread={thread}
+                          thread={thread}
                               onToggleSubthreads={
                                 subthreadCount > 0 && props.onSetSubthreadsCollapsed
                                   ? () =>
@@ -1240,13 +1310,16 @@ export function DirectoriesList(props: DirectoriesListProps) {
                                   : undefined
                               }
                           onDragOverThread={(event) => {
-                            event.preventDefault();
                             const draggedThread = draggedThreadKey
                               ? threadsByKey.get(draggedThreadKey)
                               : undefined;
+                            const session = threadPinDragSessionRef.current;
                             if (
                               !draggedThreadKey ||
                               !draggedThread ||
+                              !session ||
+                              session.canceled ||
+                              !session.sourceWasPinned ||
                               draggedThreadKey === threadKey ||
                               !directory.threadKeys.includes(draggedThreadKey)
                             ) {
@@ -1255,6 +1328,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                               return;
                             }
 
+                            event.preventDefault();
                             event.dataTransfer.dropEffect = "move";
                             dropIndicator.show(event.currentTarget, {
                               targetKey: rowDropKey,
@@ -1262,25 +1336,25 @@ export function DirectoriesList(props: DirectoriesListProps) {
                             });
                           }}
                           onDragStartThread={(event) => {
-                            setDraggedThreadKey(threadKey);
-                            event.dataTransfer.effectAllowed = "move";
-                            event.dataTransfer.setData("text/plain", threadKey);
+                            beginThreadPinDrag(event, threadKey, true);
                           }}
                           onDragLeaveThread={(event) => {
                             if (didDragLeaveCurrentTarget(event)) {
                               dropIndicator.clear();
                             }
                           }}
-                          onDragEndThread={() => {
-                            setDraggedThreadKey(undefined);
-                            dropIndicator.clear();
-                          }}
+                          onDragEndThread={finishThreadPinDrag}
                           onDropOnThread={(event) => {
                             event.preventDefault();
-                            setDraggedThreadKey(undefined);
-                            dropIndicator.clear();
                             const draggedKey = event.dataTransfer.getData("text/plain");
-                            if (!draggedKey) return;
+                            const session = threadPinDragSessionRef.current;
+                            const canceled =
+                              !session
+                              || session.canceled
+                              || !session.sourceWasPinned
+                              || session.threadKey !== draggedKey;
+                            finishThreadPinDrag();
+                            if (canceled || !draggedKey) return;
                             const position = getDropIndicatorPosition(event);
                             moveDirectoryPin(
                               directory,
@@ -1317,43 +1391,60 @@ export function DirectoriesList(props: DirectoriesListProps) {
                     })}
 
                     {showPinnedAppendTarget ? (
-                      <div
-                        aria-label={`Pin thread after pinned threads for ${directory.label}`}
-                        className="directory-row__pin-drop-slot"
-                        role="separator"
-                        onDragOver={(event) => {
-                          event.preventDefault();
-                          if (
-                            !draggedThreadKey
-                            || !directory.threadKeys.includes(draggedThreadKey)
-                          ) {
-                            event.dataTransfer.dropEffect = "none";
-                            dropIndicator.clear();
-                            return;
-                          }
+                      <div className="directory-row__pin-drop-boundary">
+                        <div
+                          aria-label={`Pin thread after pinned threads for ${directory.label}`}
+                          className="directory-row__pin-drop-slot"
+                          role="separator"
+                          onDragOver={(event) => {
+                            const session = threadPinDragSessionRef.current;
+                            if (
+                              !draggedThreadKey
+                              || !session
+                              || session.canceled
+                              || session.threadKey !== draggedThreadKey
+                              || !directory.threadKeys.includes(draggedThreadKey)
+                              || isPointInsideDragSource(session, {
+                                x: event.clientX,
+                                y: event.clientY,
+                              })
+                            ) {
+                              event.dataTransfer.dropEffect = "none";
+                              dropIndicator.clear();
+                              return;
+                            }
 
-                          event.dataTransfer.dropEffect = "move";
-                          dropIndicator.show(event.currentTarget, {
-                            targetKey: `pinned-append:${directory.key}`,
-                            position: "before",
-                          });
-                        }}
-                        onDragLeave={(event) => {
-                          if (didDragLeaveCurrentTarget(event)) {
-                            dropIndicator.clear();
-                          }
-                        }}
-                        onDrop={(event) => {
-                          event.preventDefault();
-                          lastDirectoryThreadDropAtRef.current = Date.now();
-                          setDraggedThreadKey(undefined);
-                          dropIndicator.clear();
-                          dropThreadAfterDirectoryPins(
-                            directory,
-                            event.dataTransfer.getData("text/plain"),
-                          );
-                        }}
-                      />
+                            event.preventDefault();
+                            event.dataTransfer.dropEffect = "move";
+                            dropIndicator.show(event.currentTarget, {
+                              targetKey: `pinned-append:${directory.key}`,
+                              position: "before",
+                            });
+                          }}
+                          onDragLeave={(event) => {
+                            if (didDragLeaveCurrentTarget(event)) {
+                              dropIndicator.clear();
+                            }
+                          }}
+                          onDrop={(event) => {
+                            event.preventDefault();
+                            const session = threadPinDragSessionRef.current;
+                            const draggedKey = event.dataTransfer.getData("text/plain");
+                            const canceled =
+                              !session
+                              || session.canceled
+                              || session.threadKey !== draggedKey
+                              || isPointInsideDragSource(session, {
+                                x: event.clientX,
+                                y: event.clientY,
+                              });
+                            lastDirectoryThreadDropAtRef.current = Date.now();
+                            finishThreadPinDrag();
+                            if (canceled) return;
+                            dropThreadAfterDirectoryPins(directory, draggedKey);
+                          }}
+                        />
+                      </div>
                     ) : null}
 
                     {directoryPinnedThreads.length > 0 &&

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -216,13 +216,8 @@ function hasPendingLaunchpadState(directory: NavigationDirectorySummary): boolea
 
 type ThreadPinDragSession = {
   canceled: boolean;
+  sourceElement: HTMLDivElement;
   sourceWasPinned: boolean;
-  sourceBounds: {
-    bottom: number;
-    left: number;
-    right: number;
-    top: number;
-  };
   threadKey: string;
 };
 
@@ -230,17 +225,18 @@ function isPointInsideDragSource(
   session: ThreadPinDragSession,
   point: { x: number; y: number },
 ): boolean {
+  const sourceBounds = session.sourceElement.getBoundingClientRect();
   if (
-    session.sourceBounds.right <= session.sourceBounds.left
-    || session.sourceBounds.bottom <= session.sourceBounds.top
+    sourceBounds.right <= sourceBounds.left
+    || sourceBounds.bottom <= sourceBounds.top
   ) {
     return false;
   }
   return (
-    point.x >= session.sourceBounds.left
-    && point.x <= session.sourceBounds.right
-    && point.y >= session.sourceBounds.top
-    && point.y <= session.sourceBounds.bottom
+    point.x >= sourceBounds.left
+    && point.x <= sourceBounds.right
+    && point.y >= sourceBounds.top
+    && point.y <= sourceBounds.bottom
   );
 }
 function getDirectoryRowLinkedDirectoryMode(
@@ -364,16 +360,10 @@ export function DirectoriesList(props: DirectoriesListProps) {
     threadKey: string,
     sourceWasPinned: boolean,
   ): void => {
-    const sourceRect = event.currentTarget.getBoundingClientRect();
     threadPinDragSessionRef.current = {
       canceled: false,
+      sourceElement: event.currentTarget,
       sourceWasPinned,
-      sourceBounds: {
-        bottom: sourceRect.bottom,
-        left: sourceRect.left,
-        right: sourceRect.right,
-        top: sourceRect.top,
-      },
       threadKey,
     };
     setDraggedThreadKey(threadKey);

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -4,9 +4,9 @@ import {
   useMemo,
   useRef,
   useState,
-  type DragEvent,
   type ReactElement,
   type MouseEvent,
+  type PointerEvent as ReactPointerEvent,
 } from "react";
 import type {
   AppServerBackendKind,
@@ -41,6 +41,10 @@ import {
 } from "./drag-drop";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import {
+  beginNativeDragInteraction,
+  endNativeDragInteraction,
+} from "../../lib/native-drag-interaction";
 import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 import {
   getSubthreadDisclosureCount,
@@ -48,6 +52,10 @@ import {
   NativeSubAgentsDisclosure,
 } from "./NativeSubAgentsDisclosure";
 import { ThreadRow } from "./ThreadRow";
+import {
+  createThreadRowPointerDragPreview,
+  type ThreadRowPointerDragPreview,
+} from "./thread-row-drag-preview";
 import {
   formatActiveThreadCount,
   formatReviewThreadCount,
@@ -165,6 +173,7 @@ function buildLaunchpadSelectionKey(directoryKey: string): string {
  * frames without swallowing the user's next intentional click.
  */
 const POST_DRAG_CLICK_SUPPRESS_MS = 150;
+const POINTER_DRAG_ACTIVATION_PX = 4;
 
 const EMPTY_EXPANDED_DIRECTORY_THREAD_MODEL: ExpandedDirectoryThreadRenderModel = {
   cappedUnpinnedThreads: [],
@@ -215,12 +224,35 @@ function hasPendingLaunchpadState(directory: NavigationDirectorySummary): boolea
 }
 
 type ThreadPinDragSession = {
+  activated: boolean;
   appendTargetElement?: HTMLDivElement;
   canceled: boolean;
+  directory: NavigationDirectorySummary;
+  directoryElement: HTMLElement;
+  frame: number;
+  lastPoint: { x: number; y: number };
+  pointerId: number;
+  preview?: ThreadRowPointerDragPreview;
+  releaseClickSuppression?: () => void;
+  removeListeners?: () => void;
+  scrollElement?: HTMLElement;
   sourceElement: HTMLDivElement;
   sourceWasPinned: boolean;
+  target?: ThreadPinPointerDropTarget;
   threadKey: string;
 };
+
+type ThreadPinPointerDropTarget =
+  | {
+      element: HTMLDivElement;
+      kind: "append";
+    }
+  | {
+      element: HTMLDivElement;
+      kind: "row";
+      position: "before" | "after";
+      threadKey: string;
+    };
 
 function setThreadPinAppendTargetActive(
   session: ThreadPinDragSession,
@@ -251,6 +283,105 @@ function isPointInsideDragSource(
     && point.y >= sourceBounds.top
     && point.y <= sourceBounds.bottom
   );
+}
+
+function getPointInsideElement(
+  element: Element,
+  point: { x: number; y: number },
+): boolean {
+  const bounds = element.getBoundingClientRect();
+  return (
+    bounds.right > bounds.left
+    && bounds.bottom > bounds.top
+    && point.x >= bounds.left
+    && point.x <= bounds.right
+    && point.y >= bounds.top
+    && point.y <= bounds.bottom
+  );
+}
+
+function resolveThreadPinPointerDropTarget(
+  session: ThreadPinDragSession,
+): ThreadPinPointerDropTarget | undefined {
+  if (
+    session.canceled
+    || isPointInsideDragSource(session, session.lastPoint)
+  ) {
+    return undefined;
+  }
+
+  if (!session.sourceWasPinned) {
+    return session.appendTargetElement
+      ? { element: session.appendTargetElement, kind: "append" }
+      : undefined;
+  }
+
+  const buildRowTarget = (
+    row: HTMLDivElement,
+  ): ThreadPinPointerDropTarget | undefined => {
+    const threadKey = row.dataset.threadPinKey;
+    if (
+      row === session.sourceElement
+      || !threadKey
+      || threadKey === session.threadKey
+    ) {
+      return undefined;
+    }
+    const bounds = row.getBoundingClientRect();
+    return {
+      element: row,
+      kind: "row",
+      position:
+        session.lastPoint.y > bounds.top + bounds.height / 2
+          ? "after"
+          : "before",
+      threadKey,
+    };
+  };
+
+  if (typeof document.elementFromPoint === "function") {
+    const hit = document.elementFromPoint(
+      session.lastPoint.x,
+      session.lastPoint.y,
+    );
+    const hitRow = hit?.closest<HTMLDivElement>(
+      '.thread-row-shell[data-thread-pin-state="pinned"]',
+    );
+    if (
+      hitRow
+      && session.directoryElement.contains(hitRow)
+    ) {
+      return buildRowTarget(hitRow);
+    }
+    if (
+      hit
+      && session.appendTargetElement?.contains(hit)
+    ) {
+      return { element: session.appendTargetElement, kind: "append" };
+    }
+    return undefined;
+  }
+
+  const pinnedRows = session.directoryElement.querySelectorAll<HTMLDivElement>(
+    '.thread-row-shell[data-thread-pin-state="pinned"]',
+  );
+  for (const row of pinnedRows) {
+    if (
+      !getPointInsideElement(row, session.lastPoint)
+    ) {
+      continue;
+    }
+    const target = buildRowTarget(row);
+    if (target) return target;
+  }
+
+  if (
+    session.appendTargetElement
+    && getPointInsideElement(session.appendTargetElement, session.lastPoint)
+  ) {
+    return { element: session.appendTargetElement, kind: "append" };
+  }
+  return undefined;
 }
 function getDirectoryRowLinkedDirectoryMode(
   thread: NavigationThreadSummary,
@@ -344,6 +475,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
   const threadPinDragSessionRef = useRef<ThreadPinDragSession | undefined>(
     undefined,
   );
+  const threadPinDragCleanupRef = useRef<(() => void) | undefined>(undefined);
   /**
    * Suppress the directory summary button's expand/collapse click
    * when the click is the trailing edge of a drag gesture. Browsers
@@ -365,50 +497,241 @@ export function DirectoriesList(props: DirectoriesListProps) {
   // pinning a thread never also minimizes the section.
   const lastDirectoryThreadDropAtRef = useRef(0);
 
-  const beginThreadPinDrag = (
-    event: DragEvent<HTMLDivElement>,
+  const deactivateThreadPinDrag = (session: ThreadPinDragSession): void => {
+    if (session.frame) {
+      cancelAnimationFrame(session.frame);
+      session.frame = 0;
+    }
+    session.preview?.remove();
+    session.preview = undefined;
+    session.sourceElement.classList.remove("is-pointer-dragging");
+    setThreadPinAppendTargetActive(session, false);
+    dropIndicator.clear();
+    session.target = undefined;
+    if (session.activated) {
+      endNativeDragInteraction();
+      session.activated = false;
+    }
+  };
+
+  const finishThreadPinDrag = (session: ThreadPinDragSession): void => {
+    deactivateThreadPinDrag(session);
+    session.removeListeners?.();
+    session.removeListeners = undefined;
+    session.releaseClickSuppression?.();
+    session.releaseClickSuppression = undefined;
+    if (threadPinDragSessionRef.current === session) {
+      threadPinDragSessionRef.current = undefined;
+    }
+    if (threadPinDragCleanupRef.current) {
+      threadPinDragCleanupRef.current = undefined;
+    }
+  };
+
+  const updateThreadPinPointerTarget = (
+    session: ThreadPinDragSession,
+  ): void => {
+    session.preview?.move(session.lastPoint);
+    session.target = resolveThreadPinPointerDropTarget(session);
+    if (!session.target) {
+      dropIndicator.clear();
+      return;
+    }
+    dropIndicator.show(session.target.element, {
+      targetKey:
+        session.target.kind === "row"
+          ? `${session.directory.key}:${session.target.threadKey}`
+          : `pinned-append:${session.directory.key}`,
+      position:
+        session.target.kind === "row" ? session.target.position : "before",
+    });
+  };
+
+  const scheduleThreadPinPointerTarget = (
+    session: ThreadPinDragSession,
+  ): void => {
+    if (session.frame || !session.activated || session.canceled) return;
+    session.frame = requestAnimationFrame(() => {
+      session.frame = 0;
+      updateThreadPinPointerTarget(session);
+    });
+  };
+
+  /**
+   * Thread pinning deliberately avoids native HTML drag-and-drop. Chromium's
+   * drag processing model suppresses ordinary input events, and its macOS
+   * trackpad path can queue momentum at scroll boundaries for seconds. A
+   * pointer session leaves wheel scrolling browser-controlled while batching
+   * our preview and hit testing to one update per animation frame.
+   */
+  const beginThreadPinPointerDrag = (
+    event: ReactPointerEvent<HTMLDivElement>,
+    directory: NavigationDirectorySummary,
     threadKey: string,
     sourceWasPinned: boolean,
   ): void => {
+    if (event.button !== 0 || !props.onReorderThreadPins) return;
+    threadPinDragCleanupRef.current?.();
+
+    const sourceElement = event.currentTarget;
+    const directoryElement = sourceElement.closest(".directory-row");
+    if (!(directoryElement instanceof HTMLElement)) return;
+
+    const startPoint = { x: event.clientX, y: event.clientY };
     const session: ThreadPinDragSession = {
+      activated: false,
       appendTargetElement:
-        event.currentTarget
-          .closest(".directory-row")
-          ?.querySelector<HTMLDivElement>(".directory-row__pin-drop-slot")
-        ?? undefined,
+        directoryElement.querySelector<HTMLDivElement>(
+          ".directory-row__pin-drop-slot",
+        ) ?? undefined,
       canceled: false,
-      sourceElement: event.currentTarget,
+      directory,
+      directoryElement,
+      frame: 0,
+      lastPoint: startPoint,
+      pointerId: event.pointerId,
+      scrollElement:
+        sourceElement.closest<HTMLElement>(".directory-list") ?? undefined,
+      sourceElement,
       sourceWasPinned,
       threadKey,
     };
     threadPinDragSessionRef.current = session;
-    setThreadPinAppendTargetActive(session, true);
-    event.dataTransfer.effectAllowed = "move";
-    event.dataTransfer.setData("text/plain", threadKey);
-  };
 
-  const finishThreadPinDrag = (): void => {
-    const session = threadPinDragSessionRef.current;
-    if (session) {
-      setThreadPinAppendTargetActive(session, false);
-    }
-    threadPinDragSessionRef.current = undefined;
-    dropIndicator.clear();
-  };
-
-  useEffect(() => {
-    const cancelThreadPinDrag = (event: KeyboardEvent): void => {
-      if (event.key !== "Escape") return;
-      const session = threadPinDragSessionRef.current;
-      if (!session) return;
-      session.canceled = true;
-      setThreadPinAppendTargetActive(session, false);
-      dropIndicator.clear();
+    let suppressClickTimer: number | undefined;
+    const removeClickSuppression = (): void => {
+      session.directoryElement.removeEventListener(
+        "click",
+        suppressReleaseClick,
+        true,
+      );
+      if (suppressClickTimer !== undefined) {
+        window.clearTimeout(suppressClickTimer);
+        suppressClickTimer = undefined;
+      }
+    };
+    const suppressReleaseClick = (clickEvent: globalThis.MouseEvent): void => {
+      clickEvent.preventDefault();
+      clickEvent.stopImmediatePropagation();
+      removeClickSuppression();
+    };
+    const armClickSuppression = (): void => {
+      session.directoryElement.addEventListener(
+        "click",
+        suppressReleaseClick,
+        true,
+      );
+      session.releaseClickSuppression = () => {
+        suppressClickTimer = window.setTimeout(
+          removeClickSuppression,
+          POST_DRAG_CLICK_SUPPRESS_MS,
+        );
+      };
     };
 
-    window.addEventListener("keydown", cancelThreadPinDrag);
-    return () => window.removeEventListener("keydown", cancelThreadPinDrag);
-  }, [dropIndicator]);
+    const activate = (): void => {
+      if (session.activated || session.canceled) return;
+      session.activated = true;
+      beginNativeDragInteraction();
+      session.sourceElement.classList.add("is-pointer-dragging");
+      setThreadPinAppendTargetActive(session, true);
+      session.preview = createThreadRowPointerDragPreview(
+        session.sourceElement,
+        startPoint,
+      );
+      armClickSuppression();
+      session.scrollElement?.addEventListener("scroll", onScroll, {
+        passive: true,
+      });
+      scheduleThreadPinPointerTarget(session);
+    };
+    const move = (pointerEvent: globalThis.PointerEvent): void => {
+      if (pointerEvent.pointerId !== session.pointerId || session.canceled) {
+        return;
+      }
+      session.lastPoint = {
+        x: pointerEvent.clientX,
+        y: pointerEvent.clientY,
+      };
+      if (
+        !session.activated
+        && Math.hypot(
+          session.lastPoint.x - startPoint.x,
+          session.lastPoint.y - startPoint.y,
+        ) < POINTER_DRAG_ACTIVATION_PX
+      ) {
+        return;
+      }
+      activate();
+      pointerEvent.preventDefault();
+      scheduleThreadPinPointerTarget(session);
+    };
+    const onScroll = (): void => scheduleThreadPinPointerTarget(session);
+    const stop = (pointerEvent: globalThis.PointerEvent): void => {
+      if (pointerEvent.pointerId !== session.pointerId) return;
+      session.lastPoint = {
+        x: pointerEvent.clientX,
+        y: pointerEvent.clientY,
+      };
+      if (session.activated && !session.canceled) {
+        if (session.frame) {
+          cancelAnimationFrame(session.frame);
+          session.frame = 0;
+        }
+        updateThreadPinPointerTarget(session);
+      }
+      const target = session.target;
+      const wasActivated = session.activated;
+      finishThreadPinDrag(session);
+      if (!target || session.canceled || !wasActivated) return;
+
+      lastDirectoryThreadDropAtRef.current = Date.now();
+      if (target.kind === "append") {
+        dropThreadAfterDirectoryPins(session.directory, session.threadKey);
+        return;
+      }
+      if (session.sourceWasPinned) {
+        moveDirectoryPin(
+          session.directory,
+          session.threadKey,
+          target.threadKey,
+          target.position,
+        );
+      }
+    };
+    const cancel = (): void => {
+      session.canceled = true;
+      finishThreadPinDrag(session);
+    };
+    const cancelOnPointer = (pointerEvent: globalThis.PointerEvent): void => {
+      if (pointerEvent.pointerId === session.pointerId) cancel();
+    };
+    const cancelOnEscape = (keyboardEvent: globalThis.KeyboardEvent): void => {
+      if (keyboardEvent.key !== "Escape") return;
+      session.canceled = true;
+      deactivateThreadPinDrag(session);
+    };
+    const removeListeners = (): void => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", stop);
+      window.removeEventListener("pointercancel", cancelOnPointer);
+      window.removeEventListener("blur", cancel);
+      window.removeEventListener("keydown", cancelOnEscape);
+      session.scrollElement?.removeEventListener("scroll", onScroll);
+    };
+    session.removeListeners = removeListeners;
+    threadPinDragCleanupRef.current = cancel;
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", stop);
+    window.addEventListener("pointercancel", cancelOnPointer);
+    window.addEventListener("blur", cancel);
+    window.addEventListener("keydown", cancelOnEscape);
+  };
+
+  useEffect(
+    () => () => threadPinDragCleanupRef.current?.(),
+    [],
+  );
   const threadsByKey = useMemo(
     () =>
       new Map(
@@ -961,7 +1284,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             draftThreadKeys={props.draftThreadKeys}
             composerSourceThreadKey={props.composerSourceThreadKey}
             compact
-            draggable={Boolean(props.onReorderThreadPins)}
+            pointerDraggable={Boolean(props.onReorderThreadPins)}
             includeLinkedDirectories
             linkedDirectoryMode={getDirectoryRowLinkedDirectoryMode(thread)}
             revealSelectedThreadRequest={props.revealSelectedThreadRequest}
@@ -971,6 +1294,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             subthreadsCollapsed={subthreadsCollapsed}
             thinkingThreadKeys={props.thinkingThreadKeys}
             thread={thread}
+            threadPinState="unpinned"
             onToggleSubthreads={
               subthreadCount > 0 && props.onSetSubthreadsCollapsed
                 ? () =>
@@ -980,10 +1304,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
                     )
                 : undefined
             }
-            onDragStartThread={(event) => {
-              beginThreadPinDrag(event, threadKey, false);
+            onPointerDownThread={(event) => {
+              beginThreadPinPointerDrag(event, directory, threadKey, false);
             }}
-            onDragEndThread={finishThreadPinDrag}
             onOpenContextMenu={props.onOpenThreadContextMenu}
             onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
             onDetachPullRequest={props.onDetachPullRequest}
@@ -1277,7 +1600,6 @@ export function DirectoriesList(props: DirectoriesListProps) {
                   <div className="sidebar-list sidebar-list--compact directory-row__threads">
                     {directoryPinnedThreads.map((thread) => {
 	                      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-	                      const rowDropKey = `${directory.key}:${threadKey}`;
                           const ordinarySubthreadCount =
                             childThreadsByParentKey.get(threadKey)?.length ?? 0;
                           const subthreadCount = getSubthreadDisclosureCount(
@@ -1296,7 +1618,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           draftThreadKeys={props.draftThreadKeys}
                           composerSourceThreadKey={props.composerSourceThreadKey}
                           compact
-                          draggable={Boolean(props.onReorderThreadPins)}
+                          pointerDraggable={Boolean(props.onReorderThreadPins)}
                           includeLinkedDirectories
                           linkedDirectoryMode={getDirectoryRowLinkedDirectoryMode(thread)}
                           revealSelectedThreadRequest={
@@ -1308,6 +1630,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                               subthreadsCollapsed={subthreadsCollapsed}
 	                          thinkingThreadKeys={props.thinkingThreadKeys}
                           thread={thread}
+                          threadPinState="pinned"
                               onToggleSubthreads={
                                 subthreadCount > 0 && props.onSetSubthreadsCollapsed
                                   ? () =>
@@ -1317,57 +1640,12 @@ export function DirectoriesList(props: DirectoriesListProps) {
                                       )
                                   : undefined
                               }
-                          onDragOverThread={(event) => {
-                            const session = threadPinDragSessionRef.current;
-                            const draggedThread = session
-                              ? threadsByKey.get(session.threadKey)
-                              : undefined;
-                            if (
-                              !draggedThread ||
-                              !session ||
-                              session.canceled ||
-                              !session.sourceWasPinned ||
-                              session.threadKey === threadKey ||
-                              !directory.threadKeys.includes(session.threadKey)
-                            ) {
-                              event.dataTransfer.dropEffect = "none";
-                              dropIndicator.clear();
-                              return;
-                            }
-
-                            event.preventDefault();
-                            event.dataTransfer.dropEffect = "move";
-                            dropIndicator.show(event.currentTarget, {
-                              targetKey: rowDropKey,
-                              position: getDropIndicatorPosition(event),
-                            });
-                          }}
-                          onDragStartThread={(event) => {
-                            beginThreadPinDrag(event, threadKey, true);
-                          }}
-                          onDragLeaveThread={(event) => {
-                            if (didDragLeaveCurrentTarget(event)) {
-                              dropIndicator.clear();
-                            }
-                          }}
-                          onDragEndThread={finishThreadPinDrag}
-                          onDropOnThread={(event) => {
-                            event.preventDefault();
-                            const draggedKey = event.dataTransfer.getData("text/plain");
-                            const session = threadPinDragSessionRef.current;
-                            const canceled =
-                              !session
-                              || session.canceled
-                              || !session.sourceWasPinned
-                              || session.threadKey !== draggedKey;
-                            finishThreadPinDrag();
-                            if (canceled || !draggedKey) return;
-                            const position = getDropIndicatorPosition(event);
-                            moveDirectoryPin(
+                          onPointerDownThread={(event) => {
+                            beginThreadPinPointerDrag(
+                              event,
                               directory,
-                              draggedKey,
                               threadKey,
-                              position,
+                              true,
                             );
                           }}
                           onMovePinnedThread={(pinnedThread, direction) => {
@@ -1404,51 +1682,6 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           aria-hidden="true"
                           className="directory-row__pin-drop-slot"
                           role="separator"
-                          onDragOver={(event) => {
-                            const session = threadPinDragSessionRef.current;
-                            if (
-                              !session
-                              || session.canceled
-                              || !directory.threadKeys.includes(session.threadKey)
-                              || isPointInsideDragSource(session, {
-                                x: event.clientX,
-                                y: event.clientY,
-                              })
-                            ) {
-                              event.dataTransfer.dropEffect = "none";
-                              dropIndicator.clear();
-                              return;
-                            }
-
-                            event.preventDefault();
-                            event.dataTransfer.dropEffect = "move";
-                            dropIndicator.show(event.currentTarget, {
-                              targetKey: `pinned-append:${directory.key}`,
-                              position: "before",
-                            });
-                          }}
-                          onDragLeave={(event) => {
-                            if (didDragLeaveCurrentTarget(event)) {
-                              dropIndicator.clear();
-                            }
-                          }}
-                          onDrop={(event) => {
-                            event.preventDefault();
-                            const session = threadPinDragSessionRef.current;
-                            const draggedKey = event.dataTransfer.getData("text/plain");
-                            const canceled =
-                              !session
-                              || session.canceled
-                              || session.threadKey !== draggedKey
-                              || isPointInsideDragSource(session, {
-                                x: event.clientX,
-                                y: event.clientY,
-                              });
-                            lastDirectoryThreadDropAtRef.current = Date.now();
-                            finishThreadPinDrag();
-                            if (canceled) return;
-                            dropThreadAfterDirectoryPins(directory, draggedKey);
-                          }}
                         />
                       </div>
                     ) : null}

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -14,7 +14,7 @@ import {
 import {
   didDragLeaveCurrentTarget,
   getDropIndicatorPosition,
-  useDropIndicatorState,
+  useDropIndicatorController,
 } from "./drag-drop";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
 import {
@@ -93,7 +93,7 @@ type RecentsListProps = {
  * the same global pinned-key list.
  */
 export function RecentsList(props: RecentsListProps) {
-  const [dropIndicator, setDropIndicator] = useDropIndicatorState();
+  const dropIndicator = useDropIndicatorController();
   const [draggedThreadKey, setDraggedThreadKey] = useState<string | undefined>(
     undefined,
   );
@@ -146,11 +146,6 @@ export function RecentsList(props: RecentsListProps) {
               queuedMessageThreadKeys={props.queuedMessageThreadKeys}
               draftThreadKeys={props.draftThreadKeys}
               composerSourceThreadKey={props.composerSourceThreadKey}
-              dropIndicator={
-                dropIndicator?.targetKey === rowDropKey
-                  ? dropIndicator.position
-                  : undefined
-              }
               draggable={children.length > 1 && Boolean(props.onUpdateSubthreadOrder)}
               includeLinkedDirectories
               nested
@@ -169,11 +164,11 @@ export function RecentsList(props: RecentsListProps) {
                   || resolveThreadParentKey(draggedThread, threadByKey) !== parentKey
                 ) {
                   event.dataTransfer.dropEffect = "none";
-                  setDropIndicator(undefined);
+                  dropIndicator.clear();
                   return;
                 }
                 event.dataTransfer.dropEffect = "move";
-                setDropIndicator({
+                dropIndicator.show(event.currentTarget, {
                   targetKey: rowDropKey,
                   position: getDropIndicatorPosition(event),
                 });
@@ -186,17 +181,17 @@ export function RecentsList(props: RecentsListProps) {
               }}
               onDragLeaveThread={(event) => {
                 if (didDragLeaveCurrentTarget(event)) {
-                  setDropIndicator(undefined);
+                  dropIndicator.clear();
                 }
               }}
               onDragEndThread={() => {
                 setDraggedThreadKey(undefined);
-                setDropIndicator(undefined);
+                dropIndicator.clear();
               }}
               onDropOnThread={(event) => {
                 event.preventDefault();
                 setDraggedThreadKey(undefined);
-                setDropIndicator(undefined);
+                dropIndicator.clear();
                 const draggedKey =
                   event.dataTransfer.getData("application/x-pwragent-subthread") ||
                   event.dataTransfer.getData("text/plain");

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -14,7 +14,7 @@ import {
 import {
   didDragLeaveCurrentTarget,
   getDropIndicatorPosition,
-  type DropIndicatorState,
+  useDropIndicatorState,
 } from "./drag-drop";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
 import {
@@ -93,9 +93,7 @@ type RecentsListProps = {
  * the same global pinned-key list.
  */
 export function RecentsList(props: RecentsListProps) {
-  const [dropIndicator, setDropIndicator] = useState<
-    DropIndicatorState | undefined
-  >(undefined);
+  const [dropIndicator, setDropIndicator] = useDropIndicatorState();
   const [draggedThreadKey, setDraggedThreadKey] = useState<string | undefined>(
     undefined,
   );
@@ -167,6 +165,7 @@ export function RecentsList(props: RecentsListProps) {
                 const draggedThread = draggedKey ? threadByKey.get(draggedKey) : undefined;
                 if (
                   !draggedThread
+                  || draggedKey === childKey
                   || resolveThreadParentKey(draggedThread, threadByKey) !== parentKey
                 ) {
                   event.dataTransfer.dropEffect = "none";

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -55,6 +55,7 @@ import {
   runtimeGitRefCopyValue,
 } from "../../lib/runtime-identity";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import { useNativeDragInteractionGuard } from "../../lib/native-drag-interaction";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
 import { selectThreadsWithDrafts } from "../../lib/useThreadDraftIndicators";
 import { formatPrimaryAccel } from "../../lib/keyboard-accel";
@@ -310,6 +311,7 @@ function uniqueContextMenuValues(
 }
 
 export function Sidebar(props: SidebarProps) {
+  useNativeDragInteractionGuard();
   const federationLabel = readRendererFederationLabel();
   const federationTarget = readRendererFederationTarget();
   const contextMenuRef = useRef<HTMLDivElement>(null);

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { isBranchDrifted } from "@pwragent/shared";
 import {
@@ -102,6 +102,10 @@ export function ThreadMetaChips({
   const pinTooltipText = pinIsActionable ? "Click to unpin" : "Pinned";
   const branchChip = thread.gitBranch ?? thread.observedGitBranch;
   const gitWorking = thread.gitWorkingState;
+  const branchTooltip = useMemo(
+    () => branchChip ? formatBranchTooltip(branchChip, gitWorking) : undefined,
+    [branchChip, gitWorking],
+  );
   const hasDirtyState = Boolean(
     gitWorking &&
       (gitWorking.dirtyFiles > 0 ||
@@ -394,7 +398,7 @@ export function ThreadMetaChips({
             kind: thread.gitBranch ? "expected" : "current",
           })}
           className="thread-row__chip path-copy-target tooltip-target thread-row__chip--mono"
-          tooltipText={formatBranchTooltip(branchChip, gitWorking)}
+          tooltipText={branchTooltip}
           value={branchChip}
         >
           <span aria-hidden="true" className="thread-row__chip-icon">

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -5,6 +5,7 @@ import {
   type KeyboardEvent,
   type MouseEvent,
   type DragEvent,
+  type PointerEvent,
 } from "react";
 import type {
   MessagingThreadBindingSummary,
@@ -25,6 +26,7 @@ import type { DropIndicatorPosition } from "./drag-drop";
 import { ReactionPicker } from "./ReactionPicker";
 import { ThreadMetaChips } from "./ThreadMetaChips";
 import { getThreadRowStatus, ThreadRowStatus } from "./ThreadRowStatus";
+import { setThreadRowNativeDragPreview } from "./thread-row-drag-preview";
 
 const HOVER_PREFETCH_DELAY_MS = 750;
 const absoluteDateFormatter = new Intl.DateTimeFormat(undefined, {
@@ -52,6 +54,7 @@ type ThreadRowProps = {
   compact?: boolean;
   dropIndicator?: DropIndicatorPosition;
   draggable?: boolean;
+  pointerDraggable?: boolean;
   includeLinkedDirectories?: boolean;
   linkedDirectoryMode?: "label" | "kind";
   nested?: boolean;
@@ -66,6 +69,7 @@ type ThreadRowProps = {
   subthreadCount?: number;
   subthreadsCollapsed?: boolean;
   thinkingThreadKeys?: Record<string, boolean>;
+  threadPinState?: "pinned" | "unpinned";
   thread: NavigationThreadSummary;
   onOpenContextMenu: (
     thread: NavigationThreadSummary,
@@ -108,6 +112,7 @@ type ThreadRowProps = {
   onDragLeaveThread?: (event: DragEvent<HTMLDivElement>) => void;
   onDragEndThread?: (event: DragEvent<HTMLDivElement>) => void;
   onDropOnThread?: (event: DragEvent<HTMLDivElement>) => void;
+  onPointerDownThread?: (event: PointerEvent<HTMLDivElement>) => void;
   onMovePinnedThread?: (
     thread: NavigationThreadSummary,
     direction: "up" | "down",
@@ -231,16 +236,20 @@ export function ThreadRow(props: ThreadRowProps) {
 
   return (
     <div
-      className={`thread-row-shell${props.draggable ? " is-draggable" : ""}${
+      className={`thread-row-shell${
+        props.draggable || props.pointerDraggable ? " is-draggable" : ""
+      }${
         props.dropIndicator ? ` is-drop-target-${props.dropIndicator}` : ""
       }${props.nested ? " thread-row-shell--nested" : ""}${
         props.subthreadCount ? " has-subthreads" : ""
       }`}
       draggable={props.draggable}
+      data-thread-pin-key={props.threadPinState ? threadKey : undefined}
+      data-thread-pin-state={props.threadPinState}
       role="listitem"
       onDragStart={(event) => {
         if (props.draggable) {
-          setThreadRowDragImage(event);
+          setThreadRowNativeDragPreview(event);
         }
         props.onDragStartThread?.(event);
       }}
@@ -248,6 +257,7 @@ export function ThreadRow(props: ThreadRowProps) {
       onDragLeave={props.onDragLeaveThread}
       onDragEnd={props.onDragEndThread}
       onDrop={props.onDropOnThread}
+      onPointerDown={props.onPointerDownThread}
       onContextMenu={(event) => {
         event.preventDefault();
         props.onOpenContextMenu(props.thread, {
@@ -462,33 +472,6 @@ export function ThreadRow(props: ThreadRowProps) {
       ) : null}
     </div>
   );
-}
-
-function setThreadRowDragImage(event: DragEvent<HTMLDivElement>): void {
-  const row = event.currentTarget.querySelector(".thread-row");
-  if (!(row instanceof HTMLElement)) {
-    return;
-  }
-
-  const rect = row.getBoundingClientRect();
-  const clone = row.cloneNode(true) as HTMLElement;
-  clone.classList.add("thread-row--drag-image");
-  clone.classList.remove("thread-row--compact");
-  clone.querySelector(".thread-row__actions")?.remove();
-  clone.querySelector(".thread-row__chip--add-reaction")?.remove();
-  clone.querySelector(".thread-row__overflow-button")?.remove();
-  clone.setAttribute("aria-hidden", "true");
-  clone.style.width = `${rect.width}px`;
-  clone.style.height = `${rect.height}px`;
-  document.body.appendChild(clone);
-
-  event.dataTransfer.setDragImage(
-    clone,
-    Math.max(0, Math.min(event.clientX - rect.left, rect.width)),
-    Math.max(0, Math.min(event.clientY - rect.top, rect.height)),
-  );
-
-  window.setTimeout(() => clone.remove(), 0);
 }
 
 function ReactionChip(props: { emoji: string; onToggle: () => void }) {

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -18,6 +18,7 @@ import {
   MESSAGING_PLATFORM_ICONS,
 } from "../../lib/messaging-platform-branding";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import { isNativeDragInteractionActive } from "../../lib/native-drag-interaction";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
 import { PrChip } from "../pr-status/PrChip";
 import type { DropIndicatorPosition } from "./drag-drop";
@@ -196,6 +197,7 @@ export function ThreadRow(props: ThreadRowProps) {
     active,
   ]);
   const armHoverPrefetch = (): void => {
+    if (isNativeDragInteractionActive()) return;
     if (
       !props.onPrefetchPullRequests
       && !props.onPrefetchGitWorkingState
@@ -205,6 +207,7 @@ export function ThreadRow(props: ThreadRowProps) {
     if (hoverTimerRef.current !== undefined) return;
     hoverTimerRef.current = window.setTimeout(() => {
       hoverTimerRef.current = undefined;
+      if (isNativeDragInteractionActive()) return;
       if (prs.length > 0) {
         props.onPrefetchPullRequests?.(props.thread);
       }

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/drag-drop.test.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/drag-drop.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDropIndicatorState,
+  type DropIndicatorState,
+} from "../drag-drop";
+
+describe("drop indicator state", () => {
+  it("preserves object identity while dragover remains in the same row half", () => {
+    const current: DropIndicatorState = {
+      targetKey: "thread-1",
+      position: "before",
+    };
+
+    expect(resolveDropIndicatorState(current, {
+      targetKey: "thread-1",
+      position: "before",
+    })).toBe(current);
+  });
+
+  it("updates when the target row or position changes", () => {
+    const current: DropIndicatorState = {
+      targetKey: "thread-1",
+      position: "before",
+    };
+    const moved: DropIndicatorState = {
+      targetKey: "thread-2",
+      position: "after",
+    };
+
+    expect(resolveDropIndicatorState(current, moved)).toBe(moved);
+    expect(resolveDropIndicatorState(current, undefined)).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/drag-drop.test.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/drag-drop.test.ts
@@ -1,33 +1,43 @@
-import { describe, expect, it } from "vitest";
-import {
-  resolveDropIndicatorState,
-  type DropIndicatorState,
-} from "../drag-drop";
+import { describe, expect, it, vi } from "vitest";
+import { createDropIndicatorController } from "../drag-drop";
 
-describe("drop indicator state", () => {
-  it("preserves object identity while dragover remains in the same row half", () => {
-    const current: DropIndicatorState = {
+describe("drop indicator controller", () => {
+  it("updates only the target elements instead of React state", () => {
+    const controller = createDropIndicatorController();
+    const first = document.createElement("div");
+    const second = document.createElement("div");
+
+    controller.show(first, {
       targetKey: "thread-1",
       position: "before",
-    };
+    });
+    expect(first.classList.contains("is-drop-target-before")).toBe(true);
 
-    expect(resolveDropIndicatorState(current, {
-      targetKey: "thread-1",
-      position: "before",
-    })).toBe(current);
-  });
-
-  it("updates when the target row or position changes", () => {
-    const current: DropIndicatorState = {
-      targetKey: "thread-1",
-      position: "before",
-    };
-    const moved: DropIndicatorState = {
+    controller.show(second, {
       targetKey: "thread-2",
       position: "after",
-    };
+    });
+    expect(first.classList.contains("is-drop-target-before")).toBe(false);
+    expect(second.classList.contains("is-drop-target-after")).toBe(true);
 
-    expect(resolveDropIndicatorState(current, moved)).toBe(moved);
-    expect(resolveDropIndicatorState(current, undefined)).toBeUndefined();
+    controller.clear();
+    expect(second.classList.contains("is-drop-target-after")).toBe(false);
+  });
+
+  it("does not rewrite an unchanged target", () => {
+    const controller = createDropIndicatorController();
+    const target = document.createElement("div");
+    const add = vi.spyOn(target.classList, "add");
+
+    controller.show(target, {
+      targetKey: "thread-1",
+      position: "before",
+    });
+    controller.show(target, {
+      targetKey: "thread-1",
+      position: "before",
+    });
+
+    expect(add).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -3803,7 +3803,7 @@ describe("Sidebar", () => {
   it("cancels over the source and appends after leaving an empty pin section", () => {
     const onReorderThreadPins = vi.fn(async () => undefined);
 
-    render(
+    const { container } = render(
       <Sidebar
         backends={backends}
         browseMode="directories"
@@ -3828,6 +3828,10 @@ describe("Sidebar", () => {
         name: "Pin thread after pinned threads for PwrAgent",
       }),
     ).not.toBeInTheDocument();
+    const mountedAppendTarget = container.querySelector(
+      ".directory-row__pin-drop-slot",
+    );
+    expect(mountedAppendTarget).toHaveAttribute("aria-hidden", "true");
 
     const row = screen
       .getByRole("button", { name: /Cross-project cleanup/i })
@@ -3849,6 +3853,8 @@ describe("Sidebar", () => {
     let appendTarget = screen.getByRole("separator", {
       name: "Pin thread after pinned threads for PwrAgent",
     });
+    expect(appendTarget).toBe(mountedAppendTarget);
+    expect(appendTarget).toHaveClass("is-drag-enabled");
     fireDragEventAt(appendTarget, "dragover", dataTransfer, { x: 50, y: 150 });
     expect(appendTarget).not.toHaveClass("is-drop-target-before");
     fireDragEventAt(appendTarget, "drop", dataTransfer, { x: 50, y: 150 });
@@ -3984,13 +3990,22 @@ describe("Sidebar", () => {
     expect(onReorderThreadPins).not.toHaveBeenCalled();
   });
 
-  it("shows directory drop targets for row edges and the pin divider", () => {
+  it("shows directory drop targets for pinned row edges and the append slot", () => {
     // Pin reorder-by-drag lives only where a pinned section is rendered, which
     // after the Updated/Created lenses became pure sort orders means the
     // Directories lens alone.
-    const pinnedThread = {
-      ...updatedSinceSeenThread,
+    const firstPinnedThread = {
+      ...sharedThread,
       pinnedRank: "1024",
+    };
+    const secondPinnedThread = {
+      ...updatedSinceSeenThread,
+      pinnedRank: "2048",
+    };
+    const unpinnedThread = {
+      ...sharedThread,
+      id: "thread-unpinned",
+      title: "Unpinned thread",
     };
 
     render(
@@ -4001,15 +4016,19 @@ describe("Sidebar", () => {
         directories={[
           {
             ...directories[0]!,
-            threadKeys: ["codex:thread-1", "codex:thread-updated"],
+            threadKeys: [
+              "codex:thread-1",
+              "codex:thread-updated",
+              "codex:thread-unpinned",
+            ],
           },
         ]}
-        inboxThreads={[sharedThread]}
+        inboxThreads={[firstPinnedThread, secondPinnedThread, unpinnedThread]}
         launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
-        threads={[sharedThread, pinnedThread]}
+        threads={[firstPinnedThread, secondPinnedThread, unpinnedThread]}
         onBrowseModeChange={() => undefined}
         onCreateThread={async () => undefined}
         onOpenLaunchpad={async () => undefined}
@@ -4041,24 +4060,26 @@ describe("Sidebar", () => {
       y: 0,
     });
 
-    fireEvent.dragOver(pinnedRow!, {
-      clientY: 75,
-      dataTransfer,
-    });
+    fireDragEventAt(pinnedRow!, "dragover", dataTransfer, { x: 50, y: 25 });
     expect(pinnedRow).toHaveClass("is-drop-target-before");
+
+    fireDragEventAt(pinnedRow!, "dragover", dataTransfer, { x: 50, y: 75 });
+    expect(pinnedRow).not.toHaveClass("is-drop-target-before");
+    expect(pinnedRow).toHaveClass("is-drop-target-after");
 
     fireEvent.dragLeave(pinnedRow!, {
       relatedTarget: null,
     });
     expect(pinnedRow).not.toHaveClass("is-drop-target-before");
+    expect(pinnedRow).not.toHaveClass("is-drop-target-after");
 
-    const divider = screen.getByRole("button", {
-      name: "Hide directory threads for PwrAgent",
+    const appendTarget = screen.getByRole("separator", {
+      name: "Pin thread after pinned threads for PwrAgent",
     });
-    fireEvent.dragOver(divider, {
+    fireEvent.dragOver(appendTarget, {
       dataTransfer,
     });
-    expect(divider).toHaveClass("is-drop-target");
+    expect(appendTarget).toHaveClass("is-drop-target-before");
   });
 
   it("renders no pinned section or drag affordance in the Created lens", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -3759,10 +3759,17 @@ describe("Sidebar", () => {
     const directoryThreads = screen.getByRole("button", {
       name: "Hide directory threads for PwrAgent",
     });
-    fireEvent.drop(
-      directoryThreads,
-      { dataTransfer: createDataTransfer("codex:thread-1") },
-    );
+    const unpinnedRow = screen
+      .getByRole("button", { name: /Cross-project cleanup/i })
+      .closest(".thread-row-shell");
+    const dataTransfer = createDataTransfer("codex:thread-1");
+    fireEvent.dragStart(unpinnedRow!, { dataTransfer });
+    const appendTarget = screen.getByRole("separator", {
+      name: "Pin thread after pinned threads for PwrAgent",
+    });
+    fireEvent.dragOver(appendTarget, { dataTransfer });
+    expect(appendTarget).toHaveClass("is-drop-target-before");
+    fireEvent.drop(appendTarget, { dataTransfer });
     fireEvent.click(directoryThreads);
 
     expect(onReorderThreadPins).toHaveBeenCalledWith([
@@ -3770,6 +3777,51 @@ describe("Sidebar", () => {
       "codex:thread-1",
     ]);
     expect(onSetDirectoryThreadsCollapsed).not.toHaveBeenCalled();
+  });
+
+  it("shows an append target while dragging into an empty directory pin section", () => {
+    const onReorderThreadPins = vi.fn(async () => undefined);
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onReorderThreadPins={onReorderThreadPins}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("separator", {
+        name: "Pin thread after pinned threads for PwrAgent",
+      }),
+    ).not.toBeInTheDocument();
+
+    const row = screen
+      .getByRole("button", { name: /Cross-project cleanup/i })
+      .closest(".thread-row-shell");
+    const dataTransfer = createDataTransfer("codex:thread-1");
+    fireEvent.dragStart(row!, { dataTransfer });
+
+    const appendTarget = screen.getByRole("separator", {
+      name: "Pin thread after pinned threads for PwrAgent",
+    });
+    fireEvent.dragOver(appendTarget, { dataTransfer });
+    expect(appendTarget).toHaveClass("is-drop-target-before");
+
+    fireEvent.drop(appendTarget, { dataTransfer });
+    expect(onReorderThreadPins).toHaveBeenCalledWith(["codex:thread-1"]);
   });
 
   it("shows directory drop targets for row edges and the pin divider", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -228,6 +228,21 @@ function createDataTransfer(threadKey: string) {
   };
 }
 
+function fireDragEventAt(
+  element: Element,
+  type: "dragover" | "drop",
+  dataTransfer: ReturnType<typeof createDataTransfer>,
+  point: { x: number; y: number },
+): void {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperties(event, {
+    clientX: { value: point.x },
+    clientY: { value: point.y },
+    dataTransfer: { value: dataTransfer },
+  });
+  fireEvent(element, event);
+}
+
 afterEach(() => {
   delete (window as unknown as {
     __pwragentFederationLabel?: unknown;
@@ -3764,6 +3779,12 @@ describe("Sidebar", () => {
       .closest(".thread-row-shell");
     const dataTransfer = createDataTransfer("codex:thread-1");
     fireEvent.dragStart(unpinnedRow!, { dataTransfer });
+    const pinnedRow = screen
+      .getByRole("button", { name: /Updated thread/i })
+      .closest(".thread-row-shell");
+    fireEvent.dragOver(pinnedRow!, { dataTransfer });
+    expect(pinnedRow).not.toHaveClass("is-drop-target-before");
+    expect(pinnedRow).not.toHaveClass("is-drop-target-after");
     const appendTarget = screen.getByRole("separator", {
       name: "Pin thread after pinned threads for PwrAgent",
     });
@@ -3779,7 +3800,7 @@ describe("Sidebar", () => {
     expect(onSetDirectoryThreadsCollapsed).not.toHaveBeenCalled();
   });
 
-  it("shows an append target while dragging into an empty directory pin section", () => {
+  it("cancels over the source and appends after leaving an empty pin section", () => {
     const onReorderThreadPins = vi.fn(async () => undefined);
 
     render(
@@ -3811,17 +3832,92 @@ describe("Sidebar", () => {
     const row = screen
       .getByRole("button", { name: /Cross-project cleanup/i })
       .closest(".thread-row-shell");
+    vi.spyOn(row!, "getBoundingClientRect").mockReturnValue({
+      bottom: 200,
+      height: 100,
+      left: 0,
+      right: 300,
+      toJSON: () => ({}),
+      top: 100,
+      width: 300,
+      x: 0,
+      y: 100,
+    });
     const dataTransfer = createDataTransfer("codex:thread-1");
-    fireEvent.dragStart(row!, { dataTransfer });
+    fireEvent.dragStart(row!, { clientX: 50, clientY: 150, dataTransfer });
 
+    let appendTarget = screen.getByRole("separator", {
+      name: "Pin thread after pinned threads for PwrAgent",
+    });
+    fireDragEventAt(appendTarget, "dragover", dataTransfer, { x: 50, y: 150 });
+    expect(appendTarget).not.toHaveClass("is-drop-target-before");
+    fireDragEventAt(appendTarget, "drop", dataTransfer, { x: 50, y: 150 });
+    expect(onReorderThreadPins).not.toHaveBeenCalled();
+
+    fireEvent.dragStart(row!, { clientX: 50, clientY: 150, dataTransfer });
+    appendTarget = screen.getByRole("separator", {
+      name: "Pin thread after pinned threads for PwrAgent",
+    });
+    fireDragEventAt(appendTarget, "dragover", dataTransfer, { x: 50, y: 90 });
+    expect(appendTarget).toHaveClass("is-drop-target-before");
+
+    fireDragEventAt(appendTarget, "drop", dataTransfer, { x: 50, y: 90 });
+    expect(onReorderThreadPins).toHaveBeenCalledWith(["codex:thread-1"]);
+  });
+
+  it("keeps an escaped directory pin drag canceled through release", () => {
+    const onReorderThreadPins = vi.fn(async () => undefined);
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onReorderThreadPins={onReorderThreadPins}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    const row = screen
+      .getByRole("button", { name: /Cross-project cleanup/i })
+      .closest(".thread-row-shell");
+    vi.spyOn(row!, "getBoundingClientRect").mockReturnValue({
+      bottom: 200,
+      height: 100,
+      left: 0,
+      right: 300,
+      toJSON: () => ({}),
+      top: 100,
+      width: 300,
+      x: 0,
+      y: 100,
+    });
+    const dataTransfer = createDataTransfer("codex:thread-1");
+    fireEvent.dragStart(row!, { clientX: 50, clientY: 150, dataTransfer });
     const appendTarget = screen.getByRole("separator", {
       name: "Pin thread after pinned threads for PwrAgent",
     });
-    fireEvent.dragOver(appendTarget, { dataTransfer });
+    fireDragEventAt(appendTarget, "dragover", dataTransfer, { x: 50, y: 90 });
     expect(appendTarget).toHaveClass("is-drop-target-before");
 
-    fireEvent.drop(appendTarget, { dataTransfer });
-    expect(onReorderThreadPins).toHaveBeenCalledWith(["codex:thread-1"]);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(
+      screen.queryByRole("separator", {
+        name: "Pin thread after pinned threads for PwrAgent",
+      }),
+    ).not.toBeInTheDocument();
+    fireEvent.dragEnd(row!, { dataTransfer });
+    expect(onReorderThreadPins).not.toHaveBeenCalled();
   });
 
   it("shows directory drop targets for row edges and the pin divider", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -3865,6 +3865,70 @@ describe("Sidebar", () => {
     expect(onReorderThreadPins).toHaveBeenCalledWith(["codex:thread-1"]);
   });
 
+  it("uses the source row's live bounds after directory-list scrolling", () => {
+    const onReorderThreadPins = vi.fn(async () => undefined);
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onReorderThreadPins={onReorderThreadPins}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    const row = screen
+      .getByRole("button", { name: /Cross-project cleanup/i })
+      .closest(".thread-row-shell");
+    const sourceBounds = vi.spyOn(row!, "getBoundingClientRect");
+    sourceBounds.mockReturnValue({
+      bottom: 200,
+      height: 100,
+      left: 0,
+      right: 300,
+      toJSON: () => ({}),
+      top: 100,
+      width: 300,
+      x: 0,
+      y: 100,
+    });
+    const dataTransfer = createDataTransfer("codex:thread-1");
+    fireEvent.dragStart(row!, { clientX: 50, clientY: 150, dataTransfer });
+
+    sourceBounds.mockReturnValue({
+      bottom: 120,
+      height: 100,
+      left: 0,
+      right: 300,
+      toJSON: () => ({}),
+      top: 20,
+      width: 300,
+      x: 0,
+      y: 20,
+    });
+    const appendTarget = screen.getByRole("separator", {
+      name: "Pin thread after pinned threads for PwrAgent",
+    });
+    fireDragEventAt(appendTarget, "dragover", dataTransfer, { x: 50, y: 50 });
+    expect(appendTarget).not.toHaveClass("is-drop-target-before");
+
+    fireDragEventAt(appendTarget, "dragover", dataTransfer, { x: 50, y: 150 });
+    expect(appendTarget).toHaveClass("is-drop-target-before");
+    fireDragEventAt(appendTarget, "drop", dataTransfer, { x: 50, y: 150 });
+    expect(onReorderThreadPins).toHaveBeenCalledWith(["codex:thread-1"]);
+  });
+
   it("keeps an escaped directory pin drag canceled through release", () => {
     const onReorderThreadPins = vi.fn(async () => undefined);
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -228,19 +228,40 @@ function createDataTransfer(threadKey: string) {
   };
 }
 
-function fireDragEventAt(
+const THREAD_PIN_POINTER_ID = 41;
+
+function startThreadPinPointerDrag(
   element: Element,
-  type: "dragover" | "drop",
-  dataTransfer: ReturnType<typeof createDataTransfer>,
   point: { x: number; y: number },
 ): void {
-  const event = new Event(type, { bubbles: true, cancelable: true });
-  Object.defineProperties(event, {
-    clientX: { value: point.x },
-    clientY: { value: point.y },
-    dataTransfer: { value: dataTransfer },
+  fireEvent.pointerDown(element, {
+    button: 0,
+    clientX: point.x,
+    clientY: point.y,
+    pointerId: THREAD_PIN_POINTER_ID,
   });
-  fireEvent(element, event);
+}
+
+function moveThreadPinPointer(
+  point: { x: number; y: number },
+): void {
+  fireEvent.pointerMove(window, {
+    buttons: 1,
+    clientX: point.x,
+    clientY: point.y,
+    pointerId: THREAD_PIN_POINTER_ID,
+  });
+}
+
+function releaseThreadPinPointer(
+  point: { x: number; y: number },
+): void {
+  fireEvent.pointerUp(window, {
+    button: 0,
+    clientX: point.x,
+    clientY: point.y,
+    pointerId: THREAD_PIN_POINTER_ID,
+  });
 }
 
 afterEach(() => {
@@ -3738,7 +3759,7 @@ describe("Sidebar", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("pins a same-directory thread by dropping it on the directory divider", () => {
+  it("pins a same-directory thread after a pointer drag leaves its source", async () => {
     const onReorderThreadPins = vi.fn(async () => undefined);
     const onSetDirectoryThreadsCollapsed = vi.fn(async () => undefined);
     const pinnedThread = {
@@ -3777,20 +3798,20 @@ describe("Sidebar", () => {
     const unpinnedRow = screen
       .getByRole("button", { name: /Cross-project cleanup/i })
       .closest(".thread-row-shell");
-    const dataTransfer = createDataTransfer("codex:thread-1");
-    fireEvent.dragStart(unpinnedRow!, { dataTransfer });
+    startThreadPinPointerDrag(unpinnedRow!, { x: 50, y: 150 });
     const pinnedRow = screen
       .getByRole("button", { name: /Updated thread/i })
       .closest(".thread-row-shell");
-    fireEvent.dragOver(pinnedRow!, { dataTransfer });
+    moveThreadPinPointer({ x: 50, y: 90 });
     expect(pinnedRow).not.toHaveClass("is-drop-target-before");
     expect(pinnedRow).not.toHaveClass("is-drop-target-after");
     const appendTarget = screen.getByRole("separator", {
       name: "Pin thread after pinned threads for PwrAgent",
     });
-    fireEvent.dragOver(appendTarget, { dataTransfer });
-    expect(appendTarget).toHaveClass("is-drop-target-before");
-    fireEvent.drop(appendTarget, { dataTransfer });
+    await waitFor(() => {
+      expect(appendTarget).toHaveClass("is-drop-target-before");
+    });
+    releaseThreadPinPointer({ x: 50, y: 90 });
     fireEvent.click(directoryThreads);
 
     expect(onReorderThreadPins).toHaveBeenCalledWith([
@@ -3800,7 +3821,72 @@ describe("Sidebar", () => {
     expect(onSetDirectoryThreadsCollapsed).not.toHaveBeenCalled();
   });
 
-  it("cancels over the source and appends after leaving an empty pin section", () => {
+  it("keeps wheel input on the normal renderer path during a pointer drag", async () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onReorderThreadPins={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    const row = screen
+      .getByRole("button", { name: /Cross-project cleanup/i })
+      .closest(".thread-row-shell") as HTMLElement;
+    expect(row).not.toHaveAttribute("draggable", "true");
+    vi.spyOn(row, "getBoundingClientRect").mockReturnValue({
+      bottom: 200,
+      height: 100,
+      left: 0,
+      right: 300,
+      toJSON: () => ({}),
+      top: 100,
+      width: 300,
+      x: 0,
+      y: 100,
+    });
+    const list = row.closest(".directory-list") as HTMLElement;
+    const onWheel = vi.fn();
+    list.addEventListener("wheel", onWheel);
+
+    startThreadPinPointerDrag(row, { x: 50, y: 150 });
+    moveThreadPinPointer({ x: 50, y: 90 });
+    await waitFor(() => {
+      expect(document.documentElement).toHaveAttribute(
+        "data-native-drag-active",
+      );
+      expect(document.body.querySelector(".thread-row--drag-image"))
+        .not.toBeNull();
+    });
+
+    const wheelEvent = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: 120,
+    });
+    list.dispatchEvent(wheelEvent);
+    expect(onWheel).toHaveBeenCalledTimes(1);
+    expect(wheelEvent.defaultPrevented).toBe(false);
+
+    releaseThreadPinPointer({ x: 50, y: 90 });
+    expect(document.documentElement).not.toHaveAttribute(
+      "data-native-drag-active",
+    );
+  });
+
+  it("cancels over the source and appends after leaving an empty pin section", async () => {
     const onReorderThreadPins = vi.fn(async () => undefined);
 
     const { container } = render(
@@ -3847,31 +3933,34 @@ describe("Sidebar", () => {
       x: 0,
       y: 100,
     });
-    const dataTransfer = createDataTransfer("codex:thread-1");
-    fireEvent.dragStart(row!, { clientX: 50, clientY: 150, dataTransfer });
+    startThreadPinPointerDrag(row!, { x: 50, y: 150 });
+    moveThreadPinPointer({ x: 60, y: 160 });
 
     let appendTarget = screen.getByRole("separator", {
       name: "Pin thread after pinned threads for PwrAgent",
     });
     expect(appendTarget).toBe(mountedAppendTarget);
     expect(appendTarget).toHaveClass("is-drag-enabled");
-    fireDragEventAt(appendTarget, "dragover", dataTransfer, { x: 50, y: 150 });
-    expect(appendTarget).not.toHaveClass("is-drop-target-before");
-    fireDragEventAt(appendTarget, "drop", dataTransfer, { x: 50, y: 150 });
+    await waitFor(() => {
+      expect(appendTarget).not.toHaveClass("is-drop-target-before");
+    });
+    releaseThreadPinPointer({ x: 50, y: 150 });
     expect(onReorderThreadPins).not.toHaveBeenCalled();
 
-    fireEvent.dragStart(row!, { clientX: 50, clientY: 150, dataTransfer });
+    startThreadPinPointerDrag(row!, { x: 50, y: 150 });
+    moveThreadPinPointer({ x: 50, y: 90 });
     appendTarget = screen.getByRole("separator", {
       name: "Pin thread after pinned threads for PwrAgent",
     });
-    fireDragEventAt(appendTarget, "dragover", dataTransfer, { x: 50, y: 90 });
-    expect(appendTarget).toHaveClass("is-drop-target-before");
+    await waitFor(() => {
+      expect(appendTarget).toHaveClass("is-drop-target-before");
+    });
 
-    fireDragEventAt(appendTarget, "drop", dataTransfer, { x: 50, y: 90 });
+    releaseThreadPinPointer({ x: 50, y: 90 });
     expect(onReorderThreadPins).toHaveBeenCalledWith(["codex:thread-1"]);
   });
 
-  it("uses the source row's live bounds after directory-list scrolling", () => {
+  it("uses the source row's live bounds after directory-list scrolling", async () => {
     const onReorderThreadPins = vi.fn(async () => undefined);
 
     render(
@@ -3909,8 +3998,14 @@ describe("Sidebar", () => {
       x: 0,
       y: 100,
     });
-    const dataTransfer = createDataTransfer("codex:thread-1");
-    fireEvent.dragStart(row!, { clientX: 50, clientY: 150, dataTransfer });
+    startThreadPinPointerDrag(row!, { x: 50, y: 150 });
+    moveThreadPinPointer({ x: 50, y: 90 });
+    const appendTarget = screen.getByRole("separator", {
+      name: "Pin thread after pinned threads for PwrAgent",
+    });
+    await waitFor(() => {
+      expect(appendTarget).toHaveClass("is-drop-target-before");
+    });
 
     sourceBounds.mockReturnValue({
       bottom: 120,
@@ -3923,19 +4018,20 @@ describe("Sidebar", () => {
       x: 0,
       y: 20,
     });
-    const appendTarget = screen.getByRole("separator", {
-      name: "Pin thread after pinned threads for PwrAgent",
+    fireEvent.scroll(row!.closest(".directory-list")!);
+    await waitFor(() => {
+      expect(appendTarget).not.toHaveClass("is-drop-target-before");
     });
-    fireDragEventAt(appendTarget, "dragover", dataTransfer, { x: 50, y: 50 });
-    expect(appendTarget).not.toHaveClass("is-drop-target-before");
 
-    fireDragEventAt(appendTarget, "dragover", dataTransfer, { x: 50, y: 150 });
-    expect(appendTarget).toHaveClass("is-drop-target-before");
-    fireDragEventAt(appendTarget, "drop", dataTransfer, { x: 50, y: 150 });
+    moveThreadPinPointer({ x: 50, y: 150 });
+    await waitFor(() => {
+      expect(appendTarget).toHaveClass("is-drop-target-before");
+    });
+    releaseThreadPinPointer({ x: 50, y: 150 });
     expect(onReorderThreadPins).toHaveBeenCalledWith(["codex:thread-1"]);
   });
 
-  it("keeps an escaped directory pin drag canceled through release", () => {
+  it("keeps an escaped directory pin drag canceled through release", async () => {
     const onReorderThreadPins = vi.fn(async () => undefined);
 
     render(
@@ -3972,13 +4068,14 @@ describe("Sidebar", () => {
       x: 0,
       y: 100,
     });
-    const dataTransfer = createDataTransfer("codex:thread-1");
-    fireEvent.dragStart(row!, { clientX: 50, clientY: 150, dataTransfer });
+    startThreadPinPointerDrag(row!, { x: 50, y: 150 });
+    moveThreadPinPointer({ x: 50, y: 90 });
     const appendTarget = screen.getByRole("separator", {
       name: "Pin thread after pinned threads for PwrAgent",
     });
-    fireDragEventAt(appendTarget, "dragover", dataTransfer, { x: 50, y: 90 });
-    expect(appendTarget).toHaveClass("is-drop-target-before");
+    await waitFor(() => {
+      expect(appendTarget).toHaveClass("is-drop-target-before");
+    });
 
     fireEvent.keyDown(window, { key: "Escape" });
     expect(
@@ -3986,11 +4083,11 @@ describe("Sidebar", () => {
         name: "Pin thread after pinned threads for PwrAgent",
       }),
     ).not.toBeInTheDocument();
-    fireEvent.dragEnd(row!, { dataTransfer });
+    releaseThreadPinPointer({ x: 50, y: 90 });
     expect(onReorderThreadPins).not.toHaveBeenCalled();
   });
 
-  it("shows directory drop targets for pinned row edges and the append slot", () => {
+  it("shows directory drop targets for pinned row edges and the append slot", async () => {
     // Pin reorder-by-drag lives only where a pinned section is rendered, which
     // after the Updated/Created lenses became pure sort orders means the
     // Directories lens alone.
@@ -4041,8 +4138,7 @@ describe("Sidebar", () => {
       .getByRole("button", { name: /Cross-project cleanup/i })
       .closest(".thread-row-shell");
     expect(draggedRow).not.toBeNull();
-    const dataTransfer = createDataTransfer("codex:thread-1");
-    fireEvent.dragStart(draggedRow!, { dataTransfer });
+    startThreadPinPointerDrag(draggedRow!, { x: 50, y: 150 });
 
     const pinnedRow = screen
       .getByRole("button", { name: /Updated thread/i })
@@ -4060,26 +4156,38 @@ describe("Sidebar", () => {
       y: 0,
     });
 
-    fireDragEventAt(pinnedRow!, "dragover", dataTransfer, { x: 50, y: 25 });
-    expect(pinnedRow).toHaveClass("is-drop-target-before");
-
-    fireDragEventAt(pinnedRow!, "dragover", dataTransfer, { x: 50, y: 75 });
-    expect(pinnedRow).not.toHaveClass("is-drop-target-before");
-    expect(pinnedRow).toHaveClass("is-drop-target-after");
-
-    fireEvent.dragLeave(pinnedRow!, {
-      relatedTarget: null,
+    moveThreadPinPointer({ x: 50, y: 25 });
+    await waitFor(() => {
+      expect(pinnedRow).toHaveClass("is-drop-target-before");
     });
-    expect(pinnedRow).not.toHaveClass("is-drop-target-before");
-    expect(pinnedRow).not.toHaveClass("is-drop-target-after");
+
+    moveThreadPinPointer({ x: 50, y: 75 });
+    await waitFor(() => {
+      expect(pinnedRow).not.toHaveClass("is-drop-target-before");
+      expect(pinnedRow).toHaveClass("is-drop-target-after");
+    });
 
     const appendTarget = screen.getByRole("separator", {
       name: "Pin thread after pinned threads for PwrAgent",
     });
-    fireEvent.dragOver(appendTarget, {
-      dataTransfer,
+    vi.spyOn(appendTarget, "getBoundingClientRect").mockReturnValue({
+      bottom: 132,
+      height: 32,
+      left: 0,
+      right: 300,
+      toJSON: () => ({}),
+      top: 100,
+      width: 300,
+      x: 0,
+      y: 100,
     });
-    expect(appendTarget).toHaveClass("is-drop-target-before");
+    moveThreadPinPointer({ x: 50, y: 115 });
+    await waitFor(() => {
+      expect(pinnedRow).not.toHaveClass("is-drop-target-before");
+      expect(pinnedRow).not.toHaveClass("is-drop-target-after");
+      expect(appendTarget).toHaveClass("is-drop-target-before");
+    });
+    releaseThreadPinPointer({ x: 50, y: 115 });
   });
 
   it("renders no pinned section or drag affordance in the Created lens", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -6,6 +6,10 @@ import type {
   NavigationThreadSummary,
 } from "@pwragent/shared";
 import { ThreadRow } from "../ThreadRow";
+import {
+  beginNativeDragInteraction,
+  endNativeDragInteraction,
+} from "../../../lib/native-drag-interaction";
 
 // Regression coverage for the unified chip-flow refactor (#188 / plan
 // 2026-05-05-001). The historical bug pattern was:
@@ -51,6 +55,7 @@ const telegramBinding: MessagingThreadBindingSummary = {
 
 afterEach(() => {
   cleanup();
+  endNativeDragInteraction();
   vi.restoreAllMocks();
 });
 
@@ -369,6 +374,39 @@ describe("ThreadRow chip flow", () => {
 
       vi.advanceTimersByTime(1);
       expect(onPrefetchPullRequests).toHaveBeenCalledWith(thread);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not complete an armed hover prefetch during a native drag", () => {
+    vi.useFakeTimers();
+    try {
+      const onPrefetchPullRequests = vi.fn();
+      const thread: NavigationThreadSummary = {
+        ...baseThread,
+        prs: [
+          {
+            provider: "github.com",
+            number: 542,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            state: "passing",
+            lifecycleState: "open",
+            checkState: "passing",
+            reviewState: "ready_for_review",
+            mergeState: "mergeable",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/542",
+          },
+        ],
+      };
+      const { container } = renderRow({ thread, onPrefetchPullRequests });
+
+      fireEvent.mouseOver(container.querySelector(".pr-chip")!);
+      beginNativeDragInteraction();
+      vi.advanceTimersByTime(750);
+
+      expect(onPrefetchPullRequests).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/renderer/src/features/navigation/drag-drop.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/drag-drop.ts
@@ -1,5 +1,5 @@
 import {
-  useCallback,
+  useEffect,
   useState,
   type DragEvent,
 } from "react";
@@ -12,37 +12,55 @@ export type DropIndicatorState = {
 };
 
 /**
- * Native dragover fires continuously while the pointer remains over a row.
- * Preserve the current object when the visible indicator did not change so
- * React can bail out instead of rerendering the entire navigation list for
- * every event. This matters especially when a trackpad scroll is running at
- * the same time as the drag.
+ * Moving an insertion line does not change application state. Keep it out of
+ * React's render path so scrolling successive rows under a held card does not
+ * rebuild the entire navigation tree for every new target.
  */
-export function resolveDropIndicatorState(
-  current: DropIndicatorState | undefined,
-  next: DropIndicatorState | undefined,
-): DropIndicatorState | undefined {
-  if (
-    current?.targetKey === next?.targetKey
-    && current?.position === next?.position
-  ) {
-    return current;
-  }
-  return next;
+export type DropIndicatorController = {
+  clear: () => void;
+  show: (element: HTMLElement, next: DropIndicatorState) => void;
+};
+
+const DROP_INDICATOR_CLASSES = [
+  "is-drop-target-before",
+  "is-drop-target-after",
+] as const;
+
+export function createDropIndicatorController(): DropIndicatorController {
+  let active:
+    | { element: HTMLElement; state: DropIndicatorState }
+    | undefined;
+
+  const clear = (): void => {
+    if (!active) return;
+    active.element.classList.remove(...DROP_INDICATOR_CLASSES);
+    active = undefined;
+  };
+
+  return {
+    clear,
+    show: (element, next) => {
+      if (
+        active?.element === element
+        && active.state.targetKey === next.targetKey
+        && active.state.position === next.position
+      ) {
+        return;
+      }
+      clear();
+      element.classList.add(`is-drop-target-${next.position}`);
+      active = { element, state: next };
+    },
+  };
 }
 
-export function useDropIndicatorState(): readonly [
-  DropIndicatorState | undefined,
-  (next: DropIndicatorState | undefined) => void,
-] {
-  const [indicator, setIndicator] = useState<DropIndicatorState | undefined>();
-  const updateIndicator = useCallback(
-    (next: DropIndicatorState | undefined) => {
-      setIndicator((current) => resolveDropIndicatorState(current, next));
-    },
-    [],
+export function useDropIndicatorController(): DropIndicatorController {
+  const [controller] = useState(createDropIndicatorController);
+  useEffect(
+    () => () => controller.clear(),
+    [controller],
   );
-  return [indicator, updateIndicator] as const;
+  return controller;
 }
 
 export function getDropIndicatorPosition(

--- a/apps/desktop/src/renderer/src/features/navigation/drag-drop.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/drag-drop.ts
@@ -1,4 +1,8 @@
-import type { DragEvent } from "react";
+import {
+  useCallback,
+  useState,
+  type DragEvent,
+} from "react";
 
 export type DropIndicatorPosition = "before" | "after";
 
@@ -6,6 +10,40 @@ export type DropIndicatorState = {
   position: DropIndicatorPosition;
   targetKey: string;
 };
+
+/**
+ * Native dragover fires continuously while the pointer remains over a row.
+ * Preserve the current object when the visible indicator did not change so
+ * React can bail out instead of rerendering the entire navigation list for
+ * every event. This matters especially when a trackpad scroll is running at
+ * the same time as the drag.
+ */
+export function resolveDropIndicatorState(
+  current: DropIndicatorState | undefined,
+  next: DropIndicatorState | undefined,
+): DropIndicatorState | undefined {
+  if (
+    current?.targetKey === next?.targetKey
+    && current?.position === next?.position
+  ) {
+    return current;
+  }
+  return next;
+}
+
+export function useDropIndicatorState(): readonly [
+  DropIndicatorState | undefined,
+  (next: DropIndicatorState | undefined) => void,
+] {
+  const [indicator, setIndicator] = useState<DropIndicatorState | undefined>();
+  const updateIndicator = useCallback(
+    (next: DropIndicatorState | undefined) => {
+      setIndicator((current) => resolveDropIndicatorState(current, next));
+    },
+    [],
+  );
+  return [indicator, updateIndicator] as const;
+}
 
 export function getDropIndicatorPosition(
   event: DragEvent<HTMLElement>,

--- a/apps/desktop/src/renderer/src/features/navigation/thread-row-drag-preview.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/thread-row-drag-preview.ts
@@ -1,0 +1,80 @@
+import type { DragEvent } from "react";
+
+type Point = {
+  x: number;
+  y: number;
+};
+
+export type ThreadRowPointerDragPreview = {
+  move: (point: Point) => void;
+  remove: () => void;
+};
+
+function buildThreadRowDragPreview(
+  source: HTMLDivElement,
+): { element: HTMLElement; rect: DOMRect } | undefined {
+  const row = source.querySelector(".thread-row");
+  if (!(row instanceof HTMLElement)) {
+    return undefined;
+  }
+
+  const rect = row.getBoundingClientRect();
+  const clone = row.cloneNode(true) as HTMLElement;
+  clone.classList.add("thread-row--drag-image");
+  clone.classList.remove("thread-row--compact");
+  clone.querySelector(".thread-row__actions")?.remove();
+  clone.querySelector(".thread-row__chip--add-reaction")?.remove();
+  clone.querySelector(".thread-row__overflow-button")?.remove();
+  clone.setAttribute("aria-hidden", "true");
+  clone.style.width = `${rect.width}px`;
+  clone.style.height = `${rect.height}px`;
+  document.body.appendChild(clone);
+  return { element: clone, rect };
+}
+
+export function setThreadRowNativeDragPreview(
+  event: DragEvent<HTMLDivElement>,
+): void {
+  const preview = buildThreadRowDragPreview(event.currentTarget);
+  if (!preview) return;
+
+  event.dataTransfer.setDragImage(
+    preview.element,
+    Math.max(
+      0,
+      Math.min(event.clientX - preview.rect.left, preview.rect.width),
+    ),
+    Math.max(
+      0,
+      Math.min(event.clientY - preview.rect.top, preview.rect.height),
+    ),
+  );
+
+  window.setTimeout(() => preview.element.remove(), 0);
+}
+
+export function createThreadRowPointerDragPreview(
+  source: HTMLDivElement,
+  point: Point,
+): ThreadRowPointerDragPreview | undefined {
+  const preview = buildThreadRowDragPreview(source);
+  if (!preview) return undefined;
+
+  const offset = {
+    x: Math.max(0, Math.min(point.x - preview.rect.left, preview.rect.width)),
+    y: Math.max(0, Math.min(point.y - preview.rect.top, preview.rect.height)),
+  };
+  preview.element.style.willChange = "transform";
+
+  const move = (nextPoint: Point): void => {
+    const x = nextPoint.x - offset.x;
+    const y = nextPoint.y - offset.y;
+    preview.element.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+  };
+  move(point);
+
+  return {
+    move,
+    remove: () => preview.element.remove(),
+  };
+}

--- a/apps/desktop/src/renderer/src/lib/__tests__/native-drag-interaction.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/native-drag-interaction.test.tsx
@@ -1,0 +1,77 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  endNativeDragInteraction,
+  NATIVE_DRAG_ACTIVE_ATTRIBUTE,
+  useNativeDragInteractionGuard,
+} from "../native-drag-interaction";
+import { useViewportTooltip } from "../useViewportTooltip";
+
+function DragTooltipHarness() {
+  useNativeDragInteractionGuard();
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+
+  return (
+    <aside className="sidebar">
+      <div className="thread-row-shell" draggable>
+        Drag source
+      </div>
+      <button
+        type="button"
+        onMouseEnter={(event) => tooltip.show(event.currentTarget, "Hover card")}
+        onMouseLeave={tooltip.hide}
+      >
+        Hover target
+      </button>
+      {tooltip.tooltipNode}
+    </aside>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  endNativeDragInteraction();
+});
+
+describe("native drag interaction guard", () => {
+  it("dismisses and blocks hover overlays until a card drag ends", () => {
+    render(<DragTooltipHarness />);
+
+    const target = screen.getByRole("button", { name: "Hover target" });
+    const source = screen.getByText("Drag source");
+    fireEvent.mouseEnter(target);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Hover card");
+
+    fireEvent.dragStart(source);
+    expect(document.documentElement).toHaveAttribute(
+      NATIVE_DRAG_ACTIVE_ATTRIBUTE,
+    );
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(target);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    fireEvent.dragEnd(source);
+    expect(document.documentElement).not.toHaveAttribute(
+      NATIVE_DRAG_ACTIVE_ATTRIBUTE,
+    );
+    fireEvent.mouseEnter(target);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Hover card");
+  });
+
+  it("clears drag interaction state on Escape", () => {
+    render(<DragTooltipHarness />);
+    const source = screen.getByText("Drag source");
+
+    fireEvent.dragStart(source);
+    expect(document.documentElement).toHaveAttribute(
+      NATIVE_DRAG_ACTIVE_ATTRIBUTE,
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(document.documentElement).not.toHaveAttribute(
+      NATIVE_DRAG_ACTIVE_ATTRIBUTE,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/__tests__/native-drag-interaction.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/native-drag-interaction.test.tsx
@@ -2,9 +2,11 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  beginNativeDragInteraction,
   endNativeDragInteraction,
   NATIVE_DRAG_ACTIVE_ATTRIBUTE,
   useNativeDragInteractionGuard,
+  waitForNativeDragInteractionEnd,
 } from "../native-drag-interaction";
 import { useViewportTooltip } from "../useViewportTooltip";
 
@@ -73,5 +75,21 @@ describe("native drag interaction guard", () => {
     expect(document.documentElement).not.toHaveAttribute(
       NATIVE_DRAG_ACTIVE_ATTRIBUTE,
     );
+  });
+
+  it("defers work until a native drag ends", async () => {
+    beginNativeDragInteraction();
+
+    let settled = false;
+    const waiting = waitForNativeDragInteractionEnd().then((waited) => {
+      settled = true;
+      return waited;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    endNativeDragInteraction();
+    await expect(waiting).resolves.toBe(true);
+    await expect(waitForNativeDragInteractionEnd()).resolves.toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -14,6 +14,10 @@ import type {
 } from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  beginNativeDragInteraction,
+  endNativeDragInteraction,
+} from "../native-drag-interaction";
 import { useThreadNavigation } from "../useThreadNavigation";
 
 describe("useThreadNavigation", () => {
@@ -23,6 +27,7 @@ describe("useThreadNavigation", () => {
   });
 
   afterEach(() => {
+    endNativeDragInteraction();
     delete (window as unknown as {
       __pwragentNavigationPreferences?: unknown;
     }).__pwragentNavigationPreferences;
@@ -101,6 +106,101 @@ describe("useThreadNavigation", () => {
       },
     });
     expect(result.current.error).toBeUndefined();
+  });
+
+  it("defers navigation deltas during a drag and preserves the dropped pin rank", async () => {
+    const buildSnapshot = (title: string): NavigationSnapshot => ({
+      backend: "all",
+      fetchedAt: 1,
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title,
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+          updatedAt: 1,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    });
+    const deferredDelta = createDeferred<
+      Awaited<
+        ReturnType<NonNullable<DesktopApi["getNavigationSnapshotTransport"]>>
+      >
+    >();
+    const getNavigationSnapshot = vi.fn(async () => buildSnapshot("Initial"));
+    const getNavigationSnapshotTransport = vi
+      .fn<NonNullable<DesktopApi["getNavigationSnapshotTransport"]>>()
+      .mockResolvedValueOnce({
+        kind: "full",
+        revision: "revision-1",
+        snapshot: buildSnapshot("Initial"),
+      })
+      .mockReturnValueOnce(deferredDelta.promise);
+    const reorderThreadPins = vi.fn<
+      NonNullable<DesktopApi["reorderThreadPins"]>
+    >(async () => ({
+      pinnedRanks: { "codex:thread-1": "1024" },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      getNavigationSnapshotTransport,
+      onAgentEvent: () => () => undefined,
+      reorderThreadPins,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.title).toBe("Initial");
+    });
+
+    let refresh!: Promise<void>;
+    act(() => {
+      refresh = result.current.refresh();
+    });
+    await waitFor(() => {
+      expect(getNavigationSnapshotTransport).toHaveBeenCalledTimes(2);
+    });
+
+    beginNativeDragInteraction();
+    await act(async () => {
+      await result.current.reorderThreadPins(["codex:thread-1"]);
+    });
+    expect(result.current.threads[0]?.pinnedRank).toBe("1024");
+
+    act(() => {
+      deferredDelta.resolve({
+        kind: "delta",
+        baseRevision: "revision-1",
+        revision: "revision-2",
+        fetchedAt: 2,
+        removedThreadKeys: [],
+        upsertedThreads: buildSnapshot("Updated during drag").threads,
+        removedDirectoryKeys: [],
+        upsertedDirectories: [],
+      });
+    });
+    await Promise.resolve();
+    expect(result.current.threads[0]?.title).toBe("Initial");
+    expect(result.current.threads[0]?.pinnedRank).toBe("1024");
+
+    await act(async () => {
+      endNativeDragInteraction();
+      await refresh;
+    });
+    expect(result.current.threads[0]).toMatchObject({
+      title: "Updated during drag",
+      pinnedRank: "1024",
+    });
+    expect(getNavigationSnapshot).not.toHaveBeenCalled();
   });
 
   it("keeps separate transport revisions while lightweight refresh scopes alternate", async () => {

--- a/apps/desktop/src/renderer/src/lib/native-drag-interaction.ts
+++ b/apps/desktop/src/renderer/src/lib/native-drag-interaction.ts
@@ -45,10 +45,11 @@ export function subscribeNativeDragInteraction(
 
 /**
  * Navigation refreshes can rebuild hundreds of sidebar rows. If a full
- * snapshot or delta arrives during a native drag, defer its React commit until
- * the held card is released so Chromium can keep servicing the gesture. The
- * boolean tells the caller whether it waited, which lets refresh code preserve
- * any pin change made by the drop over data captured before that change.
+ * snapshot or delta arrives during a sidebar drag, defer its React commit until
+ * the held card is released so Chromium can keep servicing the gesture. This
+ * state covers both native directory/subthread drags and pointer-driven thread
+ * pin drags. The boolean tells the caller whether it waited, which lets refresh
+ * code preserve any pin change made by the drop over stale data.
  */
 export function waitForNativeDragInteractionEnd(): Promise<boolean> {
   if (!active) {

--- a/apps/desktop/src/renderer/src/lib/native-drag-interaction.ts
+++ b/apps/desktop/src/renderer/src/lib/native-drag-interaction.ts
@@ -44,6 +44,27 @@ export function subscribeNativeDragInteraction(
 }
 
 /**
+ * Navigation refreshes can rebuild hundreds of sidebar rows. If a full
+ * snapshot or delta arrives during a native drag, defer its React commit until
+ * the held card is released so Chromium can keep servicing the gesture. The
+ * boolean tells the caller whether it waited, which lets refresh code preserve
+ * any pin change made by the drop over data captured before that change.
+ */
+export function waitForNativeDragInteractionEnd(): Promise<boolean> {
+  if (!active) {
+    return Promise.resolve(false);
+  }
+
+  return new Promise((resolve) => {
+    const unsubscribe = subscribeNativeDragInteraction((nextActive) => {
+      if (nextActive) return;
+      unsubscribe();
+      resolve(true);
+    });
+  });
+}
+
+/**
  * One window-level guard owns drag-time interaction state for the sidebar.
  * Native drag events keep traversing the DOM while the pointer moves over
  * nested buttons and chips; marking the document lets those descendants and

--- a/apps/desktop/src/renderer/src/lib/native-drag-interaction.ts
+++ b/apps/desktop/src/renderer/src/lib/native-drag-interaction.ts
@@ -1,0 +1,83 @@
+import { useEffect } from "react";
+
+export const NATIVE_DRAG_ACTIVE_ATTRIBUTE = "data-native-drag-active";
+
+type NativeDragListener = (active: boolean) => void;
+
+let active = false;
+const listeners = new Set<NativeDragListener>();
+
+function setNativeDragInteractionActive(next: boolean): void {
+  if (active === next) return;
+  active = next;
+  if (typeof document !== "undefined") {
+    document.documentElement.toggleAttribute(
+      NATIVE_DRAG_ACTIVE_ATTRIBUTE,
+      next,
+    );
+  }
+  for (const listener of listeners) {
+    listener(next);
+  }
+}
+
+export function beginNativeDragInteraction(): void {
+  setNativeDragInteractionActive(true);
+}
+
+export function endNativeDragInteraction(): void {
+  setNativeDragInteractionActive(false);
+}
+
+export function isNativeDragInteractionActive(): boolean {
+  return active;
+}
+
+export function subscribeNativeDragInteraction(
+  listener: NativeDragListener,
+): () => void {
+  listeners.add(listener);
+  listener(active);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * One window-level guard owns drag-time interaction state for the sidebar.
+ * Native drag events keep traversing the DOM while the pointer moves over
+ * nested buttons and chips; marking the document lets those descendants and
+ * every portalled hover surface become inert until the gesture terminates.
+ */
+export function useNativeDragInteractionGuard(): void {
+  useEffect(() => {
+    const begin = (event: DragEvent): void => {
+      if (event.defaultPrevented || !(event.target instanceof Element)) return;
+      if (
+        !event.target.closest(".thread-row-shell")
+        && !event.target.closest(".directory-row__header")
+      ) {
+        return;
+      }
+      beginNativeDragInteraction();
+    };
+    const end = (): void => endNativeDragInteraction();
+    const endOnEscape = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") end();
+    };
+
+    window.addEventListener("dragstart", begin);
+    window.addEventListener("dragend", end);
+    window.addEventListener("drop", end);
+    window.addEventListener("blur", end);
+    window.addEventListener("keydown", endOnEscape);
+    return () => {
+      window.removeEventListener("dragstart", begin);
+      window.removeEventListener("dragend", end);
+      window.removeEventListener("drop", end);
+      window.removeEventListener("blur", end);
+      window.removeEventListener("keydown", endOnEscape);
+      end();
+    };
+  }, []);
+}

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -54,6 +54,7 @@ import {
   applyNavigationSnapshotTransportResponse,
   type NavigationSnapshotTransportState,
 } from "./navigation-snapshot-transport";
+import { waitForNativeDragInteractionEnd } from "./native-drag-interaction";
 import { resolveThreadWorkingStatePath } from "./thread-working-state-path";
 import {
   agentEventMatchesThread,
@@ -874,6 +875,59 @@ function reconcileNavigationSnapshot(
       return previousThread && threadSummariesEqual(previousThread, thread)
         ? previousThread
         : thread;
+    }),
+  };
+}
+
+function preserveNavigationPinState(
+  current: NavigationSnapshot | undefined,
+  next: NavigationSnapshot,
+): NavigationSnapshot {
+  if (!current) {
+    return next;
+  }
+
+  const currentThreads = new Map(
+    current.threads.map((thread) => [
+      buildThreadIdentityKey(thread.source, thread.id),
+      thread,
+    ]),
+  );
+  const currentDirectories = new Map(
+    current.directories.map((directory) => [directory.key, directory]),
+  );
+  return {
+    ...next,
+    threads: next.threads.map((thread) => {
+      const currentThread = currentThreads.get(
+        buildThreadIdentityKey(thread.source, thread.id),
+      );
+      if (!currentThread || currentThread.pinnedRank === thread.pinnedRank) {
+        return thread;
+      }
+      const preserved = { ...thread };
+      if (currentThread.pinnedRank === undefined) {
+        delete preserved.pinnedRank;
+      } else {
+        preserved.pinnedRank = currentThread.pinnedRank;
+      }
+      return preserved;
+    }),
+    directories: next.directories.map((directory) => {
+      const currentDirectory = currentDirectories.get(directory.key);
+      if (
+        !currentDirectory
+        || currentDirectory.pinnedRank === directory.pinnedRank
+      ) {
+        return directory;
+      }
+      const preserved = { ...directory };
+      if (currentDirectory.pinnedRank === undefined) {
+        delete preserved.pinnedRank;
+      } else {
+        preserved.pinnedRank = currentDirectory.pinnedRank;
+      }
+      return preserved;
     }),
   };
 }
@@ -3019,6 +3073,8 @@ export function useThreadNavigation(
         return;
       }
 
+      let deferredForNativeDrag = await waitForNativeDragInteractionEnd();
+
       setState((current) => ({
         ...current,
         loading: !current.response,
@@ -3099,6 +3155,9 @@ export function useThreadNavigation(
         } else {
           throw new Error("Desktop bridge is missing navigation snapshot support.");
         }
+        deferredForNativeDrag =
+          (await waitForNativeDragInteractionEnd())
+          || deferredForNativeDrag;
         remoteRecoveryAttemptRef.current = 0;
         desktopApi.recordStartupProfileEvent?.("navigation-refresh:snapshot", {
           directoryCount: snapshot.directories.length,
@@ -3157,7 +3216,12 @@ export function useThreadNavigation(
 
           const responseWithConcurrentThreadStatuses =
             applyConcurrentThreadStatusObservations(
-              responseWithObservedThreadNames,
+              deferredForNativeDrag
+                ? preserveNavigationPinState(
+                    current.response,
+                    responseWithObservedThreadNames,
+                  )
+                : responseWithObservedThreadNames,
               threadStatusObservationsRef.current,
               threadStatusSequenceAtRefreshStart,
             );

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -8,6 +8,10 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
+import {
+  isNativeDragInteractionActive,
+  subscribeNativeDragInteraction,
+} from "./native-drag-interaction";
 
 const VIEWPORT_PADDING = 12;
 /** Gap between the tooltip and the target element (above or below). */
@@ -108,6 +112,10 @@ export function useViewportTooltip(options: {
   }, [state]);
 
   const show = useCallback((target: HTMLElement, content: ReactNode): void => {
+    if (isNativeDragInteractionActive()) {
+      setState(undefined);
+      return;
+    }
     const rect = target.getBoundingClientRect();
     setState({
       content,
@@ -137,9 +145,13 @@ export function useViewportTooltip(options: {
     if (!visible) {
       return;
     }
+    const unsubscribeNativeDrag = subscribeNativeDragInteraction((active) => {
+      if (active) hide();
+    });
     window.addEventListener("blur", hide);
     window.addEventListener("scroll", hide, { capture: true });
     return () => {
+      unsubscribeNativeDrag();
       window.removeEventListener("blur", hide);
       window.removeEventListener("scroll", hide, { capture: true });
     };

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1275,6 +1275,27 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps the directory pin boundary neutral in both densities", () => {
+    expect(
+      extractRuleBody(css, ".sidebar-list,\n.directory-groups"),
+    ).toContain("gap: 4px;");
+    expect(
+      extractRuleBody(css, ".directory-row__pin-drop-boundary"),
+    ).toContain("margin-block: -4px;");
+    expect(
+      extractRuleBody(
+        css,
+        ':root[data-density="compact"] .directory-row__pin-drop-boundary',
+      ),
+    ).toContain("margin-block: -2px;");
+    expect(
+      extractRuleBody(
+        css,
+        ':root[data-density="compact"] .sidebar-list,\n:root[data-density="compact"] .directory-groups',
+      ),
+    ).toContain("gap: 2px;");
+  });
+
   it("aligns the sidebar masthead and lanes to one shared inset system", () => {
     // Regression guard. The thread/directory lanes bleed to the rail walls
     // and re-inset to `--sidebar-lane-inset`, while the masthead chrome

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3827,6 +3827,29 @@ textarea,
   pointer-events: none;
 }
 
+/* Native HTML drag keeps hit-testing the live DOM beneath the drag image.
+   Sidebar rows contain buttons, copy targets, PR hover cards, menus, and
+   native-title controls; letting those surfaces activate while a card is held
+   creates dragenter/dragleave churn and can stall Chromium's edge autoscroll.
+   The window-level native-drag guard stamps this attribute for the duration of
+   a card/directory drag. Interactive descendants become transparent so the
+   stable row/drop shells receive drag events, while every hover overlay is
+   suppressed until drop, dragend, Escape, or window blur. */
+:root[data-native-drag-active] .sidebar button,
+:root[data-native-drag-active] .sidebar a,
+:root[data-native-drag-active] .sidebar input,
+:root[data-native-drag-active] .sidebar select,
+:root[data-native-drag-active] .sidebar textarea,
+:root[data-native-drag-active] .sidebar [role="button"] {
+  pointer-events: none !important;
+}
+
+:root[data-native-drag-active] [role="tooltip"],
+:root[data-native-drag-active] [role="menu"],
+:root[data-native-drag-active] .tooltip-target[data-tooltip]::after {
+  display: none !important;
+}
+
 .thread-row__actions {
   position: absolute;
   /* Align the overflow button + add-reaction chip with the title line,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5267,6 +5267,35 @@ textarea,
   padding-right: 8px;
 }
 
+.directory-row__pin-drop-slot {
+  position: relative;
+  height: 18px;
+  flex: 0 0 auto;
+  margin: -2px 6px;
+  cursor: grabbing;
+}
+
+.directory-row__pin-drop-slot::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  left: 8px;
+  height: 1px;
+  border-radius: 999px;
+  background: var(--border-subtle);
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.directory-row__pin-drop-slot.is-drop-target-before::after {
+  height: 3px;
+  background: var(--accent);
+  box-shadow:
+    0 0 0 1px var(--row-active-tint-strong),
+    0 0 14px var(--accent-shadow);
+}
+
 .directory-row__thread-divider {
   appearance: none;
   padding: 0;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5295,10 +5295,16 @@ textarea,
   z-index: 7;
   height: 0;
   flex: 0 0 auto;
-  /* The compact list contributes a 4px gap on both sides of every flex item.
-     Cancel those gaps so revealing this zero-height drag target never moves
-     the source row out from under the held card. */
+  /* The list contributes a 4px gap on both sides of this flex item. Cancel
+     those gaps so this permanently mounted zero-height target is layout-neutral
+     and starting a drag never moves the source row under the held card. */
   margin-block: -4px;
+}
+
+:root[data-density="compact"] .directory-row__pin-drop-boundary {
+  /* Compact density reduces `.sidebar-list` to a 2px gap. Keep the boundary's
+     compensation paired with that value so it remains layout-neutral. */
+  margin-block: -2px;
 }
 
 .directory-row__pin-drop-slot {
@@ -5311,6 +5317,11 @@ textarea,
   left: 6px;
   height: 32px;
   cursor: grabbing;
+  pointer-events: none;
+}
+
+.directory-row__pin-drop-slot.is-drag-enabled {
+  pointer-events: auto;
 }
 
 .directory-row__pin-drop-slot::after {
@@ -5322,8 +5333,13 @@ textarea,
   height: 1px;
   border-radius: 999px;
   background: var(--border-subtle);
+  opacity: 0;
   pointer-events: none;
   transform: translateY(-50%);
+}
+
+.directory-row__pin-drop-slot.is-drag-enabled::after {
+  opacity: 1;
 }
 
 .directory-row__pin-drop-slot.is-drop-target-before::after {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5267,18 +5267,33 @@ textarea,
   padding-right: 8px;
 }
 
-.directory-row__pin-drop-slot {
+.directory-row__pin-drop-boundary {
   position: relative;
-  height: 18px;
+  z-index: 7;
+  height: 0;
   flex: 0 0 auto;
-  margin: -2px 6px;
+  /* The compact list contributes a 4px gap on both sides of every flex item.
+     Cancel those gaps so revealing this zero-height drag target never moves
+     the source row out from under the held card. */
+  margin-block: -4px;
+}
+
+.directory-row__pin-drop-slot {
+  position: absolute;
+  /* Reach upward into the pinned lane while leaving a small guarded overlap
+     with the source row. Runtime source-bounds checks keep that overlap a
+     cancel zone; the line itself stays exactly on the section boundary. */
+  top: -24px;
+  right: 6px;
+  left: 6px;
+  height: 32px;
   cursor: grabbing;
 }
 
 .directory-row__pin-drop-slot::after {
   content: "";
   position: absolute;
-  top: 50%;
+  top: 24px;
   right: 8px;
   left: 8px;
   height: 1px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3675,6 +3675,11 @@ textarea,
   cursor: grabbing;
 }
 
+.thread-row-shell.is-pointer-dragging {
+  cursor: grabbing;
+  user-select: none;
+}
+
 .thread-row-shell.is-drop-target-before::before,
 .thread-row-shell.is-drop-target-after::after {
   content: "";
@@ -3827,14 +3832,13 @@ textarea,
   pointer-events: none;
 }
 
-/* Native HTML drag keeps hit-testing the live DOM beneath the drag image.
-   Sidebar rows contain buttons, copy targets, PR hover cards, menus, and
-   native-title controls; letting those surfaces activate while a card is held
-   creates dragenter/dragleave churn and can stall Chromium's edge autoscroll.
-   The window-level native-drag guard stamps this attribute for the duration of
-   a card/directory drag. Interactive descendants become transparent so the
-   stable row/drop shells receive drag events, while every hover overlay is
-   suppressed until drop, dragend, Escape, or window blur. */
+/* Sidebar drag sessions keep hit-testing the live DOM beneath their preview.
+   Rows contain buttons, copy targets, PR hover cards, menus, and native-title
+   controls; letting those surfaces activate while a card is held creates
+   target churn and can open hover UI over the drag. The shared drag guard
+   stamps this attribute for both pointer-driven thread pinning and the native
+   directory/subthread drags. Interactive descendants become transparent while
+   every hover overlay is suppressed until release, drop, Escape, or blur. */
 :root[data-native-drag-active] .sidebar button,
 :root[data-native-drag-active] .sidebar a,
 :root[data-native-drag-active] .sidebar input,


### PR DESCRIPTION
## Summary

- move thread, subthread, and directory insertion-line updates entirely off React state and onto the affected DOM rows
- keep the append-to-pins target mounted but inert, so starting a drag cannot rebuild the directory list or shift compact-density rows
- make an unpinned card's original row its cancel zone; after leaving that row, dropping on the pin boundary appends it to the bottom of the pinned list
- restrict unpinned cards to that bottom append position and preserve pinned-card reordering
- cancel an active directory pin drag on Escape so releasing afterward cannot change the pin order
- keep the cancel zone aligned with its source row while two-finger scrolling moves the list
- suppress every tooltip/menu and hover-triggered PR/Git refresh while a sidebar card or directory is being dragged
- make nested sidebar controls transparent to native drag hit-testing so stable row/drop shells receive the gesture
- defer full navigation snapshot commits until the native drag ends, while preserving the pin mutation made by the drop

## Root cause

Native `dragover` fires continuously while a card is held. PwrAgent originally created a fresh drop-indicator state object for every event, rerendering the full navigation list even when the pointer had not changed targets. Deduplicating identical targets helped, but two-finger scrolling still moves successive rows under the held pointer, so every row transition continued to rerender PwrAgent's much heavier directory tree.

Drop indicators now update only CSS classes on the previous and next target elements. The append boundary is permanently mounted, visually hidden and pointer-inert outside a drag, then enabled imperatively from the drag session. Starting or ending a thread drag no longer changes `DirectoriesList` React state or mounts a new flex item. Its margins match the 4px default list gap and 2px compact gap so it remains layout-neutral in both densities.

The follow-up profile captured a separate full navigation refresh during the gesture. Its drag-over samples were small and the profile was idle for most of the recording, but snapshot reconciliation and a root React commit rebuilt `DirectoriesList`, `ThreadRow`, the composer, and the thread detail pane at the front of the profile. Navigation refreshes now wait for the native drag to end before committing. If the snapshot was captured during the drag, reconciliation preserves the current thread and directory pin ranks so it cannot undo the drop's optimistic move.

The heap pair does not show a leak: the stop snapshot retained about 27,000 fewer nodes and 0.2 MB less self-size. It shows transient native `DataTransfer`/`FileList` wrapper churn during drag events, but no retained-growth explanation for the stall.

Native drag also traversed every interactive descendant under the drag image. A single window-level drag guard now closes and blocks portal tooltips, suppresses menus and CSS tooltips, prevents hover-prefetch completion, and removes nested controls from drag hit-testing until drop, dragend, Escape, or window blur.

## Validation

- focused navigation, drag-interaction, snapshot-deferral, and theme-contract tests: 298 passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint:typed`
- `pnpm lint:boundaries`
- `pnpm lint:colors`
- `git diff --check`
