### PR TITLE
feat(desktop): show initial thread load duration

### DIFF
--- a/apps/desktop/e2e/visual-regression.spec.ts
+++ b/apps/desktop/e2e/visual-regression.spec.ts
@@ -35,6 +35,7 @@ const VISUAL_WINDOW_SIZE = { width: 1440, height: 900 };
 const VISUAL_MAX_DIFF_PIXELS = 20;
 const VISUAL_CLOCK_TIME = new Date("2026-08-02T12:00:00.000Z");
 const VISUAL_APP_VERSION = "1.2.3-beta.1";
+const VISUAL_INITIAL_LOAD_DURATION = "3 ms";
 
 async function waitForFonts(page: Page): Promise<void> {
   await page.evaluate(async () => {
@@ -79,6 +80,17 @@ test.describe("visual regression", () => {
           /Existing Codex threads cannot be converted/,
         ),
       ).toBeVisible();
+      const initialLoadDuration = app.window
+        .getByText("Initial load", { exact: true })
+        .locator("xpath=following-sibling::dd");
+      await expect(initialLoadDuration).toBeVisible();
+      // The real backend read is intentionally measured, so its exact value
+      // varies by a millisecond or two between otherwise identical runs.
+      // Normalize only that volatile text while retaining the row and layout
+      // in the visual contract.
+      await initialLoadDuration.evaluate((element, duration) => {
+        element.textContent = duration;
+      }, VISUAL_INITIAL_LOAD_DURATION);
       await expect.poll(async () =>
         await app.window.evaluate(async () => {
           const bridge = globalThis as typeof globalThis & {

--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.png
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6433d6296d05992ebb8753e239092099d54d24c74efed51a7f0c0603da8ea77d
-size 143509
+oid sha256:f5dd5fb98b84d0f21e8846ea56e276af321fd3416671e6def73078be686cb4f0
+size 148757

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5094,6 +5094,7 @@ describe("DesktopBackendRegistry", () => {
 
     expect(response.replay.entries.filter((entry) => entry.type === "review"))
       .toEqual([startedEntry, resultEntry]);
+    expect(response.readDurationMs).toEqual(expect.any(Number));
     expect(response.replay.entries.map((entry) => entry.id)).toEqual([
       startedEntry.id,
       resultEntry.id,
@@ -10654,6 +10655,7 @@ script = "echo setup"
       threadId: "thread-1",
     });
 
+    expect(response.readDurationMs).toEqual(expect.any(Number));
     expect(response.replay.entries.map((entry) => entry.id)).toEqual([
       "assistant-turn-1",
       "command-turn-1",

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -735,6 +735,7 @@ describe("federation backend bridge", () => {
         return {
           backend: "codex" as const,
           fetchedAt: 1_000,
+          readDurationMs: request.limit === undefined ? 3 : 17,
           threadId: "thread-1",
           replay: {
             entries,
@@ -791,6 +792,7 @@ describe("federation backend bridge", () => {
       kind: "response",
       requestId: "latest-request",
       result: {
+        readDurationMs: 20,
         replay: {
           entries: [{ id: "latest-user" }, { id: "latest-assistant" }],
           pagination: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10238,9 +10238,14 @@ export class DesktopBackendRegistry {
     request: AppServerReadThreadRequest
   ): Promise<AppServerReadThreadResponse> {
     this.assertNotBootstrap("readThread");
+    const readStartedAt = performance.now();
     const backend = request.backend ?? "codex";
     if (isAcpBackendId(backend)) {
-      return await this.readAcpThread(request, backend);
+      const response = await this.readAcpThread(request, backend);
+      return {
+        ...response,
+        readDurationMs: Math.max(0, Math.round(performance.now() - readStartedAt)),
+      };
     }
 
     const codexStatusObservationSequence =
@@ -10392,6 +10397,7 @@ export class DesktopBackendRegistry {
     return {
       backend,
       fetchedAt: Date.now(),
+      readDurationMs: Math.max(0, Math.round(performance.now() - readStartedAt)),
       threadId: request.threadId,
       pricing,
       ...(toolAccounting ? { toolAccounting } : {}),

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -620,12 +620,20 @@ export function registerFederationBackendHandlers(params: {
         !response.replay.pagination.supportsPagination
         && (request.before !== undefined || request.limit !== undefined)
       ) {
+        const boundedReadDurationMs = response.readDurationMs;
         const {
           before: _before,
           limit: _limit,
           ...unpagedRequest
         } = request;
         response = await params.backend.readThread(unpagedRequest);
+        if (typeof boundedReadDurationMs === "number") {
+          response = {
+            ...response,
+            readDurationMs:
+              boundedReadDurationMs + (response.readDurationMs ?? 0),
+          };
+        }
       }
 
       // Bound non-paginating replays before they reach the federation

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1397,6 +1397,7 @@ function DesktopAppShell(props: {
     launchpadError: navigation.launchpadError,
     onProviderSelected: refreshSelectedAcpProvider,
     onShowNotice: showAppNotice,
+    initialLoadDurationMs: session.initialLoadDurationMs,
     loading: session.loading,
     loadingMore: session.loadingMore,
     messageCount: session.messages.length,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -89,6 +89,7 @@ type ThreadContextPanelProps = {
   backendError?: string;
   backends: BackendSummary[];
   desktopApi?: DesktopApi;
+  initialLoadDurationMs?: number;
   onRefreshNavigation?: () => Promise<void>;
   onResizingChange?: (resizing: boolean) => void;
   onWidthChange?: (width: number) => void;
@@ -711,6 +712,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             onRefreshNavigation={props.onRefreshNavigation}
             showTooltip={showRailTooltip}
             hideTooltip={hideRailTooltip}
+            initialLoadDurationMs={props.initialLoadDurationMs}
           />
         );
       case "edits":

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -882,6 +882,7 @@ export type ThreadViewProps = {
   composerDraftStore?: ComposerDraftStore;
   composerImplementation?: DesktopChatReplyComposer;
   desktopApi?: DesktopApi;
+  initialLoadDurationMs?: number;
   launchpadError?: string;
   onShowNotice?: (notice: AppNoticeToastNotice) => void;
   onProviderSelected?: (
@@ -3407,6 +3408,7 @@ export function ThreadView(props: ThreadViewProps) {
           threadToolAccountingEnabled={threadToolAccountingEnabled}
           worktreeArchiveError={props.worktreeArchiveError}
           onRestoreWorktree={props.onRestoreWorktree}
+          initialLoadDurationMs={props.initialLoadDurationMs}
         />
       </div>
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -150,6 +150,7 @@ type PanelOverrides = Partial<
     | "activeTurnId"
     | "backends"
     | "desktopApi"
+    | "initialLoadDurationMs"
     | "pinned"
     | "thread"
     | "onRefreshNavigation"
@@ -289,6 +290,22 @@ describe("ThreadContextPanel", () => {
         hour: "numeric",
         minute: "2-digit",
       }).format(updatedAt),
+    );
+  });
+
+  it("shows the initial backend load duration in Thread info", () => {
+    renderPanel({
+      initialLoadDurationMs: 1_234.4,
+      pinned: true,
+    });
+
+    const executionContext = screen
+      .getByRole("heading", { level: 3, name: "Execution context" })
+      .closest("section");
+    expect(executionContext).not.toBeNull();
+    const context = within(executionContext!);
+    expect(context.getByText("Initial load").nextElementSibling).toHaveTextContent(
+      `${(1_234).toLocaleString()} ms`,
     );
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ThreadInfoPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ThreadInfoPanel.tsx
@@ -22,6 +22,7 @@ type ThreadInfoPanelProps = {
   backends: BackendSummary[];
   platform?: string;
   desktopApi?: DesktopApi;
+  initialLoadDurationMs?: number;
   onRefreshNavigation?: () => Promise<void>;
   showTooltip: ShowRailTooltip;
   hideTooltip: HideRailTooltip;
@@ -127,6 +128,14 @@ export function ThreadInfoPanel(props: ThreadInfoPanelProps) {
           <div>
             <dt>Backend</dt>
             <dd>{formatBackendLabel(props.thread.source, props.backends)}</dd>
+          </div>
+          <div>
+            <dt>Initial load</dt>
+            <dd>
+              {typeof props.initialLoadDurationMs === "number"
+                ? `${Math.max(0, Math.round(props.initialLoadDurationMs)).toLocaleString()} ms`
+                : "Unknown"}
+            </dd>
           </div>
           <div>
             <dt>Thread ID</dt>

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -70,6 +70,7 @@ function readThreadResponse(params: {
   fetchedAt?: number;
   hasPreviousPage: boolean;
   previousCursor?: string;
+  readDurationMs?: number;
   supportsPagination?: boolean;
   threadId?: string;
   threadStatus?: AppServerReadThreadResponse["threadStatus"];
@@ -77,6 +78,7 @@ function readThreadResponse(params: {
   return {
     backend: "codex",
     fetchedAt: params.fetchedAt ?? Date.now(),
+    readDurationMs: params.readDurationMs,
     threadId: params.threadId ?? "thread-1",
     threadStatus: params.threadStatus ?? "idle",
     replay: {
@@ -169,6 +171,42 @@ describe("useThreadSessionState", () => {
     expect(getContextWindowMoonPhase(97.5)).toBe(8);
     expect(getContextWindowMoonPhase(100)).toBe(8);
     expect(getContextWindowMoonPhase(100.01)).toBe(8);
+  });
+
+  it("keeps the first successful thread-read duration across later hydrations", async () => {
+    let readCount = 0;
+    const readThread = vi.fn(async () => {
+      readCount += 1;
+      return readThreadResponse({
+        entries: [],
+        fetchedAt: readCount,
+        hasPreviousPage: false,
+        readDurationMs: readCount === 1 ? 725 : 12,
+      });
+    });
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.initialLoadDurationMs).toBe(725);
+    });
+
+    rerender({ updatedAt: 2_000 });
+    await waitFor(() => {
+      expect(result.current.response?.fetchedAt).toBe(2);
+    });
+    expect(readThread).toHaveBeenCalledTimes(2);
+    expect(result.current.initialLoadDurationMs).toBe(725);
   });
 
   it("exposes selected thread busy state from the same thinking state as row indicators", () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -145,6 +145,7 @@ type ThreadSessionEntry = {
   failedHydrationVersion?: number | "unknown";
   hydratedInitialHistoryLimit?: number;
   hydratedUpdatedAt?: number;
+  initialLoadDurationMs?: number;
   interacted: boolean;
   lastTouchedAt: number;
   loadedOlderHistory: boolean;
@@ -3613,6 +3614,7 @@ export function useThreadSessionState(params: {
   error?: string;
   expandedTranscriptActivityIds: string[];
   expandedTranscriptWorkPhaseGroupIds: string[];
+  initialLoadDurationMs?: number;
   loading: boolean;
   loadingMore: boolean;
   loadOlder: () => Promise<void>;
@@ -3959,6 +3961,8 @@ export function useThreadSessionState(params: {
               needsHydrationAfterCompletion && completionHydrationRetries < 2
                 ? undefined
                 : targetThread.updatedAt,
+            initialLoadDurationMs:
+              current.initialLoadDurationMs ?? response.readDurationMs,
             lastTouchedAt: Date.now(),
             loading: false,
             completionHydrationRetries,
@@ -6003,6 +6007,7 @@ export function useThreadSessionState(params: {
     clearPendingRequest,
     entries,
     error: selectedSession?.error,
+    initialLoadDurationMs: selectedSession?.initialLoadDurationMs,
     loading: selectedSession?.loading ?? false,
     loadingMore: selectedSession?.loadingMore ?? false,
     loadOlder,

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -874,6 +874,12 @@ export type AppServerReadThreadRequest = {
 export type AppServerReadThreadResponse = {
   backend: AppServerBackendKind;
   fetchedAt: number;
+  /**
+   * Wall-clock time spent by the owning backend registry producing this
+   * thread read. Renderers may retain the first successful value in memory as
+   * the thread's initial-load duration.
+   */
+  readDurationMs?: number;
   threadId: ThreadIdentifier;
   replay: AppServerThreadReplay;
   /**


### PR DESCRIPTION
## Summary

- measure owner-side thread read duration for Codex and ACP backends
- retain the first successful duration in renderer memory without persistence
- show the duration in milliseconds in the Thread info execution context
- carry the optional metric through federation, including pagination retries

## Why

Operators comparing Codex and ACP providers need a visible signal for slow initial thread hydration. Measuring on the owning instance keeps provider comparisons meaningful and avoids folding federation network latency into the value.

## Impact

The Thread info panel now shows an **Initial load** value. The measurement is process-local and is not written to sqlite. Older federation peers remain compatible and display an unknown value until they return the optional response field.

## Validation

- focused Vitest suites: 710 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
