### PR TITLE
fix(desktop): release stale remote history pagination

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -650,6 +650,7 @@ export function TranscriptList(props: TranscriptListProps) {
   const olderPageRequestPendingRef = useRef(false);
   const olderPageRequestGenerationRef = useRef(0);
   const lastUnderflowHistoryRequestRef = useRef<string | undefined>(undefined);
+  const latestHydrationPendingRef = useRef(false);
   const [olderPageRequestSettledKey, setOlderPageRequestSettledKey] = useState(0);
   const shouldScrollToBottomRef = useRef(true);
   const isGluedToBottomRef = useRef(true);
@@ -690,12 +691,14 @@ export function TranscriptList(props: TranscriptListProps) {
   const canLoadOlder = Boolean(
     props.pagination?.supportsPagination && props.pagination.hasPreviousPage
   );
+  const loading = props.loading;
   const loadingMore = props.loadingMore;
   const onLoadOlder = props.onLoadOlder;
   useEffect(() => {
     olderPageRequestGenerationRef.current += 1;
     olderPageRequestPendingRef.current = false;
     lastUnderflowHistoryRequestRef.current = undefined;
+    latestHydrationPendingRef.current = false;
   }, [props.threadId]);
   useEffect(() => {
     if (!loadingMore) {
@@ -705,9 +708,24 @@ export function TranscriptList(props: TranscriptListProps) {
       olderPageRequestPendingRef.current = false;
     }
   }, [loadingMore]);
+  useEffect(() => {
+    if (loading) {
+      latestHydrationPendingRef.current = true;
+      olderPageRequestPendingRef.current = false;
+      return;
+    }
+    if (!latestHydrationPendingRef.current) {
+      return;
+    }
+
+    latestHydrationPendingRef.current = false;
+    olderPageRequestPendingRef.current = false;
+    lastUnderflowHistoryRequestRef.current = undefined;
+  }, [loading]);
   const requestOlderPage = useCallback((): boolean => {
     if (
       !canLoadOlder
+      || loading
       || loadingMore
       || olderPageRequestPendingRef.current
     ) {
@@ -732,7 +750,7 @@ export function TranscriptList(props: TranscriptListProps) {
       throw error;
     }
     return true;
-  }, [canLoadOlder, loadingMore, onLoadOlder]);
+  }, [canLoadOlder, loading, loadingMore, onLoadOlder]);
   const requestOlderPageIfUnderflowing = useCallback(() => {
     const container = scrollContainerRef.current;
     if (

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -697,6 +697,14 @@ export function TranscriptList(props: TranscriptListProps) {
     olderPageRequestPendingRef.current = false;
     lastUnderflowHistoryRequestRef.current = undefined;
   }, [props.threadId]);
+  useEffect(() => {
+    if (!loadingMore) {
+      // The parent can cancel an older-page read by starting a fresher thread
+      // hydration. Mirror that cancellation locally so a stale promise cannot
+      // leave scroll pagination locked after loadingMore returns to false.
+      olderPageRequestPendingRef.current = false;
+    }
+  }, [loadingMore]);
   const requestOlderPage = useCallback((): boolean => {
     if (
       !canLoadOlder

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -912,6 +912,66 @@ describe("TranscriptList", () => {
     resolveFirstLoad?.();
   });
 
+  it("releases an in-flight older-page lock when loading is superseded", async () => {
+    const firstLoad = vi.fn(() => new Promise<void>(() => undefined));
+    const secondLoad = vi.fn(async () => undefined);
+    const commonProps = {
+      entries: [
+        {
+          type: "message" as const,
+          id: "message-1",
+          role: "assistant" as const,
+          text: "Recent history",
+        },
+      ],
+      loading: false,
+      pagination: {
+        supportsPagination: true,
+        hasPreviousPage: true,
+        previousCursor: "cursor-1",
+      },
+      threadId: "thread-1",
+    };
+    const { rerender } = render(
+      <TranscriptList
+        {...commonProps}
+        loadingMore={false}
+        onLoadOlder={firstLoad}
+      />,
+    );
+
+    const list = screen.getByRole("list");
+    list.scrollTop = 120;
+    fireEvent.scroll(list);
+    expect(firstLoad).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <TranscriptList
+        {...commonProps}
+        loadingMore={true}
+        onLoadOlder={firstLoad}
+      />,
+    );
+    rerender(
+      <TranscriptList
+        {...commonProps}
+        loadingMore={false}
+        onLoadOlder={secondLoad}
+        pagination={{
+          ...commonProps.pagination,
+          previousCursor: "cursor-after-refresh",
+        }}
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    list.scrollTop = 120;
+    fireEvent.scroll(list);
+    expect(secondLoad).toHaveBeenCalledTimes(1);
+  });
+
   it("renders automation card details as markdown in the transcript", () => {
     const automationMarkdown = `| Priority | Service | Next step |
 |---|---|---|

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -972,6 +972,71 @@ describe("TranscriptList", () => {
     expect(secondLoad).toHaveBeenCalledTimes(1);
   });
 
+  it("retries canceled older-page loading when the transcript still underflows", async () => {
+    scrollHeight = 200;
+    clientHeight = 240;
+    const firstLoad = vi.fn(() => new Promise<void>(() => undefined));
+    const secondLoad = vi.fn(async () => undefined);
+    const commonProps = {
+      entries: [
+        {
+          type: "message" as const,
+          id: "message-1",
+          role: "assistant" as const,
+          text: "Short recent history",
+        },
+      ],
+      loading: false,
+      pagination: {
+        supportsPagination: true,
+        hasPreviousPage: true,
+        previousCursor: "cursor-1",
+      },
+      threadId: "thread-underflow",
+    };
+    const { rerender } = render(
+      <TranscriptList
+        {...commonProps}
+        loadingMore={false}
+        onLoadOlder={firstLoad}
+      />,
+    );
+
+    expect(firstLoad).toHaveBeenCalledTimes(1);
+    rerender(
+      <TranscriptList
+        {...commonProps}
+        loadingMore={true}
+        onLoadOlder={firstLoad}
+      />,
+    );
+    rerender(
+      <TranscriptList
+        {...commonProps}
+        loading={true}
+        loadingMore={false}
+        onLoadOlder={secondLoad}
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(secondLoad).not.toHaveBeenCalled();
+
+    rerender(
+      <TranscriptList
+        {...commonProps}
+        loadingMore={false}
+        onLoadOlder={secondLoad}
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(secondLoad).toHaveBeenCalledTimes(1);
+  });
+
   it("renders automation card details as markdown in the transcript", () => {
     const automationMarkdown = `| Priority | Service | Next step |
 |---|---|---|

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -389,6 +389,81 @@ describe("useThreadSessionState", () => {
     );
   });
 
+  it("releases older-history loading when a fresher hydration supersedes it", async () => {
+    const initialTail = readThreadResponse({
+      entries: [
+        messageEntry({ id: "recent-1", text: "Recent 1", createdAt: 300 }),
+      ],
+      hasPreviousPage: true,
+      previousCursor: "older-page",
+    });
+    const refreshedTail = readThreadResponse({
+      entries: [
+        messageEntry({ id: "recent-2", text: "Recent 2", createdAt: 400 }),
+      ],
+      hasPreviousPage: true,
+      previousCursor: "older-page-after-refresh",
+    });
+    let resolveOlderPage:
+      | ((response: AppServerReadThreadResponse) => void)
+      | undefined;
+    const olderPagePending = new Promise<AppServerReadThreadResponse>((resolve) => {
+      resolveOlderPage = resolve;
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockReturnValueOnce(olderPagePending)
+      .mockResolvedValueOnce(refreshedTail);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      {
+        initialProps: { updatedAt: 1_000 },
+      }
+    );
+
+    await waitForThreadHydration(result);
+    act(() => {
+      void result.current.loadOlder();
+    });
+    await waitFor(() => {
+      expect(result.current.loadingMore).toBe(true);
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+
+    rerender({ updatedAt: 2_000 });
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+      expect(result.current.response?.replay.pagination.previousCursor).toBe(
+        "older-page-after-refresh",
+      );
+    });
+
+    act(() => {
+      resolveOlderPage?.(readThreadResponse({
+        entries: [
+          messageEntry({ id: "older-1", text: "Older 1", createdAt: 100 }),
+        ],
+        hasPreviousPage: false,
+      }));
+    });
+    await waitFor(() => {
+      expect(result.current.loadingMore).toBe(false);
+    });
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Recent 2",
+    ]);
+  });
+
   it("retains transcript reading state across temporary view unmounts", async () => {
     const desktopApi: DesktopApi = {
       onAgentEvent: () => () => undefined,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3786,6 +3786,11 @@ export function useThreadSessionState(params: {
         failedHydrationVersion: undefined,
         lastTouchedAt: Date.now(),
         loading: true,
+        // A latest hydration supersedes any older-page read for the same
+        // thread. Its request-version bump makes that page response stale, so
+        // release the loading state here instead of waiting for a response
+        // that will intentionally be discarded (or may never arrive).
+        loadingMore: false,
       }));
 
       try {


### PR DESCRIPTION
## What changed

- cancel stale older-page loading state when a newer thread hydration supersedes it
- release the transcript list's local older-page request lock when the parent loading cycle is cancelled
- add renderer regressions for both halves of the refresh-versus-pagination race

## Root cause

The live full-window viewer retained a valid federation cursor, but its renderer could permanently lock pagination.

A scroll-triggered `loadOlder()` marked the session `loadingMore=true`. If a navigation/thread refresh started before that page completed, the refresh incremented the shared request version. The older-page response was then correctly discarded as stale, but that early return never cleared `loadingMore`. `TranscriptList` also retained its local in-flight request lock. Every later scroll was rejected even though the replay still advertised `supportsPagination=true`, `hasPreviousPage=true`, and a valid cursor.

## Live evidence

Against dev Electron main PID 22015 and the `PwrAgent - Harold-MBP-M2-Max` viewer for thread `019febdc-b1c8-77b0-a255-277179994d2c`:

- `readThread(limit: 5)` returned 5 entries / 4 messages with cursor `item-17`
- `readThread(before: "item-17")` returned the preceding 20 entries / 16 messages
- the mounted transcript still showed only the newest 5 items at scroll-top
- `TranscriptList` props retained the valid cursor, and manually invoking `onLoadOlder` resolved

This shows the gateway/owner path preserved history and pagination; the renderer lock prevented the next request.

## Impact

Remote viewers can resume scrolling into older transcript pages after a concurrent hydration refresh instead of remaining stuck on the latest few entries.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts` (232 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; baseline warnings only)
- `pnpm lint:boundaries`
- `git diff --check`
