### PR TITLE
perf(desktop): backport sqlite accounting write controls

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -40,6 +40,7 @@ import type {
   TaskMonitorResponse,
   ThreadExecutionMode,
   ThreadOverlayState,
+  ThreadToolAccounting,
   ThreadUsageLineRecord,
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
@@ -3611,6 +3612,65 @@ describe("DesktopBackendRegistry", () => {
 
     await registry.close();
     expect(acpClient.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes persisted tool accounting when reading ACP threads", async () => {
+    const acpBackendId = "acp:grok" as AcpBackendId;
+    const threadId = "grok-tool-accounting";
+    const toolAccounting: ThreadToolAccounting = {
+      alerts: [],
+      invocations: [
+        {
+          backend: acpBackendId,
+          category: "shell",
+          debugLines: 0,
+          errorLines: 0,
+          estimatedOutputTokens: 550,
+          infoLines: 1,
+          invocationId: "inv-1",
+          itemId: "item-1",
+          noisy: false,
+          observedAt: 3_000,
+          outputChars: 2_200,
+          outputLines: 23,
+          outputTruncated: false,
+          status: "completed",
+          threadId,
+          toolName: "shell",
+          updatedAt: 3_000,
+          warningLines: 0,
+        },
+      ],
+      summaries: [],
+    };
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadToolAccounting: async () => toolAccounting,
+    };
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      overlayStore,
+      sessionId: threadId,
+      sessions: [
+        {
+          backendId: acpBackendId,
+          sessionId: threadId,
+          title: "ACP session",
+          createdAt: 1_000,
+          updatedAt: 4_000,
+          executionMode: "default",
+          status: "idle",
+        },
+      ],
+    });
+
+    const response = await registry.readThread({
+      backend: acpBackendId,
+      threadId,
+    });
+    expect(response.toolAccounting).toEqual(toolAccounting);
+
+    await registry.close();
   });
 
   it("includes persisted pricing when reading ACP threads", async () => {

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budget.ts
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budget.ts
@@ -1,0 +1,75 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { expect } from "vitest";
+import type { SqliteWriteDelta } from "./sqlite-write-metrics";
+
+const BUDGETS_PATH = path.join(import.meta.dirname, "sqlite-write-budgets.json");
+
+type Budget = {
+  commits: number;
+  note: string;
+  observedWalBytes: number;
+  rowsChanged: number;
+  statements: number;
+};
+
+type BudgetFile = Record<string, Budget>;
+
+export function expectSqliteWriteBudget(params: {
+  note: string;
+  scenario: string;
+  writes: SqliteWriteDelta;
+}): void {
+  const budgets = readBudgets();
+  const measured: Budget = {
+    commits: params.writes.commits,
+    note: params.note,
+    observedWalBytes: params.writes.walBytes,
+    rowsChanged: params.writes.rowsChanged,
+    statements: params.writes.statements,
+  };
+
+  if (process.env.UPDATE_SQLITE_WRITE_BUDGETS) {
+    budgets[params.scenario] = measured;
+    writeFileSync(
+      BUDGETS_PATH,
+      `${JSON.stringify(sortKeys(budgets), null, 2)}\n`,
+    );
+    return;
+  }
+
+  const budget = budgets[params.scenario];
+  if (!budget) {
+    throw new Error(
+      `No sqlite write budget recorded for "${params.scenario}". `
+        + "Record it with UPDATE_SQLITE_WRITE_BUDGETS=1.",
+    );
+  }
+  expect(
+    {
+      commits: measured.commits,
+      rowsChanged: measured.rowsChanged,
+      statements: measured.statements,
+    },
+    `sqlite write budget "${params.scenario}" changed; `
+      + "re-record only when the write-volume change is intentional.",
+  ).toEqual({
+    commits: budget.commits,
+    rowsChanged: budget.rowsChanged,
+    statements: budget.statements,
+  });
+}
+
+function readBudgets(): BudgetFile {
+  try {
+    return JSON.parse(readFileSync(BUDGETS_PATH, "utf8")) as BudgetFile;
+  } catch {
+    return {};
+  }
+}
+
+function sortKeys(budgets: BudgetFile): BudgetFile {
+  return Object.fromEntries(
+    Object.entries(budgets).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -1,0 +1,23 @@
+{
+  "live-thread-token-usage": {
+    "commits": 1,
+    "note": "500 cumulative usage observations across 10 turns, then one terminal flush",
+    "observedWalBytes": 65920,
+    "rowsChanged": 30,
+    "statements": 30
+  },
+  "live-thread-token-usage-timer-windows": {
+    "commits": 10,
+    "note": "10 cumulative live-usage observations separated by full one-second timer windows",
+    "observedWalBytes": 547960,
+    "rowsChanged": 30,
+    "statements": 30
+  },
+  "streamed-command-output": {
+    "commits": 2,
+    "note": "500 streamed output deltas plus the completion for one command",
+    "observedWalBytes": 37080,
+    "rowsChanged": 2,
+    "statements": 2
+  }
+}

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-metrics.ts
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-metrics.ts
@@ -1,0 +1,124 @@
+import fs from "node:fs";
+import type BetterSqlite3 from "better-sqlite3";
+
+export type SqliteWriteDelta = {
+  commits: number;
+  rowsChanged: number;
+  statements: number;
+  walBytes: number;
+};
+
+type Snapshot = SqliteWriteDelta;
+
+const WRITE_STATEMENT = /^\s*(?:INSERT|UPDATE|DELETE|REPLACE)\b/i;
+
+/**
+ * Minimal release-line adaptation of PR #1410's database instrumentation.
+ * It attaches after migrations and measures only callbacks in this test file;
+ * the broader dev/E2E reporting and process-wide aggregation are deliberately
+ * left on main.
+ */
+export function attachSqliteWriteMeter(params: {
+  db: BetterSqlite3.Database;
+  dbPath: string;
+}): {
+  measure<T>(run: () => T | Promise<T>): Promise<{
+    result: T;
+    writes: SqliteWriteDelta;
+  }>;
+} {
+  const totals: Snapshot = {
+    commits: 0,
+    rowsChanged: 0,
+    statements: 0,
+    walBytes: 0,
+  };
+  const walPath = `${params.dbPath}-wal`;
+  let walSize = readWalSize(walPath);
+  const sampleWal = (): void => {
+    const size = readWalSize(walPath);
+    if (size > walSize) {
+      totals.walBytes += size - walSize;
+    }
+    walSize = size;
+  };
+  const recordCommit = (): void => {
+    totals.commits += 1;
+    sampleWal();
+  };
+  const db = params.db;
+  const originalPrepare = db.prepare.bind(db);
+  const originalTransaction = db.transaction.bind(db);
+
+  db.prepare = ((source: string) => {
+    const statement = originalPrepare(source);
+    if (!WRITE_STATEMENT.test(source)) {
+      return statement;
+    }
+    const originalRun = statement.run.bind(statement);
+    statement.run = ((...args: unknown[]) => {
+      const result = originalRun(...(args as never[]));
+      totals.statements += 1;
+      totals.rowsChanged += result.changes;
+      if (!db.inTransaction) {
+        recordCommit();
+      }
+      return result;
+    }) as typeof statement.run;
+    return statement;
+  }) as typeof db.prepare;
+
+  const countTransaction = <T extends (...args: unknown[]) => unknown>(
+    transactionFn: T,
+  ): T =>
+    ((...args: unknown[]) => {
+      const nested = db.inTransaction;
+      const result = transactionFn(...args);
+      if (!nested) {
+        recordCommit();
+      }
+      return result;
+    }) as T;
+
+  db.transaction = ((fn: (...args: unknown[]) => unknown) => {
+    const wrapped = originalTransaction(fn) as unknown as Record<string, unknown>;
+    const counted = countTransaction(
+      wrapped as unknown as (...args: unknown[]) => unknown,
+    ) as unknown as Record<string, unknown>;
+    for (const variant of ["default", "deferred", "immediate", "exclusive"]) {
+      const original = wrapped[variant];
+      if (typeof original === "function") {
+        Object.defineProperty(counted, variant, {
+          configurable: true,
+          value: countTransaction(original as (...args: unknown[]) => unknown),
+          writable: true,
+        });
+      }
+    }
+    return counted;
+  }) as unknown as typeof db.transaction;
+
+  return {
+    async measure<T>(run: () => T | Promise<T>) {
+      const before = { ...totals };
+      const result = await run();
+      return {
+        result,
+        writes: {
+          commits: totals.commits - before.commits,
+          rowsChanged: totals.rowsChanged - before.rowsChanged,
+          statements: totals.statements - before.statements,
+          walBytes: totals.walBytes - before.walBytes,
+        },
+      };
+    },
+  };
+}
+
+function readWalSize(walPath: string): number {
+  try {
+    return fs.statSync(walPath).size;
+  } catch {
+    return 0;
+  }
+}

--- a/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
@@ -6,6 +6,10 @@ import type {
   ThreadToolInvocationRecord,
 } from "@pwragent/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  mergeStreamedToolInvocationDeltas,
+  toolInvocationFromNotification,
+} from "../app-server/tool-invocation-accounting";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import { StateDb } from "../state/state-db";
 
@@ -142,6 +146,129 @@ describe("SqliteOverlayStore tool invocation accounting", () => {
       outputLines: 10,
       status: "completed",
       warningLines: 3,
+    });
+  });
+
+  it("does not double-count streamed output repeated in a completed Codex snapshot", async () => {
+    const deltas = [
+      "[info] starting\n",
+      "[warn] still working\n",
+      "[error] command failed\n",
+    ];
+    for (const [index, delta] of deltas.entries()) {
+      await store.upsertThreadToolInvocation({
+        invocation: toolInvocationFromNotification({
+          backend: "codex",
+          notification: {
+            method: "item/commandExecution/outputDelta",
+            params: {
+              delta,
+              itemId: "cmd-with-snapshot",
+              threadId: "thread-1",
+              turnId: "turn-1",
+            },
+          },
+          now: 1_800_000_000_000 + index,
+        })!,
+      });
+    }
+
+    const aggregatedOutput = deltas.join("");
+    await store.upsertThreadToolInvocation({
+      invocation: toolInvocationFromNotification({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              aggregatedOutput,
+              exitCode: 1,
+              id: "cmd-with-snapshot",
+              status: "failed",
+              type: "commandExecution",
+            },
+          },
+        },
+        now: 1_800_000_001_000,
+      })!,
+    });
+
+    const accounting = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(accounting.invocations[0]).toMatchObject({
+      errorLines: 1,
+      estimatedOutputTokens: Math.ceil(aggregatedOutput.length / 4),
+      exitCode: 1,
+      infoLines: 1,
+      outputChars: aggregatedOutput.length,
+      outputLines: 3,
+      status: "failed",
+      warningLines: 1,
+    });
+  });
+
+  it("records coalesced output deltas identically to per-chunk writes", async () => {
+    const deltas = [
+      "warning: slow step\nbuilding module a\n",
+      "error: module b failed\nretrying\n",
+      "info: done\n",
+    ];
+    const records = deltas.map((delta, index) =>
+      toolInvocationFromNotification({
+        backend: "codex",
+        notification: {
+          method: "item/commandExecution/outputDelta",
+          params: {
+            delta,
+            itemId: "cmd-1",
+            threadId: "thread-per-chunk",
+            turnId: "turn-1",
+          },
+        },
+        now: 1_800_000_000_000 + index * 10,
+      })!,
+    );
+    for (const record of records) {
+      await store.upsertThreadToolInvocation({ invocation: record });
+    }
+
+    const coalesced = records
+      .slice(1)
+      .reduce(
+        (accumulated, record) =>
+          mergeStreamedToolInvocationDeltas(accumulated, record),
+        records[0]!,
+      );
+    await store.upsertThreadToolInvocation({
+      invocation: {
+        ...coalesced,
+        invocationId: "coalesced",
+        itemId: "coalesced",
+        threadId: "thread-coalesced",
+      },
+    });
+
+    const perChunk = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-per-chunk",
+    });
+    const single = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-coalesced",
+    });
+    expect(single.invocations[0]).toMatchObject({
+      debugLines: perChunk.invocations[0]!.debugLines,
+      errorLines: perChunk.invocations[0]!.errorLines,
+      estimatedOutputTokens: perChunk.invocations[0]!.estimatedOutputTokens,
+      infoLines: perChunk.invocations[0]!.infoLines,
+      observedAt: perChunk.invocations[0]!.observedAt,
+      outputChars: perChunk.invocations[0]!.outputChars,
+      outputLines: perChunk.invocations[0]!.outputLines,
+      warningLines: perChunk.invocations[0]!.warningLines,
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/sqlite-write-budgets.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-budgets.test.ts
@@ -1,0 +1,550 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type {
+  AgentEvent,
+  AppServerThreadReplay,
+  ThreadUsageLineRecord,
+} from "@pwragent/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DesktopBackendRegistry } from "../app-server/backend-registry";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import { StateDb } from "../state/state-db";
+import { expectSqliteWriteBudget } from "./fixtures/sqlite-write-budget";
+import { attachSqliteWriteMeter } from "./fixtures/sqlite-write-metrics";
+
+let meter: ReturnType<typeof attachSqliteWriteMeter>;
+let stateDb: StateDb;
+let store: SqliteOverlayStore;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-write-budget-"));
+  const dbPath = path.join(tempDir, "state.db");
+  stateDb = StateDb.open(dbPath);
+  meter = attachSqliteWriteMeter({ db: stateDb.raw, dbPath });
+  store = new SqliteOverlayStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("sqlite write budgets", () => {
+  it("keeps transaction variants callable and counts one commit per batch", async () => {
+    const insert = stateDb.raw.prepare(
+      "INSERT INTO thread_tool_invocations (invocation_id, backend, thread_id, "
+        + "item_id, tool_name, category, status, observed_at, updated_at, "
+        + "output_chars, output_lines, estimated_output_tokens, warning_lines, "
+        + "error_lines, info_lines, debug_lines, output_truncated, noisy) "
+        + "VALUES (?, 'codex', 't', 'i', 'commandExecution', 'shell', "
+        + "'completed', 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0)",
+    );
+    const transaction = stateDb.raw.transaction((id: string) => {
+      insert.run(id);
+    });
+
+    expect(typeof transaction.deferred).toBe("function");
+    expect(typeof transaction.immediate).toBe("function");
+    expect(typeof transaction.exclusive).toBe("function");
+    const { writes } = await meter.measure(() => {
+      transaction("plain");
+      transaction.immediate("immediate");
+    });
+    expect(writes).toMatchObject({ commits: 2, rowsChanged: 2, statements: 2 });
+  });
+
+  it("pins streamed command output to one delta batch plus completion", async () => {
+    const upsert = vi.spyOn(store, "upsertThreadToolInvocation");
+    const registry = createRegistry();
+    const emit = registryEmit(registry);
+
+    const { writes } = await meter.measure(async () => {
+      for (let index = 0; index < 500; index += 1) {
+        await emit(buildOutputDeltaEvent(`line ${index}\n`));
+      }
+      expect(upsert).not.toHaveBeenCalled();
+      await emit(buildCommandCompletedEvent());
+    });
+
+    expectSqliteWriteBudget({
+      note: "500 streamed output deltas plus the completion for one command",
+      scenario: "streamed-command-output",
+      writes,
+    });
+    const accounting = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(accounting.invocations[0]).toMatchObject({
+      outputChars: Array.from(
+        { length: 500 },
+        (_, index) => `line ${index}\n`.length,
+      ).reduce((sum, length) => sum + length, 0),
+      status: "completed",
+    });
+    expect(upsert.mock.calls).toHaveLength(2);
+    expect(upsert.mock.calls[0]?.[0].invocation.status).toBe("in_progress");
+    expect(upsert.mock.calls[1]?.[0].invocation.status).toBe("completed");
+
+    await registry.close();
+  });
+
+  it("flushes streamed command output on each bounded timer window", async () => {
+    vi.useFakeTimers();
+    const upsert = vi.spyOn(store, "upsertThreadToolInvocation");
+    const registry = createRegistry();
+    const emit = registryEmit(registry);
+
+    try {
+      await emit(buildOutputDeltaEvent("chunk one\n"));
+      await emit(buildOutputDeltaEvent("chunk two\n"));
+      await vi.advanceTimersByTimeAsync(249);
+      expect(upsert).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(upsert).toHaveBeenCalledTimes(1);
+      expect(upsert.mock.calls[0]?.[0].invocation).toMatchObject({
+        outputChars: 20,
+        status: "in_progress",
+      });
+
+      await emit(buildOutputDeltaEvent("chunk three\n"));
+      await vi.advanceTimersByTimeAsync(250);
+      expect(upsert).toHaveBeenCalledTimes(2);
+      expect(
+        (await store.readThreadToolAccounting({
+          backend: "codex",
+          threadId: "thread-1",
+        })).invocations[0],
+      ).toMatchObject({ outputChars: 32, status: "in_progress" });
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries a failed streamed-output batch", async () => {
+    vi.useFakeTimers();
+    const originalUpsert = store.upsertThreadToolInvocation.bind(store);
+    const upsert = vi
+      .spyOn(store, "upsertThreadToolInvocation")
+      .mockRejectedValueOnce(new Error("disk busy"))
+      .mockImplementation(async (params) => await originalUpsert(params));
+    const registry = createRegistry();
+    const emit = registryEmit(registry);
+
+    try {
+      await emit(buildOutputDeltaEvent("chunk one\n"));
+      await vi.advanceTimersByTimeAsync(250);
+      expect(upsert).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(upsert).toHaveBeenCalledTimes(2);
+      expect(
+        (await store.readThreadToolAccounting({
+          backend: "codex",
+          threadId: "thread-1",
+        })).invocations[0],
+      ).toMatchObject({ outputChars: 10 });
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("pins a burst of cumulative live usage to one transaction", async () => {
+    vi.useFakeTimers();
+    const registry = createRegistry();
+    const emit = registryEmit(registry);
+
+    try {
+      const { writes } = await meter.measure(async () => {
+        for (let index = 0; index < 500; index += 1) {
+          const turnIndex = index % 10;
+          const observation = Math.floor(index / 10) + 1;
+          await emit(buildLiveUsageEvent({
+            inputTokens: observation * 1_000 + turnIndex,
+            threadId: `thread-${turnIndex}`,
+            turnId: `turn-${turnIndex}`,
+          }));
+        }
+        await emit(buildTurnCompletedEvent("thread-0", "turn-0"));
+      });
+
+      expectSqliteWriteBudget({
+        note:
+          "500 cumulative usage observations across 10 turns, then one terminal flush",
+        scenario: "live-thread-token-usage",
+        writes,
+      });
+      for (let turnIndex = 0; turnIndex < 10; turnIndex += 1) {
+        const pricing = await store.readThreadPricing({
+          backend: "codex",
+          threadId: `thread-${turnIndex}`,
+        });
+        expect(pricing.lines[0]).toMatchObject({
+          inputTokens: 50_000 + turnIndex,
+          turnId: `turn-${turnIndex}`,
+        });
+      }
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("pins recurring live usage to one commit per timer window", async () => {
+    vi.useFakeTimers({
+      toFake: ["Date", "clearTimeout", "setTimeout"],
+    });
+    const batchWrite = vi.spyOn(store, "upsertThreadUsageLines");
+    const registry = createRegistry();
+    const emit = registryEmit(registry);
+
+    try {
+      const { writes } = await meter.measure(async () => {
+        for (let window = 1; window <= 10; window += 1) {
+          await emit(buildLiveUsageEvent({
+            inputTokens: window * 1_000,
+            threadId: "timer-thread",
+            turnId: "timer-turn",
+          }));
+          await vi.advanceTimersByTimeAsync(1_000);
+        }
+      });
+
+      expect(batchWrite).toHaveBeenCalledTimes(10);
+      expectSqliteWriteBudget({
+        note:
+          "10 cumulative live-usage observations separated by full one-second timer windows",
+        scenario: "live-thread-token-usage-timer-windows",
+        writes,
+      });
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("requeues a failed usage batch without overwriting a newer snapshot", async () => {
+    vi.useFakeTimers();
+    const firstWriteStarted = createDeferred();
+    const releaseFirstWrite = createDeferred();
+    const originalBatchWrite = store.upsertThreadUsageLines.bind(store);
+    const batchWrite = vi
+      .spyOn(store, "upsertThreadUsageLines")
+      .mockImplementationOnce(async () => {
+        firstWriteStarted.resolve();
+        await releaseFirstWrite.promise;
+        throw new Error("disk busy");
+      })
+      .mockImplementation(async (params) => await originalBatchWrite(params));
+    const registry = createRegistry();
+    const emit = registryEmit(registry);
+    const flush = (registry as unknown as {
+      flushLiveThreadUsageLines(): Promise<void>;
+    }).flushLiveThreadUsageLines.bind(registry);
+
+    try {
+      await emit(buildLiveUsageEvent({
+        inputTokens: 1_000,
+        threadId: "thread-retry",
+        turnId: "turn-retry",
+      }));
+      const firstFlush = flush();
+      await firstWriteStarted.promise;
+      await emit(buildLiveUsageEvent({
+        inputTokens: 2_000,
+        threadId: "thread-retry",
+        turnId: "turn-retry",
+      }));
+      releaseFirstWrite.resolve();
+      await firstFlush;
+      await flush();
+
+      expect(batchWrite).toHaveBeenCalledTimes(2);
+      expect(batchWrite.mock.calls[1]?.[0].lines[0]).toMatchObject({
+        inputTokens: 2_000,
+      });
+    } finally {
+      releaseFirstWrite.resolve();
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes live usage before replay hydration supersedes it", async () => {
+    vi.useFakeTimers();
+    const threadId = "thread-hydration-race";
+    const turnId = "turn-hydration-race";
+    const registry = createRegistry({
+      replay: buildHydratedUsageReplay({ threadId, turnId }),
+    });
+    const emit = registryEmit(registry);
+
+    try {
+      await emit(buildLiveUsageEvent({ inputTokens: 1_000, threadId, turnId }));
+      await registry.readThread({ backend: "codex", threadId });
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      const pricing = await store.readThreadPricing({
+        backend: "codex",
+        threadId,
+      });
+      expect(pricing.lines).toHaveLength(1);
+      expect(pricing.lines[0]).toMatchObject({
+        source: "hydration",
+        status: "finalized",
+        usageLineId: `codex:${threadId}:${turnId}:hydration`,
+      });
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits for an earlier usage derivation at the terminal boundary", async () => {
+    const lookupStarted = createDeferred();
+    const releaseLookup = createDeferred();
+    const readOverlay = store.getThreadOverlayState.bind(store);
+    vi.spyOn(store, "getThreadOverlayState").mockImplementationOnce(
+      async (params) => {
+        lookupStarted.resolve();
+        await releaseLookup.promise;
+        return await readOverlay(params);
+      },
+    );
+    const registry = createRegistry();
+    const emit = registryEmit(registry);
+    let terminalDelivered = false;
+    registry.onEvent((event) => {
+      if (event.notification.method === "turn/completed") {
+        terminalDelivered = true;
+      }
+    });
+
+    const usageEmit = emit(buildLiveUsageEvent({
+      inputTokens: 1_000,
+      threadId: "thread-race",
+      turnId: "turn-race",
+    }));
+    await lookupStarted.promise;
+    const terminalEmit = emit(buildTurnCompletedEvent("thread-race", "turn-race"));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(terminalDelivered).toBe(false);
+
+    releaseLookup.resolve();
+    await Promise.all([usageEmit, terminalEmit]);
+    expect(terminalDelivered).toBe(true);
+    expect(
+      (await store.readThreadPricing({
+        backend: "codex",
+        threadId: "thread-race",
+      })).lines[0],
+    ).toMatchObject({ inputTokens: 1_000 });
+    await registry.close();
+  });
+
+  it("drains pre-close usage and ignores observations accepted after close", async () => {
+    const registry = createRegistry();
+    const emit = registryEmit(registry);
+    await emit(buildLiveUsageEvent({
+      inputTokens: 1_000,
+      threadId: "thread-close",
+      turnId: "turn-close",
+    }));
+
+    await registry.close();
+    await emit(buildLiveUsageEvent({
+      inputTokens: 2_000,
+      threadId: "thread-close",
+      turnId: "turn-close",
+    }));
+
+    expect(
+      (await store.readThreadPricing({
+        backend: "codex",
+        threadId: "thread-close",
+      })).lines[0],
+    ).toMatchObject({ inputTokens: 1_000 });
+  });
+});
+
+function createRegistry(options?: { replay?: AppServerThreadReplay }) {
+  return new DesktopBackendRegistry({
+    codexClient: createStubBackendClient(options),
+    overlayStore: store as never,
+  });
+}
+
+function registryEmit(registry: DesktopBackendRegistry) {
+  return (registry as unknown as {
+    emit(event: AgentEvent): Promise<void>;
+  }).emit.bind(registry);
+}
+
+function buildOutputDeltaEvent(delta: string): AgentEvent {
+  return {
+    backend: "codex",
+    notification: {
+      method: "item/commandExecution/outputDelta",
+      params: {
+        delta,
+        itemId: "cmd-1",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+    },
+  } as AgentEvent;
+}
+
+function buildCommandCompletedEvent(): AgentEvent {
+  return {
+    backend: "codex",
+    notification: {
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "cmd-1",
+          type: "commandExecution",
+          command: "find / -xdev",
+          status: "completed",
+          exitCode: 0,
+        },
+      },
+    },
+  } as AgentEvent;
+}
+
+function buildLiveUsageEvent(params: {
+  inputTokens: number;
+  threadId: string;
+  turnId: string;
+}): AgentEvent {
+  const cachedInputTokens = Math.max(0, params.inputTokens - 100);
+  return {
+    backend: "codex",
+    notification: {
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: params.threadId,
+        turnId: params.turnId,
+        model: "gpt-5.5",
+        tokenUsage: {
+          total: {
+            inputTokens: params.inputTokens,
+            cachedInputTokens,
+            outputTokens: 100,
+          },
+          last: {
+            inputTokens: params.inputTokens,
+            cachedInputTokens,
+            outputTokens: 100,
+          },
+        },
+      },
+    },
+  } as AgentEvent;
+}
+
+function buildTurnCompletedEvent(threadId: string, turnId: string): AgentEvent {
+  return {
+    backend: "codex",
+    notification: {
+      method: "turn/completed",
+      params: {
+        threadId,
+        turnId,
+        turn: {
+          id: turnId,
+          status: "completed",
+          output: [],
+        },
+      },
+    },
+  } as AgentEvent;
+}
+
+function buildHydratedUsageReplay(params: {
+  threadId: string;
+  turnId: string;
+}): AppServerThreadReplay {
+  const usageLine: ThreadUsageLineRecord = {
+    backend: "codex",
+    cachedInputCostMicros: 0,
+    cachedInputTokens: 1_200,
+    completedAt: 2_000,
+    createdAt: 2_000,
+    currency: "USD",
+    inputTokens: 1_500,
+    model: "gpt-5.5",
+    outputCostMicros: 0,
+    outputTokens: 150,
+    priceStatus: "unpriced",
+    provider: "openai",
+    reasoningOutputTokens: 0,
+    scope: "turn",
+    source: "hydration",
+    sourceItemId: "hydrated-usage",
+    status: "finalized",
+    threadId: params.threadId,
+    totalCostMicros: 0,
+    totalTokens: 1_650,
+    turnId: params.turnId,
+    uncachedInputCostMicros: 0,
+    uncachedInputTokens: 300,
+    usageLineId: `codex:${params.threadId}:${params.turnId}:hydration`,
+  };
+  return {
+    entries: [
+      {
+        type: "activity",
+        id: "hydrated-usage",
+        summary: "Turn usage: hydrated",
+        status: "completed",
+        createdAt: 2_000,
+        details: [],
+        turn: { id: params.turnId, status: "completed" },
+        usageLine,
+      },
+    ],
+    messages: [],
+    pagination: {
+      hasPreviousPage: false,
+      supportsPagination: false,
+    },
+  };
+}
+
+function createDeferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function createStubBackendClient(options?: { replay?: AppServerThreadReplay }) {
+  return {
+    close: async () => {},
+    getInitializeResult: async () => ({
+      methods: options?.replay ? ["thread/read"] : [],
+    }),
+    onNotification: () => () => {},
+    onPendingRequest: () => () => {},
+    readThread: async () =>
+      options?.replay ?? {
+        entries: [],
+        messages: [],
+        pagination: {
+          hasPreviousPage: false,
+          supportsPagination: false,
+        },
+      },
+  } as never;
+}

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -1,4 +1,7 @@
-import type { ThreadToolInvocationRecord } from "@pwragent/shared";
+import type {
+  AppServerNotification,
+  ThreadToolInvocationRecord,
+} from "@pwragent/shared";
 import { describe, expect, it } from "vitest";
 import {
   buildToolOutputMetrics,
@@ -121,6 +124,76 @@ describe("tool invocation accounting", () => {
       turnId: "turn-1",
     });
   });
+
+  it.each([
+    {
+      field: "aggregatedOutput",
+      nestedInData: false,
+      shape: "item.aggregatedOutput",
+    },
+    {
+      field: "aggregated_output",
+      nestedInData: false,
+      shape: "item.aggregated_output",
+    },
+    {
+      field: "functionCallOutput",
+      nestedInData: false,
+      shape: "item.functionCallOutput",
+    },
+    {
+      field: "aggregatedOutput",
+      nestedInData: true,
+      shape: "item.data.aggregatedOutput",
+    },
+    {
+      field: "aggregated_output",
+      nestedInData: true,
+      shape: "item.data.aggregated_output",
+    },
+  ] as const)(
+    "extracts completed Codex command output from $shape",
+    ({ field, nestedInData }) => {
+      const output = [
+        "[info] command started",
+        "[warn] retrying step",
+        "[debug] retry detail",
+        "[error] command failed",
+        "output clipped",
+      ].join("\n");
+      const invocation = toolInvocationFromNotification({
+        backend: "codex",
+        now: 1_800_000_030_000,
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "cmd-1",
+              type: "commandExecution",
+              status: "completed",
+              ...(nestedInData
+                ? { data: { [field]: output } }
+                : { [field]: output }),
+            },
+          },
+        } as unknown as AppServerNotification,
+      });
+
+      expect(invocation).toMatchObject({
+        debugLines: 1,
+        errorLines: 1,
+        estimatedOutputTokens: Math.ceil(output.length / 4),
+        infoLines: 1,
+        outputChars: output.length,
+        outputLines: 5,
+        outputTruncated: true,
+        status: "completed",
+        warningLines: 1,
+      });
+    },
+  );
 
   it("marks completed command invocations failed from success false or exit code", () => {
     const successFalseInvocation = toolInvocationFromNotification({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -172,6 +172,7 @@ import {
   type ThreadOverlayState,
   type ThreadWorkspaceHandoffStrategy,
   type ThreadSubAgentSummary,
+  type ThreadToolInvocationRecord,
   type ThreadUsageLineRecord,
   type PrSummary,
   type WorktreeSnapshotSummary,
@@ -321,6 +322,7 @@ import {
 } from "./protocol-log-observer";
 import {
   detectNoisyPolling,
+  mergeStreamedToolInvocationDeltas,
   toolAccountingLookbackSince,
   toolInvocationFromNotification,
 } from "./tool-invocation-accounting";
@@ -5418,6 +5420,30 @@ type PendingThreadMessageOrigin = {
   turnId?: string;
 };
 
+// Command-output accounting is folded in memory so fixed-size streamed chunks
+// do not each pay for an implicit sqlite transaction on the event hot path.
+const TOOL_INVOCATION_DELTA_FLUSH_INTERVAL_MS = 250;
+
+// Live token-usage notifications are cumulative snapshots. A one-second
+// window lets repeated observations replace one another and lets concurrent
+// turns share one sqlite transaction while terminal events remain durability
+// boundaries.
+const LIVE_THREAD_USAGE_FLUSH_INTERVAL_MS = 1_000;
+
+type PendingLiveThreadUsageLine = {
+  backend: AppServerBackendKind;
+  line: ThreadUsageLineRecord;
+  observationSequence: number;
+};
+
+type LiveThreadUsageEmitWork = {
+  backend: AppServerBackendKind;
+  observationSequence: number;
+  settled: Promise<void>;
+  settle: () => void;
+  threadId: string;
+};
+
 export class DesktopBackendRegistry {
   private readonly codexClient: BackendClient;
   private readonly grokClient: BackendClient;
@@ -5526,11 +5552,32 @@ export class DesktopBackendRegistry {
     string,
     ObservedContextReplayCursor
   >();
+  /** Latest cumulative live usage waiting for one bulk sqlite transaction. */
+  private readonly pendingLiveThreadUsageLines = new Map<
+    string,
+    PendingLiveThreadUsageLine
+  >();
+  private liveThreadUsageObservationSequence = 0;
+  /**
+   * Registered synchronously at emit entry so terminal, hydration, and close
+   * can wait for already-arrived observations that are still deriving rows.
+   */
+  private readonly liveThreadUsageEmitWork = new Set<LiveThreadUsageEmitWork>();
+  private pendingLiveThreadUsageTimer: NodeJS.Timeout | undefined;
+  private liveThreadUsageFlushChain: Promise<void> = Promise.resolve();
   private readonly taskMonitorDelegations = new Map<
     string,
     TaskMonitorDelegationRecord
   >();
   private readonly taskMonitorWatchdogTimer?: NodeJS.Timeout;
+  /** Streamed command-output counters waiting for the next bounded flush. */
+  private readonly pendingToolInvocationDeltas = new Map<
+    string,
+    ThreadToolInvocationRecord
+  >();
+  private pendingToolInvocationDeltaTimer: NodeJS.Timeout | undefined;
+  /** Prevents a timer-driven delta write from overtaking a terminal row. */
+  private toolInvocationDeltaFlushChain: Promise<void> = Promise.resolve();
   /**
    * Best-effort cache of thread labels keyed by `${backend}:${threadId}`, used
    * only to label native attention/terminal notifications so multiple
@@ -6954,11 +7001,19 @@ export class DesktopBackendRegistry {
             threadId: request.threadId,
           })
         : { lines: [], summaries: [] };
+    const toolAccounting =
+      typeof this.overlayStore.readThreadToolAccounting === "function"
+        ? await this.overlayStore.readThreadToolAccounting({
+            backend,
+            threadId: request.threadId,
+          })
+        : undefined;
     return {
       backend,
       fetchedAt: Date.now(),
       pricing,
       threadId: request.threadId,
+      ...(toolAccounting ? { toolAccounting } : {}),
       ...(replay.threadStatus ? { threadStatus: replay.threadStatus } : {}),
       replay,
     };
@@ -8277,6 +8332,14 @@ export class DesktopBackendRegistry {
       messageOrigins,
     );
     if (!request.before && shouldAppendTranscriptOverlays) {
+      // Hydration supersedes live rows for the same turn. Drain observations
+      // that arrived before this read before persisting the replay snapshot,
+      // or a delayed live row could become active after hydration.
+      await this.waitForLiveThreadUsageEmitWork({
+        backend,
+        threadId: request.threadId,
+      });
+      await this.flushLiveThreadUsageLines();
       await this.persistReplayUsageLines(replayWithEnvironment);
     }
     const pricing =
@@ -12906,9 +12969,14 @@ export class DesktopBackendRegistry {
 
   async close(): Promise<void> {
     this.closed = true;
+    const liveThreadUsageEmitBarrier =
+      this.waitForLiveThreadUsageEmitWork();
     if (this.taskMonitorWatchdogTimer) {
       clearInterval(this.taskMonitorWatchdogTimer);
     }
+    await liveThreadUsageEmitBarrier;
+    await this.flushLiveThreadUsageLines();
+    await this.flushStreamedToolInvocationDeltas();
     for (const reconciliation of this.codexNativeSubAgentReconciliations.values()) {
       if (reconciliation.timer) {
         clearTimeout(reconciliation.timer);
@@ -14777,9 +14845,57 @@ export class DesktopBackendRegistry {
     );
   }
 
-  private async recordLiveThreadUsage(event: AgentEvent): Promise<void> {
+  private registerLiveThreadUsageEmitWork(
+    backend: AppServerBackendKind,
+    threadId: string,
+  ): LiveThreadUsageEmitWork {
+    let settle!: () => void;
+    const settled = new Promise<void>((resolve) => {
+      settle = resolve;
+    });
+    const work = {
+      backend,
+      observationSequence: ++this.liveThreadUsageObservationSequence,
+      settled,
+      settle,
+      threadId,
+    };
+    this.liveThreadUsageEmitWork.add(work);
+    return work;
+  }
+
+  private finishLiveThreadUsageEmitWork(
+    work: LiveThreadUsageEmitWork,
+  ): void {
+    if (!this.liveThreadUsageEmitWork.delete(work)) {
+      return;
+    }
+    work.settle();
+  }
+
+  private async waitForLiveThreadUsageEmitWork(params?: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<void> {
+    const pending = [...this.liveThreadUsageEmitWork]
+      .filter(
+        (work) =>
+          !params
+          || (work.backend === params.backend && work.threadId === params.threadId),
+      )
+      .map((work) => work.settled);
+    await Promise.all(pending);
+  }
+
+  private async recordLiveThreadUsage(
+    event: AgentEvent,
+    observationSequence?: number,
+  ): Promise<void> {
     const notification = event.notification;
-    if (notification.method !== "thread/tokenUsage/updated") {
+    if (
+      notification.method !== "thread/tokenUsage/updated"
+      || observationSequence === undefined
+    ) {
       return;
     }
     const threadId = notification.params.threadId;
@@ -14862,9 +14978,14 @@ export class DesktopBackendRegistry {
     }
     if (typeof this.overlayStore.upsertThreadUsageLine === "function") {
       logUnpricedThreadUsageLine(line);
-      await this.overlayStore.upsertThreadUsageLine({ line });
+      const batchesLiveUsage =
+        typeof this.overlayStore.upsertThreadUsageLines === "function";
+      if (!batchesLiveUsage) {
+        await this.overlayStore.upsertThreadUsageLine({ line });
+      }
       // Best-effort: a failure here must never block the load-bearing pricing
-      // push below (the turn line is already persisted).
+      // write/notification path. The bulk path prepares a rare fork baseline
+      // before arming its timer, so the later pricing event includes both.
       try {
         await this.captureForkBaselineUsageLine({
           backend: event.backend,
@@ -14884,11 +15005,136 @@ export class DesktopBackendRegistry {
           error: error instanceof Error ? error.message : String(error),
         });
       }
+      if (batchesLiveUsage) {
+        this.bufferLiveThreadUsageLine({
+          backend: event.backend,
+          line,
+          observationSequence,
+        });
+        return;
+      }
       await this.emitThreadPricingUpdated({
         backend: event.backend,
         threadId: line.parentThreadId ?? line.threadId,
       });
     }
+  }
+
+  private bufferLiveThreadUsageLine(
+    pending: PendingLiveThreadUsageLine,
+  ): void {
+    const existing = this.pendingLiveThreadUsageLines.get(
+      pending.line.usageLineId,
+    );
+    if (
+      !existing
+      || pending.observationSequence > existing.observationSequence
+    ) {
+      this.pendingLiveThreadUsageLines.set(
+        pending.line.usageLineId,
+        pending,
+      );
+    }
+    this.scheduleLiveThreadUsageFlush();
+  }
+
+  private scheduleLiveThreadUsageFlush(): void {
+    if (this.pendingLiveThreadUsageTimer || this.closed) {
+      return;
+    }
+    this.pendingLiveThreadUsageTimer = setTimeout(() => {
+      this.pendingLiveThreadUsageTimer = undefined;
+      void this.flushLiveThreadUsageLines();
+    }, LIVE_THREAD_USAGE_FLUSH_INTERVAL_MS);
+    this.pendingLiveThreadUsageTimer.unref?.();
+  }
+
+  private flushLiveThreadUsageLines(): Promise<void> {
+    const flushed = this.liveThreadUsageFlushChain.then(() =>
+      this.writePendingLiveThreadUsageLines(),
+    );
+    this.liveThreadUsageFlushChain = flushed.catch(() => undefined);
+    return flushed;
+  }
+
+  private async writePendingLiveThreadUsageLines(): Promise<void> {
+    if (this.pendingLiveThreadUsageTimer) {
+      clearTimeout(this.pendingLiveThreadUsageTimer);
+      this.pendingLiveThreadUsageTimer = undefined;
+    }
+    if (
+      this.pendingLiveThreadUsageLines.size === 0
+      || typeof this.overlayStore.upsertThreadUsageLines !== "function"
+    ) {
+      return;
+    }
+
+    const pending = [...this.pendingLiveThreadUsageLines.values()];
+    this.pendingLiveThreadUsageLines.clear();
+    try {
+      await this.overlayStore.upsertThreadUsageLines({
+        lines: pending.map((entry) => entry.line),
+      });
+    } catch (error) {
+      for (const entry of pending) {
+        this.requeueFailedLiveThreadUsageLine(entry);
+      }
+      backendRegistryLog.warn("live thread usage batch write failed", {
+        error: error instanceof Error ? error.message : String(error),
+        lineCount: pending.length,
+        usageLineIds: pending
+          .slice(0, 10)
+          .map((entry) => entry.line.usageLineId),
+      });
+      return;
+    }
+
+    const pricingTargets = new Map<
+      string,
+      { backend: AppServerBackendKind; threadId: string }
+    >();
+    for (const { backend, line } of pending) {
+      const target = {
+        backend,
+        threadId: line.parentThreadId ?? line.threadId,
+      };
+      pricingTargets.set(
+        JSON.stringify([target.backend, target.threadId]),
+        target,
+      );
+    }
+    for (const target of pricingTargets.values()) {
+      try {
+        await this.emitThreadPricingUpdated(target);
+      } catch (error) {
+        backendRegistryLog.warn("live thread pricing update failed", {
+          backend: target.backend,
+          error: error instanceof Error ? error.message : String(error),
+          threadId: target.threadId,
+        });
+      }
+    }
+  }
+
+  private requeueFailedLiveThreadUsageLine(
+    pending: PendingLiveThreadUsageLine,
+  ): void {
+    if (this.closed) {
+      return;
+    }
+    const newer = this.pendingLiveThreadUsageLines.get(
+      pending.line.usageLineId,
+    );
+    if (
+      !newer
+      || pending.observationSequence > newer.observationSequence
+    ) {
+      this.pendingLiveThreadUsageLines.set(
+        pending.line.usageLineId,
+        pending,
+      );
+    }
+    this.scheduleLiveThreadUsageFlush();
   }
 
   /**
@@ -15934,6 +16180,15 @@ export class DesktopBackendRegistry {
       return;
     }
 
+    if (event.notification.method === "item/commandExecution/outputDelta") {
+      this.bufferStreamedToolInvocationDelta(invocation);
+      return;
+    }
+
+    // The store stops summing after a row becomes terminal, so every earlier
+    // streamed delta must land before the lifecycle row.
+    await this.flushStreamedToolInvocationDeltas();
+
     const stored = await this.overlayStore.upsertThreadToolInvocation({
       invocation,
     });
@@ -15977,6 +16232,84 @@ export class DesktopBackendRegistry {
         threadId: stored.threadId,
       });
     }
+  }
+
+  private bufferStreamedToolInvocationDelta(
+    invocation: ThreadToolInvocationRecord,
+  ): void {
+    const accumulated = this.pendingToolInvocationDeltas.get(
+      invocation.invocationId,
+    );
+    this.pendingToolInvocationDeltas.set(
+      invocation.invocationId,
+      accumulated
+        ? mergeStreamedToolInvocationDeltas(accumulated, invocation)
+        : invocation,
+    );
+    this.scheduleStreamedToolInvocationFlush();
+  }
+
+  private scheduleStreamedToolInvocationFlush(): void {
+    if (this.pendingToolInvocationDeltaTimer || this.closed) {
+      return;
+    }
+    this.pendingToolInvocationDeltaTimer = setTimeout(() => {
+      this.pendingToolInvocationDeltaTimer = undefined;
+      void this.flushStreamedToolInvocationDeltas();
+    }, TOOL_INVOCATION_DELTA_FLUSH_INTERVAL_MS);
+    this.pendingToolInvocationDeltaTimer.unref?.();
+  }
+
+  private flushStreamedToolInvocationDeltas(): Promise<void> {
+    const flushed = this.toolInvocationDeltaFlushChain.then(() =>
+      this.writePendingToolInvocationDeltas(),
+    );
+    this.toolInvocationDeltaFlushChain = flushed.catch(() => undefined);
+    return flushed;
+  }
+
+  private async writePendingToolInvocationDeltas(): Promise<void> {
+    if (this.pendingToolInvocationDeltaTimer) {
+      clearTimeout(this.pendingToolInvocationDeltaTimer);
+      this.pendingToolInvocationDeltaTimer = undefined;
+    }
+    if (
+      this.pendingToolInvocationDeltas.size === 0
+      || typeof this.overlayStore.upsertThreadToolInvocation !== "function"
+    ) {
+      return;
+    }
+    const pending = [...this.pendingToolInvocationDeltas.values()];
+    this.pendingToolInvocationDeltas.clear();
+    for (const invocation of pending) {
+      try {
+        await this.overlayStore.upsertThreadToolInvocation({ invocation });
+      } catch (error) {
+        this.requeueFailedToolInvocationDelta(invocation);
+        backendRegistryLog.warn("tool invocation output accounting write failed", {
+          backend: invocation.backend,
+          error: error instanceof Error ? error.message : String(error),
+          invocationId: invocation.invocationId,
+          threadId: invocation.threadId,
+        });
+      }
+    }
+  }
+
+  private requeueFailedToolInvocationDelta(
+    invocation: ThreadToolInvocationRecord,
+  ): void {
+    if (this.closed) {
+      return;
+    }
+    const newer = this.pendingToolInvocationDeltas.get(invocation.invocationId);
+    this.pendingToolInvocationDeltas.set(
+      invocation.invocationId,
+      newer
+        ? mergeStreamedToolInvocationDeltas(invocation, newer)
+        : invocation,
+    );
+    this.scheduleStreamedToolInvocationFlush();
   }
 
   private async describeSingleBackend(
@@ -21862,7 +22195,43 @@ export class DesktopBackendRegistry {
     };
   }
 
-  private async emit(event: AgentEvent): Promise<void> {
+  private emit(event: AgentEvent): Promise<void> {
+    const isLiveThreadUsage =
+      event.notification.method === "thread/tokenUsage/updated";
+    if (isLiveThreadUsage && this.closed) {
+      return Promise.resolve();
+    }
+    const liveThreadUsageWork =
+      event.notification.method === "thread/tokenUsage/updated"
+        ? this.registerLiveThreadUsageEmitWork(
+            event.backend,
+            event.notification.params.threadId,
+          )
+        : undefined;
+    const method = event.notification.method;
+    const precedingLiveThreadUsageBarrier =
+      method === "turn/completed"
+      || method === "turn/failed"
+      || method === "turn/cancelled"
+        ? this.waitForLiveThreadUsageEmitWork()
+        : undefined;
+    const emitted = this.emitAfterLiveThreadUsageRegistration(
+      event,
+      liveThreadUsageWork,
+      precedingLiveThreadUsageBarrier,
+    );
+    return liveThreadUsageWork
+      ? emitted.finally(() => {
+          this.finishLiveThreadUsageEmitWork(liveThreadUsageWork);
+        })
+      : emitted;
+  }
+
+  private async emitAfterLiveThreadUsageRegistration(
+    event: AgentEvent,
+    liveThreadUsageWork: LiveThreadUsageEmitWork | undefined,
+    precedingLiveThreadUsageBarrier: Promise<void> | undefined,
+  ): Promise<void> {
     event = await this.withThreadMessageOrigin(event);
     this.rememberFileChangeApprovalContext(event);
     event = this.withEmbeddedFileChangeApprovalContext(event);
@@ -21940,6 +22309,8 @@ export class DesktopBackendRegistry {
       event.notification.method === "turn/failed" ||
       event.notification.method === "turn/cancelled"
     ) {
+      await precedingLiveThreadUsageBarrier;
+      await this.flushLiveThreadUsageLines();
       const notification = event.notification as {
         params: {
           threadId: string;
@@ -22232,7 +22603,10 @@ export class DesktopBackendRegistry {
       }
     }
 
-    await this.recordLiveThreadUsage(event);
+    await this.recordLiveThreadUsage(
+      event,
+      liveThreadUsageWork?.observationSequence,
+    );
     await this.recordToolInvocationAccounting(event);
     this.forgetCompletedTurnReplayObservations(event);
     await this.recordCodexNativeSubAgentActivity(event);
@@ -22243,6 +22617,10 @@ export class DesktopBackendRegistry {
     this.rememberThreadTitleFromEvent(event);
     this.notifyForAttentionRequired(event);
     await this.notifyForTerminalOutcome(event);
+
+    if (liveThreadUsageWork) {
+      this.finishLiveThreadUsageEmitWork(liveThreadUsageWork);
+    }
 
     for (const listener of this.eventListeners) {
       try {

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -208,6 +208,34 @@ export function buildToolOutputMetrics(
   };
 }
 
+/**
+ * Fold one streamed `item/commandExecution/outputDelta` record into the
+ * running accumulator for the same invocation.
+ *
+ * The summing rules mirror `mergeThreadToolInvocationForUpsert` in
+ * `overlay-store-sqlite.ts` for an in-progress row. Lifecycle records must
+ * flush separately because they carry terminal status and command metadata.
+ */
+export function mergeStreamedToolInvocationDeltas(
+  accumulated: ThreadToolInvocationRecord,
+  incoming: ThreadToolInvocationRecord,
+): ThreadToolInvocationRecord {
+  const outputChars = accumulated.outputChars + incoming.outputChars;
+  return {
+    ...incoming,
+    debugLines: accumulated.debugLines + incoming.debugLines,
+    errorLines: accumulated.errorLines + incoming.errorLines,
+    estimatedOutputTokens: Math.ceil(outputChars / OUTPUT_TOKEN_CHAR_RATIO),
+    infoLines: accumulated.infoLines + incoming.infoLines,
+    observedAt: Math.max(accumulated.observedAt, incoming.observedAt),
+    outputChars,
+    outputLines: accumulated.outputLines + incoming.outputLines,
+    outputTruncated: accumulated.outputTruncated || incoming.outputTruncated,
+    updatedAt: Math.max(accumulated.updatedAt, incoming.updatedAt),
+    warningLines: accumulated.warningLines + incoming.warningLines,
+  };
+}
+
 export function normalizeToolInvocationCommand(params: {
   args?: Record<string, unknown>;
   command?: string;
@@ -507,6 +535,11 @@ function readToolOutput(
 ): { text?: string; truncated?: boolean } {
   const data = readRecord(item?.data);
   const text =
+    readString(item, "aggregatedOutput") ??
+    readString(item, "aggregated_output") ??
+    readString(item, "functionCallOutput") ??
+    readString(data, "aggregatedOutput") ??
+    readString(data, "aggregated_output") ??
     readString(data, "output") ??
     readString(data, "text") ??
     readString(data, "result") ??

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -674,9 +674,82 @@ export class SqliteOverlayStore {
   async upsertThreadUsageLine(params: {
     line: ThreadUsageLineRecord;
   }): Promise<{ line: ThreadUsageLineRecord; summary: ThreadPricingSummary }> {
+    const { lines, summaries } = await this.upsertThreadUsageLines({
+      lines: [params.line],
+    });
+    const line = lines[0];
+    if (!line) {
+      throw new Error("Thread usage line batch did not persist its input");
+    }
+    const summary = summaries.find(
+      (candidate) =>
+        candidate.backend === line.backend
+        && candidate.currency === line.currency
+        && candidate.provider === line.provider
+        && candidate.threadId === (line.parentThreadId ?? line.threadId),
+    );
+    if (!summary) {
+      throw new Error(
+        `Thread usage line ${line.usageLineId} did not produce a pricing summary`,
+      );
+    }
+    return { line, summary };
+  }
+
+  /**
+   * Persist the latest value for every distinct usage line under one sqlite
+   * transaction. Later entries with the same id win, and affected pricing
+   * summaries are recomputed once each.
+   */
+  async upsertThreadUsageLines(params: {
+    lines: ThreadUsageLineRecord[];
+  }): Promise<{
+    lines: ThreadUsageLineRecord[];
+    summaries: ThreadPricingSummary[];
+  }> {
+    const latestLinesById = new Map<string, ThreadUsageLineRecord>();
+    for (const line of params.lines) {
+      latestLinesById.set(line.usageLineId, line);
+    }
+    if (latestLinesById.size === 0) {
+      return { lines: [], summaries: [] };
+    }
+
     const now = Date.now();
-    let line = repriceTokenUsageLine(normalizeThreadUsageLine(params.line, now));
-    const upsert = this.stateDb.raw.transaction(() => {
+    const lines = [...latestLinesById.values()].map((line) =>
+      repriceTokenUsageLine(normalizeThreadUsageLine(line, now)),
+    );
+    const summaryTargets = new Map<
+      string,
+      {
+        backend: string;
+        currency: string;
+        provider: string;
+        threadId: string;
+        updatedAt: number;
+      }
+    >();
+    const queueSummary = (target: {
+      backend: string;
+      currency: string;
+      provider: string;
+      threadId: string;
+      updatedAt: number;
+    }): void => {
+      summaryTargets.set(
+        JSON.stringify([
+          target.provider,
+          target.backend,
+          target.threadId,
+          target.currency,
+        ]),
+        target,
+      );
+    };
+    const upsertLine = (
+      inputLine: ThreadUsageLineRecord,
+    ): ThreadUsageLineRecord => {
+      let line = inputLine;
       const existing = this.readThreadUsageLineSync(line.usageLineId);
       if (existing) {
         line = mergeThreadUsageLineForUpsert(line, existing);
@@ -954,7 +1027,7 @@ export class SqliteOverlayStore {
           existingRollupThreadId !== nextRollupThreadId ||
           existing.currency !== line.currency
         ) {
-          this.recomputeThreadPricingSummarySync({
+          queueSummary({
             backend: existing.backend,
             currency: existing.currency,
             provider: existing.provider,
@@ -964,16 +1037,27 @@ export class SqliteOverlayStore {
         }
       }
 
-      return this.recomputeThreadPricingSummarySync({
+      queueSummary({
         backend: line.backend,
         currency: line.currency,
         provider: line.provider,
         threadId: line.parentThreadId ?? line.threadId,
         updatedAt: now,
       });
+      return line;
+    };
+
+    const upsert = this.stateDb.raw.transaction(() => {
+      for (let index = 0; index < lines.length; index += 1) {
+        lines[index] = upsertLine(lines[index]!);
+      }
+
+      return [...summaryTargets.values()].map((target) =>
+        this.recomputeThreadPricingSummarySync(target),
+      );
     });
 
-    return { line, summary: upsert() };
+    return { lines, summaries: upsert() };
   }
 
   async readThreadPricing(params: {
@@ -3737,6 +3821,7 @@ export type OverlayStoreLike = Pick<
   | "setAcpWorktreeDirectory"
   | "persistThreadUsageActivity"
   | "upsertThreadUsageLine"
+  | "upsertThreadUsageLines"
   | "readThreadPricing"
   | "upsertThreadToolInvocation"
   | "markThreadToolInvocationNoisy"


### PR DESCRIPTION
## Summary

Backport the SQLite/tool-accounting fixes from main onto the 1.0 maintenance line:

- coalesce streamed command-output accounting into serialized 250 ms flush windows
- read Codex completed command output from aggregate completion fields
- keep persisted tool accounting on ACP thread reads after a turn ends
- coalesce cumulative live token usage by usage-line id and persist one bulk transaction per one-second window
- preserve terminal, hydration, retry, and shutdown durability ordering
- add exact checked-in SQLite write budgets for the two backported hot paths

## Source fixes

Manually adapted from the main squash commits and PR bodies rather than replaying development commits:

- [#1406](https://github.com/pwrdrvr/PwrAgent/pull/1406) — `f54a60749936f7b52995d8b1332206e5e8d2779f` — coalesce streamed tool-invocation accounting writes
- [#1433](https://github.com/pwrdrvr/PwrAgent/pull/1433) — `07206fd5e531770ce366ee68d8c073336616737f` — account for Codex completed command output
- [#1408](https://github.com/pwrdrvr/PwrAgent/pull/1408) — `862d3d66ad857404ddab693da68f666f004998a9` — keep tool accounting on ACP threads after a turn ends
- [#1417](https://github.com/pwrdrvr/PwrAgent/pull/1417) — `cc4c51dc70ce1664fc11a6683628584bbcdf7057` — batch live token usage writes
- [#1410](https://github.com/pwrdrvr/PwrAgent/pull/1410) — `7b4c7ddcbef32e9ec029040e641b84a2887a2bbc` — SQLite write measurement/budget infrastructure

## Release-line adaptations

- The 1.0 tree types the registry directly with `OverlayStoreLike`, so the bulk usage method is added there instead of using main's later registry-local partial type.
- The Codex hydration barrier is applied to the release line's existing full-read condition; this version has no later `viewOnly` branch.
- Only the #1410 surface needed to measure and pin these paths is included: a test-only database meter attached after migrations, the budget assertion helper, the JSON budgets, and real-store scenarios. The broader dev/E2E process instrumentation, reporting scripts, environment switches, and guidance-file changes remain on main.
- No schema, renderer, messaging, release, or unrelated state changes are included.

## Ordering and durability

- Streamed tool deltas share one promise chain, flush before lifecycle rows, retry transient write failures without losing newer deltas, and drain on close.
- Live usage work registers synchronously at emit entry. Terminal events wait for preceding observations and flush before fan-out; full hydration drains live rows before superseding them; close rejects new observations and waits for accepted work.
- Failed live batches requeue by observation sequence, so an older failed snapshot cannot overwrite a newer cumulative snapshot.
- Pricing notifications are emitted only after the batch commits.

## SQLite write budgets

The checked budgets assert deterministic commits/statements/rows exactly; observed WAL bytes are recorded for review but not asserted.

| Scenario | Measured budget |
|---|---:|
| 500 streamed output deltas + completion | 2 commits, 2 statements, 2 rows, 37,080 observed WAL bytes |
| 500 usage observations across 10 turns + terminal | 1 commit, 30 statements, 30 rows, 65,920 observed WAL bytes |
| 10 separate one-second usage timer windows | 10 commits, 30 statements, 30 rows, 547,960 observed WAL bytes |

Worst-case WAL-only projections, stated explicitly per the write-volume guidance:

- Tool-output timer: `37,080 bytes / 2 commits = 18,540 bytes/commit`; `4 commits/s × 18,540 × 86,400 = 6,407 MB/day` (5.97 GiB/day) for a pathological command streaming continuously all day. Actual writes exist only while output streams, and lifecycle completion adds one terminal commit.
- Live usage timer: `547,960 bytes / 10 commits = 54,796 bytes/commit`; `1 commit/s × 54,796 × 86,400 = 4,734 MB/day` (4.41 GiB/day) at the pathological ceiling of a fresh timer window every second. Real notifications occur at model-request boundaries and repeated snapshots inside the window collapse in memory.

These are WAL projections; checkpoint copying can add additional device writes. The budgets make cadence or transaction-count regressions reviewable.

## Validation

Passed:

- `pnpm test apps/desktop/src/main/__tests__/sqlite-write-budgets.test.ts` — 10/10
- focused accounting/overlay tests — 41/41
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` — 399/399
- isolated Git fixture reruns from the broader suite: 31/31, 11/11, 13/13, and 4/4
- isolated Codex environment runtime suite with inherited `npm_config_*` noise removed — 26/26
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors (existing warning baseline only)
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
- `pnpm lint:boundaries`
- `git diff --check`

Broader `pnpm test --reporter=dot`: 5,166 passed, 3 skipped, 44 failed across six unrelated shell/Git fixture files under parallel load. Five affected files pass normally in isolation; the sixth passes 26/26 after removing inherited `npm_config_*` values whose npm warnings contaminate exact-output assertions. None of those files are changed here.
