### PR TITLE
feat(desktop): add protocol capture controls

### DIFF
--- a/apps/desktop/src/main/__tests__/diagnostics-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/diagnostics-ipc.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const handlers = new Map<string, (...args: unknown[]) => unknown>();
+const registry = vi.hoisted(() => ({
+  getCodexProtocolCaptureStatus: vi.fn(),
+  startCodexProtocolCapture: vi.fn(),
+  stopCodexProtocolCapture: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    }),
+    removeHandler: vi.fn((channel: string) => {
+      handlers.delete(channel);
+    }),
+  },
+}));
+
+vi.mock("../app-server/backend-registry", () => ({
+  getDesktopBackendRegistry: () => registry,
+}));
+
+vi.mock("../diagnostics/manual-heap-snapshot", () => ({
+  captureHeapSnapshot: vi.fn(),
+}));
+
+vi.mock("../profile", () => ({
+  resolveActiveProfilePath: vi.fn(() => "/diagnostics"),
+}));
+
+vi.mock("../window-channels", () => ({
+  subscribersForChannel: vi.fn(() => []),
+}));
+
+describe("diagnostics ipc", () => {
+  beforeEach(() => {
+    handlers.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    const { disposeDiagnosticsIpcHandlers } = await import("../ipc/diagnostics");
+    disposeDiagnosticsIpcHandlers();
+  });
+
+  it("routes Codex protocol capture status, start, and stop", async () => {
+    const status = { active: false as const, available: true };
+    const active = {
+      active: true as const,
+      available: true as const,
+      captureFilePath: "/diagnostics/protocol-captures/snippet.jsonl",
+      startedAt: "2026-08-10T12:00:00.000Z",
+    };
+    const result = {
+      captureFilePath: active.captureFilePath,
+      sizeBytes: 1536,
+      startedAt: active.startedAt,
+      stoppedAt: "2026-08-10T12:00:05.000Z",
+    };
+    registry.getCodexProtocolCaptureStatus.mockReturnValue(status);
+    registry.startCodexProtocolCapture.mockResolvedValue(active);
+    registry.stopCodexProtocolCapture.mockResolvedValue(result);
+
+    const { registerDiagnosticsIpcHandlers } = await import("../ipc/diagnostics");
+    const {
+      DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL,
+      DIAGNOSTICS_START_CODEX_PROTOCOL_CAPTURE_CHANNEL,
+      DIAGNOSTICS_STOP_CODEX_PROTOCOL_CAPTURE_CHANNEL,
+    } = await import("../../shared/ipc");
+    registerDiagnosticsIpcHandlers();
+
+    expect(
+      handlers.get(DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL)?.({}),
+    ).toEqual(status);
+    await expect(
+      handlers.get(DIAGNOSTICS_START_CODEX_PROTOCOL_CAPTURE_CHANNEL)?.({}),
+    ).resolves.toEqual(active);
+    await expect(
+      handlers.get(DIAGNOSTICS_STOP_CODEX_PROTOCOL_CAPTURE_CHANNEL)?.({}),
+    ).resolves.toEqual(result);
+  });
+});

--- a/apps/desktop/src/main/__tests__/protocol-capture.test.ts
+++ b/apps/desktop/src/main/__tests__/protocol-capture.test.ts
@@ -99,6 +99,37 @@ describe("ProtocolCaptureStore", () => {
     expect(index["capture-1"]?.threadIds).toEqual(["thread-1"]);
   });
 
