### PR TITLE
feat(desktop): group star map orbit cards into project clouds

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -1,6 +1,5 @@
 import {
   useCallback,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -42,6 +41,14 @@ export type StarMapChatCardProps = {
   onRaise: (cardKey: string) => void;
   onRectChange: (cardKey: string, rect: ChatCardRect) => void;
   rect: ChatCardRect;
+  /**
+   * Canvas scale. The card lives IN the map, so a pointer that travels N
+   * screen pixels crosses N / scale canvas pixels — without this the card
+   * outruns the cursor exactly the way a zoomed thread card used to.
+   */
+  scale: number;
+  /** Canvas extent the card is kept inside, in canvas pixels. */
+  bounds: { width: number; height: number };
   thread: NavigationThreadSummary;
   /** Stack position; the host owns the order, we only read our depth. */
   zIndex: number;
@@ -55,13 +62,8 @@ type DragState = {
   startRect: ChatCardRect;
 };
 
-function viewportSize(): { width: number; height: number } {
-  if (typeof window === "undefined") return { width: 1440, height: 900 };
-  return { width: window.innerWidth, height: window.innerHeight };
-}
-
 /**
- * One floating chat card over the star map.
+ * One chat card, anchored in the star map.
  *
  * The card owns its own thread session rather than borrowing App's single
  * mounted ThreadView: that is what lets several cards be open at once, and
@@ -70,7 +72,7 @@ function viewportSize(): { width: number; height: number } {
  * handed, so a card over a peer's thread reads and writes on that peer.
  */
 export function StarMapChatCard(props: StarMapChatCardProps) {
-  const { cardKey, desktopApi, onOpenFull, onRaise, onRectChange, rect, thread } =
+  const { bounds, cardKey, desktopApi, onOpenFull, onRaise, onRectChange, rect, scale, thread } =
     props;
   const dragRef = useRef<DragState | undefined>(undefined);
   const [sendError, setSendError] = useState<string | undefined>(undefined);
@@ -126,9 +128,10 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     (event: ReactPointerEvent) => {
       const drag = dragRef.current;
       if (!drag || drag.pointerId !== event.pointerId) return;
-      const deltaX = event.clientX - drag.originX;
-      const deltaY = event.clientY - drag.originY;
-      const viewport = viewportSize();
+      // Screen pixels in, canvas pixels out.
+      const zoom = scale > 0 ? scale : 1;
+      const deltaX = (event.clientX - drag.originX) / zoom;
+      const deltaY = (event.clientY - drag.originY) / zoom;
       const next =
         drag.kind === "move"
           ? clampChatCardRect(
@@ -137,17 +140,17 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
                 left: drag.startRect.left + deltaX,
                 top: drag.startRect.top + deltaY,
               },
-              viewport,
+              bounds,
             )
           : resizeChatCardRect({
               rect: drag.startRect,
               deltaX,
               deltaY,
-              viewport,
+              viewport: bounds,
             });
       onRectChange(cardKey, next);
     },
-    [cardKey, onRectChange],
+    [bounds, cardKey, onRectChange, scale],
   );
 
   const endDrag = useCallback((event: ReactPointerEvent) => {
@@ -157,21 +160,9 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     event.currentTarget.releasePointerCapture?.(event.pointerId);
   }, []);
 
-  // A card parked against an edge must stay reachable when the window
-  // shrinks under it. The listener reads the current rect through a ref
-  // rather than closing over it: `rect` changes on every pointermove, and
-  // depending on it here tore the listener down and re-added it on every
-  // frame of a drag.
-  const rectRef = useRef(rect);
-  rectRef.current = rect;
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const onResize = () => {
-      onRectChange(cardKey, clampChatCardRect(rectRef.current, viewportSize()));
-    };
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, [cardKey, onRectChange]);
+  // No window-resize clamp: the card is anchored in the map, not in the
+  // window. Resizing the window changes what part of the galaxy is on
+  // screen, which is a pan, not a reason to move a card off its spot.
 
   /**
    * Returns whether the turn actually reached the backend. A peer can drop

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -163,6 +164,29 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   // No window-resize clamp: the card is anchored in the map, not in the
   // window. Resizing the window changes what part of the galaxy is on
   // screen, which is a pan, not a reason to move a card off its spot.
+  //
+  // The CANVAS shrinking is a different matter. Archiving no longer
+  // shrinks it (cloud extents are carried forward), but switching lens or
+  // hiding offline instances still can, and the view clamps to the canvas
+  // — so a card left outside the new bounds would be unreachable. Read
+  // through a ref so this fires on a bounds change and not on every frame
+  // of a drag.
+  const rectRef = useRef(rect);
+  rectRef.current = rect;
+  useEffect(() => {
+    const clamped = clampChatCardRect(rectRef.current, {
+      width: bounds.width,
+      height: bounds.height,
+    });
+    if (
+      clamped.left !== rectRef.current.left
+      || clamped.top !== rectRef.current.top
+      || clamped.width !== rectRef.current.width
+      || clamped.height !== rectRef.current.height
+    ) {
+      onRectChange(cardKey, clamped);
+    }
+  }, [bounds.width, bounds.height, cardKey, onRectChange]);
 
   /**
    * Returns whether the turn actually reached the backend. A peer can drop

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -49,6 +49,7 @@ import {
   computeClusterCloud,
   emptyCloudMemory,
   forgetCluster,
+  resolveCloudDrop,
   type StarMapClusterPlacement,
   type StarMapCloudMemory,
 } from "./star-map-clusters";
@@ -2216,6 +2217,70 @@ export function StarMapScreen(props: StarMapScreenProps) {
       </svg>
     ) : null;
 
+  /**
+   * A card dropped inside another cloud joins it, where "joining" is a
+   * thing the data can actually express — see `resolveCloudDrop`. Only
+   * parent/child membership moves: a project cloud groups on the thread's
+   * workspace, and a drag does not get to relink that.
+   *
+   * The hand-placed offset is cleared on the way, because it was measured
+   * from the OLD cloud's centre; keeping it would fling the card back out
+   * of the cloud it was just dropped into.
+   */
+  const applyCloudDrop = useCallback(
+    (params: {
+      instanceId: string;
+      thread: NavigationThreadSummary;
+      point: { x: number; y: number };
+    }): boolean => {
+      const cloud = clusterClouds?.get(params.instanceId);
+      if (!cloud || !desktopApi?.setThreadParent) return false;
+      const drop = resolveCloudDrop({
+        clusters: cloud.clusters,
+        point: params.point,
+        thread: params.thread,
+      });
+      if (drop.kind === "none") return false;
+
+      const threadKey = buildThreadIdentityKey(
+        params.thread.source,
+        params.thread.id,
+      );
+      arrangement.setCardPosition(params.instanceId, threadKey, null);
+      // The target cloud is about to gain or lose a card, so it re-fits
+      // rather than trying to seat the newcomer in a shape built without
+      // it. Every other cloud keeps its layout.
+      cloudMemory.current.set(
+        params.instanceId,
+        forgetCluster(
+          cloudMemory.current.get(params.instanceId) ?? emptyCloudMemory(),
+          drop.clusterKey,
+        ),
+      );
+      void desktopApi
+        .setThreadParent({
+          backend: params.thread.source,
+          threadId: params.thread.id,
+          ...(drop.kind === "adopt"
+            ? {
+                parentThreadId: drop.parent.id,
+                parentThreadBackend: drop.parent.source,
+              }
+            : { parentThreadId: null, parentThreadBackend: null }),
+        })
+        .then(() => refreshOwner(params.instanceId))
+        .catch((error: unknown) => {
+          setCardError(
+            error instanceof Error
+              ? error.message
+              : "Could not regroup that thread.",
+          );
+        });
+      return true;
+    },
+    [arrangement, clusterClouds, desktopApi, refreshOwner],
+  );
+
   const renderCloud = (position: {
     instanceId: string;
     x: number;
@@ -2424,7 +2489,30 @@ export function StarMapScreen(props: StarMapScreenProps) {
                           `${position.instanceId}::${threadKey}`,
                           delta,
                         ),
-                      onCommitOffset: (offset) =>
+                      onCommitOffset: (offset) => {
+                        // Where the card actually landed, body-relative
+                        // and by its centre — a drop is about the middle
+                        // of the card, not its top-left corner.
+                        if (
+                          cardCluster
+                          && applyCloudDrop({
+                            instanceId: position.instanceId,
+                            point: {
+                              x: anchorSlot.dx + offset.dx,
+                              y:
+                                anchorSlot.dy
+                                + offset.dy
+                                + (heights[index]
+                                  ?? STAR_MAP_ESTIMATED_CARD_HEIGHT) / 2,
+                            },
+                            thread,
+                          })
+                        ) {
+                          // Regrouped: the card belongs to another cloud
+                          // now and `applyCloudDrop` already cleared the
+                          // offset this would otherwise write back.
+                          return;
+                        }
                         arrangement.setCardPosition(
                           position.instanceId,
                           threadKey,
@@ -2439,7 +2527,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
                                   slot.dy + offset.dy - cardCluster.center.y,
                               }
                             : offset,
-                        ),
+                        );
+                      },
                     }
                   : undefined
               }

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -46,7 +46,10 @@ import {
 import {
   buildInstanceClusters,
   computeClusterCloud,
+  emptyCloudMemory,
+  forgetCluster,
   type StarMapClusterPlacement,
+  type StarMapCloudMemory,
 } from "./star-map-clusters";
 import {
   addFilterMatchCounts,
@@ -127,12 +130,26 @@ const LANE_CANVAS_PADDING = 120;
  */
 const ORBIT_LOAD_CARD_DY = -150;
 /**
- * The load card paints above every thread card in its cloud. Thread cards
- * take z 0..n by stack position, so a load card left at 0 ends up UNDER the
- * cards it sits among — and an operator-summoned readout hiding behind a
- * thread card reads as a broken button.
+ * Paint layers inside one cloud. `.star-map__cloud` is positioned with a
+ * z-index, so it opens a stacking context and these values are local to
+ * one instance's cards.
+ *
+ * Thread cards take 0..n by stack position, and n is NO LONGER BOUNDED —
+ * a cloud expands as far as the operator asks — so everything that must
+ * paint above the stack is pinned well clear of it rather than derived
+ * from a card cap. Deriving the load card's layer from the lane cap is
+ * exactly how it ended up underneath the 50th card, and the CSS hover
+ * raise (which must also clear the stack) had the same bug: a hovered
+ * card was pushed BELOW its neighbours instead of above them.
+ *
+ * `.star-map__cluster-label` / `-overflow` (chrome) and
+ * `.star-map-card-shell:hover` live in app.css and are pinned to these
+ * numbers by star-map-z-layers.test.ts.
  */
-const STAR_MAP_LOAD_CARD_Z = LANE_MAX_CARDS_PER_INSTANCE + 10;
+const STAR_MAP_CARD_MAX_Z = 4000;
+export const STAR_MAP_CLOUD_CHROME_Z = 5000;
+export const STAR_MAP_CARD_HOVER_Z = 6000;
+const STAR_MAP_LOAD_CARD_Z = 7000;
 /**
  * Chat cards float above the map chrome (close button, filters, view
  * options) so a card being read is never underneath a control strip.
@@ -260,6 +277,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const [expandedClusters, setExpandedClusters] = useState<Set<string>>(
     new Set(),
   );
+  /**
+   * Last cloud layout per instance. Held in a ref rather than state: it is
+   * an output of the layout that the next layout reads back, so writing it
+   * must not itself schedule a render. See `StarMapCloudMemory`.
+   */
+  const cloudMemory = useRef(new Map<string, StarMapCloudMemory>());
   // Orbit places bodies on a canvas larger than the window, so the surface
   // pans and zooms rather than compressing the map to fit.
   const [view, setView] = useState({ x: 0, y: 0, scale: 1 });
@@ -689,15 +712,20 @@ export function StarMapScreen(props: StarMapScreenProps) {
           expandedKeys.add(entry.slice(prefix.length));
         }
       }
-      clouds.set(
-        instanceId,
-        computeClusterCloud({
-          clusters: buildInstanceClusters({ threads, expandedKeys }),
-          cardWidth: ORBIT_CARD_WIDTH,
-          heightForThread: (threadKey) =>
-            cardHeights.get(threadKey) ?? STAR_MAP_ESTIMATED_CARD_HEIGHT,
-        }),
-      );
+      const cloud = computeClusterCloud({
+        clusters: buildInstanceClusters({ threads, expandedKeys }),
+        cardWidth: ORBIT_CARD_WIDTH,
+        heightForThread: (threadKey) =>
+          cardHeights.get(threadKey) ?? STAR_MAP_ESTIMATED_CARD_HEIGHT,
+        memory: cloudMemory.current.get(instanceId),
+      });
+      // Carrying the layout forward is what keeps an archived thread from
+      // moving everything else: seats, ring allocation and cloud centres
+      // all persist across the snapshot that removed it. Re-running this
+      // memo with the same input is idempotent — every thread and cloud
+      // simply keeps what it was just given.
+      cloudMemory.current.set(instanceId, cloud.memory);
+      clouds.set(instanceId, cloud);
     }
     return clouds;
   }, [attentionByInstance, cardHeights, expandedClusters, orbitMode]);
