### PR TITLE
fix(desktop): backport thread directory enrichment hardening

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1431,6 +1431,83 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("contains a directory enrichment failure to the affected thread", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const managedWorktree = "/Users/vitaliy/.codex/worktrees/a21d/giphy-services";
+    const localDirectory = "/Users/vitaliy/projects/healthy";
+    const threadDirectoryEnricher = vi.fn(async (projectKey?: string) => {
+      if (projectKey === managedWorktree) {
+        throw Object.assign(new Error("spawn git EACCES"), { code: "EACCES" });
+      }
+      return {
+        linkedDirectories: [
+          {
+            id: projectKey ?? "missing",
+            label: path.basename(projectKey ?? "missing"),
+            path: projectKey ?? "missing",
+            kind: "local" as const,
+          },
+        ],
+      };
+    });
+    const client = new CodexAppServerClient({
+      command: "codex",
+      threadDirectoryEnricher,
+    });
+    const threads: AppServerThreadSummary[] = [
+      {
+        id: "broken-worktree-thread",
+        title: "Broken worktree",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: managedWorktree,
+        linkedDirectories: [],
+      },
+      {
+        id: "healthy-thread",
+        title: "Healthy thread",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: localDirectory,
+        linkedDirectories: [],
+      },
+    ];
+
+    await expect(client.enrichThreadDirectories(threads)).resolves.toEqual([
+      expect.objectContaining({
+        id: "broken-worktree-thread",
+        linkedDirectories: [
+          {
+            id: managedWorktree,
+            label: "giphy-services",
+            path: managedWorktree,
+            worktreePath: managedWorktree,
+            kind: "worktree",
+          },
+        ],
+      }),
+      expect.objectContaining({
+        id: "healthy-thread",
+        linkedDirectories: [
+          expect.objectContaining({
+            path: localDirectory,
+            kind: "local",
+          }),
+        ],
+      }),
+    ]);
+    expect(codexClientLogWarn).toHaveBeenCalledWith(
+      "thread directory enrichment failed",
+      expect.objectContaining({
+        threadId: "broken-worktree-thread",
+        projectKey: managedWorktree,
+        error: "spawn git EACCES",
+      }),
+    );
+
+    await client.close();
+  });
+
   it("keeps cheap thread summaries from rendering managed worktrees as local", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     const threadDirectoryEnricher = vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
@@ -165,6 +165,104 @@ describe("createThreadDirectoryEnricher", () => {
     });
   });
 
