### PR TITLE
fix(desktop): harden child handoffs

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -22384,7 +22384,8 @@ command = "pnpm dev"
       turnId: "turn-1",
       title: "Investigate issue XYZ",
       seedMode: "clean",
-      groupingMode: "none",
+      groupingMode: "subthread",
+      groupedUnderThreadId: "ordinary-thread",
       inheritedSettings: {
         backend: "codex",
         executionMode: "full-access",
@@ -22484,7 +22485,7 @@ command = "pnpm dev"
         sourceTitle: "Parent Thread",
         taskTitle: "Investigate issue XYZ",
         seedMode: "clean",
-        groupingMode: "none",
+        groupingMode: "subthread",
         workspace: {
           mode: "new_worktree",
           cwd: expect.stringContaining("handoff"),
@@ -22495,6 +22496,152 @@ command = "pnpm dev"
 
     await registry.close();
     await rm(root, { recursive: true, force: true });
+  });
+
+  it("rejects a Grok model on an inherited Codex backend and accepts an explicit Grok backend", async () => {
+    const acpBackendId = "acp:grok" as AcpBackendId;
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "turn/start"] },
+      models: [{ id: "gpt-5.6-sol", label: "GPT-5.6 Sol" }],
+      threads: [
+        {
+          id: "codex-parent",
+          title: "Codex parent",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          updatedAt: 1000,
+        },
+      ],
+    });
+    const installedAgent: AcpInstalledAgentRecord = {
+      ...createKimiAgentRecord(acpBackendId),
+      registryId: "grok",
+      name: "Grok",
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        checkedAt: 1000,
+        models: {
+          currentModelId: "grok-4.5",
+          availableModels: [
+            {
+              id: "grok-4.5",
+              label: "Grok 4.5",
+            },
+          ],
+        },
+      },
+    };
+    const { acpClient, registry } = createKimiAcpRegistry({
+      acpBackendId,
+      codexClient,
+      installedAgent,
+      sessionId: "grok-child",
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "codex-parent",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const wrongBackendResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "codex-parent",
+        turnId: "turn-1",
+        callId: "call-wrong-backend",
+        requestId: "call-wrong-backend",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          task: "Ask Grok to investigate the issue.",
+          model: "grok",
+          workspaceMode: "none",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(wrongBackendResponse).toMatchObject({ success: false });
+    expect(
+      JSON.parse(
+        (wrongBackendResponse as { contentItems: Array<{ text: string }> })
+          .contentItems[0]!.text,
+      ),
+    ).toEqual({
+      code: "invalid_arguments",
+      message:
+        'model="grok" is not available for backend="codex". Available models: gpt-5.6-sol. To request Grok, pass backend="acp:grok" and an exact discovered model ID such as model="grok-4.5".',
+    });
+    expect(codexClient.lastStartThreadParams).toBeUndefined();
+    expect(acpClient.startSession).not.toHaveBeenCalled();
+
+    const mcpWrongBackendResponse = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "codex-parent",
+      turnId: "turn-1",
+      tool: "handoff_task",
+      args: {
+        task: "Ask Grok to investigate the issue over MCP.",
+        model: "grok",
+        workspaceMode: "none",
+      },
+    });
+    expect(mcpWrongBackendResponse).toMatchObject({
+      isError: true,
+      structuredContent: {
+        code: "invalid_arguments",
+        message: expect.stringContaining(
+          'pass backend="acp:grok" and an exact discovered model ID',
+        ),
+      },
+    });
+    expect(codexClient.lastStartThreadParams).toBeUndefined();
+    expect(acpClient.startSession).not.toHaveBeenCalled();
+
+    const explicitGrokResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "codex-parent",
+        turnId: "turn-1",
+        callId: "call-explicit-grok",
+        requestId: "call-explicit-grok",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          backend: acpBackendId,
+          task: "Ask Grok to investigate the issue.",
+          model: "grok-4.5",
+          workspaceMode: "none",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(explicitGrokResponse).toMatchObject({ success: true });
+    expect(
+      JSON.parse(
+        (explicitGrokResponse as { contentItems: Array<{ text: string }> })
+          .contentItems[0]!.text,
+      ),
+    ).toMatchObject({
+      backend: acpBackendId,
+      groupingMode: "subthread",
+      groupedUnderThreadId: "codex-parent",
+      inheritedSettings: {
+        backend: acpBackendId,
+        model: "grok-4.5",
+      },
+    });
+    expect(acpClient.startSession).toHaveBeenCalledOnce();
+
+    await registry.close();
   });
 
   it("groups an ACP handoff under a Codex parent", async () => {
@@ -25292,6 +25439,7 @@ script = "printf setup"
         tool: "handoff_task",
         arguments: {
           task: "Investigate issue XYZ and report back.",
+          groupingMode: "none",
           workspaceMode: "same_workspace",
         },
       },
@@ -25940,22 +26088,23 @@ script = "printf setup"
     }
   });
 
