### PR TITLE
feat(desktop): capture Codex account usage

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -306,6 +306,25 @@ Two things to know before running it:
   are rewritten, but an agent can echo anything it read into a transcript.
   Read a capture before committing it as a fixture.
 
+## Capturing Codex Account Protocol
+
+`scripts/capture-codex-usage-protocol.ts` records a complete Codex App Server
+probe without reading Codex-owned storage. It reads account, rate-limit, and
+account-wide usage state; runs one isolated ephemeral structured turn with
+profile tools, hooks, apps, skills, and MCP servers disabled; and reads the
+same state again:
+
+```bash
+pnpm --filter @pwragent/desktop capture:codex-usage -- \
+  --codex-home /path/to/codex-profile \
+  --capture-root .local/protocol-captures
+```
+
+Use this when an account type appears to expose incomplete quota or usage
+information. The JSONL output contains every protocol frame and can include
+account identity, local paths, prompts, and model output. Keep captures under
+`.local/`, which is gitignored; never commit a raw account capture.
+
 ## Accessibility
 
 The renderer is audited against WCAG 2.0 / 2.1 / 2.2 Level AA via

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,6 +15,7 @@
     "analyze:protocol-capture": "tsx ./scripts/analyze-protocol-capture.ts",
     "analyze:startup-cpu-profile": "tsx ./scripts/analyze-startup-cpu-profile.ts",
     "build": "electron-vite build",
+    "capture:codex-usage": "tsx ./scripts/capture-codex-usage-protocol.ts",
     "postbuild": "node ./scripts/check-main-bundle-boundary.mjs",
     "dev": "node ./scripts/dev.mjs --",
     "dev:dev": "node ./scripts/dev.mjs -- --profile dev",

