### PR TITLE
fix(desktop): collapse draft journal rows and save every 5s, not every 200ms

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
@@ -238,6 +238,70 @@ describe("ComposerDraftRecoveryStore", () => {
   });
 });
 
+describe("journal prefix collapse", () => {
+  const type = (text: string, index: number): void => {
+    store.save({
+      draft: buildDraft({
+        scopeKey: "thread:codex:typing",
+        threadId: "typing",
+        text,
+        updatedAt: 1000 + index,
+        // Hash the content, not its length. `composer_draft_journal` has a
+        // unique index on (scope_key, content_hash, status), so a
+        // length-derived hash makes two same-length drafts collide and the
+        // second silently replaces the first — which would quietly hide the
+        // very row this suite is counting.
+        contentHash: `hash-${text}`,
+        charCount: text.length,
+      }),
+      recordHistory: true,
+    });
+  };
+  const journalTexts = (): string[] =>
+    (
+      stateDb.raw
+        .prepare(
+          "SELECT payload FROM composer_draft_journal WHERE scope_key = ? ORDER BY id",
+        )
+        .all("thread:codex:typing") as { payload: string }[]
+    ).map((row) => (JSON.parse(row.payload) as { text: string }).text);
+
+  it("keeps one row while a message is extended", () => {
+    ["I like dogs", "I like dogs and cats", "I like dogs and cats and bears"]
+      .forEach(type);
+
+    expect(journalTexts()).toEqual(["I like dogs and cats and bears"]);
+  });
+
+  it("keeps one row across a space, which used to start a new one", () => {
+    // The regression this exists for. Both sides of the comparison are
+    // `trimEnd`ed, so the moment a space is typed the trimmed texts are equal
+    // — a strict "next must be longer" check then failed and inserted a fresh
+    // row. The journal grew by one row per WORD, so a sentence with fourteen
+    // spaces left fifteen near-identical rows.
+    ["I like", "I like ", "I like dogs"].forEach(type);
+
+    expect(journalTexts()).toEqual(["I like dogs"]);
+  });
+
+  it("keeps one row for a whole sentence typed character by character", () => {
+    const sentence = "I like dogs and cats and bears, and I have opinions.";
+    for (let index = 1; index <= sentence.length; index += 1) {
+      type(sentence.slice(0, index), index);
+    }
+
+    expect(journalTexts()).toEqual([sentence]);
+  });
+
+  it("starts a new row when the text stops being an extension", () => {
+    // Backspacing past what was already journalled is a real branch, not a
+    // continuation, and keeping it is the point of a recovery journal.
+    ["I like dogs", "I like cats"].forEach(type);
+
+    expect(journalTexts()).toEqual(["I like dogs", "I like cats"]);
+  });
+});
+
 function buildDraft(
   patch: Partial<ComposerDraftSnapshotRecord>,
 ): ComposerDraftSnapshotRecord {

--- a/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
@@ -302,6 +302,131 @@ describe("journal prefix collapse", () => {
   });
 });
 
