### PR TITLE
fix(desktop): harden thread directory enrichment

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1672,6 +1672,83 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("contains a directory enrichment failure to the affected thread", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const managedWorktree = "/Users/vitaliy/.codex/worktrees/a21d/giphy-services";
+    const localDirectory = "/Users/vitaliy/projects/healthy";
+    const threadDirectoryEnricher = vi.fn(async (projectKey?: string) => {
+      if (projectKey === managedWorktree) {
+        throw Object.assign(new Error("spawn git EACCES"), { code: "EACCES" });
+      }
+      return {
+        linkedDirectories: [
+          {
+            id: projectKey ?? "missing",
+            label: path.basename(projectKey ?? "missing"),
+            path: projectKey ?? "missing",
+            kind: "local" as const,
+          },
+        ],
+      };
+    });
+    const client = new CodexAppServerClient({
+      command: "codex",
+      threadDirectoryEnricher,
+    });
+    const threads: AppServerThreadSummary[] = [
+      {
+        id: "broken-worktree-thread",
+        title: "Broken worktree",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: managedWorktree,
+        linkedDirectories: [],
+      },
+      {
+        id: "healthy-thread",
+        title: "Healthy thread",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: localDirectory,
+        linkedDirectories: [],
+      },
+    ];
+
+    await expect(client.enrichThreadDirectories(threads)).resolves.toEqual([
+      expect.objectContaining({
+        id: "broken-worktree-thread",
+        linkedDirectories: [
+          {
+            id: managedWorktree,
+            label: "giphy-services",
+            path: managedWorktree,
+            worktreePath: managedWorktree,
+            kind: "worktree",
+          },
+        ],
+      }),
+      expect.objectContaining({
+        id: "healthy-thread",
+        linkedDirectories: [
+          expect.objectContaining({
+            path: localDirectory,
+            kind: "local",
+          }),
+        ],
+      }),
+    ]);
+    expect(codexClientLogWarn).toHaveBeenCalledWith(
+      "thread directory enrichment failed",
+      expect.objectContaining({
+        threadId: "broken-worktree-thread",
+        projectKey: managedWorktree,
+        error: "spawn git EACCES",
+      }),
+    );
+
+    await client.close();
+  });
+
   it("keeps cheap thread summaries from rendering managed worktrees as local", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     const threadDirectoryEnricher = vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
@@ -165,6 +165,104 @@ describe("createThreadDirectoryEnricher", () => {
     });
   });
 
