### PR TITLE
fix(desktop): age out abandoned composer drafts

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
@@ -236,6 +236,88 @@ describe("ComposerDraftRecoveryStore", () => {
       }),
     ]);
   });
+
+  describe("composer_draft_latest retention", () => {
+    // 2026-08-11, so the arithmetic below reads as real dates rather than
+    // offsets from an implicit now.
+    const NOW = 1_786_500_000_000;
+    const DAY = 24 * 60 * 60 * 1000;
+
+    const countLatest = (): number =>
+      (
+        stateDb.raw
+          .prepare("SELECT COUNT(*) AS n FROM composer_draft_latest")
+          .get() as { n: number }
+      ).n;
+
+    const seedDraft = (scope: string, updatedAt: number): void => {
+      store.save({
+        draft: buildDraft({
+          scopeKey: `thread:codex:${scope}`,
+          threadId: scope,
+          text: `draft ${scope}`,
+          updatedAt,
+        }),
+      });
+    };
+
+    it("keeps drafts edited this year", () => {
+      // The bar for discarding current work is high on purpose: a draft five
+      // months old is still something someone meant to send.
+      seedDraft("today", NOW);
+      seedDraft("last-month", NOW - 30 * DAY);
+      seedDraft("five-months-ago", NOW - 150 * DAY);
+
+      stateDb.cleanupExpired(NOW);
+
+      expect(countLatest()).toBe(3);
+    });
+
+    it("ages out a draft nobody has edited in half a year", () => {
+      seedDraft("recent", NOW - DAY);
+      seedDraft("ancient", NOW - 200 * DAY);
+
+      stateDb.cleanupExpired(NOW);
+
+      expect(store.listLatest().map((draft) => draft.scopeKey)).toEqual([
+        "thread:codex:recent",
+      ]);
+    });
+
+    it("does not delete a draft when its thread is archived", () => {
+      // Archiving is reversible here (`restoreThread` / the Codex
+      // `thread/unarchive` method), so discarding unsent text at archive time
+      // would destroy data at the one moment the operator can undo the action
+      // that caused it. An archived thread's draft stays put and stays
+      // reachable through the composer's recovery cycle; it only leaves once
+      // it has gone stale like any other. Staleness is also the only signal
+      // available here — the state layer cannot tell a deleted thread from an
+      // archived one, and an archived thread cannot be opened, so its draft
+      // is exactly what this ages out.
+      seedDraft("archived-thread", NOW - DAY);
+
+      stateDb.cleanupExpired(NOW);
+
+      expect(
+        store
+          .listCandidates({ includeSent: true, limit: 20 })
+          .map((candidate) => candidate.scopeKey),
+      ).toContain("thread:codex:archived-thread");
+    });
+
+    it("does not evict on volume alone", () => {
+      // A row cap would fire here and a staleness sweep must not: these are
+      // all current drafts, and destroying the oldest of them because there
+      // are many is exactly the data loss this sweep exists to avoid.
+      for (let index = 0; index < 600; index += 1) {
+        seedDraft(`thread-${index}`, NOW - index * 1000);
+      }
+
+      stateDb.cleanupExpired(NOW);
+
+      expect(countLatest()).toBe(600);
+    });
+  });
 });
 
 describe("journal prefix collapse", () => {

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -6,9 +6,16 @@
     "rowsChanged": 1,
     "statements": 1
   },
+  "cleanup-expired-gc-pass": {
+    "commits": 1,
+    "note": "one whole cleanupExpired GC pass doing real work in both composer sweeps: ageing out 20 drafts past 180 days AND collapsing a 30-row journal prefix chain to 1. commits is the assertion that matters (every sweep rides one transaction); statements/rows legitimately move when a sweep is added, so re-record rather than reading it as a composer regression",
+    "observedWalBytes": 45320,
+    "rowsChanged": 49,
+    "statements": 45
+  },
   "composer-draft-typing": {
     "commits": 70,
-    "note": "typing one 70-character message with a save per keystroke: exactly one journal row survives, and commits track saves because each save is its own transaction",
+    "note": "70 direct store saves (a stress case for prefix collapse, NOT the app's typing cadence \u2014 the renderer coalesces to one save per 5s): exactly one journal row survives, and commits track save calls because each save is its own transaction",
     "observedWalBytes": 1738640,
     "rowsChanged": 140,
     "statements": 209

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -1134,6 +1134,92 @@ function buildInvocation(invocationId: string) {
     });
   });
 
