### PR TITLE
fix(desktop): reduce Star Map idle CPU

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -143,6 +144,39 @@ const SNAP_THRESHOLD_PX = 6;
  */
 const CANVAS_CLICK_SLOP_PX = 4;
 
+const STAR_FIELD = generateStarField(STAR_COUNT);
+
+/**
+ * Static sky behind the live map.
+ *
+ * The map re-renders whenever active-thread state advances. Keeping the 130
+ * circles behind a memo boundary means React does not reconcile a decorative
+ * subtree on every streamed update. The stars intentionally stay still: 130
+ * independent SVG opacity animations kept Chromium painting continuously even
+ * when the operator was not touching the map.
+ */
+const StarMapSky = memo(function StarMapSky() {
+  return (
+    <svg
+      className="star-map__sky"
+      viewBox="0 0 100 100"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      {STAR_FIELD.map((star, index) => (
+        <circle
+          key={index}
+          className="star-map__star"
+          cx={star.x}
+          cy={star.y}
+          r={star.radius * 0.08}
+          fillOpacity={star.opacity}
+        />
+      ))}
+    </svg>
+  );
+});
+
 type StarMapScreenProps = {
   desktopApi?: DesktopApi;
   /** Local navigation snapshot threads (already live in the App shell). */
@@ -180,7 +214,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
     width: number;
     height: number;
   }>({ width: 1280, height: 800 });
-  const stars = useMemo(() => generateStarField(STAR_COUNT), []);
   const [intakeTarget, setIntakeTarget] = useState<IntakeDialogTarget>();
   // Which instance the operator is focused on. Selection is deliberately
   // view-local and unsynced: it is a "where am I looking" gesture, not a
@@ -197,6 +230,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const [cardHeights, setCardHeights] = useState<Map<string, number>>(
     new Map(),
   );
+  const cardResizeObserverRef = useRef<ResizeObserver | null>(null);
+  const observedCardElementsRef = useRef(new Map<HTMLElement, string>());
   const [preferences, setPreferences] = useState<StarMapViewPreferences>(
     readStoredPreferences,
   );
@@ -251,30 +286,82 @@ export function StarMapScreen(props: StarMapScreenProps) {
     return () => observer.disconnect();
   }, []);
 
-  // Deliberately dependency-free: a card's height changes whenever its chip
-  // content does, and no prop reliably signals that. The identity check
-  // below is the loop guard - an unchanged measurement returns the very
-  // same Map, so the state never updates and the cycle stops.
+  // Card height changes are driven by the browser's layout observer rather
+  // than a synchronous offsetHeight sweep after every render. Active threads
+  // can update many times a second; forcing layout for every visible card on
+  // each update was enough to keep the renderer hot while the map sat idle.
+  useLayoutEffect(() => {
+    if (typeof ResizeObserver === "undefined") return;
+    const observedCardElements = observedCardElementsRef.current;
+    const observer = new ResizeObserver((entries) => {
+      const measured = new Map<string, number>();
+      for (const entry of entries) {
+        const element = entry.target as HTMLElement;
+        // Ignore a notification queued before this card was unobserved.
+        const key = observedCardElements.get(element);
+        const height = entry.borderBoxSize[0]?.blockSize
+          ?? entry.contentRect.height;
+        if (key && height > 0) measured.set(key, height);
+      }
+      if (measured.size === 0) return;
+      setCardHeights((current) => {
+        if (
+          [...measured].every(([key, height]) => current.get(key) === height)
+        ) {
+          return current;
+        }
+        const next = new Map(current);
+        for (const [key, height] of measured) next.set(key, height);
+        return next;
+      });
+    });
+    cardResizeObserverRef.current = observer;
+    return () => {
+      observer.disconnect();
+      cardResizeObserverRef.current = null;
+      observedCardElements.clear();
+    };
+  }, []);
+
+  // Reconcile observer membership after React adds or removes cards. This
+  // queries the small mounted card set but deliberately reads no geometry;
+  // ResizeObserver delivers the initial and subsequent border-box sizes after
+  // layout without turning each live-state render into a forced reflow.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useLayoutEffect(() => {
     const root = viewportRef.current;
-    if (!root) return;
-    const measured = new Map<string, number>();
+    const observer = cardResizeObserverRef.current;
+    if (!root || !observer) return;
+    const present = new Set<HTMLElement>();
+    const presentKeys = new Set<string>();
     for (const element of root.querySelectorAll<HTMLElement>(
       "[data-thread-key]",
     )) {
       const key = element.dataset.threadKey;
-      if (key) measured.set(key, element.offsetHeight);
+      if (!key) continue;
+      present.add(element);
+      presentKeys.add(key);
+      if (observedCardElementsRef.current.get(element) === key) continue;
+      observer.unobserve(element);
+      observedCardElementsRef.current.set(element, key);
+      observer.observe(element);
     }
