### PR TITLE
fix(ci): materialize macOS Git LFS assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,6 +407,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         timeout-minutes: 10
+        with:
+          lfs: true
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
@@ -446,6 +448,15 @@ jobs:
         timeout-minutes: 10
         with:
           lfs: true
+
+      - name: Materialize Git LFS assets
+        # These jobs reuse persistent runner workspaces. A previous checkout
+        # can leave an LFS pointer at an unchanged path, and checkout --force
+        # does not necessarily rewrite it after fetching the LFS object.
+        # Pull explicitly so Playwright always receives PNG bytes rather than
+        # the pointer text, even when this runner served another job first.
+        timeout-minutes: 5
+        run: git lfs pull
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1


### PR DESCRIPTION
## Summary

- make the shared macOS dependency-setup checkout materialize Git LFS assets
- explicitly run `git lfs pull` after checkout in each macOS desktop E2E lane
- document why the explicit materialization is required on persistent runner workspaces

## Root cause

The self-hosted macOS jobs reuse persistent runner workspaces. `macos-install-deps` previously checked out the repository without LFS materialization, which could leave the tracked visual baseline as its 131-byte Git LFS pointer. A later `actions/checkout` invocation in the E2E matrix fetched the LFS object successfully, but `checkout --force` could leave the already-matching pointer path untouched.

Playwright then received pointer text at `todo-thread-shell-darwin.png` and failed with `Could not decode expected image as PNG`. The same failure occurred on `main` and unrelated pull requests, confirming it was workflow state rather than application code.

## Impact

Both macOS E2E lanes now re-materialize every LFS path after checkout regardless of which job previously used that persistent runner. The setup job also stops reintroducing unsmudged pointers into the shared workspace.

## Validation

- `git diff origin/main...HEAD --check`
- Ruby YAML parse of `.github/workflows/ci.yml`
- `git lfs version` — 3.6.0
- `git lfs pull`