@@ -727,6 +755,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
 
   const toggleClusterExpanded = useCallback(
     (instanceId: string, clusterKey: string) => {
+      // Unfolding or folding a cloud is a request to re-fit THAT cloud, so
+      // it forgets its seats and centre. Everything else keeps its layout.
+      cloudMemory.current.set(
+        instanceId,
+        forgetCluster(
+          cloudMemory.current.get(instanceId) ?? emptyCloudMemory(),
+          clusterKey,
+        ),
+      );
       setExpandedClusters((current) => {
         const next = new Set(current);
         const key = `${instanceId}::${clusterKey}`;
@@ -1872,7 +1909,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
               // Cloud slots hang cards from the top like lanes; only the
               // ring fallback (which renders no cards) centred on its slot.
               centered={orbitMode && !position.clusters}
-              stackIndex={index}
+              // Clamped so a deep cloud can never reach the layers above
+              // the stack (chrome, hover raise, load card).
+              stackIndex={Math.min(index, STAR_MAP_CARD_MAX_Z)}
               cardKey={`${position.instanceId}::${threadKey}`}
               selected={selection.has(`${position.instanceId}::${threadKey}`)}
               onToggleSelect={() =>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -41,6 +41,7 @@ import {
   cardRingSlots,
   computeOrbitPlacement,
   galaxyArmPath,
+  shouldPanOnWheel,
   shouldStartCanvasPan,
 } from "./star-map-orbit";
 import {
@@ -1037,6 +1038,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
       viewport: { width: viewportSize.width, height: viewportSize.height },
     };
     const onWheel = (event: WheelEvent) => {
+      // Pinch (ctrl+wheel) is a map gesture wherever the pointer is; a
+      // plain scroll over a chat card belongs to that card's transcript.
+      if (!event.ctrlKey && !shouldPanOnWheel(event.target)) return;
       event.preventDefault();
       if (event.ctrlKey) {
         operatorMovedViewRef.current = true;

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -2647,8 +2647,23 @@ export function StarMapScreen(props: StarMapScreenProps) {
           return (
             <div
               key={position.instanceId}
-              className="star-map__anchor"
-              style={{ left: position.x, top: position.y }}
+              className={`star-map__anchor${
+                overview ? " star-map__anchor--overview" : ""
+              }`}
+              style={{
+                left: position.x,
+                top: position.y,
+                // In overview the body is the only thing naming the
+                // machine — its cards are gone — so it counter-scales with
+                // the cloud labels rather than shrinking into the sky. The
+                // translate keeps it centred on its anchor point; the
+                // scale is applied about that same centre.
+                ...(overview
+                  ? {
+                      transform: `translate(-50%, -50%) scale(${chromeScale})`,
+                    }
+                  : {}),
+              }}
             >
               <StarMapInstanceCard
                 instanceId={position.instanceId}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -79,6 +79,7 @@ import { computeProjectLayout } from "./star-map-project-layout";
 import { StarMapProjectBody } from "./StarMapProjectBody";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { StarMapChatCard } from "./StarMapChatCard";
+import { chatCardEdgeToward } from "./star-map-chat-card-geometry";
 import type { StarMapCardMenuAction } from "./StarMapCardMenu";
 import { useStarMapChatCards } from "./useStarMapChatCards";
 import { IntakeDialog, type IntakeDialogTarget } from "./IntakeDialog";
@@ -1017,6 +1018,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
       ? { width: projectLayout.canvasWidth, height: projectLayout.canvasHeight }
       : lanesCanvas;
 
+  /** Canvas extent for callbacks defined above it (see `cardRectsRef`). */
+  const canvasBoundsRef = useRef(panZoomCanvas);
+  canvasBoundsRef.current = panZoomCanvas;
+
   // Trackpad: two-finger drag pans, pinch (ctrl+wheel) zooms about the
   // pointer. Registered natively because the listener must not be passive.
   // Sits below panZoomCanvas because the clamp needs the canvas size.
@@ -1231,6 +1236,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
   }, [displayLabelPartsById, peers]);
 
   const chatCards = useStarMapChatCards();
+  /** Threads with a chat card open, so their card can say so. */
+  const chattingThreadKeys = useMemo(
+    () => new Set(chatCards.cards.map((card) => card.key)),
+    [chatCards.cards],
+  );
   const { desktopApi, onFocusLocalInstance, onOpenLocalThread } = props;
   const openInstance = useCallback(
     (instanceId: string) => {
@@ -1251,7 +1261,31 @@ export function StarMapScreen(props: StarMapScreenProps) {
   // thread needs no pin and no snapshot merge.
   const openThread = useCallback(
     (thread: NavigationThreadSummary) => {
-      chatCards.open(thread);
+      // Open beside the thread's own card, in map coordinates. `cardRects`
+      // is read through a ref because it is declared further down; the
+      // callback only ever runs after a render has computed it.
+      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      let anchor: SnapRect | undefined;
+      for (const [key, rect] of cardRectsRef.current) {
+        if (key.endsWith(`::${threadKey}`)) {
+          anchor = rect;
+          break;
+        }
+      }
+      chatCards.open(
+        thread,
+        anchor
+          ? {
+              anchor: {
+                height: anchor.height,
+                width: anchor.width,
+                x: anchor.x,
+                y: anchor.y,
+              },
+              bounds: canvasBoundsRef.current,
+            }
+          : undefined,
+      );
     },
     [chatCards],
   );
@@ -1469,6 +1503,14 @@ export function StarMapScreen(props: StarMapScreenProps) {
     }
     return rects;
   }, [arrangement, bodies, lanes]);
+
+  /**
+   * Latest card geometry and canvas extent, for callbacks defined above
+   * them (opening a chat card beside its thread). Refs rather than deps so
+   * those callbacks stay stable across every snapshot.
+   */
+  const cardRectsRef = useRef(cardRects);
+  cardRectsRef.current = cardRects;
 
   /**
    * Build the snap for one card. Threshold is screen-space so the pull
@@ -1749,6 +1791,75 @@ export function StarMapScreen(props: StarMapScreenProps) {
     [bodies, cardRects, lanes, selection, view.scale],
   );
 
+  /**
+   * A line from each open chat card to the thread card it belongs to.
+   *
+   * Opening beside the source does most of the work, but a card can be
+   * dragged anywhere in the galaxy afterwards — and five open chats with
+   * no visible owner is the thing to avoid. Drawn inside the canvas, so
+   * it pans and zooms with both of its endpoints for free.
+   *
+   * A chat card whose thread has no card on the map (filtered out, or
+   * folded into a cloud's overflow) simply gets no tether: a line to
+   * nowhere is worse than no line.
+   */
+  const chatTethers = useMemo(() => {
+    if (chatCards.cards.length === 0 || projectsMode) return [];
+    return chatCards.cards.flatMap((card) => {
+      let source: SnapRect | undefined;
+      for (const [key, rect] of cardRects) {
+        if (key.endsWith(`::${card.key}`)) {
+          source = rect;
+          break;
+        }
+      }
+      if (!source) return [];
+      const target = {
+        x: source.x + source.width / 2,
+        y: source.y + source.height / 2,
+      };
+      const from = chatCardEdgeToward(card.rect, target);
+      const midX = (from.x + target.x) / 2;
+      const midY = (from.y + target.y) / 2;
+      // A shallow arc, so the tether reads as part of the same sky as the
+      // instance links rather than as a UI connector.
+      const lift = 0.12;
+      return [
+        {
+          key: card.key,
+          path:
+            `M ${from.x.toFixed(2)} ${from.y.toFixed(2)}`
+            + ` Q ${(midX + (target.y - from.y) * lift).toFixed(2)}`
+            + ` ${(midY - (target.x - from.x) * lift).toFixed(2)}`
+            + ` ${target.x.toFixed(2)} ${target.y.toFixed(2)}`,
+          target,
+        },
+      ];
+    });
+  }, [cardRects, chatCards.cards, projectsMode]);
+
+  const chatTetherPaths =
+    chatTethers.length > 0 ? (
+      <svg
+        className="star-map__tethers"
+        width={panZoomCanvas.width || viewportSize.width}
+        height={panZoomCanvas.height || viewportSize.height}
+        aria-hidden="true"
+      >
+        {chatTethers.map((tether) => (
+          <g key={tether.key}>
+            <path className="star-map__tether" d={tether.path} />
+            <circle
+              className="star-map__tether-anchor"
+              cx={tether.target.x}
+              cy={tether.target.y}
+              r={3}
+            />
+          </g>
+        ))}
+      </svg>
+    ) : null;
+
   const renderCloud = (position: {
     instanceId: string;
     x: number;
@@ -1914,6 +2025,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
               stackIndex={Math.min(index, STAR_MAP_CARD_MAX_Z)}
               cardKey={`${position.instanceId}::${threadKey}`}
               selected={selection.has(`${position.instanceId}::${threadKey}`)}
+              chatting={chattingThreadKeys.has(threadKey)}
               onToggleSelect={() =>
                 toggleSelected(`${position.instanceId}::${threadKey}`)
               }
@@ -2384,6 +2496,40 @@ export function StarMapScreen(props: StarMapScreenProps) {
               );
             })
           : null}
+        {chatTetherPaths}
+        {/* Chat cards live INSIDE `.star-map__canvas`: they are objects in
+            the galaxy, not windows over it. Panning away and coming back
+            finds the open chats exactly where they were left, which is the
+            whole point of opening five of them and scooting off. */}
+        {chatCards.cards.map((card) => {
+          const target = card.thread.federation?.ref.target;
+          const cardInstanceId =
+            target && isRemoteFederationTarget(target)
+              ? target.instanceId
+              : undefined;
+          return (
+            <StarMapChatCard
+              key={card.key}
+              cardKey={card.key}
+              desktopApi={props.desktopApi}
+              instanceIcon={celestialIcons.iconFor(cardInstanceId)}
+              instanceLabel={
+                cardInstanceId
+                  ? displayLabelById.get(cardInstanceId)
+                  : displayLabelById.get(localInstanceId ?? "")
+              }
+              onClose={chatCards.close}
+              onOpenFull={openThreadFully}
+              onRaise={chatCards.raise}
+              onRectChange={chatCards.setRect}
+              rect={card.rect}
+              thread={card.thread}
+              scale={view.scale}
+              bounds={panZoomCanvas}
+              zIndex={STAR_MAP_CHAT_CARD_BASE_Z + chatCards.depthOf(card.key)}
+            />
+          );
+        })}
         </div>
       </div>
       {intakeTarget ? (
@@ -2412,36 +2558,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
           }}
         />
       ) : null}
-      {/* Chat cards sit outside `.star-map__canvas` on purpose: they are
-          windows over the star field, not objects in it, so panning and
-          zooming the map must not move or scale them. */}
-      {chatCards.cards.map((card) => {
-        const target = card.thread.federation?.ref.target;
-        const cardInstanceId =
-          target && isRemoteFederationTarget(target)
-            ? target.instanceId
-            : undefined;
-        return (
-          <StarMapChatCard
-            key={card.key}
-            cardKey={card.key}
-            desktopApi={props.desktopApi}
-            instanceIcon={celestialIcons.iconFor(cardInstanceId)}
-            instanceLabel={
-              cardInstanceId
-                ? displayLabelById.get(cardInstanceId)
-                : displayLabelById.get(localInstanceId ?? "")
-            }
-            onClose={chatCards.close}
-            onOpenFull={openThreadFully}
-            onRaise={chatCards.raise}
-            onRectChange={chatCards.setRect}
-            rect={card.rect}
-            thread={card.thread}
-            zIndex={STAR_MAP_CHAT_CARD_BASE_Z + chatCards.depthOf(card.key)}
-          />
-        );
-      })}
       {cardError ? (
         <p className="star-map__card-error" role="alert">
           {cardError}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -147,7 +147,7 @@ const ORBIT_LOAD_CARD_DY = -150;
  * `.star-map-card-shell:hover` live in app.css and are pinned to these
  * numbers by star-map-z-layers.test.ts.
  */
-const STAR_MAP_CARD_MAX_Z = 4000;
+export const STAR_MAP_CARD_MAX_Z = 4000;
 export const STAR_MAP_CLOUD_CHROME_Z = 5000;
 export const STAR_MAP_CARD_HOVER_Z = 6000;
 const STAR_MAP_LOAD_CARD_Z = 7000;
@@ -692,6 +692,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
       const kept = [...current].filter((key) => present.has(key));
       return kept.length === current.size ? current : new Set(kept);
     });
+    // Keyed on `.size` rather than the set: the guard above returns the
+    // same reference when nothing is released, so identity would be a
+    // stable dep too — but size makes the "runs when the set grows or
+    // shrinks" intent explicit and cannot loop through its own setState.
   }, [archivedThreadKeys.size, props.localThreads, remote]);
 
   /**
@@ -1266,10 +1270,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
       // callback only ever runs after a render has computed it.
       const threadKey = buildThreadIdentityKey(thread.source, thread.id);
       let anchor: SnapRect | undefined;
-      for (const [key, rect] of cardRectsRef.current) {
-        if (key.endsWith(`::${threadKey}`)) {
-          anchor = rect;
-          break;
+      // `cardRects` is built from the lane/orbit bodies, which is NOT where
+      // the projects lens draws its cards — anchoring to it there would
+      // open the chat at a position unrelated to anything on screen. That
+      // lens falls back to the cascade until it publishes its own rects.
+      if (!projectsModeRef.current) {
+        for (const [key, rect] of cardRectsRef.current) {
+          if (key.endsWith(`::${threadKey}`)) {
+            anchor = rect;
+            break;
+          }
         }
       }
       chatCards.open(
@@ -1511,6 +1521,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
    */
   const cardRectsRef = useRef(cardRects);
   cardRectsRef.current = cardRects;
+  const projectsModeRef = useRef(projectsMode);
+  projectsModeRef.current = projectsMode;
 
   /**
    * Build the snap for one card. Threshold is screen-space so the pull
@@ -1740,34 +1752,44 @@ export function StarMapScreen(props: StarMapScreenProps) {
       override?: { baseSlot: StarMapCardSlot; height: number },
     ) => {
       const selfKey = `${instanceId}::${threadKey}`;
-      if (!cardRects.has(selfKey)) return undefined;
-      // A card carrying a selection must not snap to the rest of it. Those
-      // cards travel rigidly with this one, so their relative offset never
-      // changes and every "alignment" against them is a false latch at
-      // whatever spacing the group already had.
-      const passengers = selection.has(selfKey) ? selection : undefined;
-      const others = [...cardRects.entries()]
-        .filter(([key]) => key !== selfKey && !passengers?.has(key))
-        .map(([, rect]) => rect);
-      if (others.length === 0) return undefined;
-
-      const body = bodies.find((entry) => entry.instanceId === instanceId);
-      const lane = lanes.get(instanceId);
-      const index =
-        lane?.threads.findIndex(
-          (thread) =>
-            buildThreadIdentityKey(thread.source, thread.id) === threadKey,
-        ) ?? -1;
-      const baseSlot =
-        override?.baseSlot ?? (index >= 0 ? body?.slots[index] : undefined);
-      if (!body || !baseSlot) return undefined;
-
-      // See the note in `cardRects`: unmeasured cards report 0, not undefined.
-      const height =
-        override?.height ?? (lane?.heights[index] || STAR_MAP_ESTIMATED_CARD_HEIGHT);
-      const scale = view.scale > 0 ? view.scale : 1;
-
+      // Everything below runs INSIDE the returned closure, which only runs
+      // while a card is actually being dragged. Doing it here instead cost
+      // a full pass over every card's rect — plus a thread-key rebuild per
+      // lane entry — once per card per render, so a map of n cards paid
+      // O(n^2) on every snapshot while nothing was being dragged at all.
       return (offset: { dx: number; dy: number }) => {
+        const unchanged = { dx: offset.dx, dy: offset.dy, guides: [] };
+        const selfRect = cardRects.get(selfKey);
+        if (!selfRect) return unchanged;
+        // A card carrying a selection must not snap to the rest of it.
+        // Those cards travel rigidly with this one, so their relative
+        // offset never changes and every "alignment" against them is a
+        // false latch at whatever spacing the group already had.
+        const passengers = selection.has(selfKey) ? selection : undefined;
+        const others: SnapRect[] = [];
+        for (const [key, rect] of cardRects) {
+          if (key === selfKey || passengers?.has(key)) continue;
+          others.push(rect);
+        }
+        if (others.length === 0) return unchanged;
+
+        const body = bodies.find((entry) => entry.instanceId === instanceId);
+        const lane = lanes.get(instanceId);
+        const index =
+          lane?.threads.findIndex(
+            (thread) =>
+              buildThreadIdentityKey(thread.source, thread.id) === threadKey,
+          ) ?? -1;
+        const baseSlot =
+          override?.baseSlot ?? (index >= 0 ? body?.slots[index] : undefined);
+        if (!body || !baseSlot) return unchanged;
+
+        // See the note in `cardRects`: unmeasured cards report 0, not
+        // undefined.
+        const height =
+          override?.height
+          ?? (lane?.heights[index] || STAR_MAP_ESTIMATED_CARD_HEIGHT);
+        const scale = view.scale > 0 ? view.scale : 1;
         const snap = resolveSnap({
           defaultGap: STAR_MAP_CARD_GAP,
           moving: {

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -1662,18 +1662,20 @@ export function StarMapScreen(props: StarMapScreenProps) {
             }}
           />
         ) : null}
-        {/* Outlines paint under the cards: same layer, earlier in DOM. */}
+        {/* Nebula smudges paint under the cards: same layer, earlier in
+            DOM. Sized past the card extent so the glow falls off around
+            the cloud instead of stopping at it. */}
         {position.clusters?.map((cluster) =>
           cluster.chromeless ? null : (
-            <div
-              key={`cluster:${cluster.key}`}
-              className="star-map__cluster"
+            <span
+              key={`cluster-halo:${cluster.key}`}
+              className="star-map__cluster-halo"
               aria-hidden="true"
               style={{
-                left: cluster.rect.x,
-                top: cluster.rect.y,
-                width: cluster.rect.width,
-                height: cluster.rect.height,
+                left: cluster.center.x,
+                top: cluster.center.y,
+                width: cluster.extent.rx * 2.6,
+                height: cluster.extent.ry * 2.7,
               }}
             />
           ),
@@ -1729,11 +1731,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
         {visible.map((thread, index) => {
           const slot = slots[index];
           const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-          const clusterIndex = position.clusterIndexByCard?.[index];
-          const cardCluster =
-            clusterIndex !== undefined
-              ? position.clusters?.[clusterIndex]
-              : undefined;
           return (
             <StarMapThreadCard
               key={threadKey}
@@ -1762,18 +1759,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
               onToggleSelect={() =>
                 toggleSelected(`${position.instanceId}::${threadKey}`)
               }
-              // Inside a labeled project cloud the directory chips repeat
-              // the pill; the projects lens sets the same precedent ("the
-              // project IS the sun").
-              cardFields={
-                cardCluster?.isProject
-                  ? {
-                      ...preferences.cardFields,
-                      primaryDirectory: false,
-                      secondaryDirectories: false,
-                    }
-                  : preferences.cardFields
-              }
+              // Cards keep their full chip anatomy inside a cloud — the
+              // cloud label groups them, it does not replace what they say.
+              cardFields={preferences.cardFields}
               menuActions={cardMenuActions(thread, position.instanceId)}
               drag={
                 // Drags persist + sync only once the durable instance id is
@@ -1843,17 +1831,17 @@ export function StarMapScreen(props: StarMapScreenProps) {
             && clusterCardKeys.every((key) => selection.has(key));
           return (
             <button
-              key={`cluster-pill:${cluster.key}`}
+              key={`cluster-label:${cluster.key}`}
               type="button"
-              className="star-map__cluster-pill"
-              style={{ left: cluster.rect.x + 12, top: cluster.rect.y + 10 }}
+              className="star-map__cluster-label"
+              style={{ left: cluster.labelSlot.dx, top: cluster.labelSlot.dy }}
               aria-pressed={allSelected}
               aria-label={`Select the ${cluster.label} cards (${cluster.threads.length} threads)`}
               onClick={() =>
                 toggleClusterSelection(position.instanceId, cluster)
               }
             >
-              <span className="star-map__cluster-label">{cluster.label}</span>
+              <span className="star-map__cluster-name">{cluster.label}</span>
               <span className="star-map__cluster-count">
                 {cluster.threads.length}
               </span>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -37,11 +37,17 @@ import {
   type StarMapCardSlot,
 } from "./star-map-layout";
 import {
+  cardRingExtent,
   cardRingSlots,
   computeOrbitPlacement,
   galaxyArmPath,
   shouldStartCanvasPan,
 } from "./star-map-orbit";
+import {
+  buildInstanceClusters,
+  computeClusterCloud,
+  type StarMapClusterPlacement,
+} from "./star-map-clusters";
 import {
   addFilterMatchCounts,
   countFilterMatches,
@@ -103,10 +109,15 @@ import { useStarMapThreads } from "./useStarMapThreads";
  */
 const LANE_MAX_CARDS_PER_INSTANCE = 40;
 const STAR_COUNT = 130;
-/** Orbit rings use a fixed card width; lanes narrow theirs to fit. */
+/** Orbit clouds use a fixed card width; lanes narrow theirs to fit. */
 const ORBIT_CARD_WIDTH = 200;
-/** A ring crowds geometrically, so orbit stays shallower than a column. */
-const ORBIT_MAX_CARDS_PER_INSTANCE = 16;
+/**
+ * Projects-lens ring cap: a ring crowds geometrically, so a project body
+ * stays shallower than a column. The orbit lens no longer rings — its caps
+ * live in star-map-clusters (per-group plus a cloud backstop), each cloud
+ * carrying its own "+N more" chip instead of truncating silently.
+ */
+const PROJECT_MAX_CARDS_PER_BODY = 16;
 /** Breathing room past the longest column / widest lane when panning. */
 const LANE_CANVAS_PADDING = 120;
 /**
@@ -230,6 +241,14 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const observedCardElementsRef = useRef(new Map<HTMLElement, string>());
   const [preferences, setPreferences] = useState<StarMapViewPreferences>(
     readStoredPreferences,
+  );
+  /**
+   * Project clouds the operator expanded past the per-group cap, keyed
+   * `instanceId::clusterKey`. View-local like the selection: how much of a
+   * cloud is unfolded is a "what am I looking at" gesture, not fleet state.
+   */
+  const [expandedClusters, setExpandedClusters] = useState<Set<string>>(
+    new Set(),
   );
   // Orbit places bodies on a canvas larger than the window, so the surface
   // pans and zooms rather than compressing the map to fit.
@@ -608,6 +627,50 @@ export function StarMapScreen(props: StarMapScreenProps) {
     remote,
   ]);
 
+  /**
+   * Orbit-lens project clouds: each instance's threads grouped by project,
+   * capped per group, and seated around the body. Undefined outside orbit
+   * so the other lenses pay nothing for it.
+   */
+  const clusterClouds = useMemo(() => {
+    if (!orbitMode) return undefined;
+    const clouds = new Map<
+      string,
+      ReturnType<typeof computeClusterCloud>
+    >();
+    for (const [instanceId, threads] of attentionByInstance) {
+      const prefix = `${instanceId}::`;
+      const expandedKeys = new Set<string>();
+      for (const entry of expandedClusters) {
+        if (entry.startsWith(prefix)) {
+          expandedKeys.add(entry.slice(prefix.length));
+        }
+      }
+      clouds.set(
+        instanceId,
+        computeClusterCloud({
+          clusters: buildInstanceClusters({ threads, expandedKeys }),
+          cardWidth: ORBIT_CARD_WIDTH,
+          heightForThread: (threadKey) =>
+            cardHeights.get(threadKey) ?? STAR_MAP_ESTIMATED_CARD_HEIGHT,
+        }),
+      );
+    }
+    return clouds;
+  }, [attentionByInstance, cardHeights, expandedClusters, orbitMode]);
+
+  const toggleClusterExpanded = useCallback(
+    (instanceId: string, clusterKey: string) => {
+      setExpandedClusters((current) => {
+        const next = new Set(current);
+        const key = `${instanceId}::${clusterKey}`;
+        if (!next.delete(key)) next.add(key);
+        return next;
+      });
+    },
+    [],
+  );
+
   const projects = useMemo(
     () => groupThreadsByProject(attentionByInstance),
     [attentionByInstance],
@@ -626,7 +689,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
           key: project.key,
           cardCount: Math.min(
             project.threads.length,
-            ORBIT_MAX_CARDS_PER_INSTANCE,
+            PROJECT_MAX_CARDS_PER_BODY,
           ),
           mass: project.mass,
         })),
@@ -689,27 +752,37 @@ export function StarMapScreen(props: StarMapScreenProps) {
       { threads: NavigationThreadSummary[]; heights: number[]; count: number }
     >();
     for (const [instanceId, threads] of attentionByInstance) {
+      // Orbit reads its cloud layout: the flat list is already grouped,
+      // capped per cluster, and slot-aligned, so the lane triple simply
+      // mirrors it. Per-cloud "+N more" chips carry the overflow.
+      if (orbitMode) {
+        const cloud = clusterClouds?.get(instanceId);
+        result.set(instanceId, {
+          threads: cloud?.threads ?? [],
+          heights: cloud?.heights ?? [],
+          count: cloud?.threads.length ?? 0,
+        });
+        continue;
+      }
       const heights = threads.map(
         (thread) =>
           cardHeights.get(buildThreadIdentityKey(thread.source, thread.id))
           ?? STAR_MAP_ESTIMATED_CARD_HEIGHT,
       );
       // A lane is no longer bounded by the window: the column grows as long
-      // as it needs and the operator pans and zooms into it, the way the
-      // orbit lens already worked. Truncating at the fold hid curated
-      // threads that were never coming back into view — the cap that
-      // remains is a DOM-size backstop, not a design limit.
-      const count = orbitMode
-        ? Math.min(threads.length, ORBIT_MAX_CARDS_PER_INSTANCE)
-        : visibleCardCount({
-            heights,
-            availableHeight: Number.POSITIVE_INFINITY,
-            max: LANE_MAX_CARDS_PER_INSTANCE,
-          });
+      // as it needs and the operator pans and zooms into it. Truncating at
+      // the fold hid curated threads that were never coming back into
+      // view — the cap that remains is a DOM-size backstop, not a design
+      // limit.
+      const count = visibleCardCount({
+        heights,
+        availableHeight: Number.POSITIVE_INFINITY,
+        max: LANE_MAX_CARDS_PER_INSTANCE,
+      });
       result.set(instanceId, { threads, heights, count });
     }
     return result;
-  }, [attentionByInstance, cardHeights, orbitMode]);
+  }, [attentionByInstance, cardHeights, clusterClouds, orbitMode]);
 
   const topology = useMemo(
     () =>
@@ -727,38 +800,55 @@ export function StarMapScreen(props: StarMapScreenProps) {
       computeOrbitPlacement({
         nodes: topology,
         cardCounts: new Map(
-          // Deliberately NOT counting the load card: ring radius is derived
-          // from card count, so including it would move every thread card
-          // on the ring the moment the load card opened.
+          // Deliberately NOT counting the load card: extent is derived
+          // from the cards, so including it would move every thread card
+          // in the cloud the moment the load card opened.
           [...lanes].map(([instanceId, lane]) => [instanceId, lane.count]),
         ),
         cardWidth: ORBIT_CARD_WIDTH,
+        // Cloud extents measured from the seated clusters, so instance
+        // spacing tracks what is actually drawn rather than a ring formula.
+        extents: clusterClouds
+          ? new Map(
+              [...clusterClouds].map(([instanceId, cloud]) => [
+                instanceId,
+                cloud.extent,
+              ]),
+            )
+          : undefined,
       }),
-    [lanes, topology],
+    [clusterClouds, lanes, topology],
   );
 
   /** Bodies plus their card slots, in whichever space the layout uses. */
   const bodies = useMemo(() => {
     if (orbitMode) {
-      return orbit.instances.map((instance) => ({
-        instanceId: instance.instanceId,
-        isHub: instance.isHub,
-        x: instance.x,
-        y: instance.y,
-        slots: instance.cardSlots,
-        cardWidth: ORBIT_CARD_WIDTH,
-        // Above the body, at a radius that does not depend on how many
-        // cards the rings hold — so opening it disturbs nothing. Gated on
-        // membership like the lanes branch: without the check the card
-        // rendered forever in this lens, and dismissing it only flipped the
-        // toggle that reads the same membership.
-        loadSlot: loadCardInstances.has(instance.instanceId)
-          ? { dx: 0, dy: ORBIT_LOAD_CARD_DY }
-          : undefined,
-        // Rings grow their radius, so orbit's canvas is already sized by
-        // `computeOrbitPlacement`; only lanes derive theirs from content.
-        contentBottom: 0,
-      }));
+      return orbit.instances.map((instance) => {
+        const cloud = clusterClouds?.get(instance.instanceId);
+        return {
+          instanceId: instance.instanceId,
+          isHub: instance.isHub,
+          x: instance.x,
+          y: instance.y,
+          // Cloud slots when the instance has a thread feed; the ring
+          // fallback only ever renders zero cards (no cloud, no lane).
+          slots: cloud?.slots ?? instance.cardSlots,
+          clusters: cloud?.clusters,
+          clusterIndexByCard: cloud?.clusterIndexByCard,
+          cardWidth: ORBIT_CARD_WIDTH,
+          // Above the body, at a radius that does not depend on how many
+          // cards the clouds hold — so opening it disturbs nothing. Gated
+          // on membership like the lanes branch: without the check the card
+          // rendered forever in this lens, and dismissing it only flipped
+          // the toggle that reads the same membership.
+          loadSlot: loadCardInstances.has(instance.instanceId)
+            ? { dx: 0, dy: ORBIT_LOAD_CARD_DY }
+            : undefined,
+          // Clouds grow their extent, so orbit's canvas is already sized by
+          // `computeOrbitPlacement`; only lanes derive theirs from content.
+          contentBottom: 0,
+        };
+      });
     }
     return laneLayout.positions.map((position) => {
       const lane = lanes.get(position.instanceId);
@@ -790,7 +880,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
             : 0,
       };
     });
-  }, [laneLayout, lanes, loadCardInstances, orbit, orbitMode]);
+  }, [clusterClouds, laneLayout, lanes, loadCardInstances, orbit, orbitMode]);
 
   /**
    * Lanes canvas: as wide as the instance row and as tall as the longest
@@ -1398,6 +1488,34 @@ export function StarMapScreen(props: StarMapScreenProps) {
     });
   }, []);
 
+  /**
+   * A cloud's label pill selects its visible cards as one group, so the
+   * existing group drag moves the whole cloud. Only visible cards join —
+   * a hidden card has no shell to move, and a selection entry that cannot
+   * be seen would surface as a card teleporting on some later expand.
+   */
+  const toggleClusterSelection = useCallback(
+    (instanceId: string, cluster: StarMapClusterPlacement) => {
+      const keys = cluster.threads
+        .slice(0, cluster.visibleCount)
+        .map(
+          (thread) =>
+            `${instanceId}::${buildThreadIdentityKey(thread.source, thread.id)}`,
+        );
+      if (keys.length === 0) return;
+      setSelection((current) => {
+        const allSelected = keys.every((key) => current.has(key));
+        const next = new Set(current);
+        for (const key of keys) {
+          if (allSelected) next.delete(key);
+          else next.add(key);
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
   const commitSelectionMove = useCallback(
     (draggedKey: string, delta: { dx: number; dy: number }) => {
       if (!selection.has(draggedKey)) return;
@@ -1500,6 +1618,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
     cardWidth: number;
     /** Set when this instance shows a load card; never a thread slot. */
     loadSlot?: StarMapCardSlot;
+    /** Orbit lens: project clouds with outlines, pills and overflow chips. */
+    clusters?: StarMapClusterPlacement[];
+    /** Cluster index per flat card, aligned with `slots`. */
+    clusterIndexByCard?: number[];
   }) => {
     const lane = lanes.get(position.instanceId);
     const threads = lane?.threads ?? [];
@@ -1540,6 +1662,22 @@ export function StarMapScreen(props: StarMapScreenProps) {
             }}
           />
         ) : null}
+        {/* Outlines paint under the cards: same layer, earlier in DOM. */}
+        {position.clusters?.map((cluster) =>
+          cluster.chromeless ? null : (
+            <div
+              key={`cluster:${cluster.key}`}
+              className="star-map__cluster"
+              aria-hidden="true"
+              style={{
+                left: cluster.rect.x,
+                top: cluster.rect.y,
+                width: cluster.rect.width,
+                height: cluster.rect.height,
+              }}
+            />
+          ),
+        )}
         {loadSlot ? (
           <StarMapLoadCard
             key={`load:${position.instanceId}`}
@@ -1591,6 +1729,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
         {visible.map((thread, index) => {
           const slot = slots[index];
           const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+          const clusterIndex = position.clusterIndexByCard?.[index];
+          const cardCluster =
+            clusterIndex !== undefined
+              ? position.clusters?.[clusterIndex]
+              : undefined;
           return (
             <StarMapThreadCard
               key={threadKey}
@@ -1610,14 +1753,27 @@ export function StarMapScreen(props: StarMapScreenProps) {
               baseSlot={slot}
               offset={arrangement.offsetFor(position.instanceId, threadKey)}
               width={position.cardWidth}
-              centered={orbitMode}
+              // Cloud slots hang cards from the top like lanes; only the
+              // ring fallback (which renders no cards) centred on its slot.
+              centered={orbitMode && !position.clusters}
               stackIndex={index}
               cardKey={`${position.instanceId}::${threadKey}`}
               selected={selection.has(`${position.instanceId}::${threadKey}`)}
               onToggleSelect={() =>
                 toggleSelected(`${position.instanceId}::${threadKey}`)
               }
-              cardFields={preferences.cardFields}
+              // Inside a labeled project cloud the directory chips repeat
+              // the pill; the projects lens sets the same precedent ("the
+              // project IS the sun").
+              cardFields={
+                cardCluster?.isProject
+                  ? {
+                      ...preferences.cardFields,
+                      primaryDirectory: false,
+                      secondaryDirectories: false,
+                    }
+                  : preferences.cardFields
+              }
               menuActions={cardMenuActions(thread, position.instanceId)}
               drag={
                 // Drags persist + sync only once the durable instance id is
@@ -1671,6 +1827,62 @@ export function StarMapScreen(props: StarMapScreenProps) {
             +{overflow} more
           </span>
         ) : null}
+        {position.clusters?.map((cluster) => {
+          if (cluster.chromeless) return null;
+          const clusterCardKeys = cluster.threads
+            .slice(0, cluster.visibleCount)
+            .map(
+              (thread) =>
+                `${position.instanceId}::${buildThreadIdentityKey(
+                  thread.source,
+                  thread.id,
+                )}`,
+            );
+          const allSelected =
+            clusterCardKeys.length > 0
+            && clusterCardKeys.every((key) => selection.has(key));
+          return (
+            <button
+              key={`cluster-pill:${cluster.key}`}
+              type="button"
+              className="star-map__cluster-pill"
+              style={{ left: cluster.rect.x + 12, top: cluster.rect.y + 10 }}
+              aria-pressed={allSelected}
+              aria-label={`Select the ${cluster.label} cards (${cluster.threads.length} threads)`}
+              onClick={() =>
+                toggleClusterSelection(position.instanceId, cluster)
+              }
+            >
+              <span className="star-map__cluster-label">{cluster.label}</span>
+              <span className="star-map__cluster-count">
+                {cluster.threads.length}
+              </span>
+            </button>
+          );
+        })}
+        {position.clusters?.map((cluster) =>
+          cluster.overflowSlot ? (
+            <button
+              key={`cluster-overflow:${cluster.key}`}
+              type="button"
+              className="star-map__cluster-overflow"
+              style={{
+                left: cluster.overflowSlot.dx,
+                top: cluster.overflowSlot.dy,
+              }}
+              aria-label={
+                cluster.overflow > 0
+                  ? `Show ${cluster.overflow} more ${cluster.label} threads`
+                  : `Show fewer ${cluster.label} threads`
+              }
+              onClick={() =>
+                toggleClusterExpanded(position.instanceId, cluster.key)
+              }
+            >
+              {cluster.overflow > 0 ? `+${cluster.overflow} more` : "Show fewer"}
+            </button>
+          ) : null,
+        )}
       </div>
     );
   };
@@ -1921,9 +2133,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
               if (!project) return null;
               const visible = project.threads.slice(
                 0,
-                ORBIT_MAX_CARDS_PER_INSTANCE,
+                PROJECT_MAX_CARDS_PER_BODY,
               );
               const slots = cardRingSlots(visible.length, ORBIT_CARD_WIDTH);
+              const ringOverflow = project.threads.length - visible.length;
               return (
                 <div
                   key={`project:${placement.key}`}
@@ -1986,6 +2199,21 @@ export function StarMapScreen(props: StarMapScreenProps) {
                       />
                     );
                   })}
+                  {/* The ring truncates silently otherwise — the same lie
+                      the orbit lens used to tell. */}
+                  {ringOverflow > 0 ? (
+                    <span
+                      className="star-map__cloud-overflow"
+                      style={{
+                        transform: `translate(-50%, ${
+                          cardRingExtent(visible.length, ORBIT_CARD_WIDTH).ry
+                          + 24
+                        }px)`,
+                      }}
+                    >
+                      +{ringOverflow} more
+                    </span>
+                  ) : null}
                 </div>
               );
             })

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -91,8 +91,10 @@ import {
 } from "./star-map-preferences";
 import {
   clampStarMapView,
+  isOverviewZoom,
   MAX_ZOOM,
   MIN_ZOOM,
+  overviewChromeScale,
   placeStarMapView,
   type StarMapView,
 } from "./star-map-view-geometry";
@@ -347,6 +349,13 @@ export function StarMapScreen(props: StarMapScreenProps) {
     [paintView],
   );
   const orbitMode = preferences.layout === "orbit";
+  /**
+   * Pulled far enough out that cards are unreadable. The map draws named
+   * clouds instead — legible at a glance, and a few DOM nodes instead of
+   * every card in the fleet.
+   */
+  const overview = isOverviewZoom(view.scale);
+  const chromeScale = overviewChromeScale(view.scale);
   /** Projects as suns: threads pooled across instances, one body per repo. */
   const projectsMode = preferences.layout === "projects";
   /**
@@ -2096,7 +2105,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
             onDismiss={() => toggleLoadCard(position.instanceId)}
           />
         ) : null}
-        {visible.map((thread, index) => {
+        {(overview && position.clusters ? [] : visible).map((thread, index) => {
           const slot = slots[index];
           const threadKey = buildThreadIdentityKey(thread.source, thread.id);
           const storedOffset = arrangement.offsetFor(
@@ -2241,8 +2250,21 @@ export function StarMapScreen(props: StarMapScreenProps) {
             <button
               key={`cluster-label:${cluster.key}`}
               type="button"
-              className="star-map__cluster-label"
-              style={{ left: cluster.labelSlot.dx, top: cluster.labelSlot.dy }}
+              className={`star-map__cluster-label${
+                overview ? " star-map__cluster-label--overview" : ""
+              }`}
+              style={{
+                left: cluster.labelSlot.dx,
+                // In overview the label IS the cloud, so it sits on the
+                // centre rather than above the cards it is captioning, and
+                // counter-scales to stay readable as the canvas shrinks.
+                top: overview ? cluster.center.y : cluster.labelSlot.dy,
+                ...(overview
+                  ? {
+                      transform: `translate(-50%, -50%) scale(${chromeScale})`,
+                    }
+                  : {}),
+              }}
               aria-pressed={allSelected}
               aria-label={`Select the ${cluster.label} cards (${cluster.threads.length} threads)`}
               onClick={() =>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -231,6 +231,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const [enteringThreadKeys, setEnteringThreadKeys] = useState<Set<string>>(
     new Set(),
   );
+  /**
+   * Threads the operator archived from a card whose snapshot has not
+   * caught up yet. Hidden immediately — a remote instance's feed refreshes
+   * on its own cadence, and an Archive click that visibly does nothing for
+   * ten seconds reads as broken. Restored on failure; released once the
+   * thread leaves its source feed for real.
+   */
+  const [archivedThreadKeys, setArchivedThreadKeys] = useState<Set<string>>(
+    new Set(),
+  );
   const [remoteRefreshNonce, setRemoteRefreshNonce] = useState(0);
   // Cards vary in height with their chip rows, so lanes stack from real
   // measurements - a fixed pitch clipped tall cards mid-glyph.
@@ -595,6 +605,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
   );
 
   const attentionByInstance = useMemo(() => {
+    const withoutArchived = (threads: NavigationThreadSummary[]) =>
+      archivedThreadKeys.size === 0
+        ? threads
+        : threads.filter(
+            (thread) =>
+              !archivedThreadKeys.has(
+                buildThreadIdentityKey(thread.source, thread.id),
+              ),
+          );
     const result = new Map<string, NavigationThreadSummary[]>();
     // The main-window snapshot also carries viewer-side pinned REMOTE
     // threads (Cmd+K unification). Those render under their owning
@@ -602,30 +621,54 @@ export function StarMapScreen(props: StarMapScreenProps) {
     // locally-owned threads only, or pinned remote cards would double up.
     result.set(
       localInstanceId,
-      selectFilteredThreads({
-        threads: props.localThreads.filter(
-          (thread) =>
-            !thread.federation
-            || !isRemoteFederationTarget(thread.federation.ref.target),
-        ),
-        selection: filterSelection,
-        sessionKeys: props.sessionKeys,
-      }),
+      withoutArchived(
+        selectFilteredThreads({
+          threads: props.localThreads.filter(
+            (thread) =>
+              !thread.federation
+              || !isRemoteFederationTarget(thread.federation.ref.target),
+          ),
+          selection: filterSelection,
+          sessionKeys: props.sessionKeys,
+        }),
+      ),
     );
     for (const [instanceId, threads] of remote.threadsByInstance) {
       result.set(
         instanceId,
-        selectFilteredThreads({ threads, selection: filterSelection }),
+        withoutArchived(
+          selectFilteredThreads({ threads, selection: filterSelection }),
+        ),
       );
     }
     return result;
   }, [
+    archivedThreadKeys,
     filterSelection,
     localInstanceId,
     props.localThreads,
     props.sessionKeys,
     remote,
   ]);
+
+  // Release optimistic hides once the thread has left its feed for real,
+  // so a future thread reusing the key is not silently invisible.
+  useEffect(() => {
+    if (archivedThreadKeys.size === 0) return;
+    const present = new Set<string>();
+    for (const thread of props.localThreads) {
+      present.add(buildThreadIdentityKey(thread.source, thread.id));
+    }
+    for (const threads of remote.threadsByInstance.values()) {
+      for (const thread of threads) {
+        present.add(buildThreadIdentityKey(thread.source, thread.id));
+      }
+    }
+    setArchivedThreadKeys((current) => {
+      const kept = [...current].filter((key) => present.has(key));
+      return kept.length === current.size ? current : new Set(kept);
+    });
+  }, [archivedThreadKeys.size, props.localThreads, remote]);
 
   /**
    * Orbit-lens project clouds: each instance's threads grouped by project,
@@ -658,6 +701,29 @@ export function StarMapScreen(props: StarMapScreenProps) {
     }
     return clouds;
   }, [attentionByInstance, cardHeights, expandedClusters, orbitMode]);
+
+  /**
+   * The anchor a hand-placed card's stored offset is measured from in the
+   * cluster lens: its cloud's centre. A placed card therefore rides with
+   * its cloud when the cloud re-seats, and holds its spot in the cloud
+   * when cloudmates come and go — the scatter slots reflow around it
+   * without touching it. Undefined outside orbit (lanes keep slot-relative
+   * offsets) and for non-thread cards like the load card.
+   */
+  const clusterAnchorFor = useCallback(
+    (instanceId: string, threadKey: string) => {
+      const cloud = clusterClouds?.get(instanceId);
+      if (!cloud) return undefined;
+      const index = cloud.threads.findIndex(
+        (thread) =>
+          buildThreadIdentityKey(thread.source, thread.id) === threadKey,
+      );
+      if (index < 0) return undefined;
+      const cluster = cloud.clusters[cloud.clusterIndexByCard[index]];
+      return { slot: cloud.slots[index], center: cluster.center };
+    },
+    [clusterClouds],
+  );
 
   const toggleClusterExpanded = useCallback(
     (instanceId: string, clusterKey: string) => {
@@ -871,6 +937,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
         x: position.x,
         y: position.y,
         slots,
+        // Lanes have no clouds; present for a uniform body shape so the
+        // shared consumers (cardRects, renderCloud) can branch on them.
+        clusters: undefined,
+        clusterIndexByCard: undefined,
         cardWidth: laneLayout.cardWidth,
         loadSlot: hasLoad ? { dx: 0, dy: STAR_MAP_CLOUD_TOP } : undefined,
         contentBottom: lastSlot
@@ -1252,6 +1322,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
           key: "archive",
           label: "Archive thread",
           onSelect: () => {
+            const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+            // Hide the card NOW. A remote feed refreshes on its own
+            // cadence, and an Archive that visibly does nothing until the
+            // next tick reads as a broken button.
+            setArchivedThreadKeys((current) => new Set(current).add(threadKey));
             void desktopApi
               .archiveThread?.({
                 backend: thread.source,
@@ -1259,12 +1334,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
                 threadId: thread.id,
               })
               .then(() => {
-                chatCards.close(
-                  buildThreadIdentityKey(thread.source, thread.id),
-                );
+                chatCards.close(threadKey);
                 refreshOwner(instanceId);
               })
               .catch((error: unknown) => {
+                // The archive did not happen; the card comes back.
+                setArchivedThreadKeys((current) => {
+                  const next = new Set(current);
+                  next.delete(threadKey);
+                  return next;
+                });
                 setCardError(
                   error instanceof Error
                     ? error.message
@@ -1327,14 +1406,25 @@ export function StarMapScreen(props: StarMapScreenProps) {
         if (!slot) return;
         const threadKey = buildThreadIdentityKey(thread.source, thread.id);
         const offset = arrangement.offsetFor(position.instanceId, threadKey);
+        // Placed cards anchor to their cloud centre in the cluster lens —
+        // the same rule the render path applies — so their rects land
+        // where the cards actually paint.
+        const cardCluster =
+          offset !== undefined && position.clusterIndexByCard !== undefined
+            ? position.clusters?.[position.clusterIndexByCard[index]]
+            : undefined;
+        const anchor = cardCluster
+          ? { dx: cardCluster.center.x, dy: cardCluster.center.y }
+          : slot;
         // `||`, not `??`: an unmeasured card reports 0, and a zero-height
         // rect is invisible to both snapping and selection.
         const height = lane.heights[index] || STAR_MAP_ESTIMATED_CARD_HEIGHT;
         rects.set(`${position.instanceId}::${threadKey}`, {
           // Cards are centred on their slot horizontally (marginLeft is
           // -width/2), so the rect's left edge is half a card back.
-          x: position.x + slot.dx + (offset?.dx ?? 0) - position.cardWidth / 2,
-          y: position.y + slot.dy + (offset?.dy ?? 0),
+          x:
+            position.x + anchor.dx + (offset?.dx ?? 0) - position.cardWidth / 2,
+          y: position.y + anchor.dy + (offset?.dy ?? 0),
           width: position.cardWidth,
           height,
         });
@@ -1536,17 +1626,29 @@ export function StarMapScreen(props: StarMapScreenProps) {
         if (separator < 0) continue;
         const instanceId = key.slice(0, separator);
         const threadKey = key.slice(separator + 2);
-        const current = arrangement.offsetFor(instanceId, threadKey) ?? {
-          dx: 0,
-          dy: 0,
-        };
+        const current = arrangement.offsetFor(instanceId, threadKey);
+        // A passenger placed for the first time by this group move needs
+        // the same cloud-centre anchoring a directly-dragged card gets:
+        // its stored offset will be read against the cloud centre, so its
+        // scatter position has to be folded in before the delta.
+        const anchor =
+          current === undefined
+            ? clusterAnchorFor(instanceId, threadKey)
+            : undefined;
+        const base = current
+          ?? (anchor
+            ? {
+                dx: anchor.slot.dx - anchor.center.x,
+                dy: anchor.slot.dy - anchor.center.y,
+              }
+            : { dx: 0, dy: 0 });
         arrangement.setCardPosition(instanceId, threadKey, {
-          dx: current.dx + delta.dx,
-          dy: current.dy + delta.dy,
+          dx: base.dx + delta.dx,
+          dy: base.dy + delta.dy,
         });
       }
     },
-    [arrangement, selection, shellsByKey],
+    [arrangement, clusterAnchorFor, selection, shellsByKey],
   );
 
   const snapFor = useCallback(
@@ -1731,6 +1833,23 @@ export function StarMapScreen(props: StarMapScreenProps) {
         {visible.map((thread, index) => {
           const slot = slots[index];
           const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+          const storedOffset = arrangement.offsetFor(
+            position.instanceId,
+            threadKey,
+          );
+          const cardCluster =
+            position.clusterIndexByCard !== undefined
+              ? position.clusters?.[position.clusterIndexByCard[index]]
+              : undefined;
+          // A placed card anchors to its cloud's centre instead of its
+          // scatter slot: cloudmates arriving or archiving away reflow the
+          // scatter, and an offset over a moving slot made every arranged
+          // card jump. See `clusterAnchorFor`.
+          const anchored =
+            cardCluster !== undefined && storedOffset !== undefined;
+          const anchorSlot = anchored
+            ? { dx: cardCluster.center.x, dy: cardCluster.center.y }
+            : slot;
           return (
             <StarMapThreadCard
               key={threadKey}
@@ -1747,8 +1866,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
                   ? undefined
                   : position.instanceId,
               )}
-              baseSlot={slot}
-              offset={arrangement.offsetFor(position.instanceId, threadKey)}
+              baseSlot={anchorSlot}
+              offset={storedOffset}
               width={position.cardWidth}
               // Cloud slots hang cards from the top like lanes; only the
               // ring fallback (which renders no cards) centred on its slot.
@@ -1776,6 +1895,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
                         position.instanceId,
                         threadKey,
                         position.cardWidth,
+                        // Anchored cards drag from the cloud centre, which
+                        // the lane-slot lookup inside snapFor cannot know.
+                        anchored
+                          ? {
+                              baseSlot: anchorSlot,
+                              height:
+                                heights[index]
+                                ?? STAR_MAP_ESTIMATED_CARD_HEIGHT,
+                            }
+                          : undefined,
                       ),
                       onGuidesChange: setActiveGuides,
                       onGroupDelta: (delta) =>
@@ -1792,7 +1921,17 @@ export function StarMapScreen(props: StarMapScreenProps) {
                         arrangement.setCardPosition(
                           position.instanceId,
                           threadKey,
-                          offset,
+                          // First placement: the drag ran against the
+                          // scatter slot, so re-express the result from
+                          // the cloud centre before it persists.
+                          cardCluster && !anchored
+                            ? {
+                                dx:
+                                  slot.dx + offset.dx - cardCluster.center.x,
+                                dy:
+                                  slot.dy + offset.dy - cardCluster.center.y,
+                              }
+                            : offset,
                         ),
                     }
                   : undefined

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -66,6 +66,8 @@ export function StarMapThreadCard(props: {
   cardKey: string;
   /** Part of a multi-card selection, so it moves with the others. */
   selected?: boolean;
+  /** This thread has a chat card open on the map, tethered to this card. */
+  chatting?: boolean;
   /**
    * Add or remove this card from the selection. Deliberately outside
    * `drag`: amending a selection has to work before the durable instance
@@ -126,7 +128,9 @@ export function StarMapThreadCard(props: {
     <div
       className={`star-map-card-shell${
         props.entering ? " star-map-card-shell--entering" : ""
-      }${props.selected ? " star-map-card-shell--selected" : ""}`}
+      }${props.selected ? " star-map-card-shell--selected" : ""}${
+        props.chatting ? " star-map-card-shell--chatting" : ""
+      }`}
       style={style}
       data-thread-key={threadKey}
       data-card-key={props.cardKey}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -99,6 +99,10 @@ export function StarMapThreadCard(props: {
   const titleTooltip = useViewportTooltip({
     className: "viewport-tooltip star-map-card__tooltip",
   });
+  // Thread keys carry a `backend:id` colon, which is legal in an id
+  // attribute but parses as a pseudo-class in a CSS selector — anything
+  // resolving this id via querySelector would silently find nothing.
+  const chatStateId = `star-map-chat-open-${threadKey.replace(/[^\w-]/g, "-")}`;
   const left = props.baseSlot.dx + (props.offset?.dx ?? 0);
   const top = props.baseSlot.dy + (props.offset?.dy ?? 0);
   const style: CSSProperties = {
@@ -161,11 +165,22 @@ export function StarMapThreadCard(props: {
           // become its accessible name; the chips stay readable as content,
           // and the kebab beside it gets a distinct name of its own.
           aria-label={`Open thread: ${thread.title}`}
+          // The accent ring says "a chat card for this thread is open on
+          // the map", which is otherwise sighted-only. It rides
+          // `aria-describedby` rather than the label because it describes
+          // the thread's state, not what the button does — the same rule
+          // the hover cards follow (see AGENTS.md).
+          aria-describedby={props.chatting ? chatStateId : undefined}
           onClick={() => {
             if (consumeSuppressedClick()) return;
             props.onOpen(thread);
           }}
         >
+          {props.chatting ? (
+            <span className="star-map-card__state" id={chatStateId}>
+              Chat card open on the map
+            </span>
+          ) : null}
           <ThreadRowStatus status={status} />
           <span
             className="star-map-card__title"

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -78,6 +78,8 @@ function renderCard(params: {
       onRectChange={() => undefined}
       rect={RECT}
       thread={params.thread}
+      scale={1}
+      bounds={{ width: 4000, height: 3000 }}
       zIndex={40}
     />,
   );

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts
@@ -7,7 +7,9 @@ import {
   CHAT_CARD_MIN_HEIGHT,
   CHAT_CARD_MIN_WIDTH,
   cascadeChatCardRect,
+  chatCardEdgeToward,
   clampChatCardRect,
+  placeChatCardBesideAnchor,
   raiseChatCard,
   resizeChatCardRect,
 } from "../star-map-chat-card-geometry";
@@ -174,5 +176,84 @@ describe("raiseChatCard", () => {
 
   it("appends an unknown key", () => {
     expect(raiseChatCard(["a"], "b")).toEqual(["a", "b"]);
+  });
+});
+
+describe("placeChatCardBesideAnchor", () => {
+  const bounds = { width: 4000, height: 3000 };
+  const anchor = { x: 1000, y: 900, width: 200, height: 120 };
+
+  it("opens to the right of the thread card it belongs to", () => {
+    const rect = placeChatCardBesideAnchor({ anchor, bounds, occupied: [] });
+    expect(rect.left).toBeGreaterThan(anchor.x + anchor.width);
+    // Vertically overlapping the anchor, so the pairing reads at a glance.
+    expect(rect.top).toBeLessThan(anchor.y + anchor.height);
+    expect(rect.top + rect.height).toBeGreaterThan(anchor.y);
+  });
+
+  it("opens to the left when the right would leave the canvas", () => {
+    const rect = placeChatCardBesideAnchor({
+      anchor: { ...anchor, x: bounds.width - 260 },
+      bounds,
+      occupied: [],
+    });
+    expect(rect.left + rect.width).toBeLessThanOrEqual(bounds.width);
+  });
+
+  it("steps aside rather than opening on top of another chat card", () => {
+    const first = placeChatCardBesideAnchor({ anchor, bounds, occupied: [] });
+    const second = placeChatCardBesideAnchor({
+      anchor,
+      bounds,
+      occupied: [first],
+    });
+    const overlaps =
+      first.left < second.left + second.width
+      && second.left < first.left + first.width
+      && first.top < second.top + second.height
+      && second.top < first.top + first.height;
+    expect(overlaps).toBe(false);
+  });
+
+  it("keeps the card inside the canvas", () => {
+    const rect = placeChatCardBesideAnchor({
+      anchor: { x: 0, y: 0, width: 200, height: 120 },
+      bounds,
+      occupied: [],
+    });
+    expect(rect.top).toBeGreaterThanOrEqual(0);
+    expect(rect.left + rect.width).toBeLessThanOrEqual(bounds.width);
+  });
+});
+
+describe("chatCardEdgeToward", () => {
+  const rect = { left: 100, top: 100, width: 200, height: 100 };
+
+  it("stops on the border facing the thread card", () => {
+    const right = chatCardEdgeToward(rect, { x: 1000, y: 150 });
+    expect(right.x).toBeCloseTo(300, 5);
+    const above = chatCardEdgeToward(rect, { x: 200, y: -500 });
+    expect(above.y).toBeCloseTo(100, 5);
+  });
+
+  it("never reports a point outside the card", () => {
+    for (const target of [
+      { x: 0, y: 0 },
+      { x: 5000, y: 5000 },
+      { x: 200, y: 5000 },
+    ]) {
+      const point = chatCardEdgeToward(rect, target);
+      expect(point.x).toBeGreaterThanOrEqual(rect.left - 0.001);
+      expect(point.x).toBeLessThanOrEqual(rect.left + rect.width + 0.001);
+      expect(point.y).toBeGreaterThanOrEqual(rect.top - 0.001);
+      expect(point.y).toBeLessThanOrEqual(rect.top + rect.height + 0.001);
+    }
+  });
+
+  it("degenerates to the centre when the target sits on it", () => {
+    expect(chatCardEdgeToward(rect, { x: 200, y: 150 })).toEqual({
+      x: 200,
+      y: 150,
+    });
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts
@@ -200,19 +200,31 @@ describe("placeChatCardBesideAnchor", () => {
     expect(rect.left + rect.width).toBeLessThanOrEqual(bounds.width);
   });
 
-  it("steps aside rather than opening on top of another chat card", () => {
+  it("stays beside its thread even when that overlaps other cards", () => {
+    // Being next to the thread it belongs to beats being tidy. An overlap
+    // is the operator's to resolve by dragging, so placement must not go
+    // hunting for free space and land the card somewhere unrelated.
+    const crowd = Array.from({ length: 4 }, (unused, index) => ({
+      left: anchor.x + 200 + index * 40,
+      top: anchor.y + index * 40,
+      width: 420,
+      height: 520,
+    }));
+    const rect = placeChatCardBesideAnchor({ anchor, bounds, occupied: crowd });
+    expect(rect.left).toBeLessThan(anchor.x + 900);
+    expect(Math.abs(rect.top - anchor.y)).toBeLessThan(600);
+  });
+
+  it("offsets a card opened at the exact same spot as another", () => {
+    // Perfectly stacked cards hide the older one completely, which reads
+    // as the click having done nothing.
     const first = placeChatCardBesideAnchor({ anchor, bounds, occupied: [] });
     const second = placeChatCardBesideAnchor({
       anchor,
       bounds,
       occupied: [first],
     });
-    const overlaps =
-      first.left < second.left + second.width
-      && second.left < first.left + first.width
-      && first.top < second.top + second.height
-      && second.top < first.top + first.height;
-    expect(overlaps).toBe(false);
+    expect(second.left === first.left && second.top === first.top).toBe(false);
   });
 
   it("keeps the card inside the canvas", () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -362,6 +362,28 @@ describe("star map overview zoom", () => {
       container.querySelectorAll(".star-map__cluster-label--overview").length,
     ).toBe(2);
 
+    // The instance has to come with them. Its cards are gone at this
+    // zoom, so the body and its name are the only things saying which
+    // machine you are looking at — and a 13px pill at 0.12 scale paints
+    // at a pixel and a half.
+    const anchor = container.querySelector(
+      ".star-map__anchor",
+    ) as HTMLElement;
+    expect(anchor.className).toContain("star-map__anchor--overview");
+    const instanceScale = /scale\(([\d.]+)\)/.exec(anchor.style.transform);
+    expect(instanceScale).not.toBeNull();
+    expect(Number(instanceScale![1])).toBeGreaterThan(1);
+    // Counter-scaled by the SAME factor as the cloud names, or the two
+    // would drift apart as the operator kept pulling out.
+    const label = container.querySelector(
+      ".star-map__cluster-label--overview",
+    ) as HTMLElement;
+    expect(/scale\(([\d.]+)\)/.exec(label.style.transform)?.[1]).toBe(
+      instanceScale![1],
+    );
+    // And it still names the machine.
+    expect(anchor.textContent).toContain("Harold-MBP-M5-Max");
+
     // Coming back in restores the cards rather than stranding the map in
     // an overview it cannot leave. Each pinch step doubles the scale, so
     // climbing back from the floor past the threshold takes a few.
@@ -378,6 +400,12 @@ describe("star map overview zoom", () => {
         container.querySelectorAll(".star-map-card-shell").length,
       ).toBeGreaterThan(0);
     });
+    // Back at reading zoom the instance drops its counter-scale rather
+    // than staying blown up over the cards.
+    expect(
+      (container.querySelector(".star-map__anchor") as HTMLElement).style
+        .transform,
+    ).not.toContain("scale(");
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -72,36 +72,37 @@ describe("star map project cloud chrome", () => {
     window.localStorage.removeItem("pwragent.starMap.filterSelection");
   });
 
-  it("labels each project cloud with a pill carrying its total", async () => {
+  it("labels each project cloud with its name and total", async () => {
     renderOrbit([
       projectThread("a1", "/repo/alpha", "AlphaDir"),
       projectThread("a2", "/repo/alpha", "AlphaDir"),
       projectThread("b1", "/repo/beta", "BetaDir"),
+      projectThread("b2", "/repo/beta", "BetaDir"),
     ]);
-    const alphaPill = await screen.findByRole("button", {
+    const alphaLabel = await screen.findByRole("button", {
       name: /Select the alpha cards \(2 threads\)/,
     });
-    expect(alphaPill.textContent).toContain("alpha");
-    expect(alphaPill.textContent).toContain("2");
+    expect(alphaLabel.textContent).toContain("alpha");
+    expect(alphaLabel.textContent).toContain("2");
     expect(
       screen.getByRole("button", {
-        name: /Select the beta cards \(1 threads\)/,
+        name: /Select the beta cards \(2 threads\)/,
       }),
     ).toBeTruthy();
   });
 
-  it("hides the redundant directory chip inside a labeled cloud", async () => {
+  it("keeps every card chip inside a labeled cloud", async () => {
     renderOrbit([
       projectThread("a1", "/repo/alpha", "AlphaDir"),
       projectThread("a2", "/repo/alpha", "AlphaDir"),
     ]);
     await screen.findByRole("button", { name: /Select the alpha cards/ });
-    // The cloud's pill says "alpha"; the per-card chip would repeat it as
-    // the directory label, which is exactly the chip hygiene rule.
-    expect(screen.queryByText("AlphaDir")).toBeNull();
+    // The cloud groups cards; it must not strip their anatomy — the
+    // directory chips render exactly as they would anywhere else.
+    expect(screen.getAllByText("AlphaDir").length).toBeGreaterThan(0);
   });
 
-  it("keeps directory chips on cards outside a project cloud", async () => {
+  it("floats a lone card chromeless — no label, no chip", async () => {
     renderOrbit([
       {
         ...projectThread("x", "/repo/gamma", "GammaDir"),
@@ -109,8 +110,8 @@ describe("star map project cloud chrome", () => {
       } as unknown as NavigationThreadSummary,
     ]);
     await screen.findByRole("button", { name: /Open thread: Thread x/ });
-    // A lone no-project cloud is chromeless: no pill, no outline.
     expect(screen.queryByRole("button", { name: /Select the/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /more .* threads/ })).toBeNull();
   });
 
   it("truncates a big cloud at the group cap and expands on the chip", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -357,8 +357,17 @@ describe("star map chat cards in map space", () => {
     expect(
       Math.abs(Number.parseFloat(chat.style.left) - cardLeft),
     ).toBeLessThan(800);
-    // The card end of the pairing says so too.
+    // The card end of the pairing says so too — and says it to a screen
+    // reader, not only to the eye.
     expect(shell.className).toContain("star-map-card-shell--chatting");
+    const open = shell.querySelector(".star-map-card__open")!;
+    const described = open.getAttribute("aria-describedby");
+    expect(described).toBeTruthy();
+    expect(shell.querySelector(`#${described}`)?.textContent).toContain(
+      "Chat card open",
+    );
+    // The button still NAMES its action; the state is a description.
+    expect(open.getAttribute("aria-label")).toBe("Open thread: Thread a1");
   });
 
   it("draws no tether when the thread has no card on the map", async () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -3,6 +3,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { StarMapScreen } from "../StarMapScreen";
+import {
+  buildInstanceClusters,
+  computeClusterCloud,
+} from "../star-map-clusters";
 
 /**
  * Orbit-lens project cloud chrome: the label pills, the per-cloud "+N
@@ -47,14 +51,18 @@ function projectThread(
   } as unknown as NavigationThreadSummary;
 }
 
-function renderOrbit(threads: NavigationThreadSummary[]) {
+function renderOrbit(
+  threads: NavigationThreadSummary[],
+  api?: Partial<DesktopApi>,
+) {
   window.localStorage.setItem(
     "pwragent.starMap.viewPreferences",
     JSON.stringify({ layout: "orbit" }),
   );
-  return render(
+  const desktopApi: DesktopApi = { ...buildDesktopApi(), ...api };
+  const view = render(
     <StarMapScreen
-      desktopApi={buildDesktopApi()}
+      desktopApi={desktopApi}
       localThreads={threads}
       sessionKeys={{}}
       localInstanceLabel="Mac-Mini-M4"
@@ -64,6 +72,28 @@ function renderOrbit(threads: NavigationThreadSummary[]) {
       onFocusLocalInstance={() => undefined}
     />,
   );
+  const rerenderThreads = (next: NavigationThreadSummary[]) =>
+    view.rerender(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={next}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+  return { ...view, rerenderThreads };
+}
+
+function cardShell(container: HTMLElement, threadKey: string): HTMLElement {
+  const shell = container.querySelector(`[data-thread-key="${threadKey}"]`);
+  if (!(shell instanceof HTMLElement)) {
+    throw new Error(`No card shell for ${threadKey}`);
+  }
+  return shell;
 }
 
 describe("star map project cloud chrome", () => {
@@ -189,5 +219,89 @@ describe("star map project cloud chrome", () => {
         container.querySelectorAll(".star-map-card-shell--selected"),
       ).toHaveLength(0);
     });
+  });
+
+  it("anchors a placed card to its cloud when a cloudmate archives away", async () => {
+    const threads = [
+      projectThread("a1", "/repo/alpha", "AlphaDir"),
+      projectThread("a2", "/repo/alpha", "AlphaDir"),
+      projectThread("a3", "/repo/alpha", "AlphaDir"),
+    ];
+    const stored = { dx: 140, dy: 90 };
+    const { container, rerenderThreads } = renderOrbit(threads, {
+      readStarMapArrangement: vi.fn(async () => ({
+        entries: [
+          {
+            instanceId: "pwr_local",
+            threadKey: "codex:a1",
+            dx: stored.dx,
+            dy: stored.dy,
+            updatedAt: 10,
+            by: "pwr_local",
+          },
+        ],
+      })),
+      setStarMapCardPosition: vi.fn(async () => ({ entries: [] })),
+    });
+
+    // jsdom has no ResizeObserver, so every card keeps the estimated
+    // height — the same inputs the screen feeds the pure layout, which
+    // makes the expected anchor computable here.
+    const centerFor = (list: NavigationThreadSummary[]) =>
+      computeClusterCloud({
+        clusters: buildInstanceClusters({ threads: list }),
+        cardWidth: 200,
+        heightForThread: () => 112,
+      }).clusters[0].center;
+
+    const before = centerFor(threads);
+    await waitFor(() => {
+      const shell = cardShell(container, "codex:a1");
+      expect(shell.style.left).toBe(`${before.x + stored.dx}px`);
+      expect(shell.style.top).toBe(`${before.y + stored.dy}px`);
+    });
+
+    // A cloudmate archives away: the scatter reflows, the cloud origin
+    // shifts a little — and the placed card keeps EXACTLY its stored
+    // offset from that origin instead of resetting.
+    rerenderThreads(threads.slice(0, 2));
+    const after = centerFor(threads.slice(0, 2));
+    await waitFor(() => {
+      const shell = cardShell(container, "codex:a1");
+      expect(shell.style.left).toBe(`${after.x + stored.dx}px`);
+      expect(shell.style.top).toBe(`${after.y + stored.dy}px`);
+    });
+  });
+
+  it("hides a card the moment Archive is chosen", async () => {
+    // Never resolves: the point is what happens BEFORE the backend and
+    // the next snapshot catch up.
+    const archiveThread = vi.fn(
+      () => new Promise(() => undefined),
+    ) as unknown as DesktopApi["archiveThread"];
+    renderOrbit(
+      [
+        projectThread("a1", "/repo/alpha", "AlphaDir"),
+        projectThread("a2", "/repo/alpha", "AlphaDir"),
+      ],
+      { archiveThread },
+    );
+    await screen.findByRole("button", { name: /Open thread: Thread a1/ });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Thread a1" }),
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Archive thread" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /Open thread: Thread a1/ }),
+      ).toBeNull();
+    });
+    expect(archiveThread).toHaveBeenCalledTimes(1);
+    // The rest of the cloud is untouched.
+    expect(
+      screen.getByRole("button", { name: /Open thread: Thread a2/ }),
+    ).toBeTruthy();
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -311,6 +311,72 @@ describe("star map project cloud chrome", () => {
  * the canvas transform, so panning away and coming back finds them where
  * they were left.
  */
+/**
+ * Pulled far out, a card is an unreadable smudge that still costs a whole
+ * subtree to mount. The map trades every card for one label per cloud, so
+ * the fleet stays legible AND the DOM shrinks exactly when it would
+ * otherwise be at its largest.
+ */
+describe("star map overview zoom", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+  });
+
+  it("drops cards for named clouds when zoomed out, and brings them back", async () => {
+    const { container } = renderOrbit([
+      projectThread("a1", "/repo/alpha", "AlphaDir"),
+      projectThread("a2", "/repo/alpha", "AlphaDir"),
+      projectThread("b1", "/repo/beta", "BetaDir"),
+      projectThread("b2", "/repo/beta", "BetaDir"),
+    ]);
+    await screen.findByRole("button", { name: /Select the alpha cards/ });
+    expect(
+      container.querySelectorAll(".star-map-card-shell").length,
+    ).toBeGreaterThan(0);
+
+    const viewport = container.querySelector(
+      ".star-map__viewport",
+    ) as HTMLElement;
+    // Positive deltaY with ctrl is pinch-out; one step lands on MIN_ZOOM.
+    fireEvent.wheel(viewport, {
+      deltaY: 240,
+      ctrlKey: true,
+      clientX: 400,
+      clientY: 300,
+    });
+
+    await waitFor(() => {
+      expect(container.querySelectorAll(".star-map-card-shell")).toHaveLength(
+        0,
+      );
+    });
+    // The clouds are still named, which is the whole point of going out.
+    expect(
+      screen.getByRole("button", { name: /Select the alpha cards/ }),
+    ).toBeTruthy();
+    expect(
+      container.querySelectorAll(".star-map__cluster-label--overview").length,
+    ).toBe(2);
+
+    // Coming back in restores the cards rather than stranding the map in
+    // an overview it cannot leave. Each pinch step doubles the scale, so
+    // climbing back from the floor past the threshold takes a few.
+    for (let step = 0; step < 3; step += 1) {
+      fireEvent.wheel(viewport, {
+        deltaY: -240,
+        ctrlKey: true,
+        clientX: 400,
+        clientY: 300,
+      });
+    }
+    await waitFor(() => {
+      expect(
+        container.querySelectorAll(".star-map-card-shell").length,
+      ).toBeGreaterThan(0);
+    });
+  });
+});
+
 describe("star map chat cards in map space", () => {
   afterEach(() => {
     window.localStorage.removeItem("pwragent.starMap.viewPreferences");

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -370,6 +370,38 @@ describe("star map chat cards in map space", () => {
     expect(open.getAttribute("aria-label")).toBe("Open thread: Thread a1");
   });
 
+  it("scrolls the transcript instead of panning the galaxy", async () => {
+    const { container } = renderOrbit([
+      projectThread("a1", "/repo/alpha", "AlphaDir"),
+      projectThread("a2", "/repo/alpha", "AlphaDir"),
+    ]);
+    await screen.findByRole("button", { name: /Open thread: Thread a1/ });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Open thread: Thread a1/ }),
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-chat-card")).not.toBeNull();
+    });
+
+    const canvas = container.querySelector(".star-map__canvas") as HTMLElement;
+    const chat = container.querySelector(".star-map-chat-card") as HTMLElement;
+    const before = canvas.style.transform;
+
+    // The card is inside the canvas, so its wheel events reach the
+    // viewport's listener; the map must leave them alone.
+    fireEvent.wheel(chat, { deltaY: 240 });
+    expect(canvas.style.transform).toBe(before);
+
+    // Bare sky still pans, so the exception is scoped to the card.
+    fireEvent.wheel(
+      container.querySelector(".star-map__viewport") as HTMLElement,
+      { deltaY: 240 },
+    );
+    await waitFor(() => {
+      expect(canvas.style.transform).not.toBe(before);
+    });
+  });
+
   it("draws no tether when the thread has no card on the map", async () => {
     const { container, rerenderThreads } = renderOrbit([
       projectThread("a1", "/repo/alpha", "AlphaDir"),

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -1,0 +1,192 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { StarMapScreen } from "../StarMapScreen";
+
+/**
+ * Orbit-lens project cloud chrome: the label pills, the per-cloud "+N
+ * more" expand chips, and the chip hygiene inside a labeled cloud. The
+ * geometry itself is pinned in star-map-clusters.test.ts; this file pins
+ * what the operator actually sees and clicks.
+ */
+
+function buildDesktopApi(): DesktopApi {
+  return {
+    readFederationHealth: vi.fn(async () => ({
+      health: {
+        enabled: false,
+        role: "client" as const,
+        status: "disabled" as const,
+        instanceId: "pwr_local",
+        localCelestialIcon: "sun" as const,
+        localLabel: "Harold-MBP-M5-Max",
+        localProfileName: "default",
+        peers: [],
+      },
+    })),
+    onAgentEvent: vi.fn(() => () => undefined),
+  };
+}
+
+function projectThread(
+  id: string,
+  path: string,
+  label: string,
+): NavigationThreadSummary {
+  return {
+    id,
+    title: `Thread ${id}`,
+    titleSource: "generated",
+    linkedDirectories: [
+      { id: `dir-${path}`, label, path, kind: "local" },
+    ],
+    source: "codex",
+    inbox: { inInbox: false },
+    updatedAt: 100,
+  } as unknown as NavigationThreadSummary;
+}
+
+function renderOrbit(threads: NavigationThreadSummary[]) {
+  window.localStorage.setItem(
+    "pwragent.starMap.viewPreferences",
+    JSON.stringify({ layout: "orbit" }),
+  );
+  return render(
+    <StarMapScreen
+      desktopApi={buildDesktopApi()}
+      localThreads={threads}
+      sessionKeys={{}}
+      localInstanceLabel="Mac-Mini-M4"
+      floating={false}
+      onClose={() => undefined}
+      onOpenLocalThread={() => undefined}
+      onFocusLocalInstance={() => undefined}
+    />,
+  );
+}
+
+describe("star map project cloud chrome", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+  });
+
+  it("labels each project cloud with a pill carrying its total", async () => {
+    renderOrbit([
+      projectThread("a1", "/repo/alpha", "AlphaDir"),
+      projectThread("a2", "/repo/alpha", "AlphaDir"),
+      projectThread("b1", "/repo/beta", "BetaDir"),
+    ]);
+    const alphaPill = await screen.findByRole("button", {
+      name: /Select the alpha cards \(2 threads\)/,
+    });
+    expect(alphaPill.textContent).toContain("alpha");
+    expect(alphaPill.textContent).toContain("2");
+    expect(
+      screen.getByRole("button", {
+        name: /Select the beta cards \(1 threads\)/,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("hides the redundant directory chip inside a labeled cloud", async () => {
+    renderOrbit([
+      projectThread("a1", "/repo/alpha", "AlphaDir"),
+      projectThread("a2", "/repo/alpha", "AlphaDir"),
+    ]);
+    await screen.findByRole("button", { name: /Select the alpha cards/ });
+    // The cloud's pill says "alpha"; the per-card chip would repeat it as
+    // the directory label, which is exactly the chip hygiene rule.
+    expect(screen.queryByText("AlphaDir")).toBeNull();
+  });
+
+  it("keeps directory chips on cards outside a project cloud", async () => {
+    renderOrbit([
+      {
+        ...projectThread("x", "/repo/gamma", "GammaDir"),
+        linkedDirectories: [],
+      } as unknown as NavigationThreadSummary,
+    ]);
+    await screen.findByRole("button", { name: /Open thread: Thread x/ });
+    // A lone no-project cloud is chromeless: no pill, no outline.
+    expect(screen.queryByRole("button", { name: /Select the/ })).toBeNull();
+  });
+
+  it("truncates a big cloud at the group cap and expands on the chip", async () => {
+    const threads = Array.from({ length: 12 }, (unused, index) =>
+      projectThread(`t${index}`, "/repo/alpha", "AlphaDir"),
+    );
+    renderOrbit(threads);
+
+    const chip = await screen.findByRole("button", {
+      name: /Show 4 more alpha threads/,
+    });
+    expect(chip.textContent).toBe("+4 more");
+    expect(
+      screen.getAllByRole("button", { name: /^Open thread:/ }),
+    ).toHaveLength(8);
+
+    // Re-query at click time: card measurement re-renders the map, and a
+    // node captured by an earlier waitFor can already be detached.
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show 4 more alpha threads/ }),
+    );
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button", { name: /^Open thread:/ }),
+      ).toHaveLength(12);
+    });
+
+    // The chip stays so the cloud can fold back down.
+    expect(
+      screen.getByRole("button", { name: /Show fewer alpha threads/ })
+        .textContent,
+    ).toBe("Show fewer");
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show fewer alpha threads/ }),
+    );
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button", { name: /^Open thread:/ }),
+      ).toHaveLength(8);
+    });
+  });
+
+  it("selects the cloud's visible cards from the pill", async () => {
+    const { container } = renderOrbit([
+      projectThread("a1", "/repo/alpha", "AlphaDir"),
+      projectThread("a2", "/repo/alpha", "AlphaDir"),
+      projectThread("b1", "/repo/beta", "BetaDir"),
+    ]);
+    const pill = await screen.findByRole("button", {
+      name: /Select the alpha cards/,
+    });
+    expect(pill.getAttribute("aria-pressed")).toBe("false");
+
+    // Re-query at click time — see the expand test above.
+    fireEvent.click(
+      screen.getByRole("button", { name: /Select the alpha cards/ }),
+    );
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("button", { name: /Select the alpha cards/ })
+          .getAttribute("aria-pressed"),
+      ).toBe("true");
+    });
+    expect(
+      container.querySelectorAll(".star-map-card-shell--selected"),
+    ).toHaveLength(2);
+
+    // Second click releases the same cloud.
+    fireEvent.click(
+      screen.getByRole("button", { name: /Select the alpha cards/ }),
+    );
+    await waitFor(() => {
+      expect(
+        container.querySelectorAll(".star-map-card-shell--selected"),
+      ).toHaveLength(0);
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -305,3 +305,81 @@ describe("star map project cloud chrome", () => {
     ).toBeTruthy();
   });
 });
+
+/**
+ * Chat cards are objects in the galaxy, not windows over it: they ride
+ * the canvas transform, so panning away and coming back finds them where
+ * they were left.
+ */
+describe("star map chat cards in map space", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+  });
+
+  it("renders the chat card inside the transformed canvas", async () => {
+    const { container } = renderOrbit([
+      projectThread("a1", "/repo/alpha", "AlphaDir"),
+      projectThread("a2", "/repo/alpha", "AlphaDir"),
+    ]);
+    await screen.findByRole("button", { name: /Open thread: Thread a1/ });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Open thread: Thread a1/ }),
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-chat-card")).not.toBeNull();
+    });
+    // Inside the canvas is what makes it pan and zoom with the map; a
+    // card mounted beside the canvas would sit still while the sky moved.
+    expect(
+      container.querySelector(".star-map__canvas .star-map-chat-card"),
+    ).not.toBeNull();
+  });
+
+  it("opens the card beside the thread it belongs to, and tethers them", async () => {
+    const { container } = renderOrbit([
+      projectThread("a1", "/repo/alpha", "AlphaDir"),
+      projectThread("a2", "/repo/alpha", "AlphaDir"),
+    ]);
+    await screen.findByRole("button", { name: /Open thread: Thread a1/ });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Open thread: Thread a1/ }),
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(".star-map__tether")).not.toBeNull();
+    });
+    const shell = cardShell(container, "codex:a1");
+    const chat = container.querySelector(".star-map-chat-card") as HTMLElement;
+    // Beside its card rather than cascaded into a corner: the horizontal
+    // gap is a card-width or two, not the width of the map.
+    const cardLeft = Number.parseFloat(shell.style.left);
+    expect(
+      Math.abs(Number.parseFloat(chat.style.left) - cardLeft),
+    ).toBeLessThan(800);
+    // The card end of the pairing says so too.
+    expect(shell.className).toContain("star-map-card-shell--chatting");
+  });
+
+  it("draws no tether when the thread has no card on the map", async () => {
+    const { container, rerenderThreads } = renderOrbit([
+      projectThread("a1", "/repo/alpha", "AlphaDir"),
+      projectThread("a2", "/repo/alpha", "AlphaDir"),
+    ]);
+    await screen.findByRole("button", { name: /Open thread: Thread a1/ });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Open thread: Thread a1/ }),
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".star-map__tether")).not.toBeNull();
+    });
+
+    // The thread leaves the map (archived here) while its chat stays open.
+    rerenderThreads([projectThread("a2", "/repo/alpha", "AlphaDir")]);
+    await waitFor(() => {
+      expect(container.querySelector(".star-map__tether")).toBeNull();
+    });
+    // A line to nowhere is worse than no line, but the chat stays open.
+    expect(container.querySelector(".star-map-chat-card")).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-clusters.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-clusters.test.ts
@@ -4,7 +4,6 @@ import {
   buildInstanceClusters,
   computeClusterCloud,
   orderParentAdjacent,
-  ORBIT_MAX_CARDS_PER_CLOUD,
   ORBIT_MAX_CARDS_PER_GROUP,
 } from "../star-map-clusters";
 
