### PR TITLE
fix(desktop): verify ACP path overrides

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -19,6 +19,13 @@ const KIMI_CODE_INSTALL_COMMAND =
 const KIMI_CODE_WINDOWS_INSTALL_COMMAND =
   "irm https://code.kimi.com/kimi-code/install.ps1 | iex";
 
+type AcpCliPathUpdateResult =
+  | { saved: false }
+  | {
+      saved: true;
+      verification: "verified" | "failed" | "deferred";
+    };
+
 /** Look up the persisted CLI-path override for an agent by its registry id. */
 function cliPathSnapshotFor(
   snapshot: DesktopSettingsSnapshot | undefined,
@@ -140,16 +147,22 @@ export function AcpAgentsSettings(props: {
                       cliPath,
                     );
                     if (!saved) {
-                      return false;
+                      return { saved: false };
                     }
-                    return await refresh(true, true);
+                    if (!enabledSnapshotFor(props.snapshot, registryId)) {
+                      return { saved: true, verification: "deferred" };
+                    }
+                    return {
+                      saved: true,
+                      verification: await refresh(true, true)
+                        ? "verified"
+                        : "failed",
+                    };
                   }
                 : undefined
             }
             onEnabledChange={props.onEnabledChange}
-            onRefresh={() => {
-              void refresh(true, true);
-            }}
+            onRefresh={() => refresh(true, true)}
           />
         </Fragment>
       ))}
