### PR TITLE
feat(desktop): compact live run strip above the composer

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -377,6 +377,18 @@ Things to know when extending the audit:
   hand-written fixture (same class as `readme-recents-hero/`) whose
   threads are `threadStatus: "active"` for exactly that reason. Check
   what your surface renders before trusting a green run.
+- **Some surfaces need seeded sqlite, not a richer fixture.** The active
+  sub-agents strip only renders when a thread has a non-terminal sub-agent or
+  an undismissed failure, and no replay fixture produces one — every producer
+  persists a `ThreadSubAgentSummary` through `upsertThreadSubAgent` into the
+  `threads` payload. `e2e/fixtures/sub-agent-state-seeding.ts` writes that row
+  directly (seed after launch, then `window.reload()` — the renderer does not
+  re-poll on a direct sqlite mutation), the same shape the README capture
+  spec's seeders use. A hand-written `threads` row encodes assumptions about
+  the storage key and payload that the app can change underneath it, and a
+  seeder writing a row nothing reads would leave the audit green while it
+  scanned an absent surface, so `src/main/__tests__/sub-agent-state-seeding.test.ts`
+  pins the round-trip in vitest.
 - **Every surface is audited in both themes.** The file wraps its
   `describe` in `for (const theme of AUDIT_THEMES)` and threads the theme
   into `launchAuditApp({ theme })`, so a new block is gated in light and

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -151,6 +151,21 @@ elements and fail Playwright strict mode. When writing specs:
 - Target the history buttons themselves via their test ids:
   `history-nav-back` / `history-nav-forward`.
 
+The composer's stop-the-turn button is the same story and has the test id
+`composer-stop-turn`. Use it rather than `getByRole("button", { name:
+"Stop" })`, which 21 call sites across 10 specs once relied on. Adding the
+active sub-agents strip broke every one of them, because a row control named
+"Stop sub-agent: <task>" still matches: **Playwright matches an accessible
+`name` as a normalized substring by default**, so qualifying the new button's
+label was not enough — only `exact: true` or a test id disambiguates. The
+`toHaveCount(0)` assertions were the sharpest edge, since they assert no Stop
+button exists anywhere in the window.
+
+Note the vitest/Playwright asymmetry when you write a unit test to guard one
+of these: Testing Library matches a string `name` **exactly**, so a unit
+assertion that "Stop" no longer resolves will pass while the Playwright
+locator it was meant to protect still breaks.
+
 The same trap runs in the other direction, and it bites the *renderer*
 rather than the spec: **`getByLabel` matches on substring**, and 31 call
 sites across 23 specs drive the composer with `getByLabel("Reply")`. A new

--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -32,6 +32,11 @@ import AxeBuilder from "@axe-core/playwright";
 import type { DesktopAppearanceTheme } from "@pwragent/shared";
 import { expect, test, type Page } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
+import { stateDbPathForHomeRoot } from "./fixtures/readme-state-seeding";
+import {
+  buildAuditSubAgents,
+  seedThreadSubAgents,
+} from "./fixtures/sub-agent-state-seeding";
 
 const specDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -333,6 +338,84 @@ for (const theme of AUDIT_THEMES) {
             }),
           ).toBeVisible();
           await runAxe(app.window, "sidebar rows carrying copy chips");
