### PR TITLE
fix(release): package and lazy-load macOS canvas

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -90,6 +90,11 @@ electronFuses:
   grantFileProtocolExtraPrivileges: true
 
 mac:
+  # Both prebuilt canvas bindings are intentionally present in both temporary
+  # per-arch apps. They have distinct package paths and runtime selects the
+  # matching one, so keep the identical single-arch files side-by-side when
+  # electron-builder merges the universal app.
+  x64ArchFiles: "Contents/Resources/app.asar.unpacked/node_modules/@napi-rs/canvas-darwin-*/**"
   category: public.app-category.developer-tools
   icon: build/icon.icns
   hardenedRuntime: true

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -113,6 +113,8 @@
     "vite": "^7.3.2"
   },
   "optionalDependencies": {
+    "@napi-rs/canvas-darwin-arm64": "1.0.3",
+    "@napi-rs/canvas-darwin-x64": "1.0.3",
     "@napi-rs/canvas-win32-x64-msvc": "1.0.3"
   }
 }

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -52,6 +52,18 @@ const __dirname = dirname(__filename);
 const desktopRoot = resolve(__dirname, "..");
 const repoRoot = resolve(desktopRoot, "..", "..");
 const stageDir = join(desktopRoot, "release-stage");
+const MAC_CANVAS_BINDINGS = [
+  {
+    binding: "skia.darwin-arm64.node",
+    lipoArch: "arm64",
+    packageName: "canvas-darwin-arm64",
+  },
+  {
+    binding: "skia.darwin-x64.node",
+    lipoArch: "x86_64",
+    packageName: "canvas-darwin-x64",
+  },
+];
 
 const args = process.argv.slice(2);
 const dryrun = args.includes("--dryrun");
@@ -361,6 +373,25 @@ function verifyWindowsCanvasBindingInStage() {
   console.log("  verified Windows x64 canvas native binding in release-stage");
 }
 
