### PR TITLE
feat(desktop): expose Codex MCP status and reload

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -10,10 +10,12 @@ import type {
   ForkThreadRequest,
   InterruptTurnRequest,
   ListBackendsRequest,
+  ListThreadMcpServersRequest,
   MaterializeDirectoryLaunchpadRequest,
   QueueThreadExecutionModeRequest,
   RunCodexEnvironmentActionRequest,
   RetainThreadBranchDriftRequest,
+  ReloadCodexMcpConfigRequest,
   StopCodexEnvironmentActionRequest,
   SetAcpSessionRuntimeOptionRequest,
   SetCodexThreadEnvironmentRequest,
@@ -96,6 +98,17 @@ const registry = {
     threadId: request.threadId,
     reviewThreadId: request.threadId,
     turnId: "turn-review-1",
+  })),
+  listThreadMcpServers: vi.fn(async (request: ListThreadMcpServersRequest) => ({
+    backend: request.backend,
+    threadId: request.threadId,
+    detail: request.detail ?? "toolsAndAuthOnly" as const,
+    servers: [],
+  })),
+  reloadCodexMcpConfig: vi.fn(async (request: ReloadCodexMcpConfigRequest) => ({
+    backend: request.backend,
+    threadId: request.threadId,
+    queued: true as const,
   })),
   cancelQueuedTurn: vi.fn(() => true),
   cancelQueuedTurnWithDisposition: vi.fn((queueEntryId: string) => ({
@@ -191,6 +204,17 @@ const federationMock = vi.hoisted(() => {
       backend: request.backend,
       threadId: request.threadId,
       turnId: "remote-compact-1",
+    })),
+    listThreadMcpServers: vi.fn(async (request: ListThreadMcpServersRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      detail: request.detail ?? "toolsAndAuthOnly" as const,
+      servers: [],
+    })),
+    reloadCodexMcpConfig: vi.fn(async (request: ReloadCodexMcpConfigRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      queued: true as const,
     })),
     interruptTurn: vi.fn(async (request: InterruptTurnRequest) => ({
       backend: request.backend,
@@ -415,6 +439,8 @@ describe("agent ipc", () => {
     registry.startTurn.mockClear();
     registry.submitTurn.mockClear();
     registry.startReview.mockClear();
+    registry.listThreadMcpServers.mockClear();
+    registry.reloadCodexMcpConfig.mockClear();
     registry.cancelQueuedTurn.mockClear();
     registry.cancelQueuedTurnWithDisposition.mockClear();
     registry.interruptTurn.mockClear();
@@ -453,6 +479,8 @@ describe("agent ipc", () => {
       AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL,
       AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
       AGENT_COMPACT_THREAD_CHANNEL,
+      AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL,
+      AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL,
       AGENT_FORK_THREAD_CHANNEL,
       AGENT_INTERRUPT_TURN_CHANNEL,
       AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
@@ -512,6 +540,17 @@ describe("agent ipc", () => {
       target: { type: "uncommittedChanges" },
     });
     await handlers.get(AGENT_COMPACT_THREAD_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+    });
+    await handlers.get(AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      detail: "full",
+    });
+    await handlers.get(AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL)?.({}, {
       backend: "codex",
       federationTarget,
       threadId: "thread-1",
@@ -743,6 +782,17 @@ describe("agent ipc", () => {
     });
     expect(registry.sendThreadPrAutoDispatchNow).not.toHaveBeenCalled();
     expect(registry.applyThreadModelMigration).not.toHaveBeenCalled();
+    expect(federationMock.remoteBackend.listThreadMcpServers).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      detail: "full",
+    });
+    expect(federationMock.remoteBackend.reloadCodexMcpConfig).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(registry.listThreadMcpServers).not.toHaveBeenCalled();
+    expect(registry.reloadCodexMcpConfig).not.toHaveBeenCalled();
     expect(federationMock.remoteBackend.checkThreadBranchDrift).toHaveBeenCalledWith({
       backend: "codex",
       expectedBranch: "feature/expected",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1414,6 +1414,11 @@ class MockBackendClient {
   lastCompactThreadParams?: {
     threadId: string;
   };
+  lastListMcpServersParams?: {
+    threadId: string;
+    detail: "toolsAndAuthOnly" | "full";
+  };
+  reloadMcpConfigCallCount = 0;
   lastArchiveThreadParams?: {
     threadId: string;
   };
@@ -1869,6 +1874,24 @@ class MockBackendClient {
       turnId: "compact-turn-1",
       itemId: "compact-item-1",
     };
+  }
+
+  async listMcpServers(params: {
+    threadId: string;
+    detail: "toolsAndAuthOnly" | "full";
+  }) {
+    this.lastListMcpServersParams = params;
+    return [
+      {
+        name: "atlassian-rovo",
+        authStatus: "oAuth" as const,
+        tools: ["fetch", "search"],
+      },
+    ];
+  }
+
+  async reloadMcpConfig(): Promise<void> {
+    this.reloadMcpConfigCallCount += 1;
   }
 
   async trustProject(params: {
@@ -34630,6 +34653,51 @@ script = "printf setup"
     expect(codexClient.lastCompactThreadParams).toEqual({
       threadId: "thread-1",
     });
+
+    await registry.close();
+  });
+
+  it("lists and reloads MCP config through the thread's Codex client", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["mcpServerStatus/list", "config/mcpServer/reload"],
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock({ executionMode: "default" }),
+    });
+
+    await expect(registry.listThreadMcpServers({
+      backend: "codex",
+      threadId: "thread-1",
+      detail: "toolsAndAuthOnly",
+    })).resolves.toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      detail: "toolsAndAuthOnly",
+      servers: [
+        {
+          name: "atlassian-rovo",
+          authStatus: "oAuth",
+          tools: ["fetch", "search"],
+        },
+      ],
+    });
+    expect(codexClient.lastListMcpServersParams).toEqual({
+      threadId: "thread-1",
+      detail: "toolsAndAuthOnly",
+    });
+
+    await expect(registry.reloadCodexMcpConfig({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      queued: true,
+    });
+    expect(codexClient.reloadMcpConfigCallCount).toBe(1);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -141,6 +141,9 @@ class MockTransport implements JsonRpcTransport {
     nextCursor: null,
   };
   static mcpServerStatusError: { code?: number; message: string } | undefined;
+  static mcpServerStatusThreadError:
+    | { code?: number; message: string }
+    | undefined;
   static lastConfigValueWritePayload: unknown;
   static rateLimitsResult: unknown = {
     rateLimitsByLimitId: {}
@@ -676,14 +679,18 @@ class MockTransport implements JsonRpcTransport {
     }
 
     if (payload.method === "mcpServerStatus/list") {
-      if (MockTransport.mcpServerStatusError) {
+      const error = payload.params?.threadId
+        ? MockTransport.mcpServerStatusThreadError
+          ?? MockTransport.mcpServerStatusError
+        : MockTransport.mcpServerStatusError;
+      if (error) {
         this.messageHandler(
           JSON.stringify({
             jsonrpc: "2.0",
             id: payload.id,
             error: {
-              code: MockTransport.mcpServerStatusError.code ?? -32000,
-              message: MockTransport.mcpServerStatusError.message,
+              code: error.code ?? -32000,
+              message: error.message,
             },
           }),
         );
@@ -1180,6 +1187,7 @@ describe("CodexAppServerClient", () => {
     };
     MockTransport.configReadError = undefined;
     MockTransport.mcpServerStatusError = undefined;
+    MockTransport.mcpServerStatusThreadError = undefined;
     MockTransport.threadMcpServerStatusResult = {
       data: [],
       nextCursor: null,
@@ -6506,6 +6514,61 @@ describe("CodexAppServerClient", () => {
       detail: "full",
       limit: 100,
     });
+
+    await client.close();
+  });
+
+  it("falls back to global MCP inventory when the thread is not loaded", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.mcpServerStatusThreadError = {
+      code: -32602,
+      message: "thread not found: thread-idle",
+    };
+    MockTransport.threadMcpServerStatusResult = {
+      data: [
+        {
+          name: "atlassian-rovo",
+          serverInfo: null,
+          authStatus: "oAuth",
+          tools: { search: { inputSchema: { type: "object" } } },
+          resources: [],
+          resourceTemplates: [],
+        },
+      ],
+      nextCursor: null,
+    };
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await expect(client.listMcpServers({
+      threadId: "thread-idle",
+      detail: "toolsAndAuthOnly",
+    })).resolves.toEqual([
+      {
+        name: "atlassian-rovo",
+        authStatus: "oAuth",
+        tools: ["search"],
+      },
+    ]);
+    const requests = MockTransport.instances.at(-1)!.sentMessages
+      .map((message) => JSON.parse(message) as {
+        method?: string;
+        params?: Record<string, unknown>;
+      })
+      .filter((message) => message.method === "mcpServerStatus/list");
+    expect(requests.map((request) => request.params)).toEqual([
+      {
+        threadId: "thread-idle",
+        detail: "toolsAndAuthOnly",
+        limit: 100,
+      },
+      {
+        detail: "toolsAndAuthOnly",
+        limit: 100,
+      },
+    ]);
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -699,6 +699,17 @@ class MockTransport implements JsonRpcTransport {
       return;
     }
 
+    if (payload.method === "config/mcpServer/reload") {
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: {},
+        }),
+      );
+      return;
+    }
+
     if (payload.method === "account/rateLimits/read") {
       this.messageHandler(
         JSON.stringify({
@@ -6420,6 +6431,101 @@ describe("CodexAppServerClient", () => {
         ],
       },
     ]);
+
+    await client.close();
+  });
+
+  it("normalizes MCP inventory without forwarding tool schemas", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadMcpServerStatusResult = {
+      data: [
+        {
+          name: "atlassian-rovo",
+          serverInfo: null,
+          authStatus: "oAuth",
+          tools: {
+            search: {
+              description: "Never forward this schema",
+              inputSchema: { type: "object", properties: { query: {} } },
+            },
+            fetch: { inputSchema: { type: "object" } },
+          },
+          resources: [
+            {
+              name: "sites",
+              title: "Confluence sites",
+              uri: "atlassian://sites",
+            },
+          ],
+          resourceTemplates: [
+            {
+              name: "page",
+              uriTemplate: "atlassian://page/{id}",
+            },
+          ],
+        },
+      ],
+      nextCursor: null,
+    };
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await expect(client.listMcpServers({
+      threadId: "thread-1",
+      detail: "full",
+    })).resolves.toEqual([
+      {
+        name: "atlassian-rovo",
+        authStatus: "oAuth",
+        tools: ["fetch", "search"],
+        resources: [
+          {
+            name: "sites",
+            title: "Confluence sites",
+            uri: "atlassian://sites",
+          },
+        ],
+        resourceTemplates: [
+          {
+            name: "page",
+            uriTemplate: "atlassian://page/{id}",
+          },
+        ],
+      },
+    ]);
+    const request = MockTransport.instances.at(-1)!.sentMessages
+      .map((message) => JSON.parse(message) as {
+        method?: string;
+        params?: Record<string, unknown>;
+      })
+      .find((message) => message.method === "mcpServerStatus/list");
+    expect(request?.params).toEqual({
+      threadId: "thread-1",
+      detail: "full",
+      limit: 100,
+    });
+
+    await client.close();
+  });
+
+  it("reloads MCP config through the app-server protocol", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await expect(client.reloadMcpConfig()).resolves.toBeUndefined();
+    const requests = MockTransport.instances.at(-1)!.sentMessages.map(
+      (message) => JSON.parse(message) as { method?: string; params?: unknown },
+    );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "config/mcpServer/reload",
+      }),
+    );
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -2127,6 +2127,25 @@ describe("federation backend bridge", () => {
         threadId: "thread-1",
         turnId: "compact-1",
       })),
+      listThreadMcpServers: vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        detail: "full" as const,
+        servers: [
+          {
+            name: "atlassian-rovo",
+            authStatus: "oAuth" as const,
+            tools: ["search"],
+            resources: [],
+            resourceTemplates: [],
+          },
+        ],
+      })),
+      reloadCodexMcpConfig: vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        queued: true as const,
+      })),
       controlActiveTurn: vi.fn(async (request) => ({
         ok: true as const,
         backend: request.backend,
@@ -2197,6 +2216,7 @@ describe("federation backend bridge", () => {
     router.registerConnection({
       peerId: "gateway_one",
       capabilities: [
+        "thread_detail",
         "turn_control",
         "pending_request_control",
         "environment_actions",
@@ -2223,6 +2243,36 @@ describe("federation backend bridge", () => {
         sourceInstanceId: "gateway_one",
         targetInstanceId: "client_one",
         createdAt: 1_000,
+      },
+    });
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
+        id: "mcp-inventory-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.listThreadMcpServers,
+        params: {
+          backend: "codex",
+          threadId: "thread-1",
+          detail: "full",
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "client_one",
+        createdAt: 1_010,
+      },
+    });
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
+        id: "mcp-reload-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.reloadCodexMcpConfig,
+        params: { backend: "codex", threadId: "thread-1" },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "client_one",
+        createdAt: 1_020,
       },
     });
     await router.routeEnvelope({
@@ -2309,6 +2359,15 @@ describe("federation backend bridge", () => {
       backend: "codex",
       threadId: "thread-1",
     });
+    expect(backend.listThreadMcpServers).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      detail: "full",
+    });
+    expect(backend.reloadCodexMcpConfig).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
     expect(backend.resolveActiveTurn).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-1",
@@ -2353,6 +2412,25 @@ describe("federation backend bridge", () => {
         kind: "response",
         requestId: "compact-request",
         result: { turnId: "compact-1" },
+      },
+      {
+        kind: "response",
+        requestId: "mcp-inventory-request",
+        result: {
+          detail: "full",
+          servers: [
+            {
+              name: "atlassian-rovo",
+              authStatus: "oAuth",
+              tools: ["search"],
+            },
+          ],
+        },
+      },
+      {
+        kind: "response",
+        requestId: "mcp-reload-request",
+        result: { queued: true },
       },
       {
         kind: "response",
@@ -2426,6 +2504,8 @@ describe("federation backend bridge", () => {
         cancelScheduledThreadAction: vi.fn(),
         sendScheduledThreadActionNow: vi.fn(),
         compactThread: vi.fn(),
+        listThreadMcpServers: vi.fn(),
+        reloadCodexMcpConfig: vi.fn(),
         resolveActiveTurn: vi.fn(),
         interruptTurn: vi.fn(),
         stopSubAgent: vi.fn(),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -112,6 +112,8 @@ import {
   type LatestCodexConfigWarningResponse,
   type ListBackendsRequest,
   type ListBackendsResponse,
+  type ListThreadMcpServersRequest,
+  type ListThreadMcpServersResponse,
   type EditGroupCommitInput,
   type EditGroupCommitState,
   type LinkedDirectorySummary,
@@ -140,6 +142,8 @@ import {
   type SetAcpSessionRuntimeOptionResponse,
   type RenameThreadRequest,
   type RenameThreadResponse,
+  type ReloadCodexMcpConfigRequest,
+  type ReloadCodexMcpConfigResponse,
   applyNavigationLaunchpadProviderSettingsPatch,
   projectNavigationLaunchpadProviderSettings,
   type RestoreWorktreeRequest,
@@ -707,6 +711,11 @@ type BackendClient = {
   compactThread?(params: {
     threadId: string;
   }): Promise<{ threadId: string; turnId: string; itemId?: string }>;
+  listMcpServers?(params: {
+    threadId: string;
+    detail: ListThreadMcpServersResponse["detail"];
+  }): Promise<ListThreadMcpServersResponse["servers"]>;
+  reloadMcpConfig?(): Promise<void>;
   steerTurn?(params: {
     threadId: string;
     input: AppServerTurnInputItem[];
@@ -13670,6 +13679,52 @@ export class DesktopBackendRegistry {
       threadId: result.threadId,
       turnId: result.turnId,
       itemId: result.itemId,
+    };
+  }
+
+  async listThreadMcpServers(
+    params: ListThreadMcpServersRequest,
+  ): Promise<ListThreadMcpServersResponse> {
+    if (isAcpBackendId(params.backend)) {
+      throw new Error("MCP inventory is only available for Codex threads");
+    }
+    const detail = params.detail ?? "toolsAndAuthOnly";
+    const servers = await this.withCodexThreadClient(
+      params.threadId,
+      async (client) => {
+        if (!client.listMcpServers) {
+          throw new Error("Selected backend does not support MCP inventory");
+        }
+        return await client.listMcpServers({
+          threadId: params.threadId,
+          detail,
+        });
+      },
+    );
+    return {
+      backend: params.backend,
+      threadId: params.threadId,
+      detail,
+      servers,
+    };
+  }
+
+  async reloadCodexMcpConfig(
+    params: ReloadCodexMcpConfigRequest,
+  ): Promise<ReloadCodexMcpConfigResponse> {
+    if (isAcpBackendId(params.backend)) {
+      throw new Error("MCP config reload is only available for Codex threads");
+    }
+    await this.withCodexThreadClient(params.threadId, async (client) => {
+      if (!client.reloadMcpConfig) {
+        throw new Error("Selected backend does not support MCP config reload");
+      }
+      await client.reloadMcpConfig();
+    });
+    return {
+      backend: params.backend,
+      threadId: params.threadId,
+      queued: true,
     };
   }
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -5611,6 +5611,11 @@ function isUnmaterializedThreadError(error: unknown): boolean {
   );
 }
 
+function isThreadNotFoundError(error: unknown): boolean {
+  const text = error instanceof Error ? error.message : String(error);
+  return text.toLowerCase().includes("thread not found:");
+}
+
 function readCodexThreadSourceKind(
   record: Record<string, unknown>,
   sessionRecord: Record<string, unknown> | null,
@@ -7613,33 +7618,44 @@ export class CodexAppServerClient {
   }): Promise<CodexMcpServerSummary[]> {
     await this.ensureInitialized();
 
-    const servers: CodexMcpServerSummary[] = [];
-    const seenCursors = new Set<string>();
-    let cursor: string | undefined;
-    do {
-      const result = await requestWithFallbacks({
-        client: this.connection,
-        methods: ["mcpServerStatus/list"],
-        payloads: [{
-          threadId: params.threadId,
-          detail: params.detail,
-          limit: 100,
-          ...(cursor ? { cursor } : {}),
-        }],
-        timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
-      });
-      const page = readMcpServerStatusPage(result, params.detail);
-      servers.push(...page.servers);
-      cursor = page.nextCursor;
-      if (cursor) {
-        if (seenCursors.has(cursor)) {
-          throw new Error("codex_mcp_inventory_repeated_cursor");
+    const listPages = async (threadId?: string) => {
+      const servers: CodexMcpServerSummary[] = [];
+      const seenCursors = new Set<string>();
+      let cursor: string | undefined;
+      do {
+        const result = await requestWithFallbacks({
+          client: this.connection,
+          methods: ["mcpServerStatus/list"],
+          payloads: [{
+            ...(threadId ? { threadId } : {}),
+            detail: params.detail,
+            limit: 100,
+            ...(cursor ? { cursor } : {}),
+          }],
+          timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+        });
+        const page = readMcpServerStatusPage(result, params.detail);
+        servers.push(...page.servers);
+        cursor = page.nextCursor;
+        if (cursor) {
+          if (seenCursors.has(cursor)) {
+            throw new Error("codex_mcp_inventory_repeated_cursor");
+          }
+          seenCursors.add(cursor);
         }
-        seenCursors.add(cursor);
-      }
-    } while (cursor);
+      } while (cursor);
 
-    return servers.sort((left, right) => left.name.localeCompare(right.name));
+      return servers.sort((left, right) => left.name.localeCompare(right.name));
+    };
+
+    try {
+      return await listPages(params.threadId);
+    } catch (error) {
+      if (!isThreadNotFoundError(error)) {
+        throw error;
+      }
+      return await listPages();
+    }
   }
 
   async reloadMcpConfig(): Promise<void> {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -49,6 +49,8 @@ import type {
   BackendModelOption,
   BackendRateLimitSummary,
   CodexThreadEnvironmentRuntime,
+  CodexMcpInventoryDetail,
+  CodexMcpServerSummary,
   LinkedDirectorySummary,
 } from "@pwragent/shared";
 import { getMainLogger } from "../log";
@@ -701,6 +703,94 @@ function readMcpServerInventoryPage(value: unknown): {
     throw new Error("codex_title_mcp_inventory_invalid_cursor");
   }
   return { names, namesWithTools, nextCursor: nextCursorValue.trim() };
+}
+
+function readMcpAuthStatus(value: unknown): CodexMcpServerSummary["authStatus"] {
+  if (
+    value === "unsupported"
+    || value === "notLoggedIn"
+    || value === "bearerToken"
+    || value === "oAuth"
+  ) {
+    return value;
+  }
+  throw new Error("codex_mcp_inventory_invalid_auth_status");
+}
+
+function readMcpResourceSummaries(
+  value: unknown,
+): NonNullable<CodexMcpServerSummary["resources"]> {
+  if (!Array.isArray(value)) {
+    throw new Error("codex_mcp_inventory_invalid_resources");
+  }
+  return value.map((item) => {
+    const record = asRecord(item);
+    const name = readStringFromRecord(record, "name");
+    const uri = readStringFromRecord(record, "uri");
+    if (!name || !uri) {
+      throw new Error("codex_mcp_inventory_invalid_resource");
+    }
+    const title = readStringFromRecord(record, "title");
+    return { name, uri, ...(title ? { title } : {}) };
+  });
+}
+
+function readMcpResourceTemplateSummaries(
+  value: unknown,
+): NonNullable<CodexMcpServerSummary["resourceTemplates"]> {
+  if (!Array.isArray(value)) {
+    throw new Error("codex_mcp_inventory_invalid_resource_templates");
+  }
+  return value.map((item) => {
+    const record = asRecord(item);
+    const name = readStringFromRecord(record, "name");
+    const uriTemplate = readStringFromRecord(record, "uriTemplate");
+    if (!name || !uriTemplate) {
+      throw new Error("codex_mcp_inventory_invalid_resource_template");
+    }
+    const title = readStringFromRecord(record, "title");
+    return { name, uriTemplate, ...(title ? { title } : {}) };
+  });
+}
+
+function readMcpServerStatusPage(
+  value: unknown,
+  detail: CodexMcpInventoryDetail,
+): { servers: CodexMcpServerSummary[]; nextCursor?: string } {
+  const record = asRecord(value);
+  if (!record || !Array.isArray(record.data)) {
+    throw new Error("codex_mcp_inventory_invalid_response");
+  }
+
+  const servers = record.data.map((item) => {
+    const server = asRecord(item);
+    const name = readStringFromRecord(server, "name");
+    const tools = asRecord(server?.tools);
+    if (!name || !tools) {
+      throw new Error("codex_mcp_inventory_invalid_server");
+    }
+    return {
+      name,
+      authStatus: readMcpAuthStatus(server?.authStatus),
+      tools: Object.keys(tools).sort((left, right) => left.localeCompare(right)),
+      ...(detail === "full"
+        ? {
+            resources: readMcpResourceSummaries(server?.resources),
+            resourceTemplates: readMcpResourceTemplateSummaries(
+              server?.resourceTemplates,
+            ),
+          }
+        : {}),
+    } satisfies CodexMcpServerSummary;
+  });
+  const nextCursorValue = record.nextCursor;
+  if (nextCursorValue === null || nextCursorValue === undefined) {
+    return { servers };
+  }
+  if (typeof nextCursorValue !== "string" || !nextCursorValue.trim()) {
+    throw new Error("codex_mcp_inventory_invalid_cursor");
+  }
+  return { servers, nextCursor: nextCursorValue.trim() };
 }
 
 function readThreadInstructionSources(value: unknown): string[] | null {
@@ -7515,6 +7605,51 @@ export class CodexAppServerClient {
     });
 
     return extractSkillCatalog(result);
+  }
+
+  async listMcpServers(params: {
+    threadId: string;
+    detail: CodexMcpInventoryDetail;
+  }): Promise<CodexMcpServerSummary[]> {
+    await this.ensureInitialized();
+
+    const servers: CodexMcpServerSummary[] = [];
+    const seenCursors = new Set<string>();
+    let cursor: string | undefined;
+    do {
+      const result = await requestWithFallbacks({
+        client: this.connection,
+        methods: ["mcpServerStatus/list"],
+        payloads: [{
+          threadId: params.threadId,
+          detail: params.detail,
+          limit: 100,
+          ...(cursor ? { cursor } : {}),
+        }],
+        timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+      });
+      const page = readMcpServerStatusPage(result, params.detail);
+      servers.push(...page.servers);
+      cursor = page.nextCursor;
+      if (cursor) {
+        if (seenCursors.has(cursor)) {
+          throw new Error("codex_mcp_inventory_repeated_cursor");
+        }
+        seenCursors.add(cursor);
+      }
+    } while (cursor);
+
+    return servers.sort((left, right) => left.name.localeCompare(right.name));
+  }
+
+  async reloadMcpConfig(): Promise<void> {
+    await this.ensureInitialized();
+    await requestWithFallbacks({
+      client: this.connection,
+      methods: ["config/mcpServer/reload"],
+      payloads: [undefined],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
   }
 
   async listModels(

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -40,6 +40,8 @@ import type {
   InterruptTurnResponse,
   ListBackendsRequest,
   ListBackendsResponse,
+  ListThreadMcpServersRequest,
+  ListThreadMcpServersResponse,
   ListModelSettingsRecentsRequest,
   ListModelSettingsRecentsResponse,
   ListRecentFileReferencesResponse,
@@ -82,6 +84,8 @@ import type {
   ResolveThreadResponse,
   RetainThreadBranchDriftRequest,
   RetainThreadBranchDriftResponse,
+  ReloadCodexMcpConfigRequest,
+  ReloadCodexMcpConfigResponse,
   RenameThreadRequest,
   RenameThreadResponse,
   ResolveActiveTurnRequest,
@@ -256,6 +260,8 @@ export const FEDERATION_BACKEND_METHODS = {
   cancelScheduledThreadAction: "backend.cancelScheduledThreadAction",
   sendScheduledThreadActionNow: "backend.sendScheduledThreadActionNow",
   compactThread: "backend.compactThread",
+  listThreadMcpServers: "backend.listThreadMcpServers",
+  reloadCodexMcpConfig: "backend.reloadCodexMcpConfig",
   controlActiveTurn: "backend.controlActiveTurn",
   resolveActiveTurn: "backend.resolveActiveTurn",
   interruptTurn: "backend.interruptTurn",
@@ -346,6 +352,8 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.cancelScheduledThreadAction]: "scheduled_actions",
   [FEDERATION_BACKEND_METHODS.sendScheduledThreadActionNow]: "scheduled_actions",
   [FEDERATION_BACKEND_METHODS.compactThread]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.listThreadMcpServers]: "thread_detail",
+  [FEDERATION_BACKEND_METHODS.reloadCodexMcpConfig]: "turn_control",
   [FEDERATION_BACKEND_METHODS.controlActiveTurn]: "turn_control",
   [FEDERATION_BACKEND_METHODS.resolveActiveTurn]: "turn_control",
   [FEDERATION_BACKEND_METHODS.interruptTurn]: "turn_control",
@@ -477,6 +485,12 @@ export type FederationBackendOperations = {
     request: ScheduledThreadActionIdRequest,
   ): Promise<ScheduledThreadActionMutationResponse>;
   compactThread(request: CompactThreadRequest): Promise<CompactThreadResponse>;
+  listThreadMcpServers(
+    request: ListThreadMcpServersRequest,
+  ): Promise<ListThreadMcpServersResponse>;
+  reloadCodexMcpConfig(
+    request: ReloadCodexMcpConfigRequest,
+  ): Promise<ReloadCodexMcpConfigResponse>;
   controlActiveTurn?(
     request: ControlActiveTurnRequest,
   ): Promise<ControlActiveTurnResponse>;
@@ -840,6 +854,20 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.compactThread(
         envelope.params as CompactThreadRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.listThreadMcpServers,
+    async (envelope) =>
+      await params.backend.listThreadMcpServers(
+        envelope.params as ListThreadMcpServersRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.reloadCodexMcpConfig,
+    async (envelope) =>
+      await params.backend.reloadCodexMcpConfig(
+        envelope.params as ReloadCodexMcpConfigRequest,
       ),
   );
   if (params.backend.controlActiveTurn) {
@@ -1352,6 +1380,24 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<CompactThreadResponse> {
     return await this.rpc.request<CompactThreadResponse>({
       method: FEDERATION_BACKEND_METHODS.compactThread,
+      params: request,
+    });
+  }
+
+  async listThreadMcpServers(
+    request: ListThreadMcpServersRequest,
+  ): Promise<ListThreadMcpServersResponse> {
+    return await this.rpc.request<ListThreadMcpServersResponse>({
+      method: FEDERATION_BACKEND_METHODS.listThreadMcpServers,
+      params: request,
+    });
+  }
+
+  async reloadCodexMcpConfig(
+    request: ReloadCodexMcpConfigRequest,
+  ): Promise<ReloadCodexMcpConfigResponse> {
+    return await this.rpc.request<ReloadCodexMcpConfigResponse>({
+      method: FEDERATION_BACKEND_METHODS.reloadCodexMcpConfig,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -37,6 +37,7 @@ import type {
   InterruptTurnResponse,
   ListScheduledThreadActionsRequest,
   ListScheduledThreadActionsResponse,
+  ListThreadMcpServersResponse,
   MaterializeDirectoryLaunchpadResponse,
   ListModelSettingsRecentsRequest,
   ListModelSettingsRecentsResponse,
@@ -52,6 +53,7 @@ import type {
   ResetFederationEnrollmentRequest,
   RetainThreadBranchDriftResponse,
   RenameThreadResponse,
+  ReloadCodexMcpConfigResponse,
   RunCodexEnvironmentActionResponse,
   ScheduledThreadActionIdRequest,
   ScheduledThreadActionMutationResponse,
@@ -112,9 +114,11 @@ import {
   type InterruptTurnRequest,
   type ListWorktreeUnpublishedCommitsRequest,
   type ListWorktreeUnpublishedCommitsResponse,
+  type ListThreadMcpServersRequest,
   type MaterializeDirectoryLaunchpadRequest,
   type MaterializeDirectoryLaunchpadOptions,
   type MarkThreadSeenRequest,
+  type ReloadCodexMcpConfigRequest,
   type SetThreadPinRequest,
   type SetThreadPinResponse,
   type SetThreadReactionRequest,
@@ -4174,6 +4178,16 @@ function localBackendOperations(): FederationBackendOperations {
       request: CompactThreadRequest,
     ): Promise<CompactThreadResponse> {
       return await getDesktopBackendRegistry().compactThread(request);
+    },
+    async listThreadMcpServers(
+      request: ListThreadMcpServersRequest,
+    ): Promise<ListThreadMcpServersResponse> {
+      return await getDesktopBackendRegistry().listThreadMcpServers(request);
+    },
+    async reloadCodexMcpConfig(
+      request: ReloadCodexMcpConfigRequest,
+    ): Promise<ReloadCodexMcpConfigResponse> {
+      return await getDesktopBackendRegistry().reloadCodexMcpConfig(request);
     },
     async controlActiveTurn(
       request: ControlActiveTurnRequest,

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -28,10 +28,14 @@ import {
   type LatestCodexConfigWarningResponse,
   type ListBackendsRequest,
   type ListBackendsResponse,
+  type ListThreadMcpServersRequest,
+  type ListThreadMcpServersResponse,
   type QueueThreadExecutionModeRequest,
   type QueueThreadExecutionModeResponse,
   type RetainThreadBranchDriftRequest,
   type RetainThreadBranchDriftResponse,
+  type ReloadCodexMcpConfigRequest,
+  type ReloadCodexMcpConfigResponse,
   type RunCodexEnvironmentActionRequest,
   type RunCodexEnvironmentActionResponse,
   type StopCodexEnvironmentActionRequest,
@@ -83,6 +87,8 @@ import {
   AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL,
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
   AGENT_COMPACT_THREAD_CHANNEL,
+  AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL,
+  AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
   AGENT_STOP_SUB_AGENT_CHANNEL,
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
@@ -700,6 +706,44 @@ export function registerAgentIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL);
+  ipcMain.handle(
+    AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL,
+    async (
+      _event,
+      request: ListThreadMcpServersRequest,
+    ): Promise<ListThreadMcpServersResponse> => {
+      if (
+        request.federationTarget
+        && isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .listThreadMcpServers(stripFederationTarget(request));
+      }
+      return await registry.listThreadMcpServers(request);
+    },
+  );
+
+  ipcMain.removeHandler(AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL);
+  ipcMain.handle(
+    AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL,
+    async (
+      _event,
+      request: ReloadCodexMcpConfigRequest,
+    ): Promise<ReloadCodexMcpConfigResponse> => {
+      if (
+        request.federationTarget
+        && isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .reloadCodexMcpConfig(stripFederationTarget(request));
+      }
+      return await registry.reloadCodexMcpConfig(request);
+    },
+  );
+
   ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
   ipcMain.handle(
     AGENT_INTERRUPT_TURN_CHANNEL,
@@ -1159,6 +1203,8 @@ export function disposeAgentIpcHandlers(): void {
   ipcMain.removeHandler(AGENT_FORK_THREAD_CHANNEL);
   ipcMain.removeHandler(AGENT_START_REVIEW_CHANNEL);
   ipcMain.removeHandler(AGENT_COMPACT_THREAD_CHANNEL);
+  ipcMain.removeHandler(AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL);
+  ipcMain.removeHandler(AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL);
   ipcMain.removeHandler(AGENT_START_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_STOP_SUB_AGENT_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -36,11 +36,15 @@ import type {
   ListAutomationsResponse,
   ListBackendsRequest,
   ListBackendsResponse,
+  ListThreadMcpServersRequest,
+  ListThreadMcpServersResponse,
   ListDesktopPwrAgentProfilesResponse,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   QueueThreadExecutionModeRequest,
   QueueThreadExecutionModeResponse,
+  ReloadCodexMcpConfigRequest,
+  ReloadCodexMcpConfigResponse,
   LatestCodexConfigWarningResponse,
   SetAcpSessionRuntimeOptionRequest,
   SetAcpSessionRuntimeOptionResponse,
@@ -400,6 +404,8 @@ import {
   APPEARANCE_CHANGED_EVENT_CHANNEL,
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
   AGENT_COMPACT_THREAD_CHANNEL,
+  AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL,
+  AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
   AGENT_STOP_SUB_AGENT_CHANNEL,
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
@@ -1320,6 +1326,14 @@ const desktopApi = Object.freeze({
     request: CompactThreadRequest
   ): Promise<CompactThreadResponse> =>
     await ipcRenderer.invoke(AGENT_COMPACT_THREAD_CHANNEL, request),
+  listThreadMcpServers: async (
+    request: ListThreadMcpServersRequest,
+  ): Promise<ListThreadMcpServersResponse> =>
+    await ipcRenderer.invoke(AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL, request),
+  reloadCodexMcpConfig: async (
+    request: ReloadCodexMcpConfigRequest,
+  ): Promise<ReloadCodexMcpConfigResponse> =>
+    await ipcRenderer.invoke(AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL, request),
   startTurn: async (
     request: StartTurnRequest
   ): Promise<StartTurnResponse> =>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -26,6 +26,7 @@ import type {
   BackendSummary,
   CodexEnvironmentOption,
   CodexEnvironmentActionRun,
+  CodexMcpInventoryDetail,
   CodexThreadEnvironmentRuntime,
   DesktopApplicationDiscoveryCandidate,
   DesktopApplicationsSnapshot,
@@ -312,6 +313,7 @@ type ComposerProps = {
     { label: string; path: string } | undefined
   >;
   onClearPickDirectoryError?: () => void;
+  onShowMcpInventory?: (detail: CodexMcpInventoryDetail) => void;
   pickDirectoryError?: string;
   pickingDirectory?: boolean;
   setExecutionModeError?: string;
@@ -689,6 +691,25 @@ const SLASH_COMMANDS: SlashCommandSuggestion[] = [
     description: "Review current staged, unstaged, and untracked changes",
     source: "pwragent",
     sourceLabel: "PwrAgent",
+  },
+];
+
+const CODEX_MCP_SLASH_COMMANDS: SlashCommandSuggestion[] = [
+  {
+    id: "codex-mcp",
+    label: "/mcp",
+    insertText: "/mcp",
+    description: "List MCP tools and authentication status",
+    source: "pwragent",
+    sourceLabel: "Codex",
+  },
+  {
+    id: "codex-mcp-verbose",
+    label: "/mcp verbose",
+    insertText: "/mcp verbose",
+    description: "List MCP tools, resources, and resource templates",
+    source: "pwragent",
+    sourceLabel: "Codex",
   },
 ];
 
@@ -2049,6 +2070,7 @@ function ComposerThreadOptionsMenu(props: {
   disabled?: boolean;
   existingCodexThread?: boolean;
   onAgentThreadChange?: (agentThread: boolean) => void;
+  onShowMcpInventory?: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const menuId = useId();
@@ -2112,6 +2134,22 @@ function ComposerThreadOptionsMenu(props: {
               </span>
             </button>
           </div>
+          {props.onShowMcpInventory ? (
+            <>
+              <div className="composer-dropdown__separator" role="separator" />
+              <button
+                className="composer-dropdown__option composer-thread-options__option"
+                role="menuitem"
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  props.onShowMcpInventory?.();
+                }}
+              >
+                <span className="composer-thread-options__label">MCP tools</span>
+              </button>
+            </>
+          ) : null}
         </div>
       ) : null}
     </div>
@@ -3262,6 +3300,10 @@ export function Composer(props: ComposerProps) {
       );
     })
   );
+  const supportsMcpInventory =
+    !isLaunchpad
+    && props.thread?.source === "codex"
+    && Boolean(props.onShowMcpInventory);
 
   const selectionStart = Math.min(
     inputRef.current?.selectionStart ?? draft.length,
@@ -4565,8 +4607,17 @@ export function Composer(props: ComposerProps) {
       props.providerCommands?.map((command) =>
         providerCommandToSlashSuggestion(command, props.backends)
       ) ?? [];
-    return supportsReview ? [...SLASH_COMMANDS, ...commands] : commands;
-  }, [props.backends, props.providerCommands, supportsReview]);
+    const localCommands = supportsReview ? [...SLASH_COMMANDS] : [];
+    if (supportsMcpInventory) {
+      localCommands.push(...CODEX_MCP_SLASH_COMMANDS);
+    }
+    return [...localCommands, ...commands];
+  }, [
+    props.backends,
+    props.providerCommands,
+    supportsMcpInventory,
+    supportsReview,
+  ]);
   const filteredSlashCommands = useMemo(() => {
     if (!slashTrigger) {
       return [];
@@ -4827,6 +4878,12 @@ export function Composer(props: ComposerProps) {
   const parsedReviewCommand = supportsReview ? parseReviewCommand(draft) : undefined;
   const isBareReviewCommand = draft.trim() === "/review";
   const isCompactCommand = supportsCompactCommand && draft.trim() === "/compact";
+  const mcpInventoryDetail: CodexMcpInventoryDetail | undefined =
+    supportsMcpInventory && draft.trim().toLowerCase() === "/mcp"
+      ? "toolsAndAuthOnly"
+      : supportsMcpInventory && draft.trim().toLowerCase() === "/mcp verbose"
+        ? "full"
+        : undefined;
   const isReviewComposerOpen = Boolean(
     supportsReview && reviewConfig && parsedReviewCommand
   );
@@ -5917,6 +5974,44 @@ export function Composer(props: ComposerProps) {
       props.onActiveTurnIdChange?.(undefined);
       setSendError(error instanceof Error ? error.message : String(error));
     }
+  };
+
+  const showMcpInventory = (detail: CodexMcpInventoryDetail): void => {
+    if (imageAttachments.length > 0 || fileAttachments.length > 0) {
+      setSendError("/mcp does not accept attachments.");
+      return;
+    }
+    if (!supportsMcpInventory || !props.onShowMcpInventory) {
+      setSendError("MCP inventory is not available for this thread.");
+      return;
+    }
+
+    const submittedScopeKey = composerScopeKey;
+    const submittedSnapshot = latestDraftSnapshotRef.current.snapshot;
+    const emptySnapshot = createEmptyComposerDraftSnapshot();
+    clearComposerDraftSnapshot(submittedScopeKey);
+    latestDraftSnapshotRef.current = {
+      scopeKey: submittedScopeKey,
+      snapshot: emptySnapshot,
+    };
+    pendingProgrammaticComposerChangeRef.current = {
+      expectedDraft: "",
+      expectedSkillTokensSignature: getComposerSkillTokensSignature([]),
+      staleDraft: submittedSnapshot.draft,
+      staleSkillTokensSignature: getComposerSkillTokensSignature(
+        submittedSnapshot.skillTokens,
+      ),
+    };
+    flushSync(() => {
+      clearComposerDraft();
+      setImageAttachments([]);
+      setFileAttachments([]);
+      setReviewConfig(undefined);
+    });
+    setSendError(undefined);
+    recordComposerDraftHistory(submittedScopeKey, submittedSnapshot, "sent");
+    props.onShowMcpInventory(detail);
+    requestAnimationFrame(() => inputRef.current?.focus());
   };
 
   /**
@@ -7395,6 +7490,10 @@ export function Composer(props: ComposerProps) {
     }
     if (isCompactCommand) {
       await submitCompactThread();
+      return;
+    }
+    if (mcpInventoryDetail) {
+      showMcpInventory(mcpInventoryDetail);
       return;
     }
 
@@ -9503,6 +9602,16 @@ export function Composer(props: ComposerProps) {
 
     if (command.label.toLowerCase() === "/compact") {
       void submitCompactThread();
+      return true;
+    }
+
+    if (command.id === "codex-mcp") {
+      showMcpInventory("toolsAndAuthOnly");
+      return true;
+    }
+
+    if (command.id === "codex-mcp-verbose") {
+      showMcpInventory("full");
       return true;
     }
 
@@ -11941,6 +12050,11 @@ export function Composer(props: ComposerProps) {
                       void changeAgentThread(agentThread);
                     }
                   : undefined
+            }
+            onShowMcpInventory={
+              supportsMcpInventory
+                ? () => props.onShowMcpInventory?.("toolsAndAuthOnly")
+                : undefined
             }
           />
         </div>

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -12021,6 +12021,75 @@ describe("Composer", () => {
     expect(startTurn).not.toHaveBeenCalled();
   });
 
+  it("opens Codex MCP inventory locally instead of sending a turn", async () => {
+    const onShowMcpInventory = vi.fn();
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        onShowMcpInventory={onShowMcpInventory}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "MCP inventory",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "/mcp verbose" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(onShowMcpInventory).toHaveBeenCalledWith("full");
+    expect(startTurn).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(textarea).toHaveValue("");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Thread options" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "MCP tools" }));
+    expect(onShowMcpInventory).toHaveBeenLastCalledWith("toolsAndAuthOnly");
+  });
+
+  it("does not advertise MCP inventory for ACP threads", async () => {
+    render(
+      <Composer
+        disabled={false}
+        onShowMcpInventory={vi.fn()}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "ACP thread",
+          titleSource: "explicit",
+          source: "acp:grok",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/mcp" },
+    });
+    const commands = screen.queryByRole("listbox", { name: "Commands" });
+    expect(commands?.textContent ?? "").not.toContain("MCP tools");
+  });
+
   it("runs exact compact slash command on Enter even after review was selected", async () => {
     const compactThreadResponse = createDeferred<{
       backend: CompactThreadRequest["backend"];

--- a/apps/desktop/src/renderer/src/features/thread-detail/McpInventoryPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/McpInventoryPanel.tsx
@@ -25,6 +25,8 @@ type McpInventoryPanelProps = {
 const RELOAD_TOOLTIP =
   "Re-read installed MCP configuration and queue it for loaded Codex threads. "
   + "Each thread receives the updated MCP list when its next turn starts.";
+const TOOL_PREVIEW_LIMIT = 8;
+const CATALOG_PREVIEW_LIMIT = 3;
 
 export function McpInventoryPanel(props: McpInventoryPanelProps) {
   const [collapsed, setCollapsed] = useState(false);
@@ -202,17 +204,23 @@ function McpServerRow(props: {
           {formatAuthStatus(props.server.authStatus)}
         </span>
       </div>
-      <InventoryLine label="Tools" values={props.server.tools} />
+      <InventoryLine
+        label="Tools"
+        previewLimit={TOOL_PREVIEW_LIMIT}
+        values={props.server.tools}
+      />
       {props.detail === "full" ? (
         <>
           <InventoryLine
             label="Resources"
+            previewLimit={CATALOG_PREVIEW_LIMIT}
             values={(props.server.resources ?? []).map((resource) =>
               `${resource.title ?? resource.name} (${resource.uri})`
             )}
           />
           <InventoryLine
             label="Templates"
+            previewLimit={CATALOG_PREVIEW_LIMIT}
             values={(props.server.resourceTemplates ?? []).map((template) =>
               `${template.title ?? template.name} (${template.uriTemplate})`
             )}
@@ -223,13 +231,46 @@ function McpServerRow(props: {
   );
 }
 
-function InventoryLine(props: { label: string; values: string[] }) {
+function InventoryLine(props: {
+  label: string;
+  previewLimit: number;
+  values: string[];
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const hasOverflow = props.values.length > props.previewLimit;
+  const visibleValues = expanded || !hasOverflow
+    ? props.values
+    : props.values.slice(0, props.previewLimit);
+  const hiddenCount = props.values.length - visibleValues.length;
+
   return (
     <div className="mcp-inventory-panel__line">
-      <span className="mcp-inventory-panel__line-label">{props.label}</span>
-      <span className="mcp-inventory-panel__line-value">
-        {props.values.length > 0 ? props.values.join(", ") : "None"}
+      <span className="mcp-inventory-panel__line-label">
+        {props.label}
+        <span className="mcp-inventory-panel__line-count">
+          {` · ${props.values.length}`}
+        </span>
       </span>
+      <div className="mcp-inventory-panel__line-value">
+        <span className="mcp-inventory-panel__line-items">
+          {visibleValues.length > 0 ? visibleValues.join(", ") : "None"}
+        </span>
+        {hasOverflow ? (
+          <button
+            type="button"
+            className="mcp-inventory-panel__line-toggle"
+            aria-expanded={expanded}
+            aria-label={
+              expanded
+                ? `Show fewer ${props.label}`
+                : `Show ${hiddenCount} more ${props.label}`
+            }
+            onClick={() => setExpanded((current) => !current)}
+          >
+            {expanded ? "Show less" : `Show ${hiddenCount} more`}
+          </button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/McpInventoryPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/McpInventoryPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import type {
   CodexMcpAuthStatus,
   CodexMcpInventoryDetail,
@@ -35,8 +35,12 @@ export function McpInventoryPanel(props: McpInventoryPanelProps) {
   const [reloadStatus, setReloadStatus] = useState<string>();
   const bodyId = useId();
   const reloadTooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const rendererFederationTarget = useMemo(
+    () => readRendererFederationTarget(),
+    [],
+  );
   const federationTarget =
-    props.thread.federation?.ref.target ?? readRendererFederationTarget();
+    props.thread.federation?.ref.target ?? rendererFederationTarget;
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/desktop/src/renderer/src/features/thread-detail/McpInventoryPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/McpInventoryPanel.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useId, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type {
   CodexMcpAuthStatus,
   CodexMcpInventoryDetail,
   CodexMcpServerSummary,
   NavigationThreadSummary,
 } from "@pwragent/shared";
-import { CloseIcon } from "../../icons";
+import { CheckIcon, CloseIcon } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
@@ -27,6 +27,7 @@ const RELOAD_TOOLTIP =
   + "Each thread receives the updated MCP list when its next turn starts.";
 const TOOL_PREVIEW_LIMIT = 8;
 const CATALOG_PREVIEW_LIMIT = 3;
+const RELOAD_CONFIRMATION_MS = 5_000;
 
 export function McpInventoryPanel(props: McpInventoryPanelProps) {
   const [collapsed, setCollapsed] = useState(false);
@@ -34,7 +35,9 @@ export function McpInventoryPanel(props: McpInventoryPanelProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [reloading, setReloading] = useState(false);
+  const [reloadConfirmed, setReloadConfirmed] = useState(false);
   const [reloadStatus, setReloadStatus] = useState<string>();
+  const reloadConfirmationTimeoutRef = useRef<number | undefined>(undefined);
   const bodyId = useId();
   const reloadTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const rendererFederationTarget = useMemo(
@@ -79,9 +82,26 @@ export function McpInventoryPanel(props: McpInventoryPanelProps) {
     props.thread.source,
   ]);
 
+  useEffect(() => {
+    return () => {
+      if (reloadConfirmationTimeoutRef.current !== undefined) {
+        window.clearTimeout(reloadConfirmationTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const reloadConfig = async (): Promise<void> => {
-    if (!props.desktopApi?.reloadCodexMcpConfig || reloading) return;
+    if (
+      !props.desktopApi?.reloadCodexMcpConfig
+      || reloading
+      || reloadConfirmed
+    ) return;
+    if (reloadConfirmationTimeoutRef.current !== undefined) {
+      window.clearTimeout(reloadConfirmationTimeoutRef.current);
+      reloadConfirmationTimeoutRef.current = undefined;
+    }
     setReloading(true);
+    setReloadConfirmed(false);
     setReloadStatus(undefined);
     try {
       await props.desktopApi.reloadCodexMcpConfig({
@@ -92,7 +112,13 @@ export function McpInventoryPanel(props: McpInventoryPanelProps) {
       setReloadStatus(
         "Config reload queued. The updated MCP list applies when the next turn starts.",
       );
+      setReloadConfirmed(true);
+      reloadConfirmationTimeoutRef.current = window.setTimeout(() => {
+        reloadConfirmationTimeoutRef.current = undefined;
+        setReloadConfirmed(false);
+      }, RELOAD_CONFIRMATION_MS);
     } catch (nextError) {
+      setReloadConfirmed(false);
       setReloadStatus(
         nextError instanceof Error ? nextError.message : String(nextError),
       );
@@ -131,11 +157,21 @@ export function McpInventoryPanel(props: McpInventoryPanelProps) {
         <div className="live-work-rail__header-actions">
           <button
             type="button"
-            className="mcp-inventory-panel__reload"
+            className={
+              `mcp-inventory-panel__reload${
+                reloadConfirmed
+                  ? " mcp-inventory-panel__reload--success"
+                  : ""
+              }`
+            }
             aria-describedby={
               reloadTooltip.visible ? reloadTooltip.tooltipId : undefined
             }
-            disabled={reloading || !props.desktopApi?.reloadCodexMcpConfig}
+            disabled={
+              reloading
+              || reloadConfirmed
+              || !props.desktopApi?.reloadCodexMcpConfig
+            }
             onClick={() => void reloadConfig()}
             onMouseEnter={(event) =>
               reloadTooltip.show(event.currentTarget, RELOAD_TOOLTIP)
@@ -146,7 +182,12 @@ export function McpInventoryPanel(props: McpInventoryPanelProps) {
             }
             onBlur={reloadTooltip.hide}
           >
-            {reloading ? "Reloading…" : "Reload Config"}
+            {reloadConfirmed ? (
+              <>
+                <CheckIcon size={12} aria-hidden="true" />
+                Reload queued
+              </>
+            ) : reloading ? "Reloading…" : "Reload Config"}
           </button>
           {reloadTooltip.tooltipNode}
           <button

--- a/apps/desktop/src/renderer/src/features/thread-detail/McpInventoryPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/McpInventoryPanel.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useId, useState } from "react";
+import type {
+  CodexMcpAuthStatus,
+  CodexMcpInventoryDetail,
+  CodexMcpServerSummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import { CloseIcon } from "../../icons";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { readRendererFederationTarget } from "../../lib/federation-window";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
+
+export type McpInventoryPanelRequest = {
+  detail: CodexMcpInventoryDetail;
+  requestId: number;
+};
+
+type McpInventoryPanelProps = {
+  desktopApi?: DesktopApi;
+  onDismiss: () => void;
+  request: McpInventoryPanelRequest;
+  thread: NavigationThreadSummary;
+};
+
+const RELOAD_TOOLTIP =
+  "Re-read installed MCP configuration and queue it for loaded Codex threads. "
+  + "Each thread receives the updated MCP list when its next turn starts.";
+
+export function McpInventoryPanel(props: McpInventoryPanelProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const [servers, setServers] = useState<CodexMcpServerSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [reloading, setReloading] = useState(false);
+  const [reloadStatus, setReloadStatus] = useState<string>();
+  const bodyId = useId();
+  const reloadTooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const federationTarget =
+    props.thread.federation?.ref.target ?? readRendererFederationTarget();
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(undefined);
+    setReloadStatus(undefined);
+    void props.desktopApi?.listThreadMcpServers?.({
+      backend: props.thread.source,
+      ...(federationTarget ? { federationTarget } : {}),
+      threadId: props.thread.id,
+      detail: props.request.detail,
+    }).then((response) => {
+      if (cancelled) return;
+      setServers(response.servers);
+      setLoading(false);
+    }).catch((nextError: unknown) => {
+      if (cancelled) return;
+      setError(nextError instanceof Error ? nextError.message : String(nextError));
+      setLoading(false);
+    });
+    if (!props.desktopApi?.listThreadMcpServers) {
+      setError("MCP inventory is unavailable in this build.");
+      setLoading(false);
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    federationTarget,
+    props.desktopApi,
+    props.request.detail,
+    props.request.requestId,
+    props.thread.id,
+    props.thread.source,
+  ]);
+
+  const reloadConfig = async (): Promise<void> => {
+    if (!props.desktopApi?.reloadCodexMcpConfig || reloading) return;
+    setReloading(true);
+    setReloadStatus(undefined);
+    try {
+      await props.desktopApi.reloadCodexMcpConfig({
+        backend: props.thread.source,
+        ...(federationTarget ? { federationTarget } : {}),
+        threadId: props.thread.id,
+      });
+      setReloadStatus(
+        "Config reload queued. The updated MCP list applies when the next turn starts.",
+      );
+    } catch (nextError) {
+      setReloadStatus(
+        nextError instanceof Error ? nextError.message : String(nextError),
+      );
+    } finally {
+      setReloading(false);
+    }
+  };
+
+  const toolCount = servers.reduce(
+    (total, server) => total + server.tools.length,
+    0,
+  );
+  const title = loading
+    ? "MCP Tools"
+    : `MCP Tools · ${servers.length} server${servers.length === 1 ? "" : "s"}`
+      + ` · ${toolCount} tool${toolCount === 1 ? "" : "s"}`;
+
+  return (
+    <aside
+      className={`live-work-rail mcp-inventory-panel${
+        collapsed ? " live-work-rail--collapsed" : ""
+      }`}
+      aria-label={title}
+    >
+      <header className="live-work-rail__header">
+        <button
+          type="button"
+          className="live-work-rail__collapse"
+          aria-expanded={!collapsed}
+          aria-controls={bodyId}
+          onClick={() => setCollapsed((current) => !current)}
+        >
+          <span className="live-work-rail__chevron" aria-hidden="true" />
+          <span className="live-work-rail__title">{title}</span>
+        </button>
+        <div className="live-work-rail__header-actions">
+          <button
+            type="button"
+            className="mcp-inventory-panel__reload"
+            aria-describedby={
+              reloadTooltip.visible ? reloadTooltip.tooltipId : undefined
+            }
+            disabled={reloading || !props.desktopApi?.reloadCodexMcpConfig}
+            onClick={() => void reloadConfig()}
+            onMouseEnter={(event) =>
+              reloadTooltip.show(event.currentTarget, RELOAD_TOOLTIP)
+            }
+            onMouseLeave={reloadTooltip.hide}
+            onFocus={(event) =>
+              reloadTooltip.show(event.currentTarget, RELOAD_TOOLTIP)
+            }
+            onBlur={reloadTooltip.hide}
+          >
+            {reloading ? "Reloading…" : "Reload Config"}
+          </button>
+          {reloadTooltip.tooltipNode}
+          <button
+            type="button"
+            className="mcp-inventory-panel__dismiss"
+            aria-label="Close MCP tools"
+            title="Close MCP tools"
+            onClick={props.onDismiss}
+          >
+            <CloseIcon size={13} aria-hidden="true" />
+          </button>
+        </div>
+      </header>
+      <div id={bodyId} className="live-work-rail__body" hidden={collapsed}>
+        {loading ? (
+          <p className="mcp-inventory-panel__state" role="status">
+            Reading MCP inventory…
+          </p>
+        ) : error ? (
+          <p className="mcp-inventory-panel__state mcp-inventory-panel__state--error">
+            {error}
+          </p>
+        ) : servers.length === 0 ? (
+          <p className="mcp-inventory-panel__state">No MCP servers available.</p>
+        ) : (
+          <ul className="mcp-inventory-panel__servers">
+            {servers.map((server) => (
+              <McpServerRow
+                key={server.name}
+                detail={props.request.detail}
+                server={server}
+              />
+            ))}
+          </ul>
+        )}
+        {reloadStatus ? (
+          <p className="mcp-inventory-panel__reload-status" role="status">
+            {reloadStatus}
+          </p>
+        ) : null}
+      </div>
+    </aside>
+  );
+}
+
+function McpServerRow(props: {
+  detail: CodexMcpInventoryDetail;
+  server: CodexMcpServerSummary;
+}) {
+  return (
+    <li className="mcp-inventory-panel__server">
+      <div className="mcp-inventory-panel__server-header">
+        <span className="mcp-inventory-panel__server-name">{props.server.name}</span>
+        <span className="mcp-inventory-panel__auth">
+          {formatAuthStatus(props.server.authStatus)}
+        </span>
+      </div>
+      <InventoryLine label="Tools" values={props.server.tools} />
+      {props.detail === "full" ? (
+        <>
+          <InventoryLine
+            label="Resources"
+            values={(props.server.resources ?? []).map((resource) =>
+              `${resource.title ?? resource.name} (${resource.uri})`
+            )}
+          />
+          <InventoryLine
+            label="Templates"
+            values={(props.server.resourceTemplates ?? []).map((template) =>
+              `${template.title ?? template.name} (${template.uriTemplate})`
+            )}
+          />
+        </>
+      ) : null}
+    </li>
+  );
+}
+
+function InventoryLine(props: { label: string; values: string[] }) {
+  return (
+    <div className="mcp-inventory-panel__line">
+      <span className="mcp-inventory-panel__line-label">{props.label}</span>
+      <span className="mcp-inventory-panel__line-value">
+        {props.values.length > 0 ? props.values.join(", ") : "None"}
+      </span>
+    </div>
+  );
+}
+
+function formatAuthStatus(status: CodexMcpAuthStatus): string {
+  switch (status) {
+    case "notLoggedIn":
+      return "Sign-in required";
+    case "bearerToken":
+      return "Bearer token";
+    case "oAuth":
+      return "OAuth";
+    case "unsupported":
+      return "No authentication";
+  }
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -93,6 +93,10 @@ import { TranscriptCopyButton } from "./TranscriptCopyButton";
 import { TranscriptList } from "./TranscriptList";
 import { LiveWorkRail } from "./LiveWorkRail";
 import {
+  McpInventoryPanel,
+  type McpInventoryPanelRequest,
+} from "./McpInventoryPanel";
+import {
   PwrSnapConnectionPrompt,
   pwrSnapConnectionIds,
 } from "./PwrSnapConnectionPrompt";
@@ -1423,6 +1427,22 @@ export function ThreadView(props: ThreadViewProps) {
   const selectedThreadKey = selectedThread
     ? buildThreadIdentityKey(selectedThread.source, selectedThread.id)
     : undefined;
+  const [mcpInventoryRequest, setMcpInventoryRequest] =
+    useState<McpInventoryPanelRequest>();
+  const mcpInventoryRequestSequence = useRef(0);
+  useEffect(() => {
+    setMcpInventoryRequest(undefined);
+  }, [selectedThreadKey]);
+  const showMcpInventory = useCallback(
+    (detail: McpInventoryPanelRequest["detail"]): void => {
+      mcpInventoryRequestSequence.current += 1;
+      setMcpInventoryRequest({
+        detail,
+        requestId: mcpInventoryRequestSequence.current,
+      });
+    },
+    [],
+  );
   const onLoadOlder = props.onLoadOlder;
   const onRenderedTranscriptEntryLimitChange =
     props.onRenderedTranscriptEntryLimitChange;
@@ -3259,6 +3279,14 @@ export function ThreadView(props: ThreadViewProps) {
             }
           />
 
+          {mcpInventoryRequest && selectedThread?.source === "codex" ? (
+            <McpInventoryPanel
+              desktopApi={props.desktopApi}
+              onDismiss={() => setMcpInventoryRequest(undefined)}
+              request={mcpInventoryRequest}
+              thread={selectedThread}
+            />
+          ) : null}
 
           <Composer
             activeTurnId={props.activeTurnId}
@@ -3269,6 +3297,7 @@ export function ThreadView(props: ThreadViewProps) {
             codexFastAllowed={props.codexFastAllowed}
             desktopApi={props.desktopApi}
             onShowNotice={props.onShowNotice}
+            onShowMcpInventory={showMcpInventory}
             composerImplementation={props.composerImplementation}
             draftStore={props.composerDraftStore}
             directory={props.selectedDirectory}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx
@@ -1,11 +1,21 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { McpInventoryPanel } from "../McpInventoryPanel";
 
 afterEach(() => {
   cleanup();
+  delete (window as typeof window & {
+    __pwragentFederationTarget?: unknown;
+  }).__pwragentFederationTarget;
 });
 
 const thread = {
@@ -94,5 +104,47 @@ describe("McpInventoryPanel", () => {
     expect(await screen.findByRole("status")).toHaveTextContent(
       "applies when the next turn starts",
     );
+  });
+
+  it("keeps the federation-window target stable across state updates", async () => {
+    (window as typeof window & {
+      __pwragentFederationTarget?: {
+        scope: "remote";
+        instanceId: string;
+      };
+    }).__pwragentFederationTarget = {
+      scope: "remote",
+      instanceId: "owner-instance",
+    };
+    const listThreadMcpServers = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      detail: "toolsAndAuthOnly" as const,
+      servers: [],
+    }));
+
+    render(
+      <McpInventoryPanel
+        desktopApi={{ listThreadMcpServers }}
+        onDismiss={vi.fn()}
+        request={{ detail: "toolsAndAuthOnly", requestId: 1 }}
+        thread={thread}
+      />,
+    );
+
+    expect(await screen.findByText("No MCP servers available.")).toBeInTheDocument();
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    expect(listThreadMcpServers).toHaveBeenCalledTimes(1);
+    expect(listThreadMcpServers).toHaveBeenCalledWith({
+      backend: "codex",
+      federationTarget: {
+        scope: "remote",
+        instanceId: "owner-instance",
+      },
+      threadId: "thread-1",
+      detail: "toolsAndAuthOnly",
+    });
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx
@@ -106,6 +106,56 @@ describe("McpInventoryPanel", () => {
     );
   });
 
+  it("collapses large server catalogs into expandable previews", async () => {
+    const tools = Array.from({ length: 10 }, (_, index) => `tool-${index + 1}`);
+    const resources = Array.from({ length: 4 }, (_, index) => ({
+      name: `resource-${index + 1}`,
+      uri: `plugin://resource-${index + 1}`,
+    }));
+
+    render(
+      <McpInventoryPanel
+        desktopApi={{
+          listThreadMcpServers: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            detail: "full",
+            servers: [
+              {
+                name: "codex_apps",
+                authStatus: "oAuth",
+                tools,
+                resources,
+                resourceTemplates: [],
+              },
+            ],
+          }),
+        }}
+        onDismiss={vi.fn()}
+        request={{ detail: "full", requestId: 1 }}
+        thread={thread}
+      />,
+    );
+
+    const panel = await screen.findByRole("complementary", {
+      name: "MCP Tools · 1 server · 10 tools",
+    });
+    expect(panel).toHaveTextContent("tool-8");
+    expect(panel).not.toHaveTextContent("tool-9");
+    expect(panel).toHaveTextContent("resource-3");
+    expect(panel).not.toHaveTextContent("resource-4");
+
+    fireEvent.click(screen.getByRole("button", { name: "Show 2 more Tools" }));
+    expect(panel).toHaveTextContent("tool-10");
+    fireEvent.click(screen.getByRole("button", { name: "Show fewer Tools" }));
+    expect(panel).not.toHaveTextContent("tool-9");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show 1 more Resources" }),
+    );
+    expect(panel).toHaveTextContent("resource-4");
+  });
+
   it("keeps the federation-window target stable across state updates", async () => {
     (window as typeof window & {
       __pwragentFederationTarget?: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx
@@ -5,7 +5,6 @@ import {
   fireEvent,
   render,
   screen,
-  waitFor,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DesktopApi } from "../../../lib/desktop-api";
@@ -13,6 +12,7 @@ import { McpInventoryPanel } from "../McpInventoryPanel";
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   delete (window as typeof window & {
     __pwragentFederationTarget?: unknown;
   }).__pwragentFederationTarget;
@@ -63,7 +63,7 @@ describe("McpInventoryPanel", () => {
     });
   });
 
-  it("queues a config reload and explains the next-turn boundary", async () => {
+  it("holds confirmed reload feedback and explains the next-turn boundary", async () => {
     const reloadCodexMcpConfig = vi.fn(async () => ({
       backend: "codex" as const,
       threadId: "thread-1",
@@ -93,17 +93,31 @@ describe("McpInventoryPanel", () => {
     expect(await screen.findByRole("tooltip")).toHaveTextContent(
       "Re-read installed MCP configuration",
     );
-    fireEvent.click(reload);
-
-    await waitFor(() => {
-      expect(reloadCodexMcpConfig).toHaveBeenCalledWith({
-        backend: "codex",
-        threadId: "thread-1",
-      });
+    vi.useFakeTimers();
+    await act(async () => {
+      fireEvent.click(reload);
+      await Promise.resolve();
     });
-    expect(await screen.findByRole("status")).toHaveTextContent(
+
+    expect(reloadCodexMcpConfig).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const confirmed = screen.getByRole("button", { name: "Reload queued" });
+    expect(confirmed).toBeDisabled();
+    expect(screen.getByRole("status")).toHaveTextContent(
       "applies when the next turn starts",
     );
+
+    await act(async () => {
+      vi.advanceTimersByTime(4_999);
+    });
+    expect(screen.getByRole("button", { name: "Reload queued" })).toBeDisabled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.getByRole("button", { name: "Reload Config" })).toBeEnabled();
   });
 
   it("collapses large server catalogs into expandable previews", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx
@@ -1,0 +1,98 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { McpInventoryPanel } from "../McpInventoryPanel";
+
+afterEach(() => {
+  cleanup();
+});
+
+const thread = {
+  id: "thread-1",
+  title: "MCP inventory",
+  titleSource: "explicit" as const,
+  source: "codex" as const,
+  executionMode: "default" as const,
+  linkedDirectories: [],
+  inbox: { inInbox: false },
+};
+
+describe("McpInventoryPanel", () => {
+  it("shows the bounded tools-and-auth inventory", async () => {
+    const listThreadMcpServers = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      detail: "toolsAndAuthOnly" as const,
+      servers: [
+        {
+          name: "atlassian-rovo",
+          authStatus: "oAuth" as const,
+          tools: ["fetch", "search"],
+        },
+      ],
+    }));
+
+    render(
+      <McpInventoryPanel
+        desktopApi={{ listThreadMcpServers }}
+        onDismiss={vi.fn()}
+        request={{ detail: "toolsAndAuthOnly", requestId: 1 }}
+        thread={thread}
+      />,
+    );
+
+    expect(screen.getByText("Reading MCP inventory…")).toBeInTheDocument();
+    expect(await screen.findByText("atlassian-rovo")).toBeInTheDocument();
+    expect(screen.getByText("fetch, search")).toBeInTheDocument();
+    expect(screen.getByText("OAuth")).toBeInTheDocument();
+    expect(listThreadMcpServers).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      detail: "toolsAndAuthOnly",
+    });
+  });
+
+  it("queues a config reload and explains the next-turn boundary", async () => {
+    const reloadCodexMcpConfig = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      queued: true as const,
+    }));
+    const desktopApi: DesktopApi = {
+      listThreadMcpServers: async () => ({
+        backend: "codex",
+        threadId: "thread-1",
+        detail: "full",
+        servers: [],
+      }),
+      reloadCodexMcpConfig,
+    };
+
+    render(
+      <McpInventoryPanel
+        desktopApi={desktopApi}
+        onDismiss={vi.fn()}
+        request={{ detail: "full", requestId: 1 }}
+        thread={thread}
+      />,
+    );
+
+    const reload = screen.getByRole("button", { name: "Reload Config" });
+    fireEvent.mouseEnter(reload);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Re-read installed MCP configuration",
+    );
+    fireEvent.click(reload);
+
+    await waitFor(() => {
+      expect(reloadCodexMcpConfig).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+      });
+    });
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "applies when the next turn starts",
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -92,6 +92,8 @@ import type {
   ListAutomationsResponse,
   ListBackendsRequest,
   ListBackendsResponse,
+  ListThreadMcpServersRequest,
+  ListThreadMcpServersResponse,
   ListAcpAgentSettingsRequest,
   ListAcpAgentSettingsResponse,
   AcknowledgeAcpAgentUpdateRequest,
@@ -268,6 +270,8 @@ import type {
   CancelThreadExecutionModeQueueResponse,
   QueueThreadExecutionModeRequest,
   QueueThreadExecutionModeResponse,
+  ReloadCodexMcpConfigRequest,
+  ReloadCodexMcpConfigResponse,
   SetAcpSessionRuntimeOptionRequest,
   SetAcpSessionRuntimeOptionResponse,
   SetThreadExecutionModeRequest,
@@ -611,6 +615,12 @@ export type DesktopApi = {
   compactThread?: (
     request: CompactThreadRequest
   ) => Promise<CompactThreadResponse>;
+  listThreadMcpServers?: (
+    request: ListThreadMcpServersRequest,
+  ) => Promise<ListThreadMcpServersResponse>;
+  reloadCodexMcpConfig?: (
+    request: ReloadCodexMcpConfigRequest,
+  ) => Promise<ReloadCodexMcpConfigResponse>;
   startTurn?: (request: StartTurnRequest) => Promise<StartTurnResponse>;
   cancelQueuedTurn?: (
     request: CancelQueuedTurnRequest,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13887,7 +13887,7 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .mcp-inventory-panel__line {
   display: grid;
-  grid-template-columns: 72px minmax(0, 1fr);
+  grid-template-columns: 88px minmax(0, 1fr);
   gap: 8px;
   font-size: 11px;
   line-height: 1.45;
@@ -13898,12 +13898,45 @@ a.transcript-message__messaging-origin:focus-visible {
   font-weight: 600;
 }
 
+.mcp-inventory-panel__line-count {
+  font-weight: 400;
+}
+
 .mcp-inventory-panel__line-value {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
   min-width: 0;
   color: var(--text-secondary);
   font-family: var(--font-mono);
   overflow-wrap: anywhere;
   user-select: text;
+}
+
+.mcp-inventory-panel__line-items {
+  min-width: 0;
+}
+
+.mcp-inventory-panel__line-toggle {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  user-select: none;
+}
+
+.mcp-inventory-panel__line-toggle:hover {
+  color: var(--accent-bright);
+}
+
+.mcp-inventory-panel__line-toggle:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 .mcp-inventory-panel__state,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13812,6 +13812,10 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 .mcp-inventory-panel__reload {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
   padding: 3px 8px;
   font-size: 11px;
   font-weight: 600;
@@ -13841,6 +13845,13 @@ a.transcript-message__messaging-origin:focus-visible {
 .mcp-inventory-panel__reload:disabled {
   cursor: default;
   opacity: 0.55;
+}
+
+.mcp-inventory-panel__reload--success:disabled {
+  border-color: var(--success-border);
+  background: var(--success-soft);
+  color: var(--success-text);
+  opacity: 1;
 }
 
 .mcp-inventory-panel__servers {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13797,6 +13797,135 @@ a.transcript-message__messaging-origin:focus-visible {
   display: none;
 }
 
+.mcp-inventory-panel {
+  max-height: min(44vh, 420px);
+}
+
+.mcp-inventory-panel__reload,
+.mcp-inventory-panel__dismiss {
+  flex: 0 0 auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.mcp-inventory-panel__reload {
+  padding: 3px 8px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.mcp-inventory-panel__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+}
+
+.mcp-inventory-panel__reload:hover:not(:disabled),
+.mcp-inventory-panel__dismiss:hover {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.mcp-inventory-panel__reload:focus-visible,
+.mcp-inventory-panel__dismiss:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.mcp-inventory-panel__reload:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.mcp-inventory-panel__servers {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mcp-inventory-panel__server {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+}
+
+.mcp-inventory-panel__server-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.mcp-inventory-panel__server-name {
+  min-width: 0;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.mcp-inventory-panel__auth {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.mcp-inventory-panel__line {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 8px;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.mcp-inventory-panel__line-label {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.mcp-inventory-panel__line-value {
+  min-width: 0;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+  user-select: text;
+}
+
+.mcp-inventory-panel__state,
+.mcp-inventory-panel__reload-status {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.mcp-inventory-panel__state--error {
+  color: var(--danger-text);
+}
+
+.mcp-inventory-panel__reload-status {
+  padding: 7px 8px;
+  border: 1px solid var(--info-border);
+  border-radius: 6px;
+  background: var(--info-soft);
+  color: var(--info-text);
+}
+
 .live-work-rail__section {
   display: flex;
   flex-direction: column;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -66,6 +66,10 @@ export const SCHEDULED_ACTIONS_CANCEL_CHANNEL = "scheduled-actions:cancel";
 export const SCHEDULED_ACTIONS_SEND_NOW_CHANNEL = "scheduled-actions:send-now";
 export const AGENT_START_REVIEW_CHANNEL = "agent:start-review";
 export const AGENT_COMPACT_THREAD_CHANNEL = "agent:compact-thread";
+export const AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL =
+  "agent:list-thread-mcp-servers";
+export const AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL =
+  "agent:reload-codex-mcp-config";
 export const AGENT_INTERRUPT_TURN_CHANNEL = "agent:interrupt-turn";
 export const AGENT_STOP_SUB_AGENT_CHANNEL = "agent:stop-sub-agent";
 export const AGENT_STEER_TURN_CHANNEL = "agent:steer-turn";

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -406,6 +406,60 @@ export type CompactThreadResponse = {
   itemId?: string;
 };
 
+export type CodexMcpInventoryDetail = "toolsAndAuthOnly" | "full";
+
+export type CodexMcpAuthStatus =
+  | "unsupported"
+  | "notLoggedIn"
+  | "bearerToken"
+  | "oAuth";
+
+export type CodexMcpResourceSummary = {
+  name: string;
+  title?: string;
+  uri: string;
+};
+
+export type CodexMcpResourceTemplateSummary = {
+  name: string;
+  title?: string;
+  uriTemplate: string;
+};
+
+export type CodexMcpServerSummary = {
+  name: string;
+  authStatus: CodexMcpAuthStatus;
+  tools: string[];
+  resources?: CodexMcpResourceSummary[];
+  resourceTemplates?: CodexMcpResourceTemplateSummary[];
+};
+
+export type ListThreadMcpServersRequest = {
+  backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
+  threadId: ThreadIdentifier;
+  detail?: CodexMcpInventoryDetail;
+};
+
+export type ListThreadMcpServersResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  detail: CodexMcpInventoryDetail;
+  servers: CodexMcpServerSummary[];
+};
+
+export type ReloadCodexMcpConfigRequest = {
+  backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
+  threadId: ThreadIdentifier;
+};
+
+export type ReloadCodexMcpConfigResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  queued: true;
+};
+
 export type SteerTurnRequest = {
   backend: AppServerBackendKind;
   federationTarget?: FederationTarget;


### PR DESCRIPTION
## What

- expose Codex `/mcp` and `/mcp verbose` as local composer commands
- render MCP server, authentication, tool, resource, and resource-template status in a bounded panel above the composer
- add a Codex-only **Reload Config** action with a tooltip and success copy that explain the next-turn activation boundary
- route MCP inventory and reload requests through the owning Codex profile and across Federation when the thread is remote
- add the same MCP inventory entry to the composer thread-options menu

## Why

Codex's `/mcp` command is a status view; it does not refresh a loaded thread's MCP configuration. Codex App Server exposes `config/mcpServer/reload` separately. That method re-reads MCP config and queues loaded threads to receive the new MCP list on their next active turn, which lets PwrAgent recover from plugin/MCP installation changes without replacing the thread UUID or migrating thread relationships.

This intentionally affects MCP configuration only. It does not attempt to replace Codex dynamic tools.

## Impact

- Codex threads gain `/mcp`, `/mcp verbose`, and an MCP tools menu action.
- ACP threads do not advertise or handle these commands.
- Slash commands are intercepted locally and never sent to the model as chat input.
- Remote-thread requests retain existing Federation capability checks (`thread_detail` for status, `turn_control` for reload).

## Checks

- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (passes with the repository's existing warning baseline)
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- focused Vitest suite: 6 files, 968 tests passed
- `git diff --check`

Headed desktop E2E was not run because repository guidance requires an operator-provided off-desktop lab for headed runs.
