### PR TITLE
feat(desktop): center the thread-jump palette over a scrim

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -739,14 +739,14 @@ function DesktopAppShell(props: {
   // writeConfig call is fire-and-forget; a failed write just means the
   // preference isn't remembered next launch.
   const writeConfig = settings.writeConfig;
-  // Thread-list quick search (⌘K anywhere, ⌘F while the sidebar is focused).
-  // Owns its own open state and the sidebar peek it needs to render.
+  // Thread-jump palette (⌘K anywhere, ⌘F while the sidebar is focused). Owns
+  // its own open state and the sidebar peek a jump's landing scroll needs.
   const threadJump = useThreadJump({ sidebarHidden, setSidebarHidden });
   const endSidebarPeek = threadJump.endPeek;
   const setSidebarHiddenPersisted = useCallback(
     (next: boolean) => {
       // An explicit toggle (⌘B, the chips) is the operator stating a preference,
-      // so it ends any quick-search peek in flight.
+      // so it ends any jump-landing peek in flight.
       endSidebarPeek();
       setSidebarHidden(next);
       void writeConfig({ ui: { sidebarHidden: next } });
@@ -1819,8 +1819,8 @@ function DesktopAppShell(props: {
           }}
           threadJumpOpen={threadJump.open}
           onThreadJumpOpenChange={(open) => {
-            // Every close (Escape, outside click, picking a thread) goes through
-            // closeJump so a peeked-open sidebar goes back to hidden.
+            // Every close (Escape, scrim click, picking a thread) goes through
+            // closeJump, so the toggle state can't drift from what's on screen.
             if (open) {
               threadJump.openJump();
               return;
@@ -1831,16 +1831,13 @@ function DesktopAppShell(props: {
             setMainView("thread");
             navigation.selectThread(thread);
             // Reveal on the next frame, once the new selection has rendered.
-            // Do it even when the sidebar is only peeked open (⌘K over a hidden
-            // sidebar). Hidden rows reveal asynchronously as their collapsed
-            // containers reopen, so keep a peek laid out until ThreadRow reports
-            // that the selected row mounted and scrolled. The offset survives
-            // restoring the hidden preference, and an instant scroll avoids
-            // dismissing the peek partway through an animation.
-            const instant = threadJump.isPeeking();
-            if (instant) {
-              threadJump.deferPeekRestore();
-            }
+            // Do it even when the sidebar is hidden (⌘B): peek it open for the
+            // scroll, because hidden rows reveal asynchronously as their
+            // collapsed containers reopen, and hold that peek until ThreadRow
+            // reports the selected row mounted and scrolled. The offset
+            // survives restoring the hidden preference, and an instant scroll
+            // avoids dismissing the peek partway through an animation.
+            const instant = threadJump.beginRevealPeek();
             requestAnimationFrame(() => revealSelectedThreadInList({ instant }));
           }}
           onJumpToRemoteThread={(thread) => {
@@ -1852,10 +1849,7 @@ function DesktopAppShell(props: {
             // merged snapshot carries the new row, then select it — the
             // selection scopes ThreadView's IPC to the owning instance via
             // selectedThreadFederationTarget.
-            const instant = threadJump.isPeeking();
-            if (instant) {
-              threadJump.deferPeekRestore();
-            }
+            const instant = threadJump.beginRevealPeek();
             void (async () => {
               try {
                 await desktopApi?.addRemoteThreadPin?.({

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1454,6 +1454,10 @@ export function Sidebar(props: SidebarProps) {
 
   return (
     <aside className="sidebar" aria-label="Threads">
+      {/* Mounted here because this is where the thread set and the jump
+          handlers already live, but it PORTALS onto document.body — the
+          sidebar is a container-query element (a containing block for fixed
+          descendants) and ⌘B hides it with `display: none`. */}
       {props.threadJumpOpen ? (
         <SidebarSearchPopup
           threads={props.threads}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1494,9 +1494,11 @@ export function Sidebar(props: SidebarProps) {
         <div className="sidebar__masthead-actions">
           <MastheadActionButton
             ariaLabel="Search threads"
+            // ⌘K leads: it's the one an operator reaches for by reflex, and
+            // the palette it opens is the surface this button most resembles.
             tooltipText={[
-              `Open Search All  (${formatPrimaryAccel("F", { shift: true })})`,
               `Quick Thread List Search  (${formatPrimaryAccel("K")})`,
+              `Open Search All  (${formatPrimaryAccel("F", { shift: true })})`,
               `Context Search  (${formatPrimaryAccel("F")}) — Thread List in sidebar, Thread Chat elsewhere`,
             ].join("\n")}
             ariaPressed={props.threadSearchActive}

--- a/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   type KeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactElement,
 } from "react";
@@ -145,13 +146,13 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
     props.onClose();
   };
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
     if (event.key === "Escape") {
       event.preventDefault();
       props.onClose();
       return;
     }
-    // The palette is modal: the only tab stop inside it is this field (rows are
+    // The palette is modal: the only tab stop inside it is the field (rows are
     // driven by aria-activedescendant, not focus), so Tab must not walk out
     // into the dimmed app behind the scrim.
     if (event.key === "Tab") {
@@ -236,9 +237,12 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
   // peer latency is the footer's job now, so a loading state no longer leaves
   // a section header standing over nothing.
   const showRemoteSection =
-    trimmed && remoteSearchAvailable && remoteRows.length > 0;
+    Boolean(trimmed) && remoteSearchAvailable && remoteRows.length > 0;
   const showEmpty =
-    trimmed && results.length === 0 && remoteRows.length === 0 && !remoteLoading;
+    Boolean(trimmed)
+    && results.length === 0
+    && remoteRows.length === 0
+    && !remoteLoading;
   // The listbox is only in the DOM once it has rows, so `aria-controls` has to
   // come and go with it — a dangling idref is an invalid attribute value, not
   // a harmless one.
@@ -260,6 +264,23 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
         role="dialog"
         aria-modal="true"
         aria-label="Jump to thread"
+        // Bound on the panel, not the field: pressing any non-focusable chrome
+        // in here (the footer legend, the padding around the input) moves focus
+        // to <body> in Chromium, and a handler on the input alone would leave
+        // the palette in a dead state where Escape, ↑↓, and typing all do
+        // nothing. Keydown bubbles from the field either way.
+        onKeyDown={handleKeyDown}
+        // And keep the caret there in the first place. Suppressing the default
+        // focus move on every press but the field's own costs nothing — click
+        // still fires, so rows activate normally — and means no press inside
+        // the palette can strand the keyboard.
+        onMouseDown={(event: ReactMouseEvent<HTMLDivElement>) => {
+          if (event.target === inputRef.current) {
+            return;
+          }
+          event.preventDefault();
+          inputRef.current?.focus();
+        }}
       >
         <div className="jump-palette__field">
           <span className="jump-palette__icon" aria-hidden>
@@ -278,7 +299,6 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
             placeholder="Jump to thread, PR #, branch, repo…"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            onKeyDown={handleKeyDown}
           />
           <span className="jump-palette__esc" aria-hidden>
             esc

--- a/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
@@ -1,11 +1,14 @@
 import {
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
   type KeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
   type ReactElement,
 } from "react";
+import { createPortal } from "react-dom";
 import {
   buildThreadIdentityKey,
   federatedThreadIdentityKey,
@@ -36,18 +39,29 @@ type SidebarSearchPopupProps = {
 };
 
 /**
- * Quick-jump popup over the thread list (⌘K, or ⌘F while the sidebar is
- * focused). Local threads filter instantly from the in-memory thread set by
- * title, PR number, branch, and linked directory; connected federation peers
- * are queried asynchronously (debounced) and append below the local hits
- * with an instance chip. ↑/↓ move the active row across both sections,
- * Enter (or click) jumps, Escape closes.
+ * Quick-jump palette (⌘K, or ⌘F while the sidebar is focused). Local threads
+ * filter instantly from the in-memory thread set by title, PR number, branch,
+ * and linked directory; connected federation peers are queried asynchronously
+ * (debounced) and append below the local hits with an instance chip. ↑/↓ move
+ * the active row across both sections, Enter (or click) jumps, Escape closes.
+ *
+ * It renders through a PORTAL onto `document.body`, and that is load-bearing
+ * twice over. `.sidebar` declares `container: sidebar / inline-size`, and an
+ * element with a `container-type` is a containing block for fixed-position
+ * descendants — a scrim left inside the rail would size itself to the ~300px
+ * sidebar rather than the window, and the rail's `overflow: hidden` would clip
+ * it besides. The portal also survives `⌘B`, which hides the sidebar with
+ * `display: none` while leaving this component mounted, so the palette no
+ * longer needs the sidebar revealed underneath it to be visible at all.
  */
 export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement {
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
-  const rootRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const idPrefix = useId();
+  const listId = `${idPrefix}-results`;
+  const rowId = (index: number): string => `${idPrefix}-row-${index}`;
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -109,16 +123,17 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
     );
   }, [combinedRows.length]);
 
-  // Dismiss when focus or a click lands outside the popup.
+  // Keyboard steering is the point of this surface, so the active row has to
+  // stay on screen once the list scrolls past its own height.
   useEffect(() => {
-    const onPointerDown = (event: PointerEvent): void => {
-      if (!rootRef.current?.contains(event.target as Node)) {
-        props.onClose();
-      }
-    };
-    document.addEventListener("pointerdown", onPointerDown);
-    return () => document.removeEventListener("pointerdown", onPointerDown);
-  }, [props]);
+    const row = listRef.current?.querySelector(".jump-palette__row.is-active");
+    // jsdom has no layout and so no scrollIntoView; guard the same way
+    // ThreadRow's reveal effect does.
+    if (typeof row?.scrollIntoView !== "function") {
+      return;
+    }
+    row.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, combinedRows.length]);
 
   const jump = (thread: NavigationThreadSummary): void => {
     const remote = Boolean(thread.federation);
@@ -134,6 +149,13 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
     if (event.key === "Escape") {
       event.preventDefault();
       props.onClose();
+      return;
+    }
+    // The palette is modal: the only tab stop inside it is this field (rows are
+    // driven by aria-activedescendant, not focus), so Tab must not walk out
+    // into the dimmed app behind the scrim.
+    if (event.key === "Tab") {
+      event.preventDefault();
       return;
     }
     if (event.key === "ArrowDown") {
@@ -164,96 +186,167 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
       ? federatedThreadIdentityKey(thread.federation.ref)
       : buildThreadIdentityKey(thread.source, thread.id);
     return (
-      <li key={key} role="option" aria-selected={index === activeIndex}>
+      <li
+        key={key}
+        id={rowId(index)}
+        role="option"
+        aria-selected={index === activeIndex}
+      >
         <button
           type="button"
-          className={`sidebar-search__result${
+          className={`jump-palette__row${
             index === activeIndex ? " is-active" : ""
           }`}
+          // Not a tab stop: focus stays in the field so typing never breaks,
+          // and the active row is published via aria-activedescendant.
+          tabIndex={-1}
           onMouseEnter={() => setActiveIndex(index)}
           onClick={() => jump(thread)}
         >
-          <span className="sidebar-search__result-title">{thread.title}</span>
-          {thread.agent || description || thread.federation ? (
-            <span className="sidebar-search__result-meta">
-              {thread.federation ? (
-                <InstanceChip
-                  icon={thread.federation.celestialIcon}
-                  instanceId={
-                    thread.federation.ref.target.scope === "remote"
-                      ? thread.federation.ref.target.instanceId
-                      : ""
-                  }
-                  label={thread.federation.instanceLabel}
-                />
-              ) : null}
-              {thread.agent ? <AgentThreadChip /> : null}
-              {description ? <span>{description}</span> : null}
-            </span>
+          <span className="jump-palette__row-title">{thread.title}</span>
+          {thread.federation ? (
+            <InstanceChip
+              icon={thread.federation.celestialIcon}
+              instanceId={
+                thread.federation.ref.target.scope === "remote"
+                  ? thread.federation.ref.target.instanceId
+                  : ""
+              }
+              label={thread.federation.instanceLabel}
+            />
+          ) : null}
+          {thread.agent ? <AgentThreadChip /> : null}
+          {description.pr ? (
+            <span className="jump-palette__row-pr">{description.pr}</span>
+          ) : null}
+          {description.branch ? (
+            // Clipped from the LEFT (`direction: rtl` in CSS) so a long
+            // `agent/…` prefix gives way and the disambiguating leaf survives.
+            <span className="jump-palette__row-branch">{description.branch}</span>
+          ) : null}
+          {description.directory ? (
+            <span className="jump-palette__row-repo">{description.directory}</span>
           ) : null}
         </button>
       </li>
     );
   };
 
+  // The divider only earns its place once there are rows under it. In-flight
+  // peer latency is the footer's job now, so a loading state no longer leaves
+  // a section header standing over nothing.
   const showRemoteSection =
-    trimmed && remoteSearchAvailable && (remoteLoading || remoteRows.length > 0);
+    trimmed && remoteSearchAvailable && remoteRows.length > 0;
   const showEmpty =
     trimmed && results.length === 0 && remoteRows.length === 0 && !remoteLoading;
+  // The listbox is only in the DOM once it has rows, so `aria-controls` has to
+  // come and go with it — a dangling idref is an invalid attribute value, not
+  // a harmless one.
+  const listVisible = Boolean(trimmed) && (results.length > 0 || showRemoteSection);
 
-  return (
-    <div className="sidebar-search" ref={rootRef} role="dialog" aria-label="Jump to thread">
-      <div className="sidebar-search__field">
-        <span className="sidebar-search__icon" aria-hidden>
-          <SearchIcon size={14} />
-        </span>
-        <input
-          ref={inputRef}
-          className="sidebar-search__input"
-          aria-label="Jump to thread"
-          placeholder="Jump to thread, PR #, branch…"
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          onKeyDown={handleKeyDown}
-        />
-      </div>
-      {trimmed && (results.length > 0 || showRemoteSection) ? (
-        <ul className="sidebar-search__results" role="listbox">
-          {results.map((thread, index) => renderRow(thread, index))}
-          {showRemoteSection ? (
-            <li
-              aria-hidden="true"
-              className="sidebar-search__section-divider"
-              role="presentation"
-            >
-              Other instances
-            </li>
-          ) : null}
-          {remoteRows.map((thread, index) =>
-            renderRow(thread, results.length + index),
-          )}
-          {remoteLoading && remoteRows.length === 0 ? (
-            <li
-              aria-hidden="true"
-              className="sidebar-search__loading"
-              role="presentation"
-            >
+  return createPortal(
+    <div
+      className="jump-palette"
+      onPointerDown={(event: ReactPointerEvent<HTMLDivElement>) => {
+        // Scrim press only. A drag that starts inside the panel and releases
+        // out here must not count as a dismissal.
+        if (event.target === event.currentTarget) {
+          props.onClose();
+        }
+      }}
+    >
+      <div
+        className="jump-palette__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Jump to thread"
+      >
+        <div className="jump-palette__field">
+          <span className="jump-palette__icon" aria-hidden>
+            <SearchIcon size={16} />
+          </span>
+          <input
+            ref={inputRef}
+            className="jump-palette__input"
+            aria-label="Jump to thread"
+            aria-controls={listVisible ? listId : undefined}
+            aria-activedescendant={
+              listVisible ? rowId(activeIndex) : undefined
+            }
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="Jump to thread, PR #, branch, repo…"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleKeyDown}
+          />
+          <span className="jump-palette__esc" aria-hidden>
+            esc
+          </span>
+        </div>
+        {listVisible ? (
+          <ul
+            className="jump-palette__results"
+            id={listId}
+            ref={listRef}
+            role="listbox"
+            aria-label="Threads"
+          >
+            {results.map((thread, index) => renderRow(thread, index))}
+            {showRemoteSection ? (
+              <li
+                aria-hidden="true"
+                className="jump-palette__section-divider"
+                role="presentation"
+              >
+                Other instances
+              </li>
+            ) : null}
+            {remoteRows.map((thread, index) =>
+              renderRow(thread, results.length + index),
+            )}
+          </ul>
+        ) : showEmpty ? (
+          <p className="jump-palette__empty">No threads match</p>
+        ) : null}
+        <div className="jump-palette__foot">
+          <span>↑↓ navigate</span>
+          <span>↵ open</span>
+          <span>esc close</span>
+          <span className="jump-palette__foot-spacer" />
+          {/* Peer latency lives in the footer rather than as a list row: a
+              status line that grows and vanishes between keystrokes would push
+              results under the operator's cursor mid-selection. */}
+          {remoteLoading ? (
+            <span className="jump-palette__foot-remote">
               Searching other instances…
-            </li>
+            </span>
           ) : null}
-        </ul>
-      ) : showEmpty ? (
-        <p className="sidebar-search__empty">No threads match</p>
-      ) : null}
-    </div>
+          {trimmed ? (
+            <span className="jump-palette__foot-count">
+              {combinedRows.length}
+              {combinedRows.length === 1 ? " result" : " results"}
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </div>,
+    document.body,
   );
 }
+
+type ThreadDescription = {
+  /** Rendered with its `#`, e.g. `#1483`. */
+  pr?: string;
+  branch?: string;
+  directory?: string;
+};
 
 function describeThread(
   thread: NavigationThreadSummary,
   query: string,
-): string {
-  const parts: string[] = [];
+): ThreadDescription {
+  const description: ThreadDescription = {};
   const pr = threadHasExactPrNumberMatch(thread, query)
     ? (thread.prs ?? []).find(
         (candidate) =>
@@ -261,14 +354,14 @@ function describeThread(
       )
     : (thread.prs ?? [])[0];
   if (pr) {
-    parts.push(`#${pr.number}`);
+    description.pr = `#${pr.number}`;
   }
   if (thread.gitBranch) {
-    parts.push(thread.gitBranch);
+    description.branch = thread.gitBranch;
   }
   const directory = (thread.linkedDirectories ?? [])[0];
   if (directory?.label) {
-    parts.push(directory.label);
+    description.directory = directory.label;
   }
-  return parts.join(" · ");
+  return description;
 }

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
@@ -374,6 +374,84 @@ describe("SidebarSearchPopup", () => {
     await settleRemoteSearch();
   });
 
+  it("closes on Escape", async () => {
+    const onClose = vi.fn();
+    render(
+      <SidebarSearchPopup
+        threads={[localThread({})]}
+        onJumpToThread={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "Jump to thread" }), {
+      key: "Escape",
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    await settleRemoteSearch();
+  });
+
+  it("still steers from the keyboard after a press on the panel's chrome", async () => {
+    // Pressing non-focusable chrome (the footer legend, the padding around the
+    // field) moves focus to <body> in Chromium. A handler bound to the input
+    // alone would leave Escape, ↑↓, and typing all dead from here.
+    const onJumpToThread = vi.fn();
+    render(
+      <SidebarSearchPopup
+        threads={[
+          localThread({ id: "one", title: "First fix" }),
+          localThread({ id: "two", title: "Second fix" }),
+        ]}
+        onJumpToThread={onJumpToThread}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Jump to thread" });
+    fireEvent.change(input, { target: { value: "fix" } });
+
+    const dialog = screen.getByRole("dialog", { name: "Jump to thread" });
+    // jsdom doesn't implement the focus-move-on-mousedown default, so assert
+    // the suppression itself rather than an activeElement it hands us free.
+    // fireEvent returns false once a handler called preventDefault.
+    expect(fireEvent.mouseDown(screen.getByText("↑↓ navigate"))).toBe(false);
+
+    // Dispatched on the dialog, not the field: a handler bound to the input
+    // would never see these.
+    fireEvent.keyDown(dialog, { key: "ArrowDown" });
+    fireEvent.keyDown(dialog, { key: "Enter" });
+
+    expect(onJumpToThread).toHaveBeenCalledTimes(1);
+    expect(onJumpToThread.mock.calls[0][0].id).toBe("two");
+    await settleRemoteSearch();
+  });
+
+  it("moves one row per arrow press, not two", async () => {
+    // The handler moved from the field to the panel; leaving a copy on both
+    // would double-count every keystroke as it bubbled.
+    const onJumpToThread = vi.fn();
+    render(
+      <SidebarSearchPopup
+        threads={[
+          localThread({ id: "one", title: "First fix" }),
+          localThread({ id: "two", title: "Second fix" }),
+          localThread({ id: "three", title: "Third fix" }),
+        ]}
+        onJumpToThread={onJumpToThread}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Jump to thread" });
+    fireEvent.change(input, { target: { value: "fix" } });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onJumpToThread.mock.calls[0][0].id).toBe("two");
+    await settleRemoteSearch();
+  });
+
   it("keeps Tab inside the modal instead of walking into the dimmed app", async () => {
     render(
       <SidebarSearchPopup

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
@@ -308,4 +308,125 @@ describe("SidebarSearchPopup", () => {
       screen.queryByText("Searching other instances…"),
     ).not.toBeInTheDocument();
   });
+
+  it("portals a modal dialog out of whatever mounted it", async () => {
+    // The sidebar is a container-query element — a containing block for fixed
+    // descendants — and ⌘B hides it with `display: none`. A palette left
+    // inside it would center on the rail and vanish with it.
+    render(
+      <aside className="sidebar">
+        <SidebarSearchPopup
+          threads={[localThread({})]}
+          onJumpToThread={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </aside>,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Jump to thread" });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog.closest(".sidebar")).toBeNull();
+    await settleRemoteSearch();
+  });
+
+  it("closes on a scrim press but not on a press inside the panel", async () => {
+    const onClose = vi.fn();
+    render(
+      <SidebarSearchPopup
+        threads={[localThread({})]}
+        onJumpToThread={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Jump to thread" });
+    fireEvent.pointerDown(dialog);
+    expect(onClose).not.toHaveBeenCalled();
+
+    const scrim = dialog.parentElement;
+    expect(scrim).not.toBeNull();
+    fireEvent.pointerDown(scrim as HTMLElement);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    await settleRemoteSearch();
+  });
+
+  it("publishes the arrowed-to row through aria-activedescendant", async () => {
+    render(
+      <SidebarSearchPopup
+        threads={[
+          localThread({ id: "one", title: "First fix" }),
+          localThread({ id: "two", title: "Second fix" }),
+        ]}
+        onJumpToThread={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Jump to thread" });
+    fireEvent.change(input, { target: { value: "fix" } });
+
+    const rows = screen.getAllByRole("option");
+    expect(input).toHaveAttribute("aria-activedescendant", rows[0]?.id);
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+
+    expect(input).toHaveAttribute("aria-activedescendant", rows[1]?.id);
+    await settleRemoteSearch();
+  });
+
+  it("keeps Tab inside the modal instead of walking into the dimmed app", async () => {
+    render(
+      <SidebarSearchPopup
+        threads={[localThread({})]}
+        onJumpToThread={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Jump to thread" });
+    const tab = fireEvent.keyDown(input, { key: "Tab" });
+
+    // fireEvent returns false once a handler called preventDefault.
+    expect(tab).toBe(false);
+    await settleRemoteSearch();
+  });
+
+  it("counts local and remote hits together in the footer", async () => {
+    jumpSearchRemoteThreads.mockResolvedValue({
+      results: [remoteThread({ threadId: "r1", title: "Remote fix" })],
+    });
+
+    render(
+      <SidebarSearchPopup
+        threads={[localThread({ title: "Local fix" })]}
+        onJumpToThread={vi.fn()}
+        onJumpToRemoteThread={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Jump to thread" }), {
+      target: { value: "fix" },
+    });
+    await settleRemoteSearch();
+
+    expect(screen.getByText("2 results")).toBeInTheDocument();
+  });
+
+  it("counts a lone hit in the singular", async () => {
+    render(
+      <SidebarSearchPopup
+        threads={[localThread({ title: "Local fix" })]}
+        onJumpToThread={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Jump to thread" }), {
+      target: { value: "fix" },
+    });
+
+    expect(screen.getByText("1 result")).toBeInTheDocument();
+    await settleRemoteSearch();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -780,7 +780,7 @@ describe("Sidebar", () => {
     const searchButton = screen.getByRole("button", { name: "Search threads" });
     fireEvent.mouseEnter(searchButton);
     expect((await screen.findByRole("tooltip")).textContent).toBe(
-      "Open Search All  (Ctrl+Shift+F)\nQuick Thread List Search  (Ctrl+K)\nContext Search  (Ctrl+F) — Thread List in sidebar, Thread Chat elsewhere",
+      "Quick Thread List Search  (Ctrl+K)\nOpen Search All  (Ctrl+Shift+F)\nContext Search  (Ctrl+F) — Thread List in sidebar, Thread Chat elsewhere",
     );
     fireEvent.mouseLeave(searchButton);
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadJump.test.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadJump.test.ts
@@ -1,29 +1,8 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useThreadJump } from "../useThreadJump";
 
-// The peek restore is deliberately deferred a frame (a jump's scroll-into-view
-// has to land while the sidebar still has layout), so drive frames by hand.
-let frames: FrameRequestCallback[] = [];
-
-beforeEach(() => {
-  frames = [];
-  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
-    frames.push(callback),
-  );
-});
-
-function flushFrame(): void {
-  const queued = frames.splice(0);
-  act(() => {
-    for (const callback of queued) {
-      callback(0);
-    }
-  });
-}
-
 afterEach(() => {
-  vi.unstubAllGlobals();
   cleanup();
 });
 
@@ -47,65 +26,62 @@ function renderThreadJump(initialSidebarHidden: boolean): {
 }
 
 describe("useThreadJump", () => {
-  it("opens without touching a sidebar that's already showing", () => {
-    const { hook, setSidebarHidden } = renderThreadJump(false);
+  it("opens without touching the sidebar, hidden or not", () => {
+    // The palette portals onto document.body, so it no longer needs the
+    // sidebar laid out to be visible — and a sidebar the operator deliberately
+    // hid must not flash open behind a palette they may only be passing
+    // through.
+    const shown = renderThreadJump(false);
+    act(() => shown.hook.result.current.openJump());
+    expect(shown.hook.result.current.open).toBe(true);
+    expect(shown.setSidebarHidden).not.toHaveBeenCalled();
 
-    act(() => hook.result.current.openJump());
-
-    expect(hook.result.current.open).toBe(true);
-    expect(setSidebarHidden).not.toHaveBeenCalled();
+    const hidden = renderThreadJump(true);
+    act(() => hidden.hook.result.current.openJump());
+    expect(hidden.hook.result.current.open).toBe(true);
+    expect(hidden.setSidebarHidden).not.toHaveBeenCalled();
+    expect(hidden.sidebarHidden()).toBe(true);
   });
 
-  it("peeks a hidden sidebar open, then puts it back when the search closes", () => {
-    // ⌘K over a hidden sidebar has to reveal it — the popup renders inside it.
-    // But hiding the sidebar is a deliberate choice, so the reveal is temporary.
+  it("closes without touching the sidebar", () => {
     const { hook, setSidebarHidden, sidebarHidden } = renderThreadJump(true);
 
     act(() => hook.result.current.openJump());
-    expect(setSidebarHidden).toHaveBeenLastCalledWith(false);
-    expect(sidebarHidden()).toBe(false);
-    expect(hook.result.current.isPeeking()).toBe(true);
-
     act(() => hook.result.current.closeJump());
-    flushFrame();
 
     expect(hook.result.current.open).toBe(false);
-    expect(setSidebarHidden).toHaveBeenLastCalledWith(true);
+    expect(setSidebarHidden).not.toHaveBeenCalled();
     expect(sidebarHidden()).toBe(true);
   });
 
-  it("holds the sidebar for a frame on close, so a jump's scroll can land first", () => {
-    // Picking a thread closes the popup AND schedules the scroll that centers
-    // the chosen row. `scrollIntoView` does nothing inside a `display: none`
-    // subtree, so re-hiding in the same commit would eat the scroll and strand
-    // the row off-screen the next time the sidebar came back.
+  it("peeks a hidden sidebar open for a jump's landing scroll", () => {
+    // `scrollIntoView` does nothing inside a `display: none` subtree, so the
+    // row a jump selects would be stranded off-screen the next time the
+    // sidebar came back.
     const { hook, setSidebarHidden, sidebarHidden } = renderThreadJump(true);
-    act(() => hook.result.current.openJump());
-    setSidebarHidden.mockClear();
 
-    act(() => hook.result.current.closeJump());
+    let peeked = false;
+    act(() => {
+      peeked = hook.result.current.beginRevealPeek();
+    });
 
-    // Still laid out: this is the frame the reveal runs in.
-    expect(setSidebarHidden).not.toHaveBeenCalled();
+    expect(peeked).toBe(true);
+    expect(setSidebarHidden).toHaveBeenLastCalledWith(false);
     expect(sidebarHidden()).toBe(false);
-
-    flushFrame();
-
-    expect(setSidebarHidden).toHaveBeenCalledWith(true);
   });
 
-  it("keeps a peek open until an asynchronous selected-row reveal completes", () => {
+  it("holds the peek until the selected row reports it scrolled", () => {
+    // Hidden rows reveal asynchronously as their collapsed containers reopen,
+    // so the sidebar has to stay laid out until ThreadRow says it landed.
     const { hook, setSidebarHidden, sidebarHidden } = renderThreadJump(true);
-    act(() => hook.result.current.openJump());
+
+    act(() => {
+      hook.result.current.beginRevealPeek();
+    });
+    act(() => hook.result.current.closeJump());
     setSidebarHidden.mockClear();
 
-    act(() => hook.result.current.deferPeekRestore());
-    act(() => hook.result.current.closeJump());
-    flushFrame();
-
-    expect(hook.result.current.open).toBe(false);
     expect(sidebarHidden()).toBe(false);
-    expect(setSidebarHidden).not.toHaveBeenCalled();
 
     act(() => hook.result.current.completePeekRestore());
 
@@ -113,62 +89,47 @@ describe("useThreadJump", () => {
     expect(sidebarHidden()).toBe(true);
   });
 
-  it("reports the peek to callers before the popup's close clears it", () => {
-    // App reads isPeeking() inside onJumpToThread to choose an instant scroll —
-    // and the popup calls onJumpToThread BEFORE onClose, so the peek must still
-    // be readable at that moment.
-    const { hook } = renderThreadJump(true);
-    act(() => hook.result.current.openJump());
-
-    expect(hook.result.current.isPeeking()).toBe(true);
-
-    act(() => hook.result.current.closeJump());
-    flushFrame();
-
-    expect(hook.result.current.isPeeking()).toBe(false);
-  });
-
-  it("leaves a visible sidebar alone when the search closes", () => {
+  it("reports no peek — and starts none — when the sidebar is already showing", () => {
+    // The return value picks the scroll behavior: only a peek about to be
+    // re-hidden needs the instant, single-frame scroll.
     const { hook, setSidebarHidden } = renderThreadJump(false);
 
-    act(() => hook.result.current.openJump());
-    act(() => hook.result.current.closeJump());
-    flushFrame();
+    let peeked = true;
+    act(() => {
+      peeked = hook.result.current.beginRevealPeek();
+    });
 
-    expect(hook.result.current.open).toBe(false);
+    expect(peeked).toBe(false);
+    expect(setSidebarHidden).not.toHaveBeenCalled();
+
+    act(() => hook.result.current.completePeekRestore());
+
     expect(setSidebarHidden).not.toHaveBeenCalled();
   });
 
   it("lets an explicit sidebar preference win over a peek in flight", () => {
-    // If anything persists a sidebar preference while a peek is open, that's the
-    // operator stating what they want and the peek must not revert it on close.
-    // No path in today's UI reaches this (clicking a toggle chip dismisses the
-    // popup first, and ⌘B is inert while the caret is in the popup's field) —
-    // this pins the contract so a future one can't silently undo a saved
-    // preference.
+    // If anything persists a sidebar preference while a peek is open, that's
+    // the operator stating what they want, and the pending restore must not
+    // undo it.
     const { hook, setSidebarHidden } = renderThreadJump(true);
-    act(() => hook.result.current.openJump());
+    act(() => {
+      hook.result.current.beginRevealPeek();
+    });
     setSidebarHidden.mockClear();
 
     act(() => hook.result.current.endPeek());
-    act(() => hook.result.current.closeJump());
-    flushFrame();
+    act(() => hook.result.current.completePeekRestore());
 
-    expect(hook.result.current.open).toBe(false);
     expect(setSidebarHidden).not.toHaveBeenCalled();
   });
 
-  it("toggles closed on a second ⌘K, restoring the peek", () => {
-    const { hook, setSidebarHidden, sidebarHidden } = renderThreadJump(true);
+  it("toggles closed on a second ⌘K", () => {
+    const { hook } = renderThreadJump(true);
 
     act(() => hook.result.current.toggleJump());
     expect(hook.result.current.open).toBe(true);
 
     act(() => hook.result.current.toggleJump());
-    flushFrame();
-
     expect(hook.result.current.open).toBe(false);
-    expect(setSidebarHidden).toHaveBeenLastCalledWith(true);
-    expect(sidebarHidden()).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/useThreadJump.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/useThreadJump.ts
@@ -1,15 +1,19 @@
 import { useCallback, useRef, useState } from "react";
 
 /**
- * Owns the thread-list quick search — the popup opened by ⌘K from anywhere, or
- * by ⌘F while the sidebar holds focus.
+ * Owns the thread-jump palette — the modal opened by ⌘K from anywhere, or by
+ * ⌘F while the sidebar holds focus.
  *
- * The popup renders inside the sidebar, and a hidden sidebar (⌘B) is
- * `display: none`, so opening the search over a hidden sidebar has to reveal it
- * first. That reveal is a PEEK, not a preference change: it never writes
- * config.toml, and closing the search puts the sidebar back. Someone who
- * deliberately hides their sidebar shouldn't have it silently — and permanently
- * — reopened just because they reached for a thread.
+ * The palette itself portals onto `document.body`, so opening it no longer
+ * requires a sidebar at all. What still does is the *landing*: picking a thread
+ * scrolls its row into view, and `scrollIntoView` is a no-op inside the
+ * `display: none` subtree that ⌘B leaves behind. So a hidden sidebar is
+ * revealed at PICK time, not at open time — a PEEK, never a preference change.
+ * It writes nothing to config.toml, and it goes back the moment the row reports
+ * that it mounted and scrolled. Someone who deliberately hides their sidebar
+ * shouldn't have it silently — and permanently — reopened just because they
+ * reached for a thread, nor watch it flash open behind a palette they were only
+ * passing through.
  */
 export function useThreadJump(options: {
   sidebarHidden: boolean;
@@ -19,99 +23,68 @@ export function useThreadJump(options: {
   open: boolean;
   openJump: () => void;
   closeJump: () => void;
-  /** Keep a peek laid out until an asynchronous selected-row reveal completes. */
-  deferPeekRestore: () => void;
-  /** Restore a deferred peek after the selected row has mounted and scrolled. */
-  completePeekRestore: () => void;
   /**
-   * Whether the sidebar on screen right now is a peek — i.e. it's about to be
-   * hidden again when the search closes. Callers that scroll the thread list on
-   * the way out need this: the scroll has to be instant, not animated, to land
-   * before the sidebar goes away. Read it at event time, not during render.
+   * Reveal a hidden sidebar so a jump's scroll-into-view has layout to land in,
+   * and hold it revealed until {@link completePeekRestore}. Returns whether a
+   * peek actually started — callers use it to pick an INSTANT scroll, since a
+   * smooth one animates over several frames and re-hiding the sidebar
+   * mid-animation abandons it wherever it got to.
    */
-  isPeeking: () => boolean;
+  beginRevealPeek: () => boolean;
+  /** Restore the peek after the selected row has mounted and scrolled. */
+  completePeekRestore: () => void;
   /** ⌘K again backs out of a jump you didn't mean to start. */
   toggleJump: () => void;
   /**
    * Call from whatever persists the sidebar preference (⌘B, the toggle chips).
-   * An explicit preference outranks a peek: ending it here means the closing
-   * search can't revert what the operator just chose. Nothing in today's UI can
-   * actually toggle the sidebar while the popup is up — a click dismisses the
-   * popup first, and ⌘B is inert while the caret sits in its field — so this is
-   * a rail, not a live path.
+   * An explicit preference outranks a peek: ending it here means a pending
+   * reveal can't revert what the operator just chose.
    */
   endPeek: () => void;
 } {
   const { sidebarHidden, setSidebarHidden } = options;
   const [open, setOpen] = useState(false);
   const peekedRef = useRef(false);
-  const peekRestoreDeferredRef = useRef(false);
 
   const openJump = useCallback(() => {
-    if (sidebarHidden) {
-      peekedRef.current = true;
-      setSidebarHidden(false);
-    }
     setOpen(true);
-  }, [sidebarHidden, setSidebarHidden]);
+  }, []);
 
   const closeJump = useCallback(() => {
     setOpen(false);
+  }, []);
+
+  const beginRevealPeek = useCallback(() => {
+    if (!sidebarHidden) {
+      return false;
+    }
+    peekedRef.current = true;
+    setSidebarHidden(false);
+    return true;
+  }, [sidebarHidden, setSidebarHidden]);
+
+  const completePeekRestore = useCallback(() => {
     if (!peekedRef.current) {
       return;
     }
-    if (peekRestoreDeferredRef.current) {
-      return;
-    }
-    peekedRef.current = false;
-    // Restore on the NEXT frame, not in this commit. Picking a thread closes the
-    // popup and schedules a scroll-the-selected-row-into-view for that same
-    // frame (App's onJumpToThread), and `scrollIntoView` inside a
-    // `display: none` subtree is a no-op — so re-hiding here would silently eat
-    // the scroll and the row would be off-screen when the sidebar came back.
-    // Chromium restores a scroll offset across `display: none`, so all we owe
-    // the reveal is a laid-out sidebar for the frame it runs in. Its rAF was
-    // queued first, so it runs before ours.
-    requestAnimationFrame(() => setSidebarHidden(true));
-  }, [setSidebarHidden]);
-
-  const deferPeekRestore = useCallback(() => {
-    if (peekedRef.current) {
-      peekRestoreDeferredRef.current = true;
-    }
-  }, []);
-
-  const completePeekRestore = useCallback(() => {
-    if (!peekedRef.current || !peekRestoreDeferredRef.current) {
-      return;
-    }
-    peekRestoreDeferredRef.current = false;
     peekedRef.current = false;
     setSidebarHidden(true);
   }, [setSidebarHidden]);
 
   const toggleJump = useCallback(() => {
-    if (open) {
-      closeJump();
-      return;
-    }
-    openJump();
-  }, [open, closeJump, openJump]);
+    setOpen((current) => !current);
+  }, []);
 
   const endPeek = useCallback(() => {
     peekedRef.current = false;
-    peekRestoreDeferredRef.current = false;
   }, []);
-
-  const isPeeking = useCallback(() => peekedRef.current, []);
 
   return {
     open,
     openJump,
     closeJump,
-    deferPeekRestore,
+    beginRevealPeek,
     completePeekRestore,
-    isPeeking,
     toggleJump,
     endPeek,
   };

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -913,67 +913,122 @@ textarea,
   container: sidebar / inline-size;
 }
 
-/* Thread-list quick-jump popup (⌘F while the sidebar is focused). Floats below
-   the masthead, over the thread list. */
-.sidebar-search {
-  position: absolute;
-  z-index: 40;
-  top: 52px;
-  left: 10px;
-  right: 10px;
+/* Thread-jump palette (⌘K, or ⌘F while the sidebar is focused). A centered
+   modal over a scrim, portalled onto document.body — see the component's
+   comment for why it cannot live inside `.sidebar`.
+
+   Layer 140, not the 120 the Settings and Star Map layers use: ⌘K is a
+   window-global chord that stays live inside text fields, so the palette has
+   to clear whichever full-window layer is up. Same reasoning as
+   `.pr-status-card` and `.messaging-status-tooltip`. */
+.jump-palette {
+  position: fixed;
+  inset: 0;
+  z-index: 140;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 11vh 16px 16px;
+  background: var(--scrim-strong);
+  animation: jump-palette-fade 110ms ease both;
+}
+
+.jump-palette__panel {
   display: flex;
   flex-direction: column;
-  max-height: calc(100% - 64px);
+  width: min(640px, 100%);
+  max-height: 66vh;
   overflow: hidden;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
   background: var(--bg-panel-elevated);
   box-shadow: var(--shadow-popover);
+  animation: jump-palette-rise 130ms cubic-bezier(0.2, 0.7, 0.3, 1) both;
 }
 
-.sidebar-search__field {
+@keyframes jump-palette-fade {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes jump-palette-rise {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .jump-palette,
+  .jump-palette__panel {
+    animation: none;
+  }
+}
+
+.jump-palette__field {
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 10px;
+  gap: 10px;
+  padding: 13px 15px;
   border-bottom: 1px solid var(--border-subtle);
 }
 
-.sidebar-search__icon {
+.jump-palette__icon {
   display: inline-flex;
   color: var(--text-muted);
 }
 
-.sidebar-search__input {
+.jump-palette__input {
   flex: 1;
   min-width: 0;
   border: none;
   background: transparent;
   color: var(--text-primary);
-  font: inherit;
+  font-family: var(--font-sans);
+  font-size: 15px;
+  font-weight: 500;
   outline: none;
 }
 
-.sidebar-search__input::placeholder {
+.jump-palette__input::placeholder {
   color: var(--text-muted);
 }
 
-.sidebar-search__results {
+.jump-palette__esc {
+  flex: none;
+  padding: 3px 7px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  color: var(--text-subtle);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.jump-palette__results {
+  flex: 1 1 auto;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 2px;
   margin: 0;
-  padding: 4px;
+  padding: 6px;
   overflow-y: auto;
   list-style: none;
 }
 
-.sidebar-search__result {
+/* One line per thread: the title flexes and everything that disambiguates it
+   rides the right edge in fixed columns. Two-line rows inside a ~300px rail
+   were what truncated branch names mid-word. */
+.jump-palette__row {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: center;
+  gap: 10px;
   width: 100%;
-  padding: 6px 8px;
+  padding: 8px 10px;
   border: none;
   border-radius: 6px;
   background: transparent;
@@ -982,72 +1037,119 @@ textarea,
   cursor: pointer;
 }
 
-.sidebar-search__result.is-active {
+/* The tint alone is a near-invisible delta against the elevated panel in dark
+   theme, and this is the one surface steered entirely by that cue. */
+.jump-palette__row.is-active {
   background: var(--bg-row-active);
+  box-shadow: inset 0 0 0 1px var(--accent-border);
 }
 
-.sidebar-search__result-title {
+.jump-palette__row-title {
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
-  font-size: 13px;
-  font-weight: 600;
   color: var(--text-primary);
+  font-size: 13.5px;
+  font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.sidebar-search__result-meta {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  overflow: hidden;
+.jump-palette__row-pr {
+  flex: none;
+  color: var(--text-muted);
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--text-muted);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/* `direction: rtl` puts the ellipsis at the START, so a long `agent/…` prefix
+   gives way before the branch leaf does. The content is neutral-punctuated
+   ASCII, so no glyph reordering occurs. */
+.jump-palette__row-branch {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  direction: rtl;
+  color: var(--text-subtle);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-align: right;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.sidebar-search__result-meta .chip--agent {
+.jump-palette__row-repo {
   flex: none;
-  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  height: 19px;
+  padding: 0 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-panel);
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+}
+
+.jump-palette__row .chip--agent,
+.jump-palette__row .chip--instance {
+  flex: none;
+  height: 19px;
   padding: 0 6px;
   font-family: var(--font-sans, sans-serif);
   font-size: 10px;
 }
 
-.sidebar-search__empty {
+.jump-palette__empty {
   margin: 0;
-  padding: 12px;
-  color: var(--text-muted);
-  font-size: 12px;
+  padding: 34px 20px;
+  color: var(--text-subtle);
+  font-size: 13px;
   text-align: center;
 }
 
 /* ⌘K federated section: remote hits append below the instant local rows. */
-.sidebar-search__section-divider {
-  margin: 2px 0 0;
-  padding: 6px 8px 2px;
+.jump-palette__section-divider {
+  margin: 4px 0 0;
+  padding: 10px 10px 5px;
   border-top: 1px solid var(--border-subtle);
   color: var(--text-muted);
-  font-size: 10px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
   font-weight: 600;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
-.sidebar-search__loading {
-  padding: 6px 8px 8px;
+.jump-palette__foot {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  padding: 9px 15px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-panel);
+  color: var(--text-subtle);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 500;
+}
+
+.jump-palette__foot-spacer {
+  flex: 1;
+}
+
+.jump-palette__foot-remote {
   color: var(--text-muted);
-  font-size: 11px;
   font-style: italic;
 }
 
-.sidebar-search__result-meta .chip--instance {
-  flex: none;
-  height: 18px;
-  padding: 0 6px;
-  font-family: var(--font-sans, sans-serif);
-  font-size: 10px;
+.jump-palette__foot-count {
+  font-variant-numeric: tabular-nums;
 }
 
 /* Instance chip: peer celestial icon (placeholder glyph when unassigned)

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -933,6 +933,16 @@ textarea,
   animation: jump-palette-fade 110ms ease both;
 }
 
+/* Windows keeps its wordmark, masthead actions, and the global Messaging
+   controller in the fixed title strip, and that strip owns the window's drag
+   region. Every other full-window surface stays below it — Settings sits
+   inside `.app-shell`, which is already offset by `--win-titlebar-h`. This
+   one is portalled to the body, so it has to reproduce that offset by hand
+   rather than dimming a strip the operator still needs to drag the window by. */
+:root[data-platform="win32"] .jump-palette {
+  top: var(--win-titlebar-h);
+}
+
 .jump-palette__panel {
   display: flex;
   flex-direction: column;
@@ -1001,7 +1011,7 @@ textarea,
   padding: 3px 7px;
   border: 1px solid var(--border-subtle);
   border-radius: 5px;
-  color: var(--text-subtle);
+  color: var(--text-muted);
   font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 600;
@@ -1065,14 +1075,20 @@ textarea,
 }
 
 /* `direction: rtl` puts the ellipsis at the START, so a long `agent/…` prefix
-   gives way before the branch leaf does. The content is neutral-punctuated
-   ASCII, so no glyph reordering occurs. */
+   gives way before the branch leaf does. Safe for branch names, which git
+   forbids from starting or ending in the neutral characters that would
+   reorder under an RTL paragraph direction.
+
+   Shrinks twice as fast as the title and caps at 40% of the row: with equal
+   shrink factors a long branch beside a long title clips both, and the title
+   is the identifier the operator is actually reading. */
 .jump-palette__row-branch {
-  flex: 0 1 auto;
+  flex: 0 2 auto;
   min-width: 0;
+  max-width: 40%;
   overflow: hidden;
   direction: rtl;
-  color: var(--text-subtle);
+  color: var(--text-muted);
   font-family: var(--font-mono);
   font-size: 11px;
   text-align: right;
@@ -1107,7 +1123,7 @@ textarea,
 .jump-palette__empty {
   margin: 0;
   padding: 34px 20px;
-  color: var(--text-subtle);
+  color: var(--text-muted);
   font-size: 13px;
   text-align: center;
 }
@@ -1133,7 +1149,7 @@ textarea,
   padding: 9px 15px;
   border-top: 1px solid var(--border-subtle);
   background: var(--bg-panel);
-  color: var(--text-subtle);
+  color: var(--text-muted);
   font-family: var(--font-mono);
   font-size: 10.5px;
   font-weight: 500;
@@ -1144,7 +1160,6 @@ textarea,
 }
 
 .jump-palette__foot-remote {
-  color: var(--text-muted);
   font-style: italic;
 }
 


### PR DESCRIPTION
## Why

The ⌘K quick-jump popup rendered as a child of `<aside class="sidebar">`, absolutely positioned at `top: 52px; left/right: 10px`, z-index 40. Every complaint about it followed from that mount point:

- **Nothing dimmed**, so it never read as modal — easy to miss that it opened at all.
- **The sidebar's ~300px width amputated the meta line**, truncating branches mid-word (`fix/federated-provenance-…`, `agent/refine-lfs-ready-noti…`) — precisely the part that disambiguates two similarly-titled threads.
- The thread list stayed lit around the panel's edges, so the palette read as a filter on the list rather than a command surface.

## What

Modeled on PwrGit's ⌘K palette:

- Centered modal, `min(640px, 92vw)`, over the existing `--scrim-strong` token (already the modal scrim for `.pr-detach-warning-modal` / `.settings-confirm-modal`).
- **Single-line rows**: title flexes; PR / branch / repo ride the right edge as their own columns. The branch clips from the *left* (`direction: rtl`) so a long `agent/…` prefix gives way and the leaf survives.
- Footer legend (`↑↓ navigate · ↵ open · esc close`), live result count, and an `esc` pill in the field.
- Active row gets an inset `--accent-border` hairline on top of the tint — `--bg-row-active` (`#120800`) against `--bg-panel-elevated` (`#101010`) is a near-invisible delta in dark theme, and this is the one surface steered entirely by that cue.
- Input at 15px/500 with a placeholder that names the whole search space.

### Deliberately *not* copied from PwrGit

- Its **14px radius** — the desktop non-negotiables cap radius at 8px.
- Its **`--bg-overlay` token name** — `--scrim-strong` already exists here.
- Its **`⌘P pin` footer slot** — this palette is pure navigation; pin ordering only makes sense in the Directories lens.

## The portal is load-bearing

`.sidebar` declares `container: sidebar / inline-size`, and an element with a `container-type` is **a containing block for fixed-position descendants**. A `position: fixed; inset: 0` scrim left inside the rail would size and center itself on the ~300px sidebar rather than the viewport, and `overflow: hidden` would clip it besides. So the palette portals onto `document.body`.

Layer 140 rather than 120, matching `.pr-status-card` / `.messaging-status-tooltip`: ⌘K stays live inside text fields, so the palette has to clear whichever full-window layer (Settings, Star Map) is up.

## Peek machinery gets simpler

`useThreadJump` revealed a hidden sidebar on **open**, because the popup rendered inside it. Portalled, that reason is gone — but the *landing* still needs it, since `scrollIntoView` is a no-op inside a `display: none` subtree. So the reveal moves to **pick**:

- ⌘B'd-away sidebars no longer flash open behind a palette the operator may only be passing through.
- `deferPeekRestore` folds into the new `beginRevealPeek()`, whose return value picks the instant (single-frame) scroll.
- `endPeek` still lets an explicit ⌘B outrank a restore in flight.

## Accessibility

It claimed `role="dialog"` without being modal. Now it also has `aria-modal`, a Tab trap (the field is the only tab stop — rows are published via `aria-activedescendant` rather than focus, and carry `tabIndex={-1}`), and a scrim press in place of the document-level `pointerdown` listener. `aria-controls` is set only while the listbox is actually mounted, since a dangling idref is an invalid attribute value rather than a harmless one.

## Compatibility

Accessible names are unchanged — dialog and input are still `Jump to thread`, and the strings `Other instances` / `Searching other instances…` are intact — so existing unit and E2E assertions keep working. The peer-latency line moves into the footer, where it can't push results under the cursor between keystrokes.

## Testing

- `pnpm test apps/desktop/src/renderer/src/features/navigation/` — 200 passed. All pre-existing `SidebarSearchPopup` assertions pass unmodified; 6 new ones cover the portal, scrim dismissal, `aria-activedescendant`, the Tab trap, and the footer count. `useThreadJump` tests rewritten for the pick-time peek.
- `pnpm test` (full workspace) — 7383 passed. One pre-existing failure in `codex-environment-runtime.test.ts` (5 cases), confirmed identical on a stashed clean tree: this machine's global npmrc leaks `npm warn Unknown global config` lines into asserted command output. Unrelated to this change (renderer-only).
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors`, `pnpm lint:boundaries` — all clean.

**Not run locally:** desktop E2E. `thread-title-reveal.spec.ts` exercises exactly the hide-sidebar → ⌘K → pick → still-hidden path this changes, and `a11y.spec.ts` should probably grow a block for the palette now that it's a real modal surface — worth doing on the lab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)