### PR TITLE
ci(desktop): split Linux E2E into parallel lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,10 +364,18 @@ jobs:
           retention-days: 7
 
   desktop-e2e:
-    name: Desktop E2E
+    name: Linux Desktop E2E (lane ${{ matrix.lane }} of 2)
     runs-on: ubuntu-latest
     needs: [changes, install-deps]
     if: needs.changes.outputs.code_impacting == 'true'
+    strategy:
+      # GitHub-hosted Linux capacity can run both halves concurrently. Keep
+      # the other shard running after a failure so its artifacts still show
+      # whether the failure is isolated or suite-wide.
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        lane: [1, 2]
     timeout-minutes: 20
     steps:
       - name: Checkout repository
@@ -387,18 +395,42 @@ jobs:
 
       - name: Run desktop replay-backed Electron tests
         timeout-minutes: 10
-        run: xvfb-run --auto-servernum pnpm run test:desktop-e2e
+        run: >-
+          xvfb-run --auto-servernum
+          pnpm --filter @pwragent/desktop test:e2e
+          --shard=${{ matrix.lane }}/2
 
       - name: Upload desktop Playwright artifacts
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         timeout-minutes: 10
         with:
-          name: desktop-e2e-artifacts
+          name: desktop-e2e-linux-lane-${{ matrix.lane }}-artifacts
           path: |
             apps/desktop/playwright-report/
             apps/desktop/test-results/
           retention-days: 30
+
+  desktop-e2e-result:
+    # Preserve the required status-check context while the work runs as two
+    # independently named matrix jobs. `always()` is required so a failed
+    # lane reaches this job and cannot turn the aggregate check into a skip.
+    name: Desktop E2E
+    runs-on: ubuntu-latest
+    needs: [changes, desktop-e2e]
+    if: >-
+      always() &&
+      needs.changes.outputs.code_impacting == 'true'
+    timeout-minutes: 5
+    steps:
+      - name: Require both Linux Desktop E2E lanes
+        env:
+          LINUX_E2E_RESULT: ${{ needs.desktop-e2e.result }}
+        run: |
+          if [[ "$LINUX_E2E_RESULT" != "success" ]]; then
+            echo "Linux Desktop E2E matrix result: $LINUX_E2E_RESULT"
+            exit 1
+          fi
 
   macos-install-deps:
     name: Setup macOS Dependencies


### PR DESCRIPTION
## Summary

- split the Linux desktop E2E suite into two concurrent Playwright shards
- keep both lanes running after a failure and upload lane-specific artifacts
- preserve the required `Desktop E2E` status through an aggregate result job

## Why

The single Linux desktop E2E job is currently a 7–8 minute long pole. GitHub-hosted Linux capacity can run two shards concurrently, matching the existing macOS E2E layout and reducing the Linux wall-clock portion when the suite is reasonably balanced.

## Validation

- parsed `.github/workflows/ci.yml` as YAML
- asserted the two-lane matrix, shard arguments, unique artifact names, and required-check aggregation
- ran `git diff --check`

The full desktop E2E suite was not run locally; this change is exercised by the PR workflow.
