### PR TITLE
fix(desktop): name remote threads in the quit dialog

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -87,6 +87,7 @@ const federationMock = vi.hoisted(() => {
     ),
     searchForJump: vi.fn(async () => ({ results: [] })),
     threadFromPeer: vi.fn(async (): Promise<unknown> => undefined),
+    rememberThreadNames: vi.fn(),
   };
   return {
     remoteBackend,
@@ -1815,6 +1816,52 @@ describe("app server ipc", () => {
         federation: { peerStatus: "disconnected" },
       }],
     });
+  });
+
+  // Remote thread names are remembered here because a federation window's
+  // navigation never reaches RemoteThreadSummaryCache. That is a side errand:
+  // the operator asked for a snapshot, and losing a name costs a thread id in
+  // a quit dialog somewhere, not this window's contents.
+  it("remembers remote thread names without letting that break the snapshot", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "peer_remembers_names",
+    };
+    const snapshot = {
+      backend: "all" as const,
+      fetchedAt: 1_000,
+      federationTarget,
+      unchanged: false,
+      threads: [],
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    };
+    federationMock.runtime.remoteNavigationSnapshot
+      .mockResolvedValueOnce(snapshot)
+      .mockResolvedValueOnce(snapshot);
+
+    registerAppServerIpcHandlers();
+    const handler = handlers.get(NAVIGATION_SNAPSHOT_CHANNEL);
+
+    await expect(handler?.({}, { federationTarget })).resolves.toBe(snapshot);
+    expect(
+      federationMock.remoteThreadSummaries.rememberThreadNames,
+    ).toHaveBeenCalledWith("peer_remembers_names", snapshot.threads);
+
+    federationMock.remoteThreadSummaries.rememberThreadNames.mockImplementationOnce(
+      () => {
+        throw new Error("federation runtime unavailable");
+      },
+    );
+    await expect(
+      handler?.({}, { federationTarget, forceRefresh: true, refreshMode: "full" }),
+    ).resolves.toBe(snapshot);
   });
 
   it("overlays viewer-owned directory disclosure state on remote snapshots", async () => {

--- a/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
@@ -76,7 +76,12 @@ vi.mock("electron", () => ({
   },
 }));
 
-vi.mock("../terminal/integrated-terminal-service", () => ({
+vi.mock("../terminal/integrated-terminal-service", async (importOriginal) => ({
+  // byThreadKey is a pure comparator the merge under test uses; only the
+  // service itself needs faking.
+  ...(await importOriginal<
+    typeof import("../terminal/integrated-terminal-service")
+  >()),
   IntegratedTerminalService: class {
     constructor(options: { onSessionsChanged: (sessions: unknown[]) => void }) {
       mocks.localSessionsChanged = options.onSessionsChanged;
@@ -452,6 +457,62 @@ describe("integrated terminal IPC federation branch", () => {
     mocks.localRevealSession.mockReturnValue(false);
 
     expect(revealIntegratedTerminal("codex:vanished").revealed).toBe(false);
+  });
+
+  // Remote mounts allocate a PTY per viewer window, so the same peer thread
+  // can be open twice. Reporting no owner would drop the caller back to the
+  // focused-or-first window, which is the bug the owner exists to avoid.
+  it("names an owner even when two windows host the same remote thread", async () => {
+    const first = fakeWebContents(21);
+    const second = fakeWebContents(22);
+    for (const [id, sender] of [
+      [21, first],
+      [22, second],
+    ] as const) {
+      mocks.federationWindowIds.add(id);
+      mocks.federationTargets.set(id, { scope: "remote", instanceId: "peer-a" });
+      mocks.remotePtyOpen.mockResolvedValueOnce({
+        sessionId: `remote-session-${id}`,
+        cwd: "/owner/worktree",
+        shell: "/bin/zsh",
+      });
+      await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
+        threadKey: "codex:shared-thread",
+        cols: 80,
+        rows: 24,
+      });
+    }
+
+    const result = revealIntegratedTerminal("codex:shared-thread");
+    expect(result.revealed).toBe(true);
+    expect([first, second]).toContain(result.owner);
+  });
+
+  // A local shell and a peer's shell can share a thread key. Naming the
+  // instance must reach the peer's session, not the local registry.
+  it("skips the local registry when the caller names an owning instance", async () => {
+    mocks.localRevealSession.mockReturnValue(true);
+    const federationWindow = fakeWebContents(31);
+    mocks.federationWindowIds.add(31);
+    mocks.federationTargets.set(31, { scope: "remote", instanceId: "peer-a" });
+    await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, federationWindow, {
+      threadKey: "codex:shared-key",
+      cols: 80,
+      rows: 24,
+    });
+
+    const result = revealIntegratedTerminal("codex:shared-key", {
+      instanceId: "peer-a",
+    });
+
+    expect(mocks.localRevealSession).not.toHaveBeenCalled();
+    expect(result.owner).toBe(federationWindow);
+
+    // ...and a different instance owns nothing here.
+    expect(
+      revealIntegratedTerminal("codex:shared-key", { instanceId: "peer-b" })
+        .revealed,
+    ).toBe(false);
   });
 
   it("throws for a federation window with no remote target instead of spawning locally", async () => {

--- a/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
@@ -4,6 +4,7 @@ import {
   INTEGRATED_TERMINAL_CLOSE_CHANNEL,
   INTEGRATED_TERMINAL_CREATE_CHANNEL,
   INTEGRATED_TERMINAL_LIST_CHANNEL,
+  INTEGRATED_TERMINAL_REVEAL_CHANNEL,
   INTEGRATED_TERMINAL_SESSIONS_CHANNEL,
   INTEGRATED_TERMINAL_SET_PANEL_HIDDEN_CHANNEL,
   INTEGRATED_TERMINAL_WRITE_CHANNEL,
@@ -25,6 +26,7 @@ const mocks = vi.hoisted(() => {
     localWrite: vi.fn(),
     localClose: vi.fn(),
     localSetPanelHidden: vi.fn(),
+    localRevealSession: vi.fn(() => false),
     federationWindowIds: new Set<number>(),
     federationTargets: new Map<number, { scope: "remote"; instanceId: string }>(),
     connectedPeers: [
@@ -37,7 +39,7 @@ const mocks = vi.hoisted(() => {
     localQuitSnapshot: {
       count: 0,
       sessionIds: [] as string[],
-      threadKeys: [] as string[],
+      threads: [] as Array<{ threadKey: string }>,
     },
     channelSubscribers: [] as Array<{ id: number; send: (...args: unknown[]) => void }>,
     localSessionsChanged: undefined as
@@ -85,6 +87,7 @@ vi.mock("../terminal/integrated-terminal-service", () => ({
     close = mocks.localClose;
     listSessions = vi.fn(() => []);
     setPanelHidden = mocks.localSetPanelHidden;
+    revealSession = mocks.localRevealSession;
     getQuitSnapshot = () => mocks.localQuitSnapshot;
     dispose = vi.fn();
   },
@@ -131,6 +134,7 @@ import {
   disposeIntegratedTerminalIpcHandlers,
   getIntegratedTerminalQuitSnapshot,
   registerIntegratedTerminalIpcHandlers,
+  revealIntegratedTerminal,
 } from "../ipc/integrated-terminal";
 
 function fakeWebContents(id: number): WebContents {
@@ -161,7 +165,8 @@ describe("integrated terminal IPC federation branch", () => {
         capabilities: ["remote_pty"],
       },
     ];
-    mocks.localQuitSnapshot = { count: 0, sessionIds: [], threadKeys: [] };
+    mocks.localQuitSnapshot = { count: 0, sessionIds: [], threads: [] };
+    mocks.localRevealSession.mockReturnValue(false);
     mocks.channelSubscribers = [];
     mocks.localSessionsChanged = undefined;
     disposeIntegratedTerminalIpcHandlers();
@@ -381,7 +386,7 @@ describe("integrated terminal IPC federation branch", () => {
     mocks.localQuitSnapshot = {
       count: 1,
       sessionIds: ["local-session"],
-      threadKeys: ["codex:local-thread"],
+      threads: [{ threadKey: "codex:local-thread" }],
     };
     await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
       threadKey: "codex:remote-pinned",
@@ -392,11 +397,61 @@ describe("integrated terminal IPC federation branch", () => {
 
     const snapshot = getIntegratedTerminalQuitSnapshot();
     expect(snapshot.count).toBe(2);
-    expect(snapshot.threadKeys).toEqual([
-      "codex:local-thread",
-      "codex:remote-pinned",
+    // The owning peer rides along: the quit dialog cannot name a remote
+    // thread by asking the LOCAL thread list about it.
+    expect(snapshot.threads).toEqual([
+      { threadKey: "codex:local-thread" },
+      {
+        threadKey: "codex:remote-pinned",
+        target: { scope: "remote", instanceId: "peer-a" },
+        instanceLabel: "Peer Mac",
+      },
     ]);
     expect(snapshot.sessionIds).toContain("remote-session");
+  });
+
+  it("reveals a remote terminal in the window that owns it", async () => {
+    const federationWindow = fakeWebContents(11);
+    mocks.federationWindowIds.add(11);
+    mocks.federationTargets.set(11, { scope: "remote", instanceId: "peer-a" });
+    const otherWindow = fakeWebContents(12);
+    mocks.channelSubscribers = [
+      federationWindow as unknown as { id: number; send: (...args: unknown[]) => void },
+      otherWindow as unknown as { id: number; send: (...args: unknown[]) => void },
+    ];
+    await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, federationWindow, {
+      threadKey: "codex:remote-thread",
+      cols: 80,
+      rows: 24,
+    });
+    await invoke(INTEGRATED_TERMINAL_SET_PANEL_HIDDEN_CHANNEL, federationWindow, {
+      threadKey: "codex:remote-thread",
+      hidden: true,
+    });
+
+    const result = revealIntegratedTerminal("codex:remote-thread");
+
+    // Asking only the LOCAL PTY registry reported "no such session" and the
+    // quit dialog's terminal row silently did nothing.
+    expect(result.revealed).toBe(true);
+    expect(result.owner).toBe(federationWindow);
+    const revealCalls = (
+      federationWindow.send as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls.filter(
+      ([channel]) => channel === INTEGRATED_TERMINAL_REVEAL_CHANNEL,
+    );
+    expect(revealCalls).toHaveLength(1);
+    // A window that does not own the session must not open a terminal panel
+    // for a thread it may not even have.
+    expect(
+      (otherWindow.send as unknown as { mock: { calls: unknown[][] } }).mock.calls,
+    ).toHaveLength(0);
+  });
+
+  it("reports nothing to reveal when no window owns the thread", async () => {
+    mocks.localRevealSession.mockReturnValue(false);
+
+    expect(revealIntegratedTerminal("codex:vanished").revealed).toBe(false);
   });
 
   it("throws for a federation window with no remote target instead of spawning locally", async () => {

--- a/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
+++ b/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
@@ -260,7 +260,7 @@ describe("resolveTerminalShell", () => {
     expect(service.getQuitSnapshot()).toEqual({
       count: 1,
       sessionIds: [response.sessionId],
-      threadKeys: ["codex:thread-a"],
+      threads: [{ threadKey: "codex:thread-a" }],
     });
   });
 
@@ -286,7 +286,7 @@ describe("resolveTerminalShell", () => {
     expect(service.getQuitSnapshot()).toEqual({
       count: 0,
       sessionIds: [],
-      threadKeys: [],
+      threads: [],
     });
   });
 
@@ -314,7 +314,7 @@ describe("resolveTerminalShell", () => {
     expect(service.getQuitSnapshot()).toEqual({
       count: 1,
       sessionIds: [response.sessionId],
-      threadKeys: ["codex:thread-linux-pipeline"],
+      threads: [{ threadKey: "codex:thread-linux-pipeline" }],
     });
   });
 
@@ -342,7 +342,7 @@ describe("resolveTerminalShell", () => {
     expect(service.getQuitSnapshot()).toEqual({
       count: 0,
       sessionIds: [],
-      threadKeys: [],
+      threads: [],
     });
   });
 
@@ -372,7 +372,7 @@ describe("resolveTerminalShell", () => {
     expect(service.getQuitSnapshot()).toEqual({
       count: 1,
       sessionIds: [response.sessionId],
-      threadKeys: ["codex:thread-linux-lookup-failed"],
+      threads: [{ threadKey: "codex:thread-linux-lookup-failed" }],
     });
   });
 
@@ -398,7 +398,7 @@ describe("resolveTerminalShell", () => {
     expect(service.getQuitSnapshot()).toEqual({
       count: 1,
       sessionIds: [response.sessionId],
-      threadKeys: ["codex:thread-windows"],
+      threads: [{ threadKey: "codex:thread-windows" }],
     });
   });
 
@@ -429,7 +429,7 @@ describe("resolveTerminalShell", () => {
     expect(service.getQuitSnapshot()).toEqual({
       count: 1,
       sessionIds: [response.sessionId],
-      threadKeys: ["codex:thread-lookup-failed"],
+      threads: [{ threadKey: "codex:thread-lookup-failed" }],
     });
   });
 
@@ -593,7 +593,7 @@ describe("resolveTerminalShell", () => {
     expect(service.getQuitSnapshot()).toEqual({
       count: 0,
       sessionIds: [],
-      threadKeys: [],
+      threads: [],
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
@@ -149,6 +149,30 @@ describe("quit dialog row links", () => {
     });
   });
 
+  // A thread key does not identify a thread across instances, so a peer's row
+  // and a same-keyed local row would otherwise encode to the same action and
+  // the click could not tell them apart.
+  it("round-trips the owning instance for a remote row", () => {
+    const item: QuitBlockerItem = {
+      kind: "terminal",
+      backend: "codex",
+      threadId: "thread-3",
+      threadKey: "codex:thread-3",
+      target: { scope: "remote", instanceId: "peer-a" },
+    };
+
+    expect(parseQuitItemAction(formatQuitItemAction(item))).toEqual({
+      threadKey: "codex:thread-3",
+      kind: "terminal",
+      instanceId: "peer-a",
+    });
+
+    // A local row carries no instance, and must not grow one.
+    expect(
+      parseQuitItemAction(formatQuitItemAction({ ...item, target: undefined })),
+    ).toEqual({ threadKey: "codex:thread-3", kind: "terminal" });
+  });
+
   it("ignores actions that are not row links", () => {
     expect(parseQuitItemAction("manual-confirm")).toBeUndefined();
     expect(parseQuitItemAction("countdown-cancel")).toBeUndefined();
@@ -318,6 +342,7 @@ describe("clicking a quit dialog row", () => {
 
     expect(revealIntegratedTerminal).toHaveBeenCalledWith(
       "codex:0f9c2b7a-remote",
+      { instanceId: "peer-a" },
     );
     // The dialog is what has focus, so requestShowThread would otherwise fall
     // back to whichever window subscribed first — for a peer's terminal that
@@ -348,6 +373,10 @@ describe("clicking a quit dialog row", () => {
 
     clickRow(window, formatQuitItemAction(item));
 
+    expect(revealIntegratedTerminal).toHaveBeenCalledWith(
+      "codex:local-thread",
+      {},
+    );
     expect(requestShowThread).toHaveBeenCalledWith(
       { backend: "codex", threadId: "local-thread" },
       { preferWebContents: undefined },

--- a/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
@@ -11,8 +11,10 @@ type FakeDialogWindow = {
   closed: number;
   once: (event: string, handler: (...args: unknown[]) => void) => void;
   webContents: { on: () => void; setWindowOpenHandler: () => void };
+  /** The data: URL the dialog loaded, so tests can read the page it built. */
+  loadedUrl?: string;
   /** Stays pending unless a test settles it — the real load is async too. */
-  loadURL: () => Promise<void>;
+  loadURL: (url: string) => Promise<void>;
   rejectLoad: (error: Error) => void;
   isDestroyed: () => boolean;
   isMinimized: () => boolean;
@@ -42,7 +44,10 @@ function createFakeDialogWindow(): FakeDialogWindow {
       on: vi.fn(),
       setWindowOpenHandler: vi.fn(),
     },
-    loadURL: () => loaded,
+    loadURL: (url: string) => {
+      window.loadedUrl = url;
+      return loaded;
+    },
     rejectLoad: (error) => rejectLoad(error),
     isDestroyed: () => window.destroyed,
     isMinimized: () => window.minimized,
@@ -92,7 +97,10 @@ vi.mock("../settings/appearance-bootstrap", () => ({
   readBootstrapAppearance: () => ({ theme: "dark" }),
 }));
 
+import type { WebContents } from "electron";
 import { parseThreadIdentityKey } from "@pwragent/shared";
+import { revealIntegratedTerminal } from "../ipc/integrated-terminal";
+import { requestShowThread } from "../window-show-thread";
 import {
   focusActiveQuitConfirmationDialog,
   formatQuitItemAction,
@@ -249,6 +257,101 @@ describe("raising the open quit dialog", () => {
     expect(focusActiveQuitConfirmationDialog()).toBe(true);
 
     window.listeners.get("closed")?.();
+    await expect(pending).resolves.toBe("manual-cancel");
+  });
+});
+
+describe("clicking a quit dialog row", () => {
+  afterEach(async () => {
+    for (const window of dialogWindows) {
+      if (!window.destroyed) {
+        window.listeners.get("closed")?.();
+      }
+    }
+    await Promise.resolve();
+    dialogWindows.length = 0;
+    vi.mocked(revealIntegratedTerminal).mockReset();
+  });
+
+  /**
+   * Fire the dialog's own `will-navigate` handler with a row action, using
+   * the per-dialog navigation prefix the page was actually built with.
+   */
+  function clickRow(window: (typeof dialogWindows)[number], action: string) {
+    const on = window.webContents.on as unknown as {
+      mock: { calls: Array<[string, (event: unknown, url: string) => void]> };
+    };
+    const willNavigate = on.mock.calls.find(
+      ([event]) => event === "will-navigate",
+    )?.[1];
+    if (!willNavigate) throw new Error("dialog registered no will-navigate handler");
+    const prefix = /pwragent-quit-confirmation:\/\/[^/]+\//.exec(
+      decodeURIComponent(window.loadedUrl ?? ""),
+    )?.[0];
+    if (!prefix) throw new Error("dialog page carries no navigation prefix");
+    willNavigate({ preventDefault: vi.fn() }, `${prefix}${action}`);
+  }
+
+  it("routes the show-thread request to the window that owns a remote terminal", async () => {
+    const owner = { id: 11 } as unknown as WebContents;
+    vi.mocked(revealIntegratedTerminal).mockReturnValue({
+      revealed: true,
+      owner,
+    });
+    const item: QuitBlockerItem = {
+      kind: "terminal",
+      backend: "codex",
+      threadId: "0f9c2b7a-remote",
+      threadKey: "codex:0f9c2b7a-remote",
+      target: { scope: "remote", instanceId: "peer-a" },
+    };
+    const pending = showQuitConfirmationDialog({
+      countdownSeconds: 10,
+      inProgressThreadCount: 0,
+      terminalSessionCount: 1,
+      items: [item],
+    });
+    const window = dialogWindows.at(-1)!;
+    window.listeners.get("ready-to-show")?.();
+
+    clickRow(window, formatQuitItemAction(item));
+
+    expect(revealIntegratedTerminal).toHaveBeenCalledWith(
+      "codex:0f9c2b7a-remote",
+    );
+    // The dialog is what has focus, so requestShowThread would otherwise fall
+    // back to whichever window subscribed first — for a peer's terminal that
+    // is a window with no such thread.
+    expect(requestShowThread).toHaveBeenCalledWith(
+      { backend: "codex", threadId: "0f9c2b7a-remote" },
+      { preferWebContents: owner },
+    );
+    await expect(pending).resolves.toBe("manual-cancel");
+  });
+
+  it("leaves a local terminal row on the ordinary broadcast path", async () => {
+    vi.mocked(revealIntegratedTerminal).mockReturnValue({ revealed: true });
+    const item: QuitBlockerItem = {
+      kind: "terminal",
+      backend: "codex",
+      threadId: "local-thread",
+      threadKey: "codex:local-thread",
+    };
+    const pending = showQuitConfirmationDialog({
+      countdownSeconds: 10,
+      inProgressThreadCount: 0,
+      terminalSessionCount: 1,
+      items: [item],
+    });
+    const window = dialogWindows.at(-1)!;
+    window.listeners.get("ready-to-show")?.();
+
+    clickRow(window, formatQuitItemAction(item));
+
+    expect(requestShowThread).toHaveBeenCalledWith(
+      { backend: "codex", threadId: "local-thread" },
+      { preferWebContents: undefined },
+    );
     await expect(pending).resolves.toBe("manual-cancel");
   });
 });

--- a/apps/desktop/src/main/__tests__/quit-dialog-render.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-dialog-render.test.ts
@@ -73,6 +73,35 @@ describe("quit dialog HTML", () => {
     expect(html).toContain("overflow-y: auto");
   });
 
+  it("names the owning peer on a remote terminal row", () => {
+    const html = buildQuitConfirmationHtml({
+      countdownSeconds: 10,
+      inProgressThreadCount: 0,
+      terminalSessionCount: 1,
+      actionRunCount: 0,
+      items: [
+        {
+          kind: "terminal",
+          backend: "codex",
+          threadId: "0f9c2b7a-remote",
+          threadKey: "codex:0f9c2b7a-remote",
+          title: "Reap Windows Worktrees",
+          target: { scope: "remote", instanceId: "peer-a" },
+          detail: "Studio Mac",
+        },
+      ],
+      navigationPrefix: "pwragent-quit-confirmation://tok/",
+      colorScheme: "dark",
+      palette: QUIT_DIALOG_PALETTES.dark,
+    });
+
+    // The name the viewer already shows for this thread, plus the machine the
+    // shell is actually running on.
+    expect(html).toContain("Reap Windows Worktrees");
+    expect(html).toContain("Studio Mac");
+    expect(html).not.toContain(">0f9c2b7a-remote<");
+  });
+
   it("escapes the action detail, which carries a user-configured command", () => {
     const html = buildQuitConfirmationHtml({
       countdownSeconds: 10,

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -577,7 +577,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
     const listLocalThreads = vi.fn(async () => [
       { source: "codex" as const, id: "local-thread", title: "Local Work" },
     ]);
-    const cachedRemoteThreadSummary = vi.fn(() => ({
+    const cachedRemoteThreadName = vi.fn(() => ({
       title: "Reap Windows Worktrees",
       titleSource: "derived" as const,
     }));
@@ -585,7 +585,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
 
     const titles = await resolveQuitBlockerThreadTitles([localItem, remoteItem], {
       listLocalThreads,
-      cachedRemoteThreadSummary,
+      cachedRemoteThreadName,
       listRemoteThreadPins,
     });
 
@@ -593,7 +593,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
       "Reap Windows Worktrees",
     );
     expect(titles.get(quitBlockerTitleKey(localItem))).toBe("Local Work");
-    expect(cachedRemoteThreadSummary).toHaveBeenCalledWith({
+    expect(cachedRemoteThreadName).toHaveBeenCalledWith({
       target: { scope: "remote", instanceId: "peer-a" },
       backend: "codex",
       threadId: "0f9c2b7a-remote",
@@ -612,7 +612,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
 
     const titles = await resolveQuitBlockerThreadTitles([remoteItem], {
       listLocalThreads: async () => [],
-      cachedRemoteThreadSummary: () => undefined,
+      cachedRemoteThreadName: () => undefined,
       listRemoteThreadPins: async () => [
         {
           ref: {
@@ -651,7 +651,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
 
     const pending = resolveQuitBlockerThreadTitles([remoteItem], {
       listLocalThreads: async () => [],
-      cachedRemoteThreadSummary: () => ({
+      cachedRemoteThreadName: () => ({
         title: "Reap Windows Worktrees",
         titleSource: "derived" as const,
       }),
@@ -674,7 +674,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
 
     const titles = await resolveQuitBlockerThreadTitles([remoteItem], {
       listLocalThreads: async () => [],
-      cachedRemoteThreadSummary: () => ({
+      cachedRemoteThreadName: () => ({
         title: "0f9c2b7a-remote",
         titleSource: "fallback" as const,
       }),
@@ -699,7 +699,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
       [collidingLocal, remoteItem],
       {
         listLocalThreads: async () => [],
-        cachedRemoteThreadSummary: () => ({
+        cachedRemoteThreadName: () => ({
           title: "Reap Windows Worktrees",
           titleSource: "derived" as const,
         }),
@@ -722,7 +722,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
       listLocalThreads: async () => [
         { source: "codex" as const, id: "local-thread", title: "Local Work" },
       ],
-      cachedRemoteThreadSummary: () => {
+      cachedRemoteThreadName: () => {
         throw new Error("federation runtime unavailable");
       },
       listRemoteThreadPins: async () => {

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -19,9 +19,9 @@ vi.mock("../ipc/integrated-terminal", () => ({
   getIntegratedTerminalQuitSnapshot: vi.fn(() => ({
     count: 0,
     sessionIds: [],
-    threadKeys: [],
+    threads: [],
   })),
-  revealIntegratedTerminal: vi.fn(() => false),
+  revealIntegratedTerminal: vi.fn(() => ({ revealed: false })),
 }));
 
 vi.mock("../window-show-thread", () => ({ requestShowThread: vi.fn() }));
@@ -577,22 +577,23 @@ describe("resolveQuitBlockerThreadTitles", () => {
     const listLocalThreads = vi.fn(async () => [
       { source: "codex" as const, id: "local-thread", title: "Local Work" },
     ]);
-    const remoteThreadSummary = vi.fn(async () => ({
+    const cachedRemoteThreadSummary = vi.fn(() => ({
       title: "Reap Windows Worktrees",
       titleSource: "derived" as const,
     }));
+    const listRemoteThreadPins = vi.fn(async () => []);
 
     const titles = await resolveQuitBlockerThreadTitles([localItem, remoteItem], {
       listLocalThreads,
-      remoteThreadSummary,
-      listRemoteThreadPins: async () => [],
+      cachedRemoteThreadSummary,
+      listRemoteThreadPins,
     });
 
     expect(titles.get(quitBlockerTitleKey(remoteItem))).toBe(
       "Reap Windows Worktrees",
     );
     expect(titles.get(quitBlockerTitleKey(localItem))).toBe("Local Work");
-    expect(remoteThreadSummary).toHaveBeenCalledWith({
+    expect(cachedRemoteThreadSummary).toHaveBeenCalledWith({
       target: { scope: "remote", instanceId: "peer-a" },
       backend: "codex",
       threadId: "0f9c2b7a-remote",
@@ -600,16 +601,18 @@ describe("resolveQuitBlockerThreadTitles", () => {
     // The local list is a peer-blind lookup; asking it about a remote thread
     // is what produced the uuid in the first place.
     expect(listLocalThreads).toHaveBeenCalledTimes(1);
+    // The memory cache answered, so the store is never read.
+    expect(listRemoteThreadPins).not.toHaveBeenCalled();
   });
 
-  it("falls back to the pinned row's cached title when the peer is unreachable", async () => {
+  it("falls back to the pinned row's cached title when nothing is cached in memory", async () => {
     const { resolveQuitBlockerThreadTitles, quitBlockerTitleKey } = await import(
       "../quit-manager"
     );
 
     const titles = await resolveQuitBlockerThreadTitles([remoteItem], {
       listLocalThreads: async () => [],
-      remoteThreadSummary: async () => undefined,
+      cachedRemoteThreadSummary: () => undefined,
       listRemoteThreadPins: async () => [
         {
           ref: {
@@ -636,39 +639,31 @@ describe("resolveQuitBlockerThreadTitles", () => {
     );
   });
 
-  it("uses the cached pin rather than waiting out a slow peer", async () => {
+  // A thread can only be a quit blocker because it is mounted in a window on
+  // this machine, so its name is already cached. Reaching for the peer here
+  // could only re-answer a question we can answer, while making shutdown wait
+  // on a machine that may be asleep.
+  it("never waits on a peer", async () => {
     const { resolveQuitBlockerThreadTitles, quitBlockerTitleKey } = await import(
       "../quit-manager"
     );
+    let settled = false;
 
-    const titles = await resolveQuitBlockerThreadTitles([remoteItem], {
+    const pending = resolveQuitBlockerThreadTitles([remoteItem], {
       listLocalThreads: async () => [],
-      // A peer whose navigation snapshot has gone stale has to refetch, which
-      // can outlast the whole quit-title budget. Blocking on it would take the
-      // locally cached name down with it.
-      remoteThreadSummary: () => new Promise(() => undefined),
-      listRemoteThreadPins: async () => [
-        {
-          ref: {
-            backend: "codex" as const,
-            threadId: "0f9c2b7a-remote",
-            target: { scope: "remote" as const, instanceId: "peer-a" },
-          },
-          addedAt: 1,
-          instanceLabel: "Studio Mac",
-          summary: {
-            source: "codex" as const,
-            id: "0f9c2b7a-remote",
-            title: "Reap Windows Worktrees",
-            titleSource: "derived" as const,
-            linkedDirectories: [],
-            inbox: { inInbox: false },
-          },
-        },
-      ],
-      peerTimeoutMs: 5,
+      cachedRemoteThreadSummary: () => ({
+        title: "Reap Windows Worktrees",
+        titleSource: "derived" as const,
+      }),
+      // A peer round trip would park here forever. Nothing may await it.
+      listRemoteThreadPins: () => new Promise(() => undefined),
+    }).then((titles) => {
+      settled = true;
+      return titles;
     });
 
+    const titles = await pending;
+    expect(settled).toBe(true);
     expect(titles.get(quitBlockerTitleKey(remoteItem))).toBe(
       "Reap Windows Worktrees",
     );
@@ -679,7 +674,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
 
     const titles = await resolveQuitBlockerThreadTitles([remoteItem], {
       listLocalThreads: async () => [],
-      remoteThreadSummary: async () => ({
+      cachedRemoteThreadSummary: () => ({
         title: "0f9c2b7a-remote",
         titleSource: "fallback" as const,
       }),
@@ -704,7 +699,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
       [collidingLocal, remoteItem],
       {
         listLocalThreads: async () => [],
-        remoteThreadSummary: async () => ({
+        cachedRemoteThreadSummary: () => ({
           title: "Reap Windows Worktrees",
           titleSource: "derived" as const,
         }),
@@ -718,7 +713,7 @@ describe("resolveQuitBlockerThreadTitles", () => {
     expect(titles.get(quitBlockerTitleKey(collidingLocal))).toBeUndefined();
   });
 
-  it("still names local rows when the peer lookup throws", async () => {
+  it("still names local rows when the remote lookups throw", async () => {
     const { resolveQuitBlockerThreadTitles, quitBlockerTitleKey } = await import(
       "../quit-manager"
     );
@@ -727,8 +722,8 @@ describe("resolveQuitBlockerThreadTitles", () => {
       listLocalThreads: async () => [
         { source: "codex" as const, id: "local-thread", title: "Local Work" },
       ],
-      remoteThreadSummary: async () => {
-        throw new Error("peer unreachable");
+      cachedRemoteThreadSummary: () => {
+        throw new Error("federation runtime unavailable");
       },
       listRemoteThreadPins: async () => {
         throw new Error("overlay store unavailable");

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -336,7 +336,10 @@ describe("createQuitManager", () => {
       getQuitBlockers: () =>
         buildQuitBlockerSnapshot({
           inProgressThreads: { count: 0, threadIds: [] },
-          terminalSessions: { count: 1, threadKeys: ["codex:thread-1"] },
+          terminalSessions: {
+            count: 1,
+            threads: [{ threadKey: "codex:thread-1" }],
+          },
         }),
       resolveThreadTitles: async () =>
         new Map([["codex:thread-1", "Migrate Next Chunk"]]),
@@ -359,6 +362,55 @@ describe("createQuitManager", () => {
     );
   });
 
+  it("titles a remote terminal row from its owning peer, not the local list", async () => {
+    const { buildQuitBlockerSnapshot, createQuitManager, quitBlockerTitleKey } =
+      await import("../quit-manager");
+    const confirm = vi.fn(async () => "manual-cancel" as const);
+    const target = { scope: "remote" as const, instanceId: "peer-a" };
+    const manager = createQuitManager({
+      confirm,
+      getConfirmationEnabled: () => true,
+      getQuitBlockers: () =>
+        buildQuitBlockerSnapshot({
+          inProgressThreads: { count: 0, threadIds: [] },
+          terminalSessions: {
+            count: 1,
+            threads: [
+              {
+                threadKey: "codex:0f9c2b7a-remote",
+                target,
+                instanceLabel: "Studio Mac",
+              },
+            ],
+          },
+        }),
+      resolveThreadTitles: async (items) =>
+        new Map(
+          items.map((item) => [
+            quitBlockerTitleKey(item),
+            item.target ? "Reap Windows Worktrees" : "wrong thread",
+          ]),
+        ),
+      log: {},
+      performQuit: vi.fn(),
+    });
+
+    await expect(manager.requestQuit({ source: "menu" })).resolves.toBe(false);
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [
+          expect.objectContaining({
+            kind: "terminal",
+            title: "Reap Windows Worktrees",
+            threadKey: "codex:0f9c2b7a-remote",
+            target,
+          }),
+        ],
+      }),
+    );
+  });
+
   it("still shows the dialog when thread-title resolution fails", async () => {
     const { buildQuitBlockerSnapshot, createQuitManager } = await import(
       "../quit-manager"
@@ -371,7 +423,10 @@ describe("createQuitManager", () => {
       getQuitBlockers: () =>
         buildQuitBlockerSnapshot({
           inProgressThreads: { count: 0, threadIds: [] },
-          terminalSessions: { count: 1, threadKeys: ["codex:thread-1"] },
+          terminalSessions: {
+            count: 1,
+            threads: [{ threadKey: "codex:thread-1" }],
+          },
         }),
       resolveThreadTitles: async () => {
         throw new Error("app-server unavailable");
@@ -408,7 +463,10 @@ describe("buildQuitBlockerSnapshot", () => {
 
     const snapshot = buildQuitBlockerSnapshot({
       inProgressThreads: { count: 1, threadIds: ["codex:thread-turn"] },
-      terminalSessions: { count: 1, threadKeys: ["acp:grok:thread-term"] },
+      terminalSessions: {
+        count: 1,
+        threads: [{ threadKey: "acp:grok:thread-term" }],
+      },
       actionRuns: [
         {
           runId: "run-1",
@@ -450,6 +508,235 @@ describe("buildQuitBlockerSnapshot", () => {
         detail: "pnpm dev · pid 4242",
       },
     ]);
+  });
+
+  it("carries a remote terminal's owning peer onto its row", async () => {
+    const { buildQuitBlockerSnapshot } = await import("../quit-manager");
+
+    const snapshot = buildQuitBlockerSnapshot({
+      inProgressThreads: { count: 0, threadIds: [] },
+      terminalSessions: {
+        count: 2,
+        threads: [
+          { threadKey: "codex:local-thread" },
+          {
+            threadKey: "codex:remote-thread",
+            target: { scope: "remote", instanceId: "peer-a" },
+            instanceLabel: "Studio Mac",
+          },
+        ],
+      },
+    });
+
+    // Without the target the title resolver has no way to know the thread
+    // lives on another machine, and the row reads as a raw uuid.
+    expect(snapshot.items).toEqual([
+      {
+        kind: "terminal",
+        backend: "codex",
+        threadId: "local-thread",
+        threadKey: "codex:local-thread",
+      },
+      {
+        kind: "terminal",
+        backend: "codex",
+        threadId: "remote-thread",
+        threadKey: "codex:remote-thread",
+        target: { scope: "remote", instanceId: "peer-a" },
+        // The peer's name is the only thing distinguishing this row from a
+        // local shell on a thread with the same key.
+        detail: "Studio Mac",
+      },
+    ]);
+    expect(snapshot.terminalThreadKeys).toEqual([
+      "codex:local-thread",
+      "codex:remote-thread",
+    ]);
+  });
+});
+
+describe("resolveQuitBlockerThreadTitles", () => {
+  const localItem = {
+    kind: "terminal" as const,
+    backend: "codex" as const,
+    threadId: "local-thread",
+    threadKey: "codex:local-thread",
+  };
+  const remoteItem = {
+    kind: "terminal" as const,
+    backend: "codex" as const,
+    threadId: "0f9c2b7a-remote",
+    threadKey: "codex:0f9c2b7a-remote",
+    target: { scope: "remote" as const, instanceId: "peer-a" },
+  };
+
+  it("names a remote thread from the peer's cached navigation summary", async () => {
+    const { resolveQuitBlockerThreadTitles, quitBlockerTitleKey } = await import(
+      "../quit-manager"
+    );
+    const listLocalThreads = vi.fn(async () => [
+      { source: "codex" as const, id: "local-thread", title: "Local Work" },
+    ]);
+    const remoteThreadSummary = vi.fn(async () => ({
+      title: "Reap Windows Worktrees",
+      titleSource: "derived" as const,
+    }));
+
+    const titles = await resolveQuitBlockerThreadTitles([localItem, remoteItem], {
+      listLocalThreads,
+      remoteThreadSummary,
+      listRemoteThreadPins: async () => [],
+    });
+
+    expect(titles.get(quitBlockerTitleKey(remoteItem))).toBe(
+      "Reap Windows Worktrees",
+    );
+    expect(titles.get(quitBlockerTitleKey(localItem))).toBe("Local Work");
+    expect(remoteThreadSummary).toHaveBeenCalledWith({
+      target: { scope: "remote", instanceId: "peer-a" },
+      backend: "codex",
+      threadId: "0f9c2b7a-remote",
+    });
+    // The local list is a peer-blind lookup; asking it about a remote thread
+    // is what produced the uuid in the first place.
+    expect(listLocalThreads).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the pinned row's cached title when the peer is unreachable", async () => {
+    const { resolveQuitBlockerThreadTitles, quitBlockerTitleKey } = await import(
+      "../quit-manager"
+    );
+
+    const titles = await resolveQuitBlockerThreadTitles([remoteItem], {
+      listLocalThreads: async () => [],
+      remoteThreadSummary: async () => undefined,
+      listRemoteThreadPins: async () => [
+        {
+          ref: {
+            backend: "codex" as const,
+            threadId: "0f9c2b7a-remote",
+            target: { scope: "remote" as const, instanceId: "peer-a" },
+          },
+          addedAt: 1,
+          instanceLabel: "Studio Mac",
+          summary: {
+            source: "codex" as const,
+            id: "0f9c2b7a-remote",
+            title: "Reap Windows Worktrees",
+            titleSource: "derived" as const,
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          },
+        },
+      ],
+    });
+
+    expect(titles.get(quitBlockerTitleKey(remoteItem))).toBe(
+      "Reap Windows Worktrees",
+    );
+  });
+
+  it("uses the cached pin rather than waiting out a slow peer", async () => {
+    const { resolveQuitBlockerThreadTitles, quitBlockerTitleKey } = await import(
+      "../quit-manager"
+    );
+
+    const titles = await resolveQuitBlockerThreadTitles([remoteItem], {
+      listLocalThreads: async () => [],
+      // A peer whose navigation snapshot has gone stale has to refetch, which
+      // can outlast the whole quit-title budget. Blocking on it would take the
+      // locally cached name down with it.
+      remoteThreadSummary: () => new Promise(() => undefined),
+      listRemoteThreadPins: async () => [
+        {
+          ref: {
+            backend: "codex" as const,
+            threadId: "0f9c2b7a-remote",
+            target: { scope: "remote" as const, instanceId: "peer-a" },
+          },
+          addedAt: 1,
+          instanceLabel: "Studio Mac",
+          summary: {
+            source: "codex" as const,
+            id: "0f9c2b7a-remote",
+            title: "Reap Windows Worktrees",
+            titleSource: "derived" as const,
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          },
+        },
+      ],
+      peerTimeoutMs: 5,
+    });
+
+    expect(titles.get(quitBlockerTitleKey(remoteItem))).toBe(
+      "Reap Windows Worktrees",
+    );
+  });
+
+  it("ignores a fallback title, which is just the thread id again", async () => {
+    const { resolveQuitBlockerThreadTitles } = await import("../quit-manager");
+
+    const titles = await resolveQuitBlockerThreadTitles([remoteItem], {
+      listLocalThreads: async () => [],
+      remoteThreadSummary: async () => ({
+        title: "0f9c2b7a-remote",
+        titleSource: "fallback" as const,
+      }),
+      listRemoteThreadPins: async () => [],
+    });
+
+    expect(titles.size).toBe(0);
+  });
+
+  it("keeps a remote thread's title off a local thread that shares its key", async () => {
+    const { resolveQuitBlockerThreadTitles, quitBlockerTitleKey } = await import(
+      "../quit-manager"
+    );
+    const collidingLocal = {
+      kind: "turn" as const,
+      backend: "codex" as const,
+      threadId: "0f9c2b7a-remote",
+      threadKey: "codex:0f9c2b7a-remote",
+    };
+
+    const titles = await resolveQuitBlockerThreadTitles(
+      [collidingLocal, remoteItem],
+      {
+        listLocalThreads: async () => [],
+        remoteThreadSummary: async () => ({
+          title: "Reap Windows Worktrees",
+          titleSource: "derived" as const,
+        }),
+        listRemoteThreadPins: async () => [],
+      },
+    );
+
+    expect(titles.get(quitBlockerTitleKey(remoteItem))).toBe(
+      "Reap Windows Worktrees",
+    );
+    expect(titles.get(quitBlockerTitleKey(collidingLocal))).toBeUndefined();
+  });
+
+  it("still names local rows when the peer lookup throws", async () => {
+    const { resolveQuitBlockerThreadTitles, quitBlockerTitleKey } = await import(
+      "../quit-manager"
+    );
+
+    const titles = await resolveQuitBlockerThreadTitles([localItem, remoteItem], {
+      listLocalThreads: async () => [
+        { source: "codex" as const, id: "local-thread", title: "Local Work" },
+      ],
+      remoteThreadSummary: async () => {
+        throw new Error("peer unreachable");
+      },
+      listRemoteThreadPins: async () => {
+        throw new Error("overlay store unavailable");
+      },
+    });
+
+    expect(titles.get(quitBlockerTitleKey(localItem))).toBe("Local Work");
+    expect(titles.get(quitBlockerTitleKey(remoteItem))).toBeUndefined();
   });
 });
 

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -383,6 +383,76 @@ describe("RemoteThreadSummaryCache — threadFromPeer", () => {
   });
 });
 
+describe("RemoteThreadSummaryCache — cachedThreadFromPeer", () => {
+  it("answers from the cache without ever contacting the peer", async () => {
+    const fetchSnapshot = vi.fn(async () =>
+      snapshotOf([
+        stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Parent" }),
+      ]),
+    );
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot,
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    // Cold: nothing cached yet, and asking must not go fetch it.
+    expect(
+      cache.cachedThreadFromPeer({
+        target: remoteTarget("peer-a"),
+        backend: "codex",
+        threadId: "t1",
+      }),
+    ).toBeUndefined();
+    expect(fetchSnapshot).not.toHaveBeenCalled();
+
+    // Warm it the way ordinary navigation does.
+    await cache.searchForJump({ query: "Parent" });
+    expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+
+    expect(
+      cache.cachedThreadFromPeer({
+        target: remoteTarget("peer-a"),
+        backend: "codex",
+        threadId: "t1",
+      })?.title,
+    ).toBe("Parent");
+    expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  // A name that is one navigation refresh out of date still beats the raw
+  // thread id, and the alternative costs the round trip this tier avoids.
+  it("serves a lapsed entry rather than refetching", async () => {
+    let now = 1_000;
+    const fetchSnapshot = vi.fn(async () =>
+      snapshotOf([
+        stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Parent" }),
+      ]),
+    );
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot,
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+      ttlMs: 10,
+      now: () => now,
+    });
+
+    await cache.searchForJump({ query: "Parent" });
+    now += 10_000;
+
+    expect(
+      cache.cachedThreadFromPeer({
+        target: remoteTarget("peer-a"),
+        backend: "codex",
+        threadId: "t1",
+      })?.title,
+    ).toBe("Parent");
+    expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+  });
+});
+
 /** Let a kicked-off background refresh chain settle. */
 async function settle(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -383,8 +383,15 @@ describe("RemoteThreadSummaryCache — threadFromPeer", () => {
   });
 });
 
-describe("RemoteThreadSummaryCache — cachedThreadFromPeer", () => {
-  it("answers from the cache without ever contacting the peer", async () => {
+describe("RemoteThreadSummaryCache — remembered thread names", () => {
+  const nameOf = (cache: RemoteThreadSummaryCache, threadId: string) =>
+    cache.cachedThreadNameFromPeer({
+      target: remoteTarget("peer-a"),
+      backend: "codex",
+      threadId,
+    })?.title;
+
+  it("answers from remembered names without ever contacting the peer", async () => {
     const fetchSnapshot = vi.fn(async () =>
       snapshotOf([
         stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Parent" }),
@@ -397,33 +404,69 @@ describe("RemoteThreadSummaryCache — cachedThreadFromPeer", () => {
       peerStatus: () => ({}),
     });
 
-    // Cold: nothing cached yet, and asking must not go fetch it.
-    expect(
-      cache.cachedThreadFromPeer({
-        target: remoteTarget("peer-a"),
-        backend: "codex",
-        threadId: "t1",
-      }),
-    ).toBeUndefined();
+    // Cold: nothing seen yet, and asking must not go fetch it.
+    expect(nameOf(cache, "t1")).toBeUndefined();
     expect(fetchSnapshot).not.toHaveBeenCalled();
 
-    // Warm it the way ordinary navigation does.
     await cache.searchForJump({ query: "Parent" });
     expect(fetchSnapshot).toHaveBeenCalledTimes(1);
 
-    expect(
-      cache.cachedThreadFromPeer({
-        target: remoteTarget("peer-a"),
-        backend: "codex",
-        threadId: "t1",
-      })?.title,
-    ).toBe("Parent");
+    expect(nameOf(cache, "t1")).toBe("Parent");
     expect(fetchSnapshot).toHaveBeenCalledTimes(1);
   });
 
-  // A name that is one navigation refresh out of date still beats the raw
-  // thread id, and the alternative costs the round trip this tier avoids.
-  it("serves a lapsed entry rather than refetching", async () => {
+  // A federation window reads its navigation straight from the runtime and
+  // never populates the snapshot cache above. Without this, a peer's thread
+  // open in that window has no name here at all.
+  it("remembers names handed in from outside this cache", () => {
+    const fetchSnapshot = vi.fn(async () => snapshotOf([]));
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot,
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    cache.rememberThreadNames("peer-a", [
+      stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Parent" }),
+    ]);
+
+    expect(nameOf(cache, "t1")).toBe("Parent");
+    expect(fetchSnapshot).not.toHaveBeenCalled();
+  });
+
+  // Snapshots are backend- and filter-scoped, so a narrower one must not
+  // erase what a wider one already taught us.
+  it("merges rather than replacing, and ignores fallback titles", () => {
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([]),
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    cache.rememberThreadNames("peer-a", [
+      stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Parent" }),
+      stampedThread({ instanceId: "peer-a", threadId: "t2", title: "Sibling" }),
+    ]);
+    cache.rememberThreadNames("peer-a", [
+      stampedThread({ instanceId: "peer-a", threadId: "t3", title: "Cousin" }),
+      // A fallback title IS the thread id; recording it would overwrite a
+      // real name with nothing.
+      {
+        ...stampedThread({ instanceId: "peer-a", threadId: "t1", title: "t1" }),
+        titleSource: "fallback",
+      },
+    ]);
+
+    expect(nameOf(cache, "t1")).toBe("Parent");
+    expect(nameOf(cache, "t2")).toBe("Sibling");
+    expect(nameOf(cache, "t3")).toBe("Cousin");
+  });
+
+  // A name one navigation refresh out of date still beats the raw thread id,
+  // and every alternative costs the round trip this tier avoids.
+  it("survives TTL lapse and invalidate", async () => {
     let now = 1_000;
     const fetchSnapshot = vi.fn(async () =>
       snapshotOf([
@@ -441,14 +484,10 @@ describe("RemoteThreadSummaryCache — cachedThreadFromPeer", () => {
 
     await cache.searchForJump({ query: "Parent" });
     now += 10_000;
+    cache.invalidate("peer-a");
+    cache.invalidate();
 
-    expect(
-      cache.cachedThreadFromPeer({
-        target: remoteTarget("peer-a"),
-        backend: "codex",
-        threadId: "t1",
-      })?.title,
-    ).toBe("Parent");
+    expect(nameOf(cache, "t1")).toBe("Parent");
     expect(fetchSnapshot).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -193,9 +193,42 @@ export class RemoteThreadSummaryCache {
   }
 
   /**
-   * A single thread from a connected peer's cached snapshot, or undefined
-   * when the peer is unreachable or the thread is absent (e.g. archived).
-   * Used for best-effort lookups like companion parent-pinning.
+   * A single thread out of what is ALREADY cached for a peer. Never contacts
+   * the peer, never refetches on a lapsed TTL, never registers peer interest
+   * — it is a map read, and it is safe on any path that must not wait.
+   *
+   * This is the middle tier of thread-name resolution:
+   *
+   * 1. Local only — this instance's thread list. Correct only when the caller
+   *    knows every thread it can see is its own.
+   * 2. Local + cached remote (this method) — the right default. A mounted
+   *    remote thread is on screen because something already fetched it, so
+   *    its name is in hand; asking the peer again buys nothing.
+   * 3. Local + live remote (`threadFromPeer`) — for callers that genuinely
+   *    need current data and can afford to wait on a peer.
+   *
+   * Deliberately ignores the TTL and the peer's connection state: a slightly
+   * stale name beats the raw thread id, and both alternatives here cost a
+   * round trip that tier 2 exists to avoid.
+   */
+  cachedThreadFromPeer(params: {
+    target: FederationRemoteTarget;
+    backend: NavigationThreadSummary["source"];
+    threadId: string;
+  }): NavigationThreadSummary | undefined {
+    return this.cache
+      .get(params.target.instanceId)
+      ?.threads.find(
+        (thread) =>
+          thread.source === params.backend && thread.id === params.threadId,
+      );
+  }
+
+  /**
+   * A single thread from a connected peer's snapshot, fetching when the cache
+   * has lapsed; undefined when the peer is unreachable or the thread is absent
+   * (e.g. archived). Tier 3 — it can wait on the peer. Callers that only need
+   * a name should use `cachedThreadFromPeer`.
    */
   async threadFromPeer(params: {
     target: FederationRemoteTarget;

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -21,6 +21,12 @@ export type RemoteThreadSummaryPeer = {
   capabilities: FederationCapability[];
 };
 
+/** A peer's display name for one of its threads. */
+export type RemoteThreadName = {
+  title: string;
+  titleSource: NavigationThreadSummary["titleSource"];
+};
+
 export type ResolvedRemotePins = {
   /** One stamped row per pin: fresh from the peer when reachable, else the
    *  cached payload stamped with the peer's current (non-connected) status. */
@@ -64,6 +70,16 @@ export class RemoteThreadSummaryCache {
   private readonly archivedCache = new Map<
     string,
     { fetchedAt: number; threadKeys: Set<string> }
+  >();
+  /**
+   * Display names per instance, keyed by thread identity. Deliberately NOT
+   * cleared by `invalidate` — see `cachedThreadNameFromPeer`. Dropping a name
+   * can only send a row back to its thread id, and a name is stale-tolerant
+   * in a way the snapshots above are not.
+   */
+  private readonly threadNames = new Map<
+    string,
+    Map<string, RemoteThreadName>
   >();
   private readonly peerInterestTimers = new Map<
     string,
@@ -193,35 +209,70 @@ export class RemoteThreadSummaryCache {
   }
 
   /**
-   * A single thread out of what is ALREADY cached for a peer. Never contacts
-   * the peer, never refetches on a lapsed TTL, never registers peer interest
-   * — it is a map read, and it is safe on any path that must not wait.
+   * Record what a peer calls its threads, from any snapshot that reached this
+   * instance. Called from every path that fetches a peer snapshot — this
+   * cache's own fetch, and the federation-window navigation read, which does
+   * NOT go through this cache and is where a viewer sees most remote threads.
+   *
+   * Merged, never replaced: a backend- or filter-scoped snapshot carries only
+   * part of a peer's threads, and forgetting a name because the latest
+   * snapshot was narrower would send a row back to its raw thread id.
+   *
+   * Only names are kept, not summaries — this exists so a display string is
+   * always in hand, and holding whole rows for every thread ever seen on
+   * every peer would be a real memory cost for no extra answer. Rows whose
+   * title IS the thread id are skipped: recording one would overwrite a real
+   * name with nothing.
+   */
+  rememberThreadNames(
+    instanceId: string,
+    threads: readonly NavigationThreadSummary[],
+  ): void {
+    let names = this.threadNames.get(instanceId);
+    for (const thread of threads) {
+      const title = thread.title?.trim();
+      if (!title || thread.titleSource === "fallback") {
+        continue;
+      }
+      names ??= new Map();
+      names.set(buildThreadIdentityKey(thread.source, thread.id), {
+        title,
+        titleSource: thread.titleSource,
+      });
+    }
+    if (names) {
+      this.threadNames.set(instanceId, names);
+    }
+  }
+
+  /**
+   * What a peer calls one of its threads, out of names ALREADY seen. Never
+   * contacts the peer, never refetches on a lapsed TTL, never registers peer
+   * interest — it is a map read, and it is safe on any path that must not
+   * wait.
    *
    * This is the middle tier of thread-name resolution:
    *
    * 1. Local only — this instance's thread list. Correct only when the caller
    *    knows every thread it can see is its own.
-   * 2. Local + cached remote (this method) — the right default. A mounted
-   *    remote thread is on screen because something already fetched it, so
-   *    its name is in hand; asking the peer again buys nothing.
+   * 2. Local + cached remote (this method) — the right default. A remote
+   *    thread the operator can see was named by some snapshot on the way to
+   *    the screen; asking the peer again buys nothing.
    * 3. Local + live remote (`threadFromPeer`) — for callers that genuinely
    *    need current data and can afford to wait on a peer.
    *
-   * Deliberately ignores the TTL and the peer's connection state: a slightly
-   * stale name beats the raw thread id, and both alternatives here cost a
-   * round trip that tier 2 exists to avoid.
+   * Deliberately survives TTL lapse, peer disconnect, and `invalidate`: a
+   * name one navigation refresh out of date beats the raw thread id, and
+   * every alternative costs the round trip tier 2 exists to avoid.
    */
-  cachedThreadFromPeer(params: {
+  cachedThreadNameFromPeer(params: {
     target: FederationRemoteTarget;
     backend: NavigationThreadSummary["source"];
     threadId: string;
-  }): NavigationThreadSummary | undefined {
-    return this.cache
+  }): RemoteThreadName | undefined {
+    return this.threadNames
       .get(params.target.instanceId)
-      ?.threads.find(
-        (thread) =>
-          thread.source === params.backend && thread.id === params.threadId,
-      );
+      ?.get(buildThreadIdentityKey(params.backend, params.threadId));
   }
 
   /**
@@ -623,6 +674,7 @@ export class RemoteThreadSummaryCache {
         fetchedAt: this.options.now?.() ?? Date.now(),
         threads,
       });
+      this.rememberThreadNames(target.instanceId, threads);
       this.touchPeerInterest(target.instanceId, ttlMs);
       // ANY successful fetch is proof of life, including one the jump
       // search started. Clearing the flag only in the pinned-refresh path

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1956,6 +1956,24 @@ class DesktopAppServerService {
             },
           );
         this.remoteNavigationSnapshotCache.set(cacheKey, snapshot);
+        // A federation window reads its navigation here, not through
+        // RemoteThreadSummaryCache, so this is the only place most remote
+        // threads are ever named on this instance. Anything that later needs
+        // a display name without paying for a peer round trip — the quit
+        // dialog's blocker rows, for one — depends on this.
+        //
+        // Remembering a name is a side errand, never a reason to fail the
+        // snapshot the operator actually asked for: the worst case of losing
+        // it is a row that reads as a thread id somewhere else.
+        try {
+          getDesktopFederationRuntime()
+            .remoteThreadSummaries()
+            .rememberThreadNames(federationTarget.instanceId, snapshot.threads);
+        } catch (error) {
+          logDebug("rememberRemoteThreadNames failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
         return await this.applyRemoteDirectoryViewerOverlays(
           snapshot,
           federationTarget.instanceId,

--- a/apps/desktop/src/main/ipc/federation-terminal.ts
+++ b/apps/desktop/src/main/ipc/federation-terminal.ts
@@ -262,12 +262,50 @@ export class FederationTerminalBridge {
    * lives on the owner), so all of them count: quitting the viewer ends them,
    * and silently killing a shell mid-command is the failure this dialog
    * exists to prevent. A future `pty.status` round-trip could narrow it.
+   *
+   * Each row carries its owning peer: the quit dialog names a thread by
+   * looking it up, and a remote thread is not in THIS instance's thread list,
+   * so a peer-blind lookup can only fall back to the raw thread id.
    */
-  quitSnapshotSessions(): Array<{ sessionId: string; threadKey: string }> {
-    return [...this.sessionsById.values()].map((session) => ({
-      sessionId: session.sessionId,
-      threadKey: session.threadKey,
-    }));
+  quitSnapshotSessions(): Array<{
+    sessionId: string;
+    threadKey: string;
+    target: FederationRemoteTarget;
+    instanceLabel?: string;
+  }> {
+    const identities = this.remoteIdentities();
+    return [...this.sessionsById.values()].map((session) => {
+      const instanceLabel = identities.get(
+        session.target.instanceId,
+      )?.instanceLabel;
+      return {
+        sessionId: session.sessionId,
+        threadKey: session.threadKey,
+        target: session.target,
+        ...(instanceLabel ? { instanceLabel } : {}),
+      };
+    });
+  }
+
+  /**
+   * Un-hide a remote thread's terminal panel and report the windows that host
+   * it. The local PTY registry knows nothing about these sessions, so asking
+   * only it — as the quit dialog's row link once did — reports "no such
+   * session" for every shell running on a peer and reveals nothing.
+   */
+  revealSession(threadKey: string): WebContents[] {
+    const owners: WebContents[] = [];
+    for (const session of this.sessionsById.values()) {
+      if (session.threadKey !== threadKey || session.webContents.isDestroyed()) {
+        continue;
+      }
+      if (session.panelHidden) {
+        session.panelHidden = false;
+        this.broadcastSessions(session.webContents);
+      }
+      owners.push(session.webContents);
+    }
+    return owners;
   }
 
   dispose(): void {

--- a/apps/desktop/src/main/ipc/federation-terminal.ts
+++ b/apps/desktop/src/main/ipc/federation-terminal.ts
@@ -293,10 +293,16 @@ export class FederationTerminalBridge {
    * only it — as the quit dialog's row link once did — reports "no such
    * session" for every shell running on a peer and reveals nothing.
    */
-  revealSession(threadKey: string): WebContents[] {
+  revealSession(threadKey: string, instanceId?: string): WebContents[] {
     const owners: WebContents[] = [];
     for (const session of this.sessionsById.values()) {
       if (session.threadKey !== threadKey || session.webContents.isDestroyed()) {
+        continue;
+      }
+      // Two instances can hold the same `backend:threadId`. When the caller
+      // knows which one it means, honor it rather than revealing a shell on
+      // the wrong machine.
+      if (instanceId && session.target.instanceId !== instanceId) {
         continue;
       }
       if (session.panelHidden) {

--- a/apps/desktop/src/main/ipc/integrated-terminal.ts
+++ b/apps/desktop/src/main/ipc/integrated-terminal.ts
@@ -19,7 +19,10 @@ import type {
   IntegratedTerminalWriteRequest,
 } from "../../shared/integrated-terminal";
 import { isRemoteFederationTarget } from "@pwragent/shared";
-import { IntegratedTerminalService } from "../terminal/integrated-terminal-service";
+import {
+  byThreadKey,
+  IntegratedTerminalService,
+} from "../terminal/integrated-terminal-service";
 import type { IntegratedTerminalQuitSnapshot } from "../terminal/integrated-terminal-service";
 import { isFederationWindowWebContents } from "../window";
 import { subscribersForChannel } from "../window-channels";
@@ -206,16 +209,17 @@ export function getIntegratedTerminalQuitSnapshot(): IntegratedTerminalQuitSnaps
           ? { instanceLabel: session.instanceLabel }
           : {}),
       })),
-    ].sort((left, right) => left.threadKey.localeCompare(right.threadKey)),
+    ].sort(byThreadKey),
   };
 }
 
 export type IntegratedTerminalRevealResult = {
   revealed: boolean;
   /**
-   * The single window hosting the session, when there is one. Callers that
-   * follow a reveal with a thread navigation use it so the request lands in
-   * the window that actually has the thread.
+   * A window hosting the revealed session. Callers that follow a reveal with
+   * a thread navigation use it so the request lands in a window that actually
+   * has the thread. Absent for local sessions, where the reveal is broadcast
+   * and no one window owns the thread.
    */
   owner?: WebContents;
 };
@@ -235,8 +239,12 @@ export type IntegratedTerminalRevealResult = {
  */
 export function revealIntegratedTerminal(
   threadKey: string,
+  options: { instanceId?: string } = {},
 ): IntegratedTerminalRevealResult {
-  if (service?.revealSession(threadKey)) {
+  // A caller naming an instance means a peer's shell, and the local registry
+  // can only answer for this machine — checking it first would reveal a local
+  // terminal that happens to share the thread key.
+  if (!options.instanceId && service?.revealSession(threadKey)) {
     // A local session is hosted by whichever windows show the thread, so the
     // broadcast is the routing.
     for (const webContents of subscribersForChannel(
@@ -246,15 +254,20 @@ export function revealIntegratedTerminal(
     }
     return { revealed: true };
   }
-  // A remote session belongs to the one window that opened it — a federation
+  // A remote session belongs to the window that opened it — a federation
   // window, or a main window showing a pinned remote thread. Telling every
   // window to open a terminal panel for it would ask windows that do not have
   // the thread to do something they cannot.
-  const owners = federationBridge?.revealSession(threadKey) ?? [];
+  const owners =
+    federationBridge?.revealSession(threadKey, options.instanceId) ?? [];
+  if (owners.length === 0) {
+    return { revealed: false };
+  }
   for (const webContents of owners) {
     webContents.send(INTEGRATED_TERMINAL_REVEAL_CHANNEL, { threadKey });
   }
-  return owners.length > 0
-    ? { revealed: true, owner: owners.length === 1 ? owners[0] : undefined }
-    : { revealed: false };
+  // Remote mounts allocate a PTY per viewer window, so the same thread can be
+  // open in more than one. Any of them demonstrably has the thread, which is
+  // more than the focused-or-first fallback can promise.
+  return { revealed: true, owner: owners[0] };
 }

--- a/apps/desktop/src/main/ipc/integrated-terminal.ts
+++ b/apps/desktop/src/main/ipc/integrated-terminal.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from "electron";
+import { ipcMain, type WebContents } from "electron";
 import {
   INTEGRATED_TERMINAL_CLOSE_CHANNEL,
   INTEGRATED_TERMINAL_CREATE_CHANNEL,
@@ -177,10 +177,10 @@ export function disposeIntegratedTerminalIpcHandlers(): void {
 }
 
 export function getIntegratedTerminalQuitSnapshot(): IntegratedTerminalQuitSnapshot {
-  const local = service?.getQuitSnapshot() ?? {
+  const local: IntegratedTerminalQuitSnapshot = service?.getQuitSnapshot() ?? {
     count: 0,
     sessionIds: [],
-    threadKeys: [],
+    threads: [],
   };
   // Quitting closes remote sessions too (the bridge ends them when the
   // window dies), so they belong in the blocker — otherwise a shell running
@@ -197,18 +197,34 @@ export function getIntegratedTerminalQuitSnapshot(): IntegratedTerminalQuitSnaps
       ...local.sessionIds,
       ...remote.map((session) => session.sessionId),
     ].sort(),
-    threadKeys: [
-      ...local.threadKeys,
-      ...remote.map((session) => session.threadKey),
-    ].sort(),
+    threads: [
+      ...local.threads,
+      ...remote.map((session) => ({
+        threadKey: session.threadKey,
+        target: session.target,
+        ...(session.instanceLabel
+          ? { instanceLabel: session.instanceLabel }
+          : {}),
+      })),
+    ].sort((left, right) => left.threadKey.localeCompare(right.threadKey)),
   };
 }
 
+export type IntegratedTerminalRevealResult = {
+  revealed: boolean;
+  /**
+   * The single window hosting the session, when there is one. Callers that
+   * follow a reveal with a thread navigation use it so the request lands in
+   * the window that actually has the thread.
+   */
+  owner?: WebContents;
+};
+
 /**
- * Ask every subscribed renderer to open a thread's terminal panel. Used by the
- * quit dialog's "running work" links: clicking a terminal row should land you
- * on the thread with the shell already on screen, whatever the panel's
- * remembered hidden state was.
+ * Ask the renderers hosting a thread's shell to open its terminal panel. Used
+ * by the quit dialog's "running work" links: clicking a terminal row should
+ * land you on the thread with the shell already on screen, whatever the
+ * panel's remembered hidden state was.
  *
  * No session, no reveal. The quit dialog renders a snapshot taken when the
  * prompt opened and can sit there indefinitely once the countdown is cancelled,
@@ -217,15 +233,28 @@ export function getIntegratedTerminalQuitSnapshot(): IntegratedTerminalQuitSnaps
  * session, which spawned a brand-new login shell in the home directory — a
  * fresh quit blocker, conjured by trying to look at one.
  */
-export function revealIntegratedTerminal(threadKey: string): boolean {
-  const revealed = service?.revealSession(threadKey) ?? false;
-  if (!revealed) {
-    return false;
+export function revealIntegratedTerminal(
+  threadKey: string,
+): IntegratedTerminalRevealResult {
+  if (service?.revealSession(threadKey)) {
+    // A local session is hosted by whichever windows show the thread, so the
+    // broadcast is the routing.
+    for (const webContents of subscribersForChannel(
+      INTEGRATED_TERMINAL_REVEAL_CHANNEL,
+    )) {
+      webContents.send(INTEGRATED_TERMINAL_REVEAL_CHANNEL, { threadKey });
+    }
+    return { revealed: true };
   }
-  for (const webContents of subscribersForChannel(
-    INTEGRATED_TERMINAL_REVEAL_CHANNEL,
-  )) {
+  // A remote session belongs to the one window that opened it — a federation
+  // window, or a main window showing a pinned remote thread. Telling every
+  // window to open a terminal panel for it would ask windows that do not have
+  // the thread to do something they cannot.
+  const owners = federationBridge?.revealSession(threadKey) ?? [];
+  for (const webContents of owners) {
     webContents.send(INTEGRATED_TERMINAL_REVEAL_CHANNEL, { threadKey });
   }
-  return true;
+  return owners.length > 0
+    ? { revealed: true, owner: owners.length === 1 ? owners[0] : undefined }
+    : { revealed: false };
 }

--- a/apps/desktop/src/main/quit-confirmation-dialog.ts
+++ b/apps/desktop/src/main/quit-confirmation-dialog.ts
@@ -267,7 +267,11 @@ export async function showQuitConfirmationDialog(
           // peer's thread is a window that never mounted it.
           const revealed =
             target.kind === "terminal"
-              ? revealIntegratedTerminal(target.threadKey)
+              ? revealIntegratedTerminal(target.threadKey, {
+                  ...(target.instanceId
+                    ? { instanceId: target.instanceId }
+                    : {}),
+                })
               : undefined;
           requestShowThread(parsed, { preferWebContents: revealed?.owner });
         }
@@ -376,33 +380,49 @@ const QUIT_ITEM_GROUPS: ReadonlyArray<{
 ];
 
 /**
- * Encode a row's target as a single URL segment.
+ * Encode a row's target as URL segments.
  *
  * The thread key travels whole rather than as `backend/threadId`: an ACP
  * backend kind ("acp:grok") contains a colon, and thread ids are opaque, so
  * splitting on delimiters here corrupts the key that the terminal registry and
  * the renderer both index by.
+ *
+ * The owning instance rides along for remote rows. A thread key does not
+ * identify a thread across instances — the same reason titles are resolved per
+ * instance — so without it a peer's row and a same-keyed local row encode to
+ * the same action and the click cannot tell them apart.
  */
 export function formatQuitItemAction(item: QuitBlockerItem): string {
-  return `show-thread/${encodeURIComponent(item.threadKey)}/${encodeURIComponent(
-    item.kind,
-  )}`;
+  const segments = [
+    "show-thread",
+    encodeURIComponent(item.threadKey),
+    encodeURIComponent(item.kind),
+  ];
+  if (item.target) {
+    segments.push(encodeURIComponent(item.target.instanceId));
+  }
+  return segments.join("/");
 }
 
 export function parseQuitItemAction(
   action: string,
-): { threadKey: string; kind: string } | undefined {
+): { threadKey: string; kind: string; instanceId?: string } | undefined {
   if (!action.startsWith("show-thread/")) {
     return undefined;
   }
-  const [, encodedThreadKey, encodedKind] = action.split("/");
+  const [, encodedThreadKey, encodedKind, encodedInstanceId] =
+    action.split("/");
   if (!encodedThreadKey) {
     return undefined;
   }
   try {
+    const instanceId = encodedInstanceId
+      ? decodeURIComponent(encodedInstanceId)
+      : undefined;
     return {
       threadKey: decodeURIComponent(encodedThreadKey),
       kind: decodeURIComponent(encodedKind ?? ""),
+      ...(instanceId ? { instanceId } : {}),
     };
   } catch {
     return undefined;

--- a/apps/desktop/src/main/quit-confirmation-dialog.ts
+++ b/apps/desktop/src/main/quit-confirmation-dialog.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow, nativeTheme } from "electron";
+import type { FederationRemoteTarget } from "@pwragent/shared";
 import { parseThreadIdentityKey } from "@pwragent/shared";
 import { revealIntegratedTerminal } from "./ipc/integrated-terminal";
 import { getMainLogger } from "./log";
@@ -22,9 +23,16 @@ export type QuitBlockerItem = {
   backend: string;
   threadId: string;
   threadKey: string;
+  /**
+   * Peer that owns this work, when it does not run on this machine. Both the
+   * title lookup and the row's navigation need it: a remote thread is absent
+   * from this instance's thread list and from every window but the one
+   * fronting that peer.
+   */
+  target?: FederationRemoteTarget;
   /** Resolved just before the dialog opens; falls back to the thread id. */
   title?: string;
-  /** Secondary line — the command and pid for an action, for example. */
+  /** Secondary line — the owning peer, or an action's command and pid. */
   detail?: string;
 };
 
@@ -253,10 +261,15 @@ export async function showQuitConfirmationDialog(
       if (target) {
         const parsed = parseThreadIdentityKey(target.threadKey);
         if (parsed) {
-          if (target.kind === "terminal") {
-            revealIntegratedTerminal(target.threadKey);
-          }
-          requestShowThread(parsed);
+          // The reveal knows which window hosts the shell. Reuse that: the
+          // dialog itself holds focus here, so an unrouted request falls
+          // through to whichever window subscribed first — which for a
+          // peer's thread is a window that never mounted it.
+          const revealed =
+            target.kind === "terminal"
+              ? revealIntegratedTerminal(target.threadKey)
+              : undefined;
+          requestShowThread(parsed, { preferWebContents: revealed?.owner });
         }
         finish("manual-cancel");
         return;

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -17,7 +17,10 @@ import { getDesktopOverlayStore } from "./app-server/desktop-overlay-store";
 import { getDesktopFederationRuntime } from "./federation/federation-runtime";
 import { getIntegratedTerminalQuitSnapshot } from "./ipc/integrated-terminal";
 import { getMainLogger } from "./log";
-import type { IntegratedTerminalQuitThread } from "./terminal/integrated-terminal-service";
+import {
+  byThreadKey,
+  type IntegratedTerminalQuitThread,
+} from "./terminal/integrated-terminal-service";
 import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
 import {
   focusActiveQuitConfirmationDialog,
@@ -228,9 +231,7 @@ export function buildQuitBlockerSnapshot(params: {
   actionRuns?: DetachedCommandSummary[];
 }): QuitBlockerSnapshot {
   const threadIds = [...params.inProgressThreads.threadIds].sort();
-  const terminalThreads = [...params.terminalSessions.threads].sort(
-    (left, right) => left.threadKey.localeCompare(right.threadKey),
-  );
+  const terminalThreads = [...params.terminalSessions.threads].sort(byThreadKey);
   const terminalThreadKeys = terminalThreads.map((thread) => thread.threadKey);
   const actionRuns = params.actionRuns ?? [];
 
@@ -345,10 +346,10 @@ export type QuitBlockerTitleResolverDependencies = {
     }>
   >;
   /**
-   * A peer's summary of one of its threads out of data ALREADY held locally.
+   * What a peer calls one of its threads, out of names ALREADY seen locally.
    * Synchronous by contract: this must not become a peer round trip.
    */
-  cachedRemoteThreadSummary: (params: {
+  cachedRemoteThreadName: (params: {
     target: FederationRemoteTarget;
     backend: AppServerBackendKind;
     threadId: string;
@@ -367,15 +368,21 @@ export type QuitBlockerTitleResolverDependencies = {
  * asked to decide about a uuid while their sidebar showed that same thread by
  * name.
  *
- * Reaching the peer (tier 3) is deliberately NOT done here. A thread can only
- * be a quit blocker because it is mounted in a window on this machine, which
- * means its summary was already fetched and cached — the name is in hand. A
- * round trip could only re-answer a question we can already answer, while
- * making shutdown wait on a machine that may be asleep.
+ * Reaching the peer (tier 3) is deliberately NOT done here. A remote thread
+ * is a quit blocker because a window on this machine has its terminal open,
+ * which means some snapshot named it on the way to the screen — so the name
+ * is normally already in hand, and a round trip would re-answer a question we
+ * can answer while making shutdown wait on a machine that may be asleep.
  *
- * Two cached sources, both local reads: the peer navigation-summary cache in
- * memory, and the pinned rows' persisted summaries (which survive a restart,
- * so a freshly launched app can still name a pinned remote thread).
+ * Two cached sources, both local reads: the remembered names from every peer
+ * snapshot this instance has seen, and the pinned rows' persisted summaries
+ * (which survive a restart, so a freshly launched app can still name a pinned
+ * remote thread before anything has talked to that peer).
+ *
+ * Neither is a guarantee. A peer's thread that no snapshot has named on this
+ * instance — nothing pinned it and no navigation read reached it — still
+ * falls back to its thread id, which is the correct outcome: the alternative
+ * is blocking shutdown on a peer to learn something cosmetic.
  *
  * Every lookup degrades to "no title" rather than throwing: a row that reads
  * as a thread id still links correctly, and nothing here is worth delaying a
@@ -407,9 +414,9 @@ export async function resolveQuitBlockerThreadTitles(
 
   const resolveRemote = async (): Promise<void> => {
     if (remoteItems.length === 0) return;
-    const summaries = remoteItems.map(({ item, target }) => {
+    const names = remoteItems.map(({ item, target }) => {
       try {
-        return dependencies.cachedRemoteThreadSummary({
+        return dependencies.cachedRemoteThreadName({
           target,
           backend: item.backend as AppServerBackendKind,
           threadId: item.threadId,
@@ -418,11 +425,10 @@ export async function resolveQuitBlockerThreadTitles(
         return undefined;
       }
     });
-    // One store read for the whole batch, and only when the in-memory cache
-    // left something unnamed — a fresh launch, typically, where nothing has
-    // fetched from the peer yet.
-    const needsPins = remoteItems.some((_, index) => !summaries[index]);
-    const pins = needsPins
+    // One store read for the whole batch, and only when the remembered names
+    // left something unnamed — a fresh launch, typically, where no snapshot
+    // has reached that peer yet.
+    const pins = names.some((name) => !name)
       ? await dependencies
           .listRemoteThreadPins()
           .catch(() => [] as ReadonlyArray<RemoteThreadPin>)
@@ -442,7 +448,7 @@ export async function resolveQuitBlockerThreadTitles(
       record(
         titles,
         item,
-        summaries[index] ?? pinnedByTitleKey.get(quitBlockerTitleKey(item)),
+        names[index] ?? pinnedByTitleKey.get(quitBlockerTitleKey(item)),
       );
     });
   };
@@ -498,13 +504,13 @@ export const appQuitManager = createQuitManager({
         await getDesktopBackendRegistry().listThreads({
           callerReason: "quit-confirmation",
         }),
-      // Cache read, no peer round trip: the same in-memory snapshot the
-      // sidebar renders these threads from, which is why it already holds
-      // the name for anything that could be blocking the quit.
-      cachedRemoteThreadSummary: (params) =>
+      // Map read, no peer round trip: names remembered from every peer
+      // snapshot this instance has seen, which is why the name is normally
+      // in hand for anything that could be blocking the quit.
+      cachedRemoteThreadName: (params) =>
         getDesktopFederationRuntime()
           .remoteThreadSummaries()
-          .cachedThreadFromPeer(params),
+          .cachedThreadNameFromPeer(params),
       listRemoteThreadPins: async () =>
         await getDesktopOverlayStore().listRemoteThreadPins(),
     }),

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -3,14 +3,21 @@ import {
   buildThreadIdentityKey,
   parseThreadIdentityKey,
   type AppServerBackendKind,
+  type AppServerThreadTitleSource,
+  type FederationRemoteTarget,
+  type NavigationThreadSummary,
+  type RemoteThreadPin,
 } from "@pwragent/shared";
 import { getDesktopBackendRegistry } from "./app-server/backend-registry";
 import {
   listRunningDetachedCommands,
   type DetachedCommandSummary,
 } from "./app-server/codex-environment-runtime";
+import { getDesktopOverlayStore } from "./app-server/desktop-overlay-store";
+import { getDesktopFederationRuntime } from "./federation/federation-runtime";
 import { getIntegratedTerminalQuitSnapshot } from "./ipc/integrated-terminal";
 import { getMainLogger } from "./log";
+import type { IntegratedTerminalQuitThread } from "./terminal/integrated-terminal-service";
 import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
 import {
   focusActiveQuitConfirmationDialog,
@@ -64,9 +71,13 @@ export type QuitManagerDependencies = {
   getConfirmationEnabled: () => boolean;
   getFocusedWindow?: () => BrowserWindow | null;
   getQuitBlockers: () => QuitBlockerSnapshot;
-  /** Best-effort thread-title lookup for the dialog's links. */
+  /**
+   * Best-effort thread-title lookup for the dialog's links, keyed by
+   * `quitBlockerTitleKey`. Takes whole items rather than thread keys because
+   * naming a row requires knowing which instance owns it.
+   */
   resolveThreadTitles?: (
-    threadKeys: string[],
+    items: QuitBlockerItem[],
   ) => Promise<Map<string, string>>;
   log: {
     info?: (message: string, meta?: Record<string, unknown>) => void;
@@ -212,24 +223,33 @@ export function buildQuitBlockerSnapshot(params: {
   };
   terminalSessions: {
     count: number;
-    threadKeys: string[];
+    threads: IntegratedTerminalQuitThread[];
   };
   actionRuns?: DetachedCommandSummary[];
 }): QuitBlockerSnapshot {
   const threadIds = [...params.inProgressThreads.threadIds].sort();
-  const terminalThreadKeys = [...params.terminalSessions.threadKeys].sort();
+  const terminalThreads = [...params.terminalSessions.threads].sort(
+    (left, right) => left.threadKey.localeCompare(right.threadKey),
+  );
+  const terminalThreadKeys = terminalThreads.map((thread) => thread.threadKey);
   const actionRuns = params.actionRuns ?? [];
 
   const items: QuitBlockerItem[] = [
+    // Turns and actions are driven by THIS instance's registry and runtime,
+    // so they are always local. Only terminals can be a peer's.
     ...threadIds.map((threadKey) => ({
       kind: "turn" as const,
       ...splitQuitThreadKey(threadKey),
       threadKey,
     })),
-    ...terminalThreadKeys.map((threadKey) => ({
+    ...terminalThreads.map((thread) => ({
       kind: "terminal" as const,
-      ...splitQuitThreadKey(threadKey),
-      threadKey,
+      ...splitQuitThreadKey(thread.threadKey),
+      threadKey: thread.threadKey,
+      ...(thread.target ? { target: thread.target } : {}),
+      // The peer's name is what separates this row from a local shell; the
+      // title alone reads as though the work is on this machine.
+      ...(thread.instanceLabel ? { detail: thread.instanceLabel } : {}),
     })),
     ...actionRuns.map((run) => ({
       kind: "action" as const,
@@ -270,11 +290,13 @@ async function withResolvedTitles(
   if (!resolve || items.length === 0) {
     return items;
   }
-  const threadKeys = [...new Set(items.map((item) => item.threadKey))];
+  const byTitleKey = new Map(
+    items.map((item) => [quitBlockerTitleKey(item), item]),
+  );
   let titles: Map<string, string>;
   try {
     titles = await Promise.race([
-      resolve(threadKeys),
+      resolve([...byTitleKey.values()]),
       new Promise<Map<string, string>>((_resolve, reject) => {
         setTimeout(
           () => reject(new Error("thread-title resolution timed out")),
@@ -289,9 +311,176 @@ async function withResolvedTitles(
     return items;
   }
   return items.map((item) => {
-    const title = titles.get(item.threadKey);
+    const title = titles.get(quitBlockerTitleKey(item));
     return title ? { ...item, title } : item;
   });
+}
+
+/**
+ * Identity of the thread a row points at. A thread key alone is not it: two
+ * instances can hold the same `backend:threadId`, and a remote row must never
+ * inherit a same-keyed local thread's name.
+ */
+export function quitBlockerTitleKey(
+  item: Pick<QuitBlockerItem, "threadKey" | "target">,
+): string {
+  return item.target
+    ? `${item.target.instanceId}::${item.threadKey}`
+    : item.threadKey;
+}
+
+type QuitBlockerThreadTitle = {
+  title?: string;
+  titleSource?: AppServerThreadTitleSource;
+};
+
+export type QuitBlockerTitleResolverDependencies = {
+  /** Threads owned by THIS instance. */
+  listLocalThreads: () => Promise<
+    ReadonlyArray<{
+      source: AppServerBackendKind;
+      id: string;
+      title?: string;
+      titleSource?: AppServerThreadTitleSource;
+    }>
+  >;
+  /** A peer's own summary of one of its threads, when it is reachable. */
+  remoteThreadSummary: (params: {
+    target: FederationRemoteTarget;
+    backend: AppServerBackendKind;
+    threadId: string;
+  }) => Promise<QuitBlockerThreadTitle | undefined>;
+  /** Locally cached rows for pinned remote threads, for offline naming. */
+  listRemoteThreadPins: () => Promise<ReadonlyArray<RemoteThreadPin>>;
+  /** Overrides `QUIT_PEER_TITLE_TIMEOUT_MS`. */
+  peerTimeoutMs?: number;
+};
+
+/**
+ * How long the peer lookups get before the cached pin rows answer instead.
+ * Deliberately well inside `QUIT_TITLE_RESOLVE_TIMEOUT_MS`: that outer race
+ * discards the WHOLE map when it fires, so a peer that has to refetch its
+ * navigation snapshot would otherwise take the locally-cached names down with
+ * it and put the operator back in front of a uuid.
+ */
+const QUIT_PEER_TITLE_TIMEOUT_MS = 750;
+
+/**
+ * Name every blocker row, asking each thread's OWNER what it is called.
+ *
+ * The local thread list cannot answer for a peer's thread — it returns
+ * nothing, the row falls back to the thread id, and the operator is asked to
+ * decide about a uuid while their sidebar shows that same thread by name. So
+ * remote rows are resolved from the peer's own navigation summary, and from
+ * the pinned row's cached summary when the peer is unreachable.
+ *
+ * Every lookup degrades to "no title" rather than throwing: a row that reads
+ * as a thread id still links correctly, and nothing here is worth delaying a
+ * quit over.
+ */
+export async function resolveQuitBlockerThreadTitles(
+  items: readonly QuitBlockerItem[],
+  dependencies: QuitBlockerTitleResolverDependencies,
+): Promise<Map<string, string>> {
+  const titles = new Map<string, string>();
+  const localItems = items.filter((item) => !item.target);
+  const remoteItems = items.flatMap((item) =>
+    item.target ? [{ item, target: item.target }] : [],
+  );
+
+  const resolveLocal = async (): Promise<void> => {
+    if (localItems.length === 0) return;
+    const threads = await dependencies.listLocalThreads();
+    const byThreadKey = new Map(
+      threads.map((thread) => [
+        buildThreadIdentityKey(thread.source, thread.id),
+        thread,
+      ]),
+    );
+    for (const item of localItems) {
+      record(titles, item, byThreadKey.get(item.threadKey));
+    }
+  };
+
+  const resolveRemote = async (): Promise<void> => {
+    if (remoteItems.length === 0) return;
+    // One store read for the whole batch; the per-item peer lookups run
+    // concurrently because each is its own round trip.
+    const pinsPromise = dependencies
+      .listRemoteThreadPins()
+      .catch(() => [] as ReadonlyArray<RemoteThreadPin>);
+    const summaries = await settleWithin(
+      Promise.all(
+        remoteItems.map(async ({ item, target }) => {
+          try {
+            return await dependencies.remoteThreadSummary({
+              target,
+              backend: item.backend as AppServerBackendKind,
+              threadId: item.threadId,
+            });
+          } catch {
+            return undefined;
+          }
+        }),
+      ),
+      dependencies.peerTimeoutMs ?? QUIT_PEER_TITLE_TIMEOUT_MS,
+      [] as Array<QuitBlockerThreadTitle | undefined>,
+    );
+    const pins = await pinsPromise;
+    const pinnedByTitleKey = new Map<string, NavigationThreadSummary>();
+    for (const pin of pins) {
+      if (pin.ref.target.scope !== "remote" || !pin.summary) continue;
+      pinnedByTitleKey.set(
+        quitBlockerTitleKey({
+          threadKey: buildThreadIdentityKey(pin.ref.backend, pin.ref.threadId),
+          target: pin.ref.target,
+        }),
+        pin.summary,
+      );
+    }
+    remoteItems.forEach(({ item }, index) => {
+      record(
+        titles,
+        item,
+        summaries[index] ?? pinnedByTitleKey.get(quitBlockerTitleKey(item)),
+      );
+    });
+  };
+
+  await Promise.all([
+    resolveLocal().catch(() => undefined),
+    resolveRemote().catch(() => undefined),
+  ]);
+  return titles;
+}
+
+/** Resolve to `fallback` if `promise` has not settled in time. Never rejects
+ *  and never cancels: the abandoned work just stops being waited on. */
+async function settleWithin<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  fallback: T,
+): Promise<T> {
+  return await Promise.race([
+    promise,
+    new Promise<T>((resolve) => {
+      setTimeout(() => resolve(fallback), timeoutMs).unref?.();
+    }),
+  ]);
+}
+
+/** A "fallback" title IS the thread id, so recording it changes nothing but
+ *  hides that the name is unknown. */
+function record(
+  titles: Map<string, string>,
+  item: QuitBlockerItem,
+  thread: QuitBlockerThreadTitle | undefined,
+): void {
+  if (!thread || thread.titleSource === "fallback") return;
+  const title = thread.title?.trim();
+  if (title) {
+    titles.set(quitBlockerTitleKey(item), title);
+  }
 }
 
 /** Split a canonical `buildThreadIdentityKey` back into its parts. Unparseable
@@ -318,20 +507,22 @@ export const appQuitManager = createQuitManager({
       terminalSessions: getIntegratedTerminalQuitSnapshot(),
       actionRuns: listRunningDetachedCommands(),
     }),
-  resolveThreadTitles: async (threadKeys) => {
-    const wanted = new Set(threadKeys);
-    const threads = await getDesktopBackendRegistry().listThreads({
-      callerReason: "quit-confirmation",
-    });
-    const titles = new Map<string, string>();
-    for (const thread of threads) {
-      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-      if (wanted.has(threadKey) && thread.title) {
-        titles.set(threadKey, thread.title);
-      }
-    }
-    return titles;
-  },
+  resolveThreadTitles: async (items) =>
+    await resolveQuitBlockerThreadTitles(items, {
+      listLocalThreads: async () =>
+        await getDesktopBackendRegistry().listThreads({
+          callerReason: "quit-confirmation",
+        }),
+      // Reads the peer's cached navigation snapshot, and only refetches when
+      // that has gone stale — the same source the sidebar renders these
+      // threads from, which is why it already knows the name.
+      remoteThreadSummary: async (params) =>
+        await getDesktopFederationRuntime()
+          .remoteThreadSummaries()
+          .threadFromPeer(params),
+      listRemoteThreadPins: async () =>
+        await getDesktopOverlayStore().listRemoteThreadPins(),
+    }),
   log: quitLog,
   performQuit: () => {
     app.quit();

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -344,35 +344,38 @@ export type QuitBlockerTitleResolverDependencies = {
       titleSource?: AppServerThreadTitleSource;
     }>
   >;
-  /** A peer's own summary of one of its threads, when it is reachable. */
-  remoteThreadSummary: (params: {
+  /**
+   * A peer's summary of one of its threads out of data ALREADY held locally.
+   * Synchronous by contract: this must not become a peer round trip.
+   */
+  cachedRemoteThreadSummary: (params: {
     target: FederationRemoteTarget;
     backend: AppServerBackendKind;
     threadId: string;
-  }) => Promise<QuitBlockerThreadTitle | undefined>;
-  /** Locally cached rows for pinned remote threads, for offline naming. */
+  }) => QuitBlockerThreadTitle | undefined;
+  /** Locally persisted rows for pinned remote threads (a sqlite read). */
   listRemoteThreadPins: () => Promise<ReadonlyArray<RemoteThreadPin>>;
-  /** Overrides `QUIT_PEER_TITLE_TIMEOUT_MS`. */
-  peerTimeoutMs?: number;
 };
 
 /**
- * How long the peer lookups get before the cached pin rows answer instead.
- * Deliberately well inside `QUIT_TITLE_RESOLVE_TIMEOUT_MS`: that outer race
- * discards the WHOLE map when it fires, so a peer that has to refetch its
- * navigation snapshot would otherwise take the locally-cached names down with
- * it and put the operator back in front of a uuid.
- */
-const QUIT_PEER_TITLE_TIMEOUT_MS = 750;
-
-/**
- * Name every blocker row, asking each thread's OWNER what it is called.
+ * Name every blocker row from what this machine already knows, including what
+ * it knows about its peers.
  *
- * The local thread list cannot answer for a peer's thread — it returns
- * nothing, the row falls back to the thread id, and the operator is asked to
- * decide about a uuid while their sidebar shows that same thread by name. So
- * remote rows are resolved from the peer's own navigation summary, and from
- * the pinned row's cached summary when the peer is unreachable.
+ * This is tier-2 resolution — local plus *cached* remote. The old lookup was
+ * tier 1: it asked this instance's thread list, which cannot answer for a
+ * peer's thread, so the row fell back to the thread id and the operator was
+ * asked to decide about a uuid while their sidebar showed that same thread by
+ * name.
+ *
+ * Reaching the peer (tier 3) is deliberately NOT done here. A thread can only
+ * be a quit blocker because it is mounted in a window on this machine, which
+ * means its summary was already fetched and cached — the name is in hand. A
+ * round trip could only re-answer a question we can already answer, while
+ * making shutdown wait on a machine that may be asleep.
+ *
+ * Two cached sources, both local reads: the peer navigation-summary cache in
+ * memory, and the pinned rows' persisted summaries (which survive a restart,
+ * so a freshly launched app can still name a pinned remote thread).
  *
  * Every lookup degrades to "no title" rather than throwing: a row that reads
  * as a thread id still links correctly, and nothing here is worth delaying a
@@ -404,29 +407,26 @@ export async function resolveQuitBlockerThreadTitles(
 
   const resolveRemote = async (): Promise<void> => {
     if (remoteItems.length === 0) return;
-    // One store read for the whole batch; the per-item peer lookups run
-    // concurrently because each is its own round trip.
-    const pinsPromise = dependencies
-      .listRemoteThreadPins()
-      .catch(() => [] as ReadonlyArray<RemoteThreadPin>);
-    const summaries = await settleWithin(
-      Promise.all(
-        remoteItems.map(async ({ item, target }) => {
-          try {
-            return await dependencies.remoteThreadSummary({
-              target,
-              backend: item.backend as AppServerBackendKind,
-              threadId: item.threadId,
-            });
-          } catch {
-            return undefined;
-          }
-        }),
-      ),
-      dependencies.peerTimeoutMs ?? QUIT_PEER_TITLE_TIMEOUT_MS,
-      [] as Array<QuitBlockerThreadTitle | undefined>,
-    );
-    const pins = await pinsPromise;
+    const summaries = remoteItems.map(({ item, target }) => {
+      try {
+        return dependencies.cachedRemoteThreadSummary({
+          target,
+          backend: item.backend as AppServerBackendKind,
+          threadId: item.threadId,
+        });
+      } catch {
+        return undefined;
+      }
+    });
+    // One store read for the whole batch, and only when the in-memory cache
+    // left something unnamed — a fresh launch, typically, where nothing has
+    // fetched from the peer yet.
+    const needsPins = remoteItems.some((_, index) => !summaries[index]);
+    const pins = needsPins
+      ? await dependencies
+          .listRemoteThreadPins()
+          .catch(() => [] as ReadonlyArray<RemoteThreadPin>)
+      : [];
     const pinnedByTitleKey = new Map<string, NavigationThreadSummary>();
     for (const pin of pins) {
       if (pin.ref.target.scope !== "remote" || !pin.summary) continue;
@@ -452,21 +452,6 @@ export async function resolveQuitBlockerThreadTitles(
     resolveRemote().catch(() => undefined),
   ]);
   return titles;
-}
-
-/** Resolve to `fallback` if `promise` has not settled in time. Never rejects
- *  and never cancels: the abandoned work just stops being waited on. */
-async function settleWithin<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  fallback: T,
-): Promise<T> {
-  return await Promise.race([
-    promise,
-    new Promise<T>((resolve) => {
-      setTimeout(() => resolve(fallback), timeoutMs).unref?.();
-    }),
-  ]);
 }
 
 /** A "fallback" title IS the thread id, so recording it changes nothing but
@@ -513,13 +498,13 @@ export const appQuitManager = createQuitManager({
         await getDesktopBackendRegistry().listThreads({
           callerReason: "quit-confirmation",
         }),
-      // Reads the peer's cached navigation snapshot, and only refetches when
-      // that has gone stale — the same source the sidebar renders these
-      // threads from, which is why it already knows the name.
-      remoteThreadSummary: async (params) =>
-        await getDesktopFederationRuntime()
+      // Cache read, no peer round trip: the same in-memory snapshot the
+      // sidebar renders these threads from, which is why it already holds
+      // the name for anything that could be blocking the quit.
+      cachedRemoteThreadSummary: (params) =>
+        getDesktopFederationRuntime()
           .remoteThreadSummaries()
-          .threadFromPeer(params),
+          .cachedThreadFromPeer(params),
       listRemoteThreadPins: async () =>
         await getDesktopOverlayStore().listRemoteThreadPins(),
     }),

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import type { WebContents } from "electron";
 import type { IPty, IDisposable } from "node-pty";
-import type { DesktopIntegratedTerminalWindowsShell } from "@pwragent/shared";
+import type {
+  DesktopIntegratedTerminalWindowsShell,
+  FederationRemoteTarget,
+} from "@pwragent/shared";
 import {
   INTEGRATED_TERMINAL_ERROR_CHANNEL,
   INTEGRATED_TERMINAL_EXIT_CHANNEL,
@@ -46,10 +49,25 @@ type TerminalSession = {
 
 type NodePtyModule = typeof import("node-pty");
 
+/**
+ * One shell holding up the quit. The owning peer travels with the thread key
+ * because a remote shell's thread does not exist in this instance's thread
+ * list — resolving its name against that list yields the raw thread id, which
+ * is exactly the uuid an operator sees in the quit dialog instead of the name
+ * their own sidebar is already showing.
+ */
+export type IntegratedTerminalQuitThread = {
+  threadKey: string;
+  /** Absent for a shell running on this machine. */
+  target?: FederationRemoteTarget;
+  /** Peer display label, when the federation runtime could compose one. */
+  instanceLabel?: string;
+};
+
 export type IntegratedTerminalQuitSnapshot = {
   count: number;
   sessionIds: string[];
-  threadKeys: string[];
+  threads: IntegratedTerminalQuitThread[];
 };
 
 type IntegratedTerminalServiceOptions = {
@@ -253,7 +271,9 @@ export class IntegratedTerminalService {
     return {
       count: sessions.length,
       sessionIds: sessions.map((session) => session.sessionId).sort(),
-      threadKeys: sessions.map((session) => session.threadKey).sort(),
+      threads: sessions
+        .map((session) => ({ threadKey: session.threadKey }))
+        .sort((left, right) => left.threadKey.localeCompare(right.threadKey)),
     };
   }
 

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -70,6 +70,20 @@ export type IntegratedTerminalQuitSnapshot = {
   threads: IntegratedTerminalQuitThread[];
 };
 
+/**
+ * Code-unit order, matching the plain `.sort()` these keys used before they
+ * became objects. `localeCompare` would reorder around the `:` and `-` that
+ * fill thread keys depending on the host locale, which is not something a
+ * quit dialog's row order should depend on.
+ */
+export function byThreadKey(
+  left: { threadKey: string },
+  right: { threadKey: string },
+): number {
+  if (left.threadKey === right.threadKey) return 0;
+  return left.threadKey < right.threadKey ? -1 : 1;
+}
+
 type IntegratedTerminalServiceOptions = {
   loadNodePty?: () => Promise<Pick<NodePtyModule, "spawn">>;
   now?: () => number;
@@ -273,7 +287,7 @@ export class IntegratedTerminalService {
       sessionIds: sessions.map((session) => session.sessionId).sort(),
       threads: sessions
         .map((session) => ({ threadKey: session.threadKey }))
-        .sort((left, right) => left.threadKey.localeCompare(right.threadKey)),
+        .sort(byThreadKey),
     };
   }
 

--- a/apps/desktop/src/main/window-show-thread.ts
+++ b/apps/desktop/src/main/window-show-thread.ts
@@ -1,11 +1,35 @@
-import { BrowserWindow } from "electron";
+import { BrowserWindow, type WebContents } from "electron";
 import { WINDOW_SHOW_THREAD_CHANNEL } from "../shared/ipc";
 import type { WindowShowThreadRequest } from "../shared/window-show-thread";
 import { subscribersForChannel } from "./window-channels";
 
-export function requestShowThread(request: WindowShowThreadRequest): void {
+export type RequestShowThreadOptions = {
+  /**
+   * Window the caller already knows holds this thread. A thread key alone
+   * does not say which window can show it: a peer's thread exists only in the
+   * federation window fronting that peer (or a main window that pinned it),
+   * so falling through to the focused-or-first window sends a remote thread
+   * somewhere it was never mounted.
+   */
+  preferWebContents?: WebContents;
+};
+
+export function requestShowThread(
+  request: WindowShowThreadRequest,
+  options: RequestShowThreadOptions = {},
+): void {
   const focused = BrowserWindow.getFocusedWindow();
   const subscribers = subscribersForChannel(WINDOW_SHOW_THREAD_CHANNEL);
+
+  const preferred = options.preferWebContents;
+  if (preferred && !preferred.isDestroyed() && subscribers.includes(preferred)) {
+    const preferredWindow = BrowserWindow.fromWebContents(preferred);
+    if (preferredWindow && !preferredWindow.isDestroyed()) {
+      showWindow(preferredWindow);
+    }
+    preferred.send(WINDOW_SHOW_THREAD_CHANNEL, request);
+    return;
+  }
 
   if (focused && !focused.isDestroyed()) {
     const focusedSubscriber = subscribers.find(


### PR DESCRIPTION
## The report

Quitting with a peer's integrated terminal running showed the blocker row as a raw UUID — while the viewer window right behind the dialog was already showing that same thread by name.

## Why

`quit-manager`'s `resolveThreadTitles` asked `BackendRegistry.listThreads({ callerReason: "quit-confirmation" })` — **this instance's** threads. A federated thread isn't in that list, the lookup returned nothing, and the row fell back to the thread id.

## Three tiers of thread-name resolution

Named on `RemoteThreadSummaryCache` so the choice is explicit rather than incidental:

1. **Local only** — this instance's thread list. Correct only when the caller knows every thread it can see is its own. This is what the quit dialog was doing.
2. **Local + cached remote** — `cachedThreadNameFromPeer`. A map read: no fetch, no TTL-triggered refetch, no peer-interest registration. The right default, and what the quit dialog now uses.
3. **Local + live remote** — the existing `threadFromPeer`, for callers that genuinely need current data and can afford to wait on a peer.

Reaching the peer is deliberately **not** done on the quit path. A remote thread is a blocker because a window on this machine has its terminal open, so some snapshot named it on the way to the screen — a round trip would re-answer a question we can answer while making shutdown wait on a machine that may be asleep. No knob is added for tier 3 here: it has no caller on this path, and a parameter with one reachable value would be dead code.

### Where remembered names come from

`RemoteThreadSummaryCache` is populated only by pinned-thread merges and ⌘K jump search — a **federation window** reads its navigation straight from the runtime and never touches that cache. Naming off that cache alone would have left the federation-window case still showing a UUID.

So the cache keeps a **name index**, merged from every snapshot that reaches this instance, including the federation-window navigation read in `readNavigationSnapshot`. Design notes:

- **Names only, not summaries.** This exists so a display string is in hand; holding whole rows for every thread ever seen on every peer would cost real memory for no extra answer.
- **Merged, never replaced.** Snapshots are backend- and filter-scoped, and a narrower one must not erase what a wider one taught us.
- **Fallback titles skipped.** A `titleSource: "fallback"` title *is* the thread id — recording one would overwrite a real name with nothing.
- **Survives TTL lapse, disconnect, and `invalidate`.** A name one refresh out of date beats a UUID, and every alternative costs the round trip tier 2 avoids.
- **Never fails a snapshot.** Remembering is a side errand, wrapped so a broken federation runtime can't break the navigation the operator actually asked for.

Second cached source: the pinned rows' persisted summaries, which survive a restart so a freshly launched app can still name a pinned remote thread before anything has talked to that peer. Neither source is a guarantee — a peer thread no snapshot has ever named still falls back to its thread id, which is the correct outcome.

## Audit: two more peer-blind lookups behind the same rows

Both on the click path of the row the operator is being asked to decide about:

| Lookup | Symptom |
|---|---|
| `revealIntegratedTerminal` consulted only the local PTY registry | Clicking a **remote** terminal row never opened its terminal panel — the local registry reports "no such session" for every shell running on a peer. |
| `requestShowThread` took only `{backend, threadId}` | The dialog holds focus at that moment, so the request fell through to `subscribers[0]`. For a federation window's terminal that's a window which never mounted the thread. |

Turns and environment actions are driven by this instance's registry and runtime, so they're local by construction. `requestShowThread`'s other caller (native approval notifications) is likewise local-only.

## Other changes

- **Quit snapshot carries the owner.** `IntegratedTerminalQuitSnapshot.threadKeys: string[]` → `threads: IntegratedTerminalQuitThread[]`, each optionally carrying its `FederationRemoteTarget` and the peer's display label.
- **Titles keyed by instance + thread key**, so a remote row can never inherit a same-keyed local thread's name — and the **row action carries the owning instance** for the same reason, so the click path can't reveal a local shell for a peer's row.
- **`revealIntegratedTerminal` reports an owner even when two windows host the same remote thread.** Remote mounts allocate a PTY per viewer window, so that is reachable; any owner demonstrably has the thread, which is more than the focused-or-first fallback can promise.
- **Deterministic sort order.** Thread keys are dense with `:` and `-`, so `localeCompare` would make row order depend on the host locale; a shared comparator restores code-unit order.
- Remote rows show the owning peer's name as their detail line; without it a remote shell reads exactly like a local one.

**PTY allocation is untouched** — `createOrAttach`, `pty.open`, `write`, `resize`, `close`, `dispose` all unmodified. Remote mounts keep their isolated per-window PTY with no replication or dual-send; the new `revealSession` only flips `panelHidden`.

## Tests

- `remote-thread-summary-cache.test.ts` — remembered names answer without contacting the peer (cold and warm); names handed in from outside the cache are remembered; merge doesn't erase and fallback titles are ignored; names survive TTL lapse and `invalidate`.
- `quit-manager.test.ts` — remote title from remembered names; pin fallback when nothing is in memory; never waits on a peer (a dependency that never settles can't block resolution); `titleSource: "fallback"` ignored; a remote thread's title kept off a same-keyed local thread; local rows still named when the remote lookups throw; snapshot carries target + label.
- `app-server-ipc.test.ts` — the federation-window read remembers names, and a throwing runtime still serves the snapshot.
- `federation-terminal-ipc.test.ts` — quit snapshot carries target + label; remote reveal reaches the owning window and only that window; an owner is named when two windows host the same thread; naming an instance skips the local registry.
- `quit-confirmation-dialog.test.ts` — the action round-trips the owning instance (and local rows don't grow one); row click routes show-thread to the reveal's owner.
- `quit-dialog-render.test.ts` — remote row renders the thread name and peer label, not the UUID.

Full suite: 521/523 files. The two failures are pre-existing and environmental, both confirmed failing identically on the base commit — `codex-environment-runtime.test.ts` (local `npm` config warnings leak into captured command output) and `acp-backend-adapter.test.ts` (5s per-test timeouts under full-suite load; passes in isolation, and imports nothing this PR touches). `typecheck`, `lint:eslint` (0 errors), `lint:boundaries`, `lint:sql`, `lint:codex-storage` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)