### PR TITLE
test(desktop): update sidebar lens visual golden

### DIFF
--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.png
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a64af1760d3f1fea0d5de1bc22dbbb6cf83aafdadfc599977c27ca3e80fe7176
-size 149884
+oid sha256:78d00fed1f87e1dc9d4774c2952cbb74bc34b27e8d21cc45a9b6ca3933a16984
+size 146829


### PR DESCRIPTION
## Summary

- replace the macOS todo-thread shell golden with the stable screenshot produced by the M2 macOS/ARM64 CI runner
- capture the icon-only Updated, Created, and Directories lens switch introduced by #1425
- keep the fix isolated from the remaining stacked lens changes

## Root cause

PR #1425 intentionally changed the sidebar lens switch from text labels to icons, but the tracked `todo-thread-shell-darwin.png` baseline was not updated. macOS lane 2 therefore reported the same 7,350-pixel sidebar-only difference on #1426 and #1427.

## Verification

- the replacement is a valid 1440×900 RGB PNG
- independent M2 CI artifacts from runs 31341010239 and 31341020922 produced the exact same SHA-256: `78d00fed1f87e1dc9d4774c2952cbb74bc34b27e8d21cc45a9b6ca3933a16984`
- `git lfs status` identifies the replacement as an LFS object
- `git lfs fsck` passes