@@ -14,19 +13,20 @@ function thread(
   id: string,
   options?: {
     path?: string;
+    title?: string;
     updatedAt?: number;
     parentId?: string;
   },
 ): NavigationThreadSummary {
   return {
     id,
-    title: `Thread ${id}`,
+    title: options?.title ?? `Thread ${id}`,
     source: "codex",
     linkedDirectories: options?.path
       ? [
           {
             id: `dir-${options.path}`,
-            label: options.path,
+            label: options.path.split("/").filter(Boolean).pop(),
             path: options.path,
             kind: "local",
           },
@@ -55,6 +55,7 @@ describe("buildInstanceClusters", () => {
     const alpha = clusters.find((cluster) => cluster.label === "alpha")!;
     expect(alpha.threads.map((entry) => entry.id)).toEqual(["a1", "a2"]);
     expect(alpha.isProject).toBe(true);
+    expect(alpha.isParentGroup).toBe(false);
   });
 
   it("pools directory-less threads into a no-project cluster", () => {
@@ -67,17 +68,89 @@ describe("buildInstanceClusters", () => {
     expect(clusters[0].label).toBe("No project");
   });
 
-  it("orders clusters heaviest first, like the projects lens", () => {
+  it("pools every scratch checkout into one Workspaces cluster", () => {
+    // The classifier collapses anything under a .pwragent projects root;
+    // twenty hash-named chats must not become twenty one-thread clouds.
     const clusters = buildInstanceClusters({
       threads: [
-        thread("solo", { path: "/repo/sleepy", updatedAt: NOW - 10_000_000 }),
-        ...Array.from({ length: 5 }, (unused, index) =>
-          thread(`busy${index}`, { path: "/repo/busy", updatedAt: NOW }),
-        ),
+        thread("w1", { path: "/Users/op/.pwragent/projects/2026-08-02-04db3f" }),
+        thread("w2", { path: "/Users/op/.pwragent/projects/2026-08-02-4e433f" }),
+        thread("w3", { path: "/Users/op/.pwragent/projects/2026-05-23-885b8f" }),
       ],
       now: NOW,
     });
-    expect(clusters[0].label).toBe("busy");
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].label).toBe("Workspaces");
+    expect(clusters[0].threads).toHaveLength(3);
+  });
+
+  it("splits a parent and its children into their own cloud", () => {
+    const clusters = buildInstanceClusters({
+      threads: [
+        thread("solo", { path: "/repo/alpha" }),
+        thread("parent", { path: "/repo/alpha", title: "MCP foundation" }),
+        thread("c1", { path: "/repo/alpha", parentId: "parent" }),
+        thread("c2", { path: "/repo/alpha", parentId: "parent" }),
+      ],
+      now: NOW,
+    });
+    expect(clusters).toHaveLength(2);
+    const parentCloud = clusters.find((cluster) => cluster.isParentGroup)!;
+    expect(parentCloud.label).toBe("MCP foundation");
+    expect(parentCloud.threads.map((entry) => entry.id)).toEqual([
+      "parent",
+      "c1",
+      "c2",
+    ]);
+    const catchAll = clusters.find((cluster) => !cluster.isParentGroup)!;
+    expect(catchAll.label).toBe("alpha");
+    expect(catchAll.threads.map((entry) => entry.id)).toEqual(["solo"]);
+  });
+
+  it("keeps grandchildren inside their root parent's cloud", () => {
+    const clusters = buildInstanceClusters({
+      threads: [
+        thread("root", { path: "/repo/alpha" }),
+        thread("child", { path: "/repo/alpha", parentId: "root" }),
+        thread("grandchild", { path: "/repo/alpha", parentId: "child" }),
+      ],
+      now: NOW,
+    });
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].isParentGroup).toBe(true);
+    expect(clusters[0].threads.map((entry) => entry.id)).toEqual([
+      "root",
+      "child",
+      "grandchild",
+    ]);
+  });
+
+  it("supports several parent clouds plus a catch-all for one project", () => {
+    const clusters = buildInstanceClusters({
+      threads: [
+        thread("p1", { path: "/repo/alpha", title: "Effort one" }),
+        thread("p1c", { path: "/repo/alpha", parentId: "p1" }),
+        thread("p2", { path: "/repo/alpha", title: "Effort two" }),
+        thread("p2c", { path: "/repo/alpha", parentId: "p2" }),
+        thread("stray", { path: "/repo/alpha" }),
+      ],
+      now: NOW,
+    });
+    expect(clusters.filter((cluster) => cluster.isParentGroup)).toHaveLength(2);
+    const catchAll = clusters.find((cluster) => !cluster.isParentGroup)!;
+    expect(catchAll.threads.map((entry) => entry.id)).toEqual(["stray"]);
+  });
+
+  it("leaves an orphan whose parent is elsewhere in the catch-all", () => {
+    const clusters = buildInstanceClusters({
+      threads: [
+        thread("orphan", { path: "/repo/alpha", parentId: "not-here" }),
+        thread("plain", { path: "/repo/alpha" }),
+      ],
+      now: NOW,
+    });
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].isParentGroup).toBe(false);
   });
 
   it("caps each cluster at the group limit and reports overflow", () => {
@@ -97,7 +170,7 @@ describe("buildInstanceClusters", () => {
       threads: Array.from({ length: 12 }, (unused, index) =>
         thread(`t${index}`, { path: "/repo/alpha" }),
       ),
-      expandedKeys: new Set(["/repo/alpha"]),
+      expandedKeys: new Set(["directory:/repo/alpha"]),
       now: NOW,
     });
     expect(clusters[0].visibleCount).toBe(12);
@@ -105,44 +178,51 @@ describe("buildInstanceClusters", () => {
     expect(clusters[0].expanded).toBe(true);
   });
 
-  it("clips at the cloud backstop and accrues the loss as overflow", () => {
-    const threads = Array.from({ length: 8 }, (unused, project) =>
+  it("never starves a cloud: every cloud shows cards regardless of fleet size", () => {
+    // The old instance-wide budget allocated 40 cards in mass order, so a
+    // big fleet's later clouds rendered zero cards and their expand chips
+    // did nothing. Every cloud must always seat its own visible set.
+    const threads = Array.from({ length: 10 }, (unused, project) =>
       Array.from({ length: 8 }, (unusedInner, index) =>
         thread(`p${project}-t${index}`, { path: `/repo/p${project}` }),
       ),
     ).flat();
     const clusters = buildInstanceClusters({ threads, now: NOW });
-    const visibleTotal = clusters.reduce(
-      (total, cluster) => total + cluster.visibleCount,
-      0,
-    );
-    expect(visibleTotal).toBe(ORBIT_MAX_CARDS_PER_CLOUD);
-    const overflowTotal = clusters.reduce(
-      (total, cluster) => total + cluster.overflow,
-      0,
-    );
-    expect(overflowTotal).toBe(threads.length - ORBIT_MAX_CARDS_PER_CLOUD);
+    expect(clusters).toHaveLength(10);
+    for (const cluster of clusters) {
+      expect(cluster.visibleCount).toBe(8);
+      expect(cluster.overflow).toBe(0);
+    }
+  });
+
+  it("expansion always works, even on the last cloud", () => {
+    const threads = [
+      ...Array.from({ length: 30 }, (unused, index) =>
+        thread(`big-${index}`, { path: "/repo/big" }),
+      ),
+      ...Array.from({ length: 12 }, (unused, index) =>
+        thread(`small-${index}`, {
+          path: "/repo/small",
+          updatedAt: NOW - 1_000_000,
+        }),
+      ),
+    ];
+    const collapsed = buildInstanceClusters({ threads, now: NOW });
+    const small = collapsed.find((cluster) => cluster.label === "small")!;
+    expect(small.visibleCount).toBe(ORBIT_MAX_CARDS_PER_GROUP);
+
+    const expanded = buildInstanceClusters({
+      threads,
+      expandedKeys: new Set(["directory:/repo/small"]),
+      now: NOW,
+    });
+    const expandedSmall = expanded.find((cluster) => cluster.label === "small")!;
+    expect(expandedSmall.visibleCount).toBe(12);
+    expect(expandedSmall.overflow).toBe(0);
   });
 });
 
 describe("orderParentAdjacent", () => {
-  it("moves children to sit directly after their parent", () => {
-    const ordered = orderParentAdjacent([
-      thread("child2", { parentId: "parent" }),
-      thread("other"),
-      thread("parent"),
-      thread("child1", { parentId: "parent" }),
-    ]);
-    // child2 sorted ahead of its parent (fresher activity) but still pulls
-    // down under it; children keep their relative order.
-    expect(ordered.map((entry) => entry.id)).toEqual([
-      "other",
-      "parent",
-      "child2",
-      "child1",
-    ]);
-  });
-
   it("keeps children adjacent under a parent that sorts first", () => {
     const ordered = orderParentAdjacent([
       thread("parent"),
@@ -158,15 +238,6 @@ describe("orderParentAdjacent", () => {
     ]);
   });
 
-  it("leaves a thread alone when its parent is not in the cloud", () => {
-    const ordered = orderParentAdjacent([
-      thread("a"),
-      thread("orphan", { parentId: "elsewhere" }),
-      thread("b"),
-    ]);
-    expect(ordered.map((entry) => entry.id)).toEqual(["a", "orphan", "b"]);
-  });
-
   it("never drops members of a parent cycle", () => {
     const ordered = orderParentAdjacent([
       thread("x", { parentId: "y" }),
@@ -174,19 +245,6 @@ describe("orderParentAdjacent", () => {
       thread("z"),
     ]);
     expect(ordered.map((entry) => entry.id).sort()).toEqual(["x", "y", "z"]);
-  });
-
-  it("nests grandchildren under their whole chain", () => {
-    const ordered = orderParentAdjacent([
-      thread("grandchild", { parentId: "child" }),
-      thread("root"),
-      thread("child", { parentId: "root" }),
-    ]);
-    expect(ordered.map((entry) => entry.id)).toEqual([
-      "root",
-      "child",
-      "grandchild",
-    ]);
   });
 });
 
@@ -216,29 +274,63 @@ describe("computeClusterCloud", () => {
     expect(cloud.clusterIndexByCard).toHaveLength(5);
   });
 
-  it("keeps every card inside its own cluster outline", () => {
-    const cloud = cloudFor([6, 3, 2]);
+  it("seats the first card at its cloud's centre", () => {
+    const cloud = cloudFor([5, 3]);
+    for (const cluster of cloud.clusters) {
+      const first = cluster.slots[0];
+      expect(first.dx).toBeCloseTo(cluster.center.x, 5);
+      expect(first.dy + height() / 2).toBeCloseTo(cluster.center.y, 5);
+    }
+  });
+
+  it("scatters the rest instead of gridding them", () => {
+    // Rings with per-thread jitter: no three cards may share an x or y
+    // coordinate, which is exactly what a column grid produced.
+    const cloud = cloudFor([8]);
+    const xs = new Map<number, number>();
+    const ys = new Map<number, number>();
+    for (const slot of cloud.slots) {
+      const x = Math.round(slot.dx);
+      const y = Math.round(slot.dy);
+      xs.set(x, (xs.get(x) ?? 0) + 1);
+      ys.set(y, (ys.get(y) ?? 0) + 1);
+    }
+    expect(Math.max(...xs.values())).toBeLessThan(3);
+    expect(Math.max(...ys.values())).toBeLessThan(3);
+  });
+
+  it("gives every card a distinct slot", () => {
+    const cloud = cloudFor([8, 8]);
+    const unique = new Set(
+      cloud.slots.map((slot) => `${Math.round(slot.dx)}:${Math.round(slot.dy)}`),
+    );
+    expect(unique.size).toBe(cloud.slots.length);
+  });
+
+  it("keeps every card inside its cloud's extent", () => {
+    const cloud = cloudFor([8, 5, 2]);
     cloud.threads.forEach((entry, index) => {
       const cluster = cloud.clusters[cloud.clusterIndexByCard[index]];
       const slot = cloud.slots[index];
-      expect(slot.dx - 100).toBeGreaterThanOrEqual(cluster.rect.x);
-      expect(slot.dx + 100).toBeLessThanOrEqual(
-        cluster.rect.x + cluster.rect.width,
+      expect(Math.abs(slot.dx - cluster.center.x) + 100).toBeLessThanOrEqual(
+        cluster.extent.rx,
       );
-      expect(slot.dy).toBeGreaterThanOrEqual(cluster.rect.y);
+      expect(slot.dy).toBeGreaterThanOrEqual(
+        cluster.center.y - cluster.extent.ry,
+      );
       expect(slot.dy + height()).toBeLessThanOrEqual(
-        cluster.rect.y + cluster.rect.height,
+        cluster.center.y + cluster.extent.ry,
       );
     });
   });
 
-  it("gives no two cards in a cluster overlapping boxes", () => {
-    const cloud = cloudFor([8]);
-    const boxes = cloud.slots.map((slot) => ({
-      left: slot.dx - 100,
-      right: slot.dx + 100,
-      top: slot.dy,
-      bottom: slot.dy + height(),
+  it("separates cloud extents from each other", () => {
+    const cloud = cloudFor([8, 8, 4, 2]);
+    const boxes = cloud.clusters.map((cluster) => ({
+      left: cluster.center.x - cluster.extent.rx,
+      right: cluster.center.x + cluster.extent.rx,
+      top: cluster.center.y - cluster.extent.ry,
+      bottom: cluster.center.y + cluster.extent.ry,
     }));
     for (let i = 0; i < boxes.length; i += 1) {
       for (let j = i + 1; j < boxes.length; j += 1) {
@@ -252,32 +344,22 @@ describe("computeClusterCloud", () => {
     }
   });
 
-  it("separates cluster outlines from each other", () => {
-    const cloud = cloudFor([8, 8, 4, 2]);
-    const rects = cloud.clusters.map((cluster) => cluster.rect);
-    for (let i = 0; i < rects.length; i += 1) {
-      for (let j = i + 1; j < rects.length; j += 1) {
-        const apart =
-          rects[i].x + rects[i].width <= rects[j].x
-          || rects[j].x + rects[j].width <= rects[i].x
-          || rects[i].y + rects[i].height <= rects[j].y
-          || rects[j].y + rects[j].height <= rects[i].y;
-        expect(apart).toBe(true);
-      }
-    }
-  });
-
-  it("keeps clusters clear of the instance's own chrome", () => {
+  it("keeps clouds clear of the instance's own chrome", () => {
     // Mirrors STAR_MAP_INSTANCE_KEEPOUT in star-map-orbit.
     const keepout = { left: -92, right: 92, top: -58, bottom: 100 };
     const cloud = cloudFor([8, 8, 4]);
     for (const cluster of cloud.clusters) {
-      const rect = cluster.rect;
+      const box = {
+        left: cluster.center.x - cluster.extent.rx,
+        right: cluster.center.x + cluster.extent.rx,
+        top: cluster.center.y - cluster.extent.ry,
+        bottom: cluster.center.y + cluster.extent.ry,
+      };
       const apart =
-        rect.x + rect.width <= keepout.left
-        || rect.x >= keepout.right
-        || rect.y + rect.height <= keepout.top
-        || rect.y >= keepout.bottom;
+        box.right <= keepout.left
+        || box.left >= keepout.right
+        || box.bottom <= keepout.top
+        || box.top >= keepout.bottom;
       expect(apart).toBe(true);
     }
   });
@@ -285,12 +367,24 @@ describe("computeClusterCloud", () => {
   it("hangs a lone cloud below the body", () => {
     const cloud = cloudFor([4]);
     expect(cloud.clusters).toHaveLength(1);
-    const rect = cloud.clusters[0].rect;
-    expect(rect.y).toBeGreaterThan(0);
-    expect(rect.x + rect.width / 2).toBeCloseTo(0, 5);
+    const cluster = cloud.clusters[0];
+    expect(cluster.center.x).toBeCloseTo(0, 5);
+    expect(cluster.center.y - cluster.extent.ry).toBeGreaterThan(0);
   });
 
-  it("is chromeless only for a lone no-project cloud", () => {
+  it("floats a single-thread cloud chromeless", () => {
+    const cloud = cloudFor([1, 5]);
+    const lone = cloud.clusters.find(
+      (cluster) => cluster.threads.length === 1,
+    )!;
+    expect(lone.chromeless).toBe(true);
+    const full = cloud.clusters.find(
+      (cluster) => cluster.threads.length === 5,
+    )!;
+    expect(full.chromeless).toBe(false);
+  });
+
+  it("is chromeless for a lone no-project cloud", () => {
     const bare = computeClusterCloud({
       clusters: buildInstanceClusters({
         threads: [thread("x"), thread("y")],
@@ -300,40 +394,35 @@ describe("computeClusterCloud", () => {
       heightForThread: height,
     });
     expect(bare.clusters[0].chromeless).toBe(true);
-
-    const project = cloudFor([2]);
-    expect(project.clusters[0].chromeless).toBe(false);
   });
 
-  it("places an overflow chip inside a capped cluster's outline", () => {
+  it("places label above and chip below a capped cloud", () => {
     const cloud = cloudFor([12]);
     const cluster = cloud.clusters[0];
     expect(cluster.overflow).toBeGreaterThan(0);
-    expect(cluster.overflowSlot).toBeDefined();
-    expect(cluster.overflowSlot!.dy).toBeLessThan(
-      cluster.rect.y + cluster.rect.height,
+    expect(cluster.labelSlot.dy).toBeLessThan(
+      cluster.center.y - cluster.extent.ry,
     );
+    expect(cluster.overflowSlot).toBeDefined();
     expect(cluster.overflowSlot!.dy).toBeGreaterThan(
-      cloud.slots[cloud.slots.length - 1].dy + height(),
+      cluster.center.y + cluster.extent.ry,
     );
   });
 
   it("keeps the chip on an expanded cluster so it can collapse", () => {
-    const cloud = cloudFor([12], ["/repo/p0"]);
+    const cloud = cloudFor([12], ["directory:/repo/p0"]);
     expect(cloud.clusters[0].overflow).toBe(0);
     expect(cloud.clusters[0].overflowSlot).toBeDefined();
   });
 
-  it("reports an extent that covers every outline", () => {
+  it("reports an extent that covers every cloud", () => {
     const cloud = cloudFor([8, 6, 3]);
     for (const cluster of cloud.clusters) {
-      expect(Math.abs(cluster.rect.x)).toBeLessThanOrEqual(cloud.extent.rx);
-      expect(Math.abs(cluster.rect.x + cluster.rect.width)).toBeLessThanOrEqual(
-        cloud.extent.rx,
-      );
-      expect(Math.abs(cluster.rect.y)).toBeLessThanOrEqual(cloud.extent.ry);
       expect(
-        Math.abs(cluster.rect.y + cluster.rect.height),
+        Math.abs(cluster.center.x) + cluster.extent.rx,
+      ).toBeLessThanOrEqual(cloud.extent.rx);
+      expect(
+        Math.abs(cluster.center.y) + cluster.extent.ry,
       ).toBeLessThanOrEqual(cloud.extent.ry);
     }
   });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-clusters.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-clusters.test.ts
@@ -49,7 +49,6 @@ describe("buildInstanceClusters", () => {
         thread("a2", { path: "/repo/alpha" }),
         thread("b2", { path: "/repo/beta" }),
       ],
-      now: NOW,
     });
     expect(clusters).toHaveLength(2);
     const alpha = clusters.find((cluster) => cluster.label === "alpha")!;
@@ -61,7 +60,6 @@ describe("buildInstanceClusters", () => {
   it("pools directory-less threads into a no-project cluster", () => {
     const clusters = buildInstanceClusters({
       threads: [thread("x"), thread("y")],
-      now: NOW,
     });
     expect(clusters).toHaveLength(1);
     expect(clusters[0].isProject).toBe(false);
@@ -77,7 +75,6 @@ describe("buildInstanceClusters", () => {
         thread("w2", { path: "/Users/op/.pwragent/projects/2026-08-02-4e433f" }),
         thread("w3", { path: "/Users/op/.pwragent/projects/2026-05-23-885b8f" }),
       ],
-      now: NOW,
     });
     expect(clusters).toHaveLength(1);
     expect(clusters[0].label).toBe("Workspaces");
@@ -92,7 +89,6 @@ describe("buildInstanceClusters", () => {
         thread("c1", { path: "/repo/alpha", parentId: "parent" }),
         thread("c2", { path: "/repo/alpha", parentId: "parent" }),
       ],
-      now: NOW,
     });
     expect(clusters).toHaveLength(2);
     const parentCloud = clusters.find((cluster) => cluster.isParentGroup)!;
@@ -114,7 +110,6 @@ describe("buildInstanceClusters", () => {
         thread("child", { path: "/repo/alpha", parentId: "root" }),
         thread("grandchild", { path: "/repo/alpha", parentId: "child" }),
       ],
-      now: NOW,
     });
     expect(clusters).toHaveLength(1);
     expect(clusters[0].isParentGroup).toBe(true);
@@ -134,7 +129,6 @@ describe("buildInstanceClusters", () => {
         thread("p2c", { path: "/repo/alpha", parentId: "p2" }),
         thread("stray", { path: "/repo/alpha" }),
       ],
-      now: NOW,
     });
     expect(clusters.filter((cluster) => cluster.isParentGroup)).toHaveLength(2);
     const catchAll = clusters.find((cluster) => !cluster.isParentGroup)!;
@@ -147,7 +141,6 @@ describe("buildInstanceClusters", () => {
         thread("orphan", { path: "/repo/alpha", parentId: "not-here" }),
         thread("plain", { path: "/repo/alpha" }),
       ],
-      now: NOW,
     });
     expect(clusters).toHaveLength(1);
     expect(clusters[0].isParentGroup).toBe(false);
@@ -158,7 +151,6 @@ describe("buildInstanceClusters", () => {
       threads: Array.from({ length: 12 }, (unused, index) =>
         thread(`t${index}`, { path: "/repo/alpha" }),
       ),
-      now: NOW,
     });
     expect(clusters[0].visibleCount).toBe(ORBIT_MAX_CARDS_PER_GROUP);
     expect(clusters[0].overflow).toBe(12 - ORBIT_MAX_CARDS_PER_GROUP);
@@ -171,11 +163,32 @@ describe("buildInstanceClusters", () => {
         thread(`t${index}`, { path: "/repo/alpha" }),
       ),
       expandedKeys: new Set(["directory:/repo/alpha"]),
-      now: NOW,
     });
     expect(clusters[0].visibleCount).toBe(12);
     expect(clusters[0].overflow).toBe(0);
     expect(clusters[0].expanded).toBe(true);
+  });
+
+  it("orders clouds by stable key, not by activity", () => {
+    // Seat angles derive from cluster order, so activity-driven ordering
+    // re-seated every cloud whenever recency shifted — placed cards
+    // teleporting because some other project got busier.
+    const keysWhen = (hot: "alpha" | "beta") =>
+      buildInstanceClusters({
+        threads: [
+          thread("a1", {
+            path: "/repo/alpha",
+            updatedAt: hot === "alpha" ? NOW : NOW - 900_000,
+          }),
+          thread("a2", { path: "/repo/alpha", updatedAt: NOW - 500_000 }),
+          thread("b1", {
+            path: "/repo/beta",
+            updatedAt: hot === "beta" ? NOW : NOW - 900_000,
+          }),
+          thread("b2", { path: "/repo/beta", updatedAt: NOW - 500_000 }),
+        ],
+      }).map((cluster) => cluster.key);
+    expect(keysWhen("alpha")).toEqual(keysWhen("beta"));
   });
 
   it("never starves a cloud: every cloud shows cards regardless of fleet size", () => {
@@ -187,7 +200,7 @@ describe("buildInstanceClusters", () => {
         thread(`p${project}-t${index}`, { path: `/repo/p${project}` }),
       ),
     ).flat();
-    const clusters = buildInstanceClusters({ threads, now: NOW });
+    const clusters = buildInstanceClusters({ threads });
     expect(clusters).toHaveLength(10);
     for (const cluster of clusters) {
       expect(cluster.visibleCount).toBe(8);
@@ -207,14 +220,13 @@ describe("buildInstanceClusters", () => {
         }),
       ),
     ];
-    const collapsed = buildInstanceClusters({ threads, now: NOW });
+    const collapsed = buildInstanceClusters({ threads });
     const small = collapsed.find((cluster) => cluster.label === "small")!;
     expect(small.visibleCount).toBe(ORBIT_MAX_CARDS_PER_GROUP);
 
     const expanded = buildInstanceClusters({
       threads,
       expandedKeys: new Set(["directory:/repo/small"]),
-      now: NOW,
     });
     const expandedSmall = expanded.find((cluster) => cluster.label === "small")!;
     expect(expandedSmall.visibleCount).toBe(12);
@@ -259,7 +271,6 @@ describe("computeClusterCloud", () => {
       clusters: buildInstanceClusters({
         threads,
         expandedKeys: new Set(expanded ?? []),
-        now: NOW,
       }),
       cardWidth: 200,
       heightForThread: height,
@@ -388,7 +399,6 @@ describe("computeClusterCloud", () => {
     const bare = computeClusterCloud({
       clusters: buildInstanceClusters({
         threads: [thread("x"), thread("y")],
-        now: NOW,
       }),
       cardWidth: 200,
       heightForThread: height,

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-clusters.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-clusters.test.ts
@@ -3,6 +3,7 @@ import type { NavigationThreadSummary } from "@pwragent/shared";
 import {
   buildInstanceClusters,
   computeClusterCloud,
+  forgetCluster,
   orderParentAdjacent,
   ORBIT_MAX_CARDS_PER_GROUP,
 } from "../star-map-clusters";
@@ -439,5 +440,204 @@ describe("computeClusterCloud", () => {
 
   it("is deterministic", () => {
     expect(cloudFor([8, 5, 2])).toEqual(cloudFor([8, 5, 2]));
+  });
+});
+
+/**
+ * The layout is incremental on purpose: archiving one thread must take
+ * one card off the map and disturb nothing else. Every assertion here is
+ * a thing that used to move on its own.
+ */
+describe("layout stability", () => {
+  const cardWidth = 200;
+
+  function layout(
+    threads: NavigationThreadSummary[],
+    memory?: ReturnType<typeof computeClusterCloud>["memory"],
+    expanded?: string[],
+  ) {
+    return computeClusterCloud({
+      clusters: buildInstanceClusters({
+        threads,
+        expandedKeys: new Set(expanded ?? []),
+      }),
+      cardWidth,
+      heightForThread: height,
+      memory,
+    });
+  }
+
+  function slotByThread(cloud: ReturnType<typeof computeClusterCloud>) {
+    return new Map(
+      cloud.threads.map((thread, index) => [thread.id, cloud.slots[index]]),
+    );
+  }
+
+  const project = (name: string, count: number, from = 0) =>
+    Array.from({ length: count }, (unused, index) =>
+      thread(`${name}-${index + from}`, { path: `/repo/${name}` }),
+    );
+
+  it("moves nothing but the archived card", () => {
+    const threads = [...project("alpha", 6), ...project("beta", 5)];
+    const before = layout(threads);
+    const after = layout(
+      threads.filter((entry) => entry.id !== "alpha-2"),
+      before.memory,
+    );
+
+    const was = slotByThread(before);
+    const now = slotByThread(after);
+    expect(now.has("alpha-2")).toBe(false);
+    expect(now.size).toBe(was.size - 1);
+    for (const [id, slot] of now) {
+      expect(slot).toEqual(was.get(id));
+    }
+  });
+
+  it("leaves every cloud centre where it was", () => {
+    const threads = [
+      ...project("alpha", 6),
+      ...project("beta", 5),
+      ...project("gamma", 3),
+    ];
+    const before = layout(threads);
+    const after = layout(
+      threads.filter((entry) => entry.id !== "beta-0"),
+      before.memory,
+    );
+    for (const cluster of after.clusters) {
+      const previous = before.clusters.find(
+        (entry) => entry.key === cluster.key,
+      )!;
+      expect(cluster.center).toEqual(previous.center);
+      expect(cluster.extent).toEqual(previous.extent);
+    }
+  });
+
+  it("does not pull a cloud inward when its outermost card leaves", () => {
+    // Extent drives cloud seating AND instance spacing, so a shrinking
+    // cloud used to shove its neighbours (and its own body) around.
+    const threads = project("alpha", 9);
+    const before = layout(threads);
+    const outermost = before.threads[before.threads.length - 1];
+    const after = layout(
+      threads.filter((entry) => entry.id !== outermost.id),
+      before.memory,
+    );
+    expect(after.clusters[0].extent).toEqual(before.clusters[0].extent);
+    expect(after.extent).toEqual(before.extent);
+  });
+
+  it("keeps the surviving clouds put when a whole cloud empties", () => {
+    const threads = [...project("alpha", 4), ...project("beta", 1)];
+    const before = layout(threads);
+    const after = layout(
+      threads.filter((entry) => !entry.id.startsWith("beta")),
+      before.memory,
+    );
+    expect(after.clusters).toHaveLength(1);
+    const alpha = after.clusters[0];
+    const previousAlpha = before.clusters.find(
+      (cluster) => cluster.key === alpha.key,
+    )!;
+    expect(alpha.center).toEqual(previousAlpha.center);
+  });
+
+  it("seats an arriving thread without moving the cards already there", () => {
+    const threads = project("alpha", 5);
+    const before = layout(threads);
+    const after = layout([...threads, thread("newcomer", { path: "/repo/alpha" })], before.memory);
+
+    const was = slotByThread(before);
+    const now = slotByThread(after);
+    for (const [id, slot] of was) {
+      expect(now.get(id)).toEqual(slot);
+    }
+    expect(now.get("newcomer")).toBeDefined();
+  });
+
+  it("gives an arrival the seat an archived card freed", () => {
+    const threads = project("alpha", 5);
+    const before = layout(threads);
+    const freed = slotByThread(before).get("alpha-2")!;
+    const without = layout(
+      threads.filter((entry) => entry.id !== "alpha-2"),
+      before.memory,
+    );
+    const after = layout(
+      [
+        ...threads.filter((entry) => entry.id !== "alpha-2"),
+        thread("newcomer", { path: "/repo/alpha" }),
+      ],
+      without.memory,
+    );
+    // Same seat, so the cloud does not sprout an outer ring for a card it
+    // has room for. The jitter is per-thread, so the position is close
+    // rather than identical.
+    const taken = slotByThread(after).get("newcomer")!;
+    expect(Math.hypot(taken.dx - freed.dx, taken.dy - freed.dy)).toBeLessThan(
+      cardWidth,
+    );
+  });
+
+  it("re-fits a cloud the operator expands, and only that cloud", () => {
+    const threads = [...project("alpha", 14), ...project("beta", 4)];
+    const before = layout(threads);
+    const alphaKey = "directory:/repo/alpha";
+    const after = layout(
+      threads,
+      forgetCluster(before.memory, alphaKey),
+      [alphaKey],
+    );
+    const beta = after.clusters.find((cluster) => cluster.key !== alphaKey)!;
+    const previousBeta = before.clusters.find(
+      (cluster) => cluster.key === beta.key,
+    )!;
+    expect(beta.center).toEqual(previousBeta.center);
+    const alpha = after.clusters.find((cluster) => cluster.key === alphaKey)!;
+    expect(alpha.slots).toHaveLength(14);
+  });
+
+  it("lays out the same way twice from a cold start", () => {
+    const threads = [...project("alpha", 6), ...project("beta", 5)];
+    expect(layout(threads)).toEqual(layout(threads));
+  });
+
+  it("is idempotent when the same input is laid out over its own memory", () => {
+    // The screen recomputes on every snapshot; feeding a layout its own
+    // memory must be a no-op or the map would drift while idle.
+    const threads = [...project("alpha", 6), ...project("beta", 5)];
+    const first = layout(threads);
+    const second = layout(threads, first.memory);
+    expect(second.slots).toEqual(first.slots);
+    expect(second.clusters.map((cluster) => cluster.center)).toEqual(
+      first.clusters.map((cluster) => cluster.center),
+    );
+  });
+
+  it("keeps a card's seat when a taller card joins its cloud", () => {
+    // Ring radii come from a nominal height, so one tall card cannot
+    // inflate the rings under everybody else.
+    const threads = project("alpha", 5);
+    const before = computeClusterCloud({
+      clusters: buildInstanceClusters({ threads }),
+      cardWidth,
+      heightForThread: () => 112,
+      memory: undefined,
+    });
+    const after = computeClusterCloud({
+      clusters: buildInstanceClusters({
+        threads: [...threads, thread("tall", { path: "/repo/alpha" })],
+      }),
+      cardWidth,
+      heightForThread: (key) => (key === "codex:tall" ? 260 : 112),
+      memory: before.memory,
+    });
+    const was = slotByThread(before);
+    const now = slotByThread(after);
+    for (const [id, slot] of was) {
+      expect(now.get(id)).toEqual(slot);
+    }
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-clusters.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-clusters.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import {
+  buildInstanceClusters,
+  computeClusterCloud,
+  orderParentAdjacent,
+  ORBIT_MAX_CARDS_PER_CLOUD,
+  ORBIT_MAX_CARDS_PER_GROUP,
+} from "../star-map-clusters";
+
+const NOW = 1_000_000;
+
+function thread(
+  id: string,
+  options?: {
+    path?: string;
+    updatedAt?: number;
+    parentId?: string;
+  },
+): NavigationThreadSummary {
+  return {
+    id,
+    title: `Thread ${id}`,
+    source: "codex",
+    linkedDirectories: options?.path
+      ? [
+          {
+            id: `dir-${options.path}`,
+            label: options.path,
+            path: options.path,
+            kind: "local",
+          },
+        ]
+      : [],
+    inbox: { inInbox: false },
+    updatedAt: options?.updatedAt ?? NOW,
+    ...(options?.parentId ? { parentThreadId: options.parentId } : {}),
+  } as unknown as NavigationThreadSummary;
+}
+
+const height = () => 112;
+
+describe("buildInstanceClusters", () => {
+  it("groups threads by project and keeps within-group order", () => {
+    const clusters = buildInstanceClusters({
+      threads: [
+        thread("a1", { path: "/repo/alpha" }),
+        thread("b1", { path: "/repo/beta" }),
+        thread("a2", { path: "/repo/alpha" }),
+        thread("b2", { path: "/repo/beta" }),
+      ],
+      now: NOW,
+    });
+    expect(clusters).toHaveLength(2);
+    const alpha = clusters.find((cluster) => cluster.label === "alpha")!;
+    expect(alpha.threads.map((entry) => entry.id)).toEqual(["a1", "a2"]);
+    expect(alpha.isProject).toBe(true);
+  });
+
+  it("pools directory-less threads into a no-project cluster", () => {
+    const clusters = buildInstanceClusters({
+      threads: [thread("x"), thread("y")],
+      now: NOW,
+    });
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].isProject).toBe(false);
+    expect(clusters[0].label).toBe("No project");
+  });
+
+  it("orders clusters heaviest first, like the projects lens", () => {
+    const clusters = buildInstanceClusters({
+      threads: [
+        thread("solo", { path: "/repo/sleepy", updatedAt: NOW - 10_000_000 }),
+        ...Array.from({ length: 5 }, (unused, index) =>
+          thread(`busy${index}`, { path: "/repo/busy", updatedAt: NOW }),
+        ),
+      ],
+      now: NOW,
+    });
+    expect(clusters[0].label).toBe("busy");
+  });
+
+  it("caps each cluster at the group limit and reports overflow", () => {
+    const clusters = buildInstanceClusters({
+      threads: Array.from({ length: 12 }, (unused, index) =>
+        thread(`t${index}`, { path: "/repo/alpha" }),
+      ),
+      now: NOW,
+    });
+    expect(clusters[0].visibleCount).toBe(ORBIT_MAX_CARDS_PER_GROUP);
+    expect(clusters[0].overflow).toBe(12 - ORBIT_MAX_CARDS_PER_GROUP);
+    expect(clusters[0].expandable).toBe(true);
+  });
+
+  it("shows every card when the cluster is expanded", () => {
+    const clusters = buildInstanceClusters({
+      threads: Array.from({ length: 12 }, (unused, index) =>
+        thread(`t${index}`, { path: "/repo/alpha" }),
+      ),
+      expandedKeys: new Set(["/repo/alpha"]),
+      now: NOW,
+    });
+    expect(clusters[0].visibleCount).toBe(12);
+    expect(clusters[0].overflow).toBe(0);
+    expect(clusters[0].expanded).toBe(true);
+  });
+
+  it("clips at the cloud backstop and accrues the loss as overflow", () => {
+    const threads = Array.from({ length: 8 }, (unused, project) =>
+      Array.from({ length: 8 }, (unusedInner, index) =>
+        thread(`p${project}-t${index}`, { path: `/repo/p${project}` }),
+      ),
+    ).flat();
+    const clusters = buildInstanceClusters({ threads, now: NOW });
+    const visibleTotal = clusters.reduce(
+      (total, cluster) => total + cluster.visibleCount,
+      0,
+    );
+    expect(visibleTotal).toBe(ORBIT_MAX_CARDS_PER_CLOUD);
+    const overflowTotal = clusters.reduce(
+      (total, cluster) => total + cluster.overflow,
+      0,
+    );
+    expect(overflowTotal).toBe(threads.length - ORBIT_MAX_CARDS_PER_CLOUD);
+  });
+});
+
+describe("orderParentAdjacent", () => {
+  it("moves children to sit directly after their parent", () => {
+    const ordered = orderParentAdjacent([
+      thread("child2", { parentId: "parent" }),
+      thread("other"),
+      thread("parent"),
+      thread("child1", { parentId: "parent" }),
+    ]);
+    // child2 sorted ahead of its parent (fresher activity) but still pulls
+    // down under it; children keep their relative order.
+    expect(ordered.map((entry) => entry.id)).toEqual([
+      "other",
+      "parent",
+      "child2",
+      "child1",
+    ]);
+  });
+
+  it("keeps children adjacent under a parent that sorts first", () => {
+    const ordered = orderParentAdjacent([
+      thread("parent"),
+      thread("stranger"),
+      thread("childA", { parentId: "parent" }),
+      thread("childB", { parentId: "parent" }),
+    ]);
+    expect(ordered.map((entry) => entry.id)).toEqual([
+      "parent",
+      "childA",
+      "childB",
+      "stranger",
+    ]);
+  });
+
+  it("leaves a thread alone when its parent is not in the cloud", () => {
+    const ordered = orderParentAdjacent([
+      thread("a"),
+      thread("orphan", { parentId: "elsewhere" }),
+      thread("b"),
+    ]);
+    expect(ordered.map((entry) => entry.id)).toEqual(["a", "orphan", "b"]);
+  });
+
+  it("never drops members of a parent cycle", () => {
+    const ordered = orderParentAdjacent([
+      thread("x", { parentId: "y" }),
+      thread("y", { parentId: "x" }),
+      thread("z"),
+    ]);
+    expect(ordered.map((entry) => entry.id).sort()).toEqual(["x", "y", "z"]);
+  });
+
+  it("nests grandchildren under their whole chain", () => {
+    const ordered = orderParentAdjacent([
+      thread("grandchild", { parentId: "child" }),
+      thread("root"),
+      thread("child", { parentId: "root" }),
+    ]);
+    expect(ordered.map((entry) => entry.id)).toEqual([
+      "root",
+      "child",
+      "grandchild",
+    ]);
+  });
+});
+
+describe("computeClusterCloud", () => {
+  function cloudFor(counts: number[], expanded?: string[]) {
+    const threads = counts.flatMap((count, project) =>
+      Array.from({ length: count }, (unused, index) =>
+        thread(`p${project}-t${index}`, { path: `/repo/p${project}` }),
+      ),
+    );
+    return computeClusterCloud({
+      clusters: buildInstanceClusters({
+        threads,
+        expandedKeys: new Set(expanded ?? []),
+        now: NOW,
+      }),
+      cardWidth: 200,
+      heightForThread: height,
+    });
+  }
+
+  it("aligns the flat threads, slots and heights", () => {
+    const cloud = cloudFor([3, 2]);
+    expect(cloud.threads).toHaveLength(5);
+    expect(cloud.slots).toHaveLength(5);
+    expect(cloud.heights).toHaveLength(5);
+    expect(cloud.clusterIndexByCard).toHaveLength(5);
+  });
+
+  it("keeps every card inside its own cluster outline", () => {
+    const cloud = cloudFor([6, 3, 2]);
+    cloud.threads.forEach((entry, index) => {
+      const cluster = cloud.clusters[cloud.clusterIndexByCard[index]];
+      const slot = cloud.slots[index];
+      expect(slot.dx - 100).toBeGreaterThanOrEqual(cluster.rect.x);
+      expect(slot.dx + 100).toBeLessThanOrEqual(
+        cluster.rect.x + cluster.rect.width,
+      );
+      expect(slot.dy).toBeGreaterThanOrEqual(cluster.rect.y);
+      expect(slot.dy + height()).toBeLessThanOrEqual(
+        cluster.rect.y + cluster.rect.height,
+      );
+    });
+  });
+
+  it("gives no two cards in a cluster overlapping boxes", () => {
+    const cloud = cloudFor([8]);
+    const boxes = cloud.slots.map((slot) => ({
+      left: slot.dx - 100,
+      right: slot.dx + 100,
+      top: slot.dy,
+      bottom: slot.dy + height(),
+    }));
+    for (let i = 0; i < boxes.length; i += 1) {
+      for (let j = i + 1; j < boxes.length; j += 1) {
+        const apart =
+          boxes[i].right <= boxes[j].left
+          || boxes[j].right <= boxes[i].left
+          || boxes[i].bottom <= boxes[j].top
+          || boxes[j].bottom <= boxes[i].top;
+        expect(apart).toBe(true);
+      }
+    }
+  });
+
+  it("separates cluster outlines from each other", () => {
+    const cloud = cloudFor([8, 8, 4, 2]);
+    const rects = cloud.clusters.map((cluster) => cluster.rect);
+    for (let i = 0; i < rects.length; i += 1) {
+      for (let j = i + 1; j < rects.length; j += 1) {
+        const apart =
+          rects[i].x + rects[i].width <= rects[j].x
+          || rects[j].x + rects[j].width <= rects[i].x
+          || rects[i].y + rects[i].height <= rects[j].y
+          || rects[j].y + rects[j].height <= rects[i].y;
+        expect(apart).toBe(true);
+      }
+    }
+  });
+
+  it("keeps clusters clear of the instance's own chrome", () => {
+    // Mirrors STAR_MAP_INSTANCE_KEEPOUT in star-map-orbit.
+    const keepout = { left: -92, right: 92, top: -58, bottom: 100 };
+    const cloud = cloudFor([8, 8, 4]);
+    for (const cluster of cloud.clusters) {
+      const rect = cluster.rect;
+      const apart =
+        rect.x + rect.width <= keepout.left
+        || rect.x >= keepout.right
+        || rect.y + rect.height <= keepout.top
+        || rect.y >= keepout.bottom;
+      expect(apart).toBe(true);
+    }
+  });
+
+  it("hangs a lone cloud below the body", () => {
+    const cloud = cloudFor([4]);
+    expect(cloud.clusters).toHaveLength(1);
+    const rect = cloud.clusters[0].rect;
+    expect(rect.y).toBeGreaterThan(0);
+    expect(rect.x + rect.width / 2).toBeCloseTo(0, 5);
+  });
+
+  it("is chromeless only for a lone no-project cloud", () => {
+    const bare = computeClusterCloud({
+      clusters: buildInstanceClusters({
+        threads: [thread("x"), thread("y")],
+        now: NOW,
+      }),
+      cardWidth: 200,
+      heightForThread: height,
+    });
+    expect(bare.clusters[0].chromeless).toBe(true);
+
+    const project = cloudFor([2]);
+    expect(project.clusters[0].chromeless).toBe(false);
+  });
+
+  it("places an overflow chip inside a capped cluster's outline", () => {
+    const cloud = cloudFor([12]);
+    const cluster = cloud.clusters[0];
+    expect(cluster.overflow).toBeGreaterThan(0);
+    expect(cluster.overflowSlot).toBeDefined();
+    expect(cluster.overflowSlot!.dy).toBeLessThan(
+      cluster.rect.y + cluster.rect.height,
+    );
+    expect(cluster.overflowSlot!.dy).toBeGreaterThan(
+      cloud.slots[cloud.slots.length - 1].dy + height(),
+    );
+  });
+
+  it("keeps the chip on an expanded cluster so it can collapse", () => {
+    const cloud = cloudFor([12], ["/repo/p0"]);
+    expect(cloud.clusters[0].overflow).toBe(0);
+    expect(cloud.clusters[0].overflowSlot).toBeDefined();
+  });
+
+  it("reports an extent that covers every outline", () => {
+    const cloud = cloudFor([8, 6, 3]);
+    for (const cluster of cloud.clusters) {
+      expect(Math.abs(cluster.rect.x)).toBeLessThanOrEqual(cloud.extent.rx);
+      expect(Math.abs(cluster.rect.x + cluster.rect.width)).toBeLessThanOrEqual(
+        cloud.extent.rx,
+      );
+      expect(Math.abs(cluster.rect.y)).toBeLessThanOrEqual(cloud.extent.ry);
+      expect(
+        Math.abs(cluster.rect.y + cluster.rect.height),
+      ).toBeLessThanOrEqual(cloud.extent.ry);
+    }
+  });
+
+  it("is deterministic", () => {
+    expect(cloudFor([8, 5, 2])).toEqual(cloudFor([8, 5, 2]));
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-clusters.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-clusters.test.ts
@@ -5,6 +5,7 @@ import {
   computeClusterCloud,
   forgetCluster,
   orderParentAdjacent,
+  resolveCloudDrop,
   ORBIT_MAX_CARDS_PER_GROUP,
 } from "../star-map-clusters";
 
@@ -639,5 +640,114 @@ describe("layout stability", () => {
     for (const [id, slot] of was) {
       expect(now.get(id)).toEqual(slot);
     }
+  });
+});
+
+
+/**
+ * Cloud membership is derived, so a drop can only change it by changing
+ * the data the grouping reads — and only one of the two kinds of cloud
+ * reads data a drag is allowed to touch.
+ */
+describe("resolveCloudDrop", () => {
+  function cloudOf(threads: NavigationThreadSummary[]) {
+    return computeClusterCloud({
+      clusters: buildInstanceClusters({ threads }),
+      cardWidth: 200,
+      heightForThread: height,
+    });
+  }
+
+  const parented = [
+    thread("parent", { path: "/repo/alpha", title: "MCP foundation" }),
+    thread("child", { path: "/repo/alpha", parentId: "parent" }),
+    thread("stray", { path: "/repo/alpha" }),
+    thread("other", { path: "/repo/beta" }),
+  ];
+
+  function centerOf(
+    cloud: ReturnType<typeof computeClusterCloud>,
+    predicate: (key: string) => boolean,
+  ) {
+    return cloud.clusters.find((cluster) => predicate(cluster.key))!.center;
+  }
+
+  it("adopts a card dropped into a parent cloud", () => {
+    const cloud = cloudOf(parented);
+    const drop = resolveCloudDrop({
+      clusters: cloud.clusters,
+      point: centerOf(cloud, (key) => key.includes("::pc:")),
+      thread: parented[2],
+    });
+    expect(drop.kind).toBe("adopt");
+    expect(drop.kind === "adopt" && drop.parent.id).toBe("parent");
+  });
+
+  it("releases a child dropped back on its project's catch-all", () => {
+    const cloud = cloudOf(parented);
+    const drop = resolveCloudDrop({
+      clusters: cloud.clusters,
+      point: centerOf(
+        cloud,
+        (key) => key === "directory:/repo/alpha",
+      ),
+      thread: parented[1],
+    });
+    expect(drop.kind).toBe("release");
+  });
+
+  it("never relinks a thread's project", () => {
+    // A project cloud groups on the thread's workspace — where its
+    // commands run. Dropping a card there moves the card and nothing else.
+    const cloud = cloudOf(parented);
+    const drop = resolveCloudDrop({
+      clusters: cloud.clusters,
+      point: centerOf(cloud, (key) => key === "directory:/repo/beta"),
+      thread: parented[2],
+    });
+    expect(drop.kind).toBe("none");
+  });
+
+  it("does nothing for a card dropped back in its own cloud", () => {
+    const cloud = cloudOf(parented);
+    const drop = resolveCloudDrop({
+      clusters: cloud.clusters,
+      point: centerOf(cloud, (key) => key.includes("::pc:")),
+      thread: parented[1],
+    });
+    expect(drop.kind).toBe("none");
+  });
+
+  it("does nothing for a drop on bare sky", () => {
+    const cloud = cloudOf(parented);
+    const drop = resolveCloudDrop({
+      clusters: cloud.clusters,
+      point: { x: 100_000, y: 100_000 },
+      thread: parented[2],
+    });
+    expect(drop.kind).toBe("none");
+  });
+
+  it("refuses to adopt a parent into its own descendant", () => {
+    // Walking up from the candidate would come back around to the card
+    // being dragged, and the grouping would fold in on itself.
+    const chain = [
+      thread("root", { path: "/repo/alpha", title: "Root" }),
+      thread("mid", { path: "/repo/alpha", parentId: "root" }),
+      thread("leaf", { path: "/repo/alpha", parentId: "mid" }),
+      thread("second", { path: "/repo/alpha", title: "Second" }),
+      thread("second-child", { path: "/repo/alpha", parentId: "second" }),
+    ];
+    const cloud = cloudOf(chain);
+    const rootCloud = cloud.clusters.find((cluster) =>
+      cluster.threads.some((entry) => entry.id === "leaf"),
+    )!;
+    // Drag the ROOT onto the cloud its own descendants are in.
+    const drop = resolveCloudDrop({
+      clusters: cloud.clusters,
+      point: rootCloud.center,
+      thread: chain[0],
+    });
+    expect(drop.kind).toBe("none");
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
@@ -221,6 +221,22 @@ describe("shouldStartCanvasPan", () => {
       false,
     );
 
+    // Chat cards live inside the canvas, so a press on one bubbles to the
+    // viewport. Without this the card dragged AND the galaxy panned.
+    const chat = element(
+      '<section class="star-map-chat-card">'
+      + '<header class="star-map-chat-card__bar"><span>Title</span></header>'
+      + '<div class="star-map-chat-card__body">transcript</div>'
+      + "</section>",
+    );
+    expect(shouldStartCanvasPan(chat)).toBe(false);
+    expect(
+      shouldStartCanvasPan(chat.querySelector(".star-map-chat-card__bar")),
+    ).toBe(false);
+    expect(
+      shouldStartCanvasPan(chat.querySelector(".star-map-chat-card__body")),
+    ).toBe(false);
+
     const chrome = element(
       '<div class="star-map__chrome"><p>PwrAgent</p></div>',
     );

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-orbit.test.ts
@@ -6,6 +6,7 @@ import {
   cardRingSlots,
   computeOrbitPlacement,
   galaxyArmPath,
+  shouldPanOnWheel,
   shouldStartCanvasPan,
 } from "../star-map-orbit";
 import {
@@ -456,5 +457,46 @@ describe("empty instances do not reserve a phantom ring", () => {
       return Math.hypot(a.x - hub.x, a.y - hub.y);
     };
     expect(spread(0)).toBeLessThan(spread(6));
+  });
+});
+
+describe("shouldPanOnWheel", () => {
+  function element(html: string): Element {
+    const host = document.createElement("div");
+    host.innerHTML = html;
+    return host.firstElementChild!;
+  }
+
+  it("pans on bare sky", () => {
+    expect(shouldPanOnWheel(element('<div class="star-map__sky" />'))).toBe(
+      true,
+    );
+  });
+
+  it("pans over a thread card, which scrolls nothing of its own", () => {
+    const shell = element(
+      '<div class="star-map-card-shell"><div class="star-map-card">x</div></div>',
+    );
+    expect(shouldPanOnWheel(shell.firstElementChild)).toBe(true);
+  });
+
+  it("leaves the wheel to a chat card's transcript", () => {
+    // Chat cards live inside the canvas now, so their wheel events reach
+    // the viewport listener — which preventDefaulted every one of them and
+    // panned the galaxy instead of scrolling the transcript.
+    const chat = element(
+      '<section class="star-map-chat-card">'
+      + '<div class="star-map-chat-card__transcript"><p>line</p></div>'
+      + "</section>",
+    );
+    expect(shouldPanOnWheel(chat)).toBe(false);
+    expect(
+      shouldPanOnWheel(chat.querySelector(".star-map-chat-card__transcript")),
+    ).toBe(false);
+    expect(shouldPanOnWheel(chat.querySelector("p"))).toBe(false);
+  });
+
+  it("pans for a non-element target", () => {
+    expect(shouldPanOnWheel(null)).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-performance.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-performance.test.tsx
@@ -144,3 +144,4 @@ describe("star map idle performance", () => {
     expect(offsetHeight).not.toHaveBeenCalled();
   });
 });
+

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-projects.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-projects.test.ts
@@ -72,27 +72,52 @@ describe("groupThreadsByProject", () => {
     ["peer", [remote, orphan]],
   ]);
 
+  // Project keys carry the shared directory classifier's prefix, so the
+  // Star Map and the Directories lens file threads under the same rows.
   it("pools threads for one project across instances", () => {
     const projects = groupThreadsByProject(byInstance);
-    const pwragent = projects.find((p) => p.key === "/repos/PwrAgnt");
+    const pwragent = projects.find(
+      (p) => p.key === "directory:/repos/PwrAgnt",
+    );
     expect(pwragent?.threads.map((t) => t.id)).toEqual(["r1", "l1"]);
   });
 
   it("names a project after its repo folder", () => {
     const projects = groupThreadsByProject(byInstance);
-    expect(projects.find((p) => p.key === "/repos/PwrSnap")?.label).toBe(
-      "PwrSnap",
-    );
+    expect(
+      projects.find((p) => p.key === "directory:/repos/PwrSnap")?.label,
+    ).toBe("PwrSnap");
   });
 
   it("orders threads within a project by recent activity", () => {
     const projects = groupThreadsByProject(byInstance);
-    const ids = projects.find((p) => p.key === "/repos/PwrAgnt")!.threads;
+    const ids = projects.find(
+      (p) => p.key === "directory:/repos/PwrAgnt",
+    )!.threads;
     expect(ids[0].updatedAt).toBeGreaterThan(ids[1].updatedAt!);
   });
 
   it("puts the busiest project first", () => {
-    expect(groupThreadsByProject(byInstance)[0].key).toBe("/repos/PwrAgnt");
+    expect(groupThreadsByProject(byInstance)[0].key).toBe(
+      "directory:/repos/PwrAgnt",
+    );
+  });
+
+  it("pools scratch checkouts into one Workspaces project", () => {
+    const w1 = thread({
+      id: "w1",
+      repoPath: "/Users/op/.pwragent/projects/2026-08-02-04db3f",
+      label: "2026-08-02-04db3f",
+    });
+    const w2 = thread({
+      id: "w2",
+      repoPath: "/Users/op/.pwragent/projects/2026-05-23-885b8f",
+      label: "2026-05-23-885b8f",
+    });
+    const projects = groupThreadsByProject(new Map([["local", [w1, w2]]]));
+    expect(projects).toHaveLength(1);
+    expect(projects[0].label).toBe("Workspaces");
+    expect(projects[0].threads).toHaveLength(2);
   });
 
   it("gives directory-less threads a home", () => {

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-geometry.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-geometry.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
-  centerStarMapView,
-  clampStarMapView,
   MAX_ZOOM,
   MIN_VISIBLE_FRACTION,
   MIN_ZOOM,
+  STAR_MAP_OVERVIEW_ZOOM,
+  centerStarMapView,
+  clampStarMapView,
+  isOverviewZoom,
+  overviewChromeScale,
   type StarMapView,
 } from "../star-map-view-geometry";
 
@@ -107,5 +110,40 @@ describe("centerStarMapView", () => {
       const centered = centerStarMapView({ canvas, viewport: VIEWPORT });
       expect(clamp(centered, canvas)).toEqual(centered);
     }
+  });
+});
+
+describe("overview zoom", () => {
+  it("lets the operator pull out well past card legibility", () => {
+    // The galaxy outgrew the old floor: a fleet of clouds did not fit on
+    // screen at 0.35, so there was no view that answered "where am I".
+    expect(MIN_ZOOM).toBeLessThan(0.35);
+    expect(MIN_ZOOM).toBeLessThan(STAR_MAP_OVERVIEW_ZOOM);
+  });
+
+  it("switches to named clouds below the threshold, not at reading zoom", () => {
+    expect(isOverviewZoom(MIN_ZOOM)).toBe(true);
+    expect(isOverviewZoom(STAR_MAP_OVERVIEW_ZOOM - 0.01)).toBe(true);
+    expect(isOverviewZoom(STAR_MAP_OVERVIEW_ZOOM)).toBe(false);
+    expect(isOverviewZoom(1)).toBe(false);
+  });
+
+  it("counter-scales chrome so a label survives the shrinking canvas", () => {
+    // A 13px label at 0.2 scale paints at 2.6px without this.
+    expect(overviewChromeScale(0.5)).toBeCloseTo(2, 5);
+    expect(overviewChromeScale(0.25)).toBeCloseTo(4, 5);
+  });
+
+  it("caps the counter-scale rather than growing labels without bound", () => {
+    const atFloor = overviewChromeScale(MIN_ZOOM);
+    expect(atFloor).toBeLessThan(1 / MIN_ZOOM);
+    // Past the cap labels shrink with the map, which is the honest signal
+    // that there is more map than window.
+    expect(overviewChromeScale(MIN_ZOOM / 2)).toBe(atFloor);
+  });
+
+  it("treats a nonsense scale as unzoomed rather than dividing by zero", () => {
+    expect(Number.isFinite(overviewChromeScale(0))).toBe(true);
+    expect(overviewChromeScale(0)).toBe(1);
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-view-stability.test.tsx
@@ -293,9 +293,9 @@ describe("star map view bounds", () => {
     window.localStorage.removeItem("pwragent.starMap.filterSelection");
   });
 
-  async function openOrbit() {
+  async function openOrbit(count = 9) {
     seedLayout("orbit");
-    const rendered = renderMap({ threads: threads(9) });
+    const rendered = renderMap({ threads: threads(count) });
     await waitFor(() => {
       expect(
         screen.getByRole("button", { name: /Open this instance/ }),
@@ -439,33 +439,30 @@ describe("star map view bounds", () => {
     // Resetting is also how the operator says "you place it again" — the
     // ownership flag has to clear, or auto-centring stays off for the life
     // of the mounted map.
-    const { rerender } = await openOrbit();
+    //
+    // The canvas is resized here by EXPANDING a cloud rather than by
+    // taking threads away: cloud layout is incremental now, so losing a
+    // card deliberately leaves every seat, extent and centre alone (see
+    // star-map-clusters). Unfolding a cloud is an operator action, and
+    // re-fitting that cloud is the point of it.
+    await openOrbit(12);
 
     pan(-900, -600);
     fireEvent.click(screen.getByRole("button", { name: "View" }));
     fireEvent.click(screen.getByRole("button", { name: "Reset view" }));
     const beforeResize = canvas().style.transform;
 
-    rerender(
-      <StarMapScreen
-        desktopApi={buildDesktopApi()}
-        localThreads={threads(4)}
-        sessionKeys={{}}
-        localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
-        onOpenLocalThread={() => undefined}
-        onFocusLocalInstance={() => undefined}
-      />,
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show 4 more PwrSnap threads/ }),
     );
-
     await waitFor(() => {
       expect(
-        screen.queryByRole("button", { name: /Open thread: Thread t8/ }),
-      ).toBeNull();
+        screen.getAllByRole("button", { name: /^Open thread:/ }),
+      ).toHaveLength(12);
     });
-    // The smaller cloud re-centres, which it would not do if the map were
-    // still treating the view as the operator's.
+
+    // The re-fitted cloud re-centres, which it would not do if the map
+    // were still treating the view as the operator's.
     expect(canvas().style.transform).not.toBe(beforeResize);
     const box = canvasBox();
     expect(readTransform()).toEqual({
@@ -482,7 +479,20 @@ describe("star map view bounds", () => {
     // a legally-parked view can leave nothing on screen. Recovery is
     // manual. If a future change closes this properly, this test should
     // fail and be rewritten, not deleted.
-    const { rerender } = await openOrbit();
+    //
+    // The shrink is driven by folding an expanded cloud back up. Archiving
+    // no longer shrinks anything: cloud seats, extents and centres are
+    // carried forward so losing a card moves nothing else, which closed
+    // the far more common route into this gap.
+    await openOrbit(12);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show 4 more PwrSnap threads/ }),
+    );
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button", { name: /^Open thread:/ }),
+      ).toHaveLength(12);
+    });
     const wide = canvasBox();
 
     // Park hard against the left bound: the canvas's right edge is all
@@ -492,22 +502,13 @@ describe("star map view bounds", () => {
       visible(readTransform().x, wide.width, VIEWPORT.width),
     ).toBeGreaterThanOrEqual(VIEWPORT.width * MIN_VISIBLE_FRACTION);
 
-    rerender(
-      <StarMapScreen
-        desktopApi={buildDesktopApi()}
-        localThreads={threads(1)}
-        sessionKeys={{}}
-        localInstanceLabel="Mac-Mini-M4"
-        floating={false}
-        onClose={() => undefined}
-        onOpenLocalThread={() => undefined}
-        onFocusLocalInstance={() => undefined}
-      />,
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show fewer PwrSnap threads/ }),
     );
     await waitFor(() => {
       expect(
-        screen.queryByRole("button", { name: /Open thread: Thread t8/ }),
-      ).toBeNull();
+        screen.getAllByRole("button", { name: /^Open thread:/ }),
+      ).toHaveLength(8);
     });
 
     const narrow = canvasBox();

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-z-layers.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-z-layers.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  STAR_MAP_CARD_HOVER_Z,
+  STAR_MAP_CLOUD_CHROME_Z,
+} from "../StarMapScreen";
+
+/**
+ * The cloud's paint order lives in two files — inline `zIndex` on the
+ * cards (StarMapScreen) and `z-index` on the chrome and the hover raise
+ * (app.css) — so nothing in either file can tell you the scale is
+ * consistent. This test is that check.
+ *
+ * It exists because the hover raise was pinned just above a card cap that
+ * later stopped bounding anything: a hovered card carrying stack index 60
+ * was set to 49 and DROPPED BEHIND its neighbours. Hover is supposed to
+ * surface the card under the pointer, so a value that can demote it is
+ * not a tuning miss, it is the opposite behaviour.
+ */
+const CSS = readFileSync(
+  path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../styles/app.css",
+  ),
+  "utf8",
+);
+
+function zIndexIn(selector: string): number {
+  const block = new RegExp(
+    `${selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[^{]*\\{([^}]*)\\}`,
+  ).exec(CSS);
+  if (!block) throw new Error(`No CSS block for ${selector}`);
+  const declaration = /z-index:\s*(\d+)/.exec(block[1]);
+  if (!declaration) throw new Error(`No z-index in ${selector}`);
+  return Number(declaration[1]);
+}
+
+describe("star map cloud paint layers", () => {
+  /** Matches the clamp in StarMapScreen's card render. */
+  const CARD_MAX_Z = 4000;
+
+  it("raises a hovered card above every card the stack can produce", () => {
+    expect(zIndexIn(".star-map-card-shell:hover")).toBe(STAR_MAP_CARD_HOVER_Z);
+    expect(STAR_MAP_CARD_HOVER_Z).toBeGreaterThan(CARD_MAX_Z);
+  });
+
+  it("keeps the hover raise !important so an inline stack index cannot win", () => {
+    // Every shell carries `style="z-index: <stack position>"`, which beats
+    // an ordinary rule outright — the raise silently did nothing for the
+    // whole life of the previous `z-index: 5`.
+    expect(
+      /\.star-map-card-shell:hover[^{]*\{[^}]*z-index:\s*\d+\s*!important/.test(
+        CSS,
+      ),
+    ).toBe(true);
+  });
+
+  it("floats cloud chrome above the cards but below a hovered one", () => {
+    expect(zIndexIn(".star-map__cluster-label")).toBe(STAR_MAP_CLOUD_CHROME_Z);
+    expect(zIndexIn(".star-map__cluster-overflow")).toBe(
+      STAR_MAP_CLOUD_CHROME_Z,
+    );
+    expect(STAR_MAP_CLOUD_CHROME_Z).toBeGreaterThan(CARD_MAX_Z);
+    expect(STAR_MAP_CLOUD_CHROME_Z).toBeLessThan(STAR_MAP_CARD_HOVER_Z);
+  });
+
+  it("keeps the nebula smudge under its cards", () => {
+    expect(zIndexIn(".star-map__cluster-halo")).toBe(0);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-z-layers.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-z-layers.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   STAR_MAP_CARD_HOVER_Z,
+  STAR_MAP_CARD_MAX_Z,
   STAR_MAP_CLOUD_CHROME_Z,
 } from "../StarMapScreen";
 
@@ -38,8 +39,7 @@ function zIndexIn(selector: string): number {
 }
 
 describe("star map cloud paint layers", () => {
-  /** Matches the clamp in StarMapScreen's card render. */
-  const CARD_MAX_Z = 4000;
+  const CARD_MAX_Z = STAR_MAP_CARD_MAX_Z;
 
   it("raises a hovered card above every card the stack can produce", () => {
     expect(zIndexIn(".star-map-card-shell:hover")).toBe(STAR_MAP_CARD_HOVER_Z);

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-chat-card-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-chat-card-geometry.ts
@@ -132,17 +132,8 @@ export function raiseChatCard(
 
 /** Gap between a chat card and the thread card it belongs to. */
 const CHAT_CARD_ANCHOR_GAP = 28;
-/** How many times a card steps aside before it accepts an overlap. */
+/** How many times a card steps off an exact stack before giving up. */
 const CHAT_CARD_NUDGE_LIMIT = 8;
-
-function rectsOverlap(a: ChatCardRect, b: ChatCardRect): boolean {
-  return (
-    a.left < b.left + b.width
-    && b.left < a.left + a.width
-    && a.top < b.top + b.height
-    && b.top < a.top + a.height
-  );
-}
 
 /**
  * Where a chat card opens: beside the card it belongs to.
@@ -153,9 +144,12 @@ function rectsOverlap(a: ChatCardRect, b: ChatCardRect): boolean {
  * most of what makes the pairing legible; the tether drawn between them
  * says the rest.
  *
- * Prefers the right of the anchor, falls back to its left when that would
- * leave the canvas, then steps diagonally clear of chat cards that are
- * already open.
+ * Prefers the right of the anchor and falls back to its left when that
+ * would leave the canvas. It deliberately does NOT hunt for free space:
+ * being next to its thread beats being tidy, and an overlap is the
+ * operator's to resolve by dragging the card wherever they want it. The
+ * only avoidance left is against a card opened at the very same spot,
+ * which would hide the older one completely.
  */
 export function placeChatCardBesideAnchor(params: {
   /** The thread card, in canvas pixels. */
@@ -179,23 +173,19 @@ export function placeChatCardBesideAnchor(params: {
 
   let candidate = clampChatCardRect({ left, top, width, height }, params.bounds);
   for (let nudge = 0; nudge < CHAT_CARD_NUDGE_LIMIT; nudge += 1) {
-    const blocker = params.occupied.find((other) =>
-      rectsOverlap(candidate, other),
+    const stacked = params.occupied.some(
+      (other) =>
+        Math.abs(other.left - candidate.left) < CHAT_CARD_CASCADE_STEP
+        && Math.abs(other.top - candidate.top) < CHAT_CARD_CASCADE_STEP,
     );
-    if (!blocker) break;
-    // Step clear of the whole blocker, not by a token offset: a cascade
-    // step is a fraction of a card, so nudging by one leaves the new card
-    // still on top of the old one.
-    const below = blocker.top + blocker.height + CHAT_CARD_ANCHOR_GAP;
+    if (!stacked) break;
     candidate = clampChatCardRect(
-      below + height <= params.bounds.height
-        ? { left: candidate.left, top: below, width, height }
-        : {
-            left: blocker.left + blocker.width + CHAT_CARD_ANCHOR_GAP,
-            top,
-            width,
-            height,
-          },
+      {
+        left: candidate.left + CHAT_CARD_CASCADE_STEP,
+        top: candidate.top + CHAT_CARD_CASCADE_STEP,
+        width,
+        height,
+      },
       params.bounds,
     );
   }

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-chat-card-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-chat-card-geometry.ts
@@ -129,3 +129,96 @@ export function raiseChatCard(
   if (!order.includes(key)) return [...order, key];
   return [...order.filter((entry) => entry !== key), key];
 }
+
+/** Gap between a chat card and the thread card it belongs to. */
+const CHAT_CARD_ANCHOR_GAP = 28;
+/** How many times a card steps aside before it accepts an overlap. */
+const CHAT_CARD_NUDGE_LIMIT = 8;
+
+function rectsOverlap(a: ChatCardRect, b: ChatCardRect): boolean {
+  return (
+    a.left < b.left + b.width
+    && b.left < a.left + a.width
+    && a.top < b.top + b.height
+    && b.top < a.top + a.height
+  );
+}
+
+/**
+ * Where a chat card opens: beside the card it belongs to.
+ *
+ * Chat cards live IN the map — they pan and zoom with the galaxy and hold
+ * their place in it — so a card opens next to its thread rather than
+ * cascading from a corner of the window. Opening beside the source is
+ * most of what makes the pairing legible; the tether drawn between them
+ * says the rest.
+ *
+ * Prefers the right of the anchor, falls back to its left when that would
+ * leave the canvas, then steps diagonally clear of chat cards that are
+ * already open.
+ */
+export function placeChatCardBesideAnchor(params: {
+  /** The thread card, in canvas pixels. */
+  anchor: { x: number; y: number; width: number; height: number };
+  /** Chat cards already open, in canvas pixels. */
+  occupied: readonly ChatCardRect[];
+  /** Canvas extent, so a card cannot open somewhere unreachable. */
+  bounds: { width: number; height: number };
+  size?: { width: number; height: number };
+}): ChatCardRect {
+  const width = params.size?.width ?? CHAT_CARD_DEFAULT_WIDTH;
+  const height = params.size?.height ?? CHAT_CARD_DEFAULT_HEIGHT;
+  const rightOf = params.anchor.x + params.anchor.width + CHAT_CARD_ANCHOR_GAP;
+  const leftOf = params.anchor.x - CHAT_CARD_ANCHOR_GAP - width;
+  const left = rightOf + width <= params.bounds.width || leftOf < 0
+    ? rightOf
+    : leftOf;
+  // Vertically centred on the anchor: the card reads as belonging to the
+  // thread beside it rather than to whatever it happens to sit above.
+  const top = params.anchor.y + params.anchor.height / 2 - height / 3;
+
+  let candidate = clampChatCardRect({ left, top, width, height }, params.bounds);
+  for (let nudge = 0; nudge < CHAT_CARD_NUDGE_LIMIT; nudge += 1) {
+    const blocker = params.occupied.find((other) =>
+      rectsOverlap(candidate, other),
+    );
+    if (!blocker) break;
+    // Step clear of the whole blocker, not by a token offset: a cascade
+    // step is a fraction of a card, so nudging by one leaves the new card
+    // still on top of the old one.
+    const below = blocker.top + blocker.height + CHAT_CARD_ANCHOR_GAP;
+    candidate = clampChatCardRect(
+      below + height <= params.bounds.height
+        ? { left: candidate.left, top: below, width, height }
+        : {
+            left: blocker.left + blocker.width + CHAT_CARD_ANCHOR_GAP,
+            top,
+            width,
+            height,
+          },
+      params.bounds,
+    );
+  }
+  return candidate;
+}
+
+/**
+ * Where a tether meets a chat card: the point on its border facing the
+ * thread card, so the line stops at the edge instead of disappearing
+ * under an opaque card.
+ */
+export function chatCardEdgeToward(
+  rect: ChatCardRect,
+  target: { x: number; y: number },
+): { x: number; y: number } {
+  const centerX = rect.left + rect.width / 2;
+  const centerY = rect.top + rect.height / 2;
+  const dx = target.x - centerX;
+  const dy = target.y - centerY;
+  if (dx === 0 && dy === 0) return { x: centerX, y: centerY };
+  // Scale the direction until it lands on whichever border it crosses.
+  const scaleX = dx === 0 ? Infinity : rect.width / 2 / Math.abs(dx);
+  const scaleY = dy === 0 ? Infinity : rect.height / 2 / Math.abs(dy);
+  const scale = Math.min(scaleX, scaleY);
+  return { x: centerX + dx * scale, y: centerY + dy * scale };
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-clusters.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-clusters.ts
@@ -2,7 +2,7 @@ import {
   buildThreadIdentityKey,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
-import { STAR_MAP_CARD_GAP, type StarMapCardSlot } from "./star-map-layout";
+import { type StarMapCardSlot } from "./star-map-layout";
 import { STAR_MAP_INSTANCE_KEEPOUT } from "./star-map-orbit";
 import {
   projectMass,
@@ -15,62 +15,74 @@ import {
  * Project clouds for the orbit lens.
  *
  * A flat ring seats cards purely by sort index, so two projects with
- * interleaved activity times provably alternate around the ring — the
- * "intermingled mess" this module exists to fix. Instead, an instance's
- * cards group by project into labeled clouds seated around the body, each
- * capped per group with an honest overflow chip rather than one silent
- * instance-wide truncation.
+ * interleaved activity times provably alternate around the ring. Instead,
+ * an instance's cards group into clouds — a nebula smudge under a loose
+ * ring scatter of cards, not an outlined grid:
+ *
+ * - each parent thread with children present becomes its own cloud, the
+ *   parent in the middle and its children orbiting it;
+ * - the rest of a project pools into that project's catch-all cloud;
+ * - every scratch checkout collapses into ONE "Workspaces" cloud via the
+ *   shared directory classifier, instead of a hash-named body per chat.
+ *
+ * Each cloud caps what it shows by default and carries a working "+N
+ * more" chip. There is deliberately NO cross-cloud budget: allocating a
+ * fixed instance-wide card budget in mass order starved every later
+ * cloud to zero cards and made expansion a no-op — the exact failure an
+ * honest overflow chip exists to prevent.
  */
 
 /**
- * Default visible cards per project cloud. Small enough that four projects
- * still fit around one body; the per-cloud "+N more" chip expands past it.
+ * Default visible cards per cloud. Small enough that several clouds fit
+ * around one body; the per-cloud "+N more" chip expands past it.
  */
 export const ORBIT_MAX_CARDS_PER_GROUP = 8;
-/**
- * DOM-size backstop across an instance's clouds, matching the lane cap: a
- * fleet of five instances at this ceiling is already 200 mounted cards.
- * Never silent — a cloud clipped by the backstop reports the clipped cards
- * in its own overflow chip.
- */
-export const ORBIT_MAX_CARDS_PER_CLOUD = 40;
 
-/** Clouds of up to this many cards stack one column; larger use two. */
-const SINGLE_COLUMN_MAX = 4;
-const CLUSTER_COLUMN_GAP = 14;
-const CLUSTER_PAD_X = 16;
-/** Room inside the outline's top edge for the label pill row. */
-const CLUSTER_PAD_TOP = 44;
-const CLUSTER_PAD_BOTTOM = 14;
-/** Height reserved for the overflow chip row, gap included. */
-const CLUSTER_OVERFLOW_HEIGHT = 24;
-const CLUSTER_OVERFLOW_GAP = 10;
-/** Clearance between two clouds' outlines. */
-const CLUSTER_GAP = 44;
+/** Cards may shingle slightly on a ring; hover raises the one under the
+ * pointer, and the overlap is what makes the scatter read as a cloud
+ * rather than a grid. */
+const RING_PACKING = 0.82;
+/** Extra x-radius on ring 1 so it clears the centre card. */
+const RING_BASE_RX_FACTOR = 1.05;
+const RING_STEP_RX_FACTOR = 1.0;
+const RING_BASE_RY_PAD = 26;
+const RING_STEP_RY_PAD = 20;
+/** Max angular jitter as a share of a slot's angular pitch. */
+const JITTER_ANGLE_SHARE = 0.35;
+/** Max outward-only radial jitter. */
+const JITTER_RADIUS_SHARE = 0.12;
+/** Breathing room the cloud claims past its outermost card. */
+const CLOUD_EXTENT_PAD = 26;
+/** Vertical room above/below the cards for the label and the chip. */
+const CLOUD_LABEL_ROOM = 30;
+const CLOUD_CHIP_ROOM = 30;
+
+/** Clearance between two clouds' extents when seating. */
+const CLUSTER_GAP = 56;
 /** Clearance between a cloud and the instance's own chrome. */
-const KEEPOUT_GAP = 14;
+const KEEPOUT_GAP = 18;
 /** First radius probed when seating a cloud around the body. */
-const SEAT_BASE_RADIUS = 150;
+const SEAT_BASE_RADIUS = 170;
 const SEAT_RADIUS_STEP = 26;
 const SEAT_MAX_PROBES = 240;
-/**
- * Same base rotation as the galaxy scatter in star-map-orbit: clouds leave
- * the cardinal axes so two of them never sit at exactly N/S.
- */
+/** Same base rotation as the galaxy scatter: clouds leave the cardinal
+ * axes so two of them never sit at exactly N/S. */
 const SEAT_BASE_ROTATION = 0.22;
 /** Clouds are wide and short-ish, so seating stretches horizontally. */
 const SEAT_ASPECT_X = 1.3;
 
 export type StarMapClusterSpec = {
-  /** Stable identity: the repo root path, or the no-project sentinel. */
+  /** Stable identity: project key, or `${projectKey}::pc:${parentKey}`. */
   key: string;
+  /** Project name for catch-all clouds; the parent's title otherwise. */
   label: string;
   /** False only for the pooled no-project cloud. */
   isProject: boolean;
+  /** Set when this cloud is one parent thread and its descendants. */
+  isParentGroup: boolean;
   /** Full ordered membership; the first `visibleCount` render. */
   threads: NavigationThreadSummary[];
   visibleCount: number;
-  /** Hidden members — per-cloud cap plus any backstop clipping. */
   overflow: number;
   expanded: boolean;
   /** Whether the expand chip has anything to do. */
@@ -78,16 +90,20 @@ export type StarMapClusterSpec = {
 };
 
 export type StarMapClusterPlacement = StarMapClusterSpec & {
-  /** Outline box, body-relative top-left. */
-  rect: { x: number; y: number; width: number; height: number };
+  /** Cloud centre, body-relative. */
+  center: { x: number; y: number };
+  /** Half-extent of the drawn cards around the centre. */
+  extent: { rx: number; ry: number };
   /** Per visible card: dx = centre x, dy = top y, body-relative. */
   slots: StarMapCardSlot[];
-  /** Centre of the overflow chip row, when the cloud shows one. */
+  /** Centre of the floating label, body-relative. */
+  labelSlot: StarMapCardSlot;
+  /** Centre of the overflow chip, when the cloud shows one. */
   overflowSlot?: StarMapCardSlot;
   /**
-   * A lone no-project cloud renders without outline or pill — there is
-   * nothing to distinguish it from, and a "No project" frame around the
-   * whole map would be chrome about nothing.
+   * A lone card needs no nebula, no label, no chip — it just floats.
+   * Twenty one-thread clouds wearing full chrome is how the map turned
+   * into a spreadsheet.
    */
   chromeless: boolean;
 };
@@ -99,9 +115,9 @@ export type StarMapClusterCloud = {
   /** Flat slots aligned with `threads`. */
   slots: StarMapCardSlot[];
   heights: number[];
-  /** Cluster index per flat card, for per-cloud chip hygiene. */
+  /** Cluster index per flat card. */
   clusterIndexByCard: number[];
-  /** Half-extent of the drawn cloud set, for inter-instance spacing. */
+  /** Half-extent of the whole drawn cloud set, for instance spacing. */
   extent: { rx: number; ry: number };
 };
 
@@ -117,15 +133,20 @@ function parentKeyOf(thread: NavigationThreadSummary): string | undefined {
   );
 }
 
+/** Stable [0,1) from a string, for deterministic willy-nilly. */
+function noise(value: string, salt: number): number {
+  let hash = 0x811c9dc5 ^ salt;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return ((hash >>> 0) % 10_000) / 10_000;
+}
+
 /**
- * Reorder a cloud so children sit directly under their parent.
- *
- * Eight stacked-PR children sorted by recency scatter through the stack in
- * whatever order their turns last ran; adjacency is what makes them read
- * as one piece of work. Threads whose parent is not in this cloud keep
- * their place, and a parent's children keep their relative order. Cycle
- * members (a thread that is its own ancestor) fall back to their original
- * position rather than vanishing.
+ * Reorder a cloud so children sit directly after their parent (DFS), for
+ * the clouds that still mix relationships (a catch-all holding an orphan
+ * chain). Cycle members fall back to their original position.
  */
 export function orderParentAdjacent(
   threads: readonly NavigationThreadSummary[],
@@ -157,7 +178,6 @@ export function orderParentAdjacent(
     for (const child of childrenOf.get(key) ?? []) visit(child);
   };
   for (const root of roots) visit(root);
-  // Anything not reached hangs off a cycle; keep it rather than lose it.
   for (const thread of threads) {
     if (!emitted.has(threadKeyOf(thread))) {
       emitted.add(threadKeyOf(thread));
@@ -168,12 +188,15 @@ export function orderParentAdjacent(
 }
 
 /**
- * Group one instance's filtered threads into capped project clouds.
+ * Group one instance's filtered threads into capped clouds.
  *
- * Threads arrive already sorted (pins first, then recency) and keep that
- * order inside their cloud, apart from the parent-adjacency pass. Clouds
- * order by the same mass the projects lens uses, heaviest first, so the
- * busiest project seats nearest the body.
+ * Buckets come from the shared directory classifier (via
+ * `threadProjectKey`), so every scratch checkout pools into one
+ * "Workspaces" cloud. Within a bucket, each root parent that has
+ * children present splits out into its own parent/child cloud (parent
+ * first, descendants in DFS order); the remainder stays in the bucket's
+ * catch-all. Clouds order by the same mass the projects lens uses,
+ * heaviest first, so the busiest work seats nearest the body.
  */
 export function buildInstanceClusters(params: {
   threads: readonly NavigationThreadSummary[];
@@ -181,125 +204,207 @@ export function buildInstanceClusters(params: {
   expandedKeys?: ReadonlySet<string>;
   now?: number;
 }): StarMapClusterSpec[] {
-  const groups = new Map<string, NavigationThreadSummary[]>();
+  const buckets = new Map<string, NavigationThreadSummary[]>();
   for (const thread of params.threads) {
     const key = threadProjectKey(thread);
-    const members = groups.get(key);
+    const members = buckets.get(key);
     if (members) members.push(thread);
-    else groups.set(key, [thread]);
+    else buckets.set(key, [thread]);
   }
+
+  type Draft = {
+    key: string;
+    label: string;
+    isProject: boolean;
+    isParentGroup: boolean;
+    threads: NavigationThreadSummary[];
+    mass: number;
+  };
   const now = params.now ?? Date.now();
-  const massed = [...groups.entries()].map(([key, members]) => {
-    const lastActivityAt = members.reduce(
-      (latest, thread) => Math.max(latest, thread.updatedAt ?? 0),
-      0,
-    );
-    return {
-      key,
-      label: threadProjectLabel(members[0]),
-      isProject: key !== STAR_MAP_NO_PROJECT_KEY,
-      threads: orderParentAdjacent(members),
-      mass: projectMass({ cardCount: members.length, lastActivityAt, now }),
-      expanded: params.expandedKeys?.has(key) ?? false,
+  const drafts: Draft[] = [];
+
+  for (const [bucketKey, members] of buckets) {
+    const ordered = orderParentAdjacent(members);
+    const present = new Set(members.map(threadKeyOf));
+    const isProject = bucketKey !== STAR_MAP_NO_PROJECT_KEY;
+    const bucketLabel = threadProjectLabel(members[0]);
+
+    // Root parents: threads with children in this bucket whose own
+    // parent is absent (or self/cyclic). `ordered` is DFS, so a root's
+    // descendants follow it contiguously — collect until the next root.
+    const hasChildren = new Set<string>();
+    for (const thread of members) {
+      const parentKey = parentKeyOf(thread);
+      if (
+        parentKey !== undefined
+        && parentKey !== threadKeyOf(thread)
+        && present.has(parentKey)
+      ) {
+        hasChildren.add(parentKey);
+      }
+    }
+    const isRoot = (thread: NavigationThreadSummary) => {
+      const parentKey = parentKeyOf(thread);
+      return (
+        parentKey === undefined
+        || parentKey === threadKeyOf(thread)
+        || !present.has(parentKey)
+      );
     };
-  });
-  massed.sort(
+
+    const rest: NavigationThreadSummary[] = [];
+    let index = 0;
+    while (index < ordered.length) {
+      const thread = ordered[index];
+      if (isRoot(thread) && hasChildren.has(threadKeyOf(thread))) {
+        const group: NavigationThreadSummary[] = [thread];
+        index += 1;
+        while (index < ordered.length && !isRoot(ordered[index])) {
+          group.push(ordered[index]);
+          index += 1;
+        }
+        drafts.push({
+          key: `${bucketKey}::pc:${threadKeyOf(thread)}`,
+          label: thread.title,
+          isProject,
+          isParentGroup: true,
+          threads: group,
+          mass: massOf(group, now),
+        });
+        continue;
+      }
+      rest.push(thread);
+      index += 1;
+    }
+    if (rest.length > 0) {
+      drafts.push({
+        key: bucketKey,
+        label: bucketLabel,
+        isProject,
+        isParentGroup: false,
+        threads: rest,
+        mass: massOf(rest, now),
+      });
+    }
+  }
+
+  drafts.sort(
     (left, right) =>
       right.mass - left.mass || left.label.localeCompare(right.label),
   );
 
-  let budget = ORBIT_MAX_CARDS_PER_CLOUD;
-  return massed.map((cluster) => {
-    const desired = cluster.expanded
-      ? cluster.threads.length
-      : Math.min(cluster.threads.length, ORBIT_MAX_CARDS_PER_GROUP);
-    const visibleCount = Math.max(0, Math.min(desired, budget));
-    budget -= visibleCount;
+  return drafts.map((draft) => {
+    const expanded = params.expandedKeys?.has(draft.key) ?? false;
+    const visibleCount = expanded
+      ? draft.threads.length
+      : Math.min(draft.threads.length, ORBIT_MAX_CARDS_PER_GROUP);
     return {
-      key: cluster.key,
-      label: cluster.label,
-      isProject: cluster.isProject,
-      threads: cluster.threads,
+      key: draft.key,
+      label: draft.label,
+      isProject: draft.isProject,
+      isParentGroup: draft.isParentGroup,
+      threads: draft.threads,
       visibleCount,
-      overflow: cluster.threads.length - visibleCount,
-      expanded: cluster.expanded,
-      expandable: cluster.threads.length > ORBIT_MAX_CARDS_PER_GROUP,
+      overflow: draft.threads.length - visibleCount,
+      expanded,
+      expandable: draft.threads.length > ORBIT_MAX_CARDS_PER_GROUP,
     };
   });
 }
 
-type SizedCluster = {
+function massOf(threads: readonly NavigationThreadSummary[], now: number): number {
+  const lastActivityAt = threads.reduce(
+    (latest, thread) => Math.max(latest, thread.updatedAt ?? 0),
+    0,
+  );
+  return projectMass({ cardCount: threads.length, lastActivityAt, now });
+}
+
+type ScatteredCluster = {
   spec: StarMapClusterSpec;
-  width: number;
-  height: number;
-  /** Cluster-local card slots, from the outline's top-left corner. */
+  /** Cloud-local card slots (dx from centre, dy = card TOP from centre). */
   slots: StarMapCardSlot[];
-  overflowSlot?: StarMapCardSlot;
+  extent: { rx: number; ry: number };
 };
 
 /**
- * Stack a cloud's visible cards into one or two columns, row-major so the
- * pins-then-recency order reads left-right, top-down. Rows step by the
- * tallest card in the row — heights vary with chip rows, and a fixed pitch
- * either clips or wastes.
+ * Scatter a cloud's visible cards: the first card in the middle (for a
+ * parent/child cloud that IS the parent), the rest walking elliptical
+ * rings with deterministic per-thread jitter — willy-nilly like the
+ * original orbit, never a grid. Cards may shingle slightly on purpose;
+ * they are opaque and hover raises the one under the pointer.
  */
-function sizeCluster(params: {
+function scatterCluster(params: {
   spec: StarMapClusterSpec;
   cardWidth: number;
   heightForThread: (threadKey: string) => number;
-}): SizedCluster {
+}): ScatteredCluster {
   const visible = params.spec.threads.slice(0, params.spec.visibleCount);
-  const columns = visible.length > SINGLE_COLUMN_MAX ? 2 : 1;
-  const contentWidth =
-    columns * params.cardWidth + (columns - 1) * CLUSTER_COLUMN_GAP;
-  const width = contentWidth + CLUSTER_PAD_X * 2;
+  const heights = visible.map((thread) =>
+    params.heightForThread(threadKeyOf(thread)),
+  );
+  const maxHeight = heights.reduce((top, height) => Math.max(top, height), 1);
   const slots: StarMapCardSlot[] = [];
-  let y = CLUSTER_PAD_TOP;
-  for (let start = 0; start < visible.length; start += columns) {
-    const row = visible.slice(start, start + columns);
-    for (let column = 0; column < row.length; column += 1) {
+  if (visible.length > 0) {
+    slots.push({ dx: 0, dy: -heights[0] / 2 });
+  }
+
+  // The whole cloud leans a little, per cloud, so no two clouds start
+  // their rings at the same bearing.
+  const baseAngle = Math.PI / 2 + (noise(params.spec.key, 3) * 2 - 1) * 0.7;
+  let ringIndex = 0;
+  let seated = 1;
+  while (seated < visible.length) {
+    ringIndex += 1;
+    const rx =
+      params.cardWidth
+      * (RING_BASE_RX_FACTOR + (ringIndex - 1) * RING_STEP_RX_FACTOR);
+    const ry =
+      (maxHeight + RING_BASE_RY_PAD)
+      + (ringIndex - 1) * (maxHeight + RING_STEP_RY_PAD);
+    const capacity = Math.max(
+      4,
+      Math.floor((2 * Math.PI * rx) / (params.cardWidth * RING_PACKING)),
+    );
+    const onThisRing = Math.min(visible.length - seated, capacity);
+    const pitch = (2 * Math.PI) / onThisRing;
+    for (let position = 0; position < onThisRing; position += 1) {
+      const thread = visible[seated + position];
+      const key = threadKeyOf(thread);
+      const angle =
+        baseAngle
+        + position * pitch
+        + (ringIndex % 2 === 1 ? 0 : pitch / 2)
+        + (noise(key, 5) * 2 - 1) * pitch * JITTER_ANGLE_SHARE;
+      const reach = 1 + noise(key, 7) * JITTER_RADIUS_SHARE;
+      const height = heights[seated + position];
       slots.push({
-        dx:
-          CLUSTER_PAD_X
-          + column * (params.cardWidth + CLUSTER_COLUMN_GAP)
-          + params.cardWidth / 2,
-        dy: y,
+        dx: Math.cos(angle) * rx * reach,
+        dy: Math.sin(angle) * ry * reach - height / 2,
       });
     }
-    const rowHeight = Math.max(
-      ...row.map((thread) => params.heightForThread(threadKeyOf(thread))),
-    );
-    y += rowHeight + STAR_MAP_CARD_GAP;
+    seated += onThisRing;
   }
-  let bottom = visible.length > 0 ? y - STAR_MAP_CARD_GAP : CLUSTER_PAD_TOP;
-  // The chip appears for hidden cards, and stays while expanded so the
-  // cloud can be re-collapsed.
-  const showChip =
-    params.spec.overflow > 0
-    || (params.spec.expanded && params.spec.expandable);
-  let overflowSlot: StarMapCardSlot | undefined;
-  if (showChip) {
-    overflowSlot = {
-      dx: width / 2,
-      dy:
-        bottom
-        + (visible.length > 0 ? CLUSTER_OVERFLOW_GAP : 0)
-        + CLUSTER_OVERFLOW_HEIGHT / 2,
-    };
-    bottom = overflowSlot.dy + CLUSTER_OVERFLOW_HEIGHT / 2;
-  }
+
+  let rx = 0;
+  let ry = 0;
+  slots.forEach((slot, index) => {
+    rx = Math.max(rx, Math.abs(slot.dx) + params.cardWidth / 2);
+    ry = Math.max(ry, Math.abs(slot.dy), Math.abs(slot.dy + heights[index]));
+  });
   return {
     spec: params.spec,
-    width,
-    height: bottom + CLUSTER_PAD_BOTTOM,
     slots,
-    overflowSlot,
+    extent: {
+      rx: rx + CLOUD_EXTENT_PAD,
+      ry: ry + CLOUD_EXTENT_PAD,
+    },
   };
 }
 
-type Rect = { x: number; y: number; width: number; height: number };
+type Box = { x: number; y: number; width: number; height: number };
 
-function rectsOverlap(a: Rect, b: Rect, gap: number): boolean {
+function boxesOverlap(a: Box, b: Box, gap: number): boolean {
   return (
     a.x < b.x + b.width + gap
     && b.x < a.x + a.width + gap
@@ -308,64 +413,82 @@ function rectsOverlap(a: Rect, b: Rect, gap: number): boolean {
   );
 }
 
-const KEEPOUT_RECT: Rect = {
+const KEEPOUT_BOX: Box = {
   x: -STAR_MAP_INSTANCE_KEEPOUT.halfWidth,
   y: -STAR_MAP_INSTANCE_KEEPOUT.above,
   width: STAR_MAP_INSTANCE_KEEPOUT.halfWidth * 2,
   height: STAR_MAP_INSTANCE_KEEPOUT.above + STAR_MAP_INSTANCE_KEEPOUT.below,
 };
 
+function boxFor(
+  center: { x: number; y: number },
+  scattered: ScatteredCluster,
+): Box {
+  return {
+    x: center.x - scattered.extent.rx,
+    y: center.y - scattered.extent.ry - CLOUD_LABEL_ROOM,
+    width: scattered.extent.rx * 2,
+    height: scattered.extent.ry * 2 + CLOUD_LABEL_ROOM + CLOUD_CHIP_ROOM,
+  };
+}
+
 /**
- * Seat sized clouds around the body: a lone cloud hangs centred below it
- * (the lane shape), several distribute by angle — heaviest first, just off
+ * Seat scattered clouds around the body: a lone cloud hangs centred
+ * below it, several distribute by angle — heaviest first, just off
  * vertical — each walking outward along its own bearing until it clears
- * the chrome and every cloud already seated. Deterministic: same clouds,
- * same sky.
+ * the chrome and every cloud already seated. Deterministic.
  */
-function seatClusters(sized: readonly SizedCluster[]): Rect[] {
-  if (sized.length === 1) {
-    const only = sized[0];
+function seatClusters(
+  scattered: readonly ScatteredCluster[],
+): { x: number; y: number }[] {
+  if (scattered.length === 1) {
+    const only = scattered[0];
     return [
       {
-        x: -only.width / 2,
-        y: STAR_MAP_INSTANCE_KEEPOUT.below + KEEPOUT_GAP,
-        width: only.width,
-        height: only.height,
+        x: 0,
+        y:
+          STAR_MAP_INSTANCE_KEEPOUT.below
+          + KEEPOUT_GAP
+          + CLOUD_LABEL_ROOM
+          + only.extent.ry,
       },
     ];
   }
-  const placed: Rect[] = [];
-  sized.forEach((cluster, index) => {
+  const placedBoxes: Box[] = [];
+  const centers: { x: number; y: number }[] = [];
+  scattered.forEach((cluster, index) => {
     const angle =
-      Math.PI / 2 + SEAT_BASE_ROTATION + (index * 2 * Math.PI) / sized.length;
+      Math.PI / 2
+      + SEAT_BASE_ROTATION
+      + (index * 2 * Math.PI) / scattered.length;
     let radius = SEAT_BASE_RADIUS;
-    let candidate: Rect = { x: 0, y: 0, width: cluster.width, height: cluster.height };
+    let center = { x: 0, y: 0 };
     for (let probe = 0; probe < SEAT_MAX_PROBES; probe += 1) {
-      candidate = {
-        x: Math.cos(angle) * radius * SEAT_ASPECT_X - cluster.width / 2,
-        y: Math.sin(angle) * radius - cluster.height / 2,
-        width: cluster.width,
-        height: cluster.height,
+      center = {
+        x: Math.cos(angle) * radius * SEAT_ASPECT_X,
+        y: Math.sin(angle) * radius,
       };
+      const box = boxFor(center, cluster);
       const clear =
-        !rectsOverlap(candidate, KEEPOUT_RECT, KEEPOUT_GAP)
-        && placed.every((other) => !rectsOverlap(candidate, other, CLUSTER_GAP));
+        !boxesOverlap(box, KEEPOUT_BOX, KEEPOUT_GAP)
+        && placedBoxes.every((other) => !boxesOverlap(box, other, CLUSTER_GAP));
       if (clear) break;
       radius += SEAT_RADIUS_STEP;
     }
-    placed.push(candidate);
+    placedBoxes.push(boxFor(center, cluster));
+    centers.push(center);
   });
-  return placed;
+  return centers;
 }
 
 /** Extent an instance claims when its clouds are empty — its own body. */
 const EMPTY_CLOUD_EXTENT = 70;
 
 /**
- * Lay out one instance's project clouds and flatten them for rendering.
+ * Lay out one instance's clouds and flatten them for rendering.
  *
  * The flat `threads`/`slots`/`heights` triple is what the screen's lane
- * plumbing already speaks (index-aligned, slot dy = card top), so cluster
+ * plumbing already speaks (index-aligned, slot dy = card top), so cloud
  * membership rides alongside instead of reshaping every consumer.
  */
 export function computeClusterCloud(params: {
@@ -373,14 +496,14 @@ export function computeClusterCloud(params: {
   cardWidth: number;
   heightForThread: (threadKey: string) => number;
 }): StarMapClusterCloud {
-  const sized = params.clusters.map((spec) =>
-    sizeCluster({
+  const scattered = params.clusters.map((spec) =>
+    scatterCluster({
       spec,
       cardWidth: params.cardWidth,
       heightForThread: params.heightForThread,
     }),
   );
-  const rects = seatClusters(sized);
+  const centers = seatClusters(scattered);
 
   const clusters: StarMapClusterPlacement[] = [];
   const threads: NavigationThreadSummary[] = [];
@@ -390,11 +513,11 @@ export function computeClusterCloud(params: {
   let rx = EMPTY_CLOUD_EXTENT;
   let ry = EMPTY_CLOUD_EXTENT;
 
-  sized.forEach((cluster, index) => {
-    const rect = rects[index];
+  scattered.forEach((cluster, index) => {
+    const center = centers[index];
     const bodySlots = cluster.slots.map((slot) => ({
-      dx: rect.x + slot.dx,
-      dy: rect.y + slot.dy,
+      dx: center.x + slot.dx,
+      dy: center.y + slot.dy,
     }));
     const visible = cluster.spec.threads.slice(0, cluster.spec.visibleCount);
     visible.forEach((thread, cardIndex) => {
@@ -403,20 +526,34 @@ export function computeClusterCloud(params: {
       heights.push(params.heightForThread(threadKeyOf(thread)));
       clusterIndexByCard.push(index);
     });
+    const chromeless =
+      cluster.spec.threads.length === 1
+      || (scattered.length === 1 && !cluster.spec.isProject);
+    const showChip =
+      cluster.spec.overflow > 0
+      || (cluster.spec.expanded && cluster.spec.expandable);
     clusters.push({
       ...cluster.spec,
-      rect,
+      center,
+      extent: cluster.extent,
       slots: bodySlots,
-      overflowSlot: cluster.overflowSlot
+      labelSlot: {
+        dx: center.x,
+        dy: center.y - cluster.extent.ry - CLOUD_LABEL_ROOM / 2,
+      },
+      overflowSlot: showChip
         ? {
-            dx: rect.x + cluster.overflowSlot.dx,
-            dy: rect.y + cluster.overflowSlot.dy,
+            dx: center.x,
+            dy: center.y + cluster.extent.ry + CLOUD_CHIP_ROOM / 2,
           }
         : undefined,
-      chromeless: sized.length === 1 && !cluster.spec.isProject,
+      chromeless,
     });
-    rx = Math.max(rx, Math.abs(rect.x), Math.abs(rect.x + rect.width));
-    ry = Math.max(ry, Math.abs(rect.y), Math.abs(rect.y + rect.height));
+    rx = Math.max(rx, Math.abs(center.x) + cluster.extent.rx);
+    ry = Math.max(
+      ry,
+      Math.abs(center.y) + cluster.extent.ry + CLOUD_LABEL_ROOM + CLOUD_CHIP_ROOM,
+    );
   });
 
   return { clusters, threads, slots, heights, clusterIndexByCard, extent: { rx, ry } };

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-clusters.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-clusters.ts
@@ -716,3 +716,93 @@ export function computeClusterCloud(params: {
     memory: { centers: nextCenters, rings: nextRings, seats: nextSeats },
   };
 }
+
+export type StarMapCloudDrop =
+  /** Nothing to do: same cloud, a project cloud, or an illegal parent. */
+  | { kind: "none" }
+  /** Make the dragged thread a child of this cloud's parent. */
+  | { kind: "adopt"; clusterKey: string; parent: NavigationThreadSummary }
+  /** Take the dragged thread out of the parent cloud it was in. */
+  | { kind: "release"; clusterKey: string };
+
+/** Which cloud, if any, a point falls inside. */
+function clusterAt(
+  clusters: readonly StarMapClusterPlacement[],
+  point: { x: number; y: number },
+): StarMapClusterPlacement | undefined {
+  return clusters.find(
+    (cluster) =>
+      Math.abs(point.x - cluster.center.x) <= cluster.extent.rx
+      && Math.abs(point.y - cluster.center.y) <= cluster.extent.ry,
+  );
+}
+
+/**
+ * What dropping a card at this point means.
+ *
+ * Cloud membership is DERIVED, not stored, so a drop can only change it
+ * by changing the data the grouping reads — and the two kinds of cloud
+ * read very different data:
+ *
+ * - A parent/child cloud groups on `parentThreadId`, which the contract
+ *   calls a UI-only relationship that "only controls sidebar grouping".
+ *   Re-parenting on a drop is safe, reversible, and means exactly what
+ *   the gesture looks like it means.
+ * - A project cloud groups on the thread's linked directory — its actual
+ *   workspace, where its commands run and its worktree lives. A drag
+ *   must never silently relink that, so dropping on one moves the card
+ *   and changes nothing else.
+ *
+ * Dropping a child back on its own project's catch-all cloud releases
+ * it, which is the inverse gesture and the only way out that does not
+ * require finding the thread in the sidebar.
+ */
+export function resolveCloudDrop(params: {
+  clusters: readonly StarMapClusterPlacement[];
+  /** Centre of the dropped card, body-relative. */
+  point: { x: number; y: number };
+  thread: NavigationThreadSummary;
+}): StarMapCloudDrop {
+  const draggedKey = threadKeyOf(params.thread);
+  const target = clusterAt(params.clusters, params.point);
+  if (!target) return { kind: "none" };
+
+  const home = params.clusters.find((cluster) =>
+    cluster.threads.some((thread) => threadKeyOf(thread) === draggedKey),
+  );
+  if (target.key === home?.key) return { kind: "none" };
+
+  if (!target.isParentGroup) {
+    // Only a release, and only out of a parent cloud into the catch-all
+    // of the project the thread already belongs to. Any other landing is
+    // a project change, which a drag does not get to make.
+    const sameProject =
+      home?.isParentGroup === true && home.key.startsWith(`${target.key}::pc:`);
+    return sameProject && params.thread.parentThreadId !== undefined
+      ? { kind: "release", clusterKey: target.key }
+      : { kind: "none" };
+  }
+
+  const parent = target.threads[0];
+  if (!parent || threadKeyOf(parent) === draggedKey) return { kind: "none" };
+
+  // A thread cannot be adopted by its own descendant: walking up from the
+  // candidate would come back around to the card being dragged, and the
+  // grouping would fold in on itself.
+  const byKey = new Map<string, NavigationThreadSummary>();
+  for (const cluster of params.clusters) {
+    for (const thread of cluster.threads) byKey.set(threadKeyOf(thread), thread);
+  }
+  const seen = new Set<string>();
+  let walk: NavigationThreadSummary | undefined = parent;
+  while (walk) {
+    const key = threadKeyOf(walk);
+    if (key === draggedKey) return { kind: "none" };
+    if (seen.has(key)) break;
+    seen.add(key);
+    const parentKey = parentKeyOf(walk);
+    walk = parentKey ? byKey.get(parentKey) : undefined;
+  }
+
+  return { kind: "adopt", clusterKey: target.key, parent };
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-clusters.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-clusters.ts
@@ -1,0 +1,423 @@
+import {
+  buildThreadIdentityKey,
+  type NavigationThreadSummary,
+} from "@pwragent/shared";
+import { STAR_MAP_CARD_GAP, type StarMapCardSlot } from "./star-map-layout";
+import { STAR_MAP_INSTANCE_KEEPOUT } from "./star-map-orbit";
+import {
+  projectMass,
+  STAR_MAP_NO_PROJECT_KEY,
+  threadProjectKey,
+  threadProjectLabel,
+} from "./star-map-projects";
+
+/**
+ * Project clouds for the orbit lens.
+ *
+ * A flat ring seats cards purely by sort index, so two projects with
+ * interleaved activity times provably alternate around the ring — the
+ * "intermingled mess" this module exists to fix. Instead, an instance's
+ * cards group by project into labeled clouds seated around the body, each
+ * capped per group with an honest overflow chip rather than one silent
+ * instance-wide truncation.
+ */
+
+/**
+ * Default visible cards per project cloud. Small enough that four projects
+ * still fit around one body; the per-cloud "+N more" chip expands past it.
+ */
+export const ORBIT_MAX_CARDS_PER_GROUP = 8;
+/**
+ * DOM-size backstop across an instance's clouds, matching the lane cap: a
+ * fleet of five instances at this ceiling is already 200 mounted cards.
+ * Never silent — a cloud clipped by the backstop reports the clipped cards
+ * in its own overflow chip.
+ */
+export const ORBIT_MAX_CARDS_PER_CLOUD = 40;
+
+/** Clouds of up to this many cards stack one column; larger use two. */
+const SINGLE_COLUMN_MAX = 4;
+const CLUSTER_COLUMN_GAP = 14;
+const CLUSTER_PAD_X = 16;
+/** Room inside the outline's top edge for the label pill row. */
+const CLUSTER_PAD_TOP = 44;
+const CLUSTER_PAD_BOTTOM = 14;
+/** Height reserved for the overflow chip row, gap included. */
+const CLUSTER_OVERFLOW_HEIGHT = 24;
+const CLUSTER_OVERFLOW_GAP = 10;
+/** Clearance between two clouds' outlines. */
+const CLUSTER_GAP = 44;
+/** Clearance between a cloud and the instance's own chrome. */
+const KEEPOUT_GAP = 14;
+/** First radius probed when seating a cloud around the body. */
+const SEAT_BASE_RADIUS = 150;
+const SEAT_RADIUS_STEP = 26;
+const SEAT_MAX_PROBES = 240;
+/**
+ * Same base rotation as the galaxy scatter in star-map-orbit: clouds leave
+ * the cardinal axes so two of them never sit at exactly N/S.
+ */
+const SEAT_BASE_ROTATION = 0.22;
+/** Clouds are wide and short-ish, so seating stretches horizontally. */
+const SEAT_ASPECT_X = 1.3;
+
+export type StarMapClusterSpec = {
+  /** Stable identity: the repo root path, or the no-project sentinel. */
+  key: string;
+  label: string;
+  /** False only for the pooled no-project cloud. */
+  isProject: boolean;
+  /** Full ordered membership; the first `visibleCount` render. */
+  threads: NavigationThreadSummary[];
+  visibleCount: number;
+  /** Hidden members — per-cloud cap plus any backstop clipping. */
+  overflow: number;
+  expanded: boolean;
+  /** Whether the expand chip has anything to do. */
+  expandable: boolean;
+};
+
+export type StarMapClusterPlacement = StarMapClusterSpec & {
+  /** Outline box, body-relative top-left. */
+  rect: { x: number; y: number; width: number; height: number };
+  /** Per visible card: dx = centre x, dy = top y, body-relative. */
+  slots: StarMapCardSlot[];
+  /** Centre of the overflow chip row, when the cloud shows one. */
+  overflowSlot?: StarMapCardSlot;
+  /**
+   * A lone no-project cloud renders without outline or pill — there is
+   * nothing to distinguish it from, and a "No project" frame around the
+   * whole map would be chrome about nothing.
+   */
+  chromeless: boolean;
+};
+
+export type StarMapClusterCloud = {
+  clusters: StarMapClusterPlacement[];
+  /** Flat visible threads across every cloud, in draw order. */
+  threads: NavigationThreadSummary[];
+  /** Flat slots aligned with `threads`. */
+  slots: StarMapCardSlot[];
+  heights: number[];
+  /** Cluster index per flat card, for per-cloud chip hygiene. */
+  clusterIndexByCard: number[];
+  /** Half-extent of the drawn cloud set, for inter-instance spacing. */
+  extent: { rx: number; ry: number };
+};
+
+function threadKeyOf(thread: NavigationThreadSummary): string {
+  return buildThreadIdentityKey(thread.source, thread.id);
+}
+
+function parentKeyOf(thread: NavigationThreadSummary): string | undefined {
+  if (!thread.parentThreadId) return undefined;
+  return buildThreadIdentityKey(
+    thread.parentThreadBackend ?? thread.source,
+    thread.parentThreadId,
+  );
+}
+
+/**
+ * Reorder a cloud so children sit directly under their parent.
+ *
+ * Eight stacked-PR children sorted by recency scatter through the stack in
+ * whatever order their turns last ran; adjacency is what makes them read
+ * as one piece of work. Threads whose parent is not in this cloud keep
+ * their place, and a parent's children keep their relative order. Cycle
+ * members (a thread that is its own ancestor) fall back to their original
+ * position rather than vanishing.
+ */
+export function orderParentAdjacent(
+  threads: readonly NavigationThreadSummary[],
+): NavigationThreadSummary[] {
+  const present = new Set(threads.map(threadKeyOf));
+  const childrenOf = new Map<string, NavigationThreadSummary[]>();
+  const roots: NavigationThreadSummary[] = [];
+  for (const thread of threads) {
+    const parentKey = parentKeyOf(thread);
+    if (
+      parentKey !== undefined
+      && parentKey !== threadKeyOf(thread)
+      && present.has(parentKey)
+    ) {
+      const siblings = childrenOf.get(parentKey);
+      if (siblings) siblings.push(thread);
+      else childrenOf.set(parentKey, [thread]);
+    } else {
+      roots.push(thread);
+    }
+  }
+  const ordered: NavigationThreadSummary[] = [];
+  const emitted = new Set<string>();
+  const visit = (thread: NavigationThreadSummary) => {
+    const key = threadKeyOf(thread);
+    if (emitted.has(key)) return;
+    emitted.add(key);
+    ordered.push(thread);
+    for (const child of childrenOf.get(key) ?? []) visit(child);
+  };
+  for (const root of roots) visit(root);
+  // Anything not reached hangs off a cycle; keep it rather than lose it.
+  for (const thread of threads) {
+    if (!emitted.has(threadKeyOf(thread))) {
+      emitted.add(threadKeyOf(thread));
+      ordered.push(thread);
+    }
+  }
+  return ordered;
+}
+
+/**
+ * Group one instance's filtered threads into capped project clouds.
+ *
+ * Threads arrive already sorted (pins first, then recency) and keep that
+ * order inside their cloud, apart from the parent-adjacency pass. Clouds
+ * order by the same mass the projects lens uses, heaviest first, so the
+ * busiest project seats nearest the body.
+ */
+export function buildInstanceClusters(params: {
+  threads: readonly NavigationThreadSummary[];
+  /** Cluster keys the operator expanded past the per-group cap. */
+  expandedKeys?: ReadonlySet<string>;
+  now?: number;
+}): StarMapClusterSpec[] {
+  const groups = new Map<string, NavigationThreadSummary[]>();
+  for (const thread of params.threads) {
+    const key = threadProjectKey(thread);
+    const members = groups.get(key);
+    if (members) members.push(thread);
+    else groups.set(key, [thread]);
+  }
+  const now = params.now ?? Date.now();
+  const massed = [...groups.entries()].map(([key, members]) => {
+    const lastActivityAt = members.reduce(
+      (latest, thread) => Math.max(latest, thread.updatedAt ?? 0),
+      0,
+    );
+    return {
+      key,
+      label: threadProjectLabel(members[0]),
+      isProject: key !== STAR_MAP_NO_PROJECT_KEY,
+      threads: orderParentAdjacent(members),
+      mass: projectMass({ cardCount: members.length, lastActivityAt, now }),
+      expanded: params.expandedKeys?.has(key) ?? false,
+    };
+  });
+  massed.sort(
+    (left, right) =>
+      right.mass - left.mass || left.label.localeCompare(right.label),
+  );
+
+  let budget = ORBIT_MAX_CARDS_PER_CLOUD;
+  return massed.map((cluster) => {
+    const desired = cluster.expanded
+      ? cluster.threads.length
+      : Math.min(cluster.threads.length, ORBIT_MAX_CARDS_PER_GROUP);
+    const visibleCount = Math.max(0, Math.min(desired, budget));
+    budget -= visibleCount;
+    return {
+      key: cluster.key,
+      label: cluster.label,
+      isProject: cluster.isProject,
+      threads: cluster.threads,
+      visibleCount,
+      overflow: cluster.threads.length - visibleCount,
+      expanded: cluster.expanded,
+      expandable: cluster.threads.length > ORBIT_MAX_CARDS_PER_GROUP,
+    };
+  });
+}
+
+type SizedCluster = {
+  spec: StarMapClusterSpec;
+  width: number;
+  height: number;
+  /** Cluster-local card slots, from the outline's top-left corner. */
+  slots: StarMapCardSlot[];
+  overflowSlot?: StarMapCardSlot;
+};
+
+/**
+ * Stack a cloud's visible cards into one or two columns, row-major so the
+ * pins-then-recency order reads left-right, top-down. Rows step by the
+ * tallest card in the row — heights vary with chip rows, and a fixed pitch
+ * either clips or wastes.
+ */
+function sizeCluster(params: {
+  spec: StarMapClusterSpec;
+  cardWidth: number;
+  heightForThread: (threadKey: string) => number;
+}): SizedCluster {
+  const visible = params.spec.threads.slice(0, params.spec.visibleCount);
+  const columns = visible.length > SINGLE_COLUMN_MAX ? 2 : 1;
+  const contentWidth =
+    columns * params.cardWidth + (columns - 1) * CLUSTER_COLUMN_GAP;
+  const width = contentWidth + CLUSTER_PAD_X * 2;
+  const slots: StarMapCardSlot[] = [];
+  let y = CLUSTER_PAD_TOP;
+  for (let start = 0; start < visible.length; start += columns) {
+    const row = visible.slice(start, start + columns);
+    for (let column = 0; column < row.length; column += 1) {
+      slots.push({
+        dx:
+          CLUSTER_PAD_X
+          + column * (params.cardWidth + CLUSTER_COLUMN_GAP)
+          + params.cardWidth / 2,
+        dy: y,
+      });
+    }
+    const rowHeight = Math.max(
+      ...row.map((thread) => params.heightForThread(threadKeyOf(thread))),
+    );
+    y += rowHeight + STAR_MAP_CARD_GAP;
+  }
+  let bottom = visible.length > 0 ? y - STAR_MAP_CARD_GAP : CLUSTER_PAD_TOP;
+  // The chip appears for hidden cards, and stays while expanded so the
+  // cloud can be re-collapsed.
+  const showChip =
+    params.spec.overflow > 0
+    || (params.spec.expanded && params.spec.expandable);
+  let overflowSlot: StarMapCardSlot | undefined;
+  if (showChip) {
+    overflowSlot = {
+      dx: width / 2,
+      dy:
+        bottom
+        + (visible.length > 0 ? CLUSTER_OVERFLOW_GAP : 0)
+        + CLUSTER_OVERFLOW_HEIGHT / 2,
+    };
+    bottom = overflowSlot.dy + CLUSTER_OVERFLOW_HEIGHT / 2;
+  }
+  return {
+    spec: params.spec,
+    width,
+    height: bottom + CLUSTER_PAD_BOTTOM,
+    slots,
+    overflowSlot,
+  };
+}
+
+type Rect = { x: number; y: number; width: number; height: number };
+
+function rectsOverlap(a: Rect, b: Rect, gap: number): boolean {
+  return (
+    a.x < b.x + b.width + gap
+    && b.x < a.x + a.width + gap
+    && a.y < b.y + b.height + gap
+    && b.y < a.y + a.height + gap
+  );
+}
+
+const KEEPOUT_RECT: Rect = {
+  x: -STAR_MAP_INSTANCE_KEEPOUT.halfWidth,
+  y: -STAR_MAP_INSTANCE_KEEPOUT.above,
+  width: STAR_MAP_INSTANCE_KEEPOUT.halfWidth * 2,
+  height: STAR_MAP_INSTANCE_KEEPOUT.above + STAR_MAP_INSTANCE_KEEPOUT.below,
+};
+
+/**
+ * Seat sized clouds around the body: a lone cloud hangs centred below it
+ * (the lane shape), several distribute by angle — heaviest first, just off
+ * vertical — each walking outward along its own bearing until it clears
+ * the chrome and every cloud already seated. Deterministic: same clouds,
+ * same sky.
+ */
+function seatClusters(sized: readonly SizedCluster[]): Rect[] {
+  if (sized.length === 1) {
+    const only = sized[0];
+    return [
+      {
+        x: -only.width / 2,
+        y: STAR_MAP_INSTANCE_KEEPOUT.below + KEEPOUT_GAP,
+        width: only.width,
+        height: only.height,
+      },
+    ];
+  }
+  const placed: Rect[] = [];
+  sized.forEach((cluster, index) => {
+    const angle =
+      Math.PI / 2 + SEAT_BASE_ROTATION + (index * 2 * Math.PI) / sized.length;
+    let radius = SEAT_BASE_RADIUS;
+    let candidate: Rect = { x: 0, y: 0, width: cluster.width, height: cluster.height };
+    for (let probe = 0; probe < SEAT_MAX_PROBES; probe += 1) {
+      candidate = {
+        x: Math.cos(angle) * radius * SEAT_ASPECT_X - cluster.width / 2,
+        y: Math.sin(angle) * radius - cluster.height / 2,
+        width: cluster.width,
+        height: cluster.height,
+      };
+      const clear =
+        !rectsOverlap(candidate, KEEPOUT_RECT, KEEPOUT_GAP)
+        && placed.every((other) => !rectsOverlap(candidate, other, CLUSTER_GAP));
+      if (clear) break;
+      radius += SEAT_RADIUS_STEP;
+    }
+    placed.push(candidate);
+  });
+  return placed;
+}
+
+/** Extent an instance claims when its clouds are empty — its own body. */
+const EMPTY_CLOUD_EXTENT = 70;
+
+/**
+ * Lay out one instance's project clouds and flatten them for rendering.
+ *
+ * The flat `threads`/`slots`/`heights` triple is what the screen's lane
+ * plumbing already speaks (index-aligned, slot dy = card top), so cluster
+ * membership rides alongside instead of reshaping every consumer.
+ */
+export function computeClusterCloud(params: {
+  clusters: readonly StarMapClusterSpec[];
+  cardWidth: number;
+  heightForThread: (threadKey: string) => number;
+}): StarMapClusterCloud {
+  const sized = params.clusters.map((spec) =>
+    sizeCluster({
+      spec,
+      cardWidth: params.cardWidth,
+      heightForThread: params.heightForThread,
+    }),
+  );
+  const rects = seatClusters(sized);
+
+  const clusters: StarMapClusterPlacement[] = [];
+  const threads: NavigationThreadSummary[] = [];
+  const slots: StarMapCardSlot[] = [];
+  const heights: number[] = [];
+  const clusterIndexByCard: number[] = [];
+  let rx = EMPTY_CLOUD_EXTENT;
+  let ry = EMPTY_CLOUD_EXTENT;
+
+  sized.forEach((cluster, index) => {
+    const rect = rects[index];
+    const bodySlots = cluster.slots.map((slot) => ({
+      dx: rect.x + slot.dx,
+      dy: rect.y + slot.dy,
+    }));
+    const visible = cluster.spec.threads.slice(0, cluster.spec.visibleCount);
+    visible.forEach((thread, cardIndex) => {
+      threads.push(thread);
+      slots.push(bodySlots[cardIndex]);
+      heights.push(params.heightForThread(threadKeyOf(thread)));
+      clusterIndexByCard.push(index);
+    });
+    clusters.push({
+      ...cluster.spec,
+      rect,
+      slots: bodySlots,
+      overflowSlot: cluster.overflowSlot
+        ? {
+            dx: rect.x + cluster.overflowSlot.dx,
+            dy: rect.y + cluster.overflowSlot.dy,
+          }
+        : undefined,
+      chromeless: sized.length === 1 && !cluster.spec.isProject,
+    });
+    rx = Math.max(rx, Math.abs(rect.x), Math.abs(rect.x + rect.width));
+    ry = Math.max(ry, Math.abs(rect.y), Math.abs(rect.y + rect.height));
+  });
+
+  return { clusters, threads, slots, heights, clusterIndexByCard, extent: { rx, ry } };
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-clusters.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-clusters.ts
@@ -2,7 +2,10 @@ import {
   buildThreadIdentityKey,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
-import { type StarMapCardSlot } from "./star-map-layout";
+import {
+  STAR_MAP_ESTIMATED_CARD_HEIGHT,
+  type StarMapCardSlot,
+} from "./star-map-layout";
 import { STAR_MAP_INSTANCE_KEEPOUT } from "./star-map-orbit";
 import {
   STAR_MAP_NO_PROJECT_KEY,
@@ -41,6 +44,12 @@ export const ORBIT_MAX_CARDS_PER_GROUP = 8;
  * pointer, and the overlap is what makes the scatter read as a cloud
  * rather than a grid. */
 const RING_PACKING = 0.82;
+/**
+ * Ring radii are sized from a nominal card height rather than the tallest
+ * card currently in the cloud: a card's real height then only ever moves
+ * that card, and a tall arrival cannot push the whole cloud outward.
+ */
+const NOMINAL_CARD_HEIGHT = STAR_MAP_ESTIMATED_CARD_HEIGHT;
 /** Extra x-radius on ring 1 so it clears the centre card. */
 const RING_BASE_RX_FACTOR = 1.05;
 const RING_STEP_RX_FACTOR = 1.0;
@@ -64,9 +73,6 @@ const KEEPOUT_GAP = 18;
 const SEAT_BASE_RADIUS = 170;
 const SEAT_RADIUS_STEP = 26;
 const SEAT_MAX_PROBES = 240;
-/** Same base rotation as the galaxy scatter: clouds leave the cardinal
- * axes so two of them never sit at exactly N/S. */
-const SEAT_BASE_ROTATION = 0.22;
 /** Clouds are wide and short-ish, so seating stretches horizontally. */
 const SEAT_ASPECT_X = 1.3;
 
@@ -118,6 +124,8 @@ export type StarMapClusterCloud = {
   clusterIndexByCard: number[];
   /** Half-extent of the whole drawn cloud set, for instance spacing. */
   extent: { rx: number; ry: number };
+  /** Feed back into the next layout to keep everything where it is. */
+  memory: StarMapCloudMemory;
 };
 
 function threadKeyOf(thread: NavigationThreadSummary): string {
@@ -305,86 +313,177 @@ export function buildInstanceClusters(params: {
   });
 }
 
-type ScatteredCluster = {
-  spec: StarMapClusterSpec;
-  /** Cloud-local card slots (dx from centre, dy = card TOP from centre). */
-  slots: StarMapCardSlot[];
-  extent: { rx: number; ry: number };
+/**
+ * Where a cloud's cards and bodies were put last time.
+ *
+ * The layout is incremental, not a pure function of the current set, and
+ * that is the whole point: archiving one thread must remove one card and
+ * change NOTHING else. A set-derived layout cannot do that — every card's
+ * seat came from its index in the visible list, every cloud's extent from
+ * its occupied seats, and every cloud's centre from packing those extents,
+ * so one departure rippled through all three.
+ *
+ * So seats are remembered per thread, ring allocation only grows, and a
+ * cloud keeps the centre it was given. A new thread takes the lowest free
+ * seat; a new cloud is seated around what is already placed. Nothing that
+ * was already on screen moves unless the operator asks for it (expand or
+ * collapse drops that cloud's memory, and the map re-fits it).
+ */
+export type StarMapCloudMemory = {
+  /** Cloud centre per cluster key, body-relative. */
+  centers: Map<string, { x: number; y: number }>;
+  /** Seat index per thread, per cluster key. */
+  seats: Map<string, Map<string, number>>;
+  /** Rings allocated per cluster key. Grows; never shrinks on its own. */
+  rings: Map<string, number>;
 };
 
+export function emptyCloudMemory(): StarMapCloudMemory {
+  return { centers: new Map(), seats: new Map(), rings: new Map() };
+}
+
+/** Forget one cloud, so the next layout re-fits it from scratch. */
+export function forgetCluster(
+  memory: StarMapCloudMemory,
+  clusterKey: string,
+): StarMapCloudMemory {
+  const centers = new Map(memory.centers);
+  const seats = new Map(memory.seats);
+  const rings = new Map(memory.rings);
+  centers.delete(clusterKey);
+  seats.delete(clusterKey);
+  rings.delete(clusterKey);
+  return { centers, seats, rings };
+}
+
 /**
- * Scatter a cloud's visible cards: the first card in the middle (for a
- * parent/child cloud that IS the parent), the rest walking elliptical
- * rings with deterministic per-thread jitter — willy-nilly like the
- * original orbit, never a grid. Cards may shingle slightly on purpose;
- * they are opaque and hover raises the one under the pointer.
+ * Ring geometry for one ring index, in cloud-local pixels.
+ *
+ * Capacity is fixed per ring — derived from the ring's circumference and
+ * the card width alone — so seat N always lands at the same angle no
+ * matter how many cards the cloud currently holds. Deriving the angular
+ * pitch from the member count instead is what made every card in a cloud
+ * shuffle when one of them left.
  */
-function scatterCluster(params: {
-  spec: StarMapClusterSpec;
-  cardWidth: number;
-  heightForThread: (threadKey: string) => number;
-}): ScatteredCluster {
-  const visible = params.spec.threads.slice(0, params.spec.visibleCount);
-  const heights = visible.map((thread) =>
-    params.heightForThread(threadKeyOf(thread)),
-  );
-  const maxHeight = heights.reduce((top, height) => Math.max(top, height), 1);
-  const slots: StarMapCardSlot[] = [];
-  if (visible.length > 0) {
-    slots.push({ dx: 0, dy: -heights[0] / 2 });
-  }
-
-  // The whole cloud leans a little, per cloud, so no two clouds start
-  // their rings at the same bearing.
-  const baseAngle = Math.PI / 2 + (noise(params.spec.key, 3) * 2 - 1) * 0.7;
-  let ringIndex = 0;
-  let seated = 1;
-  while (seated < visible.length) {
-    ringIndex += 1;
-    const rx =
-      params.cardWidth
-      * (RING_BASE_RX_FACTOR + (ringIndex - 1) * RING_STEP_RX_FACTOR);
-    const ry =
-      (maxHeight + RING_BASE_RY_PAD)
-      + (ringIndex - 1) * (maxHeight + RING_STEP_RY_PAD);
-    const capacity = Math.max(
-      4,
-      Math.floor((2 * Math.PI * rx) / (params.cardWidth * RING_PACKING)),
-    );
-    const onThisRing = Math.min(visible.length - seated, capacity);
-    const pitch = (2 * Math.PI) / onThisRing;
-    for (let position = 0; position < onThisRing; position += 1) {
-      const thread = visible[seated + position];
-      const key = threadKeyOf(thread);
-      const angle =
-        baseAngle
-        + position * pitch
-        + (ringIndex % 2 === 1 ? 0 : pitch / 2)
-        + (noise(key, 5) * 2 - 1) * pitch * JITTER_ANGLE_SHARE;
-      const reach = 1 + noise(key, 7) * JITTER_RADIUS_SHARE;
-      const height = heights[seated + position];
-      slots.push({
-        dx: Math.cos(angle) * rx * reach,
-        dy: Math.sin(angle) * ry * reach - height / 2,
-      });
-    }
-    seated += onThisRing;
-  }
-
-  let rx = 0;
-  let ry = 0;
-  slots.forEach((slot, index) => {
-    rx = Math.max(rx, Math.abs(slot.dx) + params.cardWidth / 2);
-    ry = Math.max(ry, Math.abs(slot.dy), Math.abs(slot.dy + heights[index]));
-  });
+function ringGeometry(
+  ring: number,
+  cardWidth: number,
+): { rx: number; ry: number; capacity: number } {
+  const rx =
+    cardWidth * (RING_BASE_RX_FACTOR + (ring - 1) * RING_STEP_RX_FACTOR);
+  const ry =
+    NOMINAL_CARD_HEIGHT
+    + RING_BASE_RY_PAD
+    + (ring - 1) * (NOMINAL_CARD_HEIGHT + RING_STEP_RY_PAD);
   return {
-    spec: params.spec,
-    slots,
-    extent: {
-      rx: rx + CLOUD_EXTENT_PAD,
-      ry: ry + CLOUD_EXTENT_PAD,
-    },
+    rx,
+    ry,
+    capacity: Math.max(
+      4,
+      Math.floor((2 * Math.PI * rx) / (cardWidth * RING_PACKING)),
+    ),
   };
+}
+
+/** Which ring a seat sits on, and where around it. Seat 0 is the centre. */
+function seatAddress(
+  seat: number,
+  cardWidth: number,
+): { ring: number; position: number; capacity: number } {
+  if (seat <= 0) return { ring: 0, position: 0, capacity: 1 };
+  let remaining = seat - 1;
+  let ring = 1;
+  // Bounded by the seat index: each ring seats at least four cards.
+  for (;;) {
+    const { capacity } = ringGeometry(ring, cardWidth);
+    if (remaining < capacity) return { ring, position: remaining, capacity };
+    remaining -= capacity;
+    ring += 1;
+  }
+}
+
+/**
+ * Where a seat's card sits, cloud-local. `dy` is the card's TOP edge, so
+ * a card's own height only ever moves that card.
+ */
+function seatSlot(params: {
+  seat: number;
+  cardWidth: number;
+  clusterKey: string;
+  threadKey: string;
+  height: number;
+}): StarMapCardSlot {
+  const address = seatAddress(params.seat, params.cardWidth);
+  if (address.ring === 0) return { dx: 0, dy: -params.height / 2 };
+  const ring = ringGeometry(address.ring, params.cardWidth);
+  // The cloud leans a little as a whole, so no two clouds start their
+  // rings on the same bearing.
+  const baseAngle =
+    Math.PI / 2 + (noise(params.clusterKey, 3) * 2 - 1) * 0.7;
+  const pitch = (2 * Math.PI) / address.capacity;
+  const angle =
+    baseAngle
+    + address.position * pitch
+    + (address.ring % 2 === 1 ? 0 : pitch / 2)
+    + (noise(params.threadKey, 5) * 2 - 1) * pitch * JITTER_ANGLE_SHARE;
+  const reach = 1 + noise(params.threadKey, 7) * JITTER_RADIUS_SHARE;
+  return {
+    dx: Math.cos(angle) * ring.rx * reach,
+    dy: Math.sin(angle) * ring.ry * reach - params.height / 2,
+  };
+}
+
+/**
+ * Half-extent a cloud claims for its allocated rings. Derived from the
+ * allocation rather than from the seats currently filled, so a card
+ * leaving the outermost ring does not shrink the cloud and re-seat its
+ * neighbours.
+ */
+function extentForRings(
+  rings: number,
+  cardWidth: number,
+): { rx: number; ry: number } {
+  if (rings <= 0) {
+    return {
+      rx: cardWidth / 2 + CLOUD_EXTENT_PAD,
+      ry: NOMINAL_CARD_HEIGHT / 2 + CLOUD_EXTENT_PAD,
+    };
+  }
+  const ring = ringGeometry(rings, cardWidth);
+  const reach = 1 + JITTER_RADIUS_SHARE;
+  return {
+    rx: ring.rx * reach + cardWidth / 2 + CLOUD_EXTENT_PAD,
+    ry: ring.ry * reach + NOMINAL_CARD_HEIGHT / 2 + CLOUD_EXTENT_PAD,
+  };
+}
+
+/**
+ * Seat assignment for one cloud: everyone who was here keeps their seat,
+ * and arrivals take the lowest free one.
+ */
+function assignSeats(params: {
+  visible: readonly NavigationThreadSummary[];
+  previous?: Map<string, number>;
+}): Map<string, number> {
+  const seats = new Map<string, number>();
+  const taken = new Set<number>();
+  for (const thread of params.visible) {
+    const key = threadKeyOf(thread);
+    const prior = params.previous?.get(key);
+    if (prior !== undefined && !taken.has(prior)) {
+      seats.set(key, prior);
+      taken.add(prior);
+    }
+  }
+  let cursor = 0;
+  for (const thread of params.visible) {
+    const key = threadKeyOf(thread);
+    if (seats.has(key)) continue;
+    while (taken.has(cursor)) cursor += 1;
+    seats.set(key, cursor);
+    taken.add(cursor);
+  }
+  return seats;
 }
 
 type Box = { x: number; y: number; width: number; height: number };
@@ -407,63 +506,46 @@ const KEEPOUT_BOX: Box = {
 
 function boxFor(
   center: { x: number; y: number },
-  scattered: ScatteredCluster,
+  extent: { rx: number; ry: number },
 ): Box {
   return {
-    x: center.x - scattered.extent.rx,
-    y: center.y - scattered.extent.ry - CLOUD_LABEL_ROOM,
-    width: scattered.extent.rx * 2,
-    height: scattered.extent.ry * 2 + CLOUD_LABEL_ROOM + CLOUD_CHIP_ROOM,
+    x: center.x - extent.rx,
+    y: center.y - extent.ry - CLOUD_LABEL_ROOM,
+    width: extent.rx * 2,
+    height: extent.ry * 2 + CLOUD_LABEL_ROOM + CLOUD_CHIP_ROOM,
   };
 }
 
+function isClear(box: Box, placed: readonly Box[]): boolean {
+  return (
+    !boxesOverlap(box, KEEPOUT_BOX, KEEPOUT_GAP)
+    && placed.every((other) => !boxesOverlap(box, other, CLUSTER_GAP))
+  );
+}
+
 /**
- * Seat scattered clouds around the body: a lone cloud hangs centred
- * below it, several distribute by angle — heaviest first, just off
- * vertical — each walking outward along its own bearing until it clears
- * the chrome and every cloud already seated. Deterministic.
+ * Seat one cloud on its own bearing, walking outward until it clears the
+ * instance's chrome and everything already placed. The bearing comes from
+ * the cluster key rather than its position in the list, so a cloud that
+ * disappears does not rotate its neighbours.
  */
-function seatClusters(
-  scattered: readonly ScatteredCluster[],
-): { x: number; y: number }[] {
-  if (scattered.length === 1) {
-    const only = scattered[0];
-    return [
-      {
-        x: 0,
-        y:
-          STAR_MAP_INSTANCE_KEEPOUT.below
-          + KEEPOUT_GAP
-          + CLOUD_LABEL_ROOM
-          + only.extent.ry,
-      },
-    ];
+function seatCluster(params: {
+  key: string;
+  extent: { rx: number; ry: number };
+  placed: readonly Box[];
+}): { x: number; y: number } {
+  const angle = noise(params.key, 11) * 2 * Math.PI;
+  let radius = SEAT_BASE_RADIUS;
+  let center = { x: 0, y: 0 };
+  for (let probe = 0; probe < SEAT_MAX_PROBES; probe += 1) {
+    center = {
+      x: Math.cos(angle) * radius * SEAT_ASPECT_X,
+      y: Math.sin(angle) * radius,
+    };
+    if (isClear(boxFor(center, params.extent), params.placed)) break;
+    radius += SEAT_RADIUS_STEP;
   }
-  const placedBoxes: Box[] = [];
-  const centers: { x: number; y: number }[] = [];
-  scattered.forEach((cluster, index) => {
-    const angle =
-      Math.PI / 2
-      + SEAT_BASE_ROTATION
-      + (index * 2 * Math.PI) / scattered.length;
-    let radius = SEAT_BASE_RADIUS;
-    let center = { x: 0, y: 0 };
-    for (let probe = 0; probe < SEAT_MAX_PROBES; probe += 1) {
-      center = {
-        x: Math.cos(angle) * radius * SEAT_ASPECT_X,
-        y: Math.sin(angle) * radius,
-      };
-      const box = boxFor(center, cluster);
-      const clear =
-        !boxesOverlap(box, KEEPOUT_BOX, KEEPOUT_GAP)
-        && placedBoxes.every((other) => !boxesOverlap(box, other, CLUSTER_GAP));
-      if (clear) break;
-      radius += SEAT_RADIUS_STEP;
-    }
-    placedBoxes.push(boxFor(center, cluster));
-    centers.push(center);
-  });
-  return centers;
+  return center;
 }
 
 /** Extent an instance claims when its clouds are empty — its own body. */
@@ -471,6 +553,10 @@ const EMPTY_CLOUD_EXTENT = 70;
 
 /**
  * Lay out one instance's clouds and flatten them for rendering.
+ *
+ * Pure: the previous layout arrives as `memory` and the next one is
+ * returned, so the caller owns the continuity and the function stays
+ * testable. See `StarMapCloudMemory` for why the layout is incremental.
  *
  * The flat `threads`/`slots`/`heights` triple is what the screen's lane
  * plumbing already speaks (index-aligned, slot dy = card top), so cloud
@@ -480,15 +566,92 @@ export function computeClusterCloud(params: {
   clusters: readonly StarMapClusterSpec[];
   cardWidth: number;
   heightForThread: (threadKey: string) => number;
+  memory?: StarMapCloudMemory;
 }): StarMapClusterCloud {
-  const scattered = params.clusters.map((spec) =>
-    scatterCluster({
+  const previous = params.memory ?? emptyCloudMemory();
+  const nextSeats = new Map<string, Map<string, number>>();
+  const nextRings = new Map<string, number>();
+  const nextCenters = new Map<string, { x: number; y: number }>();
+
+  const sized = params.clusters.map((spec) => {
+    const visible = spec.threads.slice(0, spec.visibleCount);
+    const seats = assignSeats({
+      visible,
+      previous: previous.seats.get(spec.key),
+    });
+    nextSeats.set(spec.key, seats);
+    const highestSeat = [...seats.values()].reduce(
+      (top, seat) => Math.max(top, seat),
+      -1,
+    );
+    const needed =
+      highestSeat < 0 ? 0 : seatAddress(highestSeat, params.cardWidth).ring;
+    // Grow-only: an outermost card leaving must not pull the cloud in and
+    // shove its neighbours around. Collapsing the cloud is the operator's
+    // call and drops this memory (see `forgetCluster`).
+    const rings = Math.max(needed, previous.rings.get(spec.key) ?? 0);
+    nextRings.set(spec.key, rings);
+    return {
       spec,
-      cardWidth: params.cardWidth,
-      heightForThread: params.heightForThread,
-    }),
+      seats,
+      slots: visible.map((thread) =>
+        seatSlot({
+          cardWidth: params.cardWidth,
+          clusterKey: spec.key,
+          height: params.heightForThread(threadKeyOf(thread)),
+          seat: seats.get(threadKeyOf(thread)) ?? 0,
+          threadKey: threadKeyOf(thread),
+        }),
+      ),
+      extent: extentForRings(rings, params.cardWidth),
+      visible,
+    };
+  });
+
+  // Retained clouds keep their centre; only clouds that are new — or that
+  // grew into a neighbour — are seated. Deterministic order so a fresh map
+  // lays out the same way twice.
+  const placed: Box[] = [];
+  const retained = sized.filter((cluster) =>
+    previous.centers.has(cluster.spec.key),
   );
-  const centers = seatClusters(scattered);
+  const arrivals = sized.filter(
+    (cluster) => !previous.centers.has(cluster.spec.key),
+  );
+  const reseat: typeof sized = [];
+  for (const cluster of retained) {
+    const center = previous.centers.get(cluster.spec.key)!;
+    const box = boxFor(center, cluster.extent);
+    if (isClear(box, placed)) {
+      nextCenters.set(cluster.spec.key, center);
+      placed.push(box);
+    } else {
+      // It outgrew its seat. The cloud that changed is the one that moves.
+      reseat.push(cluster);
+    }
+  }
+  const lonely =
+    sized.length === 1 && previous.centers.size === 0 ? sized[0] : undefined;
+  for (const cluster of [...reseat, ...arrivals]) {
+    const center =
+      cluster === lonely
+        ? {
+            // A lone cloud hangs under the body, where a lane would put it.
+            x: 0,
+            y:
+              STAR_MAP_INSTANCE_KEEPOUT.below
+              + KEEPOUT_GAP
+              + CLOUD_LABEL_ROOM
+              + cluster.extent.ry,
+          }
+        : seatCluster({
+            extent: cluster.extent,
+            key: cluster.spec.key,
+            placed,
+          });
+    nextCenters.set(cluster.spec.key, center);
+    placed.push(boxFor(center, cluster.extent));
+  }
 
   const clusters: StarMapClusterPlacement[] = [];
   const threads: NavigationThreadSummary[] = [];
@@ -498,14 +661,13 @@ export function computeClusterCloud(params: {
   let rx = EMPTY_CLOUD_EXTENT;
   let ry = EMPTY_CLOUD_EXTENT;
 
-  scattered.forEach((cluster, index) => {
-    const center = centers[index];
+  sized.forEach((cluster, index) => {
+    const center = nextCenters.get(cluster.spec.key)!;
     const bodySlots = cluster.slots.map((slot) => ({
       dx: center.x + slot.dx,
       dy: center.y + slot.dy,
     }));
-    const visible = cluster.spec.threads.slice(0, cluster.spec.visibleCount);
-    visible.forEach((thread, cardIndex) => {
+    cluster.visible.forEach((thread, cardIndex) => {
       threads.push(thread);
       slots.push(bodySlots[cardIndex]);
       heights.push(params.heightForThread(threadKeyOf(thread)));
@@ -513,7 +675,7 @@ export function computeClusterCloud(params: {
     });
     const chromeless =
       cluster.spec.threads.length === 1
-      || (scattered.length === 1 && !cluster.spec.isProject);
+      || (sized.length === 1 && !cluster.spec.isProject);
     const showChip =
       cluster.spec.overflow > 0
       || (cluster.spec.expanded && cluster.spec.expandable);
@@ -537,9 +699,20 @@ export function computeClusterCloud(params: {
     rx = Math.max(rx, Math.abs(center.x) + cluster.extent.rx);
     ry = Math.max(
       ry,
-      Math.abs(center.y) + cluster.extent.ry + CLOUD_LABEL_ROOM + CLOUD_CHIP_ROOM,
+      Math.abs(center.y)
+        + cluster.extent.ry
+        + CLOUD_LABEL_ROOM
+        + CLOUD_CHIP_ROOM,
     );
   });
 
-  return { clusters, threads, slots, heights, clusterIndexByCard, extent: { rx, ry } };
+  return {
+    clusters,
+    threads,
+    slots,
+    heights,
+    clusterIndexByCard,
+    extent: { rx, ry },
+    memory: { centers: nextCenters, rings: nextRings, seats: nextSeats },
+  };
 }

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-clusters.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-clusters.ts
@@ -5,7 +5,6 @@ import {
 import { type StarMapCardSlot } from "./star-map-layout";
 import { STAR_MAP_INSTANCE_KEEPOUT } from "./star-map-orbit";
 import {
-  projectMass,
   STAR_MAP_NO_PROJECT_KEY,
   threadProjectKey,
   threadProjectLabel,
@@ -195,14 +194,15 @@ export function orderParentAdjacent(
  * "Workspaces" cloud. Within a bucket, each root parent that has
  * children present splits out into its own parent/child cloud (parent
  * first, descendants in DFS order); the remainder stays in the bucket's
- * catch-all. Clouds order by the same mass the projects lens uses,
- * heaviest first, so the busiest work seats nearest the body.
+ * catch-all. Clouds order by their stable key, NOT by activity: seat
+ * angles derive from this order, and a mass ordering re-seated every
+ * cloud whenever recency shifted — hand-arranged cards teleporting
+ * because some other project got busier.
  */
 export function buildInstanceClusters(params: {
   threads: readonly NavigationThreadSummary[];
   /** Cluster keys the operator expanded past the per-group cap. */
   expandedKeys?: ReadonlySet<string>;
-  now?: number;
 }): StarMapClusterSpec[] {
   const buckets = new Map<string, NavigationThreadSummary[]>();
   for (const thread of params.threads) {
@@ -218,9 +218,7 @@ export function buildInstanceClusters(params: {
     isProject: boolean;
     isParentGroup: boolean;
     threads: NavigationThreadSummary[];
-    mass: number;
   };
-  const now = params.now ?? Date.now();
   const drafts: Draft[] = [];
 
   for (const [bucketKey, members] of buckets) {
@@ -269,7 +267,6 @@ export function buildInstanceClusters(params: {
           isProject,
           isParentGroup: true,
           threads: group,
-          mass: massOf(group, now),
         });
         continue;
       }
@@ -283,15 +280,11 @@ export function buildInstanceClusters(params: {
         isProject,
         isParentGroup: false,
         threads: rest,
-        mass: massOf(rest, now),
       });
     }
   }
 
-  drafts.sort(
-    (left, right) =>
-      right.mass - left.mass || left.label.localeCompare(right.label),
-  );
+  drafts.sort((left, right) => left.key.localeCompare(right.key));
 
   return drafts.map((draft) => {
     const expanded = params.expandedKeys?.has(draft.key) ?? false;
@@ -310,14 +303,6 @@ export function buildInstanceClusters(params: {
       expandable: draft.threads.length > ORBIT_MAX_CARDS_PER_GROUP,
     };
   });
-}
-
-function massOf(threads: readonly NavigationThreadSummary[], now: number): number {
-  const lastActivityAt = threads.reduce(
-    (latest, thread) => Math.max(latest, thread.updatedAt ?? 0),
-    0,
-  );
-  return projectMass({ cardCount: threads.length, lastActivityAt, now });
 }
 
 type ScatteredCluster = {

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
@@ -412,10 +412,18 @@ export function computeOrbitPlacement(params: {
  * to match nothing here and so started a pan. It is the card's own mark
  * and overhangs the card's top-right corner, so dragging the card from it
  * is the right behaviour — but it is a change, not just a port.
+ *
+ * `.star-map-chat-card` is listed for the same reason, and it became load
+ * bearing the moment chat cards moved INSIDE the canvas: a press on a
+ * chat card bubbles to the viewport, so without it the card dragged and
+ * the whole galaxy panned underneath it at the same time. Its transcript,
+ * title bar and resize corner are all plain containers, so only naming
+ * the card itself covers them.
  */
 export function shouldStartCanvasPan(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
   return !target.closest(
-    "button, a, input, label, .star-map-card-shell, .star-map__chrome, .star-map__filters",
+    "button, a, input, label, .star-map-card-shell, .star-map-chat-card,"
+      + " .star-map__chrome, .star-map__filters",
   );
 }

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
@@ -44,6 +44,16 @@ const KEEPOUT_GAP = 10;
 const INSTANCE_KEEPOUT_ABOVE = 58;
 
 /**
+ * The keep-out box shared with the cluster layout, so project clouds clear
+ * the same chrome the ring slots do.
+ */
+export const STAR_MAP_INSTANCE_KEEPOUT = {
+  halfWidth: INSTANCE_KEEPOUT_HALF_WIDTH,
+  above: INSTANCE_KEEPOUT_ABOVE,
+  below: INSTANCE_KEEPOUT_BELOW,
+} as const;
+
+/**
  * Does a card centred here clear the instance's own chrome?
  *
  * Only the handful of slots that actually collide get pushed out (see
@@ -265,13 +275,20 @@ export function computeOrbitPlacement(params: {
   /** Visible card count per instance. */
   cardCounts: ReadonlyMap<string, number>;
   cardWidth: number;
+  /**
+   * Measured half-extent of an instance's drawn cloud, when the caller
+   * lays cards out itself (the project-cluster clouds). Instances without
+   * an entry fall back to the ring extent their card count implies.
+   */
+  extents?: ReadonlyMap<string, { rx: number; ry: number }>;
 }): OrbitPlacement {
   const root = params.nodes.find((node) => node.depth === 0);
   if (!root) {
     return { instances: [], links: [], canvasWidth: 0, canvasHeight: 0 };
   }
   const extentFor = (instanceId: string) =>
-    cardRingExtent(params.cardCounts.get(instanceId) ?? 0, params.cardWidth);
+    params.extents?.get(instanceId)
+    ?? cardRingExtent(params.cardCounts.get(instanceId) ?? 0, params.cardWidth);
   const radiusFor = (instanceId: string) => extentFor(instanceId).rx;
 
   const raw = new Map<string, { x: number; y: number }>();

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
@@ -420,6 +420,21 @@ export function computeOrbitPlacement(params: {
  * title bar and resize corner are all plain containers, so only naming
  * the card itself covers them.
  */
+/**
+ * Whether a wheel event over the map should pan the canvas.
+ *
+ * A chat card is a scrollable window that now lives INSIDE the canvas, so
+ * its wheel events reach the viewport listener — which preventDefaults
+ * every one of them and turns it into a pan. That silently took scrolling
+ * away from every open transcript. Pinch-zoom (ctrl+wheel) is deliberately
+ * NOT routed through here: it is unambiguously a map gesture, and a
+ * transcript cannot consume it.
+ */
+export function shouldPanOnWheel(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return true;
+  return !target.closest(".star-map-chat-card");
+}
+
 export function shouldStartCanvasPan(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
   return !target.closest(

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-projects.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-projects.ts
@@ -1,5 +1,6 @@
 import {
   buildThreadIdentityKey,
+  classifyDirectory,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
 
@@ -53,26 +54,31 @@ export const STAR_MAP_NO_PROJECT_KEY = "__no-project__";
 const NO_PROJECT_LABEL = "No project";
 
 /**
- * A thread's project is the repo its primary linked directory belongs to.
- *
- * `path` is the repo root even for worktree entries (which carry the
- * worktree separately in `worktreePath`), so grouping on it collapses
- * every worktree of a repo onto one body. Grouping on the label instead
- * would scatter a repo across a body per worktree, since worktree labels
- * are generated per-workspace.
+ * A thread's project is whatever directory row the Directories lens would
+ * file its primary linked directory under, via the shared classifier:
+ * worktrees collapse onto their repo root, and every scratch checkout
+ * collapses into ONE "Workspaces" project. Grouping on the raw path
+ * instead gave each hash-named scratch dir its own one-thread body.
  */
 export function threadProjectKey(thread: NavigationThreadSummary): string {
   const primary = thread.linkedDirectories[0];
-  return primary?.path ?? STAR_MAP_NO_PROJECT_KEY;
+  return primary ? classifyDirectory(primary).key : STAR_MAP_NO_PROJECT_KEY;
 }
 
 /** Display label for a thread's project; shared with the cluster layout. */
 export function threadProjectLabel(thread: NavigationThreadSummary): string {
   const primary = thread.linkedDirectories[0];
   if (!primary) return NO_PROJECT_LABEL;
-  // Prefer the repo folder name over a worktree-generated label.
-  const segments = primary.path.split("/").filter(Boolean);
-  return segments[segments.length - 1] ?? primary.label;
+  const descriptor = classifyDirectory(primary);
+  // A label the classifier computed itself ("Workspaces", "Codex Chats",
+  // a worktree collapsed onto its repo) is canonical — keep it. When it
+  // just echoed the directory's own label, prefer the repo folder name:
+  // worktree labels are generated per-workspace, and a cloud named
+  // "2026-07-31-b3ba9c" is the spreadsheet this lens is escaping.
+  if (descriptor.label !== primary.label) return descriptor.label;
+  const path = descriptor.path ?? primary.path;
+  const segments = path.split(/[\\/]/).filter(Boolean);
+  return segments[segments.length - 1] ?? descriptor.label;
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-projects.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-projects.ts
@@ -66,7 +66,8 @@ export function threadProjectKey(thread: NavigationThreadSummary): string {
   return primary?.path ?? STAR_MAP_NO_PROJECT_KEY;
 }
 
-function projectLabel(thread: NavigationThreadSummary): string {
+/** Display label for a thread's project; shared with the cluster layout. */
+export function threadProjectLabel(thread: NavigationThreadSummary): string {
   const primary = thread.linkedDirectories[0];
   if (!primary) return NO_PROJECT_LABEL;
   // Prefer the repo folder name over a worktree-generated label.
@@ -97,7 +98,7 @@ export function groupThreadsByProject(
           key,
           label: key === STAR_MAP_NO_PROJECT_KEY
             ? NO_PROJECT_LABEL
-            : projectLabel(thread),
+            : threadProjectLabel(thread),
           lastActivityAt: thread.updatedAt ?? 0,
           mass: 0,
           threads: [thread],

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-view-geometry.ts
@@ -13,8 +13,40 @@ export type StarMapView = { x: number; y: number; scale: number };
 
 export type StarMapViewBox = { width: number; height: number };
 
-export const MIN_ZOOM = 0.35;
+/**
+ * How far out the map can be pulled.
+ *
+ * Well below the point where a card is readable, on purpose: past
+ * `STAR_MAP_OVERVIEW_ZOOM` the map stops drawing cards at all and shows
+ * named clouds instead, so the far end of the range is for answering
+ * "which solar system am I in" rather than for reading anything.
+ */
+export const MIN_ZOOM = 0.12;
 export const MAX_ZOOM = 2;
+
+/**
+ * Below this scale a thread card is a ~130px smudge of unreadable text
+ * that still costs a full subtree to mount. The map trades all of them
+ * for one label per cloud — the fleet stays legible AND the DOM shrinks
+ * to a handful of nodes exactly when there would otherwise be hundreds.
+ */
+export const STAR_MAP_OVERVIEW_ZOOM = 0.5;
+
+/** Whether the view is far enough out to drop to named clouds. */
+export function isOverviewZoom(scale: number): boolean {
+  return scale < STAR_MAP_OVERVIEW_ZOOM;
+}
+
+/**
+ * Counter-scale for chrome that must stay readable while the canvas
+ * shrinks under it. Capped so a label does not grow without bound as the
+ * operator keeps pulling out — past the cap the labels shrink too, which
+ * is the honest signal that there is more map than window.
+ */
+export function overviewChromeScale(scale: number): number {
+  const safe = scale > 0 ? scale : 1;
+  return Math.min(1 / safe, 1 / MIN_ZOOM / 1.6);
+}
 
 /**
  * How much of the canvas has to stay on screen, per axis, as a fraction of

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapChatCards.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapChatCards.ts
@@ -5,6 +5,7 @@ import {
 } from "@pwragent/shared";
 import {
   cascadeChatCardRect,
+  placeChatCardBesideAnchor,
   raiseChatCard,
   type ChatCardRect,
 } from "./star-map-chat-card-geometry";
@@ -21,7 +22,19 @@ export type StarMapChatCardsController = {
   closeAll: () => void;
   /** Stack depth of a card, lowest first. */
   depthOf: (cardKey: string) => number;
-  open: (thread: NavigationThreadSummary) => void;
+  /**
+   * Open a card for a thread. `placement` puts it beside the thread's own
+   * card on the map; without one the card cascades from a corner, which
+   * is the fallback when the thread has no card on screen (filtered out,
+   * or folded into a cloud's overflow).
+   */
+  open: (
+    thread: NavigationThreadSummary,
+    placement?: {
+      anchor: { x: number; y: number; width: number; height: number };
+      bounds: { width: number; height: number };
+    },
+  ) => void;
   raise: (cardKey: string) => void;
   setRect: (cardKey: string, rect: ChatCardRect) => void;
 };
@@ -48,7 +61,13 @@ export function useStarMapChatCards(): StarMapChatCardsController {
   }, []);
 
   const open = useCallback(
-    (thread: NavigationThreadSummary) => {
+    (
+      thread: NavigationThreadSummary,
+      placement?: {
+        anchor: { x: number; y: number; width: number; height: number };
+        bounds: { width: number; height: number };
+      },
+    ) => {
       const key = buildThreadIdentityKey(thread.source, thread.id);
       setCards((current) => {
         if (current.some((card) => card.key === key)) return current;
@@ -56,10 +75,16 @@ export function useStarMapChatCards(): StarMapChatCardsController {
           ...current,
           {
             key,
-            rect: cascadeChatCardRect({
-              openCardCount: current.length,
-              viewport: viewportSize(),
-            }),
+            rect: placement
+              ? placeChatCardBesideAnchor({
+                  anchor: placement.anchor,
+                  bounds: placement.bounds,
+                  occupied: current.map((card) => card.rect),
+                })
+              : cascadeChatCardRect({
+                  openCardCount: current.length,
+                  viewport: viewportSize(),
+                }),
             thread,
           },
         ];

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -24767,3 +24767,30 @@ a.transcript-message__messaging-origin:focus-visible {
     0 0 0 1px color-mix(in srgb, var(--accent) 50%, transparent),
     0 8px 28px color-mix(in srgb, var(--accent) 25%, transparent);
 }
+
+/* Tether from an open chat card to the thread card it belongs to. Drawn
+   inside the canvas, so it pans and zooms with both endpoints. */
+.star-map__tethers {
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.star-map__tether {
+  fill: none;
+  stroke: color-mix(in srgb, var(--accent) 45%, transparent);
+  stroke-width: 1.5;
+  stroke-dasharray: 4 4;
+}
+
+.star-map__tether-anchor {
+  fill: color-mix(in srgb, var(--accent) 70%, transparent);
+}
+
+/* The card end of that tether: the thread whose chat is open. */
+.star-map-card-shell--chatting .star-map-card {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent);
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -24789,6 +24789,22 @@ a.transcript-message__messaging-origin:focus-visible {
   fill: color-mix(in srgb, var(--accent) 70%, transparent);
 }
 
+/* Names the accent ring for a screen reader without painting anything.
+   Scoped to the map rather than added as a global utility: this PR is the
+   only caller, and a repo-wide visually-hidden primitive deserves its own
+   decision. */
+.star-map-card__state {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 /* The card end of that tether: the thread whose chat is open. */
 .star-map-card-shell--chatting .star-map-card {
   border-color: var(--accent-border);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9895,6 +9895,98 @@ textarea,
   white-space: nowrap;
 }
 
+/* Project cloud chrome in the orbit lens. The outline is decorative and
+   never intercepts a gesture: pans start straight through it, and the
+   pill/chip controls are separate sibling buttons painted above the
+   cards. */
+.star-map__cluster {
+  position: absolute;
+  z-index: 0;
+  border: 1px dashed color-mix(in srgb, var(--border-strong) 70%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-panel) 22%, transparent);
+  pointer-events: none;
+}
+
+/* Pill and chip paint above the thread cards (z 0..n by stack position)
+   and below the load card (STAR_MAP_LOAD_CARD_Z = 50). */
+.star-map__cluster-pill {
+  display: inline-flex;
+  position: absolute;
+  z-index: 48;
+  align-items: center;
+  gap: 6px;
+  max-width: 208px;
+  padding: 3px 9px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+  color: var(--text-secondary);
+  font-size: 11px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.star-map__cluster-pill:hover {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+/* Pressed = every visible card in the cloud is in the selection. */
+.star-map__cluster-pill[aria-pressed="true"] {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+
+.star-map__cluster-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.star-map__cluster-count {
+  min-width: 14px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-muted) 18%, transparent);
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  line-height: 15px;
+  text-align: center;
+}
+
+.star-map__cluster-pill[aria-pressed="true"] .star-map__cluster-count {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  color: var(--text-primary);
+}
+
+/* Slot is the chip's centre, so the button centres itself on it. */
+.star-map__cluster-overflow {
+  position: absolute;
+  z-index: 48;
+  transform: translate(-50%, -50%);
+  padding: 3px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg-panel) 75%, transparent);
+  color: var(--text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.star-map__cluster-overflow:hover {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+.star-map__cluster-pill:focus-visible,
+.star-map__cluster-overflow:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
 /* Shell: position, stacking, drag target and rise animation. The visual
    card is a plain button inside it, so the kebab can be a sibling rather
    than a button nested in a button. */
@@ -10750,7 +10842,10 @@ textarea,
 .star-map-card,
 .star-map-card *,
 .star-map-load-card,
-.star-map-load-card * {
+.star-map-load-card *,
+.star-map__cluster-pill,
+.star-map__cluster-pill *,
+.star-map__cluster-overflow {
   -webkit-app-region: no-drag;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9920,12 +9920,13 @@ textarea,
 }
 
 /* Label and chip paint above the thread cards (z 0..n by stack position)
-   and below the load card (STAR_MAP_LOAD_CARD_Z = 50). The label floats
-   over the sky the way the instance name does — no box around it. */
+   and below the load card. The label floats over the sky the way the
+   instance name does — no box around it. See the layer scale in
+   StarMapScreen, pinned by star-map-z-layers.test.ts. */
 .star-map__cluster-label {
   display: inline-flex;
   position: absolute;
-  z-index: 48;
+  z-index: 5000;
   transform: translate(-50%, -50%);
   align-items: baseline;
   gap: 6px;
@@ -9967,7 +9968,7 @@ textarea,
    like the lanes overflow text, but clickable. */
 .star-map__cluster-overflow {
   position: absolute;
-  z-index: 48;
+  z-index: 5000;
   transform: translate(-50%, -50%);
   padding: 3px 10px;
   border: none;
@@ -10027,11 +10028,12 @@ textarea,
    must not move under the pointer. */
 .star-map-card-shell:hover {
   /* !important because each shell carries an inline z-index (its stack
-     position), which otherwise beats any hover rule — cards deeper than
-     the old value of 5 never actually raised. Cloud rings shingle cards
-     on purpose, so the raise has to clear every stacked card (0..n) and
-     the cloud label/chip at 48, while staying under the load card at 50. */
-  z-index: 49 !important;
+     position), which otherwise beats any hover rule. The value has to
+     clear EVERY stacked card: cloud membership is unbounded, so a raise
+     pinned just above a card cap silently became a demotion for cards
+     past it. See the layer scale in StarMapScreen (pinned by
+     star-map-z-layers.test.ts). */
+  z-index: 6000 !important;
 }
 
 .star-map-card-shell:hover .star-map-card {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9953,6 +9953,22 @@ textarea,
   color: var(--text-primary);
 }
 
+/* Overview: the label stops captioning a cloud and becomes the cloud.
+   Sized in ems so the counter-scale in StarMapScreen carries it. */
+.star-map__cluster-label--overview {
+  padding: 6px 14px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-panel) 70%, transparent);
+  color: var(--text-primary);
+  font-size: 13px;
+  letter-spacing: 0.02em;
+}
+
+.star-map__cluster-label--overview .star-map__cluster-count {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
 .star-map__cluster-name {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9895,81 +9895,84 @@ textarea,
   white-space: nowrap;
 }
 
-/* Project cloud chrome in the orbit lens. The outline is decorative and
-   never intercepts a gesture: pans start straight through it, and the
-   pill/chip controls are separate sibling buttons painted above the
-   cards. */
-.star-map__cluster {
+/* Cloud chrome in the orbit lens: a nebula, not a box. The smudge is a
+   soft accent-tinted glow under the cards — like a nebula low in a dark
+   sky — and never intercepts a gesture: pans start straight through it,
+   and the label/chip controls are separate sibling buttons. */
+.star-map__cluster-halo {
   position: absolute;
   z-index: 0;
-  border: 1px dashed color-mix(in srgb, var(--border-strong) 70%, transparent);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--bg-panel) 22%, transparent);
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background:
+    radial-gradient(
+      42% 40% at 38% 42%,
+      color-mix(in srgb, var(--accent) 9%, transparent),
+      transparent 100%
+    ),
+    radial-gradient(
+      closest-side at 50% 50%,
+      color-mix(in srgb, var(--accent) 8%, transparent),
+      color-mix(in srgb, var(--accent) 4%, transparent) 55%,
+      transparent 82%
+    );
   pointer-events: none;
 }
 
-/* Pill and chip paint above the thread cards (z 0..n by stack position)
-   and below the load card (STAR_MAP_LOAD_CARD_Z = 50). */
-.star-map__cluster-pill {
+/* Label and chip paint above the thread cards (z 0..n by stack position)
+   and below the load card (STAR_MAP_LOAD_CARD_Z = 50). The label floats
+   over the sky the way the instance name does — no box around it. */
+.star-map__cluster-label {
   display: inline-flex;
   position: absolute;
   z-index: 48;
-  align-items: center;
+  transform: translate(-50%, -50%);
+  align-items: baseline;
   gap: 6px;
-  max-width: 208px;
-  padding: 3px 9px;
-  border: 1px solid var(--border-subtle);
+  max-width: 240px;
+  padding: 3px 8px;
+  border: none;
   border-radius: 6px;
-  background: var(--bg-panel);
+  background: transparent;
   color: var(--text-secondary);
   font-size: 11px;
+  letter-spacing: 0.05em;
   white-space: nowrap;
   cursor: pointer;
 }
 
-.star-map__cluster-pill:hover {
-  border-color: var(--border-strong);
+.star-map__cluster-label:hover {
+  background: color-mix(in srgb, var(--bg-panel) 60%, transparent);
   color: var(--text-primary);
 }
 
 /* Pressed = every visible card in the cloud is in the selection. */
-.star-map__cluster-pill[aria-pressed="true"] {
-  border-color: var(--accent-border);
+.star-map__cluster-label[aria-pressed="true"] {
   background: var(--accent-soft);
   color: var(--text-primary);
 }
 
-.star-map__cluster-label {
+.star-map__cluster-name {
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .star-map__cluster-count {
-  min-width: 14px;
-  padding: 0 4px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--text-muted) 18%, transparent);
-  color: var(--text-secondary);
+  color: var(--text-muted);
   font-size: 10px;
   font-variant-numeric: tabular-nums;
-  line-height: 15px;
-  text-align: center;
 }
 
-.star-map__cluster-pill[aria-pressed="true"] .star-map__cluster-count {
-  background: color-mix(in srgb, var(--accent) 22%, transparent);
-  color: var(--text-primary);
-}
-
-/* Slot is the chip's centre, so the button centres itself on it. */
+/* Slot is the chip's centre, so the button centres itself on it. Quiet
+   like the lanes overflow text, but clickable. */
 .star-map__cluster-overflow {
   position: absolute;
   z-index: 48;
   transform: translate(-50%, -50%);
   padding: 3px 10px;
-  border: 1px solid var(--border-subtle);
+  border: none;
   border-radius: 6px;
-  background: color-mix(in srgb, var(--bg-panel) 75%, transparent);
+  background: transparent;
   color: var(--text-muted);
   font-size: 11px;
   white-space: nowrap;
@@ -9977,15 +9980,16 @@ textarea,
 }
 
 .star-map__cluster-overflow:hover {
-  border-color: var(--border-strong);
+  background: color-mix(in srgb, var(--bg-panel) 60%, transparent);
   color: var(--text-primary);
 }
 
-.star-map__cluster-pill:focus-visible,
+.star-map__cluster-label:focus-visible,
 .star-map__cluster-overflow:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 1px;
 }
+
 
 /* Shell: position, stacking, drag target and rise animation. The visual
    card is a plain button inside it, so the kebab can be a sibling rather
@@ -10022,7 +10026,12 @@ textarea,
    everything below the first line unclickable.) No transform: the card
    must not move under the pointer. */
 .star-map-card-shell:hover {
-  z-index: 5;
+  /* !important because each shell carries an inline z-index (its stack
+     position), which otherwise beats any hover rule — cards deeper than
+     the old value of 5 never actually raised. Cloud rings shingle cards
+     on purpose, so the raise has to clear every stacked card (0..n) and
+     the cloud label/chip at 48, while staying under the load card at 50. */
+  z-index: 49 !important;
 }
 
 .star-map-card-shell:hover .star-map-card {
@@ -10843,8 +10852,8 @@ textarea,
 .star-map-card *,
 .star-map-load-card,
 .star-map-load-card *,
-.star-map__cluster-pill,
-.star-map__cluster-pill *,
+.star-map__cluster-label,
+.star-map__cluster-label *,
 .star-map__cluster-overflow {
   -webkit-app-region: no-drag;
 }

--- a/packages/shared/src/directory-navigation.ts
+++ b/packages/shared/src/directory-navigation.ts
@@ -15,7 +15,7 @@ import {
   isToolManagedWorktreePath,
 } from "./worktree-paths.js";
 
-type DirectoryDescriptor = Pick<
+export type DirectoryDescriptor = Pick<
   NavigationDirectorySummary,
   "key" | "kind" | "label" | "path"
 >;
@@ -117,7 +117,17 @@ function matchCodexChatsRoot(value: string): string | undefined {
   return codexChatsRootMatch?.[1];
 }
 
-function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescriptor {
+/**
+ * Classify a linked directory into the row the Directories lens would file
+ * it under: scratch checkouts collapse into one "Workspaces" pseudo-
+ * directory, Codex chat dirs into "Codex Chats", worktrees onto their repo
+ * root. Exported so the Star Map groups threads by the same brain — twenty
+ * scratch chats must read as one Workspaces cloud, not twenty hash-named
+ * bodies.
+ */
+export function classifyDirectory(
+  directory: LinkedDirectorySummary,
+): DirectoryDescriptor {
   // Canonicalize separators up front so a directory keyed via different path
   // representations (Windows `C:\…` vs the forward-slashed `C:/…` we normalize
   // codex/git paths to) collapses to ONE directory row instead of duplicating.


### PR DESCRIPTION
## Summary

- The orbit lens seated cards on elliptical rings purely by sort index (pins-then-recency), so two projects with interleaved activity times provably alternated around the ring — search-compare and giphy-services cards intermingled into one mess. It also truncated every instance at 16 cards **silently**: the `+N more` badge only rendered when `!orbitMode`.
- New pure module `star-map-clusters.ts`: groups an instance's filtered threads by project (same `threadProjectKey` + mass formula the projects lens uses), pulls children directly under their parent via `parentThreadId` (children keep relative order; cycles can't drop threads), caps each cloud at 8 visible cards with a 40-card per-instance DOM backstop, stacks cards in one or two measured columns, and seats clouds radially around the body — clear of the instance keep-out box and of each other, deterministically.
- Cloud chrome: dashed outline (decorative, `pointer-events: none`, pans pass through) plus a label pill carrying the project name and total thread count. Clicking the pill selects the cloud's visible cards, so the existing group drag moves the whole cloud; `aria-pressed` tracks it.
- Honest overflow everywhere: each cloud gets a real `+N more` **button** that expands the cloud in place (then reads "Show fewer"); backstop clipping accrues into the same chip. The projects lens keeps its 16-card rings but now renders a `+N more` badge instead of truncating silently.
- Chip hygiene: cards inside a labeled project cloud drop their directory chips (`primaryDirectory`/`secondaryDirectories`), following the projects lens precedent ("the project IS the sun"). No-project clouds keep them, and a lone no-project cloud renders chromeless.
- `computeOrbitPlacement` accepts measured cloud extents so instance spacing tracks what is actually drawn rather than a ring formula. Cluster cloud slots are top-anchored like lanes, which also makes the snap math's top-edge assumption correct in orbit.

## Verification

- 283 tests pass across all 20 star-map files, 27 of them new: 22 geometry/grouping tests in `star-map-clusters.test.ts` (caps, overflow accrual, parent adjacency, keep-out clearance, outline separation, determinism) and 5 operator-visible behaviors in `star-map-cluster-chrome.test.tsx` (pills, expand/collapse cycle, chip hygiene, chromeless no-project cloud, cloud selection from the pill).
- `pnpm lint:eslint` (0 errors), `pnpm lint:colors`, `pnpm lint:boundaries`, and `pnpm --filter @pwragent/desktop typecheck` all clean.
- Cluster chrome uses existing theme tokens only (no raw color literals), radius ≤ 8px, and joins the `-webkit-app-region: no-drag` list so pill/chip clicks survive the title-bar drag band.

## Notes

- Cloud expansion state is view-local like the selection — how much of a cloud is unfolded is a "what am I looking at" gesture, not fleet state. Card drag offsets persist and sync exactly as before (keyed per `instanceId::threadKey`).
- Slot semantics in orbit changed from center-anchored ring points to top-anchored cloud stacks, so hand-placed offsets from the old ring layout will render relative to new base slots — same class of shift as any layout change, and offsets remain valid deltas.
- Running the vitest suite under Node 26 fails broadly with `localStorage` errors; that's the Node mismatch, not the suite — use the repo's pinned Node 24.14.1 (`nvm use`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)