### PR TITLE
fix(desktop): send navigation snapshot deltas

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2137,6 +2137,47 @@ describe("app server ipc", () => {
     });
   });
 
+  it("keeps renderer delta transport opt-in at the navigation IPC boundary", async () => {
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const once = vi.fn();
+    const event = {
+      sender: {
+        id: 42,
+        once,
+      },
+    };
+    registerAppServerIpcHandlers();
+    const handler = handlers.get(NAVIGATION_SNAPSHOT_CHANNEL);
+
+    const first = await handler?.(event, {
+      transport: { protocol: 1 },
+    }) as { kind: string; revision: string };
+    const second = await handler?.(event, {
+      transport: {
+        protocol: 1,
+        baseRevision: first.revision,
+      },
+    }) as { kind: string; revision: string };
+    const third = await handler?.(event, {
+      transport: {
+        protocol: 1,
+        baseRevision: second.revision,
+      },
+    });
+
+    expect(first.kind).toBe("full");
+    expect(second).toMatchObject({
+      kind: "delta",
+      upsertedThreads: [],
+    });
+    expect(third).toEqual({
+      kind: "unchanged",
+      revision: second.revision,
+    });
+    expect(once).toHaveBeenCalledWith("destroyed", expect.any(Function));
+    expect(once).toHaveBeenCalledTimes(1);
+  });
+
   it("removes a viewer-side remote pin when the owner proves it is archived", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");

--- a/apps/desktop/src/main/__tests__/navigation-snapshot-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/navigation-snapshot-transport.test.ts
@@ -156,4 +156,41 @@ describe("NavigationSnapshotTransport", () => {
       snapshot,
     }).kind).toBe("full");
   });
+
+  it("retains independent revisions for full and active-recent scopes", () => {
+    const transport = new NavigationSnapshotTransport();
+    const snapshot = buildSnapshot([buildThread(1)]);
+    const full = transport.encode({
+      rendererId: 11,
+      request: {},
+      snapshot,
+    });
+    const activeRecent = transport.encode({
+      rendererId: 11,
+      request: { refreshMode: "active-recent" },
+      snapshot,
+    });
+    if (full.kind !== "full" || activeRecent.kind !== "full") {
+      throw new Error("Expected independent full baselines");
+    }
+
+    expect(transport.encode({
+      baseRevision: full.revision,
+      rendererId: 11,
+      request: { refreshMode: "full" },
+      snapshot,
+    })).toEqual({
+      kind: "unchanged",
+      revision: full.revision,
+    });
+    expect(transport.encode({
+      baseRevision: activeRecent.revision,
+      rendererId: 11,
+      request: { refreshMode: "active-recent" },
+      snapshot,
+    })).toEqual({
+      kind: "unchanged",
+      revision: activeRecent.revision,
+    });
+  });
 });

