### PR TITLE
feat(desktop): surface unsent composer drafts on thread rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,14 +192,23 @@ accidental.
 ## Current Product Direction
 
 - Threads are first-class and may exist without a directory.
-- Attention, Inbox, Recents, and Directories share the thread lens switch. The
-  tabs are icon-only; the lens name lives in `aria-label` and the tooltip.
+- Attention, Drafts, Inbox, Recents, and Directories share the thread lens
+  switch. The tabs are icon-only; the lens name lives in `aria-label` and the
+  tooltip.
 - Attention is the work-queue lens: threads with a live turn or waiting to be
   reviewed, in recent-activity order. Its tab is two indicators with counts
   (scanner + in-progress, cookie + unread) rather than an icon, and each goes
   grey at zero so the tab reads as "nothing running, nothing unread" without
   being opened. A zero is shown, never hidden — a vanishing count makes an
   idle tab look like a broken one.
+- Drafts is the second state lens: threads holding unsent composer text, in
+  recent-activity order. A draft belongs to whoever typed it — it is stored in
+  that machine's `composer_draft_latest` table, re-hydrated on the next launch,
+  and deliberately **never federated**. A viewer that half-writes a reply to a
+  peer's thread sees its own "Draft" chip on that row; the owning instance does
+  not, because publishing an operator's unsent text to another machine is not
+  something the affordance is worth. Threads carry the chip in every lens, not
+  only this one.
 - Inbox is the default browsing lens: all threads in recent-activity order.
 - Recents shows all threads in thread-creation order so active threads do not
   jump around.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,11 @@ accidental.
   peer's thread sees its own "Draft" chip on that row; the owning instance does
   not, because publishing an operator's unsent text to another machine is not
   something the affordance is worth. Threads carry the chip in every lens, not
-  only this one.
+  only this one. Two limits are deliberate rather than bugs: the storage is
+  machine-wide but each window reads it once at mount, so a second open window
+  does not light up until it restarts; and launchpad (new-thread) composer text
+  has no thread row, so the lens says "replies" and its empty state says "No
+  unsent replies."
 - Inbox is the default browsing lens: all threads in recent-activity order.
 - Recents shows all threads in thread-creation order so active threads do not
   jump around.

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -38,8 +38,11 @@ summary.
 
 ## Non-Negotiables
 
-- Attention, Inbox, Recents, and Directories live in one icon-only thread lens
-  switch; Inbox is the default browsing lens.
+- Attention, Drafts, Inbox, Recents, and Directories live in one icon-only
+  thread lens switch; Inbox is the default browsing lens.
+- A thread's unsent composer draft is window-local state, never federated.
+  Derive it from the composer draft store (`useThreadDraftIndicators`), not
+  from `NavigationThreadSummary`.
 - Attention is a work queue: focusing a thread there must not clear its unread
   cookie, only replying does. See "Current Product Direction" in the
   [repo-root `AGENTS.md`](../../AGENTS.md) for why that rule is lens-scoped

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -151,6 +151,16 @@ elements and fail Playwright strict mode. When writing specs:
 - Target the history buttons themselves via their test ids:
   `history-nav-back` / `history-nav-forward`.
 
+The same trap runs in the other direction, and it bites the *renderer*
+rather than the spec: **`getByLabel` matches on substring**, and 31 call
+sites across 23 specs drive the composer with `getByLabel("Reply")`. A new
+`aria-label` anywhere in the app that merely *contains* "reply" turns every
+one of them into a strict-mode violation as soon as the labelled element
+renders. The unsent-draft chip was originally labelled "Unsent draft reply"
+and did exactly that — the unit suite was green and only Desktop E2E caught
+it. When you add an `aria-label`, grep the specs for the words in it before
+you settle on the wording.
+
 ## Inspecting Branch Drift Dialog E2E
 
 To open the replay-backed "Thread branch changed" dialog and keep Electron

--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -282,6 +282,23 @@ for (const theme of AUDIT_THEMES) {
           ).toHaveCount(1);
           await runAxe(app.window, "open thread view");
         });
+
+        // The unsent-draft chip is the one row chip that paints no
+        // background of its own — it is `background: transparent` with a
+        // dashed border, so unlike every other chip its contrast pair is
+        // whatever surface happens to sit behind the row (default, hover,
+        // selected). Nothing else in this gate renders it, because a draft
+        // only exists once something has been typed. Keep this step last:
+        // it deliberately leaves composer text behind.
+        await test.step("thread row carrying an unsent draft", async () => {
+          await app.window
+            .getByRole("textbox", { name: "Reply" })
+            .fill("Half-written reply the operator has not sent.");
+          await expect(
+            app.window.getByRole("img", { name: "Unsent draft" }).first(),
+          ).toBeVisible();
+          await runAxe(app.window, "thread row carrying an unsent draft");
+        });
       } finally {
         await app.close();
       }

