### PR TITLE
fix(desktop): reap Windows git worktree removal

### DIFF
--- a/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
@@ -18,8 +18,7 @@ function toForwardSlashes(value: string): string {
 }
 
 async function git(cwd: string, args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync("git", args, {
-    cwd,
+  const { stdout } = await execFileAsync("git", ["-C", cwd, ...args], {
     encoding: "utf8",
     maxBuffer: 1024 * 1024 * 10,
   });
@@ -66,7 +65,7 @@ async function createRepo(): Promise<string> {
 afterEach(async () => {
   await Promise.all(
     cleanupPaths.splice(0).map((target) =>
-      rm(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }),
+      rm(target, { recursive: true, force: true }),
     ),
   );
 });

--- a/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
+++ b/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
@@ -15,6 +15,7 @@ import {
   WINDOWS_JOB_STARTUP_PROGRESS_TIMEOUT_MS,
   wrapCommandInWindowsJob,
 } from "../windows-job-wrapper";
+import { runGitCommand } from "../app-server/git-executable";
 import { resolveWindowsBashShell } from "../windows-shell";
 
 function decodeBase64(value: string): string {
@@ -22,7 +23,7 @@ function decodeBase64(value: string): string {
 }
 
 async function runWrappedCommand(params: {
-  args: [string, string];
+  args: string[];
   command: string;
   cwd: string;
 }): Promise<{
@@ -106,16 +107,16 @@ describe("wrapCommandInWindowsJob", () => {
       "C:\\Program Files\\Git\\usr\\bin\\bash.exe",
     );
     expect(
-      decodeBase64(wrapped.env.PWRAGENT_JOB_WRAPPER_ARGUMENT_0!),
-    ).toBe("-lc");
-    expect(
-      decodeBase64(wrapped.env.PWRAGENT_JOB_WRAPPER_ARGUMENT_1!),
-    ).toBe(
+      JSON.parse(
+        decodeBase64(wrapped.env.PWRAGENT_JOB_WRAPPER_ARGUMENTS!),
+      ),
+    ).toEqual([
+      "-lc",
       [
         "trap 'pwragent_exit=$?; trap - EXIT; set +e; pwragent_exit_file=$(/usr/bin/cygpath.exe -u \"$PWRAGENT_JOB_WRAPPER_EXIT_FILE\"); if [ -n \"$pwragent_exit_file\" ]; then printf \"%s\" \"$pwragent_exit\" > \"$pwragent_exit_file\"; fi; exit \"$pwragent_exit\"' EXIT",
         command,
       ].join("\n"),
-    );
+    ]);
     expect(wrapped.env.PWRAGENT_JOB_WRAPPER_CWD).toBe("C:\\work tree");
     expect(wrapped.env.PWRAGENT_JOB_WRAPPER_READY_FILE).toBe(
       wrapped.readyFilePath,
@@ -136,6 +137,29 @@ describe("wrapCommandInWindowsJob", () => {
       PATH: "C:\\tools",
       SystemRoot: "C:\\Windows",
     });
+    wrapped.cleanup();
+  });
+
+  it("preserves a native command's complete argument vector", () => {
+    const args = [
+      "-C",
+      "C:\\repo with spaces",
+      "worktree",
+      "remove",
+      "--force",
+      "C:\\worktrees\\feature with spaces",
+    ];
+    const wrapped = wrapCommandInWindowsJob({
+      args,
+      command: "C:\\Program Files\\Git\\cmd\\git.exe",
+      env: { SystemRoot: "C:\\Windows" },
+    });
+
+    expect(
+      JSON.parse(
+        decodeBase64(wrapped.env.PWRAGENT_JOB_WRAPPER_ARGUMENTS!),
+      ),
+    ).toEqual(args);
     wrapped.cleanup();
   });
 
@@ -330,6 +354,11 @@ describe("wrapCommandInWindowsJob", () => {
           stderr: "",
         });
         expect(nativeResult.stdout).toContain("job-native");
+
+        const gitResult = await runGitCommand(root, ["init", "-b", "main"], {
+          ownProcessTree: true,
+        });
+        expect(gitResult.stderr).toBe("");
 
         const bashResult = await runWrappedCommand({
           args: [

--- a/apps/desktop/src/main/__tests__/worktree-archive-service.test.ts
+++ b/apps/desktop/src/main/__tests__/worktree-archive-service.test.ts
@@ -9,8 +9,7 @@ import { WorktreeArchiveService } from "../app-server/worktree-archive-service";
 const execFileAsync = promisify(execFile);
 
 async function git(cwd: string, args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync("git", args, {
-    cwd,
+  const { stdout } = await execFileAsync("git", ["-C", cwd, ...args], {
     encoding: "utf8",
     maxBuffer: 1024 * 1024 * 10,
   });

--- a/apps/desktop/src/main/app-server/git-executable.ts
+++ b/apps/desktop/src/main/app-server/git-executable.ts
@@ -1,7 +1,9 @@
 import { execFile as execFileCallback } from "node:child_process";
+import path from "node:path";
 import { promisify } from "node:util";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { gitCandidateInputs } from "../settings/git-discovery";
+import { wrapCommandInWindowsJob } from "../windows-job-wrapper";
 
 const execFile = promisify(execFileCallback);
 
@@ -56,6 +58,34 @@ async function canRunGit(
   }
 }
 
+async function resolveWindowsJobExecutable(
+  command: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string> {
+  if (path.win32.isAbsolute(command)) {
+    return command;
+  }
+
+  const systemRoot = Object.entries(env).find(
+    ([key]) => key.toUpperCase() === "SYSTEMROOT",
+  )?.[1];
+  const where = systemRoot
+    ? path.win32.join(systemRoot, "System32", "where.exe")
+    : "where.exe";
+  const { stdout } = await execFile(where, [command], {
+    encoding: "utf8",
+    env,
+  });
+  const resolved = stdout
+    .split(/\r?\n/)
+    .map((candidate) => candidate.trim())
+    .find((candidate) => path.win32.isAbsolute(candidate));
+  if (!resolved) {
+    throw new Error(`Unable to resolve an absolute executable path for ${command}.`);
+  }
+  return resolved;
+}
+
 export async function resolveGitExecutable(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<string> {
@@ -92,19 +122,46 @@ export async function resolveGitExecutable(
 export async function runGitCommand(
   cwd: string,
   args: string[],
-  options: { env?: NodeJS.ProcessEnv } = {},
+  options: {
+    env?: NodeJS.ProcessEnv;
+    ownProcessTree?: boolean;
+  } = {},
 ): Promise<{
   stdout: string;
   stderr: string;
 }> {
   const env = buildPwrAgentChildProcessEnv(options.env ?? process.env);
   const git = await resolveGitExecutable(env);
-  const { stdout, stderr } = await execFile(git, ["-C", cwd, ...args], {
-    encoding: "utf8",
+  const gitArgs = ["-C", cwd, ...args];
+  const jobExecutable =
+    process.platform === "win32" && options.ownProcessTree
+      ? await resolveWindowsJobExecutable(git, env)
+      : git;
+  const windowsJobLaunch =
+    process.platform === "win32" && options.ownProcessTree
+      ? wrapCommandInWindowsJob({
+          args: gitArgs,
+          command: jobExecutable,
+          env,
+        })
+      : undefined;
+  const launch = windowsJobLaunch ?? {
+    args: gitArgs,
+    command: git,
     env,
-  });
-  return {
-    stdout: stdout.trim(),
-    stderr: (stderr ?? "").trim(),
   };
+
+  try {
+    const { stdout, stderr } = await execFile(launch.command, launch.args, {
+      encoding: "utf8",
+      env: launch.env,
+      maxBuffer: 1024 * 1024 * 10,
+    });
+    return {
+      stdout: stdout.trim(),
+      stderr: (stderr ?? "").trim(),
+    };
+  } finally {
+    windowsJobLaunch?.cleanup();
+  }
 }

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -115,8 +115,7 @@ async function runGit(
   args: string[],
   env?: NodeJS.ProcessEnv,
 ): Promise<GitResult> {
-  return await execFileAsync("git", args, {
-    cwd,
+  return await execFileAsync("git", ["-C", cwd, ...args], {
     env: buildPwrAgentChildProcessEnv(env ?? process.env),
     maxBuffer: 1024 * 1024 * 10,
   });

--- a/apps/desktop/src/main/app-server/worktree-archive-service.ts
+++ b/apps/desktop/src/main/app-server/worktree-archive-service.ts
@@ -1,14 +1,15 @@
 import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
 import { mkdtemp, mkdir, realpath, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type {
   AppServerBackendKind,
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
+import { runGitCommand } from "./git-executable";
 
 const execFileAsync = promisify(execFile);
 
@@ -60,11 +61,20 @@ type WorktreeArchiveServiceOptions = {
 async function runGit(
   cwd: string,
   args: string[],
-  options: { env?: NodeJS.ProcessEnv } = {},
+  options: {
+    env?: NodeJS.ProcessEnv;
+    ownProcessTree?: boolean;
+  } = {},
 ): Promise<GitResult> {
-  return await execFileAsync("git", args, {
-    cwd,
-    env: buildPwrAgentChildProcessEnv(process.env, options.env),
+  const env = buildPwrAgentChildProcessEnv(process.env, options.env);
+  if (process.platform === "win32" && options.ownProcessTree) {
+    return await runGitCommand(cwd, args, {
+      env,
+      ownProcessTree: true,
+    });
+  }
+  return await execFileAsync("git", ["-C", cwd, ...args], {
+    env,
     maxBuffer: 1024 * 1024 * 10,
   });
 }
@@ -180,7 +190,14 @@ export class WorktreeArchiveService {
     });
     const snapshotRef = snapshotRefForBackend(params.backend, worktreePath);
     await this.runGit(repositoryPath, ["update-ref", snapshotRef, snapshotCommit]);
-    await this.runGit(repositoryPath, ["worktree", "remove", "--force", worktreePath]);
+    await this.runGit(
+      repositoryPath,
+      ["worktree", "remove", "--force", worktreePath],
+      // Git for Windows can hand work to another git.exe after the launcher
+      // exits. Own that complete process tree atomically and do not report the
+      // archive complete until the Job's active-process count reaches zero.
+      { ownProcessTree: true },
+    );
 
     const archivedAt = params.now ?? Date.now();
     return {
@@ -416,13 +433,17 @@ export class WorktreeArchiveService {
   private async runGit(
     cwd: string,
     args: string[],
-    options: { env?: NodeJS.ProcessEnv } = {},
+    options: {
+      env?: NodeJS.ProcessEnv;
+      ownProcessTree?: boolean;
+    } = {},
   ): Promise<GitResult> {
     return await runGit(cwd, args, {
       env: {
         ...this.gitEnv,
         ...options.env,
       },
+      ownProcessTree: options.ownProcessTree,
     });
   }
 }

--- a/apps/desktop/src/main/windows-job-wrapper.ts
+++ b/apps/desktop/src/main/windows-job-wrapper.ts
@@ -9,8 +9,7 @@ import os from "node:os";
 import path from "node:path";
 
 const EXECUTABLE_ENV = "PWRAGENT_JOB_WRAPPER_EXECUTABLE";
-const ARGUMENT_0_ENV = "PWRAGENT_JOB_WRAPPER_ARGUMENT_0";
-const ARGUMENT_1_ENV = "PWRAGENT_JOB_WRAPPER_ARGUMENT_1";
+const ARGUMENTS_ENV = "PWRAGENT_JOB_WRAPPER_ARGUMENTS";
 const WORKING_DIRECTORY_ENV = "PWRAGENT_JOB_WRAPPER_CWD";
 const READY_FILE_ENV = "PWRAGENT_JOB_WRAPPER_READY_FILE";
 const EXIT_FILE_ENV = "PWRAGENT_JOB_WRAPPER_EXIT_FILE";
@@ -28,16 +27,15 @@ const BASH_EXIT_TRAP =
 const WINDOWS_JOB_WRAPPER_SCRIPT = String.raw`
 $ErrorActionPreference = 'Stop'
 $application = [string]$env:PWRAGENT_JOB_WRAPPER_EXECUTABLE
-$argument0 = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String([string]$env:PWRAGENT_JOB_WRAPPER_ARGUMENT_0))
-$argument1 = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String([string]$env:PWRAGENT_JOB_WRAPPER_ARGUMENT_1))
+$argumentsJson = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String([string]$env:PWRAGENT_JOB_WRAPPER_ARGUMENTS))
+$arguments = @((ConvertFrom-Json -InputObject $argumentsJson) | ForEach-Object { [string]$_ })
 $workingDirectory = [string]$env:PWRAGENT_JOB_WRAPPER_CWD
 $readyFile = [string]$env:PWRAGENT_JOB_WRAPPER_READY_FILE
 $exitFile = [string]$env:PWRAGENT_JOB_WRAPPER_EXIT_FILE
 $startupStartedAt = [long]$env:PWRAGENT_JOB_WRAPPER_STARTED_AT
 $startupStatusFile = [string]$env:PWRAGENT_JOB_WRAPPER_STARTUP_STATUS_FILE
 Remove-Item Env:PWRAGENT_JOB_WRAPPER_EXECUTABLE -ErrorAction SilentlyContinue
-Remove-Item Env:PWRAGENT_JOB_WRAPPER_ARGUMENT_0 -ErrorAction SilentlyContinue
-Remove-Item Env:PWRAGENT_JOB_WRAPPER_ARGUMENT_1 -ErrorAction SilentlyContinue
+Remove-Item Env:PWRAGENT_JOB_WRAPPER_ARGUMENTS -ErrorAction SilentlyContinue
 Remove-Item Env:PWRAGENT_JOB_WRAPPER_CWD -ErrorAction SilentlyContinue
 Remove-Item Env:PWRAGENT_JOB_WRAPPER_READY_FILE -ErrorAction SilentlyContinue
 Remove-Item Env:PWRAGENT_JOB_WRAPPER_STARTED_AT -ErrorAction SilentlyContinue
@@ -430,7 +428,7 @@ try {
   Write-StartupPhase -Phase 'helper-ready'
   $exitCode = [PwrAgentWindowsJobRunner]::Run(
     $application,
-    [string[]]@($argument0, $argument1),
+    [string[]]$arguments,
     $workingDirectory,
     $readyFile,
     $startupStatusFile,
@@ -657,7 +655,7 @@ function encodeArgument(value: string): string {
 }
 
 export function wrapCommandInWindowsJob(params: {
-  args: [string, string];
+  args: string[];
   command: string;
   cwd?: string;
   env: NodeJS.ProcessEnv;
@@ -694,10 +692,10 @@ export function wrapCommandInWindowsJob(params: {
   // native process created above is therefore not always the process whose
   // exit code represents the shell script. Have every POSIX `-lc` invocation
   // report its own exact status for the wrapper to return.
-  const argument1 =
-    params.args[0] === "-lc"
-      ? `${BASH_EXIT_TRAP}\n${params.args[1]}`
-      : params.args[1];
+  const wrappedArgs = [...params.args];
+  if (wrappedArgs[0] === "-lc" && wrappedArgs[1] !== undefined) {
+    wrappedArgs[1] = `${BASH_EXIT_TRAP}\n${wrappedArgs[1]}`;
+  }
   return {
     command: powershell,
     args: [
@@ -720,8 +718,7 @@ export function wrapCommandInWindowsJob(params: {
     env: {
       ...params.env,
       [EXECUTABLE_ENV]: params.command,
-      [ARGUMENT_0_ENV]: encodeArgument(params.args[0]),
-      [ARGUMENT_1_ENV]: encodeArgument(argument1),
+      [ARGUMENTS_ENV]: encodeArgument(JSON.stringify(wrappedArgs)),
       [WORKING_DIRECTORY_ENV]: params.cwd ?? process.cwd(),
       [READY_FILE_ENV]: readyFilePath,
       [EXIT_FILE_ENV]: exitFilePath,


### PR DESCRIPTION
## Summary

- run `git worktree remove` inside the existing atomic Windows Job Object boundary
- wait for the Job's active-process count to reach zero before reporting archive completion
- invoke ordinary Git commands with `git -C` so temporary repositories are not inherited as process working directories
- transport full native argument vectors through the Windows Job wrapper and resolve bare `git` commands to an absolute executable path before suspended launch
- remove the test cleanup retry so the suite proves immediate process readiness

## Root cause

Git-for-Windows can hand execution from its launcher to another `git.exe`. The handoff/archive path awaited the immediate child, but it did not atomically own all descendants. Test helpers also launched Git with the temporary repository as the native process working directory. A surviving launcher descendant could therefore keep the repository directory busy while `afterEach` recursively removed the fixture root, producing intermittent `EBUSY` failures and a cascading timeout.

The fix uses the repository's existing suspended-launch + `KILL_ON_JOB_CLOSE` Job Object boundary for the removal command. The wrapper returns only after the Job reports zero active processes.

## Impact

Windows workspace handoff cleanup now has an explicit process-ownership and readiness boundary. No retries, wider timeouts, worker reductions, or CI serialization were added.

## Validation

- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- focused wrapper and Git discovery Vitest coverage
- PwrSuiteLab Windows run `pwrlab-pwragent-e2e-20260811-010459-204f2e68`: 10/10 stress repetitions passed; 11/11 focused tests passed per iteration (110 total); no `EBUSY`, timeouts, Job-wrapper errors, `CreateProcess` errors, or persistent processes
