### PR TITLE
fix(agent-core): launch ACP path overrides at runtime

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -3010,6 +3010,161 @@ describe("AcpBackendAdapter", () => {
     }
   });
 
+  it("keeps a stale client alive until its active turn finishes", async () => {
+    const backendId = "acp:gemini" as AcpBackendId;
+    const firstAgent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      version: "1.0.0",
+      activeCommand: "/path/gemini",
+      launchDescriptor: {
+        backendId,
+        registryId: "gemini",
+        distributionKind: "local",
+        command: "/path/gemini",
+        args: ["--acp", "--skip-trust"],
+        env: {},
+      },
+    };
+    const overrideAgent: AcpInstalledAgentRecord = {
+      ...firstAgent,
+      activeCommand: "/override/gemini",
+      launchDescriptor: {
+        ...firstAgent.launchDescriptor!,
+        command: "/override/gemini",
+      },
+    };
+    let discovered = firstAgent;
+    let active = true;
+    const firstDispose = vi.fn(async () => undefined);
+    const secondDispose = vi.fn(async () => undefined);
+    const firstClient = {
+      dispose: firstDispose,
+      hasActiveTurns: () => active,
+      initialize: vi.fn(async () => undefined),
+    };
+    const secondClient = {
+      dispose: secondDispose,
+      hasActiveTurns: () => false,
+      initialize: vi.fn(async () => undefined),
+    };
+    const createAcpClient = vi
+      .fn()
+      .mockReturnValueOnce(firstClient)
+      .mockReturnValueOnce(secondClient);
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => firstAgent,
+        listInstalledAgents: () => [firstAgent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      captureStores: [],
+      createAcpClient: createAcpClient as never,
+      discoverLocalAcpAgents: async () => [discovered],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    discovered = overrideAgent;
+    adapter.invalidateLocalAgentDiscovery();
+
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    expect(firstDispose).not.toHaveBeenCalled();
+    expect(createAcpClient).toHaveBeenCalledOnce();
+
+    active = false;
+    await expect(adapter.getClient(backendId)).resolves.toBe(secondClient);
+    expect(firstDispose).toHaveBeenCalledOnce();
+    expect(createAcpClient).toHaveBeenCalledTimes(2);
+
+    await adapter.close();
+    expect(secondDispose).toHaveBeenCalledOnce();
+  });
+
+  it("merges discovery with agent metadata written while discovery was pending", async () => {
+    const backendId = "acp:gemini" as AcpBackendId;
+    const launchDescriptor = {
+      backendId,
+      registryId: "gemini",
+      distributionKind: "local" as const,
+      command: "/path/gemini",
+      args: ["--acp", "--skip-trust"],
+      env: {},
+    };
+    const discovered: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      version: "1.0.0",
+      activeCommand: launchDescriptor.command,
+      launchDescriptor,
+      updatedAt: 2000,
+    };
+    let cached: AcpInstalledAgentRecord = {
+      ...discovered,
+      updatedAt: 1000,
+    };
+    let finishDiscovery:
+      | ((agents: AcpInstalledAgentRecord[]) => void)
+      | undefined;
+    const upsertInstalledAgent = vi.fn((record: AcpInstalledAgentRecord) => {
+      cached = record;
+    });
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => cached,
+        listInstalledAgents: () => [cached],
+        upsertInstalledAgent,
+      },
+      captureStores: [],
+      discoverLocalAcpAgents: () =>
+        new Promise((resolve) => {
+          finishDiscovery = resolve;
+        }),
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    const listing = adapter.listAvailableAgents();
+    await vi.waitFor(() => expect(finishDiscovery).toBeDefined());
+    cached = {
+      ...cached,
+      updatedAt: 4000,
+      lastDiscoveredAt: 4000,
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        checkedAt: 4000,
+        models: {
+          currentModelId: "gemini-2.5-pro",
+          availableModels: [
+            { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+          ],
+        },
+      },
+      update: {
+        status: "up-to-date",
+        checkedAt: 4000,
+        currentVersion: "1.0.0",
+      },
+      updateCommand: launchDescriptor.command,
+    };
+    finishDiscovery?.([discovered]);
+
+    await expect(listing).resolves.toEqual([
+      expect.objectContaining({
+        updatedAt: 4000,
+        lastDiscoveredAt: 4000,
+        runtimeCapabilities: cached.runtimeCapabilities,
+        update: cached.update,
+        updateCommand: launchDescriptor.command,
+      }),
+    ]);
+    expect(upsertInstalledAgent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ updatedAt: 2000 }),
+    );
+
+    await adapter.close();
+  });
+
   it("replaces a cached Kimi model catalog with a legacy-CLI diagnostic", async () => {
     const backendId = "acp:kimi" as AcpBackendId;
     const cached: AcpInstalledAgentRecord = {

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -77,6 +77,7 @@ describe("AcpAgentClient", () => {
     });
 
     await client.initialize();
+    expect(client.hasActiveTurns()).toBe(false);
     const session = await client.startSession({
       cwd: "/repo",
       executionMode: "default",
@@ -86,12 +87,14 @@ describe("AcpAgentClient", () => {
       sessionId: session.sessionId,
       prompt: "hello",
     });
+    expect(client.hasActiveTurns()).toBe(true);
     transport.emitSessionUpdate(session.sessionId, {
       kind: "agent_message_chunk",
       content: "Done",
     });
     promptResponse.resolve({ turnId: "turn-1" });
     const prompt = await promptPromise;
+    expect(client.hasActiveTurns()).toBe(false);
 
     expect(transport.requests.map((request) => request.method)).toEqual([
       "initialize",
@@ -197,6 +200,7 @@ describe("AcpAgentClient", () => {
       prompt: "hello",
       turnId: "turn-1",
     });
+    expect(client.hasActiveTurns()).toBe(true);
     transport.emitSessionUpdate(session.sessionId, {
       session_update: "agent_message_chunk",
       content: { type: "text", text: "Kimi says hi." },
@@ -212,6 +216,7 @@ describe("AcpAgentClient", () => {
     });
 
     expect(sessionUpdates).toContain("agent_message_chunk");
+    expect(client.hasActiveTurns()).toBe(false);
     expect(transport.requests[2]?.timeoutMs).toBe(60 * 60_000);
   });
 

--- a/apps/desktop/src/main/__tests__/acp-runtime-override-launch.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-runtime-override-launch.test.ts
@@ -29,13 +29,22 @@ const PROVIDERS: ProviderCase[] = [
 
 const tempDirs: string[] = [];
 
+// These fixtures intentionally exercise direct execution of Node shebang
+// files, matching the macOS/Linux CLI installations involved in this bug.
+// Windows cannot execute extensionless shebang files through execFile/spawn;
+// a Windows runtime test needs a real native executable fixture, not a .cmd
+// shim that would change the production launch semantics under test.
+const describeExecutableAcp = process.platform === "win32"
+  ? describe.skip
+  : describe;
+
 afterEach(() => {
   for (const tempDir of tempDirs.splice(0)) {
     rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
-describe("ACP runtime path overrides", () => {
+describeExecutableAcp("ACP runtime path overrides", () => {
   it.each(PROVIDERS)(
     "launches the $registryId absolute override after startup with a stale cached default",
     async ({ expectedArgs, registryId }) => {

--- a/apps/desktop/src/main/__tests__/acp-runtime-override-launch.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-runtime-override-launch.test.ts
@@ -1,0 +1,285 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AcpBackendId } from "@pwragent/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AcpAgentStore } from "../acp/acp-agent-store";
+import { discoverLocalAcpAgentRecords } from "../acp/acp-instance-discovery";
+import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
+import { AcpSessionStore } from "../acp/acp-session-store";
+import {
+  createExecutableAcpProviderFixture,
+  type ExecutableAcpProviderFixture,
+} from "../acp/testing/executable-acp-agent-fixture";
+import { AcpBackendAdapter } from "../app-server/acp-backend-adapter";
+import { installedAcpAgentSettingsEntry } from "../ipc/settings";
+import { StateDb } from "../state/state-db";
+
+type ProviderCase = {
+  expectedArgs: string[];
+  registryId: "gemini" | "grok" | "kimi" | "qwen";
+};
+
+const PROVIDERS: ProviderCase[] = [
+  { registryId: "gemini", expectedArgs: ["--acp", "--skip-trust"] },
+  { registryId: "grok", expectedArgs: ["agent", "stdio"] },
+  { registryId: "kimi", expectedArgs: ["acp"] },
+  { registryId: "qwen", expectedArgs: ["--acp"] },
+];
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("ACP runtime path overrides", () => {
+  it.each(PROVIDERS)(
+    "launches the $registryId absolute override after startup with a stale cached default",
+    async ({ expectedArgs, registryId }) => {
+      const tempDir = makeTempDir(`pwragent-${registryId}-override-`);
+      const fixture = createExecutableAcpProviderFixture({
+        rootDir: tempDir,
+        registryId,
+      });
+      const env = fixtureDiscoveryEnv(fixture);
+      const stateDb = StateDb.open(path.join(tempDir, "state.db"));
+      const agentStore = new AcpAgentStore(stateDb);
+      const sessionStore = new AcpSessionStore(stateDb);
+      let adapter: AcpBackendAdapter | undefined;
+
+      try {
+        adapter = createAdapter({
+          agentStore,
+          sessionStore,
+          discover: async () => [
+            await discoverSingleProvider({ env, registryId }),
+          ],
+        });
+        await adapter.listAvailableAgents();
+        await adapter.close();
+        adapter = undefined;
+
+        expect(
+          agentStore.getInstalledAgent(`acp:${registryId}` as AcpBackendId)
+            ?.activeCommand,
+        ).toBe(fixture.defaultCommand);
+        const persistDiscovered = vi.spyOn(agentStore, "upsertInstalledAgent");
+
+        adapter = createAdapter({
+          agentStore,
+          sessionStore,
+          discover: async () => [
+            await discoverSingleProvider({
+              env,
+              overridePath: fixture.overrideCommand,
+              registryId,
+            }),
+          ],
+        });
+
+        const client = await adapter.getClient(
+          `acp:${registryId}` as AcpBackendId,
+        );
+        await client.startSession({
+          cwd: tempDir,
+          executionMode: "default",
+          mcpServers: "none",
+        });
+
+        const persisted = agentStore.getInstalledAgent(
+          `acp:${registryId}` as AcpBackendId,
+        );
+        expect(persisted).toMatchObject({
+          activeCommand: fixture.overrideCommand,
+          launchDescriptor: {
+            command: fixture.overrideCommand,
+            args: expectedArgs,
+          },
+        });
+        expect(persisted?.instances).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              command: fixture.overrideCommand,
+              source: "override",
+            }),
+            expect.objectContaining({
+              command: fixture.defaultCommand,
+              source: "path",
+            }),
+          ]),
+        );
+
+        const settingsEntry = installedAcpAgentSettingsEntry(
+          persisted as AcpInstalledAgentRecord,
+        );
+        const settingsUsing = settingsEntry.instances?.find(
+          (instance) => instance.command === settingsEntry.activeCommand,
+        );
+        expect(settingsUsing).toMatchObject({
+          command: fixture.overrideCommand,
+          source: "override",
+        });
+
+        expect(acpLaunchMarkers(fixture)).toEqual([
+          expect.objectContaining({
+            argv: expectedArgs,
+            executable: fixture.overrideCommand,
+            id: `${registryId}-override`,
+            version: "0.2.0-override",
+          }),
+        ]);
+        const writesBeforeCachedLookup = persistDiscovered.mock.calls.length;
+        await adapter.listAvailableAgents();
+        expect(persistDiscovered).toHaveBeenCalledTimes(writesBeforeCachedLookup);
+      } finally {
+        await adapter?.close();
+        stateDb.close();
+      }
+    },
+    30_000,
+  );
+
+  it("disposes a memoized client when the Grok override changes", async () => {
+    const tempDir = makeTempDir("pwragent-grok-override-change-");
+    const first = createExecutableAcpProviderFixture({
+      rootDir: tempDir,
+      registryId: "grok",
+      suffix: "first",
+    });
+    const second = createExecutableAcpProviderFixture({
+      rootDir: tempDir,
+      registryId: "grok",
+      suffix: "second",
+    });
+    const env = fixtureDiscoveryEnv(first);
+    const stateDb = StateDb.open(path.join(tempDir, "state.db"));
+    const agentStore = new AcpAgentStore(stateDb);
+    const sessionStore = new AcpSessionStore(stateDb);
+    let overridePath = first.overrideCommand;
+    let adapter: AcpBackendAdapter | undefined;
+
+    try {
+      agentStore.upsertInstalledAgent(
+        await discoverSingleProvider({ env, registryId: "grok" }),
+      );
+      adapter = createAdapter({
+        agentStore,
+        sessionStore,
+        discover: async () => [
+          await discoverSingleProvider({
+            env,
+            overridePath,
+            registryId: "grok",
+          }),
+        ],
+      });
+
+      const firstClient = await adapter.getClient("acp:grok");
+      await firstClient.startSession({
+        cwd: tempDir,
+        executionMode: "default",
+        mcpServers: "none",
+      });
+
+      overridePath = second.overrideCommand;
+      adapter.invalidateLocalAgentDiscovery();
+      const secondClient = await adapter.getClient("acp:grok");
+      await secondClient.startSession({
+        cwd: tempDir,
+        executionMode: "default",
+        mcpServers: "none",
+      });
+
+      expect(secondClient).not.toBe(firstClient);
+      await vi.waitFor(() => {
+        expect(
+          first.readMarkers().some((marker) => marker.kind === "disposed"),
+        ).toBe(true);
+      });
+      expect(acpLaunchMarkers(first)).toEqual([
+        expect.objectContaining({
+          argv: ["agent", "stdio"],
+          executable: first.overrideCommand,
+        }),
+      ]);
+      expect(acpLaunchMarkers(second)).toEqual([
+        expect.objectContaining({
+          argv: ["agent", "stdio"],
+          executable: second.overrideCommand,
+        }),
+      ]);
+      expect(agentStore.getInstalledAgent("acp:grok")).toMatchObject({
+        activeCommand: second.overrideCommand,
+        launchDescriptor: { command: second.overrideCommand },
+      });
+    } finally {
+      await adapter?.close();
+      stateDb.close();
+    }
+  }, 30_000);
+});
+
+function createAdapter(params: {
+  agentStore: AcpAgentStore;
+  discover: () => Promise<AcpInstalledAgentRecord[]>;
+  sessionStore: AcpSessionStore;
+}): AcpBackendAdapter {
+  return new AcpBackendAdapter({
+    acpAgentStore: params.agentStore,
+    acpRolloutStore: null,
+    acpSessionStore: params.sessionStore,
+    captureStores: [],
+    checkGrokCliUpdate: null,
+    discoverLocalAcpAgents: params.discover,
+    emit: async () => undefined,
+    handleServerRequest: async () => ({ decision: "accept" }),
+  });
+}
+
+async function discoverSingleProvider(params: {
+  env: NodeJS.ProcessEnv;
+  overridePath?: string;
+  registryId: ProviderCase["registryId"];
+}): Promise<AcpInstalledAgentRecord> {
+  const records = await discoverLocalAcpAgentRecords({
+    enabledRegistryIds: [params.registryId],
+    env: params.env,
+    ...(params.overridePath
+      ? { preferences: { [params.registryId]: { overridePath: params.overridePath } } }
+      : {}),
+  });
+  const record = records.find(
+    (candidate) => candidate.registryId === params.registryId,
+  );
+  if (!record) {
+    throw new Error(`Fake ${params.registryId} executable was not discovered`);
+  }
+  return record;
+}
+
+function fixtureDiscoveryEnv(
+  fixture: ExecutableAcpProviderFixture,
+): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    PATH: [
+      path.dirname(fixture.defaultCommand),
+      path.dirname(process.execPath),
+      "/usr/bin",
+      "/bin",
+    ].join(path.delimiter),
+  };
+}
+
+function acpLaunchMarkers(fixture: ExecutableAcpProviderFixture) {
+  return fixture.readMarkers().filter((marker) => marker.kind === "acp");
+}
+
+function makeTempDir(prefix: string): string {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(tempDir);
+  return tempDir;
+}

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -310,6 +310,10 @@ export class AcpAgentClient {
     });
   }
 
+  hasActiveTurns(): boolean {
+    return this.activeTurns.size > 0;
+  }
+
   async dispose(): Promise<void> {
     this.options.rolloutStore?.flushAll?.();
     this.unsubscribe?.();

--- a/apps/desktop/src/main/acp/testing/executable-acp-agent-fixture.ts
+++ b/apps/desktop/src/main/acp/testing/executable-acp-agent-fixture.ts
@@ -1,0 +1,149 @@
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+export type ExecutableAcpMarker = {
+  argv: string[];
+  executable: string;
+  id: string;
+  kind: "acp" | "disposed" | "probe";
+  version: string;
+};
+
+export type ExecutableAcpProviderFixture = {
+  defaultCommand: string;
+  markerPath: string;
+  overrideCommand: string;
+  readMarkers: () => ExecutableAcpMarker[];
+};
+
+export function createExecutableAcpProviderFixture(params: {
+  rootDir: string;
+  registryId: "gemini" | "grok" | "kimi" | "qwen";
+  suffix?: string;
+}): ExecutableAcpProviderFixture {
+  const suffix = params.suffix ? `-${params.suffix}` : "";
+  const defaultDir = path.join(params.rootDir, `path-bin${suffix}`);
+  const overrideDir = path.join(params.rootDir, `override-bin${suffix}`);
+  const markerPath = path.join(
+    params.rootDir,
+    `${params.registryId}${suffix}-invocations.jsonl`,
+  );
+  const defaultCommand = path.join(defaultDir, params.registryId);
+  const overrideCommand = path.join(
+    overrideDir,
+    `${params.registryId}-absolute-override`,
+  );
+  mkdirSync(defaultDir, { recursive: true });
+  mkdirSync(overrideDir, { recursive: true });
+  writeExecutable({
+    command: defaultCommand,
+    id: `${params.registryId}-default${suffix}`,
+    markerPath,
+    registryId: params.registryId,
+    version: "0.1.0-default",
+  });
+  writeExecutable({
+    command: overrideCommand,
+    id: `${params.registryId}-override${suffix}`,
+    markerPath,
+    registryId: params.registryId,
+    version: "0.2.0-override",
+  });
+
+  return {
+    defaultCommand,
+    markerPath,
+    overrideCommand,
+    readMarkers: () => readMarkers(markerPath),
+  };
+}
+
+function writeExecutable(params: {
+  command: string;
+  id: string;
+  markerPath: string;
+  registryId: "gemini" | "grok" | "kimi" | "qwen";
+  version: string;
+}): void {
+  const source = `#!/usr/bin/env node
+const fs = require("node:fs");
+const readline = require("node:readline");
+const argv = process.argv.slice(2);
+const executable = ${JSON.stringify(params.command)};
+const id = ${JSON.stringify(params.id)};
+const markerPath = ${JSON.stringify(params.markerPath)};
+const registryId = ${JSON.stringify(params.registryId)};
+const version = ${JSON.stringify(params.version)};
+const record = (kind) => {
+  fs.appendFileSync(markerPath, JSON.stringify({
+    argv,
+    executable,
+    id,
+    kind,
+    version,
+  }) + "\\n");
+};
+if (argv.includes("--version")) {
+  record("probe");
+  process.stdout.write(
+    registryId === "kimi"
+      ? "kimi-code " + version + "\\n"
+      : registryId + " " + version + "\\n",
+  );
+  process.exit(0);
+}
+if (argv.includes("--help")) {
+  record("probe");
+  const help = registryId === "grok"
+    ? "Run the agent over stdio"
+    : registryId === "qwen"
+      ? "Qwen Code --acp"
+      : registryId === "gemini"
+        ? "Usage: gemini --acp"
+        : "Agent Client Protocol server";
+  process.stdout.write(help + "\\n");
+  process.exit(0);
+}
+record("acp");
+process.on("SIGTERM", () => {
+  record("disposed");
+  process.exit(0);
+});
+const lines = readline.createInterface({ input: process.stdin });
+lines.on("line", (line) => {
+  const request = JSON.parse(line);
+  if (request.id === undefined) return;
+  const result = request.method === "initialize"
+    ? { protocolVersion: 1, agentCapabilities: {} }
+    : request.method === "session/new"
+      ? { sessionId: id + "-session" }
+      : {};
+  process.stdout.write(JSON.stringify({
+    jsonrpc: "2.0",
+    id: request.id,
+    result,
+  }) + "\\n");
+});
+`;
+  writeFileSync(params.command, source, "utf8");
+  chmodSync(params.command, 0o755);
+}
+
+function readMarkers(markerPath: string): ExecutableAcpMarker[] {
+  try {
+    return readFileSync(markerPath, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as ExecutableAcpMarker);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -128,6 +128,7 @@ export type AcpRuntimeClient = Pick<
     Pick<
       AcpAgentClient,
       | "didSessionLoadReplayHistory"
+      | "hasActiveTurns"
       | "readProviderStatus"
       | "sendControlPrompt"
       | "setRuntimeOption"
@@ -1410,6 +1411,12 @@ export class AcpBackendAdapter {
       return await cached.promise;
     }
     if (cached) {
+      // One ACP client owns every live turn for this backend. Keep routing
+      // control and session operations to that process until its last turn
+      // reaches a terminal state; the next idle lookup adopts the new path.
+      if (cached.client.hasActiveTurns?.() === true) {
+        return await cached.promise;
+      }
       this.acpClients.delete(backend);
       await this.disposeAcpClient(cached);
       if (this.closed) {
@@ -1668,15 +1675,19 @@ export class AcpBackendAdapter {
   }
 
   async listAvailableAgents(): Promise<AcpInstalledAgentRecord[]> {
+    const discoveredAgents = (await this.readLocalAgentsOnce())
+      .map(normalizeInstalledAcpAgent)
+      .filter((agent) => !isBannedAcpRegistryId(agent.registryId));
+    // Discovery probes are asynchronous and can overlap runtime-capability or
+    // update-check writes. Read the durable cache only after discovery, then
+    // merge and persist synchronously so those newer fields cannot be rolled
+    // back by a snapshot captured before the probe started.
     const installedAgents = (this.acpAgentStore?.listInstalledAgents() ?? [])
       .map(normalizeInstalledAcpAgent)
       .filter((agent) => !isBannedAcpRegistryId(agent.registryId));
     const installedByBackendId = new Map(
       installedAgents.map((agent) => [agent.backendId, agent]),
     );
-    const discoveredAgents = (await this.readLocalAgentsOnce())
-      .map(normalizeInstalledAcpAgent)
-      .filter((agent) => !isBannedAcpRegistryId(agent.registryId));
     const effectiveDiscoveredAgents = discoveredAgents.map((agent) => {
       const cached = installedByBackendId.get(agent.backendId);
       const sameRuntime =

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -146,6 +146,7 @@ export type AcpSessionStoreLike =
 
 type AcpClientEntry = {
   client: AcpRuntimeClient;
+  launchIdentity: string;
   promise: Promise<AcpRuntimeClient>;
   disposePromise?: Promise<void>;
 };
@@ -399,12 +400,23 @@ function normalizeInstalledAcpAgent(
     : { ...agent, runtimeCapabilities };
 }
 
-function isLegacyKimiInstalledRecord(agent: AcpInstalledAgentRecord): boolean {
-  if (agent.registryId !== "kimi") {
-    return false;
-  }
-  const major = Number.parseInt(agent.version?.split(".")[0] ?? "", 10);
-  return Number.isFinite(major) && major >= 1;
+function acpAgentLaunchIdentity(agent: AcpInstalledAgentRecord): string {
+  const descriptor = agent.launchDescriptor;
+  return JSON.stringify({
+    activeCommand: agent.activeCommand,
+    launchDescriptor: descriptor
+      ? {
+          backendId: descriptor.backendId,
+          registryId: descriptor.registryId,
+          distributionKind: descriptor.distributionKind,
+          command: descriptor.command,
+          args: descriptor.args,
+          env: Object.fromEntries(Object.entries(descriptor.env).sort()),
+          cwd: descriptor.cwd,
+          installPath: descriptor.installPath,
+        }
+      : undefined,
+  });
 }
 
 function effectiveAcpAgentCapabilities(
@@ -927,6 +939,10 @@ export class AcpBackendAdapter {
     request: AppServerPendingRequestNotification,
   ) => Promise<unknown>;
   private readonly acpClients = new Map<AcpBackendId, AcpClientEntry>();
+  private readonly acpClientResolutions = new Map<
+    AcpBackendId,
+    Promise<AcpRuntimeClient>
+  >();
   private readonly liveNotificationFingerprints = new Map<string, string>();
   private readonly providerStatuses = new Map<AcpBackendId, AcpProviderStatus>();
   private readonly providerStatusRefreshAttempts = new Map<AcpBackendId, number>();
@@ -1367,18 +1383,44 @@ export class AcpBackendAdapter {
     if (this.closed) {
       throw new Error("ACP backend adapter is closed");
     }
-    const cached = this.acpClients.get(backend);
-    if (cached) {
-      return await cached.promise;
+    const resolving = this.acpClientResolutions.get(backend);
+    if (resolving) {
+      return await resolving;
     }
 
+    const resolution = this.resolveClient(backend);
+    this.acpClientResolutions.set(backend, resolution);
+    try {
+      return await resolution;
+    } finally {
+      if (this.acpClientResolutions.get(backend) === resolution) {
+        this.acpClientResolutions.delete(backend);
+      }
+    }
+  }
+
+  private async resolveClient(backend: AcpBackendId): Promise<AcpRuntimeClient> {
     const agent = await this.resolveInstalledAgent(backend);
     if (this.closed) {
       throw new Error("ACP backend adapter is closed");
     }
+    const launchIdentity = acpAgentLaunchIdentity(agent);
+    const cached = this.acpClients.get(backend);
+    if (cached?.launchIdentity === launchIdentity) {
+      return await cached.promise;
+    }
+    if (cached) {
+      this.acpClients.delete(backend);
+      await this.disposeAcpClient(cached);
+      if (this.closed) {
+        throw new Error("ACP backend adapter is closed");
+      }
+    }
+
     const client = this.createAcpClient(agent);
     const entry: AcpClientEntry = {
       client,
+      launchIdentity,
       promise: Promise.resolve(client),
     };
     entry.promise = (async () => {
@@ -1635,19 +1677,20 @@ export class AcpBackendAdapter {
     const discoveredAgents = (await this.readLocalAgentsOnce())
       .map(normalizeInstalledAcpAgent)
       .filter((agent) => !isBannedAcpRegistryId(agent.registryId));
-    const effectiveDiscoveredAgents = discoveredAgents.flatMap((agent) => {
+    const effectiveDiscoveredAgents = discoveredAgents.map((agent) => {
       const cached = installedByBackendId.get(agent.backendId);
-      if (cached && !isLegacyKimiInstalledRecord(cached)) {
-        return [];
-      }
       const sameRuntime =
         agent.installStatus === "installed"
         && cached?.installStatus === "installed"
         && cached.version === agent.version
-        && cached.activeCommand === agent.activeCommand;
-      return [{
+        && acpAgentLaunchIdentity(cached) === acpAgentLaunchIdentity(agent);
+      return {
         ...agent,
         installedAt: cached?.installedAt ?? agent.installedAt,
+        updatedAt:
+          sameRuntime && cached
+            ? Math.max(agent.updatedAt, cached.updatedAt)
+            : agent.updatedAt,
         ...(sameRuntime && cached?.runtimeCapabilities
           ? { runtimeCapabilities: cached.runtimeCapabilities }
           : {}),
@@ -1657,14 +1700,21 @@ export class AcpBackendAdapter {
         ...(sameRuntime && cached?.lastDiscoveryError !== undefined
           ? { lastDiscoveryError: cached.lastDiscoveryError }
           : {}),
-      }];
+        ...(sameRuntime && cached?.update !== undefined
+          ? { update: cached.update }
+          : {}),
+        ...(sameRuntime && cached?.updateCommand !== undefined
+          ? { updateCommand: cached.updateCommand }
+          : {}),
+      };
     });
     for (const agent of effectiveDiscoveredAgents) {
-      // A known legacy Kimi cache must never outrank fresh local discovery: it
-      // may now resolve to the supported side-by-side install, or to a durable
-      // non-launchable compatibility diagnostic. Other cached providers retain
-      // the existing cache-first behavior.
-      this.acpAgentStore?.upsertInstalledAgent(agent);
+      const cached = installedByBackendId.get(agent.backendId);
+      if (!cached || JSON.stringify(cached) !== JSON.stringify(agent)) {
+        // Fresh discovery owns launch selection. The durable record is a cache
+        // of that result, never an authority that can suppress a new override.
+        this.acpAgentStore?.upsertInstalledAgent(agent);
+      }
     }
     const discoveredBackendIds = new Set(
       effectiveDiscoveredAgents.map((agent) => agent.backendId),
@@ -1684,6 +1734,7 @@ export class AcpBackendAdapter {
     this.closed = true;
     const acpClients = [...this.acpClients.entries()];
     this.acpClients.clear();
+    this.acpClientResolutions.clear();
     this.liveNotificationFingerprints.clear();
     this.providerStatuses.clear();
     this.providerStatusRefreshAttempts.clear();

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -524,7 +524,7 @@ function acpAgentSettingsEntry(params: {
   };
 }
 
-function installedAcpAgentSettingsEntry(
+export function installedAcpAgentSettingsEntry(
   record: AcpInstalledAgentRecord,
   registryAgent?: AcpRegistryAgent,
 ): AcpAgentSettingsEntry {


### PR DESCRIPTION
## What changed

- make fresh local ACP discovery authoritative over stale installed-agent cache records
- key memoized ACP clients by the resolved launch identity and dispose/recreate them when the command, args, env, cwd, or install path changes
- preserve runtime/update metadata only when discovery resolves to the same executable launch identity
- add an executable Node.js shebang fixture harness with distinct PATH/default and absolute-override binaries for Gemini, Grok, Kimi, and Qwen
- assert the Settings contract, persisted `activeCommand` and `launchDescriptor`, and the process invocation marker all select the same override

## Root cause

Startup's `AcpBackendAdapter.listAvailableAgents` dropped every fresh discovered provider when any non-legacy cached record existed. Settings refresh used a separate discovery path and updated the UI/database correctly, so the screen could say “Using” while startup kept launching the cached default descriptor.

The adapter also memoized clients solely by backend ID. Clearing discovery after a path change did not invalidate a client already initialized with the prior executable.

The upstream `@pwrdrvr/agent-acp` discovery correctly probes the absolute override first while retaining PATH/default candidates, so no agent-kit change is required.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-runtime-override-launch.test.ts apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts apps/desktop/src/main/__tests__/settings-ipc.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx` (95 tests)
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`

The new harness starts a session through real stdio child processes and records executable identity plus argv. Version-probe markers are tracked separately and are not treated as proof of session execution.