-  it("creates new-worktree handoffs from a labeled target repo path in the task", async () => {
+  it("does not switch a same-project child to a nested path mentioned in the task", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-task-cwd-"));
     const scratchPath = path.join(root, "scratch-workspace");
     const repoPath = path.join(root, "PwrAgnt");
-    const worktreePath = path.join(repoPath, ".worktrees", "handoff-task");
+    const nestedPackagePath = path.join(repoPath, "apps", "desktop");
+    const worktreePath = path.join(scratchPath, ".worktrees", "handoff-task");
     try {
-      await mkdir(scratchPath, { recursive: true });
+      await mkdir(nestedPackagePath, { recursive: true });
       await mkdir(worktreePath, { recursive: true });
-      const canonicalRepoPath = await realpath(repoPath);
+      const canonicalScratchPath = await realpath(scratchPath);
       const canonicalWorktreePath = await realpath(worktreePath);
       const prepareLaunchpadWorkspace = vi.fn(async (_launchpad: {
         directoryPath?: string;
         workMode: "local" | "worktree";
       }) => ({
         cwd: canonicalWorktreePath,
-        repositoryPath: canonicalRepoPath,
+        repositoryPath: canonicalScratchPath,
         workMode: "worktree" as const,
       }));
 
@@ -25994,10 +26143,10 @@ script = "printf setup"
             if (
               cwd?.startsWith(worktreePath)
               || cwd?.startsWith(canonicalWorktreePath)
-              || cwd?.startsWith(repoPath)
-              || cwd?.startsWith(canonicalRepoPath)
+              || cwd?.startsWith(scratchPath)
+              || cwd?.startsWith(canonicalScratchPath)
             ) {
-              return canonicalRepoPath;
+              return canonicalScratchPath;
             }
             return cwd;
           }),
@@ -26039,7 +26188,7 @@ script = "printf setup"
             task: [
               "Investigate the messaging bug.",
               "Target repository:",
-              `- "${repoPath}"`,
+              `- "${nestedPackagePath}"`,
             ].join("\n"),
             title: "Messaging handoff target repo",
             workspaceMode: "new_worktree",
@@ -26056,12 +26205,12 @@ script = "printf setup"
         expectedDir(
           prepareLaunchpadWorkspace.mock.calls[0]?.[0].directoryPath ?? "",
         ),
-      ).toBe(expectedDir(repoPath));
+      ).toBe(expectedDir(scratchPath));
       const handoffCwd = expectedDir(codexClient.lastStartThreadParams?.cwd ?? "");
       expect(handoffCwd).toContain(
-        expectedDir(await realpath(path.join(repoPath, ".worktrees"))),
+        expectedDir(await realpath(path.join(scratchPath, ".worktrees"))),
       );
