### PR TITLE
fix(desktop): clean up safe hook dependencies

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -818,6 +818,7 @@ function DesktopAppShell(props: {
     (Boolean(settings.snapshot) &&
       settings.snapshot?.onboarding?.completed.value !== false);
   const profiles = usePwrAgentProfiles(desktopApi);
+  const refreshProfiles = profiles.refresh;
   const runtimeIdentity = useRuntimeIdentity(desktopApi);
   const navigation = useThreadNavigation(desktopApi, {
     enabled: normalAppEnabled,
@@ -1253,11 +1254,11 @@ function DesktopAppShell(props: {
       return;
     }
     return desktopApi.onReplayOnboardingRequested(() => {
-      void profiles.refresh().finally(() => {
+      void refreshProfiles().finally(() => {
         setOnboardingOpen("replay");
       });
     });
-  }, [desktopApi, profiles.refresh]);
+  }, [desktopApi, refreshProfiles]);
   useEffect(() => {
     // Auto-launch on the first snapshot where `completed === false`.
     // `autoOpenSeen` blocks re-opens after the user dismissed without

--- a/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
@@ -365,7 +365,10 @@ export function AutomationEditor(props: AutomationEditorProps) {
   const selectedGroup = telegramGroups.find(
     (group) => group.id === groupSelection,
   );
-  const destGroups = providerGroups[destProvider] ?? [];
+  const destGroups = useMemo(
+    () => providerGroups[destProvider] ?? [],
+    [destProvider, providerGroups],
+  );
   const selectedDestGroup = destGroups.find(
     (group) => group.id === destGroupSelection,
   );

--- a/apps/desktop/src/renderer/src/features/composer/ReferencePicker.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ReferencePicker.tsx
@@ -82,6 +82,7 @@ function isPickableDirectory(directory: NavigationDirectorySummary): boolean {
 }
 
 export function ReferencePicker(props: ReferencePickerProps): ReactElement {
+  const { onClose, open } = props;
   const [tab, setTab] = useState<ReferencePickerTab>("projects");
   const [query, setQuery] = useState("");
   const [menuShift, setMenuShift] = useState(0);
@@ -91,17 +92,17 @@ export function ReferencePicker(props: ReferencePickerProps): ReactElement {
   const panelId = useId();
 
   useEffect(() => {
-    if (!props.open) {
+    if (!open) {
       return;
     }
     const onPointerDown = (event: PointerEvent) => {
       if (!containerRef.current?.contains(event.target as Node)) {
-        props.onClose();
+        onClose();
       }
     };
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        props.onClose();
+        onClose();
       }
     };
     document.addEventListener("pointerdown", onPointerDown);
@@ -110,7 +111,7 @@ export function ReferencePicker(props: ReferencePickerProps): ReactElement {
       document.removeEventListener("pointerdown", onPointerDown);
       document.removeEventListener("keydown", onKeyDown);
     };
-  }, [props.open, props.onClose]);
+  }, [onClose, open]);
 
   // The popover is anchored to the trigger, which sits near the right edge of
   // the composer toolbar — keep it inside the viewport by nudging it back in

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -153,8 +153,9 @@ export function useDurableComposerDraftStore(
   }, [baseStore, desktopApi]);
 
   useEffect(() => {
+    const pendingSaves = pendingSavesRef.current;
     return () => {
-      for (const [scopeKey, pending] of [...pendingSavesRef.current]) {
+      for (const [scopeKey, pending] of [...pendingSaves]) {
         flushPendingSave(scopeKey, pending);
       }
     };
@@ -233,7 +234,6 @@ export function useDurableComposerDraftStore(
       flushPendingSave,
       hydrationVersion,
       persistDraftHistory,
-      rememberLocalRecoveryCandidate,
     ],
   );
 }

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -49,6 +49,8 @@ export function AppNoticeToast(props: {
   const [paused, setPaused] = useState(false);
   const timeoutRef = useRef<number | undefined>(undefined);
   const onDismissRef = useRef(props.onDismiss);
+  const noticeId = props.notice?.id;
+  const noticePresent = props.notice !== undefined;
   const autoDismiss = props.notice?.autoDismiss !== false;
 
   useEffect(() => {
@@ -64,7 +66,7 @@ export function AppNoticeToast(props: {
   }, [props.notice?.id]);
 
   useEffect(() => {
-    if (!props.notice || !autoDismiss || paused) {
+    if (!noticePresent || !autoDismiss || paused) {
       return;
     }
 
@@ -79,7 +81,7 @@ export function AppNoticeToast(props: {
         timeoutRef.current = undefined;
       }
     };
-  }, [autoDismiss, paused, props.notice?.id]);
+  }, [autoDismiss, noticeId, noticePresent, paused]);
 
   if (!props.notice) {
     return null;

--- a/apps/desktop/src/renderer/src/features/notifications/MessagingErrorNotices.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/MessagingErrorNotices.tsx
@@ -26,6 +26,7 @@ export function MessagingErrorNotices(props: {
     notice: AppNoticeToastNotice | undefined,
   ) => void;
 }) {
+  const onNoticeChanged = props.onNoticeChanged;
   const [statusByPlatform, setStatusByPlatform] = useState(
     () => new Map<MessagingChannelKind, MessagingPlatformNoticeState>(),
   );
@@ -88,7 +89,7 @@ export function MessagingErrorNotices(props: {
   }
 
   useEffect(() => {
-    if (!props.onNoticeChanged) return;
+    if (!onNoticeChanged) return;
     for (const [platform, state] of statusByPlatform) {
       const noticeKey = state.notice
         ? messagingNoticePublicationKey(state.notice)
@@ -97,11 +98,11 @@ export function MessagingErrorNotices(props: {
         continue;
       }
       publishedNoticeKeysRef.current.set(platform, noticeKey);
-      props.onNoticeChanged(platform, state.notice);
+      onNoticeChanged(platform, state.notice);
     }
-  }, [props.onNoticeChanged, statusByPlatform]);
+  }, [onNoticeChanged, statusByPlatform]);
 
-  if (props.onNoticeChanged) return null;
+  if (onNoticeChanged) return null;
 
   return notices.map(({ notice, platform }) => (
     <AppNoticeToast

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -2285,13 +2285,13 @@ function PairingTokenField(props: {
     [],
   );
 
-  const refresh = async () => {
+  const refresh = useCallback(async () => {
     if (!props.desktopApi?.listMessagingPairingRequests) return;
     const result = await props.desktopApi.listMessagingPairingRequests({
       platform: props.platform,
     });
     setEntries(result.entries);
-  };
+  }, [props.desktopApi, props.platform]);
 
   useEffect(() => {
     void refresh();
@@ -2302,7 +2302,7 @@ function PairingTokenField(props: {
       }
       void refresh();
     });
-  }, [props.desktopApi, props.platform, setGeneratedMessage]);
+  }, [props.desktopApi, props.platform, refresh, setGeneratedMessage]);
 
   const selectScope = (nextScope: MessagingPairingScope) => {
     setScope(nextScope);

--- a/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
+++ b/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
@@ -158,7 +158,6 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
     }),
     [
       clearSecret,
-      desktopApi?.readSettings,
       error,
       loading,
       refresh,

--- a/apps/desktop/src/renderer/src/features/thread-detail/MarkdownFilesWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/MarkdownFilesWindow.tsx
@@ -21,6 +21,7 @@ export function MarkdownFilesWindow() {
   const selectedFile = snapshot?.files.find(
     (file) => file.path === snapshot.selectedPath,
   ) ?? snapshot?.files[0];
+  const selectedPath = selectedFile?.path;
   const markdownApplications = useMemo(
     () => applicationsSnapshotForEditor(snapshot),
     [snapshot],
@@ -75,13 +76,13 @@ export function MarkdownFilesWindow() {
 
   useEffect(() => {
     const reader = desktopApi?.readMarkdownFile;
-    if (!reader || !selectedFile) {
+    if (!reader || !selectedPath) {
       return;
     }
 
     let cancelled = false;
     setLoadState({ status: "loading" });
-    void reader({ path: selectedFile.path })
+    void reader({ path: selectedPath })
       .then((response) => {
         if (cancelled) return;
         if (response.error || response.content === undefined) {
@@ -104,7 +105,7 @@ export function MarkdownFilesWindow() {
     return () => {
       cancelled = true;
     };
-  }, [desktopApi, selectedFile?.path]);
+  }, [desktopApi, selectedPath]);
 
   const selectFile = useCallback(
     (file: MarkdownFileViewerFile) => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -706,6 +706,7 @@ function MarkdownDocumentModal(props: {
   skills?: AppServerSkillSummary[];
   target: MarkdownViewerTarget;
 }) {
+  const onClose = props.onClose;
   const contentRef = useRef<HTMLDivElement>(null);
   const [loadState, setLoadState] = useState<
     | { status: "loading" }
@@ -768,7 +769,7 @@ function MarkdownDocumentModal(props: {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
-        props.onClose();
+        onClose();
         return;
       }
 
@@ -801,7 +802,7 @@ function MarkdownDocumentModal(props: {
       window.removeEventListener("keydown", handleKeyDown, true);
       restoreFocus?.focus?.();
     };
-  }, [props.onClose]);
+  }, [onClose]);
 
   if (typeof document === "undefined") {
     return null;

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -1013,9 +1013,6 @@ export function TranscriptList(props: TranscriptListProps) {
       threadId: props.threadId
     };
   }, [
-    props.pendingRequest,
-    props.pendingMcpInteraction,
-    props.pendingUserInput,
     props.pendingStatusText,
     props.runningTurnUsageText,
     props.threadId,
@@ -1128,17 +1125,20 @@ export function TranscriptList(props: TranscriptListProps) {
     scrollToBottom();
   }, [props.reglueRequestKey, scrollToBottom]);
 
+  const onViewportChange = props.onViewportChange;
+  const viewportThreadId = props.threadId;
   useEffect(() => {
+    const savedViewports = savedViewportsRef.current;
     return () => {
-      if (!props.threadId) {
-        props.onViewportChange?.(undefined);
+      if (!viewportThreadId) {
+        onViewportChange?.(undefined);
         return;
       }
 
-      const viewport = savedViewportsRef.current.get(props.threadId);
-      props.onViewportChange?.(viewport);
+      const viewport = savedViewports.get(viewportThreadId);
+      onViewportChange?.(viewport);
     };
-  }, [props.onViewportChange, props.threadId]);
+  }, [onViewportChange, viewportThreadId]);
 
   useLayoutEffect(() => {
     const container = scrollContainerRef.current;

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -32,7 +32,7 @@ type SubAgentDetailsModalProps = {
  * final response, run timing, model, and token/pricing usage.
  */
 export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
-  const { subAgent } = props;
+  const { onClose, subAgent } = props;
   const contentRef = useRef<HTMLDivElement>(null);
   const desktopApi = useDesktopApi();
   const openSubAgentTranscriptWindow = desktopApi?.openSubAgentTranscriptWindow;
@@ -54,7 +54,7 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
-        props.onClose();
+        onClose();
         return;
       }
       if (event.key !== "Tab") {
@@ -84,7 +84,7 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
       window.removeEventListener("keydown", handleKeyDown, true);
       restoreFocus?.focus?.();
     };
-  }, [props.onClose]);
+  }, [onClose]);
 
   const tone = subAgentTone(subAgent.status);
   const usage = subAgent.monitorUsage;

--- a/apps/desktop/src/renderer/src/lib/useAppearance.ts
+++ b/apps/desktop/src/renderer/src/lib/useAppearance.ts
@@ -53,6 +53,8 @@ export type UseAppearanceInput = {
  */
 export function useAppearance(input: UseAppearanceInput): AppearanceController {
   const { snapshotPreference, writeConfig } = input;
+  const snapshotDensity = snapshotPreference?.density;
+  const snapshotTheme = snapshotPreference?.theme;
 
   const [appearance, setAppearanceState] = useState<AppearanceState>(() => {
     const initial = snapshotPreference ?? readBridgedAppearance();
@@ -67,20 +69,21 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
   // We compare by value to avoid stomping local in-flight writes that
   // haven't been re-read yet.
   useEffect(() => {
-    if (!snapshotPreference) return;
+    if (!snapshotDensity || !snapshotTheme) return;
     setAppearanceState((current) => {
       if (
-        current.theme === snapshotPreference.theme
-        && current.density === snapshotPreference.density
+        current.theme === snapshotTheme
+        && current.density === snapshotDensity
       ) {
         return current;
       }
       return {
-        ...snapshotPreference,
-        resolvedTheme: resolveTheme(snapshotPreference.theme),
+        density: snapshotDensity,
+        resolvedTheme: resolveTheme(snapshotTheme),
+        theme: snapshotTheme,
       };
     });
-  }, [snapshotPreference?.theme, snapshotPreference?.density]);
+  }, [snapshotDensity, snapshotTheme]);
 
   // Apply DOM attributes whenever the resolved appearance changes. No
   // localStorage cache to maintain — the source of truth is TOML, the


### PR DESCRIPTION
## Summary

- reduce `react-hooks/exhaustive-deps` warnings from 42 to 26
- fix 16 mechanically safe findings without suppressions, rule changes, or unrelated formatting
- keep complex composer, thread, and deliberate rerun behavior unchanged

## Behavioral reasoning

The fixes are limited to dependency changes with clear lifecycle semantics:

- memoize the automation destination-group fallback so its reconciliation effect does not rerun on a newly allocated empty array
- extract stable callback or primitive fields before effects so dependency arrays describe exactly what the closure reads
- preserve notice timer identity by depending on notice presence, id, and auto-dismiss state rather than the full notice object
- snapshot mutable map refs inside effects before cleanup
- remove dependencies that callbacks do not read
- wrap the pairing-request refresh function in `useCallback`
- adopt appearance snapshot fields through their existing narrow theme/density dependencies

No imports, ESLint configuration, rule severity, suppressions, or explicit-any findings were changed.

## Warning delta

- before: 42 `react-hooks/exhaustive-deps` warnings
- after: 26 `react-hooks/exhaustive-deps` warnings
- delta: -16

## Deferred cases

The remaining 26 warnings were left for targeted follow-up because changing them safely requires deeper behavioral coverage or because comments/code show deliberate rerun semantics:

- `Composer.tsx`: 12 — draft persistence, queued-turn submission, slash triggers, steer lifecycle, and scope changes
- `ComposerTiptapInput.tsx`: 3 — controlled editor state, undo history, markdown conversion, and selection synchronization
- `ThreadView.tsx`: 4 — branch-drift detection and selected-thread lifecycle
- `ThreadFindBar.tsx`: 2 — callbacks and match state are deliberately excluded to avoid restarting pagination/landing loops
- `LogsWindow.tsx`: 1 — `renderVersion` intentionally triggers recomputation after ref-backed buffer changes
- `useAutomations.ts`: 1 — request-key equality intentionally differs from request object identity
- `ThreadMarkdown.tsx`: 1 — renderer-component closure needs a broader structural pass
- `useThreadNavigation.ts`: 1 — navigation lifecycle/API identity
- `useThreadSessionState.ts`: 1 — thread hydration lifecycle/API identity

## Validation

- `pnpm test <11 affected renderer test files>` — 11 files, 283 tests passed
- `pnpm lint:eslint` — passed with zero errors; exhaustive-deps count verified at 26
- `pnpm typecheck` — passed
- `git diff --check` — passed
- dependency-boundary validation not run because the diff changes no imports