-    setCardHeights((current) => {
-      if (
-        current.size === measured.size
-        && [...measured].every(([key, height]) => current.get(key) === height)
-      ) {
-        return current;
-      }
-      return measured;
-    });
+
+    const removedKeys = new Set<string>();
+    for (const [element, key] of observedCardElementsRef.current) {
+      if (present.has(element)) continue;
+      observer.unobserve(element);
+      observedCardElementsRef.current.delete(element);
+      if (!presentKeys.has(key)) removedKeys.add(key);
+    }
+    if (removedKeys.size > 0) {
+      setCardHeights((current) => {
+        if (![...removedKeys].some((key) => current.has(key))) return current;
+        const next = new Map(current);
+        for (const key of removedKeys) next.delete(key);
+        return next;
+      });
+    }
   });
 
   const startCanvasPan = (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -1630,24 +1717,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
         className="star-map__viewport"
         onPointerDown={startCanvasPan}
       >
-        <svg
-          className="star-map__sky"
-          viewBox="0 0 100 100"
-          preserveAspectRatio="none"
-          aria-hidden="true"
-        >
-          {stars.map((star, index) => (
-            <circle
-              key={index}
-              className="star-map__star"
-              cx={star.x}
-              cy={star.y}
-              r={star.radius * 0.08}
-              fillOpacity={star.opacity}
-              style={{ animationDelay: `${star.twinkleDelay}s` }}
-            />
-          ))}
-        </svg>
+        <StarMapSky />
         <div
           ref={canvasRef}
           // Every lens is now a transformed canvas sized to its content —
@@ -1712,9 +1782,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
                   }`}
                   d={d}
                 />
-                {healthy ? (
-                  <path className="star-map__link-flow" d={d} />
-                ) : null}
               </g>
             );
           })}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-performance.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-performance.test.tsx
@@ -1,0 +1,146 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { StarMapScreen } from "../StarMapScreen";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(
+  path.resolve(testDir, "../../../styles/app.css"),
+  "utf8",
+);
+
+function buildDesktopApi(): DesktopApi {
+  return {
+    readFederationHealth: vi.fn(async () => ({
+      health: {
+        enabled: false,
+        role: "client" as const,
+        status: "disabled" as const,
+        instanceId: "pwr_local",
+        localCelestialIcon: "sun" as const,
+        localLabel: "Local",
+        localProfileName: "default",
+        peers: [],
+      },
+    })),
+    onAgentEvent: vi.fn(() => () => undefined),
+  } as unknown as DesktopApi;
+}
+
+function thread(id: string): NavigationThreadSummary {
+  return {
+    id,
+    title: `Thread ${id}`,
+    titleSource: "generated",
+    linkedDirectories: [],
+    source: "codex",
+    inbox: { inInbox: true, reason: "updated-since-seen" },
+    updatedAt: 100,
+  } as unknown as NavigationThreadSummary;
+}
+
+function screen(threads: readonly NavigationThreadSummary[]) {
+  return (
+    <StarMapScreen
+      desktopApi={buildDesktopApi()}
+      localThreads={threads}
+      sessionKeys={{}}
+      floating={false}
+      onClose={() => undefined}
+      onOpenLocalThread={() => undefined}
+      onFocusLocalInstance={() => undefined}
+    />
+  );
+}
+
+describe("star map idle performance", () => {
+  const OriginalResizeObserver = globalThis.ResizeObserver;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: OriginalResizeObserver,
+    });
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+  });
+
+  it("has no perpetual star or link animation", () => {
+    expect(css).not.toContain("star-map-twinkle");
+    expect(css).not.toContain("star-map-flow");
+    expect(css).not.toContain(".star-map__link-flow");
+  });
+
+  it("promotes the large canvas only while pointer-panning", () => {
+    const canvasRule = css.match(
+      /\.star-map__canvas\.is-transformed\s*\{[\s\S]*?\n\}/,
+    )?.[0];
+    const panningRule = css.match(
+      /\.star-map__viewport\.is-panning \.star-map__canvas\.is-transformed\s*\{[\s\S]*?\n\}/,
+    )?.[0];
+    expect(canvasRule).not.toContain("will-change");
+    expect(panningRule).toContain("will-change: transform;");
+  });
+
+  it("updates card layout from ResizeObserver without reading offsetHeight", async () => {
+    const observers: Array<{
+      callback: ResizeObserverCallback;
+      elements: Set<Element>;
+    }> = [];
+    class ResizeObserverMock {
+      private readonly record: (typeof observers)[number];
+
+      constructor(callback: ResizeObserverCallback) {
+        this.record = { callback, elements: new Set() };
+        observers.push(this.record);
+      }
+
+      observe = (element: Element) => this.record.elements.add(element);
+      unobserve = (element: Element) => this.record.elements.delete(element);
+      disconnect = () => this.record.elements.clear();
+    }
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: ResizeObserverMock,
+    });
+
+    const offsetHeight = vi.spyOn(
+      HTMLElement.prototype,
+      "offsetHeight",
+      "get",
+    );
+    const { container, rerender } = render(screen([thread("a"), thread("b")]));
+    await waitFor(() => {
+      expect(container.querySelectorAll("[data-thread-key]")).toHaveLength(2);
+    });
+
+    const shells = [
+      ...container.querySelectorAll<HTMLElement>("[data-thread-key]"),
+    ];
+    const cardObserver = observers.find((observer) =>
+      observer.elements.has(shells[0]),
+    );
+    expect(cardObserver).toBeTruthy();
+    act(() => {
+      cardObserver?.callback(
+        shells.map((element, index) => ({
+          target: element,
+          borderBoxSize: [{ blockSize: index === 0 ? 180 : 90 }],
+          contentRect: { height: index === 0 ? 180 : 90 },
+        })) as unknown as ResizeObserverEntry[],
+        {} as ResizeObserver,
+      );
+    });
+
+    await waitFor(() => {
+      expect(shells[1].style.top).toBe("292px");
+    });
+    rerender(screen([thread("a"), thread("b")]));
+    expect(offsetHeight).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-layout.ts
@@ -292,8 +292,6 @@ export type StarMapStar = {
   y: number;
   radius: number;
   opacity: number;
-  /** Twinkle phase offset in seconds. */
-  twinkleDelay: number;
 };
 
 /**
@@ -318,7 +316,6 @@ export function generateStarField(count: number, seed = 7): StarMapStar[] {
       y: next() * 100,
       radius: 0.5 + brightness * 1.1,
       opacity: 0.25 + brightness * 0.65,
-      twinkleDelay: next() * 6,
     });
   }
   return stars;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9221,22 +9221,6 @@ textarea,
   fill: currentColor;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .star-map__star {
-    animation: star-map-twinkle 5.5s ease-in-out infinite;
-  }
-}
-
-@keyframes star-map-twinkle {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.35;
-  }
-}
-
 .star-map__links {
   position: absolute;
   inset: 0;
@@ -9262,30 +9246,6 @@ textarea,
 .star-map__link--dead {
   stroke: var(--border-strong);
   stroke-dasharray: 6 5;
-}
-
-/* Comet dots streaming along healthy arcs. Static under reduced motion
-   (the solid arc already encodes "healthy"). */
-.star-map__link-flow {
-  fill: none;
-  stroke: var(--accent-bright);
-  stroke-width: 2.25;
-  stroke-linecap: round;
-  stroke-dasharray: 1 26;
-  opacity: 0;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .star-map__link-flow {
-    opacity: 0.95;
-    animation: star-map-flow 2.4s linear infinite;
-  }
-}
-
-@keyframes star-map-flow {
-  to {
-    stroke-dashoffset: -27;
-  }
 }
 
 .star-map__anchor {
@@ -10460,6 +10420,12 @@ textarea,
   left: 0;
   top: 0;
   transform-origin: 0 0;
+}
+
+/* Promote the large canvas only for the direct-manipulation window. Keeping
+   the whole off-screen map permanently promoted retains a large compositor
+   surface even while the operator is only reading it. */
+.star-map__viewport.is-panning .star-map__canvas.is-transformed {
   will-change: transform;
 }
 


### PR DESCRIPTION
## Summary

- remove perpetual SVG star and healthy-link animations from the Star Map
- memoize the static star field so live thread updates do not reconcile 130 decorative circles
- replace per-render `offsetHeight` sweeps with `ResizeObserver`-driven card measurements
- promote the large transformed canvas only while pointer-panning
- add regression coverage for idle animation, compositor promotion, and forced-layout reads

## Root cause

A sustained renderer profile captured with the Star Map open showed a large share of unattributed Chromium `(program)` work alongside repeated React reconciliation. The view kept 130 SVG opacity animations and animated SVG link dash offsets running indefinitely, while every live thread update synchronously read every visible card's `offsetHeight`. The transformed off-screen canvas was also permanently marked `will-change: transform`, retaining compositor resources while idle.

Together these made an otherwise idle Star Map continuously paint, reflow, and retain a large promoted surface. The post-close profiles contain no Star Map stacks, confirming this is hot mounted-view work rather than an unmount leak.

## Impact

The Star Map becomes still when idle, card layout updates only when dimensions actually change, and the large canvas is promoted only during direct manipulation. Live thread state continues to update normally, and healthy/pending/dead links remain visually distinct without perpetual motion.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/star-map` — 18 files, 254 tests passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — 0 errors (existing warning baseline remains)
- `git diff --check`