--- a/apps/desktop/scripts/capture-codex-usage-protocol.ts
+++ b/apps/desktop/scripts/capture-codex-usage-protocol.ts
@@ -1,0 +1,247 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type {
+  BackendAccountSummary,
+  BackendRateLimitSummary,
+} from "@pwragent/shared";
+import { CodexAppServerClient } from "../src/main/codex-app-server/client";
+import { ProtocolCaptureStore } from "../src/main/testing/capture-store";
+import { createProtocolCaptureObserver } from "../src/main/testing/protocol-capture";
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_PROMPT =
+  "Return a JSON object whose status is exactly: usage capture complete.";
+const PROBE_RESPONSE_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["status"],
+  properties: {
+    status: {
+      type: "string",
+      const: "usage capture complete",
+    },
+  },
+} as const;
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  const captureRoot = path.resolve(
+    optionalString(args["capture-root"])
+      ?? path.join(process.cwd(), ".local", "protocol-captures"),
+  );
+  const timeoutMs = optionalPositiveInteger(args["timeout-ms"]) ?? DEFAULT_TIMEOUT_MS;
+  const prompt = optionalString(args.prompt) ?? DEFAULT_PROMPT;
+  const codexHome = optionalString(args["codex-home"]);
+  const captureId = [
+    new Date().toISOString().replace(/[:.]/g, "-"),
+    "codex-usage-probe",
+  ].join("-");
+  const store = new ProtocolCaptureStore({
+    backend: "codex",
+    backendInstance: "usage-probe",
+    captureId,
+    rootDir: captureRoot,
+  });
+  const client = new CodexAppServerClient({
+    command: optionalString(args.command) ?? "codex",
+    connectionObserver: createProtocolCaptureObserver({
+      backend: "codex",
+      store,
+    }),
+    env: codexHome
+      ? {
+          ...process.env,
+          CODEX_HOME: path.resolve(codexHome),
+        }
+      : process.env,
+    requestTimeoutMs: timeoutMs,
+  });
+
+  client.onRequest(() => ({ decision: "decline" }));
+
+  let accountBefore: BackendAccountSummary | undefined;
+  let rateLimitsBefore: BackendRateLimitSummary[] = [];
+  let accountAfter: BackendAccountSummary | undefined;
+  let rateLimitsAfter: BackendRateLimitSummary[] = [];
+  let accountUsageBefore: unknown;
+  let accountUsageAfter: unknown;
+  let probe: Awaited<ReturnType<CodexAppServerClient["generateStructuredObject"]>> | undefined;
+
+  try {
+    accountBefore = await client.readAccount();
+    rateLimitsBefore = await client.readRateLimits();
+    accountUsageBefore = await readOptionalAccountUsage(client);
+    probe = await client.generateStructuredObject({
+      prompt,
+      schema: PROBE_RESPONSE_SCHEMA,
+      isMatch: (record) => record.status === "usage capture complete",
+      timeoutMs,
+    });
+    accountAfter = await client.readAccount();
+    rateLimitsAfter = await client.readRateLimits();
+    accountUsageAfter = await readOptionalAccountUsage(client);
+  } finally {
+    await client.close().catch(() => undefined);
+    await store.close();
+  }
+
+  const captureStats = await fs.stat(store.captureFilePath);
+  const summary = {
+    capturePath: store.captureFilePath,
+    captureBytes: captureStats.size,
+    probe,
+    accountBefore: summarizeAccount(accountBefore),
+    rateLimitsBefore,
+    accountUsageBefore: summarizeAccountUsage(accountUsageBefore),
+    accountAfter: summarizeAccount(accountAfter),
+    rateLimitsAfter,
+    accountUsageAfter: summarizeAccountUsage(accountUsageAfter),
+  };
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+}
+
+async function readOptionalAccountUsage(
+  client: CodexAppServerClient,
+): Promise<unknown> {
+  try {
+    return await client.readAccountUsage();
+  } catch (error) {
+    return {
+      unavailable: true,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function summarizeAccountUsage(value: unknown): Record<string, unknown> {
+  const root = asRecord(value);
+  const summary = asRecord(root?.summary);
+  const dailyUsageBuckets = Array.isArray(root?.dailyUsageBuckets)
+    ? root.dailyUsageBuckets
+    : undefined;
+  if (root?.unavailable === true) {
+    return {
+      available: false,
+      error: readString(root.error),
+    };
+  }
+  return {
+    available: Boolean(root),
+    responseKeys: root ? Object.keys(root).sort() : [],
+    summary: summary
+      ? {
+          lifetimeTokens: readFiniteNumber(summary.lifetimeTokens),
+          peakDailyTokens: readFiniteNumber(summary.peakDailyTokens),
+          longestRunningTurnSec: readFiniteNumber(summary.longestRunningTurnSec),
+          currentStreakDays: readFiniteNumber(summary.currentStreakDays),
+          longestStreakDays: readFiniteNumber(summary.longestStreakDays),
+        }
+      : undefined,
+    dailyUsageBucketCount: dailyUsageBuckets?.length,
+  };
+}
+
+function summarizeAccount(account: BackendAccountSummary | undefined): {
+  type?: BackendAccountSummary["type"];
+  planType?: string;
+  requiresOpenaiAuth?: boolean;
+  emailPresent: boolean;
+} {
+  return {
+    type: account?.type,
+    planType: account?.planType,
+    requiresOpenaiAuth: account?.requiresOpenaiAuth,
+    emailPresent: Boolean(account?.email),
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+type ParsedArgs = Record<string, string[]>;
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      parsed[key] = ["true"];
+      continue;
+    }
+
+    parsed[key] ??= [];
+    parsed[key].push(next);
+    index += 1;
+  }
+  return parsed;
+}
+
+function optionalString(values: string[] | undefined): string | undefined {
+  const value = values?.at(-1)?.trim();
+  return value ? value : undefined;
+}
+
+function optionalPositiveInteger(values: string[] | undefined): number | undefined {
+  const value = optionalString(values);
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`Expected a positive integer, got: ${value}`);
+  }
+  return parsed;
+}
+
+function printUsage(): void {
+  const exampleRoot = path.join(".local", "protocol-captures");
+  console.log(`Usage:
+  pnpm --filter @pwragent/desktop capture:codex-usage -- \\
+    --codex-home /path/to/codex-profile \\
+    --capture-root ${exampleRoot}
+
+The harness records every Codex App Server JSON-RPC frame while it:
+  1. reads account, rate-limit, and usage state,
+  2. starts one isolated ephemeral helper thread with profile capabilities disabled,
+  3. runs one structured no-tools turn, and
+  4. reads account, rate-limit, and usage state again.
+
+Options:
+  --codex-home <path>   Override CODEX_HOME for the app-server process.
+  --capture-root <path> Output directory (default: ${exampleRoot}).
+  --prompt <text>       Override the isolated probe prompt.
+  --command <path>      Codex CLI command (default: codex).
+  --timeout-ms <ms>     Request and turn timeout (default: ${DEFAULT_TIMEOUT_MS}).
+  --help                Show this help.
+
+Captures can contain account identity, paths, prompts, and model output. Keep
+them under .local/ (gitignored), inspect them before sharing, and never commit
+raw captures.`);
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -145,6 +145,10 @@ class MockTransport implements JsonRpcTransport {
   static rateLimitsResult: unknown = {
     rateLimitsByLimitId: {}
   };
+  static accountUsageResult: unknown = {
+    summary: {},
+    dailyUsageBuckets: [],
+  };
   static unfilteredThreadListResult: unknown[] | undefined;
   static threadListResultBySearchTerm = new Map<string, unknown[]>();
   static turnInterruptResponseMode: "success" | "timeout" = "success";
@@ -710,6 +714,17 @@ class MockTransport implements JsonRpcTransport {
       return;
     }
 
+    if (payload.method === "account/usage/read") {
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: MockTransport.accountUsageResult,
+        }),
+      );
+      return;
+    }
+
     if (payload.method === "thread/read") {
       const threadId = (JSON.parse(message) as { params?: { threadId?: string } }).params?.threadId;
       const readThreadError = threadId
@@ -1176,6 +1191,10 @@ describe("CodexAppServerClient", () => {
     MockTransport.lastConfigValueWritePayload = undefined;
     MockTransport.rateLimitsResult = {
       rateLimitsByLimitId: {}
+    };
+    MockTransport.accountUsageResult = {
+      summary: {},
+      dailyUsageBuckets: [],
     };
     MockTransport.unfilteredThreadListResult = undefined;
     MockTransport.threadListResultBySearchTerm.clear();
@@ -2136,6 +2155,49 @@ describe("CodexAppServerClient", () => {
         windowMinutes: 10_080,
       },
     ]);
+  });
+
+  it("normalizes an individual account limit with numeric string totals", async () => {
+    MockTransport.rateLimitsResult = {
+      rateLimits: {
+        limitId: "codex",
+        primary: null,
+        secondary: null,
+        individualLimit: {
+          limit: "100000",
+          used: "3500.4",
+          remainingPercent: 96,
+          resetsAt: 1_800_000_000,
+        },
+      },
+    };
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({ command: "codex" });
+
+    await expect(client.readRateLimits()).resolves.toEqual([
+      {
+        name: "Individual limit",
+        limitId: "codex",
+        limit: 100000,
+        used: 3500.4,
+        remaining: 96499.6,
+        usedPercent: 4,
+        resetAt: 1_800_000_000_000,
+      },
+    ]);
+  });
+
+  it("reads account-wide token usage through the app-server protocol", async () => {
+    MockTransport.accountUsageResult = {
+      summary: { lifetimeTokens: 1234 },
+      dailyUsageBuckets: [{ startDate: "2026-08-01", tokens: 1234 }],
+    };
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({ command: "codex" });
+
+    await expect(client.readAccountUsage()).resolves.toEqual(
+      MockTransport.accountUsageResult,
+    );
   });
 
   it("uses query payloads when filtering the codex thread list", async () => {
@@ -7934,7 +7996,36 @@ describe("CodexAppServerClient", () => {
         method: "thread/start",
         params: expect.objectContaining({
           baseInstructions: "Keep behavioral and uncertain changes visible.",
+          environments: [],
           model: "gpt-5.6-luna",
+          runtimeWorkspaceRoots: [
+            path.join(os.tmpdir(), "pwragent", "codex-title-helper"),
+          ],
+          config: expect.objectContaining({
+            include_apps_instructions: false,
+            include_environment_context: false,
+            project_doc_max_bytes: 0,
+            features: expect.objectContaining({
+              apps: false,
+              hooks: false,
+              plugins: false,
+              tool_suggest: false,
+            }),
+            hooks: expect.objectContaining({
+              PreToolUse: [],
+              SessionStart: [],
+              Stop: [],
+              UserPromptSubmit: [],
+            }),
+            mcp_servers: {
+              context7: { enabled: false },
+              github: { enabled: false },
+            },
+            orchestrator: {
+              mcp: { enabled: false },
+              skills: { enabled: false },
+            },
+          }),
         }),
       }),
     );
@@ -7953,6 +8044,55 @@ describe("CodexAppServerClient", () => {
         }),
       }),
     );
