### PR TITLE
docs(release): correct Windows signing certificate-lifetime guidance

### DIFF
--- a/docs/desktop-windows-signing.md
+++ b/docs/desktop-windows-signing.md
@@ -146,13 +146,25 @@ outside the environment reads every value as empty, which is otherwise
 indistinguishable from an intentional unsigned build. Local and PR builds omit
 the flag and stay unsigned.
 
-## Renewal
+## Certificate lifetime and renewal
 
-Signing breaks when any of these lapse — put them on a calendar:
+**The certificate profile's *Expiry date* is always a couple of days out, and
+that is not a problem.** Artifact Signing issues short-lived certificates and
+reissues them on a rolling basis; the near-term date in the portal is the
+current certificate, not a deadline. No action is needed, and no calendar entry
+belongs on it.
+
+Signatures outlive those certificates because they are **timestamped**.
+electron-builder defaults to `http://timestamp.acs.microsoft.com` with SHA256
+(see `TimestampRfc3161` / `TimestampDigest` in `app-builder-lib`'s
+`windowsSignAzureManager.js`) and we do not override either, so an installer
+signed today still verifies long after its signing certificate has expired.
+
+Two things genuinely do lapse and will break signing — put *these* on a
+calendar:
 
 | Item | Expires | Renew via |
 |---|---|---|
-| Certificate profile `pwrdrvr-public-trust` | 2026-08-13 | Azure portal → certificate profile |
 | Client secret (`AZURE_CLIENT_SECRET`) | ≤24 mo from creation | Entra app registration → Certificates & secrets, then update the GitHub secret |
 | Identity validation | 2028-09-29 | Azure portal → Identity validation → **Renew** |
 


### PR DESCRIPTION
## What

Docs-only follow-up to #694. Corrects the certificate-lifetime guidance in `docs/desktop-windows-signing.md`.

## Why

The renewal table listed the **certificate profile's expiry as something to calendar and renew**. That's wrong, and actively misleading.

Azure Artifact Signing issues **short-lived certificates** and reissues them on a rolling basis, so the profile's *Expiry date* column in the portal always sits a couple of days out **by design**. It is the current certificate, not a deadline. I read that column as an imminent outage while setting this up and raised a false alarm — a future maintainer would do the same, at worse timing.

Signatures outlive those certificates because they're **timestamped**. `app-builder-lib`'s `windowsSignAzureManager.js` defaults:

```js
TimestampRfc3161: timestampRfc3161 || "http://timestamp.acs.microsoft.com",
TimestampDigest: timestampDigest || "SHA256",
```

We override neither, so an installer signed today still verifies long after its signing certificate has expired. No code change is needed — this PR just stops the doc from claiming otherwise.

## What's left in the renewal table

The two items that genuinely do lapse and break signing:

- **Client secret** (`AZURE_CLIENT_SECRET`) — ≤24 months
- **Identity validation** — 2028-09-29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