+  it.each([
+    {
+      failure: "cannot execute git",
+      error: Object.assign(new Error("spawn git EACCES"), { code: "EACCES" }),
+    },
+    {
+      failure: "git crashes",
+      error: Object.assign(new Error("git terminated by SIGSEGV"), { signal: "SIGSEGV" }),
+    },
+    {
+      failure: "git times out",
+      error: Object.assign(new Error("git timed out"), { code: "ETIMEDOUT", killed: true }),
+    },
+  ])("preserves a managed worktree identity when $failure", async ({ error }) => {
+    const projectPath = "/Users/vitaliy/.codex/worktrees/a21d/giphy-services";
+    const execFileMock = vi.fn(
+      (
+        _file: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null) => void,
+      ) => callback(error),
+    );
+    vi.doMock("node:fs/promises", () => ({
+      access: vi.fn(async (targetPath: string) => {
+        if (targetPath === path.resolve(projectPath)) {
+          return undefined;
+        }
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      }),
+      readFile: vi.fn(),
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFile: execFileMock,
+    }));
+
+    const { createThreadDirectoryEnricher } = await import(
+      "../app-server/thread-directory-enricher"
+    );
+    const enricher = createThreadDirectoryEnricher();
+
+    await expect(enricher(projectPath)).resolves.toEqual({
+      linkedDirectories: [
+        {
+          id: expectedDir(projectPath),
+          path: expectedDir(projectPath),
+          worktreePath: expectedDir(projectPath),
+          label: "giphy-services",
+          kind: "worktree",
+        },
+      ],
+    });
+    expect(execFileMock).toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["-C", path.resolve(projectPath)]),
+      expect.objectContaining({ timeout: 2_000 }),
+      expect.any(Function),
+    );
+  });
+
+  it("keeps a normal directory usable when git is unavailable", async () => {
+    const projectPath = "/Users/vitaliy/projects/not-a-repository";
+    vi.doMock("node:fs/promises", () => ({
+      access: vi.fn(async (targetPath: string) => {
+        if (targetPath === path.resolve(projectPath)) {
+          return undefined;
+        }
+        throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+      }),
+      readFile: vi.fn(),
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFile: vi.fn(
+        (
+          _file: string,
+          _args: string[],
+          _options: unknown,
+          callback: (error: Error | null) => void,
+        ) => callback(Object.assign(new Error("spawn git EACCES"), { code: "EACCES" })),
+      ),
+    }));
+
+    const { createThreadDirectoryEnricher } = await import(
+      "../app-server/thread-directory-enricher"
+    );
+
+    await expect(createThreadDirectoryEnricher()(projectPath)).resolves.toEqual({
+      linkedDirectories: [
+        {
+          id: expectedDir(projectPath),
+          path: expectedDir(projectPath),
+          label: "not-a-repository",
+          kind: "local",
+        },
+      ],
+    });
+  });
+
   it("returns no linked directories when the anchored path no longer exists", async () => {
     vi.doMock("node:fs/promises", () => ({
       access: vi.fn(async () => {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -6325,7 +6325,19 @@ export class CodexAppServerClient {
         thread: EnrichedCodexThread;
       }> => {
         const projectKey = await resolveThreadProjectKey(thread);
-        const enrichment = await this.threadDirectoryEnricher(projectKey);
+        let enrichment: ThreadDirectoryEnrichment;
+        try {
+          enrichment = await this.threadDirectoryEnricher(projectKey);
+        } catch (error) {
+          codexClientLog.warn("thread directory enrichment failed", {
+            threadId: thread.id,
+            projectKey,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          enrichment = {
+            linkedDirectories: buildProjectKeyLinkedDirectories(projectKey),
+          };
+        }
         const {
           originator: _originator,
           path: _path,

--- a/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
+++ b/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
@@ -8,6 +8,8 @@ import { getMainLogger } from "../log";
 
 const execFile = promisify(execFileCallback);
 const threadDirectoryLog = getMainLogger("pwragent:thread-directory-enricher");
+const GIT_DIRECTORY_PROBE_TIMEOUT_MS = 2_000;
+const GIT_DIRECTORY_PROBE_MAX_BUFFER_BYTES = 1024 * 1024;
 
 /**
  * Normalize a resolved filesystem path to forward slashes for use as a stable,
@@ -43,8 +45,22 @@ type GitMetadataEvidence = {
 async function runGit(projectKey: string, args: string[]): Promise<string> {
   const result = await execFile("git", ["-C", projectKey, ...args], {
     env: process.env,
+    maxBuffer: GIT_DIRECTORY_PROBE_MAX_BUFFER_BYTES,
+    timeout: GIT_DIRECTORY_PROBE_TIMEOUT_MS,
   });
   return result.stdout.trim();
+}
+
+function buildFallbackLinkedDirectory(currentPath: string): LinkedDirectorySummary {
+  const directoryPath = path.resolve(currentPath);
+  const isManagedWorktree = isToolManagedWorktreePath(directoryPath);
+  return {
+    id: toDirectoryId(directoryPath),
+    path: toDirectoryId(directoryPath),
+    ...(isManagedWorktree ? { worktreePath: toDirectoryId(directoryPath) } : {}),
+    label: path.basename(directoryPath) || directoryPath,
+    kind: isManagedWorktree ? "worktree" : "local",
+  };
 }
 
 async function pathExists(targetPath: string): Promise<boolean> {
@@ -266,25 +282,18 @@ async function loadThreadDirectoryEnrichment(
       };
     }
 
-    const fallbackPath = path.resolve(currentPath);
-    if (isToolManagedWorktreePath(fallbackPath)) {
-      threadDirectoryLog.warn("managed worktree path fell back to local directory", {
+    const fallbackDirectory = buildFallbackLinkedDirectory(currentPath);
+    if (fallbackDirectory.kind === "worktree") {
+      threadDirectoryLog.warn("managed worktree repository relationship unavailable", {
         projectKey,
-        fallbackPath,
+        fallbackPath: fallbackDirectory.worktreePath,
         error: error instanceof Error ? error.message : String(error),
         gitMetadata: gitMetadataFallback.evidence,
       });
     }
 
     return {
-      linkedDirectories: [
-        {
-          id: toDirectoryId(fallbackPath),
-          path: toDirectoryId(fallbackPath),
-          label: path.basename(fallbackPath) || fallbackPath,
-          kind: "local",
-        },
-      ],
+      linkedDirectories: [fallbackDirectory],
     };
   }
 }


### PR DESCRIPTION
## Summary

Backports the logical squashed change from #1461 onto the 1.0 maintenance trunk.

- bound startup-time Git directory probes to 2 seconds and cap output at 1 MiB
- preserve structurally recognized Codex/PwrAgent worktrees when Git is unavailable, crashes, times out, or the repository relationship has disappeared
- isolate unexpected directory-enricher failures to the affected thread and retain the structural fallback
- carry over coverage for EACCES, crashes, timeouts, non-repository local directories, and batch failure isolation

## Provenance

- Original PR: #1461
- Source squash: `59566c2a7a2b1df8cdf9a01b9e04978e1d39a95d`

## 1.0-specific adaptation

The 1.0 trunk predates `buildPwrAgentChildProcessEnv`, so the backport retains the branch's existing `process.env` handling in `runGit` while adding the timeout and output cap. No newer main-only child-process helper was pulled into the maintenance branch.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check origin/releases/1.0..HEAD`
