### PR TITLE
fix(release): repair Windows signed installer packaging

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,6 +7,7 @@ namespaced with `ci:` when they start, skip, or narrow CI work.
 |---|---|---|
 | `ci:build-preview` | `preview-build.yml` | Builds an unsigned macOS preview DMG and uploads it as a workflow artifact. Use for PRs that change release packaging, installer assets, or desktop distribution behavior. |
 | `ci:windows-package` | `ci.yml` | Builds the unsigned Windows NSIS installer (`release.mjs --win`) and uploads it as a workflow artifact. Off by default — the normal Windows CI job is build + test only. Adding the label alone does not start CI; add it before opening the PR, rerun CI, or push a commit after adding it. The release workflow (`release.yml`) builds the Windows installer automatically on version tags. |
+| `ci:windows-signing` | `ci.yml` | Installs `TrustedSigning` on Windows and proves a fresh non-interactive PowerShell 7 process resolves `Invoke-TrustedSigning`. For same-repository PRs, it also requests the `windows-signing` environment and runs the installer build with `--require-signing`; fork PRs can run only the credential-free preflight. The environment currently permits only `v*` tags, so its protected PR job is rejected unless that policy is deliberately changed outside the workflow. Add this label before opening the PR, or push another commit after adding it. |
 
 If you add another label-influenced workflow path, document it here in the same
 change as the workflow update.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,88 @@ jobs:
             apps/desktop/release-stage/dist/SHA256SUMS
           retention-days: 7
 
+  windows-signing-preflight:
+    name: Windows signing preflight (label-gated)
+    # The preflight is intentionally credential-free so forks can prove that
+    # a fresh PowerShell 7 process resolves Invoke-TrustedSigning. The actual
+    # signing job below remains limited to same-repository PRs and protected by
+    # the windows-signing environment.
+    needs: changes
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:windows-signing') }}
+    runs-on: windows-2022
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        timeout-minutes: 10
+        with:
+          persist-credentials: false
+
+      - name: Install and verify TrustedSigning
+        shell: pwsh -NoProfile -NonInteractive -File {0}
+        run: ./scripts/release/install-trusted-signing.ps1
+
+  windows-signing:
+    name: Windows signed installer (protected, label-gated)
+    needs: [changes, windows-signing-preflight]
+    if: >-
+      ${{
+        github.event_name == 'pull_request'
+        && contains(github.event.pull_request.labels.*.name, 'ci:windows-signing')
+        && github.event.pull_request.head.repo.full_name == github.repository
+      }}
+    environment: windows-signing
+    # Match the release job's supported Visual Studio toolchain.
+    runs-on: windows-2022
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        timeout-minutes: 10
+        with:
+          persist-credentials: false
+
+      - name: Install Node.js and dependencies
+        uses: pwrdrvr/configure-nodejs@e19a1a140ed1851a536fcc2cc116e9d3df6b0ce9 # v1.2.0
+        timeout-minutes: 15
+        with:
+          node-version: 24.14.1
+          working-directory: .
+
+      - name: Install and verify TrustedSigning
+        shell: pwsh -NoProfile -NonInteractive -File {0}
+        run: ./scripts/release/install-trusted-signing.ps1
+
+      - name: Package signed Windows installer
+        timeout-minutes: 25
+        env:
+          WIN_AZURE_SIGN_PUBLISHER_NAME: ${{ vars.WIN_AZURE_SIGN_PUBLISHER_NAME }}
+          WIN_AZURE_SIGN_ENDPOINT: ${{ vars.WIN_AZURE_SIGN_ENDPOINT }}
+          WIN_AZURE_SIGN_ACCOUNT: ${{ vars.WIN_AZURE_SIGN_ACCOUNT }}
+          WIN_AZURE_SIGN_PROFILE: ${{ vars.WIN_AZURE_SIGN_PROFILE }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        run: node apps/desktop/scripts/release.mjs --win --no-publish --require-signing
+
+      - name: Upload signed Windows installer artifact
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        timeout-minutes: 10
+        with:
+          name: windows-signed-installer-pr
+          path: |
+            apps/desktop/release-stage/dist/*.exe
+            apps/desktop/release-stage/dist/*.exe.blockmap
+            apps/desktop/release-stage/dist/SHA256SUMS
+          retention-days: 7
+
   desktop-e2e:
     name: Linux Desktop E2E (lane ${{ matrix.lane }} of 2)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,6 +237,10 @@ jobs:
           node-version: 24.14.1
           working-directory: .
 
+      - name: Install and verify TrustedSigning
+        shell: pwsh -NoProfile -NonInteractive -File {0}
+        run: ./scripts/release/install-trusted-signing.ps1
+
       # Signs via Azure Artifact Signing when the `windows-signing` environment
       # provides the config (vars.WIN_AZURE_SIGN_*) and the Entra
       # service-principal secrets (AZURE_*). With none of them set, release.mjs

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -12,6 +12,8 @@ electronVersion: 41.10.3
 asar: true
 asarUnpack:
   - "**/*.node"
+  # @napi-rs/canvas loads its ICU data beside the Windows native binding.
+  - "node_modules/@napi-rs/canvas-win32-x64-msvc/**/*"
 compression: normal
 
 # Files included in the .app bundle. Run via apps/desktop/scripts/release.mjs

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -111,5 +111,8 @@
     "electron-vite": "^5.0.0",
     "tsx": "^4.20.6",
     "vite": "^7.3.2"
+  },
+  "optionalDependencies": {
+    "@napi-rs/canvas-win32-x64-msvc": "1.0.3"
   }
 }

