### PR TITLE
fix(desktop): include source titles in federated provenance

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -27753,6 +27753,12 @@ script = "printf setup"
         titleSource: "fallback",
         source: "codex",
         linkedDirectories: [],
+      }, {
+        id: "parent-thread",
+        title: "M4 runner-host conversion preflight",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
       }],
     });
     const overlayStore = createOverlayStoreMock();
@@ -27863,6 +27869,7 @@ script = "printf setup"
               sourceThread: {
                 backend: "codex",
                 threadId: "parent-thread",
+                title: "M4 runner-host conversion preflight",
               },
             },
           },
@@ -27878,6 +27885,7 @@ script = "printf setup"
         sourceThread: {
           backend: "codex",
           threadId: "parent-thread",
+          title: "M4 runner-host conversion preflight",
         },
       },
     });
@@ -28872,6 +28880,13 @@ script = "printf setup"
   it("resolves and sends to a federated thread after a local UUID miss", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
+      threads: [{
+        id: "parent-thread",
+        title: "M4 runner-host conversion preflight",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
+      }],
     });
     const registry = new DesktopBackendRegistry({
       codexClient,
@@ -28948,6 +28963,7 @@ script = "printf setup"
         sourceThread: {
           backend: "codex",
           threadId: "parent-thread",
+          title: "M4 runner-host conversion preflight",
         },
       },
       executionMode: undefined,
@@ -29021,6 +29037,13 @@ script = "printf setup"
   it("routes stop and steer controls to an explicit federated owner", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
+      threads: [{
+        id: "parent-thread",
+        title: "M4 runner-host conversion preflight",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
+      }],
     });
     const registry = new DesktopBackendRegistry({
       codexClient,
@@ -29083,6 +29106,7 @@ script = "printf setup"
         sourceThread: {
           backend: "codex",
           threadId: "parent-thread",
+          title: "M4 runner-host conversion preflight",
         },
       },
     });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -24029,6 +24029,24 @@ export class DesktopBackendRegistry {
     });
   }
 
+  private async buildAgentMessageOrigin(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<AppServerThreadMessageOrigin> {
+    const sourceThread = await this.resolveThread(params).catch(() => undefined);
+    const sourceTitle = sourceThread?.title.trim();
+    return {
+      kind: "agent",
+      sourceThread: {
+        backend: params.backend,
+        threadId: params.threadId,
+        ...(sourceTitle && sourceThread?.titleSource !== "fallback"
+          ? { title: sourceTitle }
+          : {}),
+      },
+    };
+  }
+
   private async sendMessageToThread(
     request: PwrAgentThreadOrchestrationRequest<"send_message_to_thread">,
   ): Promise<PwrAgentThreadOrchestrationResponse> {
@@ -24100,13 +24118,10 @@ export class DesktopBackendRegistry {
         ...(request.args.sandbox ? { sandbox: request.args.sandbox } : {}),
       };
       const input = [{ type: "text" as const, text: prompt }];
-      const messageOrigin = {
-        kind: "agent" as const,
-        sourceThread: {
-          backend: request.context.backend,
-          threadId: request.context.threadId,
-        },
-      };
+      const messageOrigin = await this.buildAgentMessageOrigin({
+        backend: request.context.backend,
+        threadId: request.context.threadId,
+      });
       let targetTitle: string | undefined;
       let targetInstanceId: string | undefined;
       let turn: {
@@ -24349,6 +24364,10 @@ export class DesktopBackendRegistry {
       );
     }
 
+    const messageOrigin = await this.buildAgentMessageOrigin({
+      backend: request.context.backend,
+      threadId: request.context.threadId,
+    });
     const remoteRequest = {
       operation: request.operation === "stop_thread" ? "stop" as const : "steer" as const,
       backend,
@@ -24362,13 +24381,7 @@ export class DesktopBackendRegistry {
             input: [{ type: "text" as const, text: request.args.prompt }],
           }
         : {}),
-      messageOrigin: {
-        kind: "agent" as const,
-        sourceThread: {
-          backend: request.context.backend,
-          threadId: request.context.threadId,
-        },
-      },
+      messageOrigin,
     };
 
     try {


### PR DESCRIPTION
## Summary

- I include the invoking thread's resolved, non-fallback title in agent message and steer provenance.
- I keep the receiver's existing Federation trust boundary: the receiving instance authenticates the owner machine, while the supplied title makes the live card useful immediately.
- I retain Federation resolution as the fallback for provenance created by older or temporarily unresolved senders.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` (500 tests)
- `pnpm test apps/desktop/src/main/__tests__/federated-thread-origin-hydrator.test.ts apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts apps/desktop/src/main/__tests__/federation-runtime.test.ts apps/desktop/src/main/__tests__/agent-ipc.test.ts` (94 tests)
- `pnpm lint:eslint` (passes with 30 pre-existing warnings)
- `pnpm typecheck`
- `pnpm lint:boundaries`

## Notes

- The first signed checkpoint intentionally adds three red tests covering local follow-up, federated follow-up, and federated steer provenance. The second signed checkpoint makes them green.