+
+    await client.close();
+  });
+
+  it("returns a structured helper failure as soon as Codex reports it", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadStartResult = {
+      thread: { id: "structured-helper" },
+      instructionSources: [],
+    };
+    MockTransport.turnStartResult = {
+      turn: { id: "structured-turn" },
+    };
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+    const probePromise = client.generateStructuredObject({
+      prompt: "Return the requested status object.",
+      schema: {
+        type: "object",
+        required: ["status"],
+        properties: { status: { type: "string" } },
+      },
+      isMatch: (record) => record.status === "complete",
+      timeoutMs: 5_000,
+    });
+    const transport = await waitForLatestTransportRequest("turn/start");
+
+    transport.emitInbound({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: {
+        threadId: "structured-helper",
+        turn: {
+          id: "structured-turn",
+          status: "failed",
+          error: { message: "probe failed" },
+        },
+      },
+    });
+
+    await expect(probePromise).resolves.toEqual({
+      status: "failed",
+      reason: "codex_title_turn_failed",
+    });
+    expect(transport.sentMessages.map(
+      (message) => (JSON.parse(message) as { method?: string }).method,
+    )).toContain("thread/unsubscribe");
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -436,6 +436,12 @@ describe("buildBindingStatusIntent", () => {
             usedPercent: 27,
             resetAt: new Date(2026, 5, 10, 0, 0, 0).getTime(),
           },
+          {
+            name: "Individual limit",
+            limit: 100000,
+            used: 3500.4,
+            usedPercent: 4,
+          },
         ],
       },
       createdAt: 1000,
