### PR TITLE
fix(desktop): backport ACP completion compatibility

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -2591,7 +2591,7 @@ describe("AcpAgentClient", () => {
     expect(client.readReplay(session.sessionId).entries).toEqual([]);
   });
 
-  it("preserves a Grok assistant stream across transient vendor updates", async () => {
+  it("distinguishes known tool progress from standalone tool updates", async () => {
     const promptResponse = createDeferred<unknown>();
     const transport = new FakeAcpAgentTransport({
       "session/prompt": promptResponse.promise,
@@ -2623,6 +2623,16 @@ describe("AcpAgentClient", () => {
       method: "_x.ai/session_notification",
       sessionId: session.sessionId,
       update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "background-tool",
+        title: "Background check",
+        status: "in_progress",
+      },
+    });
+    transport.emitVendorNotification({
+      method: "_x.ai/session_notification",
+      sessionId: session.sessionId,
+      update: {
         sessionUpdate: "agent_message_chunk",
         content: "Before ",
       },
@@ -2642,16 +2652,49 @@ describe("AcpAgentClient", () => {
       method: "_x.ai/session_notification",
       sessionId: session.sessionId,
       update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "background-tool",
+        title: "Background check",
+        status: "completed",
+      },
+    });
+    transport.emitVendorNotification({
+      method: "_x.ai/session_notification",
+      sessionId: session.sessionId,
+      update: {
         sessionUpdate: "agent_message_chunk",
         content: "after",
+      },
+    });
+    transport.emitVendorNotification({
+      method: "_x.ai/session_notification",
+      sessionId: session.sessionId,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "standalone-tool",
+        title: "Standalone check",
+        status: "completed",
+      },
+    });
+    transport.emitVendorNotification({
+      method: "_x.ai/session_notification",
+      sessionId: session.sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: "Later",
       },
     });
 
     expect(assistantMessageItemIds).toEqual([
       "assistant:turn-1:0",
       "assistant:turn-1:0",
+      "assistant:turn-1:1",
     ]);
-    expect(client.readReplay(session.sessionId).entries).toEqual([
+    expect(
+      client
+        .readReplay(session.sessionId)
+        .entries.filter((entry) => entry.type === "message"),
+    ).toEqual([
       expect.objectContaining({
         type: "message",
         role: "user",
@@ -2662,12 +2705,63 @@ describe("AcpAgentClient", () => {
         role: "assistant",
         text: "Before after",
       }),
+      expect.objectContaining({
+        type: "message",
+        role: "assistant",
+        text: "Later",
+      }),
     ]);
 
     promptResponse.resolve({ turnId: "turn-1" });
     await vi.waitFor(() => {
       expect(client.readReplay(session.sessionId).threadStatus).toBe("idle");
     });
+  });
+
+  it("does not advance a seen Grok thread for last_turn_summary metadata", async () => {
+    let now = 1000;
+    const transport = new FakeAcpAgentTransport();
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      store,
+      transport,
+      now: () => now,
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    now = 1100;
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "Finished the requested work." },
+    });
+    const seenUpdatedAt =
+      store.getSession("acp:grok", session.sessionId)?.updatedAt;
+
+    now = 1200;
+    transport.emitVendorNotification({
+      method: "_x.ai/session_notification",
+      sessionId: session.sessionId,
+      update: {
+        sessionUpdate: "last_turn_summary",
+        summary: "Requested work complete",
+      },
+    });
+
+    expect(store.getSession("acp:grok", session.sessionId)?.updatedAt).toBe(
+      seenUpdatedAt,
+    );
+    expect(
+      client
+        .readReplay(session.sessionId)
+        .entries.some(
+          (entry) =>
+            entry.type === "activity" && entry.summary.startsWith("ACP update:"),
+        ),
+    ).toBe(false);
   });
 
   it("keeps a tracked Grok turn active until session/prompt resolves", async () => {
@@ -3071,64 +3165,67 @@ describe("AcpAgentClient", () => {
     await client.dispose();
   });
 
-  it("preserves a visible assistant stream across hidden ACP thought chunks", async () => {
-    const assistantMessageItemIds: Array<string | undefined> = [];
-    const transport = new FakeAcpAgentTransport();
-    const client = new AcpAgentClient({
-      backendId: "acp:qwen",
-      store,
-      transport,
-      now: () => 1000,
-      onSessionUpdate: ({ assistantMessageItemId, update }) => {
-        if (
-          (update.sessionUpdate ?? update.session_update ?? update.kind) ===
-          "agent_message_chunk"
-        ) {
-          assistantMessageItemIds.push(assistantMessageItemId);
-        }
-      },
-    });
+  it.each(["acp:qwen", "acp:grok"] as const)(
+    "preserves a visible assistant stream across hidden %s thought chunks",
+    async (backendId) => {
+      const assistantMessageItemIds: Array<string | undefined> = [];
+      const transport = new FakeAcpAgentTransport();
+      const client = new AcpAgentClient({
+        backendId,
+        store,
+        transport,
+        now: () => 1000,
+        onSessionUpdate: ({ assistantMessageItemId, update }) => {
+          if (
+            (update.sessionUpdate ?? update.session_update ?? update.kind) ===
+            "agent_message_chunk"
+          ) {
+            assistantMessageItemIds.push(assistantMessageItemId);
+          }
+        },
+      });
 
-    await client.initialize();
-    const session = await client.startSession({
-      cwd: "/repo",
-      executionMode: "default",
-    });
-    client.startPrompt({
-      sessionId: session.sessionId,
-      prompt: "hello",
-      turnId: "turn-1",
-    });
+      await client.initialize();
+      const session = await client.startSession({
+        cwd: "/repo",
+        executionMode: "default",
+      });
+      client.startPrompt({
+        sessionId: session.sessionId,
+        prompt: "hello",
+        turnId: "turn-1",
+      });
 
-    transport.emitSessionUpdate(session.sessionId, {
-      sessionUpdate: "agent_message_chunk",
-      content: { type: "text", text: "Visible " },
-    });
-    transport.emitSessionUpdate(session.sessionId, {
-      sessionUpdate: "agent_thought_chunk",
-      content: { type: "text", text: "hidden reasoning" },
-    });
-    transport.emitSessionUpdate(session.sessionId, {
-      sessionUpdate: "agent_message_chunk",
-      content: { type: "text", text: "answer." },
-    });
+      transport.emitSessionUpdate(session.sessionId, {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Visible " },
+      });
+      transport.emitSessionUpdate(session.sessionId, {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "hidden reasoning" },
+      });
+      transport.emitSessionUpdate(session.sessionId, {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "answer." },
+      });
 
-    expect(assistantMessageItemIds).toEqual([
-      "assistant:turn-1:0",
-      "assistant:turn-1:0",
-    ]);
-    expect(client.readReplay(session.sessionId).lastAssistantMessage).toBe(
-      "Visible answer.",
-    );
-    expect(
-      client
-        .readReplay(session.sessionId)
-        .entries.some(
-          (entry) =>
-            entry.type === "message" && entry.text.includes("hidden reasoning"),
-        ),
-    ).toBe(false);
-  });
+      expect(assistantMessageItemIds).toEqual([
+        "assistant:turn-1:0",
+        "assistant:turn-1:0",
+      ]);
+      expect(client.readReplay(session.sessionId).lastAssistantMessage).toBe(
+        "Visible answer.",
+      );
+      expect(
+        client
+          .readReplay(session.sessionId)
+          .entries.some(
+            (entry) =>
+              entry.type === "message" && entry.text.includes("hidden reasoning"),
+          ),
+      ).toBe(false);
+    },
+  );
 
   it("strips legacy transcript updates when upserting stored sessions", () => {
     store.upsertSession({

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -1181,6 +1181,7 @@ describe("AcpSessionReplayNormalizer", () => {
       "tool_call_delta_chunk",
       "pending_interaction",
       "interaction_resolved",
+      "response_completed",
     ]) {
       normalizer.apply({
         sessionId: "session-1",
@@ -1201,6 +1202,208 @@ describe("AcpSessionReplayNormalizer", () => {
         text: "Before after",
       }),
     ]);
+  });
+
+  it("updates known tool progress without splitting a streaming assistant message", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "background-tool",
+        title: "Background check",
+        status: "in_progress",
+      },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: { sessionUpdate: "agent_message_chunk", content: "Before " },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1002,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "background-tool",
+        title: "Background check",
+        status: "completed",
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1003,
+      update: { sessionUpdate: "agent_message_chunk", content: "after" },
+    });
+
+    expect(
+      replay.entries.filter((entry) => entry.type === "message"),
+    ).toEqual([
+      expect.objectContaining({
+        id: "assistant:session-1:0",
+        role: "assistant",
+        text: "Before after",
+      }),
+    ]);
+  });
+
+  it("splits assistant messages around a standalone tool update", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { sessionUpdate: "agent_message_chunk", content: "Before" },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "standalone-tool",
+        title: "Standalone check",
+        status: "completed",
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1002,
+      update: { sessionUpdate: "agent_message_chunk", content: "After" },
+    });
+
+    expect(
+      replay.entries.map((entry) =>
+        entry.type === "message" ? `${entry.id}:${entry.text}` : entry.type
+      ),
+    ).toEqual([
+      "assistant:session-1:0:Before",
+      "activity",
+      "assistant:session-1:1:After",
+    ]);
+  });
+
+  it("keeps an unrecognized update from splitting a streaming assistant message", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { sessionUpdate: "agent_message_chunk", content: "Overall: " },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: { sessionUpdate: "some_future_grok_update", detail: "opaque" },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1002,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: "the patch is fine.",
+      },
+    });
+
+    expect(
+      replay.entries.map((entry) =>
+        entry.type === "message"
+          ? `${entry.id}:${entry.text}`
+          : entry.type === "activity"
+            ? entry.summary
+            : entry.type
+      ),
+    ).toEqual([
+      "assistant:session-1:0:Overall: the patch is fine.",
+      "ACP update: some_future_grok_update",
+    ]);
+  });
+
+  it("keeps distinct unknown kinds from colliding while deduping replays", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+    const firstUpdate = {
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { sessionUpdate: "some_future_grok_update" },
+    };
+
+    normalizer.apply(firstUpdate);
+    normalizer.apply(firstUpdate);
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { sessionUpdate: "another_future_update" },
+    });
+
+    expect(
+      replay.entries.flatMap((entry) =>
+        entry.type === "activity" ? [entry.summary] : []
+      ),
+    ).toEqual([
+      "ACP update: some_future_grok_update",
+      "ACP update: another_future_update",
+    ]);
+  });
+
+  it.each(["plan", "file", "terminal", "turn_started"])(
+    "keeps %s as an assistant message boundary",
+    (sessionUpdate) => {
+      const normalizer = new AcpSessionReplayNormalizer();
+
+      normalizer.apply({
+        sessionId: "session-1",
+        receivedAt: 1000,
+        update: { sessionUpdate: "agent_message_chunk", content: "Before" },
+      });
+      normalizer.apply({
+        sessionId: "session-1",
+        receivedAt: 1001,
+        update: { sessionUpdate, title: "Boundary", status: "completed" },
+      });
+      const replay = normalizer.apply({
+        sessionId: "session-1",
+        receivedAt: 1002,
+        update: { sessionUpdate: "agent_message_chunk", content: "After" },
+      });
+
+      expect(
+        replay.entries.flatMap((entry) =>
+          entry.type === "message" ? [`${entry.id}:${entry.text}`] : []
+        ),
+      ).toEqual([
+        "assistant:session-1:0:Before",
+        "assistant:session-1:1:After",
+      ]);
+    },
+  );
+
+  it("keeps Grok last_turn_summary out of the transcript and turn lifecycle", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+    normalizer.recordUserPrompt({
+      sessionId: "session-1",
+      prompt: "Inspect this",
+      turnId: "turn-1",
+      receivedAt: 1000,
+      waitingForAgent: true,
+    });
+
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "last_turn_summary",
+        summary: "Inspection complete",
+      },
+    });
+
+    expect(replay.threadStatus).toBe("active");
+    expect(replay.entries).toHaveLength(2);
+    expect(
+      replay.entries.some(
+        (entry) => entry.type === "activity" && entry.summary.startsWith("ACP update:"),
+      ),
+    ).toBe(false);
   });
 
   it("treats Grok turn_completed as an idempotent turn finish", () => {

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -15,6 +15,7 @@ import {
   AcpSessionReplayNormalizer,
   isGrokTransientUpdateKind,
   readAcpContentText,
+  readAcpToolCallId,
   readAcpTopicTitle,
   shouldSurfaceAcpThoughtsAsMessages,
   type AcpSessionUpdate,
@@ -124,6 +125,7 @@ type AcpActiveTurn = {
   activeAssistantMessagePhase?: AppServerTranscriptPhase;
   assistantText: string;
   assistantMessageSequence: number;
+  knownToolCallIds: Set<string>;
   turnId: string;
 };
 
@@ -813,6 +815,11 @@ export class AcpAgentClient {
       updateKind === "agent_message_chunk" ||
       (updateKind === "agent_thought_chunk" && this.surfaceThoughtsAsMessages);
     const text = readUpdateText(update);
+    const toolCallId = readAcpToolCallId(update);
+    const updatesKnownToolCall =
+      updateKind === "tool_call_update"
+      && toolCallId !== undefined
+      && activeTurn?.knownToolCallIds.has(toolCallId) === true;
     let assistantMessageItemId: string | undefined;
     if (shouldTrackAssistantTextUpdate && activeTurn && text) {
       const phase: AppServerTranscriptPhase =
@@ -829,9 +836,17 @@ export class AcpAgentClient {
       !isAssistantTextUpdate
       && activeTurn
       && !isGrokTransientUpdateKind(updateKind)
+      && !updatesKnownToolCall
     ) {
       activeTurn.activeAssistantMessageItemId = undefined;
       activeTurn.activeAssistantMessagePhase = undefined;
+    }
+    if (
+      activeTurn
+      && toolCallId
+      && (updateKind === "tool_call" || updateKind === "tool_call_update")
+    ) {
+      activeTurn.knownToolCallIds.add(toolCallId);
     }
     const replay = this.normalizerFor(sessionId).apply({
       sessionId,
@@ -1142,6 +1157,7 @@ export class AcpAgentClient {
     this.activeTurns.set(sessionId, {
       assistantText: "",
       assistantMessageSequence: 0,
+      knownToolCallIds: new Set<string>(),
       turnId,
     });
     this.updateSessionStatus(sessionId, "active");

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -35,7 +35,7 @@ export type AcpSessionReplayNormalizerOptions = {
 };
 
 export function shouldSurfaceAcpThoughtsAsMessages(backendId: string): boolean {
-  return backendId !== "acp:qwen";
+  return backendId !== "acp:qwen" && backendId !== "acp:grok";
 }
 
 export function isGrokTransientUpdateKind(kind: string | undefined): boolean {
@@ -43,6 +43,22 @@ export function isGrokTransientUpdateKind(kind: string | undefined): boolean {
     kind === "tool_call_delta_chunk"
     || kind === "pending_interaction"
     || kind === "interaction_resolved"
+    || kind === "response_completed"
+    // Grok publishes this after its canonical `turn_completed` update as
+    // session metadata. It is not a second lifecycle event or transcript item.
+    || kind === "last_turn_summary"
+  );
+}
+
+export function readAcpToolCallId(
+  update: Record<string, unknown>,
+): string | undefined {
+  return (
+    readString(update, "toolCallId")
+    ?? readString(update, "tool_call_id")
+    ?? readString(update, "id")
+    ?? readString(update, "itemId")
+    ?? readString(update, "item_id")
   );
 }
 
@@ -56,6 +72,7 @@ export class AcpSessionReplayNormalizer {
   private activeAssistantMessagePhase?: AppServerTranscriptPhase;
   private assistantMessageSequence = 0;
   private generatedMessageSequence = 0;
+  private readonly knownToolCallIds = new Set<string>();
 
   constructor(private readonly options: AcpSessionReplayNormalizerOptions = {}) {}
 
@@ -75,6 +92,7 @@ export class AcpSessionReplayNormalizer {
     this.activeAssistantMessageId = undefined;
     this.activeAssistantMessagePhase = undefined;
     this.assistantMessageSequence = 0;
+    this.knownToolCallIds.clear();
     this.upsertMessage({
       id,
       role: "user",
@@ -106,6 +124,7 @@ export class AcpSessionReplayNormalizer {
     }
     this.activeAssistantMessageId = undefined;
     this.activeAssistantMessagePhase = undefined;
+    this.knownToolCallIds.clear();
     this.status = "idle";
     return this.replay();
   }
@@ -125,6 +144,7 @@ export class AcpSessionReplayNormalizer {
     }
     this.activeAssistantMessageId = undefined;
     this.activeAssistantMessagePhase = undefined;
+    this.knownToolCallIds.clear();
     this.status = "idle";
     this.upsertActivity({
       type: "activity",
@@ -182,6 +202,7 @@ export class AcpSessionReplayNormalizer {
     } else if (kind === "user_message_chunk") {
       this.activeAssistantMessageId = undefined;
       this.activeAssistantMessagePhase = undefined;
+      this.knownToolCallIds.clear();
       this.applyUserMessageChunk(update, createdAt);
     } else if (kind === "available_commands_update") {
       // Command metadata belongs in provider capabilities, not the transcript.
@@ -205,18 +226,42 @@ export class AcpSessionReplayNormalizer {
     } else if (readAcpTopicTitle(update.update)) {
       // Topic updates are thread metadata, not transcript entries.
     } else {
-      this.activeAssistantMessageId = undefined;
-      this.activeAssistantMessagePhase = undefined;
+      const toolCallId = readAcpToolCallId(update.update);
+      // A tool_call is the semantic boundary between assistant messages.
+      // Updates for that known call may arrive while the provider is already
+      // streaming the next message, so only those preserve the active bubble.
+      // A standalone tool_call_update remains a boundary for providers that
+      // use it as their only notification for a tool invocation.
+      const updatesKnownToolCall =
+        kind === "tool_call_update"
+        && toolCallId !== undefined
+        && this.knownToolCallIds.has(toolCallId);
+      if (
+        toolCallId
+        && (kind === "tool_call" || kind === "tool_call_update")
+      ) {
+        this.knownToolCallIds.add(toolCallId);
+      }
+      // Each branch below ends the active assistant bubble only if that update
+      // really is a message boundary. Failing to recognize a future update is
+      // not evidence that the assistant stopped speaking.
       if (kind === "plan") {
+        this.endActiveAssistantMessage();
         this.removeCurrentAgentWaitingActivity();
         this.upsertPlan(update, createdAt);
       } else if (kind === "tool_call" || kind === "tool_call_update") {
+        if (!updatesKnownToolCall) {
+          this.endActiveAssistantMessage();
+        }
         this.removeCurrentAgentWaitingActivity();
         this.upsertActivity(toolActivity(update, kind, createdAt));
       } else if (kind === "file" || kind === "terminal") {
+        this.endActiveAssistantMessage();
         this.removeCurrentAgentWaitingActivity();
         this.upsertActivity(toolActivity(update, kind, createdAt));
       } else if (kind === "turn_started") {
+        this.endActiveAssistantMessage();
+        this.knownToolCallIds.clear();
         this.status = "active";
       } else if (kind === "turn_finished") {
         this.recordTurnFinished(readString(update.update, "turnId"), createdAt);
@@ -237,6 +282,9 @@ export class AcpSessionReplayNormalizer {
           waitingForAgent: readBoolean(update.update, "waitingForAgent"),
         });
       } else {
+        // Keep a breadcrumb for forward compatibility without destructively
+        // splitting the assistant message that surrounds it. Later chunks
+        // append to the earlier message entry, so the activity sorts after it.
         this.removeCurrentAgentWaitingActivity();
         this.upsertActivity(unknownActivity(update, kind, createdAt));
       }
@@ -346,6 +394,11 @@ export class AcpSessionReplayNormalizer {
         `assistant:${this.currentTurnId ?? update.sessionId}:${this.assistantMessageSequence++}`;
     }
     return this.activeAssistantMessageId;
+  }
+
+  private endActiveAssistantMessage(): void {
+    this.activeAssistantMessageId = undefined;
+    this.activeAssistantMessagePhase = undefined;
   }
 
   private resetAssistantMessageIfPhaseChanged(
@@ -813,11 +866,7 @@ function toolActivity(
   createdAt: number,
 ): AppServerThreadActivityEntry {
   const id =
-    readString(update.update, "toolCallId") ??
-    readString(update.update, "tool_call_id") ??
-    readString(update.update, "id") ??
-    readString(update.update, "itemId") ??
-    readString(update.update, "item_id") ??
+    readAcpToolCallId(update.update) ??
     `${kind}:${update.sessionId}`;
   const webSearch = readAcpWebSearch(update.update);
   if (webSearch) {
@@ -1089,7 +1138,7 @@ function unknownActivity(
   kind: string,
   createdAt: number,
 ): AppServerThreadActivityEntry {
-  const id = `unknown:${update.sessionId}:${createdAt}`;
+  const id = `unknown:${update.sessionId}:${createdAt}:${kind}`;
   return {
     type: "activity",
     id,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -8577,6 +8577,193 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("rechecks a selected thinking thread when idle has no terminal event", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const readThread = vi.fn(async ({ backend, threadId }) => ({
+      backend: backend ?? "codex",
+      fetchedAt: Date.now(),
+      threadId,
+      threadStatus: "idle" as const,
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+    act(() => {
+      result.current.setActiveTurnId("turn-1");
+      result.current.setPendingStatusText("Thinking");
+    });
+
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        agentEventHandler?.({
+          backend: "codex",
+          notification: {
+            method: "thread/status/changed",
+            params: {
+              threadId: "thread-1",
+              status: { type: "idle" },
+            },
+          },
+        });
+      });
+
+      expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBe(true);
+
+      await act(async () => {
+        vi.advanceTimersByTime(1_501);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(readThread).toHaveBeenCalledTimes(2);
+      expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears renderer-owned thinking for an unfocused thread that remains idle", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    let threadOneReadCount = 0;
+    const readThread = vi.fn(async ({ backend, threadId }) => {
+      const isDurableCompletion =
+        threadId === "thread-1" && ++threadOneReadCount === 2;
+      const entries: AppServerThreadEntry[] = isDurableCompletion
+        ? [
+            {
+              ...messageEntry({
+                createdAt: 3_000,
+                id: "assistant-final",
+                text: "Durable final response.",
+              }),
+              phase: "final",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+              },
+            },
+          ]
+        : [];
+      return {
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        threadStatus: "idle" as const,
+        replay: {
+          entries,
+          messages: entries.flatMap((entry) =>
+            entry.type === "message"
+              ? [{
+                  id: entry.id,
+                  role: entry.role,
+                  text: entry.text,
+                  createdAt: entry.createdAt,
+                }]
+              : []
+          ),
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      };
+    });
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ currentThread }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: currentThread,
+        }),
+      {
+        initialProps: {
+          currentThread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+        },
+      }
+    );
+
+    await waitForThreadHydration(result);
+    act(() => {
+      result.current.setActiveTurnId("turn-1");
+      result.current.setPendingStatusText("Thinking");
+    });
+    rerender({
+      currentThread: buildThread({ id: "thread-2", updatedAt: 2_000 }),
+    });
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        agentEventHandler?.({
+          backend: "codex",
+          notification: {
+            method: "thread/status/changed",
+            params: {
+              threadId: "thread-1",
+              status: { type: "idle" },
+            },
+          },
+        });
+      });
+
+      expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(1_501);
+      });
+
+      expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
+      expect(readThread).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    rerender({
+      currentThread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+    });
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+      expect(result.current.messages.map((message) => message.text)).toContain(
+        "Durable final response."
+      );
+    });
+  });
+
   it("renders item/fileChange/outputDelta as a Changed file activity entry", async () => {
     let agentEventHandler:
       | ((event: {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -59,6 +59,7 @@ const SUPPORTED_APPROVAL_REQUEST_METHODS = new Set([
   "item/commandExecution/requestApproval",
   "item/fileChange/requestApproval",
 ]);
+const ACP_IDLE_RECONCILIATION_GRACE_MS = 1_500;
 
 export function getContextWindowMoonPhase(usedPercent: number): number {
   if (usedPercent < 10) {
@@ -151,6 +152,7 @@ type ThreadSessionEntry = {
   pendingStatusText?: string;
   pendingTurnUsage?: TurnUsageAccumulator;
   response?: AppServerReadThreadResponse;
+  staleThinkingRecheckAt?: number;
   thinkingSinceAt?: number;
   viewport?: ThreadViewportState;
 };
@@ -3639,6 +3641,80 @@ export function useThreadSessionState(params: {
   }, [initialHistoryLimit, loadLatest, sessions, thread, threadKey, updateSession]);
 
   useEffect(() => {
+    if (!thread || !threadKey) {
+      return;
+    }
+    const recheckAt = sessions[threadKey]?.staleThinkingRecheckAt;
+    if (typeof recheckAt !== "number") {
+      return;
+    }
+    const timer = setTimeout(() => {
+      updateSession(threadKey, (current) => ({
+        ...current,
+        hydratedUpdatedAt: undefined,
+        lastTouchedAt: Date.now(),
+        staleThinkingRecheckAt: undefined,
+      }));
+      void loadLatest(thread);
+    }, Math.max(0, recheckAt - Date.now()) + 1);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [loadLatest, sessions, thread, threadKey, updateSession]);
+
+  useEffect(() => {
+    const timers = Object.entries(sessions).flatMap(
+      ([sessionThreadKey, session]) => {
+        if (
+          sessionThreadKey === threadKey
+          || typeof session.staleThinkingRecheckAt !== "number"
+        ) {
+          return [];
+        }
+
+        const recheckAt = session.staleThinkingRecheckAt;
+        return [
+          setTimeout(() => {
+            updateSession(sessionThreadKey, (current) => {
+              if (
+                current.staleThinkingRecheckAt !== recheckAt
+                || hasPendingInteraction(current)
+              ) {
+                return current;
+              }
+
+              // An unfocused thread has no NavigationThreadSummary to pass to
+              // loadLatest(). After the grace period, clear renderer-owned
+              // live state and hydrate durable completion when next selected.
+              return {
+                ...current,
+                activeTurnId: undefined,
+                activeTurnStartedAt: undefined,
+                completionHydrationRetries: 0,
+                expectOwnUpdate: false,
+                hydratedUpdatedAt: undefined,
+                needsHydrationAfterCompletion: true,
+                optimisticEntries: current.optimisticEntries.filter(
+                  (entry) => !isLiveOptimisticEntry(entry)
+                ),
+                pendingAssistantMessage: undefined,
+                pendingStatusText: undefined,
+                staleThinkingRecheckAt: undefined,
+              };
+            });
+          }, Math.max(0, recheckAt - Date.now()) + 1),
+        ];
+      }
+    );
+
+    return () => {
+      for (const timer of timers) {
+        clearTimeout(timer);
+      }
+    };
+  }, [sessions, threadKey, updateSession]);
+
+  useEffect(() => {
     if (!desktopApi?.onAgentEvent) {
       return;
     }
@@ -4486,9 +4562,24 @@ export function useThreadSessionState(params: {
               ? event.notification.params.status.type
               : undefined;
 
+          if (statusType === "active") {
+            return {
+              ...current,
+              lastTouchedAt: nextLastTouchedAt,
+              staleThinkingRecheckAt: undefined,
+            };
+          }
+
           if (statusType === "idle") {
-            if (current.activeTurnId || current.pendingStatusText) {
-              return current;
+            const shouldRecheckStaleThinking =
+              hasThinkingState(current) && !hasPendingInteraction(current);
+            if (shouldRecheckStaleThinking) {
+              return {
+                ...current,
+                lastTouchedAt: nextLastTouchedAt,
+                staleThinkingRecheckAt:
+                  nextLastTouchedAt + ACP_IDLE_RECONCILIATION_GRACE_MS,
+              };
             }
 
             return {
@@ -4498,6 +4589,7 @@ export function useThreadSessionState(params: {
               lastTouchedAt: nextLastTouchedAt,
               pendingAssistantMessage: undefined,
               pendingStatusText: undefined,
+              staleThinkingRecheckAt: undefined,
             };
           }
         }


### PR DESCRIPTION
## Summary

- hide Grok provider reasoning while preserving deliberate user-visible ACP assistant messages
- keep one assistant message across late progress updates for known tools, while retaining real tool calls and standalone tool updates as message boundaries
- treat Grok `response_completed` and `last_turn_summary` notifications as transport/session metadata rather than transcript or lifecycle events
- preserve assistant-message identity across unknown future ACP updates while retaining a non-destructive diagnostic breadcrumb
- reconcile renderer-owned thinking state when an ACP backend reports idle without a matching terminal event

## Source fixes

This is a manual maintenance-line adaptation of the squash commits and PR decisions from `main`:

- #1344 — `946e1287c`: hide Grok reasoning and preserve ACP streams
- #1346 — `d9a9cd6da`: reconcile ACP completion state
- #1389 — `be40aff8a`: filter Grok post-turn metadata
- #1402 — `c44bfaf74`: stop unknown ACP updates from splitting assistant messages

No development-history commits were replayed.

## Release-line adaptations

- adapted known-tool identity tracking to the 1.0 `AcpActiveTurn` and `AcpSessionReplayNormalizer` state models
- retained the 1.0 prompt-resolution terminal path: Grok `turn_completed` remains deferred while a tracked `session/prompt` request is active
- added a bounded 1.5-second idle reconciliation to the older renderer cache model: selected threads perform an authoritative reread, while unfocused threads clear only renderer-owned live state and request durable hydration when selected
- preserved raw provider updates in the existing ACP rollout path while filtering only their transcript/lifecycle presentation
- kept the backport scoped to ACP normalization, completion reconciliation, and focused regression coverage; it does not include the draft bundled Grok runtime or custom `grok-build` 1.0.0 work

## Root cause

Grok can interleave late progress for an already-started tool with one assistant response stream, and it publishes response/post-turn metadata that is not a turn terminal. The 1.0 normalizer reset assistant identity for every unclassified or tool update, while the renderer could retain stale thinking state after an idle status arrived without a normalized terminal event.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx` — 218 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; 138 existing warnings
- `pnpm lint:boundaries`
