### PR TITLE
fix(desktop): keep offline warning in thread pane

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -451,6 +451,10 @@ test.describe("federation remote window", () => {
       });
       await expect(locallyMountedRemoteRow).toBeVisible({ timeout: 30_000 });
       await expect(locallyMountedRemoteCard).not.toHaveClass(/is-remote-offline/);
+      await locallyMountedRemoteRow.click();
+      await expect(
+        window.getByText(/Remote transcript for Remote gateway thread one/),
+      ).toBeVisible({ timeout: 30_000 });
 
       // Local-only chrome stays hidden in the remote window.
       await expect(
@@ -729,6 +733,18 @@ test.describe("federation remote window", () => {
       await expect(
         remote.locator(".federation-disconnected-banner"),
       ).toBeVisible({ timeout: 30_000 });
+      await expect(remote.locator(".app-main")).toHaveClass(
+        /app-main--federation-disconnected/,
+      );
+      await expect(
+        remote.locator(".federation-disconnected-banner"),
+      ).toContainText("Gateway is unreachable");
+      await expect(
+        window.locator(".federation-disconnected-banner"),
+      ).toContainText("Gateway is unreachable");
+      await expect(window.locator(".app-main")).toHaveClass(
+        /app-main--federation-disconnected/,
+      );
       await expect(
         remote.locator(".composer-tiptap-input__editor"),
       ).toHaveAttribute("contenteditable", "true", { timeout: 15_000 });
@@ -747,6 +763,15 @@ test.describe("federation remote window", () => {
       await expect(
         remote.locator(".federation-disconnected-banner"),
       ).toHaveCount(0, { timeout: 60_000 });
+      await expect(remote.locator(".app-main")).not.toHaveClass(
+        /app-main--federation-disconnected/,
+      );
+      await expect(
+        window.locator(".federation-disconnected-banner"),
+      ).toHaveCount(0);
+      await expect(window.locator(".app-main")).not.toHaveClass(
+        /app-main--federation-disconnected/,
+      );
       await expect(
         remote.locator(".thread-row__title", {
           hasText: "Remote gateway thread one",

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1941,6 +1941,10 @@ function DesktopAppShell(props: {
           className={`app-main${
             threadDetailPending ? " app-main--thread-detail-pending" : ""
           }${
+            !peerConnectivity.connected
+              ? " app-main--federation-disconnected"
+              : ""
+          }${
             mainView === "star-map" && starMapFloatOpen
               ? " app-main--star-map-float"
               : ""
@@ -2031,7 +2035,7 @@ function DesktopAppShell(props: {
             // surface that fails silently.
             <div className="federation-disconnected-banner" role="alert">
               <span className="federation-disconnected-banner__dot" aria-hidden="true" />
-              {`${readRendererFederationLabel() ?? "Remote instance"} is unreachable — reconnecting. Threads shown may be stale.`}
+              {`${activeFederationOwnerLabel ?? "Remote instance"} is unreachable — reconnecting. Threads shown may be stale.`}
             </div>
           ) : null}
           {mainView === "search" ? (

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5493,6 +5493,14 @@ textarea,
   -webkit-app-region: drag;
 }
 
+/* The connectivity notice and the thread surface are vertical regions of the
+   same pane. Without this explicit column, `.app-main`'s default flex row
+   turns the notice into a second full-height pane and squeezes the retained
+   stale thread off to the right. */
+.app-main--federation-disconnected {
+  flex-direction: column;
+}
+
 .app-shell__settings-layer {
   display: flex;
   position: absolute;
@@ -11768,6 +11776,7 @@ textarea,
    — the runtime is auto-reconnecting and the state is expected to heal. */
 .federation-disconnected-banner {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   gap: 8px;
   margin: 10px 16px 0;


### PR DESCRIPTION
## Summary

- stack the federation disconnect warning above the retained thread instead of rendering it as a competing horizontal pane
- label the warning with the active remote owner in both remote-viewer and locally mounted-thread contexts
- extend the two-instance federation E2E to cover disconnect and recovery in both windows

## Root cause

`.app-main` is a flex row. Adding the disconnect banner as a sibling of the thread surface caused the banner to consume a second full-height pane and squeeze the cached thread to the right.

## User impact

When a remote owner is unavailable, the last-known thread remains readable and the composer remains draftable, with a compact warning above the thread. Reconnection removes the warning and restores the normal layout.

## Validation

- `pnpm exec eslint apps/desktop/src/renderer/src/App.tsx apps/desktop/e2e/federation-remote-window.spec.ts`
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx` (28 passed)
- `pnpm --filter @pwragent/desktop test:e2e e2e/federation-remote-window.spec.ts --grep "enrolls, browses remote threads"` (1 passed)
- `git diff --check`