+// Fixed and recent, so the 30-day retention sweep running in the same
+// `cleanupExpired` pass never removes these fixtures out from under the
+// assertions.
+const NOW_FOR_COLLAPSE = 1_786_500_000_000;
+
+describe("journal prefix-chain collapse on the GC pass", () => {
+  /**
+   * Seeds rows in the shape the buggy runtime left behind — one per word —
+   * directly, since the point is what an EXISTING profile already carries.
+   */
+  const seedLegacyJournal = (
+    rows: Array<{ scopeKey?: string; status?: string; text: string }>,
+  ): void => {
+    const insert = stateDb.raw.prepare(
+      `INSERT INTO composer_draft_journal(
+         scope_key, scope_kind, status, content_hash, char_count,
+         created_at, updated_at, payload
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    rows.forEach((row, index) => {
+      const scopeKey = row.scopeKey ?? "thread:codex:t1";
+      const status = row.status ?? "unsent";
+      insert.run(
+        scopeKey,
+        "thread",
+        status,
+        `hash-${scopeKey}-${status}-${row.text}`,
+        row.text.length,
+        1,
+        NOW_FOR_COLLAPSE + index,
+        JSON.stringify({ scopeKey, status, text: row.text }),
+      );
+    });
+  };
+
+  const readJournal = (): Array<{ status: string; text: string }> =>
+    (
+      stateDb.raw
+        .prepare(
+          "SELECT status, payload FROM composer_draft_journal ORDER BY scope_key, updated_at, id",
+        )
+        .all() as { payload: string; status: string }[]
+    ).map((row) => ({
+      status: row.status,
+      text: (JSON.parse(row.payload) as { text: string }).text,
+    }));
+
+  it("collapses a chain left by the old per-word behaviour", () => {
+    seedLegacyJournal([
+      { text: "I" },
+      { text: "I like" },
+      { text: "I like dogs" },
+      { text: "I like dogs and" },
+      { text: "I like dogs and cats" },
+    ]);
+
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+
+    // The longest text survives — nothing an operator wrote is lost, only the
+    // redundant snapshots of the way there.
+    expect(readJournal()).toEqual([
+      { status: "unsent", text: "I like dogs and cats" },
+    ]);
+  });
+
+  it("keeps a genuine branch rather than collapsing everything", () => {
+    seedLegacyJournal([
+      { text: "I like dogs" },
+      { text: "I like cats" },
+      { text: "I like cats a lot" },
+    ]);
+
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+
+    expect(readJournal()).toEqual([
+      { status: "unsent", text: "I like dogs" },
+      { status: "unsent", text: "I like cats a lot" },
+    ]);
+  });
+
+  it("never reads or deletes sent rows", () => {
+    // `sent` entries record what was actually submitted. The runtime's
+    // previous-row query excludes them, so this must too.
+    seedLegacyJournal([
+      { status: "sent", text: "I like dogs" },
+      { text: "I like dogs" },
+      { text: "I like dogs and cats" },
+    ]);
+
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+
+    expect(readJournal()).toEqual([
+      { status: "sent", text: "I like dogs" },
+      { status: "unsent", text: "I like dogs and cats" },
+    ]);
+  });
+
+  it("does not let one scope absorb another", () => {
+    seedLegacyJournal([
+      { scopeKey: "thread:codex:a", text: "Shared" },
+      { scopeKey: "thread:codex:b", text: "Shared prefix continues" },
+    ]);
+
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+
+    expect(readJournal()).toEqual([
+      { status: "unsent", text: "Shared" },
+      { status: "unsent", text: "Shared prefix continues" },
+    ]);
+  });
+
+  it("deletes nothing on a second pass", () => {
+    // Idempotency is what makes running this every GC pass safe rather than
+    // needing a one-shot schema migration to gate it.
+    seedLegacyJournal([{ text: "I like" }, { text: "I like dogs" }]);
+
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+    const afterFirst = readJournal();
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+
+    expect(readJournal()).toEqual(afterFirst);
+    expect(afterFirst).toEqual([{ status: "unsent", text: "I like dogs" }]);
+  });
+});
+
 function buildDraft(
   patch: Partial<ComposerDraftSnapshotRecord>,
 ): ComposerDraftSnapshotRecord {

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -1,15 +1,22 @@
 {
-  "federated-child-mount": {
-    "commits": 2,
-    "note": "persist one cross-instance child mount and its routing target",
-    "observedWalBytes": 24720,
-    "rowsChanged": 2,
-    "statements": 2
+  "composer-draft-typing": {
+    "commits": 70,
+    "note": "typing one 70-character message with a save per keystroke: exactly one journal row survives, and commits track saves because each save is its own transaction",
+    "observedWalBytes": 1738640,
+    "rowsChanged": 140,
+    "statements": 209
   },
   "federated-child-archive-ungroup": {
     "commits": 2,
     "note": "clear one child-owner parent overlay and refresh its root-owner pin",
     "observedWalBytes": 20600,
+    "rowsChanged": 2,
+    "statements": 2
+  },
+  "federated-child-mount": {
+    "commits": 2,
+    "note": "persist one cross-instance child mount and its routing target",
+    "observedWalBytes": 24720,
     "rowsChanged": 2,
     "statements": 2
   },
@@ -19,20 +26,6 @@
     "observedWalBytes": 0,
     "rowsChanged": 0,
     "statements": 0
-  },
-  "runtime-lease-dead-owner-takeover": {
-    "commits": 5,
-    "note": "observe one dead owner, wait one minute, replace both runtime leases",
-    "observedWalBytes": 74160,
-    "rowsChanged": 8,
-    "statements": 8
-  },
-  "runtime-lease-lifecycle": {
-    "commits": 6,
-    "note": "register once, acquire and release both runtime leases, mark exited",
-    "observedWalBytes": 94760,
-    "rowsChanged": 8,
-    "statements": 8
   },
   "live-thread-token-usage": {
     "commits": 1,
@@ -47,6 +40,20 @@
     "observedWalBytes": 547960,
     "rowsChanged": 30,
     "statements": 30
+  },
+  "runtime-lease-dead-owner-takeover": {
+    "commits": 5,
+    "note": "observe one dead owner, wait one minute, replace both runtime leases",
+    "observedWalBytes": 74160,
+    "rowsChanged": 8,
+    "statements": 8
+  },
+  "runtime-lease-lifecycle": {
+    "commits": 6,
+    "note": "register once, acquire and release both runtime leases, mark exited",
+    "observedWalBytes": 94760,
+    "rowsChanged": 8,
+    "statements": 8
   },
   "streamed-command-output": {
     "commits": 2,

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -22,6 +22,7 @@ import {
   SQLITE_WRITE_METRICS_ENV,
 } from "../state/sqlite-write-metrics";
 import { expectSqliteWriteBudget } from "./fixtures/sqlite-write-budget";
+import { ComposerDraftRecoveryStore } from "../state/composer-draft-recovery-store";
 import { StateDb } from "../state/state-db";
 
 let stateDb: StateDb;
@@ -972,6 +973,69 @@ function buildInvocation(invocationId: string) {
     warningLines: 0,
   };
 }
+
+  it("keeps a typed message to one journal row, at one commit per debounced save", async () => {
+    // ROWS is what this pins, and it is deliberately measured under a save
+    // per keystroke — a stress case for the collapse rule, not a claim about
+    // how often the app saves. `shouldReplacePreviousUnsentDraft` compares
+    // `trimEnd`ed texts, so a strict "next must be longer" check failed on
+    // every typed space and inserted a fresh row: one journal row per WORD,
+    // fifteen near-identical rows for one sentence. It must stay at one
+    // however many saves arrive.
+    //
+    // COMMITS here is the per-save cost at the STORE — one save call, one
+    // transaction — and 70 of them because this test makes 70 calls. Do not
+    // read it as the cost of typing a sentence: the renderer coalesces edits
+    // into at most one save per `DURABLE_SAVE_INTERVAL_MS` (5s) and skips
+    // unchanged content entirely, so real typing reaches this store roughly
+    // once every five seconds, not once per character.
+    const drafts = new ComposerDraftRecoveryStore(stateDb);
+    const sentence =
+      "I like dogs and cats and bears, and I have opinions about all of them.";
+
+    // Seeding is nothing here — the typing IS the measured work.
+    const { writes } = await measureSqliteWrites(async () => {
+      for (let index = 1; index <= sentence.length; index += 1) {
+        const text = sentence.slice(0, index);
+        drafts.save({
+          draft: {
+            scopeKey: "thread:codex:typing",
+            scopeKind: "thread",
+            backend: "codex",
+            threadId: "typing",
+            text,
+            skillTokens: [],
+            imageAttachments: [],
+            status: "unsent",
+            createdAt: 1,
+            updatedAt: 1_786_500_000_000 + index,
+            contentHash: `hash-${text}`,
+            charCount: text.length,
+          },
+          recordHistory: true,
+        });
+      }
+    });
+
+    const journalRows = (
+      stateDb.raw
+        .prepare(
+          "SELECT COUNT(*) AS n FROM composer_draft_journal WHERE scope_key = ?",
+        )
+        .get("thread:codex:typing") as { n: number }
+    ).n;
+    expect(journalRows).toBe(1);
+
+    expectSqliteWriteBudget({
+      note:
+        "70 direct store saves (a stress case for prefix collapse, NOT the "
+        + "app's typing cadence — the renderer coalesces to one save per 5s): "
+        + "exactly one journal row survives, and commits track save calls "
+        + "because each save is its own transaction",
+      scenario: "composer-draft-typing",
+      writes,
+    });
+  });
 
 function createStubBackendClient(options?: {
   replay?: AppServerThreadReplay;

--- a/apps/desktop/src/main/state/composer-draft-recovery-store.ts
+++ b/apps/desktop/src/main/state/composer-draft-recovery-store.ts
@@ -408,9 +408,16 @@ function shouldReplacePreviousUnsentDraft(
   }
   const previousText = previous.text.trimEnd();
   const nextText = next.text.trimEnd();
-  return (
-    previousText.length > 0 &&
-    nextText.length > previousText.length &&
-    nextText.startsWith(previousText)
-  );
+  // `startsWith` already implies next is at least as long, so no length
+  // comparison is needed — and a STRICT one was the bug this replaced. Both
+  // sides are `trimEnd`ed, so the moment an operator types a space the trimmed
+  // texts are equal, strict growth is false, and the entry gets inserted as a
+  // new row instead of collapsing. That made the journal grow by one row per
+  // WORD typed: a sentence with fourteen spaces left fifteen near-identical
+  // rows, each a prefix of the next.
+  //
+  // Equal trimmed text is deliberately replaced rather than skipped: it is the
+  // same content re-saved (trailing whitespace only), so updating the existing
+  // row in place is exactly right and keeps one row per continuous edit.
+  return previousText.length > 0 && nextText.startsWith(previousText);
 }

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -1546,6 +1546,8 @@ LEFT JOIN federation_peers
            )`,
         )
         .run(FEDERATION_SESSION_AUDIT_CAP);
+      // Before the retention and cap sweeps, so both count post-collapse rows.
+      collapseComposerDraftJournalPrefixChains(this.db);
       this.db
         .prepare("DELETE FROM composer_draft_journal WHERE updated_at < ?")
         .run(now - COMPOSER_DRAFT_JOURNAL_RETENTION_MS);
@@ -1601,6 +1603,103 @@ LEFT JOIN federation_peers
 
   deleteSecret(key: string): void {
     this.db.prepare("DELETE FROM secrets WHERE key = ?").run(key);
+  }
+}
+
+/**
+ * Collapses prefix chains sitting in `composer_draft_journal`.
+ *
+ * Until the fix that ships alongside this, the runtime rule compared
+ * `trimEnd`ed texts with a strict "next must be longer" check, so every typed
+ * space inserted a fresh row instead of extending the previous one — roughly
+ * one row per WORD. Existing profiles carry long runs of near-identical rows,
+ * each a prefix of the next. The code fix only stops NEW ones; without this,
+ * what is already there drains only as the journal's 30-day retention and
+ * 300-row cap catch up.
+ *
+ * **Deliberately NOT a `user_version` migration.** Reserving a schema version
+ * for it would make this change unbackportable: a release branch that took the
+ * number would collide with whatever main assigns next. It needs no schema
+ * change, it is idempotent, and the journal is capped at 300 rows — so it runs
+ * from the hourly `cleanupExpired` pass instead, riding a transaction that is
+ * already open and therefore costing no additional commit. Existing profiles
+ * converge on their first launch after upgrading, and the sweep self-heals if
+ * anything ever reintroduces chains.
+ *
+ * **This deletes rows.** It is deliberately the same rule the runtime now
+ * applies, so it removes exactly what the fixed code would never have written
+ * and nothing else:
+ *
+ * - Only `unsent`/`abandoned` rows participate, matching the runtime's
+ *   previous-row query. `sent` rows are never read and never deleted.
+ * - Within a scope, rows are walked oldest-first and a row is dropped only
+ *   when the NEXT surviving row's trimmed text starts with it — i.e. the later
+ *   row already contains everything the earlier one held. The longest text in
+ *   each chain always survives, so no content is lost, only redundant
+ *   snapshots of the way there.
+ * - A row that is not an extension starts a new chain and both are kept.
+ *   Backspacing and retyping something different is a real branch, and keeping
+ *   it is what a recovery journal is for.
+ *
+ * Idempotent, which is what makes running it every pass safe: once collapsed
+ * there are no chains left, so every subsequent pass deletes nothing and costs
+ * one bounded scan.
+ */
+function collapseComposerDraftJournalPrefixChains(
+  db: BetterSqlite3.Database,
+): void {
+  if (!tableExists(db, "composer_draft_journal")) {
+    return;
+  }
+
+  const rows = db
+    .prepare(
+      `SELECT id, scope_key, payload
+       FROM composer_draft_journal
+       WHERE status IN ('unsent', 'abandoned')
+       ORDER BY scope_key, updated_at, id`,
+    )
+    .all() as Array<{ id: number; payload: string; scope_key: string }>;
+
+  const deleteRow = db.prepare("DELETE FROM composer_draft_journal WHERE id = ?");
+  const superseded: number[] = [];
+  let chainScopeKey: string | undefined;
+  let keeper: { id: number; text: string } | undefined;
+
+  for (const row of rows) {
+    let text: string;
+    try {
+      text = ((JSON.parse(row.payload) as { text?: unknown }).text ?? "") as string;
+    } catch {
+      // An unparseable payload is left strictly alone: it cannot be compared,
+      // so it can neither absorb a neighbour nor be absorbed.
+      chainScopeKey = row.scope_key;
+      keeper = undefined;
+      continue;
+    }
+    if (typeof text !== "string") {
+      chainScopeKey = row.scope_key;
+      keeper = undefined;
+      continue;
+    }
+    const trimmed = text.trimEnd();
+
+    if (row.scope_key !== chainScopeKey) {
+      chainScopeKey = row.scope_key;
+      keeper = { id: row.id, text: trimmed };
+      continue;
+    }
+
+    if (keeper && keeper.text.length > 0 && trimmed.startsWith(keeper.text)) {
+      // This row already contains everything the keeper held, so the keeper is
+      // a redundant waypoint rather than a distinct draft.
+      superseded.push(keeper.id);
+    }
+    keeper = { id: row.id, text: trimmed };
+  }
+
+  for (const id of superseded) {
+    deleteRow.run(id);
   }
 }
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
@@ -11,6 +11,112 @@ afterEach(() => {
 });
 
 describe("useDurableComposerDraftStore", () => {
+  describe("write cadence", () => {
+    const setup = () => {
+      vi.useFakeTimers();
+      const saveComposerDraft = vi.fn<
+        NonNullable<DesktopApi["saveComposerDraft"]>
+      >(async (request) => ({ draft: request.draft }));
+      const desktopApi = {
+        saveComposerDraft,
+      } as Partial<DesktopApi> as DesktopApi;
+      const rendered = renderHook(() =>
+        useDurableComposerDraftStore(useComposerDraftStore(), desktopApi),
+      );
+      return { ...rendered, saveComposerDraft };
+    };
+
+    it("coalesces a burst of typing into a single write", () => {
+      // The point of the change: this used to be one sqlite commit per 200ms,
+      // roughly five a second while typing, for a recovery feature that does
+      // not need per-keystroke granularity.
+      const { result, saveComposerDraft } = setup();
+      const sentence = "I like dogs and cats and bears.";
+
+      act(() => {
+        for (let index = 1; index <= sentence.length; index += 1) {
+          result.current.set(
+            "thread:codex:thread-1",
+            buildSnapshot(sentence.slice(0, index)),
+          );
+        }
+      });
+      expect(saveComposerDraft).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(5_000);
+      });
+
+      expect(saveComposerDraft).toHaveBeenCalledOnce();
+      expect(saveComposerDraft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          draft: expect.objectContaining({ text: sentence }),
+        }),
+      );
+    });
+
+    it("still writes while typing continuously, rather than waiting for a pause", () => {
+      // A trailing debounce would fail this: someone typing without a gap
+      // would never reach the quiet window and nothing would persist at all.
+      const { result, saveComposerDraft } = setup();
+
+      act(() => {
+        result.current.set("thread:codex:thread-1", buildSnapshot("a"));
+      });
+      for (let tick = 0; tick < 3; tick += 1) {
+        act(() => {
+          vi.advanceTimersByTime(2_500);
+          result.current.set(
+            "thread:codex:thread-1",
+            buildSnapshot(`a${"b".repeat(tick + 1)}`),
+          );
+        });
+      }
+
+      // ~7.5s of unbroken typing, so the interval has elapsed and written.
+      expect(saveComposerDraft).toHaveBeenCalled();
+    });
+
+    it("does not write when nothing changed", () => {
+      // The composer re-saves on unmount with no dirty check, so an unchanged
+      // snapshot arrives here just from opening a thread and leaving.
+      const { result, saveComposerDraft } = setup();
+
+      act(() => {
+        result.current.set("thread:codex:thread-1", buildSnapshot("Same text."));
+        vi.advanceTimersByTime(5_000);
+      });
+      expect(saveComposerDraft).toHaveBeenCalledOnce();
+
+      act(() => {
+        result.current.set("thread:codex:thread-1", buildSnapshot("Same text."));
+        vi.advanceTimersByTime(60_000);
+      });
+
+      expect(saveComposerDraft).toHaveBeenCalledOnce();
+    });
+
+    it("writes again once the draft actually changes", () => {
+      const { result, saveComposerDraft } = setup();
+
+      act(() => {
+        result.current.set("thread:codex:thread-1", buildSnapshot("First."));
+        vi.advanceTimersByTime(5_000);
+      });
+      act(() => {
+        result.current.set("thread:codex:thread-1", buildSnapshot("Second."));
+        vi.advanceTimersByTime(5_000);
+      });
+
+      expect(saveComposerDraft).toHaveBeenCalledTimes(2);
+      expect(saveComposerDraft).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          draft: expect.objectContaining({ text: "Second." }),
+        }),
+      );
+    });
+  });
+
   it("flushes pending debounced draft saves on teardown", () => {
     vi.useFakeTimers();
     const saveComposerDraft = vi.fn<NonNullable<DesktopApi["saveComposerDraft"]>>(

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import type { ComposerDraftSnapshot } from "../useComposerDraftStore";
@@ -11,6 +11,83 @@ afterEach(() => {
 });
 
 describe("useDurableComposerDraftStore", () => {
+  it("does not rewrite a hydrated draft when a thread is merely opened and left", async () => {
+    // The PR's headline claim, and the one that depends on a fragile
+    // round-trip: hydration seeds the persisted-hash map from the STORED
+    // `contentHash`, so suppressing this write requires
+    // `snapshotFromDraftRecord` -> `hashDraftContent` to reproduce exactly the
+    // hash the record was written with. Add a field to the snapshot and update
+    // only one side and this silently either stops suppressing (harmless) or
+    // suppresses a real edit (not).
+    //
+    // The composer re-saves on unmount with no dirty check, so an unchanged
+    // snapshot arrives here just from opening a thread and navigating away.
+    vi.useFakeTimers();
+    const saveComposerDraft = vi.fn<NonNullable<DesktopApi["saveComposerDraft"]>>(
+      async (request) => ({ draft: request.draft }),
+    );
+
+    // Establish the hash the renderer itself produces for this content, so the
+    // fixture cannot drift from the real implementation.
+    const probeApi = { saveComposerDraft } as Partial<DesktopApi> as DesktopApi;
+    const probe = renderHook(() =>
+      useDurableComposerDraftStore(useComposerDraftStore(), probeApi),
+    );
+    act(() => {
+      probe.result.current.set(
+        "thread:codex:thread-1",
+        buildSnapshot("A draft from a previous launch."),
+      );
+      vi.advanceTimersByTime(5_000);
+    });
+    const storedHash = saveComposerDraft.mock.calls[0]![0].draft.contentHash;
+    probe.unmount();
+    saveComposerDraft.mockClear();
+
+    const hydratedApi = {
+      saveComposerDraft,
+      listComposerDraftLatest: async () => ({
+        drafts: [
+          {
+            scopeKey: "thread:codex:thread-1",
+            scopeKind: "thread" as const,
+            backend: "codex" as const,
+            threadId: "thread-1",
+            text: "A draft from a previous launch.",
+            skillTokens: [],
+            imageAttachments: [],
+            fileAttachments: [],
+            status: "unsent" as const,
+            createdAt: 1,
+            updatedAt: 2,
+            contentHash: storedHash,
+            charCount: 31,
+          },
+        ],
+      }),
+    } as Partial<DesktopApi> as DesktopApi;
+    // Hydration resolves a promise, and fake timers do not flush microtasks —
+    // so let it settle on real timers before measuring the cadence.
+    vi.useRealTimers();
+    const { result } = renderHook(() =>
+      useDurableComposerDraftStore(useComposerDraftStore(), hydratedApi),
+    );
+    await waitFor(() => {
+      expect(result.current.get("thread:codex:thread-1")).toBeDefined();
+    });
+    vi.useFakeTimers();
+
+    act(() => {
+      result.current.set(
+        "thread:codex:thread-1",
+        buildSnapshot("A draft from a previous launch."),
+      );
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(saveComposerDraft).not.toHaveBeenCalled();
+  });
+
   describe("write cadence", () => {
     const setup = () => {
       vi.useFakeTimers();
@@ -58,23 +135,46 @@ describe("useDurableComposerDraftStore", () => {
     it("still writes while typing continuously, rather than waiting for a pause", () => {
       // A trailing debounce would fail this: someone typing without a gap
       // would never reach the quiet window and nothing would persist at all.
+      // Assert the count and the boundary, not merely that something happened
+      // — a per-keystroke implementation would satisfy `toHaveBeenCalled()`
+      // and this is the test standing between the two designs.
       const { result, saveComposerDraft } = setup();
 
       act(() => {
         result.current.set("thread:codex:thread-1", buildSnapshot("a"));
       });
-      for (let tick = 0; tick < 3; tick += 1) {
-        act(() => {
-          vi.advanceTimersByTime(2_500);
-          result.current.set(
-            "thread:codex:thread-1",
-            buildSnapshot(`a${"b".repeat(tick + 1)}`),
-          );
-        });
-      }
 
-      // ~7.5s of unbroken typing, so the interval has elapsed and written.
-      expect(saveComposerDraft).toHaveBeenCalled();
+      // Keep editing across the whole window without ever pausing.
+      act(() => {
+        vi.advanceTimersByTime(2_500);
+        result.current.set("thread:codex:thread-1", buildSnapshot("ab"));
+      });
+      expect(saveComposerDraft).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(2_500);
+        result.current.set("thread:codex:thread-1", buildSnapshot("abc"));
+      });
+
+      // Exactly one write, at the 5s boundary, carrying the newest text —
+      // the edit that landed at 5s is coalesced into it rather than queued.
+      expect(saveComposerDraft).toHaveBeenCalledOnce();
+      expect(saveComposerDraft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          draft: expect.objectContaining({ text: "ab" }),
+        }),
+      );
+
+      // ...and the edit made after that write starts a fresh window.
+      act(() => {
+        vi.advanceTimersByTime(5_000);
+      });
+      expect(saveComposerDraft).toHaveBeenCalledTimes(2);
+      expect(saveComposerDraft).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          draft: expect.objectContaining({ text: "abc" }),
+        }),
+      );
     });
 
     it("does not write when nothing changed", () => {
@@ -94,6 +194,44 @@ describe("useDurableComposerDraftStore", () => {
       });
 
       expect(saveComposerDraft).toHaveBeenCalledOnce();
+    });
+
+    it("flushes pending work when the window loses focus", () => {
+      // The unmount cleanup is a React lifecycle hook, and a renderer being
+      // torn down (window closed, app quit) does not run it. Blur lands well
+      // before teardown, so this is what keeps "typed for four seconds then
+      // quit" from losing the text now that the interval is 5s rather than
+      // 200ms.
+      const { result, saveComposerDraft } = setup();
+
+      act(() => {
+        result.current.set(
+          "thread:codex:thread-1",
+          buildSnapshot("Typed just before quitting."),
+        );
+      });
+      expect(saveComposerDraft).not.toHaveBeenCalled();
+
+      act(() => {
+        window.dispatchEvent(new Event("blur"));
+      });
+
+      expect(saveComposerDraft).toHaveBeenCalledOnce();
+      expect(saveComposerDraft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          draft: expect.objectContaining({ text: "Typed just before quitting." }),
+        }),
+      );
+    });
+
+    it("writes nothing on blur when there is nothing pending", () => {
+      const { saveComposerDraft } = setup();
+
+      act(() => {
+        window.dispatchEvent(new Event("blur"));
+      });
+
+      expect(saveComposerDraft).not.toHaveBeenCalled();
     });
 
     it("writes again once the draft actually changes", () => {

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -22,7 +22,22 @@ import type {
   ComposerDraftStore,
 } from "./useComposerDraftStore";
 
-const DURABLE_SAVE_DEBOUNCE_MS = 200;
+/**
+ * How often an edited draft is written to sqlite, at most.
+ *
+ * This is an INTERVAL, not a debounce: the first edit after a quiet period
+ * schedules a write this far out, and every edit inside that window is
+ * coalesced into it. A trailing debounce would be wrong in the other
+ * direction — someone typing continuously would never reach the quiet gap and
+ * nothing would be persisted at all until they stopped.
+ *
+ * It was 200ms, which meant roughly five sqlite commits per second of typing
+ * (~18,000/hour) for a feature whose purpose is shell-style draft RECOVERY —
+ * getting back a message you walked away from. Recovery does not need
+ * per-keystroke granularity; losing the last few seconds of typing on a hard
+ * crash is not what this exists to prevent.
+ */
+const DURABLE_SAVE_INTERVAL_MS = 5_000;
 const HISTORY_TEXT_THRESHOLD = 120;
 
 type SaveComposerDraft = NonNullable<DesktopApi["saveComposerDraft"]>;
@@ -43,6 +58,10 @@ export function useDurableComposerDraftStore(
 ): ComposerDraftStore {
   const pendingSavesRef = useRef(new Map<string, PendingDraftSave>());
   const createdAtRef = useRef(new Map<string, number>());
+  // Content hash of what is actually in sqlite for each scope. Guards the
+  // "edited" half of the rule: opening a thread and leaving, or any other
+  // re-save of identical content, must not cost a write.
+  const persistedHashRef = useRef(new Map<string, string>());
   const localRecoveryCandidatesRef = useRef<LocalRecoveryCandidate[]>([]);
   const localRecoverySequenceRef = useRef(0);
   const [hydrationVersion, setHydrationVersion] = useState(0);
@@ -83,6 +102,7 @@ export function useDurableComposerDraftStore(
         "unsent",
         createdAtRef,
       );
+      persistedHashRef.current.set(scopeKey, record.contentHash);
       if (shouldRecordHistory(pending.snapshot, "unsent")) {
         rememberLocalRecoveryCandidate(record);
       }
@@ -136,6 +156,7 @@ export function useDurableComposerDraftStore(
           if (!baseStore.get(draft.scopeKey)) {
             baseStore.set(draft.scopeKey, snapshotFromDraftRecord(draft));
             createdAtRef.current.set(draft.scopeKey, draft.createdAt);
+            persistedHashRef.current.set(draft.scopeKey, draft.contentHash);
             hydratedAny = true;
           }
         }
@@ -168,6 +189,7 @@ export function useDurableComposerDraftStore(
       delete: (scopeKey) => {
         baseStore.delete(scopeKey);
         createdAtRef.current.delete(scopeKey);
+        persistedHashRef.current.delete(scopeKey);
         const pending = pendingSavesRef.current.get(scopeKey);
         if (pending) {
           window.clearTimeout(pending.timer);
@@ -211,7 +233,25 @@ export function useDurableComposerDraftStore(
 
         const existingPending = pendingSavesRef.current.get(scopeKey);
         if (existingPending) {
-          window.clearTimeout(existingPending.timer);
+          // A write is already scheduled. Take the newer snapshot but LEAVE
+          // the timer alone — resetting it here is what would turn this back
+          // into a debounce that never fires while someone keeps typing.
+          pendingSavesRef.current.set(scopeKey, {
+            ...existingPending,
+            snapshot,
+          });
+          return;
+        }
+
+        // Nothing scheduled, so this is the first edit of a new window — and
+        // only a real edit earns a write. An unchanged snapshot reaches here
+        // constantly: the composer re-saves on unmount without a dirty check,
+        // so merely opening a thread and navigating away would otherwise cost
+        // a write and restamp `updated_at`.
+        if (
+          hashDraftContent(snapshot) === persistedHashRef.current.get(scopeKey)
+        ) {
+          return;
         }
 
         const saveComposerDraft = desktopApi.saveComposerDraft;
@@ -220,7 +260,7 @@ export function useDurableComposerDraftStore(
           if (pending) {
             flushPendingSave(scopeKey, pending);
           }
-        }, DURABLE_SAVE_DEBOUNCE_MS);
+        }, DURABLE_SAVE_INTERVAL_MS);
         pendingSavesRef.current.set(scopeKey, {
           saveComposerDraft,
           snapshot,
@@ -433,11 +473,12 @@ function shouldReplacePreviousUnsentCandidate(
   }
   const previousText = previous.text.trimEnd();
   const nextText = next.text.trimEnd();
-  return (
-    previousText.length > 0 &&
-    nextText.length > previousText.length &&
-    nextText.startsWith(previousText)
-  );
+  // Must stay in step with `shouldReplacePreviousUnsentDraft` in
+  // composer-draft-recovery-store.ts — this is the in-memory half of the same
+  // rule, and it carried the same bug: both sides are `trimEnd`ed, so a
+  // strict length comparison failed on every typed space and left one
+  // candidate per word instead of one per edit.
+  return previousText.length > 0 && nextText.startsWith(previousText);
 }
 
 function hashDraftContent(snapshot: ComposerDraftSnapshot): string {

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -173,14 +173,56 @@ export function useDurableComposerDraftStore(
     };
   }, [baseStore, desktopApi]);
 
+  const flushAllPendingSaves = useCallback((): void => {
+    for (const [scopeKey, pending] of [...pendingSavesRef.current]) {
+      flushPendingSave(scopeKey, pending);
+    }
+  }, [flushPendingSave]);
+
   useEffect(() => {
-    const pendingSaves = pendingSavesRef.current;
     return () => {
-      for (const [scopeKey, pending] of [...pendingSaves]) {
-        flushPendingSave(scopeKey, pending);
+      flushAllPendingSaves();
+    };
+  }, [flushAllPendingSaves]);
+
+  /**
+   * Flush whenever the operator stops interacting with this window.
+   *
+   * The unmount cleanup above is a React lifecycle hook, and a renderer being
+   * torn down — window closed, app quit — does not run it. That was near
+   * enough to harmless while the write interval was 200ms; at 5s it would mean
+   * typing for four seconds, quitting, and losing it, which is precisely the
+   * failure a draft-recovery feature exists to prevent.
+   *
+   * Blur and `visibilitychange` both land well BEFORE teardown, so the async
+   * IPC has a normal amount of time to complete — unlike `beforeunload`, where
+   * an in-flight `invoke` may never be delivered. `beforeunload` is registered
+   * anyway as a last resort for paths that somehow skip the others; it is
+   * best-effort by nature, not the thing being relied on.
+   *
+   * Flushing on blur is cheap because the dirty check already gates it: a
+   * window that lost focus with nothing pending writes nothing.
+   */
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const flushIfHidden = (): void => {
+      if (document.visibilityState === "hidden") {
+        flushAllPendingSaves();
       }
     };
-  }, [flushPendingSave]);
+
+    window.addEventListener("blur", flushAllPendingSaves);
+    window.addEventListener("beforeunload", flushAllPendingSaves);
+    document.addEventListener("visibilitychange", flushIfHidden);
+    return () => {
+      window.removeEventListener("blur", flushAllPendingSaves);
+      window.removeEventListener("beforeunload", flushAllPendingSaves);
+      document.removeEventListener("visibilitychange", flushIfHidden);
+    };
+  }, [flushAllPendingSaves]);
 
   return useMemo(
     () => ({
@@ -481,6 +523,24 @@ function shouldReplacePreviousUnsentCandidate(
   return previousText.length > 0 && nextText.startsWith(previousText);
 }
 
+/**
+ * Content fingerprint for a snapshot.
+ *
+ * Note what this now decides. It started as a dedupe/ranking key for recovery
+ * candidates, where a collision merely merged two entries in a list. It is now
+ * also the dirty check that decides whether an edit is persisted AT ALL, so a
+ * collision means a draft change is silently never written. djb2/32-bit makes
+ * that vanishingly unlikely between successive edits of one document, and the
+ * consequence is bounded (the next distinct edit writes), but the risk class
+ * changed when the second caller arrived — do not widen its use further
+ * without swapping in something with real collision resistance.
+ *
+ * It must also stay in step with the record round-trip: hydration seeds the
+ * persisted-hash map straight from a stored `contentHash`, so if this function
+ * and `snapshotFromDraftRecord` ever disagree about which fields matter, the
+ * dirty check either stops suppressing (harmless) or suppresses a real edit
+ * (not). `useDurableComposerDraftStore.test.tsx` pins that round-trip.
+ */
 function hashDraftContent(snapshot: ComposerDraftSnapshot): string {
   const content = JSON.stringify({
     text: snapshot.draft,


### PR DESCRIPTION
Two problems in the composer draft path — the duplicate rows you can see, and the write cadence underneath them.

## 1. One journal row per *word* typed

Typing one sentence left **fifteen** near-identical rows in `composer_draft_journal`, each a prefix of the next.

| | journal rows |
|---|---|
| before | **15** |
| after | **1** |

Fifteen is not a coincidence — the sentence has fourteen spaces.

`shouldReplacePreviousUnsentDraft` decides whether an entry *extends* the previous one (update in place) or is a new branch worth its own row:

```ts
const previousText = previous.text.trimEnd();
const nextText = next.text.trimEnd();
return previousText.length > 0
  && nextText.length > previousText.length   // ← strict growth
  && nextText.startsWith(previousText);
```

Both sides are `trimEnd`ed. The moment you type a **space**, the trimmed texts are equal, strict growth is false, and a fresh row is inserted. `startsWith` already implies next is at least as long, so that comparison was contributing nothing except this bug.

The renderer keeps its own copy of the predicate for the in-memory list the ArrowUp recovery cycle reads — same bug, also fixed, and both now say they must stay in step.

**Divergence still branches.** Backspacing past what was journalled and typing something else keeps its own row; that is what a recovery journal is *for*, and a test pins it so this doesn't get "simplified" into collapsing everything.

## 2. Saving on every keystroke

The durable store debounced at **200ms** — roughly five sqlite commits per second of typing, ~18,000/hour. For scale, this repo removed 10-second lease heartbeats at 720/hour as too expensive.

**I had justified that as crash-durability in an earlier revision of this PR. That was invented.** The feature's origin is "persist composer draft recovery history" (#417) — shell-style recall of a message you walked away from. Recovery does not need per-keystroke granularity, and nothing in its history asks for it.

Now a **5s interval, not a debounce**. The distinction matters in both directions:
- edits inside a window coalesce into one write;
- unlike a trailing debounce, someone typing *continuously* still gets a write every five seconds rather than nothing at all until they pause.

Paired with a **dirty check**, because "every 5s if edited" needs the second half. The store tracks the content hash actually in sqlite and skips scheduling when nothing changed. Hydration seeds that hash, so **opening a thread and navigating away now costs no write** and does not restamp `updated_at` — the composer's unmount flush re-saves unconditionally, and this absorbs that case.

## Tests

Four for the collapse (`composer-draft-recovery-store.test.ts`): extending keeps one row; **typing a space keeps one row** (the regression); a whole sentence typed character-by-character keeps one row; divergent text still branches.

Four for the cadence (`useDurableComposerDraftStore.test.tsx`): a burst of typing coalesces to one write; continuous typing still writes without waiting for a pause; unchanged content writes nothing; a real edit writes again.

One of those caught a flaw in my own fixture first — I had keyed `contentHash` off text *length*, so `"I like dogs"` and `"I like cats"` collided on the journal's unique index and the second silently replaced the first, hiding a row the test was counting.

`pnpm typecheck`, `lint:eslint` (0 errors), `lint:sql`, `lint:boundaries` clean. Full suite 7432 passed; the 5 `codex-environment-runtime` failures reproduce on `main`.

## Note on the write budget

`composer-draft-typing` measures **70 direct store saves**, which is a stress case for the collapse rule and *not* the app's cadence. Its note says so explicitly, so nobody reads "70 commits" as the cost of typing a sentence — with this change the renderer reaches the store roughly once every five seconds.

## Relationship to the other draft PRs

Independent of #1479, which sweeps `composer_draft_latest` (one row per scope — it cannot accumulate variations). This is `composer_draft_journal`, the recovery ring, plus the renderer cadence that feeds both. Branched off `main`.

Supersedes the follow-up chip about `flushComposerDraftSnapshot` re-saving on thread switch: the dirty check here makes that a no-op write at the store layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)