--- a/apps/desktop/scripts/asar-entry-paths.mjs
+++ b/apps/desktop/scripts/asar-entry-paths.mjs
@@ -1,3 +1,33 @@
 export function normalizeAsarListing(listing) {
   return listing.map((entry) => entry.replaceAll("\\", "/"));
 }
+
+const windowsX64CanvasBindingRoot =
+  "/node_modules/@napi-rs/canvas-win32-x64-msvc";
+
+export function requiredPackagedRuntimeFiles(platform, arch) {
+  if (platform !== "win32" || arch !== "x64") {
+    return [];
+  }
+
+  return [
+    {
+      entry: `${windowsX64CanvasBindingRoot}/package.json`,
+      unpacked: false,
+    },
+    {
+      entry: `${windowsX64CanvasBindingRoot}/icudtl.dat`,
+      unpacked: true,
+    },
+    {
+      entry: `${windowsX64CanvasBindingRoot}/skia.win32-x64-msvc.node`,
+      unpacked: true,
+    },
+  ];
+}
+
+export function missingPackagedRuntimeFiles(listing, platform, arch) {
+  const entries = new Set(normalizeAsarListing(listing));
+  return requiredPackagedRuntimeFiles(platform, arch)
+    .filter(({ entry }) => !entries.has(entry));
+}

