### PR TITLE
chore(lint): reduce ESLint warning baseline

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -2178,7 +2178,7 @@ describe("AcpSessionReplayNormalizer", () => {
       const normalizer = new AcpSessionReplayNormalizer({
         surfaceThoughtsAsMessages: false,
       });
-      let replay = normalizer.replay();
+      let replay: ReturnType<typeof normalizer.replay> | undefined;
       for (const record of grokReviewSession.parentUpdates) {
         replay = normalizer.apply({
           sessionId: record.params.sessionId,
@@ -2189,7 +2189,7 @@ describe("AcpSessionReplayNormalizer", () => {
         // capture cannot place them; inject them where they landed live —
         // between the assistant's first and last streamed chunks.
         if (record.params.update.sessionUpdate === "agent_message_chunk") {
-          replay = normalizer.apply({
+          normalizer.apply({
             sessionId: record.params.sessionId,
             receivedAt: record.params._meta.agentTimestampMs + 1,
             update: grokReviewSession.liveOnlyUpdates.sessionInfoUpdate,
@@ -2201,7 +2201,7 @@ describe("AcpSessionReplayNormalizer", () => {
           });
         }
       }
-      return replay;
+      return replay ?? normalizer.replay();
     }
 
     it("shows the operator's prompt without the review artifact", () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -36185,7 +36185,7 @@ script = "printf setup"
     const messagingStore = createMessagingArchiveCleanupStoreMock({
       bindings: [{ id: "binding-telegram", threadId: "thread-1" }],
     });
-    let registry!: DesktopBackendRegistry;
+    const registryRef: { current?: DesktopBackendRegistry } = {};
     let nestedNavigationResolved = false;
     const messagingArchiveCleaner = {
       requests: [] as Array<{
@@ -36199,17 +36199,18 @@ script = "printf setup"
         origin: "thread-archive";
       }) {
         messagingArchiveCleaner.requests.push(request);
-        await registry.listThreads();
+        await registryRef.current!.listThreads();
         nestedNavigationResolved = true;
         return { notifiedCount: 1, revokedCount: 1 };
       },
     };
-    registry = new DesktopBackendRegistry({
+    const registry = new DesktopBackendRegistry({
       codexClient,
       messagingArchiveCleaner,
       messagingStore,
       overlayStore: createOverlayStoreMock(),
     });
+    registryRef.current = registry;
 
     const timeout = new Promise<"timeout">((resolve) => {
       setTimeout(() => resolve("timeout"), 100);

--- a/apps/desktop/src/main/__tests__/image-input-files.test.ts
+++ b/apps/desktop/src/main/__tests__/image-input-files.test.ts
@@ -60,6 +60,31 @@ describe("image input files", () => {
     ]);
   });
 
+  it("removes ASCII control characters from materialized image paths", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-image-inputs-"));
+    try {
+      const result = await materializeLocalImageInputs(
+        [{
+          type: "image",
+          name: "unsafe\u0000\u001fname.png",
+          url: "data:image/png;base64,AQID",
+        }],
+        { resolveRoot: () => tempDir },
+      );
+
+      const imagePath = result[0]?.type === "localImage" ? result[0].path : "";
+      expect(imagePath).toBe(
+        path.join(
+          tempDir,
+          "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+          "unsafename.png",
+        ),
+      );
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("converts file URLs for supported local image paths", async () => {
     const sourceRoot = await mkdtemp(path.join(os.tmpdir(), "pwragent-image-source-"));
     const materializedRoot = await mkdtemp(path.join(os.tmpdir(), "pwragent-image-inputs-"));

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2003,9 +2003,9 @@ describe("MessagingController", () => {
         workspaceId: "T012WORKSPACE",
       },
     };
-    let harnessDelivered: MessagingSurfaceIntent[] | undefined;
+    const harnessDeliveredRef: { current?: MessagingSurfaceIntent[] } = {};
     const deliver = options?.deliver ?? (async (intent: MessagingSurfaceIntent) => {
-      harnessDelivered?.push(intent);
+      harnessDeliveredRef.current?.push(intent);
       const surface = {
         channel: "slack" as const,
         id: `surface:${intent.id}`,
@@ -2107,7 +2107,7 @@ describe("MessagingController", () => {
         ? { toolUpdateDefaultMode: options.toolUpdateDefaultMode }
         : {}),
     });
-    harnessDelivered = harness.delivered;
+    harnessDeliveredRef.current = harness.delivered;
     await harness.store.upsertBinding({
       id: "binding-slack-signals",
       authorizedActorIds: ["user-1"],
@@ -6303,7 +6303,6 @@ describe("MessagingController", () => {
   });
 
   it("does not double-report materialized first-turn start failures that emitted backend failure events", async () => {
-    let harness: Awaited<ReturnType<typeof createHarness>>;
     const materializeDirectoryLaunchpad = vi.fn(
       async (
         request: MaterializeDirectoryLaunchpadRequest,
@@ -6344,7 +6343,7 @@ describe("MessagingController", () => {
         };
       },
     );
-    harness = await createHarness({ materializeDirectoryLaunchpad });
+    const harness = await createHarness({ materializeDirectoryLaunchpad });
 
     await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
     await harness.controller.handleInboundEvent(
@@ -6373,7 +6372,6 @@ describe("MessagingController", () => {
   });
 
   it("binds a materialized thread before fast first-turn terminal events", async () => {
-    let harness: Awaited<ReturnType<typeof createHarness>>;
     const materializeDirectoryLaunchpad = vi.fn(
       async (
         request: MaterializeDirectoryLaunchpadRequest,
@@ -6414,7 +6412,7 @@ describe("MessagingController", () => {
         };
       },
     );
-    harness = await createHarness({ materializeDirectoryLaunchpad });
+    const harness = await createHarness({ materializeDirectoryLaunchpad });
 
     await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
     await harness.controller.handleInboundEvent(
@@ -6460,7 +6458,6 @@ describe("MessagingController", () => {
   });
 
   it("routes quick follow-ups to the materialized binding while the first turn starts", async () => {
-    let harness: Awaited<ReturnType<typeof createHarness>>;
     let resolveMaterialized!: () => void;
     let resolveFirstTurn!: () => void;
     const materialized = new Promise<void>((resolve) => {
@@ -6505,7 +6502,7 @@ describe("MessagingController", () => {
         };
       },
     );
-    harness = await createHarness({ materializeDirectoryLaunchpad });
+    const harness = await createHarness({ materializeDirectoryLaunchpad });
 
     await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
     await harness.controller.handleInboundEvent(
@@ -21822,10 +21819,10 @@ async function createHarness(options?: {
   // Mirror the real BackendRegistry emit-after-mutation behavior: the
   // mutation methods also fan out a notification on the bus so the
   // controller's refreshStatusSurfacesForThread path runs end-to-end.
-  let controllerRef: MessagingController | undefined;
+  const controllerRef: { current?: MessagingController } = {};
   const setThreadExecutionMode = vi.fn(async (request: SetThreadExecutionModeRequest) => {
-    if (controllerRef) {
-      await controllerRef.handleBackendEvent({
+    if (controllerRef.current) {
+      await controllerRef.current.handleBackendEvent({
         backend: request.backend,
         notification: {
           method: "thread/executionMode/updated",
@@ -21841,8 +21838,8 @@ async function createHarness(options?: {
   const setAcpSessionRuntimeOption = vi.fn(
     options?.setAcpSessionRuntimeOption ??
       (async (request: SetAcpSessionRuntimeOptionRequest) => {
-        if (controllerRef) {
-          await controllerRef.handleBackendEvent({
+        if (controllerRef.current) {
+          await controllerRef.current.handleBackendEvent({
             backend: request.backend,
             notification: {
               method: "thread/acpRuntime/updated",
@@ -21887,8 +21884,8 @@ async function createHarness(options?: {
     }),
   );
   const setThreadModelSettings = vi.fn(async (request: SetThreadModelSettingsRequest) => {
-    if (controllerRef) {
-      await controllerRef.handleBackendEvent({
+    if (controllerRef.current) {
+      await controllerRef.current.handleBackendEvent({
         backend: request.backend,
         notification: {
           method: "thread/modelSettings/updated",
@@ -22054,7 +22051,7 @@ async function createHarness(options?: {
     showStreamingOption: options?.showStreamingOption,
     toolUpdateDefaultMode: options?.toolUpdateDefaultMode,
   });
-  controllerRef = controller;
+  controllerRef.current = controller;
 
   return {
     controller,

--- a/apps/desktop/src/main/__tests__/messaging-markdown-file-attachment-selector.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-markdown-file-attachment-selector.test.ts
@@ -66,6 +66,24 @@ describe("MessagingMarkdownFileAttachmentSelector", () => {
     expect(manyLinesSelection?.previewTruncated).toBe(true);
   });
 
+  it("replaces ASCII control characters in attachment names", () => {
+    const selector = new MessagingMarkdownFileAttachmentSelector();
+    const selection = selector.selectFromCompletedItem({
+      type: "fileChange",
+      changes: [
+        {
+          path: "docs/report\u0000\u001f.md",
+          kind: {
+            type: "add",
+            content: "# Report\n",
+          },
+        },
+      ],
+    });
+
+    expect(selection?.attachmentName).toBe("report__.md");
+  });
+
   it("skips multiple changes, non-markdown files, updates, and oversized files", () => {
     const selector = new MessagingMarkdownFileAttachmentSelector();
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -16504,15 +16504,15 @@ export class DesktopBackendRegistry {
     // from the runtime helper into the renderer's actionRuns entry and
     // into the post-startThread output/exit handlers.
     const autoActionRunId = randomUUID();
-    let pendingActionThreadId: string | undefined;
+    const pendingActionThreadIdRef: { current?: string } = {};
     const queuedActionDetachedExits: CodexEnvironmentDetachedExit[] = [];
     const queuedActionDetachedOutputs: CodexEnvironmentDetachedOutput[] = [];
     const codexActionBackend: AppServerBackendKind = launchpad.backend;
     const onActionDetachedExit = (event: CodexEnvironmentDetachedExit) => {
-      if (pendingActionThreadId && codexEnvironmentSelection?.action?.id) {
+      if (pendingActionThreadIdRef.current && codexEnvironmentSelection?.action?.id) {
         void this.handleCodexEnvironmentActionDetachedExit({
           backend: codexActionBackend,
-          threadId: pendingActionThreadId,
+          threadId: pendingActionThreadIdRef.current,
           runId: autoActionRunId,
           event,
         });
@@ -16521,10 +16521,10 @@ export class DesktopBackendRegistry {
       queuedActionDetachedExits.push(event);
     };
     const onActionDetachedOutput = (event: CodexEnvironmentDetachedOutput) => {
-      if (pendingActionThreadId && codexEnvironmentSelection?.action?.id) {
+      if (pendingActionThreadIdRef.current && codexEnvironmentSelection?.action?.id) {
         void this.handleCodexEnvironmentActionDetachedOutput({
           backend: codexActionBackend,
-          threadId: pendingActionThreadId,
+          threadId: pendingActionThreadIdRef.current,
           runId: autoActionRunId,
           event,
         });
@@ -16603,7 +16603,7 @@ export class DesktopBackendRegistry {
         directory: linkedDirectory,
       });
     }
-    pendingActionThreadId = startThreadResponse.threadId;
+    pendingActionThreadIdRef.current = startThreadResponse.threadId;
     // The auto-started environment action spawned before this thread existed;
     // give its detached-process record an owner now so the quit dialog can name
     // it and link back here.

--- a/apps/desktop/src/main/app-server/codex-environment-config.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-config.ts
@@ -25,8 +25,8 @@ type RawEnvironmentConfig = {
 type ParserContext = "" | "setup" | "cleanup" | "action";
 
 const KEY_LINE = /^\s*([A-Za-z_][A-Za-z0-9_-]*)\s*=\s*(.*)$/;
-const SECTION_LINE = /^\s*\[\s*([^\[\]]+?)\s*\]\s*(?:#.*)?$/;
-const ARRAY_SECTION_LINE = /^\s*\[\[\s*([^\[\]]+?)\s*\]\]\s*(?:#.*)?$/;
+const SECTION_LINE = /^\s*\[\s*([^[\]]+?)\s*\]\s*(?:#.*)?$/;
+const ARRAY_SECTION_LINE = /^\s*\[\[\s*([^[\]]+?)\s*\]\]\s*(?:#.*)?$/;
 
 export async function listCodexEnvironmentOptions(
   directoryPath?: string,

--- a/apps/desktop/src/main/app-server/image-input-files.ts
+++ b/apps/desktop/src/main/app-server/image-input-files.ts
@@ -161,13 +161,14 @@ function sanitizeImageBasename(
   name: string | undefined,
   extension: string,
 ): string | undefined {
-  const normalized = name
+  const basename = name
     ?.trim()
     .replace(/\\/g, "/")
     .split("/")
-    .pop()
-    ?.replace(/[\u0000-\u001f\u007f]/g, "")
-    .trim();
+    .pop();
+  const normalized = basename
+    ? stripAsciiControlCharacters(basename).trim()
+    : basename;
   if (!normalized) {
     return undefined;
   }
@@ -182,6 +183,17 @@ function sanitizeImageBasename(
   }
 
   return `${stem}.${extension}`;
+}
+
+function stripAsciiControlCharacters(value: string): string {
+  let result = "";
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (codePoint > 0x1f && codePoint !== 0x7f) {
+      result += character;
+    }
+  }
+  return result;
 }
 
 function extensionForMimeType(mimeType: "image/jpeg" | "image/png"): "jpg" | "png" {

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -534,7 +534,7 @@ export class ThreadMigrationService {
     sourceProfile: string;
   }): Promise<{ wasArchived: boolean }> {
     const { item, runId, sourceProfile } = params;
-    let wasArchived = false;
+    let wasArchived: boolean;
     try {
       wasArchived = (
         await this.findSourceThreadState(sourceProfile, item.sourceThreadId)

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -6677,19 +6677,16 @@ async function requestThreadListPages(params: {
 
     if (maxPagesLimit !== undefined && pageCount >= maxPagesLimit) {
       terminalReason = "max-pages";
-      cursor = undefined;
       break;
     }
 
     const nextCursor = page.nextCursor?.trim();
     if (!nextCursor) {
       terminalReason = "no-next-cursor";
-      cursor = undefined;
       break;
     }
     if (seenCursors.has(nextCursor)) {
       terminalReason = "repeated-cursor";
-      cursor = undefined;
       break;
     }
 

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -222,7 +222,6 @@ import {
   publicPeerSummary,
 } from "./federation-health";
 import {
-  FEDERATION_PTY_ERROR_METHOD,
   FEDERATION_PTY_EXIT_METHOD,
   FEDERATION_PTY_OUTPUT_METHOD,
   FEDERATION_PTY_METHOD_CAPABILITIES,
@@ -1536,7 +1535,7 @@ export class DesktopFederationRuntime {
     // early boot or in store-injected test harnesses that db may be
     // absent — fall back to the bare store record (mirrors the menu's
     // peer-lookup guard in main/index.ts).
-    let visible: FederationPeerSummary[] = [];
+    let visible: FederationPeerSummary[];
     try {
       visible = this.visiblePeers();
     } catch {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -842,7 +842,7 @@ function installApplicationMenu(): void {
     }));
   // Peer lookup touches the profile state db; during early boot (or a
   // torn-down app state in tests) just render the menu without peers.
-  let federationPeers: Array<{ instanceId: string; label: string }> = [];
+  let federationPeers: Array<{ instanceId: string; label: string }>;
   try {
     federationPeers = getDesktopFederationRuntime()
       .connectedPeerTargets()

--- a/apps/desktop/src/main/messaging/core/messaging-markdown-file-attachment-selector.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-markdown-file-attachment-selector.ts
@@ -229,8 +229,23 @@ function isMarkdownFilePath(filePath: string): boolean {
 function markdownAttachmentName(filePath: string): string {
   const normalized = filePath.replace(/\\/g, "/");
   const basename = path.posix.basename(normalized) || "artifact.md";
-  const safe = basename.replace(/[\x00-\x1f\x7f/\\]/g, "_").trim();
+  const safe = sanitizeMarkdownAttachmentBasename(basename).trim();
   return safe.toLowerCase().endsWith(".md") ? safe : `${safe || "artifact"}.md`;
+}
+
+function sanitizeMarkdownAttachmentBasename(value: string): string {
+  let result = "";
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    result +=
+      codePoint <= 0x1f
+      || codePoint === 0x7f
+      || character === "/"
+      || character === "\\"
+        ? "_"
+        : character;
+  }
+  return result;
 }
 
 function readRecord(value: unknown): Record<string, unknown> | undefined {

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -2980,8 +2980,27 @@ function clipStatusText(value: string | undefined): string | undefined {
   if (value === undefined) {
     return undefined;
   }
-  const normalized = value.replace(/[\u0000-\u001f\u007f]+/g, " ").trim();
+  const normalized = replaceAsciiControlCharacterRuns(value).trim();
   return normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
+}
+
+function replaceAsciiControlCharacterRuns(value: string): string {
+  let result = "";
+  let replacingControlRun = false;
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    const isControl = codePoint <= 0x1f || codePoint === 0x7f;
+    if (isControl) {
+      if (!replacingControlRun) {
+        result += " ";
+      }
+      replacingControlRun = true;
+      continue;
+    }
+    replacingControlRun = false;
+    result += character;
+  }
+  return result;
 }
 
 function describeConversation(

--- a/apps/desktop/src/main/profile.ts
+++ b/apps/desktop/src/main/profile.ts
@@ -656,7 +656,7 @@ export function startProfileRuntimeHeartbeat(
   const markerDir = resolveProfileRuntimeMarkerDir(normalizedProfileName, options);
   fs.mkdirSync(markerDir, { recursive: true });
   const markerPath = path.join(markerDir, `${processId}-${marker.instanceId}.json`);
-  let interval: ReturnType<typeof setInterval> | undefined;
+  const intervalRef: { current?: ReturnType<typeof setInterval> } = {};
   const writeMarker = (): void => {
     marker.heartbeatAt = now();
     try {
@@ -671,17 +671,18 @@ export function startProfileRuntimeHeartbeat(
       // race the deleter; let the heartbeat die quietly.
       const code = (error as NodeJS.ErrnoException).code;
       if (code === "ENOENT" || code === "EACCES" || code === "EPERM") {
-        if (interval) clearInterval(interval);
+        if (intervalRef.current) clearInterval(intervalRef.current);
         return;
       }
       throw error;
     }
   };
   writeMarker();
-  interval = setInterval(
+  const interval = setInterval(
     writeMarker,
     options?.intervalMs ?? PROFILE_RUNTIME_HEARTBEAT_INTERVAL_MS,
   );
+  intervalRef.current = interval;
   if (interval.unref) interval.unref();
 
   return {

--- a/apps/desktop/src/main/settings/toml-editor.ts
+++ b/apps/desktop/src/main/settings/toml-editor.ts
@@ -99,9 +99,9 @@ type SourceModel = {
   sections: SectionLocation[];
 };
 
-const KEY_LINE = /^(\s*)([A-Za-z_][A-Za-z0-9_\-]*)\s*=\s*/;
-const SECTION_HEADER = /^\s*\[\s*([^\[\]]+?)\s*\]\s*(#.*)?$/;
-const ARRAY_OF_TABLES_HEADER = /^\s*\[\[\s*([^\[\]]+?)\s*\]\]\s*(#.*)?$/;
+const KEY_LINE = /^(\s*)([A-Za-z_][A-Za-z0-9_-]*)\s*=\s*/;
+const SECTION_HEADER = /^\s*\[\s*([^[\]]+?)\s*\]\s*(#.*)?$/;
+const ARRAY_OF_TABLES_HEADER = /^\s*\[\[\s*([^[\]]+?)\s*\]\]\s*(#.*)?$/;
 const INTEGER_LITERAL = /^-?\d+$/;
 const FLOAT_LITERAL = /^-?(?:\d+\.\d+(?:[eE][-+]?\d+)?|\d+[eE][-+]?\d+)$/;
 
@@ -762,7 +762,7 @@ function parseInlineTable(
     if (eq === -1) return undefined;
     const key = field.slice(0, eq).trim();
     const valueText = field.slice(eq + 1).trim();
-    if (!/^[A-Za-z_][A-Za-z0-9_\-]*$/.test(key)) return undefined;
+    if (!/^[A-Za-z_][A-Za-z0-9_-]*$/.test(key)) return undefined;
     const parsed = tryParseValue(valueText);
     if (!parsed) return undefined;
     if (

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ReferencePicker.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ReferencePicker.test.tsx
@@ -4,7 +4,6 @@ import {
   fireEvent,
   render,
   screen,
-  within,
 } from "@testing-library/react";
 import type { NavigationDirectorySummary } from "@pwragent/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
@@ -329,7 +329,7 @@ export function SettingsSection(props: {
     const currentIndex = sections.findIndex((section) => section.id === sectionId);
     if (currentIndex === -1) return;
 
-    let nextIndex = currentIndex;
+    let nextIndex: number;
     if (direction === "next") {
       nextIndex = Math.min(sections.length - 1, currentIndex + 1);
     } else if (direction === "previous") {

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -22,9 +22,6 @@ import type { DesktopApi } from "../../lib/desktop-api";
 import { useCelestialIcons } from "../../lib/useCelestialIcons";
 import { useFederationHealth } from "../../lib/useFederationHealth";
 import {
-  STAR_MAP_ATTENTION_CATEGORIES,
-  STAR_MAP_ATTENTION_LABELS,
-  type StarMapAttentionCategory,
   type StarMapSessionKeys,
 } from "./attention";
 import {
@@ -32,7 +29,6 @@ import {
   computeCardSlots,
   computeStarMapLayout,
   generateStarField,
-  STAR_MAP_BODY_ROW_Y,
   STAR_MAP_CARD_GAP,
   STAR_MAP_CLOUD_TOP,
   STAR_MAP_ESTIMATED_CARD_HEIGHT,

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
-import { isAgentThread, threadAttentionCategories } from "../attention";
+import { threadAttentionCategories } from "../attention";
 import {
   cloudDetentRadius,
   computeStarMapLayout,
@@ -337,6 +337,4 @@ describe("resolveCardDragOffset", () => {
     expect(near).toBeGreaterThan(detentRadius + 200);
   });
 });
-
-
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1402,7 +1402,6 @@ export function ThreadView(props: ThreadViewProps) {
   const selectedThreadKey = selectedThread
     ? buildThreadIdentityKey(selectedThread.source, selectedThread.id)
     : undefined;
-  const transcriptEntryCount = props.transcriptEntries.length;
   const onLoadOlder = props.onLoadOlder;
   const onRenderedTranscriptEntryLimitChange =
     props.onRenderedTranscriptEntryLimitChange;
@@ -1420,8 +1419,6 @@ export function ThreadView(props: ThreadViewProps) {
     canLoadFromServer: canLoadServerTranscriptHistory,
     expandLimit: expandTranscriptEntryLimit,
     hasMoreHistory: hasMoreTranscriptHistory,
-    hiddenCount: hiddenTranscriptEntryCount,
-    limit: transcriptEntryLimit,
     loadOlder: loadOlderTranscript,
     visibleEntries: visibleTranscriptEntries,
     visiblePagination: visibleTranscriptPagination,

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCommandOutput.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCommandOutput.tsx
@@ -109,10 +109,21 @@ function isAgentCommand(rawCommand: string | undefined): boolean {
 }
 
 function sanitizeCommandOutput(value: string | undefined): string {
-  return (value ?? "")
+  const normalizedNewlines = (value ?? "")
     .replace(/\r\n/g, "\n")
-    .replace(/\r/g, "\n")
-    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "\uFFFD");
+    .replace(/\r/g, "\n");
+  let sanitized = "";
+  for (const character of normalizedNewlines) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    const isDisallowedControl =
+      codePoint <= 0x08
+      || codePoint === 0x0b
+      || codePoint === 0x0c
+      || (codePoint >= 0x0e && codePoint <= 0x1f)
+      || codePoint === 0x7f;
+    sanitized += isDisallowedControl ? "\uFFFD" : character;
+  }
+  return sanitized;
 }
 
 function buildOutputPreview(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
@@ -260,6 +260,35 @@ describe("TranscriptCommandOutput", () => {
     expect(copyText).toHaveBeenNthCalledWith(2, "line 1\nline 2");
   });
 
+  it("replaces disallowed control characters without removing tabs or newlines", () => {
+    const copyText = vi.fn(async () => undefined);
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        copyText,
+      },
+    });
+
+    render(
+      <TranscriptCommandOutput
+        detail={{
+          id: "cmd-control-output",
+          kind: "command",
+          label: "print controls",
+          status: "completed",
+          command: {
+            displayCommand: "print controls",
+            output: "keep\tthis\nreplace\u0000\u000b\u007fthese",
+          },
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy output" }));
+
+    expect(copyText).toHaveBeenCalledWith("keep\tthis\nreplace\uFFFD\uFFFD\uFFFDthese");
+  });
+
   it("shortens the displayed cwd without changing executable command text", () => {
     const copyText = vi.fn(async () => undefined);
     Object.defineProperty(window, "pwragent", {

--- a/packages/messaging/interface/src/__tests__/messaging-interface.test.ts
+++ b/packages/messaging/interface/src/__tests__/messaging-interface.test.ts
@@ -124,14 +124,14 @@ describe("messaging interface package", () => {
     // U+00A0 NO-BREAK SPACE — Telegram iOS / some clipboard pipelines
     // substitute this for a plain space when pasting. Before the
     // tokenizer learned to recognize Unicode whitespace, a paste like
-    // this would tokenize as one big "pair <token>" blob and
+    // this would tokenize as one big "pair <token>" blob and
     // `extractMessagingPairingToken` would return undefined — silently
     // dropping the operator's pairing attempt.
     const token = "123456789ABCDEFGHJKLMNPQRSTUVWXY";
-    expect(extractMessagingPairingToken(`pair ${token}`)).toBe(token);
-    expect(extractMessagingPairingToken(`pair ${token}`)).toBe(token);
-    expect(extractMessagingPairingToken(`pair ${token}`)).toBe(token);
-    expect(extractMessagingPairingToken(`pair　${token}`)).toBe(token);
+    expect(extractMessagingPairingToken(`pair\u00a0${token}`)).toBe(token);
+    expect(extractMessagingPairingToken(`pair\u202f${token}`)).toBe(token);
+    expect(extractMessagingPairingToken(`pair\u2009${token}`)).toBe(token);
+    expect(extractMessagingPairingToken(`pair\u3000${token}`)).toBe(token);
   });
 
   it("looksLikePairingAttempt routes typo'd / malformed tokens through", () => {

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -1306,7 +1306,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
    * with the server, so writes here take effect immediately.
    */
   private async reconcileSlashCommandsAcrossTeams(): Promise<void> {
-    let teams: Array<{ id: string; name?: string }> = [];
+    let teams: Array<{ id: string; name?: string }>;
     try {
       teams = (await this.client.getMyTeams()) as Array<{ id: string; name?: string }>;
     } catch (error) {

--- a/packages/messaging/providers/mattermost/src/mattermost-commands.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-commands.ts
@@ -315,7 +315,7 @@ export async function reconcileMattermostCommands(params: {
     desiredByTrigger.set(spec.trigger, spec);
   }
 
-  let existing: MattermostCommandRecord[] = [];
+  let existing: MattermostCommandRecord[];
   try {
     existing = await params.api.getCustomTeamCommands(params.teamId);
   } catch (error) {


### PR DESCRIPTION
## Summary

- reduce the existing ESLint warning baseline from 134 to 91 (43 warnings removed)
- remove unused imports, destructured values, and dead assignments
- convert eligible single-assignment bindings to `const` or stable refs where callbacks require deferred initialization
- remove redundant regular-expression escapes and represent intentional control-character filtering with equivalent character-code logic
- replace literal irregular Unicode whitespace in tests with explicit escapes
- add focused regression coverage for image paths, messaging attachment names, and command-output control-character sanitization

This is intentionally stacked on #1431 so the persistent content-based ESLint cache remains the base for follow-up cleanup.

## Deferred warnings

The remaining 91 warnings are the riskier baseline categories:

- 42 `react-hooks/exhaustive-deps` warnings
- 49 `@typescript-eslint/no-explicit-any` warnings

Those were left unchanged to avoid speculative lifecycle changes or broad type rewrites. This PR does not disable rules, loosen ESLint configuration, or add suppression comments.

## Validation

- `pnpm lint:eslint` — 0 errors, 91 warnings (down from 134)
- focused Vitest run — 20 files passed, 1,505 tests passed
- targeted profile/backend-registry rerun — 2 files passed, 529 tests passed
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