+  it.each([
+    {
+      failure: "cannot execute git",
+      error: Object.assign(new Error("spawn git EACCES"), { code: "EACCES" }),
+    },
+    {
+      failure: "git crashes",
+      error: Object.assign(new Error("git terminated by SIGSEGV"), { signal: "SIGSEGV" }),
+    },
+    {
+      failure: "git times out",
+      error: Object.assign(new Error("git timed out"), { code: "ETIMEDOUT", killed: true }),
+    },
+  ])("preserves a managed worktree identity when $failure", async ({ error }) => {
+    const projectPath = "/Users/vitaliy/.codex/worktrees/a21d/giphy-services";
+    const execFileMock = vi.fn(
+      (
+        _file: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null) => void,
+      ) => callback(error),
+    );
+    vi.doMock("node:fs/promises", () => ({
+      access: vi.fn(async (targetPath: string) => {
+        if (targetPath === path.resolve(projectPath)) {
+          return undefined;
+        }
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      }),
+      readFile: vi.fn(),
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFile: execFileMock,
+    }));
+
+    const { createThreadDirectoryEnricher } = await import(
+      "../app-server/thread-directory-enricher"
+    );
+    const enricher = createThreadDirectoryEnricher();
+
+    await expect(enricher(projectPath)).resolves.toEqual({
+      linkedDirectories: [
+        {
+          id: expectedDir(projectPath),
+          path: expectedDir(projectPath),
+          worktreePath: expectedDir(projectPath),
+          label: "giphy-services",
+          kind: "worktree",
+        },
+      ],
+    });
+    expect(execFileMock).toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["-C", projectPath]),
+      expect.objectContaining({ timeout: 2_000 }),
+      expect.any(Function),
+    );
+  });
+
+  it("keeps a normal directory usable when git is unavailable", async () => {
+    const projectPath = "/Users/vitaliy/projects/not-a-repository";
+    vi.doMock("node:fs/promises", () => ({
+      access: vi.fn(async (targetPath: string) => {
+        if (targetPath === path.resolve(projectPath)) {
+          return undefined;
+        }
+        throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+      }),
+      readFile: vi.fn(),
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFile: vi.fn(
+        (
+          _file: string,
+          _args: string[],
+          _options: unknown,
+          callback: (error: Error | null) => void,
+        ) => callback(Object.assign(new Error("spawn git EACCES"), { code: "EACCES" })),
+      ),
+    }));
+
+    const { createThreadDirectoryEnricher } = await import(
+      "../app-server/thread-directory-enricher"
+    );
+
+    await expect(createThreadDirectoryEnricher()(projectPath)).resolves.toEqual({
+      linkedDirectories: [
+        {
+          id: expectedDir(projectPath),
+          path: expectedDir(projectPath),
+          label: "not-a-repository",
+          kind: "local",
+        },
+      ],
+    });
+  });
+
   it("returns no linked directories when the anchored path no longer exists", async () => {
     vi.doMock("node:fs/promises", () => ({
       access: vi.fn(async () => {

--- a/apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
@@ -219,7 +219,7 @@ describe("createThreadDirectoryEnricher", () => {
     });
     expect(execFileMock).toHaveBeenCalledWith(
       "git",
-      expect.arrayContaining(["-C", projectPath]),
+      expect.arrayContaining(["-C", path.resolve(projectPath)]),
       expect.objectContaining({ timeout: 2_000 }),
       expect.any(Function),
     );

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -7461,7 +7461,19 @@ export class CodexAppServerClient {
         thread: EnrichedCodexThread;
       }> => {
         const projectKey = await resolveThreadProjectKey(thread);
-        const enrichment = await this.threadDirectoryEnricher(projectKey);
+        let enrichment: ThreadDirectoryEnrichment;
+        try {
+          enrichment = await this.threadDirectoryEnricher(projectKey);
+        } catch (error) {
+          codexClientLog.warn("thread directory enrichment failed", {
+            threadId: thread.id,
+            projectKey,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          enrichment = {
+            linkedDirectories: buildProjectKeyLinkedDirectories(projectKey),
+          };
+        }
         const {
           codexThreadSourceKind: _codexThreadSourceKind,
           originator: _originator,

--- a/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
+++ b/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
@@ -9,6 +9,8 @@ import { getMainLogger } from "../log";
 
 const execFile = promisify(execFileCallback);
 const threadDirectoryLog = getMainLogger("pwragent:thread-directory-enricher");
+const GIT_DIRECTORY_PROBE_TIMEOUT_MS = 2_000;
+const GIT_DIRECTORY_PROBE_MAX_BUFFER_BYTES = 1024 * 1024;
 
 /**
  * Normalize a resolved filesystem path to forward slashes for use as a stable,
@@ -44,8 +46,22 @@ type GitMetadataEvidence = {
 async function runGit(projectKey: string, args: string[]): Promise<string> {
   const result = await execFile("git", ["-C", projectKey, ...args], {
     env: buildPwrAgentChildProcessEnv(process.env),
+    maxBuffer: GIT_DIRECTORY_PROBE_MAX_BUFFER_BYTES,
+    timeout: GIT_DIRECTORY_PROBE_TIMEOUT_MS,
   });
   return result.stdout.trim();
+}
+
+function buildFallbackLinkedDirectory(currentPath: string): LinkedDirectorySummary {
+  const directoryPath = path.resolve(currentPath);
+  const isManagedWorktree = isToolManagedWorktreePath(directoryPath);
+  return {
+    id: toDirectoryId(directoryPath),
+    path: toDirectoryId(directoryPath),
+    ...(isManagedWorktree ? { worktreePath: toDirectoryId(directoryPath) } : {}),
+    label: path.basename(directoryPath) || directoryPath,
+    kind: isManagedWorktree ? "worktree" : "local",
+  };
 }
 
 async function pathExists(targetPath: string): Promise<boolean> {
@@ -267,25 +283,18 @@ async function loadThreadDirectoryEnrichment(
       };
     }
 
-    const fallbackPath = path.resolve(currentPath);
-    if (isToolManagedWorktreePath(fallbackPath)) {
-      threadDirectoryLog.warn("managed worktree path fell back to local directory", {
+    const fallbackDirectory = buildFallbackLinkedDirectory(currentPath);
+    if (fallbackDirectory.kind === "worktree") {
+      threadDirectoryLog.warn("managed worktree repository relationship unavailable", {
         projectKey,
-        fallbackPath,
+        fallbackPath: fallbackDirectory.worktreePath,
         error: error instanceof Error ? error.message : String(error),
         gitMetadata: gitMetadataFallback.evidence,
       });
     }
 
     return {
-      linkedDirectories: [
-        {
-          id: toDirectoryId(fallbackPath),
-          path: toDirectoryId(fallbackPath),
-          label: path.basename(fallbackPath) || fallbackPath,
-          kind: "local",
-        },
-      ],
+      linkedDirectories: [fallbackDirectory],
     };
   }
 }


### PR DESCRIPTION
## What changed

- Bound startup-time Git directory probes to two seconds and cap their output.
- Preserve structurally recognized Codex/PwrAgent worktrees as worktrees when Git is unavailable, crashes, times out, or the .git relationship is missing.
- Contain unexpected directory-enricher failures to the affected thread and retain a structural directory fallback instead of rejecting the whole thread batch.
- Add regression coverage for EACCES, Git crashes, timeouts, non-repository local directories, and batch-level failure isolation.

## Why

A reported startup log showed a managed Codex worktree whose .git metadata had disappeared. Main already caught the immediate git rev-parse failure, but it downgraded that path to a local checkout. Git probes also had no deadline, and an unexpected enricher rejection could still escape the concurrent mapper and reject the complete thread list.

The reported warning is nonfatal on current main, so this does not claim that warning alone caused the startup watchdog dialog. This change closes the adjacent failure modes and ensures directory metadata enrichment remains best-effort rather than startup-critical.

## Validation

- pnpm test apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts (146 tests)
- pnpm typecheck
- pnpm lint:eslint (passes with existing repository warnings)
- pnpm lint:boundaries
- git diff --check

A separate releases/1.0 backport can follow after this PR is reviewed and approved.