+function verifyMacCanvasBindingsInStage() {
+  for (const { binding, packageName } of MAC_CANVAS_BINDINGS) {
+    const bindingPath = join(
+      stageDir,
+      "node_modules",
+      "@napi-rs",
+      packageName,
+      binding,
+    );
+    if (!existsSync(bindingPath)) {
+      throw new Error(
+        `pnpm deploy omitted @napi-rs/${packageName} from the universal macOS release stage. `
+          + "Keep both Darwin bindings as explicit optional dependencies and deploy for both CPU architectures.",
+      );
+    }
+  }
+  console.log("  verified arm64 and x64 canvas native bindings in release-stage");
+}
+
 function stageDesktopVersion() {
   const manifestPath = join(stageDir, "package.json");
   if (!existsSync(manifestPath)) {
@@ -428,12 +459,24 @@ if (!signStageOnly) {
   mkdirSync(stageDir, { recursive: true });
   runChecked(
     "pnpm",
-    ["deploy", "--filter", "@pwragent/desktop", "--prod", "--legacy", stageDir],
+    [
+      ...(!linux && !win
+        ? ["--cpu=x64", "--cpu=arm64", "--os=darwin"]
+        : []),
+      "deploy",
+      "--filter",
+      "@pwragent/desktop",
+      "--prod",
+      "--legacy",
+      stageDir,
+    ],
     { cwd: repoRoot },
   );
   patchStageDependencyManifests();
   if (win) {
     verifyWindowsCanvasBindingInStage();
+  } else if (!linux) {
+    verifyMacCanvasBindingsInStage();
   }
 
   // 4. Copy the build output, notices, changelog, and electron-builder inputs into the stage so
@@ -596,6 +639,22 @@ runChecked("lipo", [
   "x86_64",
   "arm64",
 ]);
+for (const { binding, lipoArch, packageName } of MAC_CANVAS_BINDINGS) {
+  runChecked("lipo", [
+    join(
+      builtApp,
+      "Contents",
+      "Resources",
+      "app.asar.unpacked",
+      "node_modules",
+      "@napi-rs",
+      packageName,
+      binding,
+    ),
+    "-verify_arch",
+    lipoArch,
+  ]);
+}
 
 step("verify packaged asar contents");
 runChecked("node", [join(desktopRoot, "scripts", "verify-asar-contents.mjs"), builtApp]);

--- a/apps/desktop/src/main/__tests__/pdf-canvas-lazy-loading.test.ts
+++ b/apps/desktop/src/main/__tests__/pdf-canvas-lazy-loading.test.ts
@@ -1,0 +1,43 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+
+const canvasModuleLoaded = vi.hoisted(() => vi.fn());
+
+vi.mock("@napi-rs/canvas", async () => {
+  canvasModuleLoaded();
+  return vi.importActual<typeof import("@napi-rs/canvas")>("@napi-rs/canvas");
+});
+
+import {
+  calculateComposerPdfPreviewDimensions,
+  renderComposerPdfPreview,
+} from "../pdf/composer-pdf-preview";
+import {
+  calculatePdfRenderDimensions,
+  renderPdfPages,
+} from "../pdf/pdf-page-renderer";
+
+const jeepStickerPageFixture = fileURLToPath(
+  new URL("./fixtures/pdf/jeep-sticker-page-size.pdf", import.meta.url),
+);
+
+describe("PDF canvas lazy loading", () => {
+  it("loads the native canvas module only when PDF pixels are requested", async () => {
+    expect(canvasModuleLoaded).not.toHaveBeenCalled();
+
+    calculateComposerPdfPreviewDimensions({ height: 792, width: 1224 });
+    calculatePdfRenderDimensions({ height: 792, profile: "medium", width: 1224 });
+
+    expect(canvasModuleLoaded).not.toHaveBeenCalled();
+
+    const data = await readFile(jeepStickerPageFixture);
+    await renderComposerPdfPreview({ data });
+
+    expect(canvasModuleLoaded).toHaveBeenCalledTimes(1);
+
+    await renderPdfPages({ data, profile: "low" });
+
+    expect(canvasModuleLoaded).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/main/pdf/composer-pdf-preview.ts
+++ b/apps/desktop/src/main/pdf/composer-pdf-preview.ts
@@ -1,4 +1,3 @@
-import { createCanvas } from "@napi-rs/canvas";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -52,6 +51,7 @@ export async function renderComposerPdfPreview(params: {
       const viewport = page.getViewport({
         scale: dimensions.width / sourceViewport.width,
       });
+      const { createCanvas } = await import("@napi-rs/canvas");
       const canvas = createCanvas(dimensions.width, dimensions.height);
       const canvasContext = canvas.getContext("2d");
 

--- a/apps/desktop/src/main/pdf/pdf-page-renderer.ts
+++ b/apps/desktop/src/main/pdf/pdf-page-renderer.ts
@@ -1,4 +1,3 @@
-import { createCanvas } from "@napi-rs/canvas";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -268,6 +267,7 @@ export async function renderPdfPages(params: {
       }
     }
 
+    const { createCanvas } = await import("@napi-rs/canvas");
     const pages: RenderedPdfPage[] = [];
     let encodedBytes = 0;
     let wireBytes = 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,12 @@ importers:
         specifier: ^7.3.2
         version: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.5)
     optionalDependencies:
+      '@napi-rs/canvas-darwin-arm64':
+        specifier: 1.0.3
+        version: 1.0.3
+      '@napi-rs/canvas-darwin-x64':
+        specifier: 1.0.3
+        version: 1.0.3
       '@napi-rs/canvas-win32-x64-msvc':
         specifier: 1.0.3
         version: 1.0.3


### PR DESCRIPTION
## Summary

- I defer `@napi-rs/canvas` evaluation until PDF pixels are actually rendered. Ordinary main-process startup and the pure PDF sizing helpers no longer load the native canvas module.
- I make both Darwin 1.0.3 bindings explicit optional dependencies and collect both CPU variants for the universal macOS release stage.
- I preserve PR #1490's explicit Windows binding, ICU unpacking, and Windows stage verification. The macOS path adds its own stage checks, allows the two architecture-specific canvas package paths through the universal merge, and verifies each final Mach-O slice with `lipo`.

## Verification

- [x] `pnpm install --frozen-lockfile`
- [x] Focused Vitest suite: 6 files / 25 tests, including canvas lazy loading, both PDF renderers, release helpers, and Windows ASAR entry handling
- [x] `pnpm lint:eslint` (0 errors; 33 existing warnings)
- [x] `pnpm typecheck`
- [x] `pnpm lint:boundaries`
- [x] `pnpm lint:codex-storage`
- [x] `pnpm licenses:check`
- [x] `RELEASE_TAG=v1.1.0-beta.1 pnpm release:check`
- [x] Full `pnpm test`: 530 files, 7,564 passed, 2 skipped
- [x] `node apps/desktop/scripts/release.mjs --prepare-only`
- [x] `node apps/desktop/scripts/release.mjs --sign-stage-only --dryrun`
- [x] Final universal app: main executable and `better-sqlite3` verify as x86_64 + arm64; Darwin canvas bindings verify as their respective single architecture; ASAR audit passes with 9,280 entries
- [x] Packaged runtime smoke under both slices: arm64 and Rosetta/x86_64 each imported canvas and created a 2x2 canvas

## Notes

- The pre-change import graph reached both PDF modules from ordinary startup, and the production main bundle contained a static `@napi-rs/canvas` import. `@napi-rs/canvas` selects and loads its native binding during module evaluation. The rebuilt bundle now contains only two call-site `await import("@napi-rs/canvas")` expressions, and the focused test proves importing both PDF modules and calling their pure sizing helpers does not evaluate canvas. Import and native-load failures still reject the same public async render operations; I did not catch or translate them.
- The lockfile knew about both Darwin packages, but the arm64-hosted release stage physically contained only the arm64 package. Before this change, a real universal dry run failed during merge because `skia.darwin-arm64.node` was present identically in both temporary apps and was not covered by `x64ArchFiles`. Deploying with explicit Darwin arm64 + x64 support materializes both thin Mach-O packages; the final runtime selects the package matching `process.arch`.
- Registry package measurements for 1.0.3: Darwin arm64 is 27,025,913 bytes unpacked (27,025,024-byte `.node`, 12,572,509-byte tarball); Darwin x64 is 32,182,174 bytes unpacked (32,181,296-byte `.node`, 13,544,963-byte tarball). Each Darwin package contains only its README, manifest, and native binding; neither contains ICU data.
- I measured package impact with same-source, ad-hoc-signed, non-notarized universal builds. Because the unmodified build could not merge, the counterfactual baseline added only the `x64ArchFiles` merge allowance while retaining its arm64-only dependency stage. Adding the x64 package changed the app bundle from 623,464 KiB to 655,160 KiB (+31,696 KiB allocated), `app.asar.unpacked` by the same +31,696 KiB, and `app.asar` by only 1,013 bytes. The DMG changed from 247,607,106 to 261,033,424 bytes (+13,426,318 bytes / 12.804 MiB / 5.42%); the ZIP changed from 239,494,760 to 252,427,109 bytes (+12,932,349 bytes / 12.333 MiB / 5.40%). Signed/notarized release artifacts may vary slightly.
- Dynamic import improves ordinary startup/module/native-library loading, but it does not reduce packaged bytes. The native packages remain in the installer so the first PDF request works offline on either architecture.
