### PR TITLE
fix(messaging): detect Slack mentions anywhere

### DIFF
--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -1642,6 +1642,42 @@ describe("SlackAdapter", () => {
     ]);
   });
 
+  it("preserves line breaks around a mid-message app mention", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "app_mention",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        ts: "1712023032.123456",
+        user: "U012ABCDEF0",
+        text: "context:\n<@U0BOTUSERID> explain this",
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        kind: "text",
+        botMention: true,
+        text: "context:\nexplain this",
+      }),
+    ]);
+  });
+
   it("routes bare leading app mentions as the help command", async () => {
     const socket = fakeSocket();
     const adapter = new SlackAdapter({
@@ -1783,7 +1819,7 @@ describe("SlackAdapter", () => {
       team: "T012ABCDEF0",
       ts: "1712023032.123456",
       user: "U012ABCDEF0",
-      text: "please <@U0BOTUSERID> help",
+      text: "show `<@U0BOTUSERID>` literally, then <@U0BOTUSERID> help",
     };
 
     await socket.emitEvent("slack_event", {
@@ -1805,9 +1841,45 @@ describe("SlackAdapter", () => {
       expect.objectContaining({
         kind: "text",
         botMention: true,
-        text: "please help",
+        text: "show `<@U0BOTUSERID>` literally, then help",
       }),
     ]);
+  });
+
+  it.each([
+    ["inline", "show `<@U0BOTUSERID>` literally"],
+    ["fenced", "```\n<@U0BOTUSERID>\n```"],
+  ])("does not treat bot tokens in %s code as mentions", async (_kind, text) => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: { ...baseConfig, responseMode: "mention_only" },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "message",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        ts: "1712023032.123456",
+        user: "U012ABCDEF0",
+        text,
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({ kind: "text", text }),
+    ]);
+    expect(events[0]).not.toHaveProperty("botMention");
   });
 
   it("strips the configured prefix from Slack slash commands", async () => {

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -1606,6 +1606,42 @@ describe("SlackAdapter", () => {
     ]);
   });
 
+  it("routes app mentions that appear after other message content", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "app_mention",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        ts: "1712023032.123456",
+        user: "U012ABCDEF0",
+        text: ":thread: <@U0BOTUSERID> attach the search thread",
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        kind: "text",
+        botMention: true,
+        text: ":thread: attach the search thread",
+      }),
+    ]);
+  });
+
   it("routes bare leading app mentions as the help command", async () => {
     const socket = fakeSocket();
     const adapter = new SlackAdapter({
@@ -1728,7 +1764,7 @@ describe("SlackAdapter", () => {
     ]);
   });
 
-  it("deduplicates app_mention and message events for the same Slack post", async () => {
+  it("preserves mention detection when message arrives before app_mention", async () => {
     const socket = fakeSocket();
     const adapter = new SlackAdapter({
       config: baseConfig,
@@ -1747,16 +1783,9 @@ describe("SlackAdapter", () => {
       team: "T012ABCDEF0",
       ts: "1712023032.123456",
       user: "U012ABCDEF0",
-      text: "<@U0BOTUSERID> help",
+      text: "please <@U0BOTUSERID> help",
     };
 
-    await socket.emitEvent("slack_event", {
-      ack: async () => undefined,
-      event: {
-        ...event,
-        type: "app_mention",
-      },
-    });
     await socket.emitEvent("slack_event", {
       ack: async () => undefined,
       event: {
@@ -1764,12 +1793,19 @@ describe("SlackAdapter", () => {
         type: "message",
       },
     });
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        ...event,
+        type: "app_mention",
+      },
+    });
 
     expect(events).toEqual([
       expect.objectContaining({
         kind: "text",
         botMention: true,
-        text: "help",
+        text: "please help",
       }),
     ]);
   });

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -2605,16 +2605,43 @@ function slackConversationUrl(channelId: string, teamId?: string): string {
 export function stripBotMention(text: string, botUserId: string | undefined): string {
   if (!botUserId) return text;
   const mention = `<@${botUserId}>`;
-  const mentionIndex = text.indexOf(mention);
+  const mentionIndex = findSlackMentionOutsideCode(text, mention);
   if (mentionIndex < 0) return text;
 
   const before = text.slice(0, mentionIndex);
   const after = text.slice(mentionIndex + mention.length);
-  if (!before.trim()) return after.trimStart();
-  if (!after.trim()) return before.trimEnd();
+  const trailingWhitespace = before.match(/[ \t]+$/u)?.[0] ?? "";
+  const leadingWhitespace = after.match(/^[ \t]+/u)?.[0] ?? "";
+  const prefix = before.slice(0, before.length - trailingWhitespace.length);
+  const suffix = after.slice(leadingWhitespace.length);
+  const prefixEndsLine = prefix.length === 0 || /[\r\n]$/u.test(prefix);
+  const suffixStartsLine = suffix.length === 0 || /^[\r\n]/u.test(suffix);
+  const needsSpace = !prefixEndsLine
+    && !suffixStartsLine
+    && Boolean(trailingWhitespace || leadingWhitespace);
+  return `${prefix}${needsSpace ? " " : ""}${suffix}`;
+}
 
-  const separated = /\s$/u.test(before) || /^\s/u.test(after);
-  return `${before.trimEnd()}${separated ? " " : ""}${after.trimStart()}`;
+function findSlackMentionOutsideCode(text: string, mention: string): number {
+  let inFencedCode = false;
+  let inInlineCode = false;
+  for (let index = 0; index < text.length;) {
+    if (!inInlineCode && text.startsWith("```", index)) {
+      inFencedCode = !inFencedCode;
+      index += 3;
+      continue;
+    }
+    if (!inFencedCode && text[index] === "`") {
+      inInlineCode = !inInlineCode;
+      index += 1;
+      continue;
+    }
+    if (!inFencedCode && !inInlineCode && text.startsWith(mention, index)) {
+      return index;
+    }
+    index += 1;
+  }
+  return -1;
 }
 
 function parseCommand(text: string): { command: string; args: string[] } | undefined {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -1001,7 +1001,10 @@ export class SlackAdapter implements SlackProviderAdapter {
     });
     const rawText = event.text ?? "";
     const strippedText = stripBotMention(rawText, this.botUserId);
-    const isMention = strippedText !== rawText;
+    // Slack's app_mention event is the authoritative addressed-to-us signal.
+    // Also inspect message text because Slack can deliver the same post as both
+    // app_mention and message, and either copy may win our deduplication race.
+    const isMention = event.type === "app_mention" || strippedText !== rawText;
     const text = strippedText.trim();
     const isPairingMessage = Boolean(extractMessagingPairingToken(rawText));
     const command = isMention && text.length === 0
@@ -2601,7 +2604,17 @@ function slackConversationUrl(channelId: string, teamId?: string): string {
 
 export function stripBotMention(text: string, botUserId: string | undefined): string {
   if (!botUserId) return text;
-  return text.replace(new RegExp(`^\\s*<@${escapeRegex(botUserId)}>\\s*`), "");
+  const mention = `<@${botUserId}>`;
+  const mentionIndex = text.indexOf(mention);
+  if (mentionIndex < 0) return text;
+
+  const before = text.slice(0, mentionIndex);
+  const after = text.slice(mentionIndex + mention.length);
+  if (!before.trim()) return after.trimStart();
+  if (!after.trim()) return before.trimEnd();
+
+  const separated = /\s$/u.test(before) || /^\s/u.test(after);
+  return `${before.trimEnd()}${separated ? " " : ""}${after.trimStart()}`;
 }
 
 function parseCommand(text: string): { command: string; args: string[] } | undefined {
@@ -2985,8 +2998,4 @@ function safeEqual(left: string, right: string): boolean {
   const rightBuffer = Buffer.from(right);
   return leftBuffer.byteLength === rightBuffer.byteLength
     && timingSafeEqual(leftBuffer, rightBuffer);
-}
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }


### PR DESCRIPTION
## Summary

- treat Slack `app_mention` events as an authoritative bot-mention signal
- detect the exact `<@BOT_USER_ID>` token anywhere in message text
- remove an in-message bot mention cleanly before forwarding the prompt
- preserve mention detection when Slack's duplicate `message` event arrives before `app_mention`

## Root cause

The Slack adapter inferred `botMention` only by stripping a mention anchored at the start of `event.text`. Slack emits `app_mention` for messages that mention the app anywhere, but the adapter ignored the event type. It also deduplicates equivalent `message` and `app_mention` deliveries, so whichever event arrived first determined the result.

## Impact

Messages such as `:thread: @PwrAgent attach this thread` now reach mention-only Slack bindings and are forwarded without the bot mention token.

## Validation

- `pnpm test packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts` (76 passed)
- `pnpm --filter @pwragent/messaging-provider-slack typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
