### PR TITLE
fix(desktop): apply star map card menu actions to the selection

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -1113,6 +1113,19 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const [marquee, setMarquee] = useState<SnapRect | undefined>(undefined);
 
   /**
+   * A card key names its owning instance, and the local instance's durable
+   * id only arrives with federation health — until then the local cloud is
+   * keyed "local". A selection swept in that window points at a cloud that
+   * no longer exists the moment health lands: the counter keeps counting,
+   * no card paints as selected, and the kebab finds nothing of it to act
+   * on. Drop it, the same way a card withholds dragging until the durable
+   * id is known rather than persisting against the placeholder.
+   */
+  useEffect(() => {
+    setSelection((current) => (current.size > 0 ? new Set() : current));
+  }, [localInstanceId]);
+
+  /**
    * Refresh whichever cloud owns a thread. Archive removes it from the
    * owning instance, so the map has to re-fetch rather than guess.
    */

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -183,6 +183,19 @@ type StarMapCardTarget = {
   thread: NavigationThreadSummary;
 };
 
+/**
+ * What one card's menu acts on: every target, and the subset an unread
+ * action applies to. Resolved together because both are answers to the
+ * same question — which cards is this menu about — and splitting them
+ * put a per-card `filter` back in the render path.
+ */
+type StarMapCardTargets = {
+  all: readonly StarMapCardTarget[];
+  unseen: readonly StarMapCardTarget[];
+};
+
+const NO_CARD_TARGETS: readonly StarMapCardTarget[] = [];
+
 type StarMapScreenProps = {
   desktopApi?: DesktopApi;
   /** Local navigation snapshot threads (already live in the App shell). */
@@ -1133,6 +1146,28 @@ export function StarMapScreen(props: StarMapScreenProps) {
   }, [lanes]);
 
   /**
+   * The selection resolved to cards, once per render rather than once per
+   * card. Every card's kebab asks this same question, so resolving it in
+   * `cardMenuTargets` made the render quadratic in a selection an operator
+   * can sweep to forty cards a cloud.
+   */
+  const selectedTargets = useMemo((): StarMapCardTargets => {
+    const all: StarMapCardTarget[] = [];
+    for (const key of selection) {
+      // Keys that resolve to nothing are the load card, which is not a
+      // thread, and cards no longer on the map — filtered out, or on an
+      // instance that dropped. Both fall out of the action rather than
+      // failing it; the same reasoning as `commitSelectionMove`.
+      const target = targetsByCardKey.get(key);
+      if (target) all.push(target);
+    }
+    return {
+      all,
+      unseen: all.filter((target) => target.thread.inbox.inInbox),
+    };
+  }, [selection, targetsByCardKey]);
+
+  /**
    * The cards a kebab action applies to. A menu opened on a card that is
    * part of the selection acts on the whole selection — the same rule the
    * thread list's context menu follows — because the gesture that visibly
@@ -1144,51 +1179,77 @@ export function StarMapScreen(props: StarMapScreenProps) {
     (
       thread: NavigationThreadSummary,
       instanceId: string,
-    ): StarMapCardTarget[] => {
-      const self: StarMapCardTarget = { instanceId, thread };
+    ): StarMapCardTargets => {
       const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-      if (!selection.has(`${instanceId}::${threadKey}`)) return [self];
-      const targets: StarMapCardTarget[] = [];
-      for (const key of selection) {
-        // Keys that resolve to nothing are the load card, which is not a
-        // thread, and cards no longer on the map — filtered out, or on an
-        // instance that dropped. Both fall out of the action rather than
-        // failing it; the same reasoning as `commitSelectionMove`.
-        const target = targetsByCardKey.get(key);
-        if (target) targets.push(target);
+      if (
+        selection.has(`${instanceId}::${threadKey}`)
+        && selectedTargets.all.length > 0
+      ) {
+        return selectedTargets;
       }
-      return targets.length > 0 ? targets : [self];
+      const self = [{ instanceId, thread }];
+      return {
+        all: self,
+        unseen: thread.inbox.inInbox ? self : NO_CARD_TARGETS,
+      };
     },
-    [selection, targetsByCardKey],
+    [selectedTargets, selection],
   );
+
+  /** Take one card out of the selection, for when it leaves for good. */
+  const dropFromSelection = useCallback((target: StarMapCardTarget) => {
+    const key = `${target.instanceId}::${buildThreadIdentityKey(
+      target.thread.source,
+      target.thread.id,
+    )}`;
+    setSelection((current) => {
+      if (!current.has(key)) return current;
+      const next = new Set(current);
+      next.delete(key);
+      return next;
+    });
+  }, []);
 
   /**
    * Run one per-thread mutation across a menu's targets. Settles as a
-   * group so a single failing card cannot cancel the rest, reports the
-   * first failure rather than swallowing it, and refreshes each owning
-   * cloud once — including after a partial failure, where the map is now
-   * out of date for whichever cards did land.
+   * group so a single failing card cannot cancel the rest, reports what
+   * failed rather than swallowing it, and refreshes each owning cloud
+   * once — including after a partial failure, where the map is now out of
+   * date for whichever cards did land.
    */
   const runOnCardTargets = useCallback(
-    (
-      targets: StarMapCardTarget[],
-      fallbackMessage: string,
-      run: (target: StarMapCardTarget) => Promise<unknown> | undefined,
-    ) => {
+    (options: {
+      /**
+       * The sentence before the reason, unpunctuated. It takes the counts
+       * because "could not archive" across four cards has to say how many
+       * of them are still sitting there.
+       */
+      describeFailure: (failed: number, total: number) => string;
+      run: (target: StarMapCardTarget) => Promise<unknown> | undefined;
+      targets: readonly StarMapCardTarget[];
+    }) => {
+      const targets = [...options.targets];
       void Promise.allSettled(
-        targets.map((target) => run(target) ?? Promise.resolve()),
+        targets.map((target) => options.run(target) ?? Promise.resolve()),
       ).then((results) => {
-        const failure = results.find(
+        const failures = results.filter(
           (result): result is PromiseRejectedResult =>
             result.status === "rejected",
         );
-        setCardError(
-          failure
-            ? failure.reason instanceof Error
-              ? failure.reason.message
-              : fallbackMessage
-            : undefined,
-        );
+        if (failures.length > 0) {
+          const summary = options.describeFailure(
+            failures.length,
+            targets.length,
+          );
+          // Only the first reason: several cards failing the same way is
+          // the common case, and a stack of near-identical sentences buries
+          // the count that says how much of the action survived.
+          const detail =
+            failures[0].reason instanceof Error
+              ? failures[0].reason.message
+              : undefined;
+          setCardError(detail ? `${summary}: ${detail}` : `${summary}.`);
+        }
         for (const instanceId of new Set(
           targets.map((target) => target.instanceId),
         )) {
@@ -1214,9 +1275,10 @@ export function StarMapScreen(props: StarMapScreenProps) {
           onSelect: () => openThreadFully(thread),
         },
       ];
-      const unseenTargets = targets.filter(
-        (target) => target.thread.inbox.inInbox,
-      );
+      // The unread subset, not the whole selection: an already-seen card
+      // has nothing to mark, and the count says so. Same shape as the
+      // thread list's `bulkArchivableThreads`.
+      const unseenTargets = targets.unseen;
       if (desktopApi?.markThreadSeen && unseenTargets.length > 0) {
         actions.push({
           key: "mark-seen",
@@ -1225,10 +1287,12 @@ export function StarMapScreen(props: StarMapScreenProps) {
               ? `Mark ${unseenTargets.length} threads as seen`
               : "Mark as seen",
           onSelect: () => {
-            runOnCardTargets(
-              unseenTargets,
-              "Could not mark that thread seen.",
-              (target) =>
+            runOnCardTargets({
+              describeFailure: (failed, total) =>
+                total === 1
+                  ? "Could not mark that thread seen"
+                  : `Could not mark ${failed} of ${total} threads seen`,
+              run: (target) =>
                 desktopApi.markThreadSeen?.({
                   backend: target.thread.source,
                   federationTarget:
@@ -1236,7 +1300,8 @@ export function StarMapScreen(props: StarMapScreenProps) {
                     ?? readRendererFederationTarget(),
                   threadId: target.thread.id,
                 }),
-            );
+              targets: unseenTargets,
+            });
           },
         });
       }
@@ -1269,14 +1334,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
           // the cards they gathered, before they commit to the one action
           // here they cannot undo from this surface.
           label:
-            targets.length > 1
-              ? `Archive ${targets.length} threads`
+            targets.all.length > 1
+              ? `Archive ${targets.all.length} threads`
               : "Archive thread",
           onSelect: () => {
-            runOnCardTargets(
-              targets,
-              "Could not archive that thread.",
-              (target) =>
+            runOnCardTargets({
+              describeFailure: (failed, total) =>
+                total === 1
+                  ? "Could not archive that thread"
+                  : `Could not archive ${failed} of ${total} threads`,
+              run: (target) =>
                 desktopApi
                   .archiveThread?.({
                     backend: target.thread.source,
@@ -1292,22 +1359,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
                         target.thread.id,
                       ),
                     );
+                    // An archived card is gone for good, unlike one a
+                    // filter or a flapping instance takes off the map, so
+                    // the selection drops it rather than counting it
+                    // forever. Per card and on success only: a card whose
+                    // archive was refused is still sitting there, and
+                    // still selected.
+                    dropFromSelection(target);
                   }),
-            );
-            // Archived cards are gone for good, unlike the ones a filter
-            // or a flapping instance takes off the map, so the selection
-            // drops them rather than counting them forever.
-            setSelection((current) => {
-              const next = new Set(current);
-              for (const target of targets) {
-                next.delete(
-                  `${target.instanceId}::${buildThreadIdentityKey(
-                    target.thread.source,
-                    target.thread.id,
-                  )}`,
-                );
-              }
-              return next;
+              targets: targets.all,
             });
           },
         });
@@ -1319,6 +1379,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       cardMenuTargets,
       chatCards,
       desktopApi,
+      dropFromSelection,
       openThreadFully,
       runOnCardTargets,
     ],
@@ -1337,10 +1398,17 @@ export function StarMapScreen(props: StarMapScreenProps) {
    * card can exclude itself. Absolute rather than cloud-local so cards
    * belonging to different instances can still align with each other —
    * the operator sees one map, not several coordinate systems.
+   *
+   * Empty under the projects lens, which draws none of these bodies: its
+   * cards sit on project arms instead, and `bodies` still reports the lane
+   * geometry they are NOT at. Measuring a sweep against rects nothing is
+   * painted at selects cards the operator cannot see — harmless while the
+   * selection only moved cards (the lens has no drag), and not harmless at
+   * all now that the kebab acts on it.
    */
   const cardRects = useMemo(() => {
     const rects = new Map<string, SnapRect>();
-    for (const position of bodies) {
+    for (const position of projectsMode ? [] : bodies) {
       // The load card is placed by hand like any other, so it belongs in the
       // same geometry: cards align to it, guides draw against it, and a
       // marquee sweeps it up. Keyed by its POSITION entry so the shared
@@ -1386,7 +1454,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
       });
     }
     return rects;
-  }, [arrangement, bodies, lanes]);
+  }, [arrangement, bodies, lanes, projectsMode]);
 
   /**
    * Canvas scale for the overlays drawn inside the transform. Every lens
@@ -2213,6 +2281,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
         <StarMapViewOptions
           preferences={preferences}
           onChange={(next) => {
+            // A lens change re-places every card, and one lens (projects)
+            // paints no selected state at all. Carrying a selection across
+            // that boundary leaves the operator holding cards they can no
+            // longer point at — which the kebab would then act on.
+            if (next.layout !== preferences.layout) setSelection(new Set());
             setPreferences(next);
             writeStoredPreferences(next);
           }}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -173,6 +173,16 @@ const StarMapSky = memo(function StarMapSky() {
   );
 });
 
+/**
+ * One card a menu action is about. The thread alone is not enough: the
+ * same thread can be shown under more than one instance's cloud, and the
+ * owning instance is what says which cloud has to refresh afterwards.
+ */
+type StarMapCardTarget = {
+  instanceId: string;
+  thread: NavigationThreadSummary;
+};
+
 type StarMapScreenProps = {
   desktopApi?: DesktopApi;
   /** Local navigation snapshot threads (already live in the App shell). */
@@ -1084,6 +1094,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
 
   const [cardError, setCardError] = useState<string | undefined>(undefined);
 
+  /** Cards the operator has gathered, by card key. */
+  const [selection, setSelection] = useState<ReadonlySet<string>>(new Set());
+  /** The live sweep rect, while a marquee drag is in flight. */
+  const [marquee, setMarquee] = useState<SnapRect | undefined>(undefined);
+
   /**
    * Refresh whichever cloud owns a thread. Archive removes it from the
    * owning instance, so the map has to re-fetch rather than guess.
@@ -1099,39 +1114,129 @@ export function StarMapScreen(props: StarMapScreenProps) {
     [localInstanceId, props],
   );
 
+  /**
+   * Every card on the map by selection key, so a set of keys can be turned
+   * back into the threads it stands for. Built from the slice each lane
+   * actually renders, which is the same slice a marquee can sweep.
+   */
+  const targetsByCardKey = useMemo(() => {
+    const result = new Map<string, StarMapCardTarget>();
+    for (const [instanceId, lane] of lanes) {
+      for (const thread of lane.threads.slice(0, lane.count)) {
+        result.set(
+          `${instanceId}::${buildThreadIdentityKey(thread.source, thread.id)}`,
+          { instanceId, thread },
+        );
+      }
+    }
+    return result;
+  }, [lanes]);
+
+  /**
+   * The cards a kebab action applies to. A menu opened on a card that is
+   * part of the selection acts on the whole selection — the same rule the
+   * thread list's context menu follows — because the gesture that visibly
+   * gathered five cards must not be silently discarded by the menu that
+   * comes next. A menu opened on a card outside the selection acts on that
+   * card alone, and leaves the selection where it was.
+   */
+  const cardMenuTargets = useCallback(
+    (
+      thread: NavigationThreadSummary,
+      instanceId: string,
+    ): StarMapCardTarget[] => {
+      const self: StarMapCardTarget = { instanceId, thread };
+      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      if (!selection.has(`${instanceId}::${threadKey}`)) return [self];
+      const targets: StarMapCardTarget[] = [];
+      for (const key of selection) {
+        // Keys that resolve to nothing are the load card, which is not a
+        // thread, and cards no longer on the map — filtered out, or on an
+        // instance that dropped. Both fall out of the action rather than
+        // failing it; the same reasoning as `commitSelectionMove`.
+        const target = targetsByCardKey.get(key);
+        if (target) targets.push(target);
+      }
+      return targets.length > 0 ? targets : [self];
+    },
+    [selection, targetsByCardKey],
+  );
+
+  /**
+   * Run one per-thread mutation across a menu's targets. Settles as a
+   * group so a single failing card cannot cancel the rest, reports the
+   * first failure rather than swallowing it, and refreshes each owning
+   * cloud once — including after a partial failure, where the map is now
+   * out of date for whichever cards did land.
+   */
+  const runOnCardTargets = useCallback(
+    (
+      targets: StarMapCardTarget[],
+      fallbackMessage: string,
+      run: (target: StarMapCardTarget) => Promise<unknown> | undefined,
+    ) => {
+      void Promise.allSettled(
+        targets.map((target) => run(target) ?? Promise.resolve()),
+      ).then((results) => {
+        const failure = results.find(
+          (result): result is PromiseRejectedResult =>
+            result.status === "rejected",
+        );
+        setCardError(
+          failure
+            ? failure.reason instanceof Error
+              ? failure.reason.message
+              : fallbackMessage
+            : undefined,
+        );
+        for (const instanceId of new Set(
+          targets.map((target) => target.instanceId),
+        )) {
+          refreshOwner(instanceId);
+        }
+      });
+    },
+    [refreshOwner],
+  );
+
   const cardMenuActions = useCallback(
     (
       thread: NavigationThreadSummary,
       instanceId: string,
     ): StarMapCardMenuAction[] => {
-      const federationTarget =
-        thread.federation?.ref.target ?? readRendererFederationTarget();
+      const targets = cardMenuTargets(thread, instanceId);
       const actions: StarMapCardMenuAction[] = [
         {
           key: "open-full",
+          // Single-target on purpose: a selection is a set of things to act
+          // on, not a set of windows to open.
           label: "Open in full view",
           onSelect: () => openThreadFully(thread),
         },
       ];
-      if (desktopApi?.markThreadSeen && thread.inbox.inInbox) {
+      const unseenTargets = targets.filter(
+        (target) => target.thread.inbox.inInbox,
+      );
+      if (desktopApi?.markThreadSeen && unseenTargets.length > 0) {
         actions.push({
           key: "mark-seen",
-          label: "Mark as seen",
+          label:
+            unseenTargets.length > 1
+              ? `Mark ${unseenTargets.length} threads as seen`
+              : "Mark as seen",
           onSelect: () => {
-            void desktopApi
-              .markThreadSeen?.({
-                backend: thread.source,
-                federationTarget,
-                threadId: thread.id,
-              })
-              .then(() => refreshOwner(instanceId))
-              .catch((error: unknown) => {
-                setCardError(
-                  error instanceof Error
-                    ? error.message
-                    : "Could not mark that thread seen.",
-                );
-              });
+            runOnCardTargets(
+              unseenTargets,
+              "Could not mark that thread seen.",
+              (target) =>
+                desktopApi.markThreadSeen?.({
+                  backend: target.thread.source,
+                  federationTarget:
+                    target.thread.federation?.ref.target
+                    ?? readRendererFederationTarget(),
+                  threadId: target.thread.id,
+                }),
+            );
           },
         });
       }
@@ -1160,33 +1265,63 @@ export function StarMapScreen(props: StarMapScreenProps) {
         actions.push({
           danger: true,
           key: "archive",
-          label: "Archive thread",
+          // The count is the operator's confirmation that the menu is about
+          // the cards they gathered, before they commit to the one action
+          // here they cannot undo from this surface.
+          label:
+            targets.length > 1
+              ? `Archive ${targets.length} threads`
+              : "Archive thread",
           onSelect: () => {
-            void desktopApi
-              .archiveThread?.({
-                backend: thread.source,
-                federationTarget,
-                threadId: thread.id,
-              })
-              .then(() => {
-                chatCards.close(
-                  buildThreadIdentityKey(thread.source, thread.id),
+            runOnCardTargets(
+              targets,
+              "Could not archive that thread.",
+              (target) =>
+                desktopApi
+                  .archiveThread?.({
+                    backend: target.thread.source,
+                    federationTarget:
+                      target.thread.federation?.ref.target
+                      ?? readRendererFederationTarget(),
+                    threadId: target.thread.id,
+                  })
+                  .then(() => {
+                    chatCards.close(
+                      buildThreadIdentityKey(
+                        target.thread.source,
+                        target.thread.id,
+                      ),
+                    );
+                  }),
+            );
+            // Archived cards are gone for good, unlike the ones a filter
+            // or a flapping instance takes off the map, so the selection
+            // drops them rather than counting them forever.
+            setSelection((current) => {
+              const next = new Set(current);
+              for (const target of targets) {
+                next.delete(
+                  `${target.instanceId}::${buildThreadIdentityKey(
+                    target.thread.source,
+                    target.thread.id,
+                  )}`,
                 );
-                refreshOwner(instanceId);
-              })
-              .catch((error: unknown) => {
-                setCardError(
-                  error instanceof Error
-                    ? error.message
-                    : "Could not archive that thread.",
-                );
-              });
+              }
+              return next;
+            });
           },
         });
       }
       return actions;
     },
-    [arrangement, chatCards, desktopApi, openThreadFully, refreshOwner],
+    [
+      arrangement,
+      cardMenuTargets,
+      chatCards,
+      desktopApi,
+      openThreadFully,
+      runOnCardTargets,
+    ],
   );
 
   const linkState = (peerId: string) => {
@@ -1253,13 +1388,6 @@ export function StarMapScreen(props: StarMapScreenProps) {
     return rects;
   }, [arrangement, bodies, lanes]);
 
-  /**
-   * Build the snap for one card. Threshold is screen-space so the pull
-   * feels the same at every zoom, then converted into the canvas units the
-   * geometry works in — the same reasoning as the drag threshold.
-   */
-  const [selection, setSelection] = useState<ReadonlySet<string>>(new Set());
-  const [marquee, setMarquee] = useState<SnapRect | undefined>(undefined);
   /**
    * Canvas scale for the overlays drawn inside the transform. Every lens
    * scales now, lanes included, so the live value always applies.
@@ -1431,6 +1559,11 @@ export function StarMapScreen(props: StarMapScreenProps) {
     [arrangement, selection, shellsByKey],
   );
 
+  /**
+   * Build the snap for one card. Threshold is screen-space so the pull
+   * feels the same at every zoom, then converted into the canvas units the
+   * geometry works in — the same reasoning as the drag threshold.
+   */
   const snapFor = useCallback(
     (
       instanceId: string,

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
@@ -9,20 +9,21 @@ import { StarMapScreen } from "../StarMapScreen";
  * empty space, so the modifier is what keeps them apart.
  */
 
+/** What the map learns about itself once federation health lands. */
+const LOCAL_HEALTH = {
+  enabled: false,
+  role: "client" as const,
+  status: "disabled" as const,
+  instanceId: "pwr_local",
+  localCelestialIcon: "sun" as const,
+  localLabel: "Harold-MBP-M5-Max",
+  localProfileName: "default",
+  peers: [],
+};
+
 function buildDesktopApi(): DesktopApi {
   return {
-    readFederationHealth: vi.fn(async () => ({
-      health: {
-        enabled: false,
-        role: "client" as const,
-        status: "disabled" as const,
-        instanceId: "pwr_local",
-        localCelestialIcon: "sun" as const,
-        localLabel: "Harold-MBP-M5-Max",
-        localProfileName: "default",
-        peers: [],
-      },
-    })),
+    readFederationHealth: vi.fn(async () => ({ health: LOCAL_HEALTH })),
     onAgentEvent: vi.fn(() => () => undefined),
     readStarMapArrangement: vi.fn(async () => ({ entries: [] })),
     setStarMapCardPosition: vi.fn(async () => undefined),
@@ -89,8 +90,24 @@ function renderMap(
   };
 }
 
-/** Sweep the whole cloud, so every card lands in the selection. */
-function sweepEverything(modifier: "shiftKey" | "metaKey" = "shiftKey") {
+/**
+ * Sweep the whole cloud, so every card lands in the selection.
+ *
+ * Waits for the cards to carry their owning instance's DURABLE id first.
+ * `ready()` only proves the instance body rendered; the local cloud is
+ * keyed "local" until `readFederationHealth` resolves, and a sweep in that
+ * window builds a selection of keys that name a cloud about to disappear.
+ * Nothing retries it, so the assertion that follows measures a race rather
+ * than the selection. This is a precondition, not a timeout — a slower
+ * machine widens the window, which is why CI hit it and this laptop rarely
+ * did.
+ */
+async function sweepEverything(modifier: "shiftKey" | "metaKey" = "shiftKey") {
+  await waitFor(() => {
+    const keys = shells().map((shell) => shell.dataset.cardKey ?? "");
+    expect(keys.length).toBeGreaterThan(0);
+    expect(keys.every((key) => key.startsWith("pwr_local::"))).toBe(true);
+  });
   fireEvent.pointerDown(viewport(), {
     button: 0,
     [modifier]: true,
@@ -160,14 +177,7 @@ describe("star map marquee selection", () => {
     expect(document.querySelector(".star-map-card-shell--selected")).toBeNull();
 
     // A sweep large enough to cover the whole cloud.
-    fireEvent.pointerDown(viewport(), {
-      button: 0,
-      shiftKey: true,
-      clientX: -4000,
-      clientY: -4000,
-    });
-    fireEvent.pointerMove(window, { clientX: 4000, clientY: 4000 });
-    fireEvent.pointerUp(window, { clientX: 4000, clientY: 4000 });
+    await sweepEverything();
 
     await waitFor(() => {
       expect(
@@ -213,14 +223,7 @@ describe("star map marquee selection", () => {
     renderMap(4);
     await ready();
 
-    fireEvent.pointerDown(viewport(), {
-      button: 0,
-      shiftKey: true,
-      clientX: -4000,
-      clientY: -4000,
-    });
-    fireEvent.pointerMove(window, { clientX: 4000, clientY: 4000 });
-    fireEvent.pointerUp(window, { clientX: 4000, clientY: 4000 });
+    await sweepEverything();
 
     await waitFor(() => {
       expect(
@@ -263,7 +266,7 @@ describe("star map selection is amendable", () => {
     await ready();
     expect(screen.queryByText(/cards selected/)).toBeNull();
 
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => {
       expect(screen.getByText(/\d+ cards selected/)).toBeTruthy();
     });
@@ -273,7 +276,7 @@ describe("star map selection is amendable", () => {
   it("clears the selection on a click on empty canvas", async () => {
     renderMap(4);
     await ready();
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => expect(selectedShells().length).toBeGreaterThan(1));
 
     // Press and release in the same spot: a click, not an abandoned pan.
@@ -286,7 +289,7 @@ describe("star map selection is amendable", () => {
   it("keeps the selection when a pan is released somewhere else", async () => {
     renderMap(4);
     await ready();
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => expect(selectedShells().length).toBeGreaterThan(1));
     const before = selectedShells().length;
 
@@ -301,7 +304,7 @@ describe("star map selection is amendable", () => {
     const onClose = vi.fn();
     renderMap(4, { onClose });
     await ready();
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => expect(selectedShells().length).toBeGreaterThan(1));
 
     const layer = document.querySelector(".star-map");
@@ -319,7 +322,7 @@ describe("star map selection is amendable", () => {
   it("takes a card back out of the selection on a modifier-click", async () => {
     renderMap(4);
     await ready();
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => expect(selectedShells().length).toBeGreaterThan(1));
     const before = selectedShells().length;
 
@@ -336,7 +339,7 @@ describe("star map selection is amendable", () => {
   it("extends the selection on a Cmd-sweep and replaces it on a Shift-sweep", async () => {
     renderMap(4);
     await ready();
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => expect(selectedShells().length).toBeGreaterThan(1));
     const before = selectedShells().length;
 
@@ -367,7 +370,7 @@ describe("star map selection is amendable", () => {
     const desktopApi = buildDesktopApi();
     const { showThreads } = renderMap(4, { desktopApi });
     await ready();
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => expect(selectedShells().length).toBe(4));
 
     // Two cards leave — a filter change, or the instance that owns them
@@ -415,7 +418,7 @@ describe("star map card menu acts on the selection", () => {
     const desktopApi = buildMutatingDesktopApi();
     renderMap(4, { desktopApi });
     await ready();
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => expect(selectedShells()).toHaveLength(4));
 
     openCardMenu("t0");
@@ -437,7 +440,7 @@ describe("star map card menu acts on the selection", () => {
     const desktopApi = buildMutatingDesktopApi();
     renderMap(3, { desktopApi });
     await ready();
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => expect(selectedShells()).toHaveLength(3));
 
     openCardMenu("t1");
@@ -458,7 +461,7 @@ describe("star map card menu acts on the selection", () => {
     const desktopApi = buildMutatingDesktopApi();
     renderMap(4, { desktopApi });
     await ready();
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => expect(selectedShells()).toHaveLength(4));
 
     // Take one card back out, then use its kebab: the menu is about the
@@ -491,7 +494,7 @@ describe("star map card menu acts on the selection", () => {
     const onRefreshLocalThreads = vi.fn();
     renderMap(3, { desktopApi, onRefreshLocalThreads });
     await ready();
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => expect(selectedShells()).toHaveLength(3));
 
     openCardMenu("t0");
@@ -524,7 +527,7 @@ describe("star map card menu acts on the selection", () => {
     const onRefreshLocalThreads = vi.fn();
     renderMap(4, { desktopApi, onRefreshLocalThreads });
     await ready();
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => expect(selectedShells()).toHaveLength(4));
 
     openCardMenu("t0");
@@ -544,7 +547,7 @@ describe("star map card menu acts on the selection", () => {
     const desktopApi = buildMutatingDesktopApi();
     const { showThreads } = renderMap(4, { desktopApi });
     await ready();
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => expect(selectedShells()).toHaveLength(4));
 
     // Two cards leave — a filter change, or their instance dropping. They
@@ -566,7 +569,7 @@ describe("star map card menu acts on the selection", () => {
     const desktopApi = buildMutatingDesktopApi();
     renderMap(4, { desktopApi });
     await ready();
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => expect(screen.getByText("4 cards selected")).toBeTruthy());
 
     openCardMenu("t0");
@@ -600,7 +603,7 @@ describe("star map selection stops at the projects lens", () => {
     // The cards are on screen, so the sweep has something to miss.
     await waitFor(() => expect(shells()).toHaveLength(4));
 
-    sweepEverything();
+    await sweepEverything();
     await act(async () => {
       await Promise.resolve();
     });
@@ -611,10 +614,60 @@ describe("star map selection stops at the projects lens", () => {
     expect(screen.getByRole("menuitem", { name: "Archive thread" })).toBeTruthy();
   });
 
+  it("drops a selection swept before the durable instance id arrived", async () => {
+    // Every pending read, not just the last one: `useCelestialIcons` reads
+    // federation health too, so holding a single resolver lands the wrong
+    // caller's promise and leaves the one that owns `instanceId` hanging.
+    const pendingHealthReads: ((value: unknown) => void)[] = [];
+    const desktopApi = {
+      ...buildDesktopApi(),
+      readFederationHealth: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            pendingHealthReads.push(resolve);
+          }),
+      ),
+    } as unknown as DesktopApi;
+    renderMap(4, { desktopApi });
+
+    // Cards render under the placeholder id while health is still in
+    // flight — this is the window a real operator can sweep in.
+    await waitFor(() => expect(shells()).toHaveLength(4));
+    expect(shells()[0].dataset.cardKey?.startsWith("local::")).toBe(true);
+
+    fireEvent.pointerDown(viewport(), {
+      button: 0,
+      shiftKey: true,
+      clientX: -4000,
+      clientY: -4000,
+    });
+    fireEvent.pointerMove(window, { clientX: 4000, clientY: 4000 });
+    fireEvent.pointerUp(window, { clientX: 4000, clientY: 4000 });
+    await waitFor(() => {
+      expect(screen.getByText("4 cards selected")).toBeTruthy();
+    });
+
+    await act(async () => {
+      for (const resolve of pendingHealthReads) {
+        resolve({ health: LOCAL_HEALTH });
+      }
+    });
+
+    // Every card is now keyed to the durable id, so the swept keys point at
+    // nothing. A counter still claiming four cards — none of them painted
+    // selected, none of them reachable from the kebab — is worse than an
+    // empty selection.
+    await waitFor(() => {
+      expect(shells()[0]?.dataset.cardKey?.startsWith("pwr_local::")).toBe(true);
+    });
+    expect(screen.queryByText(/cards selected/)).toBeNull();
+    expect(selectedShells()).toHaveLength(0);
+  });
+
   it("drops the selection when the operator switches lens", async () => {
     renderMap(4);
     await ready();
-    sweepEverything();
+    await sweepEverything();
     await waitFor(() => expect(screen.getByText("4 cards selected")).toBeTruthy());
 
     fireEvent.click(screen.getByRole("button", { name: "View" }));

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
@@ -29,6 +29,22 @@ function buildDesktopApi(): DesktopApi {
   } as unknown as DesktopApi;
 }
 
+/**
+ * A bridge whose per-thread mutations resolve, so a menu action can be
+ * followed all the way to what it asked the main process to do.
+ */
+function buildMutatingDesktopApi(overrides?: Partial<DesktopApi>): DesktopApi {
+  return {
+    ...buildDesktopApi(),
+    archiveThread: vi.fn(async (request: { threadId: string }) => ({
+      backend: "codex" as const,
+      threadId: request.threadId,
+    })),
+    markThreadSeen: vi.fn(async () => undefined),
+    ...overrides,
+  } as unknown as DesktopApi;
+}
+
 function thread(id: string): NavigationThreadSummary {
   return {
     id,
@@ -43,7 +59,11 @@ function thread(id: string): NavigationThreadSummary {
 
 function renderMap(
   count: number,
-  overrides?: { desktopApi?: DesktopApi; onClose?: () => void },
+  overrides?: {
+    desktopApi?: DesktopApi;
+    onClose?: () => void;
+    onRefreshLocalThreads?: () => void;
+  },
 ) {
   const desktopApi = overrides?.desktopApi ?? buildDesktopApi();
   const screenFor = (threadCount: number) => (
@@ -58,6 +78,7 @@ function renderMap(
       onClose={overrides?.onClose ?? (() => undefined)}
       onOpenLocalThread={() => undefined}
       onFocusLocalInstance={() => undefined}
+      onRefreshLocalThreads={overrides?.onRefreshLocalThreads}
     />
   );
   const result = render(screenFor(count));
@@ -102,6 +123,21 @@ function viewport(): HTMLElement {
 function shells(): HTMLElement[] {
   return [...document.querySelectorAll(".star-map-card-shell[data-thread-key]")]
     .filter((node): node is HTMLElement => node instanceof HTMLElement);
+}
+
+/** Thread ids a mocked per-thread mutation was actually asked about. */
+function requestedThreadIds(request: unknown): string[] {
+  const mocked = request as {
+    mock?: { calls: [{ threadId: string }][] };
+  };
+  if (!mocked?.mock) throw new Error("request is not a mock");
+  return mocked.mock.calls.map(([input]) => input.threadId).sort();
+}
+
+function openCardMenu(threadId: string) {
+  fireEvent.click(
+    screen.getByRole("button", { name: `Actions for Thread ${threadId}` }),
+  );
 }
 
 async function ready() {
@@ -359,5 +395,133 @@ describe("star map selection is amendable", () => {
     for (const call of moved) {
       expect(JSON.stringify(call)).not.toMatch(/t2|t3/);
     }
+  });
+});
+
+/**
+ * A selection that survives the kebab opening, then acts on one card, is
+ * the worst of both worlds: the operator watched five cards stay lit,
+ * chose a destructive action, and got one card archived and a re-laid-out
+ * cloud that reads as "they all went". The map follows the thread list —
+ * a menu opened on a selected row is about the selection.
+ */
+describe("star map card menu acts on the selection", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+  });
+
+  it("archives every selected card, not only the one whose kebab was used", async () => {
+    const desktopApi = buildMutatingDesktopApi();
+    renderMap(4, { desktopApi });
+    await ready();
+    sweepEverything();
+    await waitFor(() => expect(selectedShells()).toHaveLength(4));
+
+    openCardMenu("t0");
+    // The count is the operator's confirmation, before committing, that the
+    // menu is about the cards they gathered.
+    fireEvent.click(screen.getByRole("menuitem", { name: "Archive 4 threads" }));
+
+    await waitFor(() => {
+      expect(requestedThreadIds(desktopApi.archiveThread)).toEqual([
+        "t0",
+        "t1",
+        "t2",
+        "t3",
+      ]);
+    });
+  });
+
+  it("marks the whole selection seen from one card's kebab", async () => {
+    const desktopApi = buildMutatingDesktopApi();
+    renderMap(3, { desktopApi });
+    await ready();
+    sweepEverything();
+    await waitFor(() => expect(selectedShells()).toHaveLength(3));
+
+    openCardMenu("t1");
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Mark 3 threads as seen" }),
+    );
+
+    await waitFor(() => {
+      expect(requestedThreadIds(desktopApi.markThreadSeen)).toEqual([
+        "t0",
+        "t1",
+        "t2",
+      ]);
+    });
+  });
+
+  it("acts on one card when its kebab is opened outside the selection", async () => {
+    const desktopApi = buildMutatingDesktopApi();
+    renderMap(4, { desktopApi });
+    await ready();
+    sweepEverything();
+    await waitFor(() => expect(selectedShells()).toHaveLength(4));
+
+    // Take one card back out, then use its kebab: the menu is about the
+    // card it hangs off, not the selection beside it.
+    fireEvent.pointerDown(shells()[3], {
+      button: 0,
+      shiftKey: true,
+      clientX: 500,
+      clientY: 400,
+    });
+    await waitFor(() => expect(selectedShells()).toHaveLength(3));
+
+    openCardMenu("t3");
+    fireEvent.click(screen.getByRole("menuitem", { name: "Archive thread" }));
+
+    await waitFor(() => {
+      expect(requestedThreadIds(desktopApi.archiveThread)).toEqual(["t3"]);
+    });
+    // ...and the selection it was never part of is left alone.
+    expect(selectedShells()).toHaveLength(3);
+  });
+
+  it("archives the rest of the selection when one card fails, and says which", async () => {
+    const desktopApi = buildMutatingDesktopApi({
+      archiveThread: vi.fn(async (request: { threadId: string }) => {
+        if (request.threadId === "t1") throw new Error("peer is offline");
+        return { backend: "codex" as const, threadId: request.threadId };
+      }),
+    } as unknown as Partial<DesktopApi>);
+    const onRefreshLocalThreads = vi.fn();
+    renderMap(3, { desktopApi, onRefreshLocalThreads });
+    await ready();
+    sweepEverything();
+    await waitFor(() => expect(selectedShells()).toHaveLength(3));
+
+    openCardMenu("t0");
+    fireEvent.click(screen.getByRole("menuitem", { name: "Archive 3 threads" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/peer is offline/);
+    // One card refusing must not cancel the two that would have gone.
+    expect(requestedThreadIds(desktopApi.archiveThread)).toEqual([
+      "t0",
+      "t1",
+      "t2",
+    ]);
+    // The cloud is out of date for whichever cards did land, so it still
+    // has to re-fetch.
+    expect(onRefreshLocalThreads).toHaveBeenCalled();
+  });
+
+  it("stops counting cards it archived, unlike cards a filter took away", async () => {
+    const desktopApi = buildMutatingDesktopApi();
+    renderMap(4, { desktopApi });
+    await ready();
+    sweepEverything();
+    await waitFor(() => expect(screen.getByText("4 cards selected")).toBeTruthy());
+
+    openCardMenu("t0");
+    fireEvent.click(screen.getByRole("menuitem", { name: "Archive 4 threads" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/cards selected/)).toBeNull();
+    });
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-selection.test.tsx
@@ -498,7 +498,11 @@ describe("star map card menu acts on the selection", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: "Archive 3 threads" }));
 
     const alert = await screen.findByRole("alert");
-    expect(alert.textContent).toMatch(/peer is offline/);
+    // How much of the action survived is the operator's next question, and
+    // the reason alone cannot answer it.
+    expect(alert.textContent).toContain(
+      "Could not archive 1 of 3 threads: peer is offline",
+    );
     // One card refusing must not cancel the two that would have gone.
     expect(requestedThreadIds(desktopApi.archiveThread)).toEqual([
       "t0",
@@ -508,6 +512,54 @@ describe("star map card menu acts on the selection", () => {
     // The cloud is out of date for whichever cards did land, so it still
     // has to re-fetch.
     expect(onRefreshLocalThreads).toHaveBeenCalled();
+    // The refused card is still sitting there, so it is still selected —
+    // only the two that actually left drop out of the count.
+    await waitFor(() => {
+      expect(screen.getByText("1 card selected")).toBeTruthy();
+    });
+  });
+
+  it("refreshes an owning cloud once, not once per archived card", async () => {
+    const desktopApi = buildMutatingDesktopApi();
+    const onRefreshLocalThreads = vi.fn();
+    renderMap(4, { desktopApi, onRefreshLocalThreads });
+    await ready();
+    sweepEverything();
+    await waitFor(() => expect(selectedShells()).toHaveLength(4));
+
+    openCardMenu("t0");
+    fireEvent.click(screen.getByRole("menuitem", { name: "Archive 4 threads" }));
+
+    await waitFor(() => {
+      expect(onRefreshLocalThreads).toHaveBeenCalledTimes(1);
+    });
+    // Let any straggling settle land before claiming it stayed at one.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(onRefreshLocalThreads).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips selected cards that are no longer on the map", async () => {
+    const desktopApi = buildMutatingDesktopApi();
+    const { showThreads } = renderMap(4, { desktopApi });
+    await ready();
+    sweepEverything();
+    await waitFor(() => expect(selectedShells()).toHaveLength(4));
+
+    // Two cards leave — a filter change, or their instance dropping. They
+    // stay in the selection on purpose (see above), but an action cannot
+    // reach a card the map can no longer resolve.
+    showThreads(2);
+    await waitFor(() => expect(shells()).toHaveLength(2));
+    expect(screen.getByText("4 cards selected")).toBeTruthy();
+
+    openCardMenu("t0");
+    fireEvent.click(screen.getByRole("menuitem", { name: "Archive 2 threads" }));
+
+    await waitFor(() => {
+      expect(requestedThreadIds(desktopApi.archiveThread)).toEqual(["t0", "t1"]);
+    });
   });
 
   it("stops counting cards it archived, unlike cards a filter took away", async () => {
@@ -522,6 +574,54 @@ describe("star map card menu acts on the selection", () => {
 
     await waitFor(() => {
       expect(screen.queryByText(/cards selected/)).toBeNull();
+    });
+  });
+});
+
+/**
+ * The projects lens paints no selected state on its cards, and its cards
+ * are not where the lane geometry says they are. A selection there is one
+ * the operator can neither see nor point at — which is exactly what a
+ * destructive menu action must not be about.
+ */
+describe("star map selection stops at the projects lens", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+    window.localStorage.removeItem("pwragent.starMap.filterSelection");
+  });
+
+  it("selects nothing when a sweep runs under the projects lens", async () => {
+    window.localStorage.setItem(
+      "pwragent.starMap.viewPreferences",
+      JSON.stringify({ layout: "projects" }),
+    );
+    const desktopApi = buildMutatingDesktopApi();
+    renderMap(4, { desktopApi });
+    // The cards are on screen, so the sweep has something to miss.
+    await waitFor(() => expect(shells()).toHaveLength(4));
+
+    sweepEverything();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText(/cards? selected/)).toBeNull();
+    // And the kebab is about the card it hangs off, singular.
+    openCardMenu("t0");
+    expect(screen.getByRole("menuitem", { name: "Archive thread" })).toBeTruthy();
+  });
+
+  it("drops the selection when the operator switches lens", async () => {
+    renderMap(4);
+    await ready();
+    sweepEverything();
+    await waitFor(() => expect(screen.getByText("4 cards selected")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "View" }));
+    fireEvent.click(screen.getByRole("button", { name: "Projects" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/cards? selected/)).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## The bug

Shift-drag on the Star Map gathers cards the same way shift-click gathers rows in the thread list, and the cards stay lit when a card's kebab is opened. **Archive thread** then archived exactly one thread — the card whose kebab was used.

What the operator sees is worse than "one card archived": removing a card re-lays-out the cloud, so it visibly shifts. Reported as *"I thought 'oh it's gone!' … but it was like 6" over to the right and only the card whose kebab menu I interacted with was gone."* The gesture that selected five cards was silently discarded by the menu that came next.

## The fix

The kebab resolves its targets the way `Sidebar`'s thread context menu already does (`resolveContextMenuThreads`):

- A menu opened on a **selected** card is about the **whole selection**.
- A menu opened on a card **outside** the selection is about **that card alone**, and leaves the selection untouched.

The label carries the count — `Archive 4 threads` — so the scope is visible *before* the click rather than inferred from the aftermath. **Mark as seen** follows the same rule (over the selected cards that are actually unread). **Open in full view** stays single-target: a selection is a set of things to act on, not a set of windows to open.

Targets settle as a group via `Promise.allSettled`, so:

- one offline peer cannot cancel the archives that would have landed,
- the first failure is surfaced in the existing card-error alert,
- every owning cloud refreshes even after a partial failure, since the map is now stale for whichever cards did land.

Archived cards are removed from the selection. That is deliberately different from the existing rule for cards a filter or a flapping instance takes off the map (those stay selected on purpose — see `commitSelectionMove`); archived ones are not coming back, so a counter that keeps naming them is simply wrong.

## Tests

Five new cases in `star-map-selection.test.tsx`. Four of them fail on the pre-fix `StarMapScreen.tsx` (verified by stashing the source change); the fifth pins the unchanged single-card behavior so the fix can't over-reach:

- archives every selected card, not only the one whose kebab was used
- marks the whole selection seen from one card's kebab
- acts on one card when its kebab is opened outside the selection *(passes before and after — the guard)*
- archives the rest of the selection when one card fails, and says which
- stops counting cards it archived

`pnpm test apps/desktop/src/renderer/src/features/star-map/` — 18 files, 261 tests pass. `pnpm typecheck` and `pnpm lint:eslint` clean (0 errors, no new warnings).

## Not addressed

The cloud re-layout when cards leave is untouched — with the whole selection archived it now reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)