+  it("keeps the hourly GC pass at one commit while sweeping stale drafts", async () => {
+    // Added for the composer-draft staleness sweep, but it measures the WHOLE
+    // `cleanupExpired` call, because that is the unit that costs a commit.
+    // The number to defend is `commits: 1` — every sweep in there rides one
+    // transaction, and a new sweep that opens its own would show up here as a
+    // second commit. Statements and rows legitimately move when someone adds
+    // a sweep; re-record then, and do not read such a change as a composer
+    // regression.
+    const NOW = 1_786_500_000_000;
+    const DAY = 24 * 60 * 60 * 1000;
+    const drafts = new ComposerDraftRecoveryStore(stateDb);
+    for (let index = 0; index < 40; index += 1) {
+      drafts.save({
+        draft: {
+          scopeKey: `thread:codex:thread-${index}`,
+          scopeKind: "thread",
+          backend: "codex",
+          threadId: `thread-${index}`,
+          text: `draft ${index}`,
+          skillTokens: [],
+          imageAttachments: [],
+          status: "unsent",
+          createdAt: 1,
+          // Half are stale enough to sweep, half are current.
+          updatedAt: index < 20 ? NOW - 200 * DAY : NOW - DAY,
+          contentHash: `hash-${index}`,
+          charCount: 7,
+        },
+      });
+    }
+
+    // Also give the journal prefix-collapse real work, so this budget covers
+    // every sweep in the transaction rather than only the one it was written
+    // for. These rows have to be inserted RAW: `save()` applies the collapse
+    // at write time, so seeding through it would leave an already-collapsed
+    // journal and the GC pass would measure nothing.
+    const insertJournalRow = stateDb.raw.prepare(
+      `INSERT INTO composer_draft_journal(
+         scope_key, scope_kind, status, content_hash, char_count,
+         created_at, updated_at, payload
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const sentence = "I like dogs and cats and bears";
+    for (let index = 1; index <= sentence.length; index += 1) {
+      const text = sentence.slice(0, index);
+      insertJournalRow.run(
+        "thread:codex:journal",
+        "thread",
+        "unsent",
+        `journal-hash-${text}`,
+        text.length,
+        1,
+        NOW - DAY + index,
+        JSON.stringify({ text }),
+      );
+    }
+
+    // Seeding is outside the measured region, so the budget tracks the sweeps.
+    const { writes } = await measureSqliteWrites(async () => {
+      stateDb.cleanupExpired(NOW);
+    });
+
+    // The collapse ran inside the measured pass: one row survives the chain.
+    expect(
+      (
+        stateDb.raw
+          .prepare(
+            "SELECT COUNT(*) AS n FROM composer_draft_journal WHERE scope_key = ?",
+          )
+          .get("thread:codex:journal") as { n: number }
+      ).n,
+    ).toBe(1);
+
+    expectSqliteWriteBudget({
+      note:
+        "one whole cleanupExpired GC pass doing real work in both composer "
+        + "sweeps: ageing out 20 drafts past 180 days AND collapsing a 30-row "
+        + "journal prefix chain to 1. commits is the assertion that matters "
+        + "(every sweep rides one transaction); statements/rows legitimately "
+        + "move when a sweep is added, so re-record rather than reading it as "
+        + "a composer regression",
+      scenario: "cleanup-expired-gc-pass",
+      writes,
+    });
+  });
+
 function createStubBackendClient(options?: {
   replay?: AppServerThreadReplay;
 }) {

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -1016,6 +1016,46 @@ const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const APP_RUNTIME_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
 const COMPOSER_DRAFT_JOURNAL_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const COMPOSER_DRAFT_JOURNAL_CAP = 300;
+/**
+ * Retention for `composer_draft_latest` — one row per composer scope holding
+ * unsent text. The table had no retention of any kind; rows are deleted only
+ * when the renderer clears that scope's composer, so a draft whose thread the
+ * operator can no longer reach stayed forever. Archiving is how that happens:
+ * `archiveThread` cleans up messaging bindings, child threads, and worktrees,
+ * but has never touched drafts, and both the Drafts lens and the thread-row
+ * chip can only mark threads present in the navigation snapshot.
+ *
+ * **The clock tracks edits.** It did not always: `flushComposerDraftSnapshot`
+ * re-saves on composer unmount with no dirty check, so opening a thread and
+ * navigating away used to re-stamp `updated_at` and this sweep only reached
+ * drafts on threads nobody visited. The durable store now compares against the
+ * content hash actually in sqlite and skips writing unchanged content — and
+ * seeds that hash at hydration — so a thread merely opened does not move its
+ * draft's timestamp. Reverting or bypassing that dirty check silently widens
+ * this sweep back to "not opened in 180 days", which is a different and much
+ * narrower rule than what this comment now promises.
+ *
+ * A staleness sweep rather than a row cap, because staleness is the property
+ * an abandoned draft actually has. A count cap does nothing about orphans —
+ * twenty unreachable rows sitting under a five-hundred-row ceiling are never
+ * evicted, since orphans do not move the count — and at the ceiling it would
+ * evict by recency, destroying whichever unsent text happened to be oldest.
+ *
+ * **This still deletes unsent text with no warning and no undo**, and the
+ * journal's own 30-day retention means there is no recoverable copy left by
+ * the time this fires. Staleness makes that loss predictable and remote
+ * instead of triggered by unrelated volume; it does not eliminate it. That
+ * trade is the reason for the length of the window, not a reason to shorten
+ * it later without thinking about what gets destroyed.
+ *
+ * Note this is NOT primarily a disk-space measure: a row is a draft's text
+ * plus its editor document, on the order of a couple of KB, so even thousands
+ * of orphans are single-digit megabytes on one profile. What it buys is that
+ * the Drafts lens stops accumulating threads the operator walked away from
+ * half a year ago — and only from the next window launch, since the renderer
+ * hydrates the lens once at mount.
+ */
+const COMPOSER_DRAFT_LATEST_RETENTION_MS = 180 * 24 * 60 * 60 * 1000;
 const PR_STATUS_WATCH_HISTORY_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 /**
  * Per-platform cap for the messaging activity log. Older rows are
@@ -1568,6 +1608,12 @@ LEFT JOIN federation_peers
            )`,
         )
         .run(COMPOSER_DRAFT_JOURNAL_CAP);
+      // Every row here is unsent by construction — `save()` deletes the row
+      // for any other status — so this needs no status filter. Rides the same
+      // transaction as the sweeps above, costing no additional commit.
+      this.db
+        .prepare("DELETE FROM composer_draft_latest WHERE updated_at < ?")
+        .run(now - COMPOSER_DRAFT_LATEST_RETENTION_MS);
     });
     cleanup();
     this.db.pragma("incremental_vacuum");


