### PR TITLE
test(desktop): reduce explicit-any lint warnings

### DIFF
--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -14,6 +14,7 @@ import type {
   CreateScheduledThreadActionRequest,
   DesktopPwrAgentProfileSummary,
   DesktopSettingsSnapshot,
+  NavigationSnapshot,
   StartTurnRequest,
   StartTurnResponse,
 } from "@pwragent/shared";
@@ -2556,7 +2557,7 @@ describe("App", () => {
         };
       }) => void
     >();
-    let navigationSnapshot: any = {
+    let navigationSnapshot: NavigationSnapshot = {
       backend: "all",
       fetchedAt: Date.now(),
       unchanged: false,
@@ -2739,7 +2740,7 @@ describe("App", () => {
         };
       }) => void
     >();
-    let navigationSnapshot: any = {
+    let navigationSnapshot: NavigationSnapshot = {
       backend: "all" as const,
       fetchedAt: Date.now(),
       unchanged: false,
@@ -3032,7 +3033,7 @@ describe("App", () => {
         };
       }) => void
     >();
-    let navigationSnapshot: any = {
+    let navigationSnapshot: NavigationSnapshot = {
       backend: "all" as const,
       fetchedAt: Date.now(),
       unchanged: false,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -4015,7 +4015,7 @@ describe("ThreadView", () => {
     let agentEventHandler: ((event: AgentEvent) => void) | undefined;
     const getThreadFileDiff = vi.fn(async () => ({ diff: liveDiff }));
 
-    const renderThread = (transcriptEntries: any[]) => (
+    const renderThread = (transcriptEntries: AppServerThreadEntry[]) => (
       <ThreadView
         addOptimisticUserMessage={(_text) => "optimistic-1"}
         backends={[]}
@@ -5840,7 +5840,7 @@ describe("ThreadView", () => {
       | undefined;
 
     function Harness() {
-      const [entries, setEntries] = useState<any[]>([]);
+      const [entries, setEntries] = useState<AppServerThreadEntry[]>([]);
 
       return (
         <ThreadView
@@ -6111,7 +6111,7 @@ describe("ThreadView", () => {
       // `activeTurnId` on `turn/completed` so the rail flips from
       // live → pinned. The Harness simulates that here.
       const [activeTurnId, setActiveTurnId] = useState<string | undefined>("turn-1");
-      const [entries, setEntries] = useState<any[]>([]);
+      const [entries, setEntries] = useState<AppServerThreadEntry[]>([]);
       return (
         <ThreadView
           activeTurnId={activeTurnId}
@@ -6242,7 +6242,7 @@ describe("ThreadView", () => {
 
     function Harness() {
       const [activeTurnId, setActiveTurnId] = useState<string | undefined>("turn-1");
-      const [entries, setEntries] = useState<any[]>([]);
+      const [entries, setEntries] = useState<AppServerThreadEntry[]>([]);
       return (
         <>
           <button type="button" onClick={() => setActiveTurnId("turn-2")}>
@@ -6363,7 +6363,7 @@ describe("ThreadView", () => {
     ].join("\n");
 
     function Harness() {
-      const [entries, setEntries] = useState<any[]>([]);
+      const [entries, setEntries] = useState<AppServerThreadEntry[]>([]);
       return (
         <ThreadView
           activeTurnId="turn-1"

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -931,7 +931,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("marks the selected thread seen again when a refresh advances it", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     const markThreadSeen = vi.fn(
       async (
         request: Parameters<NonNullable<DesktopApi["markThreadSeen"]>>[0]
@@ -1027,6 +1027,11 @@ describe("useThreadNavigation", () => {
             params: {
               threadId: "thread-other",
               turnId: "turn-other",
+              turn: {
+                id: "turn-other",
+                status: "completed",
+                output: [],
+              },
             },
           },
         });
@@ -1044,7 +1049,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("clears a selected-thread unread update when the seen write resolves after selecting away", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     const delayedSeen = createDeferred<{
       backend: "codex";
       threadId: string;
@@ -1154,6 +1159,11 @@ describe("useThreadNavigation", () => {
             params: {
               threadId: "thread-other",
               turnId: "turn-other",
+              turn: {
+                id: "turn-other",
+                status: "completed",
+                output: [],
+              },
             },
           },
         });
@@ -1190,7 +1200,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("keeps selected refreshes unread while the window is backgrounded", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     const markThreadSeen = vi.fn(
       async (
         request: Parameters<NonNullable<DesktopApi["markThreadSeen"]>>[0]
@@ -1291,6 +1301,11 @@ describe("useThreadNavigation", () => {
             params: {
               threadId: "thread-other",
               turnId: "turn-other",
+              turn: {
+                id: "turn-other",
+                status: "completed",
+                output: [],
+              },
             },
           },
         });
@@ -1308,7 +1323,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("keeps selected refreshes unread while the thread view is hidden", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     const markThreadSeen = vi.fn(
       async (
         request: Parameters<NonNullable<DesktopApi["markThreadSeen"]>>[0]
@@ -1414,6 +1429,11 @@ describe("useThreadNavigation", () => {
             params: {
               threadId: "thread-other",
               turnId: "turn-other",
+              turn: {
+                id: "turn-other",
+                status: "completed",
+                output: [],
+              },
             },
           },
         });
@@ -1495,7 +1515,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("coalesces repeated turn lifecycle notifications into one navigation refresh", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,
       fetchedAt: Date.now(),
@@ -1546,18 +1566,52 @@ describe("useThreadNavigation", () => {
 
     expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
 
+    const terminalNotifications: AgentEvent["notification"][] = [
+      {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+      {
+        method: "turn/failed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "failed",
+            error: {
+              message: "Turn failed",
+            },
+          },
+        },
+      },
+      {
+        method: "turn/cancelled",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "cancelled",
+          },
+        },
+      },
+    ];
+
     await act(async () => {
-      for (const method of ["turn/completed", "turn/failed", "turn/cancelled"] as const) {
+      for (const notification of terminalNotifications) {
         for (const listener of listeners) {
           listener({
             backend: "codex",
-            notification: {
-              method,
-              params: {
-                threadId: "thread-1",
-                turnId: "turn-1",
-              },
-            },
+            notification,
           });
         }
       }
@@ -2143,7 +2197,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("does not move selection to another thread when refresh temporarily drops the selected thread", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     let includeSelectedThread = true;
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,
@@ -2220,6 +2274,11 @@ describe("useThreadNavigation", () => {
             params: {
               threadId: "thread-1",
               turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
             },
           },
         });
@@ -7935,7 +7994,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("refreshes the selected thread when only the observed branch changes", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     let navigationCallCount = 0;
     const getNavigationSnapshot = vi.fn(async () => {
       navigationCallCount += 1;
@@ -7995,6 +8054,11 @@ describe("useThreadNavigation", () => {
             params: {
               threadId: "thread-1",
               turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
             },
           },
         });
@@ -8010,7 +8074,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("refreshes the selected thread when only reactions change", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     let navigationCallCount = 0;
     const getNavigationSnapshot = vi.fn(async () => {
       navigationCallCount += 1;
@@ -8070,6 +8134,11 @@ describe("useThreadNavigation", () => {
             params: {
               threadId: "019e0755-ac96-7be2-a94d-78a6912eccb6",
               turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
             },
           },
         });
@@ -8082,7 +8151,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("refreshes the selected thread when review sub-agents change", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     let navigationCallCount = 0;
     const getNavigationSnapshot = vi.fn(async () => {
       navigationCallCount += 1;
@@ -8228,7 +8297,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("patches the snapshot for thread/executionMode/updated without refetching", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,
       fetchedAt: Date.now(),
@@ -8298,7 +8367,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("applies pull request update notification payloads before unchanged refreshes", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     const initialPr: PrSummary = {
       provider: "github.com",
       number: 123,
@@ -8386,7 +8455,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("fans out pull request status updates to every visible matching PR key", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     const initialPr: PrSummary = {
       provider: "github.com",
       number: 255,
@@ -8520,7 +8589,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("patches the snapshot for thread/executionMode/queued and queueCleared", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     let navigationSnapshot: NavigationSnapshot = {
       backend: "all" as const,
       fetchedAt: Date.now(),
@@ -8656,7 +8725,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("patches the snapshot for thread/modelSettings/updated without refetching", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,
       fetchedAt: Date.now(),
@@ -9003,7 +9072,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("patches the snapshot for thread/codexEnvironment/updated without refetching", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,
       fetchedAt: Date.now(),
@@ -9086,7 +9155,7 @@ describe("useThreadNavigation", () => {
   });
 
   it("refreshes the snapshot when thread directory metadata is repaired", async () => {
-    const listeners = new Set<(event: any) => void>();
+    const listeners = new Set<(event: AgentEvent) => void>();
     let navigationSnapshot: NavigationSnapshot = {
       backend: "all",
       fetchedAt: Date.now(),

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -8,6 +8,7 @@ import type {
   AppServerThreadEntry,
   AppServerThreadMessage,
   AppServerThreadMessageEntry,
+  NavigationThreadSummary,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -24,7 +25,7 @@ import { readRendererSequence } from "../../features/thread-detail/live-transcri
 function buildThread(params: {
   id: string;
   updatedAt: number;
-}): any {
+}): NavigationThreadSummary {
   return {
     id: params.id,
     title: `Thread ${params.id}`,
@@ -5582,7 +5583,7 @@ describe("useThreadSessionState", () => {
                 modelContextWindow: 258400,
               },
             },
-          } as any,
+          },
         });
         listener({
           backend: "codex",
@@ -5594,7 +5595,7 @@ describe("useThreadSessionState", () => {
                 planType: "pro",
               },
             },
-          } as any,
+          },
         });
         listener({
           backend: "codex",
@@ -5606,7 +5607,7 @@ describe("useThreadSessionState", () => {
               itemId: "call-1",
               delta: "To github.com:pwrdrvr/PwrAgent.git\n",
             },
-          } as any,
+          },
         });
       }
     });
@@ -6101,7 +6102,7 @@ describe("useThreadSessionState", () => {
               },
             },
           },
-        } as any,
+        },
       });
     });
 
@@ -7149,7 +7150,7 @@ describe("useThreadSessionState", () => {
               },
             },
           },
-        } as any);
+        });
       }
     });
 
@@ -7211,6 +7212,13 @@ describe("useThreadSessionState", () => {
 
     await waitForThreadHydration(result);
 
+    const commandItem = {
+      id: "tool-2",
+      type: "commandExecution",
+      command: "pnpm test",
+      status: "inProgress",
+    };
+
     act(() => {
       for (const listener of agentEventListeners) {
         listener({
@@ -7220,15 +7228,10 @@ describe("useThreadSessionState", () => {
             params: {
               threadId: "thread-2",
               turnId: "turn-2",
-              item: {
-                id: "tool-2",
-                type: "commandExecution",
-                command: "pnpm test",
-                status: "inProgress",
-              },
+              item: commandItem,
             },
           },
-        } as any);
+        });
       }
     });
 
@@ -7271,6 +7274,13 @@ describe("useThreadSessionState", () => {
 
     await waitForThreadHydration(result);
 
+    const commandItem = {
+      id: "tool-2",
+      type: "commandExecution",
+      command: "pnpm test",
+      status: "inProgress",
+    };
+
     act(() => {
       for (const listener of agentEventListeners) {
         listener({
@@ -7280,15 +7290,10 @@ describe("useThreadSessionState", () => {
             params: {
               threadId: "thread-2",
               turnId: "turn-2",
-              item: {
-                id: "tool-2",
-                type: "commandExecution",
-                command: "pnpm test",
-                status: "inProgress",
-              },
+              item: commandItem,
             },
           },
-        } as any);
+        });
       }
     });
 
@@ -7375,7 +7380,7 @@ describe("useThreadSessionState", () => {
                 status: "in_progress",
               },
             },
-          } as any,
+          },
         });
       }
     });
@@ -7548,7 +7553,7 @@ describe("useThreadSessionState", () => {
     const event = {
       backend: "codex" as const,
       notification: {
-        method: "item/started",
+        method: "item/started" as const,
         params: {
           threadId: "thread-1",
           turnId: "turn-1",
@@ -7564,7 +7569,7 @@ describe("useThreadSessionState", () => {
 
     act(() => {
       for (const listener of agentEventListeners) {
-        listener(event as any);
+        listener(event);
       }
     });
 
@@ -7574,7 +7579,7 @@ describe("useThreadSessionState", () => {
 
     act(() => {
       for (const listener of agentEventListeners) {
-        listener(event as any);
+        listener(event);
       }
     });
 
@@ -7622,7 +7627,7 @@ describe("useThreadSessionState", () => {
     const event = {
       backend: "codex" as const,
       notification: {
-        method: "item/started",
+        method: "item/started" as const,
         params: {
           threadId: "thread-1",
           turnId: "turn-1",
@@ -7638,7 +7643,7 @@ describe("useThreadSessionState", () => {
 
     act(() => {
       for (const listener of agentEventListeners) {
-        listener(event as any);
+        listener(event);
       }
     });
 
@@ -7648,7 +7653,7 @@ describe("useThreadSessionState", () => {
 
     act(() => {
       for (const listener of agentEventListeners) {
-        listener(event as any);
+        listener(event);
       }
     });
 
@@ -7705,7 +7710,7 @@ describe("useThreadSessionState", () => {
                 status: "in_progress",
               },
             },
-          } as any,
+          },
         });
       }
     });
@@ -7728,7 +7733,7 @@ describe("useThreadSessionState", () => {
               },
             },
           },
-        } as any);
+        });
       }
     });
 
@@ -7750,7 +7755,7 @@ describe("useThreadSessionState", () => {
               },
             },
           },
-        } as any);
+        });
       }
     });
 
@@ -7808,7 +7813,7 @@ describe("useThreadSessionState", () => {
                 status: "in_progress",
               },
             },
-          } as any,
+          },
         });
       }
     });
@@ -7833,7 +7838,7 @@ describe("useThreadSessionState", () => {
                 },
               },
             },
-          } as any,
+          },
         });
       }
     });
@@ -7897,7 +7902,7 @@ describe("useThreadSessionState", () => {
               reason: "Network access is required.",
               command: "npm view dive",
             },
-          } as any,
+          },
         });
       }
     });
