### PR TITLE
fix(desktop): make provider onboarding cross-platform

### DIFF
--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -16,17 +16,9 @@ import { launchElectronApp } from "./fixtures/electron-app";
  * a real browser flow; integration of the login button is left to
  * unit tests (see `apps/desktop/src/main/__tests__/`).
  *
- * Uses the test runner's executable as a deterministic discovery candidate.
- * Its version output satisfies the provider gate without depending on a real
- * Codex install or attempting an external login.
+ * Uses a deterministic fake Codex executable whose version output satisfies
+ * the provider gate without depending on a real install or external login.
  */
-
-const wizardLaunchOptions = {
-  // No `fixturePath`: thread replay isn't relevant for wizard-only specs.
-  suppressOnboarding: false,
-  requiresReplayDriver: false,
-  env: { PWRAGENT_CODEX_COMMAND: process.execPath },
-};
 
 const fakeProviderNames = [
   "codex",
@@ -47,7 +39,7 @@ const fakeProviderVersions: Record<FakeProviderName, string> = {
 function fakeProviderScript(): string {
   return `#!${process.execPath}
 const path = require("node:path");
-const name = path.basename(process.argv[1]);
+const name = path.basename(process.argv[1]).replace(/\\.(?:cmd|c?js)$/i, "");
 const args = process.argv.slice(2);
 
 if (args.includes("--version")) {
@@ -71,6 +63,44 @@ if (name === "qwen") {
   console.log("Codex CLI");
 }
 `;
+}
+
+async function launchWizard(
+  env: Record<string, string | undefined> = {},
+) {
+  const homeRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "pwragent-onboarding-wizard-e2e-"),
+  );
+  const codexCommand = path.join(
+    homeRoot,
+    ".local",
+    "bin",
+    process.platform === "win32" ? "codex.cmd" : "codex",
+  );
+  fs.mkdirSync(path.dirname(codexCommand), { recursive: true });
+  if (process.platform === "win32") {
+    const scriptPath = path.join(path.dirname(codexCommand), "codex.js");
+    fs.writeFileSync(scriptPath, fakeProviderScript(), "utf8");
+    fs.writeFileSync(
+      codexCommand,
+      `@echo off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`,
+      "utf8",
+    );
+  } else {
+    fs.writeFileSync(codexCommand, fakeProviderScript(), "utf8");
+    fs.chmodSync(codexCommand, 0o755);
+  }
+
+  return await launchElectronApp({
+    homeRoot,
+    // No `fixturePath`: thread replay isn't relevant for wizard-only specs.
+    suppressOnboarding: false,
+    requiresReplayDriver: false,
+    env: {
+      PWRAGENT_CODEX_COMMAND: codexCommand,
+      ...env,
+    },
+  });
 }
 
 function wellKnownFakeProviderCommands(
@@ -180,7 +210,7 @@ async function expectFakeProvidersFound(
 
 test.describe("Onboarding wizard", () => {
   test("fires on a fresh PWRAGENT_HOME and walks Welcome → Done in Shared mode", async () => {
-    const app = await launchElectronApp(wizardLaunchOptions);
+    const app = await launchWizard();
     try {
       // Welcome screen visible.
       await expect(
@@ -255,7 +285,7 @@ test.describe("Onboarding wizard", () => {
   });
 
   test("messaging-safety gate flashes once, resets on re-entry, and unlocks after acknowledgement", async () => {
-    const app = await launchElectronApp(wizardLaunchOptions);
+    const app = await launchWizard();
     try {
       // Walk to the messaging-safety step (same path as the Shared walk).
       await app.window.getByRole("button", { name: /Get started/i }).click();
@@ -329,7 +359,7 @@ test.describe("Onboarding wizard", () => {
   });
 
   test("back navigation preserves the Welcome round trip and density selection across Thread presentation ↔ Models", async () => {
-    const app = await launchElectronApp(wizardLaunchOptions);
+    const app = await launchWizard();
     try {
       // Welcome → Thread presentation.
       await app.window.getByRole("button", { name: /Get started/i }).click();
@@ -385,10 +415,7 @@ test.describe("Onboarding wizard", () => {
   });
 
   test("PWRAGENT_PROFILE=<missing> opens the slim 'Set up `foo`?' confirmation step", async () => {
-    const app = await launchElectronApp({
-      ...wizardLaunchOptions,
-      env: { PWRAGENT_PROFILE: "ghost-test" },
-    });
+    const app = await launchWizard({ PWRAGENT_PROFILE: "ghost-test" });
     try {
       // Bootstrap-confirm step renders with the requested name baked in.
       await expect(
@@ -418,7 +445,7 @@ test.describe("Onboarding wizard", () => {
   });
 
   test("dismiss-confirmation modal appears in bootstrap mode with three actions", async () => {
-    const app = await launchElectronApp(wizardLaunchOptions);
+    const app = await launchWizard();
     try {
       await expect(
         app.window.getByRole("heading", {
@@ -476,7 +503,7 @@ test.describe("Onboarding wizard", () => {
     // bootstrap-profile's empty codex.profile pairing), AND there
     // should be NO `default/` dir under `<HOME>/.pwragent/profiles/`
     // (only `personal/` and `work/`).
-    const app = await launchElectronApp(wizardLaunchOptions);
+    const app = await launchWizard();
     try {
       // Unsigned Electron must never reach macOS safeStorage during E2E.
       // This value is inherited by the detached `personal` process below;
@@ -576,7 +603,7 @@ test.describe("Onboarding wizard", () => {
   });
 
   test("provider tabs show CLI-specific install instructions", async () => {
-    const app = await launchElectronApp(wizardLaunchOptions);
+    const app = await launchWizard();
     try {
       // Welcome → Thread presentation → Models.
       await app.window.getByRole("button", { name: /Get started/i }).click();

--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -51,6 +51,11 @@ if (args.includes("--version")) {
   process.exit(0);
 }
 
+if (name === "codex" && args[0] === "login" && args[1] === "status") {
+  console.error("Not logged in");
+  process.exit(1);
+}
+
 if (name === "qwen") {
   console.log("Qwen Code");
 } else if (name === "grok") {

--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -587,7 +587,11 @@ test.describe("Onboarding wizard", () => {
         }),
       ).toBeVisible();
       await expect(
-        app.window.getByText(/brew update && brew install --cask codex/i),
+        app.window.getByText(
+          process.platform === "win32"
+            ? /chatgpt\.com\/codex\/install\.ps1/i
+            : /chatgpt\.com\/codex\/install\.sh/i,
+        ),
       ).toBeVisible();
       await app.window.getByRole("tab", { name: /Gemini CLI/i }).click();
       await expect(
@@ -595,12 +599,28 @@ test.describe("Onboarding wizard", () => {
       ).toBeVisible();
       await app.window.getByRole("tab", { name: /Kimi Code/i }).click();
       await expect(
-        app.window.getByText(/@moonshot-ai\/kimi-code/i),
+        app.window.getByText(
+          process.platform === "win32"
+            ? /kimi-code\/install\.ps1/i
+            : /kimi-code\/install\.sh/i,
+        ),
       ).toBeVisible();
       await app.window.getByRole("tab", { name: /Qwen Code/i }).click();
-      await expect(app.window.getByText(/brew install qwen-code/i)).toBeVisible();
+      await expect(
+        app.window.getByText(
+          process.platform === "win32"
+            ? /install-qwen-standalone\.ps1/i
+            : /install-qwen-standalone\.sh/i,
+        ),
+      ).toBeVisible();
       await app.window.getByRole("tab", { name: /Grok Build/i }).click();
-      await expect(app.window.getByText(/x\.ai\/cli\/install\.sh/i)).toBeVisible();
+      await expect(
+        app.window.getByText(
+          process.platform === "win32"
+            ? /x\.ai\/cli\/install\.ps1/i
+            : /x\.ai\/cli\/install\.sh/i,
+        ),
+      ).toBeVisible();
     } finally {
       await app.close();
     }

--- a/apps/desktop/src/main/__tests__/codex-discovery-coordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-discovery-coordinator.test.ts
@@ -22,6 +22,22 @@ function notInstalledSnapshot(): CodexDiscoverySnapshot {
   return { candidates: [] };
 }
 
+function unvalidatedSnapshot(command: string): CodexDiscoverySnapshot {
+  return {
+    candidates: [
+      {
+        command,
+        executable: true,
+        selected: true,
+        source: "path",
+        versionFailureReason: "version_not_reported",
+      },
+    ],
+    selectedCommand: command,
+    selectedSource: "path",
+  };
+}
+
 function deferred<T>(): {
   promise: Promise<T>;
   resolve: (value: T) => void;
@@ -34,6 +50,53 @@ function deferred<T>(): {
 }
 
 describe("CodexDiscoveryCoordinator", () => {
+  it("prefers a Windows PATHEXT launcher over an extensionless npm shim", async () => {
+    const windowsCommand = "C:\\nvm4w\\nodejs\\codex.CMD";
+    const env = {
+      Path: "C:\\nvm4w\\nodejs;C:\\Windows\\System32",
+      PATHEXT: ".COM;.EXE;.BAT;.CMD",
+    };
+    const discover = vi.fn(async () => selectedSnapshot(windowsCommand));
+    const coordinator = new CodexDiscoveryCoordinator({
+      discover,
+      pathExists: async (candidate) => candidate === windowsCommand,
+      platform: "win32",
+      resolveEnv: async () => env,
+    });
+
+    await expect(coordinator.resolve()).resolves.toMatchObject({
+      command: windowsCommand,
+      version: "0.126.0",
+    });
+    expect(discover).toHaveBeenCalledWith({
+      configuredCommand: windowsCommand,
+      env,
+      platform: "win32",
+    });
+  });
+
+  it("rejects executable-looking candidates whose Codex version did not validate", async () => {
+    const command = "C:\\nvm4w\\nodejs\\codex";
+    const coordinator = new CodexDiscoveryCoordinator({
+      discover: async () => unvalidatedSnapshot(command),
+      resolveEnv: async () => ({ PATH: "C:\\nvm4w\\nodejs" }),
+    });
+
+    await expect(coordinator.discover()).resolves.toEqual({
+      candidates: [
+        expect.objectContaining({
+          command,
+          executable: false,
+          failureReason: "version_not_reported",
+          selected: false,
+        }),
+      ],
+    });
+    await expect(coordinator.resolve()).rejects.toThrow(
+      "codex CLI not found",
+    );
+  });
+
   it("single-flights concurrent probes and waits for the hydrated environment", async () => {
     const hydratedEnv = deferred<NodeJS.ProcessEnv>();
     const discover = vi.fn(async () => selectedSnapshot("/nvm/bin/codex"));

--- a/apps/desktop/src/main/__tests__/codex-discovery-coordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-discovery-coordinator.test.ts
@@ -97,6 +97,57 @@ describe("CodexDiscoveryCoordinator", () => {
     );
   });
 
+  it("selects a validated fallback after rejecting the discovered selection", async () => {
+    const invalidCommand = "C:\\nvm4w\\nodejs\\codex";
+    const validCommand = "C:\\nvm4w\\nodejs\\codex.cmd";
+    const snapshot: CodexDiscoverySnapshot = {
+      candidates: [
+        {
+          command: invalidCommand,
+          executable: true,
+          selected: true,
+          source: "path",
+          versionFailureReason: "version_not_reported",
+        },
+        {
+          command: validCommand,
+          executable: true,
+          selected: false,
+          source: "application",
+          version: "0.126.0",
+        },
+      ],
+      selectedCommand: invalidCommand,
+      selectedSource: "path",
+    };
+    const coordinator = new CodexDiscoveryCoordinator({
+      discover: async () => snapshot,
+      resolveEnv: async () => ({ PATH: "C:\\nvm4w\\nodejs" }),
+    });
+
+    await expect(coordinator.discover()).resolves.toMatchObject({
+      candidates: [
+        expect.objectContaining({
+          command: invalidCommand,
+          executable: false,
+          selected: false,
+        }),
+        expect.objectContaining({
+          command: validCommand,
+          selected: true,
+          version: "0.126.0",
+        }),
+      ],
+      selectedCommand: validCommand,
+      selectedSource: "application",
+    });
+    await expect(coordinator.resolve()).resolves.toMatchObject({
+      command: validCommand,
+      source: "application",
+      version: "0.126.0",
+    });
+  });
+
   it("single-flights concurrent probes and waits for the hydrated environment", async () => {
     const hydratedEnv = deferred<NodeJS.ProcessEnv>();
     const discover = vi.fn(async () => selectedSnapshot("/nvm/bin/codex"));

--- a/apps/desktop/src/main/codex-discovery-coordinator.ts
+++ b/apps/desktop/src/main/codex-discovery-coordinator.ts
@@ -5,6 +5,9 @@ import {
   type CodexDiscoverySnapshot,
   type ResolvedCodexCommandCandidate,
 } from "@pwrdrvr/codex-discovery";
+import { constants as fsConstants } from "node:fs";
+import { access } from "node:fs/promises";
+import path from "node:path";
 
 export const CODEX_DISCOVERY_SUCCESS_TTL_MS = 5 * 60_000;
 export const CODEX_DISCOVERY_NOT_INSTALLED_TTL_MS = 15_000;
@@ -36,6 +39,8 @@ export type CodexDiscoveryCoordinatorOptions = {
   failureTtlMs?: number;
   notInstalledTtlMs?: number;
   now?: () => number;
+  pathExists?: (candidate: string) => Promise<boolean>;
+  platform?: NodeJS.Platform;
   resolveEnv: () => Promise<NodeJS.ProcessEnv>;
   staleSuccessTtlMs?: number;
   successTtlMs?: number;
@@ -61,6 +66,8 @@ export class CodexDiscoveryCoordinator {
   private readonly inFlight = new Map<string, InFlightDiscovery>();
   private readonly notInstalledTtlMs: number;
   private readonly now: () => number;
+  private readonly pathExists: (candidate: string) => Promise<boolean>;
+  private readonly platform: NodeJS.Platform;
   private readonly staleSuccessTtlMs: number;
   private readonly successTtlMs: number;
   private generation = 0;
@@ -72,6 +79,8 @@ export class CodexDiscoveryCoordinator {
     this.notInstalledTtlMs =
       options.notInstalledTtlMs ?? CODEX_DISCOVERY_NOT_INSTALLED_TTL_MS;
     this.now = options.now ?? Date.now;
+    this.pathExists = options.pathExists ?? defaultPathExists;
+    this.platform = options.platform ?? process.platform;
     this.staleSuccessTtlMs =
       options.staleSuccessTtlMs ?? CODEX_DISCOVERY_STALE_SUCCESS_TTL_MS;
     this.successTtlMs =
@@ -212,7 +221,19 @@ export class CodexDiscoveryCoordinator {
   ): Promise<CodexDiscoverySnapshot> {
     try {
       const env = await this.options.resolveEnv();
-      const snapshot = await this.discoverFn({ configuredCommand, env });
+      const windowsPathCommand =
+        !configuredCommand && this.platform === "win32"
+          ? await findWindowsCodexPathCommand(env, this.pathExists)
+          : undefined;
+      const discovered = await this.discoverFn({
+        configuredCommand: configuredCommand ?? windowsPathCommand,
+        env,
+        ...(this.options.platform ? { platform: this.options.platform } : {}),
+      });
+      const snapshot = normalizeCodexDiscoverySnapshot(
+        discovered,
+        windowsPathCommand,
+      );
       if (generation === this.generation) {
         this.cache.set(configuredCommand?.trim() ?? "", {
           cachedAt: this.now(),
@@ -230,4 +251,97 @@ export class CodexDiscoveryCoordinator {
       throw error;
     }
   }
+}
+
+async function defaultPathExists(candidate: string): Promise<boolean> {
+  try {
+    await access(candidate, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function windowsEnvValue(
+  env: NodeJS.ProcessEnv,
+  name: string,
+): string | undefined {
+  const key = Object.keys(env).find(
+    (candidate) => candidate.toLowerCase() === name.toLowerCase(),
+  );
+  return key ? env[key] : undefined;
+}
+
+async function findWindowsCodexPathCommand(
+  env: NodeJS.ProcessEnv,
+  pathExists: (candidate: string) => Promise<boolean>,
+): Promise<string | undefined> {
+  const pathValue = windowsEnvValue(env, "PATH");
+  if (!pathValue?.trim()) return undefined;
+
+  const rawExtensions = windowsEnvValue(env, "PATHEXT")?.trim()
+    || ".COM;.EXE;.BAT;.CMD";
+  const extensions = rawExtensions
+    .split(";")
+    .map((extension) => extension.trim())
+    .filter(Boolean)
+    .map((extension) => (extension.startsWith(".") ? extension : `.${extension}`));
+
+  for (const rawDirectory of pathValue.split(";")) {
+    const directory = rawDirectory.trim().replace(/^"(.+)"$/, "$1");
+    if (!directory) continue;
+    for (const extension of extensions) {
+      const candidate = path.win32.join(directory, `codex${extension}`);
+      if (await pathExists(candidate)) return candidate;
+    }
+  }
+  return undefined;
+}
+
+function normalizeCodexDiscoverySnapshot(
+  snapshot: CodexDiscoverySnapshot,
+  windowsPathCommand?: string,
+): CodexDiscoverySnapshot {
+  const candidates = snapshot.candidates.map((candidate) => {
+    const source =
+      windowsPathCommand
+      && candidate.command.toLowerCase() === windowsPathCommand.toLowerCase()
+      && candidate.source === "config"
+        ? "path"
+        : candidate.source;
+    if (
+      candidate.selected
+      && (
+        !candidate.version
+        || Boolean(candidate.failureReason)
+        || Boolean(candidate.versionFailureReason)
+      )
+    ) {
+      return {
+        ...candidate,
+        source,
+        executable: false,
+        selected: false,
+        failureReason:
+          candidate.failureReason
+          ?? candidate.versionFailureReason
+          ?? "version_not_reported",
+      };
+    }
+    return source === candidate.source ? candidate : { ...candidate, source };
+  });
+  const selected = candidates.find((candidate) => candidate.selected);
+  const {
+    selectedCommand: _selectedCommand,
+    selectedSource: _selectedSource,
+    ...rest
+  } = snapshot;
+  return selected
+    ? {
+        ...rest,
+        candidates,
+        selectedCommand: selected.command,
+        selectedSource: selected.source,
+      }
+    : { ...rest, candidates };
 }

--- a/apps/desktop/src/main/codex-discovery-coordinator.ts
+++ b/apps/desktop/src/main/codex-discovery-coordinator.ts
@@ -302,7 +302,7 @@ function normalizeCodexDiscoverySnapshot(
   snapshot: CodexDiscoverySnapshot,
   windowsPathCommand?: string,
 ): CodexDiscoverySnapshot {
-  const candidates = snapshot.candidates.map((candidate) => {
+  const normalizedCandidates = snapshot.candidates.map((candidate) => {
     const source =
       windowsPathCommand
       && candidate.command.toLowerCase() === windowsPathCommand.toLowerCase()
@@ -330,7 +330,27 @@ function normalizeCodexDiscoverySnapshot(
     }
     return source === candidate.source ? candidate : { ...candidate, source };
   });
-  const selected = candidates.find((candidate) => candidate.selected);
+  const isValidated = (
+    candidate: (typeof normalizedCandidates)[number],
+  ): boolean =>
+    candidate.executable
+    && Boolean(candidate.version)
+    && !candidate.failureReason
+    && !candidate.versionFailureReason;
+  const selectedIndex = normalizedCandidates.findIndex(
+    (candidate) => candidate.selected && isValidated(candidate),
+  );
+  const fallbackIndex =
+    selectedIndex >= 0
+      ? selectedIndex
+      : normalizedCandidates.findIndex(isValidated);
+  const candidates = normalizedCandidates.map((candidate, index) => {
+    const selected = index === fallbackIndex;
+    return candidate.selected === selected
+      ? candidate
+      : { ...candidate, selected };
+  });
+  const selected = fallbackIndex >= 0 ? candidates[fallbackIndex] : undefined;
   const {
     selectedCommand: _selectedCommand,
     selectedSource: _selectedSource,

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -1672,26 +1672,62 @@ type OnboardingBackendId =
   | "qwen"
   | "grok";
 
+type OnboardingDesktopPlatform = "darwin" | "win32" | "linux";
+type OnboardingInstallCommand = { label: string; command: string };
+
+function onboardingDesktopPlatform(platform?: string): OnboardingDesktopPlatform {
+  if (platform === "win32" || platform === "linux") return platform;
+  return "darwin";
+}
+
+function onboardingPlatformLabel(platform: OnboardingDesktopPlatform): string {
+  if (platform === "win32") return "Windows";
+  if (platform === "linux") return "Linux";
+  return "macOS";
+}
+
 const ONBOARDING_BACKENDS: ReadonlyArray<{
   id: OnboardingBackendId;
   name: string;
   description: string;
   docsUrl: string;
-  installCommands: ReadonlyArray<{ label: string; command: string }>;
+  installCommands: Record<
+    OnboardingDesktopPlatform,
+    ReadonlyArray<OnboardingInstallCommand>
+  >;
+  platformNotes?: Partial<Record<OnboardingDesktopPlatform, string>>;
 }> = [
   {
     id: "codex",
     name: "Codex CLI",
     description:
       "OpenAI's coding agent. Sign in with your ChatGPT account after install.",
-    docsUrl: "https://github.com/openai/codex",
-    installCommands: [
-      {
-        label: "Homebrew (refresh first)",
-        command: "brew update && brew install --cask codex",
-      },
-      { label: "npm", command: "npm install -g @openai/codex" },
-    ],
+    docsUrl: "https://learn.chatgpt.com/docs/codex/cli",
+    installCommands: {
+      darwin: [
+        {
+          label: "Recommended",
+          command: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
+        },
+        { label: "Homebrew", command: "brew install --cask codex" },
+        { label: "npm", command: "npm install -g @openai/codex" },
+      ],
+      linux: [
+        {
+          label: "Recommended",
+          command: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
+        },
+        { label: "npm", command: "npm install -g @openai/codex" },
+      ],
+      win32: [
+        {
+          label: "PowerShell (recommended)",
+          command:
+            'powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"',
+        },
+        { label: "npm", command: "npm install -g @openai/codex" },
+      ],
+    },
   },
   {
     id: "gemini",
@@ -1699,35 +1735,111 @@ const ONBOARDING_BACKENDS: ReadonlyArray<{
     description:
       "Google's terminal coding agent with Google-account and API-key login options.",
     docsUrl: "https://geminicli.com/docs/get-started/installation/",
-    installCommands: [
-      { label: "Homebrew", command: "brew install gemini-cli" },
-      { label: "npm", command: "npm install -g @google/gemini-cli" },
-    ],
+    installCommands: {
+      darwin: [
+        { label: "Homebrew", command: "brew install gemini-cli" },
+        { label: "npm", command: "npm install -g @google/gemini-cli" },
+      ],
+      linux: [
+        { label: "npm", command: "npm install -g @google/gemini-cli" },
+      ],
+      win32: [
+        { label: "npm", command: "npm install -g @google/gemini-cli" },
+      ],
+    },
   },
   {
     id: "kimi",
     name: "Kimi Code",
     description:
-      "Moonshot AI's terminal coding agent with account or API-key login.",
-    docsUrl: "https://www.kimi.com/help/kimi-code/cli-getting-started",
-    installCommands: [
-      {
-        label: "macOS / Linux",
-        command: "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
-      },
-      { label: "npm", command: "npm install -g @moonshot-ai/kimi-code" },
-    ],
+      "Moonshot AI's Node.js coding agent. Run /login for OAuth or an API key.",
+    docsUrl: "https://moonshotai.github.io/kimi-code/en/guides/getting-started",
+    installCommands: {
+      darwin: [
+        {
+          label: "Recommended",
+          command: "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
+        },
+        {
+          label: "npm (Node.js 22.19+)",
+          command: "npm install -g @moonshot-ai/kimi-code",
+        },
+      ],
+      linux: [
+        {
+          label: "Recommended",
+          command: "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
+        },
+        {
+          label: "npm (Node.js 22.19+)",
+          command: "npm install -g @moonshot-ai/kimi-code",
+        },
+      ],
+      win32: [
+        {
+          label: "PowerShell (recommended)",
+          command: "irm https://code.kimi.com/kimi-code/install.ps1 | iex",
+        },
+        {
+          label: "npm (Node.js 22.19+)",
+          command: "npm install -g @moonshot-ai/kimi-code",
+        },
+      ],
+    },
+    platformNotes: {
+      win32:
+        "Install Git for Windows before first launch; Kimi uses its bundled Git Bash.",
+    },
   },
   {
     id: "qwen",
     name: "Qwen Code",
     description:
-      "Qwen's agentic coding CLI with account and API-provider options.",
+      "Qwen's coding agent. Run /auth for ModelStudio, third-party, or custom providers.",
     docsUrl: "https://qwenlm.github.io/qwen-code-docs/en/users/quickstart/",
-    installCommands: [
-      { label: "Homebrew", command: "brew install qwen-code" },
-      { label: "npm", command: "npm install -g @qwen-code/qwen-code@latest" },
-    ],
+    installCommands: {
+      darwin: [
+        {
+          label: "Recommended",
+          command:
+            "curl -fsSL https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/installation/install-qwen-standalone.sh | bash",
+        },
+        { label: "Homebrew", command: "brew install qwen-code" },
+        {
+          label: "npm (Node.js 22+)",
+          command: "npm install -g @qwen-code/qwen-code@latest",
+        },
+      ],
+      linux: [
+        {
+          label: "Recommended",
+          command:
+            "curl -fsSL https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/installation/install-qwen-standalone.sh | bash",
+        },
+        { label: "Homebrew", command: "brew install qwen-code" },
+        {
+          label: "npm (Node.js 22+)",
+          command: "npm install -g @qwen-code/qwen-code@latest",
+        },
+      ],
+      win32: [
+        {
+          label: "PowerShell (recommended)",
+          command:
+            "irm https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/installation/install-qwen-standalone.ps1 | iex",
+        },
+        {
+          label: "npm (Node.js 22+)",
+          command: "npm install -g @qwen-code/qwen-code@latest",
+        },
+      ],
+    },
+    platformNotes: {
+      darwin: "Qwen OAuth has ended; choose a provider from /auth after launch.",
+      linux: "Qwen OAuth has ended; choose a provider from /auth after launch.",
+      win32:
+        "Restart the terminal after install. Qwen OAuth has ended; use /auth after launch.",
+    },
   },
   {
     id: "grok",
@@ -1735,12 +1847,26 @@ const ONBOARDING_BACKENDS: ReadonlyArray<{
     description:
       "xAI's coding agent. The CLI opens browser sign-in on first launch.",
     docsUrl: "https://docs.x.ai/build/overview",
-    installCommands: [
-      {
-        label: "macOS / Linux",
-        command: "curl -fsSL https://x.ai/cli/install.sh | bash",
-      },
-    ],
+    installCommands: {
+      darwin: [
+        {
+          label: "Recommended",
+          command: "curl -fsSL https://x.ai/cli/install.sh | bash",
+        },
+      ],
+      linux: [
+        {
+          label: "Recommended",
+          command: "curl -fsSL https://x.ai/cli/install.sh | bash",
+        },
+      ],
+      win32: [
+        {
+          label: "PowerShell",
+          command: "irm https://x.ai/cli/install.ps1 | iex",
+        },
+      ],
+    },
   },
 ];
 
@@ -1759,7 +1885,12 @@ function installedOnboardingBackendNames(
 
 function selectedCodexCandidate(snapshot: DesktopSettingsSnapshot | undefined) {
   return snapshot?.models.codex.discovery.candidates.find(
-    (candidate) => candidate.selected && candidate.executable,
+    (candidate) =>
+      candidate.selected
+      && candidate.executable
+      && Boolean(candidate.version)
+      && !candidate.failureReason
+      && !candidate.versionFailureReason,
   );
 }
 
@@ -1790,6 +1921,7 @@ export function BackendRequirementsStep(props: {
   const snapshot = props.settings.snapshot;
   const discovery = snapshot?.models.codex.discovery;
   const codexCandidate = selectedCodexCandidate(snapshot);
+  const platform = onboardingDesktopPlatform(props.desktopApi?.platform);
   const onAcpEntriesChange = props.onAcpEntriesChange;
 
   const updateAcpEntries = useCallback(
@@ -1860,6 +1992,8 @@ export function BackendRequirementsStep(props: {
   const activeDefinition =
     ONBOARDING_BACKENDS.find((backend) => backend.id === activeBackend)
     ?? ONBOARDING_BACKENDS[0];
+  const activeInstallCommands = activeDefinition.installCommands[platform];
+  const activePlatformNote = activeDefinition.platformNotes?.[platform];
   const activeAcpEntry =
     activeBackend === "codex"
       ? undefined
@@ -1880,7 +2014,7 @@ export function BackendRequirementsStep(props: {
           Install at least one AI provider
         </h1>
         <p className="onboarding-wizard__sub">
-          PwrAgent connects to provider CLIs already installed on this Mac.
+          PwrAgent connects to provider CLIs already installed on this computer.
           Pick a tab for setup instructions, then refresh discovery.
         </p>
       </header>
@@ -1962,17 +2096,19 @@ export function BackendRequirementsStep(props: {
                     <li key={candidate.command}>
                       <code>{candidate.command}</code>
                       <span className="onboarding-wizard__prereq-paths-reason">
-                        {candidate.failureReason ?? "not executable"}
+                        {candidate.failureReason
+                          ?? candidate.versionFailureReason
+                          ?? "not executable"}
                       </span>
                     </li>
                   ))}
                 </ul>
               ) : (
                 <p>
-                  Homebrew installs are checked directly at both{" "}
-                  <code>/usr/local/bin/codex</code> (Intel) and{" "}
-                  <code>/opt/homebrew/bin/codex</code> (Apple silicon), even
-                  when the app&rsquo;s PATH does not include them.
+                  PwrAgent checks PATH and common{" "}
+                  {onboardingPlatformLabel(platform)} install locations. If
+                  you just installed Codex, refresh discovery after the
+                  installer finishes.
                 </p>
               )}
             </details>
@@ -1980,14 +2116,22 @@ export function BackendRequirementsStep(props: {
         ) : null}
 
         <div className="onboarding-wizard__prereq-install">
-          <strong>Install or update {activeDefinition.name}:</strong>
+          <strong>
+            Install or update {activeDefinition.name} on{" "}
+            {onboardingPlatformLabel(platform)}:
+          </strong>
           <ul>
-            {activeDefinition.installCommands.map((install) => (
+            {activeInstallCommands.map((install) => (
               <li key={install.command}>
                 {install.label}: <code>{install.command}</code>
               </li>
             ))}
           </ul>
+          {activePlatformNote ? (
+            <p className="onboarding-wizard__prereq-install-note">
+              {activePlatformNote}
+            </p>
+          ) : null}
           <a href={activeDefinition.docsUrl} target="_blank" rel="noreferrer">
             Open official setup guide ↗
           </a>

--- a/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
@@ -49,6 +49,34 @@ const noCodexSnapshot = {
   },
 } as unknown as DesktopSettingsSnapshot;
 
+function codexSnapshot(params: {
+  command: string;
+  version?: string;
+  versionFailureReason?: string;
+}): DesktopSettingsSnapshot {
+  return {
+    models: {
+      codex: {
+        discovery: {
+          selectedCommand: params.command,
+          candidates: [
+            {
+              command: params.command,
+              source: "path",
+              executable: true,
+              selected: true,
+              ...(params.version ? { version: params.version } : {}),
+              ...(params.versionFailureReason
+                ? { versionFailureReason: params.versionFailureReason }
+                : {}),
+            },
+          ],
+        },
+      },
+    },
+  } as unknown as DesktopSettingsSnapshot;
+}
+
 function acpEntry(
   registryId: "gemini" | "kimi" | "qwen" | "grok",
   installed = true,
@@ -80,6 +108,27 @@ function acpEntry(
 }
 
 describe("AI provider onboarding", () => {
+  it("requires a version-validated Codex candidate before enabling Continue", () => {
+    expect(
+      isBackendRequirementSatisfied(
+        codexSnapshot({
+          command: "C:\\nvm4w\\nodejs\\codex",
+          versionFailureReason: "version_not_reported",
+        }),
+        [],
+      ),
+    ).toBe(false);
+    expect(
+      isBackendRequirementSatisfied(
+        codexSnapshot({
+          command: "C:\\nvm4w\\nodejs\\codex.cmd",
+          version: "0.126.0",
+        }),
+        [],
+      ),
+    ).toBe(true);
+  });
+
   it("accepts any supported installed ACP provider", () => {
     expect(isBackendRequirementSatisfied(noCodexSnapshot, [])).toBe(false);
     expect(
@@ -96,7 +145,7 @@ describe("AI provider onboarding", () => {
     ).toBe(true);
   });
 
-  it("shows provider-specific official install commands without an xAI key field", () => {
+  it("shows provider-specific macOS install commands without an xAI key field", () => {
     const settings = {
       snapshot: noCodexSnapshot,
       refresh: vi.fn(async () => undefined),
@@ -111,18 +160,83 @@ describe("AI provider onboarding", () => {
     );
 
     expect(
-      screen.getByText(/brew update && brew install --cask codex/i),
+      screen.getByText(/chatgpt\.com\/codex\/install\.sh/i),
     ).toBeVisible();
+    expect(screen.getByText(/brew install --cask codex/i)).toBeVisible();
     fireEvent.click(screen.getByRole("tab", { name: /Gemini CLI/i }));
     expect(screen.getByText(/@google\/gemini-cli/i)).toBeVisible();
     fireEvent.click(screen.getByRole("tab", { name: /Kimi Code/i }));
     expect(screen.getByText(/@moonshot-ai\/kimi-code/i)).toBeVisible();
     fireEvent.click(screen.getByRole("tab", { name: /Qwen Code/i }));
-    expect(screen.getByText(/brew install qwen-code/i)).toBeVisible();
+    expect(screen.getByText(/install-qwen-standalone\.sh/i)).toBeVisible();
     fireEvent.click(screen.getByRole("tab", { name: /Grok Build/i }));
     expect(screen.getByText(/x\.ai\/cli\/install\.sh/i)).toBeVisible();
     expect(screen.queryByText(/xAI API key/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("shows native Windows installers and Windows-only prerequisites", () => {
+    const settings = {
+      snapshot: noCodexSnapshot,
+      refresh: vi.fn(async () => undefined),
+    } as unknown as DesktopSettingsState;
+    const desktopApi = { platform: "win32" } as DesktopApi;
+
+    render(
+      <BackendRequirementsStep
+        settings={settings}
+        desktopApi={desktopApi}
+        acpEntries={[]}
+        onAcpEntriesChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Codex CLI on Windows/i)).toBeVisible();
+    expect(screen.getByText(/chatgpt\.com\/codex\/install\.ps1/i)).toBeVisible();
+    expect(screen.queryByText(/brew install/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/installed on this Mac/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: /Kimi Code/i }));
+    expect(screen.getByText(/kimi-code\/install\.ps1/i)).toBeVisible();
+    expect(screen.getByText(/Install Git for Windows/i)).toBeVisible();
+
+    fireEvent.click(screen.getByRole("tab", { name: /Qwen Code/i }));
+    expect(screen.getByText(/install-qwen-standalone\.ps1/i)).toBeVisible();
+    expect(screen.getByText(/Qwen OAuth has ended/i)).toBeVisible();
+
+    fireEvent.click(screen.getByRole("tab", { name: /Grok Build/i }));
+    expect(screen.getByText(/x\.ai\/cli\/install\.ps1/i)).toBeVisible();
+  });
+
+  it("shows Linux installers without macOS or Windows package commands", () => {
+    const settings = {
+      snapshot: noCodexSnapshot,
+      refresh: vi.fn(async () => undefined),
+    } as unknown as DesktopSettingsState;
+    const desktopApi = { platform: "linux" } as DesktopApi;
+
+    render(
+      <BackendRequirementsStep
+        settings={settings}
+        desktopApi={desktopApi}
+        acpEntries={[]}
+        onAcpEntriesChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Codex CLI on Linux/i)).toBeVisible();
+    expect(screen.getByText(/chatgpt\.com\/codex\/install\.sh/i)).toBeVisible();
+    expect(screen.queryByText(/--cask codex/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/install\.ps1/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: /Kimi Code/i }));
+    expect(screen.getByText(/kimi-code\/install\.sh/i)).toBeVisible();
+
+    fireEvent.click(screen.getByRole("tab", { name: /Qwen Code/i }));
+    expect(screen.getByText(/install-qwen-standalone\.sh/i)).toBeVisible();
+
+    fireEvent.click(screen.getByRole("tab", { name: /Grok Build/i }));
+    expect(screen.getByText(/x\.ai\/cli\/install\.sh/i)).toBeVisible();
   });
 
   it("refreshes Codex and ACP discovery together", async () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -25483,6 +25483,11 @@ a.transcript-message__messaging-origin:focus-visible {
   border: 1px solid var(--border-strong);
   border-radius: 3px;
   padding: 1px 5px;
+  overflow-wrap: anywhere;
+}
+.onboarding-wizard__prereq-install-note {
+  margin: 0 0 8px;
+  color: var(--text-muted);
 }
 .onboarding-wizard__prereq-install a {
   color: var(--accent);


### PR DESCRIPTION
## Summary

- I made the onboarding provider instructions platform-aware for macOS, Windows, and Linux, using current official installers and authentication guidance for Codex, Kimi Code, Qwen Code, Grok Build, and Gemini CLI.
- I fixed the Windows Codex false positive shown by an extensionless npm shim such as `C:\nvm4w\nodejs\codex`: PwrAgent now prefers PATHEXT launchers such as `codex.cmd` and requires a validated Codex version before treating the provider as usable.
- I normalize discovery snapshots so an invalid selected candidate cannot hide an available, version-validated fallback.
- I added unit and Playwright coverage for the platform command matrix and the provider-readiness gate.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/codex-discovery-coordinator.test.ts apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx`
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm --filter @pwragent/desktop exec playwright test e2e/onboarding-wizard.spec.ts --list`

## Notes

- I based the command and prerequisite updates on current official vendor documentation verified on 2026-08-11.
- Executing Windows `.cmd`/`.bat` shims belongs to `@pwrdrvr/codex-discovery`. The package fix is in draft [pwrdrvr/agent-kit#25](https://github.com/pwrdrvr/agent-kit/pull/25); this PR must consume its published patch release before the npm/NVM launcher path is complete.
- The Windows UI and npm-shim behavior are covered by deterministic tests; a headed Windows wizard pass can provide final platform visual confirmation.