--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.png
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5dd5fb98b84d0f21e8846ea56e276af321fd3416671e6def73078be686cb4f0
-size 148757
+oid sha256:2618e70e464adc7fc82dc0485787008c9ac0dca1afa48f21203ff1c620cb4ced
+size 148993

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -61,6 +61,7 @@ import {
   estimateTokenUsageCost,
   isAcpBackendId,
   isRemoteFederationTarget,
+  normalizeNavigationBrowseMode,
   normalizeThreadIdentityKey,
   parseThreadIdentityKey,
   projectNavigationLaunchpadProviderSettings,
@@ -473,20 +474,15 @@ function normalizeLaunchpadDefaults(
 }
 
 const NAVIGATION_BROWSE_MODE_META_KEY = "navigation_browse_mode";
-const DEFAULT_NAVIGATION_BROWSE_MODE: NavigationBrowseMode = "inbox";
 const LEGACY_HANDOFF_AGENT_INSTRUCTIONS =
   "Work only on the delegated task from the parent PwrAgent thread. Keep progress and results in this thread.";
 
-export function normalizeNavigationBrowseMode(
-  value: unknown,
-): NavigationBrowseMode {
-  return value === "attention"
-    || value === "inbox"
-    || value === "recents"
-    || value === "directories"
-    ? value
-    : DEFAULT_NAVIGATION_BROWSE_MODE;
-}
+/**
+ * Re-exported from `@pwragent/shared` so the persisted-lens allowlist has one
+ * definition across main, preload, and the renderer. Existing importers keep
+ * pointing here.
+ */
+export { normalizeNavigationBrowseMode };
 
 function shouldApplyAcpExecutionModeSnapshot(
   current: ThreadOverlayState | undefined,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,9 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
 import {
+  DEFAULT_NAVIGATION_BROWSE_MODE,
+  normalizeNavigationBrowseMode,
+} from "@pwragent/shared";
+import {
   createEventSubscriptionMultiplexer,
 } from "./event-subscription-multiplexer";
 import type {
@@ -2111,19 +2115,16 @@ function readBootstrapNavigationPreferences(): {
     if (!arg.startsWith(NAVIGATION_ARG_PREFIX)) continue;
     try {
       const raw = JSON.parse(arg.slice(NAVIGATION_ARG_PREFIX.length));
-      const browseMode =
-        raw &&
-        (raw.browseMode === "inbox" ||
-          raw.browseMode === "recents" ||
-          raw.browseMode === "directories")
-          ? raw.browseMode
-          : "inbox";
-      return { browseMode };
+      // Shared allowlist, not a hand-copied one: this decoder used to list
+      // only inbox/recents/directories, so an operator whose saved lens was
+      // Attention got Inbox at first paint and then a visible jump — the
+      // exact flicker this bootstrap hint exists to prevent.
+      return { browseMode: normalizeNavigationBrowseMode(raw?.browseMode) };
     } catch {
       break;
     }
   }
-  return { browseMode: "inbox" };
+  return { browseMode: DEFAULT_NAVIGATION_BROWSE_MODE };
 }
 const bootstrapNavigationPreferences = readBootstrapNavigationPreferences();
 const bootstrapFederationTarget = readFederationWindowTargetFromArgv(

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -86,6 +86,7 @@ import { useQueuedTurnRelease } from "./lib/useQueuedTurnRelease";
 import { useScheduledThreadActionProjection } from "./lib/useScheduledThreadActionProjection";
 import { useQueuedTurnProjection } from "./lib/useQueuedTurnProjection";
 import { useThreadQueuedMessageIndicators } from "./lib/useThreadQueuedMessageIndicators";
+import { useThreadDraftIndicators } from "./lib/useThreadDraftIndicators";
 import { CodexConfigWarningBanner } from "./features/codex-config/CodexConfigWarningBanner";
 import type { AppNoticeToastNotice } from "./features/notifications/AppNoticeToast";
 import { AppNoticeStack } from "./features/notifications/AppNoticeStack";
@@ -1141,6 +1142,12 @@ function DesktopAppShell(props: {
     composerDraftStore,
     threads: navigation.threads,
   });
+  // Per-thread "Draft" chip state and the Drafts lens's population, from the
+  // same store. Local to this window by design — see useThreadDraftIndicators.
+  const draftThreadKeys = useThreadDraftIndicators({
+    composerDraftStore,
+    threads: navigation.threads,
+  });
   // Fetch the boot info once at mount. Stable for the renderer's
   // lifetime — the main process records the decision before this
   // window opens, and graduating the bootstrap profile spawns a
@@ -1758,6 +1765,7 @@ function DesktopAppShell(props: {
           inputRequestThreadKeys={session.inputRequestThreadKeys}
           terminalThreadKeys={terminalThreadKeys}
           queuedMessageThreadKeys={queuedMessageThreadKeys}
+          draftThreadKeys={draftThreadKeys}
           composerSourceThreadKey={navigation.composerSourceThreadKey}
           revealSelectedThreadRequest={revealSelectedThreadRequest}
           onRevealSelectedThreadComplete={threadJump.completePeekRestore}
@@ -2143,6 +2151,12 @@ function DesktopAppShell(props: {
               <LazyStarMapScreen
                 desktopApi={desktopApi}
                 localThreads={navigation.threads}
+                // Not part of `sessionKeys`: those are only trusted for the
+                // local instance's cards, because thinking/approval keys are
+                // inferred from an unscoped event stream. A draft is this
+                // window's own composer state, so it is authoritative for
+                // every card it matches, local or remote.
+                draftThreadKeys={draftThreadKeys}
                 sessionKeys={{
                   approvalRequestThreadKeys: session.approvalRequestThreadKeys,
                   inputRequestThreadKeys: session.inputRequestThreadKeys,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -160,7 +160,9 @@ import {
   formatRunningDurationMs,
 } from "../thread-detail/EnvActionRunsView";
 import {
+  buildThreadComposerScopeKey,
   getNextReleasableQueuedTurn,
+  hasComposerDraftContent,
   useComposerDraftStore,
   type ComposerDraftSnapshot,
   type ComposerDraftStore,
@@ -892,9 +894,7 @@ function getLaunchpadDirectoryKeyFromScope(scopeKey: string): string | undefined
     : undefined;
 }
 
-function getThreadComposerScopeKey(backend: string, threadId: string): string {
-  return `thread:${backend}:${threadId}`;
-}
+const getThreadComposerScopeKey = buildThreadComposerScopeKey;
 
 function createReviewConfig(params: {
   directory?: NavigationDirectorySummary;
@@ -2937,7 +2937,7 @@ export function Composer(props: ComposerProps) {
   const composerScopeKey = props.launchpad
     ? `launchpad:${props.launchpad.directoryKey}`
     : props.thread
-      ? `thread:${props.thread.source}:${props.thread.id}`
+      ? buildThreadComposerScopeKey(props.thread.source, props.thread.id)
       : "empty";
   const prAutoDispatchPending = props.thread?.prAutoDispatchPending;
   const localDraftStore = useComposerDraftStore();
@@ -3750,19 +3750,13 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    if (
-      !state.draft.trim() &&
-      state.skillTokens.length === 0 &&
-      state.imageAttachments.length === 0 &&
-      (state.fileAttachments?.length ?? 0) === 0
-    ) {
+    // Shared with the store's draft-presence tracking, so "the composer is
+    // empty" and "this thread has no draft" can never diverge.
+    if (!hasComposerDraftContent(state)) {
       const previous = latestDraftSnapshotRef.current;
       if (
         previous.scopeKey === scopeKey &&
-        (previous.snapshot.draft.trim() ||
-          previous.snapshot.skillTokens.length > 0 ||
-          previous.snapshot.imageAttachments.length > 0 ||
-          (previous.snapshot.fileAttachments?.length ?? 0) > 0)
+        hasComposerDraftContent(previous.snapshot)
       ) {
         recordComposerDraftHistory(scopeKey, previous.snapshot, "abandoned");
       }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -894,8 +894,6 @@ function getLaunchpadDirectoryKeyFromScope(scopeKey: string): string | undefined
     : undefined;
 }
 
-const getThreadComposerScopeKey = buildThreadComposerScopeKey;
-
 function createReviewConfig(params: {
   directory?: NavigationDirectorySummary;
   thread?: NavigationThreadSummary;
@@ -5310,7 +5308,7 @@ export function Composer(props: ComposerProps) {
         // process and every surface should show its contents, not just
         // the window that submitted. Known ids and in-flight local
         // submissions keep their richer local state untouched.
-        const mirrorScopeKey = getThreadComposerScopeKey(
+        const mirrorScopeKey = buildThreadComposerScopeKey(
           event.backend,
           notificationThreadId,
         );
@@ -5345,7 +5343,7 @@ export function Composer(props: ComposerProps) {
         typeof turnQueueRecord?.queueEntryId === "string" &&
         (
           draftStore.getQueuedTurns(
-            getThreadComposerScopeKey(event.backend, notificationThreadId),
+            buildThreadComposerScopeKey(event.backend, notificationThreadId),
           ).some(
             (queued) => queued.queueEntryId === turnQueueRecord.queueEntryId,
           )
@@ -5358,7 +5356,7 @@ export function Composer(props: ComposerProps) {
           )
         )
       ) {
-        const queueScopeKey = getThreadComposerScopeKey(
+        const queueScopeKey = buildThreadComposerScopeKey(
           event.backend,
           notificationThreadId,
         );

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -209,6 +209,9 @@ function createComposerDraftStore(): ComposerDraftStore {
     getQueuedTurns: (scopeKey) => queuedTurns.get(scopeKey) ?? [],
     getQueuedTurnVersion: () => 0,
     subscribeQueuedTurns: () => () => {},
+    hasDraftContent: () => false,
+    getDraftPresenceVersion: () => 0,
+    subscribeDraftPresence: () => () => {},
     removeQueuedTurnAt: (scopeKey, index) => {
       const current = queuedTurns.get(scopeKey) ?? [];
       const next = [...current];
@@ -1129,6 +1132,9 @@ describe("Composer", () => {
       getQueuedTurns: () => [],
       getQueuedTurnVersion: () => 0,
       subscribeQueuedTurns: () => () => undefined,
+      hasDraftContent: () => false,
+      getDraftPresenceVersion: () => 0,
+      subscribeDraftPresence: () => () => undefined,
       removeQueuedTurnAt: () => undefined,
       removeQueuedTurnById: () => undefined,
       shiftQueuedTurn: () => undefined,

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -1,6 +1,7 @@
 import { useMemo, useRef } from "react";
 import type { JSONContent } from "@tiptap/react";
 import type {
+  AppServerBackendKind,
   AppServerReviewTarget,
   AppServerTurnInputItem,
   ComposerDraftLifecycle,
@@ -9,6 +10,7 @@ import type {
   NavigationLaunchpadFileAttachment,
   NavigationLaunchpadImageAttachment,
   ModelSettingsRecent,
+  ThreadIdentifier,
 } from "@pwragent/shared";
 import type { ComposerSkillToken } from "./ComposerInputTypes";
 
@@ -70,8 +72,8 @@ export type ComposerPendingSteerSnapshot = {
  * before this existed four hand-rolled copies of the template literal did.
  */
 export function buildThreadComposerScopeKey(
-  backend: string,
-  threadId: string,
+  backend: AppServerBackendKind,
+  threadId: ThreadIdentifier,
 ): string {
   return `thread:${backend}:${threadId}`;
 }

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -251,6 +251,11 @@ export function useComposerDraftStore(): ComposerDraftStore {
           draftPresenceListenersRef.current.delete(listener);
         };
       },
+      // Presence is synced after the pop, so a scope whose only content was
+      // the parked draft reads as absent until the composer `set`s the
+      // returned snapshot back as the active one. Both happen inside the same
+      // React event, so the two notifications batch into one render and the
+      // chip does not visibly blink.
       popDraft: (scopeKey) => {
         const current = draftStackStoreRef.current.get(scopeKey) ?? [];
         const restored = current.at(-1);

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -63,9 +63,58 @@ export type ComposerPendingSteerSnapshot = {
   fileAttachments: NavigationLaunchpadFileAttachment[];
 };
 
+/**
+ * The one definition of a thread composer's draft scope key. Everything that
+ * reads or writes the store — the composer, the queued-turn release loop, the
+ * sidebar's draft and queued indicators — has to agree on this string, and
+ * before this existed four hand-rolled copies of the template literal did.
+ */
+export function buildThreadComposerScopeKey(
+  backend: string,
+  threadId: string,
+): string {
+  return `thread:${backend}:${threadId}`;
+}
+
+/**
+ * Whether a snapshot holds anything an operator would be sorry to lose. The
+ * same test the durable store uses to decide a draft is worth journalling, so
+ * "this thread has an unsent draft" and "this draft is recoverable" can never
+ * disagree. Whitespace-only text is not content: the composer leaves a
+ * trailing newline behind constantly and a chip that lit up for it would be
+ * noise.
+ */
+export function hasComposerDraftContent(
+  snapshot: ComposerDraftSnapshot | undefined,
+): boolean {
+  if (!snapshot) {
+    return false;
+  }
+  return (
+    snapshot.draft.trim().length > 0
+    || snapshot.imageAttachments.length > 0
+    || (snapshot.fileAttachments?.length ?? 0) > 0
+    || snapshot.skillTokens.length > 0
+  );
+}
+
 export type ComposerDraftStore = {
   delete(scopeKey: string): void;
   get(scopeKey: string): ComposerDraftSnapshot | undefined;
+  /**
+   * Whether this scope currently holds unsent content — its active draft or
+   * anything parked beneath it. Pairs with `subscribeDraftPresence` so
+   * surfaces outside the composer can mark a thread as having a draft.
+   */
+  hasDraftContent(scopeKey: string): boolean;
+  /**
+   * Monotonic counter bumped when a scope *gains or loses* draft content.
+   * Deliberately not bumped on every edit: the sidebar only cares whether a
+   * draft exists, and a per-keystroke notification would re-render every
+   * thread row for the whole time an operator is typing.
+   */
+  getDraftPresenceVersion(): number;
+  subscribeDraftPresence(listener: () => void): () => void;
   /** Remove and return the most recently parked draft beneath this scope. */
   popDraft(scopeKey: string): ComposerDraftSnapshot | undefined;
   /** Park a draft beneath this scope's active draft. */
@@ -150,6 +199,12 @@ export function useComposerDraftStore(): ComposerDraftStore {
   // fans out to listeners registered via `subscribeQueuedTurns`.
   const queuedTurnVersionRef = useRef(0);
   const queuedTurnListenersRef = useRef(new Set<() => void>());
+  // Same reactivity bridge, one level coarser: presence, not content. The
+  // set holds every scope key that currently has unsent content, and the
+  // version only moves when membership does.
+  const draftPresenceRef = useRef(new Set<string>());
+  const draftPresenceVersionRef = useRef(0);
+  const draftPresenceListenersRef = useRef(new Set<() => void>());
 
   return useMemo(() => {
     const notifyQueuedTurnChange = (): void => {
@@ -159,11 +214,43 @@ export function useComposerDraftStore(): ComposerDraftStore {
       }
     };
 
+    // Re-reads both the active draft and the parked stack for one scope and
+    // notifies only on a transition. Every mutation path below calls it; the
+    // early return is what keeps typing free of re-renders.
+    const syncDraftPresence = (scopeKey: string): void => {
+      const present =
+        hasComposerDraftContent(storeRef.current.get(scopeKey))
+        || (draftStackStoreRef.current.get(scopeKey) ?? []).some(
+          hasComposerDraftContent,
+        );
+      if (present === draftPresenceRef.current.has(scopeKey)) {
+        return;
+      }
+      if (present) {
+        draftPresenceRef.current.add(scopeKey);
+      } else {
+        draftPresenceRef.current.delete(scopeKey);
+      }
+      draftPresenceVersionRef.current += 1;
+      for (const listener of draftPresenceListenersRef.current) {
+        listener();
+      }
+    };
+
     return {
       delete: (scopeKey) => {
         storeRef.current.delete(scopeKey);
+        syncDraftPresence(scopeKey);
       },
       get: (scopeKey) => storeRef.current.get(scopeKey),
+      hasDraftContent: (scopeKey) => draftPresenceRef.current.has(scopeKey),
+      getDraftPresenceVersion: () => draftPresenceVersionRef.current,
+      subscribeDraftPresence: (listener) => {
+        draftPresenceListenersRef.current.add(listener);
+        return () => {
+          draftPresenceListenersRef.current.delete(listener);
+        };
+      },
       popDraft: (scopeKey) => {
         const current = draftStackStoreRef.current.get(scopeKey) ?? [];
         const restored = current.at(-1);
@@ -176,11 +263,13 @@ export function useComposerDraftStore(): ComposerDraftStore {
         } else {
           draftStackStoreRef.current.set(scopeKey, next);
         }
+        syncDraftPresence(scopeKey);
         return restored;
       },
       pushDraft: (scopeKey, snapshot) => {
         const current = draftStackStoreRef.current.get(scopeKey) ?? [];
         draftStackStoreRef.current.set(scopeKey, [...current, snapshot]);
+        syncDraftPresence(scopeKey);
       },
       deletePendingSteer: (scopeKey) => {
         pendingSteerStoreRef.current.delete(scopeKey);
@@ -262,6 +351,7 @@ export function useComposerDraftStore(): ComposerDraftStore {
       },
       set: (scopeKey, snapshot) => {
         storeRef.current.set(scopeKey, snapshot);
+        syncDraftPresence(scopeKey);
       },
     };
   }, []);

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -63,6 +63,7 @@ type DirectoriesListProps = {
   terminalThreadKeys?: Record<string, boolean>;
   inputRequestThreadKeys?: Record<string, boolean>;
   queuedMessageThreadKeys?: Record<string, ThreadQueuedMessageState>;
+  draftThreadKeys?: Record<string, boolean>;
   composerSourceThreadKey?: string;
   directories: NavigationDirectorySummary[];
   revealSelectedThreadRequest?: number;
@@ -745,6 +746,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
               terminalThreadKeys={props.terminalThreadKeys}
               inputRequestThreadKeys={props.inputRequestThreadKeys}
               queuedMessageThreadKeys={props.queuedMessageThreadKeys}
+              draftThreadKeys={props.draftThreadKeys}
               composerSourceThreadKey={props.composerSourceThreadKey}
               compact
               draggable={reorderable}
@@ -884,6 +886,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             terminalThreadKeys={props.terminalThreadKeys}
             inputRequestThreadKeys={props.inputRequestThreadKeys}
             queuedMessageThreadKeys={props.queuedMessageThreadKeys}
+            draftThreadKeys={props.draftThreadKeys}
             composerSourceThreadKey={props.composerSourceThreadKey}
             compact
             draggable={Boolean(props.onReorderThreadPins)}
@@ -1228,6 +1231,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           terminalThreadKeys={props.terminalThreadKeys}
                           inputRequestThreadKeys={props.inputRequestThreadKeys}
                           queuedMessageThreadKeys={props.queuedMessageThreadKeys}
+                          draftThreadKeys={props.draftThreadKeys}
                           composerSourceThreadKey={props.composerSourceThreadKey}
                           compact
                           dropIndicator={

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -30,6 +30,7 @@ type RecentsListProps = {
   terminalThreadKeys?: Record<string, boolean>;
   inputRequestThreadKeys?: Record<string, boolean>;
   queuedMessageThreadKeys?: Record<string, ThreadQueuedMessageState>;
+  draftThreadKeys?: Record<string, boolean>;
   composerSourceThreadKey?: string;
   revealSelectedThreadRequest?: number;
   selectedThreadKey?: string;
@@ -145,6 +146,7 @@ export function RecentsList(props: RecentsListProps) {
               terminalThreadKeys={props.terminalThreadKeys}
               inputRequestThreadKeys={props.inputRequestThreadKeys}
               queuedMessageThreadKeys={props.queuedMessageThreadKeys}
+              draftThreadKeys={props.draftThreadKeys}
               composerSourceThreadKey={props.composerSourceThreadKey}
               dropIndicator={
                 dropIndicator?.targetKey === rowDropKey
@@ -277,6 +279,7 @@ export function RecentsList(props: RecentsListProps) {
           terminalThreadKeys={props.terminalThreadKeys}
           inputRequestThreadKeys={props.inputRequestThreadKeys}
           queuedMessageThreadKeys={props.queuedMessageThreadKeys}
+          draftThreadKeys={props.draftThreadKeys}
           composerSourceThreadKey={props.composerSourceThreadKey}
           includeLinkedDirectories
           revealSelectedThreadRequest={props.revealSelectedThreadRequest}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -36,6 +36,7 @@ import { copyText } from "../../lib/copy-text";
 import {
   BranchIcon,
   CalendarPlusIcon,
+  DraftIcon,
   FolderIcon,
   HistoryIcon,
   SearchIcon,
@@ -55,6 +56,7 @@ import {
 } from "../../lib/runtime-identity";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
+import { selectThreadsWithDrafts } from "../../lib/useThreadDraftIndicators";
 import { formatPrimaryAccel } from "../../lib/keyboard-accel";
 import {
   DetachPullRequestWarning,
@@ -115,6 +117,11 @@ type SidebarProps = {
    * "Scheduled"/"Queued" thread-row chip. Absent key = no pending send.
    */
   queuedMessageThreadKeys?: Record<string, ThreadQueuedMessageState>;
+  /**
+   * Threads holding unsent composer text. Window-local: a draft never
+   * leaves the machine it was typed on (see useThreadDraftIndicators).
+   */
+  draftThreadKeys?: Record<string, boolean>;
   /** Identity key of the card to highlight as the open composer's source. */
   composerSourceThreadKey?: string;
   /** Incremented when the thread title asks the active lens to reveal its row. */
@@ -254,6 +261,7 @@ type SidebarProps = {
  */
 const BROWSE_MODES = [
   "attention",
+  "drafts",
   "inbox",
   "recents",
   "directories",
@@ -263,6 +271,7 @@ const BROWSE_MODES = [
 // text — they are the tab's accessible name and the first line of its tooltip.
 const browseModeLabels = {
   attention: "Attention",
+  drafts: "Drafts",
   inbox: "Updated",
   recents: "Created",
   directories: "Directories",
@@ -270,6 +279,7 @@ const browseModeLabels = {
 
 // Attention is absent: it renders its two live indicators instead of an icon.
 const browseModeIcons = {
+  drafts: DraftIcon,
   inbox: HistoryIcon,
   recents: CalendarPlusIcon,
   directories: FolderIcon,
@@ -279,6 +289,7 @@ const browseModeIcons = {
 // gone, so the viewport tooltip carries both the name and the explanation.
 const browseModeTooltips = {
   attention: "Attention — threads in progress or waiting to be reviewed",
+  drafts: "Drafts — threads with a reply you started and never sent",
   inbox: "Updated — all threads, most recently updated first",
   recents: "Created — all threads, newest created first",
   directories: "Directories — threads grouped by linked Git directory",
@@ -405,12 +416,24 @@ export function Sidebar(props: SidebarProps) {
       ),
     [props.thinkingThreadKeys, updatedOrderThreads],
   );
+  /**
+   * The Drafts lens: everything holding unsent composer text, in the same
+   * most-recently-updated order Attention uses. Filtered from the very map the
+   * rows render their "Draft" chip from, so the lens and the chips agree by
+   * construction.
+   */
+  const draftThreads = useMemo(
+    () => selectThreadsWithDrafts(updatedOrderThreads, props.draftThreadKeys),
+    [props.draftThreadKeys, updatedOrderThreads],
+  );
   const visibleThreads =
     props.browseMode === "attention"
       ? attentionThreads
-      : props.browseMode === "recents"
-        ? props.recentThreads ?? props.threads
-        : updatedOrderThreads;
+      : props.browseMode === "drafts"
+        ? draftThreads
+        : props.browseMode === "recents"
+          ? props.recentThreads ?? props.threads
+          : updatedOrderThreads;
   /**
    * The two numbers on the Attention tab. Counted over the very rows the lens
    * renders, not over `props.threads`, so the tab and the list cannot report
@@ -1643,6 +1666,7 @@ export function Sidebar(props: SidebarProps) {
               terminalThreadKeys={props.terminalThreadKeys}
               inputRequestThreadKeys={props.inputRequestThreadKeys}
               queuedMessageThreadKeys={props.queuedMessageThreadKeys}
+              draftThreadKeys={props.draftThreadKeys}
               composerSourceThreadKey={props.composerSourceThreadKey}
               directories={props.directories}
               revealSelectedThreadRequest={directoryRevealRequest}
@@ -1684,7 +1708,9 @@ export function Sidebar(props: SidebarProps) {
               <p className="sidebar-empty">
                 {props.browseMode === "attention"
                   ? "Nothing running, nothing to review."
-                  : "No threads yet."}
+                  : props.browseMode === "drafts"
+                    ? "No unsent drafts."
+                    : "No threads yet."}
               </p>
             ) : (
               <RecentsList
@@ -1692,6 +1718,7 @@ export function Sidebar(props: SidebarProps) {
                 terminalThreadKeys={props.terminalThreadKeys}
                 inputRequestThreadKeys={props.inputRequestThreadKeys}
                 queuedMessageThreadKeys={props.queuedMessageThreadKeys}
+                draftThreadKeys={props.draftThreadKeys}
                 composerSourceThreadKey={props.composerSourceThreadKey}
                 revealSelectedThreadRequest={revealSelectedThreadRequest}
                 selectedThreadKey={props.selectedItemKey}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1709,7 +1709,11 @@ export function Sidebar(props: SidebarProps) {
                 {props.browseMode === "attention"
                   ? "Nothing running, nothing to review."
                   : props.browseMode === "drafts"
-                    ? "No unsent drafts."
+                    // "replies", not "drafts": launchpad (new-thread) composer
+                    // text is equally unsent but belongs to a directory rather
+                    // than a thread, so this lens cannot show it and must not
+                    // claim there is nothing to find.
+                    ? "No unsent replies."
                     : "No threads yet."}
               </p>
             ) : (

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useState, type ReactNode } from "react";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { isBranchDrifted } from "@pwragent/shared";
-import { BranchIcon, FolderIcon, PinIcon, TerminalIcon, WorktreeIcon } from "../../icons";
+import {
+  BranchIcon,
+  DraftIcon,
+  FolderIcon,
+  PinIcon,
+  TerminalIcon,
+  WorktreeIcon,
+} from "../../icons";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { copyText } from "../../lib/copy-text";
 import { readRendererFederationTarget } from "../../lib/federation-window";
@@ -12,6 +19,13 @@ import { AgentThreadChip } from "./AgentThreadChip";
 
 type ThreadMetaChipsProps = {
   hasApprovalRequest?: boolean;
+  /**
+   * Unsent composer text is parked on this thread. Distinct from "Queued" and
+   * "Scheduled", which are messages already committed to send — a draft is
+   * work the operator has not decided to send at all, and is the one pending
+   * state nothing else will ever clear for them.
+   */
+  hasUnsentDraft?: boolean;
   /** A shell is alive for this thread — the row is how you find it again. */
   hasIntegratedTerminal?: boolean;
   hasInputRequest?: boolean;
@@ -55,6 +69,7 @@ type ThreadMetaChipsProps = {
 
 export function ThreadMetaChips({
   hasApprovalRequest = false,
+  hasUnsentDraft = false,
   hasIntegratedTerminal = false,
   hasInputRequest = false,
   onUnpin,
@@ -79,6 +94,9 @@ export function ThreadMetaChips({
   // Sidebar rows are a clipped scroll region, so a native `title` gets
   // edge-clipped — the viewport tooltip is what the neighbouring chips use.
   const terminalTooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  // Same reason as the terminal chip: the sidebar clips a native `title`, and
+  // the Star Map layer would paint over one anyway.
+  const draftTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const branchDrifted = isBranchDrifted(thread.gitBranch, thread.observedGitBranch);
   const pinIsActionable = Boolean(onUnpin);
   const pinTooltipText = pinIsActionable ? "Click to unpin" : "Pinned";
@@ -242,6 +260,27 @@ export function ThreadMetaChips({
           Queued
         </span>
       ) : null}
+
+      {hasUnsentDraft ? (
+        <span
+          aria-label="Unsent draft reply"
+          className="thread-row__chip thread-row__chip--draft"
+          data-thread-draft="unsent"
+          onMouseEnter={(event) =>
+            draftTooltip.show(
+              event.currentTarget,
+              "Unsent draft reply\nThis thread has composer text you have not sent.",
+            )
+          }
+          onMouseLeave={draftTooltip.hide}
+        >
+          <span aria-hidden="true" className="thread-row__chip-icon">
+            <DraftIcon size={12} />
+          </span>
+          <span className="thread-row__chip-label">Draft</span>
+        </span>
+      ) : null}
+      {draftTooltip.tooltipNode}
 
       {hasApprovalRequest ? (
         <span

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -246,6 +246,7 @@ export function ThreadMetaChips({
       {queuedMessageState === "scheduled" ? (
         <span
           aria-label="A message is scheduled to send"
+          role="img"
           className="thread-row__chip thread-row__chip--scheduled"
           title="A message is scheduled to send"
         >
@@ -254,6 +255,7 @@ export function ThreadMetaChips({
       ) : queuedMessageState === "queued" ? (
         <span
           aria-label="A message is queued to send"
+          role="img"
           className="thread-row__chip thread-row__chip--queued"
           title="A message is queued to send"
         >
@@ -263,13 +265,25 @@ export function ThreadMetaChips({
 
       {hasUnsentDraft ? (
         <span
-          aria-label="Unsent draft reply"
+          // Deliberately does NOT contain the word "reply". Playwright's
+          // `getByLabel` is a substring match, and 31 specs across 23 files
+          // drive the composer with `getByLabel("Reply")` — an
+          // "Unsent draft reply" label made every one of them a strict-mode
+          // violation the moment a thread had a draft. See "E2E Locator
+          // Hygiene Around Global Chrome" in apps/desktop/AGENTS.md.
+          aria-label="Unsent draft"
+          // Without an explicit role this is a generic element, where
+          // `aria-label` is prohibited and silently dropped — the chip would
+          // announce as its visible "Draft" text and the fuller label would
+          // never be heard. Same reason the pin and terminal markers below
+          // carry one.
+          role="img"
           className="thread-row__chip thread-row__chip--draft"
           data-thread-draft="unsent"
           onMouseEnter={(event) =>
             draftTooltip.show(
               event.currentTarget,
-              "Unsent draft reply\nThis thread has composer text you have not sent.",
+              "Unsent draft\nThis thread has composer text you have not sent.",
             )
           }
           onMouseLeave={draftTooltip.hide}

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -41,6 +41,8 @@ type ThreadRowProps = {
    * "Scheduled"/"Queued" chip. Absent key = no pending send.
    */
   queuedMessageThreadKeys?: Record<string, ThreadQueuedMessageState>;
+  /** Threads with unsent composer text, keyed like the maps above. */
+  draftThreadKeys?: Record<string, boolean>;
   /**
    * Identity key of the card the open composer was spawned from. When it
    * matches this row, the row renders as the orange "composing" source.
@@ -360,6 +362,7 @@ export function ThreadRow(props: ThreadRowProps) {
                 : undefined
             }
             queuedMessageState={props.queuedMessageThreadKeys?.[threadKey]}
+            hasUnsentDraft={props.draftThreadKeys?.[threadKey] === true}
             includeLinkedDirectories={props.includeLinkedDirectories}
             linkedDirectoryMode={props.linkedDirectoryMode}
             thread={props.thread}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -740,11 +740,12 @@ describe("Sidebar", () => {
     // the whole name — a tab that loses its aria-label announces as unlabeled.
     expect(lensTabs.map((tab) => tab.getAttribute("aria-label"))).toEqual([
       "Attention, 0 active threads, 1 thread to review",
+      "Drafts",
       "Updated",
       "Created",
       "Directories",
     ]);
-    expect(lensTabs[3]).toHaveAttribute("aria-selected", "true");
+    expect(lensTabs[4]).toHaveAttribute("aria-selected", "true");
     expect(screen.getAllByText("PwrAgent").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Cross-project cleanup").length).toBeGreaterThan(0);
     expect(screen.getAllByText("OpenAI").length).toBeGreaterThan(0);
@@ -2453,6 +2454,137 @@ describe("Sidebar", () => {
         "Attention — threads in progress or waiting to be reviewed"
           + "\n1 active thread · 1 thread to review",
       );
+    });
+  });
+
+  describe("Drafts lens", () => {
+    const draftThread = {
+      ...sharedThread,
+      id: "thread-with-draft",
+      title: "Thread with a draft",
+      inbox: { inInbox: false },
+    };
+    const plainThread = {
+      ...sharedThread,
+      id: "thread-without-draft",
+      title: "Thread without a draft",
+      inbox: { inInbox: false },
+    };
+    const allThreads = [draftThread, plainThread];
+    // Keyed exactly as `buildThreadIdentityKey` builds it — the same string
+    // ThreadRow looks its chip up under.
+    const draftThreadKeys = {
+      [`${draftThread.source}:${draftThread.id}`]: true,
+    };
+
+    const renderDrafts = (
+      browseMode: "drafts" | "inbox" = "drafts",
+      onBrowseModeChange = vi.fn(),
+    ) =>
+      render(
+        <Sidebar
+          backends={backends}
+          browseMode={browseMode}
+          createThreadError={undefined}
+          directories={directories}
+          draftThreadKeys={draftThreadKeys}
+          inboxThreads={allThreads}
+          launchpadError={undefined}
+          loading={false}
+          creatingThread={undefined}
+          selectedItemKey={undefined}
+          threads={allThreads}
+          onBrowseModeChange={onBrowseModeChange}
+          onCreateThread={async () => undefined}
+          onOpenLaunchpad={async () => undefined}
+          onSelectThread={() => undefined}
+        />,
+      );
+
+    it("lists only threads holding unsent composer text", () => {
+      renderDrafts();
+
+      const browseSection = screen.getByRole("region", {
+        name: "Thread browser",
+      });
+      const rows = within(browseSection as HTMLElement).getAllByRole("button", {
+        name: /Thread with a draft|Thread without a draft/i,
+      });
+      expect(rows.map((row) => row.textContent)).toEqual([
+        expect.stringContaining("Thread with a draft"),
+      ]);
+    });
+
+    it("marks the drafted row with a Draft chip in every lens", () => {
+      renderDrafts("inbox");
+
+      const browseSection = screen.getByRole("region", {
+        name: "Thread browser",
+      });
+      // The chip is a sibling of the row's open button, so assert against
+      // the whole row shell rather than the button.
+      const rowFor = (title: string): HTMLElement => {
+        const button = within(browseSection as HTMLElement).getByRole(
+          "button",
+          { name: new RegExp(title, "i") },
+        );
+        const shell = button.closest(".thread-row-shell");
+        expect(shell).not.toBeNull();
+        return shell as HTMLElement;
+      };
+
+      expect(
+        rowFor("Thread with a draft").querySelector(
+          '[data-thread-draft="unsent"]',
+        ),
+      ).toBeInTheDocument();
+      expect(
+        rowFor("Thread without a draft").querySelector(
+          '[data-thread-draft="unsent"]',
+        ),
+      ).toBeNull();
+    });
+
+    it("switches to the lens from its tab", () => {
+      const onBrowseModeChange = vi.fn();
+      renderDrafts("inbox", onBrowseModeChange);
+
+      const tab = screen.getByRole("tab", { name: "Drafts" });
+      expect(tab).toHaveAttribute("aria-selected", "false");
+      fireEvent.click(tab);
+      expect(onBrowseModeChange).toHaveBeenCalledWith("drafts");
+    });
+
+    it("explains the lens in its tooltip", async () => {
+      renderDrafts();
+
+      fireEvent.mouseEnter(screen.getByRole("tab", { name: "Drafts" }));
+      expect((await screen.findByRole("tooltip")).textContent).toBe(
+        "Drafts — threads with a reply you started and never sent",
+      );
+    });
+
+    it("shows an empty state when nothing is half-written", () => {
+      render(
+        <Sidebar
+          backends={backends}
+          browseMode="drafts"
+          createThreadError={undefined}
+          directories={directories}
+          inboxThreads={allThreads}
+          launchpadError={undefined}
+          loading={false}
+          creatingThread={undefined}
+          selectedItemKey={undefined}
+          threads={allThreads}
+          onBrowseModeChange={() => undefined}
+          onCreateThread={async () => undefined}
+          onOpenLaunchpad={async () => undefined}
+          onSelectThread={() => undefined}
+        />,
+      );
+
+      expect(screen.getByText("No unsent drafts.")).toBeInTheDocument();
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2584,7 +2584,9 @@ describe("Sidebar", () => {
         />,
       );
 
-      expect(screen.getByText("No unsent drafts.")).toBeInTheDocument();
+      // "replies", not "drafts": launchpad composer text is equally unsent
+      // but has no thread row, so the lens must not claim it covers it.
+      expect(screen.getByText("No unsent replies.")).toBeInTheDocument();
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -464,6 +464,74 @@ describe("ThreadRow chip flow", () => {
     expect(screen.queryByText("now fix/current")).not.toBeInTheDocument();
   });
 
+  describe("unsent draft chip", () => {
+    const draftKeys = { [`${baseThread.source}:${baseThread.id}`]: true };
+
+    it("renders only when the thread's scope holds unsent text", () => {
+      const { container: without } = renderRow();
+      expect(without.querySelector('[data-thread-draft="unsent"]')).toBeNull();
+
+      cleanup();
+
+      const { container: with_ } = renderRow({ draftThreadKeys: draftKeys });
+      const chip = with_.querySelector('[data-thread-draft="unsent"]');
+      expect(chip).not.toBeNull();
+      expect(chip).toHaveTextContent("Draft");
+    });
+
+    it("names itself for assistive tech without shadowing the composer", () => {
+      // role="img" is load-bearing: on a generic element `aria-label` is
+      // prohibited and dropped, so the chip would announce only as "Draft".
+      // The label deliberately omits the word "reply" — `getByLabel` is a
+      // substring match and 31 E2E call sites drive the composer with
+      // `getByLabel("Reply")`.
+      const { container } = renderRow({ draftThreadKeys: draftKeys });
+      const chip = container.querySelector('[data-thread-draft="unsent"]')!;
+      expect(chip).toHaveAttribute("role", "img");
+      expect(chip).toHaveAttribute("aria-label", "Unsent draft");
+      expect(chip.getAttribute("aria-label")).not.toMatch(/reply/i);
+    });
+
+    it("sits inside the shared chip flow, before bindings and PR chips", () => {
+      const { container } = renderRow({
+        draftThreadKeys: draftKeys,
+        thread: {
+          ...baseThread,
+          messagingBindings: [telegramBinding],
+          reactions: ["🙂"],
+          prs: [
+            {
+              provider: "github.com",
+              number: 123,
+              org: "pwrdrvr",
+              repo: "PwrAgent",
+              state: "passing",
+              url: "https://github.com/pwrdrvr/PwrAgent/pull/123",
+            },
+          ],
+        },
+      });
+      const flow = container.querySelector(".thread-row__chips") as HTMLElement;
+      expect(flow.querySelector('[data-thread-draft="unsent"]')).not.toBeNull();
+
+      const chipNodes = Array.from(flow.children) as HTMLElement[];
+      const indexOf = (selector: string): number =>
+        chipNodes.findIndex(
+          (el) => el.matches(selector) || el.querySelector(selector) !== null,
+        );
+      const draftIdx = indexOf('[data-thread-draft="unsent"]');
+      const bindingIdx = indexOf(
+        ".thread-row__chip--binding, .thread-row__chip-wrap",
+      );
+      const prIdx = indexOf(".thread-row__chip--pr, [data-pr-chip]");
+      // Draft is meta, so it packs with the fixed-width metadata ahead of
+      // the variable-count binding / PR chips rather than trailing them.
+      expect(draftIdx).toBeGreaterThanOrEqual(0);
+      if (bindingIdx >= 0) expect(draftIdx).toBeLessThan(bindingIdx);
+      if (prIdx >= 0) expect(draftIdx).toBeLessThan(prIdx);
+    });
+  });
+
   it("orders chips: meta → bindings → PR → reactions", () => {
     const threadWithEverything: NavigationThreadSummary = {
       ...baseThread,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -178,6 +178,12 @@ type StarMapScreenProps = {
   /** Local navigation snapshot threads (already live in the App shell). */
   localThreads: readonly NavigationThreadSummary[];
   sessionKeys: StarMapSessionKeys;
+  /**
+   * Threads with unsent composer text in THIS window, keyed by
+   * `buildThreadIdentityKey`. Applies to remote cards too — unlike
+   * `sessionKeys`, a draft is local state and needs no peer to confirm it.
+   */
+  draftThreadKeys?: Record<string, boolean>;
   /** Fallback label for the local instance card (instanceLabel setting). */
   localInstanceLabel?: string;
   /** A thread is floating over the map; the map shoves left behind it. */
@@ -1600,6 +1606,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
                   ? props.sessionKeys
                   : undefined
               }
+              hasUnsentDraft={props.draftThreadKeys?.[threadKey] === true}
               riseDelayMs={index * 45}
               entering={enteringThreadKeys.has(threadKey)}
               instanceIcon={celestialIcons.iconFor(
@@ -1953,6 +1960,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
                           owner === localInstanceId
                             ? props.sessionKeys
                             : undefined
+                        }
+                        hasUnsentDraft={
+                          props.draftThreadKeys?.[threadKey] === true
                         }
                         instanceIcon={celestialIcons.iconFor(
                           owner === localInstanceId ? undefined : owner,

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -40,6 +40,13 @@ import type { StarMapSessionKeys } from "./attention";
 export function StarMapThreadCard(props: {
   thread: NavigationThreadSummary;
   sessionKeys?: StarMapSessionKeys;
+  /**
+   * Separate from `sessionKeys` on purpose: the caller withholds those from
+   * remote cards because thinking/approval keys come from an unscoped event
+   * stream. A draft is this window's own composer state, so it is just as
+   * true of a peer's thread as of a local one.
+   */
+  hasUnsentDraft?: boolean;
   entering?: boolean;
   /** Staggered rise-in offset so a cloud settles like a constellation. */
   riseDelayMs?: number;
@@ -182,6 +189,7 @@ export function StarMapThreadCard(props: {
             hasInputRequest={
               props.sessionKeys?.inputRequestThreadKeys?.[threadKey] === true
             }
+            hasUnsentDraft={props.hasUnsentDraft}
             includeLinkedDirectories={props.cardFields.primaryDirectory}
             linkedDirectoryMode="label"
             // In the instance lenses the lane and the watermark already say

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapScreen.test.tsx
@@ -73,6 +73,41 @@ function seedLayout(layout: "lanes" | "orbit" | "projects") {
 }
 
 describe("StarMapScreen", () => {
+  it("marks a card whose thread holds an unsent draft", async () => {
+    // Drafts ride a prop of their own rather than `sessionKeys`, which the
+    // screen only trusts for local cards — a draft is this window's own
+    // composer state, so no peer has to confirm it.
+    const { container } = render(
+      <StarMapScreen
+        desktopApi={buildDesktopApi()}
+        localThreads={[unreadThread("t1"), unreadThread("t2")]}
+        sessionKeys={{}}
+        draftThreadKeys={{ "codex:t1": true }}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-card")).not.toBeNull();
+    });
+
+    const drafted = starMapCard(
+      screen.getByRole("button", { name: "Open thread: Thread t1" }),
+    );
+    expect(
+      drafted.querySelector('[data-thread-draft="unsent"]'),
+    ).not.toBeNull();
+
+    const undrafted = starMapCard(
+      screen.getByRole("button", { name: "Open thread: Thread t2" }),
+    );
+    expect(undrafted.querySelector('[data-thread-draft="unsent"]')).toBeNull();
+  });
+
   // Filter selection and view preferences both persist to localStorage,
   // so without this a test that clicks a chip silently changes the
   // starting state of every test after it.

--- a/apps/desktop/src/renderer/src/icons/DraftIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/DraftIcon.tsx
@@ -1,0 +1,15 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+/**
+ * A pencil poised over a baseline — text written but not sent. Deliberately
+ * unlike `EditsIcon` (a document with change marks, which is about files an
+ * agent touched) so a row carrying both never reads as one repeated glyph.
+ */
+export function DraftIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L9 17l-4 1 1-4z" />
+      <path d="M4 21h16" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
+++ b/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
@@ -9,6 +9,7 @@ import {
   CloseIcon,
   CopyIcon,
   DiscordIcon,
+  DraftIcon,
   FileCodeIcon,
   FolderIcon,
   HistoryIcon,
@@ -50,6 +51,7 @@ const ALL_ICONS = [
   ["SkillIcon", SkillIcon],
   ["HistoryIcon", HistoryIcon],
   ["CalendarPlusIcon", CalendarPlusIcon],
+  ["DraftIcon", DraftIcon],
 ] as const;
 
 describe("icon library", () => {

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -16,6 +16,7 @@ export { ChevronUpIcon } from "./ChevronUpIcon";
 export { CloseIcon } from "./CloseIcon";
 export { CopyIcon } from "./CopyIcon";
 export { DiscordIcon } from "./DiscordIcon";
+export { DraftIcon } from "./DraftIcon";
 export { EditorIcon } from "./EditorIcon";
 export { EditsIcon } from "./EditsIcon";
 export { FeishuIcon } from "./FeishuIcon";

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -33,6 +33,9 @@ function createComposerDraftStore(): ComposerDraftStore {
     getQueuedTurns: (scopeKey) => queuedTurns.get(scopeKey) ?? [],
     getQueuedTurnVersion: () => 0,
     subscribeQueuedTurns: () => () => {},
+    hasDraftContent: () => false,
+    getDraftPresenceVersion: () => 0,
+    subscribeDraftPresence: () => () => {},
     removeQueuedTurnAt: (scopeKey, index) => {
       const current = queuedTurns.get(scopeKey) ?? [];
       const next = [...current];

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadDraftIndicators.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadDraftIndicators.test.tsx
@@ -1,0 +1,212 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import {
+  buildThreadComposerScopeKey,
+  useComposerDraftStore,
+  type ComposerDraftSnapshot,
+  type ComposerDraftStore,
+} from "../../features/composer/useComposerDraftStore";
+import {
+  selectThreadsWithDrafts,
+  useThreadDraftIndicators,
+} from "../useThreadDraftIndicators";
+
+function makeThread(id: string): NavigationThreadSummary {
+  return {
+    id,
+    title: id,
+    titleSource: "explicit",
+    source: "codex",
+    executionMode: "default",
+    updatedAt: 0,
+    inbox: { inInbox: false },
+    linkedDirectories: [],
+  };
+}
+
+function makeSnapshot(
+  overrides: Partial<ComposerDraftSnapshot> = {},
+): ComposerDraftSnapshot {
+  return {
+    draft: "",
+    imageAttachments: [],
+    fileAttachments: [],
+    skillTokens: [],
+    ...overrides,
+  };
+}
+
+function scopeKey(thread: NavigationThreadSummary): string {
+  return buildThreadComposerScopeKey(thread.source, thread.id);
+}
+
+function renderIndicators(threads: NavigationThreadSummary[]) {
+  const renders = { count: 0 };
+  const rendered = renderHook(
+    ({ threads: currentThreads }) => {
+      renders.count += 1;
+      const store = useComposerDraftStore();
+      const indicators = useThreadDraftIndicators({
+        composerDraftStore: store,
+        threads: currentThreads,
+      });
+      return { store, indicators };
+    },
+    { initialProps: { threads } },
+  );
+  return { ...rendered, renders };
+}
+
+function setDraft(
+  store: ComposerDraftStore,
+  thread: NavigationThreadSummary,
+  snapshot: ComposerDraftSnapshot,
+): void {
+  act(() => {
+    store.set(scopeKey(thread), snapshot);
+  });
+}
+
+describe("useThreadDraftIndicators", () => {
+  it("marks a thread once its composer holds text", () => {
+    const thread = makeThread("thread-1");
+    const { result } = renderIndicators([thread]);
+
+    expect(result.current.indicators).toEqual({});
+
+    setDraft(result.current.store, thread, makeSnapshot({ draft: "half a " }));
+
+    expect(result.current.indicators).toEqual({ "codex:thread-1": true });
+  });
+
+  it("ignores whitespace-only text", () => {
+    // The composer leaves a trailing newline behind constantly; a chip that
+    // lit up for one would be permanent noise.
+    const thread = makeThread("thread-1");
+    const { result } = renderIndicators([thread]);
+
+    setDraft(result.current.store, thread, makeSnapshot({ draft: "  \n " }));
+
+    expect(result.current.indicators).toEqual({});
+  });
+
+  it("marks a thread carrying only attachments", () => {
+    const thread = makeThread("thread-1");
+    const { result } = renderIndicators([thread]);
+
+    setDraft(
+      result.current.store,
+      thread,
+      makeSnapshot({
+        fileAttachments: [
+          { id: "file-1", label: "notes.md", path: "/tmp/notes.md" },
+        ],
+      }),
+    );
+
+    expect(result.current.indicators).toEqual({ "codex:thread-1": true });
+  });
+
+  it("clears when the draft is deleted", () => {
+    const thread = makeThread("thread-1");
+    const { result } = renderIndicators([thread]);
+
+    setDraft(result.current.store, thread, makeSnapshot({ draft: "text" }));
+    expect(result.current.indicators).toEqual({ "codex:thread-1": true });
+
+    act(() => {
+      result.current.store.delete(scopeKey(thread));
+    });
+
+    expect(result.current.indicators).toEqual({});
+  });
+
+  it("keeps the mark while a draft is parked beneath a newer one", () => {
+    // `pushDraft` parks the current draft under the scope rather than
+    // destroying it. That parked text is still unsent work.
+    const thread = makeThread("thread-1");
+    const { result } = renderIndicators([thread]);
+
+    act(() => {
+      result.current.store.pushDraft(
+        scopeKey(thread),
+        makeSnapshot({ draft: "parked" }),
+      );
+    });
+
+    expect(result.current.indicators).toEqual({ "codex:thread-1": true });
+
+    act(() => {
+      result.current.store.popDraft(scopeKey(thread));
+    });
+
+    expect(result.current.indicators).toEqual({});
+  });
+
+  it("does not re-render the subscriber on every keystroke", () => {
+    // The store notifies on presence transitions only. Without that, every
+    // character typed into the composer would re-render the whole thread
+    // list.
+    const thread = makeThread("thread-1");
+    const { result, renders } = renderIndicators([thread]);
+
+    setDraft(result.current.store, thread, makeSnapshot({ draft: "a" }));
+    const rendersAfterFirstCharacter = renders.count;
+
+    for (const draft of ["ab", "abc", "abcd"]) {
+      setDraft(result.current.store, thread, makeSnapshot({ draft }));
+    }
+
+    expect(renders.count).toBe(rendersAfterFirstCharacter);
+    expect(result.current.indicators).toEqual({ "codex:thread-1": true });
+  });
+
+  it("scopes the mark to the thread that was typed into", () => {
+    const typed = makeThread("thread-1");
+    const untouched = makeThread("thread-2");
+    const { result } = renderIndicators([typed, untouched]);
+
+    setDraft(result.current.store, typed, makeSnapshot({ draft: "text" }));
+
+    expect(result.current.indicators).toEqual({ "codex:thread-1": true });
+  });
+
+  it("unsubscribes on unmount", () => {
+    const thread = makeThread("thread-1");
+    const unsubscribe = vi.fn();
+    const store = {
+      getDraftPresenceVersion: () => 0,
+      hasDraftContent: () => false,
+      subscribeDraftPresence: () => unsubscribe,
+    } as unknown as ComposerDraftStore;
+
+    const { unmount } = renderHook(() =>
+      useThreadDraftIndicators({ composerDraftStore: store, threads: [thread] }),
+    );
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+});
+
+describe("selectThreadsWithDrafts", () => {
+  it("keeps the given order and drops undrafted threads", () => {
+    const first = makeThread("thread-1");
+    const second = makeThread("thread-2");
+    const third = makeThread("thread-3");
+
+    expect(
+      selectThreadsWithDrafts([first, second, third], {
+        "codex:thread-3": true,
+        "codex:thread-1": true,
+      }),
+    ).toEqual([first, third]);
+  });
+
+  it("returns nothing when no map has been threaded down", () => {
+    expect(selectThreadsWithDrafts([makeThread("thread-1")], undefined)).toEqual(
+      [],
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -6,6 +6,7 @@ import type {
   NavigationThreadSummary,
 } from "@pwragent/shared";
 import {
+  buildThreadComposerScopeKey,
   getNextReleasableQueuedTurn,
   type ComposerDraftStore,
   type ComposerQueuedTurnSnapshot,
@@ -119,7 +120,7 @@ function isIdleStatusNotification(event: AgentEvent): boolean {
 }
 
 function getThreadScopeKey(thread: Pick<NavigationThreadSummary, "id" | "source">): string {
-  return `thread:${thread.source}:${thread.id}`;
+  return buildThreadComposerScopeKey(thread.source, thread.id);
 }
 
 function isThreadSelected(

--- a/apps/desktop/src/renderer/src/lib/useThreadDraftIndicators.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadDraftIndicators.ts
@@ -1,4 +1,4 @@
-import { useMemo, useSyncExternalStore } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
 import {
@@ -10,15 +10,13 @@ import {
  * Derives the per-thread "has an unsent draft" map the sidebar, the Drafts
  * lens, and the Star Map all read.
  *
- * A draft belongs to whoever typed it. It lives in this window's composer
- * store, is persisted to this machine's `composer_draft_latest` table, and is
- * re-hydrated on the next launch — it is never sent to the thread's owning
- * instance. That is what makes the affordance work unchanged in a federation
- * viewer window: a reply half-written against a peer's thread is the viewer's
- * own unsent work, keyed by the same `thread:<backend>:<id>` scope key the
- * composer wrote it under, so it surfaces on the row the operator was
- * looking at. Nothing about it needs to cross the wire, and federating it
- * would publish an operator's unsent text to another machine.
+ * A draft belongs to whoever typed it, and is never sent to the thread's
+ * owning instance. That is what makes the affordance work unchanged in a
+ * federation viewer window: a reply half-written against a peer's thread is
+ * the viewer's own unsent work, keyed by the same `thread:<backend>:<id>`
+ * scope key the composer wrote it under, so it surfaces on the row the
+ * operator was looking at. Nothing about it needs to cross the wire, and
+ * federating it would publish an operator's unsent text to another machine.
  *
  * Keyed by `buildThreadIdentityKey` to match how ThreadRow and the Star Map
  * card look their state up, and how the scope key itself is built.
@@ -26,16 +24,45 @@ import {
  * Reacts to *presence* changes only (see `subscribeDraftPresence`), so typing
  * into the composer re-renders the thread list once — when the draft appears —
  * rather than on every keystroke.
+ *
+ * Three known limits, none of them silent-by-accident:
+ *
+ * 1. **The storage is machine-wide; this view is per-window.** Drafts persist
+ *    to `composer_draft_latest`, which every window on the profile shares, but
+ *    a window only reads it once at mount (`useDurableComposerDraftStore`
+ *    hydration) and there is no main -> renderer change event. So a draft typed
+ *    in one window does not light up a row in another already-open window
+ *    until that window restarts. Fixing it means broadcasting on draft
+ *    save/clear, which fires up to ~5/s per typing operator against every open
+ *    window; that trade is worth making deliberately, not as a side effect of
+ *    this chip.
+ * 2. **Only threads in the current navigation snapshot can be marked.** A
+ *    draft on an archived thread, or on a remote thread that is not pinned
+ *    into the snapshot, has no row to carry a chip and no slot in the Drafts
+ *    lens. Nothing deletes its `composer_draft_latest` row when a thread is
+ *    archived either, so it is unreachable rather than merely hidden.
+ * 3. **Launchpad drafts are out of scope.** `launchpad:<directoryKey>` text is
+ *    equally unsent, but it belongs to a directory rather than a thread and
+ *    has no row to hang a chip on. The lens copy says "replies" for that
+ *    reason — do not widen it to "drafts" without giving launchpad text a home.
  */
 export function useThreadDraftIndicators(params: {
   composerDraftStore: ComposerDraftStore;
   threads: NavigationThreadSummary[];
 }): Record<string, boolean> {
   const { composerDraftStore, threads } = params;
-  const version = useSyncExternalStore(
-    (listener) => composerDraftStore.subscribeDraftPresence(listener),
-    () => composerDraftStore.getDraftPresenceVersion(),
+  // Both callbacks are memoized against the store rather than written inline:
+  // `useSyncExternalStore` re-subscribes whenever `subscribe` changes identity,
+  // and an inline arrow changes on every render.
+  const subscribe = useCallback(
+    (listener: () => void) => composerDraftStore.subscribeDraftPresence(listener),
+    [composerDraftStore],
   );
+  const getSnapshot = useCallback(
+    () => composerDraftStore.getDraftPresenceVersion(),
+    [composerDraftStore],
+  );
+  const version = useSyncExternalStore(subscribe, getSnapshot);
 
   return useMemo(() => {
     const indicators: Record<string, boolean> = {};

--- a/apps/desktop/src/renderer/src/lib/useThreadDraftIndicators.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadDraftIndicators.ts
@@ -1,0 +1,75 @@
+import { useMemo, useSyncExternalStore } from "react";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { buildThreadIdentityKey } from "@pwragent/shared";
+import {
+  buildThreadComposerScopeKey,
+  type ComposerDraftStore,
+} from "../features/composer/useComposerDraftStore";
+
+/**
+ * Derives the per-thread "has an unsent draft" map the sidebar, the Drafts
+ * lens, and the Star Map all read.
+ *
+ * A draft belongs to whoever typed it. It lives in this window's composer
+ * store, is persisted to this machine's `composer_draft_latest` table, and is
+ * re-hydrated on the next launch — it is never sent to the thread's owning
+ * instance. That is what makes the affordance work unchanged in a federation
+ * viewer window: a reply half-written against a peer's thread is the viewer's
+ * own unsent work, keyed by the same `thread:<backend>:<id>` scope key the
+ * composer wrote it under, so it surfaces on the row the operator was
+ * looking at. Nothing about it needs to cross the wire, and federating it
+ * would publish an operator's unsent text to another machine.
+ *
+ * Keyed by `buildThreadIdentityKey` to match how ThreadRow and the Star Map
+ * card look their state up, and how the scope key itself is built.
+ *
+ * Reacts to *presence* changes only (see `subscribeDraftPresence`), so typing
+ * into the composer re-renders the thread list once — when the draft appears —
+ * rather than on every keystroke.
+ */
+export function useThreadDraftIndicators(params: {
+  composerDraftStore: ComposerDraftStore;
+  threads: NavigationThreadSummary[];
+}): Record<string, boolean> {
+  const { composerDraftStore, threads } = params;
+  const version = useSyncExternalStore(
+    (listener) => composerDraftStore.subscribeDraftPresence(listener),
+    () => composerDraftStore.getDraftPresenceVersion(),
+  );
+
+  return useMemo(() => {
+    const indicators: Record<string, boolean> = {};
+    for (const thread of threads) {
+      if (
+        composerDraftStore.hasDraftContent(
+          buildThreadComposerScopeKey(thread.source, thread.id),
+        )
+      ) {
+        indicators[buildThreadIdentityKey(thread.source, thread.id)] = true;
+      }
+    }
+    return indicators;
+    // `version` is intentionally a dependency (not referenced in the body):
+    // it forces recomputation when draft presence changes, since the store's
+    // backing Set is a ref whose identity never changes. exhaustive-deps
+    // can't see that and flags it as unnecessary.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [composerDraftStore, threads, version]);
+}
+
+/**
+ * Threads with an unsent draft, in the order they were given. The Drafts lens
+ * renders this directly, so the tab's count and the list can never disagree.
+ */
+export function selectThreadsWithDrafts(
+  threads: NavigationThreadSummary[],
+  draftThreadKeys: Record<string, boolean> | undefined,
+): NavigationThreadSummary[] {
+  if (!draftThreadKeys) {
+    return [];
+  }
+  return threads.filter(
+    (thread) =>
+      draftThreadKeys[buildThreadIdentityKey(thread.source, thread.id)] === true,
+  );
+}

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -34,10 +34,12 @@ import {
   buildPullRequestStatusKey,
   buildThreadIdentityKey,
   compareThreadsByCreatedAtDesc,
+  DEFAULT_NAVIGATION_BROWSE_MODE,
   federatedThreadIdentityKey,
   insertSubthreadIdAfter,
   isRemoteFederationTarget,
   isSubthreadLaunchpadKey,
+  normalizeNavigationBrowseMode,
   resolveThreadParentKey,
   shortenDerivedThreadTitle,
   sortSubthreadSummaries,
@@ -101,7 +103,6 @@ const NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS = 5 * 60_000;
 const NAVIGATION_BACKGROUND_REFRESH_IDLE_AFTER_MS = 30 * 60_000;
 const NAVIGATION_FOCUS_REFRESH_MIN_INTERVAL_MS = 60_000;
 const NAVIGATION_REMOTE_RECOVERY_MAX_DELAY_MS = 30_000;
-const DEFAULT_BROWSE_MODE: BrowseMode = "inbox";
 const NAVIGATION_ACTIVITY_EVENTS = [
   "input",
   "keydown",
@@ -109,14 +110,8 @@ const NAVIGATION_ACTIVITY_EVENTS = [
   "pointerdown",
 ] as const;
 
-function normalizeBrowseMode(value: unknown): BrowseMode {
-  return value === "attention"
-    || value === "inbox"
-    || value === "recents"
-    || value === "directories"
-    ? value
-    : DEFAULT_BROWSE_MODE;
-}
+const DEFAULT_BROWSE_MODE = DEFAULT_NAVIGATION_BROWSE_MODE;
+const normalizeBrowseMode = normalizeNavigationBrowseMode;
 
 function readBridgedBrowseMode(): BrowseMode {
   if (typeof window === "undefined") {

--- a/apps/desktop/src/renderer/src/lib/useThreadQueuedMessageIndicators.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadQueuedMessageIndicators.ts
@@ -1,7 +1,10 @@
 import { useMemo, useSyncExternalStore } from "react";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
-import type { ComposerDraftStore } from "../features/composer/useComposerDraftStore";
+import {
+  buildThreadComposerScopeKey,
+  type ComposerDraftStore,
+} from "../features/composer/useComposerDraftStore";
 
 /**
  * A thread's pending outbound-message state, in descending information
@@ -10,12 +13,6 @@ import type { ComposerDraftStore } from "../features/composer/useComposerDraftSt
  * that has both surfaces the scheduled signal.
  */
 export type ThreadQueuedMessageState = "scheduled" | "queued";
-
-function getThreadScopeKey(
-  thread: Pick<NavigationThreadSummary, "id" | "source">,
-): string {
-  return `thread:${thread.source}:${thread.id}`;
-}
 
 /**
  * Derives a per-thread map of pending outbound-message indicators from the
@@ -56,7 +53,7 @@ export function useThreadQueuedMessageIndicators(params: {
           "scheduled";
       }
       const queuedTurns = composerDraftStore.getQueuedTurns(
-        getThreadScopeKey(thread),
+        buildThreadComposerScopeKey(thread.source, thread.id),
       );
       if (queuedTurns.length === 0) {
         continue;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -422,13 +422,16 @@
    The "Scheduled"/"Queued" pending-send and detached-work "Unpublished"
    chips also stay visible: these time-sensitive commitments need to remain
    visible at a glance, so they survive the density strip like the pin marker.
+   "Draft" survives for the same reason from the other direction: it is the
+   one pending state nothing but the operator will ever resolve, so hiding it
+   in the denser view is exactly where it would be lost.
 
    Scope the rule to `.thread-row__chips` so non-list surfaces that
    carry a `.thread-row__chip--*` variant (e.g. the questionnaire's mode
    chip in the transcript) don't get collapsed when compact density is
    on. The skill chip in the composer and the standalone SkillChip use
    `.chip` directly and aren't affected by this rule. */
-:root[data-density="compact"] .thread-row__chips .thread-row__chip:not(.thread-row__chip--reaction):not(.thread-row__chip--agent):not(.thread-row__chip--pin):not(.thread-row__chip--scheduled):not(.thread-row__chip--queued):not(.thread-row__chip--unpublished) {
+:root[data-density="compact"] .thread-row__chips .thread-row__chip:not(.thread-row__chip--reaction):not(.thread-row__chip--agent):not(.thread-row__chip--pin):not(.thread-row__chip--scheduled):not(.thread-row__chip--queued):not(.thread-row__chip--draft):not(.thread-row__chip--unpublished) {
   display: none;
 }
 
@@ -2933,8 +2936,13 @@ textarea,
   line-height: 1.16;
 }
 
+/* Only ever worn together with `--fill`, so this padding is the gap between
+   the runtime-identity divider and the lens switch. 16px read as a hole: the
+   row above it is 6px of padding around a single line of text, so the strip
+   was floating away from the chrome it belongs to. 10px keeps the lens switch
+   legible as its own band without the drift. */
 .sidebar__section {
-  padding: 16px 0 0;
+  padding: 10px 0 0;
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -3014,7 +3022,7 @@ textarea,
      lane inset. See `--sidebar-masthead-pull` on `.sidebar`. */
   width: calc(100% - 2 * var(--sidebar-masthead-pull));
   margin-inline: var(--sidebar-masthead-pull);
-  /* Four tabs, three of which are a single 16px icon. The Attention tab
+  /* Five tabs, four of which are a single 16px icon. The Attention tab
      carries two indicator + count pairs, so it is the only one whose content
      can outgrow an equal share — `min-content` floors every track at its own
      content width and lets Attention take what it needs before the icon tabs
@@ -3026,9 +3034,9 @@ textarea,
 
      Measured at the 280px sidebar minimum (a 264px container, see
      `--sidebar-masthead-pull`): Attention floors at ~74px with two-digit
-     counts, leaving ~58px per icon tab. The container query below is what
+     counts, leaving ~44px per icon tab. The container query below is what
      keeps that true past two digits. */
-  grid-template-columns: repeat(4, minmax(min-content, 1fr));
+  grid-template-columns: repeat(5, minmax(min-content, 1fr));
   gap: 2px;
   padding: 3px;
   border: 1px solid var(--border-subtle);
@@ -3147,7 +3155,7 @@ textarea,
 }
 
 /* The narrow end of the sidebar's resize range (280px minimum → a 264px
-   container). Four tracks share less room here, and a three-digit count on the
+   container). Five tracks share less room here, and a three-digit count on the
    Attention tab would push the icon tabs below a comfortable target. Tighten
    the Attention tab's own padding and gaps first — the icon tabs never need
    to give, since a 16px glyph fits any track this control can produce. */
@@ -4301,6 +4309,21 @@ textarea,
   border: 1px solid var(--accent-border);
   background: var(--accent-soft);
   color: var(--accent-bright);
+  font-weight: 600;
+}
+
+/* Unsent draft. Deliberately the quietest of the three pending states: a
+   Scheduled or Queued message is already committed to send and the app will
+   act on it, whereas a draft is waiting on the operator and nothing is going
+   to happen until they come back. So it takes the dashed neutral outline
+   rather than the accent — the accent is a signal in this theme, and "you
+   left something half-written" is a reminder, not an alert. The dash is what
+   distinguishes it at a glance from the solid neutral chips (branch, path)
+   it sits beside. */
+.thread-row__chip--draft {
+  border: 1px dashed var(--border-strong);
+  background: transparent;
+  color: var(--text-secondary);
   font-weight: 600;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3032,10 +3032,13 @@ textarea,
      and let the counts be cut mid-digit — and a half-eaten count reads as a
      different number.
 
-     Measured at the 280px sidebar minimum (a 264px container, see
-     `--sidebar-masthead-pull`): Attention floors at ~74px with two-digit
-     counts, leaving ~44px per icon tab. The container query below is what
-     keeps that true past two digits. */
+     At the 280px sidebar minimum (a 264px container, see
+     `--sidebar-masthead-pull`) Attention floors at ~74px with two-digit
+     counts. What the four icon tabs then divide is arithmetic, not a
+     measurement: 264 − 4px padding − 4 × 1px gap = 256, less Attention's 74,
+     is ~45px each — comfortably above the 28px an icon tab can shrink to
+     (16px glyph + 2 × 6px padding). The container query below is what keeps
+     that true past two digits. */
   grid-template-columns: repeat(5, minmax(min-content, 1fr));
   gap: 2px;
   padding: 3px;

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -9,6 +9,35 @@ before editing types. The reader/writer migration behavior lives in the desktop
 app, but the shared contract should still be shaped to support recognized
 legacy config values and current canonical values cleanly.
 
+## No Import-Time Work
+
+`package.json` declares `"sideEffects": false`. That is a promise to every
+bundler that importing any module here does nothing but define values — so a
+module whose exports are unused can be **dropped entirely**. It is what keeps
+the preload bundle at its baseline size: preload imports one function from
+this package, and without the flag Rollup cannot shake the `export *` barrel
+and drags in ~7 KB (a 23% increase on a bundle parsed at every window
+creation, before first paint).
+
+The rule that follows: **no module in this package may do work at import
+time.** Concretely, at module scope:
+
+- No bare statements — no `console.*`, no calls whose result is discarded.
+- No mutation of anything outside the module: no `globalThis`/`window`
+  assignment, no registering into a shared registry, no polyfills.
+- No reading ambient state that could differ per call: `Date.UTC(2026, 3, 23)`
+  is fine (a constant), `Date.now()` at module scope is not.
+
+Pure value construction bound to an export is fine and already common here —
+`new Set([...])` of literals, `new RegExp` built from local constants,
+`.map` over a local catalog.
+
+Violating this does not fail a test. It produces a module that a bundler
+silently omits, and the symptom appears far away as a missing export at
+runtime. If you ever genuinely need import-time work, the fix is to remove
+the flag (and re-measure the preload bundle), not to leave a false
+declaration in place.
+
 ## Dependency Boundary Enforcement
 
 **DO NOT, under any circumstances, loosen the dependency boundary rules.**

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": "./src/index.ts"
   },

--- a/packages/shared/src/contracts/__tests__/navigation-browse-mode.test.ts
+++ b/packages/shared/src/contracts/__tests__/navigation-browse-mode.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_NAVIGATION_BROWSE_MODE,
+  NAVIGATION_BROWSE_MODES,
+  normalizeNavigationBrowseMode,
+} from "../navigation";
+
+describe("normalizeNavigationBrowseMode", () => {
+  it("accepts every declared lens", () => {
+    for (const mode of NAVIGATION_BROWSE_MODES) {
+      expect(normalizeNavigationBrowseMode(mode)).toBe(mode);
+    }
+  });
+
+  it("accepts the two state lenses", () => {
+    // Regression: preload carried its own hand-copied allowlist that omitted
+    // `attention`, so an operator whose saved lens was Attention got Inbox at
+    // first paint and then a visible jump. `drafts` is the newer state lens
+    // and would have drifted the same way.
+    expect(normalizeNavigationBrowseMode("attention")).toBe("attention");
+    expect(normalizeNavigationBrowseMode("drafts")).toBe("drafts");
+  });
+
+  it("falls back to the default for anything else", () => {
+    expect(DEFAULT_NAVIGATION_BROWSE_MODE).toBe("inbox");
+    for (const value of [undefined, null, "", "unknown", 3, {}]) {
+      expect(normalizeNavigationBrowseMode(value)).toBe(
+        DEFAULT_NAVIGATION_BROWSE_MODE,
+      );
+    }
+  });
+});

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -413,13 +413,43 @@ export function buildPullRequestStatusKey(
 export type DirectorySummaryKind = "directory" | "workspace" | "unlinked";
 /**
  * `attention` is the work-queue lens: threads with a live turn or waiting to
- * be reviewed. The other three are browsing lenses over every thread.
+ * be reviewed. `drafts` is the other state lens: threads holding unsent
+ * composer text on this machine. The remaining three are browsing lenses over
+ * every thread.
  */
 export type NavigationBrowseMode =
   | "attention"
+  | "drafts"
   | "inbox"
   | "recents"
   | "directories";
+
+export const NAVIGATION_BROWSE_MODES = [
+  "attention",
+  "drafts",
+  "inbox",
+  "recents",
+  "directories",
+] as const satisfies readonly NavigationBrowseMode[];
+
+export const DEFAULT_NAVIGATION_BROWSE_MODE: NavigationBrowseMode = "inbox";
+
+/**
+ * The one allowlist for a persisted / bridged lens value. Lives here rather
+ * than in the desktop app because three processes decode it independently —
+ * main (sqlite), preload (the pre-paint `additionalArguments` hint), and the
+ * renderer — and a hand-copied list drifts: preload's copy silently omitted
+ * `attention`, so an operator whose saved lens was Attention got Inbox on the
+ * first paint and then a jump, which is the exact flicker the bootstrap hint
+ * exists to prevent.
+ */
+export function normalizeNavigationBrowseMode(
+  value: unknown,
+): NavigationBrowseMode {
+  return NAVIGATION_BROWSE_MODES.includes(value as NavigationBrowseMode)
+    ? (value as NavigationBrowseMode)
+    : DEFAULT_NAVIGATION_BROWSE_MODE;
+}
 export type LaunchpadWorkMode = "local" | "worktree";
 
 export type CodexEnvironmentOption = {


### PR DESCRIPTION
## Why

A half-written reply was invisible outside the thread it lived in. It persists to `composer_draft_latest` and survives a relaunch, so the text was never lost — but nothing in the sidebar, the Star Map, or any lens said it was there, and the only way to find one was to remember.

## What

**A "Draft" chip on every surface that renders a thread row**, plus a **Drafts lens** that collects them.

- `ComposerDraftStore` grows draft-presence reactivity alongside the existing queued-turn bridge. It notifies on *transitions* only — a scope gaining or losing recoverable content — not on every edit. A per-keystroke notification would re-render the whole thread list for as long as an operator is typing; a test pins that it doesn't.
- `useThreadDraftIndicators` derives the per-thread map, keyed by `buildThreadIdentityKey` so it lands on the same rows the queued and approval maps do. The Drafts lens filters from that same map, so the lens and the chips agree by construction.
- The chip is the quietest of the three pending states — a dashed neutral outline, not the accent. Scheduled and Queued are messages the app will act on; a draft is waiting on the operator and nothing happens until they come back. It survives the Compact density strip for the same reason from the other direction: it is the one pending state nothing else will ever resolve.

## Federation, remote viewers, Star Map

**A draft belongs to whoever typed it.** It stays in that window's store and that machine's sqlite, and is deliberately **not** federated:

- A federation viewer that half-writes a reply to a peer's thread sees its own chip on that row — the scope key is the same `thread:<backend>:<id>` the composer wrote it under, so the affordance works there unchanged with no wire changes, no `FEDERATION_PROTOCOL_VERSION` bump, and no new capability.
- The **owning** instance does not see it. Publishing an operator's unsent text to another machine is not worth an affordance. If we ever want a real "my draft follows me between machines" feature, that is a separate design with its own privacy call — flagging it rather than deciding it here.
- The Star Map takes draft keys as **their own prop** rather than through `sessionKeys`. The screen withholds `sessionKeys` from remote cards because thinking/approval keys come from an unscoped event stream; a draft is this window's own composer state and needs no peer to confirm it, so it applies to local and remote cards alike.

## Also in here

- **Lens switch top gap 16px → 10px.** The row above it is 6px of padding around one line of text, so 16 read as a hole and the strip floated away from the chrome it belongs to. `.sidebar__section` is only ever worn together with `--fill`, so nothing else moves.
- **`normalizeNavigationBrowseMode` moves to `@pwragent/shared`.** Three processes decoded the persisted lens independently, and preload's hand-copied allowlist had already dropped `attention` — so an operator whose saved lens was Attention got Inbox at first paint and then a visible jump, the exact flicker the bootstrap hint exists to prevent. `drafts` would have drifted the same way. Pre-existing bug, fixed in the code this PR already had to touch.
- **Four hand-rolled copies** of the `thread:<backend>:<id>` scope key collapse into `buildThreadComposerScopeKey`, and the composer's inline "is the composer empty" predicate becomes the shared `hasComposerDraftContent` the store tracks presence with.

## Validation

- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries`, `pnpm lint:colors`, `pnpm lint:sql`, `pnpm lint:codex-storage` — all clean.
- `pnpm test`: 7290 passed. The 5 failures in `codex-environment-runtime.test.ts` reproduce identically on `main` — local npm config warnings leaking into captured setup output, unrelated to this change.
- New tests: draft-presence reactivity + the no-re-render-per-keystroke guarantee, the Drafts lens (membership, chip in other lenses, tab switch, tooltip, empty state), the Star Map card chip, and the shared browse-mode normalizer including the `attention` regression.

## Needs a lab run before merge

`e2e/visual-regression.spec.ts` goldens will shift — a fifth lens tab plus the tighter top gap. They have to be regenerated on the Tart lab guest, not from a desktop:

```
~/pwrdrvr/PwrSuiteLab/macos-tart/run-e2e.sh --confirm-live-run \
  --workload pwragent --local /path/to/PwrAgent \
  e2e/visual-regression.spec.ts --update-snapshots
```

The README / docs-site screenshots also show the lens strip and will drift, but those are regenerated on demand and not CI-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)