@@ -7966,7 +7971,7 @@ describe("useThreadSessionState", () => {
                 type: "full-access",
               },
             },
-          } as any,
+          },
         });
       }
     });
@@ -8041,7 +8046,7 @@ describe("useThreadSessionState", () => {
                 },
               ],
             },
-          } as any,
+          },
         });
       }
     });
@@ -8218,7 +8223,7 @@ describe("useThreadSessionState", () => {
                 },
               ],
             },
-          } as any,
+          },
         });
       }
     });
@@ -9219,7 +9224,7 @@ describe("useThreadSessionState", () => {
             reason: "Network access is required.",
             command: "npm view dive",
           },
-        } as any,
+        },
       });
     });
 


### PR DESCRIPTION
## Summary

- replace broad test fixture `any` types with existing `NavigationSnapshot`, `NavigationThreadSummary`, `AppServerThreadEntry`, and `AgentEvent` contracts
- make terminal lifecycle fixtures contract-complete and preserve command-item fixture inference without changing runtime behavior
- reduce `@typescript-eslint/no-explicit-any` warnings from **49 to 2** (47 warnings removed)

## Deferred cases

Two warnings remain in `useThreadNavigation.test.tsx`:

- `navigation/directoryGitStatus/updated`
- `navigation/threadGitWorkingState/updated`

Those notification contracts exist separately in the shared navigation contracts but are not currently members of the `AgentEvent` / `AppServerNotification` union. This PR deliberately does not widen production contracts or add assertions that would hide that mismatch.

## Impact

Test-only typing cleanup. No runtime behavior or public API changes.

## Validation

- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx` — 314 passed
- `pnpm lint:eslint` — 0 errors; explicit-any warnings 49 → 2
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`