### PR TITLE
fix(desktop): keep toasts above Star Map

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -720,6 +720,20 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("layers app toasts above the full-window Star Map", () => {
+    const starMapLayerRule = extractRuleBody(
+      css,
+      ".app-shell__star-map-layer",
+    );
+    const toastStackRule = extractRuleBody(css, ".app-toast-stack");
+    const readZIndex = (rule: string): number =>
+      Number(rule.match(/z-index:\s*(\d+);/)?.[1] ?? Number.NaN);
+
+    expect(readZIndex(toastStackRule)).toBeGreaterThan(
+      readZIndex(starMapLayerRule),
+    );
+  });
+
   it("right-aligns the keyboard shortcut hint chip on context menu items", () => {
     // The `__shortcut` chip is the discoverability surface for
     // the otherwise-invisible Cmd+(Shift+)Arrow reorder shortcut.

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5864,7 +5864,9 @@ textarea,
 
 .app-toast-stack {
   position: fixed;
-  z-index: 80;
+  /* App-level notices must remain visible over full-window surfaces such as
+     Star Map (120) and its floating thread (130). */
+  z-index: 140;
   left: 16px;
   bottom: 16px;
   display: flex;
@@ -5985,7 +5987,7 @@ textarea,
 }
 
 .app-notice-toast__thread-menu {
-  z-index: 90;
+  z-index: 150;
 }
 
 .app-notice-toast__status {


### PR DESCRIPTION
## Summary

- elevate the app-level toast stack above the full-window Star Map and its floating thread
- keep toast thread-link context menus above the elevated toast stack
- add a focused theme contract that prevents Star Map from covering app toasts again

## Root cause

The toast host remains mounted while Star Map is open, but `.app-toast-stack` used `z-index: 80` while the full-window Star Map layer uses `z-index: 120`. The opaque Star Map surface therefore painted over local backend and other app-level notices, hiding problems the operator needs to see.

## User impact

Sticky local-instance errors and other app notices now remain visible and interactive while the operator is in Star Map, including when a thread is floating over the map.

## Validation

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx -t "scopes all backend error toast paths"`
- `pnpm lint:eslint` (passes with the existing warning baseline)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:colors`
- `git diff --check`
