### PR TITLE
fix(desktop): preserve eager scheduled thread names

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -3603,7 +3603,192 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("retires a name observation after a snapshot acknowledges it", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const snapshot = (title: string, updatedAt: number): NavigationSnapshot => ({
+      backend: "all",
+      fetchedAt: updatedAt,
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title,
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: true, reason: "new-thread" },
+          updatedAt,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    });
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce(snapshot("Initial title", 1_000))
+      .mockResolvedValueOnce(snapshot("Generated title", 2_000))
+      .mockResolvedValueOnce(snapshot("Newer remote title", 3_000));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.title).toBe("Initial title");
+    });
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/name/updated",
+          params: {
+            threadId: "thread-1",
+            threadName: "Generated title",
+          },
+        },
+      });
+    });
+    expect(result.current.threads[0]?.title).toBe("Generated title");
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.threads[0]?.title).toBe("Generated title");
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.threads[0]?.title).toBe("Newer remote title");
+  });
+
+  it("isolates observed names for same-id threads owned by different peers", async () => {
+    const firstTarget = {
+      scope: "remote" as const,
+      instanceId: "first-owner",
+    };
+    const secondTarget = {
+      scope: "remote" as const,
+      instanceId: "second-owner",
+    };
+    (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = firstTarget;
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const navigationSnapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: 1_000,
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [
+        {
+          id: "shared-session-id",
+          title: "First owner title",
+          titleSource: "explicit",
+          source: "acp:kimi",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          federation: {
+            ref: {
+              backend: "acp:kimi",
+              target: firstTarget,
+              threadId: "shared-session-id",
+            },
+            instanceLabel: "First Owner",
+          },
+          updatedAt: 1_000,
+        },
+        {
+          id: "shared-session-id",
+          title: "Second owner title",
+          titleSource: "explicit",
+          source: "acp:kimi",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          federation: {
+            ref: {
+              backend: "acp:kimi",
+              target: secondTarget,
+              threadId: "shared-session-id",
+            },
+            instanceLabel: "Second Owner",
+          },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const getNavigationSnapshot = vi.fn(async () => navigationSnapshot);
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    const titlesByOwner = (): Record<string, string> => Object.fromEntries(
+      result.current.threads.map((thread) => [
+        thread.federation?.ref.target.scope === "remote"
+          ? thread.federation.ref.target.instanceId
+          : "local",
+        thread.title,
+      ]),
+    );
+
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(2);
+    });
+    act(() => {
+      agentEventHandler?.({
+        backend: "acp:kimi",
+        federationTarget: firstTarget,
+        notification: {
+          method: "thread/name/updated",
+          params: {
+            threadId: "shared-session-id",
+            threadName: "Renamed first owner",
+          },
+        },
+      });
+    });
+    expect(titlesByOwner()).toEqual({
+      "first-owner": "Renamed first owner",
+      "second-owner": "Second owner title",
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(titlesByOwner()).toEqual({
+      "first-owner": "Renamed first owner",
+      "second-owner": "Second owner title",
+    });
+  });
+
   it("keeps an eager generated name that arrives while a scheduled thread materializes", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "scheduled-thread-owner",
+    };
+    (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = federationTarget;
     const directoryKey = "directory:/Users/huntharo/github/PwrSuiteLab";
     let agentEventHandler:
       | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
@@ -3640,6 +3825,7 @@ describe("useThreadNavigation", () => {
         backend: "codex",
         executionMode: "default",
       },
+      federationTarget,
     };
     const scheduledFor = Date.now() + 60 * 60 * 1_000;
     const staleHydratedSnapshot: NavigationSnapshot = {
@@ -3654,6 +3840,14 @@ describe("useThreadNavigation", () => {
           source: "codex",
           linkedDirectories: [],
           inbox: { inInbox: true, reason: "new-thread" },
+          federation: {
+            ref: {
+              backend: "codex",
+              target: federationTarget,
+              threadId: "thread-scheduled",
+            },
+            instanceLabel: "Scheduled Thread Owner",
+          },
           scheduledStart: {
             actionId: "scheduled-action:1",
             scheduledFor,
@@ -3679,6 +3873,7 @@ describe("useThreadNavigation", () => {
     > = vi.fn(async () => {
       agentEventHandler?.({
         backend: "codex",
+        federationTarget,
         notification: {
           method: "thread/name/updated",
           params: {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -3603,6 +3603,146 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("keeps an eager generated name that arrives while a scheduled thread materializes", async () => {
+    const directoryKey = "directory:/Users/huntharo/github/PwrSuiteLab";
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const initialSnapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: 1_000,
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory",
+          label: "PwrSuiteLab",
+          path: "/Users/huntharo/github/PwrSuiteLab",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad: {
+            directoryKey,
+            directoryKind: "directory",
+            directoryLabel: "PwrSuiteLab",
+            directoryPath: "/Users/huntharo/github/PwrSuiteLab",
+            backend: "codex",
+            executionMode: "full-access",
+            prompt: "Update all Tart VMs to macOS 26.6.1",
+            workMode: "local",
+            createdAt: 1,
+            updatedAt: 2,
+          },
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const scheduledFor = Date.now() + 60 * 60 * 1_000;
+    const staleHydratedSnapshot: NavigationSnapshot = {
+      ...initialSnapshot,
+      fetchedAt: 2_000,
+      inboxThreadKeys: ["codex:thread-scheduled"],
+      threads: [
+        {
+          id: "thread-scheduled",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: true, reason: "new-thread" },
+          scheduledStart: {
+            actionId: "scheduled-action:1",
+            scheduledFor,
+            state: "scheduled",
+          },
+          updatedAt: 2_000,
+        },
+      ],
+      directories: [
+        {
+          ...initialSnapshot.directories[0]!,
+          threadKeys: ["codex:thread-scheduled"],
+          launchpad: undefined,
+        },
+      ],
+    };
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce(initialSnapshot)
+      .mockResolvedValue(staleHydratedSnapshot);
+    const materializeDirectoryLaunchpad: NonNullable<
+      DesktopApi["materializeDirectoryLaunchpad"]
+    > = vi.fn(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/name/updated",
+          params: {
+            threadId: "thread-scheduled",
+            threadName: "Update Tart VMs to macOS 26.6.1",
+          },
+        },
+      });
+      return {
+        backend: "codex" as const,
+        threadId: "thread-scheduled",
+        executionMode: "full-access" as const,
+        workMode: "local" as const,
+        scheduledAction: {
+          id: "scheduled-action:1",
+          backend: "codex" as const,
+          threadId: "thread-scheduled",
+          kind: "turn" as const,
+          origin: "desktop" as const,
+          status: "scheduled" as const,
+          scheduledFor,
+          displayText: "Update all Tart VMs to macOS 26.6.1",
+          createdAt: 1_000,
+          updatedAt: 1_000,
+        },
+      };
+    });
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedLaunchpad?.directoryKey).toBe(directoryKey);
+    });
+
+    await act(async () => {
+      await result.current.materializeDirectoryLaunchpad(
+        directoryKey,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        scheduledFor,
+      );
+    });
+
+    expect(result.current.selectedThread).toMatchObject({
+      id: "thread-scheduled",
+      title: "Update Tart VMs to macOS 26.6.1",
+      titleSource: "explicit",
+      scheduledStart: {
+        scheduledFor,
+        state: "scheduled",
+      },
+    });
+  });
+
   it("clears the viewer-persisted launchpad after remote materialization", async () => {
     const federationTarget = {
       scope: "remote" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -33,6 +33,7 @@ import {
   buildPullRequestStatusKey,
   buildThreadIdentityKey,
   compareThreadsByCreatedAtDesc,
+  federatedThreadIdentityKey,
   insertSubthreadIdAfter,
   isRemoteFederationTarget,
   isSubthreadLaunchpadKey,
@@ -45,6 +46,7 @@ import { fileLabelFromPath } from "./directory-references";
 import { readRendererFederationTarget } from "./federation-window";
 import { resolveThreadWorkingStatePath } from "./thread-working-state-path";
 import {
+  agentEventMatchesThread,
   agentEventThreadIdentityKey,
   federationTargetsEqual,
   threadSummaryIdentityKey,
@@ -898,20 +900,20 @@ function applyConcurrentThreadStatusObservations(
 
 function applyObservedThreadNames(
   snapshot: NavigationSnapshot,
-  observations: ReadonlyMap<string, ThreadNameObservation>,
+  observations: Map<string, ThreadNameObservation>,
 ): NavigationSnapshot {
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
-    const observation = observations.get(
-      buildThreadIdentityKey(thread.source, thread.id),
-    );
+    const threadKey = threadSummaryIdentityKey(thread);
+    const observation = observations.get(threadKey);
+    if (!observation) {
+      return thread;
+    }
     if (
-      !observation
-      || (
-        thread.title === observation.threadName
-        && thread.titleSource === "explicit"
-      )
+      thread.title === observation.threadName
+      && thread.titleSource === "explicit"
     ) {
+      observations.delete(threadKey);
       return thread;
     }
     changed = true;
@@ -1645,16 +1647,28 @@ function getFallbackSelectionAfterRemoval(
 
 function applyThreadNameUpdate(
   snapshot: NavigationSnapshot | undefined,
-  params: { backend: AppServerBackendKind; threadId: string; threadName?: string }
+  params: {
+    backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
+    threadId: string;
+    threadName?: string;
+  }
 ): NavigationSnapshot | undefined {
   const threadName = params.threadName?.trim();
   if (!snapshot || !threadName) {
     return snapshot;
   }
 
+  const threadKey = params.federationTarget
+    ? federatedThreadIdentityKey({
+        backend: params.backend,
+        target: params.federationTarget,
+        threadId: params.threadId,
+      })
+    : buildThreadIdentityKey(params.backend, params.threadId);
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
-    if (thread.source !== params.backend || thread.id !== params.threadId) {
+    if (threadSummaryIdentityKey(thread) !== threadKey) {
       return thread;
     }
 
@@ -3052,6 +3066,10 @@ export function useThreadNavigation(
         const optimisticThreadKey = optimisticSelection
           ? buildThreadIdentityKey(optimisticSelection.source, optimisticSelection.id)
           : undefined;
+        const responseWithObservedThreadNames = applyObservedThreadNames(
+          response,
+          threadNameObservationsRef.current,
+        );
 
         setState((current) => {
           if (current.response && response.unchanged && !preferredSelectionKey) {
@@ -3063,10 +3081,6 @@ export function useThreadNavigation(
             };
           }
 
-          const responseWithObservedThreadNames = applyObservedThreadNames(
-            response,
-            threadNameObservationsRef.current,
-          );
           const responseWithConcurrentThreadStatuses =
             applyConcurrentThreadStatusObservations(
               responseWithObservedThreadNames,
@@ -3766,19 +3780,20 @@ export function useThreadNavigation(
           return;
         }
         threadNameObservationsRef.current.set(
-          buildThreadIdentityKey(event.backend, threadId),
+          agentEventThreadIdentityKey(event, threadId),
           { threadName: nextThreadName },
         );
         setState((current) => ({
           ...current,
           response: applyThreadNameUpdate(current.response, {
             backend: event.backend,
+            federationTarget: event.federationTarget,
             threadId,
             threadName: nextThreadName,
           }),
         }));
         setOptimisticThread((current) => {
-          if (current?.source !== event.backend || current.id !== threadId) {
+          if (!current || !agentEventMatchesThread(event, current, threadId)) {
             return current;
           }
 
@@ -5961,7 +5976,13 @@ export function useThreadNavigation(
           : undefined,
       });
       const observedThreadName = threadNameObservationsRef.current.get(
-        buildThreadIdentityKey(response.backend, response.threadId),
+        federationTarget
+          ? federatedThreadIdentityKey({
+              backend: response.backend,
+              target: federationTarget,
+              threadId: response.threadId,
+            })
+          : buildThreadIdentityKey(response.backend, response.threadId),
       )?.threadName;
       const namedOptimisticMaterializedThread = observedThreadName
         ? {
@@ -6343,12 +6364,14 @@ export function useThreadNavigation(
         ...current,
         response: applyThreadNameUpdate(current.response, {
           backend: thread.source,
+          federationTarget: thread.federation?.ref.target,
           threadId: thread.id,
           threadName: nextName,
         }),
       }));
       setRetainedUnreadThread((current) =>
-        current?.source === thread.source && current.id === thread.id
+        current
+        && threadSummaryIdentityKey(current) === threadSummaryIdentityKey(thread)
           ? {
               ...current,
               title: nextName,
@@ -6357,7 +6380,8 @@ export function useThreadNavigation(
           : current
       );
       setOptimisticThread((current) =>
-        current?.source === thread.source && current.id === thread.id
+        current
+        && threadSummaryIdentityKey(current) === threadSummaryIdentityKey(thread)
           ? {
               ...current,
               title: nextName,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -147,6 +147,10 @@ type ThreadStatusObservation = {
   threadStatus: AppServerThreadStatus;
 };
 
+type ThreadNameObservation = {
+  threadName: string;
+};
+
 type PrChipLocation = {
   threadIndex: number;
   prIndex: number;
@@ -887,6 +891,34 @@ function applyConcurrentThreadStatusObservations(
     return {
       ...thread,
       threadStatus: observation.threadStatus,
+    };
+  });
+  return changed ? { ...snapshot, threads } : snapshot;
+}
+
+function applyObservedThreadNames(
+  snapshot: NavigationSnapshot,
+  observations: ReadonlyMap<string, ThreadNameObservation>,
+): NavigationSnapshot {
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    const observation = observations.get(
+      buildThreadIdentityKey(thread.source, thread.id),
+    );
+    if (
+      !observation
+      || (
+        thread.title === observation.threadName
+        && thread.titleSource === "explicit"
+      )
+    ) {
+      return thread;
+    }
+    changed = true;
+    return {
+      ...thread,
+      title: observation.threadName,
+      titleSource: "explicit" as const,
     };
   });
   return changed ? { ...snapshot, threads } : snapshot;
@@ -2858,6 +2890,13 @@ export function useThreadNavigation(
   const threadStatusObservationsRef = useRef(
     new Map<string, ThreadStatusObservation>(),
   );
+  // A newly-created thread can be named by the helper before the materialize
+  // IPC response gives the renderer an optimistic row to update. Retain the
+  // authoritative event so that response and a stale first refresh cannot
+  // put "Untitled thread" back over the generated name.
+  const threadNameObservationsRef = useRef(
+    new Map<string, ThreadNameObservation>(),
+  );
   const setNavigationBrowseModeRequestRef = useRef(setNavigationBrowseModeRequest);
   const stateRef = useRef(state);
 
@@ -3024,9 +3063,13 @@ export function useThreadNavigation(
             };
           }
 
+          const responseWithObservedThreadNames = applyObservedThreadNames(
+            response,
+            threadNameObservationsRef.current,
+          );
           const responseWithConcurrentThreadStatuses =
             applyConcurrentThreadStatusObservations(
-              response,
+              responseWithObservedThreadNames,
               threadStatusObservationsRef.current,
               threadStatusSequenceAtRefreshStart,
             );
@@ -3718,21 +3761,24 @@ export function useThreadNavigation(
           threadId: string;
           threadName?: string;
         };
+        const nextThreadName = threadName?.trim();
+        if (!nextThreadName) {
+          return;
+        }
+        threadNameObservationsRef.current.set(
+          buildThreadIdentityKey(event.backend, threadId),
+          { threadName: nextThreadName },
+        );
         setState((current) => ({
           ...current,
           response: applyThreadNameUpdate(current.response, {
             backend: event.backend,
             threadId,
-            threadName,
+            threadName: nextThreadName,
           }),
         }));
         setOptimisticThread((current) => {
           if (current?.source !== event.backend || current.id !== threadId) {
-            return current;
-          }
-
-          const nextThreadName = threadName?.trim();
-          if (!nextThreadName) {
             return current;
           }
 
@@ -5914,6 +5960,16 @@ export function useThreadNavigation(
             }
           : undefined,
       });
+      const observedThreadName = threadNameObservationsRef.current.get(
+        buildThreadIdentityKey(response.backend, response.threadId),
+      )?.threadName;
+      const namedOptimisticMaterializedThread = observedThreadName
+        ? {
+            ...optimisticMaterializedThread,
+            title: observedThreadName,
+            titleSource: "explicit" as const,
+          }
+        : optimisticMaterializedThread;
       const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
       // Sub-thread launchpads drop the new child directly below their source
       // card. Plain new-thread launchpads have no parent and skip this. Await
@@ -5941,7 +5997,7 @@ export function useThreadNavigation(
         shouldSelectMaterializedThread || !optimisticThreadRef.current;
       setOptimisticThread((current) =>
         shouldSelectMaterializedThread || !current
-          ? optimisticMaterializedThread
+          ? namedOptimisticMaterializedThread
           : current
       );
       if (shouldSelectMaterializedThread) {
@@ -5994,7 +6050,9 @@ export function useThreadNavigation(
       try {
         await refresh(
           shouldSelectMaterializedThread ? nextThreadKey : undefined,
-          shouldProjectOptimisticThread ? optimisticMaterializedThread : undefined,
+          shouldProjectOptimisticThread
+            ? namedOptimisticMaterializedThread
+            : undefined,
         );
       } catch (error) {
         setLaunchpadError(error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
## Summary

- retain authoritative `thread/name/updated` events across new-thread materialization
- apply an eager generated title to the optimistic thread and the first navigation refresh
- add regression coverage for a scheduled thread whose naming event arrives before its materialization response

## Root cause

The title helper already ran when the scheduled thread was created, but it could finish before the renderer inserted the new thread. The renderer then discarded the rename event and hydrated a stale `Untitled thread` snapshot.

## Impact

Scheduling a new thread now shows its generated name as soon as the naming helper finishes instead of leaving the row untitled until a later refresh.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "materializes and names a thread now while scheduling its first turn"`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `git diff --check`
