### PR TITLE
feat(desktop): fly the star map with WASD

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapKeyHint.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapKeyHint.tsx
@@ -1,4 +1,5 @@
 import type { StarMapCameraKey } from "./star-map-keyboard";
+import { useKeyboardLayoutLabels } from "./useKeyboardLayoutLabels";
 
 /**
  * The clue that the map flies from the keyboard.
@@ -13,8 +14,15 @@ import type { StarMapCameraKey } from "./star-map-keyboard";
  * keyboard rather than to something else, which matters most in the case
  * where a key does nothing because the camera is already parked against
  * its bounds.
+ *
+ * The pan caps are labelled from the operator's real keyboard layout, not
+ * hardcoded to W/A/S/D. The camera binds by physical position, so on AZERTY
+ * the correct keys are the ones engraved Z Q S D — drawing "W" there would
+ * point at the wrong key while the right one silently worked.
  */
 export function StarMapKeyHint(props: { held: ReadonlySet<StarMapCameraKey> }) {
+  const labels = useKeyboardLayoutLabels();
+
   const cap = (key: StarMapCameraKey, label: string, modifier?: string) => (
     <kbd
       className={`star-map__key${
@@ -33,17 +41,17 @@ export function StarMapKeyHint(props: { held: ReadonlySet<StarMapCameraKey> }) {
       // at a time is noise. One sentence carries the whole control set,
       // including the alternates the picture has no room for.
       aria-label={
-        "Camera controls: W, A, S and D or the arrow keys pan the map. "
-        + "Hold Shift to move faster. Minus and equals zoom out and in. "
-        + "Zero resets the view."
+        `Camera controls: ${labels.KeyW}, ${labels.KeyA}, ${labels.KeyS} and `
+        + `${labels.KeyD} or the arrow keys pan the map. Hold Shift to move `
+        + "faster. Minus and equals zoom out and in. Zero resets the view."
       }
     >
       <span className="star-map__key-group" aria-hidden="true">
         <span className="star-map__key-pad">
-          {cap("up", "W", "up")}
-          {cap("left", "A", "left")}
-          {cap("down", "S", "down")}
-          {cap("right", "D", "right")}
+          {cap("up", labels.KeyW, "up")}
+          {cap("left", labels.KeyA, "left")}
+          {cap("down", labels.KeyS, "down")}
+          {cap("right", labels.KeyD, "right")}
         </span>
         <span className="star-map__key-label">pan</span>
       </span>
@@ -51,6 +59,16 @@ export function StarMapKeyHint(props: { held: ReadonlySet<StarMapCameraKey> }) {
         {cap("zoomOut", "−")}
         {cap("zoomIn", "+")}
         <span className="star-map__key-label">zoom</span>
+      </span>
+      {/* Shift and 0 were previously in the label only — the two controls
+          hardest to guess were the two the picture did not show. */}
+      <span className="star-map__key-group" aria-hidden="true">
+        <kbd className="star-map__key star-map__key--wide">⇧</kbd>
+        <span className="star-map__key-label">faster</span>
+      </span>
+      <span className="star-map__key-group" aria-hidden="true">
+        <kbd className="star-map__key">0</kbd>
+        <span className="star-map__key-label">reset</span>
       </span>
     </div>
   );

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapKeyHint.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapKeyHint.tsx
@@ -1,0 +1,57 @@
+import type { StarMapCameraKey } from "./star-map-keyboard";
+
+/**
+ * The clue that the map flies from the keyboard.
+ *
+ * A control nobody can see is a control nobody uses, and WASD is not
+ * discoverable on a surface that also drags: the operator reaches for the
+ * mouse, it works, and the faster gesture is never found. So the keys sit
+ * on the map at rest, in the corner the other chrome leaves free.
+ *
+ * The caps also light up under the keys actually being held. That is not
+ * decoration: it is the only feedback that the map is responding to the
+ * keyboard rather than to something else, which matters most in the case
+ * where a key does nothing because the camera is already parked against
+ * its bounds.
+ */
+export function StarMapKeyHint(props: { held: ReadonlySet<StarMapCameraKey> }) {
+  const cap = (key: StarMapCameraKey, label: string, modifier?: string) => (
+    <kbd
+      className={`star-map__key${
+        modifier ? ` star-map__key--${modifier}` : ""
+      }${props.held.has(key) ? " is-held" : ""}`}
+    >
+      {label}
+    </kbd>
+  );
+
+  return (
+    <div
+      className="star-map__key-hint"
+      role="note"
+      // The caps are a picture of a keyboard; spelling them out one glyph
+      // at a time is noise. One sentence carries the whole control set,
+      // including the alternates the picture has no room for.
+      aria-label={
+        "Camera controls: W, A, S and D or the arrow keys pan the map. "
+        + "Hold Shift to move faster. Minus and equals zoom out and in. "
+        + "Zero resets the view."
+      }
+    >
+      <span className="star-map__key-group" aria-hidden="true">
+        <span className="star-map__key-pad">
+          {cap("up", "W", "up")}
+          {cap("left", "A", "left")}
+          {cap("down", "S", "down")}
+          {cap("right", "D", "right")}
+        </span>
+        <span className="star-map__key-label">pan</span>
+      </span>
+      <span className="star-map__key-group" aria-hidden="true">
+        {cap("zoomOut", "−")}
+        {cap("zoomIn", "+")}
+        <span className="star-map__key-label">zoom</span>
+      </span>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -83,6 +83,7 @@ import {
   MAX_ZOOM,
   MIN_ZOOM,
   placeStarMapView,
+  type StarMapView,
 } from "./star-map-view-geometry";
 import { StarMapViewOptions } from "./StarMapViewOptions";
 import { StarMapKeyHint } from "./StarMapKeyHint";
@@ -237,10 +238,60 @@ export function StarMapScreen(props: StarMapScreenProps) {
   // pans and zooms rather than compressing the map to fit.
   const [view, setView] = useState({ x: 0, y: 0, scale: 1 });
   /**
+   * Where the view is *right now*, which is not always what React state
+   * says.
+   *
+   * Both direct-manipulation gestures — the pointer drag and the keyboard
+   * camera — write the canvas transform by hand on an animation frame and
+   * only commit to state when the gesture ends, because a `setView` per
+   * frame re-renders every card on the map to move one transform. That
+   * leaves a window where `view` is stale, and every writer has to agree on
+   * a single live value or they fight: the keyboard camera used to keep a
+   * private copy, so a pinch mid-flight was computed from the pre-flight
+   * base and then thrown away on landing, and `0` (reset view) mid-flight
+   * did nothing at all.
+   *
+   * So this ref is the one source of truth for "where is the view", and
+   * `paintView` / `commitView` below are the only ways to move it.
+   */
+  const viewRef = useRef(view);
+  /**
    * Set once the operator pans or zooms. From then on the view is theirs:
    * nothing that merely changes the map's contents may move it.
    */
   const operatorMovedViewRef = useRef(false);
+
+  /**
+   * Move the view without telling React. For gesture frames: writes the
+   * live ref and the transform, so the next frame of any writer composes
+   * on top of it rather than on a stale base.
+   */
+  const paintView = useCallback((next: StarMapView) => {
+    viewRef.current = next;
+    const canvas = canvasRef.current;
+    if (canvas) {
+      canvas.style.transform =
+        `translate(${next.x}px, ${next.y}px) scale(${next.scale})`;
+    }
+  }, []);
+
+  /**
+   * Move the view and tell React. For anything that ends a gesture or
+   * happens outside one — `view.scale` feeds the card-drag detent and the
+   * overlay stroke widths, so it cannot stay stale indefinitely.
+   *
+   * Paints as well as commits: React skips the style write when its own
+   * last-rendered transform already equals the new one, which is exactly
+   * the case after a run of hand-written frames. Committing alone would
+   * leave the DOM showing the gesture's last frame.
+   */
+  const commitView = useCallback(
+    (next: StarMapView) => {
+      paintView(next);
+      setView(next);
+    },
+    [paintView],
+  );
   const orbitMode = preferences.layout === "orbit";
   /** Projects as suns: threads pooled across instances, one body per repo. */
   const projectsMode = preferences.layout === "projects";
@@ -389,7 +440,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
     // Scale is captured for the whole gesture. A pinch mid-drag moves the
     // live transform out of step with it until pointerup re-reads the real
     // scale from state; the drag has always worked this way.
-    const base = view;
+    // Read from the live ref, not React state: a keyboard flight may have
+    // moved the view since the last commit.
+    const base = viewRef.current;
     /** Latest raw pointer position, unclamped. Both writers clamp it. */
     let pointerX = base.x;
     let pointerY = base.y;
@@ -405,12 +458,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
           // transform straight onto the canvas, so an unclamped live path
           // would let the map leave the window and then jump back on
           // pointerup when the clamped state landed.
-          const clamped = clampStarMapView({
-            view: { x: pointerX, y: pointerY, scale: base.scale },
-            ...bounds,
-          });
-          canvas.style.transform =
-            `translate(${clamped.x}px, ${clamped.y}px) scale(${base.scale})`;
+          paintView(
+            clampStarMapView({
+              view: { x: pointerX, y: pointerY, scale: base.scale },
+              ...bounds,
+            }),
+          );
         });
       }
     };
@@ -430,9 +483,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
       // has to be in bounds on its own account — and a flick released
       // before any frame ran still commits where the pointer actually
       // ended up.
-      setView((current) =>
+      commitView(
         clampStarMapView({
-          view: { ...current, x: pointerX, y: pointerY },
+          view: { ...viewRef.current, x: pointerX, y: pointerY },
           ...bounds,
         }),
       );
@@ -834,18 +887,25 @@ export function StarMapScreen(props: StarMapScreenProps) {
     };
     const onWheel = (event: WheelEvent) => {
       event.preventDefault();
+      // Both branches read the LIVE view rather than a `setView` updater's
+      // `current`. During a keyboard flight the committed state is frozen at
+      // the last landing, so an updater would compute this pinch from a base
+      // several hundred pixels stale and then have it overwritten on the next
+      // animation frame. Reading and writing the same ref lets the two
+      // gestures compose: fly with WASD and pinch to zoom at the same time.
+      operatorMovedViewRef.current = true;
+      const current = viewRef.current;
       if (event.ctrlKey) {
-        operatorMovedViewRef.current = true;
         const rect = element.getBoundingClientRect();
         const pointerX = event.clientX - rect.left;
         const pointerY = event.clientY - rect.top;
-        setView((current) => {
-          const scale = Math.min(
-            MAX_ZOOM,
-            Math.max(MIN_ZOOM, current.scale * (1 - event.deltaY / 240)),
-          );
-          const ratio = scale / current.scale;
-          return clampStarMapView({
+        const scale = Math.min(
+          MAX_ZOOM,
+          Math.max(MIN_ZOOM, current.scale * (1 - event.deltaY / 240)),
+        );
+        const ratio = scale / current.scale;
+        commitView(
+          clampStarMapView({
             view: {
               scale,
               // Keep the point under the cursor pinned while scaling.
@@ -853,12 +913,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
               y: pointerY - (pointerY - current.y) * ratio,
             },
             ...bounds,
-          });
-        });
+          }),
+        );
         return;
       }
-      operatorMovedViewRef.current = true;
-      setView((current) =>
+      commitView(
         clampStarMapView({
           view: {
             ...current,
@@ -872,6 +931,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
     element.addEventListener("wheel", onWheel, { passive: false });
     return () => element.removeEventListener("wheel", onWheel);
   }, [
+    commitView,
     topAnchoredView,
     panZoomCanvas.width,
     panZoomCanvas.height,
@@ -897,7 +957,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
    */
   useEffect(() => {
     if (operatorMovedViewRef.current) return;
-    setView(
+    commitView(
       placeStarMapView({
         canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
         viewport: { width: viewportSize.width, height: viewportSize.height },
@@ -905,6 +965,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       }),
     );
   }, [
+    commitView,
     topAnchoredView,
     panZoomCanvas.width,
     panZoomCanvas.height,
@@ -925,7 +986,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
    */
   const resetView = useCallback(() => {
     operatorMovedViewRef.current = false;
-    setView(
+    // commitView, not setView: `0` can be pressed mid-flight, and the
+    // keyboard camera's next frame reads the live ref. Committing to state
+    // alone would be silently overwritten by that frame — and, because
+    // React's last-rendered transform still matched, would not even repaint.
+    commitView(
       placeStarMapView({
         canvas: { width: panZoomCanvas.width, height: panZoomCanvas.height },
         viewport: { width: viewportSize.width, height: viewportSize.height },
@@ -933,6 +998,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       }),
     );
   }, [
+    commitView,
     topAnchoredView,
     panZoomCanvas.width,
     panZoomCanvas.height,
@@ -955,11 +1021,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const heldCameraKeys = useStarMapCameraKeys({
     enabled: !props.floating,
     layerRef,
-    canvasRef,
-    view,
+    liveViewRef: viewRef,
     canvas: panZoomCanvas,
     viewport: viewportSize,
-    onChange: setView,
+    onPaint: paintView,
+    onCommit: commitView,
     onMoveStart: claimView,
     onResetView: resetView,
   });

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -85,6 +85,8 @@ import {
   placeStarMapView,
 } from "./star-map-view-geometry";
 import { StarMapViewOptions } from "./StarMapViewOptions";
+import { StarMapKeyHint } from "./StarMapKeyHint";
+import { useStarMapCameraKeys } from "./useStarMapCameraKeys";
 import { StarMapInstanceCard } from "./StarMapInstanceCard";
 import {
   StarMapLoadCard,
@@ -937,6 +939,30 @@ export function StarMapScreen(props: StarMapScreenProps) {
     viewportSize.width,
     viewportSize.height,
   ]);
+
+  const claimView = useCallback(() => {
+    operatorMovedViewRef.current = true;
+  }, []);
+
+  /**
+   * WASD / arrows fly the camera, `-` and `=` work the zoom, `0` resets.
+   *
+   * A map you fly over should move the way every other map you fly over
+   * moves, and the pointer gestures alone leave the operator's other hand
+   * with nothing to do. Disabled while a thread floats over the map: the
+   * map has shoved aside and `w` belongs to the composer.
+   */
+  const heldCameraKeys = useStarMapCameraKeys({
+    enabled: !props.floating,
+    layerRef,
+    canvasRef,
+    view,
+    canvas: panZoomCanvas,
+    viewport: viewportSize,
+    onChange: setView,
+    onMoveStart: claimView,
+    onResetView: resetView,
+  });
 
   const peerById = useMemo(
     () => new Map(peers.map((peer) => [peer.id, peer])),
@@ -2127,6 +2153,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
           </span>
         </div>
       ) : null}
+      {/* Bottom-left: the keys the map flies with. Hidden while a thread
+          floats over the map, because the camera is off then. */}
+      {props.floating ? null : <StarMapKeyHint held={heldCameraKeys} />}
       {/* The only thing on the surface that admits a selection exists.
           `role="status"` so the count is heard, not just seen — the cards
           themselves carry no selected state to a screen reader. */}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/keyboard-layout-labels.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/keyboard-layout-labels.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_KEY_CAP_LABELS,
+  resolveKeyCapLabels,
+} from "../useKeyboardLayoutLabels";
+
+/**
+ * The camera binds by physical position, so the hint has to be labelled from
+ * the board in front of the operator rather than from the binding. These are
+ * the merge rules; the browser capability itself is not testable here.
+ */
+describe("resolveKeyCapLabels", () => {
+  it("falls back to the QWERTY engravings with no layout map", () => {
+    expect(resolveKeyCapLabels(undefined)).toEqual(DEFAULT_KEY_CAP_LABELS);
+  });
+
+  it("labels the pan cluster from the operator's layout", () => {
+    // AZERTY: the WASD positions are engraved Z Q S D.
+    const labels = resolveKeyCapLabels(
+      new Map([
+        ["KeyW", "z"],
+        ["KeyA", "q"],
+        ["KeyS", "s"],
+        ["KeyD", "d"],
+      ]),
+    );
+    expect(labels).toEqual({ KeyW: "Z", KeyA: "Q", KeyS: "S", KeyD: "D" });
+  });
+
+  it("keeps the QWERTY letter for a position that prints nothing usable", () => {
+    // A dead key reports "", and some positions report a multi-character
+    // name; neither fits an 18px cap, so the fallback letter stays.
+    const labels = resolveKeyCapLabels(
+      new Map([
+        ["KeyW", ""],
+        ["KeyA", "Dead"],
+        ["KeyS", "o"],
+      ]),
+    );
+    expect(labels.KeyW).toBe("W");
+    expect(labels.KeyA).toBe("A");
+    expect(labels.KeyS).toBe("O");
+    // A code the layout omits entirely also keeps its fallback.
+    expect(labels.KeyD).toBe("D");
+  });
+
+  it("never invents a cap for a code the hint does not draw", () => {
+    const labels = resolveKeyCapLabels(new Map([["KeyQ", "a"]]));
+    expect(Object.keys(labels).sort()).toEqual(["KeyA", "KeyD", "KeyS", "KeyW"]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-camera-keys.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-camera-keys.test.tsx
@@ -1,0 +1,247 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { StarMapScreen } from "../StarMapScreen";
+
+/**
+ * The map flies from the keyboard.
+ *
+ * The pointer gestures are complete on their own, which is exactly why this
+ * needed proving end to end rather than only in the pure step function: the
+ * camera writes the canvas transform by hand while keys are held and only
+ * commits to React state on release, so "it moved" and "it stayed moved"
+ * are two different claims.
+ */
+
+function buildDesktopApi(): DesktopApi {
+  return {
+    readFederationHealth: vi.fn(async () => ({
+      health: {
+        enabled: false,
+        role: "client" as const,
+        status: "disabled" as const,
+        instanceId: "pwr_local",
+        localCelestialIcon: "sun" as const,
+        localLabel: "Harold-MBP-M5-Max",
+        localProfileName: "default",
+        peers: [],
+      },
+    })),
+    onAgentEvent: vi.fn(() => () => undefined),
+  } as unknown as DesktopApi;
+}
+
+function thread(id: string): NavigationThreadSummary {
+  return {
+    id,
+    title: `Thread ${id}`,
+    titleSource: "generated",
+    linkedDirectories: [
+      { id: `${id}-dir`, label: "PwrSnap", path: "/repos/PwrSnap", kind: "local" },
+    ],
+    source: "codex",
+    inbox: { inInbox: true, reason: "updated-since-seen" },
+    updatedAt: 100,
+  } as unknown as NavigationThreadSummary;
+}
+
+function canvas(): HTMLElement {
+  const element = document.querySelector(".star-map__canvas");
+  if (!element) throw new Error("canvas not found");
+  return element as HTMLElement;
+}
+
+function layer(): HTMLElement {
+  const element = document.querySelector(".star-map");
+  if (!element) throw new Error("layer not found");
+  return element as HTMLElement;
+}
+
+function readTransform(): { x: number; y: number; scale: number } {
+  const raw = canvas().style.transform;
+  const match = /translate\((-?[\d.]+)px, (-?[\d.]+)px\) scale\(([\d.]+)\)/.exec(
+    raw,
+  );
+  if (!match) throw new Error(`unparsable transform: ${raw}`);
+  return { x: Number(match[1]), y: Number(match[2]), scale: Number(match[3]) };
+}
+
+/** Let one animation frame run, so the camera integrates a step. */
+async function flushFrame() {
+  await act(async () => {
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => resolve(undefined));
+    });
+  });
+}
+
+async function openMap(floating = false) {
+  const rendered = render(
+    <StarMapScreen
+      desktopApi={buildDesktopApi()}
+      localThreads={Array.from({ length: 9 }, (_, index) => thread(`t${index}`))}
+      sessionKeys={{}}
+      localInstanceLabel="Mac-Mini-M4"
+      floating={floating}
+      onClose={() => undefined}
+      onOpenLocalThread={() => undefined}
+      onFocusLocalInstance={() => undefined}
+    />,
+  );
+  await waitFor(() => {
+    expect(screen.getByRole("button", { name: /Open this instance/ })).toBeTruthy();
+  });
+  return rendered;
+}
+
+describe("star map keyboard camera", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+  });
+
+  it("flies the camera while a direction key is held", async () => {
+    await openMap();
+    const before = readTransform();
+
+    fireEvent.keyDown(layer(), { key: "d" });
+    await flushFrame();
+
+    // D flies the camera right, so the canvas beneath travels left.
+    expect(readTransform().x).toBeLessThan(before.x);
+    expect(readTransform().y).toBe(before.y);
+
+    fireEvent.keyDown(layer(), { key: "w" });
+    await flushFrame();
+    expect(readTransform().y).toBeGreaterThan(before.y);
+
+    fireEvent.keyUp(window, { key: "d" });
+    fireEvent.keyUp(window, { key: "w" });
+    await flushFrame();
+  });
+
+  it("stops when the key comes up, and commits where it landed", async () => {
+    await openMap();
+    const before = readTransform();
+
+    fireEvent.keyDown(layer(), { key: "a" });
+    await flushFrame();
+    fireEvent.keyUp(window, { key: "a" });
+    // The frame after the release lands the flight and hands the view back
+    // to React.
+    await flushFrame();
+    const landed = readTransform();
+    expect(landed.x).toBeGreaterThan(before.x);
+
+    // Nothing moves once the key is up, however many frames go by.
+    await flushFrame();
+    await flushFrame();
+    expect(readTransform()).toEqual(landed);
+
+    // The proof that the flight was COMMITTED rather than only painted: a
+    // pointer drag reads the view from React state, so it must build on
+    // where the keyboard left off rather than on the pre-flight value.
+    const viewport = document.querySelector(".star-map__viewport")!;
+    fireEvent.pointerDown(viewport, { button: 0, clientX: 500, clientY: 400 });
+    fireEvent.pointerMove(window, { clientX: 460, clientY: 400 });
+    fireEvent.pointerUp(window, { clientX: 460, clientY: 400 });
+    expect(readTransform().x).toBeCloseTo(landed.x - 40, 6);
+  });
+
+  it("zooms about the centre of the window on the minus and equals keys", async () => {
+    await openMap();
+    const before = readTransform();
+
+    fireEvent.keyDown(layer(), { key: "=" });
+    await flushFrame();
+    const zoomed = readTransform();
+    expect(zoomed.scale).toBeGreaterThan(before.scale);
+    // Same canvas point stays under the middle of the window.
+    expect((640 - zoomed.x) / zoomed.scale).toBeCloseTo((640 - before.x) / before.scale, 4);
+
+    fireEvent.keyUp(window, { key: "=" });
+    await flushFrame();
+
+    fireEvent.keyDown(layer(), { key: "-" });
+    await flushFrame();
+    expect(readTransform().scale).toBeLessThan(zoomed.scale);
+    fireEvent.keyUp(window, { key: "-" });
+    await flushFrame();
+  });
+
+  it("puts the map back where it opens on 0", async () => {
+    await openMap();
+    const opened = readTransform();
+
+    fireEvent.keyDown(layer(), { key: "d" });
+    await flushFrame();
+    fireEvent.keyUp(window, { key: "d" });
+    await flushFrame();
+    expect(readTransform().x).not.toBe(opened.x);
+
+    fireEvent.keyDown(layer(), { key: "0" });
+    expect(readTransform()).toEqual(opened);
+  });
+
+  it("leaves modified keystrokes to the app and the OS", async () => {
+    // Cmd-W is "close window", not "fly up", and Ctrl-D is not a pan.
+    await openMap();
+    const before = readTransform();
+
+    fireEvent.keyDown(layer(), { key: "w", metaKey: true });
+    fireEvent.keyDown(layer(), { key: "d", ctrlKey: true });
+    await flushFrame();
+
+    expect(readTransform()).toEqual(before);
+  });
+
+  it("releases every key when the window loses focus", async () => {
+    // Cmd-Tab away mid-flight and no keyup ever arrives; without this the
+    // camera flies on with nothing holding it.
+    await openMap();
+
+    fireEvent.keyDown(layer(), { key: "d" });
+    await flushFrame();
+    const flying = readTransform();
+
+    fireEvent.blur(window);
+    await flushFrame();
+    const released = readTransform();
+    await flushFrame();
+
+    expect(readTransform()).toEqual(released);
+    expect(released.x).toBeLessThanOrEqual(flying.x);
+  });
+
+  it("shows the keys on the map, lit under the ones being held", async () => {
+    await openMap();
+    const hint = document.querySelector(".star-map__key-hint");
+    expect(hint).toBeTruthy();
+    expect(hint?.querySelectorAll(".star-map__key").length).toBe(6);
+    expect(document.querySelectorAll(".star-map__key.is-held").length).toBe(0);
+
+    // Asserted synchronously, not through `waitFor`: the held set is React
+    // state written straight from the key handler, so if it needed waiting
+    // for, that would itself be the bug.
+    fireEvent.keyDown(layer(), { key: "a" });
+    expect(document.querySelector(".star-map__key--left.is-held")).toBeTruthy();
+
+    fireEvent.keyUp(window, { key: "a" });
+    expect(document.querySelectorAll(".star-map__key.is-held").length).toBe(0);
+    await flushFrame();
+  });
+
+  it("hands the keyboard back to the thread floating over the map", async () => {
+    // The map has shoved aside and the operator is in a composer, where `w`
+    // means `w`.
+    await openMap(true);
+    expect(document.querySelector(".star-map__key-hint")).toBeNull();
+    const before = readTransform();
+
+    fireEvent.keyDown(layer(), { key: "d" });
+    await flushFrame();
+
+    expect(readTransform()).toEqual(before);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-camera-keys.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-camera-keys.test.tsx
@@ -105,19 +105,19 @@ describe("star map keyboard camera", () => {
     await openMap();
     const before = readTransform();
 
-    fireEvent.keyDown(layer(), { key: "d" });
+    fireEvent.keyDown(layer(), { key: "d", code: "KeyD" });
     await flushFrame();
 
     // D flies the camera right, so the canvas beneath travels left.
     expect(readTransform().x).toBeLessThan(before.x);
     expect(readTransform().y).toBe(before.y);
 
-    fireEvent.keyDown(layer(), { key: "w" });
+    fireEvent.keyDown(layer(), { key: "w", code: "KeyW" });
     await flushFrame();
     expect(readTransform().y).toBeGreaterThan(before.y);
 
-    fireEvent.keyUp(window, { key: "d" });
-    fireEvent.keyUp(window, { key: "w" });
+    fireEvent.keyUp(window, { key: "d", code: "KeyD" });
+    fireEvent.keyUp(window, { key: "w", code: "KeyW" });
     await flushFrame();
   });
 
@@ -125,9 +125,9 @@ describe("star map keyboard camera", () => {
     await openMap();
     const before = readTransform();
 
-    fireEvent.keyDown(layer(), { key: "a" });
+    fireEvent.keyDown(layer(), { key: "a", code: "KeyA" });
     await flushFrame();
-    fireEvent.keyUp(window, { key: "a" });
+    fireEvent.keyUp(window, { key: "a", code: "KeyA" });
     // The frame after the release lands the flight and hands the view back
     // to React.
     await flushFrame();
@@ -153,20 +153,20 @@ describe("star map keyboard camera", () => {
     await openMap();
     const before = readTransform();
 
-    fireEvent.keyDown(layer(), { key: "=" });
+    fireEvent.keyDown(layer(), { key: "=", code: "Equal" });
     await flushFrame();
     const zoomed = readTransform();
     expect(zoomed.scale).toBeGreaterThan(before.scale);
     // Same canvas point stays under the middle of the window.
     expect((640 - zoomed.x) / zoomed.scale).toBeCloseTo((640 - before.x) / before.scale, 4);
 
-    fireEvent.keyUp(window, { key: "=" });
+    fireEvent.keyUp(window, { key: "=", code: "Equal" });
     await flushFrame();
 
-    fireEvent.keyDown(layer(), { key: "-" });
+    fireEvent.keyDown(layer(), { key: "-", code: "Minus" });
     await flushFrame();
     expect(readTransform().scale).toBeLessThan(zoomed.scale);
-    fireEvent.keyUp(window, { key: "-" });
+    fireEvent.keyUp(window, { key: "-", code: "Minus" });
     await flushFrame();
   });
 
@@ -174,14 +174,83 @@ describe("star map keyboard camera", () => {
     await openMap();
     const opened = readTransform();
 
-    fireEvent.keyDown(layer(), { key: "d" });
+    fireEvent.keyDown(layer(), { key: "d", code: "KeyD" });
     await flushFrame();
-    fireEvent.keyUp(window, { key: "d" });
+    fireEvent.keyUp(window, { key: "d", code: "KeyD" });
     await flushFrame();
     expect(readTransform().x).not.toBe(opened.x);
 
-    fireEvent.keyDown(layer(), { key: "0" });
+    fireEvent.keyDown(layer(), { key: "0", code: "Digit0" });
     expect(readTransform()).toEqual(opened);
+  });
+
+  it("resets the view on 0 even while a direction key is held", async () => {
+    // Regression: the camera used to keep a private copy of the view, so a
+    // reset mid-flight was overwritten by the next animation frame — and,
+    // because React's last-rendered transform still matched, it did not even
+    // repaint. Pressing 0 did nothing at all.
+    await openMap();
+    const opened = readTransform();
+
+    fireEvent.keyDown(layer(), { key: "d", code: "KeyD" });
+    await flushFrame();
+    await flushFrame();
+    expect(readTransform().x).toBeLessThan(opened.x);
+
+    fireEvent.keyDown(layer(), { key: "0", code: "Digit0" });
+    expect(readTransform()).toEqual(opened);
+
+    // Still flying, so the NEXT frame continues from the reset position
+    // rather than teleporting back to where the flight had reached.
+    await flushFrame();
+    const afterReset = readTransform();
+    expect(afterReset.x).toBeLessThan(opened.x);
+    expect(afterReset.x).toBeGreaterThan(opened.x - 100);
+
+    fireEvent.keyUp(window, { key: "d", code: "KeyD" });
+    await flushFrame();
+  });
+
+  it("composes a trackpad pinch with an in-flight keyboard pan", async () => {
+    // Regression: the wheel handler read React state, which is frozen at the
+    // last landing while the keyboard is flying, so a pinch was computed
+    // from a stale base and then discarded by the next frame.
+    await openMap();
+    const viewport = document.querySelector(".star-map__viewport")!;
+
+    fireEvent.keyDown(layer(), { key: "d", code: "KeyD" });
+    await flushFrame();
+    const flying = readTransform();
+
+    fireEvent.wheel(viewport, { deltaY: -120, ctrlKey: true, clientX: 640, clientY: 400 });
+    const pinched = readTransform();
+    expect(pinched.scale).toBeGreaterThan(flying.scale);
+
+    // The flight carries on from the zoomed view: scale is kept, and the pan
+    // keeps going in the same direction.
+    await flushFrame();
+    const after = readTransform();
+    expect(after.scale).toBe(pinched.scale);
+    expect(after.x).toBeLessThan(pinched.x);
+
+    fireEvent.keyUp(window, { key: "d", code: "KeyD" });
+    await flushFrame();
+    expect(readTransform().scale).toBe(pinched.scale);
+  });
+
+  it("keeps flying when focus is on nothing, not just on the layer", async () => {
+    // Closing the portaled intake dialog drops focus on document.body, and
+    // the hint stays on screen advertising keys that then did nothing.
+    await openMap();
+    (document.activeElement as HTMLElement | null)?.blur();
+    const before = readTransform();
+
+    fireEvent.keyDown(document.body, { key: "d", code: "KeyD" });
+    await flushFrame();
+
+    expect(readTransform().x).toBeLessThan(before.x);
+    fireEvent.keyUp(window, { key: "d", code: "KeyD" });
+    await flushFrame();
   });
 
   it("leaves modified keystrokes to the app and the OS", async () => {
@@ -189,8 +258,8 @@ describe("star map keyboard camera", () => {
     await openMap();
     const before = readTransform();
 
-    fireEvent.keyDown(layer(), { key: "w", metaKey: true });
-    fireEvent.keyDown(layer(), { key: "d", ctrlKey: true });
+    fireEvent.keyDown(layer(), { key: "w", code: "KeyW", metaKey: true });
+    fireEvent.keyDown(layer(), { key: "d", code: "KeyD", ctrlKey: true });
     await flushFrame();
 
     expect(readTransform()).toEqual(before);
@@ -201,7 +270,7 @@ describe("star map keyboard camera", () => {
     // camera flies on with nothing holding it.
     await openMap();
 
-    fireEvent.keyDown(layer(), { key: "d" });
+    fireEvent.keyDown(layer(), { key: "d", code: "KeyD" });
     await flushFrame();
     const flying = readTransform();
 
@@ -218,16 +287,16 @@ describe("star map keyboard camera", () => {
     await openMap();
     const hint = document.querySelector(".star-map__key-hint");
     expect(hint).toBeTruthy();
-    expect(hint?.querySelectorAll(".star-map__key").length).toBe(6);
+    expect(hint?.querySelectorAll(".star-map__key").length).toBe(8);
     expect(document.querySelectorAll(".star-map__key.is-held").length).toBe(0);
 
     // Asserted synchronously, not through `waitFor`: the held set is React
     // state written straight from the key handler, so if it needed waiting
     // for, that would itself be the bug.
-    fireEvent.keyDown(layer(), { key: "a" });
+    fireEvent.keyDown(layer(), { key: "a", code: "KeyA" });
     expect(document.querySelector(".star-map__key--left.is-held")).toBeTruthy();
 
-    fireEvent.keyUp(window, { key: "a" });
+    fireEvent.keyUp(window, { key: "a", code: "KeyA" });
     expect(document.querySelectorAll(".star-map__key.is-held").length).toBe(0);
     await flushFrame();
   });
@@ -239,7 +308,7 @@ describe("star map keyboard camera", () => {
     expect(document.querySelector(".star-map__key-hint")).toBeNull();
     const before = readTransform();
 
-    fireEvent.keyDown(layer(), { key: "d" });
+    fireEvent.keyDown(layer(), { key: "d", code: "KeyD" });
     await flushFrame();
 
     expect(readTransform()).toEqual(before);

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-keyboard.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-keyboard.test.ts
@@ -39,42 +39,69 @@ function fly(params: {
 }
 
 describe("resolveStarMapCameraKey", () => {
-  it("maps WASD and the arrows to the same four directions", () => {
-    expect(resolveStarMapCameraKey("w")).toBe("up");
-    expect(resolveStarMapCameraKey("ArrowUp")).toBe("up");
-    expect(resolveStarMapCameraKey("a")).toBe("left");
-    expect(resolveStarMapCameraKey("ArrowLeft")).toBe("left");
-    expect(resolveStarMapCameraKey("s")).toBe("down");
-    expect(resolveStarMapCameraKey("ArrowDown")).toBe("down");
-    expect(resolveStarMapCameraKey("d")).toBe("right");
-    expect(resolveStarMapCameraKey("ArrowRight")).toBe("right");
+  it("binds movement to physical key POSITION, not the character", () => {
+    // The whole point of `code`: these are the WASD positions regardless of
+    // what the layout prints on them.
+    expect(resolveStarMapCameraKey({ key: "w", code: "KeyW" })).toBe("up");
+    expect(resolveStarMapCameraKey({ key: "s", code: "KeyS" })).toBe("down");
+    expect(resolveStarMapCameraKey({ key: "a", code: "KeyA" })).toBe("left");
+    expect(resolveStarMapCameraKey({ key: "d", code: "KeyD" })).toBe("right");
   });
 
-  it("accepts capitals, because Shift is the sprint key", () => {
-    // Holding Shift to sprint changes what the letter keys report, so a
-    // case-sensitive map would make the camera stop the moment it sprints.
-    expect(resolveStarMapCameraKey("W")).toBe("up");
-    expect(resolveStarMapCameraKey("D")).toBe("right");
+  it("flies the same physical keys on AZERTY, where they report z/q/s/d", () => {
+    // The regression this exists for: binding on `event.key` left every
+    // AZERTY operator unable to pan at all, while the hint drew an
+    // inverted-T claiming those exact positions.
+    expect(resolveStarMapCameraKey({ key: "z", code: "KeyW" })).toBe("up");
+    expect(resolveStarMapCameraKey({ key: "q", code: "KeyA" })).toBe("left");
+    expect(resolveStarMapCameraKey({ key: "s", code: "KeyS" })).toBe("down");
+    expect(resolveStarMapCameraKey({ key: "d", code: "KeyD" })).toBe("right");
   });
 
-  it("zooms on both faces of the minus and equals keys", () => {
-    expect(resolveStarMapCameraKey("=")).toBe("zoomIn");
-    // Shifted `=` and the numpad both report "+".
-    expect(resolveStarMapCameraKey("+")).toBe("zoomIn");
-    expect(resolveStarMapCameraKey("-")).toBe("zoomOut");
-    expect(resolveStarMapCameraKey("_")).toBe("zoomOut");
+  it("flies the same physical keys on Dvorak, where they report ,aoe", () => {
+    expect(resolveStarMapCameraKey({ key: ",", code: "KeyW" })).toBe("up");
+    expect(resolveStarMapCameraKey({ key: "a", code: "KeyA" })).toBe("left");
+    expect(resolveStarMapCameraKey({ key: "o", code: "KeyS" })).toBe("down");
+    expect(resolveStarMapCameraKey({ key: "e", code: "KeyD" })).toBe("right");
+  });
+
+  it("does NOT fly a letter that merely spells w/a/s/d on another layout", () => {
+    // AZERTY's physical Z reports key "w". Panning for it would put "up" on
+    // two keys and undo the position binding.
+    expect(resolveStarMapCameraKey({ key: "w", code: "KeyZ" })).toBeUndefined();
+    expect(resolveStarMapCameraKey({ key: "a", code: "KeyQ" })).toBeUndefined();
+  });
+
+  it("maps the arrows and the zoom pair by position too", () => {
+    expect(resolveStarMapCameraKey({ key: "ArrowUp", code: "ArrowUp" })).toBe("up");
+    expect(resolveStarMapCameraKey({ key: "ArrowLeft", code: "ArrowLeft" })).toBe("left");
+    expect(resolveStarMapCameraKey({ key: "=", code: "Equal" })).toBe("zoomIn");
+    expect(resolveStarMapCameraKey({ key: "-", code: "Minus" })).toBe("zoomOut");
+    expect(resolveStarMapCameraKey({ key: "+", code: "NumpadAdd" })).toBe("zoomIn");
+    expect(resolveStarMapCameraKey({ key: "-", code: "NumpadSubtract" })).toBe("zoomOut");
+  });
+
+  it("falls back to the character only when an event carries no code", () => {
+    // Synthetic events often set `key` alone; the map should still fly.
+    expect(resolveStarMapCameraKey({ key: "w" })).toBe("up");
+    expect(resolveStarMapCameraKey({ key: "W" })).toBe("up");
+    expect(resolveStarMapCameraKey({ key: "ArrowDown" })).toBe("down");
+    expect(resolveStarMapCameraKey({ key: "=" })).toBe("zoomIn");
   });
 
   it("leaves every other key alone", () => {
-    for (const key of ["q", "e", "Escape", "Enter", " ", "PageUp", "Tab"]) {
-      expect(resolveStarMapCameraKey(key)).toBeUndefined();
+    for (const code of ["KeyQ", "KeyE", "Escape", "Enter", "Space", "PageUp", "Tab"]) {
+      expect(resolveStarMapCameraKey({ key: "x", code })).toBeUndefined();
     }
   });
 
-  it("resets on zero only", () => {
-    expect(isStarMapResetViewKey("0")).toBe(true);
-    expect(isStarMapResetViewKey("1")).toBe(false);
-    expect(isStarMapResetViewKey("o")).toBe(false);
+  it("resets on zero, digit row or numpad", () => {
+    expect(isStarMapResetViewKey({ key: "0", code: "Digit0" })).toBe(true);
+    expect(isStarMapResetViewKey({ key: "0", code: "Numpad0" })).toBe(true);
+    expect(isStarMapResetViewKey({ key: "0" })).toBe(true);
+    expect(isStarMapResetViewKey({ key: ")", code: "Digit0" })).toBe(true);
+    expect(isStarMapResetViewKey({ key: "1", code: "Digit1" })).toBe(false);
+    expect(isStarMapResetViewKey({ key: "o", code: "KeyO" })).toBe(false);
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-keyboard.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-keyboard.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import {
+  isStarMapResetViewKey,
+  isStarMapTypingTarget,
+  resolveStarMapCameraKey,
+  STAR_MAP_MAX_FRAME_MS,
+  STAR_MAP_PAN_SPEED,
+  STAR_MAP_PAN_SPRINT,
+  stepStarMapCamera,
+  type StarMapCameraKey,
+} from "../star-map-keyboard";
+import {
+  MAX_ZOOM,
+  MIN_ZOOM,
+  MIN_VISIBLE_FRACTION,
+} from "../star-map-view-geometry";
+
+const CANVAS = { width: 4000, height: 3000 };
+const VIEWPORT = { width: 1280, height: 800 };
+
+/** One integration step, well clear of the bounds on every side. */
+const STEP_MS = 100;
+const STEP_PX = (STAR_MAP_PAN_SPEED * STEP_MS) / 1000;
+
+function fly(params: {
+  held: StarMapCameraKey[];
+  elapsedMs?: number;
+  sprint?: boolean;
+  view?: { x: number; y: number; scale: number };
+}) {
+  return stepStarMapCamera({
+    view: params.view ?? { x: -500, y: -400, scale: 1 },
+    held: new Set(params.held),
+    elapsedMs: params.elapsedMs ?? STEP_MS,
+    sprint: params.sprint ?? false,
+    canvas: CANVAS,
+    viewport: VIEWPORT,
+  });
+}
+
+describe("resolveStarMapCameraKey", () => {
+  it("maps WASD and the arrows to the same four directions", () => {
+    expect(resolveStarMapCameraKey("w")).toBe("up");
+    expect(resolveStarMapCameraKey("ArrowUp")).toBe("up");
+    expect(resolveStarMapCameraKey("a")).toBe("left");
+    expect(resolveStarMapCameraKey("ArrowLeft")).toBe("left");
+    expect(resolveStarMapCameraKey("s")).toBe("down");
+    expect(resolveStarMapCameraKey("ArrowDown")).toBe("down");
+    expect(resolveStarMapCameraKey("d")).toBe("right");
+    expect(resolveStarMapCameraKey("ArrowRight")).toBe("right");
+  });
+
+  it("accepts capitals, because Shift is the sprint key", () => {
+    // Holding Shift to sprint changes what the letter keys report, so a
+    // case-sensitive map would make the camera stop the moment it sprints.
+    expect(resolveStarMapCameraKey("W")).toBe("up");
+    expect(resolveStarMapCameraKey("D")).toBe("right");
+  });
+
+  it("zooms on both faces of the minus and equals keys", () => {
+    expect(resolveStarMapCameraKey("=")).toBe("zoomIn");
+    // Shifted `=` and the numpad both report "+".
+    expect(resolveStarMapCameraKey("+")).toBe("zoomIn");
+    expect(resolveStarMapCameraKey("-")).toBe("zoomOut");
+    expect(resolveStarMapCameraKey("_")).toBe("zoomOut");
+  });
+
+  it("leaves every other key alone", () => {
+    for (const key of ["q", "e", "Escape", "Enter", " ", "PageUp", "Tab"]) {
+      expect(resolveStarMapCameraKey(key)).toBeUndefined();
+    }
+  });
+
+  it("resets on zero only", () => {
+    expect(isStarMapResetViewKey("0")).toBe(true);
+    expect(isStarMapResetViewKey("1")).toBe(false);
+    expect(isStarMapResetViewKey("o")).toBe(false);
+  });
+});
+
+describe("isStarMapTypingTarget", () => {
+  function target(html: string, selector?: string): Element {
+    const host = document.createElement("div");
+    host.innerHTML = html;
+    const element = selector ? host.querySelector(selector) : host.firstElementChild;
+    if (!element) throw new Error("no target");
+    return element;
+  }
+
+  it("leaves text entry to the field", () => {
+    expect(isStarMapTypingTarget(target("<input />"))).toBe(true);
+    expect(isStarMapTypingTarget(target("<textarea></textarea>"))).toBe(true);
+  });
+
+  it("treats a chat card as a window over the map, not part of it", () => {
+    // A chat card is a thread you are reading, so `w` inside one belongs to
+    // the card even when the press lands on its chrome rather than a field.
+    expect(
+      isStarMapTypingTarget(
+        target(
+          '<div class="star-map-chat-card"><button>Close</button></div>',
+          "button",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("lets bare sky and map chrome fly the camera", () => {
+    expect(isStarMapTypingTarget(target('<div class="star-map__sky"></div>'))).toBe(
+      false,
+    );
+    expect(
+      isStarMapTypingTarget(target('<button class="star-map__filter-chip" />')),
+    ).toBe(false);
+  });
+});
+
+describe("stepStarMapCamera", () => {
+  it("moves the canvas opposite the camera", () => {
+    // D flies the camera right, so the content under it travels left.
+    const right = fly({ held: ["right"] });
+    expect(right.x).toBe(-500 - STEP_PX);
+    expect(right.y).toBe(-400);
+
+    const up = fly({ held: ["up"] });
+    expect(up.y).toBe(-400 + STEP_PX);
+    expect(up.x).toBe(-500);
+  });
+
+  it("normalises diagonals so two keys are not faster than one", () => {
+    const straight = fly({ held: ["right"] });
+    const diagonal = fly({ held: ["right", "down"] });
+    const straightDistance = Math.hypot(straight.x + 500, straight.y + 400);
+    const diagonalDistance = Math.hypot(diagonal.x + 500, diagonal.y + 400);
+    expect(diagonalDistance).toBeCloseTo(straightDistance, 6);
+  });
+
+  it("cancels opposing keys instead of drifting", () => {
+    const stalled = fly({ held: ["left", "right"] });
+    expect(stalled.x).toBe(-500);
+    expect(stalled.y).toBe(-400);
+  });
+
+  it("sprints on Shift", () => {
+    const cruise = fly({ held: ["right"] });
+    const sprint = fly({ held: ["right"], sprint: true });
+    expect(-500 - sprint.x).toBeCloseTo((-500 - cruise.x) * STAR_MAP_PAN_SPRINT, 6);
+  });
+
+  it("scales the step by elapsed time, not by frame count", () => {
+    const half = fly({ held: ["right"], elapsedMs: 50 });
+    expect(-500 - half.x).toBeCloseTo(STAR_MAP_PAN_SPEED * 0.05, 6);
+  });
+
+  it("caps one step so a backgrounded window does not teleport the map", () => {
+    // A window that stops receiving animation frames delivers a multi-second
+    // gap as its next `elapsedMs`; integrating it whole would slam the map
+    // into its clamp the instant the operator came back.
+    const long = fly({ held: ["right"], elapsedMs: 10_000 });
+    const capped = fly({ held: ["right"], elapsedMs: STAR_MAP_MAX_FRAME_MS });
+    expect(long).toEqual(capped);
+  });
+
+  it("does nothing when no key is held", () => {
+    const view = { x: -500, y: -400, scale: 1 };
+    expect(stepStarMapCamera({
+      view,
+      held: new Set<StarMapCameraKey>(),
+      elapsedMs: 16,
+      sprint: false,
+      canvas: CANVAS,
+      viewport: VIEWPORT,
+    })).toBe(view);
+  });
+
+  it("zooms about the centre of the window", () => {
+    // The keyboard has no pointer to zoom about, so the one fixed point the
+    // operator can predict is the middle of the screen.
+    const before = { x: -500, y: -400, scale: 1 };
+    const after = fly({ held: ["zoomIn"], view: before, elapsedMs: 100 });
+    expect(after.scale).toBeGreaterThan(1);
+
+    const centerX = VIEWPORT.width / 2;
+    const centerY = VIEWPORT.height / 2;
+    // The canvas point under the centre is unchanged by the zoom.
+    expect((centerX - after.x) / after.scale).toBeCloseTo(
+      (centerX - before.x) / before.scale,
+      6,
+    );
+    expect((centerY - after.y) / after.scale).toBeCloseTo(
+      (centerY - before.y) / before.scale,
+      6,
+    );
+  });
+
+  it("parks against the zoom limits rather than drifting past them", () => {
+    let view = { x: -500, y: -400, scale: 1 };
+    for (let step = 0; step < 200; step += 1) {
+      view = fly({ held: ["zoomIn"], view, elapsedMs: 100 });
+    }
+    expect(view.scale).toBe(MAX_ZOOM);
+    // Held at the ceiling the canvas must stop moving too: a ratio computed
+    // off the unclamped scale would keep sliding it sideways forever.
+    const parked = fly({ held: ["zoomIn"], view, elapsedMs: 100 });
+    expect(parked).toEqual(view);
+
+    for (let step = 0; step < 400; step += 1) {
+      view = fly({ held: ["zoomOut"], view, elapsedMs: 100 });
+    }
+    expect(view.scale).toBe(MIN_ZOOM);
+  });
+
+  it("keeps a strip of canvas on screen however long a key is held", () => {
+    let view = { x: -500, y: -400, scale: 1 };
+    for (let step = 0; step < 500; step += 1) {
+      view = fly({ held: ["left", "up"], view, elapsedMs: 100 });
+    }
+    const overlapX = Math.min(VIEWPORT.width, view.x + CANVAS.width * view.scale)
+      - Math.max(0, view.x);
+    expect(overlapX).toBeGreaterThanOrEqual(VIEWPORT.width * MIN_VISIBLE_FRACTION);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-keyboard.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-keyboard.ts
@@ -1,0 +1,196 @@
+/**
+ * Keyboard camera for the star map.
+ *
+ * The map is a surface you fly over rather than a document you scroll, so
+ * it moves the way a PC game moves: WASD (and the arrows, for the people
+ * who never took to WASD) drive the camera, `-` / `=` work the zoom under
+ * the right hand, and both run *continuously* while the key is held rather
+ * than in discrete hops. A per-keypress nudge is what a form does; holding
+ * a direction and watching the field slide past is what a map does.
+ *
+ * Everything here is pure: the hook owns the timing and the DOM, this owns
+ * the rules. Speeds are in screen pixels per second, deliberately NOT in
+ * canvas units — panning has to feel identical at every zoom, exactly as
+ * the pointer drag does, and `view.x` / `view.y` are already screen-pixel
+ * translates.
+ */
+
+import {
+  clampStarMapView,
+  MAX_ZOOM,
+  MIN_ZOOM,
+  type StarMapView,
+  type StarMapViewBox,
+} from "./star-map-view-geometry";
+
+/** One direction the camera can be flying in. */
+export type StarMapCameraKey =
+  | "up"
+  | "down"
+  | "left"
+  | "right"
+  | "zoomIn"
+  | "zoomOut";
+
+/**
+ * Cruise speed, in screen pixels per second.
+ *
+ * Sized so a press-and-release crosses a useful distance without
+ * overshooting the map, and a held key crosses a 1280px window in about a
+ * second — fast enough to feel like flying, slow enough to stop on a card.
+ */
+export const STAR_MAP_PAN_SPEED = 1200;
+
+/** Shift is sprint, the way it is in every game that has a run button. */
+export const STAR_MAP_PAN_SPRINT = 2.5;
+
+/**
+ * Zoom rate in octaves (doublings) per second. The full MIN_ZOOM..MAX_ZOOM
+ * range is about 2.5 octaves, so a held key sweeps the whole range in
+ * roughly 1.8s. Exponential rather than linear because zoom is perceived
+ * multiplicatively: a flat `scale += k` crawls when zoomed out and lurches
+ * when zoomed in.
+ */
+export const STAR_MAP_ZOOM_OCTAVES_PER_SEC = 1.4;
+
+/**
+ * Longest frame the camera will integrate in one step.
+ *
+ * A backgrounded window delivers its next animation frame seconds after
+ * the last one. Without this cap that gap integrates in a single step and
+ * the map teleports to its clamp the instant the operator comes back.
+ */
+export const STAR_MAP_MAX_FRAME_MS = 100;
+
+/**
+ * Which camera direction a key drives, or `undefined` for a key the map
+ * does not fly with.
+ *
+ * Zoom sits on `-` and `=` because that is the near-universal keyboard
+ * zoom pair — main row and numpad both, and `+` arrives for free since
+ * shifted `=` reports as `+`. Deliberately not Page Up / Page Down: those
+ * read as "pan by a page" at least as often as they read as zoom, and a
+ * wrong guess on a movement key is worse than an absent one.
+ */
+export function resolveStarMapCameraKey(
+  key: string,
+): StarMapCameraKey | undefined {
+  switch (key.length === 1 ? key.toLowerCase() : key) {
+    case "w":
+    case "ArrowUp":
+      return "up";
+    case "s":
+    case "ArrowDown":
+      return "down";
+    case "a":
+    case "ArrowLeft":
+      return "left";
+    case "d":
+    case "ArrowRight":
+      return "right";
+    case "=":
+    case "+":
+      return "zoomIn";
+    case "-":
+    case "_":
+      return "zoomOut";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * `0` puts the map back where it opens — the same key every design tool
+ * and browser uses for "back to 100%", and the keyboard's way in to the
+ * "Reset view" action already in the View popover.
+ */
+export function isStarMapResetViewKey(key: string): boolean {
+  return key === "0";
+}
+
+/**
+ * Whether a key event aimed at this element should be left alone.
+ *
+ * The map layer hosts real text entry — chat card composers, and any input
+ * a card grows later — and a chat card is a window *over* the star field
+ * rather than part of it, so `w` typed into one must reach the composer,
+ * not fly the camera.
+ */
+export function isStarMapTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  if (target instanceof HTMLElement && target.isContentEditable) return true;
+  return Boolean(
+    target.closest(
+      "input, textarea, select, [contenteditable], [role='dialog'], .star-map-chat-card",
+    ),
+  );
+}
+
+/**
+ * Advance the camera by one frame.
+ *
+ * Pan is applied first and zoom second, about the centre of the window —
+ * the keyboard has no pointer to zoom about, and the centre is the only
+ * fixed point the operator can predict. Clamped through the same
+ * `clampStarMapView` every other operator-driven write goes through, so a
+ * held key parks against the bounds instead of flying the map away.
+ */
+export function stepStarMapCamera(params: {
+  view: StarMapView;
+  held: ReadonlySet<StarMapCameraKey>;
+  elapsedMs: number;
+  /** Shift held: sprint. */
+  sprint: boolean;
+  /** Untransformed canvas size for the current lens. */
+  canvas: StarMapViewBox;
+  viewport: StarMapViewBox;
+}): StarMapView {
+  const seconds =
+    Math.min(Math.max(params.elapsedMs, 0), STAR_MAP_MAX_FRAME_MS) / 1000;
+  if (seconds === 0 || params.held.size === 0) return params.view;
+
+  let x = params.view.x;
+  let y = params.view.y;
+
+  // Diagonals are normalised, or holding two directions would travel a
+  // factor of sqrt(2) faster than holding one.
+  let dx = (params.held.has("right") ? 1 : 0) - (params.held.has("left") ? 1 : 0);
+  let dy = (params.held.has("down") ? 1 : 0) - (params.held.has("up") ? 1 : 0);
+  const length = Math.hypot(dx, dy);
+  if (length > 0) {
+    dx /= length;
+    dy /= length;
+    const distance =
+      STAR_MAP_PAN_SPEED * seconds * (params.sprint ? STAR_MAP_PAN_SPRINT : 1);
+    // The camera moves one way, so the canvas under it moves the other.
+    x -= dx * distance;
+    y -= dy * distance;
+  }
+
+  const zoomDirection =
+    (params.held.has("zoomIn") ? 1 : 0) - (params.held.has("zoomOut") ? 1 : 0);
+  let scale = params.view.scale;
+  if (zoomDirection !== 0 && scale > 0) {
+    const next = Math.min(
+      MAX_ZOOM,
+      Math.max(
+        MIN_ZOOM,
+        scale * 2 ** (STAR_MAP_ZOOM_OCTAVES_PER_SEC * seconds * zoomDirection),
+      ),
+    );
+    // Ratio comes off the CLAMPED scale, so a key held at either end of
+    // the range stops moving the canvas instead of drifting it sideways.
+    const ratio = next / scale;
+    const centerX = params.viewport.width / 2;
+    const centerY = params.viewport.height / 2;
+    x = centerX - (centerX - x) * ratio;
+    y = centerY - (centerY - y) * ratio;
+    scale = next;
+  }
+
+  return clampStarMapView({
+    view: { x, y, scale },
+    canvas: params.canvas,
+    viewport: params.viewport,
+  });
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-keyboard.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-keyboard.ts
@@ -63,49 +63,83 @@ export const STAR_MAP_ZOOM_OCTAVES_PER_SEC = 1.4;
 export const STAR_MAP_MAX_FRAME_MS = 100;
 
 /**
- * Which camera direction a key drives, or `undefined` for a key the map
- * does not fly with.
+ * Physical key positions, by `KeyboardEvent.code`.
  *
- * Zoom sits on `-` and `=` because that is the near-universal keyboard
- * zoom pair — main row and numpad both, and `+` arrives for free since
- * shifted `=` reports as `+`. Deliberately not Page Up / Page Down: those
- * read as "pan by a page" at least as often as they read as zoom, and a
- * wrong guess on a movement key is worse than an absent one.
+ * `code` names the key's POSITION on the board, not the character it
+ * produces, and that distinction is the whole point here. `event.key` for
+ * the physical W is "w" on QWERTY but "z" on AZERTY and "," on Dvorak, so a
+ * key-based binding silently locks every non-QWERTY operator out of the
+ * headline control — and the on-screen hint draws an inverted-T, which is a
+ * claim about position that only `code` can honour. Games bind movement by
+ * position for exactly this reason.
+ *
+ * Zoom sits on `-` and `=` because that is the near-universal keyboard zoom
+ * pair, numpad included. Deliberately not Page Up / Page Down: those read
+ * as "pan by a page" at least as often as they read as zoom, and a wrong
+ * guess on a movement key is worse than an absent one.
+ */
+const CAMERA_BY_CODE: Readonly<Record<string, StarMapCameraKey>> = {
+  KeyW: "up",
+  KeyS: "down",
+  KeyA: "left",
+  KeyD: "right",
+  ArrowUp: "up",
+  ArrowDown: "down",
+  ArrowLeft: "left",
+  ArrowRight: "right",
+  Equal: "zoomIn",
+  NumpadAdd: "zoomIn",
+  Minus: "zoomOut",
+  NumpadSubtract: "zoomOut",
+};
+
+/**
+ * Character fallback, used ONLY when an event carries no `code`.
+ *
+ * Synthetic events (including a good deal of test tooling) often set `key`
+ * alone. Falling back on an event that HAS a `code` we do not recognise
+ * would undo the layout fix — on AZERTY the physical Z reports `key: "w"`,
+ * and we must not pan for it.
+ */
+const CAMERA_BY_KEY: Readonly<Record<string, StarMapCameraKey>> = {
+  w: "up",
+  s: "down",
+  a: "left",
+  d: "right",
+  ArrowUp: "up",
+  ArrowDown: "down",
+  ArrowLeft: "left",
+  ArrowRight: "right",
+  "=": "zoomIn",
+  "+": "zoomIn",
+  "-": "zoomOut",
+  _: "zoomOut",
+};
+
+/** The shape this module needs from a keyboard event. */
+export type StarMapKeyStroke = { key: string; code?: string };
+
+/**
+ * Which camera direction a keystroke drives, or `undefined` for a key the
+ * map does not fly with.
  */
 export function resolveStarMapCameraKey(
-  key: string,
+  stroke: StarMapKeyStroke,
 ): StarMapCameraKey | undefined {
-  switch (key.length === 1 ? key.toLowerCase() : key) {
-    case "w":
-    case "ArrowUp":
-      return "up";
-    case "s":
-    case "ArrowDown":
-      return "down";
-    case "a":
-    case "ArrowLeft":
-      return "left";
-    case "d":
-    case "ArrowRight":
-      return "right";
-    case "=":
-    case "+":
-      return "zoomIn";
-    case "-":
-    case "_":
-      return "zoomOut";
-    default:
-      return undefined;
-  }
+  if (stroke.code) return CAMERA_BY_CODE[stroke.code];
+  const key = stroke.key.length === 1 ? stroke.key.toLowerCase() : stroke.key;
+  return CAMERA_BY_KEY[key];
 }
 
 /**
- * `0` puts the map back where it opens — the same key every design tool
- * and browser uses for "back to 100%", and the keyboard's way in to the
- * "Reset view" action already in the View popover.
+ * `0` puts the map back where it opens — the same key every design tool and
+ * browser uses for "back to 100%", and the keyboard's way in to the "Reset
+ * view" action already in the View popover. Digit row and numpad both; `0`
+ * is unshifted on every layout we bind, so the character fallback is safe.
  */
-export function isStarMapResetViewKey(key: string): boolean {
-  return key === "0";
+export function isStarMapResetViewKey(stroke: StarMapKeyStroke): boolean {
+  if (stroke.code) return stroke.code === "Digit0" || stroke.code === "Numpad0";
+  return stroke.key === "0";
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/star-map/useKeyboardLayoutLabels.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useKeyboardLayoutLabels.ts
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+
+/**
+ * What to print on a key cap, given where the key sits on the board.
+ *
+ * The camera binds by physical position (`KeyboardEvent.code`), which is
+ * what makes WASD work on every layout. That leaves the hint with a problem
+ * it cannot solve from the binding alone: on AZERTY the key in the W
+ * position is engraved Z, so drawing a "W" cap points a French operator at
+ * the wrong key even though pressing the right one works.
+ *
+ * `navigator.keyboard.getLayoutMap()` answers exactly this — code to the
+ * character that key currently produces — so the hint can be labelled for
+ * the board in front of the operator. Chromium-only, which is fine for
+ * Electron, and it degrades to the QWERTY engravings anywhere it is absent.
+ *
+ * Deliberately labels only; nothing here influences what the keys DO.
+ */
+
+/** The subset of the Keyboard Map API this needs. */
+type KeyboardLayoutSource = {
+  keyboard?: {
+    getLayoutMap?: () => Promise<Map<string, string>>;
+  };
+};
+
+export type StarMapKeyCapLabels = Readonly<Record<string, string>>;
+
+/** QWERTY engravings — the fallback, and the shape of the result. */
+export const DEFAULT_KEY_CAP_LABELS: StarMapKeyCapLabels = {
+  KeyW: "W",
+  KeyA: "A",
+  KeyS: "S",
+  KeyD: "D",
+};
+
+/**
+ * Resolve cap labels for the codes we draw, falling back per-code.
+ *
+ * Exported for tests: the layout map is a browser capability, so the
+ * merging rules are worth pinning without one.
+ */
+export function resolveKeyCapLabels(
+  layout: ReadonlyMap<string, string> | undefined,
+): StarMapKeyCapLabels {
+  if (!layout) return DEFAULT_KEY_CAP_LABELS;
+  const resolved: Record<string, string> = { ...DEFAULT_KEY_CAP_LABELS };
+  for (const code of Object.keys(DEFAULT_KEY_CAP_LABELS)) {
+    const engraved = layout.get(code);
+    // A dead key or a non-printing position reports "" or a multi-character
+    // name; neither fits a 18px cap, so keep the QWERTY letter rather than
+    // draw something unreadable.
+    if (engraved && engraved.length === 1) {
+      resolved[code] = engraved.toUpperCase();
+    }
+  }
+  return resolved;
+}
+
+/**
+ * Cap labels for the operator's actual keyboard layout.
+ *
+ * Starts on the QWERTY fallback and swaps in the real engravings once the
+ * async layout map resolves — a frame of "W A S D" on an AZERTY board beats
+ * a frame of nothing, and the binding is correct either way.
+ */
+export function useKeyboardLayoutLabels(): StarMapKeyCapLabels {
+  const [labels, setLabels] = useState<StarMapKeyCapLabels>(
+    DEFAULT_KEY_CAP_LABELS,
+  );
+
+  useEffect(() => {
+    const source = navigator as Navigator & KeyboardLayoutSource;
+    const getLayoutMap = source.keyboard?.getLayoutMap;
+    if (!getLayoutMap) return;
+    let cancelled = false;
+    // Rejects when the document is not focused, among other things; a hint
+    // labelled QWERTY is a cosmetic miss, not a reason to surface an error.
+    Promise.resolve(getLayoutMap.call(source.keyboard))
+      .then((layout) => {
+        if (!cancelled) setLabels(resolveKeyCapLabels(layout));
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return labels;
+}

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapCameraKeys.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapCameraKeys.ts
@@ -1,0 +1,213 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+import {
+  isStarMapResetViewKey,
+  isStarMapTypingTarget,
+  resolveStarMapCameraKey,
+  stepStarMapCamera,
+  type StarMapCameraKey,
+} from "./star-map-keyboard";
+import type { StarMapView, StarMapViewBox } from "./star-map-view-geometry";
+
+const NO_KEYS: ReadonlySet<StarMapCameraKey> = new Set();
+
+/**
+ * Fly the map's camera from the keyboard.
+ *
+ * Held keys are integrated on an animation frame and written straight onto
+ * the canvas element's transform, committing to React state only when the
+ * last key comes up — the same shape as the pointer drag in StarMapScreen,
+ * and for the same reason: a `setView` per frame re-renders every card on
+ * the map sixty times a second to move one transform.
+ *
+ * Returns the currently-held directions so the on-screen key hint can light
+ * up under the operator's fingers. That set changes on keydown/keyup only,
+ * never per frame, so it costs one render per press rather than per frame.
+ */
+export function useStarMapCameraKeys(params: {
+  /**
+   * Off while a thread floats over the map: the map has shoved aside and
+   * the operator is working in the thread, where `w` means `w`.
+   */
+  enabled: boolean;
+  /** Keydown is scoped here, so the map only flies while it has focus. */
+  layerRef: RefObject<HTMLElement | null>;
+  /** The transformed canvas, written directly during flight. */
+  canvasRef: RefObject<HTMLElement | null>;
+  view: StarMapView;
+  /** Untransformed canvas size for the current lens. */
+  canvas: StarMapViewBox;
+  viewport: StarMapViewBox;
+  /** Commit the flown-to view once the keys are released. */
+  onChange: (next: StarMapView) => void;
+  /** First press claims the view for the operator, as a drag does. */
+  onMoveStart: () => void;
+  /** `0`: back to where the map opens. */
+  onResetView: () => void;
+}): ReadonlySet<StarMapCameraKey> {
+  const [held, setHeld] = useState<ReadonlySet<StarMapCameraKey>>(NO_KEYS);
+  const heldRef = useRef<ReadonlySet<StarMapCameraKey>>(NO_KEYS);
+  const sprintRef = useRef(false);
+  /** Live view during flight; the loop owns it, React state follows. */
+  const viewRef = useRef(params.view);
+  const flyingRef = useRef(false);
+
+  /**
+   * Everything the loop reads that is not the held keys lives in refs, so
+   * the listener effect below depends on nothing that changes while the
+   * operator is flying. A cloud gaining a card resizes the canvas, and
+   * re-registering the listeners on that would strand every held key with
+   * no keyup listener left to release it.
+   */
+  const boundsRef = useRef({
+    canvas: params.canvas,
+    viewport: params.viewport,
+  });
+  const callbacksRef = useRef({
+    onChange: params.onChange,
+    onMoveStart: params.onMoveStart,
+    onResetView: params.onResetView,
+  });
+  useEffect(() => {
+    boundsRef.current = { canvas: params.canvas, viewport: params.viewport };
+    callbacksRef.current = {
+      onChange: params.onChange,
+      onMoveStart: params.onMoveStart,
+      onResetView: params.onResetView,
+    };
+  });
+
+  // Adopt outside writes to the view (wheel, reset, lens switch) only when
+  // the keyboard is not flying; mid-flight the loop holds the newer value.
+  useEffect(() => {
+    if (flyingRef.current) return;
+    viewRef.current = params.view;
+  }, [params.view]);
+
+  const { enabled, layerRef, canvasRef } = params;
+
+  useEffect(() => {
+    const layer = layerRef.current;
+    if (!enabled || !layer) return;
+
+    let frame = 0;
+    let last = 0;
+
+    const setHeldKeys = (next: ReadonlySet<StarMapCameraKey>) => {
+      heldRef.current = next;
+      setHeld(next);
+    };
+
+    /** Hand the flown-to view back to React and stop integrating. */
+    const land = () => {
+      flyingRef.current = false;
+      last = 0;
+      callbacksRef.current.onChange(viewRef.current);
+    };
+
+    const runFrame = (now: number) => {
+      frame = 0;
+      if (heldRef.current.size === 0) {
+        land();
+        return;
+      }
+      // The first frame of a flight has no previous timestamp to measure
+      // against; assume one 60Hz frame rather than integrating zero, so a
+      // tap released before the second frame still moves the map.
+      const elapsed = last === 0 ? 1000 / 60 : now - last;
+      last = now;
+      const next = stepStarMapCamera({
+        view: viewRef.current,
+        held: heldRef.current,
+        elapsedMs: elapsed,
+        sprint: sprintRef.current,
+        canvas: boundsRef.current.canvas,
+        viewport: boundsRef.current.viewport,
+      });
+      viewRef.current = next;
+      const canvas = canvasRef.current;
+      if (canvas) {
+        canvas.style.transform =
+          `translate(${next.x}px, ${next.y}px) scale(${next.scale})`;
+      }
+      frame = requestAnimationFrame(runFrame);
+    };
+
+    const fly = () => {
+      if (frame) return;
+      flyingRef.current = true;
+      frame = requestAnimationFrame(runFrame);
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      // Cmd/Ctrl/Alt combinations belong to the app and the OS: Cmd-W is
+      // "close window", not "fly up".
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (isStarMapTypingTarget(event.target)) return;
+      sprintRef.current = event.shiftKey;
+      if (isStarMapResetViewKey(event.key)) {
+        event.preventDefault();
+        callbacksRef.current.onResetView();
+        return;
+      }
+      const camera = resolveStarMapCameraKey(event.key);
+      if (!camera) return;
+      // Arrows would otherwise scroll whatever is under focus as well.
+      event.preventDefault();
+      // Auto-repeat re-fires keydown for a key that is already down; the
+      // loop, not the repeat rate, is what moves the map.
+      if (heldRef.current.has(camera)) return;
+      setHeldKeys(new Set(heldRef.current).add(camera));
+      callbacksRef.current.onMoveStart();
+      fly();
+    };
+
+    /**
+     * Keyup is on the window and ungated: a key pressed on the map and
+     * released after focus moved elsewhere still has to come up, or the
+     * camera flies on with nothing holding it.
+     */
+    const onKeyUp = (event: KeyboardEvent) => {
+      sprintRef.current = event.shiftKey;
+      const camera = resolveStarMapCameraKey(event.key);
+      if (!camera || !heldRef.current.has(camera)) return;
+      const next = new Set(heldRef.current);
+      next.delete(camera);
+      setHeldKeys(next);
+    };
+
+    /**
+     * A window that loses focus never receives the keyup — Cmd-Tab away
+     * mid-flight and the map would keep flying. Same for a hidden window,
+     * whose animation frames stop arriving entirely.
+     */
+    const releaseAll = () => {
+      if (heldRef.current.size === 0) return;
+      setHeldKeys(NO_KEYS);
+      // A scheduled frame will land on its own. Nothing is scheduled while
+      // the window is hidden, so land here rather than waiting for a frame
+      // that may never arrive.
+      if (!frame) land();
+    };
+
+    layer.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    window.addEventListener("blur", releaseAll);
+    document.addEventListener("visibilitychange", releaseAll);
+    return () => {
+      layer.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("blur", releaseAll);
+      document.removeEventListener("visibilitychange", releaseAll);
+      if (frame) cancelAnimationFrame(frame);
+      frame = 0;
+      // Teardown mid-flight (the map closing, or the thread floating over
+      // it) still owes React the distance already flown, or the next render
+      // snaps the canvas back to wherever the last commit left it.
+      if (flyingRef.current) land();
+      heldRef.current = NO_KEYS;
+      setHeld(NO_KEYS);
+    };
+  }, [enabled, layerRef, canvasRef]);
+
+  return held;
+}

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapCameraKeys.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapCameraKeys.ts
@@ -32,13 +32,20 @@ export function useStarMapCameraKeys(params: {
   /** Keydown is scoped here, so the map only flies while it has focus. */
   layerRef: RefObject<HTMLElement | null>;
   /** The transformed canvas, written directly during flight. */
-  canvasRef: RefObject<HTMLElement | null>;
-  view: StarMapView;
+  /**
+   * Where the view is right now, shared with every other writer. The
+   * keyboard camera does NOT keep a private copy: a pinch or a `0` landing
+   * mid-flight has to compose with the flight rather than be discarded by
+   * it.
+   */
+  liveViewRef: RefObject<StarMapView>;
   /** Untransformed canvas size for the current lens. */
   canvas: StarMapViewBox;
   viewport: StarMapViewBox;
+  /** Move the view for one frame, without telling React. */
+  onPaint: (next: StarMapView) => void;
   /** Commit the flown-to view once the keys are released. */
-  onChange: (next: StarMapView) => void;
+  onCommit: (next: StarMapView) => void;
   /** First press claims the view for the operator, as a drag does. */
   onMoveStart: () => void;
   /** `0`: back to where the map opens. */
@@ -47,8 +54,6 @@ export function useStarMapCameraKeys(params: {
   const [held, setHeld] = useState<ReadonlySet<StarMapCameraKey>>(NO_KEYS);
   const heldRef = useRef<ReadonlySet<StarMapCameraKey>>(NO_KEYS);
   const sprintRef = useRef(false);
-  /** Live view during flight; the loop owns it, React state follows. */
-  const viewRef = useRef(params.view);
   const flyingRef = useRef(false);
 
   /**
@@ -63,27 +68,22 @@ export function useStarMapCameraKeys(params: {
     viewport: params.viewport,
   });
   const callbacksRef = useRef({
-    onChange: params.onChange,
+    onPaint: params.onPaint,
+    onCommit: params.onCommit,
     onMoveStart: params.onMoveStart,
     onResetView: params.onResetView,
   });
   useEffect(() => {
     boundsRef.current = { canvas: params.canvas, viewport: params.viewport };
     callbacksRef.current = {
-      onChange: params.onChange,
+      onPaint: params.onPaint,
+      onCommit: params.onCommit,
       onMoveStart: params.onMoveStart,
       onResetView: params.onResetView,
     };
   });
 
-  // Adopt outside writes to the view (wheel, reset, lens switch) only when
-  // the keyboard is not flying; mid-flight the loop holds the newer value.
-  useEffect(() => {
-    if (flyingRef.current) return;
-    viewRef.current = params.view;
-  }, [params.view]);
-
-  const { enabled, layerRef, canvasRef } = params;
+  const { enabled, layerRef, liveViewRef } = params;
 
   useEffect(() => {
     const layer = layerRef.current;
@@ -101,7 +101,7 @@ export function useStarMapCameraKeys(params: {
     const land = () => {
       flyingRef.current = false;
       last = 0;
-      callbacksRef.current.onChange(viewRef.current);
+      callbacksRef.current.onCommit(liveViewRef.current);
     };
 
     const runFrame = (now: number) => {
@@ -115,20 +115,17 @@ export function useStarMapCameraKeys(params: {
       // tap released before the second frame still moves the map.
       const elapsed = last === 0 ? 1000 / 60 : now - last;
       last = now;
+      // Reads the SHARED live view every frame, so a pinch or a reset that
+      // landed since the last frame is the base this one builds on.
       const next = stepStarMapCamera({
-        view: viewRef.current,
+        view: liveViewRef.current,
         held: heldRef.current,
         elapsedMs: elapsed,
         sprint: sprintRef.current,
         canvas: boundsRef.current.canvas,
         viewport: boundsRef.current.viewport,
       });
-      viewRef.current = next;
-      const canvas = canvasRef.current;
-      if (canvas) {
-        canvas.style.transform =
-          `translate(${next.x}px, ${next.y}px) scale(${next.scale})`;
-      }
+      callbacksRef.current.onPaint(next);
       frame = requestAnimationFrame(runFrame);
     };
 
@@ -138,18 +135,35 @@ export function useStarMapCameraKeys(params: {
       frame = requestAnimationFrame(runFrame);
     };
 
+    /**
+     * Whether the map should answer the keyboard at all right now.
+     *
+     * Bound on `window` rather than the layer, because the layer only sees
+     * keys while focus is inside it — and focus escapes routinely (closing
+     * the portaled intake dialog drops it on `document.body`), which left
+     * the always-visible hint advertising keys that did nothing. Focus on
+     * NOTHING means the map, since the map is the surface; focus on
+     * something outside the layer belongs to that something.
+     */
+    const mapHasKeyboard = () => {
+      const active = document.activeElement;
+      if (!active || active === document.body) return true;
+      return layer.contains(active);
+    };
+
     const onKeyDown = (event: KeyboardEvent) => {
       // Cmd/Ctrl/Alt combinations belong to the app and the OS: Cmd-W is
       // "close window", not "fly up".
       if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (!mapHasKeyboard()) return;
       if (isStarMapTypingTarget(event.target)) return;
       sprintRef.current = event.shiftKey;
-      if (isStarMapResetViewKey(event.key)) {
+      if (isStarMapResetViewKey(event)) {
         event.preventDefault();
         callbacksRef.current.onResetView();
         return;
       }
-      const camera = resolveStarMapCameraKey(event.key);
+      const camera = resolveStarMapCameraKey(event);
       if (!camera) return;
       // Arrows would otherwise scroll whatever is under focus as well.
       event.preventDefault();
@@ -168,7 +182,7 @@ export function useStarMapCameraKeys(params: {
      */
     const onKeyUp = (event: KeyboardEvent) => {
       sprintRef.current = event.shiftKey;
-      const camera = resolveStarMapCameraKey(event.key);
+      const camera = resolveStarMapCameraKey(event);
       if (!camera || !heldRef.current.has(camera)) return;
       const next = new Set(heldRef.current);
       next.delete(camera);
@@ -189,12 +203,12 @@ export function useStarMapCameraKeys(params: {
       if (!frame) land();
     };
 
-    layer.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keydown", onKeyDown);
     window.addEventListener("keyup", onKeyUp);
     window.addEventListener("blur", releaseAll);
     document.addEventListener("visibilitychange", releaseAll);
     return () => {
-      layer.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keydown", onKeyDown);
       window.removeEventListener("keyup", onKeyUp);
       window.removeEventListener("blur", releaseAll);
       document.removeEventListener("visibilitychange", releaseAll);
@@ -207,7 +221,7 @@ export function useStarMapCameraKeys(params: {
       heldRef.current = NO_KEYS;
       setHeld(NO_KEYS);
     };
-  }, [enabled, layerRef, canvasRef]);
+  }, [enabled, layerRef, liveViewRef]);
 
   return held;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10189,6 +10189,12 @@ textarea,
   transition: background 90ms ease, border-color 90ms ease, color 90ms ease;
 }
 
+/* Modifier caps carry a glyph rather than a letter and read cramped at the
+   square letter width. */
+.star-map__key--wide {
+  min-width: 24px;
+}
+
 .star-map__key.is-held {
   border-color: var(--accent-border);
   background: var(--accent-soft);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10108,6 +10108,102 @@ textarea,
   outline-offset: 1px;
 }
 
+/* Keyboard camera hint. Bottom-LEFT: the selection readout owns the middle
+   and the close button owns the top-right, so this is the one corner where
+   a permanent affordance costs nothing.
+
+   Same surface and text tokens as `.star-map__filter-chip`, deliberately.
+   The obvious way to make a permanent hint recede is a blanket `opacity`,
+   but that composites the LABEL down too — `--text-muted` is already the
+   quietest text token the theme has, and knocking it back another 28%
+   walks it off the AA contrast the a11y gate holds this surface to. Size
+   and corner do the receding instead. */
+.star-map__key-hint {
+  display: flex;
+  position: absolute;
+  bottom: 18px;
+  left: 16px;
+  z-index: 8;
+  align-items: flex-end;
+  gap: 16px;
+  padding: 8px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg-panel) 75%, transparent);
+  pointer-events: none;
+  -webkit-app-region: no-drag;
+}
+
+/* Bottom-aligned, not centred: the pan group is two rows tall, and a
+   centred label lands in the gap between W and A S D reading as though it
+   belongs to neither. Sitting it on the A S D row puts it level with the
+   zoom group's label too. */
+.star-map__key-group {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+/* The classic inverted-T: W over A S D, so the cluster is recognisable as
+   a keyboard rather than read as four separate keys. Every cap is placed
+   by name — leaving A/S/D to auto-flow puts them in the gaps beside W. */
+.star-map__key-pad {
+  display: grid;
+  grid-template-areas:
+    ". up ."
+    "left down right";
+  gap: 3px;
+}
+
+.star-map__key--up {
+  grid-area: up;
+}
+
+.star-map__key--left {
+  grid-area: left;
+}
+
+.star-map__key--down {
+  grid-area: down;
+}
+
+.star-map__key--right {
+  grid-area: right;
+}
+
+.star-map__key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  background: var(--bg-panel);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  transition: background 90ms ease, border-color 90ms ease, color 90ms ease;
+}
+
+.star-map__key.is-held {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+
+/* Line box matched to a cap so bottom-aligning the group centres the word
+   against the caps beside it rather than hanging it off their baseline. */
+.star-map__key-label {
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 18px;
+  letter-spacing: 0.04em;
+}
+
 /* Alignment guides, drawn only while a card is being dragged. They exist
    so a snap is explainable: without the line, a card latching reads as the
    drag sticking for no reason. */


### PR DESCRIPTION
## Summary

- The star map only moved by pointer — drag the sky, wheel to pan, pinch to zoom. That left the operator's other hand with nothing to do and made the map the one full-screen surface in the app with no keyboard path across it. It now flies like a map game.
- `W` `A` `S` `D` and the arrow keys drive the camera; `Shift` sprints (2.5×); `-` / `=` (also `+` and the numpad pair) work the zoom under the right hand; `0` resets the view.
- Movement is **continuous while a key is held**, integrated on an animation frame — not a nudge per press. A nudge is what a form does; holding a direction and watching the field slide past is what a map does. Diagonals are normalised so two keys aren't a factor of √2 faster than one.
- Zoom is exponential (perceived multiplicatively — a flat `scale += k` crawls when zoomed out and lurches when zoomed in) and pivots on the **centre of the window**: the keyboard has no pointer to zoom about, and the centre is the only fixed point the operator can predict.
- Everything routes through the same `clampStarMapView` as every other operator-driven write, so a held key parks against the bounds instead of flying the map away, and the first press claims the view for the operator exactly as a drag does.
- A control nobody can see is a control nobody uses, so the keys sit on the map bottom-left and light up under the ones being held.

### On the zoom bindings

`-` / `=` is the near-universal keyboard zoom pair: Factorio binds keyboard zoom to numpad `+`/`-`, and the same pair carries across map games and every zoomable app. Shifted `=` reports as `+`, so the main row and the numpad both arrive for free. Page Up / Page Down was deliberately **not** bound — it reads as "pan by a page" at least as often as it reads as zoom, and a wrong guess on a movement key is worse than an absent one. `0` matches the ⌘0 "back to 100%" convention and is the keyboard's way in to the "Reset view" action already in the View popover.

### Shape of the implementation

Held keys are integrated on an animation frame and written **straight onto the canvas transform**, committing to React state only when the last key comes up. This is the same shape as the existing pointer drag in `StarMapScreen`, and for the same reason: a `setView` per frame re-renders every card on the map sixty times a second to move one transform. The returned held-key set changes on keydown/keyup only, so the hint costs one render per press rather than per frame.

Split three ways so the rules are testable without a DOM:

| File | Role |
|---|---|
| `star-map-keyboard.ts` | Pure: key→direction mapping, the integration step, the typing-target guard |
| `useStarMapCameraKeys.ts` | Owns timing, listeners, and the imperative transform writes |
| `StarMapKeyHint.tsx` | The on-screen clue |

### Edge cases handled

- **Typing wins.** Inputs, textareas, contenteditable, dialogs, and `.star-map-chat-card` are excluded — a chat card is a window *over* the star field, so `w` typed into one belongs to the composer.
- **Modified keystrokes are left alone.** ⌘W is "close window", not "fly up".
- **Focus loss releases every key.** ⌘-Tab away mid-flight and no keyup ever arrives; `blur` and `visibilitychange` land the flight. Since no frame is scheduled while the window is hidden, that path lands inline rather than waiting for a frame that may never come.
- **One step is capped at 100 ms.** A backgrounded window delivers a multi-second gap as its next frame; integrating it whole would slam the map into its clamp the instant the operator came back.
- **Teardown mid-flight still commits.** The map closing (or a thread floating over it) owes React the distance already flown, or the next render snaps the canvas back to the last commit.
- **Auto-repeat is ignored** — the loop, not the OS repeat rate, is what moves the map.
- **Disabled while a thread floats over the map**, where the map has shoved aside and `w` means `w`. The hint hides with it.

## Verification

- `star-map-keyboard.test.ts` (18) — direction mapping incl. capitals (Shift is sprint, so a case-sensitive map would stall the camera the moment it sprinted), both faces of the zoom keys, diagonal normalisation, opposing keys cancelling, time-scaled steps, the frame cap, centre-pinned zoom, parking at `MIN_ZOOM`/`MAX_ZOOM` without sideways drift, and the visible-strip bound holding over 500 held frames.
- `star-map-camera-keys.test.tsx` (8) — end to end through `StarMapScreen`. Includes a commit proof that isn't just "the transform moved": after a flight, a pointer drag (which reads the view from React state) must build on where the keyboard landed rather than the pre-flight value.
- Full renderer suite: **2440 tests / 155 files**, green. Star-map suite 280/280.
- `typecheck`, `lint:eslint` (no findings in the new files), `lint:colors`, `lint:boundaries` — all clean.
- **WCAG AA a11y gate passes on the star map surface in both themes** (`e2e/a11y.spec.ts -g "star map"`).
- Visually verified in both themes under the real Electron build, via a throwaway inspect spec (removed before commit). Confirmed the inverted-T geometry numerically — W centred above S — and that a 300 ms hold moved the canvas 359.96px against a 1200 px/s cruise speed.

## Notes

- **The hint deliberately does not use a blanket `opacity` to recede.** That was the first instinct and it's wrong: `opacity` composites the *label* down too, and `--text-muted` is already the quietest text token the theme has. Knocking it back another 28% walks it off the AA contrast this surface is gated on. Size and corner do the receding instead; the surface and text tokens are copied from `.star-map__filter-chip`, which the gate already audits in both themes.
- **The WASD pad places every cap by name** (`grid-template-areas`). Leaving A/S/D to auto-flow puts them in the free cells *beside* W rather than on the row below it — the auto-placement cursor doesn't skip past an explicitly-placed item.
- Bottom-left was the one free corner: the selection readout owns bottom-centre, `Close map` the top-right, brand + View the top-left, and the filters top-centre.
- The hook's listener effect depends on nothing that changes during a flight — bounds and callbacks live in refs. A cloud gaining a card resizes the canvas, and re-registering listeners on that would strand every held key with no keyup listener left to release it.
- One unexplained flake seen once in the star-map suite, during a run that overlapped three Electron E2E processes (15.7s vs a usual 4s). It could not be reproduced across 15 subsequent runs including two full renderer suites, and its name wasn't captured. A `waitFor` around a synchronous state read in the new hint test was tightened as the most plausible contributor, but that is not a confirmed cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)