@@ -444,7 +450,7 @@ describe("buildBindingStatusIntent", () => {
     });
 
     expect(intent.text).toContain(
-      "Rate limits: 5h limit: 95% left, resets 6:02 PM; Weekly limit: 73% left, resets Jun 10; Spark 5h limit: 100% left, resets 7:20 PM; Spark Weekly limit: 100% left, resets Jun 12",
+      "Rate limits: 5h limit: 95% left, resets 6:02 PM; Weekly limit: 73% left, resets Jun 10; Individual limit: 3,500/100,000 used, 96% left; Spark 5h limit: 100% left, resets 7:20 PM; Spark Weekly limit: 100% left, resets Jun 12",
     );
     expect(intent.text).not.toContain("GPT-5.3-Codex-Spark");
     expect(intent.text).not.toContain("95 remaining");

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -906,6 +906,25 @@ function pickFiniteNumber(
   return undefined;
 }
 
+function pickFiniteNumericValue(
+  record: Record<string, unknown>,
+  keys: string[],
+): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string" && value.trim()) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return undefined;
+}
+
 function pickBoolean(
   record: Record<string, unknown>,
   keys: string[]
@@ -1313,6 +1332,45 @@ function extractRateLimitSummaries(value: unknown): BackendRateLimitSummary[] {
       windowMinutes,
     });
   };