+        });
+      } finally {
+        await app.close();
+      }
+    });
+
+    // The active sub-agents strip above the composer. Nothing else in this
+    // gate renders it: it only appears when a thread has a non-terminal
+    // sub-agent or an undismissed failure, and no fixture produces one.
+    //
+    // It carries contrast pairs nothing else does — the `--status-*` dots, the
+    // `--danger-text` "Failed" cell, the neutral count pill, and two row
+    // controls sized right at the WCAG 2.2 target floor — so it went unaudited
+    // in both themes for as long as it shipped without this block.
+    //
+    // No dedicated replay fixture, unlike the copy-chip block: the surface's
+    // data comes from the sqlite seeder rather than the fixture, so a private
+    // fixture would be a file containing nothing this test depends on. What it
+    // does need from the smoke fixture — a thread that exists and opens — is
+    // exactly what that fixture guarantees for every other block here.
+    test("active sub-agents strip has no violations", async () => {
+      const app = await launchAuditApp({ theme });
+      try {
+        seedThreadSubAgents({
+          stateDbPath: stateDbPathForHomeRoot(app.homeRoot),
+          subAgents: buildAuditSubAgents(),
+          threadId: "thread-smoke",
+        });
+        // The renderer does not re-poll on a direct sqlite mutation.
+        await app.window.reload();
+
+        const smokeThread = app.window
+          .getByRole("button", { name: /Replay smoke thread/i })
+          .first();
+        await expect(smokeThread).toBeVisible();
+        await smokeThread.click();
+
+        // Four rows seeds the disclosure collapsed, so the header audits
+        // first and the list is opened deliberately below.
+        const strip = app.window.getByRole("button", {
+          name: /^Active sub-agents \(2\), 2 failed$/,
+        });
+
+        await test.step("sub-agents strip header", async () => {
+          await expect(strip).toBeVisible();
+          await expect(strip).toHaveAttribute("aria-expanded", "false");
+          // Bulk dismiss only renders past one failure; assert it is painted
+          // so the audit cannot go quiet by the seed drifting to a single one.
+          await expect(
+            app.window.getByRole("button", {
+              name: "Dismiss all 2 failed sub-agents",
+            }),
+          ).toBeVisible();
+          await runAxe(app.window, "sub-agents strip header");
+        });
+
+        await test.step("sub-agents strip expanded rows", async () => {
+          await strip.click();
+          await expect(strip).toHaveAttribute("aria-expanded", "true");
+          // One assertion per row branch. Without these the scan still passes
+          // on an empty list and stops auditing the states it exists for.
+          await expect(
+            app.window.getByRole("button", {
+              name: /^Stop sub-agent: Run and monitor/,
+            }),
+          ).toBeVisible();
+          // Exact: `getByText` matches substrings, and "Blocked on approval"
+          // is sanctioned copy elsewhere in the style guide.
+          await expect(
+            app.window.getByText("Blocked", { exact: true }),
+          ).toBeVisible();
+          await expect(
+            app.window.getByRole("button", {
+              name: /^Dismiss failed sub-agent: Build and verify/,
+            }),
+          ).toBeVisible();
+          await expect(app.window.locator(".live-strip__item")).toHaveCount(4);
+          await runAxe(app.window, "sub-agents strip expanded rows");
         });
       } finally {
         await app.close();

--- a/apps/desktop/e2e/acp-runtime-modes.spec.ts
+++ b/apps/desktop/e2e/acp-runtime-modes.spec.ts
@@ -708,7 +708,7 @@ test("shows ACP tool progress while a turn is still running", async () => {
     await app.window.getByLabel("Reply").fill("Inspect the project README.");
     await app.window.getByRole("button", { name: "Send" }).click();
 
-    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByTestId("composer-stop-turn")).toBeVisible();
     const readSummary = app.window.getByRole("button", { name: "Read README.md" });
     await expect(readSummary).toBeVisible();
     await readSummary.click();

--- a/apps/desktop/e2e/approval-pending.spec.ts
+++ b/apps/desktop/e2e/approval-pending.spec.ts
@@ -33,7 +33,7 @@ async function openApprovalPendingReplay() {
     .fill("Read /etc/hosts and tell me the first three lines.");
   await app.window.getByRole("button", { name: "Send" }).click();
 
-  await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+  await expect(app.window.getByTestId("composer-stop-turn")).toBeVisible();
   await expect(
     app.window
       .getByRole("region", { name: "Transcript" })
@@ -115,7 +115,7 @@ test("dismisses the pending approval UI after approval", async () => {
       app.window.getByRole("button", { name: "Cancel turn" })
     ).toHaveCount(0);
     await expect(
-      app.window.getByRole("button", { name: "Stop" })
+      app.window.getByTestId("composer-stop-turn")
     ).toBeVisible();
     await expect(app.window.getByRole("status")).toContainText("Thinking");
   } finally {
@@ -152,7 +152,7 @@ test("stops the active turn after a queued access-mode change", async () => {
     // (and dropdown value) stays at "default" until the queue flushes.
     await expect(accessMode).toHaveAttribute("data-value", "default");
 
-    await app.window.getByRole("button", { name: "Stop" }).click();
+    await app.window.getByTestId("composer-stop-turn").click();
 
     await expect
       .poll(async () => await app.getInterruptTurnCalls())

--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -456,7 +456,7 @@ test("existing running thread keeps selected environment after pending state cle
 
     await app.advance({ stepId: "existing-thread-status-active" });
     await app.advance({ stepId: "existing-thread-turn-started" });
-    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByTestId("composer-stop-turn")).toBeVisible();
 
     const environmentDropdown = app.window.getByRole("button", {
       name: "Environment",

--- a/apps/desktop/e2e/composer-image-thread-switch.spec.ts
+++ b/apps/desktop/e2e/composer-image-thread-switch.spec.ts
@@ -321,7 +321,7 @@ test("keeps a pasted composer image after switching away from a newly created th
     await app.advance({ stepId: "assistant-message-2" });
     await expect(transcript).toContainText("Second response completed.");
     await app.advance({ stepId: "turn-completed-1" });
-    await expect(app.window.getByRole("button", { name: "Stop" })).toHaveCount(0);
+    await expect(app.window.getByTestId("composer-stop-turn")).toHaveCount(0);
 
     await pasteDelayedImage(app.window);
     await app.window

--- a/apps/desktop/e2e/execution-mode-routing.spec.ts
+++ b/apps/desktop/e2e/execution-mode-routing.spec.ts
@@ -33,7 +33,7 @@ test("applies the correct per-turn permission policy after execution mode toggle
     await app.window.getByRole("button", { name: "Send" }).click();
 
     await expect(
-      app.window.getByRole("button", { name: "Stop" })
+      app.window.getByTestId("composer-stop-turn")
     ).toBeVisible();
 
     await expect

--- a/apps/desktop/e2e/fixtures/sub-agent-state-seeding.ts
+++ b/apps/desktop/e2e/fixtures/sub-agent-state-seeding.ts
@@ -1,0 +1,152 @@
+// Direct sqlite seeder for a thread's sub-agents, in the same class as
+// `readme-state-seeding.ts`.
+//
+// Sub-agents are not replay-fixture data. Every producer (task monitors, code
+// review, Codex's own spawnAgent, the title helper) persists a
+// `ThreadSubAgentSummary` through `overlayStore.upsertThreadSubAgent`, which
+// lands in the `threads` table's `payload` JSON — so driving a fixture would
+// mean replaying whichever protocol traffic happens to create one, and would
+// pin the test to that producer rather than to the surface. Writing the
+// overlay row states the end state directly.
+//
+// Call AFTER launch (the schema is created on first boot) and reload the
+// window afterwards: the renderer does not re-poll on a direct sqlite
+// mutation. Same shape as the README capture spec's seeders.
+import Database from "better-sqlite3";
+import type { ThreadSubAgentSummary } from "@pwragent/shared";
+
+type ThreadOverlayPayload = {
+  backend: string;
+  threadId: string;
+  executionMode: string;
+  extraLinkedDirectories: string[];
+  subAgents?: ThreadSubAgentSummary[];
+};
+
+/**
+ * Merges `subAgents` into the overlay row for `threadId`, preserving whatever
+ * the app has already written there.
+ *
+ * The row is located by the `threadId` inside its payload rather than by a
+ * recomputed key: `putThread` runs the key through
+ * `encodeThreadIdentityKeyForStorage`, and duplicating that transform here
+ * would be a second source of truth that silently drifts. Falls back to
+ * inserting `<backend>:<threadId>` when the thread has no overlay row yet,
+ * which is the same key `buildThreadIdentityKey` produces.
+ */
+export function seedThreadSubAgents(params: {
+  backend?: string;
+  stateDbPath: string;
+  subAgents: ThreadSubAgentSummary[];
+  threadId: string;
+}): void {
+  const backend = params.backend ?? "codex";
+  const db = new Database(params.stateDbPath);
+  try {
+    const rows = db
+      .prepare("SELECT thread_id, payload FROM threads")
+      .all() as Array<{ thread_id: string; payload: string }>;
+
+    const existing = rows.find((row) => {
+      try {
+        return (JSON.parse(row.payload) as ThreadOverlayPayload).threadId
+          === params.threadId;
+      } catch {
+        return false;
+      }
+    });
+
+    // upsertThreadSubAgent stores newest-first; match it so the seeded order
+    // is the order the renderer receives.
+    const subAgents = [...params.subAgents].sort(
+      (left, right) => right.createdAt - left.createdAt,
+    );
+
+    if (existing) {
+      const payload = JSON.parse(existing.payload) as ThreadOverlayPayload;
+      db.prepare("UPDATE threads SET payload = ? WHERE thread_id = ?").run(
+        JSON.stringify({ ...payload, subAgents }),
+        existing.thread_id,
+      );
+      return;
+    }
+
+    const payload: ThreadOverlayPayload = {
+      backend,
+      threadId: params.threadId,
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      subAgents,
+    };
+    db.prepare(
+      `INSERT OR REPLACE INTO threads(thread_id, directory_path, last_seen_at, dismissed_at, snoozed_until, payload)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      // Matches `buildLegacyEncodedThreadIdentityKey`, which is what
+      // `encodeThreadIdentityKeyForStorage` resolves a well-formed key to.
+      `${encodeURIComponent(backend)}:${params.threadId}`,
+      null,
+      null,
+      null,
+      null,
+      JSON.stringify(payload),
+    );
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * One sub-agent per branch the strip can render: a live run (blinking accent
+ * dot, ticking duration, Stop), one waiting on input (warning dot, no clock,
+ * no action), and two failures (error dot, danger-toned "Failed", Dismiss —
+ * two so the bulk-dismiss control renders, which only appears past one).
+ *
+ * Timestamps are fixed rather than derived from `Date.now()` so the audited
+ * duration text is stable across runs.
+ */
+export function buildAuditSubAgents(): ThreadSubAgentSummary[] {
+  const base = 1_800_000_000_000;
+  return [
+    {
+      monitorId: "audit-running",
+      task: "Run and monitor the approved headed smoke verification to terminal state",
+      status: "running",
+      createdAt: base,
+      updatedAt: base,
+      backend: "codex",
+      monitorThreadId: "audit-monitor-thread",
+      monitorTurnId: "audit-monitor-turn",
+    },
+    {
+      monitorId: "audit-blocked",
+      task: "Waiting on approval to force-push the runner branch",
+      status: "blocked",
+      createdAt: base - 1_000,
+      updatedAt: base - 1_000,
+      backend: "codex",
+      monitorThreadId: "audit-blocked-thread",
+      monitorTurnId: "audit-blocked-turn",
+    },
+    {
+      monitorId: "audit-failed-1",
+      task: "Build and verify the unregistered runner candidate",
+      status: "failed",
+      createdAt: base - 2_000,
+      updatedAt: base - 2_000,
+      backend: "codex",
+      monitorThreadId: "audit-failed-thread-1",
+      monitorTurnId: "audit-failed-turn-1",
+    },
+    {
+      monitorId: "audit-failed-2",
+      task: "Import and qualify a digest-pinned seed without using softwareupdate",
+      status: "failed",
+      createdAt: base - 3_000,
+      updatedAt: base - 3_000,
+      backend: "codex",
+      monitorThreadId: "audit-failed-thread-2",
+      monitorTurnId: "audit-failed-turn-2",
+    },
+  ];
+}

--- a/apps/desktop/e2e/live-agent-messages.spec.ts
+++ b/apps/desktop/e2e/live-agent-messages.spec.ts
@@ -61,7 +61,7 @@ test("preserves live assistant commentary messages, exploration activity, and fi
       .fill("What would it take to add Telegram support?");
     await app.window.getByRole("button", { name: "Send" }).click();
 
-    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByTestId("composer-stop-turn")).toBeVisible();
     await expect(app.window.getByRole("status")).toContainText("Thinking");
     await expectAtTranscriptBottom(list);
 
@@ -125,7 +125,7 @@ test("preserves live assistant commentary messages, exploration activity, and fi
 
     await app.advance({ stepId: "turn-completed-1" });
 
-    await expect(app.window.getByRole("button", { name: "Stop" })).toHaveCount(0);
+    await expect(app.window.getByTestId("composer-stop-turn")).toHaveCount(0);
     await expect(app.window.getByText("Thinking")).toHaveCount(0);
     await expectAtTranscriptBottom(list);
     const workedForToggle = transcript.getByRole("button", {

--- a/apps/desktop/e2e/managed-review.spec.ts
+++ b/apps/desktop/e2e/managed-review.spec.ts
@@ -132,7 +132,7 @@ test("managed review failure leaves one start marker and clears Stop state", asy
 
     const transcript = fixture.app.window.getByRole("region", { name: "Transcript" });
     await expect(transcript.getByText("Review changes against main")).toHaveCount(1);
-    await expect(fixture.app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(fixture.app.window.getByTestId("composer-stop-turn")).toBeVisible();
     await expect.poll(async () => await fixture.app.getLastStartTurn()).toMatchObject({
       threadId: "managed-review-child",
       input: [{ type: "text", text: expect.stringContaining("Perform a code review") }],
@@ -141,7 +141,7 @@ test("managed review failure leaves one start marker and clears Stop state", asy
     await fixture.app.advance({ stepId: "managed-review-child-failed" });
 
     await expect(
-      fixture.app.window.getByRole("button", { name: "Stop" }),
+      fixture.app.window.getByTestId("composer-stop-turn"),
     ).toHaveCount(0);
     await expect(transcript).toContainText("Turn failed");
     await expect(transcript).not.toContainText("Code review completed");

--- a/apps/desktop/e2e/stale-thinking-indicator.spec.ts
+++ b/apps/desktop/e2e/stale-thinking-indicator.spec.ts
@@ -43,7 +43,7 @@ test("clears the thread-list thinking indicator after completed retained activit
         name: "Stale thinking replay",
       })
     ).toBeVisible();
-    await expect(app.window.getByRole("button", { name: "Stop" })).toHaveCount(0);
+    await expect(app.window.getByTestId("composer-stop-turn")).toHaveCount(0);
     await expect(app.window.getByRole("status")).toHaveCount(0);
   } finally {
     await app.close();

--- a/apps/desktop/e2e/todo-list-rendering.spec.ts
+++ b/apps/desktop/e2e/todo-list-rendering.spec.ts
@@ -67,7 +67,7 @@ test("renders live plan updates from turn/plan/updated notifications", async () 
       .getByLabel("Reply")
       .fill("Create a three-step task list before you inspect the renderer.");
     await app.window.getByRole("button", { name: "Send" }).click();
-    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByTestId("composer-stop-turn")).toBeVisible();
     await expect(app.window.getByRole("status")).toContainText("Thinking");
 
     // After issue #495 the live plan renders in the LiveWorkRail

--- a/apps/desktop/e2e/turn-lifecycle.spec.ts
+++ b/apps/desktop/e2e/turn-lifecycle.spec.ts
@@ -307,25 +307,25 @@ test("keeps transient turn UI through metadata and premature idle notifications"
       );
     await app.window.getByRole("button", { name: "Send" }).click();
 
-    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByTestId("composer-stop-turn")).toBeVisible();
     await expect(app.window.getByRole("status")).toContainText("Thinking");
 
     await app.advance({ stepId: "status-active-1" });
     await app.advance({ stepId: "turn-started-1" });
     await app.advance({ stepId: "token-usage-1" });
-    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByTestId("composer-stop-turn")).toBeVisible();
     await expect(app.window.getByRole("status")).toContainText("Thinking");
 
     await app.advance({ stepId: "rate-limits-1" });
-    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByTestId("composer-stop-turn")).toBeVisible();
     await expect(app.window.getByRole("status")).toContainText("Thinking");
 
     await app.advance({ stepId: "command-output-1" });
-    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByTestId("composer-stop-turn")).toBeVisible();
     await expect(app.window.getByRole("status")).toContainText("Thinking");
 
     await app.advance({ stepId: "status-idle-midturn" });
-    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByTestId("composer-stop-turn")).toBeVisible();
     await expect(app.window.getByRole("status")).toContainText("Thinking");
 
     await app.advance({ stepId: "assistant-delta-1" });
@@ -337,13 +337,13 @@ test("keeps transient turn UI through metadata and premature idle notifications"
 
     await app.advance({ stepId: "status-idle-1" });
 
-    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByTestId("composer-stop-turn")).toBeVisible();
     await expect(app.window.getByRole("status")).toContainText("Thinking");
 
     await app.advance({ stepId: "turn-completed-1" });
 
     await expect(
-      app.window.getByRole("button", { name: "Stop" })
+      app.window.getByTestId("composer-stop-turn")
     ).toHaveCount(0);
     await expect(
       app.window.getByText("Thinking")
@@ -488,7 +488,7 @@ test("keeps the in-thread thinking indicator visible for active turns without pe
 
     await app.advance({ stepId: "turn-started-1" });
 
-    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByTestId("composer-stop-turn")).toBeVisible();
     await expect(transcript.getByRole("status")).toContainText("Thinking");
     await expect(
       app.window

--- a/apps/desktop/src/main/__tests__/sub-agent-state-seeding.test.ts
+++ b/apps/desktop/src/main/__tests__/sub-agent-state-seeding.test.ts
@@ -1,0 +1,102 @@
+// Pins the a11y gate's sub-agent seeder against the real overlay schema.
+//
+// `e2e/fixtures/sub-agent-state-seeding.ts` writes the `threads` table by
+// hand, so it encodes three assumptions the app could change underneath it:
+// the storage key format, the overlay payload shape, and the fact that
+// `subAgents` lives in that payload at all. If any drifts, the seeder writes a
+// row nothing reads — and the a11y block it feeds would keep passing while
+// auditing a strip that never rendered. That failure is silent by
+// construction, which is exactly why it gets a test rather than a comment.
+//
+// It lives here rather than beside the fixture because `e2e/` is Playwright's;
+// this needs vitest and a real sqlite file, and it costs no Electron launch.
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { StateDb } from "../state/state-db";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import {
+  buildAuditSubAgents,
+  seedThreadSubAgents,
+} from "../../../e2e/fixtures/sub-agent-state-seeding";
+
+function freshStateDbPath(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "sub-agent-seed-"));
+  const dbPath = path.join(dir, "state.db");
+  // Create the schema the way the app does, then close over the same file.
+  StateDb.open(dbPath, { profileName: "default" });
+  return dbPath;
+}
+
+function openStore(dbPath: string): SqliteOverlayStore {
+  return new SqliteOverlayStore(StateDb.open(dbPath, { profileName: "default" }));
+}
+
+describe("seedThreadSubAgents", () => {
+  it("reaches the overlay store when the thread has no row yet", async () => {
+    // The a11y block seeds immediately after launch, before opening the
+    // thread, so this is the path it actually takes.
+    const dbPath = freshStateDbPath();
+
+    seedThreadSubAgents({
+      stateDbPath: dbPath,
+      subAgents: buildAuditSubAgents(),
+      threadId: "thread-smoke",
+    });
+
+    const state = await openStore(dbPath).getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-smoke",
+    });
+
+    expect(state?.subAgents).toHaveLength(4);
+    expect(state?.subAgents?.map((subAgent) => subAgent.status)).toEqual([
+      "running",
+      "blocked",
+      "failed",
+      "failed",
+    ]);
+  });
+
+  it("preserves existing overlay state when a row already exists", async () => {
+    const dbPath = freshStateDbPath();
+    await openStore(dbPath).setThreadReaction({
+      backend: "codex",
+      threadId: "thread-two",
+      emoji: "🔥",
+      present: true,
+    });
+
+    seedThreadSubAgents({
+      stateDbPath: dbPath,
+      subAgents: buildAuditSubAgents().slice(0, 2),
+      threadId: "thread-two",
+    });
+
+    const state = await openStore(dbPath).getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-two",
+    });
+
+    expect(state?.subAgents).toHaveLength(2);
+    // Merging, not clobbering — the seeder must not wipe what the app wrote.
+    expect(state?.reactions).toEqual(["🔥"]);
+  });
+
+  it("covers every row branch the strip can render", () => {
+    // The audit is only worth its runtime if the seed exercises each visual
+    // state. Drop one and the gate silently stops auditing that contrast pair.
+    const statuses = buildAuditSubAgents().map((subAgent) => subAgent.status);
+
+    expect(new Set(statuses)).toEqual(new Set(["running", "blocked", "failed"]));
+    // Two failures, because the bulk-dismiss control only renders past one.
+    expect(statuses.filter((status) => status === "failed")).toHaveLength(2);
+    // Stop only renders for a running sub-agent carrying a monitor turn.
+    const running = buildAuditSubAgents().find(
+      (subAgent) => subAgent.status === "running",
+    );
+    expect(running?.monitorThreadId).toBeTruthy();
+    expect(running?.monitorTurnId).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -159,6 +159,7 @@ import {
   formatDurationMs,
   formatRunningDurationMs,
 } from "../thread-detail/EnvActionRunsView";
+import { ActiveSubAgentsStrip } from "../thread-detail/ActiveSubAgentsStrip";
 import {
   buildThreadComposerScopeKey,
   getNextReleasableQueuedTurn,
@@ -10151,6 +10152,15 @@ export function Composer(props: ComposerProps) {
           conveys the action prompt visually. Stacking another header
           above an input that already names itself was redundant
           chrome. */}
+
+      {/* Topmost in the band: ambient agent work the operator did not just
+          launch. Env action rows sit below it, nearer the input, because they
+          carry the Stop the operator is most likely to reach for. */}
+      <ActiveSubAgentsStrip
+        desktopApi={props.desktopApi}
+        onRefreshNavigation={props.onRefreshNavigation}
+        thread={props.thread}
+      />
 
       {props.showEnvActionAnchors === false ? null : (
         <EnvActionAnchorList

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -12158,6 +12158,7 @@ export function Composer(props: ComposerProps) {
           {activeTurnId ? (
             <button
               className="button button--ghost"
+              data-testid="composer-stop-turn"
               disabled={props.disabled || interrupting}
               type="button"
               onClick={() => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
@@ -36,10 +36,10 @@ function buildRun(
 
 describe("EnvActionAnchorEntry", () => {
   describe("status branches", () => {
-    it("renders the running label with Stop and Terminate while started", () => {
+    it("renders the running label with Stop in the summary while started", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date(1_700_000_000_750));
-      render(
+      const { container } = render(
         <EnvActionAnchorEntry
           run={buildRun({ status: "started", pid: 12345 })}
           environmentName="PwrAgnt"
@@ -53,14 +53,46 @@ describe("EnvActionAnchorEntry", () => {
       expect(
         screen.getByRole("button", { name: "Stop" }),
       ).toBeInTheDocument();
+      // Force-stop is the destructive escalation and now costs one deliberate
+      // expand: it exists, but never in the collapsed summary next to Stop.
+      const summary = container.querySelector(
+        ".composer__queued-env-action-summary",
+      );
       expect(
-        screen.getByRole("button", { name: "Terminate" }),
+        summary?.querySelector(".composer__queued-env-action-terminate-action"),
+      ).toBeNull();
+      expect(
+        screen.getByRole("button", { name: "Terminate now" }),
       ).toBeInTheDocument();
       // The pid meta and the command echo land in the same anchor.
       expect(screen.getByText(/pid 12345/)).toBeInTheDocument();
       expect(screen.getByText(/running for 0s/)).toBeInTheDocument();
       expect(screen.queryByText(/750ms/)).toBeNull();
       expect(screen.getByText(/\$ pnpm test/)).toBeInTheDocument();
+    });
+
+    it("marks a running row with the blinking liveness dot, and finished rows without one", () => {
+      const { container, rerender } = render(
+        <EnvActionAnchorEntry
+          run={buildRun({ status: "started" })}
+          environmentName={undefined}
+          onDismiss={() => {}}
+        />,
+      );
+      // Reuses the house `.status-dot--blink` pulse, which the existing
+      // prefers-reduced-motion rule in app.css already suppresses.
+      expect(
+        container.querySelector(".status-dot--active.status-dot--blink"),
+      ).not.toBeNull();
+
+      rerender(
+        <EnvActionAnchorEntry
+          run={buildRun({ status: "exited", exitCode: 0 })}
+          environmentName={undefined}
+          onDismiss={() => {}}
+        />,
+      );
+      expect(container.querySelector(".status-dot--blink")).toBeNull();
     });
 
     it("renders the exited label with exit code + duration meta and shows Dismiss", () => {
@@ -238,17 +270,12 @@ describe("EnvActionAnchorEntry", () => {
         expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
       });
 
-      const terminateButton = screen.getByRole("button", { name: "Terminate" });
-      expect(terminateButton).not.toHaveAttribute("title");
-      fireEvent.mouseEnter(terminateButton);
-      expect(await screen.findByRole("tooltip")).toHaveClass("viewport-tooltip");
-      expect(screen.getByRole("tooltip")).toHaveTextContent("Terminate now");
-      expect(screen.getByRole("tooltip")).toHaveTextContent("Force-kills");
-
-      fireEvent.mouseLeave(terminateButton);
-      await waitFor(() => {
-        expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
-      });
+      // Terminate is no longer an icon control in the summary, so it carries
+      // no tooltip — the expanded body states the consequence in prose.
+      expect(screen.getByRole("button", { name: "Terminate now" })).toHaveClass(
+        "composer__queued-env-action-terminate-action",
+      );
+      expect(screen.getByText(/Force-kills the process tree/)).toBeInTheDocument();
 
       const sidebarButton = screen.getByRole("button", {
         name: "Move action to the sidebar Actions panel",
@@ -275,7 +302,7 @@ describe("EnvActionAnchorEntry", () => {
       expect(onStop).toHaveBeenCalledWith(run, "stop");
     });
 
-    it("invokes onStop with terminate when the user clicks Terminate", () => {
+    it("invokes onStop with terminate from the expanded body's Terminate now", () => {
       const onStop = vi.fn();
       const run = buildRun({ status: "started" });
       render(
@@ -286,8 +313,20 @@ describe("EnvActionAnchorEntry", () => {
           onStop={onStop}
         />,
       );
-      fireEvent.click(screen.getByRole("button", { name: "Terminate" }));
+      fireEvent.click(screen.getByRole("button", { name: "Terminate now" }));
       expect(onStop).toHaveBeenCalledWith(run, "terminate");
+    });
+
+    it("offers no force-stop control once the run is no longer started", () => {
+      render(
+        <EnvActionAnchorEntry
+          run={buildRun({ status: "exited", exitCode: 0 })}
+          environmentName={undefined}
+          onDismiss={() => {}}
+          onStop={() => {}}
+        />,
+      );
+      expect(screen.queryByRole("button", { name: "Terminate now" })).toBeNull();
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
@@ -170,13 +170,18 @@ export function ActiveSubAgentsStrip(props: {
           <span className="live-strip__chevron" aria-hidden="true" />
           <span className="live-strip__label">{heading}</span>
           <span className="live-strip__count">{headingCount}</span>
+          {/* Beside the count, not at the far edge. Parked after the spacer it
+              sat ~730px from the label it modifies and read as a stray artifact
+              rather than "these are working". Only genuine work sweeps — a
+              strip holding nothing but blocked or failed rows must not imply
+              something is progressing. */}
+          {running.length > 0 ? <ThinkingScanner compact /> : null}
+          <span className="live-strip__row-spacer" />
+          {/* Trailing, so the tally sits next to the Dismiss all that acts on
+              it. Leading, it collided with the count and read as "1 12". */}
           {failedNote ? (
             <span className="live-strip__note">{failedNote}</span>
           ) : null}
-          <span className="live-strip__row-spacer" />
-          {/* Only genuine work sweeps. A strip holding nothing but blocked or
-              failed rows must not imply something is progressing. */}
-          {running.length > 0 ? <ThinkingScanner compact /> : null}
         </button>
         {/* Clearing failures one at a time is fine for one or two and a chore
             at a dozen. Only ever clears failures — a running sub-agent is
@@ -241,26 +246,32 @@ export function ActiveSubAgentsStrip(props: {
                     screen reader — and page-wide `name: "Stop"` is the
                     established E2E handle for the composer's stop-the-turn
                     button, which this must not shadow. */}
-                {failedRow ? (
-                  <button
-                    aria-label={`Dismiss failed sub-agent: ${subAgent.task}`}
-                    className="live-strip__item-action"
-                    type="button"
-                    onClick={() => dismissFailure(subAgent.monitorId)}
-                  >
-                    Dismiss
-                  </button>
-                ) : canStop ? (
-                  <button
-                    aria-label={`Stop sub-agent: ${subAgent.task}`}
-                    className="live-strip__item-action live-strip__item-action--danger"
-                    disabled={stopping}
-                    type="button"
-                    onClick={() => void stopSubAgent(subAgent)}
-                  >
-                    {stopping ? "Stopping…" : "Stop"}
-                  </button>
-                ) : null}
+                {/* Always rendered, even when empty. A blocked row has no
+                    action, and without a reserved slot its state text slid
+                    right to the edge while every neighbour's stopped short —
+                    the right rail stopped being a column. */}
+                <span className="live-strip__item-slot">
+                  {failedRow ? (
+                    <button
+                      aria-label={`Dismiss failed sub-agent: ${subAgent.task}`}
+                      className="live-strip__item-action"
+                      type="button"
+                      onClick={() => dismissFailure(subAgent.monitorId)}
+                    >
+                      Dismiss
+                    </button>
+                  ) : canStop ? (
+                    <button
+                      aria-label={`Stop sub-agent: ${subAgent.task}`}
+                      className="live-strip__item-action live-strip__item-action--danger"
+                      disabled={stopping}
+                      type="button"
+                      onClick={() => void stopSubAgent(subAgent)}
+                    >
+                      {stopping ? "Stopping…" : "Stop"}
+                    </button>
+                  ) : null}
+                </span>
               </li>
             );
           })}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
@@ -106,6 +106,7 @@ export function ActiveSubAgentsStrip(props: {
     <section className="live-strip" aria-label="Active sub-agents">
       <button
         aria-expanded={expanded}
+        aria-label={`Active sub-agents (${visible.length})`}
         className="live-strip__row"
         type="button"
         onClick={() => setExpanded((current) => !current)}
@@ -152,8 +153,15 @@ export function ActiveSubAgentsStrip(props: {
                         Math.max(0, now - subAgent.createdAt),
                       )}
                 </span>
+                {/* Both controls name their target. The visible text stays a
+                    single word so the row does not grow, but an unqualified
+                    "Stop" would be read out identically for every row by a
+                    screen reader — and page-wide `name: "Stop"` is the
+                    established E2E handle for the composer's stop-the-turn
+                    button, which this must not shadow. */}
                 {failedRow ? (
                   <button
+                    aria-label={`Dismiss failed sub-agent: ${subAgent.task}`}
                     className="live-strip__item-action"
                     type="button"
                     onClick={() => dismissFailure(subAgent.monitorId)}
@@ -162,6 +170,7 @@ export function ActiveSubAgentsStrip(props: {
                   </button>
                 ) : canStop ? (
                   <button
+                    aria-label={`Stop sub-agent: ${subAgent.task}`}
                     className="live-strip__item-action live-strip__item-action--danger"
                     disabled={stopping}
                     type="button"

--- a/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
@@ -73,6 +73,21 @@ export function ActiveSubAgentsStrip(props: {
     setDismissedFailures((current) => new Set(current).add(monitorId));
   };
 
+  const dismissAllFailures = (): void => {
+    setDismissedFailures((current) => {
+      const next = new Set(current);
+      for (const subAgent of failed) {
+        next.add(subAgent.monitorId);
+      }
+      return next;
+    });
+  };
+
+  // A thread that accumulated a dozen failures reads as "13 active sub-agents"
+  // under an Active heading with nothing running, which is simply false. The
+  // heading follows what is actually in the list.
+  const heading = running.length > 0 ? "Active sub-agents" : "Failed sub-agents";
+
   const stopSubAgent = async (
     subAgent: ThreadSubAgentSummary,
   ): Promise<void> => {
@@ -103,20 +118,35 @@ export function ActiveSubAgentsStrip(props: {
   };
 
   return (
-    <section className="live-strip" aria-label="Active sub-agents">
-      <button
-        aria-expanded={expanded}
-        aria-label={`Active sub-agents (${visible.length})`}
-        className="live-strip__row"
-        type="button"
-        onClick={() => setExpanded((current) => !current)}
-      >
-        <span className="live-strip__chevron" aria-hidden="true" />
-        <span className="live-strip__label">Active sub-agents</span>
-        <span className="live-strip__count">{visible.length}</span>
-        <span className="live-strip__row-spacer" />
-        {running.length > 0 ? <ThinkingScanner compact /> : null}
-      </button>
+    <section className="live-strip" aria-label={heading}>
+      <div className="live-strip__header">
+        <button
+          aria-expanded={expanded}
+          aria-label={`${heading} (${visible.length})`}
+          className="live-strip__row"
+          type="button"
+          onClick={() => setExpanded((current) => !current)}
+        >
+          <span className="live-strip__chevron" aria-hidden="true" />
+          <span className="live-strip__label">{heading}</span>
+          <span className="live-strip__count">{visible.length}</span>
+          <span className="live-strip__row-spacer" />
+          {running.length > 0 ? <ThinkingScanner compact /> : null}
+        </button>
+        {/* Clearing failures one at a time is fine for one or two and a chore
+            at a dozen. Only ever clears failures — a running sub-agent is
+            never swept up by it. */}
+        {failed.length > 1 ? (
+          <button
+            aria-label={`Dismiss all ${failed.length} failed sub-agents`}
+            className="live-strip__item-action live-strip__dismiss-all"
+            type="button"
+            onClick={dismissAllFailures}
+          >
+            Dismiss all
+          </button>
+        ) : null}
+      </div>
       {expanded ? (
         <ul className="live-strip__list">
           {visible.map((subAgent) => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
@@ -19,8 +19,21 @@ function isFailedSubAgent(subAgent: ThreadSubAgentSummary): boolean {
   return subAgent.status === "failed" || subAgent.status === "failure";
 }
 
+/**
+ * Waiting on input, not working. It belongs in the strip — arguably more than
+ * a healthy run does — but it must not blink an accent dot and count up an
+ * elapsed timer as though something were happening.
+ */
+function isBlockedSubAgent(subAgent: ThreadSubAgentSummary): boolean {
+  return subAgent.status === "blocked" && !isTerminalSubAgent(subAgent);
+}
+
 function isRunningSubAgent(subAgent: ThreadSubAgentSummary): boolean {
-  return !isTerminalSubAgent(subAgent) && !isFailedSubAgent(subAgent);
+  return (
+    !isTerminalSubAgent(subAgent)
+    && !isFailedSubAgent(subAgent)
+    && !isBlockedSubAgent(subAgent)
+  );
 }
 
 /**
@@ -47,6 +60,7 @@ export function ActiveSubAgentsStrip(props: {
 
   const subAgents = props.thread?.subAgents ?? [];
   const running = subAgents.filter(isRunningSubAgent);
+  const blocked = subAgents.filter(isBlockedSubAgent);
   // Successful and cancelled sub-agents leave immediately — the sidebar and the
   // rail panel already hold them. Failures linger until dismissed: the strip
   // vanishing is how an operator misses one, and neither of those surfaces is
@@ -55,13 +69,32 @@ export function ActiveSubAgentsStrip(props: {
     (subAgent) =>
       isFailedSubAgent(subAgent) && !dismissedFailures.has(subAgent.monitorId),
   );
-  const visible = [...running, ...failed];
+  const visible = [...running, ...blocked, ...failed];
 
-  // Seeded once, on mount: one or two rows cost almost nothing and saying what
-  // is running is the point, while three or more is the wall this strip exists
-  // to avoid. A later count change must not yank the disclosure out from under
-  // an operator who already made a choice, so this never re-evaluates.
-  const [expanded, setExpanded] = useState(() => visible.length <= 2);
+  // One or two rows cost almost nothing and saying what is running is the
+  // point; three or more is the wall this strip exists to avoid. A later count
+  // change must not yank the disclosure out from under an operator who already
+  // made a choice, so this is evaluated exactly once and never again.
+  //
+  // It has to be seeded on the first render that has ROWS, not on mount. The
+  // Composer mounts this component unconditionally and it returns null while
+  // empty, so a mount-time seed always read a count of zero and pinned
+  // `expanded` to true for the life of the window — the collapse-at-3+ rule
+  // never fired in the app, only in tests that rendered straight into a
+  // populated state.
+  //
+  // "Once" means once per appearance, not once per window. The strip emptying
+  // is a natural boundary: the next batch is new work and deserves to be sized
+  // to itself rather than governed by whatever the session's first batch
+  // happened to be.
+  const [expanded, setExpanded] = useState(true);
+  const [seeded, setSeeded] = useState(false);
+  if (!seeded && visible.length > 0) {
+    setSeeded(true);
+    setExpanded(visible.length <= 2);
+  } else if (seeded && visible.length === 0) {
+    setSeeded(false);
+  }
 
   const now = useNowWhileActive(running.length > 0);
 
@@ -83,10 +116,15 @@ export function ActiveSubAgentsStrip(props: {
     });
   };
 
-  // A thread that accumulated a dozen failures reads as "13 active sub-agents"
-  // under an Active heading with nothing running, which is simply false. The
-  // heading follows what is actually in the list.
-  const heading = running.length > 0 ? "Active sub-agents" : "Failed sub-agents";
+  // The heading and the count must agree, and both must describe what is
+  // actually in the list. A thread carrying one live monitor and a dozen old
+  // failures is not "13 active sub-agents"; neither is a thread of pure
+  // failures "active" at all.
+  const activeCount = running.length + blocked.length;
+  const heading = activeCount > 0 ? "Active sub-agents" : "Failed sub-agents";
+  const headingCount = activeCount > 0 ? activeCount : failed.length;
+  const failedNote =
+    activeCount > 0 && failed.length > 0 ? `${failed.length} failed` : undefined;
 
   const stopSubAgent = async (
     subAgent: ThreadSubAgentSummary,
@@ -122,15 +160,22 @@ export function ActiveSubAgentsStrip(props: {
       <div className="live-strip__header">
         <button
           aria-expanded={expanded}
-          aria-label={`${heading} (${visible.length})`}
+          aria-label={`${heading} (${headingCount})${
+            failedNote ? `, ${failedNote}` : ""
+          }`}
           className="live-strip__row"
           type="button"
           onClick={() => setExpanded((current) => !current)}
         >
           <span className="live-strip__chevron" aria-hidden="true" />
           <span className="live-strip__label">{heading}</span>
-          <span className="live-strip__count">{visible.length}</span>
+          <span className="live-strip__count">{headingCount}</span>
+          {failedNote ? (
+            <span className="live-strip__note">{failedNote}</span>
+          ) : null}
           <span className="live-strip__row-spacer" />
+          {/* Only genuine work sweeps. A strip holding nothing but blocked or
+              failed rows must not imply something is progressing. */}
           {running.length > 0 ? <ThinkingScanner compact /> : null}
         </button>
         {/* Clearing failures one at a time is fine for one or two and a chore
@@ -151,6 +196,7 @@ export function ActiveSubAgentsStrip(props: {
         <ul className="live-strip__list">
           {visible.map((subAgent) => {
             const failedRow = isFailedSubAgent(subAgent);
+            const blockedRow = isBlockedSubAgent(subAgent);
             const stopping = stoppingIds.has(subAgent.monitorId);
             const canStop =
               subAgent.status === "running"
@@ -169,19 +215,25 @@ export function ActiveSubAgentsStrip(props: {
                   className={
                     failedRow
                       ? "status-dot status-dot--error"
-                      : "status-dot status-dot--active status-dot--blink"
+                      : blockedRow
+                        ? "status-dot status-dot--warning"
+                        : "status-dot status-dot--active status-dot--blink"
                   }
                 />
                 <span className="live-strip__item-text" title={subAgent.task}>
                   {subAgent.task}
                 </span>
-                {/* Never color alone: the row states its outcome in words. */}
+                {/* Never color alone: the row states its state in words, and a
+                    blocked row shows no elapsed time because nothing is
+                    elapsing — it is waiting on input. */}
                 <span className="live-strip__item-time">
                   {failedRow
                     ? "Failed"
-                    : formatRunningDurationMs(
-                        Math.max(0, now - subAgent.createdAt),
-                      )}
+                    : blockedRow
+                      ? "Blocked"
+                      : formatRunningDurationMs(
+                          Math.max(0, now - subAgent.createdAt),
+                        )}
                 </span>
                 {/* Both controls name their target. The visible text stays a
                     single word so the row does not grow, but an unqualified

--- a/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ActiveSubAgentsStrip.tsx
@@ -1,0 +1,180 @@
+import { useState, type ReactNode } from "react";
+import type {
+  NavigationThreadSummary,
+  ThreadSubAgentSummary,
+} from "@pwragent/shared";
+import { isTerminalSubAgent } from "./context-panels/subagent-format";
+import { useNowWhileActive } from "./context-panels/RailCardTiming";
+import { ThinkingScanner } from "./ThinkingScanner";
+import { formatRunningDurationMs } from "../../lib/format-duration";
+import type { DesktopApi } from "../../lib/desktop-api";
+
+/**
+ * `subAgentTone` treats both spellings as an error state, but
+ * `isTerminalSubAgent` only lists `"failure"` — a record that reports
+ * `"failed"` without a completion boundary would otherwise read as still
+ * running here and blink at the operator forever.
+ */
+function isFailedSubAgent(subAgent: ThreadSubAgentSummary): boolean {
+  return subAgent.status === "failed" || subAgent.status === "failure";
+}
+
+function isRunningSubAgent(subAgent: ThreadSubAgentSummary): boolean {
+  return !isTerminalSubAgent(subAgent) && !isFailedSubAgent(subAgent);
+}
+
+/**
+ * Active sub-agents, as a compact strip above the composer.
+ *
+ * Covers every producer at once — PwrAgent task monitors, code review (which
+ * is also the ACP path), Codex's own `spawnAgent`, and the title helper —
+ * because all four persist the same `ThreadSubAgentSummary` through one store.
+ * Reads the navigation snapshot the renderer already holds; adds no IPC and no
+ * polling of its own.
+ *
+ * The rail panel remains the full-detail surface. This is a presence indicator
+ * with a Stop button, deliberately not a second copy of the card.
+ */
+export function ActiveSubAgentsStrip(props: {
+  desktopApi?: DesktopApi;
+  onRefreshNavigation?: () => Promise<void>;
+  thread?: NavigationThreadSummary;
+}): ReactNode {
+  const [dismissedFailures, setDismissedFailures] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [stoppingIds, setStoppingIds] = useState<Set<string>>(() => new Set());
+
+  const subAgents = props.thread?.subAgents ?? [];
+  const running = subAgents.filter(isRunningSubAgent);
+  // Successful and cancelled sub-agents leave immediately — the sidebar and the
+  // rail panel already hold them. Failures linger until dismissed: the strip
+  // vanishing is how an operator misses one, and neither of those surfaces is
+  // in their eyeline while they are typing.
+  const failed = subAgents.filter(
+    (subAgent) =>
+      isFailedSubAgent(subAgent) && !dismissedFailures.has(subAgent.monitorId),
+  );
+  const visible = [...running, ...failed];
+
+  // Seeded once, on mount: one or two rows cost almost nothing and saying what
+  // is running is the point, while three or more is the wall this strip exists
+  // to avoid. A later count change must not yank the disclosure out from under
+  // an operator who already made a choice, so this never re-evaluates.
+  const [expanded, setExpanded] = useState(() => visible.length <= 2);
+
+  const now = useNowWhileActive(running.length > 0);
+
+  if (visible.length === 0) {
+    return null;
+  }
+
+  const dismissFailure = (monitorId: string): void => {
+    setDismissedFailures((current) => new Set(current).add(monitorId));
+  };
+
+  const stopSubAgent = async (
+    subAgent: ThreadSubAgentSummary,
+  ): Promise<void> => {
+    const thread = props.thread;
+    if (!thread || !props.desktopApi?.stopSubAgent) return;
+    setStoppingIds((current) => new Set(current).add(subAgent.monitorId));
+    try {
+      await props.desktopApi.stopSubAgent({
+        backend: thread.source,
+        ...(thread.federation?.ref.target
+          ? { federationTarget: thread.federation.ref.target }
+          : {}),
+        threadId: thread.id,
+        monitorId: subAgent.monitorId,
+      });
+      await props.onRefreshNavigation?.();
+    } catch {
+      // The rail panel owns error reporting for stop failures; surfacing a
+      // message here would push the composer down, which is the one thing this
+      // strip must not do.
+    } finally {
+      setStoppingIds((current) => {
+        const next = new Set(current);
+        next.delete(subAgent.monitorId);
+        return next;
+      });
+    }
+  };
+
+  return (
+    <section className="live-strip" aria-label="Active sub-agents">
+      <button
+        aria-expanded={expanded}
+        className="live-strip__row"
+        type="button"
+        onClick={() => setExpanded((current) => !current)}
+      >
+        <span className="live-strip__chevron" aria-hidden="true" />
+        <span className="live-strip__label">Active sub-agents</span>
+        <span className="live-strip__count">{visible.length}</span>
+        <span className="live-strip__row-spacer" />
+        {running.length > 0 ? <ThinkingScanner compact /> : null}
+      </button>
+      {expanded ? (
+        <ul className="live-strip__list">
+          {visible.map((subAgent) => {
+            const failedRow = isFailedSubAgent(subAgent);
+            const stopping = stoppingIds.has(subAgent.monitorId);
+            const canStop =
+              subAgent.status === "running"
+              && Boolean(subAgent.monitorThreadId)
+              && Boolean(subAgent.monitorTurnId)
+              && Boolean(props.desktopApi?.stopSubAgent);
+            return (
+              <li
+                className={`live-strip__item${
+                  failedRow ? " live-strip__item--failed" : ""
+                }`}
+                key={subAgent.monitorId}
+              >
+                <span
+                  aria-hidden="true"
+                  className={
+                    failedRow
+                      ? "status-dot status-dot--error"
+                      : "status-dot status-dot--active status-dot--blink"
+                  }
+                />
+                <span className="live-strip__item-text" title={subAgent.task}>
+                  {subAgent.task}
+                </span>
+                {/* Never color alone: the row states its outcome in words. */}
+                <span className="live-strip__item-time">
+                  {failedRow
+                    ? "Failed"
+                    : formatRunningDurationMs(
+                        Math.max(0, now - subAgent.createdAt),
+                      )}
+                </span>
+                {failedRow ? (
+                  <button
+                    className="live-strip__item-action"
+                    type="button"
+                    onClick={() => dismissFailure(subAgent.monitorId)}
+                  >
+                    Dismiss
+                  </button>
+                ) : canStop ? (
+                  <button
+                    className="live-strip__item-action live-strip__item-action--danger"
+                    disabled={stopping}
+                    type="button"
+                    onClick={() => void stopSubAgent(subAgent)}
+                  >
+                    {stopping ? "Stopping…" : "Stop"}
+                  </button>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
@@ -223,6 +223,16 @@ export function EnvActionRunEntry(props: {
           className="composer__queued-env-action-chevron"
           aria-hidden="true"
         />
+        {status === "started" ? (
+          // Liveness, paired with the once-a-second elapsed counter in `meta`.
+          // The dot answers "is it frozen?" at a glance; the counter answers it
+          // definitively and is the half that survives prefers-reduced-motion,
+          // which suppresses `.status-dot--blink`.
+          <span
+            className="status-dot status-dot--active status-dot--blink"
+            aria-hidden="true"
+          />
+        ) : null}
         <span className="composer__queued-env-action-summary-text">
           <span className="composer__queued-label">{label}</span>
           <span className="composer__queued-text">
@@ -243,40 +253,22 @@ export function EnvActionRunEntry(props: {
         </span>
         <span className="composer__queued-env-action-actions">
           {status === "started" ? (
-            <>
-              <EnvActionControlButton
-                ariaLabel="Stop"
-                className="composer__queued-env-action-stop"
-                disabled={stopping}
-                tooltip={[
-                  "Stop gracefully",
-                  "Sends SIGTERM first, then force terminates if the process tree does not exit.",
-                ].join("\n")}
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  props.onStop?.(run, "stop");
-                }}
-              >
-                <EnvActionStopIcon />
-              </EnvActionControlButton>
-              <EnvActionControlButton
-                ariaLabel="Terminate"
-                className="composer__queued-env-action-terminate"
-                disabled={stopping && terminationMode === "terminate"}
-                tooltip={[
-                  "Terminate now",
-                  "Force-kills the process tree immediately.",
-                ].join("\n")}
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  props.onStop?.(run, "terminate");
-                }}
-              >
-                <EnvActionTerminateIcon />
-              </EnvActionControlButton>
-            </>
+            <EnvActionControlButton
+              ariaLabel="Stop"
+              className="composer__queued-env-action-stop"
+              disabled={stopping}
+              tooltip={[
+                "Stop gracefully",
+                "Sends SIGTERM first, then force terminates if the process tree does not exit.",
+              ].join("\n")}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                props.onStop?.(run, "stop");
+              }}
+            >
+              <EnvActionStopIcon />
+            </EnvActionControlButton>
           ) : (
             <button
               className="composer__secondary-action composer__queued-env-action-dismiss"
@@ -331,6 +323,29 @@ export function EnvActionRunEntry(props: {
           </div>
           <EnvActionOutputBlock output={output} status={status} />
         </div>
+        {status === "started" ? (
+          <div className="composer__queued-env-action-section">
+            <div className="composer__queued-env-action-section-label">
+              Force stop
+            </div>
+            <button
+              className="composer__secondary-action composer__queued-env-action-terminate-action"
+              type="button"
+              disabled={stopping && terminationMode === "terminate"}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                props.onStop?.(run, "terminate");
+              }}
+            >
+              Terminate now
+            </button>
+            <p className="composer__queued-env-action-hint">
+              Force-kills the process tree immediately. Stop sends SIGTERM
+              first and only escalates if the tree does not exit.
+            </p>
+          </div>
+        ) : null}
       </div>
     </details>
   );
@@ -391,25 +406,6 @@ function EnvActionStopIcon(): ReactNode {
       aria-hidden="true"
     >
       <rect x="7" y="7" width="10" height="10" rx="2" />
-    </svg>
-  );
-}
-
-function EnvActionTerminateIcon(): ReactNode {
-  return (
-    <svg
-      className="composer__queued-env-action-icon"
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      aria-hidden="true"
-    >
-      <circle cx="12" cy="12" r="7" />
-      <line x1="7.05" y1="7.05" x2="16.95" y2="16.95" />
     </svg>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
@@ -1,0 +1,348 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  NavigationThreadSummary,
+  ThreadSubAgentSummary,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { ActiveSubAgentsStrip } from "../ActiveSubAgentsStrip";
+
+afterEach(() => {
+  cleanup();
+});
+
+function buildSubAgent(
+  overrides: Partial<ThreadSubAgentSummary> = {},
+): ThreadSubAgentSummary {
+  return {
+    monitorId: overrides.monitorId ?? "monitor-1",
+    task: overrides.task ?? "Watch the deployment",
+    status: overrides.status ?? "running",
+    createdAt: overrides.createdAt ?? 1_800_000_000_000,
+    updatedAt: overrides.updatedAt ?? 1_800_000_000_000,
+    backend: overrides.backend ?? "codex",
+    monitorThreadId: overrides.monitorThreadId ?? "monitor-thread",
+    monitorTurnId: overrides.monitorTurnId ?? "monitor-turn",
+    ...overrides,
+  };
+}
+
+function buildThread(
+  subAgents: ThreadSubAgentSummary[],
+): NavigationThreadSummary {
+  return {
+    id: "parent-thread",
+    title: "Parent thread",
+    titleSource: "explicit",
+    source: "codex",
+    linkedDirectories: [],
+    inbox: { inInbox: true },
+    subAgents,
+  } as NavigationThreadSummary;
+}
+
+describe("ActiveSubAgentsStrip", () => {
+  describe("presence", () => {
+    it("renders nothing when the thread has no sub-agents", () => {
+      const { container } = render(
+        <ActiveSubAgentsStrip thread={buildThread([])} />,
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders nothing when every sub-agent has finished", () => {
+      // Successful and cancelled sub-agents leave immediately — the sidebar
+      // and the rail panel already hold them.
+      const { container } = render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({
+              monitorId: "done",
+              status: "success",
+              completedAt: 1_800_000_001_000,
+            }),
+            buildSubAgent({
+              monitorId: "gone",
+              status: "cancelled",
+              completedAt: 1_800_000_001_000,
+            }),
+          ])}
+        />,
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders nothing when the thread itself is undefined", () => {
+      const { container } = render(<ActiveSubAgentsStrip />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("counts only the rows it shows, ignoring finished sub-agents", () => {
+      render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "a" }),
+            buildSubAgent({ monitorId: "b" }),
+            buildSubAgent({
+              monitorId: "done",
+              status: "success",
+              completedAt: 1_800_000_001_000,
+            }),
+          ])}
+        />,
+      );
+      expect(screen.getByText("2")).toBeInTheDocument();
+    });
+  });
+
+  describe("disclosure", () => {
+    it("seeds expanded at one or two active sub-agents", () => {
+      render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "a", task: "First task" }),
+            buildSubAgent({ monitorId: "b", task: "Second task" }),
+          ])}
+        />,
+      );
+      expect(
+        screen.getByRole("button", { name: /Active sub-agents/ }),
+      ).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getByText("First task")).toBeInTheDocument();
+    });
+
+    it("seeds collapsed at three or more, hiding the rows", () => {
+      render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "a", task: "First task" }),
+            buildSubAgent({ monitorId: "b", task: "Second task" }),
+            buildSubAgent({ monitorId: "c", task: "Third task" }),
+          ])}
+        />,
+      );
+      expect(
+        screen.getByRole("button", { name: /Active sub-agents/ }),
+      ).toHaveAttribute("aria-expanded", "false");
+      expect(screen.queryByText("First task")).toBeNull();
+      // The count still reports what is running while collapsed.
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+
+    it("keeps a manual collapse when the active count later changes", () => {
+      // The seed is a mount-time convenience, not a live rule: re-evaluating
+      // it would yank the disclosure out from under an operator who already
+      // made a choice.
+      const { rerender } = render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([buildSubAgent({ monitorId: "a" })])}
+        />,
+      );
+      const toggle = screen.getByRole("button", { name: /Active sub-agents/ });
+      expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+      fireEvent.click(toggle);
+      expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+      rerender(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "a" }),
+            buildSubAgent({ monitorId: "b" }),
+            buildSubAgent({ monitorId: "c" }),
+          ])}
+        />,
+      );
+      expect(
+        screen.getByRole("button", { name: /Active sub-agents/ }),
+      ).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("renders every active row so the capped list scrolls rather than truncating", () => {
+      const { container } = render(
+        <ActiveSubAgentsStrip
+          thread={buildThread(
+            Array.from({ length: 6 }, (_unused, index) =>
+              buildSubAgent({
+                monitorId: `monitor-${index}`,
+                task: `Task ${index}`,
+              }),
+            ),
+          )}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: /Active sub-agents/ }));
+      // The four-row cap is a max-height on .live-strip__list, so all six rows
+      // must exist in the DOM — a silently truncated list would read as
+      // "that's everything" when it isn't.
+      expect(container.querySelectorAll(".live-strip__item")).toHaveLength(6);
+    });
+  });
+
+  describe("failed sub-agents", () => {
+    it("keeps a failed sub-agent visible and states the outcome in words", () => {
+      render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({
+              monitorId: "broken",
+              status: "failed",
+              task: "Broken monitor",
+            }),
+          ])}
+        />,
+      );
+      expect(screen.getByText("Broken monitor")).toBeInTheDocument();
+      // Never color alone.
+      expect(screen.getByText("Failed")).toBeInTheDocument();
+    });
+
+    it("treats the 'failure' spelling the same as 'failed'", () => {
+      render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({
+              monitorId: "broken",
+              status: "failure",
+              task: "Other spelling",
+            }),
+          ])}
+        />,
+      );
+      expect(screen.getByText("Failed")).toBeInTheDocument();
+    });
+
+    it("does not blink or offer Stop for a failed row", () => {
+      const { container } = render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "broken", status: "failed" }),
+          ])}
+        />,
+      );
+      // A finished failure must not animate.
+      expect(container.querySelector(".status-dot--blink")).toBeNull();
+      expect(container.querySelector(".thinking-scanner")).toBeNull();
+      expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+    });
+
+    it("removes a failed row once dismissed, and the strip with it", () => {
+      const { container } = render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "broken", status: "failed" }),
+          ])}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe("liveness", () => {
+    it("shows the shared thinking scanner only while something is running", () => {
+      const { container, rerender } = render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([buildSubAgent({ monitorId: "a" })])}
+        />,
+      );
+      expect(container.querySelector(".thinking-scanner")).not.toBeNull();
+      expect(
+        container.querySelector(".status-dot--active.status-dot--blink"),
+      ).not.toBeNull();
+
+      rerender(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "a", status: "failed" }),
+          ])}
+        />,
+      );
+      expect(container.querySelector(".thinking-scanner")).toBeNull();
+    });
+
+    it("ticks at most once per second, and only while something runs", () => {
+      const setIntervalSpy = vi.spyOn(window, "setInterval");
+      try {
+        const { unmount } = render(
+          <ActiveSubAgentsStrip
+            thread={buildThread([buildSubAgent({ monitorId: "a" })])}
+          />,
+        );
+        expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 1_000);
+        unmount();
+        setIntervalSpy.mockClear();
+
+        render(
+          <ActiveSubAgentsStrip
+            thread={buildThread([
+              buildSubAgent({ monitorId: "a", status: "failed" }),
+            ])}
+          />,
+        );
+        expect(setIntervalSpy).not.toHaveBeenCalled();
+      } finally {
+        setIntervalSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("stop interaction", () => {
+    it("routes Stop through desktopApi with the thread's backend and federation target", async () => {
+      const stopSubAgent = vi.fn().mockResolvedValue({ ok: true });
+      const onRefreshNavigation = vi.fn().mockResolvedValue(undefined);
+      const thread = {
+        ...buildThread([buildSubAgent({ monitorId: "monitor-1" })]),
+        federation: { ref: { target: "peer-instance" } },
+      } as NavigationThreadSummary;
+
+      render(
+        <ActiveSubAgentsStrip
+          desktopApi={{ stopSubAgent } as unknown as DesktopApi}
+          onRefreshNavigation={onRefreshNavigation}
+          thread={thread}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+      await waitFor(() => {
+        expect(stopSubAgent).toHaveBeenCalledWith({
+          backend: "codex",
+          federationTarget: "peer-instance",
+          threadId: "parent-thread",
+          monitorId: "monitor-1",
+        });
+      });
+      await waitFor(() => {
+        expect(onRefreshNavigation).toHaveBeenCalled();
+      });
+    });
+
+    it("offers no Stop when the sub-agent has no monitor turn to stop", () => {
+      render(
+        <ActiveSubAgentsStrip
+          desktopApi={{ stopSubAgent: vi.fn() } as unknown as DesktopApi}
+          thread={buildThread([
+            buildSubAgent({ monitorId: "a", monitorTurnId: undefined }),
+          ])}
+        />,
+      );
+      expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+    });
+
+    it("recovers the button after a failed stop instead of leaving it stuck", async () => {
+      const stopSubAgent = vi.fn().mockRejectedValue(new Error("nope"));
+      render(
+        <ActiveSubAgentsStrip
+          desktopApi={{ stopSubAgent } as unknown as DesktopApi}
+          thread={buildThread([buildSubAgent({ monitorId: "a" })])}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Stop" })).toBeEnabled();
+      });
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
@@ -330,12 +330,17 @@ describe("ActiveSubAgentsStrip", () => {
       });
     });
 
-    it("names its controls after their sub-agent instead of claiming bare Stop/Dismiss", () => {
-      // Regression: a bare "Stop" shadowed the composer's stop-the-turn button
-      // and broke nine E2E specs that use page-wide `name: "Stop"` as its
-      // handle (managed-review.spec.ts caught it). It is also the a11y fix — a
-      // column of identically-named buttons tells a screen-reader user nothing
-      // about which sub-agent each one belongs to.
+    it("names its controls after the sub-agent they act on", () => {
+      // A column of buttons all named "Stop" tells a screen-reader user
+      // nothing about which sub-agent each one belongs to.
+      //
+      // This does NOT protect the composer's stop-the-turn button from a
+      // page-wide locator, and an earlier version of this test claimed it did.
+      // Testing Library matches a string `name` exactly, so "Stop" not
+      // matching "Stop sub-agent: …" here proves nothing about Playwright,
+      // which matches `name` as a normalized SUBSTRING by default — the E2E
+      // collision survived this exact assertion. The composer button carries
+      // data-testid="composer-stop-turn" and the specs target that instead.
       render(
         <ActiveSubAgentsStrip
           desktopApi={{ stopSubAgent: vi.fn() } as unknown as DesktopApi}
@@ -349,8 +354,6 @@ describe("ActiveSubAgentsStrip", () => {
           ])}
         />,
       );
-      expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
-      expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
       expect(
         screen.getByRole("button", {
           name: "Stop sub-agent: Watch the deployment",

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
@@ -224,7 +224,7 @@ describe("ActiveSubAgentsStrip", () => {
       // A finished failure must not animate.
       expect(container.querySelector(".status-dot--blink")).toBeNull();
       expect(container.querySelector(".thinking-scanner")).toBeNull();
-      expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+      expect(screen.queryByRole("button", { name: /^Stop sub-agent:/ })).toBeNull();
     });
 
     it("removes a failed row once dismissed, and the strip with it", () => {
@@ -235,7 +235,7 @@ describe("ActiveSubAgentsStrip", () => {
           ])}
         />,
       );
-      fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+      fireEvent.click(screen.getByRole("button", { name: /^Dismiss failed sub-agent:/ }));
       expect(container).toBeEmptyDOMElement();
     });
   });
@@ -316,7 +316,7 @@ describe("ActiveSubAgentsStrip", () => {
         />,
       );
 
-      fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+      fireEvent.click(screen.getByRole("button", { name: /^Stop sub-agent:/ }));
       await waitFor(() => {
         expect(stopSubAgent).toHaveBeenCalledWith({
           backend: "codex",
@@ -330,6 +330,39 @@ describe("ActiveSubAgentsStrip", () => {
       });
     });
 
+    it("names its controls after their sub-agent instead of claiming bare Stop/Dismiss", () => {
+      // Regression: a bare "Stop" shadowed the composer's stop-the-turn button
+      // and broke nine E2E specs that use page-wide `name: "Stop"` as its
+      // handle (managed-review.spec.ts caught it). It is also the a11y fix — a
+      // column of identically-named buttons tells a screen-reader user nothing
+      // about which sub-agent each one belongs to.
+      render(
+        <ActiveSubAgentsStrip
+          desktopApi={{ stopSubAgent: vi.fn() } as unknown as DesktopApi}
+          thread={buildThread([
+            buildSubAgent({ monitorId: "a", task: "Watch the deployment" }),
+            buildSubAgent({
+              monitorId: "b",
+              status: "failed",
+              task: "Broken monitor",
+            }),
+          ])}
+        />,
+      );
+      expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
+      expect(
+        screen.getByRole("button", {
+          name: "Stop sub-agent: Watch the deployment",
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", {
+          name: "Dismiss failed sub-agent: Broken monitor",
+        }),
+      ).toBeInTheDocument();
+    });
+
     it("offers no Stop when the sub-agent has no monitor turn to stop", () => {
       render(
         <ActiveSubAgentsStrip
@@ -339,7 +372,7 @@ describe("ActiveSubAgentsStrip", () => {
           ])}
         />,
       );
-      expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+      expect(screen.queryByRole("button", { name: /^Stop sub-agent:/ })).toBeNull();
     });
 
     it("recovers the button after a failed stop instead of leaving it stuck", async () => {
@@ -350,9 +383,9 @@ describe("ActiveSubAgentsStrip", () => {
           thread={buildThread([buildSubAgent({ monitorId: "a" })])}
         />,
       );
-      fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+      fireEvent.click(screen.getByRole("button", { name: /^Stop sub-agent:/ }));
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: "Stop" })).toBeEnabled();
+        expect(screen.getByRole("button", { name: /^Stop sub-agent:/ })).toBeEnabled();
       });
     });
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
@@ -78,6 +78,29 @@ describe("ActiveSubAgentsStrip", () => {
       expect(container).toBeEmptyDOMElement();
     });
 
+    it("counts what the heading claims, not the row total", () => {
+      // Regression: the count was `visible.length` while the heading only
+      // flipped when nothing ran, so one live monitor beside a dozen old
+      // failures read "Active sub-agents 13".
+      render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "live" }),
+            ...Array.from({ length: 12 }, (_unused, index) =>
+              buildSubAgent({ monitorId: `dead-${index}`, status: "failed" }),
+            ),
+          ])}
+        />,
+      );
+      expect(
+        screen.getByRole("button", {
+          name: "Active sub-agents (1), 12 failed",
+        }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("12 failed")).toBeInTheDocument();
+      expect(screen.queryByText("13")).toBeNull();
+    });
+
     it("counts only the rows it shows, ignoring finished sub-agents", () => {
       render(
         <ActiveSubAgentsStrip
@@ -128,6 +151,55 @@ describe("ActiveSubAgentsStrip", () => {
       expect(screen.queryByText("First task")).toBeNull();
       // The count still reports what is running while collapsed.
       expect(screen.getByText("3")).toBeInTheDocument();
+    });
+
+    it("seeds from the first render that has rows, not from an empty mount", () => {
+      // Regression: the Composer mounts this component unconditionally and it
+      // returns null while empty, so a mount-time seed always measured zero
+      // rows and pinned expanded=true forever. Every earlier test rendered
+      // straight into a populated state, which the app never does — so the
+      // collapse-at-3+ rule passed its tests and never once fired in the app.
+      const { rerender } = render(<ActiveSubAgentsStrip thread={buildThread([])} />);
+      rerender(
+        <ActiveSubAgentsStrip
+          thread={buildThread(
+            Array.from({ length: 5 }, (_unused, index) =>
+              buildSubAgent({ monitorId: `monitor-${index}` }),
+            ),
+          )}
+        />,
+      );
+      expect(
+        screen.getByRole("button", { name: /Active sub-agents/ }),
+      ).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("re-seeds for the next batch after the strip empties", () => {
+      // Seeding once per window would let a session's first batch govern every
+      // later one — a single early sub-agent would leave the strip expanded for
+      // a batch of nine hours later.
+      const { rerender } = render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([buildSubAgent({ monitorId: "solo" })])}
+        />,
+      );
+      expect(
+        screen.getByRole("button", { name: /Active sub-agents/ }),
+      ).toHaveAttribute("aria-expanded", "true");
+
+      rerender(<ActiveSubAgentsStrip thread={buildThread([])} />);
+      rerender(
+        <ActiveSubAgentsStrip
+          thread={buildThread(
+            Array.from({ length: 4 }, (_unused, index) =>
+              buildSubAgent({ monitorId: `next-${index}` }),
+            ),
+          )}
+        />,
+      );
+      expect(
+        screen.getByRole("button", { name: /Active sub-agents/ }),
+      ).toHaveAttribute("aria-expanded", "false");
     });
 
     it("keeps a manual collapse when the active count later changes", () => {
@@ -295,7 +367,7 @@ describe("ActiveSubAgentsStrip", () => {
         />,
       );
       // Three rows seeds collapsed, so expand before reading the list.
-      fireEvent.click(screen.getByRole("button", { name: /sub-agents \(3\)/ }));
+      fireEvent.click(screen.getByRole("button", { name: /Active sub-agents/ }));
       fireEvent.click(
         screen.getByRole("button", { name: "Dismiss all 2 failed sub-agents" }),
       );
@@ -313,6 +385,38 @@ describe("ActiveSubAgentsStrip", () => {
       );
       fireEvent.click(screen.getByRole("button", { name: /^Dismiss failed sub-agent:/ }));
       expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe("blocked sub-agents", () => {
+    it("shows a blocked row without a blinking dot or a running clock", () => {
+      // A blocked sub-agent is waiting on input, not working. Blinking an
+      // accent dot and counting up an elapsed timer says the opposite.
+      const { container } = render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "a", status: "blocked" }),
+          ])}
+        />,
+      );
+      expect(screen.getByText("Blocked")).toBeInTheDocument();
+      expect(container.querySelector(".status-dot--warning")).not.toBeNull();
+      expect(container.querySelector(".status-dot--blink")).toBeNull();
+      // Nothing is progressing, so nothing sweeps.
+      expect(container.querySelector(".thinking-scanner")).toBeNull();
+    });
+
+    it("still counts blocked sub-agents as active", () => {
+      render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "a", status: "blocked" }),
+          ])}
+        />,
+      );
+      expect(
+        screen.getByRole("button", { name: "Active sub-agents (1)" }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
@@ -181,6 +181,33 @@ describe("ActiveSubAgentsStrip", () => {
   });
 
   describe("failed sub-agents", () => {
+    it("does not call itself Active when nothing is running", () => {
+      // Regression: a thread with 13 failures and nothing running rendered
+      // "ACTIVE SUB-AGENTS 13", which is just false.
+      render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "a", status: "failed" }),
+            buildSubAgent({ monitorId: "b", status: "failed" }),
+          ])}
+        />,
+      );
+      expect(screen.getByText("Failed sub-agents")).toBeInTheDocument();
+      expect(screen.queryByText("Active sub-agents")).toBeNull();
+    });
+
+    it("calls itself Active again as soon as anything is running", () => {
+      render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "a", status: "failed" }),
+            buildSubAgent({ monitorId: "b" }),
+          ])}
+        />,
+      );
+      expect(screen.getByText("Active sub-agents")).toBeInTheDocument();
+    });
+
     it("keeps a failed sub-agent visible and states the outcome in words", () => {
       render(
         <ActiveSubAgentsStrip
@@ -225,6 +252,55 @@ describe("ActiveSubAgentsStrip", () => {
       expect(container.querySelector(".status-dot--blink")).toBeNull();
       expect(container.querySelector(".thinking-scanner")).toBeNull();
       expect(screen.queryByRole("button", { name: /^Stop sub-agent:/ })).toBeNull();
+    });
+
+    it("offers a bulk dismiss once more than one failure is showing", () => {
+      const { container, rerender } = render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "a", status: "failed" }),
+          ])}
+        />,
+      );
+      // One failure is not a chore; the control would just be noise.
+      expect(screen.queryByRole("button", { name: /^Dismiss all/ })).toBeNull();
+
+      rerender(
+        <ActiveSubAgentsStrip
+          thread={buildThread(
+            Array.from({ length: 13 }, (_unused, index) =>
+              buildSubAgent({
+                monitorId: `monitor-${index}`,
+                status: "failed",
+                task: `Failed task ${index}`,
+              }),
+            ),
+          )}
+        />,
+      );
+      fireEvent.click(
+        screen.getByRole("button", { name: "Dismiss all 13 failed sub-agents" }),
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("never sweeps up a running sub-agent in the bulk dismiss", () => {
+      render(
+        <ActiveSubAgentsStrip
+          thread={buildThread([
+            buildSubAgent({ monitorId: "run", task: "Still going" }),
+            buildSubAgent({ monitorId: "x", status: "failed" }),
+            buildSubAgent({ monitorId: "y", status: "failed" }),
+          ])}
+        />,
+      );
+      // Three rows seeds collapsed, so expand before reading the list.
+      fireEvent.click(screen.getByRole("button", { name: /sub-agents \(3\)/ }));
+      fireEvent.click(
+        screen.getByRole("button", { name: "Dismiss all 2 failed sub-agents" }),
+      );
+      expect(screen.getByText("Still going")).toBeInTheDocument();
+      expect(screen.queryByText("Failed")).toBeNull();
     });
 
     it("removes a failed row once dismissed, and the strip with it", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ActiveSubAgentsStrip.test.tsx
@@ -292,10 +292,21 @@ describe("ActiveSubAgentsStrip", () => {
     it("routes Stop through desktopApi with the thread's backend and federation target", async () => {
       const stopSubAgent = vi.fn().mockResolvedValue({ ok: true });
       const onRefreshNavigation = vi.fn().mockResolvedValue(undefined);
-      const thread = {
+      const federationTarget = {
+        scope: "remote",
+        instanceId: "peer-instance",
+      } as const;
+      const thread: NavigationThreadSummary = {
         ...buildThread([buildSubAgent({ monitorId: "monitor-1" })]),
-        federation: { ref: { target: "peer-instance" } },
-      } as NavigationThreadSummary;
+        federation: {
+          ref: {
+            backend: "codex",
+            target: federationTarget,
+            threadId: "remote-thread",
+          },
+          instanceLabel: "Peer",
+        },
+      };
 
       render(
         <ActiveSubAgentsStrip
@@ -309,7 +320,7 @@ describe("ActiveSubAgentsStrip", () => {
       await waitFor(() => {
         expect(stopSubAgent).toHaveBeenCalledWith({
           backend: "codex",
-          federationTarget: "peer-instance",
+          federationTarget,
           threadId: "parent-thread",
           monitorId: "monitor-1",
         });

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -175,6 +175,60 @@ describe("Tangerine Terminal theme contract", () => {
     ).toBeGreaterThanOrEqual(4.5);
   });
 
+  it("keeps every border chevron on one size", () => {
+    // The band above the composer stacks two disclosure rows whose chevrons
+    // sit directly above one another. `.composer__queued-env-action-chevron`
+    // was 10px while everything else was 8px, and the mismatch was invisible
+    // until the sub-agents strip put the two side by side.
+    //
+    // `.directory-row__chevron` is deliberately excluded: it lives in the
+    // sidebar at a different type scale, not in this band.
+    const chevrons = [
+      ".live-work-rail__chevron",
+      ".live-strip__chevron",
+      ".transcript-activity__chevron",
+      ".transcript-work-phase-group__chevron",
+      ".composer__queued-env-action-chevron",
+    ];
+
+    const sizes = chevrons.map((selector) => {
+      const body = extractRuleBody(css, selector);
+      return {
+        selector,
+        width: body.match(/\bwidth:\s*([^;]+);/)?.[1]?.trim(),
+        height: body.match(/\bheight:\s*([^;]+);/)?.[1]?.trim(),
+      };
+    });
+
+    for (const size of sizes) {
+      expect(size, `${size.selector} geometry`).toMatchObject({
+        width: "8px",
+        height: "8px",
+      });
+    }
+  });
+
+  it("keeps the band above the composer on one uppercase-label idiom", () => {
+    // `.composer__queued-label` shipped without the 0.04em tracking its two
+    // neighbours use, so the same 11px/700 caps label rendered two ways
+    // depending on which row drew it.
+    for (const selector of [
+      ".live-work-rail__title",
+      ".live-strip__label",
+      ".composer__queued-label",
+    ]) {
+      const body = extractRuleBody(css, selector);
+      expect(body, `${selector} label idiom`).toMatch(/font-size:\s*11px;/);
+      expect(body, `${selector} label idiom`).toMatch(/font-weight:\s*700;/);
+      expect(body, `${selector} label idiom`).toMatch(
+        /letter-spacing:\s*0\.04em;/,
+      );
+      expect(body, `${selector} label idiom`).toMatch(
+        /text-transform:\s*uppercase;/,
+      );
+    }
+  });
+
   it("does not leave unresolved theme token references in app.css", () => {
     const localTokens = new Set([
       "thinking-scanner-beam-width",

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -175,6 +175,28 @@ describe("Tangerine Terminal theme contract", () => {
     ).toBeGreaterThanOrEqual(4.5);
   });
 
+  it("leaves finished env-action rows flat so the quiet base stays reachable", () => {
+    // Every run carries exactly one of three status modifiers, so while all
+    // three painted at-rest chrome the transparent base and its :hover rule
+    // could never match — a stack of finished actions still rendered as a
+    // stack of cards, which is the complaint the flat base exists to answer.
+    // Only a live run and a failure earn chrome without being pointed at.
+    const painted = ["running", "failed", "exited"].filter((status) =>
+      new RegExp(
+        `\\.composer__queued--env-action\\.composer__queued--env-action-${status}\\s*\\{[^}]*(background|border-color)`,
+      ).test(css),
+    );
+
+    expect(painted).toEqual(["running", "failed"]);
+  });
+
+  it("keeps compact row actions at the WCAG 2.2 target-size floor", () => {
+    // 2.5.8 AA is 24x24. Padding alone left these around 22px.
+    expect(extractRuleBody(css, ".live-strip__item-action")).toMatch(
+      /min-height:\s*24px;/,
+    );
+  });
+
   it("keeps every border chevron on one size", () => {
     // The band above the composer stacks two disclosure rows whose chevrons
     // sit directly above one another. `.composer__queued-env-action-chevron`

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -183,6 +183,9 @@ describe("Tangerine Terminal theme contract", () => {
       "sidebar-rail-inset",
       "sidebar-lane-inset",
       "sidebar-masthead-pull",
+      // Live run strip row height — defined on `.live-strip`, not `:root`.
+      // The four-row scroll cap is derived from it, so the two cannot drift.
+      "live-strip-row-h",
     ]);
     const tokenReferences = [...css.matchAll(/var\(--([a-z0-9-]+)\)/g)].map(
       ([, token]) => token

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -18890,10 +18890,15 @@ a.transcript-message__messaging-origin:focus-visible {
   gap: 2px;
 }
 
+/* Same uppercase-label idiom as `.live-work-rail__title` and
+   `.live-strip__label`, tracking included — all three stack in the band above
+   the composer, so a label that tracks differently reads as a different kind
+   of thing. */
 .composer__queued-label {
   color: var(--text-muted);
   font-size: 11px;
   font-weight: 700;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
@@ -19000,11 +19005,14 @@ a.transcript-message__messaging-origin:focus-visible {
   background: var(--bg-panel-elevated);
 }
 
+/* padding-left matches `.live-strip__row`'s 8px so the two disclosure rows in
+   this band share a left edge — their chevrons stack directly above one
+   another and any mismatch is obvious at a glance. */
 .composer__queued-env-action-summary {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 5px 8px 5px 10px;
+  padding: 5px 8px;
   cursor: pointer;
   list-style: none;
   user-select: none;
@@ -19020,10 +19028,13 @@ a.transcript-message__messaging-origin:focus-visible {
   outline-offset: -2px;
 }
 
+/* 8px, matching `.live-work-rail__chevron` and every other border chevron in
+   the app. This was the lone 10px one, which read as a mistake once the
+   sub-agents strip put an 8px chevron two rows above it. */
 .composer__queued-env-action-chevron {
   display: inline-block;
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
   flex: 0 0 auto;
   border-right: 1.5px solid var(--text-muted);
   border-bottom: 1.5px solid var(--text-muted);
@@ -19252,6 +19263,23 @@ a.transcript-message__messaging-origin:focus-visible {
   display: flex;
   flex-direction: column;
   min-width: 0;
+}
+
+/* The toggle and the bulk-dismiss action are siblings: a button cannot nest
+   inside the toggle button. */
+.live-strip__header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.live-strip__header .live-strip__row {
+  flex: 1 1 auto;
+}
+
+.live-strip__dismiss-all {
+  margin-right: 8px;
 }
 
 /* Quiet at rest, chrome on hover/focus — same treatment as

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -19357,6 +19357,18 @@ a.transcript-message__messaging-origin:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 
+/* Secondary tally next to the count, e.g. "12 failed" beside one live run.
+   Ranks below the count via neutrals, never the accent ramp. */
+.live-strip__note {
+  flex: 0 1 auto;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Pushes the liveness mark to the trailing edge. */
 .live-strip__row-spacer {
   flex: 1 1 auto;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -63,7 +63,11 @@
   --accent-shadow: color-mix(in srgb, var(--accent) 34%, transparent);
   --focus-ring: var(--accent);
   --danger-soft: rgba(185, 66, 50, 0.24);
-  --danger-border: var(--danger-border);
+  /* Was `var(--danger-border)` — self-referential, so the property was invalid
+     at computed-value time and all 33 `var(--danger-border)` consumers fell
+     back to `currentColor` in the default (dark) theme. Alpha follows the
+     light theme's soft:border ratio against this theme's --danger-soft. */
+  --danger-border: rgba(185, 66, 50, 0.45);
   --danger-text: #ffb0a1;
   --success-soft: rgba(74, 148, 92, 0.18);
   --success-text: #9ce5b3;
@@ -18951,14 +18955,38 @@ a.transcript-message__messaging-origin:focus-visible {
    meant for the steer/permissions/queued-turn pattern; for the
    env-action anchor we override to block so <details>/<summary> can
    own the layout. */
+/* Quiet at rest. An action row is a one-line status readout, not a unit of
+   interaction, so it does not earn card chrome just for existing — N parallel
+   runs used to stack N identical elevated cards above the reply box. Chrome
+   arrives when the row is running, hovered, focused, or open. See
+   docs/brainstorms/2026-08-10-live-run-strip-above-composer-requirements.md */
 .composer__queued--env-action {
   display: block;
   padding: 0;
+  background: transparent;
+  border-color: transparent;
+}
+
+.composer__queued--env-action:hover,
+.composer__queued--env-action:focus-within,
+.composer__queued--env-action[open] {
   background: var(--bg-panel-elevated);
   border-color: var(--border-subtle);
 }
 
-.composer__queued--env-action-failed {
+/* The one row in the stack whose state is still changing keeps its chrome
+   without being pointed at. (This modifier was applied by EnvActionRunsView
+   from the start but matched no rule at all, so a running action was
+   pixel-identical to a finished one.) */
+.composer__queued--env-action.composer__queued--env-action-running {
+  background: var(--bg-panel-elevated);
+  border-color: var(--border-subtle);
+}
+
+/* Terminal states stay tinted whether or not the pointer is over them, so
+   these carry both classes to outrank the :hover rule above rather than
+   relying on source order alone. */
+.composer__queued--env-action.composer__queued--env-action-failed {
   border-color: var(--danger-border);
   background: color-mix(in srgb, var(--danger-soft) 40%, var(--bg-panel-elevated));
 }
@@ -18967,8 +18995,9 @@ a.transcript-message__messaging-origin:focus-visible {
   color: var(--danger-text);
 }
 
-.composer__queued--env-action-exited {
+.composer__queued--env-action.composer__queued--env-action-exited {
   border-color: color-mix(in srgb, var(--status-warning) 36%, var(--border-subtle));
+  background: var(--bg-panel-elevated);
 }
 
 .composer__queued-env-action-summary {
@@ -19044,11 +19073,14 @@ a.transcript-message__messaging-origin:focus-visible {
   flex: 0 0 auto;
 }
 
+/* 22px rather than 26px: the control is what sets the collapsed row's height,
+   and Terminate moved into the expanded body, so the remaining controls no
+   longer need to carry the row. */
 .composer__queued-env-action-actions .composer__queued-env-action-control {
-  width: 26px;
-  min-width: 26px;
-  min-height: 26px;
-  height: 26px;
+  width: 22px;
+  min-width: 22px;
+  min-height: 22px;
+  height: 22px;
   padding: 0;
   display: inline-flex;
   align-items: center;
@@ -19179,6 +19211,206 @@ a.transcript-message__messaging-origin:focus-visible {
   white-space: pre;
   user-select: text;
   -webkit-user-select: text;
+}
+
+/* Force-stop lives in the expanded body, not the collapsed summary: it is the
+   destructive escalation and should cost one deliberate expand rather than
+   sitting a pixel from Stop for the life of every run. */
+.composer__queued-env-action-terminate-action {
+  align-self: flex-start;
+  color: var(--danger-text);
+  border-color: var(--danger-border);
+}
+
+.composer__queued-env-action-terminate-action:hover:not(:disabled) {
+  background: var(--danger-soft);
+  border-color: var(--danger-border);
+}
+
+.composer__queued-env-action-hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+/* ============================================================
+   LIVE RUN STRIP
+   A compact disclosure row for transient run state above the composer, used
+   today by the active sub-agents group (ActiveSubAgentsStrip.tsx).
+
+   Deliberately NOT a card: the band above the reply box already stacks the
+   LiveWorkRail, the env-action rows, and the steer/permissions rows, and four
+   surfaces sharing one elevated-card treatment is what makes that band read as
+   a wall. Geometry, chevron, and label idiom are copied from the existing
+   primitives rather than re-picked — see
+   docs/brainstorms/2026-08-10-live-run-strip-above-composer-requirements.md
+   ============================================================ */
+.live-strip {
+  /* Row height is a variable because the list caps at exactly four of them. */
+  --live-strip-row-h: 28px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+/* Quiet at rest, chrome on hover/focus — same treatment as
+   `.transcript-work-phase-group__toggle`. */
+.live-strip__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
+  min-height: var(--live-strip-row-h);
+  padding: 0 8px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.live-strip__row:hover {
+  border-color: var(--border-subtle);
+  background: var(--bg-panel);
+}
+
+.live-strip__row:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* Canonical border chevron (`.live-work-rail__chevron`). `flex: 0 0 auto` is
+   mandatory — without it the 8px box collapses in a narrow column. */
+.live-strip__chevron {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-right: 1.5px solid var(--text-muted);
+  border-bottom: 1.5px solid var(--text-muted);
+  transform: rotate(-45deg);
+  transition: transform 120ms ease;
+}
+
+.live-strip__row[aria-expanded="true"] .live-strip__chevron {
+  transform: rotate(45deg);
+}
+
+.live-strip__label {
+  flex: 0 1 auto;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Counts rank via neutrals, never the accent ramp (UI-THEME "Accent ramp"). */
+.live-strip__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  padding: 0 5px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Pushes the liveness mark to the trailing edge. */
+.live-strip__row-spacer {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.live-strip__list {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 0 0 0 16px;
+  list-style: none;
+  /* Exactly four rows, then scroll — an unbounded list would push the composer
+     down the window, which is the failure this strip exists to avoid. */
+  max-height: calc(4 * var(--live-strip-row-h));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.live-strip__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  min-height: var(--live-strip-row-h);
+  padding: 0 8px;
+}
+
+.live-strip__item-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.live-strip__item-time {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.live-strip__item--failed .live-strip__item-time {
+  color: var(--danger-text);
+}
+
+.live-strip__item-action {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.live-strip__item-action:hover:not(:disabled) {
+  border-color: var(--border-subtle);
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+}
+
+.live-strip__item-action:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.live-strip__item-action:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.live-strip__item-action--danger:hover:not(:disabled) {
+  border-color: var(--danger-border);
+  background: var(--danger-soft);
+  color: var(--danger-text);
 }
 
 /* Pasted-image strip sits directly above the chat entry (see Composer.tsx).
@@ -22259,6 +22491,12 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .status-dot--error {
   background: var(--status-error);
+}
+
+/* "Running" in the dot vocabulary, matching `.rail-chip__dot--active`. Accent
+   rather than a --status-* token because a live process is not an outcome. */
+.status-dot--active {
+  background: var(--accent);
 }
 
 @keyframes status-blink {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -19000,10 +19000,14 @@ a.transcript-message__messaging-origin:focus-visible {
   color: var(--danger-text);
 }
 
-.composer__queued--env-action.composer__queued--env-action-exited {
-  border-color: color-mix(in srgb, var(--status-warning) 36%, var(--border-subtle));
-  background: var(--bg-panel-elevated);
-}
+/* `exited` deliberately has NO at-rest chrome, which is what makes the
+   transparent base above reachable at all. Every run carries exactly one of
+   the three status modifiers, so while this one also painted a background and
+   a border, no row was ever quiet and a stack of finished actions still read
+   as a stack of cards — the exact complaint the flat base was added to fix.
+   A clean exit is also not a caution, so the old --status-warning border was
+   saying the wrong thing about `exit 0`. The label and `exit N · ran Xs` carry
+   the outcome; chrome arrives on hover, focus, or open like any other row. */
 
 /* padding-left matches `.live-strip__row`'s 8px so the two disclosure rows in
    this band share a left edge — their chevrons stack directly above one
@@ -19408,19 +19412,36 @@ a.transcript-message__messaging-origin:focus-visible {
   white-space: nowrap;
 }
 
+/* A reserved, right-aligned column. Left to size themselves, "0m 12s" and
+   "Failed" ended 17px apart and the rail read as ragged across four rows. */
 .live-strip__item-time {
   flex: 0 0 auto;
+  min-width: 56px;
   color: var(--text-muted);
   font-size: 11px;
   font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+/* Holds the row's action, or holds its place when the row has none. */
+.live-strip__item-slot {
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: flex-end;
+  min-width: 62px;
 }
 
 .live-strip__item--failed .live-strip__item-time {
   color: var(--danger-text);
 }
 
+/* 24px min-height is the WCAG 2.2 AA target-size floor (2.5.8). The padding
+   alone left these around 22px, and the 28px row has the room. */
 .live-strip__item-action {
+  display: inline-flex;
+  align-items: center;
   flex: 0 0 auto;
+  min-height: 24px;
   padding: 2px 6px;
   border: 1px solid transparent;
   border-radius: 6px;

--- a/docs/brainstorms/2026-08-10-live-run-strip-above-composer-requirements.md
+++ b/docs/brainstorms/2026-08-10-live-run-strip-above-composer-requirements.md
@@ -1,0 +1,351 @@
+# Live Run Strip Above the Composer — UI Design Review and Proposal
+
+Date: 2026-08-10
+Status: proposal; open questions resolved 2026-08-10, direction not yet accepted
+Scope: the band between the transcript and the reply input; the Sub-agents rail panel
+
+## The ask
+
+Two observations from the operator:
+
+1. Env action runs are pinned above the composer, but they read as "chunky and
+   ugly and huge" blocks. They want a compact expandable line instead, plus an
+   animated embellishment so a running action visibly reads as *still running*.
+2. Running sub-agents — PwrAgent task monitors, Codex native sub-agents, and
+   anything an ACP backend spawns — deserve the same above-composer treatment:
+   capped at ~4 visible then scrollable, collapsible under an "Active
+   sub-agents" header with a count, and gone entirely once everything finishes
+   (completed sub-agents already live in the sidebar and the rail panel).
+
+## Review: what is actually there today
+
+### The band above the composer has no owner
+
+The strongest finding is that "the env action row is chunky" is a symptom, not
+the disease. There are already **three independent stacks** competing for the
+space directly above the reply input, and the proposal would add a fourth:
+
+| Order (top → bottom) | Element | Rendered by | Height behavior |
+|---|---|---|---|
+| 1 | `LiveWorkRail` — plan + edited files | [ThreadView.tsx:3241](apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx:3241) | capped `min(38vh, 360px)`, scrolls internally |
+| 2 | Env action runs, one row per run | [Composer.tsx:10163](apps/desktop/src/renderer/src/features/composer/Composer.tsx:10163) → `EnvActionAnchorList` | **unbounded** — N runs, N rows |
+| 3 | Pending steer / queued permissions / scheduled / failed | [Composer.tsx:10172+](apps/desktop/src/renderer/src/features/composer/Composer.tsx:10172) | 1–2 rows |
+| *(proposed)* | Active sub-agents | — | — |
+
+Every one of them is the same card: `1px solid var(--border-subtle)`,
+`border-radius: 8px`, `background: var(--bg-panel-elevated)`, `padding: 8px 10px`.
+`.live-work-rail` is at [app.css:13616](apps/desktop/src/renderer/src/styles/app.css:13616);
+`.composer__queued` is at [app.css:18711](apps/desktop/src/renderer/src/styles/app.css:18711).
+Identical weight, identical treatment, no hierarchy between them.
+
+Stacking four visually-identical cards is what produces "huge." Shrinking one
+card does not fix a band with no budget. **The proposal below treats the band as
+a single designed region rather than four features that each grabbed space.**
+
+This also sits against [UI-THEME.md:443](docs/UI-THEME.md:443) — "Do not put
+cards inside cards" — and
+[desktop-style-guide.md:213-226](docs/design/desktop-style-guide.md:213). A card
+is for something that "genuinely frames a unit of interaction." A one-line status
+readout is not that.
+
+### The env action row is already expandable — that is not the problem
+
+[EnvActionRunsView.tsx:217](apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx:217)
+already renders a native `<details>` / `<summary>`, collapsed by default, with a
+chevron that rotates on `[open]`. The expanded body holds Command and Output.
+
+So the requested "expandable text instead of a huge blocky border" is *almost*
+already built. What makes it read heavy at rest is four things, all fixable
+without restructuring:
+
+1. **Full card chrome at rest.** Border + elevated background on a row that is
+   idle information. The house already has a quieter idiom:
+   `.transcript-work-phase-group__toggle`
+   ([app.css:12413](apps/desktop/src/renderer/src/styles/app.css:12413)) is
+   transparent-bordered at rest and only gains `--border-subtle` + `--bg-panel`
+   on hover.
+2. **Three 26×26 icon buttons always visible** — Stop, Terminate, and
+   move-to-sidebar
+   ([app.css:18919](apps/desktop/src/renderer/src/styles/app.css:18919)).
+   Terminate is a destructive escalation that does not need permanent residency.
+3. **8px vertical padding plus a 6px inter-row gap**, multiplied by N runs.
+4. **No visual difference between running and finished.** See below.
+
+### Defect: the "running" modifier has no styling at all
+
+[EnvActionRunsView.tsx:213](apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx:213)
+applies `composer__queued--env-action-running`. Grepping `app.css` for that class
+returns **nothing**. `--env-action-failed` (18833) and `--env-action-exited`
+(18842) both have rules; running does not.
+
+A running action is therefore pixel-identical to a neutral finished one. The only
+thing distinguishing them is the text `running for 1s`, and the whole block
+contains no animation of any kind — the sole motion is the chevron's
+`transition: transform 120ms ease`. So the operator's instinct is correct and the
+gap is concrete, not aesthetic.
+
+### The sub-agent data model is already unified — no new plumbing needed
+
+Good news for the second half of the ask. Every producer writes the same type
+through the same store:
+
+- Type `ThreadSubAgentSummary` — [navigation.ts:236-256](packages/shared/src/contracts/navigation.ts:236)
+- Status union `ThreadSubAgentStatus` — [navigation.ts:226](packages/shared/src/contracts/navigation.ts:226):
+  `pending | running | cancelling | blocked | failed | success | failure | cancelled`
+- Single write path: `overlayStore.upsertThreadSubAgent`
+  ([overlay-store-sqlite.ts:1854](apps/desktop/src/main/state/overlay-store-sqlite.ts:1854))
+
+Four producers, all in `backend-registry.ts`: PwrAgent task monitors
+(`persistTaskMonitorSubAgent`, 20449), code review (`persistReviewSubAgent`,
+20524 — this is the ACP path too), Codex native `spawnAgent`
+(`persistCodexNativeSubAgent`, 20119), and the thread-title helper (22328).
+Origin is classified client-side by `monitorId` prefix in
+[subagent-kind.ts](apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-kind.ts).
+
+**One strip covers PwrAgent, Codex, and ACP sub-agents with no backend work.**
+
+Two caveats:
+
+- There is no `startedAt` and no `spawnedBy` field. The card derives "Started"
+  from `createdAt` and "Spawned by …" from the `monitorId` prefix. Fine to keep
+  doing, but do not assume those fields exist.
+- `thread/subAgents/updated` triggers a **full `scheduleRefresh()`**
+  ([useThreadNavigation.ts:4147](apps/desktop/src/renderer/src/lib/useThreadNavigation.ts:4147)),
+  not an in-place patch. The strip must read from the existing navigation
+  snapshot via `useSubAgents` and must not introduce any polling of its own.
+
+Also relevant: `hasRunningSubAgent` already exists at
+[SubAgentsPanel.tsx:38](apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx:38)
+but is used only to gate the 1s duration ticker. Nothing surfaces an active
+count anywhere in the context rail — the rail tab is icon-only
+([ThreadContextPanel.tsx:639](apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx:639)).
+
+---
+
+## On the animation: recommend against the 5-second ripple
+
+The instinct is right; the specific proposal fights three existing rules and one
+piece of house physics. Concretely:
+
+**A 5s period reads as stalled, not alive.** Liveness animation answers exactly
+one question — "is this frozen?" At a 5-second cadence the operator has to watch
+for five seconds to answer it. The house cadences are 1.6s (`status-blink`,
+[app.css:22136](apps/desktop/src/renderer/src/styles/app.css:22136)) and 1.8s
+(`pwragent-thinking-scanner-sweep`,
+[app.css:15358](apps/desktop/src/renderer/src/styles/app.css:15358)).
+
+**Animating the text color specifically is out of bounds.**
+[UI-THEME.md:284](docs/UI-THEME.md:284) says status colors must "never be used in
+body copy," and the accent ramp table
+([UI-THEME.md:334-345](docs/UI-THEME.md:334)) reserves `--accent-bright` for text
+on an accent tint. A color ripple traveling across the run description is exactly
+the "decorative glow" listed as an anti-pattern at
+[UI-THEME.md:512](docs/UI-THEME.md:512).
+
+**A new keyframe is unnecessary and carries a maintenance tax.** The
+reduced-motion suppression list at
+[app.css:22287](apps/desktop/src/renderer/src/styles/app.css:22287) is a
+hand-maintained selector list, not a blanket rule — every new animated element
+must be added by hand or it ships an a11y regression.
+
+### What to do instead — two signals, one of which survives reduced motion
+
+**Env action rows: `.status-dot` + `.status-dot--blink`.** 8px, 1.6s
+`ease-in-out` opacity pulse, already the documented canonical "in flight" signal
+([UI-THEME.md:266-284](docs/UI-THEME.md:266)), already reduced-motion-guarded
+(add the new selector to the 22287 list). Semantically correct: an env action is
+a *process*, and the dot is the app's process-liveness mark.
+
+**Sub-agent rows: `<ThinkingScanner compact />`.** The 16×6px beam is the app's
+established "an agent is working" mark, already used in `TranscriptList`,
+`ThreadRowStatus`, and `Sidebar`. Because `syncThinkingScannerAnimation` pins
+`animation.startTime = 0` (PR #1187), a new instance phase-locks with the
+scanners already visible in the sidebar and transcript — the whole window
+breathes together instead of shimmering out of sync.
+
+> Trap to respect: per the comments at
+> [app.css:3131-3140](apps/desktop/src/renderer/src/styles/app.css:3131) you may
+> **not** build an idle state by switching the beam's animation off — a
+> CSS-stopped-and-restarted animation never re-pins. The idle case needs a
+> separate static element, as `.lens-switch__dormant-scanner`
+> ([app.css:3141](apps/desktop/src/renderer/src/styles/app.css:3141)) does.
+> In this design there is no idle case (the strip is absent when nothing runs),
+> so this should not bite — but do not "optimize" it later by leaving the strip
+> mounted with the animation paused.
+
+**And keep the ticking elapsed counter.** `running for 1m 04s` re-rendering every
+second is the honest liveness signal and the only one that still works under
+`prefers-reduced-motion: reduce`. Motion answers "alive?" at a glance; the
+counter answers it definitively. Two independent signals, no color in body copy.
+
+---
+
+## Proposal
+
+### 1. A shared `.live-strip` primitive
+
+One compact disclosure row, used by both features. Not a card at rest.
+
+```
+  ●  ENV ACTION   Dev - No Messaging · pid 16744 · 1m 04s          [▪]  ⌄
+  ^  ^            ^                                                ^    ^
+  |  |            |                                                |    chevron
+  |  |            |                                                Stop (running only)
+  |  |            secondary metadata, 12px/500 --text-secondary, ellipsized
+  |  uppercase label, 11px/700 --text-muted
+  blinking status dot, 8px
+```
+
+Composed entirely from existing vocabulary — no new tokens, no new keyframes:
+
+| Part | Reuse |
+|---|---|
+| Row shell | `.transcript-work-phase-group__toggle` ([app.css:12413](apps/desktop/src/renderer/src/styles/app.css:12413)) — transparent border at rest, `--border-subtle` + `--bg-panel` on hover, `--focus-ring` outline on focus-visible |
+| Chevron | canonical `.live-work-rail__chevron` geometry ([app.css:13728](apps/desktop/src/renderer/src/styles/app.css:13728)) — 8px CSS-border V, `flex: 0 0 auto`, 120ms transform |
+| Label | 11px/700 uppercase `--text-muted` (as `.live-work-rail__title`, `.composer__queued-label`) |
+| Liveness | `.status-dot--blink` or `<ThinkingScanner compact />` |
+| Terminal states | `.rail-chip` + `.rail-chip__dot--{ok,error}` ([app.css:17642](apps/desktop/src/renderer/src/styles/app.css:17642)) |
+
+Row height fixed at `28px` via a `--live-strip-row-h` custom property, so
+expand/collapse and hover never reflow neighbors
+([UI-THEME.md:460](docs/UI-THEME.md:460)).
+
+Chevron must be `children[0]` and the label `children[1]` — pinned by
+[chevron-placement.test.tsx:19-52](apps/desktop/src/renderer/src/features/thread-detail/__tests__/chevron-placement.test.tsx:19).
+
+### 2. Env actions: demote Terminate, keep the `<details>`
+
+Keep the existing `<details>` / `<summary>` structure and the existing body
+(Command, Output). Change only the summary:
+
+- Restyle `.composer__queued--env-action` to the `.live-strip` shell — drop the
+  card border and elevated background at rest.
+- **Add the missing `--env-action-running` rule** and give it the blinking dot.
+  This is a bug fix regardless of whether the rest of the proposal lands.
+- **Stop stays in the collapsed row. Terminate moves into the expanded body.**
+  Force-kill is the destructive escalation; requiring one deliberate expand
+  before offering it is better than parking it permanently one pixel from Stop.
+  This also reclaims a 26px button slot.
+- Shrink remaining controls 26×26 → 22×22.
+
+### 3. Sub-agents: a grouped strip, absent when idle
+
+A single group row with a count, expanding to a bounded child list:
+
+```
+collapsed:
+  ▰  ACTIVE SUB-AGENTS  3                                              ⌄
+
+expanded:
+  ▰  ACTIVE SUB-AGENTS  3                                              ⌃
+  ├ ▰  Run and monitor the approved M2 pwrsnap-dev headed…    7m 18s  [▪]
+  ├ ▰  Verify the Sequoia 15.7.9 installer cache cleanup       2m 04s  [▪]
+  ├ ▰  Draft the release notes for the runner maintenance PR   0m 46s  [▪]
+  └ ▰  Reconcile the Tart VM inventory against the lab manif…  0m 12s  [▪]
+     (scrolls past 4)
+```
+
+Behavior:
+
+- **Absent when idle.** Renders nothing when there are no non-terminal
+  sub-agents *and* no undismissed failures; no reserved space, no empty state.
+- **Bounded.** `max-height: calc(4 * var(--live-strip-row-h))`, `overflow-y:
+  auto`, `overscroll-behavior: contain` — matching `.context-panel__scroll`
+  ([app.css:16341](apps/desktop/src/renderer/src/styles/app.css:16341)).
+- **Membership = `!isTerminalSubAgent(subAgent)` plus undismissed failures.**
+  Reuses the existing helper from `subagent-format.ts` so the strip and the rail
+  panel can never disagree about what "running" means; the failure carve-out is
+  layered on top rather than by redefining the helper (see resolved decision 1).
+- **Starts expanded at 1–2 active, collapsed at 3+**, with a manual toggle
+  always winning thereafter. In-memory only, not persisted.
+- Row click expands nothing inline — it opens the existing
+  `SubAgentDetailsModal`. The rail panel stays the full-detail surface; the strip
+  is a presence indicator with a Stop button, not a second copy of the card.
+- Reads `useSubAgents(thread)` off the existing navigation snapshot. **No new
+  IPC, no new polling.**
+- Stop reuses `desktopApi.stopSubAgent` (`agent:stop-sub-agent`), including the
+  federated path already handled in
+  [agent-ipc.ts:738](apps/desktop/src/main/ipc/agent-ipc.ts:738).
+
+### 4. Give the band a height budget
+
+With `LiveWorkRail` at up to 360px plus two strips plus a steer row, the composer
+can be pushed well down the window. Propose a shared cap on the strip region
+(everything except `LiveWorkRail`, which already caps itself) of
+`min(20vh, 180px)`, scrolling internally past that. This is the part that
+actually answers "huge" for the long tail — a thread with six parallel env
+actions today produces six unbounded stacked cards.
+
+---
+
+## Incidental defects found during the review
+
+Both are pre-existing and independent of this work; calling them out so they are
+fixed deliberately rather than absorbed silently.
+
+1. **`--danger-border` is self-referential in the dark theme.**
+   [app.css:66](apps/desktop/src/renderer/src/styles/app.css:66) reads
+   `--danger-border: var(--danger-border);`, which is invalid at computed-value
+   time. The light theme defines it correctly at
+   [app.css:337](apps/desktop/src/renderer/src/styles/app.css:337). This means
+   `.composer__queued--env-action-failed` has no border color in dark mode —
+   which is the default theme.
+2. **`.thinking-scanner__beam` has no `prefers-reduced-motion` rule.**
+   [app.css:15346](apps/desktop/src/renderer/src/styles/app.css:15346) sweeps
+   infinitely regardless of the preference. Reusing the scanner for sub-agents
+   would propagate that gap to a new surface, so it should be closed first — but
+   note the "cannot stop and restart the beam" constraint above: the fix is
+   likely a static reduced-motion variant, not `animation: none`.
+
+## Tests this would touch
+
+- [theme-contract.test.tsx:1307-1322](apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx:1307)
+  pins thinking-scanner geometry and the shared sweep keyframe. Per
+  [UI-THEME.md:372](docs/UI-THEME.md:372), a deliberate change here lands in the
+  same commit as the change itself.
+- [chevron-placement.test.tsx](apps/desktop/src/renderer/src/features/thread-detail/__tests__/chevron-placement.test.tsx)
+  — extend to cover `.live-strip`.
+- [LiveWorkRail.test.tsx](apps/desktop/src/renderer/src/features/thread-detail/__tests__/LiveWorkRail.test.tsx),
+  [SubAgentsPanel.test.tsx](apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx)
+  — unchanged behavior, but the band reorder should get a regression test.
+- New: strip is absent at zero active sub-agents; strip scrolls past 4;
+  Terminate is not reachable while the env action row is collapsed.
+
+## Resolved decisions
+
+Settled with the operator on 2026-08-10.
+
+1. **A failed sub-agent lingers until dismissed.** Strip membership is not
+   purely `!isTerminalSubAgent`. A sub-agent reaching `failed` or `failure`
+   keeps its row, restyled with `.rail-chip--alert`
+   ([app.css:17658](apps/desktop/src/renderer/src/styles/app.css:17658)), until
+   the operator dismisses it or navigates away from the thread. Rationale: a
+   silent disappearance is the worse failure mode — the sidebar and rail copies
+   are not in the operator's eyeline while they are typing.
+
+   Consequence for §3: the strip is **not** absent whenever the active count is
+   zero. It is absent when there are no non-terminal sub-agents *and* no
+   undismissed failures. Successful and cancelled sub-agents still leave
+   immediately; only failures linger.
+
+   Consequence for the liveness mark: a lingering failed row must not carry a
+   `<ThinkingScanner>`. It gets the static alert chip instead — nothing about a
+   finished failure should animate.
+
+2. **Expanded at 1–2 active, collapsed at 3+.** Evaluated when the strip
+   mounts. A manual expand or collapse always wins and is never overridden by a
+   later count change — the auto-rule seeds the initial state only. Not
+   persisted (see decision 3).
+
+3. **No dock-to-sidebar toggle in v1.** The strip removes itself at zero, which
+   is the bulk of what a dock toggle buys, and a third dock preference alongside
+   `actionRunsDock` and `editedFilesDock` is not worth it for a self-dismissing
+   surface. Follows that the expand/collapse state from decision 2 is in-memory
+   only — no new `config.toml` key in v1.
+
+4. **Thread-scoped.** Reads `useSubAgents(props.thread)` off the existing
+   navigation snapshot, no cross-thread aggregation. Accepted limitation: a
+   sub-agent spawned from a thread the operator has navigated away from is
+   invisible in the band. The Attention lens and the sidebar remain the
+   cross-thread surfaces. Revisit only if operators report losing track of
+   off-thread monitors.


### PR DESCRIPTION
## Summary

Makes the band above the composer compact, and gives running sub-agents a home there. Two commits: the design review that settled the direction, then the implementation.

**Env action rows are quiet at rest.** They were full elevated cards whether running or long finished, so N parallel runs stacked N identical cards above the reply box. The "chunky and huge" complaint was really about the stack — `LiveWorkRail` and the steer/permissions rows use the same `--border-subtle` / `8px` / `--bg-panel-elevated` treatment, so four surfaces competed at identical visual weight. Chrome now arrives on hover, focus, open, or while running, leaving the finished bulk of the stack as plain lines.

**Running actions are finally distinguishable from finished ones.** `composer__queued--env-action-running` was applied in JSX from the start but matched no CSS rule anywhere, so a live action was pixel-identical to a dead one. It now keeps its chrome without a hover and carries a blinking `.status-dot--active`.

**Force-stop moved into the expanded body** as "Terminate now", with prose stating the consequence. It is the destructive escalation and should cost one deliberate expand rather than sitting a pixel from Stop for the life of every run. Remaining controls drop 26px → 22px, which is what set the collapsed row height.

**New `ActiveSubAgentsStrip`** covers PwrAgent task monitors, code review (which is also the ACP path), Codex native `spawnAgent`, and the title helper in one surface — all four persist the same `ThreadSubAgentSummary` through one store, so this needed no backend work. Absent when idle, caps at four rows then scrolls, seeds expanded at 1–2 active and collapsed at 3+ with a manual toggle winning thereafter. Failed sub-agents linger until dismissed rather than vanishing, and a lingering failure gets a static dot rather than the scanner.

**Liveness reuses the house vocabulary** rather than the 5s color ripple originally floated: `.status-dot--blink` (1.6s, already reduced-motion-guarded) for env actions, the phase-locked `ThinkingScanner` beam for the sub-agent group, and the elapsed counter that was already ticking — the counter is the half that survives `prefers-reduced-motion`. No new keyframes. Rationale in the brainstorm.

## Verification

- `pnpm typecheck` — passes.
- `pnpm lint:eslint` — 0 errors (30 pre-existing warnings in `Composer.tsx`, unchanged baseline).
- `pnpm lint:colors`, `pnpm lint:boundaries` — pass.
- `pnpm test` — 515/516 files, 7291 passing. The 5 failures in `codex-environment-runtime.test.ts` **reproduce on a clean tree** (verified by stashing) and are unrelated: local npm global-config warnings leak into subprocess output the test asserts on.
- 30 new tests: presence/absence, the 1–2 vs 3+ disclosure seed and that a later count change does not override a manual toggle, both failure spellings, dismissal, scanner only while running, the once-per-second tick and that it stops, `stopSubAgent` routing including the federation target, and stop-failure recovery. Updated 3 env-action tests for Terminate's new placement.
- **Not yet run headed.** Visual confirmation needs the lab guest.

## Notes

**`--danger-border` was broken in the default theme.** It read `--danger-border: var(--danger-border);` in the dark `:root` — self-referential, invalid at computed-value time, so all 33 `var(--danger-border)` consumers fell back to `currentColor`. Fixed here because the lingering-failure styling depends on it. Worth knowing why nothing caught it: the theme-contract token test checks that every referenced token *is defined*, and this one is — just circularly.

**One test change is a deliberate contract edit.** `theme-contract.test.tsx` gained `live-strip-row-h` to its `localTokens` allowlist, alongside the existing `thinking-scanner-*` and `sidebar-*` entries — it is a component-scoped custom property on `.live-strip`, not a theme token. Per `UI-THEME.md:372`, that lands in the same commit as the change.

**Known gap, deliberately not fixed here.** `.thinking-scanner__beam` has no `prefers-reduced-motion` rule, and this PR adds a fourth instance of it. Pre-existing across three existing consumers; the fix is a static variant rather than `animation: none`, because a CSS-stopped scanner animation never re-pins to the shared timeline epoch (`app.css` comments at the `.lens-switch__dormant-scanner` rule). Left out to keep this reviewable.

**Decisions recorded in the brainstorm**, in case a reviewer wants the reasoning: failed sub-agents linger; the disclosure seed is mount-time only; no dock-to-sidebar toggle in v1 (which also keeps the expand state in-memory — no new `config.toml` key); membership is thread-scoped, so a sub-agent spawned from a thread you navigated away from is not shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)