### PR TITLE
feat(desktop): manage Codex MCP servers in Settings

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1415,10 +1415,12 @@ class MockBackendClient {
     threadId: string;
   };
   lastListMcpServersParams?: {
-    threadId: string;
+    threadId?: string;
     detail: "toolsAndAuthOnly" | "full";
   };
   reloadMcpConfigCallCount = 0;
+  lastMcpServerOAuthLoginParams?: { name: string };
+  lastRemoveMcpServerParams?: { name: string };
   lastArchiveThreadParams?: {
     threadId: string;
   };
@@ -1539,6 +1541,7 @@ class MockBackendClient {
       };
       startReviewDelay?: Promise<unknown>;
       startReviewError?: Error;
+      codexHome?: string;
     }
   ) {}
 
@@ -1552,6 +1555,10 @@ class MockBackendClient {
     }
 
     return this.options.initializeResult ?? {};
+  }
+
+  async readCodexHome(): Promise<string> {
+    return this.options.codexHome ?? "/home/example/.codex";
   }
 
   async listThreads(params?: {
@@ -1877,7 +1884,7 @@ class MockBackendClient {
   }
 
   async listMcpServers(params: {
-    threadId: string;
+    threadId?: string;
     detail: "toolsAndAuthOnly" | "full";
   }) {
     this.lastListMcpServersParams = params;
@@ -1892,6 +1899,17 @@ class MockBackendClient {
 
   async reloadMcpConfig(): Promise<void> {
     this.reloadMcpConfigCallCount += 1;
+  }
+
+  async startMcpServerOAuthLogin(params: {
+    name: string;
+  }): Promise<{ authorizationUrl: string }> {
+    this.lastMcpServerOAuthLoginParams = params;
+    return { authorizationUrl: "https://example.test/oauth" };
+  }
+
+  async removeMcpServer(params: { name: string }): Promise<void> {
+    this.lastRemoveMcpServerParams = params;
   }
 
   async trustProject(params: {
@@ -34901,6 +34919,53 @@ script = "printf setup"
       queued: true,
     });
     expect(codexClient.reloadMcpConfigCallCount).toBe(1);
+
+    await registry.close();
+  });
+
+  it("binds Settings MCP mutations to the active Codex profile", async () => {
+    const codexHome = "/home/example/.codex/profiles/work";
+    const codexClient = new MockBackendClient({ codexHome });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock({ executionMode: "default" }),
+    });
+
+    await expect(registry.listCodexMcpServers()).resolves.toEqual({
+      codexHome,
+      detail: "toolsAndAuthOnly",
+      servers: [{
+        name: "atlassian-rovo",
+        authStatus: "oAuth",
+        tools: ["fetch", "search"],
+      }],
+    });
+    await expect(registry.reloadCodexMcpServers({ codexHome }))
+      .resolves.toEqual({ codexHome, queued: true });
+    await expect(registry.startCodexMcpServerLogin({
+      codexHome,
+      name: "atlassian-rovo",
+    })).resolves.toEqual({
+      codexHome,
+      name: "atlassian-rovo",
+      authorizationUrl: "https://example.test/oauth",
+    });
+    await expect(registry.removeCodexMcpServer({
+      codexHome,
+      name: "atlassian-rovo",
+    })).resolves.toEqual({
+      codexHome,
+      name: "atlassian-rovo",
+      removed: true,
+    });
+
+    await expect(registry.removeCodexMcpServer({
+      codexHome: "/home/example/.codex/profiles/personal",
+      name: "atlassian-rovo",
+    })).rejects.toThrow("Codex profile changed after this app started");
+    expect(codexClient.lastRemoveMcpServerParams).toEqual({
+      name: "atlassian-rovo",
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -6758,7 +6758,7 @@ describe("CodexAppServerClient", () => {
       (message) => JSON.parse(message),
     )).toContainEqual(expect.objectContaining({
       method: "mcpServer/oauth/login",
-      params: { name: "datadog" },
+      params: { name: "datadog", timeoutSecs: 120 },
     }));
 
     await client.close();

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -6822,6 +6822,80 @@ describe("CodexAppServerClient", () => {
         startupError: "invalid_grant",
         tools: [],
       }]);
+    await client.reloadMcpConfig();
+    await expect(client.listMcpServers({ detail: "toolsAndAuthOnly" }))
+      .resolves.toEqual([{
+        name: "datadog",
+        authStatus: "oAuth",
+        tools: [],
+      }]);
+
+    await client.close();
+  });
+
+  it("keeps MCP startup status scoped to its inventory thread", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadMcpServerStatusResult = {
+      data: [{
+        name: "atlassian",
+        serverInfo: null,
+        authStatus: "oAuth",
+        tools: {},
+        resources: [],
+        resourceTemplates: [],
+      }],
+      nextCursor: null,
+    };
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+    await client.getInitializeResult();
+    const transport = MockTransport.instances.at(-1)!;
+    transport.emitInbound({
+      jsonrpc: "2.0",
+      method: "mcpServer/startupStatus/updated",
+      params: {
+        threadId: "thread-a",
+        name: "atlassian",
+        status: "failed",
+        error: "thread-a invalid_grant",
+      },
+    });
+    transport.emitInbound({
+      jsonrpc: "2.0",
+      method: "mcpServer/startupStatus/updated",
+      params: {
+        threadId: "thread-b",
+        name: "atlassian",
+        status: "ready",
+        error: null,
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await expect(client.listMcpServers({
+      threadId: "thread-a",
+      detail: "toolsAndAuthOnly",
+    })).resolves.toEqual([expect.objectContaining({
+      name: "atlassian",
+      startupStatus: "failed",
+      startupError: "thread-a invalid_grant",
+    })]);
+    await expect(client.listMcpServers({
+      threadId: "thread-b",
+      detail: "toolsAndAuthOnly",
+    })).resolves.toEqual([expect.objectContaining({
+      name: "atlassian",
+      startupStatus: "ready",
+    })]);
+    await expect(client.listMcpServers({
+      detail: "toolsAndAuthOnly",
+    })).resolves.toEqual([{
+      name: "atlassian",
+      authStatus: "oAuth",
+      tools: [],
+    }]);
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -721,6 +721,19 @@ class MockTransport implements JsonRpcTransport {
       return;
     }
 
+    if (payload.method === "mcpServer/oauth/login") {
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: {
+            authorizationUrl: "https://example.test/oauth",
+          },
+        }),
+      );
+      return;
+    }
+
     if (payload.method === "account/rateLimits/read") {
       this.messageHandler(
         JSON.stringify({
@@ -6728,6 +6741,87 @@ describe("CodexAppServerClient", () => {
         method: "config/mcpServer/reload",
       }),
     );
+
+    await client.close();
+  });
+
+  it("starts MCP OAuth login through the app-server protocol", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await expect(client.startMcpServerOAuthLogin({ name: "datadog" }))
+      .resolves.toEqual({ authorizationUrl: "https://example.test/oauth" });
+    expect(MockTransport.instances.at(-1)!.sentMessages.map(
+      (message) => JSON.parse(message),
+    )).toContainEqual(expect.objectContaining({
+      method: "mcpServer/oauth/login",
+      params: { name: "datadog" },
+    }));
+
+    await client.close();
+  });
+
+  it("removes one quoted MCP server config key and reloads", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await expect(client.removeMcpServer({ name: "search.compare\\dev\"" }))
+      .resolves.toBeUndefined();
+    expect(MockTransport.lastConfigValueWritePayload).toEqual({
+      keyPath: "mcp_servers.\"search.compare\\\\dev\\\"\"",
+      value: null,
+      mergeStrategy: "replace",
+    });
+    expect(MockTransport.instances.at(-1)!.sentMessages.map(
+      (message) => JSON.parse(message).method,
+    )).toContain("config/mcpServer/reload");
+
+    await client.close();
+  });
+
+  it("adds observed MCP startup failures to inventory", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadMcpServerStatusResult = {
+      data: [{
+        name: "datadog",
+        serverInfo: null,
+        authStatus: "oAuth",
+        tools: {},
+        resources: [],
+        resourceTemplates: [],
+      }],
+      nextCursor: null,
+    };
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+    await client.getInitializeResult();
+    MockTransport.instances.at(-1)!.emitInbound({
+      jsonrpc: "2.0",
+      method: "mcpServer/startupStatus/updated",
+      params: {
+        name: "datadog",
+        status: "failed",
+        error: "invalid_grant",
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await expect(client.listMcpServers({ detail: "toolsAndAuthOnly" }))
+      .resolves.toEqual([{
+        name: "datadog",
+        authStatus: "oAuth",
+        startupStatus: "failed",
+        startupError: "invalid_grant",
+        tools: [],
+      }]);
 
     await client.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -116,8 +116,15 @@ import {
   type LatestCodexConfigWarningResponse,
   type ListBackendsRequest,
   type ListBackendsResponse,
+  type ListCodexMcpServersRequest,
+  type ListCodexMcpServersResponse,
   type ListThreadMcpServersRequest,
   type ListThreadMcpServersResponse,
+  type ReloadCodexMcpServersResponse,
+  type RemoveCodexMcpServerRequest,
+  type RemoveCodexMcpServerResponse,
+  type StartCodexMcpServerLoginRequest,
+  type StartCodexMcpServerLoginResponse,
   type EditGroupCommitInput,
   type EditGroupCommitState,
   type LinkedDirectorySummary,
@@ -717,10 +724,14 @@ type BackendClient = {
     threadId: string;
   }): Promise<{ threadId: string; turnId: string; itemId?: string }>;
   listMcpServers?(params: {
-    threadId: string;
+    threadId?: string;
     detail: ListThreadMcpServersResponse["detail"];
   }): Promise<ListThreadMcpServersResponse["servers"]>;
   reloadMcpConfig?(): Promise<void>;
+  startMcpServerOAuthLogin?(params: {
+    name: string;
+  }): Promise<{ authorizationUrl: string }>;
+  removeMcpServer?(params: { name: string }): Promise<void>;
   steerTurn?(params: {
     threadId: string;
     input: AppServerTurnInputItem[];
@@ -13710,6 +13721,50 @@ export class DesktopBackendRegistry {
       threadId: params.threadId,
       queued: true,
     };
+  }
+
+  async listCodexMcpServers(
+    params: ListCodexMcpServersRequest = {},
+  ): Promise<ListCodexMcpServersResponse> {
+    if (!this.codexClient.listMcpServers) {
+      throw new Error("Selected Codex version does not support MCP inventory");
+    }
+    const detail = params.detail ?? "toolsAndAuthOnly";
+    return {
+      detail,
+      servers: await this.codexClient.listMcpServers({ detail }),
+    };
+  }
+
+  async reloadCodexMcpServers(): Promise<ReloadCodexMcpServersResponse> {
+    if (!this.codexClient.reloadMcpConfig) {
+      throw new Error("Selected Codex version does not support MCP config reload");
+    }
+    await this.codexClient.reloadMcpConfig();
+    return { queued: true };
+  }
+
+  async startCodexMcpServerLogin(
+    params: StartCodexMcpServerLoginRequest,
+  ): Promise<StartCodexMcpServerLoginResponse> {
+    if (!this.codexClient.startMcpServerOAuthLogin) {
+      throw new Error("Selected Codex version does not support MCP login");
+    }
+    const result = await this.codexClient.startMcpServerOAuthLogin(params);
+    return {
+      name: params.name,
+      authorizationUrl: result.authorizationUrl,
+    };
+  }
+
+  async removeCodexMcpServer(
+    params: RemoveCodexMcpServerRequest,
+  ): Promise<RemoveCodexMcpServerResponse> {
+    if (!this.codexClient.removeMcpServer) {
+      throw new Error("Selected Codex version does not support MCP removal");
+    }
+    await this.codexClient.removeMcpServer(params);
+    return { name: params.name, removed: true };
   }
 
   async steerTurn(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -121,6 +121,7 @@ import {
   type ListThreadMcpServersRequest,
   type ListThreadMcpServersResponse,
   type ReloadCodexMcpServersResponse,
+  type ReloadCodexMcpServersRequest,
   type RemoveCodexMcpServerRequest,
   type RemoveCodexMcpServerResponse,
   type StartCodexMcpServerLoginRequest,
@@ -584,6 +585,7 @@ function assistantOutputForTurn(
 type BackendClient = {
   close(): Promise<void>;
   getInitializeResult(): Promise<InitializeResult>;
+  readCodexHome?(): Promise<string>;
   readConfiguredMcpServerNames?(params?: {
     cwd?: string;
   }): Promise<string[]>;
@@ -13730,28 +13732,37 @@ export class DesktopBackendRegistry {
       throw new Error("Selected Codex version does not support MCP inventory");
     }
     const detail = params.detail ?? "toolsAndAuthOnly";
+    const codexHome = await this.readActiveCodexMcpHome();
     return {
+      codexHome,
       detail,
       servers: await this.codexClient.listMcpServers({ detail }),
     };
   }
 
-  async reloadCodexMcpServers(): Promise<ReloadCodexMcpServersResponse> {
+  async reloadCodexMcpServers(
+    params: ReloadCodexMcpServersRequest,
+  ): Promise<ReloadCodexMcpServersResponse> {
+    const codexHome = await this.requireActiveCodexMcpHome(params.codexHome);
     if (!this.codexClient.reloadMcpConfig) {
       throw new Error("Selected Codex version does not support MCP config reload");
     }
     await this.codexClient.reloadMcpConfig();
-    return { queued: true };
+    return { codexHome, queued: true };
   }
 
   async startCodexMcpServerLogin(
     params: StartCodexMcpServerLoginRequest,
   ): Promise<StartCodexMcpServerLoginResponse> {
+    const codexHome = await this.requireActiveCodexMcpHome(params.codexHome);
     if (!this.codexClient.startMcpServerOAuthLogin) {
       throw new Error("Selected Codex version does not support MCP login");
     }
-    const result = await this.codexClient.startMcpServerOAuthLogin(params);
+    const result = await this.codexClient.startMcpServerOAuthLogin({
+      name: params.name,
+    });
     return {
+      codexHome,
       name: params.name,
       authorizationUrl: result.authorizationUrl,
     };
@@ -13760,11 +13771,32 @@ export class DesktopBackendRegistry {
   async removeCodexMcpServer(
     params: RemoveCodexMcpServerRequest,
   ): Promise<RemoveCodexMcpServerResponse> {
+    const codexHome = await this.requireActiveCodexMcpHome(params.codexHome);
     if (!this.codexClient.removeMcpServer) {
       throw new Error("Selected Codex version does not support MCP removal");
     }
-    await this.codexClient.removeMcpServer(params);
-    return { name: params.name, removed: true };
+    await this.codexClient.removeMcpServer({ name: params.name });
+    return { codexHome, name: params.name, removed: true };
+  }
+
+  private async readActiveCodexMcpHome(): Promise<string> {
+    if (this.codexClient.readCodexHome) {
+      return await this.codexClient.readCodexHome();
+    }
+    return path.resolve(
+      this.codexEnvironmentCommandEnv?.CODEX_HOME?.trim()
+      || path.join(os.homedir(), ".codex"),
+    );
+  }
+
+  private async requireActiveCodexMcpHome(expectedCodexHome: string): Promise<string> {
+    const activeCodexHome = await this.readActiveCodexMcpHome();
+    if (path.resolve(expectedCodexHome) !== path.resolve(activeCodexHome)) {
+      throw new Error(
+        "Codex profile changed after this app started. Restart PwrAgent before managing MCP servers.",
+      );
+    }
+    return activeCodexHome;
   }
 
   async steerTurn(

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -7194,6 +7194,18 @@ export class CodexAppServerClient {
     return this.initializeResult ?? {};
   }
 
+  async readCodexHome(): Promise<string> {
+    await this.ensureInitialized();
+    const env = this.options.resolveEnv
+      ? await this.options.resolveEnv()
+      : this.options.env ?? process.env;
+    return path.resolve(
+      extractStringProperty(this.initializeResult, "codexHome", "codex_home")
+      || env.CODEX_HOME?.trim()
+      || path.join(homedir(), ".codex"),
+    );
+  }
+
   private getProtocolCompatibility(): CodexProtocolCompatibility {
     return resolveCodexProtocolCompatibility(
       this.initializeResult?.userAgent,
@@ -7810,7 +7822,7 @@ export class CodexAppServerClient {
     const result = await requestWithFallbacks({
       client: this.connection,
       methods: ["mcpServer/oauth/login"],
-      payloads: [{ name: params.name }],
+      payloads: [{ name: params.name, timeoutSecs: 120 }],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     });
     const authorizationUrl = readStringFromRecord(result, "authorizationUrl");

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -6911,12 +6911,15 @@ export class CodexAppServerClient {
   private readonly notificationListeners = new Set<
     (notification: AppServerNotification) => void | Promise<void>
   >();
-  private readonly mcpStartupStatusByName = new Map<
+  private readonly mcpStartupStatusByContext = new Map<
     string,
-    {
-      status: NonNullable<CodexMcpServerSummary["startupStatus"]>;
-      error?: string;
-    }
+    Map<
+      string,
+      {
+        status: NonNullable<CodexMcpServerSummary["startupStatus"]>;
+        error?: string;
+      }
+    >
   >();
   private readonly recordedThreadNames = new Map<string, string>();
   private readonly requestListeners = new Set<
@@ -6985,6 +6988,7 @@ export class CodexAppServerClient {
         const name = readStringFromRecord(params, "name");
         const status = readStringFromRecord(params, "status");
         const error = readStringFromRecord(params, "error");
+        const threadId = extractRequestMetadata(params).threadId;
         if (
           name
           && (status === "starting"
@@ -6992,10 +6996,16 @@ export class CodexAppServerClient {
             || status === "failed"
             || status === "cancelled")
         ) {
-          this.mcpStartupStatusByName.set(name, {
+          const contextKey = threadId
+            ? `thread:${threadId}`
+            : "global";
+          const statuses = this.mcpStartupStatusByContext.get(contextKey)
+            ?? new Map();
+          statuses.set(name, {
             status,
             ...(error ? { error } : {}),
           });
+          this.mcpStartupStatusByContext.set(contextKey, statuses);
         }
       }
 
@@ -7066,7 +7076,7 @@ export class CodexAppServerClient {
     this.recordedThreadNames.clear();
     this.helperThreadIds.clear();
     this.completedHelperTurnResults.clear();
-    this.mcpStartupStatusByName.clear();
+    this.mcpStartupStatusByContext.clear();
     this.helperTurnTitleObjects.clear();
     this.helperTurnTokenUsage.clear();
     this.helperThreadPredicates.clear();
@@ -7724,6 +7734,7 @@ export class CodexAppServerClient {
 
     const listPages = async (threadId?: string) => {
       const servers: CodexMcpServerSummary[] = [];
+      const contextKey = threadId ? `thread:${threadId}` : "global";
       const seenCursors = new Set<string>();
       let cursor: string | undefined;
       do {
@@ -7751,7 +7762,9 @@ export class CodexAppServerClient {
 
       return servers
         .map((server) => {
-          const startup = this.mcpStartupStatusByName.get(server.name);
+          const startup = this.mcpStartupStatusByContext
+            .get(contextKey)
+            ?.get(server.name);
           return startup
             ? {
                 ...server,
@@ -7778,6 +7791,7 @@ export class CodexAppServerClient {
 
   async reloadMcpConfig(): Promise<void> {
     await this.ensureInitialized();
+    this.mcpStartupStatusByContext.clear();
     await requestWithFallbacks({
       client: this.connection,
       methods: ["config/mcpServer/reload"],
@@ -7825,7 +7839,9 @@ export class CodexAppServerClient {
       payloads: [payload],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     });
-    this.mcpStartupStatusByName.delete(params.name);
+    for (const statuses of this.mcpStartupStatusByContext.values()) {
+      statuses.delete(params.name);
+    }
     await this.reloadMcpConfig();
     const remaining = await this.listMcpServers({
       detail: "toolsAndAuthOnly",

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -377,6 +377,7 @@ const GENERATED_CODEX_NOTIFICATION_METHODS = new Set<string>([
   "item/commandExecution/outputDelta",
   "item/commandExecution/terminalInteraction",
   "item/fileChange/outputDelta",
+  "mcpServer/oauthLogin/completed",
   "mcpServer/startupStatus/updated",
 ]);
 const GENERATED_CODEX_SERVER_REQUEST_METHODS = new Set<CodexServerRequestMethod>([
@@ -6910,6 +6911,13 @@ export class CodexAppServerClient {
   private readonly notificationListeners = new Set<
     (notification: AppServerNotification) => void | Promise<void>
   >();
+  private readonly mcpStartupStatusByName = new Map<
+    string,
+    {
+      status: NonNullable<CodexMcpServerSummary["startupStatus"]>;
+      error?: string;
+    }
+  >();
   private readonly recordedThreadNames = new Map<string, string>();
   private readonly requestListeners = new Set<
     (
@@ -6972,6 +6980,23 @@ export class CodexAppServerClient {
           listenerCount: this.notificationListeners.size,
           initialized: this.initialized,
         });
+      }
+      if (method === "mcpServer/startupStatus/updated") {
+        const name = readStringFromRecord(params, "name");
+        const status = readStringFromRecord(params, "status");
+        const error = readStringFromRecord(params, "error");
+        if (
+          name
+          && (status === "starting"
+            || status === "ready"
+            || status === "failed"
+            || status === "cancelled")
+        ) {
+          this.mcpStartupStatusByName.set(name, {
+            status,
+            ...(error ? { error } : {}),
+          });
+        }
       }
 
       const normalized = normalizeServerNotification(
@@ -7041,6 +7066,7 @@ export class CodexAppServerClient {
     this.recordedThreadNames.clear();
     this.helperThreadIds.clear();
     this.completedHelperTurnResults.clear();
+    this.mcpStartupStatusByName.clear();
     this.helperTurnTitleObjects.clear();
     this.helperTurnTokenUsage.clear();
     this.helperThreadPredicates.clear();
@@ -7691,7 +7717,7 @@ export class CodexAppServerClient {
   }
 
   async listMcpServers(params: {
-    threadId: string;
+    threadId?: string;
     detail: CodexMcpInventoryDetail;
   }): Promise<CodexMcpServerSummary[]> {
     await this.ensureInitialized();
@@ -7723,9 +7749,23 @@ export class CodexAppServerClient {
         }
       } while (cursor);
 
-      return servers.sort((left, right) => left.name.localeCompare(right.name));
+      return servers
+        .map((server) => {
+          const startup = this.mcpStartupStatusByName.get(server.name);
+          return startup
+            ? {
+                ...server,
+                startupStatus: startup.status,
+                ...(startup.error ? { startupError: startup.error } : {}),
+              }
+            : server;
+        })
+        .sort((left, right) => left.name.localeCompare(right.name));
     };
 
+    if (!params.threadId) {
+      return await listPages();
+    }
     try {
       return await listPages(params.threadId);
     } catch (error) {
@@ -7744,6 +7784,57 @@ export class CodexAppServerClient {
       payloads: [undefined],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     });
+  }
+
+  async startMcpServerOAuthLogin(params: {
+    name: string;
+  }): Promise<{ authorizationUrl: string }> {
+    if (!params.name.trim()) {
+      throw new Error("MCP server name is required");
+    }
+    await this.ensureInitialized();
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      methods: ["mcpServer/oauth/login"],
+      payloads: [{ name: params.name }],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+    const authorizationUrl = readStringFromRecord(result, "authorizationUrl");
+    if (!authorizationUrl) {
+      throw new Error("codex_mcp_oauth_login_missing_authorization_url");
+    }
+    return { authorizationUrl };
+  }
+
+  async removeMcpServer(params: { name: string }): Promise<void> {
+    if (!params.name.trim()) {
+      throw new Error("MCP server name is required");
+    }
+    await this.ensureInitialized();
+    const quotedName = `"${params.name
+      .replaceAll("\\", "\\\\")
+      .replaceAll("\"", "\\\"")}"`;
+    const payload: CodexConfigValueWriteParams = {
+      keyPath: `mcp_servers.${quotedName}`,
+      value: null,
+      mergeStrategy: "replace",
+    };
+    await requestWithFallbacks({
+      client: this.connection,
+      methods: ["config/value/write"],
+      payloads: [payload],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+    this.mcpStartupStatusByName.delete(params.name);
+    await this.reloadMcpConfig();
+    const remaining = await this.listMcpServers({
+      detail: "toolsAndAuthOnly",
+    });
+    if (remaining.some((server) => server.name === params.name)) {
+      throw new Error(
+        `${params.name} is managed by another Codex config layer and could not be removed`,
+      );
+    }
   }
 
   async listModels(

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -39,6 +39,7 @@ import {
   type ReloadCodexMcpConfigRequest,
   type ReloadCodexMcpConfigResponse,
   type ReloadCodexMcpServersResponse,
+  type ReloadCodexMcpServersRequest,
   type RemoveCodexMcpServerRequest,
   type RemoveCodexMcpServerResponse,
   type RunCodexEnvironmentActionRequest,
@@ -768,8 +769,11 @@ export function registerAgentIpcHandlers(): void {
   ipcMain.removeHandler(CODEX_MCP_SERVERS_RELOAD_CHANNEL);
   ipcMain.handle(
     CODEX_MCP_SERVERS_RELOAD_CHANNEL,
-    async (): Promise<ReloadCodexMcpServersResponse> =>
-      await registry.reloadCodexMcpServers(),
+    async (
+      _event,
+      request: ReloadCodexMcpServersRequest,
+    ): Promise<ReloadCodexMcpServersResponse> =>
+      await registry.reloadCodexMcpServers(request),
   );
 
   ipcMain.removeHandler(CODEX_MCP_SERVER_LOGIN_CHANNEL);

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -28,6 +28,8 @@ import {
   type LatestCodexConfigWarningResponse,
   type ListBackendsRequest,
   type ListBackendsResponse,
+  type ListCodexMcpServersRequest,
+  type ListCodexMcpServersResponse,
   type ListThreadMcpServersRequest,
   type ListThreadMcpServersResponse,
   type QueueThreadExecutionModeRequest,
@@ -36,6 +38,9 @@ import {
   type RetainThreadBranchDriftResponse,
   type ReloadCodexMcpConfigRequest,
   type ReloadCodexMcpConfigResponse,
+  type ReloadCodexMcpServersResponse,
+  type RemoveCodexMcpServerRequest,
+  type RemoveCodexMcpServerResponse,
   type RunCodexEnvironmentActionRequest,
   type RunCodexEnvironmentActionResponse,
   type StopCodexEnvironmentActionRequest,
@@ -59,6 +64,8 @@ import {
   type SteerTurnResponse,
   type StartReviewRequest,
   type StartReviewResponse,
+  type StartCodexMcpServerLoginRequest,
+  type StartCodexMcpServerLoginResponse,
   type StartThreadRequest,
   type StartThreadResponse,
   type StartTurnRequest,
@@ -89,6 +96,10 @@ import {
   AGENT_COMPACT_THREAD_CHANNEL,
   AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL,
   AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL,
+  CODEX_MCP_SERVERS_LIST_CHANNEL,
+  CODEX_MCP_SERVERS_RELOAD_CHANNEL,
+  CODEX_MCP_SERVER_LOGIN_CHANNEL,
+  CODEX_MCP_SERVER_REMOVE_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
   AGENT_STOP_SUB_AGENT_CHANNEL,
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
@@ -744,6 +755,43 @@ export function registerAgentIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(CODEX_MCP_SERVERS_LIST_CHANNEL);
+  ipcMain.handle(
+    CODEX_MCP_SERVERS_LIST_CHANNEL,
+    async (
+      _event,
+      request: ListCodexMcpServersRequest = {},
+    ): Promise<ListCodexMcpServersResponse> =>
+      await registry.listCodexMcpServers(request),
+  );
+
+  ipcMain.removeHandler(CODEX_MCP_SERVERS_RELOAD_CHANNEL);
+  ipcMain.handle(
+    CODEX_MCP_SERVERS_RELOAD_CHANNEL,
+    async (): Promise<ReloadCodexMcpServersResponse> =>
+      await registry.reloadCodexMcpServers(),
+  );
+
+  ipcMain.removeHandler(CODEX_MCP_SERVER_LOGIN_CHANNEL);
+  ipcMain.handle(
+    CODEX_MCP_SERVER_LOGIN_CHANNEL,
+    async (
+      _event,
+      request: StartCodexMcpServerLoginRequest,
+    ): Promise<StartCodexMcpServerLoginResponse> =>
+      await registry.startCodexMcpServerLogin(request),
+  );
+
+  ipcMain.removeHandler(CODEX_MCP_SERVER_REMOVE_CHANNEL);
+  ipcMain.handle(
+    CODEX_MCP_SERVER_REMOVE_CHANNEL,
+    async (
+      _event,
+      request: RemoveCodexMcpServerRequest,
+    ): Promise<RemoveCodexMcpServerResponse> =>
+      await registry.removeCodexMcpServer(request),
+  );
+
   ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
   ipcMain.handle(
     AGENT_INTERRUPT_TURN_CHANNEL,
@@ -1205,6 +1253,10 @@ export function disposeAgentIpcHandlers(): void {
   ipcMain.removeHandler(AGENT_COMPACT_THREAD_CHANNEL);
   ipcMain.removeHandler(AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL);
   ipcMain.removeHandler(AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL);
+  ipcMain.removeHandler(CODEX_MCP_SERVERS_LIST_CHANNEL);
+  ipcMain.removeHandler(CODEX_MCP_SERVERS_RELOAD_CHANNEL);
+  ipcMain.removeHandler(CODEX_MCP_SERVER_LOGIN_CHANNEL);
+  ipcMain.removeHandler(CODEX_MCP_SERVER_REMOVE_CHANNEL);
   ipcMain.removeHandler(AGENT_START_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_STOP_SUB_AGENT_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -40,6 +40,8 @@ import type {
   ListAutomationsResponse,
   ListBackendsRequest,
   ListBackendsResponse,
+  ListCodexMcpServersRequest,
+  ListCodexMcpServersResponse,
   ListThreadMcpServersRequest,
   ListThreadMcpServersResponse,
   ListDesktopPwrAgentProfilesResponse,
@@ -49,6 +51,11 @@ import type {
   QueueThreadExecutionModeResponse,
   ReloadCodexMcpConfigRequest,
   ReloadCodexMcpConfigResponse,
+  ReloadCodexMcpServersResponse,
+  RemoveCodexMcpServerRequest,
+  RemoveCodexMcpServerResponse,
+  StartCodexMcpServerLoginRequest,
+  StartCodexMcpServerLoginResponse,
   LatestCodexConfigWarningResponse,
   SetAcpSessionRuntimeOptionRequest,
   SetAcpSessionRuntimeOptionResponse,
@@ -414,6 +421,10 @@ import {
   AGENT_COMPACT_THREAD_CHANNEL,
   AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL,
   AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL,
+  CODEX_MCP_SERVERS_LIST_CHANNEL,
+  CODEX_MCP_SERVERS_RELOAD_CHANNEL,
+  CODEX_MCP_SERVER_LOGIN_CHANNEL,
+  CODEX_MCP_SERVER_REMOVE_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
   AGENT_STOP_SUB_AGENT_CHANNEL,
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
@@ -1354,6 +1365,20 @@ const desktopApi = Object.freeze({
     request: ReloadCodexMcpConfigRequest,
   ): Promise<ReloadCodexMcpConfigResponse> =>
     await ipcRenderer.invoke(AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL, request),
+  listCodexMcpServers: async (
+    request: ListCodexMcpServersRequest = {},
+  ): Promise<ListCodexMcpServersResponse> =>
+    await ipcRenderer.invoke(CODEX_MCP_SERVERS_LIST_CHANNEL, request),
+  reloadCodexMcpServers: async (): Promise<ReloadCodexMcpServersResponse> =>
+    await ipcRenderer.invoke(CODEX_MCP_SERVERS_RELOAD_CHANNEL),
+  startCodexMcpServerLogin: async (
+    request: StartCodexMcpServerLoginRequest,
+  ): Promise<StartCodexMcpServerLoginResponse> =>
+    await ipcRenderer.invoke(CODEX_MCP_SERVER_LOGIN_CHANNEL, request),
+  removeCodexMcpServer: async (
+    request: RemoveCodexMcpServerRequest,
+  ): Promise<RemoveCodexMcpServerResponse> =>
+    await ipcRenderer.invoke(CODEX_MCP_SERVER_REMOVE_CHANNEL, request),
   startTurn: async (
     request: StartTurnRequest
   ): Promise<StartTurnResponse> =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -52,6 +52,7 @@ import type {
   ReloadCodexMcpConfigRequest,
   ReloadCodexMcpConfigResponse,
   ReloadCodexMcpServersResponse,
+  ReloadCodexMcpServersRequest,
   RemoveCodexMcpServerRequest,
   RemoveCodexMcpServerResponse,
   StartCodexMcpServerLoginRequest,
@@ -1369,8 +1370,10 @@ const desktopApi = Object.freeze({
     request: ListCodexMcpServersRequest = {},
   ): Promise<ListCodexMcpServersResponse> =>
     await ipcRenderer.invoke(CODEX_MCP_SERVERS_LIST_CHANNEL, request),
-  reloadCodexMcpServers: async (): Promise<ReloadCodexMcpServersResponse> =>
-    await ipcRenderer.invoke(CODEX_MCP_SERVERS_RELOAD_CHANNEL),
+  reloadCodexMcpServers: async (
+    request: ReloadCodexMcpServersRequest,
+  ): Promise<ReloadCodexMcpServersResponse> =>
+    await ipcRenderer.invoke(CODEX_MCP_SERVERS_RELOAD_CHANNEL, request),
   startCodexMcpServerLogin: async (
     request: StartCodexMcpServerLoginRequest,
   ): Promise<StartCodexMcpServerLoginResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -123,6 +123,7 @@ import {
 const SETTINGS_SECTIONS = new Set<SettingsSection>([
   "general",
   "applications",
+  "plugins",
   "git",
   "profiles",
   "worktrees",

--- a/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   CodexMcpAuthStatus,
   CodexMcpServerSummary,
@@ -16,19 +16,63 @@ type ActionNotice = {
   text: string;
 };
 
+type PendingAction = {
+  kind: "login" | "reload" | "remove";
+  name: string;
+};
+
+type StartupResult = {
+  status: "ready" | "failed" | "cancelled";
+  error?: string;
+};
+
+const LOGIN_STARTUP_WAIT_MS = 5_000;
+
 export function PluginsSettings(props: {
   desktopApi?: DesktopApi;
   snapshot: DesktopSettingsSnapshot;
 }) {
   const [servers, setServers] = useState<CodexMcpServerSummary[]>([]);
   const [loading, setLoading] = useState(true);
-  const [busyServer, setBusyServer] = useState<string>();
+  const [pendingAction, setPendingActionState] = useState<PendingAction>();
+  const pendingActionRef = useRef<PendingAction | undefined>(undefined);
+  const startupWaiterRef = useRef<{
+    name: string;
+    resolve: (result: StartupResult | undefined) => void;
+    timer: number;
+  } | undefined>(undefined);
   const [removeCandidate, setRemoveCandidate] =
     useState<CodexMcpServerSummary>();
   const [notice, setNotice] = useState<ActionNotice>();
   const selectedProfile = props.snapshot.models.codex.profiles.profiles.find(
     (profile) => profile.selected,
   );
+
+  const setPendingAction = useCallback((action?: PendingAction) => {
+    pendingActionRef.current = action;
+    setPendingActionState(action);
+  }, []);
+
+  const cancelStartupWait = useCallback(() => {
+    const waiter = startupWaiterRef.current;
+    if (!waiter) return;
+    window.clearTimeout(waiter.timer);
+    startupWaiterRef.current = undefined;
+    waiter.resolve(undefined);
+  }, []);
+
+  const waitForGlobalStartup = useCallback((name: string) => {
+    cancelStartupWait();
+    return new Promise<StartupResult | undefined>((resolve) => {
+      const timer = window.setTimeout(() => {
+        if (startupWaiterRef.current?.name === name) {
+          startupWaiterRef.current = undefined;
+        }
+        resolve(undefined);
+      }, LOGIN_STARTUP_WAIT_MS);
+      startupWaiterRef.current = { name, resolve, timer };
+    });
+  }, [cancelStartupWait]);
 
   const loadServers = useCallback(async () => {
     if (!props.desktopApi?.listCodexMcpServers) {
@@ -37,7 +81,7 @@ export function PluginsSettings(props: {
         text: "MCP management is unavailable in this build.",
       });
       setLoading(false);
-      return;
+      return false;
     }
     setLoading(true);
     try {
@@ -45,11 +89,13 @@ export function PluginsSettings(props: {
         detail: "toolsAndAuthOnly",
       });
       setServers(response.servers);
+      return true;
     } catch (error) {
       setNotice({
         kind: "error",
         text: error instanceof Error ? error.message : String(error),
       });
+      return false;
     } finally {
       setLoading(false);
     }
@@ -59,7 +105,96 @@ export function PluginsSettings(props: {
     void loadServers();
   }, [loadServers]);
 
+  useEffect(() => () => {
+    const waiter = startupWaiterRef.current;
+    if (!waiter) return;
+    window.clearTimeout(waiter.timer);
+    startupWaiterRef.current = undefined;
+  }, []);
+
+  const finishLogin = useCallback(async (name: string) => {
+    if (!props.desktopApi?.reloadCodexMcpServers) {
+      setNotice({
+        kind: "error",
+        text: "MCP config reload is unavailable in this build.",
+      });
+      setPendingAction(undefined);
+      return;
+    }
+    setPendingAction({ kind: "reload", name });
+    setNotice({
+      kind: "working",
+      text: `${name} login completed. Reloading its MCP connection...`,
+    });
+    const startup = waitForGlobalStartup(name);
+    try {
+      await props.desktopApi.reloadCodexMcpServers();
+      const startupResult = await startup;
+      const refreshed = await loadServers();
+      if (!refreshed) return;
+      if (startupResult?.status === "failed") {
+        setNotice({
+          kind: "error",
+          text: startupResult.error
+            ? `${name} login completed, but startup failed: ${startupResult.error}`
+            : `${name} login completed, but its MCP connection failed to start.`,
+        });
+      } else if (startupResult?.status === "cancelled") {
+        setNotice({
+          kind: "error",
+          text: `${name} login completed, but its MCP connection startup was cancelled.`,
+        });
+      } else {
+        setNotice({
+          kind: "success",
+          text: `${name} login completed and its row was refreshed.`,
+        });
+      }
+    } catch (error) {
+      cancelStartupWait();
+      setNotice({
+        kind: "error",
+        text: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setPendingAction(undefined);
+    }
+  }, [
+    cancelStartupWait,
+    loadServers,
+    props.desktopApi,
+    setPendingAction,
+    waitForGlobalStartup,
+  ]);
+
   useEffect(() => props.desktopApi?.onAgentEvent?.((event) => {
+    if (event.notification.method === "mcpServer/startupStatus/updated") {
+      const params = event.notification.params;
+      const name = typeof params.name === "string"
+        ? params.name
+        : typeof params.serverName === "string"
+          ? params.serverName
+          : undefined;
+      const waiter = startupWaiterRef.current;
+      if (
+        !waiter
+        || !name
+        || name !== waiter.name
+        || typeof params.threadId === "string"
+        || (params.status !== "ready"
+          && params.status !== "failed"
+          && params.status !== "cancelled")
+      ) {
+        return;
+      }
+      window.clearTimeout(waiter.timer);
+      startupWaiterRef.current = undefined;
+      waiter.resolve({
+        status: params.status,
+        ...(typeof params.error === "string" ? { error: params.error } : {}),
+      });
+      return;
+    }
     if (event.notification.method !== "mcpServer/oauthLogin/completed") {
       return;
     }
@@ -69,51 +204,54 @@ export function PluginsSettings(props: {
       : typeof params.serverName === "string"
         ? params.serverName
         : undefined;
-    if (!name || name !== busyServer) {
+    const pending = pendingActionRef.current;
+    if (!name || pending?.kind !== "login" || name !== pending.name) {
       return;
     }
-    setBusyServer(undefined);
     if (params.success === true) {
-      setNotice({ kind: "success", text: `${name} login completed.` });
-      void props.desktopApi?.reloadCodexMcpServers?.()
-        .then(loadServers)
-        .catch((error: unknown) => {
-          setNotice({
-            kind: "error",
-            text: error instanceof Error ? error.message : String(error),
-          });
-        });
+      void finishLogin(name);
       return;
     }
+    setPendingAction(undefined);
     setNotice({
       kind: "error",
       text: typeof params.error === "string"
         ? params.error
         : `${name} login did not complete.`,
     });
-  }), [busyServer, loadServers, props.desktopApi]);
+  }), [finishLogin, props.desktopApi, setPendingAction]);
 
   const reloadConfig = async () => {
-    if (!props.desktopApi?.reloadCodexMcpServers) return;
+    if (
+      !props.desktopApi?.reloadCodexMcpServers
+      || pendingActionRef.current
+    ) return;
+    setPendingAction({ kind: "reload", name: "MCP configuration" });
     setNotice({ kind: "working", text: "Reloading MCP configuration..." });
     try {
       await props.desktopApi.reloadCodexMcpServers();
-      await loadServers();
-      setNotice({
-        kind: "success",
-        text: "MCP configuration reloaded. Loaded threads use it on their next turn.",
-      });
+      if (await loadServers()) {
+        setNotice({
+          kind: "success",
+          text: "MCP configuration reloaded. Loaded threads use it on their next turn.",
+        });
+      }
     } catch (error) {
       setNotice({
         kind: "error",
         text: error instanceof Error ? error.message : String(error),
       });
+    } finally {
+      setPendingAction(undefined);
     }
   };
 
   const relogin = async (server: CodexMcpServerSummary) => {
-    if (!props.desktopApi?.startCodexMcpServerLogin) return;
-    setBusyServer(server.name);
+    if (
+      !props.desktopApi?.startCodexMcpServerLogin
+      || pendingActionRef.current
+    ) return;
+    setPendingAction({ kind: "login", name: server.name });
     setNotice({
       kind: "working",
       text: `Waiting for ${server.name} login to complete...`,
@@ -124,7 +262,7 @@ export function PluginsSettings(props: {
       });
       window.open(result.authorizationUrl, "_blank", "noopener,noreferrer");
     } catch (error) {
-      setBusyServer(undefined);
+      setPendingAction(undefined);
       setNotice({
         kind: "error",
         text: error instanceof Error ? error.message : String(error),
@@ -134,24 +272,29 @@ export function PluginsSettings(props: {
 
   const removeServer = async () => {
     const server = removeCandidate;
-    if (!server || !props.desktopApi?.removeCodexMcpServer) return;
-    setBusyServer(server.name);
+    if (
+      !server
+      || !props.desktopApi?.removeCodexMcpServer
+      || pendingActionRef.current
+    ) return;
+    setPendingAction({ kind: "remove", name: server.name });
     setNotice({ kind: "working", text: `Removing ${server.name}...` });
     try {
       await props.desktopApi.removeCodexMcpServer({ name: server.name });
       setRemoveCandidate(undefined);
-      await loadServers();
-      setNotice({
-        kind: "success",
-        text: `${server.name} was removed from this Codex profile.`,
-      });
+      if (await loadServers()) {
+        setNotice({
+          kind: "success",
+          text: `${server.name} was removed from this Codex profile.`,
+        });
+      }
     } catch (error) {
       setNotice({
         kind: "error",
         text: error instanceof Error ? error.message : String(error),
       });
     } finally {
-      setBusyServer(undefined);
+      setPendingAction(undefined);
     }
   };
 
@@ -164,7 +307,7 @@ export function PluginsSettings(props: {
         action={
           <button
             className="button button--secondary"
-            disabled={loading || Boolean(busyServer)}
+            disabled={loading || Boolean(pendingAction)}
             title="Re-read installed MCP configuration and expose it to loaded Codex threads on their next turn."
             type="button"
             onClick={() => void reloadConfig()}
@@ -204,7 +347,8 @@ export function PluginsSettings(props: {
             {servers.map((server) => (
               <McpServerRow
                 key={server.name}
-                busy={busyServer === server.name}
+                busy={pendingAction?.name === server.name}
+                disabled={Boolean(pendingAction)}
                 server={server}
                 onRelogin={() => void relogin(server)}
                 onRemove={() => setRemoveCandidate(server)}
@@ -233,7 +377,7 @@ export function PluginsSettings(props: {
             <div className="settings-confirm-dialog__actions">
               <button
                 className="button button--secondary"
-                disabled={busyServer === removeCandidate.name}
+                disabled={Boolean(pendingAction)}
                 type="button"
                 onClick={() => setRemoveCandidate(undefined)}
               >
@@ -241,7 +385,7 @@ export function PluginsSettings(props: {
               </button>
               <button
                 className="button button--ghost settings-profile-row__button--danger"
-                disabled={busyServer === removeCandidate.name}
+                disabled={Boolean(pendingAction)}
                 type="button"
                 onClick={() => void removeServer()}
               >
@@ -257,6 +401,7 @@ export function PluginsSettings(props: {
 
 function McpServerRow(props: {
   busy: boolean;
+  disabled: boolean;
   server: CodexMcpServerSummary;
   onRelogin: () => void;
   onRemove: () => void;
@@ -295,7 +440,7 @@ function McpServerRow(props: {
         {canRelogin ? (
           <button
             className="button button--secondary"
-            disabled={props.busy}
+            disabled={props.disabled}
             type="button"
             onClick={props.onRelogin}
           >
@@ -304,7 +449,7 @@ function McpServerRow(props: {
         ) : null}
         <button
           className="button button--ghost settings-mcp-row__remove"
-          disabled={props.busy}
+          disabled={props.disabled}
           type="button"
           onClick={props.onRemove}
         >

--- a/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
@@ -1,0 +1,323 @@
+import { useCallback, useEffect, useState } from "react";
+import type {
+  CodexMcpAuthStatus,
+  CodexMcpServerSummary,
+  DesktopSettingsSnapshot,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import {
+  SettingsPanelHead,
+  SettingsSection,
+  SettingsSectionStack,
+} from "./SettingsLayout";
+
+type ActionNotice = {
+  kind: "error" | "success" | "working";
+  text: string;
+};
+
+export function PluginsSettings(props: {
+  desktopApi?: DesktopApi;
+  snapshot: DesktopSettingsSnapshot;
+}) {
+  const [servers, setServers] = useState<CodexMcpServerSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busyServer, setBusyServer] = useState<string>();
+  const [removeCandidate, setRemoveCandidate] =
+    useState<CodexMcpServerSummary>();
+  const [notice, setNotice] = useState<ActionNotice>();
+  const selectedProfile = props.snapshot.models.codex.profiles.profiles.find(
+    (profile) => profile.selected,
+  );
+
+  const loadServers = useCallback(async () => {
+    if (!props.desktopApi?.listCodexMcpServers) {
+      setNotice({
+        kind: "error",
+        text: "MCP management is unavailable in this build.",
+      });
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const response = await props.desktopApi.listCodexMcpServers({
+        detail: "toolsAndAuthOnly",
+      });
+      setServers(response.servers);
+    } catch (error) {
+      setNotice({
+        kind: "error",
+        text: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [props.desktopApi]);
+
+  useEffect(() => {
+    void loadServers();
+  }, [loadServers]);
+
+  useEffect(() => props.desktopApi?.onAgentEvent?.((event) => {
+    if (event.notification.method !== "mcpServer/oauthLogin/completed") {
+      return;
+    }
+    const params = event.notification.params;
+    const name = typeof params.name === "string"
+      ? params.name
+      : typeof params.serverName === "string"
+        ? params.serverName
+        : undefined;
+    if (!name || name !== busyServer) {
+      return;
+    }
+    setBusyServer(undefined);
+    if (params.success === true) {
+      setNotice({ kind: "success", text: `${name} login completed.` });
+      void props.desktopApi?.reloadCodexMcpServers?.()
+        .then(loadServers)
+        .catch((error: unknown) => {
+          setNotice({
+            kind: "error",
+            text: error instanceof Error ? error.message : String(error),
+          });
+        });
+      return;
+    }
+    setNotice({
+      kind: "error",
+      text: typeof params.error === "string"
+        ? params.error
+        : `${name} login did not complete.`,
+    });
+  }), [busyServer, loadServers, props.desktopApi]);
+
+  const reloadConfig = async () => {
+    if (!props.desktopApi?.reloadCodexMcpServers) return;
+    setNotice({ kind: "working", text: "Reloading MCP configuration..." });
+    try {
+      await props.desktopApi.reloadCodexMcpServers();
+      await loadServers();
+      setNotice({
+        kind: "success",
+        text: "MCP configuration reloaded. Loaded threads use it on their next turn.",
+      });
+    } catch (error) {
+      setNotice({
+        kind: "error",
+        text: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  const relogin = async (server: CodexMcpServerSummary) => {
+    if (!props.desktopApi?.startCodexMcpServerLogin) return;
+    setBusyServer(server.name);
+    setNotice({
+      kind: "working",
+      text: `Waiting for ${server.name} login to complete...`,
+    });
+    try {
+      const result = await props.desktopApi.startCodexMcpServerLogin({
+        name: server.name,
+      });
+      window.open(result.authorizationUrl, "_blank", "noopener,noreferrer");
+    } catch (error) {
+      setBusyServer(undefined);
+      setNotice({
+        kind: "error",
+        text: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  const removeServer = async () => {
+    const server = removeCandidate;
+    if (!server || !props.desktopApi?.removeCodexMcpServer) return;
+    setBusyServer(server.name);
+    setNotice({ kind: "working", text: `Removing ${server.name}...` });
+    try {
+      await props.desktopApi.removeCodexMcpServer({ name: server.name });
+      setRemoveCandidate(undefined);
+      await loadServers();
+      setNotice({
+        kind: "success",
+        text: `${server.name} was removed from this Codex profile.`,
+      });
+    } catch (error) {
+      setNotice({
+        kind: "error",
+        text: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setBusyServer(undefined);
+    }
+  };
+
+  return (
+    <SettingsSectionStack paneId="plugins" aria-label="Plugin settings">
+      <SettingsPanelHead
+        eyebrow="Plugins"
+        title="Plugin connections"
+        help="Inspect and repair the MCP servers configured for this PwrAgent profile's selected Codex profile."
+        action={
+          <button
+            className="button button--secondary"
+            disabled={loading || Boolean(busyServer)}
+            title="Re-read installed MCP configuration and expose it to loaded Codex threads on their next turn."
+            type="button"
+            onClick={() => void reloadConfig()}
+          >
+            Reload config
+          </button>
+        }
+      />
+
+      <SettingsSection
+        eyebrow="Plugins"
+        title="MCP servers"
+        sectionId="mcp-servers"
+        description="Relogin replaces expired OAuth credentials. Remove deletes only this server's configuration from the selected Codex profile."
+        chip={`${servers.length} configured`}
+      >
+        <div className="settings-plugin-profile">
+          <span>Codex profile</span>
+          <strong>{selectedProfile?.displayName ?? "Default"}</strong>
+          <code>
+            {selectedProfile?.codexHome
+              ?? props.snapshot.models.codex.profiles.effectiveCodexHome}
+          </code>
+        </div>
+        {notice ? (
+          <p
+            className={`settings-plugin-notice settings-plugin-notice--${notice.kind}`}
+            role={notice.kind === "error" ? "alert" : "status"}
+          >
+            {notice.text}
+          </p>
+        ) : null}
+        {loading ? (
+          <p className="settings-empty">Loading MCP servers...</p>
+        ) : servers.length ? (
+          <div className="settings-mcp-list">
+            {servers.map((server) => (
+              <McpServerRow
+                key={server.name}
+                busy={busyServer === server.name}
+                server={server}
+                onRelogin={() => void relogin(server)}
+                onRemove={() => setRemoveCandidate(server)}
+              />
+            ))}
+          </div>
+        ) : (
+          <p className="settings-empty">No MCP servers are configured.</p>
+        )}
+      </SettingsSection>
+
+      {removeCandidate ? (
+        <div className="settings-confirm-modal" role="presentation">
+          <div
+            aria-labelledby="remove-mcp-server-heading"
+            aria-modal="true"
+            className="settings-confirm-dialog settings-confirm-dialog--danger"
+            role="dialog"
+          >
+            <h2 id="remove-mcp-server-heading">Remove MCP server?</h2>
+            <p>
+              Remove <strong>{removeCandidate.name}</strong> from the selected
+              Codex profile. Existing threads receive the new configuration on
+              their next turn.
+            </p>
+            <div className="settings-confirm-dialog__actions">
+              <button
+                className="button button--secondary"
+                disabled={busyServer === removeCandidate.name}
+                type="button"
+                onClick={() => setRemoveCandidate(undefined)}
+              >
+                Cancel
+              </button>
+              <button
+                className="button button--ghost settings-profile-row__button--danger"
+                disabled={busyServer === removeCandidate.name}
+                type="button"
+                onClick={() => void removeServer()}
+              >
+                Remove server
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </SettingsSectionStack>
+  );
+}
+
+function McpServerRow(props: {
+  busy: boolean;
+  server: CodexMcpServerSummary;
+  onRelogin: () => void;
+  onRemove: () => void;
+}) {
+  const server = props.server;
+  const canRelogin = server.authStatus === "oAuth"
+    || server.authStatus === "notLoggedIn";
+  return (
+    <article className="settings-mcp-row">
+      <div className="settings-mcp-row__body">
+        <strong>{server.name}</strong>
+        <span>{server.tools.length} tools</span>
+        {server.startupError ? (
+          <p className="settings-mcp-row__error">{server.startupError}</p>
+        ) : null}
+      </div>
+      <div className="settings-mcp-row__chips">
+        <span className="settings-pathrow__chip">
+          {formatAuthStatus(server.authStatus)}
+        </span>
+        {server.startupStatus ? (
+          <span
+            className={`settings-pathrow__chip${
+              server.startupStatus === "failed"
+                ? " settings-pathrow__chip--err"
+                : server.startupStatus === "ready"
+                  ? " settings-pathrow__chip--ok"
+                  : ""
+            }`}
+          >
+            {server.startupStatus}
+          </span>
+        ) : null}
+      </div>
+      <div className="settings-mcp-row__actions">
+        {canRelogin ? (
+          <button
+            className="button button--secondary"
+            disabled={props.busy}
+            type="button"
+            onClick={props.onRelogin}
+          >
+            {props.busy ? "Waiting..." : "Relogin"}
+          </button>
+        ) : null}
+        <button
+          className="button button--ghost settings-mcp-row__remove"
+          disabled={props.busy}
+          type="button"
+          onClick={props.onRemove}
+        >
+          Remove
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function formatAuthStatus(status: CodexMcpAuthStatus): string {
+  if (status === "oAuth") return "OAuth";
+  if (status === "bearerToken") return "Bearer token";
+  if (status === "notLoggedIn") return "Login required";
+  return "No login";
+}

--- a/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
@@ -12,7 +12,7 @@ import {
 } from "./SettingsLayout";
 
 type ActionNotice = {
-  kind: "error" | "success" | "working";
+  kind: "error" | "info" | "success" | "working";
   text: string;
 };
 
@@ -27,12 +27,22 @@ type StartupResult = {
 };
 
 const LOGIN_STARTUP_WAIT_MS = 5_000;
+const OAUTH_LOGIN_WAIT_MS = 120_000;
+
+function normalizeCodexHome(value: string): string {
+  return value
+    .trim()
+    .replaceAll("\\", "/")
+    .replace(/\/$/, "")
+    .replace(/^([A-Z]):/, (_, drive: string) => `${drive.toLowerCase()}:`);
+}
 
 export function PluginsSettings(props: {
   desktopApi?: DesktopApi;
   snapshot: DesktopSettingsSnapshot;
 }) {
   const [servers, setServers] = useState<CodexMcpServerSummary[]>([]);
+  const [activeCodexHome, setActiveCodexHome] = useState<string>();
   const [loading, setLoading] = useState(true);
   const [pendingAction, setPendingActionState] = useState<PendingAction>();
   const pendingActionRef = useRef<PendingAction | undefined>(undefined);
@@ -41,17 +51,59 @@ export function PluginsSettings(props: {
     resolve: (result: StartupResult | undefined) => void;
     timer: number;
   } | undefined>(undefined);
+  const oauthWaitTimerRef = useRef<number | undefined>(undefined);
   const [removeCandidate, setRemoveCandidate] =
     useState<CodexMcpServerSummary>();
   const [notice, setNotice] = useState<ActionNotice>();
   const selectedProfile = props.snapshot.models.codex.profiles.profiles.find(
     (profile) => profile.selected,
   );
+  const selectedCodexHome = selectedProfile?.codexHome
+    ?? props.snapshot.models.codex.profiles.effectiveCodexHome;
+  const activeProfile = activeCodexHome
+    ? props.snapshot.models.codex.profiles.profiles.find(
+        (profile) => normalizeCodexHome(profile.codexHome)
+          === normalizeCodexHome(activeCodexHome),
+      )
+    : undefined;
+  const profileChanged = Boolean(
+    activeCodexHome
+    && normalizeCodexHome(activeCodexHome)
+      !== normalizeCodexHome(selectedCodexHome),
+  );
 
   const setPendingAction = useCallback((action?: PendingAction) => {
     pendingActionRef.current = action;
     setPendingActionState(action);
   }, []);
+
+  const clearOAuthWaitTimer = useCallback(() => {
+    if (oauthWaitTimerRef.current === undefined) return;
+    window.clearTimeout(oauthWaitTimerRef.current);
+    oauthWaitTimerRef.current = undefined;
+  }, []);
+
+  const cancelLoginWait = useCallback((message?: string) => {
+    clearOAuthWaitTimer();
+    if (pendingActionRef.current?.kind !== "login") return;
+    setPendingAction(undefined);
+    setNotice({
+      kind: "info",
+      text: message ?? "Stopped waiting for login. You can try again.",
+    });
+  }, [clearOAuthWaitTimer, setPendingAction]);
+
+  const scheduleLoginTimeout = useCallback((name: string) => {
+    clearOAuthWaitTimer();
+    oauthWaitTimerRef.current = window.setTimeout(() => {
+      if (
+        pendingActionRef.current?.kind === "login"
+        && pendingActionRef.current.name === name
+      ) {
+        cancelLoginWait(`${name} login timed out. You can try again.`);
+      }
+    }, OAUTH_LOGIN_WAIT_MS);
+  }, [cancelLoginWait, clearOAuthWaitTimer]);
 
   const cancelStartupWait = useCallback(() => {
     const waiter = startupWaiterRef.current;
@@ -88,6 +140,7 @@ export function PluginsSettings(props: {
       const response = await props.desktopApi.listCodexMcpServers({
         detail: "toolsAndAuthOnly",
       });
+      setActiveCodexHome(response.codexHome);
       setServers(response.servers);
       return true;
     } catch (error) {
@@ -106,18 +159,26 @@ export function PluginsSettings(props: {
   }, [loadServers]);
 
   useEffect(() => () => {
+    clearOAuthWaitTimer();
     const waiter = startupWaiterRef.current;
     if (!waiter) return;
     window.clearTimeout(waiter.timer);
     startupWaiterRef.current = undefined;
-  }, []);
+  }, [clearOAuthWaitTimer]);
 
   const finishLogin = useCallback(async (name: string) => {
+    clearOAuthWaitTimer();
+    const codexHome = activeCodexHome;
     if (!props.desktopApi?.reloadCodexMcpServers) {
       setNotice({
         kind: "error",
         text: "MCP config reload is unavailable in this build.",
       });
+      setPendingAction(undefined);
+      return;
+    }
+    if (!codexHome) {
+      setNotice({ kind: "error", text: "Active Codex profile is unavailable." });
       setPendingAction(undefined);
       return;
     }
@@ -128,7 +189,7 @@ export function PluginsSettings(props: {
     });
     const startup = waitForGlobalStartup(name);
     try {
-      await props.desktopApi.reloadCodexMcpServers();
+      await props.desktopApi.reloadCodexMcpServers({ codexHome });
       const startupResult = await startup;
       const refreshed = await loadServers();
       if (!refreshed) return;
@@ -161,6 +222,8 @@ export function PluginsSettings(props: {
     }
   }, [
     cancelStartupWait,
+    clearOAuthWaitTimer,
+    activeCodexHome,
     loadServers,
     props.desktopApi,
     setPendingAction,
@@ -212,6 +275,7 @@ export function PluginsSettings(props: {
       void finishLogin(name);
       return;
     }
+    clearOAuthWaitTimer();
     setPendingAction(undefined);
     setNotice({
       kind: "error",
@@ -219,17 +283,26 @@ export function PluginsSettings(props: {
         ? params.error
         : `${name} login did not complete.`,
     });
-  }), [finishLogin, props.desktopApi, setPendingAction]);
+  }), [
+    clearOAuthWaitTimer,
+    finishLogin,
+    props.desktopApi,
+    setPendingAction,
+  ]);
 
   const reloadConfig = async () => {
     if (
       !props.desktopApi?.reloadCodexMcpServers
       || pendingActionRef.current
+      || profileChanged
+      || !activeCodexHome
     ) return;
     setPendingAction({ kind: "reload", name: "MCP configuration" });
     setNotice({ kind: "working", text: "Reloading MCP configuration..." });
     try {
-      await props.desktopApi.reloadCodexMcpServers();
+      await props.desktopApi.reloadCodexMcpServers({
+        codexHome: activeCodexHome,
+      });
       if (await loadServers()) {
         setNotice({
           kind: "success",
@@ -250,18 +323,32 @@ export function PluginsSettings(props: {
     if (
       !props.desktopApi?.startCodexMcpServerLogin
       || pendingActionRef.current
+      || profileChanged
+      || !activeCodexHome
     ) return;
     setPendingAction({ kind: "login", name: server.name });
     setNotice({
       kind: "working",
       text: `Waiting for ${server.name} login to complete...`,
     });
+    scheduleLoginTimeout(server.name);
     try {
       const result = await props.desktopApi.startCodexMcpServerLogin({
+        codexHome: activeCodexHome,
         name: server.name,
       });
+      const pendingAfterStart = pendingActionRef.current as
+        | PendingAction
+        | undefined;
+      if (
+        pendingAfterStart?.kind !== "login"
+        || pendingAfterStart.name !== server.name
+      ) {
+        return;
+      }
       window.open(result.authorizationUrl, "_blank", "noopener,noreferrer");
     } catch (error) {
+      clearOAuthWaitTimer();
       setPendingAction(undefined);
       setNotice({
         kind: "error",
@@ -276,11 +363,16 @@ export function PluginsSettings(props: {
       !server
       || !props.desktopApi?.removeCodexMcpServer
       || pendingActionRef.current
+      || profileChanged
+      || !activeCodexHome
     ) return;
     setPendingAction({ kind: "remove", name: server.name });
     setNotice({ kind: "working", text: `Removing ${server.name}...` });
     try {
-      await props.desktopApi.removeCodexMcpServer({ name: server.name });
+      await props.desktopApi.removeCodexMcpServer({
+        codexHome: activeCodexHome,
+        name: server.name,
+      });
       setRemoveCandidate(undefined);
       if (await loadServers()) {
         setNotice({
@@ -297,6 +389,9 @@ export function PluginsSettings(props: {
       setPendingAction(undefined);
     }
   };
+  const actionsDisabled = Boolean(pendingAction)
+    || profileChanged
+    || !activeCodexHome;
 
   return (
     <SettingsSectionStack paneId="plugins" aria-label="Plugin settings">
@@ -307,7 +402,7 @@ export function PluginsSettings(props: {
         action={
           <button
             className="button button--secondary"
-            disabled={loading || Boolean(pendingAction)}
+            disabled={loading || actionsDisabled}
             title="Re-read installed MCP configuration and expose it to loaded Codex threads on their next turn."
             type="button"
             onClick={() => void reloadConfig()}
@@ -325,20 +420,32 @@ export function PluginsSettings(props: {
         chip={`${servers.length} configured`}
       >
         <div className="settings-plugin-profile">
-          <span>Codex profile</span>
-          <strong>{selectedProfile?.displayName ?? "Default"}</strong>
-          <code>
-            {selectedProfile?.codexHome
-              ?? props.snapshot.models.codex.profiles.effectiveCodexHome}
-          </code>
+          <span>Active Codex profile</span>
+          <strong>{activeProfile?.displayName ?? "Default"}</strong>
+          <code>{activeCodexHome ?? "Loading..."}</code>
         </div>
+        {profileChanged ? (
+          <p className="settings-plugin-notice settings-plugin-notice--error" role="alert">
+            Codex profile selection changed to {selectedProfile?.displayName ?? "Default"}.
+            Restart PwrAgent before managing MCP servers for that profile.
+          </p>
+        ) : null}
         {notice ? (
-          <p
+          <div
             className={`settings-plugin-notice settings-plugin-notice--${notice.kind}`}
             role={notice.kind === "error" ? "alert" : "status"}
           >
-            {notice.text}
-          </p>
+            <span>{notice.text}</span>
+            {pendingAction?.kind === "login" ? (
+              <button
+                className="button button--ghost settings-plugin-notice__action"
+                type="button"
+                onClick={() => cancelLoginWait()}
+              >
+                Cancel login
+              </button>
+            ) : null}
+          </div>
         ) : null}
         {loading ? (
           <p className="settings-empty">Loading MCP servers...</p>
@@ -348,7 +455,7 @@ export function PluginsSettings(props: {
               <McpServerRow
                 key={server.name}
                 busy={pendingAction?.name === server.name}
-                disabled={Boolean(pendingAction)}
+                disabled={actionsDisabled}
                 server={server}
                 onRelogin={() => void relogin(server)}
                 onRemove={() => setRemoveCandidate(server)}
@@ -377,7 +484,7 @@ export function PluginsSettings(props: {
             <div className="settings-confirm-dialog__actions">
               <button
                 className="button button--secondary"
-                disabled={Boolean(pendingAction)}
+                disabled={actionsDisabled}
                 type="button"
                 onClick={() => setRemoveCandidate(undefined)}
               >
@@ -385,7 +492,7 @@ export function PluginsSettings(props: {
               </button>
               <button
                 className="button button--ghost settings-profile-row__button--danger"
-                disabled={Boolean(pendingAction)}
+                disabled={actionsDisabled}
                 type="button"
                 onClick={() => void removeServer()}
               >

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -24,6 +24,7 @@ import { ModelsSettings } from "./ModelsSettings";
 import { ProfilesSettings } from "./ProfilesSettings";
 import { PricingSettings } from "./PricingSettings";
 import { ApplicationsSettings } from "./ApplicationsSettings";
+import { PluginsSettings } from "./PluginsSettings";
 import { ArchivedThreadsSettings } from "./ArchivedThreadsSettings";
 import { ThreadManagementSettings } from "./ThreadManagementSettings";
 import { TroubleshootingSettings } from "./TroubleshootingSettings";
@@ -51,6 +52,7 @@ export type SettingsSection =
   | "profiles"
   | "pricing"
   | "applications"
+  | "plugins"
   | "worktrees"
   | "thread-management"
   | "archived"
@@ -60,6 +62,7 @@ export type SettingsSection =
 const SECTIONS: Array<{ id: SettingsSection; label: string }> = [
   { id: "general", label: "General" },
   { id: "applications", label: "Applications" },
+  { id: "plugins", label: "Plugins" },
   { id: "profiles", label: "Profiles" },
   { id: "models", label: "AI Providers" },
   { id: "pricing", label: "Usage & Pricing" },
@@ -78,6 +81,7 @@ const SECTIONS: Array<{ id: SettingsSection; label: string }> = [
 const PRIMARY_SECTIONS: SettingsSection[] = [
   "general",
   "applications",
+  "plugins",
   "profiles",
   "models",
   "pricing",
@@ -225,13 +229,29 @@ export function SettingsScreen(props: {
         {ORDERED_SECTIONS.map((item) => (
           <Fragment key={item.id}>
             <button
-              aria-current={section === item.id ? "page" : undefined}
+              aria-current={
+                section === item.id && item.id !== "plugins"
+                  ? "page"
+                  : undefined
+              }
               className={`settings-nav__button${section === item.id ? " is-active" : ""}`}
               type="button"
               onClick={() => setSection(item.id)}
             >
               {item.label}
             </button>
+            {item.id === "plugins" ? (
+              <button
+                aria-current={section === "plugins" ? "page" : undefined}
+                className={`settings-nav__subbutton${
+                  section === "plugins" ? " is-active" : ""
+                }`}
+                type="button"
+                onClick={() => setSection("plugins")}
+              >
+                MCPs
+              </button>
+            ) : null}
             {item.id === SETTINGS_NAV_DIVIDER_AFTER ? (
               <hr className="settings-nav__divider" />
             ) : null}
@@ -706,6 +726,15 @@ function SettingsSectionBody(props: {
                 : { terminal: { preferredId } },
           });
         }}
+      />
+    );
+  }
+
+  if (props.section === "plugins") {
+    return (
+      <PluginsSettings
+        desktopApi={props.desktopApi}
+        snapshot={props.snapshot}
       />
     );
   }

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -4306,6 +4306,10 @@ describe("SettingsScreen", () => {
         startupStatus: "failed" as const,
         startupError: "invalid_grant",
         tools: [],
+      }, {
+        name: "atlassian",
+        authStatus: "oAuth" as const,
+        tools: ["search"],
       }],
     }));
     const reloadCodexMcpServers = vi.fn(async () => ({ queued: true as const }));
@@ -4339,7 +4343,19 @@ describe("SettingsScreen", () => {
     );
 
     expect(await screen.findByText("invalid_grant")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Relogin" }));
+    const datadogRow = screen.getByText("datadog")
+      .closest<HTMLElement>(".settings-mcp-row");
+    const atlassianRow = screen.getByText("atlassian")
+      .closest<HTMLElement>(".settings-mcp-row");
+    expect(datadogRow).not.toBeNull();
+    expect(atlassianRow).not.toBeNull();
+    fireEvent.click(within(datadogRow!).getByRole("button", { name: "Relogin" }));
+    expect(
+      within(atlassianRow!).getByRole("button", { name: "Relogin" }),
+    ).toBeDisabled();
+    expect(
+      within(atlassianRow!).getByRole("button", { name: "Remove" }),
+    ).toBeDisabled();
     await waitFor(() => {
       expect(startCodexMcpServerLogin).toHaveBeenCalledWith({ name: "datadog" });
       expect(openSpy).toHaveBeenCalledWith(
@@ -4358,10 +4374,24 @@ describe("SettingsScreen", () => {
         },
       });
     });
-    expect(await screen.findByText("datadog login completed.")).toBeInTheDocument();
+    expect(
+      within(atlassianRow!).getByRole("button", { name: "Relogin" }),
+    ).toBeDisabled();
+    await act(async () => {
+      agentEventListener?.({
+        backend: "codex",
+        notification: {
+          method: "mcpServer/startupStatus/updated",
+          params: { name: "datadog", status: "ready" },
+        },
+      });
+    });
+    expect(await screen.findByText(
+      "datadog login completed and its row was refreshed.",
+    )).toBeInTheDocument();
     expect(reloadCodexMcpServers).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    fireEvent.click(within(datadogRow!).getByRole("button", { name: "Remove" }));
     fireEvent.click(screen.getByRole("button", { name: "Remove server" }));
     await waitFor(() => {
       expect(removeCodexMcpServer).toHaveBeenCalledWith({ name: "datadog" });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -4298,7 +4298,9 @@ describe("SettingsScreen", () => {
   });
 
   it("relogs and removes MCP servers from the Plugins settings pane", async () => {
+    const codexHome = "/home/example/.codex";
     const listCodexMcpServers = vi.fn(async () => ({
+      codexHome,
       detail: "toolsAndAuthOnly" as const,
       servers: [{
         name: "datadog",
@@ -4312,12 +4314,20 @@ describe("SettingsScreen", () => {
         tools: ["search"],
       }],
     }));
-    const reloadCodexMcpServers = vi.fn(async () => ({ queued: true as const }));
-    const startCodexMcpServerLogin = vi.fn(async () => ({
-      name: "datadog",
+    const reloadCodexMcpServers = vi.fn(async () => ({
+      codexHome,
+      queued: true as const,
+    }));
+    const startCodexMcpServerLogin = vi.fn(async (request: {
+      codexHome: string;
+      name: string;
+    }) => ({
+      codexHome,
+      name: request.name,
       authorizationUrl: "https://example.test/datadog-login",
     }));
     const removeCodexMcpServer = vi.fn(async () => ({
+      codexHome,
       name: "datadog",
       removed: true as const,
     }));
@@ -4357,7 +4367,10 @@ describe("SettingsScreen", () => {
       within(atlassianRow!).getByRole("button", { name: "Remove" }),
     ).toBeDisabled();
     await waitFor(() => {
-      expect(startCodexMcpServerLogin).toHaveBeenCalledWith({ name: "datadog" });
+      expect(startCodexMcpServerLogin).toHaveBeenCalledWith({
+        codexHome,
+        name: "datadog",
+      });
       expect(openSpy).toHaveBeenCalledWith(
         "https://example.test/datadog-login",
         "_blank",
@@ -4389,16 +4402,84 @@ describe("SettingsScreen", () => {
     expect(await screen.findByText(
       "datadog login completed and its row was refreshed.",
     )).toBeInTheDocument();
-    expect(reloadCodexMcpServers).toHaveBeenCalledTimes(1);
+    expect(reloadCodexMcpServers).toHaveBeenCalledWith({ codexHome });
 
     fireEvent.click(within(datadogRow!).getByRole("button", { name: "Remove" }));
     fireEvent.click(screen.getByRole("button", { name: "Remove server" }));
     await waitFor(() => {
-      expect(removeCodexMcpServer).toHaveBeenCalledWith({ name: "datadog" });
+      expect(removeCodexMcpServer).toHaveBeenCalledWith({
+        codexHome,
+        name: "datadog",
+      });
       expect(screen.getByText(
         "datadog was removed from this Codex profile.",
       )).toBeInTheDocument();
     });
+
+    fireEvent.click(
+      within(atlassianRow!).getByRole("button", { name: "Relogin" }),
+    );
+    expect(await screen.findByRole("button", { name: "Cancel login" }))
+      .toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel login" }));
+    expect(await screen.findByText(
+      "Stopped waiting for login. You can try again.",
+    )).toBeInTheDocument();
+    expect(
+      within(datadogRow!).getByRole("button", { name: "Relogin" }),
+    ).toBeEnabled();
+  });
+
+  it("disables MCP mutations when the selected Codex profile changed after startup", async () => {
+    const base = createSnapshot();
+    const workCodexHome = "/home/example/.codex/profiles/work";
+    const snapshot = createSnapshot({
+      models: {
+        ...base.models,
+        codex: {
+          ...base.models.codex,
+          profile: { value: "work", source: "config" },
+          profiles: {
+            ...base.models.codex.profiles,
+            effectiveCodexHome: workCodexHome,
+            profiles: base.models.codex.profiles.profiles.map((profile) => ({
+              ...profile,
+              selected: profile.name === "work",
+            })),
+          },
+        },
+      },
+    });
+
+    render(
+      <SettingsScreen
+        desktopApi={{
+          listCodexMcpServers: vi.fn(async () => ({
+            codexHome: "/home/example/.codex",
+            detail: "toolsAndAuthOnly" as const,
+            servers: [{
+              name: "atlassian",
+              authStatus: "oAuth" as const,
+              tools: ["search"],
+            }],
+          })),
+          reloadCodexMcpServers: vi.fn(),
+          removeCodexMcpServer: vi.fn(),
+          startCodexMcpServerLogin: vi.fn(),
+        }}
+        initialSection="plugins"
+        settings={createSettingsState(snapshot)}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByText(
+      "Codex profile selection changed to work. Restart PwrAgent before managing MCP servers for that profile.",
+    )).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reload config" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Relogin" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Remove" })).toBeDisabled();
+    expect(screen.getByText("/home/example/.codex")).toBeInTheDocument();
   });
 
   it("shows when messaging is disabled by a runtime override", () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -11,6 +11,7 @@ import {
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
+  AgentEvent,
   AppServerListThreadsResponse,
   AppServerThreadSummary,
   BackendSummary,
@@ -4275,6 +4276,8 @@ describe("SettingsScreen", () => {
       "← Exit Settings",
       "General",
       "Applications",
+      "Plugins",
+      "MCPs",
       "Profiles",
       "AI Providers",
       "Usage & Pricing",
@@ -4292,6 +4295,80 @@ describe("SettingsScreen", () => {
     expect(within(nav).getByRole("separator")).toHaveClass(
       "settings-nav__divider",
     );
+  });
+
+  it("relogs and removes MCP servers from the Plugins settings pane", async () => {
+    const listCodexMcpServers = vi.fn(async () => ({
+      detail: "toolsAndAuthOnly" as const,
+      servers: [{
+        name: "datadog",
+        authStatus: "oAuth" as const,
+        startupStatus: "failed" as const,
+        startupError: "invalid_grant",
+        tools: [],
+      }],
+    }));
+    const reloadCodexMcpServers = vi.fn(async () => ({ queued: true as const }));
+    const startCodexMcpServerLogin = vi.fn(async () => ({
+      name: "datadog",
+      authorizationUrl: "https://example.test/datadog-login",
+    }));
+    const removeCodexMcpServer = vi.fn(async () => ({
+      name: "datadog",
+      removed: true as const,
+    }));
+    let agentEventListener: ((event: AgentEvent) => void) | undefined;
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(
+      <SettingsScreen
+        desktopApi={{
+          listCodexMcpServers,
+          onAgentEvent: (listener) => {
+            agentEventListener = listener;
+            return () => undefined;
+          },
+          reloadCodexMcpServers,
+          removeCodexMcpServer,
+          startCodexMcpServerLogin,
+        }}
+        initialSection="plugins"
+        settings={createSettingsState()}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByText("invalid_grant")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Relogin" }));
+    await waitFor(() => {
+      expect(startCodexMcpServerLogin).toHaveBeenCalledWith({ name: "datadog" });
+      expect(openSpy).toHaveBeenCalledWith(
+        "https://example.test/datadog-login",
+        "_blank",
+        "noopener,noreferrer",
+      );
+    });
+
+    await act(async () => {
+      agentEventListener?.({
+        backend: "codex",
+        notification: {
+          method: "mcpServer/oauthLogin/completed",
+          params: { name: "datadog", success: true },
+        },
+      });
+    });
+    expect(await screen.findByText("datadog login completed.")).toBeInTheDocument();
+    expect(reloadCodexMcpServers).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove server" }));
+    await waitFor(() => {
+      expect(removeCodexMcpServer).toHaveBeenCalledWith({ name: "datadog" });
+      expect(screen.getByText(
+        "datadog was removed from this Codex profile.",
+      )).toBeInTheDocument();
+    });
   });
 
   it("shows when messaging is disabled by a runtime override", () => {

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -96,8 +96,15 @@ import type {
   ListAutomationsResponse,
   ListBackendsRequest,
   ListBackendsResponse,
+  ListCodexMcpServersRequest,
+  ListCodexMcpServersResponse,
   ListThreadMcpServersRequest,
   ListThreadMcpServersResponse,
+  ReloadCodexMcpServersResponse,
+  RemoveCodexMcpServerRequest,
+  RemoveCodexMcpServerResponse,
+  StartCodexMcpServerLoginRequest,
+  StartCodexMcpServerLoginResponse,
   ListAcpAgentSettingsRequest,
   ListAcpAgentSettingsResponse,
   AcknowledgeAcpAgentUpdateRequest,
@@ -625,6 +632,16 @@ export type DesktopApi = {
   reloadCodexMcpConfig?: (
     request: ReloadCodexMcpConfigRequest,
   ) => Promise<ReloadCodexMcpConfigResponse>;
+  listCodexMcpServers?: (
+    request?: ListCodexMcpServersRequest,
+  ) => Promise<ListCodexMcpServersResponse>;
+  reloadCodexMcpServers?: () => Promise<ReloadCodexMcpServersResponse>;
+  startCodexMcpServerLogin?: (
+    request: StartCodexMcpServerLoginRequest,
+  ) => Promise<StartCodexMcpServerLoginResponse>;
+  removeCodexMcpServer?: (
+    request: RemoveCodexMcpServerRequest,
+  ) => Promise<RemoveCodexMcpServerResponse>;
   startTurn?: (request: StartTurnRequest) => Promise<StartTurnResponse>;
   cancelQueuedTurn?: (
     request: CancelQueuedTurnRequest,

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -101,6 +101,7 @@ import type {
   ListThreadMcpServersRequest,
   ListThreadMcpServersResponse,
   ReloadCodexMcpServersResponse,
+  ReloadCodexMcpServersRequest,
   RemoveCodexMcpServerRequest,
   RemoveCodexMcpServerResponse,
   StartCodexMcpServerLoginRequest,
@@ -635,7 +636,9 @@ export type DesktopApi = {
   listCodexMcpServers?: (
     request?: ListCodexMcpServersRequest,
   ) => Promise<ListCodexMcpServersResponse>;
-  reloadCodexMcpServers?: () => Promise<ReloadCodexMcpServersResponse>;
+  reloadCodexMcpServers?: (
+    request: ReloadCodexMcpServersRequest,
+  ) => Promise<ReloadCodexMcpServersResponse>;
   startCodexMcpServerLogin?: (
     request: StartCodexMcpServerLoginRequest,
   ) => Promise<StartCodexMcpServerLoginResponse>;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6692,6 +6692,29 @@ textarea,
   outline: none;
 }
 
+.settings-nav__subbutton {
+  width: calc(100% - 24px);
+  appearance: none;
+  cursor: pointer;
+  margin: -4px 0 4px 24px;
+  padding: 6px 12px;
+  border: 0;
+  border-left: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  text-align: left;
+}
+
+.settings-nav__subbutton:hover,
+.settings-nav__subbutton:focus-visible,
+.settings-nav__subbutton.is-active {
+  border-left-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+
 .settings-nav__divider {
   width: calc(100% - 24px);
   height: 1px;
@@ -8529,6 +8552,115 @@ textarea,
 }
 
 .settings-profile-row__button--danger:hover:not([disabled]) {
+  background: var(--danger-soft);
+}
+
+.settings-plugin-profile {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 12px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.settings-plugin-profile strong {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.settings-plugin-profile code {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-plugin-notice {
+  margin: 0 0 12px;
+  padding: 8px 10px;
+  border: 1px solid var(--accent-border);
+  border-radius: 6px;
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.settings-plugin-notice--success {
+  border-color: var(--success-border);
+  background: var(--success-soft);
+  color: var(--success-text);
+}
+
+.settings-plugin-notice--error {
+  border-color: var(--danger-border);
+  background: var(--danger-soft);
+  color: var(--danger-text);
+}
+
+.settings-mcp-list {
+  display: grid;
+  gap: 8px;
+}
+
+.settings-mcp-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+}
+
+.settings-mcp-row__body {
+  min-width: 0;
+}
+
+.settings-mcp-row__body strong,
+.settings-mcp-row__body > span {
+  display: block;
+}
+
+.settings-mcp-row__body strong {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-mcp-row__body > span {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.settings-mcp-row__error {
+  margin: 6px 0 0;
+  color: var(--danger-text);
+  font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.settings-mcp-row__chips,
+.settings-mcp-row__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.settings-mcp-row__remove {
+  color: var(--danger-text);
+}
+
+.settings-mcp-row__remove:hover:not([disabled]) {
   background: var(--danger-soft);
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8579,6 +8579,10 @@ textarea,
 }
 
 .settings-plugin-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
   margin: 0 0 12px;
   padding: 8px 10px;
   border: 1px solid var(--accent-border);
@@ -8587,6 +8591,12 @@ textarea,
   color: var(--accent-bright);
   font-size: 12px;
   line-height: 1.35;
+}
+
+.settings-plugin-notice__action {
+  flex: 0 0 auto;
+  min-height: 28px;
+  padding: 0 8px;
 }
 
 .settings-plugin-notice--success {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -70,6 +70,10 @@ export const AGENT_LIST_THREAD_MCP_SERVERS_CHANNEL =
   "agent:list-thread-mcp-servers";
 export const AGENT_RELOAD_CODEX_MCP_CONFIG_CHANNEL =
   "agent:reload-codex-mcp-config";
+export const CODEX_MCP_SERVERS_LIST_CHANNEL = "codex-mcp-servers:list";
+export const CODEX_MCP_SERVERS_RELOAD_CHANNEL = "codex-mcp-servers:reload";
+export const CODEX_MCP_SERVER_LOGIN_CHANNEL = "codex-mcp-server:login";
+export const CODEX_MCP_SERVER_REMOVE_CHANNEL = "codex-mcp-server:remove";
 export const AGENT_INTERRUPT_TURN_CHANNEL = "agent:interrupt-turn";
 export const AGENT_STOP_SUB_AGENT_CHANNEL = "agent:stop-sub-agent";
 export const AGENT_STEER_TURN_CHANNEL = "agent:steer-turn";

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -443,28 +443,38 @@ export type ListCodexMcpServersRequest = {
 };
 
 export type ListCodexMcpServersResponse = {
+  codexHome: string;
   detail: CodexMcpInventoryDetail;
   servers: CodexMcpServerSummary[];
 };
 
+export type ReloadCodexMcpServersRequest = {
+  codexHome: string;
+};
+
 export type ReloadCodexMcpServersResponse = {
+  codexHome: string;
   queued: true;
 };
 
 export type StartCodexMcpServerLoginRequest = {
+  codexHome: string;
   name: string;
 };
 
 export type StartCodexMcpServerLoginResponse = {
+  codexHome: string;
   name: string;
   authorizationUrl: string;
 };
 
 export type RemoveCodexMcpServerRequest = {
+  codexHome: string;
   name: string;
 };
 
 export type RemoveCodexMcpServerResponse = {
+  codexHome: string;
   name: string;
   removed: true;
 };

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -431,9 +431,42 @@ export type CodexMcpResourceTemplateSummary = {
 export type CodexMcpServerSummary = {
   name: string;
   authStatus: CodexMcpAuthStatus;
+  startupStatus?: "starting" | "ready" | "failed" | "cancelled";
+  startupError?: string;
   tools: string[];
   resources?: CodexMcpResourceSummary[];
   resourceTemplates?: CodexMcpResourceTemplateSummary[];
+};
+
+export type ListCodexMcpServersRequest = {
+  detail?: CodexMcpInventoryDetail;
+};
+
+export type ListCodexMcpServersResponse = {
+  detail: CodexMcpInventoryDetail;
+  servers: CodexMcpServerSummary[];
+};
+
+export type ReloadCodexMcpServersResponse = {
+  queued: true;
+};
+
+export type StartCodexMcpServerLoginRequest = {
+  name: string;
+};
+
+export type StartCodexMcpServerLoginResponse = {
+  name: string;
+  authorizationUrl: string;
+};
+
+export type RemoveCodexMcpServerRequest = {
+  name: string;
+};
+
+export type RemoveCodexMcpServerResponse = {
+  name: string;
+  removed: true;
 };
 
 export type ListThreadMcpServersRequest = {


### PR DESCRIPTION
## Summary

- add Settings → Plugins → MCPs for the active Codex profile
- surface MCP auth/startup state and provider startup errors
- support OAuth relogin with positive completion feedback
- remove individual MCP config entries through Codex App Server and verify removal
- reload MCP config with visible working/success/error feedback

## Diagnosis

For thread `019feca3-7785-71b2-8346-748f4f828fa1` in the `work` Codex profile, the main log shows stale OAuth grants rather than a thread tool-cache problem:

- Datadog: `invalid_grant`
- Atlassian: `unauthorized_client: refresh_token is invalid`
- Search Compare dev: `invalid_grant: Refresh token is invalid or expired`
- localhost MCP transport: `http://localhost:10435/mcp` is not listening

## Validation

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/agent-ipc.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`