### PR TITLE
fix(desktop): harden GitHub token handling

### DIFF
--- a/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
@@ -764,6 +764,14 @@ describe("readGithubDotComAuthToken", () => {
     ]);
   });
 
+  it("preserves unprefixed legacy tokens from the direct token command", async () => {
+    const legacyToken = "a".repeat(40);
+    const run = vi.fn(async () => ({ stdout: `${legacyToken}\n` }));
+
+    await expect(readGithubDotComAuthToken("gh", run)).resolves.toBe(legacyToken);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to legacy status output, including stderr", async () => {
     const run = vi.fn()
       .mockRejectedValueOnce(new Error("unknown command: token"))
@@ -781,5 +789,29 @@ describe("readGithubDotComAuthToken", () => {
       "github.com",
       "--show-token",
     ]);
+  });
+
+  it("does not expose token-bearing output from a failed status fallback", async () => {
+    const exposedCredential = "plaintext-test-credential-that-must-not-escape";
+    const statusError = Object.assign(new Error(`Token: ${exposedCredential}`), {
+      stdout: `github.com token: ${exposedCredential}`,
+      stderr: `Authentication failed for token ${exposedCredential}`,
+    });
+    const run = vi.fn()
+      .mockRejectedValueOnce(new Error("unknown command token"))
+      .mockRejectedValueOnce(statusError);
+
+    let caught: unknown;
+    try {
+      await readGithubDotComAuthToken("gh", run);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe(
+      "GitHub CLI authentication status check failed",
+    );
+    expect(String(caught)).not.toContain(exposedCredential);
   });
 });

--- a/apps/desktop/src/main/pr-status/github-graphql-client.ts
+++ b/apps/desktop/src/main/pr-status/github-graphql-client.ts
@@ -74,7 +74,7 @@ export async function readGithubDotComAuthToken(
       "--hostname",
       "github.com",
     ]);
-    const token = findGithubToken(output);
+    const token = output.stdout.trim();
     if (token) {
       return token;
     }
@@ -82,14 +82,20 @@ export async function readGithubDotComAuthToken(
     // Older gh versions do not have `auth token`; try their status output.
   }
 
-  const output = await run(command, [
-    "auth",
-    "status",
-    "--hostname",
-    "github.com",
-    "--show-token",
-  ]);
-  return findGithubToken(output);
+  try {
+    const output = await run(command, [
+      "auth",
+      "status",
+      "--hostname",
+      "github.com",
+      "--show-token",
+    ]);
+    return findGithubToken(output);
+  } catch {
+    // This command can print a plaintext token before exiting unsuccessfully.
+    // Never propagate its stdout, stderr, or exec error message.
+    throw new Error("GitHub CLI authentication status check failed");
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Preserve any nonempty trimmed stdout returned by `gh auth token --hostname github.com`, including valid unprefixed legacy 40-character credentials.
- Sanitize failures from the legacy `gh auth status --hostname github.com --show-token` fallback so stdout, stderr, and the rejected error message cannot propagate a plaintext credential.
- Add focused regressions for both paths.

## Why

The direct token path previously accepted only credentials matching newer prefixed token formats, so valid unprefixed legacy tokens were discarded. The fallback status path allowed a rejected child-process error to escape verbatim even though GitHub CLI may include the plaintext credential in stdout, stderr, or the error message.

This was discovered while reviewing the `releases/1.0` reliability backport in #1456. The same defects were confirmed independently on current `main`.

## Impact

GitHub PR status polling continues to work with legacy unprefixed credentials, and fallback authentication failures expose only a fixed sanitized error.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/github-graphql-client.test.ts` — 51 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; existing warning baseline only
- Final diff check and credential-pattern audit
