### PR TITLE
feat(desktop): star map card drawers and markdown cards

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -7,6 +7,8 @@ import {
   type CSSProperties,
   type PointerEvent as ReactPointerEvent,
 } from "react";
+import { ThreadContextPanel } from "../thread-detail/ThreadContextPanel";
+import type { ContextTabId } from "../thread-detail/context-panels/context-tab";
 import {
   buildThreadIdentityKey,
   type CelestialIconId,
@@ -55,6 +57,13 @@ export type StarMapChatCardProps = {
   zIndex: number;
 };
 
+/**
+ * How much wider a card gets while its context rail is open. Matches
+ * `RAIL_MIN_WIDTH` in ThreadContextPanel, so the rail renders at its own
+ * minimum rather than being squeezed below it.
+ */
+export const STAR_MAP_CHAT_CARD_RAIL_WIDTH = 300;
+
 type DragState = {
   kind: "move" | "resize";
   pointerId: number;
@@ -76,6 +85,18 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   const { bounds, cardKey, desktopApi, onOpenFull, onRaise, onRectChange, rect, scale, thread } =
     props;
   const dragRef = useRef<DragState | undefined>(undefined);
+  /**
+   * The context rail, opened from the title bar.
+   *
+   * View-local rather than synced: which tab you are reading is a "what am
+   * I looking at" gesture, the same call the map makes for cloud expansion
+   * and selection.
+   */
+  const [railTab, setRailTab] = useState<ContextTabId | undefined>(undefined);
+  // Read by callbacks that must not re-bind on every pointermove.
+  const rectRef = useRef(rect);
+  rectRef.current = rect;
+  const railOpen = railTab !== undefined;
   const [sendError, setSendError] = useState<string | undefined>(undefined);
   // The card is draggable and clipped; a native `title` fights both, and
   // UI-THEME.md rules it out regardless.
@@ -154,6 +175,37 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     [bounds, cardKey, onRectChange, scale],
   );
 
+  /**
+   * Open or close the rail, growing the card by the rail's width rather
+   * than taking that width out of the transcript.
+   *
+   * A 420px card minus a 300px rail leaves 120px of transcript, which is
+   * not a chat any more. Growing the card is also what the full thread
+   * view does, so the two surfaces read the same — and the new width is
+   * clamped to the canvas, so a card near the edge cannot grow off it.
+   */
+  const toggleRail = useCallback(() => {
+    // The width change is a side effect, so it stays OUT of the state
+    // updater: React may invoke an updater more than once for the same
+    // click, which would grow the card twice for one press.
+    const opening = railTab === undefined;
+    setRailTab(opening ? "info" : undefined);
+    onRectChange(
+      cardKey,
+      clampChatCardRect(
+        {
+          ...rectRef.current,
+          width:
+            rectRef.current.width
+            + (opening
+              ? STAR_MAP_CHAT_CARD_RAIL_WIDTH
+              : -STAR_MAP_CHAT_CARD_RAIL_WIDTH),
+        },
+        bounds,
+      ),
+    );
+  }, [bounds, cardKey, onRectChange, railTab]);
+
   const endDrag = useCallback((event: ReactPointerEvent) => {
     const drag = dragRef.current;
     if (!drag || drag.pointerId !== event.pointerId) return;
@@ -171,8 +223,6 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   // — so a card left outside the new bounds would be unreachable. Read
   // through a ref so this fires on a bounds change and not on every frame
   // of a drag.
-  const rectRef = useRef(rect);
-  rectRef.current = rect;
   useEffect(() => {
     const clamped = clampChatCardRect(rectRef.current, {
       width: bounds.width,
@@ -345,6 +395,22 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           </span>
         ) : undefined}
         <button
+          aria-expanded={railOpen}
+          aria-label={
+            railOpen
+              ? `Hide thread context for ${thread.title}`
+              : `Show thread context for ${thread.title}`
+          }
+          className={`star-map-chat-card__rail-toggle${
+            railOpen ? " is-on" : ""
+          }`}
+          onClick={() => toggleRail()}
+          onPointerDown={(event) => event.stopPropagation()}
+          type="button"
+        >
+          ⌸
+        </button>
+        <button
           aria-label={`Open ${thread.title} in the full thread view`}
           className="star-map-chat-card__expand"
           onClick={() => onOpenFull(thread)}
@@ -364,7 +430,26 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         </button>
       </header>
 
-      <div className="star-map-chat-card__transcript">
+      {railOpen ? (
+        // The rail anchors itself to the nearest positioned ancestor, which
+        // inside a card is the card — so it lands on the card's right edge,
+        // full height, exactly as it does against the thread view's layout.
+        // `pinned` because a card has no hover-reveal gutter to peek from.
+        <ThreadContextPanel
+          activeTab={railTab}
+          backends={[]}
+          desktopApi={desktopApi}
+          onActiveTabChange={setRailTab}
+          pinned
+          thread={thread}
+          width={STAR_MAP_CHAT_CARD_RAIL_WIDTH}
+        />
+      ) : null}
+      <div
+        className={`star-map-chat-card__transcript${
+          railOpen ? " star-map-chat-card__transcript--railed" : ""
+        }`}
+      >
         <TranscriptList
           activeTurnId={session.activeTurnId}
           activeTurnStartedAt={session.activeTurnStartedAt}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -7,8 +7,6 @@ import {
   type CSSProperties,
   type PointerEvent as ReactPointerEvent,
 } from "react";
-import { ThreadContextPanel } from "../thread-detail/ThreadContextPanel";
-import type { ContextTabId } from "../thread-detail/context-panels/context-tab";
 import {
   buildThreadIdentityKey,
   type CelestialIconId,
@@ -43,6 +41,11 @@ export type StarMapChatCardProps = {
   onOpenFull: (thread: NavigationThreadSummary) => void;
   onRaise: (cardKey: string) => void;
   onRectChange: (cardKey: string, rect: ChatCardRect) => void;
+  /** Satellite cards, docked to this card and owned by the controller. */
+  contextOpen?: boolean;
+  terminalOpen?: boolean;
+  onToggleContext: (cardKey: string) => void;
+  onToggleTerminal: (cardKey: string) => void;
   rect: ChatCardRect;
   /**
    * Canvas scale. The card lives IN the map, so a pointer that travels N
@@ -56,13 +59,6 @@ export type StarMapChatCardProps = {
   /** Stack position; the host owns the order, we only read our depth. */
   zIndex: number;
 };
-
-/**
- * How much wider a card gets while its context rail is open. Matches
- * `RAIL_MIN_WIDTH` in ThreadContextPanel, so the rail renders at its own
- * minimum rather than being squeezed below it.
- */
-export const STAR_MAP_CHAT_CARD_RAIL_WIDTH = 300;
 
 type DragState = {
   kind: "move" | "resize";
@@ -85,18 +81,9 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
   const { bounds, cardKey, desktopApi, onOpenFull, onRaise, onRectChange, rect, scale, thread } =
     props;
   const dragRef = useRef<DragState | undefined>(undefined);
-  /**
-   * The context rail, opened from the title bar.
-   *
-   * View-local rather than synced: which tab you are reading is a "what am
-   * I looking at" gesture, the same call the map makes for cloud expansion
-   * and selection.
-   */
-  const [railTab, setRailTab] = useState<ContextTabId | undefined>(undefined);
   // Read by callbacks that must not re-bind on every pointermove.
   const rectRef = useRef(rect);
   rectRef.current = rect;
-  const railOpen = railTab !== undefined;
   const [sendError, setSendError] = useState<string | undefined>(undefined);
   // The card is draggable and clipped; a native `title` fights both, and
   // UI-THEME.md rules it out regardless.
@@ -174,37 +161,6 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     },
     [bounds, cardKey, onRectChange, scale],
   );
-
-  /**
-   * Open or close the rail, growing the card by the rail's width rather
-   * than taking that width out of the transcript.
-   *
-   * A 420px card minus a 300px rail leaves 120px of transcript, which is
-   * not a chat any more. Growing the card is also what the full thread
-   * view does, so the two surfaces read the same — and the new width is
-   * clamped to the canvas, so a card near the edge cannot grow off it.
-   */
-  const toggleRail = useCallback(() => {
-    // The width change is a side effect, so it stays OUT of the state
-    // updater: React may invoke an updater more than once for the same
-    // click, which would grow the card twice for one press.
-    const opening = railTab === undefined;
-    setRailTab(opening ? "info" : undefined);
-    onRectChange(
-      cardKey,
-      clampChatCardRect(
-        {
-          ...rectRef.current,
-          width:
-            rectRef.current.width
-            + (opening
-              ? STAR_MAP_CHAT_CARD_RAIL_WIDTH
-              : -STAR_MAP_CHAT_CARD_RAIL_WIDTH),
-        },
-        bounds,
-      ),
-    );
-  }, [bounds, cardKey, onRectChange, railTab]);
 
   const endDrag = useCallback((event: ReactPointerEvent) => {
     const drag = dragRef.current;
@@ -395,20 +351,36 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
           </span>
         ) : undefined}
         <button
-          aria-expanded={railOpen}
+          aria-expanded={props.contextOpen ?? false}
           aria-label={
-            railOpen
+            props.contextOpen
               ? `Hide thread context for ${thread.title}`
               : `Show thread context for ${thread.title}`
           }
           className={`star-map-chat-card__rail-toggle${
-            railOpen ? " is-on" : ""
+            props.contextOpen ? " is-on" : ""
           }`}
-          onClick={() => toggleRail()}
+          onClick={() => props.onToggleContext(cardKey)}
           onPointerDown={(event) => event.stopPropagation()}
           type="button"
         >
           ⌸
+        </button>
+        <button
+          aria-expanded={props.terminalOpen ?? false}
+          aria-label={
+            props.terminalOpen
+              ? `Close terminal for ${thread.title}`
+              : `Open terminal for ${thread.title}`
+          }
+          className={`star-map-chat-card__rail-toggle${
+            props.terminalOpen ? " is-on" : ""
+          }`}
+          onClick={() => props.onToggleTerminal(cardKey)}
+          onPointerDown={(event) => event.stopPropagation()}
+          type="button"
+        >
+          &gt;_
         </button>
         <button
           aria-label={`Open ${thread.title} in the full thread view`}
@@ -430,26 +402,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
         </button>
       </header>
 
-      {railOpen ? (
-        // The rail anchors itself to the nearest positioned ancestor, which
-        // inside a card is the card — so it lands on the card's right edge,
-        // full height, exactly as it does against the thread view's layout.
-        // `pinned` because a card has no hover-reveal gutter to peek from.
-        <ThreadContextPanel
-          activeTab={railTab}
-          backends={[]}
-          desktopApi={desktopApi}
-          onActiveTabChange={setRailTab}
-          pinned
-          thread={thread}
-          width={STAR_MAP_CHAT_CARD_RAIL_WIDTH}
-        />
-      ) : null}
-      <div
-        className={`star-map-chat-card__transcript${
-          railOpen ? " star-map-chat-card__transcript--railed" : ""
-        }`}
-      >
+      <div className="star-map-chat-card__transcript">
         <TranscriptList
           activeTurnId={session.activeTurnId}
           activeTurnStartedAt={session.activeTurnStartedAt}

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
@@ -1,0 +1,150 @@
+import { lazy, Suspense, useState, type CSSProperties } from "react";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { readRendererFederationTarget } from "../../lib/federation-window";
+import { isRemoteFederationTarget } from "@pwragent/shared";
+import { ThreadContextPanel } from "../thread-detail/ThreadContextPanel";
+import type { ContextTabId } from "../thread-detail/context-panels/context-tab";
+import {
+  CHAT_CARD_TERMINAL_HEIGHT,
+  type ChatCardRect,
+} from "./star-map-chat-card-geometry";
+
+// Same lazy split the thread view uses: xterm is heavy and most map
+// sessions never open a shell.
+const LazyIntegratedTerminal = lazy(async () => {
+  const module = await import("../thread-detail/IntegratedTerminal");
+  return { default: module.IntegratedTerminal };
+});
+
+/**
+ * Satellite cards docked to a chat card: the thread context rail as a card
+ * on the host's right, and the thread's terminal as a card underneath.
+ *
+ * Deliberately cards rather than panes inside the host. A pane forced the
+ * host to grow, fight over who owned the transcript's width, and reserve a
+ * gutter; a satellite just sits next to it. Their rects derive from the
+ * host's on every render, which is what makes the group move as one when
+ * the host drags — there is no second position to keep in sync.
+ */
+export function StarMapContextCard(props: {
+  desktopApi?: DesktopApi;
+  thread: NavigationThreadSummary;
+  rect: ChatCardRect;
+  zIndex: number;
+  onClose: () => void;
+}) {
+  const [tab, setTab] = useState<ContextTabId>("info");
+  const style: CSSProperties = {
+    left: `${props.rect.left}px`,
+    top: `${props.rect.top}px`,
+    width: `${props.rect.width}px`,
+    height: `${props.rect.height}px`,
+    zIndex: props.zIndex,
+  };
+  return (
+    <section
+      aria-label={`Thread context: ${props.thread.title}`}
+      className="star-map-satellite-card star-map-context-card"
+      style={style}
+    >
+      <header className="star-map-satellite-card__bar">
+        <span className="star-map-satellite-card__title">Context</span>
+        <button
+          aria-label={`Close thread context for ${props.thread.title}`}
+          className="star-map-satellite-card__close"
+          onClick={props.onClose}
+          type="button"
+        >
+          ×
+        </button>
+      </header>
+      {/* The rail anchors to its nearest positioned ancestor; this body is
+          that ancestor, so the rail fills it edge to edge. */}
+      <div className="star-map-satellite-card__body">
+        <ThreadContextPanel
+          activeTab={tab}
+          backends={[]}
+          desktopApi={props.desktopApi}
+          onActiveTabChange={setTab}
+          pinned
+          thread={props.thread}
+          width={props.rect.width}
+        />
+      </div>
+    </section>
+  );
+}
+
+export function StarMapTerminalCard(props: {
+  desktopApi?: DesktopApi;
+  thread: NavigationThreadSummary;
+  threadKey: string;
+  rect: ChatCardRect;
+  zIndex: number;
+  onClose: () => void;
+  onHeightChange: (height: number) => void;
+}) {
+  const thread = props.thread;
+  const target = thread.federation?.ref.target ?? readRendererFederationTarget();
+  const primary = thread.linkedDirectories[0];
+  const style: CSSProperties = {
+    left: `${props.rect.left}px`,
+    top: `${props.rect.top}px`,
+    width: `${props.rect.width}px`,
+    height: `${props.rect.height}px`,
+    zIndex: props.zIndex,
+  };
+  return (
+    <section
+      aria-label={`Terminal: ${thread.title}`}
+      className="star-map-satellite-card star-map-terminal-card"
+      style={style}
+    >
+      <header className="star-map-satellite-card__bar">
+        <span className="star-map-satellite-card__title">Terminal</span>
+        <button
+          aria-label={`Close terminal for ${thread.title}`}
+          className="star-map-satellite-card__close"
+          onClick={props.onClose}
+          type="button"
+        >
+          ×
+        </button>
+      </header>
+      <div className="star-map-satellite-card__body">
+        <Suspense fallback={null}>
+          <LazyIntegratedTerminal
+            desktopApi={props.desktopApi}
+            threadKey={props.threadKey}
+            cwd={primary?.worktreePath ?? primary?.path}
+            remote={
+              target && isRemoteFederationTarget(target)
+                ? {
+                    target,
+                    instanceId: target.instanceId,
+                    instanceLabel:
+                      thread.federation?.instanceLabel ?? target.instanceId,
+                    celestialIcon: thread.federation?.celestialIcon,
+                  }
+                : undefined
+            }
+            height={props.rect.height - STAR_MAP_SATELLITE_BAR_HEIGHT}
+            onHeightChange={(height) =>
+              props.onHeightChange(height + STAR_MAP_SATELLITE_BAR_HEIGHT)
+            }
+            onClose={props.onClose}
+            onExit={props.onClose}
+          />
+        </Suspense>
+      </div>
+    </section>
+  );
+}
+
+/** Title bar height, shared with the terminal's inner height math. */
+export const STAR_MAP_SATELLITE_BAR_HEIGHT = 30;
+
+/** Default rect height for a fresh terminal card, bar included. */
+export const STAR_MAP_TERMINAL_CARD_HEIGHT =
+  CHAT_CARD_TERMINAL_HEIGHT + STAR_MAP_SATELLITE_BAR_HEIGHT;

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapSatelliteCards.tsx
@@ -6,6 +6,7 @@ import { isRemoteFederationTarget } from "@pwragent/shared";
 import { ThreadContextPanel } from "../thread-detail/ThreadContextPanel";
 import type { ContextTabId } from "../thread-detail/context-panels/context-tab";
 import {
+  CHAT_CARD_CONTEXT_SPINE_WIDTH,
   CHAT_CARD_TERMINAL_HEIGHT,
   type ChatCardRect,
 } from "./star-map-chat-card-geometry";
@@ -60,8 +61,22 @@ export function StarMapContextCard(props: {
         </button>
       </header>
       {/* The rail anchors to its nearest positioned ancestor; this body is
-          that ancestor, so the rail fills it edge to edge. */}
-      <div className="star-map-satellite-card__body">
+          that ancestor, so the rail fills it edge to edge. The panel sizes
+          itself from `--context-rail-effective`, which `.thread-view`
+          defines in the full app and nothing defines here — left unset it
+          fell back to 380px inside a 300px card, overflowing the body and
+          reading as a blank strip on the left. Pin it to the width this
+          card actually gives the panel: the card minus the tab spine. */}
+      <div
+        className="star-map-satellite-card__body"
+        style={
+          {
+            "--context-rail-effective": `${
+              props.rect.width - CHAT_CARD_CONTEXT_SPINE_WIDTH
+            }px`,
+          } as CSSProperties
+        }
+      >
         <ThreadContextPanel
           activeTab={tab}
           backends={[]}
@@ -69,7 +84,7 @@ export function StarMapContextCard(props: {
           onActiveTabChange={setTab}
           pinned
           thread={props.thread}
-          width={props.rect.width}
+          width={props.rect.width - CHAT_CARD_CONTEXT_SPINE_WIDTH}
         />
       </div>
     </section>

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -81,7 +81,16 @@ import { computeProjectLayout } from "./star-map-project-layout";
 import { StarMapProjectBody } from "./StarMapProjectBody";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { StarMapChatCard } from "./StarMapChatCard";
-import { chatCardEdgeToward } from "./star-map-chat-card-geometry";
+import {
+  StarMapContextCard,
+  StarMapTerminalCard,
+  STAR_MAP_TERMINAL_CARD_HEIGHT,
+} from "./StarMapSatelliteCards";
+import {
+  chatCardEdgeToward,
+  dockContextRect,
+  dockTerminalRect,
+} from "./star-map-chat-card-geometry";
 import type { StarMapCardMenuAction } from "./StarMapCardMenu";
 import { useStarMapChatCards } from "./useStarMapChatCards";
 import { IntakeDialog, type IntakeDialogTarget } from "./IntakeDialog";
@@ -2999,6 +3008,7 @@ export function StarMapScreen(props: StarMapScreenProps) {
             target && isRemoteFederationTarget(target)
               ? target.instanceId
               : undefined;
+          const cardZ = STAR_MAP_CHAT_CARD_BASE_Z + chatCards.depthOf(card.key);
           return (
             <StarMapChatCard
               key={card.key}
@@ -3018,10 +3028,55 @@ export function StarMapScreen(props: StarMapScreenProps) {
               thread={card.thread}
               scale={view.scale}
               bounds={panZoomCanvas}
-              zIndex={STAR_MAP_CHAT_CARD_BASE_Z + chatCards.depthOf(card.key)}
+              contextOpen={card.contextOpen}
+              terminalOpen={card.terminalOpen}
+              onToggleContext={chatCards.toggleContext}
+              onToggleTerminal={chatCards.toggleTerminal}
+              zIndex={cardZ}
             />
           );
         })}
+        {/* Satellites, docked to their hosts. Rects derive from the host's
+            on every render, so the group moves as one for free; they hide
+            with the thread cards in overview, where nothing card-sized is
+            readable anyway. */}
+        {overview
+          ? null
+          : chatCards.cards.map((card) => {
+              if (!card.contextOpen && !card.terminalOpen) return null;
+              const cardZ =
+                STAR_MAP_CHAT_CARD_BASE_Z + chatCards.depthOf(card.key);
+              return (
+                <div key={`satellites:${card.key}`}>
+                  {card.contextOpen ? (
+                    <StarMapContextCard
+                      desktopApi={props.desktopApi}
+                      thread={card.thread}
+                      rect={dockContextRect(card.rect)}
+                      zIndex={cardZ}
+                      onClose={() => chatCards.toggleContext(card.key)}
+                    />
+                  ) : null}
+                  {card.terminalOpen ? (
+                    <StarMapTerminalCard
+                      desktopApi={props.desktopApi}
+                      thread={card.thread}
+                      threadKey={card.key}
+                      rect={dockTerminalRect(card.rect, {
+                        contextOpen: card.contextOpen,
+                        height:
+                          card.terminalHeight ?? STAR_MAP_TERMINAL_CARD_HEIGHT,
+                      })}
+                      zIndex={cardZ}
+                      onClose={() => chatCards.toggleTerminal(card.key)}
+                      onHeightChange={(height) =>
+                        chatCards.setTerminalHeight(card.key, height)
+                      }
+                    />
+                  ) : null}
+                </div>
+              );
+            })}
         </div>
       </div>
       {intakeTarget ? (

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -1,12 +1,8 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
-import {
-  STAR_MAP_CHAT_CARD_RAIL_WIDTH,
-  StarMapChatCard,
-} from "../StarMapChatCard";
+import { StarMapChatCard } from "../StarMapChatCard";
 import {
   DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
   DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT,
@@ -84,6 +80,8 @@ function renderCard(params: {
       thread={params.thread}
       scale={1}
       bounds={{ width: 4000, height: 3000 }}
+      onToggleContext={() => undefined}
+      onToggleTerminal={() => undefined}
       zIndex={40}
     />,
   );
@@ -240,88 +238,69 @@ describe("StarMapChatCard send failures", () => {
   });
 });
 
-describe("context rail drawer", () => {
-  /**
-   * The screen owns a card's rect and feeds it back, so the harness does
-   * too — a static rect would let the card compute its next width from a
-   * stale one and hide exactly the bug that produces.
-   */
-  function RailHarness(props: { onWidth: (width: number) => void }) {
-    const [rect, setRect] = useState(RECT);
-    return (
+describe("satellite toggles", () => {
+  function renderToggleCard(props?: {
+    contextOpen?: boolean;
+    terminalOpen?: boolean;
+    onToggleContext?: (cardKey: string) => void;
+    onToggleTerminal?: (cardKey: string) => void;
+  }) {
+    return render(
       <StarMapChatCard
         cardKey="card-1"
         desktopApi={buildApi()}
         onClose={() => undefined}
         onOpenFull={() => undefined}
         onRaise={() => undefined}
-        onRectChange={(unused, next) => {
-          props.onWidth(next.width);
-          setRect(next);
-        }}
-        rect={rect}
+        onRectChange={() => undefined}
+        rect={RECT}
         scale={1}
         bounds={{ width: 4000, height: 3000 }}
         thread={localThread()}
+        contextOpen={props?.contextOpen}
+        terminalOpen={props?.terminalOpen}
+        onToggleContext={props?.onToggleContext ?? (() => undefined)}
+        onToggleTerminal={props?.onToggleTerminal ?? (() => undefined)}
         zIndex={40}
-      />
+      />,
     );
   }
 
-  function renderRailCard(onWidth: (width: number) => void = () => undefined) {
-    return render(<RailHarness onWidth={onWidth} />);
-  }
-
-  it("opens the thread context tabs beside the transcript", async () => {
-    const { container } = renderRailCard();
-    const toggle = screen.getByRole("button", {
-      name: /Show thread context/,
-    });
+  it("asks the controller for the context satellite, and reflects it", () => {
+    const onToggleContext = vi.fn();
+    renderToggleCard({ onToggleContext });
+    const toggle = screen.getByRole("button", { name: /Show thread context/ });
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
-    expect(container.querySelector(".context-rail")).toBeNull();
-
     fireEvent.click(toggle);
-
-    await waitFor(() => {
-      expect(container.querySelector(".context-rail")).not.toBeNull();
-    });
-    expect(
-      screen.getByRole("button", { name: /Hide thread context/ }),
-    ).toBeTruthy();
-    // The transcript reserves the gutter rather than sliding under the rail.
-    expect(
-      container.querySelector(".star-map-chat-card__transcript--railed"),
-    ).not.toBeNull();
+    expect(onToggleContext).toHaveBeenCalledWith("card-1");
   });
 
-  it("grows the card by the rail's width instead of squeezing the chat", async () => {
-    // 420 minus a 300px rail leaves 120px of transcript, which is not a
-    // chat any more.
-    const widths: number[] = [];
-    renderRailCard((width) => widths.push(width));
-
-    fireEvent.click(screen.getByRole("button", { name: /Show thread context/ }));
-    await waitFor(() => expect(widths).toHaveLength(1));
-    expect(widths[0]).toBe(RECT.width + STAR_MAP_CHAT_CARD_RAIL_WIDTH);
-
-    fireEvent.click(screen.getByRole("button", { name: /Hide thread context/ }));
-    await waitFor(() => expect(widths).toHaveLength(2));
-    expect(widths[1]).toBe(RECT.width);
+  it("names the open state once the satellite is up", () => {
+    renderToggleCard({ contextOpen: true, terminalOpen: true });
+    expect(
+      screen
+        .getByRole("button", { name: /Hide thread context/ })
+        .getAttribute("aria-expanded"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByRole("button", { name: /Close terminal/ })
+        .getAttribute("aria-expanded"),
+    ).toBe("true");
   });
 
-  it("closes the rail back down", async () => {
-    const { container } = renderRailCard();
-    fireEvent.click(screen.getByRole("button", { name: /Show thread context/ }));
-    await waitFor(() => {
-      expect(container.querySelector(".context-rail")).not.toBeNull();
-    });
+  it("asks the controller for the terminal satellite", () => {
+    const onToggleTerminal = vi.fn();
+    renderToggleCard({ onToggleTerminal });
+    fireEvent.click(screen.getByRole("button", { name: /Open terminal/ }));
+    expect(onToggleTerminal).toHaveBeenCalledWith("card-1");
+  });
 
-    fireEvent.click(screen.getByRole("button", { name: /Hide thread context/ }));
-    await waitFor(() => {
-      expect(container.querySelector(".context-rail")).toBeNull();
-    });
-    expect(
-      container.querySelector(".star-map-chat-card__transcript--railed"),
-    ).toBeNull();
+  it("keeps the satellites OUT of the card: no rail pane inside", () => {
+    // The first cut rendered ThreadContextPanel inside the card, which
+    // popped over the transcript instead of docking beside it. Satellites
+    // are the screen's to render; the card only carries the toggles.
+    const { container } = renderToggleCard({ contextOpen: true });
+    expect(container.querySelector(".context-rail")).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -1,8 +1,12 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
-import { StarMapChatCard } from "../StarMapChatCard";
+import {
+  STAR_MAP_CHAT_CARD_RAIL_WIDTH,
+  StarMapChatCard,
+} from "../StarMapChatCard";
 import {
   DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
   DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT,
@@ -233,5 +237,91 @@ describe("StarMapChatCard send failures", () => {
     expect(
       await screen.findByText("in flight", { ignore: "textarea" }),
     ).toBeTruthy();
+  });
+});
+
+describe("context rail drawer", () => {
+  /**
+   * The screen owns a card's rect and feeds it back, so the harness does
+   * too — a static rect would let the card compute its next width from a
+   * stale one and hide exactly the bug that produces.
+   */
+  function RailHarness(props: { onWidth: (width: number) => void }) {
+    const [rect, setRect] = useState(RECT);
+    return (
+      <StarMapChatCard
+        cardKey="card-1"
+        desktopApi={buildApi()}
+        onClose={() => undefined}
+        onOpenFull={() => undefined}
+        onRaise={() => undefined}
+        onRectChange={(unused, next) => {
+          props.onWidth(next.width);
+          setRect(next);
+        }}
+        rect={rect}
+        scale={1}
+        bounds={{ width: 4000, height: 3000 }}
+        thread={localThread()}
+        zIndex={40}
+      />
+    );
+  }
+
+  function renderRailCard(onWidth: (width: number) => void = () => undefined) {
+    return render(<RailHarness onWidth={onWidth} />);
+  }
+
+  it("opens the thread context tabs beside the transcript", async () => {
+    const { container } = renderRailCard();
+    const toggle = screen.getByRole("button", {
+      name: /Show thread context/,
+    });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector(".context-rail")).toBeNull();
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(container.querySelector(".context-rail")).not.toBeNull();
+    });
+    expect(
+      screen.getByRole("button", { name: /Hide thread context/ }),
+    ).toBeTruthy();
+    // The transcript reserves the gutter rather than sliding under the rail.
+    expect(
+      container.querySelector(".star-map-chat-card__transcript--railed"),
+    ).not.toBeNull();
+  });
+
+  it("grows the card by the rail's width instead of squeezing the chat", async () => {
+    // 420 minus a 300px rail leaves 120px of transcript, which is not a
+    // chat any more.
+    const widths: number[] = [];
+    renderRailCard((width) => widths.push(width));
+
+    fireEvent.click(screen.getByRole("button", { name: /Show thread context/ }));
+    await waitFor(() => expect(widths).toHaveLength(1));
+    expect(widths[0]).toBe(RECT.width + STAR_MAP_CHAT_CARD_RAIL_WIDTH);
+
+    fireEvent.click(screen.getByRole("button", { name: /Hide thread context/ }));
+    await waitFor(() => expect(widths).toHaveLength(2));
+    expect(widths[1]).toBe(RECT.width);
+  });
+
+  it("closes the rail back down", async () => {
+    const { container } = renderRailCard();
+    fireEvent.click(screen.getByRole("button", { name: /Show thread context/ }));
+    await waitFor(() => {
+      expect(container.querySelector(".context-rail")).not.toBeNull();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Hide thread context/ }));
+    await waitFor(() => {
+      expect(container.querySelector(".context-rail")).toBeNull();
+    });
+    expect(
+      container.querySelector(".star-map-chat-card__transcript--railed"),
+    ).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   CHAT_CARD_CASCADE_STEP,
   CHAT_CARD_CASCADE_WRAP,
+  CHAT_CARD_CONTEXT_SPINE_WIDTH,
   CHAT_CARD_CONTEXT_WIDTH,
   CHAT_CARD_DEFAULT_HEIGHT,
   CHAT_CARD_DEFAULT_WIDTH,
@@ -282,7 +283,11 @@ describe("satellite docking", () => {
     expect(rect.left).toBe(host.left + host.width + CHAT_CARD_DOCK_GAP);
     expect(rect.top).toBe(host.top);
     expect(rect.height).toBe(host.height);
-    expect(rect.width).toBe(CHAT_CARD_CONTEXT_WIDTH);
+    // Panel plus the always-visible tab spine: the rail's panel sizes
+    // itself, and a panel-only card left its 48px misfit as a blank strip.
+    expect(rect.width).toBe(
+      CHAT_CARD_CONTEXT_WIDTH + CHAT_CARD_CONTEXT_SPINE_WIDTH,
+    );
   });
 
   it("docks the terminal under the host at the host's width", () => {
@@ -295,7 +300,10 @@ describe("satellite docking", () => {
   it("spans the whole group when the context card is open", () => {
     const rect = dockTerminalRect(host, { contextOpen: true });
     expect(rect.width).toBe(
-      host.width + CHAT_CARD_DOCK_GAP + CHAT_CARD_CONTEXT_WIDTH,
+      host.width
+      + CHAT_CARD_DOCK_GAP
+      + CHAT_CARD_CONTEXT_WIDTH
+      + CHAT_CARD_CONTEXT_SPINE_WIDTH,
     );
   });
 

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-chat-card-geometry.test.ts
@@ -2,13 +2,17 @@ import { describe, expect, it } from "vitest";
 import {
   CHAT_CARD_CASCADE_STEP,
   CHAT_CARD_CASCADE_WRAP,
+  CHAT_CARD_CONTEXT_WIDTH,
   CHAT_CARD_DEFAULT_HEIGHT,
   CHAT_CARD_DEFAULT_WIDTH,
+  CHAT_CARD_DOCK_GAP,
   CHAT_CARD_MIN_HEIGHT,
   CHAT_CARD_MIN_WIDTH,
   cascadeChatCardRect,
   chatCardEdgeToward,
   clampChatCardRect,
+  dockContextRect,
+  dockTerminalRect,
   placeChatCardBesideAnchor,
   raiseChatCard,
   resizeChatCardRect,
@@ -267,5 +271,39 @@ describe("chatCardEdgeToward", () => {
       x: 200,
       y: 150,
     });
+  });
+});
+
+describe("satellite docking", () => {
+  const host = { left: 500, top: 400, width: 420, height: 520 };
+
+  it("docks the context card on the host's right edge, matching height", () => {
+    const rect = dockContextRect(host);
+    expect(rect.left).toBe(host.left + host.width + CHAT_CARD_DOCK_GAP);
+    expect(rect.top).toBe(host.top);
+    expect(rect.height).toBe(host.height);
+    expect(rect.width).toBe(CHAT_CARD_CONTEXT_WIDTH);
+  });
+
+  it("docks the terminal under the host at the host's width", () => {
+    const rect = dockTerminalRect(host);
+    expect(rect.left).toBe(host.left);
+    expect(rect.top).toBe(host.top + host.height + CHAT_CARD_DOCK_GAP);
+    expect(rect.width).toBe(host.width);
+  });
+
+  it("spans the whole group when the context card is open", () => {
+    const rect = dockTerminalRect(host, { contextOpen: true });
+    expect(rect.width).toBe(
+      host.width + CHAT_CARD_DOCK_GAP + CHAT_CARD_CONTEXT_WIDTH,
+    );
+  });
+
+  it("derives from the host, so a moved host moves the whole group", () => {
+    const moved = { ...host, left: host.left + 300, top: host.top - 120 };
+    const before = dockContextRect(host);
+    const after = dockContextRect(moved);
+    expect(after.left - before.left).toBe(300);
+    expect(after.top - before.top).toBe(-120);
   });
 });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -565,6 +565,49 @@ describe("star map chat cards in map space", () => {
     });
   });
 
+  it("docks satellite cards to their chat card as one group", async () => {
+    const { container } = renderOrbit([
+      projectThread("a1", "/repo/alpha", "AlphaDir"),
+      projectThread("a2", "/repo/alpha", "AlphaDir"),
+    ]);
+    await screen.findByRole("button", { name: /Open thread: Thread a1/ });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Open thread: Thread a1/ }),
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-chat-card")).not.toBeNull();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show thread context/ }),
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-context-card")).not.toBeNull();
+    });
+
+    // Docked, not overlapping: the satellite starts past the host's right
+    // edge, top-aligned. Both live INSIDE the canvas so they pan together.
+    const chat = container.querySelector(".star-map-chat-card") as HTMLElement;
+    const satellite = container.querySelector(
+      ".star-map-context-card",
+    ) as HTMLElement;
+    expect(
+      container.querySelector(".star-map__canvas .star-map-context-card"),
+    ).not.toBeNull();
+    expect(Number.parseFloat(satellite.style.left)).toBeGreaterThan(
+      Number.parseFloat(chat.style.left) + Number.parseFloat(chat.style.width),
+    );
+    expect(satellite.style.top).toBe(chat.style.top);
+
+    // It closes from its own title bar too.
+    fireEvent.click(
+      screen.getByRole("button", { name: /Close thread context/ }),
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".star-map-context-card")).toBeNull();
+    });
+  });
+
   it("draws no tether when the thread has no card on the map", async () => {
     const { container, rerenderThreads } = renderOrbit([
       projectThread("a1", "/repo/alpha", "AlphaDir"),

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-cluster-chrome.test.tsx
@@ -752,6 +752,16 @@ describe("star map chat cards in map space", () => {
     );
     expect(satellite.style.top).toBe(chat.style.top);
 
+    // The panel fills the card it was given: the width var is pinned to
+    // card-minus-spine, so the 380px fallback cannot overflow and leave a
+    // blank strip where the misfit was clipped.
+    const body = satellite.querySelector(
+      ".star-map-satellite-card__body",
+    ) as HTMLElement;
+    expect(body.style.getPropertyValue("--context-rail-effective")).toBe(
+      `${Number.parseFloat(satellite.style.width) - 48}px`,
+    );
+
     // It closes from its own title bar too.
     fireEvent.click(
       screen.getByRole("button", { name: /Close thread context/ }),

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-css.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-satellite-css.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  CHAT_CARD_CONTEXT_SPINE_WIDTH,
+  CHAT_CARD_CONTEXT_WIDTH,
+  dockContextRect,
+} from "../star-map-chat-card-geometry";
+
+/**
+ * The satellite context card hosts ThreadContextPanel, whose geometry is
+ * governed by CSS the component tests cannot see — jsdom loads no
+ * stylesheet, which is exactly how "panel falls back to 380px in a 300px
+ * card" and "the rail's 32px peek margin squeezes out the tab spine"
+ * both shipped past a green suite. These assertions read app.css the way
+ * star-map-z-layers.test.ts does, so the contract at least cannot
+ * silently disappear.
+ */
+const CSS = readFileSync(
+  path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../styles/app.css",
+  ),
+  "utf8",
+);
+
+describe("satellite context card CSS contract", () => {
+  it("lets the rail fill the card, overriding its thread-view peek margin", () => {
+    // .context-rail caps itself at calc(100% - 32px) so the thread view
+    // keeps a hover-peek gutter. The satellite card is sized to
+    // panel + spine EXACTLY, so that cap left a 32px dead strip on the
+    // left and pushed the tab spine past the card's clip on the right.
+    expect(
+      /\.star-map-satellite-card__body \.context-rail \{[^}]*max-width:\s*100%/.test(
+        CSS,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps the spine constant in sync with the rail's spine width", () => {
+    const spine = /\.context-rail__spine \{[^}]*flex: 0 0 (\d+)px/.exec(CSS);
+    expect(spine).not.toBeNull();
+    expect(Number(spine![1])).toBe(CHAT_CARD_CONTEXT_SPINE_WIDTH);
+  });
+
+  it("sizes the dock rect for both rail columns", () => {
+    const rect = dockContextRect({ left: 0, top: 0, width: 420, height: 520 });
+    expect(rect.width).toBe(
+      CHAT_CARD_CONTEXT_WIDTH + CHAT_CARD_CONTEXT_SPINE_WIDTH,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-chat-card-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-chat-card-geometry.ts
@@ -215,8 +215,16 @@ export function chatCardEdgeToward(
 
 /** Gap between a chat card and a satellite docked to it. */
 export const CHAT_CARD_DOCK_GAP = 12;
-/** Width of the docked context card; matches the rail's own minimum. */
+/** Panel width inside the docked context card; the rail's own minimum. */
 export const CHAT_CARD_CONTEXT_WIDTH = 300;
+/**
+ * The rail's always-visible tab spine, to the right of its panel. The
+ * card has to be panel + spine wide: the panel sizes itself from a CSS
+ * var (`--context-rail-effective`) that nothing inside a card defines,
+ * so its 380px fallback overflowed a panel-only card and left the
+ * misfit as a blank strip on the card's left edge.
+ */
+export const CHAT_CARD_CONTEXT_SPINE_WIDTH = 48;
 /** Default height of the docked terminal card. */
 export const CHAT_CARD_TERMINAL_HEIGHT = 260;
 
@@ -229,7 +237,7 @@ export function dockContextRect(host: ChatCardRect): ChatCardRect {
   return {
     left: host.left + host.width + CHAT_CARD_DOCK_GAP,
     top: host.top,
-    width: CHAT_CARD_CONTEXT_WIDTH,
+    width: CHAT_CARD_CONTEXT_WIDTH + CHAT_CARD_CONTEXT_SPINE_WIDTH,
     height: host.height,
   };
 }
@@ -244,7 +252,10 @@ export function dockTerminalRect(
   options?: { contextOpen?: boolean; height?: number },
 ): ChatCardRect {
   const width = options?.contextOpen
-    ? host.width + CHAT_CARD_DOCK_GAP + CHAT_CARD_CONTEXT_WIDTH
+    ? host.width
+      + CHAT_CARD_DOCK_GAP
+      + CHAT_CARD_CONTEXT_WIDTH
+      + CHAT_CARD_CONTEXT_SPINE_WIDTH
     : host.width;
   return {
     left: host.left,

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-chat-card-geometry.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-chat-card-geometry.ts
@@ -212,3 +212,44 @@ export function chatCardEdgeToward(
   const scale = Math.min(scaleX, scaleY);
   return { x: centerX + dx * scale, y: centerY + dy * scale };
 }
+
+/** Gap between a chat card and a satellite docked to it. */
+export const CHAT_CARD_DOCK_GAP = 12;
+/** Width of the docked context card; matches the rail's own minimum. */
+export const CHAT_CARD_CONTEXT_WIDTH = 300;
+/** Default height of the docked terminal card. */
+export const CHAT_CARD_TERMINAL_HEIGHT = 260;
+
+/**
+ * Where a chat card's context satellite docks: on the host's right edge,
+ * top-aligned, matching its height — the same posture the rail has in the
+ * full thread view, as its own card instead of a pane inside the host.
+ */
+export function dockContextRect(host: ChatCardRect): ChatCardRect {
+  return {
+    left: host.left + host.width + CHAT_CARD_DOCK_GAP,
+    top: host.top,
+    width: CHAT_CARD_CONTEXT_WIDTH,
+    height: host.height,
+  };
+}
+
+/**
+ * Where a chat card's terminal satellite docks: under the host, spanning
+ * the whole group — host plus context card when that is open — so the
+ * group reads as one object with a work surface along its bottom edge.
+ */
+export function dockTerminalRect(
+  host: ChatCardRect,
+  options?: { contextOpen?: boolean; height?: number },
+): ChatCardRect {
+  const width = options?.contextOpen
+    ? host.width + CHAT_CARD_DOCK_GAP + CHAT_CARD_CONTEXT_WIDTH
+    : host.width;
+  return {
+    left: host.left,
+    top: host.top + host.height + CHAT_CARD_DOCK_GAP,
+    width,
+    height: options?.height ?? CHAT_CARD_TERMINAL_HEIGHT,
+  };
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-keyboard.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-keyboard.ts
@@ -156,7 +156,8 @@ export function isStarMapTypingTarget(target: EventTarget | null): boolean {
   if (target instanceof HTMLElement && target.isContentEditable) return true;
   return Boolean(
     target.closest(
-      "input, textarea, select, [contenteditable], [role='dialog'], .star-map-chat-card",
+      "input, textarea, select, [contenteditable], [role='dialog'],"
+        + " .star-map-chat-card, .star-map-satellite-card",
     ),
   );
 }

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-orbit.ts
@@ -432,13 +432,15 @@ export function computeOrbitPlacement(params: {
  */
 export function shouldPanOnWheel(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return true;
-  return !target.closest(".star-map-chat-card");
+  // Satellites scroll too: the context rail's panels and the terminal's
+  // buffer both own their wheel.
+  return !target.closest(".star-map-chat-card, .star-map-satellite-card");
 }
 
 export function shouldStartCanvasPan(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
   return !target.closest(
     "button, a, input, label, .star-map-card-shell, .star-map-chat-card,"
-      + " .star-map__chrome, .star-map__filters",
+      + " .star-map-satellite-card, .star-map__chrome, .star-map__filters",
   );
 }

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapChatCards.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapChatCards.ts
@@ -14,6 +14,12 @@ export type StarMapChatCardEntry = {
   key: string;
   rect: ChatCardRect;
   thread: NavigationThreadSummary;
+  /** The context satellite card is open, docked to the right. */
+  contextOpen?: boolean;
+  /** The terminal satellite card is open, docked below. */
+  terminalOpen?: boolean;
+  /** Operator-resized terminal height; the dock geometry supplies a default. */
+  terminalHeight?: number;
 };
 
 export type StarMapChatCardsController = {
@@ -37,6 +43,11 @@ export type StarMapChatCardsController = {
   ) => void;
   raise: (cardKey: string) => void;
   setRect: (cardKey: string, rect: ChatCardRect) => void;
+  /** Open/close the satellites. They live on the entry, so closing the
+   * chat card closes its whole group for free. */
+  toggleContext: (cardKey: string) => void;
+  toggleTerminal: (cardKey: string) => void;
+  setTerminalHeight: (cardKey: string, height: number) => void;
 };
 
 function viewportSize(): { width: number; height: number } {
@@ -110,6 +121,37 @@ export function useStarMapChatCards(): StarMapChatCardsController {
     );
   }, []);
 
+  const toggleContext = useCallback((cardKey: string) => {
+    setCards((current) =>
+      current.map((card) =>
+        card.key === cardKey
+          ? { ...card, contextOpen: !card.contextOpen }
+          : card,
+      ),
+    );
+  }, []);
+
+  const toggleTerminal = useCallback((cardKey: string) => {
+    setCards((current) =>
+      current.map((card) =>
+        card.key === cardKey
+          ? { ...card, terminalOpen: !card.terminalOpen }
+          : card,
+      ),
+    );
+  }, []);
+
+  const setTerminalHeight = useCallback(
+    (cardKey: string, height: number) => {
+      setCards((current) =>
+        current.map((card) =>
+          card.key === cardKey ? { ...card, terminalHeight: height } : card,
+        ),
+      );
+    },
+    [],
+  );
+
   const depthOf = useCallback(
     (cardKey: string) => {
       const index = order.indexOf(cardKey);
@@ -118,5 +160,16 @@ export function useStarMapChatCards(): StarMapChatCardsController {
     [order],
   );
 
-  return { cards, close, closeAll, depthOf, open, raise, setRect };
+  return {
+    cards,
+    close,
+    closeAll,
+    depthOf,
+    open,
+    raise,
+    setRect,
+    setTerminalHeight,
+    toggleContext,
+    toggleTerminal,
+  };
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -24928,3 +24928,40 @@ a.transcript-message__messaging-origin:focus-visible {
   border-color: var(--accent-border);
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent);
 }
+
+/* Context rail drawer on a star map chat card. The rail positions itself
+   against the nearest positioned ancestor — inside a card that is the
+   card — so it needs no placement here, only a gutter so the transcript
+   stops where the rail starts. The card grows by the rail's width when it
+   opens, so the transcript keeps the width it had. */
+.star-map-chat-card__transcript--railed {
+  padding-right: 300px;
+}
+
+.star-map-chat-card__rail-toggle {
+  flex: 0 0 auto;
+  padding: 2px 7px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.star-map-chat-card__rail-toggle:hover {
+  border-color: var(--border-subtle);
+  color: var(--text-primary);
+}
+
+.star-map-chat-card__rail-toggle.is-on {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+
+.star-map-chat-card__rail-toggle:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -24929,15 +24929,6 @@ a.transcript-message__messaging-origin:focus-visible {
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent);
 }
 
-/* Context rail drawer on a star map chat card. The rail positions itself
-   against the nearest positioned ancestor — inside a card that is the
-   card — so it needs no placement here, only a gutter so the transcript
-   stops where the rail starts. The card grows by the rail's width when it
-   opens, so the transcript keeps the width it had. */
-.star-map-chat-card__transcript--railed {
-  padding-right: 300px;
-}
-
 .star-map-chat-card__rail-toggle {
   flex: 0 0 auto;
   padding: 2px 7px;
@@ -24964,4 +24955,67 @@ a.transcript-message__messaging-origin:focus-visible {
 .star-map-chat-card__rail-toggle:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 1px;
+}
+
+/* Satellite cards docked to a chat card: the context rail and the
+   terminal as cards of their own, sharing the chat card's surface
+   language. Their rects derive from the host, so there is no drag
+   affordance here — the host's title bar moves the group. */
+.star-map-satellite-card {
+  display: flex;
+  position: absolute;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-popover);
+  color: var(--text-primary);
+}
+
+.star-map-satellite-card__bar {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  height: 30px;
+  padding: 0 10px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.star-map-satellite-card__title {
+  flex: 1;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.star-map-satellite-card__close {
+  flex: 0 0 auto;
+  padding: 0 4px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.star-map-satellite-card__close:hover {
+  color: var(--text-primary);
+}
+
+.star-map-satellite-card__close:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+/* The rail positions against its nearest positioned ancestor. */
+.star-map-satellite-card__body {
+  position: relative;
+  flex: 1;
+  min-height: 0;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -25019,3 +25019,13 @@ a.transcript-message__messaging-origin:focus-visible {
   flex: 1;
   min-height: 0;
 }
+
+/* The rail's own max-width keeps a 32px peek margin in the thread view.
+   Inside a satellite card that margin is the bug: the card is sized to
+   panel + spine exactly, so the cap squeezed the rail 32px narrower than
+   its no-shrink children — a blank strip on the card's left, and the tab
+   spine shoved out past the card's clip on the right. The card IS the
+   rail's whole world here; it gets all of it. */
+.star-map-satellite-card__body .context-rail {
+  max-width: 100%;
+}

--- a/docs/plans/2026-08-11-001-feat-star-map-card-drawers-plan.md
+++ b/docs/plans/2026-08-11-001-feat-star-map-card-drawers-plan.md
@@ -1,0 +1,137 @@
+# Star Map Card Drawers and Markdown Cards — Implementation Plan
+
+- **Date**: 2026-08-11
+- **Branch**: `claude/star-map-card-drawers`
+- **Base**: `claude/star-map-load-card-overview` (#1485), itself stacked on
+  `claude/star-map-card-grouping-dca8d7` (#1476)
+- **Predecessor**: [2026-08-06-001-feat-star-map-chat-cards-plan.md](2026-08-06-001-feat-star-map-chat-cards-plan.md)
+- **Issue**: [#1481](https://github.com/pwrdrvr/PwrAgent/issues/1481)
+
+## Operator requirement
+
+Three asks, all from driving the map in #1476:
+
+> I think we need to be able to click a little "right bar open" on these
+> chats that opens the right bar tabs next to the chat so I can see like
+> what sub-agents, what cost, what dates was it opened.. you know... the
+> whole nine yards.
+
+> Oh oh oh... and give me a open the bottom edge to get my PTY!!!
+
+> If we didn't already do "open this MD file" viewer in star map we should
+> do that... should be a card like the chats.
+
+## Where this starts from
+
+#1476 made chat cards objects **in** the galaxy: they render inside
+`.star-map__canvas`, pan and zoom with it, open beside the thread card they
+belong to, and tether back to it. Three separate bugs came out of that one
+change, all the same shape — the canvas's global handlers started seeing
+chat card events:
+
+| Handler | Symptom | Fix |
+|---|---|---|
+| `startCanvasPan` | Dragging a card dragged the galaxy too | `.star-map-chat-card` named in `shouldStartCanvasPan` |
+| viewport `wheel` | Scrolling a transcript panned the map | `shouldPanOnWheel`, with pinch deliberately exempt |
+| WASD flight (#1477) | Typing `w` would fly the camera | already guarded upstream |
+
+**Assume the fourth exists.** Anything added here that grows a new
+interactive surface inside the canvas — a rail with its own scroll, a
+terminal that wants every keystroke — should be checked against every
+global handler on the viewport before it is called done.
+
+## Item 1 — Context rail drawer (right edge)
+
+A toggle in the chat card's title bar opens the existing
+`ThreadContextPanel` tabs beside the transcript: thread info, pricing,
+sub-agents, edits, tool calls, PRs, linked projects, actions.
+
+**Reuse `ThreadContextPanel`.** Of its ~40 props only four are required
+(`backends`, `pinned`, `activeTab`, `onActiveTabChange`), and the panels
+largely fetch their own data from `desktopApi`, so a first pass should
+light up most tabs from `thread` + `desktopApi` alone. Tabs that stay
+empty because their data is threaded down from `ThreadView` are a second
+pass, not a blocker.
+
+### The part that is not a lift
+
+The rail is a **controlled** component in `ThreadView`: width lives on
+`.thread-view` as `--context-rail-width`, and the chat column and header
+reserve the derived `--context-rail-effective`. A chat card is a floating
+object with its own bounds and no header, so it needs its own width source
+and its own reserved gutter. This is the actual work.
+
+### Decide before building
+
+- **Widen the card, or narrow its transcript?** Widening reads better and
+  matches the full thread view, but it changes the card's rect — which the
+  tether (`chatTethers` in `StarMapScreen`) and the overlap step in
+  `placeChatCardBesideAnchor` both read. Narrowing keeps the rect still and
+  costs transcript width, which is the thing the card exists to show.
+- `RAIL_MIN_WIDTH` is 300px against a 420px default card. A widened card is
+  720px+ in canvas units; check what that looks like at 0.5 zoom, where the
+  overview threshold sits.
+
+## Item 2 — PTY drawer (bottom edge)
+
+Drag or click the card's bottom edge open to get the thread's integrated
+terminal, reusing `IntegratedTerminal` from `thread-detail`.
+
+**Test the terminal under a scale transform on day one, before any drawer
+UI exists.** Chat cards live inside the zoomed canvas; xterm sizes by
+character cells measured in pixels, and a mismeasure inside a scaled
+ancestor changes the whole approach — counter-scale the drawer, or gate it
+to zoom 1. This is the highest-risk unknown in the issue and it is cheap to
+answer with a throwaway spike.
+
+Also decide what a terminal at 0.4 zoom should do. It is probably
+unreadable; "looks bad and that is accepted" is a legitimate answer, but it
+should be a decision rather than a discovery.
+
+## Item 3 — Markdown cards
+
+There is no markdown viewer on the map today —
+`MarkdownFilesWindow` in `thread-detail` is a separate window, not a card.
+Open an `.md` file as a card like the chats: same drag, same resize, same
+canvas anchoring, same tether treatment where it has a thread to tether to.
+
+Most of the machinery already exists and should be shared rather than
+copied:
+
+- `useStarMapChatCards` owns the open set, cascade/anchored placement,
+  z-order and raise. A markdown card is another entry in that model, not a
+  parallel one — expect to generalize the entry type rather than fork the
+  hook.
+- `star-map-chat-card-geometry.ts` is already pure and card-kind agnostic:
+  `placeChatCardBesideAnchor`, `clampChatCardRect`, `resizeChatCardRect`,
+  `chatCardEdgeToward`.
+- `ThreadMarkdown` renders the content.
+
+Open question: what opens one? Candidates are a card kebab entry on a
+thread whose worktree has markdown files, the intake dialog, and drag-drop
+onto the canvas. Not decided here.
+
+## Sequencing
+
+1. **Rail drawer.** Lowest risk, and it forces the card-rect question that
+   the PTY drawer also depends on.
+2. **PTY drawer**, after the xterm-under-scale spike answers whether it is
+   a drawer or a zoom-gated drawer.
+3. **Markdown cards.** Independent of both; can be pulled forward if the
+   drawers stall on the rect decision.
+
+## Testing notes
+
+Traps that have already cost time on this surface:
+
+- Run the suite under the repo's pinned Node (24.14.1). Under Node 26 the
+  whole vitest run fails with bogus `localStorage` errors.
+- Re-query elements at click time in star map screen tests
+  (`await screen.findByRole(...)` then `fireEvent.click(screen.getByRole(...))`).
+  The map re-renders on card measurement, and a node captured across an
+  `await` is detached — the click silently does nothing.
+- Wait for federation health before asserting anything about a selection:
+  card keys name their instance, and the map drops a selection swept
+  against the placeholder id when the durable one lands.
+- Do not run the Electron/Playwright E2E suite on the operator's Mac; use
+  the PwrSuiteLab macOS Tart guest.


### PR DESCRIPTION
## Summary

Third in the stack: #1476 → #1485 → this. Tracks #1481. The plan is committed at [docs/plans/2026-08-11-001-feat-star-map-card-drawers-plan.md](https://github.com/pwrdrvr/PwrAgent/blob/claude/star-map-card-drawers/docs/plans/2026-08-11-001-feat-star-map-card-drawers-plan.md).

**Satellite cards docked to a chat card** — the sidebar's contents and a terminal as cards of their own, not panes inside the host:

- **Context card** docks on the host's right edge, top-aligned, matching its height. Reuses `ThreadContextPanel` (info, pricing, sub-agents, edits, tool calls, PRs); the panel anchors to the card's body and fills it, so it needed no placement code.
- **Terminal card** docks underneath, spanning the whole group (host + context when open), hosting the thread's `IntegratedTerminal` — local or remote — with the same lazy split the thread view uses.
- Satellite rects **derive from the host's rect every render**: dragging the host moves the group with no second position to sync; closing the host closes its satellites for free. Toggles live in the chat card's title bar (⌸ and `>_`); each satellite also closes from its own bar.
- Satellites hide with the thread cards in overview zoom.

An intermediate commit on this branch built the context rail as a pane *inside* the card; it was reviewed in the running app and rejected (popped over the transcript), and this replaces it. Both commits are kept so the pane→satellite decision is visible in history.

## Verification

- **The plan's highest-risk unknown is spiked, not assumed**: headless Chromium with this repo's exact xterm 6 + FitAddon 0.11 (DOM renderer) inside ancestor `scale(0.5)`/`scale(2)` shows fit and char measurement are layout-based — identical cols/rows/cell metrics at every scale, no overflow, and no refit needed when the transform changes. "Exact characters up close, scaled far out" falls out for free; no zoom gate, no counter-scale machinery.
- 392 star-map tests pass (12 new): dock geometry (right-dock, under-dock, group-spanning width, moved-host-moves-group), card toggles (controller calls, aria-expanded, no rail pane inside the card), and a screen-level test that the satellite docks past the host's right edge inside the canvas and closes from its own title bar.
- `typecheck`, `lint:eslint` (0 errors), `lint:colors`, `lint:boundaries` clean.

## Notes

- **The predicted fourth "canvas handler sees card events" bug is pre-empted rather than shipped**: satellites are named in `shouldStartCanvasPan` (drag), `shouldPanOnWheel` (rail panels and terminal buffer own their scroll), and `isStarMapTypingTarget` (keys typed at a shell must not fly the WASD camera).
- One PTY per thread, matching the existing session model (`createIntegratedTerminal` is keyed by threadKey); the tab-per-PTY strip from the design needs multi-session support in the terminal layer first and is deferred.
- Markdown cards (item 3 of the plan) are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)