-      expect(handoffCwd).not.toContain(expectedDir(scratchPath));
+      expect(handoffCwd).not.toContain(expectedDir(nestedPackagePath));
       const payload = JSON.parse(
         (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
       );
@@ -26070,8 +26219,8 @@ script = "printf setup"
         cwd: handoffCwd,
         linkedDirectory: {
           kind: "worktree",
-          label: "PwrAgnt",
-          path: expectedDir(await realpath(repoPath)),
+          label: "scratch-workspace",
+          path: expectedDir(await realpath(scratchPath)),
           worktreePath: handoffCwd,
         },
       });

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
@@ -52,7 +52,7 @@ describe("pwragent thread orchestration agent tools", () => {
             type: "function",
             name: "handoff_task",
             description: expect.stringMatching(
-              /Prefer this over backend-native sub-agent spawning.*cross-project handoffs are created ungrouped/,
+              /Prefer this to backend-native spawning.*Same-project handoffs default to grouped subthreads.*Cross-project handoffs are ungrouped/,
             ),
             deferLoading: false,
             inputSchema: expect.objectContaining({
@@ -63,13 +63,19 @@ describe("pwragent thread orchestration agent tools", () => {
                 }),
                 groupingMode: expect.objectContaining({
                   enum: ["none", "subthread"],
-                  description: expect.stringContaining("same-project sub-thread"),
+                  description: expect.stringContaining("defaults for same-project"),
                 }),
                 workspaceMode: expect.objectContaining({
                   enum: ["same", "same_workspace", "project_local", "new_worktree", "none"],
                 }),
                 cwd: expect.objectContaining({
-                  description: expect.stringContaining("another project"),
+                  description: expect.stringContaining("task text does not select cwd"),
+                }),
+                backend: expect.objectContaining({
+                  description: expect.stringContaining("`acp:grok`"),
+                }),
+                model: expect.objectContaining({
+                  description: expect.stringContaining("`grok-4.5`"),
                 }),
                 branchName: expect.objectContaining({
                   description: expect.stringContaining("existing base branch/ref"),
@@ -167,6 +173,22 @@ describe("pwragent thread orchestration agent tools", () => {
         ]),
       }),
     ]);
+  });
+
+  it("keeps handoff_task metadata identical across dynamic and MCP exposure", () => {
+    const router = buildPwrAgentThreadOrchestrationToolRouter(undefined);
+    const dynamicTool = router.buildDynamicToolSpecs()
+      .flatMap((spec) => spec.type === "namespace" ? spec.tools : [])
+      .find((tool) => tool.name === "handoff_task");
+    const mcpTool = router.buildMcpTools()
+      .find((tool) => tool.name === "handoff_task");
+
+    expect(dynamicTool).toBeDefined();
+    expect(mcpTool).toEqual({
+      name: dynamicTool?.name,
+      description: dynamicTool?.description,
+      inputSchema: dynamicTool?.inputSchema,
+    });
   });
 
   it("returns unavailable when no handler is registered", async () => {

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -185,7 +185,7 @@ function descriptionForOperation(
 ): string {
   switch (operation) {
     case "handoff_task":
-      return "Create and start a new PwrAgent-managed AI thread for a delegated task. Prefer this over backend-native sub-agent spawning when it can satisfy the request so the child retains PwrAgent thread management and tool access. Use backend-native spawning only when the user explicitly requests it or needs a capability this tool does not support. Use this when the user asks to hand off or delegate work to a new thread. Omitted settings inherit from the invoking turn. Clean new-thread handoff is the default; use seedMode=fork only when the user asks to fork this thread. Workspace-backed handoffs default to workspaceMode=new_worktree. Use cwd=<source project/repo path> whenever the user names a target repo/project, especially from messaging or a notes/scratch thread; putting the path only in the task text does not select the runtime workspace. In Default Access, an explicit cwd that is not already trusted will trigger an operator confirmation before PwrAgent uses that directory for handoff workspaces. Use groupingMode=subthread only for same-project follow-up work that should stay grouped under the current thread; cross-project handoffs are created ungrouped even if subthread grouping is requested. Combine groupingMode=subthread with workspaceMode=new_worktree and branchName=<existing base ref> such as origin/main when same-project related work should start from another branch. Use workspaceMode=same_workspace only when the user explicitly asks to share the caller's exact workspace. Use workspaceMode=project_local only when the delegated thread should run in the project's primary checkout instead of a managed worktree. Use workspaceMode=none only for an intentionally unscoped local thread, not as a fallback for repo work. Handoff startup can take several minutes while a worktree or Codex environment setup is prepared; if this call appears slow or uncertain, do not call handoff_task again. Use search_threads or get_thread_status and inspect pendingHandoffs until a threadId appears or the handoff reports failed. The result includes threadLink, a ready-made markdown link to the new thread. When you tell the user about the thread you created, include threadLink verbatim instead of writing out the raw threadId so PwrAgent renders it as a clickable chip; a bare id is a dead end for the user.";
+      return "Create a PwrAgent-managed thread for delegated work. Prefer this to backend-native spawning unless the user requests it or needs an unsupported capability. Omitted settings inherit from the invoking turn. Same-project handoffs default to grouped subthreads in a new worktree; omit cwd so they inherit the caller's workspace source. Pass cwd only when the user explicitly selects another project or directory; task text never selects cwd. Cross-project handoffs are ungrouped. Use seedMode=fork only for explicit forks, same_workspace only for explicit sharing, project_local for the project checkout, and none for unscoped work. Provider overrides require a registered backend and exact model ID. Startup can take minutes; do not retry while pending. Inspect pendingHandoffs for progress, and return threadLink verbatim.";
     case "attach_thread_directory":
       return "Attach an additional Git directory to the current PwrAgent thread. Use this for cross-project work when the user asks to link another repo or create a secondary worktree for another repo. Omitted backend targets the invoking thread. workspaceMode=local attaches the repository directory itself; workspaceMode=new_worktree asks PwrAgent to allocate and attach a managed worktree for the provided repository path. In Default Access, an untrusted path triggers operator confirmation before it can grant agent read/write/delete scope or allocate a managed worktree. This does not change the thread's primary cwd; use detach_thread_directory separately if a temporary local reference should be removed.";
     case "detach_thread_directory":
@@ -297,7 +297,7 @@ function inputSchemaForOperation(
             type: "string",
             enum: HANDOFF_TASK_GROUPING_MODES,
             description:
-              "`none` leaves the created thread ungrouped and is the default. `subthread` groups it under the invoking thread only when the user asks for a same-project sub-thread; cross-project handoffs are created ungrouped.",
+              "`subthread` defaults for same-project handoffs; `none` is explicitly ungrouped. Cross-project handoffs are always ungrouped.",
           },
           workspaceMode: {
             type: "string",
@@ -308,7 +308,7 @@ function inputSchemaForOperation(
           cwd: {
             type: "string",
             description:
-              "Optional source project/repo directory for workspace-backed handoffs. Set this whenever the user asks for another project, a specific repo/project, or says to create the handoff into a repo from messaging; omitted means use the invoking thread's current workspace.",
+              "Omit to inherit the caller workspace. Set only when the user explicitly selects another project or directory; task text does not select cwd.",
           },
           messagingAttachment: {
             type: "string",
@@ -316,8 +316,16 @@ function inputSchemaForOperation(
             description:
               "Whether to attach the created thread to the current messaging location. Defaults to `auto` for messaging-originated turns and `none` otherwise.",
           },
-          backend: { type: "string" },
-          model: { type: "string" },
+          backend: {
+            type: "string",
+            description:
+              "Registered backend override; omitted inherits the caller (Grok: `acp:grok`).",
+          },
+          model: {
+            type: "string",
+            description:
+              "Exact model ID for the selected backend (Grok: `grok-4.5`).",
+          },
           reasoningEffort: { type: "string" },
           serviceTier: { type: "string" },
           fastMode: { type: "boolean" },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1416,62 +1416,6 @@ function normalizeHandoffTaskCwd(cwd: string | undefined): string | undefined {
   return trimmed;
 }
 
-const HANDOFF_TASK_CWD_LABEL_PATTERN =
-  /\b(?:target\s+(?:repository|repo|project)|local\s+repo(?:sitory)?\s+path|repo(?:sitory)?\s+path|project\s+path)\b/i;
-
-function extractPathCandidatesFromHandoffText(text: string): string[] {
-  const candidates: string[] = [];
-  const seen = new Set<string>();
-  const lines = text.split(/\r?\n/);
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] ?? "";
-    const context = [
-      lines[index - 2] ?? "",
-      lines[index - 1] ?? "",
-      line,
-    ].join("\n");
-    if (!HANDOFF_TASK_CWD_LABEL_PATTERN.test(context)) {
-      continue;
-    }
-    for (const match of line.matchAll(/`([^`]+)`|"([^"]+)"|'([^']+)'|((?:~|\/)[^\s`"'),;]+)/g)) {
-      const rawCandidate = (
-        match[1] ??
-        match[2] ??
-        match[3] ??
-        match[4] ??
-        ""
-      ).trim();
-      const candidate = normalizeHandoffTaskCwd(
-        rawCandidate.replace(/[.:\]]+$/g, ""),
-      );
-      if (!candidate || (!path.isAbsolute(candidate) && !candidate.startsWith("~"))) {
-        continue;
-      }
-      if (!seen.has(candidate)) {
-        seen.add(candidate);
-        candidates.push(candidate);
-      }
-    }
-  }
-  return candidates;
-}
-
-async function inferExplicitHandoffTaskCwd(params: {
-  task: string;
-  context?: string;
-}): Promise<string | undefined> {
-  const candidates = extractPathCandidatesFromHandoffText(
-    [params.task, params.context ?? ""].join("\n"),
-  );
-  for (const candidate of candidates) {
-    const info = await stat(candidate).catch(() => undefined);
-    if (info?.isDirectory()) {
-      return candidate;
-    }
-  }
-  return undefined;
-}
-
 function sameResolvedPath(
   left: string | undefined,
   right: string | undefined,
@@ -24607,6 +24551,27 @@ export class DesktopBackendRegistry {
       );
     }
 
+    const requestedModel = request.args.model?.trim();
+    if (requestedModel) {
+      const availableModels = (
+        await this.getBackendLaunchpadOptions(backend, "agent-handoff")
+      )?.models ?? [];
+      if (
+        availableModels.length > 0
+        && !availableModels.some((model) => model.id === requestedModel)
+      ) {
+        const available = availableModels.map((model) => model.id).join(", ");
+        const grokGuidance =
+          /grok/i.test(requestedModel) && backend !== "acp:grok"
+            ? ' To request Grok, pass backend="acp:grok" and an exact discovered model ID such as model="grok-4.5".'
+            : "";
+        return threadOrchestrationFailure(
+          "invalid_arguments",
+          `model="${requestedModel}" is not available for backend="${backend}". Available models: ${available}.${grokGuidance}`,
+        );
+      }
+    }
+
     const sourceOverlay =
       (await this.overlayStore.getThreadOverlayState({
         backend: sourceBackend,
@@ -24628,7 +24593,7 @@ export class DesktopBackendRegistry {
 
     const seedMode: HandoffTaskSeedMode = request.args.seedMode ?? "clean";
     const requestedGroupingMode: HandoffTaskGroupingMode =
-      request.args.groupingMode ?? "none";
+      request.args.groupingMode ?? "subthread";
     const workspaceMode: HandoffTaskWorkspaceMode =
       request.args.workspaceMode === "same"
         ? "same_workspace"
@@ -24685,14 +24650,7 @@ export class DesktopBackendRegistry {
       overlay: sourceOverlay,
       thread: sourceThread,
     });
-    const requestedCwd =
-      normalizeHandoffTaskCwd(request.args.cwd) ??
-      (workspaceMode !== "none"
-        ? await inferExplicitHandoffTaskCwd({
-            task,
-            context: request.args.context,
-          })
-        : undefined);
+    const requestedCwd = normalizeHandoffTaskCwd(request.args.cwd);
     const sourceCwd = requestedCwd ?? callerCwd;
     const sourceLinkedDirectory = this.resolveHandoffLinkedDirectory({
       cwd: sourceCwd,


### PR DESCRIPTION
## Summary

- reject explicit handoff models that are unavailable on the selected backend, with actionable Grok provider guidance
- default same-project handoffs to grouped subthreads and keep cross-project handoffs ungrouped
- make `cwd` the only explicit workspace override so paths mentioned in task/context prose cannot redirect a child into a nested package
- keep dynamic-tool and MCP descriptions, schemas, normalization, and handler behavior on the shared agent-tool path

## Root cause

`handoff_task` inherited the caller backend before validating an explicit model. General model resolution then fell back to a valid model for that backend, while handoff metadata retained the invalid override. The handoff also defaulted omitted grouping to `none` and parsed labeled absolute paths from task/context prose as an implicit `cwd`, which allowed a nested path mention to replace the caller workspace.

## Behavior change

- `model="grok"` on an inherited Codex backend now fails before creating a thread and directs callers to `backend="acp:grok"` plus an exact discovered model such as `grok-4.5`.
- legitimate explicit `backend="acp:grok", model="grok-4.5"` handoffs remain supported.
- omitted grouping now resolves to `subthread` for same-project children; explicit cross-project targets still resolve to ungrouped.
- omitted `cwd` always inherits the invoking workspace as the handoff source. Another project/directory must be selected through the explicit `cwd` argument.

## Validation

- `pnpm test apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts` (513 tests)
- `pnpm test packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts` (9 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (passes; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`
