### PR TITLE
fix(desktop): align ACP scratch workspace launches

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2134,6 +2134,7 @@ function createKimiAcpRegistry(options?: {
   > | null;
   acpAvailableCommandProbeBudgetMs?: number;
   availableCommandsOnSessionStart?: AppServerAvailableCommandSummary[];
+  createScratchProjectDirectory?: () => Promise<string>;
   startSession?: KimiStartSession;
 }) {
   const acpBackendId =
@@ -2231,6 +2232,9 @@ function createKimiAcpRegistry(options?: {
       : {}),
     acpAvailableCommandsStore: options?.acpAvailableCommandsStore,
     acpAvailableCommandProbeBudgetMs: options?.acpAvailableCommandProbeBudgetMs,
+    createScratchProjectDirectory:
+      options?.createScratchProjectDirectory
+      ?? (async () => "/Users/test/.pwragent/projects/acp-scratch"),
   });
   return {
     acpBackendId,
@@ -12212,6 +12216,32 @@ command = "pnpm grok"
       "create_monitor_delegation",
       "cancel_monitor_delegation",
     ]);
+
+    await registry.close();
+  });
+
+  it("creates a scratch workspace for ACP thread creation when cwd is omitted", async () => {
+    const scratchPath =
+      "/Users/test/.pwragent/projects/2026-08-10-a1b2c3";
+    const { acpBackendId, acpClient, registry } = createKimiAcpRegistry({
+      createScratchProjectDirectory: async () => scratchPath,
+    });
+
+    const response = await registry.startThread({
+      backend: acpBackendId,
+    });
+
+    expect(response).toEqual({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      executionMode: "default",
+    });
+    expect(acpClient.startSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: scratchPath,
+        executionMode: "default",
+      }),
+    );
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10653,8 +10653,8 @@ export class DesktopBackendRegistry {
       ...request
     } = params;
     const modelSettings = await this.resolveModelSettings(backend, request);
-    let cwd =
-      backend === "codex" && !request.cwd?.trim()
+    let cwd: string | undefined =
+      !request.cwd?.trim()
         ? await this.createScratchProjectDirectory()
         : request.cwd;
     let resolvedLinkedDirectories = linkedDirectories;


### PR DESCRIPTION
## Summary

- allocate profile scratch workspaces for ACP threads when no CWD is supplied
- preserve the existing Codex behavior at the shared thread-launch boundary
- add regression coverage proving ACP receives the generated scratch path
- keep ACP test fixtures from touching the operator's real profile

## Root cause

`DesktopBackendRegistry.startThread` created a scratch workspace only for the Codex backend. An unscoped ACP handoff therefore passed `cwd: undefined` to the ACP client, whose protocol fallback used the Electron process CWD. In development that was `apps/desktop`, so Grok threads appeared under an accidental `desktop` project instead of the synthetic Workspaces group.

## Impact

Unscoped ACP and Codex launches now have matching semantics: both receive a generated directory under the active profile's projects root and therefore appear under Workspaces.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` — 499 passed
- focused ACP/Codex scratch-workspace and cross-provider handoff tests — 3 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; existing warning baseline only
- `pnpm lint:boundaries`