+  const addIndividualLimit = (
+    limitValue: unknown,
+    params: { limitId?: string; limitName?: string },
+  ): void => {
+    const individualLimit = asRecord(limitValue);
+    if (!individualLimit) {
+      return;
+    }
+    const limit = pickFiniteNumericValue(individualLimit, ["limit", "max", "capacity"]);
+    const used = pickFiniteNumericValue(individualLimit, ["used", "consumed"]);
+    const remainingPercent = pickFiniteNumericValue(individualLimit, [
+      "remainingPercent",
+      "remaining_percent",
+    ]);
+    const usedPercent = typeof remainingPercent === "number"
+      ? Math.max(0, Math.min(100, 100 - remainingPercent))
+      : typeof used === "number" && typeof limit === "number" && limit > 0
+        ? Math.max(0, Math.min(100, (used / limit) * 100))
+        : undefined;
+    const rawId = params.limitId?.trim();
+    const rawName = params.limitName?.trim();
+    const name = !rawId || rawId.toLowerCase() === "codex"
+      ? "Individual limit"
+      : `${rawName ?? rawId} Individual limit`;
+    out.set(name, {
+      name,
+      limitId: params.limitId,
+      limit,
+      used,
+      remaining:
+        typeof limit === "number" && typeof used === "number"
+          ? Math.max(0, limit - used)
+          : undefined,
+      usedPercent,
+      resetAt: normalizeEpochTimestamp(
+        pickNumber(individualLimit, ["resetsAt", "resets_at", "resetAt", "reset_at"]),
+      ),
+    });
+  };
   const visit = (node: unknown): void => {
     if (Array.isArray(node)) {
       node.forEach((entry) => visit(entry));
@@ -1327,6 +1385,10 @@ function extractRateLimitSummaries(value: unknown): BackendRateLimitSummary[] {
       const limitName = pickString(record, ["limitName", "limit_name", "name", "label"]);
       addWindow(record.primary, { limitId, limitName, windowKey: "primary" });
       addWindow(record.secondary, { limitId, limitName, windowKey: "secondary" });
+      addIndividualLimit(record.individualLimit ?? record.individual_limit, {
+        limitId,
+        limitName,
+      });
     }
     const byLimitId = asRecord(record.rateLimitsByLimitId ?? record.rate_limits_by_limit_id);
     if (byLimitId) {
@@ -1338,6 +1400,10 @@ function extractRateLimitSummaries(value: unknown): BackendRateLimitSummary[] {
         const limitName = pickString(snapshotRecord, ["limitName", "limit_name", "name", "label"]);
         addWindow(snapshotRecord.primary, { limitId, limitName, windowKey: "primary" });
         addWindow(snapshotRecord.secondary, { limitId, limitName, windowKey: "secondary" });
+        addIndividualLimit(
+          snapshotRecord.individualLimit ?? snapshotRecord.individual_limit,
+          { limitId, limitName },
+        );
       }
     }
     const remaining = pickFiniteNumber(record, [
@@ -7586,6 +7652,17 @@ export class CodexAppServerClient {
     });
 
     return extractRateLimitSummaries(result);
+  }
+
+  async readAccountUsage(): Promise<unknown> {
+    await this.ensureInitialized();
+
+    return await requestWithFallbacks({
+      client: this.connection,
+      methods: ["account/usage/read"],
+      payloads: [{}],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
   }
 
   async readThread(params: {

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -410,6 +410,22 @@ function formatBackendRateLimit(
   const resetText = formatRateLimitReset(rateLimit.resetAt);
   const suffix = resetText ? `, resets ${resetText}` : "";
 
+  if (
+    label === "Individual limit"
+    && rateLimit.used !== undefined
+    && rateLimit.limit !== undefined
+  ) {
+    const remainingPercent = rateLimit.usedPercent !== undefined
+      ? Math.max(0, Math.round(100 - rateLimit.usedPercent))
+      : Math.max(
+          0,
+          Math.round(((rateLimit.limit - rateLimit.used) / rateLimit.limit) * 100),
+        );
+    return `${displayLabel}: ${formatWholeNumber(
+      rateLimit.used,
+    )}/${formatWholeNumber(rateLimit.limit)} used, ${remainingPercent}% left${suffix}`;
+  }
+
   if (rateLimit.usedPercent !== undefined) {
     return `${displayLabel}: ${Math.max(
       0,
@@ -451,6 +467,9 @@ function splitRateLimitName(name: string): {
   }
   if (lower.endsWith("weekly limit")) {
     return { label: "Weekly limit", labelOrder: 1 };
+  }
+  if (lower.endsWith("individual limit")) {
+    return { label: "Individual limit", labelOrder: 2 };
   }
   return { label: trimmed, labelOrder: 99 };
 }

--- a/apps/desktop/src/renderer/src/lib/__tests__/backend-status-format.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/backend-status-format.test.ts
@@ -18,6 +18,7 @@ describe("backend status formatting", () => {
         { name: "Weekly limit", usedPercent: 39 },
         { name: "GPT-5.3-Codex-Spark 5h limit", usedPercent: 2 },
         { name: "5h limit", usedPercent: 26 },
+        { name: "Individual limit", usedPercent: 4 },
         { name: "other limit", usedPercent: 50 },
       ],
     };
@@ -25,6 +26,7 @@ describe("backend status formatting", () => {
     expect(selectVisibleRateLimits(backend).map((limit) => limit.name)).toEqual([
       "5h limit",
       "Weekly limit",
+      "Individual limit",
       "GPT-5.3-Codex-Spark 5h limit",
       "GPT-5.3-Codex-Spark Weekly limit",
     ]);
@@ -69,5 +71,16 @@ describe("backend status formatting", () => {
         resetAt: new Date(2026, 4, 18, 0, 0, 0).getTime(),
       }),
     ).toContain("resets May 18");
+  });
+
+  it("formats individual usage with totals and remaining percentage", () => {
+    expect(
+      formatRateLimitLine({
+        name: "Individual limit",
+        limit: 100000,
+        used: 3500.4,
+        usedPercent: 4,
+      }),
+    ).toBe("Individual limit: 3,500/100,000 used, 96% left");
   });
 });

--- a/apps/desktop/src/renderer/src/lib/backend-status-format.ts
+++ b/apps/desktop/src/renderer/src/lib/backend-status-format.ts
@@ -35,7 +35,9 @@ export function selectVisibleRateLimits(
         return true;
       }
       const { label } = splitRateLimitName(limit.name);
-      return label === "5h limit" || label === "Weekly limit";
+      return label === "5h limit"
+        || label === "Weekly limit"
+        || label === "Individual limit";
     })
     .sort((left, right) => {
       const leftName = splitRateLimitName(left.name);
@@ -57,6 +59,18 @@ export function formatRateLimitLine(limit: BackendRateLimitSummary): string {
   const displayLabel = isSparkRateLimit(limit) ? `Spark ${label}` : label;
   const resetText = formatRateLimitReset(limit.resetAt);
   const suffix = resetText ? `, resets ${resetText}` : "";
+  if (
+    label === "Individual limit"
+    && typeof limit.used === "number"
+    && typeof limit.limit === "number"
+  ) {
+    const remainingPercent = typeof limit.usedPercent === "number"
+      ? Math.max(0, Math.round(100 - limit.usedPercent))
+      : Math.max(0, Math.round(((limit.limit - limit.used) / limit.limit) * 100));
+    return `${displayLabel}: ${formatWholeNumber(limit.used)}/${formatWholeNumber(
+      limit.limit,
+    )} used, ${remainingPercent}% left${suffix}`;
+  }
   if (typeof limit.usedPercent === "number") {
     const remaining = Math.max(0, Math.round(100 - limit.usedPercent));
     return `${displayLabel}: ${remaining}% left${suffix}`;
@@ -85,7 +99,14 @@ function splitRateLimitName(name: string): {
   if (lower.endsWith("weekly limit")) {
     return { label: "Weekly limit", labelOrder: 1 };
   }
+  if (lower.endsWith("individual limit")) {
+    return { label: "Individual limit", labelOrder: 2 };
+  }
   return { label: trimmed, labelOrder: 99 };
+}
+
+function formatWholeNumber(value: number): string {
+  return Math.round(value).toLocaleString();
 }
 
 function isSparkRateLimit(limit: BackendRateLimitSummary): boolean {


### PR DESCRIPTION
## Summary

- add a reusable Codex App Server harness that captures account, rate-limit, account-wide usage, and one isolated ephemeral probe turn
- run the probe through the existing no-capability helper path so inherited hooks, apps, plugins, skills, environments, and MCP tools are disabled
- record normalized failed turns immediately and continue with the post-probe account reads
- normalize the alternate `individualLimit` quota shape, including numeric-string totals
- show individual usage totals, remaining percentage, and reset information in desktop and messaging status surfaces
- document that raw account captures belong under gitignored `.local/` storage and must never be committed

## Root cause

PwrAgent normalized the standard primary and secondary rate-limit windows, but ignored the app-server's alternate individual-limit shape. Accounts that report only that shape therefore appeared to have no quota information.

The first capture harness also listened only for successful normalized turn completion and relied on prompt instructions for tool avoidance. It now delegates to the existing isolated structured-helper path, which handles normalized turn failures promptly and applies the full no-capability configuration.

## Validation

- 178 focused Vitest tests passed
- desktop TypeScript check passed
- ESLint passed with no errors
- dependency-boundary lint passed
- Codex-storage boundary lint passed
- CLI help smoke test passed
- privacy scan confirmed no account identifiers are present in the diff

Raw protocol captures were not committed.
