### PR TITLE
fix(desktop): scope remote thinking status by instance

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -1,5 +1,5 @@
 import type { NavigationThreadSummary } from "@pwragent/shared";
-import { buildThreadIdentityKey } from "@pwragent/shared";
+import { threadSummaryIdentityKey } from "../../lib/federated-thread-events";
 import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 
 export type ThreadRowStatusKind = "thinking" | "unread";
@@ -14,7 +14,7 @@ export function isThreadActive(
   thread: NavigationThreadSummary,
   thinkingThreadKeys?: Record<string, boolean>,
 ): boolean {
-  const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+  const threadKey = threadSummaryIdentityKey(thread);
   return (
     thread.threadStatus === "active"
     || thinkingThreadKeys?.[threadKey] === true

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-status.test.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-status.test.ts
@@ -1,0 +1,44 @@
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { federatedThreadIdentityKey } from "@pwragent/shared";
+import { describe, expect, it } from "vitest";
+import { isThreadActive } from "../ThreadRowStatus";
+
+const remoteTarget = {
+  scope: "remote" as const,
+  instanceId: "peer-harold",
+};
+
+function buildRemoteThread(): NavigationThreadSummary {
+  return {
+    id: "thread-shared-id",
+    title: "Remote thread",
+    titleSource: "explicit",
+    source: "codex",
+    threadStatus: "idle",
+    linkedDirectories: [],
+    inbox: { inInbox: false },
+    federation: {
+      ref: {
+        backend: "codex",
+        target: remoteTarget,
+        threadId: "thread-shared-id",
+      },
+      instanceLabel: "Harold-MBP-M2-Max",
+    },
+  };
+}
+
+describe("isThreadActive", () => {
+  it("does not let an unscoped stale session mark a remote row active", () => {
+    expect(isThreadActive(buildRemoteThread(), {
+      "codex:thread-shared-id": true,
+    })).toBe(false);
+  });
+
+  it("reads renderer thinking from the remote thread identity", () => {
+    const thread = buildRemoteThread();
+    expect(isThreadActive(thread, {
+      [federatedThreadIdentityKey(thread.federation!.ref)]: true,
+    })).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-logic.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import type { NavigationThreadSummary } from "@pwragent/shared";
+import {
+  federatedThreadIdentityKey,
+  type NavigationThreadSummary,
+} from "@pwragent/shared";
 import { threadAttentionCategories } from "../attention";
 import {
   cloudDetentRadius,
@@ -91,6 +94,50 @@ describe("threadAttentionCategories", () => {
     });
     expect(categories).toContain("approval");
     expect(categories).toContain("active");
+  });
+
+  it("does not let an unscoped stale session mark a remote thread active", () => {
+    const subject = thread({
+      id: "shared-thread-id",
+      federation: {
+        ref: {
+          backend: "codex",
+          target: {
+            scope: "remote",
+            instanceId: "peer-harold",
+          },
+          threadId: "shared-thread-id",
+        },
+        instanceLabel: "Harold-MBP-M2-Max",
+      },
+    });
+
+    expect(threadAttentionCategories(subject, {
+      thinkingThreadKeys: { "codex:shared-thread-id": true },
+    })).not.toContain("active");
+  });
+
+  it("reads thinking from the remote thread identity", () => {
+    const subject = thread({
+      id: "shared-thread-id",
+      federation: {
+        ref: {
+          backend: "codex",
+          target: {
+            scope: "remote",
+            instanceId: "peer-harold",
+          },
+          threadId: "shared-thread-id",
+        },
+        instanceLabel: "Harold-MBP-M2-Max",
+      },
+    });
+
+    expect(threadAttentionCategories(subject, {
+      thinkingThreadKeys: {
+        [federatedThreadIdentityKey(subject.federation!.ref)]: true,
+      },
+    })).toContain("active");
   });
 });
 
@@ -337,4 +384,3 @@ describe("resolveCardDragOffset", () => {
     expect(near).toBeGreaterThan(detentRadius + 200);
   });
 });
-

--- a/apps/desktop/src/renderer/src/features/star-map/attention.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/attention.ts
@@ -1,7 +1,5 @@
-import {
-  buildThreadIdentityKey,
-  type NavigationThreadSummary,
-} from "@pwragent/shared";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { threadSummaryIdentityKey } from "../../lib/federated-thread-events";
 import { isOpenPullRequest } from "./star-map-preferences";
 
 export const STAR_MAP_ATTENTION_CATEGORIES = [
@@ -34,7 +32,7 @@ export function threadAttentionCategories(
   thread: NavigationThreadSummary,
   sessionKeys?: StarMapSessionKeys,
 ): StarMapAttentionCategory[] {
-  const key = buildThreadIdentityKey(thread.source, thread.id);
+  const key = threadSummaryIdentityKey(thread);
   const categories: StarMapAttentionCategory[] = [];
   if (thread.inbox.inInbox && thread.inbox.reason === "updated-since-seen") {
     categories.push("unread");
@@ -67,4 +65,3 @@ export function threadAttentionCategories(
 export function isAgentThread(thread: NavigationThreadSummary): boolean {
   return thread.agent !== undefined;
 }
-

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -29,6 +29,9 @@ describe("useThreadNavigation", () => {
     delete (window as unknown as {
       __pwragentFederationTarget?: unknown;
     }).__pwragentFederationTarget;
+    delete (window as unknown as {
+      __pwragentFederationLabel?: unknown;
+    }).__pwragentFederationLabel;
     vi.restoreAllMocks();
   });
 
@@ -3850,6 +3853,86 @@ describe("useThreadNavigation", () => {
     );
     expect(resetDirectoryLaunchpad).toHaveBeenCalledWith({ directoryKey });
     expect(result.current.selectedLaunchpad).toBeUndefined();
+  });
+
+  it("scopes a remote optimistic thread before its owner snapshot arrives", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+      __pwragentFederationLabel?: unknown;
+    }).__pwragentFederationTarget = federationTarget;
+    (window as unknown as {
+      __pwragentFederationLabel?: unknown;
+    }).__pwragentFederationLabel = "Harold-MBP-M2-Max";
+    const directoryKey = "directory:/remote/PwrAgent";
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey,
+      directoryKind: "directory",
+      directoryLabel: "PwrAgent",
+      directoryPath: "/remote/PwrAgent",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "Start remotely",
+      workMode: "local",
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const snapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [{
+        key: directoryKey,
+        kind: "directory",
+        label: "PwrAgent",
+        path: "/remote/PwrAgent",
+        threadKeys: [],
+        needsAttentionCount: 0,
+        launchpad,
+      }],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot: vi.fn(async () => snapshot),
+      materializeDirectoryLaunchpad: vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "remote-thread-new",
+        turnId: "remote-turn-new",
+        executionMode: "default" as const,
+        workMode: "local" as const,
+      })),
+      resetDirectoryLaunchpad: vi.fn(async () => ({
+        directoryKey,
+        defaults: snapshot.launchpadDefaults,
+      })),
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => {
+      expect(result.current.selectedLaunchpad?.prompt).toBe("Start remotely");
+    });
+
+    await act(async () => {
+      await result.current.materializeDirectoryLaunchpad(directoryKey);
+    });
+
+    expect(result.current.threads[0]?.federation).toEqual({
+      ref: {
+        backend: "codex",
+        target: federationTarget,
+        threadId: "remote-thread-new",
+      },
+      instanceLabel: "Harold-MBP-M2-Max",
+    });
   });
 
   it("shows a newly materialized detached worktree thread as HEAD before the backend snapshot catches up", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -43,7 +43,10 @@ import {
 } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
 import { fileLabelFromPath } from "./directory-references";
-import { readRendererFederationTarget } from "./federation-window";
+import {
+  readRendererFederationLabel,
+  readRendererFederationTarget,
+} from "./federation-window";
 import {
   applyNavigationSnapshotTransportResponse,
   type NavigationSnapshotTransportState,
@@ -2368,6 +2371,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
   parentThreadBackend?: AppServerBackendKind;
   pinnedRank?: string;
   scheduledStart?: NavigationThreadSummary["scheduledStart"];
+  federation?: NavigationThreadSummary["federation"];
 }): NavigationThreadSummary {
   const titlePrompt =
     params.optimisticUserMessage?.text?.trim() || params.launchpad.prompt.trim();
@@ -2405,6 +2409,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
     parentThreadId: params.parentThreadId,
     parentThreadBackend: params.parentThreadBackend,
     pinnedRank: params.pinnedRank,
+    federation: params.federation,
     acpRuntime: params.launchpad.acpRuntime,
     codexEnvironmentRuntime: params.codexEnvironmentRuntime,
     optimisticUserMessage: params.optimisticUserMessage,
@@ -5947,6 +5952,17 @@ export function useThreadNavigation(
         launchpad,
         backend: response.backend,
         threadId: response.threadId,
+        federation: federationTarget
+          ? {
+              ref: {
+                backend: response.backend,
+                target: federationTarget,
+                threadId: response.threadId,
+              },
+              instanceLabel:
+                readRendererFederationLabel() ?? federationTarget.instanceId,
+            }
+          : undefined,
         executionMode: response.executionMode,
         workMode: response.workMode,
         codexEnvironmentRuntime: response.codexEnvironmentRuntime,


### PR DESCRIPTION
## Summary

- scope sidebar thinking state to the full federated thread identity
- stamp remote optimistic launchpad threads with their federation target and label
- add regression coverage for stale unscoped sessions and remote optimistic materialization

## Root cause

The remote transcript and navigation snapshot correctly reported the thread idle, but an orphan optimistic unscoped session still reported it active. `ThreadRowStatus` looked up thinking state with only `backend:threadId`, so the remote row consumed the stale unscoped entry instead of its `remote:instance:backend:threadId` session. Remote optimistic launchpad materialization also omitted federation metadata, which created that split identity before the owner snapshot arrived.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-status.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (232 tests)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `git diff --check`
