### PR TITLE
fix(desktop): hide transient monitor heartbeats from transcript

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -3123,7 +3123,7 @@ describe("useThreadSessionState", () => {
     expect(readThread).toHaveBeenCalledTimes(1);
   });
 
-  it("renders task monitor usage metadata as a sibling activity entry", async () => {
+  it("keeps transient task monitor progress out of the transcript", async () => {
     let agentEventHandler:
       | ((event: {
           backend: "codex" | "acp:grok";
@@ -3199,6 +3199,36 @@ describe("useThreadSessionState", () => {
                     reasoningOutputTokens: 10,
                   },
                 },
+                transient: true,
+              },
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "monitor:monitor-1",
+            item: {
+              id: "monitor-progress-usage-1",
+              type: "taskMonitorUsage",
+              data: {
+                source: "pwragent_task_monitor",
+                monitorId: "monitor-1",
+                monitorUsage: {
+                  phase: "progress",
+                  model: "gpt-5.4-mini",
+                  tokenUsage: {
+                    inputTokens: 2_000,
+                    cachedInputTokens: 400,
+                    outputTokens: 100,
+                    reasoningOutputTokens: 20,
+                  },
+                },
+                transient: true,
               },
             },
           },
@@ -3206,10 +3236,7 @@ describe("useThreadSessionState", () => {
       });
     });
 
-    expect(transcriptLabels(result.current.entries)).toEqual([
-      "message:Still running.",
-      "activity:Monitor usage so far: 800 uncached in · 200 cached · 50 out (10 reasoning) · <$0.001 list price",
-    ]);
+    expect(transcriptLabels(result.current.entries)).toEqual([]);
   });
 
   it("keeps completion monitor usage as top-level activity after hydration", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3372,6 +3372,21 @@ function assistantMessageEntryFromCompletedItem(params: {
   };
 }
 
+function isTransientTaskMonitorItem(
+  item: Record<string, unknown> | undefined,
+): boolean {
+  if (!item) {
+    return false;
+  }
+
+  const data = readRecord(item.data);
+  return (
+    (data?.source === "pwragent_task_monitor"
+      || item.source === "pwragent_task_monitor")
+    && (data?.transient === true || item.transient === true)
+  );
+}
+
 function hasReviewEntryForTurn(
   response: AppServerReadThreadResponse | undefined,
   turnId: string | undefined
@@ -4817,12 +4832,15 @@ export function useThreadSessionState(params: {
             fallbackStartedAt: current.activeTurnStartedAt,
             fallbackStatus: "in_progress",
           });
-          const assistantMessageEntry = assistantMessageEntryFromCompletedItem({
-            itemParams: event.notification.params,
-            turn: assistantTurn,
-          });
           const item = getNotificationItem(event.notification.params);
-          const taskMonitorUsageEntry = item
+          const transientTaskMonitorItem = isTransientTaskMonitorItem(item);
+          const assistantMessageEntry = transientTaskMonitorItem
+            ? undefined
+            : assistantMessageEntryFromCompletedItem({
+                itemParams: event.notification.params,
+                turn: assistantTurn,
+              });
+          const taskMonitorUsageEntry = item && !transientTaskMonitorItem
             ? buildTaskMonitorUsageActivityEntry({
                 id: `${item.id ?? event.notification.params.turnId ?? "monitor"}:usage`,
                 item,


### PR DESCRIPTION
## Summary

- I keep transient PwrAgent task-monitor heartbeat messages and their cumulative "usage so far" activities out of the parent transcript.
- I leave the active sub-agent strip and Sub-agents rail as the live status surfaces, while preserving terminal monitor handoffs and final usage as durable history.
- The root cause was that the renderer ignored the monitor producer's existing `transient: true` marker when handling completed protocol items.

## Verification

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx` (109 tests passed)
- `pnpm lint:eslint` (0 errors; 30 existing warnings)
- `pnpm typecheck`
- `pnpm lint:boundaries`

## Notes

- The regression test covers both transient monitor progress messages with embedded usage and standalone transient monitor-usage heartbeats.
