### PR TITLE
fix(desktop): account for Codex completed command output

### DIFF
--- a/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
@@ -149,6 +149,69 @@ describe("SqliteOverlayStore tool invocation accounting", () => {
     });
   });
 
+  it("does not double-count streamed output repeated in a completed Codex snapshot", async () => {
+    const deltas = [
+      "[info] starting\n",
+      "[warn] still working\n",
+      "[error] command failed\n",
+    ];
+    for (const [index, delta] of deltas.entries()) {
+      await store.upsertThreadToolInvocation({
+        invocation: toolInvocationFromNotification({
+          backend: "codex",
+          notification: {
+            method: "item/commandExecution/outputDelta",
+            params: {
+              delta,
+              itemId: "cmd-with-snapshot",
+              threadId: "thread-1",
+              turnId: "turn-1",
+            },
+          },
+          now: 1_800_000_000_000 + index,
+        })!,
+      });
+    }
+
+    const aggregatedOutput = deltas.join("");
+    await store.upsertThreadToolInvocation({
+      invocation: toolInvocationFromNotification({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              aggregatedOutput,
+              exitCode: 1,
+              id: "cmd-with-snapshot",
+              status: "failed",
+              type: "commandExecution",
+            },
+          },
+        },
+        now: 1_800_000_001_000,
+      })!,
+    });
+
+    const accounting = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(accounting.invocations[0]).toMatchObject({
+      errorLines: 1,
+      estimatedOutputTokens: Math.ceil(aggregatedOutput.length / 4),
+      exitCode: 1,
+      infoLines: 1,
+      outputChars: aggregatedOutput.length,
+      outputLines: 3,
+      status: "failed",
+      warningLines: 1,
+    });
+  });
+
   it("records coalesced output deltas identically to per-chunk writes", async () => {
     // Codex streams fixed 8 KiB chunks; the registry folds them in memory and
     // writes once per flush window. The stored totals have to match what a

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -1,4 +1,7 @@
-import type { ThreadToolInvocationRecord } from "@pwragent/shared";
+import type {
+  AppServerNotification,
+  ThreadToolInvocationRecord,
+} from "@pwragent/shared";
 import { describe, expect, it } from "vitest";
 import {
   buildToolOutputMetrics,
@@ -121,6 +124,76 @@ describe("tool invocation accounting", () => {
       turnId: "turn-1",
     });
   });
+
+  it.each([
+    {
+      field: "aggregatedOutput",
+      nestedInData: false,
+      shape: "item.aggregatedOutput",
+    },
+    {
+      field: "aggregated_output",
+      nestedInData: false,
+      shape: "item.aggregated_output",
+    },
+    {
+      field: "functionCallOutput",
+      nestedInData: false,
+      shape: "item.functionCallOutput",
+    },
+    {
+      field: "aggregatedOutput",
+      nestedInData: true,
+      shape: "item.data.aggregatedOutput",
+    },
+    {
+      field: "aggregated_output",
+      nestedInData: true,
+      shape: "item.data.aggregated_output",
+    },
+  ] as const)(
+    "extracts completed Codex command output from $shape",
+    ({ field, nestedInData }) => {
+      const output = [
+        "[info] command started",
+        "[warn] retrying step",
+        "[debug] retry detail",
+        "[error] command failed",
+        "output clipped",
+      ].join("\n");
+      const invocation = toolInvocationFromNotification({
+        backend: "codex",
+        now: 1_800_000_030_000,
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "cmd-1",
+              type: "commandExecution",
+              status: "completed",
+              ...(nestedInData
+                ? { data: { [field]: output } }
+                : { [field]: output }),
+            },
+          },
+        } as unknown as AppServerNotification,
+      });
+
+      expect(invocation).toMatchObject({
+        debugLines: 1,
+        errorLines: 1,
+        estimatedOutputTokens: Math.ceil(output.length / 4),
+        infoLines: 1,
+        outputChars: output.length,
+        outputLines: 5,
+        outputTruncated: true,
+        status: "completed",
+        warningLines: 1,
+      });
+    },
+  );
 
   it("marks completed command invocations failed from success false or exit code", () => {
     const successFalseInvocation = toolInvocationFromNotification({

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -548,6 +548,11 @@ function readToolOutput(
 ): { text?: string; truncated?: boolean } {
   const data = readRecord(item?.data);
   const text =
+    readString(item, "aggregatedOutput") ??
+    readString(item, "aggregated_output") ??
+    readString(item, "functionCallOutput") ??
+    readString(data, "aggregatedOutput") ??
+    readString(data, "aggregated_output") ??
     readString(data, "output") ??
     readString(data, "text") ??
     readString(data, "result") ??


### PR DESCRIPTION
## Summary

- read Codex completed command output from `aggregatedOutput`, `aggregated_output`, and `functionCallOutput`, including normalized nested aggregate aliases
- persist accurate character, line, estimated-token, truncation, and diagnostic counts
- preserve streamed-delta merge behavior without double-counting a repeated completed snapshot

## Root cause

The main-process tool-accounting normalizer only checked generic `data.output` / `text` / `result` and item `output` / `stdout` / `stderr` fields. Codex `commandExecution` completion items carry the full output in aggregate fields already supported by the activity normalizer, so completed invocations were persisted with zero output metrics when no streamed totals had landed.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "coalesces streamed command output into one accounting write"`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`