+  it("restricts the capture directory and files to the current user", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const containerDir = await createTempDir();
+    cleanupPaths.push(containerDir);
+    const rootDir = path.join(containerDir, "captures");
+    await fs.mkdir(rootDir, { mode: 0o755 });
+    await fs.chmod(rootDir, 0o755);
+    const store = new ProtocolCaptureStore({
+      backend: "codex",
+      captureId: "private-capture",
+      rootDir,
+    });
+
+    await store.append({
+      direction: "outbound",
+      raw: '{"jsonrpc":"2.0","id":"rpc-1","method":"thread/list","params":{}}',
+      envelope: {
+        id: "rpc-1",
+        method: "thread/list",
+        params: {},
+      },
+    });
+    await store.close();
+
+    expect((await fs.stat(rootDir)).mode & 0o777).toBe(0o700);
+    expect((await fs.stat(store.captureFilePath)).mode & 0o777).toBe(0o600);
+    expect((await fs.stat(store.indexFilePath)).mode & 0o777).toBe(0o600);
+  });
+
   it("captures optional diagnostics without changing the raw JSON-RPC envelope", async () => {
     const rootDir = await createTempDir();
     cleanupPaths.push(rootDir);
@@ -197,6 +228,47 @@ describe("ProtocolCaptureStore", () => {
     await expect(
       fs.readFile(path.join(rootDir, "diagnostic-snippet.jsonl"), "utf8"),
     ).resolves.toBe(captureContents);
+  });
+
+  it("returns a partial handoff when capture finalization fails", async () => {
+    const rootDir = await createTempDir();
+    cleanupPaths.push(rootDir);
+    let now = Date.parse("2026-08-10T12:00:00.000Z");
+    const captureFilePath = path.join(rootDir, "partial-snippet.jsonl");
+    const session = new CodexProtocolCaptureSession({
+      createCaptureId: () => "partial-snippet",
+      now: () => now,
+      rootDir,
+    });
+    await session.start();
+    await fs.rm(rootDir, { recursive: true, force: true });
+    await expect(
+      session.observer.onMessage({
+        direction: "outbound",
+        raw: '{"jsonrpc":"2.0","id":"rpc-1","method":"thread/read","params":{"threadId":"thread-1"}}',
+        envelope: {
+          id: "rpc-1",
+          method: "thread/read",
+          params: { threadId: "thread-1" },
+        },
+      }),
+    ).rejects.toThrow();
+
+    now += 5_000;
+    const result = await session.stop();
+    expect(result).toMatchObject({
+      captureFilePath,
+      finalizationError: expect.stringContaining(
+        "Capture writes did not finish",
+      ),
+      startedAt: "2026-08-10T12:00:00.000Z",
+      stoppedAt: "2026-08-10T12:00:05.000Z",
+    });
+    expect(result?.finalizationError).toContain(
+      "Capture size could not be read",
+    );
+    expect(result?.sizeBytes).toBeUndefined();
+    expect(session.getStatus()).toEqual({ active: false, available: true });
   });
 
   it("creates an env-backed capture session only when recording is enabled", async () => {

--- a/apps/desktop/src/main/__tests__/protocol-capture.test.ts
+++ b/apps/desktop/src/main/__tests__/protocol-capture.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { ProtocolCaptureStore, readProtocolCaptureFile } from "../testing/capture-store";
 import { analyzeProtocolCaptureTraffic } from "../testing/protocol-capture-analysis";
 import { createProtocolCaptureObserver, createProtocolCaptureFromEnv } from "../testing/protocol-capture";
+import { CodexProtocolCaptureSession } from "../diagnostics/codex-protocol-capture";
 
 async function createTempDir(): Promise<string> {
   return await fs.mkdtemp(path.join(os.tmpdir(), "pwragent-protocol-capture-"));
@@ -139,6 +140,63 @@ describe("ProtocolCaptureStore", () => {
       },
       raw: '{"jsonrpc":"2.0","id":"rpc-1","method":"model/list","params":{}}',
     });
+  });
+
+  it("starts and stops a session-local Codex diagnostic capture", async () => {
+    const rootDir = await createTempDir();
+    cleanupPaths.push(rootDir);
+    let now = Date.parse("2026-08-10T12:00:00.000Z");
+    const session = new CodexProtocolCaptureSession({
+      createCaptureId: () => "diagnostic-snippet",
+      now: () => now,
+      rootDir,
+    });
+
+    expect(session.getStatus()).toEqual({ active: false, available: true });
+    await expect(session.start()).resolves.toMatchObject({
+      active: true,
+      available: true,
+      captureFilePath: path.join(rootDir, "diagnostic-snippet.jsonl"),
+    });
+
+    await session.observer.onMessage({
+      direction: "outbound",
+      raw: '{"jsonrpc":"2.0","id":"rpc-1","method":"thread/read","params":{"threadId":"thread-1"}}',
+      envelope: {
+        jsonrpc: "2.0",
+        id: "rpc-1",
+        method: "thread/read",
+        params: { threadId: "thread-1" },
+      },
+    });
+
+    now += 5_000;
+    const result = await session.stop();
+    const captureContents = await fs.readFile(
+      path.join(rootDir, "diagnostic-snippet.jsonl"),
+      "utf8",
+    );
+    expect(result).toEqual({
+      captureFilePath: path.join(rootDir, "diagnostic-snippet.jsonl"),
+      sizeBytes: Buffer.byteLength(captureContents),
+      startedAt: "2026-08-10T12:00:00.000Z",
+      stoppedAt: "2026-08-10T12:00:05.000Z",
+    });
+    expect(captureContents).toContain('"method":"thread/read"');
+    expect(session.getStatus()).toEqual({ active: false, available: true });
+
+    await session.observer.onMessage({
+      direction: "inbound",
+      raw: '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thread-1"}}',
+      envelope: {
+        jsonrpc: "2.0",
+        method: "turn/started",
+        params: { threadId: "thread-1" },
+      },
+    });
+    await expect(
+      fs.readFile(path.join(rootDir, "diagnostic-snippet.jsonl"), "utf8"),
+    ).resolves.toBe(captureContents);
   });
 
   it("creates an env-backed capture session only when recording is enabled", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -16,6 +16,10 @@ import type {
   MessagingApprovalDecision,
   MessagingBindingRecord,
 } from "@pwragent/messaging-interface";
+import type {
+  CodexProtocolCaptureResult,
+  CodexProtocolCaptureStatus,
+} from "../../shared/codex-protocol-capture";
 import { formatReviewCommand } from "../../shared/review-command";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import {
@@ -384,6 +388,7 @@ import {
   type ResolvedAgentToolMcpCallContext,
 } from "../agent-tools/agent-tool-mcp-server";
 import { createScratchProjectDirectory } from "./scratch-projects";
+import { CodexProtocolCaptureSession } from "../diagnostics/codex-protocol-capture";
 import { getDesktopOverlayStore } from "./desktop-overlay-store";
 import { createProtocolCaptureFromEnv } from "../testing/protocol-capture";
 import type { ProtocolCaptureStore } from "../testing/capture-store";
@@ -6387,6 +6392,7 @@ export class DesktopBackendRegistry {
     PendingThreadWorkspaceMoveSummary
   >();
   private readonly pendingReviewStarts = new Map<string, PendingReviewStartRecord>();
+  private readonly codexProtocolCaptureSession?: CodexProtocolCaptureSession;
   private readonly captureStores: ProtocolCaptureStore[] = [];
   private readonly eventListeners = new Set<
     (event: AgentEvent) => void | Promise<void>
@@ -6780,6 +6786,11 @@ export class DesktopBackendRegistry {
         : options?.mcpConnectionService ??
           (isAppStateInitialized() ? getPwrSnapConnectionService() : undefined);
     const replayClients = createReplayClientsFromEnv();
+    const createsLiveCodexClient =
+      !options?.codexClient && !replayClients?.codexClient;
+    this.codexProtocolCaptureSession = createsLiveCodexClient
+      ? new CodexProtocolCaptureSession()
+      : undefined;
     const codexCapture = options?.codexClient
       || replayClients
       ? undefined
@@ -6792,12 +6803,11 @@ export class DesktopBackendRegistry {
     }
     const codexObserver = createCompositeJsonRpcObserver([
       codexCapture?.observer,
+      this.codexProtocolCaptureSession?.observer,
       createProtocolLogObserverFromEnv({
         backend: "codex",
       }),
     ]);
-    const createsLiveCodexClient =
-      !options?.codexClient && !replayClients?.codexClient;
     const settingsService = createsLiveCodexClient
       ? getDesktopSettingsService()
       : undefined;
@@ -7269,6 +7279,30 @@ export class DesktopBackendRegistry {
     return () => {
       this.eventListeners.delete(listener);
     };
+  }
+
+  getCodexProtocolCaptureStatus(): CodexProtocolCaptureStatus {
+    return (
+      this.codexProtocolCaptureSession?.getStatus() ?? {
+        active: false,
+        available: false,
+      }
+    );
+  }
+
+  async startCodexProtocolCapture(): Promise<CodexProtocolCaptureStatus> {
+    if (!this.codexProtocolCaptureSession) {
+      throw new Error(
+        "Codex protocol capture is unavailable for this runtime.",
+      );
+    }
+    return await this.codexProtocolCaptureSession.start();
+  }
+
+  async stopCodexProtocolCapture(): Promise<
+    CodexProtocolCaptureResult | undefined
+  > {
+    return await this.codexProtocolCaptureSession?.stop();
   }
 
   setMessagingArchiveCleaner(
@@ -16912,6 +16946,10 @@ export class DesktopBackendRegistry {
     const recoveryDrain = this.codexInvalidIdRecoveryDrain;
     const resources = [
       { name: "acp", close: () => this.acpBackend.close() },
+      {
+        name: "codex-protocol-capture",
+        close: () => this.codexProtocolCaptureSession?.close(),
+      },
       { name: "pdf-mcp", close: () => this.pdfToolMcpServer?.close() },
       {
         name: "codex",

--- a/apps/desktop/src/main/diagnostics/codex-protocol-capture.ts
+++ b/apps/desktop/src/main/diagnostics/codex-protocol-capture.ts
@@ -107,18 +107,43 @@ export class CodexProtocolCaptureSession {
       }
 
       this.activeCapture = undefined;
-      await capture.store.close();
-      const file = await fs.stat(capture.store.captureFilePath);
+      const finalizationErrors: string[] = [];
+      try {
+        await capture.store.close();
+      } catch (error) {
+        finalizationErrors.push(
+          `Capture writes did not finish: ${errorMessage(error)}`,
+        );
+      }
+      let sizeBytes: number | undefined;
+      try {
+        sizeBytes = (await fs.stat(capture.store.captureFilePath)).size;
+      } catch (error) {
+        finalizationErrors.push(
+          `Capture size could not be read: ${errorMessage(error)}`,
+        );
+      }
       const result: CodexProtocolCaptureResult = {
         captureFilePath: capture.store.captureFilePath,
-        sizeBytes: file.size,
+        ...(finalizationErrors.length > 0
+          ? { finalizationError: finalizationErrors.join(" ") }
+          : {}),
+        ...(sizeBytes === undefined ? {} : { sizeBytes }),
         startedAt: new Date(capture.startedAt).toISOString(),
         stoppedAt: new Date(this.now()).toISOString(),
       };
-      protocolCaptureLog.info("diagnostic capture stopped", {
-        path: result.captureFilePath,
-        sizeBytes: result.sizeBytes,
-      });
+      if (result.finalizationError) {
+        protocolCaptureLog.warn("diagnostic capture stopped with warning", {
+          error: result.finalizationError,
+          path: result.captureFilePath,
+          sizeBytes: result.sizeBytes,
+        });
+      } else {
+        protocolCaptureLog.info("diagnostic capture stopped", {
+          path: result.captureFilePath,
+          sizeBytes: result.sizeBytes,
+        });
+      }
       return result;
     });
   }
@@ -135,4 +160,8 @@ export class CodexProtocolCaptureSession {
     );
     return await result;
   }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/desktop/src/main/diagnostics/codex-protocol-capture.ts
+++ b/apps/desktop/src/main/diagnostics/codex-protocol-capture.ts
@@ -1,0 +1,138 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import type { JsonRpcObserver } from "@pwrdrvr/agent-transport";
+import type {
+  CodexProtocolCaptureResult,
+  CodexProtocolCaptureStatus,
+} from "../../shared/codex-protocol-capture";
+import { getMainLogger } from "../log";
+import { resolveActiveProfilePath } from "../profile";
+import { ProtocolCaptureStore } from "../testing/capture-store";
+import {
+  buildProtocolCaptureId,
+  createProtocolCaptureObserver,
+} from "../testing/protocol-capture";
+
+const protocolCaptureLog = getMainLogger("pwragent:protocol-capture");
+
+type ActiveCapture = {
+  observer: JsonRpcObserver;
+  startedAt: number;
+  store: ProtocolCaptureStore;
+};
+
+export class CodexProtocolCaptureSession {
+  private activeCapture?: ActiveCapture;
+  private mutationQueue: Promise<void> = Promise.resolve();
+  private readonly now: () => number;
+  private readonly createCaptureId: (startedAt: number) => string;
+  private readonly resolveRootDir: () => string;
+
+  readonly observer: JsonRpcObserver = {
+    onMessage: async (event) => {
+      const capture = this.activeCapture;
+      if (!capture) {
+        return;
+      }
+      await capture.observer.onMessage(event);
+    },
+  };
+
+  constructor(options: {
+    createCaptureId?: (startedAt: number) => string;
+    now?: () => number;
+    rootDir?: string;
+  } = {}) {
+    this.now = options.now ?? (() => Date.now());
+    this.createCaptureId =
+      options.createCaptureId ??
+      ((startedAt) =>
+        [
+          buildProtocolCaptureId("codex", "default", startedAt),
+          randomUUID().slice(0, 8),
+        ].join("-"));
+    const rootDir = options.rootDir;
+    this.resolveRootDir = rootDir
+      ? () => rootDir
+      : () => resolveActiveProfilePath("state/protocol-captures");
+  }
+
+  getStatus(): CodexProtocolCaptureStatus {
+    const capture = this.activeCapture;
+    if (!capture) {
+      return { active: false, available: true };
+    }
+    return {
+      active: true,
+      available: true,
+      captureFilePath: capture.store.captureFilePath,
+      startedAt: new Date(capture.startedAt).toISOString(),
+    };
+  }
+
+  async start(): Promise<CodexProtocolCaptureStatus> {
+    return await this.mutate(async () => {
+      if (this.activeCapture) {
+        return this.getStatus();
+      }
+
+      const startedAt = this.now();
+      const store = new ProtocolCaptureStore({
+        backend: "codex",
+        backendInstance: "default",
+        captureId: this.createCaptureId(startedAt),
+        rootDir: this.resolveRootDir(),
+      });
+      await store.open();
+      this.activeCapture = {
+        observer: createProtocolCaptureObserver({
+          backend: "codex",
+          store,
+        }),
+        startedAt,
+        store,
+      };
+      protocolCaptureLog.info("diagnostic capture started", {
+        path: store.captureFilePath,
+      });
+      return this.getStatus();
+    });
+  }
+
+  async stop(): Promise<CodexProtocolCaptureResult | undefined> {
+    return await this.mutate(async () => {
+      const capture = this.activeCapture;
+      if (!capture) {
+        return undefined;
+      }
+
+      this.activeCapture = undefined;
+      await capture.store.close();
+      const file = await fs.stat(capture.store.captureFilePath);
+      const result: CodexProtocolCaptureResult = {
+        captureFilePath: capture.store.captureFilePath,
+        sizeBytes: file.size,
+        startedAt: new Date(capture.startedAt).toISOString(),
+        stoppedAt: new Date(this.now()).toISOString(),
+      };
+      protocolCaptureLog.info("diagnostic capture stopped", {
+        path: result.captureFilePath,
+        sizeBytes: result.sizeBytes,
+      });
+      return result;
+    });
+  }
+
+  async close(): Promise<void> {
+    await this.stop();
+  }
+
+  private async mutate<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.mutationQueue.then(operation);
+    this.mutationQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return await result;
+  }
+}

--- a/apps/desktop/src/main/ipc/diagnostics.ts
+++ b/apps/desktop/src/main/ipc/diagnostics.ts
@@ -2,13 +2,17 @@ import { join } from "node:path";
 import { ipcMain, type WebContents } from "electron";
 import {
   DIAGNOSTICS_CAPTURE_HEAP_SNAPSHOT_CHANNEL,
+  DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL,
   DIAGNOSTICS_HEAP_SNAPSHOT_CAPTURED_EVENT_CHANNEL,
+  DIAGNOSTICS_START_CODEX_PROTOCOL_CAPTURE_CHANNEL,
+  DIAGNOSTICS_STOP_CODEX_PROTOCOL_CAPTURE_CHANNEL,
 } from "../../shared/ipc";
 import type {
   CaptureHeapSnapshotRequest,
   CaptureHeapSnapshotResult,
 } from "../../shared/heap-snapshot";
 import { captureHeapSnapshot } from "../diagnostics/manual-heap-snapshot";
+import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { getMainLogger } from "../log";
 import { resolveActiveProfilePath } from "../profile";
 import { subscribersForChannel } from "../window-channels";
@@ -67,6 +71,21 @@ async function runCapture(
 
 export function registerDiagnosticsIpcHandlers(): void {
   ipcMain.removeHandler(DIAGNOSTICS_CAPTURE_HEAP_SNAPSHOT_CHANNEL);
+  ipcMain.removeHandler(DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL);
+  ipcMain.removeHandler(DIAGNOSTICS_START_CODEX_PROTOCOL_CAPTURE_CHANNEL);
+  ipcMain.removeHandler(DIAGNOSTICS_STOP_CODEX_PROTOCOL_CAPTURE_CHANNEL);
+  ipcMain.handle(
+    DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL,
+    () => getDesktopBackendRegistry().getCodexProtocolCaptureStatus(),
+  );
+  ipcMain.handle(
+    DIAGNOSTICS_START_CODEX_PROTOCOL_CAPTURE_CHANNEL,
+    async () => await getDesktopBackendRegistry().startCodexProtocolCapture(),
+  );
+  ipcMain.handle(
+    DIAGNOSTICS_STOP_CODEX_PROTOCOL_CAPTURE_CHANNEL,
+    async () => await getDesktopBackendRegistry().stopCodexProtocolCapture(),
+  );
   ipcMain.handle(
     DIAGNOSTICS_CAPTURE_HEAP_SNAPSHOT_CHANNEL,
     (
@@ -107,6 +126,9 @@ export function registerDiagnosticsIpcHandlers(): void {
 
 export function disposeDiagnosticsIpcHandlers(): void {
   ipcMain.removeHandler(DIAGNOSTICS_CAPTURE_HEAP_SNAPSHOT_CHANNEL);
+  ipcMain.removeHandler(DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL);
+  ipcMain.removeHandler(DIAGNOSTICS_START_CODEX_PROTOCOL_CAPTURE_CHANNEL);
+  ipcMain.removeHandler(DIAGNOSTICS_STOP_CODEX_PROTOCOL_CAPTURE_CHANNEL);
   if (pendingCapture) {
     clearTimeout(pendingCapture);
     pendingCapture = undefined;

--- a/apps/desktop/src/main/testing/capture-store.ts
+++ b/apps/desktop/src/main/testing/capture-store.ts
@@ -58,6 +58,8 @@ type CaptureIndexEntry = {
 
 const indexWriteQueues = new Map<string, Promise<void>>();
 const protocolCaptureLog = getMainLogger("pwragent:protocol-capture");
+const CAPTURE_DIRECTORY_MODE = 0o700;
+const CAPTURE_FILE_MODE = 0o600;
 
 export async function readProtocolCaptureFile(
   filePath: string,
@@ -124,7 +126,6 @@ export class ProtocolCaptureStore {
   async open(): Promise<void> {
     const nextWrite = this.writeQueue.then(async () => {
       await this.ensureInitialized();
-      await fs.appendFile(this.captureFilePath, "", "utf8");
     });
     this.writeQueue = nextWrite;
     await nextWrite;
@@ -184,7 +185,16 @@ export class ProtocolCaptureStore {
       return;
     }
 
-    await fs.mkdir(this.params.rootDir, { recursive: true });
+    await fs.mkdir(this.params.rootDir, {
+      mode: CAPTURE_DIRECTORY_MODE,
+      recursive: true,
+    });
+    await fs.chmod(this.params.rootDir, CAPTURE_DIRECTORY_MODE);
+    await fs.appendFile(this.captureFilePath, "", {
+      encoding: "utf8",
+      mode: CAPTURE_FILE_MODE,
+    });
+    await fs.chmod(this.captureFilePath, CAPTURE_FILE_MODE);
     await this.writeIndexQueued();
     this.initialized = true;
   }
@@ -265,7 +275,10 @@ async function writeJsonFileAtomically(
   value: Record<string, CaptureIndexEntry>,
 ): Promise<void> {
   const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
-  await fs.writeFile(tempPath, JSON.stringify(value, null, 2), "utf8");
+  await fs.writeFile(tempPath, JSON.stringify(value, null, 2), {
+    encoding: "utf8",
+    mode: CAPTURE_FILE_MODE,
+  });
   await fs.rename(tempPath, filePath);
 }
 

--- a/apps/desktop/src/main/testing/capture-store.ts
+++ b/apps/desktop/src/main/testing/capture-store.ts
@@ -121,6 +121,15 @@ export class ProtocolCaptureStore {
     return path.join(this.params.rootDir, "index.json");
   }
 
+  async open(): Promise<void> {
+    const nextWrite = this.writeQueue.then(async () => {
+      await this.ensureInitialized();
+      await fs.appendFile(this.captureFilePath, "", "utf8");
+    });
+    this.writeQueue = nextWrite;
+    await nextWrite;
+  }
+
   async append(params: {
     direction: "inbound" | "outbound";
     diagnostics?: ProtocolCaptureDiagnostics;

--- a/apps/desktop/src/main/testing/protocol-capture.ts
+++ b/apps/desktop/src/main/testing/protocol-capture.ts
@@ -39,7 +39,10 @@ export function createProtocolCaptureFromEnv(params: {
   const rootDir =
     process.env[CAPTURE_ROOT_ENV]?.trim() ||
     resolveActiveProfilePath("state/protocol-captures");
-  const captureId = buildCaptureId(params.backend, params.backendInstance);
+  const captureId = buildProtocolCaptureId(
+    params.backend,
+    params.backendInstance,
+  );
   const store = new ProtocolCaptureStore({
     backend: params.backend,
     backendInstance: params.backendInstance,
@@ -64,8 +67,12 @@ export function createProtocolCaptureFromEnv(params: {
   };
 }
 
-function buildCaptureId(backend: string, backendInstance: string): string {
-  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+export function buildProtocolCaptureId(
+  backend: string,
+  backendInstance: string,
+  timestampMs = Date.now(),
+): string {
+  const timestamp = new Date(timestampMs).toISOString().replace(/[:.]/g, "-");
   return `${timestamp}-${backend}-${sanitizeCapturePart(backendInstance)}`;
 }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -372,6 +372,10 @@ import type {
   CaptureHeapSnapshotResult,
 } from "../shared/heap-snapshot";
 import type {
+  CodexProtocolCaptureResult,
+  CodexProtocolCaptureStatus,
+} from "../shared/codex-protocol-capture";
+import type {
   IntegratedTerminalCloseRequest,
   IntegratedTerminalCreateRequest,
   IntegratedTerminalCreateResponse,
@@ -477,7 +481,10 @@ import {
   MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL,
   SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL,
   DIAGNOSTICS_CAPTURE_HEAP_SNAPSHOT_CHANNEL,
+  DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL,
   DIAGNOSTICS_HEAP_SNAPSHOT_CAPTURED_EVENT_CHANNEL,
+  DIAGNOSTICS_START_CODEX_PROTOCOL_CAPTURE_CHANNEL,
+  DIAGNOSTICS_STOP_CODEX_PROTOCOL_CAPTURE_CHANNEL,
   INTEGRATED_TERMINAL_CLOSE_CHANNEL,
   INTEGRATED_TERMINAL_CREATE_CHANNEL,
   INTEGRATED_TERMINAL_ERROR_CHANNEL,
@@ -1193,6 +1200,15 @@ const desktopApi = Object.freeze({
       DIAGNOSTICS_CAPTURE_HEAP_SNAPSHOT_CHANNEL,
       request,
     ),
+  getCodexProtocolCaptureStatus: async (): Promise<CodexProtocolCaptureStatus> =>
+    await ipcRenderer.invoke(
+      DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL,
+    ),
+  startCodexProtocolCapture: async (): Promise<CodexProtocolCaptureStatus> =>
+    await ipcRenderer.invoke(DIAGNOSTICS_START_CODEX_PROTOCOL_CAPTURE_CHANNEL),
+  stopCodexProtocolCapture: async (): Promise<
+    CodexProtocolCaptureResult | undefined
+  > => await ipcRenderer.invoke(DIAGNOSTICS_STOP_CODEX_PROTOCOL_CAPTURE_CHANNEL),
   onHeapSnapshotCaptured: (
     callback: (result: CaptureHeapSnapshotResult) => void,
   ): (() => void) => {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -2128,6 +2128,7 @@ function DesktopAppShell(props: {
                   setMainView("thread");
                   void navigation.showThread(target);
                 }}
+                onShowNotice={showAppNotice}
               />
             </Suspense>
           </div>

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -28,6 +28,7 @@ import { ArchivedThreadsSettings } from "./ArchivedThreadsSettings";
 import { ThreadManagementSettings } from "./ThreadManagementSettings";
 import { TroubleshootingSettings } from "./TroubleshootingSettings";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
+import type { AppNoticeToastNotice } from "../notifications/AppNoticeToast";
 import { WorktreesSettings } from "./WorktreesSettings";
 import {
   buildDiscordPatchDelta,
@@ -125,6 +126,7 @@ export function SettingsScreen(props: {
     backend: AppServerBackendKind;
     threadId: string;
   }) => void;
+  onShowNotice?: (notice: AppNoticeToastNotice) => void;
   /** Fired from the title-bar messaging controller.
    *  The App-level handler closes the Settings overlay and opens the
    *  Messaging Activity overlay (its own top-level mainView). */
@@ -308,6 +310,7 @@ export function SettingsScreen(props: {
               cachedBackends={props.cachedBackends}
               desktopApi={props.desktopApi}
               onOpenThread={props.onOpenThread}
+              onShowNotice={props.onShowNotice}
               profiles={props.profiles}
               section={section}
               settings={props.settings}
@@ -333,6 +336,7 @@ function SettingsSectionBody(props: {
     backend: AppServerBackendKind;
     threadId: string;
   }) => void;
+  onShowNotice?: (notice: AppNoticeToastNotice) => void;
   profiles?: PwrAgentProfilesState;
   section: SettingsSection;
   settings: DesktopSettingsState;
@@ -391,6 +395,7 @@ function SettingsSectionBody(props: {
     return (
       <TroubleshootingSettings
         desktopApi={props.desktopApi}
+        onShowNotice={props.onShowNotice}
         saving={props.settings.saving}
         snapshot={props.snapshot}
         onDeveloperModeChange={async (developerMode: boolean) => {

--- a/apps/desktop/src/renderer/src/features/settings/TroubleshootingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/TroubleshootingSettings.tsx
@@ -279,6 +279,9 @@ export function TroubleshootingSettings(props: {
       }
       setLastProtocolCapture(result);
       const handoff = buildCodexProtocolCaptureHandoffMessage(result);
+      const captureSize = result.sizeBytes === undefined
+        ? "Size unavailable"
+        : `Saved ${formatCodexProtocolCaptureSize(result.sizeBytes)}`;
       props.onShowNotice?.({
         actions: [
           {
@@ -292,9 +295,13 @@ export function TroubleshootingSettings(props: {
         copyText: handoff,
         detail: result.captureFilePath,
         id: `codex-protocol-capture:${result.stoppedAt}`,
-        message: `Saved ${formatCodexProtocolCaptureSize(result.sizeBytes)}. Review the capture before sharing it; raw protocol traffic can contain conversation or workspace content.`,
-        title: "Codex protocol capture saved",
-        tone: "success",
+        message: result.finalizationError
+          ? `${captureSize}. Finalization reported a warning, so the capture may be partial. Copy the details for the diagnostic path and warning.`
+          : `${captureSize}. Review the capture before sharing it; raw protocol traffic can contain conversation or workspace content.`,
+        title: result.finalizationError
+          ? "Codex protocol capture stopped with warning"
+          : "Codex protocol capture saved",
+        tone: result.finalizationError ? "warning" : "success",
       });
     } catch (error) {
       setProtocolCaptureError(
@@ -422,7 +429,15 @@ export function TroubleshootingSettings(props: {
           {lastProtocolCapture ? (
             <SettingsField
               label="Last capture"
-              sub={`${formatCodexProtocolCaptureSize(lastProtocolCapture.sizeBytes)} saved. Copy the details to hand the diagnostic path to another agent.`}
+              sub={[
+                lastProtocolCapture.sizeBytes === undefined
+                  ? "Size unavailable."
+                  : `${formatCodexProtocolCaptureSize(lastProtocolCapture.sizeBytes)} saved.`,
+                lastProtocolCapture.finalizationError
+                  ? "Finalization reported a warning; the capture may be partial."
+                  : "",
+                "Copy the details to hand the diagnostic path to another agent.",
+              ].filter(Boolean).join(" ")}
               control={
                 <SettingsCopyValue
                   copyValue={buildCodexProtocolCaptureHandoffMessage(

--- a/apps/desktop/src/renderer/src/features/settings/TroubleshootingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/TroubleshootingSettings.tsx
@@ -5,7 +5,15 @@ import type {
   DesktopSettingsSnapshot,
 } from "@pwragent/shared";
 import type { AppMetadata } from "../../../../shared/app-metadata";
+import {
+  buildCodexProtocolCaptureHandoffMessage,
+  formatCodexProtocolCaptureSize,
+  type CodexProtocolCaptureResult,
+  type CodexProtocolCaptureStatus,
+} from "../../../../shared/codex-protocol-capture";
 import { HEAP_SNAPSHOT_SECRET_WARNING } from "../../../../shared/heap-snapshot";
+import type { AppNoticeToastNotice } from "../notifications/AppNoticeToast";
+import { copyText } from "../../lib/copy-text";
 import type { DesktopApi } from "../../lib/desktop-api";
 import {
   SettingsField,
@@ -63,6 +71,7 @@ function formatHotCpuStartDelay(delayMs: DesktopHotCpuProfileStartDelayMs): stri
 
 export function TroubleshootingSettings(props: {
   desktopApi?: DesktopApi;
+  onShowNotice?: (notice: AppNoticeToastNotice) => void;
   saving: boolean;
   snapshot: DesktopSettingsSnapshot;
   onDeveloperModeChange: (value: boolean) => Promise<void>;
@@ -87,6 +96,14 @@ export function TroubleshootingSettings(props: {
   const [heapSnapshotCountdownRemainingMs, setHeapSnapshotCountdownRemainingMs] =
     useState(0);
   const [appMetadata, setAppMetadata] = useState<AppMetadata>();
+  const [protocolCaptureStatus, setProtocolCaptureStatus] = useState<
+    CodexProtocolCaptureStatus | undefined
+  >();
+  const [protocolCaptureBusy, setProtocolCaptureBusy] = useState(false);
+  const [protocolCaptureError, setProtocolCaptureError] = useState<string>();
+  const [lastProtocolCapture, setLastProtocolCapture] = useState<
+    CodexProtocolCaptureResult | undefined
+  >();
   const developerMode = props.snapshot.general.developerMode;
   const hotCpuProfilingEnabled =
     props.snapshot.general.hotCpuProfilingEnabled;
@@ -187,6 +204,107 @@ export function TroubleshootingSettings(props: {
     }
   };
 
+  const protocolCaptureApiAvailable = Boolean(
+    props.desktopApi?.getCodexProtocolCaptureStatus
+    && props.desktopApi.startCodexProtocolCapture
+    && props.desktopApi.stopCodexProtocolCapture,
+  );
+  const protocolCaptureStatusText = protocolCaptureBusy
+    ? "Updating"
+    : protocolCaptureStatus?.active
+      ? "Recording"
+      : !protocolCaptureApiAvailable
+          || protocolCaptureStatus?.available === false
+        ? "Unavailable"
+        : protocolCaptureStatus === undefined
+          ? "Checking"
+          : "Idle";
+
+  useEffect(() => {
+    let canceled = false;
+    if (!props.desktopApi?.getCodexProtocolCaptureStatus) {
+      setProtocolCaptureStatus({ active: false, available: false });
+      return;
+    }
+
+    void props.desktopApi.getCodexProtocolCaptureStatus()
+      .then((status) => {
+        if (!canceled) {
+          setProtocolCaptureStatus(status);
+        }
+      })
+      .catch((error) => {
+        if (!canceled) {
+          setProtocolCaptureError(
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      });
+    return () => {
+      canceled = true;
+    };
+  }, [props.desktopApi]);
+
+  const startProtocolCapture = async () => {
+    if (!props.desktopApi?.startCodexProtocolCapture) {
+      return;
+    }
+    setProtocolCaptureBusy(true);
+    setProtocolCaptureError(undefined);
+    try {
+      setProtocolCaptureStatus(
+        await props.desktopApi.startCodexProtocolCapture(),
+      );
+      setLastProtocolCapture(undefined);
+    } catch (error) {
+      setProtocolCaptureError(
+        error instanceof Error ? error.message : String(error),
+      );
+    } finally {
+      setProtocolCaptureBusy(false);
+    }
+  };
+
+  const stopProtocolCapture = async () => {
+    if (!props.desktopApi?.stopCodexProtocolCapture) {
+      return;
+    }
+    setProtocolCaptureBusy(true);
+    setProtocolCaptureError(undefined);
+    try {
+      const result = await props.desktopApi.stopCodexProtocolCapture();
+      setProtocolCaptureStatus({ active: false, available: true });
+      if (!result) {
+        return;
+      }
+      setLastProtocolCapture(result);
+      const handoff = buildCodexProtocolCaptureHandoffMessage(result);
+      props.onShowNotice?.({
+        actions: [
+          {
+            label: "Copy details",
+            onClick: () => {
+              void copyText(handoff, props.desktopApi);
+            },
+            tone: "primary",
+          },
+        ],
+        copyText: handoff,
+        detail: result.captureFilePath,
+        id: `codex-protocol-capture:${result.stoppedAt}`,
+        message: `Saved ${formatCodexProtocolCaptureSize(result.sizeBytes)}. Review the capture before sharing it; raw protocol traffic can contain conversation or workspace content.`,
+        title: "Codex protocol capture saved",
+        tone: "success",
+      });
+    } catch (error) {
+      setProtocolCaptureError(
+        error instanceof Error ? error.message : String(error),
+      );
+    } finally {
+      setProtocolCaptureBusy(false);
+    }
+  };
+
   const processIds = appMetadata ? formatProcessIds(appMetadata) : undefined;
 
   useEffect(() => {
@@ -250,6 +368,78 @@ export function TroubleshootingSettings(props: {
               )
             }
           />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Troubleshooting"
+        title="Codex protocol capture"
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Diagnostic snippet"
+            sub="Start immediately before reproducing an issue, then stop as soon as it occurs. The capture stays local until you choose to share it."
+            help="Raw protocol traffic can contain conversation content, file paths, and tool output. Review the file before sharing it."
+            control={
+              <div className="settings-hot-cpu-capture">
+                {protocolCaptureStatus?.active ? (
+                  <button
+                    type="button"
+                    className="button button--secondary"
+                    disabled={protocolCaptureBusy}
+                    onClick={() => {
+                      void stopProtocolCapture();
+                    }}
+                  >
+                    Stop Protocol Capture
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="button button--primary"
+                    disabled={
+                      protocolCaptureBusy
+                      || !protocolCaptureApiAvailable
+                      || protocolCaptureStatus?.available === false
+                      || protocolCaptureStatus === undefined
+                    }
+                    onClick={() => {
+                      void startProtocolCapture();
+                    }}
+                  >
+                    Start Protocol Capture
+                  </button>
+                )}
+                <span
+                  className="settings-hot-cpu-capture__status"
+                  aria-live="polite"
+                >
+                  {protocolCaptureStatusText}
+                </span>
+              </div>
+            }
+          />
+          {lastProtocolCapture ? (
+            <SettingsField
+              label="Last capture"
+              sub={`${formatCodexProtocolCaptureSize(lastProtocolCapture.sizeBytes)} saved. Copy the details to hand the diagnostic path to another agent.`}
+              control={
+                <SettingsCopyValue
+                  copyValue={buildCodexProtocolCaptureHandoffMessage(
+                    lastProtocolCapture,
+                  )}
+                  desktopApi={props.desktopApi}
+                  label="protocol capture details"
+                  value={lastProtocolCapture.captureFilePath}
+                />
+              }
+            />
+          ) : null}
+          {protocolCaptureError ? (
+            <p className="settings-row__error" role="alert">
+              {protocolCaptureError}
+            </p>
+          ) : null}
         </div>
       </SettingsSection>
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1285,6 +1285,49 @@ describe("SettingsScreen", () => {
     });
   });
 
+  it("shows a copyable warning when protocol capture finalization is partial", async () => {
+    const captureFilePath = "/diagnostics/protocol-captures/partial.jsonl";
+    const onShowNotice = vi.fn();
+    render(
+      <SettingsScreen
+        desktopApi={{
+          getCodexProtocolCaptureStatus: vi.fn(async () => ({
+            active: true as const,
+            available: true as const,
+            captureFilePath,
+            startedAt: "2026-08-10T12:00:00.000Z",
+          })),
+          startCodexProtocolCapture: vi.fn(),
+          stopCodexProtocolCapture: vi.fn(async () => ({
+            captureFilePath,
+            finalizationError: "Capture size could not be read.",
+            startedAt: "2026-08-10T12:00:00.000Z",
+            stoppedAt: "2026-08-10T12:00:05.000Z",
+          })),
+        }}
+        initialSection="troubleshooting"
+        onShowNotice={onShowNotice}
+        settings={createSettingsState()}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Stop Protocol Capture" }),
+    );
+    await waitFor(() => {
+      expect(onShowNotice).toHaveBeenCalledTimes(1);
+    });
+    expect(onShowNotice.mock.calls[0]?.[0]).toMatchObject({
+      detail: captureFilePath,
+      message: expect.stringContaining("Size unavailable"),
+      title: "Codex protocol capture stopped with warning",
+      tone: "warning",
+    });
+    expect(
+      screen.getByText(/Finalization reported a warning/),
+    ).toBeInTheDocument();
+  });
+
   it("saves thread pricing display chips", async () => {
     const baseSnapshot = createSnapshot();
     const settings = createSettingsState(

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1215,6 +1215,76 @@ describe("SettingsScreen", () => {
     });
   });
 
+  it("starts and stops a Codex protocol capture with copyable handoff details", async () => {
+    const settings = createSettingsState();
+    const captureFilePath = "/diagnostics/protocol-captures/snippet.jsonl";
+    const getCodexProtocolCaptureStatus = vi.fn(async () => ({
+      active: false as const,
+      available: true,
+    }));
+    const startCodexProtocolCapture = vi.fn(async () => ({
+      active: true as const,
+      available: true as const,
+      captureFilePath,
+      startedAt: "2026-08-10T12:00:00.000Z",
+    }));
+    const stopCodexProtocolCapture = vi.fn(async () => ({
+      captureFilePath,
+      sizeBytes: 1536,
+      startedAt: "2026-08-10T12:00:00.000Z",
+      stoppedAt: "2026-08-10T12:00:05.000Z",
+    }));
+    const copyText = vi.fn(async () => undefined);
+    const onShowNotice = vi.fn();
+
+    render(
+      <SettingsScreen
+        desktopApi={{
+          copyText,
+          getCodexProtocolCaptureStatus,
+          startCodexProtocolCapture,
+          stopCodexProtocolCapture,
+        }}
+        initialSection="troubleshooting"
+        onShowNotice={onShowNotice}
+        settings={settings}
+        onClose={() => undefined}
+      />,
+    );
+
+    const startButton = await screen.findByRole("button", {
+      name: "Start Protocol Capture",
+    });
+    expect(startButton).toBeEnabled();
+    fireEvent.click(startButton);
+    await waitFor(() => {
+      expect(startCodexProtocolCapture).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Stop Protocol Capture" }),
+    );
+    await waitFor(() => {
+      expect(stopCodexProtocolCapture).toHaveBeenCalledTimes(1);
+      expect(onShowNotice).toHaveBeenCalledTimes(1);
+    });
+
+    const notice = onShowNotice.mock.calls[0]?.[0];
+    expect(notice).toMatchObject({
+      detail: captureFilePath,
+      message: expect.stringContaining("Saved 1.5 KB"),
+      title: "Codex protocol capture saved",
+      tone: "success",
+    });
+    expect(screen.getByText(captureFilePath)).toBeInTheDocument();
+    notice.actions[0].onClick();
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(
+        expect.stringContaining(`Capture path: ${captureFilePath}`),
+      );
+    });
+  });
+
   it("saves thread pricing display chips", async () => {
     const baseSnapshot = createSnapshot();
     const settings = createSettingsState(

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -10,6 +10,10 @@ import type {
   CaptureHeapSnapshotRequest,
   CaptureHeapSnapshotResult,
 } from "../../../shared/heap-snapshot";
+import type {
+  CodexProtocolCaptureResult,
+  CodexProtocolCaptureStatus,
+} from "../../../shared/codex-protocol-capture";
 import type { HotCpuProfileCapturedEvent } from "../../../shared/hot-cpu-profile";
 import type {
   GithubPrAuthenticationFailureEvent,
@@ -799,6 +803,11 @@ export type DesktopApi = {
   captureHeapSnapshot?: (
     request: CaptureHeapSnapshotRequest,
   ) => Promise<{ delayMs: number }>;
+  getCodexProtocolCaptureStatus?: () => Promise<CodexProtocolCaptureStatus>;
+  startCodexProtocolCapture?: () => Promise<CodexProtocolCaptureStatus>;
+  stopCodexProtocolCapture?: () => Promise<
+    CodexProtocolCaptureResult | undefined
+  >;
   onHeapSnapshotCaptured?: (
     callback: (result: CaptureHeapSnapshotResult) => void,
   ) => () => void;

--- a/apps/desktop/src/shared/__tests__/codex-protocol-capture.test.ts
+++ b/apps/desktop/src/shared/__tests__/codex-protocol-capture.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCodexProtocolCaptureHandoffMessage,
+  formatCodexProtocolCaptureSize,
+} from "../codex-protocol-capture";
+
+describe("Codex protocol capture details", () => {
+  it("formats compact file sizes", () => {
+    expect(formatCodexProtocolCaptureSize(0)).toBe("0 B");
+    expect(formatCodexProtocolCaptureSize(1536)).toBe("1.5 KB");
+    expect(formatCodexProtocolCaptureSize(2 * 1024 * 1024)).toBe("2.0 MB");
+  });
+
+  it("builds a privacy-aware handoff with the path and exact size", () => {
+    const message = buildCodexProtocolCaptureHandoffMessage({
+      captureFilePath: "/diagnostics/protocol-captures/snippet.jsonl",
+      sizeBytes: 1536,
+      startedAt: "2026-08-10T12:00:00.000Z",
+      stoppedAt: "2026-08-10T12:00:05.000Z",
+    });
+
+    expect(message).toContain(
+      "Capture path: /diagnostics/protocol-captures/snippet.jsonl",
+    );
+    expect(message).toContain("Capture size: 1.5 KB (1536 bytes)");
+    expect(message).toContain("Review the file before sharing it.");
+  });
+});

--- a/apps/desktop/src/shared/__tests__/codex-protocol-capture.test.ts
+++ b/apps/desktop/src/shared/__tests__/codex-protocol-capture.test.ts
@@ -25,4 +25,21 @@ describe("Codex protocol capture details", () => {
     expect(message).toContain("Capture size: 1.5 KB (1536 bytes)");
     expect(message).toContain("Review the file before sharing it.");
   });
+
+  it("preserves the path and warning when size finalization fails", () => {
+    const message = buildCodexProtocolCaptureHandoffMessage({
+      captureFilePath: "/diagnostics/protocol-captures/partial.jsonl",
+      finalizationError: "Capture size could not be read.",
+      startedAt: "2026-08-10T12:00:00.000Z",
+      stoppedAt: "2026-08-10T12:00:05.000Z",
+    });
+
+    expect(message).toContain(
+      "Capture path: /diagnostics/protocol-captures/partial.jsonl",
+    );
+    expect(message).toContain("Capture size: unavailable");
+    expect(message).toContain(
+      "Capture finalization warning: Capture size could not be read.",
+    );
+  });
 });

--- a/apps/desktop/src/shared/codex-protocol-capture.ts
+++ b/apps/desktop/src/shared/codex-protocol-capture.ts
@@ -12,7 +12,8 @@ export type CodexProtocolCaptureStatus =
 
 export type CodexProtocolCaptureResult = {
   captureFilePath: string;
-  sizeBytes: number;
+  finalizationError?: string;
+  sizeBytes?: number;
   startedAt: string;
   stoppedAt: string;
 };
@@ -28,13 +29,19 @@ export function formatCodexProtocolCaptureSize(sizeBytes: number): string {
 export function buildCodexProtocolCaptureHandoffMessage(
   result: CodexProtocolCaptureResult,
 ): string {
+  const sizeLine = result.sizeBytes === undefined
+    ? "Capture size: unavailable"
+    : [
+        `Capture size: ${formatCodexProtocolCaptureSize(result.sizeBytes)}`,
+        `(${result.sizeBytes} bytes)`,
+      ].join(" ");
   return [
     "PwrAgent recorded a Codex App Server protocol capture.",
     `Capture path: ${result.captureFilePath}`,
-    [
-      `Capture size: ${formatCodexProtocolCaptureSize(result.sizeBytes)}`,
-      `(${result.sizeBytes} bytes)`,
-    ].join(" "),
+    sizeLine,
+    ...(result.finalizationError
+      ? [`Capture finalization warning: ${result.finalizationError}`]
+      : []),
     "Privacy note: Raw protocol traffic can contain conversation content, file paths, and tool output. Review the file before sharing it.",
   ].join("\n");
 }

--- a/apps/desktop/src/shared/codex-protocol-capture.ts
+++ b/apps/desktop/src/shared/codex-protocol-capture.ts
@@ -1,0 +1,40 @@
+export type CodexProtocolCaptureStatus =
+  | {
+      active: false;
+      available: boolean;
+    }
+  | {
+      active: true;
+      available: true;
+      captureFilePath: string;
+      startedAt: string;
+    };
+
+export type CodexProtocolCaptureResult = {
+  captureFilePath: string;
+  sizeBytes: number;
+  startedAt: string;
+  stoppedAt: string;
+};
+
+export function formatCodexProtocolCaptureSize(sizeBytes: number): string {
+  if (sizeBytes < 1024) return `${sizeBytes} B`;
+  if (sizeBytes < 1024 * 1024) {
+    return `${(sizeBytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(sizeBytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function buildCodexProtocolCaptureHandoffMessage(
+  result: CodexProtocolCaptureResult,
+): string {
+  return [
+    "PwrAgent recorded a Codex App Server protocol capture.",
+    `Capture path: ${result.captureFilePath}`,
+    [
+      `Capture size: ${formatCodexProtocolCaptureSize(result.sizeBytes)}`,
+      `(${result.sizeBytes} bytes)`,
+    ].join(" "),
+    "Privacy note: Raw protocol traffic can contain conversation content, file paths, and tool output. Review the file before sharing it.",
+  ].join("\n");
+}

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -442,6 +442,12 @@ export const DIAGNOSTICS_CAPTURE_HEAP_SNAPSHOT_CHANNEL =
   "diagnostics:capture-heap-snapshot";
 export const DIAGNOSTICS_HEAP_SNAPSHOT_CAPTURED_EVENT_CHANNEL =
   "diagnostics:heap-snapshot-captured";
+export const DIAGNOSTICS_CODEX_PROTOCOL_CAPTURE_STATUS_CHANNEL =
+  "diagnostics:codex-protocol-capture-status";
+export const DIAGNOSTICS_START_CODEX_PROTOCOL_CAPTURE_CHANNEL =
+  "diagnostics:start-codex-protocol-capture";
+export const DIAGNOSTICS_STOP_CODEX_PROTOCOL_CAPTURE_CHANNEL =
+  "diagnostics:stop-codex-protocol-capture";
 export const INTEGRATED_TERMINAL_LIST_CHANNEL = "integrated-terminal:list";
 export const INTEGRATED_TERMINAL_SET_PANEL_HIDDEN_CHANNEL =
   "integrated-terminal:set-panel-hidden";


### PR DESCRIPTION
## Summary

- Add session-local start and stop controls for Codex App Server protocol capture in Troubleshooting Settings.
- Show the saved capture path and size in an app notification with a visible **Copy details** action for agent handoff.
- Keep raw capture output outside source control and warn operators to review protocol content before sharing it.
- Cover capture lifecycle, IPC routing, handoff formatting, and Settings behavior with focused tests.

## Why

Protocol diagnostics previously required a launch-time environment setting. A short issue reproduction can now be captured without restarting the desktop app or leaving logging enabled for the rest of the session.

## User impact

Operators can start a capture immediately before reproducing an issue, stop it afterward, and copy a privacy-aware handoff containing the file path and exact size.

## Validation

- Focused Vitest suite: 78 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` (passes; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:colors`
- Staged and committed diff privacy scan; no capture output, fixture, screenshot, or identifying data included