### PR TITLE
feat(desktop): nest federated child threads across instances

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -92,6 +92,7 @@ const federationMock = vi.hoisted(() => {
     remoteBackend,
     remoteThreadSummaries,
     runtime: {
+      health: vi.fn(async () => ({ instanceId: "pwr_local" })),
       hydrateThreadMessageOrigins: vi.fn(async (response) => response),
       remoteBackend: vi.fn(() => remoteBackend),
       remoteTargetSupportsCapability: vi.fn(() => true),
@@ -2681,6 +2682,7 @@ describe("app server ipc", () => {
         title: "Fix PwrSnap controls",
         titleSource: "explicit" as const,
         parentThreadId: "parent-1",
+        parentThreadInstanceId: "peer-parent",
         linkedDirectories: [],
         inbox: { inInbox: false },
       },
@@ -2694,11 +2696,18 @@ describe("app server ipc", () => {
     expect(addRemoteThreadPinStore.mock.calls[1][0]).toMatchObject({
       ref: buildFederatedThreadRef({
         backend: "codex",
-        instanceId: "peer-laptop",
+        instanceId: "peer-parent",
         threadId: "parent-1",
       }),
       summary: parentSummary,
       pinnedVia: "companion",
+    });
+    expect(
+      federationMock.remoteThreadSummaries.threadFromPeer,
+    ).toHaveBeenCalledWith({
+      target: { scope: "remote", instanceId: "peer-parent" },
+      backend: "codex",
+      threadId: "parent-1",
     });
   });
 

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -98,6 +98,7 @@ const federationMock = vi.hoisted(() => {
       remoteTargetSupportsCapability: vi.fn(() => true),
       remoteNavigationSnapshot: vi.fn(),
       remoteThreadSummaries: vi.fn(() => remoteThreadSummaries),
+      ungroupRemoteChildrenOfArchivedThread: vi.fn(async () => undefined),
     },
   };
 });
@@ -991,6 +992,7 @@ describe("app server ipc", () => {
     federationMock.runtime.remoteTargetSupportsCapability.mockReturnValue(true);
     federationMock.runtime.hydrateThreadMessageOrigins.mockClear();
     federationMock.runtime.remoteNavigationSnapshot.mockReset();
+    federationMock.runtime.ungroupRemoteChildrenOfArchivedThread.mockClear();
     listThreads.mockClear();
     readThread.mockClear();
     getThreadTranscriptImageRoots.mockClear();
@@ -3344,6 +3346,12 @@ describe("app server ipc", () => {
     expect(archiveThread).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-1",
+    });
+    expect(
+      federationMock.runtime.ungroupRemoteChildrenOfArchivedThread,
+    ).toHaveBeenCalledWith({
+      backend: "codex",
+      parentThreadId: "thread-1",
     });
     expect(response).toEqual({
       backend: "codex",

--- a/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
@@ -710,6 +710,103 @@ describe("federation agent tools service", () => {
       backend: "codex",
       threadId: "remote-thread-9",
     });
+    expect(data.groupingMode).toBe("none");
+  });
+
+  it("groups and mounts a remotely created child beneath the calling thread", async () => {
+    const materializeDirectoryLaunchpad = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "remote-child",
+      executionMode: "default" as const,
+      workMode: "local" as const,
+      turnId: "remote-turn",
+    }));
+    const addRemoteThreadPin = vi.fn(async () => undefined);
+    const onRemoteChildMounted = vi.fn(async () => undefined);
+    const handler = createFederationAgentToolsHandler({
+      collectHostInfo: async () => localHostInfo,
+      onRemoteChildMounted,
+      targetStore: {
+        addRemoteThreadPin,
+        rememberRemoteThreadTarget: vi.fn(async (target) => ({
+          ...target,
+          firstSeenAt: 1_000,
+          lastSeenAt: 1_000,
+        })),
+        listRemoteThreadTargets: vi.fn(async () => []),
+      },
+      runtime: buildRuntime({
+        health: async () =>
+          buildHealth({
+            peers: [{
+              id: "pwr_studio",
+              label: "Studio Mac",
+              role: "client",
+              status: "connected",
+              capabilities: ["thread_navigation", "environment_actions"],
+            }],
+          }),
+        remoteBackend: (() => ({
+          getNavigationSnapshot: async () =>
+            buildSnapshot({
+              directories: [{
+                key: "dir:/repo",
+                kind: "directory",
+                label: "PwrAgent",
+                path: "/repo",
+                threadKeys: [],
+                needsAttentionCount: 0,
+              }] as NavigationSnapshot["directories"],
+            }),
+          materializeDirectoryLaunchpad,
+        })) as never,
+      }),
+    });
+
+    const response = await handler({
+      operation: "create_instance_thread",
+      context,
+      args: {
+        instanceId: "pwr_studio",
+        projectKey: "dir:/repo",
+        groupingMode: "subthread",
+        workMode: "local",
+      },
+    });
+
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentThreadId: "thread-1",
+        parentThreadBackend: "codex",
+        parentThreadInstanceId: "pwr_local",
+      }),
+    );
+    expect(addRemoteThreadPin).toHaveBeenCalledWith(expect.objectContaining({
+      ref: {
+        backend: "codex",
+        target: { scope: "remote", instanceId: "pwr_studio" },
+        threadId: "remote-child",
+      },
+      instanceLabel: "Studio Mac",
+      pinnedVia: "child",
+      summary: expect.objectContaining({
+        parentThreadId: "thread-1",
+        parentThreadBackend: "codex",
+        parentThreadInstanceId: "pwr_local",
+      }),
+    }));
+    expect(onRemoteChildMounted).toHaveBeenCalledWith({
+      instanceId: "pwr_studio",
+      backend: "codex",
+      threadId: "remote-child",
+    });
+    expect(response).toMatchObject({
+      ok: true,
+      data: {
+        groupingMode: "subthread",
+        groupedUnderThreadId: "thread-1",
+      },
+    });
   });
 
   it("merges local and peer results in search_federation_threads", async () => {

--- a/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
@@ -713,7 +713,7 @@ describe("federation agent tools service", () => {
     expect(data.groupingMode).toBe("none");
   });
 
-  it("groups and mounts a remote child beneath the caller's group root", async () => {
+  it("mounts a delegated sibling on its remote group-root owner", async () => {
     const materializeDirectoryLaunchpad = vi.fn(async () => ({
       backend: "codex" as const,
       threadId: "remote-child",
@@ -722,29 +722,40 @@ describe("federation agent tools service", () => {
       turnId: "remote-turn",
     }));
     const addRemoteThreadPin = vi.fn(async () => undefined);
+    const mountRemoteChild = vi.fn(async () => ({ mounted: true as const }));
     const onRemoteChildMounted = vi.fn(async () => undefined);
+    const rememberRemoteThreadTarget = vi.fn(async (target) => ({
+      ...target,
+      firstSeenAt: 1_000,
+      lastSeenAt: 1_000,
+    }));
     const handler = createFederationAgentToolsHandler({
       collectHostInfo: async () => localHostInfo,
       onRemoteChildMounted,
       targetStore: {
         addRemoteThreadPin,
-        rememberRemoteThreadTarget: vi.fn(async (target) => ({
-          ...target,
-          firstSeenAt: 1_000,
-          lastSeenAt: 1_000,
-        })),
+        rememberRemoteThreadTarget,
         listRemoteThreadTargets: vi.fn(async () => []),
       },
       runtime: buildRuntime({
         health: async () =>
           buildHealth({
-            peers: [{
-              id: "pwr_studio",
-              label: "Studio Mac",
-              role: "client",
-              status: "connected",
-              capabilities: ["thread_navigation", "environment_actions"],
-            }],
+            peers: [
+              {
+                id: "pwr_studio",
+                label: "Studio Mac",
+                role: "client",
+                status: "connected",
+                capabilities: ["thread_navigation", "environment_actions"],
+              },
+              {
+                id: "pwr_root",
+                label: "Root Mac",
+                role: "client",
+                status: "connected",
+                capabilities: ["thread_navigation"],
+              },
+            ],
           }),
         localBackend: (() => ({
           getNavigationSnapshot: async () =>
@@ -758,23 +769,27 @@ describe("federation agent tools service", () => {
                 inbox: { inInbox: false },
                 parentThreadId: "group-root",
                 parentThreadBackend: "acp:grok",
+                parentThreadInstanceId: "pwr_root",
               }] as NavigationSnapshot["threads"],
             }),
         })) as never,
-        remoteBackend: (() => ({
-          getNavigationSnapshot: async () =>
-            buildSnapshot({
-              directories: [{
-                key: "dir:/repo",
-                kind: "directory",
-                label: "PwrAgent",
-                path: "/repo",
-                threadKeys: [],
-                needsAttentionCount: 0,
-              }] as NavigationSnapshot["directories"],
-            }),
-          materializeDirectoryLaunchpad,
-        })) as never,
+        remoteBackend: ((target: { instanceId: string }) =>
+          target.instanceId === "pwr_root"
+            ? { mountRemoteChild }
+            : {
+                getNavigationSnapshot: async () =>
+                  buildSnapshot({
+                    directories: [{
+                      key: "dir:/repo",
+                      kind: "directory",
+                      label: "PwrAgent",
+                      path: "/repo",
+                      threadKeys: [],
+                      needsAttentionCount: 0,
+                    }] as NavigationSnapshot["directories"],
+                  }),
+                materializeDirectoryLaunchpad,
+              }) as never,
       }),
     });
 
@@ -793,25 +808,27 @@ describe("federation agent tools service", () => {
       expect.objectContaining({
         parentThreadId: "group-root",
         parentThreadBackend: "acp:grok",
-        parentThreadInstanceId: "pwr_local",
+        parentThreadInstanceId: "pwr_root",
       }),
     );
-    expect(addRemoteThreadPin).toHaveBeenCalledWith(expect.objectContaining({
+    expect(mountRemoteChild).toHaveBeenCalledWith(expect.objectContaining({
       ref: {
         backend: "codex",
         target: { scope: "remote", instanceId: "pwr_studio" },
         threadId: "remote-child",
       },
       instanceLabel: "Studio Mac",
-      pinnedVia: "child",
       summary: expect.objectContaining({
         parentThreadId: "group-root",
         parentThreadBackend: "acp:grok",
-        parentThreadInstanceId: "pwr_local",
+        parentThreadInstanceId: "pwr_root",
       }),
     }));
-    expect(onRemoteChildMounted).toHaveBeenCalledWith({
+    expect(addRemoteThreadPin).not.toHaveBeenCalled();
+    expect(onRemoteChildMounted).not.toHaveBeenCalled();
+    expect(rememberRemoteThreadTarget).toHaveBeenCalledWith({
       instanceId: "pwr_studio",
+      instanceLabel: "Studio Mac",
       backend: "codex",
       threadId: "remote-child",
     });
@@ -819,6 +836,95 @@ describe("federation agent tools service", () => {
       ok: true,
       data: {
         groupingMode: "subthread",
+        groupedUnderThreadId: "group-root",
+      },
+    });
+  });
+
+  it("mounts a locally created sibling on its remote group-root owner", async () => {
+    const materializeDirectoryLaunchpad = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "local-sibling",
+      executionMode: "default" as const,
+      workMode: "local" as const,
+    }));
+    const mountRemoteChild = vi.fn(async () => ({ mounted: true as const }));
+    const localSnapshot = buildSnapshot({
+      directories: [{
+        key: "dir:/repo",
+        kind: "directory",
+        label: "PwrAgent",
+        path: "/repo",
+        threadKeys: [],
+        needsAttentionCount: 0,
+      }] as NavigationSnapshot["directories"],
+      threads: [{
+        source: "codex",
+        id: "thread-1",
+        title: "Existing child",
+        titleSource: "derived",
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+        parentThreadId: "group-root",
+        parentThreadBackend: "codex",
+        parentThreadInstanceId: "pwr_root",
+      }] as NavigationSnapshot["threads"],
+    });
+    const handler = createFederationAgentToolsHandler({
+      collectHostInfo: async () => localHostInfo,
+      runtime: buildRuntime({
+        health: async () =>
+          buildHealth({
+            peers: [{
+              id: "pwr_root",
+              label: "Root Mac",
+              role: "client",
+              status: "connected",
+              capabilities: ["thread_navigation"],
+            }],
+          }),
+        localBackend: (() => ({
+          getNavigationSnapshot: async () => localSnapshot,
+          materializeDirectoryLaunchpad,
+        })) as never,
+        remoteBackend: (() => ({ mountRemoteChild })) as never,
+      }),
+    });
+
+    const response = await handler({
+      operation: "create_instance_thread",
+      context,
+      args: {
+        instanceId: "pwr_local",
+        projectKey: "dir:/repo",
+        groupingMode: "subthread",
+        workMode: "local",
+      },
+    });
+
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentThreadId: "group-root",
+        parentThreadBackend: "codex",
+        parentThreadInstanceId: "pwr_root",
+      }),
+    );
+    expect(mountRemoteChild).toHaveBeenCalledWith(expect.objectContaining({
+      ref: {
+        backend: "codex",
+        target: { scope: "remote", instanceId: "pwr_local" },
+        threadId: "local-sibling",
+      },
+      instanceLabel: "Local Mac",
+      summary: expect.objectContaining({
+        parentThreadId: "group-root",
+        parentThreadInstanceId: "pwr_root",
+      }),
+    }));
+    expect(response).toMatchObject({
+      ok: true,
+      data: {
+        isLocal: true,
         groupedUnderThreadId: "group-root",
       },
     });

--- a/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
@@ -713,7 +713,7 @@ describe("federation agent tools service", () => {
     expect(data.groupingMode).toBe("none");
   });
 
-  it("groups and mounts a remotely created child beneath the calling thread", async () => {
+  it("groups and mounts a remote child beneath the caller's group root", async () => {
     const materializeDirectoryLaunchpad = vi.fn(async () => ({
       backend: "codex" as const,
       threadId: "remote-child",
@@ -746,6 +746,21 @@ describe("federation agent tools service", () => {
               capabilities: ["thread_navigation", "environment_actions"],
             }],
           }),
+        localBackend: (() => ({
+          getNavigationSnapshot: async () =>
+            buildSnapshot({
+              threads: [{
+                source: "codex",
+                id: "thread-1",
+                title: "Existing child",
+                titleSource: "derived",
+                linkedDirectories: [],
+                inbox: { inInbox: false },
+                parentThreadId: "group-root",
+                parentThreadBackend: "acp:grok",
+              }] as NavigationSnapshot["threads"],
+            }),
+        })) as never,
         remoteBackend: (() => ({
           getNavigationSnapshot: async () =>
             buildSnapshot({
@@ -776,8 +791,8 @@ describe("federation agent tools service", () => {
 
     expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
       expect.objectContaining({
-        parentThreadId: "thread-1",
-        parentThreadBackend: "codex",
+        parentThreadId: "group-root",
+        parentThreadBackend: "acp:grok",
         parentThreadInstanceId: "pwr_local",
       }),
     );
@@ -790,8 +805,8 @@ describe("federation agent tools service", () => {
       instanceLabel: "Studio Mac",
       pinnedVia: "child",
       summary: expect.objectContaining({
-        parentThreadId: "thread-1",
-        parentThreadBackend: "codex",
+        parentThreadId: "group-root",
+        parentThreadBackend: "acp:grok",
         parentThreadInstanceId: "pwr_local",
       }),
     }));
@@ -804,7 +819,7 @@ describe("federation agent tools service", () => {
       ok: true,
       data: {
         groupingMode: "subthread",
-        groupedUnderThreadId: "thread-1",
+        groupedUnderThreadId: "group-root",
       },
     });
   });

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -5,6 +5,7 @@ import type {
   FederationProtocolEnvelope,
   TrustCodexProjectRequest,
 } from "@pwragent/shared";
+import { buildFederatedThreadRef } from "@pwragent/shared";
 import {
   FEDERATION_BACKEND_METHODS,
   FEDERATION_BACKEND_METHOD_CAPABILITIES,
@@ -1168,6 +1169,96 @@ describe("federation backend bridge", () => {
     });
   });
 
+  it("routes child mounts and parent changes to the owning instance", async () => {
+    const sent: FederationProtocolEnvelope[] = [];
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "viewer_one",
+      remoteInstanceId: "owner_one",
+      sendEnvelope: (envelope) => sent.push(envelope),
+      now: () => 1_000,
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+    const ref = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "child_one",
+      threadId: "thread-child",
+    });
+    const summary = {
+      source: "codex" as const,
+      id: "thread-child",
+      title: "Child",
+      titleSource: "fallback" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      parentThreadId: "thread-root",
+      parentThreadBackend: "codex" as const,
+      parentThreadInstanceId: "owner_one",
+    };
+
+    const mountPending = client.mountRemoteChild({
+      ref,
+      summary,
+      instanceLabel: "Child Mac",
+    });
+    const mountRequest = sent.at(-1)!;
+    expect(mountRequest).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.mountRemoteChild,
+      params: { ref, summary, instanceLabel: "Child Mac" },
+    });
+    rpc.receiveEnvelope({
+      id: "response-mount-child",
+      kind: "response",
+      requestId: mountRequest.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_100,
+      result: { mounted: true },
+    });
+    await expect(mountPending).resolves.toEqual({ mounted: true });
+
+    const parentPending = client.setThreadParent({
+      backend: "codex",
+      threadId: "thread-child",
+      parentThreadId: null,
+    });
+    const parentRequest = sent.at(-1)!;
+    expect(parentRequest).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.setThreadParent,
+      params: {
+        backend: "codex",
+        threadId: "thread-child",
+        parentThreadId: null,
+      },
+    });
+    rpc.receiveEnvelope({
+      id: "response-clear-parent",
+      kind: "response",
+      requestId: parentRequest.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_200,
+      result: { backend: "codex", threadId: "thread-child" },
+    });
+    await expect(parentPending).resolves.toEqual({
+      backend: "codex",
+      threadId: "thread-child",
+    });
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.mountRemoteChild
+      ],
+    ).toBe("thread_navigation");
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.setThreadParent
+      ],
+    ).toBe("thread_navigation");
+  });
+
   it("routes PR detach over RPC with turn_control authorization", async () => {
     const sent: FederationProtocolEnvelope[] = [];
     const rpc = new FederationRpcEndpoint({
@@ -2107,6 +2198,8 @@ describe("federation backend bridge", () => {
       setThreadReaction: vi.fn(),
       setThreadPin: vi.fn(),
       reorderThreadPins: vi.fn(),
+      mountRemoteChild: vi.fn(),
+      setThreadParent: vi.fn(),
       detachThreadPullRequest: vi.fn(),
       setThreadPrAutoDispatch: vi.fn(),
       cancelThreadPrAutoDispatch: vi.fn(),
@@ -2410,6 +2503,8 @@ describe("federation backend bridge", () => {
         setThreadReaction: vi.fn(),
       setThreadPin: vi.fn(),
       reorderThreadPins: vi.fn(),
+        mountRemoteChild: vi.fn(),
+        setThreadParent: vi.fn(),
         detachThreadPullRequest: vi.fn(),
         setThreadPrAutoDispatch: vi.fn(),
         cancelThreadPrAutoDispatch: vi.fn(),

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -24,6 +24,12 @@ import {
 } from "../federation/federation-backend-bridge";
 import { DesktopFederationRuntime } from "../federation/federation-runtime";
 import {
+  resetDesktopOverlayStoreForTests,
+  setDesktopOverlayStoreForTests,
+} from "../app-server/desktop-overlay-store";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import { openInMemoryStateDb } from "./sqlite-test-utils";
+import {
   FEDERATION_PEER_UNAVAILABLE_ERROR_CODE,
   FederationPeerUnavailableError,
 } from "../federation/federation-peer-unavailable-error";
@@ -420,6 +426,64 @@ describe("DesktopFederationRuntime", () => {
         },
       },
     });
+  });
+
+  it("ungroups pinned remote children on their owner after parent archive", async () => {
+    const stateDb = openInMemoryStateDb();
+    const overlayStore = new SqliteOverlayStore(stateDb);
+    setDesktopOverlayStoreForTests(overlayStore);
+    try {
+      const ref = buildFederatedThreadRef({
+        backend: "codex",
+        instanceId: "child-peer",
+        threadId: "child",
+      });
+      await overlayStore.addRemoteThreadPin({
+        ref,
+        instanceLabel: "Child Mac",
+        pinnedVia: "child",
+        summary: {
+          source: "codex",
+          id: "child",
+          title: "Remote child",
+          titleSource: "derived",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          parentThreadId: "parent",
+          parentThreadBackend: "codex",
+          parentThreadInstanceId: "parent-peer",
+        },
+      });
+      const setThreadParent = vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "child",
+      }));
+      const runtime = new DesktopFederationRuntime();
+      vi.spyOn(runtime, "health").mockResolvedValue({
+        instanceId: "parent-peer",
+      } as never);
+      vi.spyOn(runtime, "remoteBackend").mockReturnValue({
+        setThreadParent,
+      } as never);
+
+      await runtime.ungroupRemoteChildrenOfArchivedThread({
+        backend: "codex",
+        parentThreadId: "parent",
+      });
+
+      expect(setThreadParent).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "child",
+        parentThreadId: null,
+      });
+      const [pin] = await overlayStore.listRemoteThreadPins();
+      expect(pin?.summary?.parentThreadId).toBeUndefined();
+      expect(pin?.summary?.parentThreadBackend).toBeUndefined();
+      expect(pin?.summary?.parentThreadInstanceId).toBeUndefined();
+    } finally {
+      resetDesktopOverlayStoreForTests();
+      stateDb.close();
+    }
   });
 
   it("records gateway-advertised peers for client instance health and opening", () => {

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -15,6 +15,7 @@ import type {
 import {
   FEDERATION_PROTOCOL_VERSION,
   MAX_CELESTIAL_ASSIGNMENTS,
+  buildFederatedThreadRef,
   findPreferredReviewWorkspaceCwd,
 } from "@pwragent/shared";
 import {
@@ -342,6 +343,83 @@ describe("DesktopFederationRuntime", () => {
     expect(findPreferredReviewWorkspaceCwd(snapshot.threads[0])).toBe(
       pwrAgentWorktree,
     );
+  });
+
+  it("preserves a transitive child's true federation owner", async () => {
+    const response = {
+      backend: "all" as const,
+      fetchedAt: 1_000,
+      unchanged: false,
+      threads: [{
+        id: "child",
+        title: "Remote child",
+        titleSource: "derived" as const,
+        source: "codex" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+        parentThreadId: "parent",
+        parentThreadBackend: "codex" as const,
+        parentThreadInstanceId: "parent-peer",
+        federation: {
+          ref: buildFederatedThreadRef({
+            backend: "codex",
+            instanceId: "child-peer",
+            threadId: "child",
+          }),
+          instanceLabel: "Child Mac",
+        },
+      }],
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    } as NavigationSnapshot;
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.remoteBackend = () => ({
+      getNavigationSnapshot: async () => response,
+      listThreads: async () => ({ backend: "codex", fetchedAt: 1_000, threads: [] }),
+    });
+    runtime.store = () => ({
+      getPeer: (instanceId: string) => ({
+        label: instanceId === "child-peer" ? "Child Mac" : "Parent Mac",
+        status: "connected",
+      }),
+      listPeers: () => [],
+    });
+    runtime.visiblePeers = () => [
+      {
+        id: "parent-peer",
+        label: "Parent Mac",
+        role: "client",
+        status: "connected",
+        capabilities: ["thread_navigation"],
+      },
+      {
+        id: "child-peer",
+        label: "Child Mac",
+        role: "client",
+        status: "connected",
+        capabilities: ["thread_navigation", "remote_pty"],
+      },
+    ];
+
+    const snapshot = await runtime.remoteNavigationSnapshot(
+      { scope: "remote", instanceId: "parent-peer" },
+      {},
+    );
+
+    expect(snapshot.threads[0]).toMatchObject({
+      parentThreadInstanceId: "parent-peer",
+      federation: {
+        instanceLabel: "Child Mac",
+        capabilities: ["thread_navigation", "remote_pty"],
+        ref: {
+          target: { scope: "remote", instanceId: "child-peer" },
+        },
+      },
+    });
   });
 
   it("records gateway-advertised peers for client instance health and opening", () => {

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -1,4 +1,11 @@
 {
+  "federated-child-mount": {
+    "commits": 2,
+    "note": "persist one cross-instance child mount and its routing target",
+    "observedWalBytes": 24720,
+    "rowsChanged": 2,
+    "statements": 2
+  },
   "idle-hour-runtime-leases": {
     "commits": 0,
     "note": "one idle hour: PID-owned messaging and federation leases",

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -6,6 +6,13 @@
     "rowsChanged": 2,
     "statements": 2
   },
+  "federated-child-archive-ungroup": {
+    "commits": 2,
+    "note": "clear one child-owner parent overlay and refresh its root-owner pin",
+    "observedWalBytes": 20600,
+    "rowsChanged": 2,
+    "statements": 2
+  },
   "idle-hour-runtime-leases": {
     "commits": 0,
     "note": "one idle hour: PID-owned messaging and federation leases",

--- a/apps/desktop/src/main/__tests__/overlay-store-pins.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-pins.test.ts
@@ -254,4 +254,31 @@ describe("SqliteOverlayStore — thread pins", () => {
       }),
     ).resolves.toBeUndefined();
   });
+
+  it("stores a cross-instance parent without synthesizing a local parent", async () => {
+    await store.setThreadParent({
+      backend: "codex",
+      threadId: "remote-child",
+      parentThreadId: "remote-parent",
+      parentThreadBackend: "codex",
+      parentThreadInstanceId: "pwr_parent",
+    });
+
+    await expect(
+      store.getThreadOverlayState({
+        backend: "codex",
+        threadId: "remote-child",
+      }),
+    ).resolves.toMatchObject({
+      parentThreadId: "remote-parent",
+      parentThreadBackend: "codex",
+      parentThreadInstanceId: "pwr_parent",
+    });
+    await expect(
+      store.getThreadOverlayState({
+        backend: "codex",
+        threadId: "remote-parent",
+      }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/apps/desktop/src/main/__tests__/remote-thread-pins-store.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-pins-store.test.ts
@@ -276,8 +276,8 @@ describe("SqliteOverlayStore — remote thread pins", () => {
 
   it("round-trips pinnedVia and answers membership checks", async () => {
     await store.addRemoteThreadPin({
-      ref: ref("child"),
-      summary: summary({ id: "child" }),
+      ref: ref("explicit"),
+      summary: summary({ id: "explicit" }),
       instanceLabel: "Laptop",
       pinnedVia: "explicit",
     });
@@ -287,11 +287,18 @@ describe("SqliteOverlayStore — remote thread pins", () => {
       instanceLabel: "Laptop",
       pinnedVia: "companion",
     });
+    await store.addRemoteThreadPin({
+      ref: ref("child"),
+      summary: summary({ id: "child" }),
+      instanceLabel: "Laptop",
+      pinnedVia: "child",
+    });
 
     const listed = await store.listRemoteThreadPins();
     const byThread = new Map(listed.map((pin) => [pin.ref.threadId, pin]));
-    expect(byThread.get("child")?.pinnedVia).toBe("explicit");
+    expect(byThread.get("explicit")?.pinnedVia).toBe("explicit");
     expect(byThread.get("parent")?.pinnedVia).toBe("companion");
+    expect(byThread.get("child")?.pinnedVia).toBe("child");
 
     expect(await store.hasRemoteThreadPin({ ref: ref("parent") })).toBe(true);
     expect(await store.hasRemoteThreadPin({ ref: ref("nope") })).toBe(false);

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -461,6 +461,78 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
       scope: "remote",
       instanceId: "peer-b",
     });
+    expect(
+      resolved.threads[1].federation?.derivedFromMountedParent,
+    ).toBe(true);
+  });
+
+  it("does not carry ordinary same-instance siblings with a mounted parent", async () => {
+    const parent = stampedThread({
+      instanceId: "peer-a",
+      threadId: "parent",
+      title: "Parent",
+    });
+    const localChild = stampedThread({
+      instanceId: "peer-a",
+      threadId: "local-child",
+      title: "Local child",
+    });
+    localChild.parentThreadId = "parent";
+    localChild.parentThreadBackend = "codex";
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([parent, localChild]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({ status: "connected" }),
+    });
+    const pins = [pin({ instanceId: "peer-a", threadId: "parent" })];
+
+    await cache.resolvePinnedThreads(pins);
+    await settle();
+    const resolved = await cache.resolvePinnedThreads(pins);
+
+    expect(resolved.threads.map((thread) => thread.id)).toEqual(["parent"]);
+  });
+
+  it("deduplicates a transitive child that is also directly pinned", async () => {
+    const parent = stampedThread({
+      instanceId: "peer-a",
+      threadId: "parent",
+      title: "Parent",
+    });
+    const child = stampedThread({
+      instanceId: "peer-b",
+      threadId: "child",
+      title: "Child",
+    });
+    child.parentThreadId = "parent";
+    child.parentThreadBackend = "codex";
+    child.parentThreadInstanceId = "peer-a";
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a"), peer("peer-b")],
+      fetchSnapshot: async (target) =>
+        target.instanceId === "peer-a"
+          ? snapshotOf([parent, child])
+          : snapshotOf([child]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({ status: "connected" }),
+    });
+    const pins = [
+      pin({ instanceId: "peer-a", threadId: "parent" }),
+      pin({ instanceId: "peer-b", threadId: "child" }),
+    ];
+
+    await cache.resolvePinnedThreads(pins);
+    await settle();
+    const resolved = await cache.resolvePinnedThreads(pins);
+
+    expect(resolved.threads.map((thread) => thread.id)).toEqual([
+      "parent",
+      "child",
+    ]);
+    expect(
+      resolved.threads[1].federation?.derivedFromMountedParent,
+    ).toBeUndefined();
   });
 
   it("returns promptly with cached rows while a peer fetch hangs", async () => {

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -427,6 +427,42 @@ describe("RemoteThreadSummaryCache — resolvePinnedThreads", () => {
     expect(resolved.refreshed[0].summary.title).toBe("Fresh title");
   });
 
+  it("carries a transitive remote child with its mounted parent", async () => {
+    const parent = stampedThread({
+      instanceId: "peer-a",
+      threadId: "parent",
+      title: "Parent",
+    });
+    const child = stampedThread({
+      instanceId: "peer-b",
+      threadId: "child",
+      title: "Child",
+    });
+    child.parentThreadId = "parent";
+    child.parentThreadBackend = "codex";
+    child.parentThreadInstanceId = "peer-a";
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([parent, child]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({ status: "connected" }),
+    });
+    const pins = [pin({ instanceId: "peer-a", threadId: "parent" })];
+
+    await cache.resolvePinnedThreads(pins);
+    await settle();
+    const resolved = await cache.resolvePinnedThreads(pins);
+
+    expect(resolved.threads.map((thread) => thread.id)).toEqual([
+      "parent",
+      "child",
+    ]);
+    expect(resolved.threads[1].federation?.ref.target).toEqual({
+      scope: "remote",
+      instanceId: "peer-b",
+    });
+  });
+
   it("returns promptly with cached rows while a peer fetch hangs", async () => {
     let now = 0;
     let hang = false;

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -6,6 +6,7 @@ import type {
   AppServerThreadReplay,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
+import { buildFederatedThreadRef } from "@pwragent/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
 import { RuntimeLeaseManager } from "../runtime-lease-manager";
@@ -674,6 +675,37 @@ describe("sqlite write metrics", () => {
     expectSqliteWriteBudget({
       note: "one idle hour: PID-owned messaging and federation leases",
       scenario: "idle-hour-runtime-leases",
+      writes,
+    });
+  });
+
+  it("holds a federated child mount to its write budget", async () => {
+    const { writes } = await measureSqliteWrites(async () => {
+      await store.addRemoteThreadPin({
+        ref: buildFederatedThreadRef({
+          backend: "codex",
+          instanceId: "pwr_child",
+          threadId: "thread-child",
+        }),
+        instanceLabel: "Child Mac",
+        pinnedVia: "child",
+        summary: {
+          source: "codex",
+          id: "thread-child",
+          title: "Remote child",
+          titleSource: "fallback",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          parentThreadId: "thread-parent",
+          parentThreadBackend: "codex",
+          parentThreadInstanceId: "pwr_parent",
+        },
+      });
+    });
+
+    expectSqliteWriteBudget({
+      note: "persist one cross-instance child mount and its routing target",
+      scenario: "federated-child-mount",
       writes,
     });
   });

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -710,6 +710,62 @@ describe("sqlite write metrics", () => {
     });
   });
 
+  it("holds federated child archive-ungrouping to its write budget", async () => {
+    const ref = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "pwr_child",
+      threadId: "thread-child",
+    });
+    const linkedSummary = {
+      source: "codex" as const,
+      id: "thread-child",
+      title: "Remote child",
+      titleSource: "fallback" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      parentThreadId: "thread-parent",
+      parentThreadBackend: "codex" as const,
+      parentThreadInstanceId: "pwr_parent",
+    };
+    await store.addRemoteThreadPin({
+      ref,
+      instanceLabel: "Child Mac",
+      pinnedVia: "child",
+      summary: linkedSummary,
+    });
+    await store.setThreadParent({
+      backend: "codex",
+      threadId: "thread-child",
+      parentThreadId: "thread-parent",
+      parentThreadBackend: "codex",
+      parentThreadInstanceId: "pwr_parent",
+    });
+
+    const { writes } = await measureSqliteWrites(async () => {
+      await store.setThreadParent({
+        backend: "codex",
+        threadId: "thread-child",
+        parentThreadId: undefined,
+      });
+      await store.updateRemoteThreadPinSnapshots([{
+        ref,
+        instanceLabel: "Child Mac",
+        summary: {
+          ...linkedSummary,
+          parentThreadId: undefined,
+          parentThreadBackend: undefined,
+          parentThreadInstanceId: undefined,
+        },
+      }]);
+    });
+
+    expectSqliteWriteBudget({
+      note: "clear one child-owner parent overlay and refresh its root-owner pin",
+      scenario: "federated-child-archive-ungroup",
+      writes,
+    });
+  });
+
   it("holds runtime lease acquisition and release to its budget", async () => {
     const leases = new RuntimeLeaseManager({
       cwd: "/tmp/PwrAgnt",

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts
@@ -211,6 +211,7 @@ describe("pwragent federation agent tools", () => {
         threadId: "thread-2",
         executionMode: "default" as const,
         workMode: "worktree" as const,
+        groupingMode: "none" as const,
         message: "Created thread in PwrSnap on Studio Mac.",
       },
     }));
@@ -230,6 +231,7 @@ describe("pwragent federation agent tools", () => {
           input: " Fix the recorder crash ",
           workMode: "worktree",
           branchName: " origin/main ",
+          groupingMode: "subthread",
           fastMode: true,
         },
       },
@@ -250,6 +252,7 @@ describe("pwragent federation agent tools", () => {
         input: "Fix the recorder crash",
         workMode: "worktree",
         branchName: "origin/main",
+        groupingMode: "subthread",
         fastMode: true,
       },
     });

--- a/apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts
@@ -29,6 +29,7 @@ export const PWRAGENT_FEDERATION_UNAVAILABLE_MESSAGE =
   "PwrAgent federation tools are not available.";
 
 const LAUNCHPAD_WORK_MODES = ["local", "worktree"] as const;
+const INSTANCE_THREAD_GROUPING_MODES = ["none", "subthread"] as const;
 
 export type PwrAgentFederationHandler = (
   request: PwrAgentFederationRequest,
@@ -97,7 +98,7 @@ function descriptionForOperation(
     case "list_instance_projects":
       return "List the projects/directories available on one PwrAgent instance, local or remote. Pass an instanceId from list_federation_instances. Each project row carries the key to pass to create_instance_thread as projectKey, plus its label, filesystem path, and whether a launchpad (per-project environment, model, and execution-mode presets) is configured. Use this to find the project the user is talking about on the chosen instance before creating a thread there.";
     case "create_instance_thread":
-      return "Create and start a new PwrAgent thread in a project on a chosen instance, local or remote. Pass instanceId from list_federation_instances and projectKey from list_instance_projects; input becomes the first prompt of the created thread. Omitted settings inherit the project's launchpad presets, then the instance defaults — only pass model/executionMode/workMode overrides the user asked for. Consult ~/.pwragent/AGENTS.md (when it exists) for the operator's thread-startup preferences such as default projects and settings before choosing values. For delegating work on the local instance from an ordinary thread, prefer handoff_task, which offers richer workspace and grouping options; use create_instance_thread when targeting another instance or when routing intake work by instance. Thread startup can take minutes while a worktree or environment is prepared; if this call is slow, do not call it again — use search_federation_threads to check whether the thread appeared. The result includes threadLink and instanceId. Include threadLink verbatim when telling the user about the thread so it renders as a clickable chip, and preserve instanceId when passing the remote target to send_message_to_thread.";
+      return "Create and start a new PwrAgent thread in a project on a chosen instance, local or remote. Pass instanceId from list_federation_instances and projectKey from list_instance_projects; input becomes the first prompt of the created thread. Set groupingMode=subthread when the new thread is delegated child work that should stay nested beneath the caller across instances; leave it none for independent intake/routing work. Omitted settings inherit the project's launchpad presets, then the instance defaults — only pass model/executionMode/workMode overrides the user asked for. Consult ~/.pwragent/AGENTS.md (when it exists) for the operator's thread-startup preferences such as default projects and settings before choosing values. For delegating work on the local instance from an ordinary thread, prefer handoff_task, which offers richer workspace and grouping options; use create_instance_thread when targeting another instance or when routing intake work by instance. Thread startup can take minutes while a worktree or environment is prepared; if this call is slow, do not call it again — use search_federation_threads to check whether the thread appeared. The result includes threadLink and instanceId. Include threadLink verbatim when telling the user about the thread so it renders as a clickable chip, and preserve instanceId when passing the remote target to send_message_to_thread.";
     case "search_federation_threads":
       return "Search threads across every reachable PwrAgent instance, including the local one, in a single call — use it to find 'the PwrSnap thread about X' wherever it lives. Use scope to pick the search surface: `all` (default) is local plus every connected peer, `local` is this instance only, and `remote` is every connected peer excluding local — the right choice when the user knows the thread is not on this machine. Pass instanceId to target one specific instance; scope and instanceId intersect when both are given. Backend, project, archive, and update-time filters are applied on each instance before the global result limit. Results carry the owning instanceId, its display label, an isLocal flag, and a threadLink that preserves cross-instance routing; failures lists peers that could not be searched. This is a metadata search (titles, summaries, project paths). For deeper local-only search with transcript content modes, use search_threads instead. Include threadLink verbatim when mentioning a result so it renders as a clickable chip, and preserve instanceId when passing a remote target to send_message_to_thread.";
   }
@@ -182,6 +183,12 @@ function inputSchemaForOperation(
             type: "string",
             description:
               "Optional existing base branch/ref for workMode=worktree, for example `origin/main`. This is not a new feature branch name.",
+          },
+          groupingMode: {
+            type: "string",
+            enum: INSTANCE_THREAD_GROUPING_MODES,
+            description:
+              "Use subthread for delegated child work that should remain nested beneath the calling thread across instances; defaults to none for independent intake work.",
           },
         },
       };
@@ -272,7 +279,7 @@ function invalidArgumentsMessageForOperation(
     case "list_instance_projects":
       return "list_instance_projects requires a non-empty instanceId string.";
     case "create_instance_thread":
-      return "create_instance_thread requires non-empty instanceId and projectKey strings, and accepts only known workMode values.";
+      return "create_instance_thread requires non-empty instanceId and projectKey strings, and accepts only known workMode and groupingMode values.";
     case "search_federation_threads":
       return "search_federation_threads requires a non-empty query string; scope must be all, local, or remote; backend and filters must be valid; limit must be an integer between 1 and 200.";
   }
@@ -339,6 +346,13 @@ function normalizeCreateInstanceThreadArgs(
   if (args.workMode !== undefined && !workMode) {
     return undefined;
   }
+  const groupingMode =
+    args.groupingMode === undefined
+      ? undefined
+      : readChoice(args.groupingMode, INSTANCE_THREAD_GROUPING_MODES);
+  if (args.groupingMode !== undefined && !groupingMode) {
+    return undefined;
+  }
   const optionalStringFields = [
     "input",
     "model",
@@ -368,6 +382,7 @@ function normalizeCreateInstanceThreadArgs(
     ...(typeof args.fastMode === "boolean" ? { fastMode: args.fastMode } : {}),
     ...(workMode ? { workMode } : {}),
     ...(branchName ? { branchName } : {}),
+    ...(groupingMode ? { groupingMode } : {}),
   };
 }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10633,6 +10633,7 @@ export class DesktopBackendRegistry {
     requiredWorkMode?: NavigationLaunchpadDraft["workMode"];
     parentThreadId?: string;
     parentThreadBackend?: AppServerBackendKind;
+    parentThreadInstanceId?: string;
     prAutoDispatchEnabled?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
     linkedDirectories?: LinkedDirectorySummary[];
@@ -10648,6 +10649,7 @@ export class DesktopBackendRegistry {
       requiredWorkMode,
       parentThreadId,
       parentThreadBackend,
+      parentThreadInstanceId,
       prAutoDispatchEnabled,
       mcpConnectionIds,
       ...request
@@ -11010,6 +11012,7 @@ export class DesktopBackendRegistry {
         threadId: result.threadId,
         parentThreadId,
         parentThreadBackend,
+        parentThreadInstanceId,
       });
       await this.emit({
         backend,
@@ -11019,6 +11022,7 @@ export class DesktopBackendRegistry {
             threadId: result.threadId,
             parentThreadId,
             parentThreadBackend,
+            parentThreadInstanceId,
           },
         },
       });
@@ -11324,6 +11328,7 @@ export class DesktopBackendRegistry {
           threadId: result.threadId,
           parentThreadId: request.parentThreadId,
           parentThreadBackend: request.parentThreadBackend,
+          parentThreadInstanceId: request.parentThreadInstanceId,
         });
         await this.emit({
           backend,
@@ -11333,6 +11338,7 @@ export class DesktopBackendRegistry {
               threadId: result.threadId,
               parentThreadId: request.parentThreadId,
               parentThreadBackend: request.parentThreadBackend,
+              parentThreadInstanceId: request.parentThreadInstanceId,
             },
           },
         });
@@ -16597,6 +16603,8 @@ export class DesktopBackendRegistry {
       parentThreadId: request.parentThreadId ?? launchpad.parentThreadId,
       parentThreadBackend:
         request.parentThreadBackend ?? launchpad.parentThreadBackend,
+      parentThreadInstanceId:
+        request.parentThreadInstanceId ?? launchpad.parentThreadInstanceId,
     });
     const linkedDirectory = linkedDirectories?.[0];
     if (linkedDirectory) {

--- a/apps/desktop/src/main/federation/federation-agent-tools-service.ts
+++ b/apps/desktop/src/main/federation/federation-agent-tools-service.ts
@@ -396,9 +396,10 @@ async function createInstanceThread(
       `No project with key ${args.projectKey} on ${instance.label}. Use list_instance_projects for the current project list.`,
     );
   }
+  let localInstanceId: FederationInstanceId | undefined;
   let groupingParent: GroupingParent | undefined;
   if (groupingMode === "subthread") {
-    const localInstanceId = (await runtime.health()).instanceId;
+    localInstanceId = (await runtime.health()).instanceId;
     if (!localInstanceId) {
       return failure(
         "internal_error",
@@ -433,6 +434,22 @@ async function createInstanceThread(
       : {}),
     ...(args.input ? { input: [{ type: "text", text: args.input }] } : {}),
   });
+  const mountDisposition = groupingParent && localInstanceId
+    ? await mountRemoteChildAtGroupingRoot(
+        runtime,
+        targetStore,
+        onRemoteChildMounted,
+        {
+          childBackend: response.backend,
+          childInstanceId: instance.instanceId,
+          childInstanceLabel: instance.label,
+          childThreadId: response.threadId,
+          localInstanceId,
+          parent: groupingParent,
+          title: directory.label,
+        },
+      )
+    : "none";
   if (!instance.isLocal) {
     const remoteTarget = {
       instanceId: instance.instanceId,
@@ -440,33 +457,7 @@ async function createInstanceThread(
       backend: response.backend,
       threadId: response.threadId,
     };
-    let mounted = false;
-    if (groupingParent) {
-      mounted = await rememberRemoteChildPin(targetStore, {
-        ...remoteTarget,
-        parentThreadId: groupingParent.threadId,
-        parentThreadBackend: groupingParent.backend,
-        parentThreadInstanceId,
-        title: directory.label,
-      });
-    }
-    if (mounted) {
-      try {
-        await onRemoteChildMounted?.({
-          instanceId: remoteTarget.instanceId,
-          backend: remoteTarget.backend,
-          threadId: remoteTarget.threadId,
-        });
-      } catch (error) {
-        log.warn("failed to announce remotely created child mount", {
-          backend: remoteTarget.backend,
-          error: error instanceof Error ? error.message : String(error),
-          instanceId: remoteTarget.instanceId,
-          threadId: remoteTarget.threadId,
-        });
-      }
-    }
-    if (!mounted) {
+    if (mountDisposition !== "local") {
       await rememberTarget(targetStore, remoteTarget);
     }
   }
@@ -822,18 +813,113 @@ async function rememberTarget(
   }
 }
 
-async function rememberRemoteChildPin(
+async function mountRemoteChildAtGroupingRoot(
+  runtime: DesktopFederationRuntime,
   targetStore: FederationAgentThreadStore | undefined,
-  params: {
+  onRemoteChildMounted: ((params: {
     instanceId: string;
-    instanceLabel: string;
     backend: CreateInstanceThreadResult["backend"];
     threadId: string;
-    parentThreadId: string;
-    parentThreadBackend: PwrAgentFederationContext["backend"];
-    parentThreadInstanceId?: string;
+  }) => Promise<void> | void) | undefined,
+  params: {
+    childBackend: CreateInstanceThreadResult["backend"];
+    childInstanceId: FederationInstanceId;
+    childInstanceLabel: string;
+    childThreadId: string;
+    localInstanceId: FederationInstanceId;
+    parent: GroupingParent;
     title: string;
   },
+): Promise<"inherent" | "local" | "none" | "remote"> {
+  if (params.parent.instanceId === params.childInstanceId) {
+    return "inherent";
+  }
+  const pinParams = {
+    instanceId: params.childInstanceId,
+    instanceLabel: params.childInstanceLabel,
+    backend: params.childBackend,
+    threadId: params.childThreadId,
+    parentThreadId: params.parent.threadId,
+    parentThreadBackend: params.parent.backend,
+    parentThreadInstanceId: params.parent.instanceId,
+    title: params.title,
+  };
+  if (params.parent.instanceId === params.localInstanceId) {
+    const mounted = await rememberRemoteChildPin(targetStore, pinParams);
+    if (!mounted) {
+      return "none";
+    }
+    try {
+      await onRemoteChildMounted?.({
+        instanceId: params.childInstanceId,
+        backend: params.childBackend,
+        threadId: params.childThreadId,
+      });
+    } catch (error) {
+      log.warn("failed to announce remotely created child mount", {
+        backend: params.childBackend,
+        error: error instanceof Error ? error.message : String(error),
+        instanceId: params.childInstanceId,
+        threadId: params.childThreadId,
+      });
+    }
+    return "local";
+  }
+
+  try {
+    await runtime.remoteBackend({
+      scope: "remote",
+      instanceId: params.parent.instanceId,
+    }).mountRemoteChild({
+      ref: buildFederatedThreadRef(pinParams),
+      instanceLabel: params.childInstanceLabel,
+      summary: buildRemoteChildSummary(pinParams),
+    });
+    return "remote";
+  } catch (error) {
+    log.warn("failed to mount child on remote group root", {
+      childInstanceId: params.childInstanceId,
+      childThreadId: params.childThreadId,
+      error: error instanceof Error ? error.message : String(error),
+      parentInstanceId: params.parent.instanceId,
+      parentThreadId: params.parent.threadId,
+    });
+    return "none";
+  }
+}
+
+type RemoteChildPinParams = {
+  instanceId: string;
+  instanceLabel: string;
+  backend: CreateInstanceThreadResult["backend"];
+  threadId: string;
+  parentThreadId: string;
+  parentThreadBackend: PwrAgentFederationContext["backend"];
+  parentThreadInstanceId?: string;
+  title: string;
+};
+
+function buildRemoteChildSummary(
+  params: RemoteChildPinParams,
+): NavigationThreadSummary {
+  return {
+    source: params.backend,
+    id: params.threadId,
+    title: params.title,
+    titleSource: "fallback",
+    linkedDirectories: [],
+    inbox: { inInbox: false },
+    parentThreadId: params.parentThreadId,
+    parentThreadBackend: params.parentThreadBackend,
+    ...(params.parentThreadInstanceId
+      ? { parentThreadInstanceId: params.parentThreadInstanceId }
+      : {}),
+  };
+}
+
+async function rememberRemoteChildPin(
+  targetStore: FederationAgentThreadStore | undefined,
+  params: RemoteChildPinParams,
 ): Promise<boolean> {
   if (!targetStore?.addRemoteThreadPin) {
     return false;
@@ -843,19 +929,7 @@ async function rememberRemoteChildPin(
       ref: buildFederatedThreadRef(params),
       instanceLabel: params.instanceLabel,
       pinnedVia: "child",
-      summary: {
-        source: params.backend,
-        id: params.threadId,
-        title: params.title,
-        titleSource: "fallback",
-        linkedDirectories: [],
-        inbox: { inInbox: false },
-        parentThreadId: params.parentThreadId,
-        parentThreadBackend: params.parentThreadBackend,
-        ...(params.parentThreadInstanceId
-          ? { parentThreadInstanceId: params.parentThreadInstanceId }
-          : {}),
-      },
+      summary: buildRemoteChildSummary(params),
     });
     return true;
   } catch (error) {

--- a/apps/desktop/src/main/federation/federation-agent-tools-service.ts
+++ b/apps/desktop/src/main/federation/federation-agent-tools-service.ts
@@ -71,6 +71,12 @@ type ResolvedInstance = {
   target?: FederationRemoteTarget;
 };
 
+type GroupingParent = {
+  threadId: string;
+  backend: PwrAgentFederationContext["backend"];
+  instanceId: FederationInstanceId;
+};
+
 type FederationAgentThreadStore = RemoteThreadTargetStore & {
   addRemoteThreadPin?: (params: {
     ref: FederatedThreadRef;
@@ -379,19 +385,6 @@ async function createInstanceThread(
   }
   const instance = resolved.instance;
   const groupingMode = args.groupingMode ?? "none";
-  const parentThreadInstanceId = groupingMode === "subthread" && !instance.isLocal
-    ? (await runtime.health()).instanceId
-    : undefined;
-  if (
-    groupingMode === "subthread"
-    && !instance.isLocal
-    && !parentThreadInstanceId
-  ) {
-    return failure(
-      "internal_error",
-      "The local federation instance identity is unavailable, so the cross-instance parent relationship cannot be recorded.",
-    );
-  }
   const backend = backendFor(runtime, instance);
   const snapshot = await backend.getNavigationSnapshot({});
   const directory = snapshot.directories.find(
@@ -403,15 +396,37 @@ async function createInstanceThread(
       `No project with key ${args.projectKey} on ${instance.label}. Use list_instance_projects for the current project list.`,
     );
   }
+  let groupingParent: GroupingParent | undefined;
+  if (groupingMode === "subthread") {
+    const localInstanceId = (await runtime.health()).instanceId;
+    if (!localInstanceId) {
+      return failure(
+        "internal_error",
+        "The local federation instance identity is unavailable, so the cross-instance parent relationship cannot be recorded.",
+      );
+    }
+    const localSnapshot = instance.isLocal
+      ? snapshot
+      : await runtime.localBackend().getNavigationSnapshot({});
+    groupingParent = resolveGroupingParent(
+      localSnapshot,
+      context,
+      localInstanceId,
+    );
+  }
+  const parentThreadInstanceId = groupingParent
+    && groupingParent.instanceId !== instance.instanceId
+    ? groupingParent.instanceId
+    : undefined;
   const draft = buildLaunchpadDraft({ snapshot, directory, args });
   const response = await backend.materializeDirectoryLaunchpad({
     directoryKey: args.projectKey,
     launchpad: draft,
-    ...(groupingMode === "subthread"
+    ...(groupingParent
       ? {
-          parentThreadId: context.threadId,
-          parentThreadBackend: context.backend,
-          ...(!instance.isLocal
+          parentThreadId: groupingParent.threadId,
+          parentThreadBackend: groupingParent.backend,
+          ...(parentThreadInstanceId
             ? { parentThreadInstanceId }
             : {}),
         }
@@ -426,17 +441,11 @@ async function createInstanceThread(
       threadId: response.threadId,
     };
     let mounted = false;
-    if (groupingMode === "subthread") {
-      if (!parentThreadInstanceId) {
-        return failure(
-          "internal_error",
-          "The local federation instance identity is unavailable, so the cross-instance parent relationship cannot be recorded.",
-        );
-      }
+    if (groupingParent) {
       mounted = await rememberRemoteChildPin(targetStore, {
         ...remoteTarget,
-        parentThreadId: context.threadId,
-        parentThreadBackend: context.backend,
+        parentThreadId: groupingParent.threadId,
+        parentThreadBackend: groupingParent.backend,
         parentThreadInstanceId,
         title: directory.label,
       });
@@ -476,8 +485,8 @@ async function createInstanceThread(
     workMode: response.workMode,
     turnId: response.turnId,
     groupingMode,
-    ...(groupingMode === "subthread"
-      ? { groupedUnderThreadId: context.threadId }
+    ...(groupingParent
+      ? { groupedUnderThreadId: groupingParent.threadId }
       : {}),
     threadUrl: buildThreadUrl(threadLinkRef),
     threadLink: buildThreadMarkdownLink({
@@ -688,6 +697,37 @@ function backendFor(
     : runtime.remoteBackend(instance.target);
 }
 
+/**
+ * Navigation groups are one level deep. If the calling thread is already a
+ * child, delegate beneath its existing root so the new thread renders as a
+ * sibling instead of becoming an invisible grandchild. A missing caller row
+ * falls back to the caller itself, matching the renderer when a root is gone.
+ */
+function resolveGroupingParent(
+  snapshot: NavigationSnapshot,
+  context: PwrAgentFederationContext,
+  localInstanceId: FederationInstanceId,
+): GroupingParent {
+  const caller = snapshot.threads.find(
+    (thread) =>
+      thread.source === context.backend
+      && thread.id === context.threadId,
+  );
+  const parentThreadId = caller?.parentThreadId?.trim();
+  if (!caller || !parentThreadId) {
+    return {
+      threadId: context.threadId,
+      backend: context.backend,
+      instanceId: localInstanceId,
+    };
+  }
+  return {
+    threadId: parentThreadId,
+    backend: caller.parentThreadBackend ?? caller.source,
+    instanceId: caller.parentThreadInstanceId ?? localInstanceId,
+  };
+}
+
 function buildLaunchpadDraft(params: {
   snapshot: NavigationSnapshot;
   directory: NavigationSnapshot["directories"][number];
@@ -791,7 +831,7 @@ async function rememberRemoteChildPin(
     threadId: string;
     parentThreadId: string;
     parentThreadBackend: PwrAgentFederationContext["backend"];
-    parentThreadInstanceId: string;
+    parentThreadInstanceId?: string;
     title: string;
   },
 ): Promise<boolean> {
@@ -812,7 +852,9 @@ async function rememberRemoteChildPin(
         inbox: { inInbox: false },
         parentThreadId: params.parentThreadId,
         parentThreadBackend: params.parentThreadBackend,
-        parentThreadInstanceId: params.parentThreadInstanceId,
+        ...(params.parentThreadInstanceId
+          ? { parentThreadInstanceId: params.parentThreadInstanceId }
+          : {}),
       },
     });
     return true;

--- a/apps/desktop/src/main/federation/federation-agent-tools-service.ts
+++ b/apps/desktop/src/main/federation/federation-agent-tools-service.ts
@@ -7,6 +7,7 @@ import type {
   FederationInstanceDescriptor,
   FederationInstanceId,
   FederationLoadStatus,
+  FederatedThreadRef,
   FederationRemoteTarget,
   FederationThreadSearchResultSummary,
   ListFederationInstancesResult,
@@ -15,13 +16,16 @@ import type {
   ListInstanceProjectsToolArgs,
   NavigationLaunchpadDraft,
   NavigationSnapshot,
+  NavigationThreadSummary,
   PwrAgentFederationErrorCode,
+  PwrAgentFederationContext,
   PwrAgentFederationResponse,
   SearchFederationThreadsResult,
   SearchFederationThreadsToolArgs,
 } from "@pwragent/shared";
 import {
   FEDERATION_CAPABILITIES,
+  buildFederatedThreadRef,
   buildThreadMarkdownLink,
   buildThreadUrl,
   formatFederationPeerDisplayLabel,
@@ -67,6 +71,15 @@ type ResolvedInstance = {
   target?: FederationRemoteTarget;
 };
 
+type FederationAgentThreadStore = RemoteThreadTargetStore & {
+  addRemoteThreadPin?: (params: {
+    ref: FederatedThreadRef;
+    instanceLabel: string;
+    pinnedVia?: "child";
+    summary?: NavigationThreadSummary;
+  }) => Promise<unknown>;
+};
+
 /**
  * Dispatches the `federation` agent-tool catalog. Lives in federation-land
  * (not `BackendRegistry`) because the runtime already imports the registry —
@@ -85,7 +98,12 @@ export function createFederationAgentToolsHandler(
     runtime?: () => DesktopFederationRuntime;
     collectHostInfo?: () => Promise<FederationHostInfo>;
     collectLoadStatus?: () => Promise<FederationLoadStatus>;
-    targetStore?: RemoteThreadTargetStore;
+    targetStore?: FederationAgentThreadStore;
+    onRemoteChildMounted?: (params: {
+      instanceId: string;
+      backend: CreateInstanceThreadResult["backend"];
+      threadId: string;
+    }) => Promise<void> | void;
   } = {},
 ): PwrAgentFederationHandler {
   const runtime = options.runtime ?? getDesktopFederationRuntime;
@@ -111,8 +129,10 @@ export function createFederationAgentToolsHandler(
         return await createInstanceThread(
           runtime(),
           request.args,
+          request.context,
           collectHostInfo,
           options.targetStore,
+          options.onRemoteChildMounted,
         );
       }
       return await searchFederationThreads(
@@ -344,14 +364,34 @@ async function listInstanceProjects(
 async function createInstanceThread(
   runtime: DesktopFederationRuntime,
   args: CreateInstanceThreadToolArgs,
+  context: PwrAgentFederationContext,
   collectHostInfo: () => Promise<FederationHostInfo>,
-  targetStore: RemoteThreadTargetStore | undefined,
+  targetStore: FederationAgentThreadStore | undefined,
+  onRemoteChildMounted: ((params: {
+    instanceId: string;
+    backend: CreateInstanceThreadResult["backend"];
+    threadId: string;
+  }) => Promise<void> | void) | undefined,
 ): Promise<PwrAgentFederationResponse> {
   const resolved = await resolveInstance(runtime, args.instanceId, collectHostInfo);
   if (!resolved.ok) {
     return resolved.response;
   }
   const instance = resolved.instance;
+  const groupingMode = args.groupingMode ?? "none";
+  const parentThreadInstanceId = groupingMode === "subthread" && !instance.isLocal
+    ? (await runtime.health()).instanceId
+    : undefined;
+  if (
+    groupingMode === "subthread"
+    && !instance.isLocal
+    && !parentThreadInstanceId
+  ) {
+    return failure(
+      "internal_error",
+      "The local federation instance identity is unavailable, so the cross-instance parent relationship cannot be recorded.",
+    );
+  }
   const backend = backendFor(runtime, instance);
   const snapshot = await backend.getNavigationSnapshot({});
   const directory = snapshot.directories.find(
@@ -367,15 +407,59 @@ async function createInstanceThread(
   const response = await backend.materializeDirectoryLaunchpad({
     directoryKey: args.projectKey,
     launchpad: draft,
+    ...(groupingMode === "subthread"
+      ? {
+          parentThreadId: context.threadId,
+          parentThreadBackend: context.backend,
+          ...(!instance.isLocal
+            ? { parentThreadInstanceId }
+            : {}),
+        }
+      : {}),
     ...(args.input ? { input: [{ type: "text", text: args.input }] } : {}),
   });
   if (!instance.isLocal) {
-    await rememberTarget(targetStore, {
+    const remoteTarget = {
       instanceId: instance.instanceId,
       instanceLabel: instance.label,
       backend: response.backend,
       threadId: response.threadId,
-    });
+    };
+    let mounted = false;
+    if (groupingMode === "subthread") {
+      if (!parentThreadInstanceId) {
+        return failure(
+          "internal_error",
+          "The local federation instance identity is unavailable, so the cross-instance parent relationship cannot be recorded.",
+        );
+      }
+      mounted = await rememberRemoteChildPin(targetStore, {
+        ...remoteTarget,
+        parentThreadId: context.threadId,
+        parentThreadBackend: context.backend,
+        parentThreadInstanceId,
+        title: directory.label,
+      });
+    }
+    if (mounted) {
+      try {
+        await onRemoteChildMounted?.({
+          instanceId: remoteTarget.instanceId,
+          backend: remoteTarget.backend,
+          threadId: remoteTarget.threadId,
+        });
+      } catch (error) {
+        log.warn("failed to announce remotely created child mount", {
+          backend: remoteTarget.backend,
+          error: error instanceof Error ? error.message : String(error),
+          instanceId: remoteTarget.instanceId,
+          threadId: remoteTarget.threadId,
+        });
+      }
+    }
+    if (!mounted) {
+      await rememberTarget(targetStore, remoteTarget);
+    }
   }
   const threadLinkRef = {
     threadId: response.threadId,
@@ -391,6 +475,10 @@ async function createInstanceThread(
     executionMode: response.executionMode,
     workMode: response.workMode,
     turnId: response.turnId,
+    groupingMode,
+    ...(groupingMode === "subthread"
+      ? { groupedUnderThreadId: context.threadId }
+      : {}),
     threadUrl: buildThreadUrl(threadLinkRef),
     threadLink: buildThreadMarkdownLink({
       ...threadLinkRef,
@@ -691,5 +779,50 @@ async function rememberTarget(
       instanceId: target.instanceId,
       threadId: target.threadId,
     });
+  }
+}
+
+async function rememberRemoteChildPin(
+  targetStore: FederationAgentThreadStore | undefined,
+  params: {
+    instanceId: string;
+    instanceLabel: string;
+    backend: CreateInstanceThreadResult["backend"];
+    threadId: string;
+    parentThreadId: string;
+    parentThreadBackend: PwrAgentFederationContext["backend"];
+    parentThreadInstanceId: string;
+    title: string;
+  },
+): Promise<boolean> {
+  if (!targetStore?.addRemoteThreadPin) {
+    return false;
+  }
+  try {
+    await targetStore.addRemoteThreadPin({
+      ref: buildFederatedThreadRef(params),
+      instanceLabel: params.instanceLabel,
+      pinnedVia: "child",
+      summary: {
+        source: params.backend,
+        id: params.threadId,
+        title: params.title,
+        titleSource: "fallback",
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+        parentThreadId: params.parentThreadId,
+        parentThreadBackend: params.parentThreadBackend,
+        parentThreadInstanceId: params.parentThreadInstanceId,
+      },
+    });
+    return true;
+  } catch (error) {
+    log.warn("failed to mount remotely created child thread", {
+      backend: params.backend,
+      error: error instanceof Error ? error.message : String(error),
+      instanceId: params.instanceId,
+      threadId: params.threadId,
+    });
+    return false;
   }
 }

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -25,6 +25,7 @@ import type {
   DetachThreadPullRequestRequest,
   DetachThreadPullRequestResponse,
   FederationCapability,
+  FederatedThreadRef,
   FederationLoadStatus,
   FederationRequestEnvelope,
   ForkThreadRequest,
@@ -67,6 +68,7 @@ import type {
   ReorderThreadPinsRequest,
   ReorderThreadPinsResponse,
   NavigationSnapshot,
+  NavigationThreadSummary,
   DesktopApplicationsSnapshot,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
@@ -102,6 +104,8 @@ import type {
   SetThreadExecutionModeResponse,
   SetThreadModelSettingsRequest,
   SetThreadModelSettingsResponse,
+  SetThreadParentRequest,
+  SetThreadParentResponse,
   SteerTurnRequest,
   SteerTurnResponse,
   StartTurnRequest,
@@ -156,6 +160,16 @@ export type FederatedTranscriptImageResponse = {
 
 export type FederationStartTurnRequest = StartTurnRequest & {
   messageOrigin?: AppServerThreadMessageOrigin;
+};
+
+export type FederationMountRemoteChildRequest = {
+  ref: FederatedThreadRef;
+  summary: NavigationThreadSummary;
+  instanceLabel: string;
+};
+
+export type FederationMountRemoteChildResponse = {
+  mounted: true;
 };
 
 type ResolvedSourceInstance = {
@@ -240,6 +254,8 @@ export const FEDERATION_BACKEND_METHODS = {
   setThreadReaction: "backend.setThreadReaction",
   setThreadPin: "backend.setThreadPin",
   reorderThreadPins: "backend.reorderThreadPins",
+  mountRemoteChild: "backend.mountRemoteChild",
+  setThreadParent: "backend.setThreadParent",
   detachThreadPullRequest: "backend.detachThreadPullRequest",
   setThreadPrAutoDispatch: "backend.setThreadPrAutoDispatch",
   cancelThreadPrAutoDispatch: "backend.cancelThreadPrAutoDispatch",
@@ -327,6 +343,8 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.setThreadReaction]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.setThreadPin]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.reorderThreadPins]: "thread_navigation",
+  [FEDERATION_BACKEND_METHODS.mountRemoteChild]: "thread_navigation",
+  [FEDERATION_BACKEND_METHODS.setThreadParent]: "thread_navigation",
   // PR detach cancels pending auto-dispatch work and auto-dispatch arms
   // automatic repair turns, so both sit with the turn-control grants
   // (like archiveThread) rather than the browse-level navigation grants.
@@ -435,6 +453,12 @@ export type FederationBackendOperations = {
   reorderThreadPins(
     request: ReorderThreadPinsRequest,
   ): Promise<ReorderThreadPinsResponse>;
+  mountRemoteChild(
+    request: FederationMountRemoteChildRequest,
+  ): Promise<FederationMountRemoteChildResponse>;
+  setThreadParent(
+    request: SetThreadParentRequest,
+  ): Promise<SetThreadParentResponse>;
   detachThreadPullRequest(
     request: DetachThreadPullRequestRequest,
   ): Promise<DetachThreadPullRequestResponse>;
@@ -700,6 +724,20 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.reorderThreadPins(
         envelope.params as ReorderThreadPinsRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.mountRemoteChild,
+    async (envelope) =>
+      await params.backend.mountRemoteChild(
+        envelope.params as FederationMountRemoteChildRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.setThreadParent,
+    async (envelope) =>
+      await params.backend.setThreadParent(
+        envelope.params as SetThreadParentRequest,
       ),
   );
   params.router.registerHandler(
@@ -1214,6 +1252,24 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<ReorderThreadPinsResponse> {
     return await this.rpc.request<ReorderThreadPinsResponse>({
       method: FEDERATION_BACKEND_METHODS.reorderThreadPins,
+      params: request,
+    });
+  }
+
+  async mountRemoteChild(
+    request: FederationMountRemoteChildRequest,
+  ): Promise<FederationMountRemoteChildResponse> {
+    return await this.rpc.request<FederationMountRemoteChildResponse>({
+      method: FEDERATION_BACKEND_METHODS.mountRemoteChild,
+      params: request,
+    });
+  }
+
+  async setThreadParent(
+    request: SetThreadParentRequest,
+  ): Promise<SetThreadParentResponse> {
+    return await this.rpc.request<SetThreadParentResponse>({
+      method: FEDERATION_BACKEND_METHODS.setThreadParent,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -92,6 +92,7 @@ import {
   type AppServerListSkillsRequest,
   type AppServerListThreadsRequest,
   type AppServerReadThreadRequest,
+  type AppServerBackendKind,
   type AttachDirectoryToThreadRequest,
   type CancelQueuedTurnRequest,
   type CancelThreadExecutionModeQueueRequest,
@@ -103,6 +104,7 @@ import {
   type ForkThreadRequest,
   type EnsureDirectoryLaunchpadRequest,
   type FederationRemoteTarget,
+  type FederatedThreadRef,
   type DesktopApplicationsSnapshot,
   type DesktopFederationMode,
   type DesktopSettingsSnapshot,
@@ -130,6 +132,7 @@ import {
   type ReorderThreadPinsRequest,
   type ReorderThreadPinsResponse,
   type NavigationSnapshot,
+  type NavigationThreadSummary,
   type OpenDesktopApplicationRequest,
   type QueueThreadExecutionModeRequest,
   type RefreshDirectoryGitStatusesRequest,
@@ -149,6 +152,7 @@ import {
   type SetCodexThreadEnvironmentRequest,
   type SetThreadExecutionModeRequest,
   type SetThreadModelSettingsRequest,
+  type SetThreadParentRequest,
   type StartReviewRequest,
   type StartThreadRequest,
   type SteerTurnRequest,
@@ -1694,6 +1698,75 @@ export class DesktopFederationRuntime {
       },
     });
     return this.remoteThreadSummaryCache;
+  }
+
+  /**
+   * Archiving a local group root must clear parent overlays on children owned
+   * by other instances. Those relationships are visible here through the
+   * root viewer's remote child pins; mutate each child on its owner, then
+   * update the cached pin so restoring the root cannot reattach it.
+   */
+  async ungroupRemoteChildrenOfArchivedThread(params: {
+    backend: AppServerBackendKind;
+    parentThreadId: string;
+  }): Promise<void> {
+    const localInstanceId = (await this.health()).instanceId;
+    if (!localInstanceId) {
+      return;
+    }
+    const overlayStore = getDesktopOverlayStore();
+    const pins = await overlayStore.listRemoteThreadPins();
+    const children = pins.filter((pin) => {
+      const summary = pin.summary;
+      return summary?.parentThreadId === params.parentThreadId
+        && (summary.parentThreadBackend ?? summary.source) === params.backend
+        && summary.parentThreadInstanceId === localInstanceId
+        && isRemoteFederationTarget(pin.ref.target);
+    });
+    if (children.length === 0) {
+      return;
+    }
+
+    const refreshed: Array<{
+      ref: FederatedThreadRef;
+      summary: NavigationThreadSummary;
+      instanceLabel: string;
+    }> = [];
+    await Promise.all(
+      children.map(async (pin) => {
+        if (!isRemoteFederationTarget(pin.ref.target) || !pin.summary) {
+          return;
+        }
+        try {
+          await this.remoteBackend(pin.ref.target).setThreadParent({
+            backend: pin.ref.backend,
+            threadId: pin.ref.threadId,
+            parentThreadId: null,
+          });
+          const summary = { ...pin.summary };
+          delete summary.parentThreadId;
+          delete summary.parentThreadBackend;
+          delete summary.parentThreadInstanceId;
+          refreshed.push({
+            ref: pin.ref,
+            summary,
+            instanceLabel: pin.instanceLabel,
+          });
+          this.remoteThreadSummaryCache?.invalidate(pin.ref.target.instanceId);
+        } catch (error) {
+          log.warn("failed to ungroup remote child after parent archive", {
+            backend: pin.ref.backend,
+            childInstanceId: pin.ref.target.instanceId,
+            childThreadId: pin.ref.threadId,
+            error: error instanceof Error ? error.message : String(error),
+            parentThreadId: params.parentThreadId,
+          });
+        }
+      }),
+    );
+    if (refreshed.length > 0) {
+      await overlayStore.updateRemoteThreadPinSnapshots(refreshed);
+    }
   }
 
   async searchConnectedPeers(
@@ -4096,8 +4169,73 @@ function localBackendOperations(): FederationBackendOperations {
       });
       return { pinnedRanks };
     },
+    async mountRemoteChild(request) {
+      const target = request.ref.target;
+      if (!isRemoteFederationTarget(target)) {
+        throw new Error("A federated child mount must target a remote instance.");
+      }
+      await getDesktopOverlayStore().addRemoteThreadPin({
+        ref: request.ref,
+        summary: request.summary,
+        instanceLabel: request.instanceLabel,
+        pinnedVia: "child",
+      });
+      await getDesktopBackendRegistry().publishLocalEvent({
+        backend: request.ref.backend,
+        notification: {
+          method: "navigation/remoteThreadPins/changed",
+          params: {
+            instanceId: target.instanceId,
+            threadId: request.ref.threadId,
+            pinned: true,
+          },
+        },
+      });
+      return { mounted: true };
+    },
+    async setThreadParent(
+      request: SetThreadParentRequest,
+    ) {
+      const backend = request.backend ?? "codex";
+      const overlay = await getDesktopOverlayStore().setThreadParent({
+        backend,
+        threadId: request.threadId,
+        parentThreadId: request.parentThreadId,
+        parentThreadBackend: request.parentThreadBackend,
+        parentThreadInstanceId: request.parentThreadInstanceId,
+      });
+      await getDesktopBackendRegistry().publishLocalEvent({
+        backend,
+        notification: overlay.parentThreadId
+          ? {
+              method: "thread/parent/set",
+              params: {
+                threadId: request.threadId,
+                parentThreadId: overlay.parentThreadId,
+                parentThreadBackend: overlay.parentThreadBackend,
+                parentThreadInstanceId: overlay.parentThreadInstanceId,
+              },
+            }
+          : {
+              method: "thread/parent/cleared",
+              params: { threadId: request.threadId },
+            },
+      });
+      return {
+        backend,
+        threadId: request.threadId,
+        parentThreadId: overlay.parentThreadId,
+        parentThreadBackend: overlay.parentThreadBackend,
+        parentThreadInstanceId: overlay.parentThreadInstanceId,
+      };
+    },
     async archiveThread(request) {
-      return await getDesktopBackendRegistry().archiveThread(request);
+      const response = await getDesktopBackendRegistry().archiveThread(request);
+      await getDesktopFederationRuntime().ungroupRemoteChildrenOfArchivedThread({
+        backend: response.backend,
+        parentThreadId: response.threadId,
+      });
+      return response;
     },
     async startThread(request: StartThreadRequest): Promise<StartThreadResponse> {
       return await getDesktopBackendRegistry().startThread(request);

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -1556,19 +1556,40 @@ export class DesktopFederationRuntime {
     );
     const peerStatus = visiblePeer?.status ?? peer?.status;
     const threads = response.threads.map((thread) => {
+      const existingOwner = thread.federation?.ref.target;
+      const ownerInstanceId = existingOwner
+        && isRemoteFederationTarget(existingOwner)
+        ? existingOwner.instanceId
+        : target.instanceId;
+      const ownerVisiblePeer = visible.find(
+        (candidate) => candidate.id === ownerInstanceId,
+      );
+      const ownerPeer =
+        ownerVisiblePeer ?? this.store().getPeer(ownerInstanceId);
+      const ownerLabel = ownerInstanceId === target.instanceId
+        ? instanceLabel
+        : ownerPeer
+          ? formatFederationPeerDisplayLabel(ownerPeer, visible)
+          : thread.federation?.instanceLabel ?? ownerInstanceId;
       const ref = buildFederatedThreadRef({
         backend: thread.source,
-        instanceId: target.instanceId,
+        instanceId: ownerInstanceId,
         threadId: thread.id,
       });
       return {
         ...thread,
         federation: {
           ref,
-          instanceLabel,
-          peerStatus,
-          capabilities,
-          celestialIcon: visiblePeer?.celestialIcon,
+          instanceLabel: ownerLabel,
+          peerStatus:
+            ownerInstanceId === target.instanceId
+              ? peerStatus
+              : ownerVisiblePeer?.status ?? ownerPeer?.status,
+          capabilities:
+            ownerInstanceId === target.instanceId
+              ? capabilities
+              : this.viewerCapabilitiesFor(ownerInstanceId, ownerVisiblePeer),
+          celestialIcon: ownerVisiblePeer?.celestialIcon,
         },
       };
     });

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -251,6 +251,12 @@ export class RemoteThreadSummaryCache {
       group.push(pin);
       pinsByInstanceId.set(pin.ref.target.instanceId, group);
     }
+    const directPinKeys = new Set(
+      pins.map((pin) =>
+        buildThreadIdentityKey(pin.ref.backend, pin.ref.threadId)
+      ),
+    );
+    const selectedKeys = new Set<string>();
 
     for (const [instanceId, group] of pinsByInstanceId) {
       const peer = connectedByInstanceId.get(instanceId);
@@ -272,7 +278,6 @@ export class RemoteThreadSummaryCache {
           thread,
         ]),
       );
-      const selectedKeys = new Set<string>();
       for (const pin of group) {
         const threadKey = buildThreadIdentityKey(
           pin.ref.backend,
@@ -280,10 +285,12 @@ export class RemoteThreadSummaryCache {
         );
         const servedThread = servedByKey.get(threadKey);
         if (servedThread) {
-          selectedKeys.add(threadKey);
-          threads.push(
-            fetchFailed ? this.dimDegraded(servedThread) : servedThread,
-          );
+          if (!selectedKeys.has(threadKey)) {
+            selectedKeys.add(threadKey);
+            threads.push(
+              fetchFailed ? this.dimDegraded(servedThread) : servedThread,
+            );
+          }
           if (!fetchFailed) {
             refreshed.push({
               ref: pin.ref,
@@ -298,8 +305,10 @@ export class RemoteThreadSummaryCache {
           archived.push(pin.ref);
           continue;
         }
-        threads.push(this.fallbackThread(pin, fetchFailed));
-        selectedKeys.add(threadKey);
+        if (!selectedKeys.has(threadKey)) {
+          threads.push(this.fallbackThread(pin, fetchFailed));
+          selectedKeys.add(threadKey);
+        }
       }
 
       // A mounted remote parent may itself have mounted a child from another
@@ -313,6 +322,15 @@ export class RemoteThreadSummaryCache {
         ),
       );
       for (const candidate of served ?? []) {
+        const candidateFederation = candidate.federation;
+        const candidateOwner = candidateFederation?.ref.target;
+        if (
+          !candidateFederation
+          || candidateOwner?.scope !== "remote"
+          || candidateOwner.instanceId === instanceId
+        ) {
+          continue;
+        }
         const parentThreadId = candidate.parentThreadId?.trim();
         if (!parentThreadId) {
           continue;
@@ -328,11 +346,24 @@ export class RemoteThreadSummaryCache {
           parentThreadId,
         );
         const candidateKey = buildThreadIdentityKey(candidate.source, candidate.id);
-        if (!pinnedParentKeys.has(parentKey) || selectedKeys.has(candidateKey)) {
+        if (
+          !pinnedParentKeys.has(parentKey)
+          || directPinKeys.has(candidateKey)
+          || selectedKeys.has(candidateKey)
+        ) {
           continue;
         }
         selectedKeys.add(candidateKey);
-        threads.push(fetchFailed ? this.dimDegraded(candidate) : candidate);
+        const derivedCandidate = {
+          ...candidate,
+          federation: {
+            ...candidateFederation,
+            derivedFromMountedParent: true,
+          },
+        };
+        threads.push(
+          fetchFailed ? this.dimDegraded(derivedCandidate) : derivedCandidate,
+        );
       }
     }
     return { threads, refreshed, archived };

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -272,6 +272,7 @@ export class RemoteThreadSummaryCache {
           thread,
         ]),
       );
+      const selectedKeys = new Set<string>();
       for (const pin of group) {
         const threadKey = buildThreadIdentityKey(
           pin.ref.backend,
@@ -279,6 +280,7 @@ export class RemoteThreadSummaryCache {
         );
         const servedThread = servedByKey.get(threadKey);
         if (servedThread) {
+          selectedKeys.add(threadKey);
           threads.push(
             fetchFailed ? this.dimDegraded(servedThread) : servedThread,
           );
@@ -297,6 +299,40 @@ export class RemoteThreadSummaryCache {
           continue;
         }
         threads.push(this.fallbackThread(pin, fetchFailed));
+        selectedKeys.add(threadKey);
+      }
+
+      // A mounted remote parent may itself have mounted a child from another
+      // instance. Carry direct children with the pinned parent so a third
+      // viewer sees the same nested tree instead of an orphaned parent row.
+      // The child's existing federation stamp identifies its true owner and
+      // is preserved by DesktopFederationRuntime when snapshots relay.
+      const pinnedParentKeys = new Set(
+        group.map((pin) =>
+          buildThreadIdentityKey(pin.ref.backend, pin.ref.threadId)
+        ),
+      );
+      for (const candidate of served ?? []) {
+        const parentThreadId = candidate.parentThreadId?.trim();
+        if (!parentThreadId) {
+          continue;
+        }
+        if (
+          candidate.parentThreadInstanceId
+          && candidate.parentThreadInstanceId !== instanceId
+        ) {
+          continue;
+        }
+        const parentKey = buildThreadIdentityKey(
+          candidate.parentThreadBackend ?? candidate.source,
+          parentThreadId,
+        );
+        const candidateKey = buildThreadIdentityKey(candidate.source, candidate.id);
+        if (!pinnedParentKeys.has(parentKey) || selectedKeys.has(candidateKey)) {
+          continue;
+        }
+        selectedKeys.add(candidateKey);
+        threads.push(fetchFailed ? this.dimDegraded(candidate) : candidate);
       }
     }
     return { threads, refreshed, archived };

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1071,6 +1071,15 @@ export function bootstrapApp(): void {
     getDesktopBackendRegistry().setPwrAgentFederationHandler(
       createFederationAgentToolsHandler({
         targetStore: getDesktopOverlayStore(),
+        onRemoteChildMounted: async ({ backend, instanceId, threadId }) => {
+          await getDesktopBackendRegistry().publishLocalEvent({
+            backend,
+            notification: {
+              method: "navigation/remoteThreadPins/changed",
+              params: { instanceId, threadId, pinned: true },
+            },
+          });
+        },
       }),
     );
     getDesktopBackendRegistry().setFederatedThreadMessageHandler(

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2242,6 +2242,9 @@ class DesktopAppServerService {
         prs: thread.prs,
         federation: thread.federation,
         reactions: thread.reactions,
+        parentThreadId: thread.parentThreadId,
+        parentThreadBackend: thread.parentThreadBackend,
+        parentThreadInstanceId: thread.parentThreadInstanceId,
         // Viewer-owned rank: a local pin/unpin must invalidate the snapshot.
         pinnedRank: thread.pinnedRank,
         // Directory-group membership derives from these; a peer-side project
@@ -5900,9 +5903,9 @@ class DesktopAppServerService {
    * Deliberate opinion: pinning a remote sub-thread also pins its parent —
    * an orphan child renders as a bare top-level row, losing the nesting and
    * the parent's PR context that make it legible. One hop only (sub-threads
-   * are one level deep), best-effort (the parent must exist in the peer's
-   * current snapshot — an archived parent must not resurrect as a phantom
-   * row), and never downgrades an existing explicit pin. Removal stays
+   * are one level deep), best-effort (the parent must exist in its owning
+   * instance's current snapshot — an archived parent must not resurrect as a
+   * phantom row), and never downgrades an existing explicit pin. Removal stays
    * per-row: companion pins are ordinary independent pins, tagged
    * `pinnedVia: "companion"` for future group-removal UX.
    */
@@ -5914,6 +5917,8 @@ class DesktopAppServerService {
     const parentThreadId = request.summary?.parentThreadId;
     const parentBackend =
       request.summary?.parentThreadBackend ?? request.ref.backend;
+    const parentInstanceId =
+      request.summary?.parentThreadInstanceId ?? instanceId;
     if (
       !parentThreadId
       || (
@@ -5924,9 +5929,15 @@ class DesktopAppServerService {
       return undefined;
     }
     try {
+      if (
+        parentInstanceId
+        === (await getDesktopFederationRuntime().health()).instanceId
+      ) {
+        return undefined;
+      }
       const parentRef = buildFederatedThreadRef({
         backend: parentBackend,
-        instanceId,
+        instanceId: parentInstanceId,
         threadId: parentThreadId,
       });
       const overlayStore = this.getOverlayStore();
@@ -5936,7 +5947,7 @@ class DesktopAppServerService {
       const parentSummary = await getDesktopFederationRuntime()
         .remoteThreadSummaries()
         .threadFromPeer({
-          target: { scope: "remote", instanceId },
+          target: { scope: "remote", instanceId: parentInstanceId },
           backend: parentBackend,
           threadId: parentThreadId,
         });
@@ -5946,12 +5957,13 @@ class DesktopAppServerService {
       await overlayStore.addRemoteThreadPin({
         ref: parentRef,
         summary: parentSummary,
-        instanceLabel,
+        instanceLabel:
+          parentSummary.federation?.instanceLabel ?? instanceLabel,
         pinnedVia: "companion",
       });
       logDebug("addRemoteThreadPin:companion-parent", {
         backend: parentBackend,
-        instanceId,
+        instanceId: parentInstanceId,
         threadId: parentThreadId,
         childThreadId: request.ref.threadId,
       });
@@ -5960,7 +5972,7 @@ class DesktopAppServerService {
         notification: {
           method: "navigation/remoteThreadPins/changed",
           params: {
-            instanceId,
+            instanceId: parentInstanceId,
             threadId: parentThreadId,
             pinned: true,
           },
@@ -6148,6 +6160,7 @@ class DesktopAppServerService {
       threadId: request.threadId,
       parentThreadId: request.parentThreadId,
       parentThreadBackend: request.parentThreadBackend,
+      parentThreadInstanceId: request.parentThreadInstanceId,
     });
 
     logDebug("setThreadParent", {
@@ -6155,6 +6168,7 @@ class DesktopAppServerService {
       threadId: request.threadId,
       parentThreadId: overlay.parentThreadId ?? null,
       parentThreadBackend: overlay.parentThreadBackend ?? null,
+      parentThreadInstanceId: overlay.parentThreadInstanceId ?? null,
     });
 
     await getDesktopBackendRegistry().publishLocalEvent({
@@ -6166,6 +6180,7 @@ class DesktopAppServerService {
               threadId: request.threadId,
               parentThreadId: overlay.parentThreadId,
               parentThreadBackend: overlay.parentThreadBackend,
+              parentThreadInstanceId: overlay.parentThreadInstanceId,
             },
           }
         : {
@@ -6181,6 +6196,7 @@ class DesktopAppServerService {
       threadId: request.threadId,
       parentThreadId: overlay.parentThreadId,
       parentThreadBackend: overlay.parentThreadBackend,
+      parentThreadInstanceId: overlay.parentThreadInstanceId,
     };
   }
 

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1754,6 +1754,10 @@ class DesktopAppServerService {
       ...request,
       backend,
     });
+    await getDesktopFederationRuntime().ungroupRemoteChildrenOfArchivedThread({
+      backend: response.backend,
+      parentThreadId: response.threadId,
+    });
 
     logDebug("archiveThread", {
       backend,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2572,6 +2572,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     threadId: string;
     parentThreadId?: string | null;
     parentThreadBackend?: ThreadOverlayState["backend"] | null;
+    parentThreadInstanceId?: string | null;
   }): Promise<ThreadOverlayState> {
     if (
       params.parentThreadId === params.threadId
@@ -2590,14 +2591,18 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     const parentThreadBackend = parentThreadId
       ? params.parentThreadBackend ?? params.backend
       : undefined;
+    const parentThreadInstanceId = parentThreadId
+      ? params.parentThreadInstanceId?.trim() || undefined
+      : undefined;
     const nextState: ThreadOverlayState = {
       ...current,
       parentThreadId: parentThreadId || undefined,
       parentThreadBackend,
+      parentThreadInstanceId,
       pinnedRank: parentThreadId ? undefined : current.pinnedRank,
     };
     this.putThread(threadKey, nextState);
-    if (parentThreadId) {
+    if (parentThreadId && !parentThreadInstanceId) {
       const parentKey = buildThreadIdentityKey(parentThreadBackend!, parentThreadId);
       const parent = this.getThread(parentKey) ?? {
         backend: parentThreadBackend!,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2264,7 +2264,9 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
         ...(parsed.summary && typeof parsed.summary === "object"
           ? { summary: parsed.summary as NavigationThreadSummary }
           : {}),
-        ...(parsed.pinnedVia === "companion" || parsed.pinnedVia === "explicit"
+        ...(parsed.pinnedVia === "child"
+          || parsed.pinnedVia === "companion"
+          || parsed.pinnedVia === "explicit"
           ? { pinnedVia: parsed.pinnedVia }
           : {}),
         ...(typeof parsed.localPinnedRank === "string" && parsed.localPinnedRank

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1272,7 +1272,9 @@ export function Sidebar(props: SidebarProps) {
       props.onForkThread,
   );
   const contextMenuCanUnlinkSubthread = Boolean(
-    contextMenuIsSubthread && props.onSetThreadParent,
+    contextMenuIsSubthread
+    && !contextMenuIsMainWindowRemoteRow
+    && props.onSetThreadParent,
   );
   // Remote rows CAN pin here: the rank is viewer-owned (stored on the
   // remote_thread_pins row), so the owner's list never learns about it.

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1204,7 +1204,9 @@ export function Sidebar(props: SidebarProps) {
       !federationTarget,
   );
   const contextMenuCanRemoveRemotePin = Boolean(
-    contextMenuIsMainWindowRemoteRow && props.onRemoveRemoteThreadPin,
+    contextMenuIsMainWindowRemoteRow
+    && !contextMenu?.thread.federation?.derivedFromMountedParent
+    && props.onRemoveRemoteThreadPin,
   );
   const contextMenuCanRename =
     contextMenu && !contextMenuIsBulk && !contextMenuIsMainWindowRemoteRow

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1254,6 +1254,7 @@ describe("Sidebar", () => {
       ...sharedThread,
       id: "thread-derived-child",
       title: "Derived remote child",
+      parentThreadId: "thread-remote-root",
       federation: {
         ref: {
           backend: "codex",
@@ -1289,6 +1290,9 @@ describe("Sidebar", () => {
 
     expect(
       screen.queryByRole("menuitem", { name: /Remove from My List/ }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("menuitem", { name: "Unlink from Parent" }),
     ).toBeNull();
   });
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1249,6 +1249,49 @@ describe("Sidebar", () => {
     expect(onRemoveRemoteThreadPin).toHaveBeenCalledWith(remotePinnedThread);
   });
 
+  it("does not offer removal for a child derived from a mounted parent", () => {
+    const derivedChild: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "thread-derived-child",
+      title: "Derived remote child",
+      federation: {
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "peer-mini" },
+          threadId: "thread-derived-child",
+        },
+        instanceLabel: "Mac Mini",
+        peerStatus: "connected",
+        capabilities: [],
+        derivedFromMountedParent: true,
+      },
+    };
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[derivedChild]}
+        loading={false}
+        selectedItemKey="codex:thread-derived-child"
+        threads={[derivedChild]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onRemoveRemoteThreadPin={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    fireEvent.contextMenu(
+      screen.getByRole("button", { name: "Derived remote child" }),
+    );
+
+    expect(
+      screen.queryByRole("menuitem", { name: /Remove from My List/ }),
+    ).toBeNull();
+  });
+
   it("closes its context menu when another renderer menu opens", () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -790,6 +790,7 @@ function threadSummariesEqual(
     left.pinnedRank === right.pinnedRank &&
     left.parentThreadId === right.parentThreadId &&
     left.parentThreadBackend === right.parentThreadBackend &&
+    left.parentThreadInstanceId === right.parentThreadInstanceId &&
     JSON.stringify(left.subthreadOrder ?? []) ===
       JSON.stringify(right.subthreadOrder ?? []) &&
     left.subthreadsCollapsed === right.subthreadsCollapsed &&
@@ -1096,6 +1097,7 @@ function updateThreadParentInSnapshot(
     threadId: string;
     parentThreadId?: string;
     parentThreadBackend?: AppServerBackendKind;
+    parentThreadInstanceId?: string;
   },
 ): NavigationSnapshot | undefined {
   if (!snapshot) {
@@ -1110,6 +1112,7 @@ function updateThreadParentInSnapshot(
     if (
       thread.parentThreadId === params.parentThreadId
       && thread.parentThreadBackend === params.parentThreadBackend
+      && thread.parentThreadInstanceId === params.parentThreadInstanceId
     ) {
       return thread;
     }
@@ -1119,6 +1122,9 @@ function updateThreadParentInSnapshot(
       parentThreadId: params.parentThreadId,
       parentThreadBackend: params.parentThreadId
         ? params.parentThreadBackend ?? params.backend
+        : undefined,
+      parentThreadInstanceId: params.parentThreadId
+        ? params.parentThreadInstanceId
         : undefined,
       pinnedRank: params.parentThreadId ? undefined : thread.pinnedRank,
     };
@@ -1158,6 +1164,7 @@ function ungroupChildThreadsInSnapshot(
       ...thread,
       parentThreadId: undefined,
       parentThreadBackend: undefined,
+      parentThreadInstanceId: undefined,
     };
   });
 
@@ -4135,10 +4142,16 @@ export function useThreadNavigation(
       }
 
       if (method === "thread/parent/set") {
-        const { threadId, parentThreadId, parentThreadBackend } = event.notification.params as {
+        const {
+          threadId,
+          parentThreadId,
+          parentThreadBackend,
+          parentThreadInstanceId,
+        } = event.notification.params as {
           threadId: string;
           parentThreadId: string;
           parentThreadBackend?: AppServerBackendKind;
+          parentThreadInstanceId?: string;
         };
         setState((current) => ({
           ...current,
@@ -4147,6 +4160,7 @@ export function useThreadNavigation(
             threadId,
             parentThreadId,
             parentThreadBackend,
+            parentThreadInstanceId,
           }),
         }));
         scheduleRefresh();

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -26,7 +26,7 @@ import type {
   NavigationLaunchpadDefaults,
   NavigationLaunchpadImageAttachment,
 } from "./navigation";
-import type { FederationTarget } from "./federation";
+import type { FederationInstanceId, FederationTarget } from "./federation";
 import type {
   ScheduledThreadAction,
   ScheduledThreadTurnPayload,
@@ -55,6 +55,7 @@ export type StartThreadRequest = {
   acpRuntime?: BackendAcpSessionRuntimeState;
   parentThreadId?: ThreadIdentifier;
   parentThreadBackend?: AppServerBackendKind;
+  parentThreadInstanceId?: FederationInstanceId;
 };
 
 export type StartThreadResponse = {
@@ -83,6 +84,7 @@ export type ForkThreadRequest = {
   sourceThreadId: ThreadIdentifier;
   parentThreadId?: ThreadIdentifier;
   parentThreadBackend?: AppServerBackendKind;
+  parentThreadInstanceId?: FederationInstanceId;
   executionMode?: ThreadExecutionMode;
   directoryKind?: DirectorySummaryKind;
   directoryLabel?: string;
@@ -763,6 +765,7 @@ export type MaterializeDirectoryLaunchpadRequest = {
   reviewTarget?: AppServerReviewTarget;
   parentThreadId?: ThreadIdentifier;
   parentThreadBackend?: AppServerBackendKind;
+  parentThreadInstanceId?: FederationInstanceId;
   /**
    * Create the provider thread and prepare its workspace now, but defer the
    * first turn or review until this wall-clock time.

--- a/packages/shared/src/contracts/federation-tools.ts
+++ b/packages/shared/src/contracts/federation-tools.ts
@@ -156,6 +156,11 @@ export type CreateInstanceThreadToolArgs = {
   workMode?: LaunchpadWorkMode;
   /** Existing base branch/ref for workMode=worktree, e.g. `origin/main`. */
   branchName?: string;
+  /**
+   * Group the created thread beneath the calling thread, even when the two
+   * threads live on different federation instances. Defaults to ungrouped.
+   */
+  groupingMode?: "none" | "subthread";
 };
 
 export type CreateInstanceThreadResult = {
@@ -167,6 +172,8 @@ export type CreateInstanceThreadResult = {
   executionMode: ThreadExecutionMode;
   workMode: LaunchpadWorkMode;
   turnId?: string;
+  groupingMode: "none" | "subthread";
+  groupedUnderThreadId?: ThreadIdentifier;
   /** Canonical link, including instanceId for a remote owner on newer peers. */
   threadUrl?: string;
   threadLink?: string;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -29,6 +29,7 @@ import type { CelestialIconId } from "./celestial";
 import type {
   FederatedThreadRef,
   FederationCapability,
+  FederationInstanceId,
   FederationPeerSummary,
   FederationTarget,
 } from "./federation";
@@ -113,6 +114,8 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
   parentThreadId?: ThreadIdentifier;
   /** Provider that owns `parentThreadId`; defaults to this thread's provider. */
   parentThreadBackend?: AppServerBackendKind;
+  /** Federation instance that owns the parent when it differs from this thread's owner. */
+  parentThreadInstanceId?: FederationInstanceId;
   /**
    * Set only when this thread inherited copied context by forking another
    * thread. Renderer surfaces use this to distinguish fork baseline history
@@ -693,6 +696,7 @@ export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
   branchName?: string;
   parentThreadId?: string;
   parentThreadBackend?: AppServerBackendKind;
+  parentThreadInstanceId?: FederationInstanceId;
   parentThreadTitle?: string;
   /**
    * The thread card this launchpad was spawned from. May differ from
@@ -1316,11 +1320,11 @@ export type RemoteThreadPin = {
   /** Last successfully fetched summary (unstamped), for offline rendering. */
   summary?: NavigationThreadSummary;
   /**
-   * How this pin came to exist. "companion" marks a parent pulled in
-   * automatically when one of its sub-threads was pinned, so future UX can
-   * treat it differently (e.g. offer group removal). Absent = explicit.
+   * How this pin came to exist. "companion" marks a parent pulled in when one
+   * of its sub-threads was pinned; "child" marks a cross-instance child mounted
+   * by create_instance_thread. Absent = explicit.
    */
-  pinnedVia?: "explicit" | "companion";
+  pinnedVia?: "explicit" | "companion" | "child";
   /**
    * VIEWER-owned rank in the local pinned section. Completely independent
    * of the owner's own pinnedRank (which never crosses into the viewer's
@@ -1420,6 +1424,7 @@ export type SetThreadParentRequest = {
   threadId: ThreadIdentifier;
   parentThreadId?: ThreadIdentifier | null;
   parentThreadBackend?: AppServerBackendKind | null;
+  parentThreadInstanceId?: FederationInstanceId | null;
 };
 
 export type SetThreadParentResponse = {
@@ -1427,6 +1432,7 @@ export type SetThreadParentResponse = {
   threadId: ThreadIdentifier;
   parentThreadId?: ThreadIdentifier;
   parentThreadBackend?: AppServerBackendKind;
+  parentThreadInstanceId?: FederationInstanceId;
 };
 
 export type UpdateSubthreadOrderRequest = {
@@ -1767,6 +1773,8 @@ export type ThreadOverlayState = {
   parentThreadId?: ThreadIdentifier;
   /** Provider that owns `parentThreadId`; defaults to this thread's provider. */
   parentThreadBackend?: AppServerBackendKind;
+  /** Federation instance that owns the parent when it differs from this thread's owner. */
+  parentThreadInstanceId?: FederationInstanceId;
   /**
    * Set only when this thread was created by forking another thread
    * (`thread/fork`). Records the source thread the fork inherited its context

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -79,6 +79,12 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
      * peer is connected directly or advertised through a gateway relay. */
     capabilities?: FederationCapability[];
     /**
+     * This row was carried into the viewer with a mounted parent rather than
+     * selected by its own viewer-owned pin. Per-row removal is unavailable;
+     * removing the parent removes the derived row with it.
+     */
+    derivedFromMountedParent?: boolean;
+    /**
      * The owning instance's celestial identity icon, resolved from the
      * federation-wide assignment map at stamping time. Absent for peers
      * that haven't been assigned one (e.g. pre-celestial builds) —

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1682,6 +1682,7 @@ export type AppServerNotification =
         threadId: string;
         parentThreadId: string;
         parentThreadBackend?: AppServerBackendKind;
+        parentThreadInstanceId?: string;
       };
     }
   | {

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -167,7 +167,10 @@ function resolveNavigationParentThread(params: {
   overlayByThreadKey: Record<string, ThreadOverlayState | undefined>;
   source: AppServerThreadSummary["source"];
   threadId: string;
-}): Pick<NavigationThreadSummary, "parentThreadBackend" | "parentThreadId"> {
+}): Pick<
+  NavigationThreadSummary,
+  "parentThreadBackend" | "parentThreadId" | "parentThreadInstanceId"
+> {
   const directParentThreadId = params.overlay?.parentThreadId?.trim();
   if (!directParentThreadId) {
     return {};
@@ -175,6 +178,7 @@ function resolveNavigationParentThread(params: {
 
   let parentThreadId = directParentThreadId;
   const directParentThreadBackend = params.overlay?.parentThreadBackend;
+  const directParentThreadInstanceId = params.overlay?.parentThreadInstanceId;
   let parentThreadBackend = directParentThreadBackend ?? params.source;
   const seen = new Set([buildThreadIdentityKey(params.source, params.threadId)]);
   let parentKey = buildThreadIdentityKey(parentThreadBackend, parentThreadId);
@@ -186,6 +190,9 @@ function resolveNavigationParentThread(params: {
     if (!nextParentThreadId) {
       return {
         ...(directParentThreadBackend ? { parentThreadBackend } : {}),
+        ...(directParentThreadInstanceId
+          ? { parentThreadInstanceId: directParentThreadInstanceId }
+          : {}),
         parentThreadId,
       };
     }
@@ -198,6 +205,9 @@ function resolveNavigationParentThread(params: {
   return {
     ...(directParentThreadBackend
       ? { parentThreadBackend: directParentThreadBackend }
+      : {}),
+    ...(directParentThreadInstanceId
+      ? { parentThreadInstanceId: directParentThreadInstanceId }
       : {}),
     parentThreadId: directParentThreadId,
   };
@@ -568,6 +578,7 @@ export function buildNavigationSnapshotHash(params: {
       pinnedRank: thread.pinnedRank ?? null,
       parentThreadId: thread.parentThreadId ?? null,
       parentThreadBackend: thread.parentThreadBackend ?? null,
+      parentThreadInstanceId: thread.parentThreadInstanceId ?? null,
       forkSourceThreadId: thread.forkSourceThreadId ?? null,
       subthreadOrder: thread.subthreadOrder ?? [],
       subthreadsCollapsed: thread.subthreadsCollapsed ?? null,


### PR DESCRIPTION
## What

- add an explicit `groupingMode: "subthread"` option to `create_instance_thread`
- carry the parent thread's federation instance identity through remote materialization and overlays
- mount remotely created children immediately and notify navigation consumers
- preserve a transitive child's true federation owner when an intermediate peer relays its snapshot
- include direct cross-instance children when a viewer has mounted their remote parent
- resolve companion parent pins from the parent's owning instance instead of assuming parent and child share an instance

## Why

Cross-instance creation previously produced an independent remote thread. The parent relationship only identified a backend/thread pair, federation snapshot stamping assumed every relayed row belonged to the directly queried peer, and the remote-pin cache selected only the explicitly mounted row. Together, those assumptions meant an M2 viewer could mount an M5 parent but could not see a Mac Mini child nested beneath it.

Ungrouped intake remains the default. Agents opt into nesting only for delegated child work.

## Validation

- focused federation/navigation suite: 7 files, 246 tests passed
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` (0 errors; 30 pre-existing warnings)
- `pnpm lint:codex-storage`
- `git diff --check`

## SQLite write budget

Mounting one cross-instance child costs 2 commits and 24,720 observed WAL bytes. The checked-in budget covers the feature boundary. At 100 child creations/day, that projects to about 2.47 MB/day; a sustained one child/minute would be about 35.6 MB/day.
