### PR TITLE
ci: sparse checkout cache-primer jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         timeout-minutes: 10
+        with:
+          sparse-checkout: |
+            **/package.json
+            .npmrc
+            .pnpmfile.cjs
+            pnpm-lock.yaml
+            pnpm-workspace.yaml
+            apps/desktop/scripts/ensure-electron-runtime.mjs
+            apps/desktop/scripts/rebuild-native-for-electron.mjs
+          sparse-checkout-cone-mode: false
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
@@ -449,7 +459,15 @@ jobs:
         uses: actions/checkout@v7
         timeout-minutes: 10
         with:
-          lfs: true
+          sparse-checkout: |
+            **/package.json
+            .npmrc
+            .pnpmfile.cjs
+            pnpm-lock.yaml
+            pnpm-workspace.yaml
+            apps/desktop/scripts/ensure-electron-runtime.mjs
+            apps/desktop/scripts/rebuild-native-for-electron.mjs
+          sparse-checkout-cone-mode: false
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,16 +458,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         timeout-minutes: 10
-        with:
-          sparse-checkout: |
-            **/package.json
-            .npmrc
-            .pnpmfile.cjs
-            pnpm-lock.yaml
-            pnpm-workspace.yaml
-            apps/desktop/scripts/ensure-electron-runtime.mjs
-            apps/desktop/scripts/rebuild-native-for-electron.mjs
-          sparse-checkout-cone-mode: false
+        # Keep this checkout full: sparse state can persist on the self-hosted
+        # macOS runner and break a later job's checkout.
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
@@ -507,13 +499,6 @@ jobs:
         timeout-minutes: 10
         with:
           lfs: true
-
-      - name: Materialize full checkout after sparse cache primer
-        # The persistent runner can inherit skip-worktree entries from the
-        # sparse macos-install-deps checkout. actions/checkout disables sparse
-        # mode, but unchanged skipped files may remain absent on Apple Git.
-        timeout-minutes: 5
-        run: git checkout --ignore-skip-worktree-bits -- .
 
       - name: Materialize Git LFS assets
         # These jobs reuse persistent runner workspaces. A previous checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,6 +508,13 @@ jobs:
         with:
           lfs: true
 
+      - name: Materialize full checkout after sparse cache primer
+        # The persistent runner can inherit skip-worktree entries from the
+        # sparse macos-install-deps checkout. actions/checkout disables sparse
+        # mode, but unchanged skipped files may remain absent on Apple Git.
+        timeout-minutes: 5
+        run: git checkout --ignore-skip-worktree-bits -- .
+
       - name: Materialize Git LFS assets
         # These jobs reuse persistent runner workspaces. A previous checkout
         # can leave an LFS pointer at an unchanged path, and checkout --force


### PR DESCRIPTION
## Summary

- use the existing dependency-only sparse checkout for the Ubuntu cache-primer job
- keep the macOS cache-primer checkout full while skipping Git LFS assets it does not need

## Why

The Ubuntu `configure-nodejs` lookup job needs only workspace manifests, pnpm configuration, the lockfile, and the two scripts used by the desktop package's install lifecycle hook. A full checkout materializes roughly 42 MiB of tracked files, while the sparse set is about 364 KiB.

Linux full checkouts have recently taken roughly 2–5 seconds, so the expected Linux improvement is modest (about 1–2 seconds). The macOS runner reuses its workspace, where sparse state can persist beyond the primer and break a later checkout, so that job deliberately remains full. It still omits unnecessary LFS downloads.

## Validation

- parsed `.github/workflows/ci.yml` with Ruby YAML
- exercised the sparse patterns in a fresh checkout and confirmed all 17 expected files were materialized
- ran `git diff --check`
- rebased onto the latest `origin/main` before pushing
