### PR TITLE
feat(desktop): keep the load readout readable from the overview zoom

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapLoadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapLoadCard.tsx
@@ -53,6 +53,13 @@ export function StarMapLoadCard(props: {
   width: number;
   centered?: boolean;
   stackIndex: number;
+  /**
+   * Counter-scale for the overview zoom. The load readout is one of the
+   * few things worth reading from far out — it says whether the machine
+   * is busy — so it grows with the instance instead of shrinking into a
+   * speck underneath it.
+   */
+  scale?: number;
   drag?: StarMapCardDrag;
   /**
    * `instanceId::system:load:position` — the card's key in the arrangement
@@ -87,12 +94,23 @@ export function StarMapLoadCard(props: {
 
   const left = props.baseSlot.dx + (props.offset?.dx ?? 0);
   const top = props.baseSlot.dy + (props.offset?.dy ?? 0);
+  // Counter-scale, so the readout stays readable while the canvas shrinks
+  // under it. Applied about the card's own centre, which `marginLeft` and
+  // the `translateY` have already put on the slot — so the card grows in
+  // place rather than sliding off its anchor.
+  const scale = props.scale && props.scale > 0 ? props.scale : 1;
+  const transform = [
+    props.centered ? "translateY(-50%)" : "",
+    scale === 1 ? "" : `scale(${scale})`,
+  ]
+    .filter(Boolean)
+    .join(" ");
   const style: CSSProperties = {
     width: props.width,
     left,
     top,
     marginLeft: -props.width / 2,
-    ...(props.centered ? { transform: "translateY(-50%)" } : {}),
+    ...(transform ? { transform } : {}),
     zIndex: props.stackIndex,
   };
 

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -503,6 +503,13 @@ export function StarMapScreen(props: StarMapScreenProps) {
   const startCanvasPan = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
     if (!shouldStartCanvasPan(event.target)) return;
+    // A press on bare sky is also how the operator LEAVES a terminal or a
+    // chat composer. The pan's preventDefault below suppresses the
+    // browser's default focus change, so without this the shell kept
+    // focus, the flight guard kept seeing keys aimed at text, and there
+    // was no way to fly again short of Escape-ing the whole map. Focus
+    // moves to the layer, which is where the map's own keys listen.
+    layerRef.current?.focus();
     // Shift sweeps a fresh selection, Cmd/Ctrl extends the one already
     // there; everything else pans.
     if (event.shiftKey) {

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -1039,7 +1039,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
           // rendered forever in this lens, and dismissing it only flipped
           // the toggle that reads the same membership.
           loadSlot: loadCardInstances.has(instance.instanceId)
-            ? { dx: 0, dy: ORBIT_LOAD_CARD_DY }
+            ? {
+                dx: 0,
+                // In overview the body counter-scales, and a fixed offset
+                // would leave the readout buried under it. Scaling the
+                // offset by the same factor reproduces the zoom-1 layout
+                // in SCREEN pixels: offset * chromeScale * view.scale is
+                // the offset itself, so the pair reads exactly as it does
+                // close up.
+                dy: overview ? ORBIT_LOAD_CARD_DY * chromeScale : ORBIT_LOAD_CARD_DY,
+              }
             : undefined,
           // Clouds grow their extent, so orbit's canvas is already sized by
           // `computeOrbitPlacement`; only lanes derive theirs from content.
@@ -1081,7 +1090,16 @@ export function StarMapScreen(props: StarMapScreenProps) {
             : 0,
       };
     });
-  }, [clusterClouds, laneLayout, lanes, loadCardInstances, orbit, orbitMode]);
+  }, [
+    chromeScale,
+    clusterClouds,
+    laneLayout,
+    lanes,
+    loadCardInstances,
+    orbit,
+    orbitMode,
+    overview,
+  ]);
 
   /**
    * Lanes canvas: as wide as the instance row and as tall as the longest
@@ -2364,6 +2382,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
             )}
             width={position.cardWidth}
             centered={orbitMode}
+            scale={overview ? chromeScale : 1}
             stackIndex={STAR_MAP_LOAD_CARD_Z}
             sharedWith={sharedMachineLabels.get(position.instanceId)}
             cardKey={loadCardKey}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -2376,20 +2376,41 @@ export function StarMapScreen(props: StarMapScreenProps) {
             instanceLabel={instanceEntry(position.instanceId).label}
             load={instanceLoads.get(position.instanceId)}
             baseSlot={loadSlot}
-            offset={arrangement.offsetFor(
-              position.instanceId,
-              STAR_MAP_LOAD_CARD_POSITION_KEY,
-            )}
+            // In orbit's overview the whole position scales — offset
+            // included, or a hand-placed card would sit at
+            // scaledBase + rawOffset, drifting out of the group whose
+            // geometry just grew around it. Display-only: drags are
+            // disabled below, so a scaled offset is never committed.
+            offset={(() => {
+              const stored = arrangement.offsetFor(
+                position.instanceId,
+                STAR_MAP_LOAD_CARD_POSITION_KEY,
+              );
+              return stored && orbitMode && overview
+                ? {
+                    dx: stored.dx * chromeScale,
+                    dy: stored.dy * chromeScale,
+                  }
+                : stored;
+            })()}
             width={position.cardWidth}
             centered={orbitMode}
-            scale={overview ? chromeScale : 1}
+            // Orbit-gated: lanes shares this render path and zooms through
+            // the same clamp, but nothing else in a lane scales — a card
+            // counter-scaling alone there ballooned over its own column.
+            scale={orbitMode && overview ? chromeScale : 1}
             stackIndex={STAR_MAP_LOAD_CARD_Z}
             sharedWith={sharedMachineLabels.get(position.instanceId)}
             cardKey={loadCardKey}
             selected={selection.has(loadCardKey)}
             onToggleSelect={() => toggleSelected(loadCardKey)}
             drag={
-              health?.instanceId
+              // No dragging while the card is counter-scaled: a commit in
+              // that state stores an offset measured against the scaled
+              // base, which re-reads as a different position at zoom 1 —
+              // the card would jump when the operator came back in. The
+              // overview is for orientation, not arranging.
+              health?.instanceId && !(orbitMode && overview)
                 ? {
                     detentRadius,
                     scale: view.scale,

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapLoadCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapLoadCard.test.tsx
@@ -181,3 +181,47 @@ describe("StarMapLoadCard", () => {
     expect(shell?.style.top).toBe("125px");
   });
 });
+
+describe("overview counter-scale", () => {
+  it("grows with the instance instead of shrinking into a speck", () => {
+    // The load readout says whether the machine is busy, which is one of
+    // the few things worth reading from far out. Zoomed out, the instance
+    // counter-scales and a card left at true canvas size disappears
+    // underneath it.
+    const { container } = render(
+      <StarMapLoadCard
+        instanceId="pwr_local"
+        instanceLabel="Mac-Mini-M4"
+        baseSlot={{ dx: 0, dy: -150 }}
+        width={200}
+        centered
+        scale={4}
+        stackIndex={7000}
+        cardKey="pwr_local::system:load"
+        onDismiss={() => undefined}
+      />,
+    );
+    const shell = container.firstElementChild as HTMLElement;
+    expect(shell.style.transform).toContain("scale(4)");
+    // Still centred on its slot: the scale is about the card's own centre,
+    // which the translate has already put there.
+    expect(shell.style.transform).toContain("translateY(-50%)");
+  });
+
+  it("carries no scale at reading zoom", () => {
+    const { container } = render(
+      <StarMapLoadCard
+        instanceId="pwr_local"
+        instanceLabel="Mac-Mini-M4"
+        baseSlot={{ dx: 0, dy: -150 }}
+        width={200}
+        centered
+        stackIndex={7000}
+        cardKey="pwr_local::system:load"
+        onDismiss={() => undefined}
+      />,
+    );
+    const shell = container.firstElementChild as HTMLElement;
+    expect(shell.style.transform).toBe("translateY(-50%)");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -474,6 +474,122 @@ describe("star map load card in overview", () => {
   });
 });
 
+describe("star map load card overview fixes", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+  });
+
+  const loadCardApi = {
+    readStarMapArrangement: vi.fn(async () => ({
+      entries: [
+        {
+          instanceId: "pwr_local",
+          threadKey: "system:load",
+          dx: 0,
+          dy: 60,
+          updatedAt: 10,
+          by: "pwr_local",
+        },
+      ],
+    })),
+    setStarMapCardPosition: vi.fn(async () => ({ entries: [] })),
+    readFederationInstanceLoad: vi.fn(async () => ({})),
+  };
+
+  function renderLanes(threads: NavigationThreadSummary[]) {
+    window.localStorage.setItem(
+      "pwragent.starMap.viewPreferences",
+      JSON.stringify({ layout: "lanes" }),
+    );
+    const desktopApi: DesktopApi = { ...buildDesktopApi(), ...loadCardApi };
+    return render(
+      <StarMapScreen
+        desktopApi={desktopApi}
+        localThreads={threads}
+        sessionKeys={{}}
+        localInstanceLabel="Mac-Mini-M4"
+        floating={false}
+        onClose={() => undefined}
+        onOpenLocalThread={() => undefined}
+        onFocusLocalInstance={() => undefined}
+      />,
+    );
+  }
+
+  it("never scales in the lanes lens, where nothing else does", async () => {
+    // `overview` is derived from view.scale alone and lanes zooms through
+    // the same clamp, so without the orbit gate a lane's load card
+    // ballooned over its own unscaled column.
+    const { container } = renderLanes([
+      projectThread("a1", "/repo/alpha", "AlphaDir"),
+    ]);
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-load-card")).not.toBeNull();
+    });
+
+    fireEvent.wheel(
+      container.querySelector(".star-map__viewport") as HTMLElement,
+      { deltaY: 240, ctrlKey: true, clientX: 400, clientY: 300 },
+    );
+
+    await waitFor(() => {
+      const canvas = container.querySelector(
+        ".star-map__canvas",
+      ) as HTMLElement;
+      expect(canvas.style.transform).toContain("scale(0.");
+    });
+    const shell = container.querySelector(
+      ".star-map-load-shell",
+    ) as HTMLElement;
+    expect(shell.style.transform).not.toContain("scale(");
+  });
+
+  it("scales a hand-placed offset with the base, and refuses drags", async () => {
+    const setStarMapCardPosition = vi.fn(async () => ({ entries: [] }));
+    const { container } = renderOrbit(
+      [projectThread("a1", "/repo/alpha", "AlphaDir")],
+      { ...loadCardApi, setStarMapCardPosition },
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-load-card")).not.toBeNull();
+    });
+    const nearTop = Number.parseFloat(
+      (container.querySelector(".star-map-load-shell") as HTMLElement).style
+        .top,
+    );
+
+    fireEvent.wheel(
+      container.querySelector(".star-map__viewport") as HTMLElement,
+      { deltaY: 240, ctrlKey: true, clientX: 400, clientY: 300 },
+    );
+    await waitFor(() => {
+      expect(
+        (container.querySelector(".star-map-load-shell") as HTMLElement).style
+          .transform,
+      ).toContain("scale(");
+    });
+
+    const shell = container.querySelector(
+      ".star-map-load-shell",
+    ) as HTMLElement;
+    const scale = Number(/scale\(([\d.]+)\)/.exec(shell.style.transform)![1]);
+    // The WHOLE position scales — base and stored offset together — so a
+    // hand-placed card keeps its place in the group that grew around it.
+    expect(Number.parseFloat(shell.style.top)).toBeCloseTo(
+      nearTop * scale,
+      5,
+    );
+
+    // And a drag in this state commits nothing: an offset measured against
+    // the scaled base would re-read as a different position at zoom 1.
+    setStarMapCardPosition.mockClear();
+    fireEvent.pointerDown(shell, { button: 0, clientX: 300, clientY: 300 });
+    fireEvent.pointerMove(window, { clientX: 420, clientY: 360 });
+    fireEvent.pointerUp(window, { clientX: 420, clientY: 360 });
+    expect(setStarMapCardPosition).not.toHaveBeenCalled();
+  });
+});
+
 describe("star map chat cards in map space", () => {
   afterEach(() => {
     window.localStorage.removeItem("pwragent.starMap.viewPreferences");

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -409,6 +409,71 @@ describe("star map overview zoom", () => {
   });
 });
 
+describe("star map load card in overview", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+  });
+
+  it("scales and parks clear of the counter-scaled instance", async () => {
+    const { container } = renderOrbit(
+      [
+        projectThread("a1", "/repo/alpha", "AlphaDir"),
+        projectThread("a2", "/repo/alpha", "AlphaDir"),
+      ],
+      {
+        readStarMapArrangement: vi.fn(async () => ({
+          entries: [
+            {
+              instanceId: "pwr_local",
+              threadKey: "system:load",
+              dx: 0,
+              dy: 0,
+              updatedAt: 10,
+              by: "pwr_local",
+            },
+          ],
+        })),
+        setStarMapCardPosition: vi.fn(async () => ({ entries: [] })),
+        readFederationInstanceLoad: vi.fn(async () => ({})),
+      },
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-load-card")).not.toBeNull();
+    });
+    const shell = container.querySelector(
+      ".star-map-load-shell",
+    ) as HTMLElement;
+    const nearTop = Number.parseFloat(shell.style.top);
+
+    fireEvent.wheel(
+      container.querySelector(".star-map__viewport") as HTMLElement,
+      { deltaY: 240, ctrlKey: true, clientX: 400, clientY: 300 },
+    );
+
+    await waitFor(() => {
+      expect(
+        (container.querySelector(".star-map-load-shell") as HTMLElement).style
+          .transform,
+      ).toContain("scale(");
+    });
+    const far = container.querySelector(".star-map-load-shell") as HTMLElement;
+    const scale = Number(
+      /scale\(([\d.]+)\)/.exec(far.style.transform)![1],
+    );
+    expect(scale).toBeGreaterThan(1);
+    // Parked further out by the same factor, so the readout clears the
+    // instance that just grew underneath it instead of being buried.
+    expect(Number.parseFloat(far.style.top)).toBeCloseTo(nearTop * scale, 5);
+    // Same factor as the instance, so the two stay one readable group.
+    const anchor = container.querySelector(
+      ".star-map__anchor",
+    ) as HTMLElement;
+    expect(/scale\(([\d.]+)\)/.exec(anchor.style.transform)![1]).toBe(
+      String(scale),
+    );
+  });
+});
+
 describe("star map chat cards in map space", () => {
   afterEach(() => {
     window.localStorage.removeItem("pwragent.starMap.viewPreferences");

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -474,6 +474,43 @@ describe("star map load card in overview", () => {
   });
 });
 
+describe("clicking the sky releases focus back to the map", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("pwragent.starMap.viewPreferences");
+  });
+
+  it("takes focus off a chat composer so the flight keys work again", async () => {
+    // The pan's preventDefault suppresses the browser's default focus
+    // change, so a press on bare sky never blurred the composer (or a
+    // terminal) — the WASD guard kept seeing keys aimed at text, and the
+    // only way out was closing the map.
+    const { container } = renderOrbit([
+      projectThread("a1", "/repo/alpha", "AlphaDir"),
+      projectThread("a2", "/repo/alpha", "AlphaDir"),
+    ]);
+    await screen.findByRole("button", { name: /Open thread: Thread a1/ });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Open thread: Thread a1/ }),
+    );
+    const composer = (await screen.findByRole("textbox", {
+      name: /Message Thread a1/,
+    })) as HTMLTextAreaElement;
+    composer.focus();
+    expect(document.activeElement).toBe(composer);
+
+    fireEvent.pointerDown(
+      container.querySelector(".star-map__viewport") as HTMLElement,
+      { button: 0, clientX: 40, clientY: 600 },
+    );
+
+    // Focus lands on the map layer — where Escape and the flight keys
+    // already listen — not merely off the composer.
+    expect(document.activeElement).toBe(
+      container.querySelector(".star-map"),
+    );
+  });
+});
+
 describe("star map load card overview fixes", () => {
   afterEach(() => {
     window.localStorage.removeItem("pwragent.starMap.viewPreferences");


### PR DESCRIPTION
## Summary

Stacked on #1476.

- The overview zoom counter-scales the instance body so its name stays legible from far out. The load card was left behind, so pulling out **buried the readout underneath the body that had just grown over it** while it shrank to a speck. Whether a machine is busy is one of the few things worth reading from that distance, so it belongs in the group that survives the trip.
- The card now counter-scales by the same factor as the body and the cloud labels, and **its parking distance above the body scales with it**. That second half is what does the work: `offset * chromeScale * view.scale` is the offset itself, so in *screen* pixels the body and its readout render exactly as they do at zoom 1 — the arrangement that already clears.
- The scale applies about the card's own centre, which `marginLeft` and the existing `translateY(-50%)` have already put on the slot, so the card grows in place rather than sliding off its anchor.

## Verification

- 383 star-map tests pass (3 new). Component-level: the card carries the scale in its transform and keeps `translateY(-50%)` so it stays centred on its slot, and carries no scale at reading zoom. Screen-level: after a pinch-out the shell has a scale > 1, its `top` moves out by exactly that factor, and the factor is **identical** to the instance anchor's — so the two cannot drift into separate sizes.
- `typecheck`, `lint:eslint` (0 errors), `lint:colors` clean.

## Notes

- Base is the star map cluster branch, not `main` — review #1476 first.
- The same factor is deliberate across body, cloud labels, and now the load card: three counter-scales that could drift apart would stop reading as one system as the operator keeps pulling out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)