### PR DESCRIPTION
## What this is, and what it isn't

`composer_draft_latest` holds one row per composer scope with unsent text, and had **no retention of any kind**. Rows are deleted only when the renderer clears that scope's composer, so a draft whose thread the operator can no longer reach stayed forever. Archiving is how that happens in practice — `archiveThread` cleans up messaging bindings, child threads, and worktrees, but has never touched drafts.

**It is not a disk-space fix.** A row is a draft's text plus its editor document, on the order of a couple of KB. Even thousands of orphans are single-digit megabytes, on one profile, which would take one person abandoning thousands of drafts.

What it buys: **the Drafts lens stops accumulating threads the operator walked away from half a year ago** — and only from the next window launch, since the renderer hydrates that lens once at mount.

## The change

One statement added to the transaction `cleanupExpired` already opens hourly:

```sql
DELETE FROM composer_draft_latest WHERE updated_at < ?   -- now − 180 days
```

Every row in that table is unsent by construction (`save()` deletes the row for any other status), so no status filter is needed.

## The clock tracks edits

It did not always, and an earlier revision of this PR documented the opposite. The composer's unmount flush re-saved with **no dirty check**, so opening a thread and navigating away re-stamped `updated_at` — meaning this sweep only ever reached drafts on threads nobody visited.

