### PR TITLE
docs(agent-core): simplify reflected tool guidance

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -8868,19 +8868,19 @@ script = "echo setup"
     const getThreadStatusTool = pwragentDynamicTools(dynamicTools)
       .find((tool) => tool.name === "get_thread_status");
     expect(getThreadStatusTool?.description).toContain(
-      "Omit backend and threadId to inspect the current thread",
+      "Omit backend and threadId for the current thread",
     );
     expect(getThreadStatusTool?.inputSchema?.required ?? []).toEqual([]);
     const attachPullRequestTool = pwragentDynamicTools(dynamicTools)
       .find((tool) => tool.name === "attach_thread_pull_request");
     expect(attachPullRequestTool?.description).toContain(
-      "Omit backend and threadId to attach to the current thread",
+      "Omit backend and threadId for the current thread",
     );
     expect(attachPullRequestTool?.inputSchema?.required ?? []).toEqual([]);
     const checkPullRequestStatusTool = pwragentDynamicTools(dynamicTools)
       .find((tool) => tool.name === "check_thread_pull_request_status");
     expect(checkPullRequestStatusTool?.description).toContain(
-      "Omit backend and threadId to check the current thread",
+      "Omit backend and threadId for the current thread",
     );
     expect(checkPullRequestStatusTool?.inputSchema?.required ?? []).toEqual([]);
     await expect(

--- a/apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts
@@ -68,6 +68,23 @@ describe("PwrAgent messaging agent tools", () => {
       "send_private_response",
       "attach_thread_here",
     ]);
+    const privateResponseTool = specs[0]?.type === "namespace"
+      ? specs[0].tools.find((tool) => tool.name === "send_private_response")
+      : undefined;
+    expect(privateResponseTool).toMatchObject({
+      description: expect.stringContaining(
+        "Only the continuation's final response returns to the source surface",
+      ),
+      inputSchema: expect.objectContaining({
+        properties: expect.objectContaining({
+          awaitReply: expect.objectContaining({
+            description: expect.stringContaining(
+              "start a continuation from the first private reply",
+            ),
+          }),
+        }),
+      }),
+    });
     const attachTool = specs[0]?.type === "namespace"
       ? specs[0].tools.find((tool) => tool.name === "attach_thread_here")
       : undefined;

--- a/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
@@ -50,10 +50,10 @@ describe("PwrAgent thread agent tools", () => {
     expect(tools.find((tool) => tool.name === "watch_thread_pull_request"))
       .toMatchObject({
         name: "watch_thread_pull_request",
-        description: expect.stringContaining("end the current turn"),
+        description: expect.stringContaining("After creation, end the turn"),
       });
     expect(tools.find((tool) => tool.name === "read_thread")).toMatchObject({
-      description: expect.stringContaining("connected Federation peer"),
+      description: expect.stringContaining("Pass instanceId for a known remote thread"),
       inputSchema: expect.objectContaining({
         properties: expect.objectContaining({
           instanceId: expect.objectContaining({ type: "string" }),

--- a/apps/desktop/src/main/agent-tools/__tests__/agent-tool-mcp-server.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/agent-tool-mcp-server.test.ts
@@ -3,7 +3,10 @@ import {
   StreamableHTTPClientTransport,
 } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { AgentToolRouter } from "../agent-tool-router";
+import {
+  AgentToolRouter,
+  PWRAGENT_AGENT_TOOL_NAMESPACE_DESCRIPTION,
+} from "../agent-tool-router";
 import {
   AgentToolMcpServer,
   type AgentToolMcpClientContext,
@@ -60,6 +63,9 @@ describe("AgentToolMcpServer", () => {
 
     const client = await connectClient(registration);
     try {
+      expect(client.getInstructions()).toBe(
+        PWRAGENT_AGENT_TOOL_NAMESPACE_DESCRIPTION,
+      );
       await expect(client.listTools()).resolves.toMatchObject({
         tools: [
           {

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-federation-agent-tools.test.ts
@@ -18,7 +18,7 @@ describe("pwragent federation agent tools", () => {
             type: "function",
             name: "list_federation_instances",
             deferLoading: false,
-            description: expect.stringContaining("machineId"),
+            description: expect.stringContaining("known PwrAgent peers"),
             inputSchema: expect.objectContaining({
               type: "object",
               additionalProperties: false,
@@ -57,7 +57,7 @@ describe("pwragent federation agent tools", () => {
             type: "function",
             name: "search_federation_threads",
             deferLoading: false,
-            description: expect.stringContaining("every reachable PwrAgent instance"),
+            description: expect.stringContaining("local and connected PwrAgent instances"),
             inputSchema: expect.objectContaining({
               required: ["query"],
               properties: expect.objectContaining({

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-task-monitor-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-task-monitor-agent-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { resolveAgentToolCatalogs } from "../agent-tool-catalog-registry";
+import { PWRAGENT_AGENT_TOOL_NAMESPACE_DESCRIPTION } from "../agent-tool-router";
 import { buildPwrAgentTaskMonitorToolRouter } from "../pwragent-task-monitor-agent-tools";
 
 describe("PwrAgent task monitor agent tools", () => {
@@ -50,21 +51,21 @@ describe("PwrAgent task monitor agent tools", () => {
       (tool) => tool.name === "create_monitor_delegation",
     );
     expect(createMonitorTool?.description).toContain(
-      "Normally omit preferredModel and preferredReasoningEffort",
+      "Omit preferredModel and preferredReasoningEffort",
     );
     expect(createMonitorTool?.description).toContain(
-      "Do not use this to poll an attached pull request",
+      "Do not use it for an attached PR",
     );
     expect(createMonitorTool?.inputSchema).toMatchObject({
       properties: {
         preferredModel: {
           description: expect.stringContaining(
-            "Normally omit so PwrAgent uses its managed monitor default",
+            "Omit it to use the monitor default",
           ),
         },
         preferredReasoningEffort: {
           description: expect.stringContaining(
-            "Normally omit so PwrAgent uses its managed monitor default",
+            "Omit it to use the monitor default",
           ),
         },
       },
@@ -78,6 +79,35 @@ describe("PwrAgent task monitor agent tools", () => {
     expect(cancelMonitorTool?.inputSchema).toMatchObject({
       required: ["monitorId"],
     });
+  });
+
+  it("keeps reflected descriptions at 20 words or fewer", () => {
+    const descriptions = new Set<string>([
+      PWRAGENT_AGENT_TOOL_NAMESPACE_DESCRIPTION,
+    ]);
+    const visit = (value: unknown): void => {
+      if (!value || typeof value !== "object") {
+        return;
+      }
+      for (const [key, child] of Object.entries(value)) {
+        if (key === "description" && typeof child === "string") {
+          descriptions.add(child);
+        } else {
+          visit(child);
+        }
+      }
+    };
+    for (const catalog of resolveAgentToolCatalogs({})) {
+      visit(catalog.dynamicTools);
+    }
+
+    for (const description of descriptions) {
+      expect(description).not.toContain(";");
+      for (const sentence of description.split(/[.!?]+(?:\s|$)/u)) {
+        const wordCount = sentence.trim().split(/\s+/u).filter(Boolean).length;
+        expect(wordCount, sentence).toBeLessThanOrEqual(20);
+      }
+    }
   });
 
   it("dispatches dynamic and MCP monitor creation with matching ACP context", async () => {

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
@@ -17,7 +17,7 @@ describe("pwragent thread orchestration agent tools", () => {
           expect.objectContaining({
             type: "function",
             name: "attach_thread_directory",
-            description: expect.stringContaining("secondary worktree"),
+            description: expect.stringContaining("cross-project work"),
             deferLoading: false,
             inputSchema: expect.objectContaining({
               required: ["path"],
@@ -52,7 +52,7 @@ describe("pwragent thread orchestration agent tools", () => {
             type: "function",
             name: "handoff_task",
             description: expect.stringMatching(
-              /Prefer this to backend-native spawning.*Same-project handoffs default to grouped subthreads.*Cross-project handoffs are ungrouped/,
+              /Prefer this to backend spawning.*same-project handoffs create grouped subthreads.*Cross-project handoffs are not grouped/,
             ),
             deferLoading: false,
             inputSchema: expect.objectContaining({
@@ -63,13 +63,13 @@ describe("pwragent thread orchestration agent tools", () => {
                 }),
                 groupingMode: expect.objectContaining({
                   enum: ["none", "subthread"],
-                  description: expect.stringContaining("defaults for same-project"),
+                  description: expect.stringContaining("same-project default"),
                 }),
                 workspaceMode: expect.objectContaining({
                   enum: ["same", "same_workspace", "project_local", "new_worktree", "none"],
                 }),
                 cwd: expect.objectContaining({
-                  description: expect.stringContaining("task text does not select cwd"),
+                  description: expect.stringContaining("Task text does not select cwd"),
                 }),
                 backend: expect.objectContaining({
                   description: expect.stringContaining("`acp:grok`"),
@@ -78,7 +78,7 @@ describe("pwragent thread orchestration agent tools", () => {
                   description: expect.stringContaining("`grok-4.5`"),
                 }),
                 branchName: expect.objectContaining({
-                  description: expect.stringContaining("existing base branch/ref"),
+                  description: expect.stringContaining("Existing base ref"),
                 }),
               }),
             }),
@@ -86,7 +86,7 @@ describe("pwragent thread orchestration agent tools", () => {
           expect.objectContaining({
             type: "function",
             name: "move_thread_workspace",
-            description: expect.stringContaining("same-thread continuation"),
+            description: expect.stringContaining("starts a continuation"),
             deferLoading: false,
             inputSchema: expect.objectContaining({
               additionalProperties: false,
@@ -106,7 +106,7 @@ describe("pwragent thread orchestration agent tools", () => {
           expect.objectContaining({
             type: "function",
             name: "send_message_to_thread",
-            description: expect.stringMatching(/schedules\/queues.*steer_thread/),
+            description: expect.stringMatching(/queues the follow-up.*steer_thread/),
             deferLoading: false,
             inputSchema: expect.objectContaining({
               required: ["backend", "threadId", "prompt"],
@@ -120,7 +120,7 @@ describe("pwragent thread orchestration agent tools", () => {
             type: "function",
             name: "steer_thread",
             description: expect.stringMatching(
-              /next tool completion or message boundary.*never reports a queued follow-up as steered/,
+              /next tool boundary.*never reports a queued follow-up as steered/,
             ),
             deferLoading: false,
             inputSchema: expect.objectContaining({
@@ -135,7 +135,7 @@ describe("pwragent thread orchestration agent tools", () => {
           expect.objectContaining({
             type: "function",
             name: "stop_thread",
-            description: expect.stringMatching(/high-urgency.*never queues text/),
+            description: expect.stringMatching(/urgent interruption.*does not queue text/),
             deferLoading: false,
             inputSchema: expect.objectContaining({
               required: ["backend", "threadId", "requestId"],
@@ -149,7 +149,7 @@ describe("pwragent thread orchestration agent tools", () => {
           expect.objectContaining({
             type: "function",
             name: "start_review",
-            description: expect.stringContaining("after the current turn completes successfully"),
+            description: expect.stringContaining("current turn ends successfully"),
             deferLoading: false,
             inputSchema: expect.objectContaining({
               required: ["target"],

--- a/apps/desktop/src/main/agent-tools/agent-tool-mcp-server.ts
+++ b/apps/desktop/src/main/agent-tools/agent-tool-mcp-server.ts
@@ -24,6 +24,7 @@ import { getMainLogger } from "../log.js";
 import type { ResolvedAgentToolCatalog } from "./agent-tool-catalog-registry.js";
 import { agentToolFailure } from "./agent-tool-definition.js";
 import {
+  PWRAGENT_AGENT_TOOL_NAMESPACE_DESCRIPTION,
   toMcpToolResponse,
   type AgentMcpToolCallResponse,
 } from "./agent-tool-router.js";
@@ -242,8 +243,7 @@ export class AgentToolMcpServer implements AgentToolMcpServerLike {
         capabilities: {
           tools: {},
         },
-        instructions:
-          "Tools for inspecting and controlling the PwrAgent thread that registered this MCP server.",
+        instructions: PWRAGENT_AGENT_TOOL_NAMESPACE_DESCRIPTION,
       },
     );
     mcpServer.setRequestHandler(ListToolsRequestSchema, async () => ({

--- a/apps/desktop/src/main/agent-tools/agent-tool-router.ts
+++ b/apps/desktop/src/main/agent-tools/agent-tool-router.ts
@@ -40,7 +40,7 @@ export type AgentMcpToolCallResponse = {
 };
 
 export const PWRAGENT_AGENT_TOOL_NAMESPACE_DESCRIPTION =
-  "PwrAgent-native tools for managing threads, delegated work, messaging, apps, and automations. Prefer PwrAgent thread and sub-agent management tools over backend-native equivalents when they can satisfy the request. Use backend-native spawning only when the user explicitly asks for it or requires a capability PwrAgent does not support.";
+  "PwrAgent tools manage threads, delegated work, messaging, apps, automations, and connected instances. Prefer these tools to backend tools when both can do the task.";
 
 export class AgentToolRouter {
   private readonly definitions: AgentToolDefinition[];

--- a/apps/desktop/src/main/agent-tools/pwragent-app-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-app-agent-tools.ts
@@ -76,7 +76,7 @@ export function buildPwrAgentAppToolDefinitions(
 function descriptionForOperation(operation: PwrAgentAppOperationName): string {
   switch (operation) {
     case "manage_pwragent":
-      return "Read PwrAgent runtime/update status, check for upgrades, or request a PwrAgent restart/stop.";
+      return "Read PwrAgent status, check for an upgrade, or request a restart or stop.";
   }
 }
 
@@ -94,7 +94,7 @@ function inputSchemaForOperation(
             type: "string",
             enum: PWRAGENT_APP_MANAGEMENT_ACTIONS,
             description:
-              "`status` reports version, start time, uptime, and update state. `upgrade_check` checks for an available or downloaded update. `restart` restarts PwrAgent and installs a downloaded update when one is ready. `stop` quits PwrAgent.",
+              "`status` gets version, start time, uptime, and update state. `upgrade_check` checks for an available or downloaded upgrade. `restart` installs a ready upgrade and restarts PwrAgent. `stop` quits PwrAgent.",
           },
         },
       };

--- a/apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts
@@ -188,7 +188,7 @@ function inputSchemaForOperation(
             type: "string",
             enum: INSTANCE_THREAD_GROUPING_MODES,
             description:
-              "Use subthread for delegated child work that should remain nested beneath the calling thread across instances; defaults to none for independent intake work.",
+              "Use subthread for child work that must remain nested across instances. The default none keeps independent intake separate.",
           },
         },
       };

--- a/apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-federation-agent-tools.ts
@@ -94,13 +94,13 @@ function descriptionForOperation(
 ): string {
   switch (operation) {
     case "list_federation_instances":
-      return "List the PwrAgent instances this app can reach: the local instance plus any federated peers, each with its id, display label, celestial icon, operator-written purpose notes, connection status, capabilities, an isLocal flag, and host facts (OS platform/version, hostname, CPU architecture and count, total RAM, free disk, machineId). Use this first when the user wants work routed to a particular machine ('on the studio Mac', 'on the rack mini') or for 'find me a place to run this' requests — purpose notes describe intent, host facts describe capability. Instances sharing the same host.machineId are profiles on one physical machine and compete for the same CPUs/RAM — never sum their capacity. Disk/host figures are snapshots from the last handshake, not live readings. For live readings, pass includeLoad: true to attach a `load` sibling next to `host` (1/5/15-minute CPU load averages, available RAM bytes, free disk bytes, sampledAt) fetched from each reachable instance with a short per-peer timeout — instances that fail to answer in time simply omit `load`. Load is per machine, not per instance: rows sharing host.machineId report the same underlying load, so dedupe by machineId when aggregating load for placement decisions. Results are paged: at most `limit` rows (default 25) per call, with nextCursor and totalCount when more remain; pass nextCursor back promptly (tokens expire after about a minute), or better, use `query` to filter by label, notes, profile, hostname, platform, or architecture instead of paging through a large fleet. Works with federation disabled too: the result is then just the local instance, so there is no need to check whether federation is configured before calling. Only instances with status connected (or the local instance) can accept new work.";
+      return "List the local instance and known PwrAgent peers. Results include identity, purpose, status, capabilities, and host facts. Use this before you route work to a machine. Profiles with the same machineId share one host. Do not add their CPU, memory, or disk capacity. Host facts come from the last connection. Set includeLoad=true for current load, available memory, free disk, and sample time. A peer can omit load if it does not reply in time. Load is per machineId. Count it once. Use query instead of paging when possible. Cursor tokens expire after about one minute. A local-only result is valid when Federation is disabled. Only local or connected instances can accept work.";
     case "list_instance_projects":
-      return "List the projects/directories available on one PwrAgent instance, local or remote. Pass an instanceId from list_federation_instances. Each project row carries the key to pass to create_instance_thread as projectKey, plus its label, filesystem path, and whether a launchpad (per-project environment, model, and execution-mode presets) is configured. Use this to find the project the user is talking about on the chosen instance before creating a thread there.";
+      return "List projects on one local or remote PwrAgent instance. Pass an instanceId from list_federation_instances. Each result includes projectKey, label, path, and launchpad status. Use projectKey with create_instance_thread.";
     case "create_instance_thread":
-      return "Create and start a new PwrAgent thread in a project on a chosen instance, local or remote. Pass instanceId from list_federation_instances and projectKey from list_instance_projects; input becomes the first prompt of the created thread. Set groupingMode=subthread when the new thread is delegated child work that should stay nested beneath the caller across instances; leave it none for independent intake/routing work. Omitted settings inherit the project's launchpad presets, then the instance defaults — only pass model/executionMode/workMode overrides the user asked for. Consult ~/.pwragent/AGENTS.md (when it exists) for the operator's thread-startup preferences such as default projects and settings before choosing values. For delegating work on the local instance from an ordinary thread, prefer handoff_task, which offers richer workspace and grouping options; use create_instance_thread when targeting another instance or when routing intake work by instance. Thread startup can take minutes while a worktree or environment is prepared; if this call is slow, do not call it again — use search_federation_threads to check whether the thread appeared. The result includes threadLink and instanceId. Include threadLink verbatim when telling the user about the thread so it renders as a clickable chip, and preserve instanceId when passing the remote target to send_message_to_thread.";
+      return "Create a PwrAgent thread in a project on a selected instance. Get instanceId and projectKey from the list tools. The input becomes the first prompt. Set groupingMode=subthread for delegated child work across instances. Use none for independent intake. Settings inherit from the launchpad and then the instance. Set overrides only when the user requests them. Read ~/.pwragent/AGENTS.md for operator startup preferences when it exists. Use handoff_task for local delegation that needs workspace or grouping controls. Use this tool for a selected instance or instance-based intake. Startup can take minutes. Do not retry a slow request. Use search_federation_threads to check for the thread. Return threadLink verbatim. Keep instanceId for later remote calls.";
     case "search_federation_threads":
-      return "Search threads across every reachable PwrAgent instance, including the local one, in a single call — use it to find 'the PwrSnap thread about X' wherever it lives. Use scope to pick the search surface: `all` (default) is local plus every connected peer, `local` is this instance only, and `remote` is every connected peer excluding local — the right choice when the user knows the thread is not on this machine. Pass instanceId to target one specific instance; scope and instanceId intersect when both are given. Backend, project, archive, and update-time filters are applied on each instance before the global result limit. Results carry the owning instanceId, its display label, an isLocal flag, and a threadLink that preserves cross-instance routing; failures lists peers that could not be searched. This is a metadata search (titles, summaries, project paths). For deeper local-only search with transcript content modes, use search_threads instead. Include threadLink verbatim when mentioning a result so it renders as a clickable chip, and preserve instanceId when passing a remote target to send_message_to_thread.";
+      return "Search thread metadata on local and connected PwrAgent instances. Use scope=all, local, or remote to select the search area. Pass instanceId to select one instance. Scope and instanceId both apply when you set both. Filters apply before the result limit. Results include owner data, threadLink, and peer failures. Use search_threads for local transcript or advanced searches. Return threadLink verbatim. Keep instanceId for later remote calls.";
   }
 }
 
@@ -116,7 +116,7 @@ function inputSchemaForOperation(
           query: {
             type: "string",
             description:
-              "Optional case-insensitive substring filter matched against label, purpose notes, profile name, instance id, hostname, OS platform/version, and CPU architecture. Prefer filtering over paging through a large fleet. Ignored when cursor is set.",
+              "Case-insensitive filter for labels, notes, profiles, instance IDs, hostnames, platforms, and CPU architecture. Prefer this to paging. A cursor disables it.",
           },
           limit: {
             type: "integer",
@@ -127,12 +127,12 @@ function inputSchemaForOperation(
           cursor: {
             type: "string",
             description:
-              "Continuation token from a previous truncated result. Tokens expire after about a minute; on an expired-cursor error, call again without a cursor.",
+              "Continuation token from a truncated result. It expires after about one minute. After expiry, call the tool without a cursor.",
           },
           includeLoad: {
             type: "boolean",
             description:
-              "When true, attach a live `load` block (CPU load averages, available RAM, free disk, sampledAt) to each reachable instance via a short-timeout on-demand query. Instances that fail to answer in time omit `load`. Rows sharing host.machineId report the same underlying load — dedupe by machineId when aggregating.",
+              "Set true to get current load, available memory, free disk, and sampledAt. A slow peer can omit `load`. Count each machineId once.",
           },
         },
       };
@@ -177,7 +177,7 @@ function inputSchemaForOperation(
             type: "string",
             enum: LAUNCHPAD_WORK_MODES,
             description:
-              "`worktree` runs the thread in an isolated Git worktree; `local` uses the project checkout directly. Omitted inherits the project's launchpad preset.",
+              "`worktree` uses an isolated Git worktree. `local` uses the project checkout. Omit workMode to inherit the launchpad preset.",
           },
           branchName: {
             type: "string",
@@ -231,7 +231,7 @@ function inputSchemaForOperation(
             type: "string",
             enum: FEDERATION_SEARCH_SCOPES,
             description:
-              "`all` (default) searches the local instance plus every connected peer. `local` searches only this instance. `remote` searches every connected peer and excludes local — use it when the thread is known to live on another machine.",
+              "`all` is the default and searches local and connected instances. `local` searches only this instance. `remote` searches only connected peers.",
           },
           instanceId: {
             type: "string",

--- a/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
@@ -117,17 +117,17 @@ function descriptionForOperation(operation: PwrAgentMessagingOperationName): str
     case "get_current_location":
       return "Deprecated alias for get_current_messaging_surface. Inspect the messaging platform, actor, conversation, binding, compact bound-thread identity, and native thread/topic creation capability for the surface that started this Agent turn.";
     case "get_current_messaging_surface":
-      return "Inspect the messaging platform, actor, conversation, binding, compact bound-thread identity, and native thread/topic creation capability for the surface that started this Agent turn.";
+      return "Inspect the current messaging surface, actor, conversation, binding, bound thread, and native child-topic support.";
     case "send_private_response":
-      return "Send the terminal response privately to the user who initiated the current messaging turn. Use this only when the user explicitly asks for a private reply or the response contains secrets that should not be posted to the source conversation. On success, PwrAgent suppresses the normal final response on the source surface; end the turn without repeating the private content. Set awaitReply=true with replyInstructions when the private message asks the user for a response: their first reply starts a one-shot continuation turn whose final answer is delivered back to the originating surface, and PwrAgent then removes the temporary private-thread route. This cannot target an arbitrary user or be called outside an active messaging turn.";
+      return "Send the final response privately to the user who started this messaging turn. Use this only after an explicit request or to protect secrets. After success, end the turn without a public copy. Set awaitReply and replyInstructions to route one private reply back to the source surface. This tool works only in an active messaging turn and cannot target another user.";
     case "attach_thread_here":
-      return "Attach a known PwrAgent thread to the current messaging surface, creating a native child thread/topic when the provider supports it. Pass instanceId for a remote thread when known; otherwise PwrAgent checks the local instance and then resolves a remembered or connected Federation peer. This does not rename the PwrAgent thread.";
+      return "Attach a known PwrAgent thread to the current messaging surface. Use new_child for a native child topic when supported. Pass instanceId for a known remote thread. Otherwise, PwrAgent resolves the owner. This tool does not rename the PwrAgent thread.";
     case "inspect_messaging_pdfs":
-      return "List PDF attachments available only for the current active PwrAgent turn. The initial turn input already includes page metadata when probing succeeded; call this only for an attachment whose metadata was unavailable. Returns local metadata and render limits, not PDF bytes or extracted document text. In Codex Code Mode, JSON.parse the returned string; native MCP callers receive the response directly.";
+      return "List PDF attachments for the current messaging turn. Use this only when the initial attachment metadata is unavailable. The result contains local metadata and render limits, not PDF content. In Codex Code Mode, parse the JSON string. Native MCP clients receive the response directly.";
     case "search_messaging_pdf_text":
-      return "For a multi-page PDF only, locate an unknown relevant page using its embedded text layer. Use returned page-number snippets only for bounded navigation, then render pages for visual analysis. Do not use this on one-page PDFs or as a content-extraction/comparison workflow; per-turn search calls are capped. In Codex Code Mode, JSON.parse the returned string; native MCP callers receive the response directly.";
+      return "Search the text layer of a multi-page PDF to find an unknown page. Use the snippets only to select pages for rendering. Do not use this tool for one-page PDFs, extraction, or comparison. Each turn has a search limit. In Codex Code Mode, parse the JSON string. Native MCP clients receive the response directly.";
     case "render_messaging_pdf_pages":
-      return "Render explicitly selected PDF pages from the current active PwrAgent turn. The result contains page images for direct visual analysis. In Codex Code Mode, JSON.parse the returned string and pass each image block in its content array to image(item) exactly once; do not print or text() the JSON. Native MCP callers receive image content directly and must not call image(). This is the only permitted way to access PwrAgent-managed PDF pages: do not use shell, filesystem, OCR, or conversion tools on the source PDF or rendered page. Partially repeated requests return only unseen pages. Rendering is capped by page count, total pixels, encoded image bytes, and model-input bytes.";
+      return "Render selected PDF pages from the current messaging turn. In Codex Code Mode, parse the JSON string and pass each image to image(item) once. Do not print the JSON. Native MCP clients receive image content directly. Do not call image() for MCP content. Use only this tool for PwrAgent PDFs. Do not use shell, filesystem, OCR, or conversion tools. Repeated requests return only pages not shown before. Render limits apply to pages, pixels, encoded bytes, and model input.";
   }
 }
 
@@ -151,14 +151,14 @@ function inputSchemaForOperation(
           awaitReply: {
             type: "boolean",
             description:
-              "Whether the first reply in the private message thread should start a one-shot continuation whose final response returns to the originating surface. Requires replyInstructions.",
+              "Set true to route the first private reply back to the source surface. This requires replyInstructions.",
           },
           replyInstructions: {
             type: "string",
             minLength: 1,
             maxLength: 4_000,
             description:
-              "Instructions for turning the user's private reply into the final response returned to the originating surface, including what must not be repeated there. Used only when awaitReply is true.",
+              "Explain how to turn the private reply into the final source response. Include content that must stay private. Use only with awaitReply=true.",
           },
           text: {
             type: "string",
@@ -198,7 +198,7 @@ function inputSchemaForOperation(
             type: "string",
             enum: ["auto", "new_child", "current_conversation"],
             description:
-              "Where to attach the target thread. Use new_child to create a native messaging child topic/thread when supported; use current_conversation only when replacing or reusing the current conversation binding is intended.",
+              "Use new_child to create a native child topic when supported. Use current_conversation only to replace or reuse the current binding.",
           },
           targetKind: {
             type: "string",
@@ -258,7 +258,7 @@ function inputSchemaForOperation(
               minimum: 1,
             },
             description:
-              "Specific page numbers to render. Start with the smallest useful batch; pages already supplied in this turn are not emitted again.",
+              "Pages to render. Start with the smallest useful batch. PwrAgent does not return pages already supplied in this turn.",
           },
         },
       };

--- a/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
@@ -119,7 +119,7 @@ function descriptionForOperation(operation: PwrAgentMessagingOperationName): str
     case "get_current_messaging_surface":
       return "Inspect the current messaging surface, actor, conversation, binding, bound thread, and native child-topic support.";
     case "send_private_response":
-      return "Send the final response privately to the user who started this messaging turn. Use this only after an explicit request or to protect secrets. After success, end the turn without a public copy. Set awaitReply and replyInstructions to route one private reply back to the source surface. This tool works only in an active messaging turn and cannot target another user.";
+      return "Send the final response privately to the user who started this messaging turn. Use this only after an explicit request or to protect secrets. After success, end the turn without a public copy. Set awaitReply and replyInstructions to start a continuation from one private reply. Only the continuation's final response returns to the source surface. This tool works only in an active messaging turn and cannot target another user.";
     case "attach_thread_here":
       return "Attach a known PwrAgent thread to the current messaging surface. Use new_child for a native child topic when supported. Pass instanceId for a known remote thread. Otherwise, PwrAgent resolves the owner. This tool does not rename the PwrAgent thread.";
     case "inspect_messaging_pdfs":
@@ -151,7 +151,7 @@ function inputSchemaForOperation(
           awaitReply: {
             type: "boolean",
             description:
-              "Set true to route the first private reply back to the source surface. This requires replyInstructions.",
+              "Set true to start a continuation from the first private reply. Only its final response returns to the source surface. This requires replyInstructions.",
           },
           replyInstructions: {
             type: "string",

--- a/apps/desktop/src/main/agent-tools/pwragent-task-monitor-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-task-monitor-agent-tools.ts
@@ -16,7 +16,7 @@ import {
 import { AgentToolRouter } from "./agent-tool-router.js";
 
 export const TASK_MONITOR_CREATE_TOOL_DESCRIPTION =
-  "Create and start a lightweight PwrAgent-managed monitor thread for long-running asynchronous work or repeatable status checks. Do not use this to poll an attached pull request when PwrAgent PR automation can wake the thread: call check_thread_pull_request_status, follow prAutomation.guidance, and use watch_thread_pull_request for one-shot success/failure notification. Use this monitor for other work that may take more than one short status check, especially when you are about to sleep/wait/poll every few seconds for a command, job, service, or external operation to finish. If you have checked something for progress for about 30 seconds and the check is repeatable, hand it to this monitor with enough context to run that check for you. The task and monitorContext must include the exact monitoring procedure the parent was about to run itself: cwd or target location, command/status command or wait API, poll cadence, terminal success/failure conditions, and relevant log collection steps. Do not pass parent-local Codex/tool session ids such as exec_command/write_stdin session_id values; monitor threads cannot access those sessions, stdout/stderr streams, stdin, or exit status. For a local build/test/script, delegate before starting it and provide cwd plus the exact command so the monitor starts it and captures output itself. Prefer separate stdout/stderr capture files plus a combined output file when practical, and include those file paths in the final handoff. If the command is already running, provide durable process/log/status files that the monitor can read. Use pollIntervalSeconds as the combined poll and heartbeat cadence; default to 30 seconds unless the delegated procedure clearly needs a different cadence. Normally omit preferredModel and preferredReasoningEffort so PwrAgent applies the managed monitor defaults. Specify them only when the user explicitly requests an override or applicable user/project instructions require one; do not infer overrides from the parent model or task complexity. PwrAgent starts the monitor with the returned preferred model/reasoning settings and the monitor callback tools attached; do not call generic spawnAgent for this flow.";
+  "Create a PwrAgent monitor thread for long tasks or repeated status checks. Do not use it for an attached PR when PR automation can wake the thread. Use check_thread_pull_request_status and follow prAutomation.guidance. Use watch_thread_pull_request for one-time PR success or failure notifications. Delegate a repeatable check after about 30 seconds of parent polling. Give the monitor the target, exact check, interval, success and failure conditions, and log steps. Do not pass local tool session IDs. A monitor cannot access parent streams, input, or exit status. Delegate a local command before it starts so the monitor can run and capture it. For an active command, provide durable process, log, or status files. Use pollIntervalSeconds for polling and heartbeats. The default is 30 seconds. Omit preferredModel and preferredReasoningEffort unless the user or project instructions require an override. Do not use backend spawn tools for this workflow.";
 
 export const TASK_MONITOR_CREATE_TOOL_INPUT_SCHEMA = {
   type: "object",
@@ -28,12 +28,12 @@ export const TASK_MONITOR_CREATE_TOOL_INPUT_SCHEMA = {
     preferredModel: {
       type: "string",
       description:
-        "Optional explicit override. Normally omit so PwrAgent uses its managed monitor default; specify only when the user explicitly requests an override or applicable user/project instructions require one.",
+        "Optional override. Omit it to use the monitor default. Set it only when the user or project instructions require an override.",
     },
     preferredReasoningEffort: {
       type: "string",
       description:
-        "Optional explicit override. Normally omit so PwrAgent uses its managed monitor default; specify only when the user explicitly requests an override or applicable user/project instructions require one.",
+        "Optional override. Omit it to use the monitor default. Set it only when the user or project instructions require an override.",
     },
     finalHandoffPrompt: { type: "string" },
   },
@@ -42,7 +42,7 @@ export const TASK_MONITOR_CREATE_TOOL_INPUT_SCHEMA = {
 } satisfies Record<string, unknown>;
 
 export const TASK_MONITOR_CANCEL_TOOL_DESCRIPTION =
-  "Cancel an active PwrAgent-managed monitor delegation immediately. Use the monitorId returned by create_monitor_delegation. This interrupts the monitor's active turn, records a cancelled result in the parent thread, and does not start or queue another parent turn. Use this instead of send_message_to_thread when a running monitor must stop.";
+  "Cancel an active PwrAgent monitor now. Pass the monitorId from create_monitor_delegation. This interrupts the monitor and records cancellation in the parent thread. It does not start or queue a parent turn. Use this instead of send_message_to_thread to stop a monitor.";
 
 export const TASK_MONITOR_CANCEL_TOOL_INPUT_SCHEMA = {
   type: "object",

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
@@ -129,19 +129,19 @@ function descriptionForOperation(
 ): string {
   switch (operation) {
     case "search_threads":
-      return "Search known PwrAgent threads by title, summary, Agent metadata, backend, and linked directory. By default PwrAgent combines local results with metadata matches from connected Federation instances; pass instanceId to target one instance or includeRemote=false to search locally only. Omit query to inspect recent lightweight thread candidates before choosing a thread. Advanced transcript, semantic, Agent, model, and directory filters remain local-only. The response may include pendingHandoffs for handoff_task calls that are still creating a child thread and pendingWorkspaceMoves for move_thread_workspace calls that are still moving the same thread; do not retry those operations while they are starting.";
+      return "Search known PwrAgent threads. By default, metadata search includes connected peers. Content and advanced filters work only on the local instance. Omit query to list recent candidates. Use instanceId for one peer or includeRemote=false for local metadata only. Results can include pending handoffs and workspace moves. Do not retry a pending operation.";
     case "read_thread":
-      return "Read a bounded page of another known PwrAgent thread's recent transcript and activity. Use search_threads first when the threadId is unknown. Pass instanceId for a remote thread when known; otherwise PwrAgent checks the local instance and then resolves a remembered or connected Federation peer.";
+      return "Read a bounded page of transcript and activity from another known PwrAgent thread. Use search_threads when threadId is unknown. Pass instanceId for a known remote thread. Otherwise, PwrAgent resolves the owner.";
     case "get_thread_status":
-      return "Read status and compact metadata for a PwrAgent thread, including linked directories, repository groups, pull requests, live PR automation state, pendingHandoffs when this thread has child handoffs that are still being created, and pendingWorkspaceMoves when this thread has same-thread workspace moves in progress. Omit backend and threadId to inspect the current thread; pass instanceId for a remote thread when known. Follow prAutomation.guidance: when Auto-fix PR is active, do not poll CI or create a monitor thread.";
+      return "Read compact status and metadata for a PwrAgent thread. Results include linked directories, repository groups, pull requests, PR automation, pending handoffs, and workspace moves. Omit backend and threadId for the current thread. Pass instanceId for a known remote thread. Follow prAutomation.guidance. If Auto-fix PR is active, do not poll CI or create a monitor.";
     case "attach_thread_pull_request":
-      return "Attach a pull request reference to a PwrAgent thread. Omit backend and threadId to attach to the current thread. Use this when a PR was created outside the thread's current working directory or automatic branch-based discovery will not see it. Accepts a full PR/MR URL, a full provider/org/repo/number identity, or a bare number when the thread has exactly one inferable repository.";
+      return "Attach a pull request reference to a PwrAgent thread. Omit backend and threadId for the current thread. Use this when automatic branch discovery cannot find the PR. Pass a URL, a full provider identity, or a number for one inferable repository.";
     case "check_thread_pull_request_status":
-      return "Run a user-invoked pull request status check for a thread using PwrAgent's provider integration instead of shelling out. Omit backend and threadId to check the current thread. Returns PR status with freshness metadata plus live prAutomation state. When prAutomation.autoFixActive is true, do not poll CI and do not create a monitor thread; end the turn and let PwrAgent start a follow-up turn on failure or conflict. Use watch_thread_pull_request when the thread should also wake on successful completion.";
+      return "Check pull request status through the PwrAgent provider. Use this instead of a shell command. Omit backend and threadId for the current thread. The result includes freshness and prAutomation state. If prAutomation.autoFixActive is true, do not poll CI or create a monitor. End the turn. Use watch_thread_pull_request when the thread must also wake after success.";
     case "watch_thread_pull_request":
-      return "Create a durable one-shot watch for a pull request attached to the thread's primary workspace at its current head. PwrAgent starts one follow-up turn on the first requested terminal outcome: an early CI failure or merge conflict, or full CI success. Informational PRs from secondary linked repositories are not eligible. If several threads watch the same PR and head, the oldest watch receives the result and the others are satisfied without duplicate turns. If the current provider snapshot is already terminal, the result returns currentOutcome immediately without creating a watch. Omit backend and threadId for the current thread, and omit url only when exactly one eligible PR is attached. After a watch is created, end the current turn—do not poll CI and do not create a monitor thread. When Auto-fix PR is active at failure time, its repair dispatch satisfies the failure wake-up so the watch does not create a duplicate turn.";
+      return "Create a durable, one-time watch for an attached pull request at the current head. The watch wakes the thread after CI success, early failure, or a merge conflict. Only a primary-workspace PR is eligible. The oldest duplicate watch receives the result. A terminal snapshot returns currentOutcome without a new watch. Omit backend and threadId for the current thread. Omit url only when one eligible PR exists. After creation, end the turn. Do not poll CI or create a monitor. Auto-fix PR handles failure wake-ups without a duplicate turn.";
     case "mutate_thread":
-      return "Mutate guarded PwrAgent thread settings such as the PwrAgent thread title, model settings, or execution mode. Pass instanceId for a remote thread when known; otherwise PwrAgent checks the local instance and then resolves a remembered or connected Federation peer. This does not rename any attached Telegram topic, Discord thread, or other messaging surface.";
+      return "Change guarded settings on a PwrAgent thread. Pass instanceId for a known remote thread. Otherwise, PwrAgent resolves the owner. This tool does not rename a messaging topic or thread.";
   }
 }
 
@@ -216,7 +216,7 @@ function inputSchemaForOperation(
             type: "string",
             enum: ["metadata", "available", "required"],
             description:
-              "Use `metadata` for title/project/folder search only, `available` to also search bounded provider transcript content when possible, or `required` when content search must be attempted.",
+              "Use `metadata` for metadata only. Use `available` to search bounded transcript content when possible. Use `required` when content search is mandatory.",
           },
           semanticMode: {
             type: "string",

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -185,21 +185,21 @@ function descriptionForOperation(
 ): string {
   switch (operation) {
     case "handoff_task":
-      return "Create a PwrAgent-managed thread for delegated work. Prefer this to backend-native spawning unless the user requests it or needs an unsupported capability. Omitted settings inherit from the invoking turn. Same-project handoffs default to grouped subthreads in a new worktree; omit cwd so they inherit the caller's workspace source. Pass cwd only when the user explicitly selects another project or directory; task text never selects cwd. Cross-project handoffs are ungrouped. Use seedMode=fork only for explicit forks, same_workspace only for explicit sharing, project_local for the project checkout, and none for unscoped work. Provider overrides require a registered backend and exact model ID. Startup can take minutes; do not retry while pending. Inspect pendingHandoffs for progress, and return threadLink verbatim.";
+      return "Create a PwrAgent-managed thread for delegated work. Prefer this to backend spawning unless the user requests it or needs an unsupported feature. Agent settings inherit from the current turn. By default, same-project handoffs create grouped subthreads in new worktrees. Omit cwd to inherit the workspace source. Set cwd only for a user-selected project or directory. Task text never selects cwd. Cross-project handoffs are not grouped. Use fork or same_workspace only when the user requests them. Use project_local for the project checkout and none for no workspace. Provider overrides need a registered backend and exact model ID. Do not retry while startup is pending. Inspect pendingHandoffs and return threadLink verbatim.";
     case "attach_thread_directory":
-      return "Attach an additional Git directory to the current PwrAgent thread. Use this for cross-project work when the user asks to link another repo or create a secondary worktree for another repo. Omitted backend targets the invoking thread. workspaceMode=local attaches the repository directory itself; workspaceMode=new_worktree asks PwrAgent to allocate and attach a managed worktree for the provided repository path. In Default Access, an untrusted path triggers operator confirmation before it can grant agent read/write/delete scope or allocate a managed worktree. This does not change the thread's primary cwd; use detach_thread_directory separately if a temporary local reference should be removed.";
+      return "Attach another Git directory to the current PwrAgent thread. Use this for user-requested cross-project work. Omit backend for the current thread. Use workspaceMode=local for the repository or new_worktree for a managed worktree. Default Access requires confirmation for an untrusted path. This tool does not change the primary cwd. Use detach_thread_directory to remove a temporary link.";
     case "detach_thread_directory":
-      return "Detach a secondary linked directory from the current PwrAgent thread. Use this only for user-requested cleanup of extra directory references. The primary provider/runtime cwd cannot be detached. Pass directoryId when known, or path/worktreePath from get_thread_status linked directory metadata.";
+      return "Detach a secondary directory from the current PwrAgent thread. Use this only when the user requests cleanup. You cannot detach the primary provider/runtime cwd. Pass directoryId when known. Otherwise, pass path or worktreePath from get_thread_status.";
     case "move_thread_workspace":
-      return "Move the current PwrAgent thread runtime workspace after the invoking turn reaches a terminal boundary. Use this when the user asks to continue this same thread from an isolated worktree instead of creating a child handoff thread. The operation is path-keyed: pass sourcePath when the thread has multiple linked directories or when the intended workspace is not obvious. The tool returns a pending workspaceMoveId and stop-and-wait guidance; after the current turn ends, PwrAgent performs the move, updates future-turn cwd metadata, rebinds an ACP session when required, and starts a same-thread continuation with the result. Do not keep editing after a successful call in the invoking turn; wait for the continuation or inspect get_thread_status pendingWorkspaceMoves.";
+      return "Move the current thread workspace after this turn ends. Use this to move this thread to an isolated worktree. Do not create a child thread. Pass sourcePath when the thread has multiple directories or the source is unclear. After success, stop work and end the turn. PwrAgent moves the workspace, updates cwd, reconnects ACP when necessary, and starts a continuation. Check pendingWorkspaceMoves only after the turn.";
     case "send_message_to_thread":
-      return "Send an ordinary follow-up prompt as a new turn to another existing PwrAgent thread. If the target already has an active turn, this schedules/queues the follow-up instead of steering that turn. Use steer_thread when guidance must reach a long-running active turn at its next tool completion or message boundary, and stop_thread only for an urgent interruption. Use search_threads or read_thread first when the target threadId is unknown. Pass instanceId when a remote create/search result or thread link supplied it; omit it for local threads and older results, which PwrAgent resolves through durable ownership metadata and connected-peer discovery. Set includeRemote=false for a local-only lookup. Do not use this for the current thread; reply normally instead. The result includes threadLink, a ready-made markdown link to the target thread. When you mention that thread to the user, include threadLink verbatim instead of the raw threadId so it renders as a clickable chip.";
+      return "Send a follow-up as a new turn to another PwrAgent thread. If a turn is active, PwrAgent queues the follow-up. Use steer_thread for guidance to the active turn. Use stop_thread for an urgent interruption. Find an unknown thread with search_threads or read_thread. Pass instanceId from a remote result when available. Set includeRemote=false for local resolution. Reply normally to the current thread. Return threadLink verbatim.";
     case "steer_thread":
-      return "Steer the active turn on another PwrAgent thread. Use this when the target is likely to run for a while and guidance needs to reach it at the next tool completion or message boundary, avoiding wasted time and tokens. This preserves real steer semantics: it never reports a queued follow-up as steered. Use send_message_to_thread for an ordinary queued/new-turn follow-up and stop_thread for an urgent interruption. The owning local or federated instance discovers the active turn and rejects stale expectedTurnId races. Pass instanceId when known; set includeRemote=false for local-only resolution. requestId is an idempotency key: reuse it only to retry the exact same steer. The current thread cannot steer itself through this tool; reply normally instead.";
+      return "Steer the active turn on another PwrAgent thread. Use this when guidance must reach a long turn at the next tool boundary. This tool never reports a queued follow-up as steered. Use send_message_to_thread for a new turn and stop_thread for an urgent interruption. The owner rejects a stale expectedTurnId. Pass instanceId when known. Set includeRemote=false for local resolution. Reuse requestId only to retry the same steer. This thread cannot steer itself.";
     case "stop_thread":
-      return "Immediately interrupt the active turn on another PwrAgent thread. Use this high-urgency control only when the target must stop promptly; it calls the owning backend's interrupt operation and never queues text. It works for local and federated targets through turn-control routing. The owning instance discovers the active turn and rejects stale expectedTurnId races. Pass instanceId when known; set includeRemote=false for local-only resolution. requestId is an idempotency key: reuse it only to retry the exact same stop. The current turn cannot stop itself through this tool because its tool result could not be delivered safely.";
+      return "Stop the active turn on another PwrAgent thread immediately. Use this only for an urgent interruption. This tool interrupts the backend and does not queue text. The owner rejects a stale expectedTurnId. Pass instanceId when known. Set includeRemote=false for local resolution. Reuse requestId only to retry the same stop. This thread cannot stop itself.";
     case "start_review":
-      return "Schedule a code review of the invoking PwrAgent thread after the current turn completes successfully. Use this only when the operator explicitly asks for a review. Choose one structured target: uncommittedChanges, baseBranch, commit, or custom. The tool returns a pendingReviewId; after a successful call, stop work and let the current turn finish so PwrAgent can start the review. Do not poll or call the tool again for the same request.";
+      return "Schedule a review of this PwrAgent thread after the current turn ends successfully. Use this only after an explicit operator request. Select one target type. After success, stop work and end the turn. Do not poll or call this tool again.";
   }
 }
 
@@ -216,7 +216,7 @@ function inputSchemaForOperation(
           backend: {
             type: "string",
             description:
-              "Optional backend override. Omitted defaults to the invoking thread backend; the first implementation supports the current thread only.",
+              "Optional backend override. Omit it for the current thread. This implementation supports only the current thread.",
           },
           path: {
             type: "string",
@@ -227,7 +227,7 @@ function inputSchemaForOperation(
             type: "string",
             enum: ATTACH_THREAD_DIRECTORY_WORKSPACE_MODES,
             description:
-              "`local` attaches the repository directory itself and is the default. `new_worktree` asks PwrAgent to allocate a managed worktree for that repository and attach it after the source repo path is trusted.",
+              "`local` attaches the repository and is the default. `new_worktree` creates and attaches a managed worktree after PwrAgent trusts the source path.",
           },
           branchName: {
             type: "string",
@@ -250,7 +250,7 @@ function inputSchemaForOperation(
           backend: {
             type: "string",
             description:
-              "Optional backend override. Omitted defaults to the invoking thread backend; the first implementation supports the current thread only.",
+              "Optional backend override. Omit it for the current thread. This implementation supports only the current thread.",
           },
           directoryId: {
             type: "string",
@@ -291,24 +291,24 @@ function inputSchemaForOperation(
             type: "string",
             enum: HANDOFF_TASK_SEED_MODES,
             description:
-              "`clean` starts a fresh thread and is the default. `fork` copies the current thread transcript and should be used only when the user explicitly asks to fork this thread.",
+              "`clean` starts a new thread and is the default. `fork` copies this transcript. Use `fork` only when the user requests it.",
           },
           groupingMode: {
             type: "string",
             enum: HANDOFF_TASK_GROUPING_MODES,
             description:
-              "`subthread` defaults for same-project handoffs; `none` is explicitly ungrouped. Cross-project handoffs are always ungrouped.",
+              "`subthread` is the same-project default. `none` does not group the thread. Cross-project handoffs are never grouped.",
           },
           workspaceMode: {
             type: "string",
             enum: HANDOFF_TASK_WORKSPACE_MODES,
             description:
-              "`new_worktree` requests an isolated Git worktree and is the default for workspace-backed handoffs; set branchName to an existing base ref such as `origin/master` when the user asks for a specific source branch. `same_workspace` shares the selected cwd and is valid only with groupingMode=subthread. `project_local` uses the selected project's primary/local checkout. `none` allows a no-workspace thread. `same` is a legacy alias for `same_workspace`.",
+              "`new_worktree` is the default for workspace handoffs. `same_workspace` requires groupingMode=subthread. `project_local` uses the project checkout. `none` uses no workspace. `same` aliases `same_workspace`.",
           },
           cwd: {
             type: "string",
             description:
-              "Omit to inherit the caller workspace. Set only when the user explicitly selects another project or directory; task text does not select cwd.",
+              "Omit cwd to inherit the current workspace. Set it only for a user-selected project or directory. Task text does not select cwd.",
           },
           messagingAttachment: {
             type: "string",
@@ -319,7 +319,7 @@ function inputSchemaForOperation(
           backend: {
             type: "string",
             description:
-              "Registered backend override; omitted inherits the caller (Grok: `acp:grok`).",
+              "Registered backend override. Omit it to inherit the current backend. Use `acp:grok` for Grok.",
           },
           model: {
             type: "string",
@@ -335,7 +335,7 @@ function inputSchemaForOperation(
           branchName: {
             type: "string",
             description:
-              "Optional existing base branch/ref for workspaceMode=new_worktree, for example `origin/master`. This is not the new feature branch name; tell the delegated thread to create or switch to its work branch in the task text.",
+              "Existing base ref for workspaceMode=new_worktree, such as `origin/main`. This is not a new branch name. Put branch creation in the task.",
           },
         },
       };
@@ -347,7 +347,7 @@ function inputSchemaForOperation(
           backend: {
             type: "string",
             description:
-              "Optional backend override. Omitted defaults to the invoking thread backend; same-thread moves require the invoking backend.",
+              "Optional backend override. Omit it for the current backend. A same-thread move must use the current backend.",
           },
           direction: {
             type: "string",

--- a/apps/desktop/src/main/automations/automation-inspection-tool-catalog.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-tool-catalog.ts
@@ -25,7 +25,7 @@ const TOOL_CATALOG: Record<
   },
   summarize_automation_status: {
     description:
-      "Summarize automation health and recent run activity for this PwrAgent Agent thread; use this before answering whether an inbound alert is recurring.",
+      "Summarize automation health and recent runs for this PwrAgent Agent thread. Use this before you decide that an inbound alert is recurring.",
     inputSchema: {
       type: "object",
       properties: {
@@ -37,7 +37,7 @@ const TOOL_CATALOG: Record<
   },
   list_automation_runs: {
     description:
-      "List recent automation runs for this Agent thread or one attached automation, including inbound source metadata for recurrence analysis.",
+      "List recent runs for this Agent thread or one attached automation. Include inbound source data for recurrence analysis.",
     inputSchema: {
       type: "object",
       properties: {
@@ -54,7 +54,7 @@ const TOOL_CATALOG: Record<
   },
   get_automation_run: {
     description:
-      "Inspect one automation run's status, timing, trigger, inbound source metadata, output summary, and error metadata.",
+      "Inspect one automation run. Return its status, timing, trigger, inbound source, output summary, and errors.",
     inputSchema: {
       type: "object",
       properties: {
@@ -66,7 +66,7 @@ const TOOL_CATALOG: Record<
   },
   get_automation_run_artifact: {
     description:
-      "Fetch one automation run's stored output artifact, card decision, action results, and bounded transcript events.",
+      "Get one automation run artifact with its output, card decision, actions, and bounded transcript events.",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Summary

- Rewrite the 33 advertised tool descriptions and their schema guidance with short, active ASD-STE100-style sentences.
- Use one catalog overview for Codex dynamic tools and the loopback MCP server.
- Preserve operational constraints while moving field-specific facts to schema descriptions.

## Impact

Reflected tool and schema text falls from 4,937 to 3,569 words (28% less). The longest reflected sentence is 17 words, and advertised descriptions contain no semicolons.

The MCP overview now describes the full catalog instead of only thread inspection and control. Dynamic and MCP tool metadata still comes from the same definitions.

## Validation

- `pnpm test apps/desktop/src/main/agent-tools/__tests__` (42 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; 30 existing warnings)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`