@@ -260,9 +273,12 @@ function AcpAgentSection(props: {
   enabled: boolean;
   saving?: boolean;
   refreshing?: boolean;
-  onCliPathChange?: (registryId: string, cliPath: string) => Promise<boolean>;
+  onCliPathChange?: (
+    registryId: string,
+    cliPath: string,
+  ) => Promise<AcpCliPathUpdateResult>;
   onEnabledChange?: (registryId: string, enabled: boolean) => Promise<void>;
-  onRefresh: () => void;
+  onRefresh: () => Promise<boolean>;
 }) {
   const { entry, enabled } = props;
   const instances = entry.instances ?? [];
@@ -280,22 +296,28 @@ function AcpAgentSection(props: {
   const envForced = props.cliPathSnapshot?.source === "env";
   const checkingPath = pathUpdating || props.refreshing === true;
   const overrideActive =
-    normalizedSavedPath !== ""
+    enabled
+    && normalizedSavedPath !== ""
     && entry.activeCommand === normalizedSavedPath;
   const activeOverrideInstance = overrideActive
     ? instances.find((instance) => instance.command === normalizedSavedPath)
     : undefined;
   const overrideHelp = normalizedSavedPath === ""
     ? undefined
-    : checkingPath
-      ? "Checking this path and provider capabilities…"
-      : overrideActive
-        ? `Active for new threads${activeOverrideInstance?.version
-          ? ` · v${activeOverrideInstance.version}`
-          : ""}.`
-        : undefined;
+    : !enabled
+      ? "Enable this provider, then click Refresh to verify the saved path before use."
+      : checkingPath
+        ? "Checking this path and provider capabilities…"
+        : overrideActive
+          ? `Active for new threads${activeOverrideInstance?.version
+            ? ` · v${activeOverrideInstance.version}`
+            : ""}.`
+          : undefined;
   const inactiveOverrideError =
-    normalizedSavedPath !== "" && !checkingPath && !overrideActive
+    enabled
+    && normalizedSavedPath !== ""
+    && !checkingPath
+    && !overrideActive
       ? entry.activeCommand
         ? `Saved override is not active. New threads currently use ${entry.activeCommand}.`
         : "Saved override is not active. This provider cannot launch new threads."
@@ -309,10 +331,14 @@ function AcpAgentSection(props: {
     setPathActionError(undefined);
     setPathUpdating(true);
     try {
-      const updated = await props.onCliPathChange(entry.registryId, nextPath);
-      if (!updated) {
+      const result = await props.onCliPathChange(entry.registryId, nextPath);
+      if (!result.saved) {
         setDraft(savedPath);
-        setPathActionError("PwrAgent couldn't finish saving and checking this path.");
+        setPathActionError("PwrAgent couldn't save this path.");
+      } else if (result.verification === "failed") {
+        setPathActionError(
+          "Path was saved, but PwrAgent couldn't verify it. Click Refresh to try again.",
+        );
       }
     } catch (error) {
       setDraft(savedPath);
@@ -321,6 +347,19 @@ function AcpAgentSection(props: {
       setPathUpdating(false);
     }
   }
+
+  async function refreshPathStatus(): Promise<void> {
+    setPathActionError(undefined);
+    const refreshed = await props.onRefresh();
+    if (!refreshed && normalizedSavedPath !== "") {
+      setPathActionError(
+        "PwrAgent couldn't verify the saved path. Click Refresh to try again.",
+      );
+    }
+  }
+
+  const pathControlsDisabled =
+    props.saving || pathUpdating || props.refreshing || envForced;
 
   return (
     <SettingsSection
@@ -338,7 +377,7 @@ function AcpAgentSection(props: {
             control={
               <SettingsSwitch
                 checked={enabled}
-                disabled={props.saving}
+                disabled={props.saving || pathUpdating || props.refreshing}
                 label={`Enable ${entry.name}`}
                 onChange={(next) => {
                   void props.onEnabledChange?.(entry.registryId, next);
@@ -350,7 +389,11 @@ function AcpAgentSection(props: {
 
         <SettingsField
           label="Installed paths"
-          sub="Binaries detected on this machine. The active one runs new threads — click Use to pick another."
+          sub={
+            enabled
+              ? "Binaries detected on this machine. The active one runs new threads — click Use to pick another."
+              : "Previously detected binaries. Enable this provider and Refresh before launching new threads."
+          }
           source={`${instances.length} found`}
           error={detail}
           control={
@@ -359,7 +402,8 @@ function AcpAgentSection(props: {
                 <p className="settings-empty">Not installed.</p>
               ) : (
                 instances.map((instance) => {
-                  const active = instance.command === entry.activeCommand;
+                  const active =
+                    enabled && instance.command === entry.activeCommand;
                   const chips: SettingsPathRowChip[] = [
                     {
                       label: instance.source === "override" ? "override" : "path",
@@ -383,7 +427,7 @@ function AcpAgentSection(props: {
                       selected={active}
                       selectedLabel="Using"
                       useLabel="Use"
-                      disabled={props.saving || pathUpdating || envForced}
+                      disabled={pathControlsDisabled}
                       onUse={
                         props.onCliPathChange
                           ? () => {
@@ -405,7 +449,9 @@ function AcpAgentSection(props: {
             sub={
               envForced
                 ? "This path is controlled by an environment override set before PwrAgent launched."
-                : "Enter an absolute path. Save checks it immediately and updates the binary used by new threads."
+                : enabled
+                  ? "Enter an absolute path. Save checks it immediately and updates the binary used by new threads."
+                  : "Save an absolute path now. Enable this provider, then Refresh to verify it before use."
             }
             source={
               envForced
@@ -424,7 +470,7 @@ function AcpAgentSection(props: {
                   aria-label={`${entry.name} manual path`}
                   aria-invalid={Boolean(pathActionError ?? inactiveOverrideError)}
                   className="settings-input"
-                  disabled={props.saving || pathUpdating || envForced}
+                  disabled={pathControlsDisabled}
                   placeholder="Manual path — e.g. /Users/you/.local/bin/agent"
                   type="text"
                   value={draft}
@@ -433,9 +479,7 @@ function AcpAgentSection(props: {
                 <button
                   className="button button--secondary"
                   disabled={
-                    props.saving
-                    || pathUpdating
-                    || envForced
+                    pathControlsDisabled
                     || draft.trim() === normalizedSavedPath
                   }
                   type="button"
@@ -445,12 +489,7 @@ function AcpAgentSection(props: {
                 </button>
                 <button
                   className="button button--ghost"
-                  disabled={
-                    props.saving
-                    || pathUpdating
-                    || envForced
-                    || draft === ""
-                  }
+                  disabled={pathControlsDisabled || draft === ""}
                   type="button"
                   onClick={() => void commitPath("")}
                 >
@@ -470,7 +509,7 @@ function AcpAgentSection(props: {
                 className="button button--secondary"
                 disabled={props.refreshing || pathUpdating}
                 type="button"
-                onClick={props.onRefresh}
+                onClick={() => void refreshPathStatus()}
               >
                 {props.refreshing ? "Discovering…" : "Refresh"}
               </button>

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -54,7 +54,7 @@ export function AcpAgentsSettings(props: {
   snapshot?: DesktopSettingsSnapshot;
   /** Persist a per-agent CLI-path override (also used to "pin" a discovered
    *  install — picking an install writes its command as the override). */
-  onCliPathChange?: (registryId: string, cliPath: string) => Promise<void>;
+  onCliPathChange?: (registryId: string, cliPath: string) => Promise<boolean>;
   /** Persist a per-agent enabled flag (off = hidden from the model picker). */
   onEnabledChange?: (registryId: string, enabled: boolean) => Promise<void>;
 }) {
@@ -66,11 +66,11 @@ export function AcpAgentsSettings(props: {
   async function refresh(
     refreshRegistry = false,
     force = false,
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (!props.desktopApi?.listAcpAgents) {
       setError("ACP registry controls are unavailable in this build.");
       setLoading(false);
-      return;
+      return false;
     }
     if (!refreshRegistry && entries.length === 0) {
       setLoading(true);
@@ -87,8 +87,10 @@ export function AcpAgentsSettings(props: {
       if (refreshRegistry) {
         window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
       }
+      return true;
     } catch (refreshError) {
       setError(refreshError instanceof Error ? refreshError.message : String(refreshError));
+      return false;
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -130,7 +132,20 @@ export function AcpAgentsSettings(props: {
             enabled={enabledSnapshotFor(props.snapshot, entry.registryId)}
             saving={props.saving}
             refreshing={refreshing || loading}
-            onCliPathChange={props.onCliPathChange}
+            onCliPathChange={
+              props.onCliPathChange
+                ? async (registryId, cliPath) => {
+                    const saved = await props.onCliPathChange?.(
+                      registryId,
+                      cliPath,
+                    );
+                    if (!saved) {
+                      return false;
+                    }
+                    return await refresh(true, true);
+                  }
+                : undefined
+            }
             onEnabledChange={props.onEnabledChange}
             onRefresh={() => {
               void refresh(true, true);
@@ -245,7 +260,7 @@ function AcpAgentSection(props: {
   enabled: boolean;
   saving?: boolean;
   refreshing?: boolean;
-  onCliPathChange?: (registryId: string, cliPath: string) => Promise<void>;
+  onCliPathChange?: (registryId: string, cliPath: string) => Promise<boolean>;
   onEnabledChange?: (registryId: string, enabled: boolean) => Promise<void>;
   onRefresh: () => void;
 }) {
@@ -253,12 +268,59 @@ function AcpAgentSection(props: {
   const instances = entry.instances ?? [];
   const savedPath = props.cliPathSnapshot?.value ?? "";
   const [draft, setDraft] = useState(savedPath);
+  const [pathUpdating, setPathUpdating] = useState(false);
+  const [pathActionError, setPathActionError] = useState<string | undefined>();
   useEffect(() => {
     setDraft(savedPath);
   }, [savedPath]);
 
   const detail =
     entry.lastDiscoveryError ?? entry.lastError ?? entry.unavailableReason;
+  const normalizedSavedPath = savedPath.trim();
+  const envForced = props.cliPathSnapshot?.source === "env";
+  const checkingPath = pathUpdating || props.refreshing === true;
+  const overrideActive =
+    normalizedSavedPath !== ""
+    && entry.activeCommand === normalizedSavedPath;
+  const activeOverrideInstance = overrideActive
+    ? instances.find((instance) => instance.command === normalizedSavedPath)
+    : undefined;
+  const overrideHelp = normalizedSavedPath === ""
+    ? undefined
+    : checkingPath
+      ? "Checking this path and provider capabilities…"
+      : overrideActive
+        ? `Active for new threads${activeOverrideInstance?.version
+          ? ` · v${activeOverrideInstance.version}`
+          : ""}.`
+        : undefined;
+  const inactiveOverrideError =
+    normalizedSavedPath !== "" && !checkingPath && !overrideActive
+      ? entry.activeCommand
+        ? `Saved override is not active. New threads currently use ${entry.activeCommand}.`
+        : "Saved override is not active. This provider cannot launch new threads."
+      : undefined;
+
+  async function commitPath(nextPath: string): Promise<void> {
+    if (!props.onCliPathChange) {
+      return;
+    }
+    setDraft(nextPath);
+    setPathActionError(undefined);
+    setPathUpdating(true);
+    try {
+      const updated = await props.onCliPathChange(entry.registryId, nextPath);
+      if (!updated) {
+        setDraft(savedPath);
+        setPathActionError("PwrAgent couldn't finish saving and checking this path.");
+      }
+    } catch (error) {
+      setDraft(savedPath);
+      setPathActionError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setPathUpdating(false);
+    }
+  }
 
   return (
     <SettingsSection
@@ -321,14 +383,11 @@ function AcpAgentSection(props: {
                       selected={active}
                       selectedLabel="Using"
                       useLabel="Use"
-                      disabled={props.saving}
+                      disabled={props.saving || pathUpdating || envForced}
                       onUse={
                         props.onCliPathChange
                           ? () => {
-                              void props.onCliPathChange?.(
-                                entry.registryId,
-                                instance.command,
-                              );
+                              void commitPath(instance.command);
                             }
                           : undefined
                       }
@@ -343,13 +402,29 @@ function AcpAgentSection(props: {
         {props.onCliPathChange ? (
           <SettingsField
             label="Manual path"
-            sub="Override discovery with an absolute path. Save, then Refresh to re-probe."
+            sub={
+              envForced
+                ? "This path is controlled by an environment override set before PwrAgent launched."
+                : "Enter an absolute path. Save checks it immediately and updates the binary used by new threads."
+            }
+            source={
+              envForced
+                ? "env override"
+                : overrideActive
+                  ? "active override"
+                  : normalizedSavedPath
+                    ? "saved override"
+                    : undefined
+            }
+            help={overrideHelp}
+            error={pathActionError ?? inactiveOverrideError}
             control={
               <div className="settings-secret">
                 <input
                   aria-label={`${entry.name} manual path`}
+                  aria-invalid={Boolean(pathActionError ?? inactiveOverrideError)}
                   className="settings-input"
-                  disabled={props.saving}
+                  disabled={props.saving || pathUpdating || envForced}
                   placeholder="Manual path — e.g. /Users/you/.local/bin/agent"
                   type="text"
                   value={draft}
@@ -357,22 +432,27 @@ function AcpAgentSection(props: {
                 />
                 <button
                   className="button button--secondary"
-                  disabled={props.saving || draft.trim() === savedPath.trim()}
-                  type="button"
-                  onClick={() =>
-                    props.onCliPathChange?.(entry.registryId, draft.trim())
+                  disabled={
+                    props.saving
+                    || pathUpdating
+                    || envForced
+                    || draft.trim() === normalizedSavedPath
                   }
+                  type="button"
+                  onClick={() => void commitPath(draft.trim())}
                 >
-                  Save
+                  {pathUpdating ? "Checking…" : "Save"}
                 </button>
                 <button
                   className="button button--ghost"
-                  disabled={props.saving || draft === ""}
+                  disabled={
+                    props.saving
+                    || pathUpdating
+                    || envForced
+                    || draft === ""
+                  }
                   type="button"
-                  onClick={() => {
-                    setDraft("");
-                    void props.onCliPathChange?.(entry.registryId, "");
-                  }}
+                  onClick={() => void commitPath("")}
                 >
                   Clear
                 </button>
@@ -388,7 +468,7 @@ function AcpAgentSection(props: {
             <div className="settings-inline-actions">
               <button
                 className="button button--secondary"
-                disabled={props.refreshing}
+                disabled={props.refreshing || pathUpdating}
                 type="button"
                 onClick={props.onRefresh}
               >

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -98,7 +98,7 @@ export function ModelsSettings(props: {
   ) => Promise<boolean>;
   onSaveCodexFastAllowed: (allowed: boolean) => Promise<boolean>;
   /** Persist a per-ACP-agent CLI-path override (also pins a discovered install). */
-  onAcpCliPathChange: (registryId: string, cliPath: string) => Promise<void>;
+  onAcpCliPathChange: (registryId: string, cliPath: string) => Promise<boolean>;
   /** Persist a per-ACP-agent enabled flag (off = hidden from the model picker). */
   onAcpEnabledChange: (registryId: string, enabled: boolean) => Promise<void>;
 }) {

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -813,7 +813,7 @@ function SettingsSectionBody(props: {
         });
       }}
       onAcpCliPathChange={async (registryId, cliPath) => {
-        await props.settings.writeConfig({
+        return await props.settings.writeConfig({
           acpAgents: { [registryId]: { cliPath } } as NonNullable<
             DesktopSettingsConfigPatch["acpAgents"]
           >,

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -67,12 +67,13 @@ function acpSnapshot(
   registryId: "grok" | "qwen",
   cliPath: string,
   source: "config" | "env" = "config",
+  enabled = true,
 ): DesktopSettingsSnapshot {
   return {
     acpAgents: {
       [registryId]: {
         cliPath: { value: cliPath, source },
-        enabled: true,
+        enabled,
       },
     },
   } as unknown as DesktopSettingsSnapshot;
@@ -214,6 +215,62 @@ describe("AcpAgentsSettings", () => {
     });
   });
 
+  it("blocks path changes while provider discovery is running", async () => {
+    const installed = grokEntry({
+      instances: [
+        { command: "/usr/bin/grok", version: "1.0.0", source: "path" },
+        { command: "/opt/homebrew/bin/grok", version: "0.9.0", source: "path" },
+      ],
+    });
+    let resolveManualRefresh:
+      | ((value: { fetchedAt: number; entries: AcpAgentSettingsEntry[] }) => void)
+      | undefined;
+    const manualRefresh = new Promise<{
+      fetchedAt: number;
+      entries: AcpAgentSettingsEntry[];
+    }>((resolve) => {
+      resolveManualRefresh = resolve;
+    });
+    const listAcpAgents = vi.fn(
+      async (request?: { refresh?: boolean; force?: boolean }) =>
+        request?.force
+          ? manualRefresh
+          : { fetchedAt: 1000, entries: [installed] },
+    );
+    const onCliPathChange = vi.fn(async () => true);
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        snapshot={acpSnapshot("grok", "")}
+        onCliPathChange={onCliPathChange}
+      />,
+    );
+
+    expect(await screen.findByText("Grok")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Refresh" })).toBeEnabled();
+    });
+    fireEvent.change(screen.getByLabelText("Grok manual path"), {
+      target: { value: "/Users/me/bin/grok-next" },
+    });
+    screen.getByRole("button", { name: "Refresh" }).click();
+
+    expect(
+      await screen.findByRole("button", { name: "Discovering…" }),
+    ).toBeDisabled();
+    expect(screen.getByLabelText("Grok manual path")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Clear" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Use" })).toBeDisabled();
+    expect(onCliPathChange).not.toHaveBeenCalled();
+
+    resolveManualRefresh?.({ fetchedAt: 2000, entries: [installed] });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+    });
+  });
+
   it("saves and immediately verifies a manual path for new threads", async () => {
     const overridePath = "/Users/me/.local/bin/grok-local";
     const installed = grokEntry();
@@ -312,6 +369,114 @@ describe("AcpAgentsSettings", () => {
       "aria-invalid",
       "true",
     );
+  });
+
+  it("preserves a saved path when verification fails and supports retry", async () => {
+    const overridePath = "/Users/me/.local/bin/grok-local";
+    const installed = grokEntry();
+    const overridden = grokEntry({
+      activeCommand: overridePath,
+      instances: [
+        { command: overridePath, version: "2.0.0", source: "override" },
+        { command: "/usr/bin/grok", version: "1.0.0", source: "path" },
+      ],
+    });
+    let forcedAttempts = 0;
+    const listAcpAgents = vi.fn(
+      async (request?: { refresh?: boolean; force?: boolean }) => {
+        if (request?.force) {
+          forcedAttempts += 1;
+          if (forcedAttempts === 1) {
+            throw new Error("probe unavailable");
+          }
+          return { fetchedAt: 2000, entries: [overridden] };
+        }
+        return { fetchedAt: 1000, entries: [installed] };
+      },
+    );
+
+    function Harness() {
+      const [snapshot, setSnapshot] = useState(acpSnapshot("grok", ""));
+      return (
+        <AcpAgentsSettings
+          desktopApi={{ listAcpAgents } as DesktopApi}
+          snapshot={snapshot}
+          onCliPathChange={async (registryId, cliPath) => {
+            setSnapshot(acpSnapshot(registryId as "grok", cliPath));
+            return true;
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    expect(await screen.findByText("Grok")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Refresh" })).toBeEnabled();
+    });
+    fireEvent.change(screen.getByLabelText("Grok manual path"), {
+      target: { value: overridePath },
+    });
+    screen.getByRole("button", { name: "Save" }).click();
+
+    expect(
+      await screen.findByText(
+        "Path was saved, but PwrAgent couldn't verify it. Click Refresh to try again.",
+      ),
+    ).toHaveAttribute("role", "alert");
+    expect(screen.getByLabelText("Grok manual path")).toHaveValue(overridePath);
+    expect(screen.getByText("saved override")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+
+    screen.getByRole("button", { name: "Refresh" }).click();
+    expect(
+      await screen.findByText("Active for new threads · v2.0.0."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Path was saved, but PwrAgent couldn't verify it. Click Refresh to try again.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not claim a saved path is active while the provider is disabled", async () => {
+    const overridePath = "/Users/me/.local/bin/grok-local";
+    const entry = grokEntry({
+      activeCommand: overridePath,
+      instances: [
+        { command: overridePath, version: "2.0.0", source: "override" },
+      ],
+    });
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [entry],
+    }));
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        snapshot={acpSnapshot("grok", overridePath, "config", false)}
+        onCliPathChange={vi.fn(async () => true)}
+      />,
+    );
+
+    expect(await screen.findByText("Grok")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Refresh" })).toBeEnabled();
+    });
+    expect(screen.getByText("Disabled")).toBeInTheDocument();
+    expect(screen.getByText("saved override")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Enable this provider, then click Refresh to verify the saved path before use.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("active override")).not.toBeInTheDocument();
+    expect(screen.queryByText("Using")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Active for new threads · v2.0.0."),
+    ).not.toBeInTheDocument();
   });
 
   it("makes environment-forced paths read-only and explains their source", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -1,8 +1,17 @@
 import "@testing-library/jest-dom/vitest";
-import { StrictMode } from "react";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { StrictMode, useState } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { AcpAgentSettingsEntry } from "@pwragent/shared";
+import type {
+  AcpAgentSettingsEntry,
+  DesktopSettingsSnapshot,
+} from "@pwragent/shared";
 import { AcpAgentsSettings } from "../AcpAgentsSettings";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../../lib/useBackendSummaries";
@@ -27,6 +36,46 @@ function geminiEntry(): AcpAgentSettingsEntry {
     authStatus: "not-required",
     verificationStatus: "not-applicable",
   } satisfies AcpAgentSettingsEntry;
+}
+
+function grokEntry(params?: {
+  activeCommand?: string;
+  instances?: AcpAgentSettingsEntry["instances"];
+}): AcpAgentSettingsEntry {
+  const activeCommand = params?.activeCommand ?? "/usr/bin/grok";
+  return {
+    backendId: "acp:grok",
+    registryId: "grok",
+    name: "Grok",
+    version: "1.0.0",
+    authors: [],
+    distributionKind: "local",
+    distributionSource: `${activeCommand} --acp`,
+    installable: false,
+    installed: true,
+    installStatus: "installed",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+    instances: params?.instances ?? [
+      { command: activeCommand, version: "1.0.0", source: "path" },
+    ],
+    activeCommand,
+  } satisfies AcpAgentSettingsEntry;
+}
+
+function acpSnapshot(
+  registryId: "grok" | "qwen",
+  cliPath: string,
+  source: "config" | "env" = "config",
+): DesktopSettingsSnapshot {
+  return {
+    acpAgents: {
+      [registryId]: {
+        cliPath: { value: cliPath, source },
+        enabled: true,
+      },
+    },
+  } as unknown as DesktopSettingsSnapshot;
 }
 
 describe("AcpAgentsSettings", () => {
@@ -115,7 +164,7 @@ describe("AcpAgentsSettings", () => {
   });
 
   it("renders multiple installs with a 'Use' action and the active one as 'Using'", async () => {
-    const onCliPathChange = vi.fn(async () => undefined);
+    const onCliPathChange = vi.fn(async () => true);
     const desktopApi: DesktopApi = {
       listAcpAgents: vi.fn(async () => ({
         fetchedAt: 1000,
@@ -157,6 +206,138 @@ describe("AcpAgentsSettings", () => {
     expect(screen.getByText("Using")).toBeInTheDocument();
     screen.getByRole("button", { name: "Use" }).click();
     expect(onCliPathChange).toHaveBeenCalledWith("qwen", "/opt/homebrew/bin/qwen");
+    await waitFor(() => {
+      expect(desktopApi.listAcpAgents).toHaveBeenCalledWith({
+        refresh: true,
+        force: true,
+      });
+    });
+  });
+
+  it("saves and immediately verifies a manual path for new threads", async () => {
+    const overridePath = "/Users/me/.local/bin/grok-local";
+    const installed = grokEntry();
+    const overridden = grokEntry({
+      activeCommand: overridePath,
+      instances: [
+        { command: overridePath, version: "2.0.0", source: "override" },
+        { command: "/usr/bin/grok", version: "1.0.0", source: "path" },
+      ],
+    });
+    const listAcpAgents = vi.fn(
+      async (request?: { refresh?: boolean; force?: boolean }) => ({
+        fetchedAt: 1000,
+        entries: [request?.force ? overridden : installed],
+      }),
+    );
+
+    function Harness() {
+      const [snapshot, setSnapshot] = useState(acpSnapshot("grok", ""));
+      return (
+        <AcpAgentsSettings
+          desktopApi={{ listAcpAgents } as DesktopApi}
+          snapshot={snapshot}
+          onCliPathChange={async (registryId, cliPath) => {
+            setSnapshot(acpSnapshot(registryId as "grok", cliPath));
+            return true;
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    expect(await screen.findByText("Grok")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Refresh" })).toBeEnabled();
+    });
+    fireEvent.change(screen.getByLabelText("Grok manual path"), {
+      target: { value: overridePath },
+    });
+    screen.getByRole("button", { name: "Save" }).click();
+
+    await waitFor(() => {
+      expect(listAcpAgents).toHaveBeenCalledWith({ refresh: true, force: true });
+    });
+    expect(await screen.findByText("active override")).toBeInTheDocument();
+    expect(screen.getByText("override")).toBeInTheDocument();
+    expect(screen.getByText("v2.0.0")).toBeInTheDocument();
+    expect(
+      screen.getByText("Active for new threads · v2.0.0."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(overridePath)).toBeInTheDocument();
+    expect(screen.getByText("Using")).toBeInTheDocument();
+  });
+
+  it("shows when a saved manual path is not active and names the fallback", async () => {
+    const invalidPath = "/Users/me/bin/missing-grok";
+    const installed = grokEntry();
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [installed],
+    }));
+
+    function Harness() {
+      const [snapshot, setSnapshot] = useState(acpSnapshot("grok", ""));
+      return (
+        <AcpAgentsSettings
+          desktopApi={{ listAcpAgents } as DesktopApi}
+          snapshot={snapshot}
+          onCliPathChange={async (registryId, cliPath) => {
+            setSnapshot(acpSnapshot(registryId as "grok", cliPath));
+            return true;
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    expect(await screen.findByText("Grok")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Refresh" })).toBeEnabled();
+    });
+    fireEvent.change(screen.getByLabelText("Grok manual path"), {
+      target: { value: invalidPath },
+    });
+    screen.getByRole("button", { name: "Save" }).click();
+
+    expect(
+      await screen.findByText(
+        "Saved override is not active. New threads currently use /usr/bin/grok.",
+      ),
+    ).toHaveAttribute("role", "alert");
+    expect(screen.getByText("saved override")).toBeInTheDocument();
+    expect(screen.getByLabelText("Grok manual path")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  });
+
+  it("makes environment-forced paths read-only and explains their source", async () => {
+    const envPath = "/opt/company/bin/grok";
+    const entry = grokEntry({
+      activeCommand: envPath,
+      instances: [{ command: envPath, version: "1.2.3", source: "override" }],
+    });
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [entry],
+    }));
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        snapshot={acpSnapshot("grok", envPath, "env")}
+        onCliPathChange={vi.fn(async () => true)}
+      />,
+    );
+
+    expect(await screen.findByText("Grok")).toBeInTheDocument();
+    expect(screen.getByText("env override")).toBeInTheDocument();
+    expect(screen.getByLabelText("Grok manual path")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Clear" })).toBeDisabled();
   });
 
   it("renders an undiscovered provider as a 'Not installed' section", async () => {


### PR DESCRIPTION
## Summary

- automatically re-probe ACP providers after saving, selecting, or clearing a CLI path override
- show whether the saved override is active for new threads, including its detected version
- show an explicit fallback path when a saved override cannot be used
- make environment-forced paths read-only and identify their source
- serialize path and enabled-state changes against in-flight discovery
- preserve successfully saved paths when verification fails, with an explicit retry state
- avoid claiming disabled providers or their cached paths are active

## Why

Saving a manual ACP provider path only persisted the value. The installed-path list continued showing cached discovery data until the operator separately clicked Refresh, so there was no immediate confirmation that the binary worked, which version was detected, or which path new threads would actually launch.

The shared settings component affects Gemini CLI, Grok, Kimi Code, and Qwen Code.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx` (72 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:colors`
- `pnpm lint:boundaries`