**#1494 fixed that** (dirty check in the durable store, hash seeded at hydration), so a thread merely opened no longer moves its draft's timestamp. This PR has been rebased on top of it and the comment corrected.

That dependency is guarded rather than assumed: removing the dirty check fails #1494's own "does not write when nothing changed" and hydration round-trip tests, rather than silently widening this sweep back to "not opened in 180 days".

## It still deletes unsent text

No warning, no undo, and `composer_draft_journal`'s own 30-day retention means no recoverable copy survives to 180 days. Staleness makes the loss predictable and remote instead of triggered by unrelated volume; it does not eliminate it. That is why the window is long, and why shortening it later is a decision about what gets destroyed rather than a tuning knob.

## Why staleness and not a row cap

The first cut capped the table at 500 rows, evicting least-recently-updated. Wrong twice over:

- **A count cap does nothing about orphans.** Twenty unreachable rows under a five-hundred-row ceiling are never evicted, because orphans do not move the count. It would not have fixed the thing it was written for.
- **At the ceiling it destroys live work**, by recency, silently — the same data loss refused for the archive path.

## Archiving still does not delete drafts

Archiving is reversible (`restoreThread`, the Codex `thread/unarchive` method), so discarding unsent text at archive time destroys data at the one moment the operator can undo the action that caused it.

Staleness is also the only signal available: from the state layer, `threads.thread_id` is a legacy-encoded identity key and there is no reliable way to distinguish a deleted thread from an archived one, or from a live thread with no overlay row.

## Write cost — measured

The budget is scoped to the **whole GC pass** (`cleanup-expired-gc-pass`), because `measureSqliteWrites` wraps the entire `cleanupExpired` call. Its fixture drives real work through **both** composer sweeps — ageing out 20 drafts *and* collapsing a 30-row journal prefix chain to 1:

```
1 commit / 45 statements / 49 rows changed
```

`commits: 1` is the assertion that matters, and this fixture is what makes it meaningful: a second sweep doing 29 further deletes still costs no additional commit. (An earlier version of the fixture left the journal empty, so it measured none of #1494's collapse while its note claimed to cover every sweep.)

## No schema change

No `CREATE`/`ALTER`, no `user_version` bump, no migration — so the 1.0 backport path stays open.

Note one upgrade behaviour worth knowing: `startGc` calls `cleanupExpired()` at boot, not just on the hourly tick, so drafts past 180 days go on the first launch after upgrading rather than an hour in.

## Tests

Four in `composer-draft-recovery-store.test.ts`, against a fixed clock:

- drafts edited today, last month, and five months ago all survive
- a draft not edited in 200 days is swept
- an archived thread's draft is not deleted and stays reachable
- **600 current drafts are left completely alone** — the anti-regression for the row-cap approach

`pnpm typecheck`, `lint:eslint` (0 errors), `lint:sql`, `lint:boundaries` clean. Full suite 7582 passed; the 5 `codex-environment-runtime` failures reproduce on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)