### PR TITLE
fix(messaging): serialize binding status renders

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4348,6 +4348,102 @@ describe("MessagingController", () => {
     });
   });
 
+  it("reuses one status surface when initial and automatic renders race", async () => {
+    const statusIntents: Array<
+      Extract<MessagingSurfaceIntent, { kind: "status" }>
+    > = [];
+    let resolveFirstStatusDeliveryStarted: (() => void) | undefined;
+    const firstStatusDeliveryStarted = new Promise<void>((resolve) => {
+      resolveFirstStatusDeliveryStarted = resolve;
+    });
+    let firstStatusDelivery = true;
+    const harness = await createHarness({
+      deliver: async (intent) => {
+        if (intent.kind !== "status") {
+          return {
+            channel: "slack",
+            deliveredAt: 1000,
+            outcome: "presented",
+          };
+        }
+        statusIntents.push(intent);
+        if (firstStatusDelivery) {
+          firstStatusDelivery = false;
+          resolveFirstStatusDeliveryStarted?.();
+          await new Promise<void>((resolve) => setTimeout(resolve, 50));
+        }
+        const surface = intent.targetSurface ?? {
+          channel: "slack" as const,
+          id: "status-surface-1",
+        };
+        return {
+          channel: "slack",
+          deliveredAt: 1000,
+          outcome: intent.targetSurface ? "updated" as const : "presented" as const,
+          surface,
+        };
+      },
+    });
+    const event = buildTextEvent("delegate this", {
+      channel: {
+        channel: "slack",
+        conversation: {
+          id: "1786469165.289979",
+          kind: "thread",
+          parentId: "C05RKSBL1QF",
+          parentConversationId: "C05RKSBL1QF",
+          parentTitle: "giphy-services",
+          workspaceId: "T012PWRDRVR",
+        },
+      },
+    });
+    await harness.store.upsertBinding({
+      id: "binding:slack:thread:1786469165.289979:C05RKSBL1QF:codex:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: event.channel,
+      createdAt: 1000,
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+
+    const initialStatus = harness.controller.handleInboundEvent({
+      ...buildCommandEvent("/status"),
+      channel: event.channel,
+    });
+    await firstStatusDeliveryStarted;
+    await Promise.all([
+      initialStatus,
+      ...[
+        "Renamed title",
+        "Final title",
+      ].map(async (threadName) => {
+        await harness.controller.handleBackendEvent({
+          backend: "codex",
+          notification: {
+            method: "thread/name/updated",
+            params: {
+              threadId: "thread-1",
+              threadName,
+            },
+          },
+        });
+      }),
+    ]);
+
+    expect(statusIntents.map((intent) => intent.delivery?.mode)).toEqual([
+      "present",
+      "update",
+      "update",
+    ]);
+    expect(statusIntents.map((intent) => intent.targetSurface?.id)).toEqual([
+      undefined,
+      "status-surface-1",
+      "status-surface-1",
+    ]);
+  });
+
   it("finds and attaches a remote thread from a default Agent route, then keeps steering it remotely", async () => {
     const localNavigation = buildNavigationSnapshot();
     localNavigation.threads[0] = {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -177,6 +177,7 @@ import {
 } from "./messaging-markdown-file-attachment-selector.js";
 import { buildMessagingAuditContext } from "./messaging-audit.js";
 import { getMainLogger } from "../../log.js";
+import { PerKeyAsyncLock } from "../../util/per-key-async-lock.js";
 import { DeterministicInteractionMapper } from "./deterministic-interaction-mapper.js";
 import { actionsForIntent } from "./deterministic-interaction-mapper.js";
 import { parseReviewCommand } from "../../../shared/review-command.js";
@@ -832,6 +833,7 @@ export type MessagingControllerOptions = {
 export class MessagingController {
   private readonly authorizedActorIds: Set<string>;
   private readonly capabilityProfile: MessagingCapabilityProfile;
+  private readonly statusRenderLock = new PerKeyAsyncLock();
   private readonly deliveredAssistantMessageKeys = new Set<string>();
   private readonly assistantStreamBuffers = new Map<string, AssistantStreamBuffer>();
   private readonly assistantStreamDeliveryQueues = new Map<
@@ -13814,6 +13816,24 @@ export class MessagingController {
   }
 
   private async renderBindingStatus(
+    binding: MessagingBindingRecord,
+    event?: MessagingInboundEvent,
+    navigation?: NavigationSnapshot,
+  ): Promise<MessagingBindingRecord> {
+    return await this.statusRenderLock.run(binding.id, async () => {
+      const latestBinding = await this.options.store.getBinding(binding.id);
+      if (latestBinding?.revokedAt) {
+        return latestBinding;
+      }
+      return await this.renderBindingStatusUnlocked(
+        latestBinding ?? binding,
+        event,
+        navigation,
+      );
+    });
+  }
+
+  private async renderBindingStatusUnlocked(
     binding: MessagingBindingRecord,
     event?: MessagingInboundEvent,
     navigation?: NavigationSnapshot,


### PR DESCRIPTION
## Summary

- serialize status rendering per messaging binding
- reload the latest binding before each queued render so later renders update the first persisted surface
- cover the initial-status/thread-name race with a timing-controlled regression test

## Root cause

A new messaging attachment could receive an initial status render while automatic backend events, notably `thread/name/updated`, triggered additional renders. Those renders ran concurrently, each observed an empty `statusSurface`, and each emitted a `present` intent. Slack therefore posted multiple status cards; whichever delivery persisted last became the surface later controls updated.

## User impact

Newly attached threads now create one status card. Concurrent naming or lifecycle refreshes update that card instead of posting duplicates.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts` (393 passed)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` (0 errors; 33 pre-existing warnings)