### PR TITLE
feat(desktop): notify when Grok CLI updates are available

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import type {
+  AcpAgentUpdateStatus,
   AcpBackendId,
   AgentEvent,
   AppServerPendingRequestNotification,
@@ -1296,6 +1297,215 @@ describe("AcpBackendAdapter", () => {
     expect(summary?.account).toBeUndefined();
     expect(readProviderStatus).toHaveBeenCalledTimes(1);
 
+    await adapter.close();
+  });
+
+  it("checks Grok updates in the background and persists one daily result", async () => {
+    const backendId = "acp:grok" as AcpBackendId;
+    let stored: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+      version: "0.2.118",
+      activeCommand: "/opt/grok",
+    };
+    const upsertInstalledAgent = vi.fn((record: AcpInstalledAgentRecord) => {
+      stored = record;
+    });
+    const updateCheck = vi.fn(async () => ({
+      status: "available" as const,
+      checkedAt: Date.now(),
+      currentVersion: "0.2.118",
+      latestVersion: "1.0.0",
+      channel: "stable",
+    }));
+    const emit = vi.fn(async () => undefined);
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => stored,
+        listInstalledAgents: () => [stored],
+        upsertInstalledAgent,
+      },
+      captureStores: [],
+      checkGrokCliUpdate: updateCheck,
+      discoverLocalAcpAgents: async () => [],
+      emit,
+      handleServerRequest: async () => ({ decision: "accept" }),
+      isAcpAgentEnabled: () => true,
+    });
+
+    const [summary] = await adapter.describeInstalledBackends();
+    expect(summary?.kind).toBe(backendId);
+    expect(updateCheck).toHaveBeenCalledOnce();
+    await vi.waitFor(() => {
+      expect(emit).toHaveBeenCalledWith({
+        backend: backendId,
+        notification: {
+          method: "backend/acpUpdateStatus/updated",
+          params: { backend: backendId },
+        },
+      });
+    });
+    expect(upsertInstalledAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ latestVersion: "1.0.0" }),
+        updateCommand: "/opt/grok",
+      }),
+    );
+
+    await adapter.describeInstalledBackends();
+    expect(updateCheck).toHaveBeenCalledOnce();
+    await adapter.close();
+  });
+
+  it.each([
+    {
+      change: "selected command",
+      installedVersion: "0.2.118",
+      command: "/new/grok",
+      previousCommand: "/old/grok",
+    },
+    {
+      change: "installed version",
+      installedVersion: "1.0.0",
+      command: "/opt/grok",
+      previousCommand: "/opt/grok",
+    },
+  ])("does not reuse update state after a $change change", async ({
+    installedVersion,
+    command,
+    previousCommand,
+  }) => {
+    const backendId = "acp:grok" as AcpBackendId;
+    let stored: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+      version: installedVersion,
+      activeCommand: command,
+      update: {
+        status: "available",
+        checkedAt: 100,
+        currentVersion: "0.2.118",
+        latestVersion: "1.0.0",
+      },
+      updateCommand: previousCommand,
+    };
+    const updateCheck = vi.fn(async (
+      _command: string,
+      options?: {
+        installedVersion?: string;
+        previous?: AcpAgentUpdateStatus;
+      },
+    ): Promise<AcpAgentUpdateStatus> => ({
+      status: "failed",
+      checkedAt: 500,
+      currentVersion: options?.installedVersion ?? "unknown",
+      error: "offline",
+    }));
+    const emit = vi.fn(async () => undefined);
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => stored,
+        listInstalledAgents: () => [stored],
+        upsertInstalledAgent: (record) => {
+          stored = record;
+        },
+      },
+      captureStores: [],
+      checkGrokCliUpdate: updateCheck,
+      discoverLocalAcpAgents: async () => [],
+      emit,
+      handleServerRequest: async () => ({ decision: "accept" }),
+      isAcpAgentEnabled: () => true,
+    });
+
+    await adapter.describeInstalledBackends();
+    await vi.waitFor(() => {
+      expect(emit).toHaveBeenCalledOnce();
+    });
+
+    expect(updateCheck).toHaveBeenCalledWith(command, {
+      installedVersion,
+      previous: undefined,
+    });
+    expect(stored.version).toBe(installedVersion);
+    expect(stored.update).toMatchObject({
+      status: "failed",
+      currentVersion: installedVersion,
+      error: "offline",
+    });
+    await adapter.close();
+  });
+
+  it("preserves an acknowledgement committed while an update check runs", async () => {
+    const backendId = "acp:grok" as AcpBackendId;
+    let stored: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+      version: "0.2.118",
+      activeCommand: "/opt/grok",
+      update: {
+        status: "available",
+        checkedAt: 100,
+        currentVersion: "0.2.118",
+        latestVersion: "1.0.0",
+      },
+      updateCommand: "/opt/grok",
+    };
+    let finishUpdate: ((update: AcpAgentUpdateStatus) => void) | undefined;
+    const updateCheck = vi.fn(async () =>
+      await new Promise<AcpAgentUpdateStatus>((resolve) => {
+        finishUpdate = resolve;
+      }),
+    );
+    const emit = vi.fn(async () => undefined);
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => stored,
+        listInstalledAgents: () => [stored],
+        upsertInstalledAgent: (record) => {
+          stored = record;
+        },
+      },
+      captureStores: [],
+      checkGrokCliUpdate: updateCheck,
+      discoverLocalAcpAgents: async () => [],
+      emit,
+      handleServerRequest: async () => ({ decision: "accept" }),
+      isAcpAgentEnabled: () => true,
+    });
+
+    await adapter.describeInstalledBackends();
+    await vi.waitFor(() => {
+      expect(updateCheck).toHaveBeenCalledOnce();
+    });
+    stored = {
+      ...stored,
+      update: {
+        ...stored.update!,
+        dismissedAt: 400,
+      },
+    };
+    finishUpdate?.({
+      status: "available",
+      checkedAt: 500,
+      currentVersion: "0.2.118",
+      latestVersion: "1.0.0",
+    });
+    await vi.waitFor(() => {
+      expect(emit).toHaveBeenCalledOnce();
+    });
+
+    expect(stored.update).toMatchObject({
+      checkedAt: 500,
+      latestVersion: "1.0.0",
+      dismissedAt: 400,
+    });
     await adapter.close();
   });
 