--- a/apps/desktop/src/main/__tests__/navigation-snapshot-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/navigation-snapshot-transport.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import type {
+  NavigationSnapshot,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import { buildThreadIdentityKey } from "@pwragent/shared";
+import { NavigationSnapshotTransport } from "../navigation-snapshot-transport";
+
+function buildThread(index: number): NavigationThreadSummary {
+  return {
+    id: `thread-${index}`,
+    title: `Thread ${index}`,
+    titleSource: "explicit",
+    linkedDirectories: [],
+    source: "codex",
+    inbox: { inInbox: true, reason: "new-thread" },
+    createdAt: index,
+    updatedAt: index,
+  };
+}
+
+function buildSnapshot(
+  threads: NavigationThreadSummary[],
+  fetchedAt = 1,
+): NavigationSnapshot {
+  return {
+    backend: "all",
+    fetchedAt,
+    unchanged: false,
+    threads,
+    inboxThreadKeys: threads.map((thread) =>
+      buildThreadIdentityKey(thread.source, thread.id),
+    ),
+    directories: [],
+    launchpadDefaults: {
+      backend: "codex",
+      executionMode: "default",
+    },
+  };
+}
+
+describe("NavigationSnapshotTransport", () => {
+  it("reduces an unchanged 1,200-thread refresh to a revision acknowledgement", () => {
+    const transport = new NavigationSnapshotTransport();
+    const threads = Array.from({ length: 1_200 }, (_, index) =>
+      buildThread(index),
+    );
+    const full = transport.encode({
+      rendererId: 7,
+      request: {},
+      snapshot: buildSnapshot(threads),
+    });
+
+    expect(full.kind).toBe("full");
+    if (full.kind !== "full") {
+      throw new Error("Expected initial full snapshot");
+    }
+
+    const unchanged = transport.encode({
+      baseRevision: full.revision,
+      rendererId: 7,
+      request: {},
+      snapshot: buildSnapshot(threads, 2),
+    });
+
+    expect(unchanged).toEqual({
+      kind: "unchanged",
+      revision: full.revision,
+    });
+    expect(JSON.stringify(unchanged).length).toBeLessThan(
+      JSON.stringify(full).length / 1_000,
+    );
+  });
+
+  it("sends only changed thread rows until identities or order change", () => {
+    const transport = new NavigationSnapshotTransport();
+    const threads = Array.from({ length: 1_200 }, (_, index) =>
+      buildThread(index),
+    );
+    const full = transport.encode({
+      rendererId: 8,
+      request: {},
+      snapshot: buildSnapshot(threads),
+    });
+    if (full.kind !== "full") {
+      throw new Error("Expected initial full snapshot");
+    }
+    const updatedThreads = threads.map((thread, index) =>
+      index < 10
+        ? { ...thread, title: `${thread.title} updated`, updatedAt: 2_000 + index }
+        : thread,
+    );
+
+    const updated = transport.encode({
+      baseRevision: full.revision,
+      rendererId: 8,
+      request: {},
+      snapshot: buildSnapshot(updatedThreads, 2),
+    });
+
+    expect(updated.kind).toBe("delta");
+    if (updated.kind !== "delta") {
+      throw new Error("Expected delta snapshot");
+    }
+    expect(updated.upsertedThreads).toHaveLength(10);
+    expect(updated.removedThreadKeys).toEqual([]);
+    expect(updated.threadKeys).toBeUndefined();
+
+    const remainingThreads = updatedThreads.slice(5);
+    const removed = transport.encode({
+      baseRevision: updated.revision,
+      rendererId: 8,
+      request: {},
+      snapshot: buildSnapshot(remainingThreads, 3),
+    });
+
+    expect(removed.kind).toBe("delta");
+    if (removed.kind !== "delta") {
+      throw new Error("Expected delta snapshot");
+    }
+    expect(removed.removedThreadKeys).toEqual(
+      updatedThreads.slice(0, 5).map((thread) =>
+        buildThreadIdentityKey(thread.source, thread.id),
+      ),
+    );
+    expect(removed.upsertedThreads).toEqual([]);
+    expect(removed.threadKeys).toBeUndefined();
+    expect(removed.removedInboxThreadKeys).toEqual(
+      removed.removedThreadKeys,
+    );
+    expect(removed.inboxThreadKeys).toBeUndefined();
+  });
+
+  it("sends a full baseline for a stale revision or another renderer", () => {
+    const transport = new NavigationSnapshotTransport();
+    const snapshot = buildSnapshot([buildThread(1)]);
+    const first = transport.encode({
+      rendererId: 9,
+      request: {},
+      snapshot,
+    });
+    if (first.kind !== "full") {
+      throw new Error("Expected initial full snapshot");
+    }
+
+    expect(transport.encode({
+      baseRevision: "stale",
+      rendererId: 9,
+      request: {},
+      snapshot,
+    }).kind).toBe("full");
+    expect(transport.encode({
+      baseRevision: first.revision,
+      rendererId: 10,
+      request: {},
+      snapshot,
+    }).kind).toBe("full");
+  });
+});

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -52,6 +52,7 @@ import {
   type FocusedDiffAnalysisRequest,
   type FocusedDiffAnalysisResponse,
   type GetNavigationSnapshotRequest,
+  type GetNavigationSnapshotTransportRequest,
   type HandoffThreadWorkspaceRequest,
   type HandoffThreadWorkspaceResponse,
   type GetGhStatusRequest,
@@ -88,6 +89,7 @@ import {
   type NavigationDirectoryGitStatusUpdatedNotification,
   type NavigationThreadGitWorkingStateUpdatedNotification,
   type NavigationSnapshot,
+  type NavigationSnapshotTransportResponse,
   type NavigationThreadSummary,
   type AutomationThreadSummary,
   type PrSummary,
@@ -155,6 +157,7 @@ import {
   type UpdateSubthreadOrderResponse,
   type PwrAgentThreadInspectionResponse,
 } from "@pwragent/shared";
+import { NavigationSnapshotTransport } from "../navigation-snapshot-transport";
 import {
   DEFAULT_BACKGROUND_PR_POLLING,
   DEFAULT_PR_AUTO_DISPATCH_ALLOWED,
@@ -7144,6 +7147,8 @@ const GIT_MUTATION_COMMAND =
   /(?:^|[;&|]\s*)git\s+(?:-{1,2}[\w-]+(?:[= ]\S+)?\s+)*(?:commit|merge|rebase|reset|revert|stash|checkout|switch|restore|cherry-pick|pull|push|am|apply|clean)\b/;
 
 const appServerService = new DesktopAppServerService();
+const navigationSnapshotTransport = new NavigationSnapshotTransport();
+const navigationSnapshotTransportCleanupSenderIds = new Set<number>();
 
 /** Sender ids that already have a destroyed-listener reaping their PR focus. */
 const prPollingFocusCleanupSenderIds = new Set<number>();
@@ -7394,15 +7399,42 @@ export function registerAppServerIpcHandlers(): void {
   ipcMain.handle(
     NAVIGATION_SNAPSHOT_CHANNEL,
     async (
-      _event,
-      request?: GetNavigationSnapshotRequest,
-    ): Promise<NavigationSnapshot> => {
+      event,
+      request?:
+        | GetNavigationSnapshotRequest
+        | GetNavigationSnapshotTransportRequest,
+    ): Promise<NavigationSnapshot | NavigationSnapshotTransportResponse> => {
+      const transportRequest =
+        request && "transport" in request ? request : undefined;
       return await timeStartupProfileOperation({
         type: "ipc-main:getNavigationSnapshot",
         detail: {
           forceRefresh: Boolean(request?.forceRefresh),
+          transport: transportRequest?.transport.protocol ?? null,
         },
-        operation: async () => await appServerService.getNavigationSnapshot(request),
+        operation: async () => {
+          if (!transportRequest) {
+            return await appServerService.getNavigationSnapshot(request);
+          }
+          const { transport, ...snapshotRequest } = transportRequest;
+          const snapshot = await appServerService.getNavigationSnapshot(
+            snapshotRequest,
+          );
+          const rendererId = event.sender.id;
+          if (!navigationSnapshotTransportCleanupSenderIds.has(rendererId)) {
+            navigationSnapshotTransportCleanupSenderIds.add(rendererId);
+            event.sender.once("destroyed", () => {
+              navigationSnapshotTransport.clearRenderer(rendererId);
+              navigationSnapshotTransportCleanupSenderIds.delete(rendererId);
+            });
+          }
+          return navigationSnapshotTransport.encode({
+            baseRevision: transport.baseRevision,
+            rendererId,
+            request: snapshotRequest,
+            snapshot,
+          });
+        },
       });
     },
   );
@@ -8061,6 +8093,8 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL);
   unsubscribeWorkingStateEvents?.();
   unsubscribeWorkingStateEvents = undefined;
+  navigationSnapshotTransport.clear();
+  navigationSnapshotTransportCleanupSenderIds.clear();
   const registry = getExistingDesktopBackendRegistry();
   registry?.setThreadPullRequestStatusToolHandler(undefined);
   registry?.setThreadPullRequestCanonicalizer(undefined);

--- a/apps/desktop/src/main/navigation-snapshot-transport.ts
+++ b/apps/desktop/src/main/navigation-snapshot-transport.ts
@@ -7,23 +7,15 @@ import type {
   NavigationSnapshotTransportResponse,
   NavigationThreadSummary,
 } from "@pwragent/shared";
-import { buildThreadIdentityKey } from "@pwragent/shared";
+import {
+  buildNavigationSnapshotTransportScopeKey,
+  buildThreadIdentityKey,
+} from "@pwragent/shared";
 
 type CachedNavigationSnapshot = {
   revision: string;
   snapshot: NavigationSnapshot;
 };
-
-function navigationSnapshotScopeKey(
-  request: GetNavigationSnapshotRequest,
-): string {
-  return JSON.stringify({
-    backend: request.backend ?? "all",
-    federationTarget: request.federationTarget ?? { scope: "local" },
-    filter: request.filter ?? "",
-    refreshMode: request.refreshMode ?? "full",
-  });
-}
 
 function threadKey(thread: NavigationThreadSummary): string {
   return buildThreadIdentityKey(thread.source, thread.id);
@@ -190,7 +182,7 @@ export class NavigationSnapshotTransport {
     request: GetNavigationSnapshotRequest;
     snapshot: NavigationSnapshot;
   }): NavigationSnapshotTransportResponse {
-    const scopeKey = navigationSnapshotScopeKey(params.request);
+    const scopeKey = buildNavigationSnapshotTransportScopeKey(params.request);
     const rendererSnapshots =
       this.snapshotsByRenderer.get(params.rendererId) ?? new Map();
     this.snapshotsByRenderer.set(params.rendererId, rendererSnapshots);

--- a/apps/desktop/src/main/navigation-snapshot-transport.ts
+++ b/apps/desktop/src/main/navigation-snapshot-transport.ts
@@ -1,0 +1,247 @@
+import { isDeepStrictEqual } from "node:util";
+import type {
+  GetNavigationSnapshotRequest,
+  NavigationDirectorySummary,
+  NavigationSnapshot,
+  NavigationSnapshotTransportDelta,
+  NavigationSnapshotTransportResponse,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import { buildThreadIdentityKey } from "@pwragent/shared";
+
+type CachedNavigationSnapshot = {
+  revision: string;
+  snapshot: NavigationSnapshot;
+};
+
+function navigationSnapshotScopeKey(
+  request: GetNavigationSnapshotRequest,
+): string {
+  return JSON.stringify({
+    backend: request.backend ?? "all",
+    federationTarget: request.federationTarget ?? { scope: "local" },
+    filter: request.filter ?? "",
+    refreshMode: request.refreshMode ?? "full",
+  });
+}
+
+function threadKey(thread: NavigationThreadSummary): string {
+  return buildThreadIdentityKey(thread.source, thread.id);
+}
+
+function keysEqual(left: string[], right: string[]): boolean {
+  return left.length === right.length
+    && left.every((key, index) => key === right[index]);
+}
+
+function buildKeySequenceChanges(
+  currentKeys: string[],
+  previousKeys: string[],
+): {
+  addedKeys: string[];
+  changed: boolean;
+  order?: string[];
+  removedKeys: string[];
+} {
+  const previousKeySet = new Set(previousKeys);
+  const currentKeySet = new Set(currentKeys);
+  const removedKeys = previousKeys.filter((key) => !currentKeySet.has(key));
+  const addedKeys = currentKeys.filter((key) => !previousKeySet.has(key));
+  const implicitOrder = [
+    ...previousKeys.filter((key) => currentKeySet.has(key)),
+    ...addedKeys,
+  ];
+  return {
+    addedKeys,
+    changed: !keysEqual(currentKeys, previousKeys),
+    ...(!keysEqual(currentKeys, implicitOrder) ? { order: currentKeys } : {}),
+    removedKeys,
+  };
+}
+
+function buildKeyedChanges<T>(params: {
+  current: T[];
+  key: (value: T) => string;
+  previous: T[];
+}): {
+  currentKeys: string[];
+  removedKeys: string[];
+  upserted: T[];
+} {
+  const previousByKey = new Map(
+    params.previous.map((value) => [params.key(value), value]),
+  );
+  const currentKeys = params.current.map(params.key);
+  const currentKeySet = new Set(currentKeys);
+  return {
+    currentKeys,
+    removedKeys: params.previous
+      .map(params.key)
+      .filter((key) => !currentKeySet.has(key)),
+    upserted: params.current.filter((value) => {
+      const previous = previousByKey.get(params.key(value));
+      return previous === undefined || !isDeepStrictEqual(previous, value);
+    }),
+  };
+}
+
+function buildDelta(params: {
+  baseRevision: string;
+  current: NavigationSnapshot;
+  previous: NavigationSnapshot;
+  revision: string;
+}): NavigationSnapshotTransportDelta | undefined {
+  const threadChanges = buildKeyedChanges({
+    current: params.current.threads,
+    key: threadKey,
+    previous: params.previous.threads,
+  });
+  const previousThreadKeys = params.previous.threads.map(threadKey);
+  const directoryChanges = buildKeyedChanges<NavigationDirectorySummary>({
+    current: params.current.directories,
+    key: (directory) => directory.key,
+    previous: params.previous.directories,
+  });
+  const previousDirectoryKeys = params.previous.directories.map(
+    (directory) => directory.key,
+  );
+  const inboxChanges = buildKeySequenceChanges(
+    params.current.inboxThreadKeys,
+    params.previous.inboxThreadKeys,
+  );
+  const launchpadDefaultsChanged = !isDeepStrictEqual(
+    params.current.launchpadDefaults,
+    params.previous.launchpadDefaults,
+  );
+  const threadOrderChanges = buildKeySequenceChanges(
+    threadChanges.currentKeys,
+    previousThreadKeys,
+  );
+  const directoryOrderChanges = buildKeySequenceChanges(
+    directoryChanges.currentKeys,
+    previousDirectoryKeys,
+  );
+  const changed =
+    threadChanges.removedKeys.length > 0
+    || threadChanges.upserted.length > 0
+    || threadOrderChanges.changed
+    || directoryChanges.removedKeys.length > 0
+    || directoryChanges.upserted.length > 0
+    || directoryOrderChanges.changed
+    || inboxChanges.changed
+    || launchpadDefaultsChanged;
+  if (!changed) {
+    return undefined;
+  }
+
+  return {
+    kind: "delta",
+    baseRevision: params.baseRevision,
+    revision: params.revision,
+    fetchedAt: params.current.fetchedAt,
+    removedThreadKeys: threadChanges.removedKeys,
+    upsertedThreads: threadChanges.upserted,
+    ...(threadOrderChanges.order
+      ? { threadKeys: threadOrderChanges.order }
+      : {}),
+    removedDirectoryKeys: directoryChanges.removedKeys,
+    upsertedDirectories: directoryChanges.upserted,
+    ...(directoryOrderChanges.order
+      ? { directoryKeys: directoryOrderChanges.order }
+      : {}),
+    ...(inboxChanges.addedKeys.length > 0
+      ? { addedInboxThreadKeys: inboxChanges.addedKeys }
+      : {}),
+    ...(inboxChanges.removedKeys.length > 0
+      ? { removedInboxThreadKeys: inboxChanges.removedKeys }
+      : {}),
+    ...(inboxChanges.order
+      ? { inboxThreadKeys: inboxChanges.order }
+      : {}),
+    ...(launchpadDefaultsChanged
+      ? { launchpadDefaults: params.current.launchpadDefaults }
+      : {}),
+  };
+}
+
+/**
+ * Per-renderer revision cache for the Electron IPC boundary. The app-server
+ * service still builds and returns complete snapshots to every internal
+ * caller; only renderer clients that opt into protocol 1 receive deltas.
+ */
+export class NavigationSnapshotTransport {
+  private nextRevision = 0;
+  private readonly snapshotsByRenderer = new Map<
+    number,
+    Map<string, CachedNavigationSnapshot>
+  >();
+
+  clearRenderer(rendererId: number): void {
+    this.snapshotsByRenderer.delete(rendererId);
+  }
+
+  clear(): void {
+    this.snapshotsByRenderer.clear();
+  }
+
+  encode(params: {
+    baseRevision?: string;
+    rendererId: number;
+    request: GetNavigationSnapshotRequest;
+    snapshot: NavigationSnapshot;
+  }): NavigationSnapshotTransportResponse {
+    const scopeKey = navigationSnapshotScopeKey(params.request);
+    const rendererSnapshots =
+      this.snapshotsByRenderer.get(params.rendererId) ?? new Map();
+    this.snapshotsByRenderer.set(params.rendererId, rendererSnapshots);
+    const cached = rendererSnapshots.get(scopeKey);
+
+    if (
+      !cached
+      || params.baseRevision !== cached.revision
+      || params.snapshot.backend !== cached.snapshot.backend
+      || !isDeepStrictEqual(
+        params.snapshot.federationTarget,
+        cached.snapshot.federationTarget,
+      )
+    ) {
+      const revision = String(++this.nextRevision);
+      rendererSnapshots.set(scopeKey, {
+        revision,
+        snapshot: params.snapshot,
+      });
+      return {
+        kind: "full",
+        revision,
+        // `unchanged` is global overlay-store history, not proof that this
+        // renderer already owns the baseline. A recovery full must apply.
+        snapshot: { ...params.snapshot, unchanged: false },
+      };
+    }
+
+    const revision = String(this.nextRevision + 1);
+    const delta = buildDelta({
+      baseRevision: cached.revision,
+      current: params.snapshot,
+      previous: cached.snapshot,
+      revision,
+    });
+    if (!delta) {
+      rendererSnapshots.set(scopeKey, {
+        revision: cached.revision,
+        snapshot: params.snapshot,
+      });
+      return {
+        kind: "unchanged",
+        revision: cached.revision,
+      };
+    }
+
+    this.nextRevision += 1;
+    rendererSnapshots.set(scopeKey, {
+      revision,
+      snapshot: params.snapshot,
+    });
+    return delta;
+  }
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -87,6 +87,7 @@ import type {
   CodexEnvironmentSetupProgressEvent,
   CreateAutomationRequest,
   GetNavigationSnapshotRequest,
+  GetNavigationSnapshotTransportRequest,
   HandoffThreadWorkspaceRequest,
   HandoffThreadWorkspaceResponse,
   ListAcpAgentSettingsRequest,
@@ -202,6 +203,7 @@ import type {
   GetWorktreeUnpublishedCommitDiffRequest,
   GetWorktreeUnpublishedCommitDiffResponse,
   NavigationSnapshot,
+  NavigationSnapshotTransportResponse,
   ResetDirectoryLaunchpadRequest,
   ResetDirectoryLaunchpadResponse,
   RetainThreadBranchDriftRequest,
@@ -1453,6 +1455,14 @@ const desktopApi = Object.freeze({
   ): Promise<NavigationSnapshot> =>
     await invokeWithStartupProfileTiming(
       "getNavigationSnapshot",
+      NAVIGATION_SNAPSHOT_CHANNEL,
+      request,
+    ),
+  getNavigationSnapshotTransport: async (
+    request: GetNavigationSnapshotTransportRequest,
+  ): Promise<NavigationSnapshotTransportResponse> =>
+    await invokeWithStartupProfileTiming(
+      "getNavigationSnapshotTransport",
       NAVIGATION_SNAPSHOT_CHANNEL,
       request,
     ),

--- a/apps/desktop/src/renderer/src/lib/__tests__/navigation-snapshot-transport.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/navigation-snapshot-transport.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import type {
+  NavigationSnapshot,
+  NavigationSnapshotTransportFull,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import { buildThreadIdentityKey } from "@pwragent/shared";
+import { applyNavigationSnapshotTransportResponse } from "../navigation-snapshot-transport";
+
+function buildThread(id: string, title = id): NavigationThreadSummary {
+  return {
+    id,
+    title,
+    titleSource: "explicit",
+    linkedDirectories: [],
+    source: "codex",
+    inbox: { inInbox: true, reason: "new-thread" },
+  };
+}
+
+function buildFull(): NavigationSnapshotTransportFull {
+  const threads = [buildThread("one"), buildThread("two")];
+  const snapshot: NavigationSnapshot = {
+    backend: "all",
+    fetchedAt: 1,
+    unchanged: false,
+    threads,
+    inboxThreadKeys: threads.map((thread) =>
+      buildThreadIdentityKey(thread.source, thread.id),
+    ),
+    directories: [
+      {
+        key: "directory:one",
+        kind: "directory",
+        label: "One",
+        path: "/one",
+        threadKeys: [],
+        needsAttentionCount: 0,
+      },
+    ],
+    launchpadDefaults: {
+      backend: "codex",
+      executionMode: "default",
+    },
+  };
+  return { kind: "full", revision: "1", snapshot };
+}
+
+describe("applyNavigationSnapshotTransportResponse", () => {
+  it("keeps the canonical baseline for an unchanged acknowledgement", () => {
+    const full = buildFull();
+    const initial = applyNavigationSnapshotTransportResponse(undefined, full);
+    const unchanged = applyNavigationSnapshotTransportResponse(initial, {
+      kind: "unchanged",
+      revision: "1",
+    });
+
+    expect(unchanged?.snapshot.threads).toBe(full.snapshot.threads);
+    expect(unchanged?.snapshot.directories).toBe(full.snapshot.directories);
+    expect(unchanged?.snapshot.unchanged).toBe(true);
+  });
+
+  it("applies keyed updates, removals, and replacement order", () => {
+    const initial = applyNavigationSnapshotTransportResponse(
+      undefined,
+      buildFull(),
+    );
+    const three = buildThread("three");
+    const key = (thread: NavigationThreadSummary): string =>
+      buildThreadIdentityKey(thread.source, thread.id);
+
+    const updated = applyNavigationSnapshotTransportResponse(initial, {
+      kind: "delta",
+      baseRevision: "1",
+      revision: "2",
+      fetchedAt: 2,
+      removedThreadKeys: [key(buildThread("two"))],
+      upsertedThreads: [buildThread("one", "One updated"), three],
+      threadKeys: [key(three), key(buildThread("one"))],
+      removedDirectoryKeys: ["directory:one"],
+      upsertedDirectories: [],
+      directoryKeys: [],
+      addedInboxThreadKeys: [key(three)],
+      removedInboxThreadKeys: [
+        key(buildThread("one")),
+        key(buildThread("two")),
+      ],
+    });
+
+    expect(updated?.revision).toBe("2");
+    expect(updated?.snapshot.threads.map((thread) => thread.title)).toEqual([
+      "three",
+      "One updated",
+    ]);
+    expect(updated?.snapshot.directories).toEqual([]);
+    expect(updated?.snapshot.inboxThreadKeys).toEqual([key(three)]);
+    expect(updated?.snapshot.fetchedAt).toBe(2);
+    expect(updated?.snapshot.unchanged).toBe(false);
+  });
+
+  it("rejects a delta without the matching canonical baseline", () => {
+    const initial = applyNavigationSnapshotTransportResponse(
+      undefined,
+      buildFull(),
+    );
+    const delta = {
+      kind: "delta" as const,
+      baseRevision: "stale",
+      revision: "2",
+      fetchedAt: 2,
+      removedThreadKeys: [],
+      upsertedThreads: [],
+      removedDirectoryKeys: [],
+      upsertedDirectories: [],
+    };
+
+    expect(applyNavigationSnapshotTransportResponse(initial, delta)).toBeUndefined();
+    expect(applyNavigationSnapshotTransportResponse(undefined, delta)).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -47,6 +47,59 @@ describe("useThreadNavigation", () => {
     return { promise, resolve, reject };
   }
 
+  it("uses the renderer transport revision for subsequent refreshes", async () => {
+    const snapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: 1,
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const getNavigationSnapshot = vi.fn(async () => snapshot);
+    const getNavigationSnapshotTransport = vi
+      .fn<NonNullable<DesktopApi["getNavigationSnapshotTransport"]>>()
+      .mockResolvedValueOnce({
+        kind: "full",
+        revision: "revision-1",
+        snapshot,
+      })
+      .mockResolvedValueOnce({
+        kind: "unchanged",
+        revision: "revision-1",
+      });
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      getNavigationSnapshotTransport,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(getNavigationSnapshotTransport).toHaveBeenCalledTimes(1);
+    });
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(getNavigationSnapshot).not.toHaveBeenCalled();
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(1, {
+      transport: { protocol: 1 },
+    });
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(2, {
+      transport: {
+        protocol: 1,
+        baseRevision: "revision-1",
+      },
+    });
+    expect(result.current.error).toBeUndefined();
+  });
+
   it("does not let a late launchpad update replace a directory label with its internal key", async () => {
     const directoryKey = "directory:/Users/huntharo/github/PwrAgnt";
     const defaults: NavigationLaunchpadDefaults = {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -100,6 +100,99 @@ describe("useThreadNavigation", () => {
     expect(result.current.error).toBeUndefined();
   });
 
+  it("keeps separate transport revisions while lightweight refresh scopes alternate", async () => {
+    let intervalHandler: (() => void) | undefined;
+    let focusListener: (() => void) | undefined;
+    const originalSetInterval = globalThis.setInterval;
+    vi.spyOn(globalThis, "setInterval").mockImplementation(
+      (handler, timeout, ...args) => {
+        if (timeout !== 5 * 60_000) {
+          return originalSetInterval(handler, timeout, ...args);
+        }
+        intervalHandler =
+          typeof handler === "function" ? () => handler() : undefined;
+        return 1 as unknown as ReturnType<typeof setInterval>;
+      },
+    );
+    const snapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: 1,
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const getNavigationSnapshot = vi.fn(async () => snapshot);
+    const getNavigationSnapshotTransport = vi.fn<
+      NonNullable<DesktopApi["getNavigationSnapshotTransport"]>
+    >(async (request) => {
+      const revision = request.refreshMode === "active-recent"
+        ? "active-recent-revision"
+        : "full-revision";
+      return request.transport.baseRevision === revision
+        ? { kind: "unchanged", revision }
+        : { kind: "full", revision, snapshot };
+    });
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      getNavigationSnapshotTransport,
+      onWindowFocus: (callback) => {
+        focusListener = callback;
+        return () => {
+          focusListener = undefined;
+        };
+      },
+    };
+    const { unmount } = renderHook(() =>
+      useThreadNavigation(desktopApi, { lightweightNavigationRefresh: true }),
+    );
+
+    await waitFor(() => {
+      expect(getNavigationSnapshotTransport).toHaveBeenCalledTimes(1);
+    });
+    act(() => {
+      intervalHandler?.();
+    });
+    await waitFor(() => {
+      expect(getNavigationSnapshotTransport).toHaveBeenCalledTimes(2);
+    });
+    act(() => {
+      focusListener?.();
+    });
+    await waitFor(() => {
+      expect(getNavigationSnapshotTransport).toHaveBeenCalledTimes(3);
+    });
+    act(() => {
+      intervalHandler?.();
+    });
+    await waitFor(() => {
+      expect(getNavigationSnapshotTransport).toHaveBeenCalledTimes(4);
+    });
+
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(3, {
+      forceRefresh: true,
+      refreshMode: "full",
+      transport: {
+        baseRevision: "full-revision",
+        protocol: 1,
+      },
+    });
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(4, {
+      forceRefresh: true,
+      refreshMode: "active-recent",
+      transport: {
+        baseRevision: "active-recent-revision",
+        protocol: 1,
+      },
+    });
+    expect(getNavigationSnapshot).not.toHaveBeenCalled();
+    unmount();
+  });
+
   it("does not let a late launchpad update replace a directory label with its internal key", async () => {
     const directoryKey = "directory:/Users/huntharo/github/PwrAgnt";
     const defaults: NavigationLaunchpadDefaults = {

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -75,6 +75,7 @@ import type {
   EnsureDirectoryLaunchpadRequest,
   EnsureDirectoryLaunchpadResponse,
   GetNavigationSnapshotRequest,
+  GetNavigationSnapshotTransportRequest,
   HandoffThreadWorkspaceRequest,
   HandoffThreadWorkspaceResponse,
   InterruptTurnRequest,
@@ -98,6 +99,7 @@ import type {
   ListDesktopPwrAgentProfilesResponse,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
+  NavigationSnapshotTransportResponse,
   MarkThreadSeenRequest,
   OpenFederationWindowRequest,
   OpenFederationWindowResponse,
@@ -674,6 +676,9 @@ export type DesktopApi = {
   getNavigationSnapshot?: (
     request?: GetNavigationSnapshotRequest
   ) => Promise<NavigationSnapshot>;
+  getNavigationSnapshotTransport?: (
+    request: GetNavigationSnapshotTransportRequest,
+  ) => Promise<NavigationSnapshotTransportResponse>;
   setNavigationBrowseMode?: (
     request: SetNavigationBrowseModeRequest,
   ) => Promise<SetNavigationBrowseModeResponse>;

--- a/apps/desktop/src/renderer/src/lib/navigation-snapshot-transport.ts
+++ b/apps/desktop/src/renderer/src/lib/navigation-snapshot-transport.ts
@@ -1,0 +1,127 @@
+import type {
+  NavigationDirectorySummary,
+  NavigationSnapshot,
+  NavigationSnapshotTransportDelta,
+  NavigationSnapshotTransportResponse,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import { buildThreadIdentityKey } from "@pwragent/shared";
+
+export type NavigationSnapshotTransportState = {
+  revision: string;
+  snapshot: NavigationSnapshot;
+};
+
+function applyKeyedDelta<T>(params: {
+  current: T[];
+  key: (value: T) => string;
+  order?: string[];
+  removedKeys: string[];
+  upserted: T[];
+}): T[] | undefined {
+  const removed = new Set(params.removedKeys);
+  const valuesByKey = new Map(
+    params.current
+      .filter((value) => !removed.has(params.key(value)))
+      .map((value) => [params.key(value), value]),
+  );
+  for (const value of params.upserted) {
+    valuesByKey.set(params.key(value), value);
+  }
+  if (params.order) {
+    const ordered = params.order.map((key) => valuesByKey.get(key));
+    return ordered.every((value): value is T => value !== undefined)
+      ? ordered
+      : undefined;
+  }
+
+  const existingKeys = new Set<string>();
+  const next: T[] = [];
+  for (const value of params.current) {
+    const key = params.key(value);
+    if (removed.has(key)) continue;
+    const replacement = valuesByKey.get(key);
+    if (!replacement) continue;
+    existingKeys.add(key);
+    next.push(replacement);
+  }
+  for (const value of params.upserted) {
+    const key = params.key(value);
+    if (!existingKeys.has(key)) {
+      next.push(value);
+    }
+  }
+  return next;
+}
+
+function applyDelta(
+  previous: NavigationSnapshotTransportState,
+  delta: NavigationSnapshotTransportDelta,
+): NavigationSnapshotTransportState | undefined {
+  if (delta.baseRevision !== previous.revision) {
+    return undefined;
+  }
+  const threads = applyKeyedDelta<NavigationThreadSummary>({
+    current: previous.snapshot.threads,
+    key: (thread) => buildThreadIdentityKey(thread.source, thread.id),
+    order: delta.threadKeys,
+    removedKeys: delta.removedThreadKeys,
+    upserted: delta.upsertedThreads,
+  });
+  const directories = applyKeyedDelta<NavigationDirectorySummary>({
+    current: previous.snapshot.directories,
+    key: (directory) => directory.key,
+    order: delta.directoryKeys,
+    removedKeys: delta.removedDirectoryKeys,
+    upserted: delta.upsertedDirectories,
+  });
+  if (!threads || !directories) {
+    return undefined;
+  }
+  const removedInboxThreadKeys = new Set(
+    delta.removedInboxThreadKeys ?? [],
+  );
+  const inboxThreadKeys = delta.inboxThreadKeys ?? [
+    ...previous.snapshot.inboxThreadKeys.filter(
+      (key) => !removedInboxThreadKeys.has(key),
+    ),
+    ...(delta.addedInboxThreadKeys ?? []),
+  ];
+  return {
+    revision: delta.revision,
+    snapshot: {
+      ...previous.snapshot,
+      fetchedAt: delta.fetchedAt,
+      unchanged: false,
+      threads,
+      directories,
+      inboxThreadKeys,
+      launchpadDefaults:
+        delta.launchpadDefaults ?? previous.snapshot.launchpadDefaults,
+    },
+  };
+}
+
+export function applyNavigationSnapshotTransportResponse(
+  previous: NavigationSnapshotTransportState | undefined,
+  response: NavigationSnapshotTransportResponse,
+): NavigationSnapshotTransportState | undefined {
+  if (response.kind === "full") {
+    return {
+      revision: response.revision,
+      snapshot: response.snapshot,
+    };
+  }
+  if (response.kind === "unchanged") {
+    return previous?.revision === response.revision
+      ? {
+          ...previous,
+          snapshot: {
+            ...previous.snapshot,
+            unchanged: true,
+          },
+        }
+      : undefined;
+  }
+  return previous ? applyDelta(previous, response) : undefined;
+}

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -43,6 +43,10 @@ import {
 import type { DesktopApi } from "./desktop-api";
 import { fileLabelFromPath } from "./directory-references";
 import { readRendererFederationTarget } from "./federation-window";
+import {
+  applyNavigationSnapshotTransportResponse,
+  type NavigationSnapshotTransportState,
+} from "./navigation-snapshot-transport";
 import { resolveThreadWorkingStatePath } from "./thread-working-state-path";
 import {
   agentEventThreadIdentityKey,
@@ -2860,6 +2864,9 @@ export function useThreadNavigation(
   );
   const setNavigationBrowseModeRequestRef = useRef(setNavigationBrowseModeRequest);
   const stateRef = useRef(state);
+  const navigationSnapshotTransportRef = useRef<
+    NavigationSnapshotTransportState | undefined
+  >(undefined);
 
   optimisticThreadRef.current = optimisticThread;
   retainedUnreadThreadRef.current = retainedUnreadThread;
@@ -2919,6 +2926,7 @@ export function useThreadNavigation(
     ): Promise<void> => {
       if (!enabled) {
         prChipLocationIndexRef.current = undefined;
+        navigationSnapshotTransportRef.current = undefined;
         setState({
           loading: false,
           refreshing: false,
@@ -2928,12 +2936,15 @@ export function useThreadNavigation(
         return;
       }
 
-      if (!desktopApi?.getNavigationSnapshot) {
+      const getNavigationSnapshot = desktopApi?.getNavigationSnapshot;
+      const getNavigationSnapshotTransport =
+        desktopApi?.getNavigationSnapshotTransport;
+      if (!getNavigationSnapshot && !getNavigationSnapshotTransport) {
         prChipLocationIndexRef.current = undefined;
         setState({
           loading: false,
           refreshing: false,
-          error: "Desktop bridge is missing getNavigationSnapshot().",
+          error: "Desktop bridge is missing navigation snapshot support.",
           response: undefined,
         });
         return;
@@ -2970,14 +2981,61 @@ export function useThreadNavigation(
             : undefined;
         const threadStatusSequenceAtRefreshStart =
           threadStatusObservationSequenceRef.current;
-        const snapshot = snapshotRequest
-          ? await desktopApi.getNavigationSnapshot(snapshotRequest)
-          : await desktopApi.getNavigationSnapshot();
+        let snapshot: NavigationSnapshot;
+        let transportKind: "delta" | "full" | "legacy" | "unchanged" =
+          "legacy";
+        if (getNavigationSnapshotTransport) {
+          const previousTransportState =
+            navigationSnapshotTransportRef.current;
+          let transportResponse = await getNavigationSnapshotTransport({
+            ...snapshotRequest,
+            transport: {
+              protocol: 1,
+              ...(previousTransportState
+                ? { baseRevision: previousTransportState.revision }
+                : {}),
+            },
+          });
+          transportKind = transportResponse.kind;
+          let nextTransportState = applyNavigationSnapshotTransportResponse(
+            previousTransportState,
+            transportResponse,
+          );
+          if (!nextTransportState) {
+            desktopApi.recordStartupProfileEvent?.(
+              "navigation-refresh:transport-recovery",
+              { responseKind: transportResponse.kind },
+            );
+            transportResponse = await getNavigationSnapshotTransport({
+              ...snapshotRequest,
+              transport: { protocol: 1 },
+            });
+            transportKind = transportResponse.kind;
+            nextTransportState = applyNavigationSnapshotTransportResponse(
+              undefined,
+              transportResponse,
+            );
+          }
+          if (!nextTransportState) {
+            throw new Error(
+              "Navigation snapshot transport did not provide a recoverable baseline.",
+            );
+          }
+          navigationSnapshotTransportRef.current = nextTransportState;
+          snapshot = nextTransportState.snapshot;
+        } else if (getNavigationSnapshot) {
+          snapshot = snapshotRequest
+            ? await getNavigationSnapshot(snapshotRequest)
+            : await getNavigationSnapshot();
+        } else {
+          throw new Error("Desktop bridge is missing navigation snapshot support.");
+        }
         remoteRecoveryAttemptRef.current = 0;
         desktopApi.recordStartupProfileEvent?.("navigation-refresh:snapshot", {
           directoryCount: snapshot.directories.length,
           forceRefresh: Boolean(options?.forceRefresh),
           threadCount: snapshot.threads.length,
+          transportKind,
           unchanged: Boolean(snapshot.unchanged),
         });
         const filteredResponse = removeThreadKeysFromSnapshot(

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -28,6 +28,7 @@ import type {
 import {
   AGENT_PERSONA_INSTRUCTIONS_LINE_GUIDANCE,
   applyNavigationLaunchpadProviderSettingsPatch,
+  buildNavigationSnapshotTransportScopeKey,
   buildAppendPinRank,
   buildPinnedRanks,
   buildPullRequestStatusKey,
@@ -2864,9 +2865,9 @@ export function useThreadNavigation(
   );
   const setNavigationBrowseModeRequestRef = useRef(setNavigationBrowseModeRequest);
   const stateRef = useRef(state);
-  const navigationSnapshotTransportRef = useRef<
-    NavigationSnapshotTransportState | undefined
-  >(undefined);
+  const navigationSnapshotTransportByScopeRef = useRef(
+    new Map<string, NavigationSnapshotTransportState>(),
+  );
 
   optimisticThreadRef.current = optimisticThread;
   retainedUnreadThreadRef.current = retainedUnreadThread;
@@ -2926,7 +2927,7 @@ export function useThreadNavigation(
     ): Promise<void> => {
       if (!enabled) {
         prChipLocationIndexRef.current = undefined;
-        navigationSnapshotTransportRef.current = undefined;
+        navigationSnapshotTransportByScopeRef.current.clear();
         setState({
           loading: false,
           refreshing: false,
@@ -2985,8 +2986,13 @@ export function useThreadNavigation(
         let transportKind: "delta" | "full" | "legacy" | "unchanged" =
           "legacy";
         if (getNavigationSnapshotTransport) {
+          const transportScopeKey = buildNavigationSnapshotTransportScopeKey(
+            snapshotRequest ?? {},
+          );
           const previousTransportState =
-            navigationSnapshotTransportRef.current;
+            navigationSnapshotTransportByScopeRef.current.get(
+              transportScopeKey,
+            );
           let transportResponse = await getNavigationSnapshotTransport({
             ...snapshotRequest,
             transport: {
@@ -3021,7 +3027,10 @@ export function useThreadNavigation(
               "Navigation snapshot transport did not provide a recoverable baseline.",
             );
           }
-          navigationSnapshotTransportRef.current = nextTransportState;
+          navigationSnapshotTransportByScopeRef.current.set(
+            transportScopeKey,
+            nextTransportState,
+          );
           snapshot = nextTransportState.snapshot;
         } else if (getNavigationSnapshot) {
           snapshot = snapshotRequest

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1199,6 +1199,21 @@ export type GetNavigationSnapshotTransportRequest =
     };
   };
 
+/**
+ * Stable renderer/main cache scope. `forceRefresh` is a scheduling hint and
+ * does not change the semantic snapshot population.
+ */
+export function buildNavigationSnapshotTransportScopeKey(
+  request: GetNavigationSnapshotRequest,
+): string {
+  return JSON.stringify({
+    backend: request.backend ?? "all",
+    federationTarget: request.federationTarget ?? { scope: "local" },
+    filter: request.filter ?? "",
+    refreshMode: request.refreshMode ?? "full",
+  });
+}
+
 export type NavigationSnapshotTransportFull = {
   kind: "full";
   revision: string;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1186,6 +1186,55 @@ export type GetNavigationSnapshotRequest = {
   refreshMode?: "active-recent" | "full";
 };
 
+/**
+ * Opt-in renderer transport layered over the full navigation snapshot API.
+ * Internal main-process, messaging, and federation callers continue to use
+ * `GetNavigationSnapshotRequest` and always receive a complete snapshot.
+ */
+export type GetNavigationSnapshotTransportRequest =
+  GetNavigationSnapshotRequest & {
+    transport: {
+      baseRevision?: string;
+      protocol: 1;
+    };
+  };
+
+export type NavigationSnapshotTransportFull = {
+  kind: "full";
+  revision: string;
+  snapshot: NavigationSnapshot;
+};
+
+export type NavigationSnapshotTransportUnchanged = {
+  kind: "unchanged";
+  revision: string;
+};
+
+export type NavigationSnapshotTransportDelta = {
+  kind: "delta";
+  baseRevision: string;
+  revision: string;
+  fetchedAt: number;
+  removedThreadKeys: string[];
+  upsertedThreads: NavigationThreadSummary[];
+  /** Complete thread order, present only when identities moved or changed. */
+  threadKeys?: string[];
+  removedDirectoryKeys: string[];
+  upsertedDirectories: NavigationDirectorySummary[];
+  /** Complete directory order, present only when identities moved or changed. */
+  directoryKeys?: string[];
+  addedInboxThreadKeys?: string[];
+  removedInboxThreadKeys?: string[];
+  /** Complete inbox order, present only when existing identities moved. */
+  inboxThreadKeys?: string[];
+  launchpadDefaults?: NavigationLaunchpadDefaults;
+};
+
+export type NavigationSnapshotTransportResponse =
+  | NavigationSnapshotTransportFull
+  | NavigationSnapshotTransportUnchanged
+  | NavigationSnapshotTransportDelta;
+
 export type SetNavigationBrowseModeRequest = {
   browseMode: NavigationBrowseMode;
 };


### PR DESCRIPTION
## Summary

- add an opt-in, renderer-specific revision protocol at the navigation IPC boundary
- return a full baseline on first load or stale revisions, compact unchanged acknowledgements for stable snapshots, and keyed upserts/removals for real changes
- apply deltas to a canonical renderer baseline with one-shot full recovery
- preserve the existing full-snapshot contract for main-process, messaging, federation, and Settings consumers

## Root cause

The main process already marked snapshots as unchanged, but `ipcRenderer.invoke` still returned the complete snapshot. Electron therefore structured-cloned every thread and directory into the renderer before React could discard the unchanged response. Lightweight navigation refresh reduced how often this happened, but each poll still paid the full bridge and allocation cost.

## Impact

The regression fixture models 1,200 threads. Its stable refresh response is less than one-thousandth the serialized size of the initial full snapshot. Sparse changes send only changed rows; deletion-only refreshes send removed keys without resending the complete order.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/navigation-snapshot-transport.test.ts apps/desktop/src/main/__tests__/app-server-ipc.test.ts apps/desktop/src/renderer/src/lib/__tests__/navigation-snapshot-transport.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (241 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`