--- a/apps/desktop/scripts/asar-entry-paths.test.mjs
+++ b/apps/desktop/scripts/asar-entry-paths.test.mjs
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { normalizeAsarListing } from "./asar-entry-paths.mjs";
+import {
+  missingPackagedRuntimeFiles,
+  normalizeAsarListing,
+  requiredPackagedRuntimeFiles,
+} from "./asar-entry-paths.mjs";
 
 describe("ASAR entry paths", () => {
   it("normalizes Windows separators for platform-independent checks", () => {
@@ -22,5 +26,42 @@ describe("ASAR entry paths", () => {
     expect(listing).toEqual([
       "/out/main/index.js",
     ]);
+  });
+
+  it("requires the Windows x64 canvas package and native binding", () => {
+    const required = requiredPackagedRuntimeFiles("win32", "x64");
+
+    expect(required).toEqual([
+      {
+        entry: "/node_modules/@napi-rs/canvas-win32-x64-msvc/package.json",
+        unpacked: false,
+      },
+      {
+        entry: "/node_modules/@napi-rs/canvas-win32-x64-msvc/icudtl.dat",
+        unpacked: true,
+      },
+      {
+        entry: "/node_modules/@napi-rs/canvas-win32-x64-msvc/skia.win32-x64-msvc.node",
+        unpacked: true,
+      },
+    ]);
+  });
+
+  it("reports missing runtime files after normalizing separators", () => {
+    const missing = missingPackagedRuntimeFiles([
+      "\\node_modules\\@napi-rs\\canvas-win32-x64-msvc\\package.json",
+      "\\node_modules\\@napi-rs\\canvas-win32-x64-msvc\\skia.win32-x64-msvc.node",
+    ], "win32", "x64");
+
+    expect(missing).toEqual([
+      {
+        entry: "/node_modules/@napi-rs/canvas-win32-x64-msvc/icudtl.dat",
+        unpacked: true,
+      },
+    ]);
+  });
+
+  it("does not impose Windows x64 files on another target", () => {
+    expect(requiredPackagedRuntimeFiles("darwin", "arm64")).toEqual([]);
   });
 });

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -344,6 +344,23 @@ function patchStageDependencyManifests() {
   }
 }
 
+function verifyWindowsCanvasBindingInStage() {
+  const bindingPath = join(
+    stageDir,
+    "node_modules",
+    "@napi-rs",
+    "canvas-win32-x64-msvc",
+    "skia.win32-x64-msvc.node",
+  );
+  if (!existsSync(bindingPath)) {
+    throw new Error(
+      "pnpm deploy omitted @napi-rs/canvas-win32-x64-msvc from the Windows release stage. "
+        + "Keep the platform binding as an explicit optional dependency of @pwragent/desktop.",
+    );
+  }
+  console.log("  verified Windows x64 canvas native binding in release-stage");
+}
+
 function stageDesktopVersion() {
   const manifestPath = join(stageDir, "package.json");
   if (!existsSync(manifestPath)) {
@@ -415,6 +432,9 @@ if (!signStageOnly) {
     { cwd: repoRoot },
   );
   patchStageDependencyManifests();
+  if (win) {
+    verifyWindowsCanvasBindingInStage();
+  }
 
   // 4. Copy the build output, notices, changelog, and electron-builder inputs into the stage so
   //    electron-builder finds them at well-known paths.

--- a/apps/desktop/scripts/verify-asar-contents.mjs
+++ b/apps/desktop/scripts/verify-asar-contents.mjs
@@ -6,8 +6,12 @@
 
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
-import { resolve } from "node:path";
-import { normalizeAsarListing } from "./asar-entry-paths.mjs";
+import { join, resolve } from "node:path";
+import {
+  missingPackagedRuntimeFiles,
+  normalizeAsarListing,
+  requiredPackagedRuntimeFiles,
+} from "./asar-entry-paths.mjs";
 
 const args = process.argv.slice(2);
 const appPath = args[0]
@@ -45,6 +49,46 @@ const asar = require("@electron/asar");
 const listing = normalizeAsarListing(
   asar.listPackage(asarPath, { isPack: false }),
 );
+const missingRuntimeFiles = missingPackagedRuntimeFiles(
+  listing,
+  process.platform,
+  process.arch,
+);
+for (const runtimeFile of requiredPackagedRuntimeFiles(
+  process.platform,
+  process.arch,
+)) {
+  if (
+    !runtimeFile.unpacked
+    || missingRuntimeFiles.some(({ entry }) => entry === runtimeFile.entry)
+  ) {
+    continue;
+  }
+  const unpackedPath = join(
+    `${asarPath}.unpacked`,
+    ...runtimeFile.entry.slice(1).split("/"),
+  );
+  if (!existsSync(unpackedPath)) {
+    missingRuntimeFiles.push({
+      ...runtimeFile,
+      unpackedPath,
+    });
+  }
+}
+
+if (missingRuntimeFiles.length > 0) {
+  console.error("\nverify-asar-contents: required packaged runtime files are missing\n");
+  for (const runtimeFile of missingRuntimeFiles) {
+    console.error(`  ${runtimeFile.entry}`);
+    if (runtimeFile.unpackedPath) {
+      console.error(`    expected unpacked file at ${runtimeFile.unpackedPath}`);
+    }
+  }
+  console.error(
+    "\nKeep platform-native optional dependencies explicit in apps/desktop/package.json.",
+  );
+  process.exit(1);
+}
 // Each rule: [label, regex]. Anything matching → fail.
 const forbidden = [
   ["TypeScript source", /\.tsx?$/],
@@ -94,5 +138,5 @@ if (violations.length > 0) {
 }
 
 console.log(
-  `verify-asar-contents: OK (${listing.length} entries, no forbidden patterns)`,
+  `verify-asar-contents: OK (${listing.length} entries, required runtime files present, no forbidden patterns)`,
 );

--- a/docs/desktop-windows-signing.md
+++ b/docs/desktop-windows-signing.md
@@ -15,8 +15,17 @@ It needs no hardware token, works on GitHub-hosted runners, removes SmartScreen
 Signing is **opt-in and degrades gracefully**: the release job builds an
 **unsigned** installer until the signing config + credentials below are present,
 then signs automatically. Label-gated PR installer builds (`ci:windows-package`)
-are intentionally left **unsigned** (secrets are not exposed to PR validation,
-and signatures count against quota).
+are intentionally left **unsigned** (secrets are not exposed to ordinary PR
+validation, and signatures count against quota).
+
+`ci:windows-signing` is the narrower signing-repair validation path. Every
+labeled PR may run its credential-free PowerShell preflight, while only a
+same-repository PR may request the protected `windows-signing` job. That job
+still requires the environment's reviewer approval and calls `release.mjs`
+with `--require-signing`. The environment's current deployment branch policy
+permits only `v*` tags, so GitHub rejects PR deployments before exposing its
+secrets. Validating a signed PR build therefore requires a deliberate
+environment-policy change; the workflow does not bypass that protection.
 
 ## Current configuration (PwrDrvr LLC)
 
@@ -50,7 +59,12 @@ The three `AZURE_*` GitHub **secrets** come from the Entra app registration
   then auto-installs the `TrustedSigning` PowerShell module on the runner and
   invokes `Invoke-TrustedSigning`.
 - `.github/workflows/release.yml` (`windows-package` job, release tags only) —
-  supplies the env from repo variables + secrets.
+  installs and probes `TrustedSigning`, then supplies the env from repo
+  variables + secrets.
+- `scripts/release/install-trusted-signing.ps1` — installs the same module
+  electron-builder expects in PowerShell 7 and verifies that
+  `Invoke-TrustedSigning` resolves in a fresh `pwsh -NoProfile -NonInteractive`
+  process before packaging starts.
 
 ## One-time setup
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,10 @@ importers:
       vite:
         specifier: ^7.3.2
         version: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.5)
+    optionalDependencies:
+      '@napi-rs/canvas-win32-x64-msvc':
+        specifier: 1.0.3
+        version: 1.0.3
 
   packages/messaging/interface:
     dependencies:

--- a/scripts/check-desktop-release-metadata.mjs
+++ b/scripts/check-desktop-release-metadata.mjs
@@ -10,6 +10,10 @@ const electronBuilderPath = resolve(repoRoot, "apps/desktop/electron-builder.yml
 const ciWorkflowPath = resolve(repoRoot, ".github/workflows/ci.yml");
 const releaseScriptPath = resolve(repoRoot, "apps/desktop/scripts/release.mjs");
 const releaseWorkflowPath = resolve(repoRoot, ".github/workflows/release.yml");
+const trustedSigningSetupPath = resolve(
+  repoRoot,
+  "scripts/release/install-trusted-signing.ps1",
+);
 const desktopReleaseRunbookPath = resolve(repoRoot, "docs/desktop-release-runbook.md");
 const changelogPath = resolve(repoRoot, "CHANGELOG.md");
 
@@ -39,25 +43,46 @@ function escapeRegex(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function assertWorkflowJobRunner(workflow, workflowPath, jobName, expectedRunner) {
+function workflowJobBody(workflow, workflowPath, jobName) {
   const jobPattern = new RegExp(`^  ${escapeRegex(jobName)}:\\n`, "m");
   const match = workflow.match(jobPattern);
   if (!match) {
     fail(`${workflowPath} must contain a ${jobName} job`);
-    return;
+    return "";
   }
   const bodyStart = match.index + match[0].length;
   const remainder = workflow.slice(bodyStart);
   const nextJobOffset = remainder.search(/^  [A-Za-z0-9_-]+:/m);
-  const jobBody = nextJobOffset === -1
+  return nextJobOffset === -1
     ? remainder
     : remainder.slice(0, nextJobOffset);
+}
+
+function assertWorkflowJobRunner(workflow, workflowPath, jobName, expectedRunner) {
+  const jobBody = workflowJobBody(workflow, workflowPath, jobName);
   const runnerPattern = new RegExp(
     `^    runs-on:\\s+${escapeRegex(expectedRunner)}\\s*$`,
     "m",
   );
   if (!runnerPattern.test(jobBody)) {
     fail(`${workflowPath} ${jobName} must run on ${expectedRunner}`);
+  }
+}
+
+function assertWorkflowJobOrdersText(
+  workflow,
+  workflowPath,
+  jobName,
+  first,
+  second,
+) {
+  const jobBody = workflowJobBody(workflow, workflowPath, jobName);
+  const firstIndex = jobBody.indexOf(first);
+  const secondIndex = jobBody.indexOf(second);
+  if (firstIndex === -1 || secondIndex === -1 || firstIndex >= secondIndex) {
+    fail(
+      `${workflowPath} ${jobName} must place ${JSON.stringify(first)} before ${JSON.stringify(second)}`,
+    );
   }
 }
 
@@ -121,6 +146,7 @@ const electronBuilderConfig = readFileSync(electronBuilderPath, "utf8");
 const ciWorkflow = readFileSync(ciWorkflowPath, "utf8");
 const releaseScript = readFileSync(releaseScriptPath, "utf8");
 const releaseWorkflow = readFileSync(releaseWorkflowPath, "utf8");
+const trustedSigningSetup = readFileSync(trustedSigningSetupPath, "utf8");
 const desktopReleaseRunbook = readFileSync(desktopReleaseRunbookPath, "utf8");
 
 const desktopScripts = desktopPackage.scripts || {};
@@ -172,6 +198,11 @@ for (const expected of [
 
 for (const expected of [
   "releases/**",
+  "ci:windows-signing",
+  "github.event.pull_request.head.repo.full_name == github.repository",
+  "environment: windows-signing",
+  "scripts/release/install-trusted-signing.ps1",
+  "--win --no-publish --require-signing",
 ]) {
   if (!ciWorkflow.includes(expected)) {
     fail(`.github/workflows/ci.yml must contain ${JSON.stringify(expected)}`);
@@ -182,6 +213,25 @@ assertWorkflowJobRunner(
   ".github/workflows/ci.yml",
   "windows-package",
   "windows-2022",
+);
+assertWorkflowJobRunner(
+  ciWorkflow,
+  ".github/workflows/ci.yml",
+  "windows-signing-preflight",
+  "windows-2022",
+);
+assertWorkflowJobRunner(
+  ciWorkflow,
+  ".github/workflows/ci.yml",
+  "windows-signing",
+  "windows-2022",
+);
+assertWorkflowJobOrdersText(
+  ciWorkflow,
+  ".github/workflows/ci.yml",
+  "windows-signing",
+  "scripts/release/install-trusted-signing.ps1",
+  "--win --no-publish --require-signing",
 );
 
 for (const expected of [
@@ -194,6 +244,8 @@ for (const expected of [
   ".body | length",
   "PWRAGENT_LINUX_ARCH",
   "SHA256SUMS",
+  "scripts/release/install-trusted-signing.ps1",
+  "--win --no-publish --require-signing",
 ]) {
   if (!releaseWorkflow.includes(expected)) {
     fail(`.github/workflows/release.yml must contain ${JSON.stringify(expected)}`);
@@ -205,6 +257,24 @@ assertWorkflowJobRunner(
   "windows-package",
   "windows-2022",
 );
+assertWorkflowJobOrdersText(
+  releaseWorkflow,
+  ".github/workflows/release.yml",
+  "windows-package",
+  "scripts/release/install-trusted-signing.ps1",
+  "--win --no-publish --require-signing",
+);
+for (const expected of [
+  "Install-Module",
+  "-Name TrustedSigning",
+  "-MinimumVersion 0.5.0",
+  "Get-Command Invoke-TrustedSigning",
+  "-NoProfile -NonInteractive -Command",
+]) {
+  if (!trustedSigningSetup.includes(expected)) {
+    fail(`scripts/release/install-trusted-signing.ps1 must contain ${JSON.stringify(expected)}`);
+  }
+}
 for (const stepName of [
   "Upload release artifacts (debug retention)",
   "Upload Linux artifacts (debug retention)",

--- a/scripts/check-desktop-release-metadata.mjs
+++ b/scripts/check-desktop-release-metadata.mjs
@@ -9,6 +9,10 @@ const desktopPackagePath = resolve(repoRoot, "apps/desktop/package.json");
 const electronBuilderPath = resolve(repoRoot, "apps/desktop/electron-builder.yml");
 const ciWorkflowPath = resolve(repoRoot, ".github/workflows/ci.yml");
 const releaseScriptPath = resolve(repoRoot, "apps/desktop/scripts/release.mjs");
+const verifyAsarContentsPath = resolve(
+  repoRoot,
+  "apps/desktop/scripts/verify-asar-contents.mjs",
+);
 const releaseWorkflowPath = resolve(repoRoot, ".github/workflows/release.yml");
 const trustedSigningSetupPath = resolve(
   repoRoot,
@@ -145,11 +149,20 @@ if (!headingPattern.test(changelog)) {
 const electronBuilderConfig = readFileSync(electronBuilderPath, "utf8");
 const ciWorkflow = readFileSync(ciWorkflowPath, "utf8");
 const releaseScript = readFileSync(releaseScriptPath, "utf8");
+const verifyAsarContents = readFileSync(verifyAsarContentsPath, "utf8");
 const releaseWorkflow = readFileSync(releaseWorkflowPath, "utf8");
 const trustedSigningSetup = readFileSync(trustedSigningSetupPath, "utf8");
 const desktopReleaseRunbook = readFileSync(desktopReleaseRunbookPath, "utf8");
 
 const desktopScripts = desktopPackage.scripts || {};
+if (
+  desktopPackage.optionalDependencies?.["@napi-rs/canvas-win32-x64-msvc"]
+  !== desktopPackage.dependencies?.["@napi-rs/canvas"]
+) {
+  fail(
+    "apps/desktop/package.json must keep matching @napi-rs/canvas and Windows x64 binding versions",
+  );
+}
 if (desktopScripts["package:linux"] !== "node ./scripts/release.mjs --linux --no-publish") {
   fail("apps/desktop/package.json must expose package:linux for local Linux package builds");
 }
@@ -167,6 +180,7 @@ for (const expected of [
   "entry:",
   "StartupWMClass: PwrAgent",
   "private: false",
+  "node_modules/@napi-rs/canvas-win32-x64-msvc/**/*",
 ]) {
   if (!electronBuilderConfig.includes(expected)) {
     fail(`apps/desktop/electron-builder.yml must contain ${JSON.stringify(expected)}`);
@@ -193,6 +207,18 @@ for (const expected of [
 ]) {
   if (!releaseScript.includes(expected)) {
     fail(`apps/desktop/scripts/release.mjs must contain ${JSON.stringify(expected)}`);
+  }
+}
+
+for (const expected of [
+  "requiredPackagedRuntimeFiles",
+  "unpackedPath",
+  "required packaged runtime files are missing",
+]) {
+  if (!verifyAsarContents.includes(expected)) {
+    fail(
+      `apps/desktop/scripts/verify-asar-contents.mjs must contain ${JSON.stringify(expected)}`,
+    );
   }
 }
 

--- a/scripts/release/install-trusted-signing.ps1
+++ b/scripts/release/install-trusted-signing.ps1
@@ -1,0 +1,39 @@
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$pwsh = Get-Command pwsh.exe -CommandType Application -ErrorAction Stop
+Write-Host "Installing TrustedSigning with $($pwsh.Source) (PowerShell $($PSVersionTable.PSVersion))"
+
+Install-PackageProvider `
+  -Name NuGet `
+  -MinimumVersion 2.8.5.201 `
+  -Force `
+  -Scope CurrentUser | Out-Null
+Install-Module `
+  -Name TrustedSigning `
+  -MinimumVersion 0.5.0 `
+  -Force `
+  -Repository PSGallery `
+  -Scope CurrentUser
+
+$module = Get-Module -ListAvailable -Name TrustedSigning |
+  Where-Object { $_.Version -ge [version]"0.5.0" } |
+  Sort-Object Version -Descending |
+  Select-Object -First 1
+if ($null -eq $module) {
+  throw "TrustedSigning 0.5.0 or newer was not installed for the current user."
+}
+
+$probe = @'
+$ErrorActionPreference = "Stop"
+$command = Get-Command Invoke-TrustedSigning -ErrorAction Stop
+if ($command.ModuleName -ne "TrustedSigning") {
+  throw "Invoke-TrustedSigning resolved from unexpected module '$($command.ModuleName)'."
+}
+Write-Host "Fresh pwsh resolved $($command.Name) from $($command.Source)."
+'@
+
+& $pwsh.Source -NoProfile -NonInteractive -Command $probe
+if ($LASTEXITCODE -ne 0) {
+  throw "Fresh pwsh could not resolve Invoke-TrustedSigning (exit code $LASTEXITCODE)."
+}

--- a/scripts/release/install-trusted-signing.ps1
+++ b/scripts/release/install-trusted-signing.ps1
@@ -4,11 +4,15 @@ $ProgressPreference = "SilentlyContinue"
 $pwsh = Get-Command pwsh.exe -CommandType Application -ErrorAction Stop
 Write-Host "Installing TrustedSigning with $($pwsh.Source) (PowerShell $($PSVersionTable.PSVersion))"
 
-Install-PackageProvider `
-  -Name NuGet `
-  -MinimumVersion 2.8.5.201 `
-  -Force `
-  -Scope CurrentUser | Out-Null
+try {
+  Install-PackageProvider `
+    -Name NuGet `
+    -MinimumVersion 2.8.5.201 `
+    -Force `
+    -Scope CurrentUser | Out-Null
+} catch {
+  Write-Warning "NuGet provider bootstrap failed; Install-Module will verify whether it is needed: $($_.Exception.Message)"
+}
 Install-Module `
   -Name TrustedSigning `
   -MinimumVersion 0.5.0 `


### PR DESCRIPTION
## Summary

- I install the `TrustedSigning` PowerShell module explicitly on the Windows release runner and prove that `Invoke-TrustedSigning` resolves in a fresh `pwsh -NoProfile -NonInteractive` process before `release.mjs` starts.
- I added `ci:windows-signing`: its credential-free preflight is safe for any labeled PR, while the signed installer job is limited to same-repository PRs and still requests the protected `windows-signing` environment.
- I kept `--require-signing`, signing errors, the environment-scoped Azure variables/secrets, and release publishing behavior unchanged.
- I extended the release metadata check to pin the module preflight, ordering, Windows runner, protected environment, same-repository guard, and required-signing invocation.
- After manually installing the first signed PR artifact exposed a startup crash, I made `@napi-rs/canvas-win32-x64-msvc` an explicit optional desktop dependency, kept its native binding and ICU data outside ASAR, and added pre- and post-package checks so a Windows installer cannot pass while those runtime files are absent.

## Verification

- `pnpm release:check --tag v1.1.0-beta.1`
- `pnpm lint:eslint` (passes with 30 pre-existing warnings)
- `pnpm lint` (passes with the same 30 pre-existing warnings)
- `pnpm test apps/desktop/scripts/asar-entry-paths.test.mjs`
- `pnpm test apps/desktop/scripts/electron-vite-config.test.mjs`
- `actionlint -ignore 'label "pwrdrvr-macos" is unknown' .github/workflows/ci.yml .github/workflows/release.yml`
- Ruby/Psych YAML parsing for `.github/workflows/ci.yml` and `.github/workflows/release.yml`
- `git diff --check`
- [CI run 31492109553, attempt 2](https://github.com/pwrdrvr/PwrAgent/actions/runs/31492109553): all checks passed, including the credential-free preflight and protected signed-installer job.
- The protected job Azure-signed the application, bundled Windows executables, uninstaller, and final NSIS installer, then uploaded the installer, blockmap, and `SHA256SUMS` as [`windows-signed-installer-pr`](https://github.com/pwrdrvr/PwrAgent/actions/runs/31492109553/artifacts/9102005742).
- The new packaged-runtime verifier rejects that first artifact with the exact missing `@napi-rs/canvas-win32-x64-msvc` package, `icudtl.dat`, and `skia.win32-x64-msvc.node` paths. A replacement signed-artifact result will be recorded here after CI completes.

## Notes

- Release run [31460789869](https://github.com/pwrdrvr/PwrAgent/actions/runs/31460789869), job `Package Windows installer`, showed electron-builder install `TrustedSigning` and then fail when its later clean PowerShell process could not recognize `Invoke-TrustedSigning`. The new preflight turns that late signing failure into an immediate module-discovery check and leaves electron-builder's signing command intact.
- The first signed PR installer itself completed successfully, but launching the installed app failed immediately because electron-builder retained `@napi-rs/canvas` while dropping its transitive optional Windows native package. Making that platform package a direct optional dependency preserves cross-platform installs while making it visible to electron-builder's production dependency collector.
- Current `main` does not contain an Apple-signing PR label; its `ci:build-preview` path is deliberately unsigned. At PR creation, both signing environments required reviewer approval and accepted only `v*` tags, so the first protected Windows attempt was rejected before receiving a runner or credentials. The operator temporarily relaxed the `windows-signing` branch policy and approved attempt 2, which completed end to end. This PR did not modify environments, secrets, tags, releases, or `releases/1.0`.
- The temporary environment-policy relaxation should remain only through the replacement signed-installer validation, then be restored. This PR does not change that policy.