--- a/apps/desktop/src/main/__tests__/grok-cli-update.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-cli-update.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  checkGrokCliUpdate,
+  GROK_UPDATE_FAILURE_TTL_MS,
+  GROK_UPDATE_SUCCESS_TTL_MS,
+  shouldCheckGrokCliUpdate,
+} from "../acp/grok-cli-update";
+
+describe("checkGrokCliUpdate", () => {
+  it("normalizes the official JSON status and preserves same-version acknowledgement", async () => {
+    const probe = vi.fn(async () => ({
+      stdout: JSON.stringify({
+        currentVersion: "0.2.118",
+        latestVersion: "1.0.0",
+        updateAvailable: true,
+        installer: "npm",
+        channel: "stable",
+        autoUpdate: true,
+        error: null,
+      }),
+    }));
+
+    await expect(checkGrokCliUpdate("/opt/grok", {
+      now: () => 500,
+      previous: {
+        status: "available",
+        checkedAt: 100,
+        currentVersion: "0.2.118",
+        latestVersion: "1.0.0",
+        snoozedUntil: 900,
+      },
+      probe,
+    })).resolves.toEqual({
+      status: "available",
+      checkedAt: 500,
+      currentVersion: "0.2.118",
+      latestVersion: "1.0.0",
+      installer: "npm",
+      channel: "stable",
+      autoUpdate: true,
+      snoozedUntil: 900,
+    });
+    expect(probe).toHaveBeenCalledWith("/opt/grok");
+  });
+
+  it("clears acknowledgement for a new latest version", async () => {
+    const update = await checkGrokCliUpdate("grok", {
+      now: () => 500,
+      previous: {
+        status: "available",
+        checkedAt: 100,
+        currentVersion: "0.2.118",
+        latestVersion: "0.2.119",
+        dismissedAt: 200,
+      },
+      probe: async () => ({
+        stdout: JSON.stringify({
+          currentVersion: "0.2.118",
+          latestVersion: "1.0.0",
+          updateAvailable: true,
+          channel: "stable",
+          error: null,
+        }),
+      }),
+    });
+
+    expect(update.dismissedAt).toBeUndefined();
+    expect(update.latestVersion).toBe("1.0.0");
+  });
+
+  it("keeps a known available update durable across an offline retry", async () => {
+    await expect(checkGrokCliUpdate("grok", {
+      now: () => 500,
+      previous: {
+        status: "available",
+        checkedAt: 100,
+        currentVersion: "0.2.118",
+        latestVersion: "1.0.0",
+      },
+      probe: async () => ({ stdout: "not-json" }),
+    })).resolves.toMatchObject({
+      status: "available",
+      checkedAt: 500,
+      currentVersion: "0.2.118",
+      latestVersion: "1.0.0",
+      error: "Grok update check returned invalid JSON",
+    });
+  });
+
+  it("turns an initial CLI failure into quiet retryable status", async () => {
+    await expect(checkGrokCliUpdate("grok", {
+      now: () => 500,
+      installedVersion: "0.2.118",
+      probe: async () => {
+        throw new Error("offline");
+      },
+    })).resolves.toEqual({
+      status: "failed",
+      checkedAt: 500,
+      currentVersion: "0.2.118",
+      error: "offline",
+    });
+  });
+});
+
+describe("shouldCheckGrokCliUpdate", () => {
+  const previous = {
+    status: "up-to-date" as const,
+    checkedAt: 100,
+    currentVersion: "1.0.0",
+  };
+
+  it("rechecks on command or installed-version changes", () => {
+    expect(shouldCheckGrokCliUpdate({
+      command: "/new/grok",
+      installedVersion: "1.0.0",
+      now: 200,
+      previous,
+      previousCommand: "/old/grok",
+    })).toBe(true);
+    expect(shouldCheckGrokCliUpdate({
+      command: "/grok",
+      installedVersion: "1.0.1",
+      now: 200,
+      previous,
+      previousCommand: "/grok",
+    })).toBe(true);
+  });
+
+  it("uses a daily success cadence and hourly failure retry", () => {
+    expect(shouldCheckGrokCliUpdate({
+      command: "/grok",
+      installedVersion: "1.0.0",
+      now: 100 + GROK_UPDATE_SUCCESS_TTL_MS - 1,
+      previous,
+      previousCommand: "/grok",
+    })).toBe(false);
+    expect(shouldCheckGrokCliUpdate({
+      command: "/grok",
+      installedVersion: "1.0.0",
+      now: 100 + GROK_UPDATE_SUCCESS_TTL_MS,
+      previous,
+      previousCommand: "/grok",
+    })).toBe(true);
+    expect(shouldCheckGrokCliUpdate({
+      command: "/grok",
+      now: 100 + GROK_UPDATE_FAILURE_TTL_MS,
+      previous: { ...previous, status: "failed" },
+      previousCommand: "/grok",
+    })).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -1198,6 +1198,80 @@ describe("settings ipc", () => {
     }
   });
 
+  it("persists a version-keyed Grok update acknowledgement", async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "pwragent-settings-ipc-"),
+    );
+    tempRoots.push(tempRoot);
+    vi.stubEnv("PWRAGENT_HOME", tempRoot);
+    const { initializeAppState, disposeAppState, getAppStateDb } = await import(
+      "../state/app-state"
+    );
+    const { AcpAgentStore } = await import("../acp/acp-agent-store");
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const { ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    initializeAppState();
+    try {
+      const store = new AcpAgentStore(getAppStateDb());
+      store.upsertInstalledAgent({
+        backendId: "acp:grok",
+        registryId: "grok",
+        name: "Grok",
+        version: "0.2.118",
+        distributionKind: "local",
+        distributionSource: "grok agent stdio",
+        installStatus: "installed",
+        authStatus: "not-required",
+        verificationStatus: "not-applicable",
+        allowlistRuleId: "local-grok-cli",
+        installedAt: 100,
+        updatedAt: 100,
+        update: {
+          status: "available",
+          checkedAt: 200,
+          currentVersion: "0.2.118",
+          latestVersion: "1.0.0",
+        },
+      });
+      registerSettingsIpcHandlers(service);
+
+      await expect(handlers.get(ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL)?.(
+        {},
+        {
+          action: "dismiss",
+          backendId: "acp:grok",
+          latestVersion: "0.2.119",
+        },
+      )).resolves.toEqual({ applied: false });
+      const response = await handlers.get(
+        ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL,
+      )?.(
+        {},
+        {
+          action: "snooze",
+          backendId: "acp:grok",
+          latestVersion: "1.0.0",
+        },
+      ) as { applied: boolean; update: { snoozedUntil?: number } };
+
+      expect(response.applied).toBe(true);
+      expect(response.update.snoozedUntil).toBeGreaterThan(Date.now());
+      expect(
+        store.getInstalledAgent("acp:grok")?.update?.snoozedUntil,
+      ).toBe(response.update.snoozedUntil);
+    } finally {
+      disposeAppState();
+    }
+  });
+
   // The wizard PR (#491) calls this IPC the moment the operator picks
   // a Codex profile model. The handler must (1) persist the wizard
   // signal idempotently, (2) fire the same thread-list prefetch the

--- a/apps/desktop/src/main/acp/acp-registry-types.ts
+++ b/apps/desktop/src/main/acp/acp-registry-types.ts
@@ -1,4 +1,5 @@
 import type {
+  AcpAgentUpdateStatus,
   AcpAgentInstance,
   AcpBackendId,
   BackendAcpAuthStatus,
@@ -114,4 +115,6 @@ export type AcpInstalledAgentRecord = {
   // preference). `launchDescriptor.command` mirrors `activeCommand`.
   instances?: AcpAgentInstance[];
   activeCommand?: string;
+  update?: AcpAgentUpdateStatus;
+  updateCommand?: string;
 };

--- a/apps/desktop/src/main/acp/grok-cli-update.ts
+++ b/apps/desktop/src/main/acp/grok-cli-update.ts
@@ -1,0 +1,171 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import type { AcpAgentUpdateStatus } from "@pwragent/shared";
+
+const execFile = promisify(execFileCallback);
+
+export const GROK_UPDATE_SUCCESS_TTL_MS = 24 * 60 * 60_000;
+export const GROK_UPDATE_FAILURE_TTL_MS = 60 * 60_000;
+const GROK_UPDATE_CHECK_TIMEOUT_MS = 20_000;
+const GROK_UPDATE_CHECK_MAX_BUFFER_BYTES = 64 * 1024;
+
+type GrokUpdateCheckJson = {
+  currentVersion?: unknown;
+  latestVersion?: unknown;
+  updateAvailable?: unknown;
+  installer?: unknown;
+  channel?: unknown;
+  autoUpdate?: unknown;
+  error?: unknown;
+};
+
+export type GrokCliUpdateProbe = (
+  command: string,
+) => Promise<{ stdout?: string; stderr?: string }>;
+
+export function shouldCheckGrokCliUpdate(params: {
+  command: string;
+  installedVersion?: string;
+  now: number;
+  previous?: AcpAgentUpdateStatus;
+  previousCommand?: string;
+}): boolean {
+  if (!params.previous) return true;
+  if (params.previousCommand !== params.command) return true;
+  if (
+    params.installedVersion
+    && params.installedVersion !== params.previous.currentVersion
+  ) {
+    return true;
+  }
+  const ttl =
+    params.previous.status === "failed"
+    || params.previous.error
+      ? GROK_UPDATE_FAILURE_TTL_MS
+      : GROK_UPDATE_SUCCESS_TTL_MS;
+  return params.now - params.previous.checkedAt >= ttl;
+}
+
+export async function checkGrokCliUpdate(
+  command: string,
+  options: {
+    now?: () => number;
+    installedVersion?: string;
+    previous?: AcpAgentUpdateStatus;
+    probe?: GrokCliUpdateProbe;
+  } = {},
+): Promise<AcpAgentUpdateStatus> {
+  const now = options.now?.() ?? Date.now();
+  const probe = options.probe ?? defaultProbe;
+  try {
+    const result = await probe(command);
+    const parsed = parseCheckOutput(result.stdout ?? "");
+    const update: AcpAgentUpdateStatus = {
+      status: parsed.updateAvailable ? "available" : "up-to-date",
+      checkedAt: now,
+      currentVersion: parsed.currentVersion,
+      ...(parsed.latestVersion ? { latestVersion: parsed.latestVersion } : {}),
+      ...(parsed.channel ? { channel: parsed.channel } : {}),
+      ...(parsed.installer ? { installer: parsed.installer } : {}),
+      ...(parsed.autoUpdate !== undefined
+        ? { autoUpdate: parsed.autoUpdate }
+        : {}),
+    };
+    return preserveGrokUpdateAcknowledgement(options.previous, update);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.previous && options.previous.status !== "failed") {
+      return {
+        ...options.previous,
+        checkedAt: now,
+        error: message,
+      };
+    }
+    return {
+      status: "failed",
+      checkedAt: now,
+      currentVersion:
+        options.previous?.currentVersion ?? options.installedVersion ?? "unknown",
+      error: message,
+    };
+  }
+}
+
+function parseCheckOutput(output: string): {
+  currentVersion: string;
+  latestVersion?: string;
+  updateAvailable: boolean;
+  installer?: string;
+  channel?: string;
+  autoUpdate?: boolean;
+} {
+  let value: GrokUpdateCheckJson;
+  try {
+    value = JSON.parse(output.trim()) as GrokUpdateCheckJson;
+  } catch {
+    throw new Error("Grok update check returned invalid JSON");
+  }
+  if (typeof value.currentVersion !== "string" || !value.currentVersion.trim()) {
+    throw new Error("Grok update check omitted currentVersion");
+  }
+  if (typeof value.updateAvailable !== "boolean") {
+    throw new Error("Grok update check omitted updateAvailable");
+  }
+  if (typeof value.error === "string" && value.error.trim()) {
+    throw new Error(value.error.trim());
+  }
+  if (
+    value.updateAvailable
+    && (typeof value.latestVersion !== "string" || !value.latestVersion.trim())
+  ) {
+    throw new Error("Grok update check omitted latestVersion");
+  }
+  return {
+    currentVersion: value.currentVersion.trim(),
+    updateAvailable: value.updateAvailable,
+    ...(typeof value.latestVersion === "string" && value.latestVersion.trim()
+      ? { latestVersion: value.latestVersion.trim() }
+      : {}),
+    ...(typeof value.installer === "string" && value.installer.trim()
+      ? { installer: value.installer.trim() }
+      : {}),
+    ...(typeof value.channel === "string" && value.channel.trim()
+      ? { channel: value.channel.trim() }
+      : {}),
+    ...(typeof value.autoUpdate === "boolean"
+      ? { autoUpdate: value.autoUpdate }
+      : {}),
+  };
+}
+
+export function preserveGrokUpdateAcknowledgement(
+  previous: AcpAgentUpdateStatus | undefined,
+  next: AcpAgentUpdateStatus,
+): AcpAgentUpdateStatus {
+  if (
+    next.status !== "available"
+    || !previous
+    || previous.latestVersion !== next.latestVersion
+  ) {
+    return next;
+  }
+  return {
+    ...next,
+    ...(previous.dismissedAt !== undefined
+      ? { dismissedAt: previous.dismissedAt }
+      : {}),
+    ...(previous.snoozedUntil !== undefined
+      ? { snoozedUntil: previous.snoozedUntil }
+      : {}),
+  };
+}
+
+async function defaultProbe(
+  command: string,
+): Promise<{ stdout?: string; stderr?: string }> {
+  return await execFile(command, ["update", "--check", "--json"], {
+    env: { ...process.env, NO_COLOR: "1" },
+    maxBuffer: GROK_UPDATE_CHECK_MAX_BUFFER_BYTES,
+    timeout: GROK_UPDATE_CHECK_TIMEOUT_MS,
+  });
+}

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -79,6 +79,11 @@ import {
   shouldSurfaceAcpThoughtsAsMessages,
 } from "../acp/acp-session-normalizer";
 import { AcpStdioJsonRpcTransport } from "../acp/acp-stdio-transport";
+import {
+  checkGrokCliUpdate,
+  preserveGrokUpdateAcknowledgement,
+  shouldCheckGrokCliUpdate,
+} from "../acp/grok-cli-update";
 import { getMainLogger } from "../log";
 import {
   getAppStateDb,
@@ -159,6 +164,7 @@ export type AcpBackendAdapterOptions = {
   discoverLocalAcpAgents?: LocalAcpDiscovery;
   resolveLocalAcpDiscoveryEnv?: () => Promise<NodeJS.ProcessEnv>;
   isAcpAgentEnabled?: (registryId: string) => boolean;
+  checkGrokCliUpdate?: typeof checkGrokCliUpdate | null;
   emit: (event: AgentEvent) => Promise<void>;
   handleServerRequest: (
     backend: AcpBackendId,
@@ -829,6 +835,8 @@ export class AcpBackendAdapter {
   private readonly providerStatuses = new Map<AcpBackendId, AcpProviderStatus>();
   private readonly providerStatusRefreshAttempts = new Map<AcpBackendId, number>();
   private readonly providerStatusRefreshes = new Map<AcpBackendId, Promise<void>>();
+  private readonly grokUpdateChecker?: typeof checkGrokCliUpdate;
+  private readonly grokUpdateRefreshes = new Map<AcpBackendId, Promise<void>>();
   private closed = false;
   private readonly liveTurnUsage = new Map<string, AcpLiveTurnUsage>();
   private localAcpAgentsPromise?: Promise<AcpInstalledAgentRecord[]>;
@@ -839,6 +847,10 @@ export class AcpBackendAdapter {
     this.automationInspectionMcpCommand = options.automationInspectionMcpCommand;
     this.emit = options.emit;
     this.handleServerRequest = options.handleServerRequest;
+    this.grokUpdateChecker = options.checkGrokCliUpdate === null
+      ? undefined
+      : options.checkGrokCliUpdate
+        ?? (isAppStateInitialized() ? checkGrokCliUpdate : undefined);
     this.acpAgentStore =
       options.acpAgentStore === null
         ? undefined
@@ -908,6 +920,7 @@ export class AcpBackendAdapter {
       if (agent.registryId !== "grok" || !summary.available) {
         return summary;
       }
+      this.refreshGrokUpdateStatusInBackground(agent);
       // Backend discovery is also used by launchpad and messaging flows.
       // Merge only cached decoration here; vendor billing must never delay it.
       const providerStatus = this.providerStatuses.get(agent.backendId);
@@ -920,6 +933,82 @@ export class AcpBackendAdapter {
           }
         : summary;
     });
+  }
+
+  private refreshGrokUpdateStatusInBackground(
+    agent: AcpInstalledAgentRecord,
+  ): void {
+    const checker = this.grokUpdateChecker;
+    const command = agent.activeCommand ?? agent.launchDescriptor?.command;
+    const previous =
+      agent.updateCommand === command
+      && agent.version === agent.update?.currentVersion
+        ? agent.update
+        : undefined;
+    if (
+      !checker
+      || !command
+      || this.closed
+      || this.grokUpdateRefreshes.has(agent.backendId)
+      || !shouldCheckGrokCliUpdate({
+        command,
+        installedVersion: agent.version,
+        now: Date.now(),
+        previous,
+        previousCommand: agent.updateCommand,
+      })
+    ) {
+      return;
+    }
+
+    const refresh = checker(command, {
+      installedVersion: agent.version,
+      previous,
+    })
+      .then(async (update) => {
+        if (this.closed) return;
+        const current = this.acpAgentStore?.getInstalledAgent(agent.backendId)
+          ?? agent;
+        const currentCommand =
+          current.activeCommand ?? current.launchDescriptor?.command;
+        if (
+          currentCommand !== command
+          || current.version !== agent.version
+        ) {
+          return;
+        }
+        const mergedUpdate = preserveGrokUpdateAcknowledgement(
+          current.update,
+          update,
+        );
+        this.acpAgentStore?.upsertInstalledAgent({
+          ...current,
+          ...(mergedUpdate.status !== "failed"
+            && mergedUpdate.currentVersion !== "unknown"
+            ? { version: mergedUpdate.currentVersion }
+            : {}),
+          update: mergedUpdate,
+          updateCommand: command,
+        });
+        await this.emit({
+          backend: agent.backendId,
+          notification: {
+            method: "backend/acpUpdateStatus/updated",
+            params: { backend: agent.backendId },
+          },
+        });
+      })
+      .catch((error) => {
+        acpBackendAdapterLog.debug("grok_update_check_failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      })
+      .finally(() => {
+        if (this.grokUpdateRefreshes.get(agent.backendId) === refresh) {
+          this.grokUpdateRefreshes.delete(agent.backendId);
+        }
+      });
+    this.grokUpdateRefreshes.set(agent.backendId, refresh);
   }
 
   private refreshProviderStatusInBackground(backend: AcpBackendId): void {
@@ -1441,6 +1530,7 @@ export class AcpBackendAdapter {
     this.providerStatuses.clear();
     this.providerStatusRefreshAttempts.clear();
     this.providerStatusRefreshes.clear();
+    this.grokUpdateRefreshes.clear();
     this.liveTurnUsage.clear();
     await Promise.all(
       acpClients.map(async (clientPromise) => {

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import type {
   AcpAgentPreference,
   AcpAgentSettingsEntry,
+  AcknowledgeAcpAgentUpdateRequest,
+  AcknowledgeAcpAgentUpdateResponse,
   CheckDesktopCodexAuthProfileStatusRequest,
   CheckDesktopCodexAuthProfileStatusResponse,
   ClearDesktopSettingsSecretRequest,
@@ -32,6 +34,7 @@ import type {
   WriteDesktopSettingsConfigRequest,
 } from "@pwragent/shared";
 import {
+  isAcpBackendId,
   isMessagingRuntimeSecret,
   sanitizeMessagingContactHandle,
   sanitizeMessagingContactLabel,
@@ -39,6 +42,7 @@ import {
 import {
   ONBOARDING_COMPLETE_CODEX_BOOTSTRAP_CHANNEL,
   ACP_AGENTS_LIST_CHANNEL,
+  ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL,
   SETTINGS_CHECK_CODEX_AUTH_PROFILE_STATUS_CHANNEL,
   SETTINGS_CLEAR_SECRET_CHANNEL,
   SETTINGS_CREATE_CODEX_AUTH_PROFILE_CHANNEL,
@@ -99,6 +103,7 @@ import { getAppStateDb } from "../state/app-state";
 import { normalizeProfileName, resolveActiveProfileDir } from "../profile";
 
 const settingsIpcLog = getMainLogger("pwragent:settings");
+const ACP_UPDATE_SNOOZE_MS = 24 * 60 * 60_000;
 // Codex profile login now runs through @pwrdrvr/codex-discovery's
 // CodexLoginManager (extracted from this file's inline flow). PwrAgnt owns the
 // instance so the Electron seam — `shell.openExternal` — is injected and the
@@ -349,6 +354,8 @@ async function listInstalledAndLocalAcpAgents(
         const nextRecord = {
           ...record,
           runtimeCapabilities: current?.runtimeCapabilities,
+          update: current?.update,
+          updateCommand: current?.updateCommand,
           lastDiscoveredAt: current?.lastDiscoveredAt,
           lastDiscoveryError: current?.lastDiscoveryError,
           installedAt: current?.installedAt ?? record.installedAt,
@@ -534,6 +541,7 @@ function installedAcpAgentSettingsEntry(
     lastDiscoveredAt: record.lastDiscoveredAt,
     lastDiscoveryError: record.lastDiscoveryError,
     runtime: record.runtimeCapabilities,
+    update: record.update,
     ...(record.instances !== undefined ? { instances: record.instances } : {}),
     ...(record.activeCommand !== undefined
       ? { activeCommand: record.activeCommand }
@@ -910,6 +918,41 @@ export function registerSettingsIpcHandlers(
       await listAcpAgentSettings(request, service),
   );
 
+  ipcMain.removeHandler(ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL);
+  ipcMain.handle(
+    ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL,
+    async (
+      _event,
+      request: AcknowledgeAcpAgentUpdateRequest,
+    ): Promise<AcknowledgeAcpAgentUpdateResponse> => {
+      const store = new AcpAgentStore(getAppStateDb());
+      const record = isAcpBackendId(request.backendId)
+        ? store.getInstalledAgent(request.backendId)
+        : undefined;
+      if (
+        !record?.update
+        || record.update.status !== "available"
+        || record.update.latestVersion !== request.latestVersion
+      ) {
+        return { applied: false };
+      }
+      const now = Date.now();
+      const update = request.action === "dismiss"
+        ? {
+            ...record.update,
+            dismissedAt: now,
+            snoozedUntil: undefined,
+          }
+        : {
+            ...record.update,
+            dismissedAt: undefined,
+            snoozedUntil: now + ACP_UPDATE_SNOOZE_MS,
+          };
+      store.upsertInstalledAgent({ ...record, update });
+      return { applied: true, update };
+    },
+  );
+
   ipcMain.removeHandler(SETTINGS_READ_CHANNEL);
   ipcMain.handle(
     SETTINGS_READ_CHANNEL,
@@ -1186,6 +1229,7 @@ export function registerSettingsIpcHandlers(
 export function disposeSettingsIpcHandlers(): void {
   codexLoginManager.dispose();
   ipcMain.removeHandler(ACP_AGENTS_LIST_CHANNEL);
+  ipcMain.removeHandler(ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL);
   ipcMain.removeHandler(SETTINGS_READ_CHANNEL);
   ipcMain.removeHandler(SETTINGS_WRITE_CONFIG_CHANNEL);
   ipcMain.removeHandler(SETTINGS_REPLACE_SECRET_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -74,6 +74,8 @@ import type {
   HandoffThreadWorkspaceResponse,
   ListAcpAgentSettingsRequest,
   ListAcpAgentSettingsResponse,
+  AcknowledgeAcpAgentUpdateRequest,
+  AcknowledgeAcpAgentUpdateResponse,
   NavigationBrowseMode,
   AttachDirectoryToThreadRequest,
   AttachDirectoryToThreadResponse,
@@ -298,6 +300,7 @@ import {
   AGENT_TRUST_CODEX_PROJECT_CHANNEL,
   AGENT_UPDATE_THREAD_EXPECTED_BRANCH_CHANNEL,
   ACP_AGENTS_LIST_CHANNEL,
+  ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL,
   AUTOMATIONS_CREATE_CHANNEL,
   AUTOMATIONS_DELETE_CHANNEL,
   AUTOMATIONS_DRAFT_PROMPT_CHANNEL,
@@ -751,6 +754,10 @@ const desktopApi = Object.freeze({
     request?: ListAcpAgentSettingsRequest,
   ): Promise<ListAcpAgentSettingsResponse> =>
     await ipcRenderer.invoke(ACP_AGENTS_LIST_CHANNEL, request),
+  acknowledgeAcpAgentUpdate: async (
+    request: AcknowledgeAcpAgentUpdateRequest,
+  ): Promise<AcknowledgeAcpAgentUpdateResponse> =>
+    await ipcRenderer.invoke(ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL, request),
   readSettings: async (
     request?: ReadDesktopSettingsRequest,
   ): Promise<ReadDesktopSettingsResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -68,6 +68,7 @@ import { useThreadQueuedMessageIndicators } from "./lib/useThreadQueuedMessageIn
 import { CodexConfigWarningBanner } from "./features/codex-config/CodexConfigWarningBanner";
 import { AppNoticeToast } from "./features/notifications/AppNoticeToast";
 import type { AppNoticeToastNotice } from "./features/notifications/AppNoticeToast";
+import { GrokCliUpdateNotice } from "./features/notifications/GrokCliUpdateNotice";
 import { resolveBackendErrorNotice } from "./features/notifications/backend-error-notice";
 import {
   buildHeapSnapshotHandoffMessage,
@@ -274,6 +275,8 @@ function DesktopAppShell(props: {
   // is the only signal the user gets that they were quietly not run, so it
   // stays until dismissed.
   const [automationLoadNotice, setAutomationLoadNotice] =
+    useState<AppNoticeToastNotice>();
+  const [grokCliUpdateNotice, setGrokCliUpdateNotice] =
     useState<AppNoticeToastNotice>();
   // Latest thread list, mirrored into a ref so the backend-error toast
   // subscription can resolve a thread's title without re-subscribing on
@@ -1589,7 +1592,16 @@ function DesktopAppShell(props: {
         ) : null}
 
         <CodexConfigWarningBanner desktopApi={desktopApi} />
+        <GrokCliUpdateNotice
+          desktopApi={desktopApi}
+          onNoticeChanged={setGrokCliUpdateNotice}
+        />
         <div className="app-toast-stack" aria-live="polite">
+          <AppNoticeToast
+            desktopApi={desktopApi}
+            notice={grokCliUpdateNotice}
+            onDismiss={() => setGrokCliUpdateNotice(undefined)}
+          />
           <AppNoticeToast
             desktopApi={desktopApi}
             notice={navigation.archiveThreadNotice}

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -6,6 +6,11 @@ import type { DesktopApi } from "../../lib/desktop-api";
 const AUTO_DISMISS_MS = 9_000;
 
 export type AppNoticeToastNotice = {
+  actions?: readonly {
+    label: string;
+    onClick: () => void;
+    tone?: "primary" | "secondary";
+  }[];
   autoDismiss?: boolean;
   id: string;
   title: string;
@@ -64,6 +69,7 @@ export function AppNoticeToast(props: {
     [props.notice.title, props.notice.message, props.notice.detail]
       .filter(Boolean)
       .join("\n");
+  const customActions = props.notice.actions ?? [];
 
   return (
     <aside
@@ -87,27 +93,43 @@ export function AppNoticeToast(props: {
           <p className="app-notice-toast__detail">{props.notice.detail}</p>
         ) : null}
       </div>
-      <div className="app-notice-toast__actions">
-        <button
-          className="app-notice-toast__icon-button"
-          type="button"
-          aria-label="Copy notice"
-          title="Copy notice"
-          onClick={() => {
-            void copyText(copyValue, props.desktopApi);
-          }}
-        >
-          <CopyIcon size={14} aria-hidden="true" />
-        </button>
-        <button
-          className="app-notice-toast__icon-button"
-          type="button"
-          aria-label="Dismiss notice"
-          title="Dismiss notice"
-          onClick={props.onDismiss}
-        >
-          <CloseIcon size={14} aria-hidden="true" />
-        </button>
+      <div
+        className="app-notice-toast__actions"
+        data-custom-actions={customActions.length > 0 ? "true" : undefined}
+      >
+        {customActions.length > 0
+          ? customActions.map((action) => (
+              <button
+                key={action.label}
+                className={`button button--${action.tone ?? "secondary"}`}
+                type="button"
+                onClick={action.onClick}
+              >
+                {action.label}
+              </button>
+            ))
+          : <>
+              <button
+                className="app-notice-toast__icon-button"
+                type="button"
+                aria-label="Copy notice"
+                title="Copy notice"
+                onClick={() => {
+                  void copyText(copyValue, props.desktopApi);
+                }}
+              >
+                <CopyIcon size={14} aria-hidden="true" />
+              </button>
+              <button
+                className="app-notice-toast__icon-button"
+                type="button"
+                aria-label="Dismiss notice"
+                title="Dismiss notice"
+                onClick={props.onDismiss}
+              >
+                <CloseIcon size={14} aria-hidden="true" />
+              </button>
+            </>}
       </div>
       {autoDismiss ? (
         <span

--- a/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { AcpAgentSettingsEntry } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import type { AppNoticeToastNotice } from "./AppNoticeToast";
+
+export function GrokCliUpdateNotice(props: {
+  desktopApi?: DesktopApi;
+  now?: () => number;
+  onNoticeChanged: (notice: AppNoticeToastNotice | undefined) => void;
+}) {
+  const [entry, setEntry] = useState<AcpAgentSettingsEntry>();
+  const [clock, setClock] = useState(() => props.now?.() ?? Date.now());
+  const desktopApi = props.desktopApi;
+  const now = props.now ?? Date.now;
+  const onNoticeChanged = props.onNoticeChanged;
+
+  const refresh = useCallback(async () => {
+    const response = await desktopApi?.listAcpAgents?.({ refresh: false });
+    setEntry(
+      response?.entries.find((candidate) => candidate.registryId === "grok"),
+    );
+  }, [desktopApi]);
+
+  useEffect(() => {
+    void refresh().catch(() => undefined);
+    return desktopApi?.onAgentEvent?.((event) => {
+      if (
+        event.backend === "acp:grok"
+        && event.notification.method === "backend/acpUpdateStatus/updated"
+      ) {
+        void refresh().catch(() => undefined);
+      }
+    });
+  }, [desktopApi, refresh]);
+
+  const snoozedUntil = entry?.update?.snoozedUntil;
+  useEffect(() => {
+    if (!snoozedUntil || snoozedUntil <= clock) return;
+    const timeout = window.setTimeout(
+      () => setClock(now()),
+      Math.min(snoozedUntil - clock, 2_147_483_647),
+    );
+    return () => window.clearTimeout(timeout);
+  }, [clock, now, snoozedUntil]);
+
+  const acknowledge = useCallback(
+    async (action: "dismiss" | "snooze") => {
+      const latestVersion = entry?.update?.latestVersion;
+      if (!latestVersion) return;
+      const response = await desktopApi?.acknowledgeAcpAgentUpdate?.({
+        action,
+        backendId: "acp:grok",
+        latestVersion,
+      });
+      if (response?.applied && response.update) {
+        setEntry((current) =>
+          current ? { ...current, update: response.update } : current,
+        );
+        setClock(now());
+      }
+    },
+    [desktopApi, entry?.update?.latestVersion, now],
+  );
+
+  const notice = useMemo(() => buildGrokCliUpdateNotice({
+    entry,
+    now: clock,
+    onCopy: () => {
+      void desktopApi?.copyText?.("grok update");
+    },
+    onDismiss: () => {
+      void acknowledge("dismiss");
+    },
+    onSnooze: () => {
+      void acknowledge("snooze");
+    },
+  }), [acknowledge, clock, desktopApi, entry]);
+
+  useEffect(() => {
+    onNoticeChanged(notice);
+  }, [notice, onNoticeChanged]);
+
+  return null;
+}
+
+export function buildGrokCliUpdateNotice(params: {
+  entry?: AcpAgentSettingsEntry;
+  now: number;
+  onCopy: () => void;
+  onDismiss: () => void;
+  onSnooze: () => void;
+}): AppNoticeToastNotice | undefined {
+  const update = params.entry?.update;
+  if (
+    params.entry?.registryId !== "grok"
+    || update?.status !== "available"
+    || !update.latestVersion
+    || update.dismissedAt !== undefined
+    || (update.snoozedUntil ?? 0) > params.now
+  ) {
+    return undefined;
+  }
+  return {
+    id: `acp-update:acp:grok:${update.latestVersion}`,
+    autoDismiss: false,
+    title: "Grok update available",
+    message: `Grok ${update.latestVersion} is available; ${update.currentVersion} is installed.`,
+    detail: "Run grok update in a terminal, then restart active Grok sessions.",
+    copyText: "grok update",
+    tone: "warning",
+    actions: [
+      { label: "Copy command", onClick: params.onCopy, tone: "primary" },
+      { label: "Tomorrow", onClick: params.onSnooze },
+      { label: "Dismiss version", onClick: params.onDismiss },
+    ],
+  };
+}

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -120,4 +120,41 @@ describe("AppNoticeToast", () => {
     fireEvent.click(screen.getByRole("button", { name: "Dismiss notice" }));
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
+
+  it("uses exactly the supplied operator actions", () => {
+    const copyCommand = vi.fn();
+    const snooze = vi.fn();
+    const dismissVersion = vi.fn();
+    const onDismiss = vi.fn();
+
+    const { container } = render(
+      <AppNoticeToast
+        notice={{
+          ...notice,
+          actions: [
+            { label: "Copy command", onClick: copyCommand, tone: "primary" },
+            { label: "Tomorrow", onClick: snooze },
+            { label: "Dismiss version", onClick: dismissVersion },
+          ],
+          autoDismiss: false,
+        }}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    expect(screen.getAllByRole("button")).toHaveLength(3);
+    expect(screen.queryByRole("button", { name: "Copy notice" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Dismiss notice" })).toBeNull();
+    expect(
+      container.querySelector(".app-notice-toast__actions"),
+    ).toHaveAttribute("data-custom-actions", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy command" }));
+    fireEvent.click(screen.getByRole("button", { name: "Tomorrow" }));
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss version" }));
+    expect(copyCommand).toHaveBeenCalledOnce();
+    expect(snooze).toHaveBeenCalledOnce();
+    expect(dismissVersion).toHaveBeenCalledOnce();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AcpAgentSettingsEntry } from "@pwragent/shared";
+import { buildGrokCliUpdateNotice } from "../GrokCliUpdateNotice";
+
+function grokEntry(
+  update: AcpAgentSettingsEntry["update"],
+): AcpAgentSettingsEntry {
+  return {
+    backendId: "acp:grok",
+    registryId: "grok",
+    name: "Grok",
+    authors: ["xAI"],
+    distributionKind: "local",
+    distributionSource: "grok agent stdio",
+    installable: false,
+    installed: true,
+    installStatus: "installed",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+    update,
+  };
+}
+
+describe("buildGrokCliUpdateNotice", () => {
+  it("builds a version-keyed durable update notice", () => {
+    const onCopy = vi.fn();
+    const notice = buildGrokCliUpdateNotice({
+      entry: grokEntry({
+        status: "available",
+        checkedAt: 100,
+        currentVersion: "0.2.118",
+        latestVersion: "1.0.0",
+      }),
+      now: 200,
+      onCopy,
+      onDismiss: vi.fn(),
+      onSnooze: vi.fn(),
+    });
+
+    expect(notice).toMatchObject({
+      id: "acp-update:acp:grok:1.0.0",
+      autoDismiss: false,
+      message: "Grok 1.0.0 is available; 0.2.118 is installed.",
+      copyText: "grok update",
+    });
+    expect(notice?.actions?.map((action) => action.label)).toEqual([
+      "Copy command",
+      "Tomorrow",
+      "Dismiss version",
+    ]);
+    notice?.actions?.[0]?.onClick();
+    expect(onCopy).toHaveBeenCalledOnce();
+  });
+
+  it("hides dismissed, snoozed, current, and failed checks", () => {
+    const callbacks = {
+      onCopy: vi.fn(),
+      onDismiss: vi.fn(),
+      onSnooze: vi.fn(),
+    };
+    const available = {
+      status: "available" as const,
+      checkedAt: 100,
+      currentVersion: "0.2.118",
+      latestVersion: "1.0.0",
+    };
+    expect(buildGrokCliUpdateNotice({
+      entry: grokEntry({ ...available, dismissedAt: 150 }),
+      now: 200,
+      ...callbacks,
+    })).toBeUndefined();
+    expect(buildGrokCliUpdateNotice({
+      entry: grokEntry({ ...available, snoozedUntil: 300 }),
+      now: 200,
+      ...callbacks,
+    })).toBeUndefined();
+    expect(buildGrokCliUpdateNotice({
+      entry: grokEntry({ ...available, snoozedUntil: 199 }),
+      now: 200,
+      ...callbacks,
+    })).toBeDefined();
+    expect(buildGrokCliUpdateNotice({
+      entry: grokEntry({ ...available, status: "up-to-date" }),
+      now: 200,
+      ...callbacks,
+    })).toBeUndefined();
+    expect(buildGrokCliUpdateNotice({
+      entry: grokEntry({ ...available, status: "failed" }),
+      now: 200,
+      ...callbacks,
+    })).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -81,6 +81,8 @@ import type {
   ListBackendsResponse,
   ListAcpAgentSettingsRequest,
   ListAcpAgentSettingsResponse,
+  AcknowledgeAcpAgentUpdateRequest,
+  AcknowledgeAcpAgentUpdateResponse,
   ListDesktopPwrAgentProfilesResponse,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
@@ -509,6 +511,9 @@ export type DesktopApi = {
   listAcpAgents?: (
     request?: ListAcpAgentSettingsRequest
   ) => Promise<ListAcpAgentSettingsResponse>;
+  acknowledgeAcpAgentUpdate?: (
+    request: AcknowledgeAcpAgentUpdateRequest,
+  ) => Promise<AcknowledgeAcpAgentUpdateResponse>;
   readSettings?: (
     request?: ReadDesktopSettingsRequest
   ) => Promise<ReadDesktopSettingsResponse>;

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -293,6 +293,16 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps custom toast actions from collapsing the message column", () => {
+    const customActionsRule = extractRuleBody(
+      css,
+      '.app-notice-toast__actions[data-custom-actions="true"]',
+    );
+
+    expect(customActionsRule).toContain("grid-column: 1 / -1;");
+    expect(customActionsRule).toContain("justify-content: flex-end;");
+  });
+
   it("lets transcript scroll restoration own scroll anchoring", () => {
     expect(css).toMatch(
       /\.transcript-list__items\s*\{[\s\S]*?overflow-anchor:\s*none;[\s\S]*?\}/

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5116,6 +5116,11 @@ textarea,
   align-self: start;
 }
 
+.app-notice-toast__actions[data-custom-actions="true"] {
+  grid-column: 1 / -1;
+  justify-content: flex-end;
+}
+
 .app-notice-toast__icon-button {
   display: inline-grid;
   width: 30px;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -22,6 +22,8 @@ export const THREAD_MIGRATION_RETRY_CHANNEL = "thread-migration:retry";
 export const FOCUSED_DIFF_ANALYZE_CHANNEL = "focused-diff:analyze";
 export const BACKEND_LIST_CHANNEL = "backend:list";
 export const ACP_AGENTS_LIST_CHANNEL = "acp-agents:list";
+export const ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL =
+  "acp-agents:acknowledge-update";
 export const AGENT_START_THREAD_CHANNEL = "agent:start-thread";
 export const AGENT_FORK_THREAD_CHANNEL = "agent:fork-thread";
 export const AGENT_START_TURN_CHANNEL = "agent:start-turn";

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -262,6 +262,7 @@ export type AcpAgentSettingsEntry = {
   lastDiscoveredAt?: number;
   lastDiscoveryError?: string;
   runtime?: BackendAcpRuntimeCapabilities;
+  update?: AcpAgentUpdateStatus;
   // Multi-install (Wave 2 / agent-acp). Every installed executable of this
   // agent found on the machine (PATH matches + fallbacks + a passing override),
   // the one currently in effect, the user's enable toggle, and their path
@@ -270,6 +271,19 @@ export type AcpAgentSettingsEntry = {
   activeCommand?: string;
   enabled?: boolean;
   preference?: AcpAgentPreference;
+};
+
+export type AcpAgentUpdateStatus = {
+  status: "available" | "up-to-date" | "failed";
+  checkedAt: number;
+  currentVersion: string;
+  latestVersion?: string;
+  channel?: string;
+  installer?: string;
+  autoUpdate?: boolean;
+  error?: string;
+  dismissedAt?: number;
+  snoozedUntil?: number;
 };
 
 /** How a discovered ACP instance's executable path was located. Mirrors the
@@ -313,4 +327,15 @@ export type ListAcpAgentSettingsResponse = {
   fetchedAt: number;
   entries: AcpAgentSettingsEntry[];
   error?: string;
+};
+
+export type AcknowledgeAcpAgentUpdateRequest = {
+  action: "dismiss" | "snooze";
+  backendId: AppServerBackendKind;
+  latestVersion: string;
+};
+
+export type AcknowledgeAcpAgentUpdateResponse = {
+  applied: boolean;
+  update?: AcpAgentUpdateStatus;
 };

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1141,6 +1141,12 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "backend/acpUpdateStatus/updated";
+      params: {
+        backend: AppServerBackendKind;
+      };
+    }
+  | {
       method: "item/commandExecution/outputDelta";
       params: {
         threadId: string;


### PR DESCRIPTION
## Summary

- backport the official no-install `grok update --check --json` availability probe for discovered, enabled system Grok installations
- run checks in the background with a 20-second timeout, 64 KiB output bound, in-flight coalescing, and success/failure cache windows
- persist typed update and acknowledgement state in the existing profile-scoped ACP agent store
- show a durable version-keyed warning with `Copy command`, `Tomorrow`, and `Dismiss version` actions

## Source

Backport of [#1348](https://github.com/pwrdrvr/PwrAgent/pull/1348), using squash commit [`5eee2cef6`](https://github.com/pwrdrvr/PwrAgent/commit/5eee2cef69687dfc9abac19d6c41d025008eee5f) and its PR body as the source of truth.

## Release-line adaptations

- manually adapted the feature to the older 1.0 notification stack by adding its minimal custom-action seam; no newer notification-stack architecture was pulled in
- retained the requested 1.0-era `grok update` copy action and explicit operator initiation
- used the existing 1.0 profile-scoped ACP JSON payload for persisted status; no schema migration is required
- kept the system-discovered Grok executable and inherited process environment as the probe target
- preserved all 1.0 version/release metadata and existing Grok 4.5 model, effort, and pricing behavior
- excluded PR #1024's draft bundled/custom grok-build runtime, packaged Grok assets, dependencies, and installer behavior

## Behavior

- never delays backend discovery and never installs an update automatically
- checks at most every 24 hours after success and every hour after failure
- immediately rechecks after the active executable path or installed version changes
- retains a known available update during offline retries; first-time failures remain silent
- preserves dismiss/snooze state for the same latest version and resets it when the latest version changes

## Validation

- `pnpm test apps/desktop/src/main/__tests__/settings-ipc.test.ts apps/desktop/src/main/__tests__/grok-cli-update.test.ts apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx` (110 tests)
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx` (21 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with pre-existing warnings)
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop build`
- `git diff --check`
