### PR TITLE
feat(desktop): persist sender labels and replay captured messages

### DIFF
--- a/apps/desktop/src/main/__tests__/automation-prompt.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-prompt.test.ts
@@ -139,6 +139,36 @@ describe("buildAutomationTurnInput", () => {
     expect(text).toContain("ERROR api latency high");
   });
 
+
+  it("includes the source message for an operator replay", () => {
+    const [item] = buildAutomationTurnInput({
+      automation: buildAutomation(),
+      run: {
+        id: "run-replay",
+        automationId: "automation-1",
+        trigger: "manual",
+        status: "running",
+        scheduledWindows: [],
+        source: {
+          kind: "messaging",
+          sourceEventKey: "replay:m1:9000",
+          receivedAt: Date.UTC(2026, 4, 13, 14, 10),
+          matchedTriggerId: "datadog-error",
+          actor: { platformUserId: "B123", displayName: "Datadog", isBot: true },
+          conversation: { channel: "slack", conversationId: "C123" },
+          message: { text: "ERROR api latency high" },
+        },
+      },
+    });
+
+    const text = item?.type === "text" ? item.text : "";
+    expect(text).toContain("Trigger: manual Run Now");
+    expect(text).toContain(
+      "Source message (replayed by the operator for testing):",
+    );
+    expect(text).toContain("ERROR api latency high");
+  });
+
   it("injects bounded prior-run context, newest first", () => {
     const [item] = buildAutomationTurnInput({
       automation: buildAutomation(),

--- a/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
@@ -107,6 +107,49 @@ function buildSchedulerWithGate(gateRunner: AutomationGateRunner): AutomationSch
 }
 
 describe("AutomationScheduler", () => {
+  it("replays a captured message as a manual run carrying the source", async () => {
+    const automation = createIntervalAutomation({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Search bots",
+      taskPrompt: "Investigate.",
+      triggers: [
+        {
+          id: "inbound-message",
+          kind: "inbound_message",
+          conversation: { channel: "slack", conversationId: "C123" },
+        },
+      ],
+    });
+    const scheduler = buildScheduler();
+    const source = {
+      kind: "messaging" as const,
+      sourceEventKey: "replay:m1:9000",
+      receivedAt: 5_000,
+      matchedTriggerId: "inbound-message",
+      actor: { platformUserId: "B123", displayName: "Datadog", isBot: true },
+      conversation: { channel: "slack" as const, conversationId: "C123" },
+      message: { text: "ERROR rate spike" },
+    };
+
+    const result = await scheduler.replayInboundRun({ automation, source });
+    expect(result?.status).toBe("started");
+    const [run] = store.listRunsForAutomation(automation.id, 1);
+    expect(run?.trigger).toBe("manual");
+    expect(run?.source?.message?.text).toBe("ERROR rate spike");
+
+    // A second replay of the same message must create another run — the
+    // source-event dedupe polices unattended inbound traffic, not an operator
+    // pressing the button twice on purpose. It queues rather than starts
+    // because the first replay still holds the serial lane.
+    const again = await scheduler.replayInboundRun({
+      automation,
+      source: { ...source, sourceEventKey: "replay:m1:9500" },
+    });
+    expect(again?.status).toBe("queued");
+    expect(store.listRunsForAutomation(automation.id, 10)).toHaveLength(2);
+  });
+
   it("reschedules timers when start is called after an automation is added", () => {
     const timerDelays: number[] = [];
     const scheduler = new AutomationScheduler({

--- a/apps/desktop/src/main/__tests__/automation-store.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-store.test.ts
@@ -889,3 +889,51 @@ describe("AutomationStore", () => {
     expect(store.getAutomationLoadIssues()).toEqual([]);
   });
 });
+
+describe("automation run usage", () => {
+  it("persists distilled usage on the run payload and round-trips it", () => {
+    {
+      const automation = store.createAutomation({
+        backend: "codex",
+        threadId: "thread-1",
+        name: "Usage",
+        taskPrompt: "Check.",
+        schedule: { kind: "interval", every: 5, unit: "minutes", anchorAt: 0 },
+        now: 0,
+      });
+      const run = store.createRun({
+        automationId: automation.id,
+        trigger: "manual",
+        scheduledWindows: [],
+        now: 1_000,
+      });
+      expect(run).toBeDefined();
+
+      const updated = store.setRunUsage({
+        runId: run!.id,
+        usage: {
+          model: "gpt-5.6-sol",
+          uncachedInputTokens: 6_356,
+          cachedInputTokens: 581_888,
+          outputTokens: 1_192,
+          reasoningOutputTokens: 668,
+          totalCostMicros: 380_000,
+          currency: "USD",
+        },
+        now: 2_000,
+      });
+      expect(updated?.usage?.totalCostMicros).toBe(380_000);
+
+      const [listed] = store.listRunsForAutomation(automation.id, 1);
+      expect(listed?.usage).toEqual({
+        model: "gpt-5.6-sol",
+        uncachedInputTokens: 6_356,
+        cachedInputTokens: 581_888,
+        outputTokens: 1_192,
+        reasoningOutputTokens: 668,
+        totalCostMicros: 380_000,
+        currency: "USD",
+      });
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/automation-trigger-matcher.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-trigger-matcher.test.ts
@@ -6,6 +6,8 @@ import type {
 import type { MessagingInboundTextEvent } from "@pwragent/messaging-interface";
 import type { AutomationRecord } from "../automations/automation-store";
 import {
+  buildAutomationReplayCandidates,
+  buildReplayRunSourceMetadata,
   buildSourceEventKey,
   matchAutomationInboundEvent,
 } from "../automations/automation-trigger-matcher";
@@ -494,3 +496,58 @@ function slackTextEvent(
     text: overrides.text ?? "ERROR api latency high",
   };
 }
+
+describe("automation replay helpers", () => {
+  const trigger = {
+    id: "datadog-error",
+    kind: "inbound_message" as const,
+    conversation: {
+      channel: "slack" as const,
+      conversationId: "C123",
+      conversationKind: "channel" as const,
+      title: "#alerts-prod",
+    },
+    conditionGroup: {
+      join: "all" as const,
+      conditions: [
+        {
+          id: "text",
+          field: "message_text" as const,
+          operator: "contains" as const,
+          values: ["ERROR"],
+        },
+      ],
+    },
+  };
+
+  const message = (id: string, text: string) => ({
+    id,
+    provider: "slack" as const,
+    conversationId: "C123",
+    receivedAt: 5_000,
+    actor: { platformUserId: "B123", displayName: "Datadog", isBot: true },
+    text,
+  });
+
+  it("judges candidates with the same evaluator as live matching", () => {
+    const candidates = buildAutomationReplayCandidates(trigger, [
+      message("m1", "ERROR rate spike"),
+      message("m2", "deploy finished"),
+    ]);
+    expect(candidates.map((candidate) => candidate.matches)).toEqual([true, false]);
+  });
+
+  it("namespaces the replay source key away from the original event", () => {
+    const source = buildReplayRunSourceMetadata({
+      trigger,
+      message: message("m1", "ERROR rate spike"),
+      now: 9_000,
+    });
+    // The real event's dedupe key must never collide with a replay: inbound
+    // dispatch would otherwise treat a later genuine delivery as handled.
+    expect(source.sourceEventKey).toBe("replay:m1:9000");
+    expect(source.matchedTriggerId).toBe("datadog-error");
+    expect(source.conversation.title).toBe("#alerts-prod");
+    expect(source.message?.text).toBe("ERROR rate spike");
+  });
+});

--- a/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
@@ -490,6 +490,88 @@ describe("DesktopAutomationService", () => {
     });
   });
 
+  it("captures run usage from a turn-scope pricing event", async () => {
+    const service = new DesktopAutomationService({ registry, store });
+    // The registry-event subscription lives in start() — the boot path calls
+    // it; a service that was never started hears no pricing events.
+    service.start();
+    const created = await service.create({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      schedule: { kind: "interval", every: 5, unit: "minutes" },
+    });
+    const runNow = await service.runNow({ automationId: created.automation.id });
+
+    // Bind the backend turn id to the run the way the live app does.
+    await Promise.all(
+      registryListeners.map((listener) =>
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/turnQueue/updated",
+            params: {
+              threadId: "thread-1",
+              queueEntryId: runNow.queueEntryId ?? "headless:run-1",
+              origin: "automation",
+              status: "started",
+              automationRunId: runNow.run.id,
+              backendThreadId: "headless-thread-1",
+              turnId: "turn-1",
+            },
+          },
+        } as AgentEvent),
+      ),
+    );
+
+    // The registry nests readThreadPricing's result under `pricing` — the
+    // capture must read that real shape, not a flattened `lines` array.
+    await Promise.all(
+      registryListeners.map((listener) =>
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/pricing/updated",
+            params: {
+              threadId: "thread-1",
+              pricing: {
+                summaries: [],
+                lines: [
+                  {
+                    scope: "turn",
+                    turnId: "turn-1",
+                    model: "gpt-5",
+                    uncachedInputTokens: 1_000,
+                    cachedInputTokens: 2_000,
+                    outputTokens: 300,
+                    reasoningOutputTokens: 100,
+                    totalTokens: 3_300,
+                    totalCostMicros: 123_456,
+                    currency: "USD",
+                  },
+                ],
+              },
+            },
+          },
+          // Partial ThreadUsageLineRecord: only the fields the capture reads.
+        } as unknown as AgentEvent),
+      ),
+    );
+
+    const [run] = store.listRunsForAutomation(created.automation.id, 1);
+    expect(run?.usage).toEqual({
+      model: "gpt-5",
+      uncachedInputTokens: 1_000,
+      cachedInputTokens: 2_000,
+      outputTokens: 300,
+      reasoningOutputTokens: 100,
+      totalTokens: 3_300,
+      totalCostMicros: 123_456,
+      currency: "USD",
+    });
+  });
+
   it("lists an active run as the latest automation status", async () => {
     const service = new DesktopAutomationService({ registry, store });
     const created = await service.create({

--- a/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
@@ -490,7 +490,9 @@ describe("DesktopAutomationService", () => {
     });
   });
 
-  it("captures run usage from a turn-scope pricing event", async () => {
+  it("captures run usage from pricing events through one debounced write", async () => {
+    vi.useFakeTimers();
+    const setRunUsage = vi.spyOn(store, "setRunUsage");
     const service = new DesktopAutomationService({ registry, store });
     // The registry-event subscription lives in start() — the boot path calls
     // it; a service that was never started hears no pricing events.
@@ -527,37 +529,46 @@ describe("DesktopAutomationService", () => {
 
     // The registry nests readThreadPricing's result under `pricing` — the
     // capture must read that real shape, not a flattened `lines` array.
-    await Promise.all(
-      registryListeners.map((listener) =>
-        listener({
-          backend: "codex",
-          notification: {
-            method: "thread/pricing/updated",
-            params: {
-              threadId: "thread-1",
-              pricing: {
-                summaries: [],
-                lines: [
-                  {
-                    scope: "turn",
-                    turnId: "turn-1",
-                    model: "gpt-5",
-                    uncachedInputTokens: 1_000,
-                    cachedInputTokens: 2_000,
-                    outputTokens: 300,
-                    reasoningOutputTokens: 100,
-                    totalTokens: 3_300,
-                    totalCostMicros: 123_456,
-                    currency: "USD",
-                  },
-                ],
-              },
+    // Partial ThreadUsageLineRecord: only the fields the capture reads.
+    const pricingEvent = (totalCostMicros: number): AgentEvent =>
+      ({
+        backend: "codex",
+        notification: {
+          method: "thread/pricing/updated",
+          params: {
+            threadId: "thread-1",
+            pricing: {
+              summaries: [],
+              lines: [
+                {
+                  scope: "turn",
+                  turnId: "turn-1",
+                  model: "gpt-5",
+                  uncachedInputTokens: 1_000,
+                  cachedInputTokens: 2_000,
+                  outputTokens: 300,
+                  reasoningOutputTokens: 100,
+                  totalTokens: 3_300,
+                  totalCostMicros,
+                  currency: "USD",
+                },
+              ],
             },
           },
-          // Partial ThreadUsageLineRecord: only the fields the capture reads.
-        } as unknown as AgentEvent),
-      ),
-    );
+        },
+      }) as unknown as AgentEvent;
+
+    // A streaming turn re-emits cumulative snapshots: two identical events,
+    // then a newer total. Only the newest snapshot may reach sqlite, and only
+    // after the flush window — the write must not scale with event count.
+    for (const totalCostMicros of [100_000, 100_000, 123_456]) {
+      await Promise.all(
+        registryListeners.map((listener) => listener(pricingEvent(totalCostMicros))),
+      );
+    }
+    expect(setRunUsage).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(setRunUsage).toHaveBeenCalledTimes(1);
 
     const [run] = store.listRunsForAutomation(created.automation.id, 1);
     expect(run?.usage).toEqual({
@@ -570,6 +581,16 @@ describe("DesktopAutomationService", () => {
       totalCostMicros: 123_456,
       currency: "USD",
     });
+
+    // A re-emitted, unchanged snapshot after the flush schedules nothing.
+    await Promise.all(
+      registryListeners.map((listener) => listener(pricingEvent(123_456))),
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(setRunUsage).toHaveBeenCalledTimes(1);
+
+    service.dispose();
+    vi.useRealTimers();
   });
 
   it("lists an active run as the latest automation status", async () => {

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -1,4 +1,11 @@
 {
+  "automation-run-usage": {
+    "commits": 1,
+    "note": "50 cumulative pricing snapshots for one run, one debounced payload write",
+    "observedWalBytes": 16480,
+    "rowsChanged": 1,
+    "statements": 1
+  },
   "composer-draft-typing": {
     "commits": 70,
     "note": "typing one 70-character message with a save per keystroke: exactly one journal row survives, and commits track saves because each save is its own transaction",

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -32,6 +32,7 @@ import type {
 } from "../messaging/messaging-runtime";
 
 const messagingLog = {
+  debug: vi.fn(),
   error: vi.fn(),
   info: vi.fn(),
   warn: vi.fn(),

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -9,6 +9,8 @@ import type {
 import { buildFederatedThreadRef } from "@pwragent/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
+import { AutomationStore } from "../automations/automation-store";
+import { DesktopAutomationService } from "../automations/desktop-automation-service";
 import { RuntimeLeaseManager } from "../runtime-lease-manager";
 import {
   AppRuntimeInstanceStore,
@@ -226,6 +228,101 @@ describe("sqlite write metrics", () => {
       }
     } finally {
       await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("holds a burst of automation pricing snapshots to one run-usage write", async () => {
+    vi.useFakeTimers();
+    const automationStore = new AutomationStore(stateDb);
+    const registryListeners: Array<(event: AgentEvent) => void | Promise<void>> = [];
+    const registry = {
+      canStartThreadTurnImmediately: () => true,
+      getThreadAgentMetadata: async () => ({
+        name: "Agent",
+        instructionLineCount: 0,
+        instructionsTooLong: false,
+        updatedAt: 1,
+      }),
+      onEvent: (listener: (event: AgentEvent) => void | Promise<void>) => {
+        registryListeners.push(listener);
+        return () => {};
+      },
+      publishLocalEvent: async () => {},
+      setAutomationInspectionHandler: () => {},
+      startAutomationHeadlessTurn: async (params: {
+        agentThreadId: string;
+        automationRunId: string;
+        backend: string;
+      }) => ({
+        backend: params.backend,
+        headlessThreadId: "headless-1",
+        queueEntryId: `headless:${params.automationRunId}`,
+        threadId: params.agentThreadId,
+        turnId: "turn-1",
+      }),
+    } as unknown as ConstructorParameters<
+      typeof DesktopAutomationService
+    >[0]["registry"];
+    const service = new DesktopAutomationService({
+      registry,
+      store: automationStore,
+    });
+    try {
+      service.start();
+      const created = await service.create({
+        backend: "codex",
+        threadId: "thread-1",
+        name: "Usage burst",
+        taskPrompt: "Check.",
+        schedule: { kind: "interval", every: 5, unit: "minutes" },
+      });
+      await service.runNow({ automationId: created.automation.id });
+
+      const { writes } = await measureSqliteWrites(async () => {
+        // Fifty cumulative pricing snapshots for one streaming turn. Each
+        // setRunUsage rewrites the whole run payload row, so the debounce is
+        // what keeps this at one commit instead of fifty.
+        for (let observation = 1; observation <= 50; observation += 1) {
+          await Promise.all(
+            registryListeners.map((listener) =>
+              listener({
+                backend: "codex",
+                notification: {
+                  method: "thread/pricing/updated",
+                  params: {
+                    threadId: "thread-1",
+                    pricing: {
+                      summaries: [],
+                      lines: [
+                        {
+                          scope: "turn",
+                          turnId: "turn-1",
+                          model: "gpt-5",
+                          uncachedInputTokens: observation * 100,
+                          outputTokens: observation * 10,
+                          totalCostMicros: observation * 1_000,
+                          currency: "USD",
+                        },
+                      ],
+                    },
+                  },
+                },
+                // Partial ThreadUsageLineRecord: only what the capture reads.
+              } as unknown as AgentEvent),
+            ),
+          );
+        }
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+
+      expectSqliteWriteBudget({
+        note: "50 cumulative pricing snapshots for one run, one debounced payload write",
+        scenario: "automation-run-usage",
+        writes,
+      });
+    } finally {
+      service.dispose();
       vi.useRealTimers();
     }
   });

--- a/apps/desktop/src/main/automation-run-window.ts
+++ b/apps/desktop/src/main/automation-run-window.ts
@@ -1,0 +1,118 @@
+import { BrowserWindow } from "electron";
+import type { OpenAutomationRunWindowRequest } from "@pwragent/shared";
+import { getMainLogger } from "./log";
+import {
+  applyWindowSecurityHardening,
+  getPreloadPath,
+  getRendererEntry,
+} from "./window";
+import {
+  WINDOW_KIND_AUTOMATION_RUN,
+  registerWindowChannels,
+} from "./window-channels";
+import { APPEARANCE_CHANGED_EVENT_CHANNEL } from "../shared/ipc";
+import {
+  readBootstrapAppearance,
+  themedWindowAdditionalArguments,
+  themedWindowBackgroundColor,
+} from "./settings/appearance-bootstrap";
+import {
+  auxiliaryWindowChromeOptions,
+  hideAuxiliaryWindowMenuBar,
+  registerAuxiliaryWindowTitle,
+  showAndFocusAuxiliaryWindow,
+  showAuxiliaryWindowWhenReady,
+} from "./auxiliary-window-chrome";
+import {
+  placementForSourceDisplay,
+  positionWindowForSourceDisplay,
+  type WindowPlacementSource,
+} from "./window-placement";
+
+const log = getMainLogger("pwragent:automation-run-window");
+const AUTOMATION_RUN_HASH = "automation-run";
+const AUTOMATION_RUN_WINDOW_WIDTH = 1_040;
+const AUTOMATION_RUN_WINDOW_HEIGHT = 780;
+
+const runWindows = new Map<string, BrowserWindow>();
+
+/**
+ * Opens an inspection-only window for one automation run's captured events.
+ *
+ * The transcript was previously readable only inline in the automations
+ * table, where a long run competes with the table itself for space. Same
+ * pattern as the sub-agent transcript window: keyed by identity (one window
+ * per run, refocused on re-open), hash-routed into the shared renderer
+ * bundle, read-only.
+ */
+export function showAutomationRunWindow(
+  request: OpenAutomationRunWindowRequest,
+  source: WindowPlacementSource = {},
+): void {
+  const automationId = request.automationId.trim();
+  const runId = request.runId.trim();
+  if (!automationId || !runId) {
+    throw new Error("Automation run window requires automation and run ids.");
+  }
+  const current = runWindows.get(runId);
+  if (current && !current.isDestroyed()) {
+    positionWindowForSourceDisplay(current, source);
+    showAndFocusAuxiliaryWindow(current);
+    return;
+  }
+
+  const title = request.title?.trim() || "Automation run";
+  const windowTitle = `Automation run — ${title}`;
+  const appearance = readBootstrapAppearance();
+  const window = new BrowserWindow({
+    ...placementForSourceDisplay(
+      AUTOMATION_RUN_WINDOW_WIDTH,
+      AUTOMATION_RUN_WINDOW_HEIGHT,
+      source,
+    ),
+    width: AUTOMATION_RUN_WINDOW_WIDTH,
+    height: AUTOMATION_RUN_WINDOW_HEIGHT,
+    minWidth: 720,
+    minHeight: 520,
+    show: false,
+    title: windowTitle,
+    ...auxiliaryWindowChromeOptions(),
+    backgroundColor: themedWindowBackgroundColor(appearance),
+    webPreferences: {
+      preload: getPreloadPath(),
+      contextIsolation: true,
+      sandbox: true,
+      nodeIntegration: false,
+      additionalArguments: themedWindowAdditionalArguments(appearance),
+    },
+  });
+  registerAuxiliaryWindowTitle(window, windowTitle);
+  hideAuxiliaryWindowMenuBar(window);
+
+  applyWindowSecurityHardening(window);
+  registerWindowChannels(window, WINDOW_KIND_AUTOMATION_RUN, [
+    APPEARANCE_CHANGED_EVENT_CHANNEL,
+  ]);
+
+  const hash = [
+    AUTOMATION_RUN_HASH,
+    encodeURIComponent(automationId),
+    encodeURIComponent(runId),
+  ].join("/");
+  const rendererEntry = getRendererEntry();
+  if (rendererEntry.kind === "url") {
+    void window.loadURL(`${rendererEntry.value}#${hash}`);
+  } else {
+    void window.loadFile(rendererEntry.value, { hash });
+  }
+
+  showAuxiliaryWindowWhenReady(window);
+  runWindows.set(runId, window);
+  window.on("closed", () => {
+    if (runWindows.get(runId) === window) {
+      runWindows.delete(runId);
+    }
+    log.debug("automation run window closed", { runId });
+  });
+  log.debug("automation run window created", { automationId, runId });
+}

--- a/apps/desktop/src/main/automations/automation-prompt.ts
+++ b/apps/desktop/src/main/automations/automation-prompt.ts
@@ -109,13 +109,17 @@ function boundPriorText(text: string | undefined): string | undefined {
 }
 
 function formatInboundSource(run: AutomationRunSummary): string[] {
-  if (run.trigger !== "inbound_message" || !run.source) {
+  // Keyed on the source's presence, not the trigger: an operator replay is a
+  // manual run that still carries the message it is testing.
+  if (!run.source) {
     return [];
   }
   const source = run.source;
   return [
     "",
-    "Inbound source message:",
+    run.trigger === "manual"
+      ? "Source message (replayed by the operator for testing):"
+      : "Inbound source message:",
     `Matched trigger: ${source.matchedTriggerName ?? source.matchedTriggerId}`,
     `Received at: ${new Date(source.receivedAt).toISOString()}`,
     `Provider: ${source.conversation.channel}`,

--- a/apps/desktop/src/main/automations/automation-scheduler.ts
+++ b/apps/desktop/src/main/automations/automation-scheduler.ts
@@ -128,6 +128,41 @@ export class AutomationScheduler {
     return await this.submitRun({ automation, runId: run.id, windows: [], now });
   }
 
+  /**
+   * Operator-initiated replay of a captured message. Deliberately a MANUAL
+   * run that carries the message as its source: it bypasses the inbound rate
+   * limit, coalescing, and source-event dedupe (all of which exist to police
+   * unattended traffic, not an operator pressing a button), while the prompt
+   * still receives the message exactly as an inbound run would.
+   */
+  async replayInboundRun(params: {
+    automation: AutomationRecord;
+    source: AutomationRunSourceMetadata;
+    now?: number;
+  }): Promise<Awaited<ReturnType<AutomationRunner["submitRun"]>> | undefined> {
+    const now = params.now ?? this.now();
+    const automation = params.automation;
+    const active = this.options.store.findActiveRunForAutomation(automation.id);
+    const run = this.options.store.createRun({
+      automationId: automation.id,
+      trigger: "manual",
+      scheduledWindows: [],
+      source: params.source,
+      now,
+    });
+    if (!run) return undefined;
+    if (active) {
+      const queued = this.options.store.markRunQueued({
+        runId: run.id,
+        queueEntryId: buildLaneQueueEntryId(run.id),
+        queuedAt: now,
+        now,
+      });
+      return buildLaneQueuedResult({ automation, run: queued ?? run, position: 1 });
+    }
+    return await this.submitRun({ automation, runId: run.id, windows: [], now });
+  }
+
   async runFromInboundEvent(params: {
     automation: AutomationRecord;
     source: AutomationRunSourceMetadata;

--- a/apps/desktop/src/main/automations/automation-store.ts
+++ b/apps/desktop/src/main/automations/automation-store.ts
@@ -4,6 +4,7 @@ import type {
   AutomationBacklogPolicy,
   AutomationExecutionProfile,
   AutomationPriorRunLookback,
+  AutomationRunUsage,
   AutomationGateConfig,
   AutomationListItemSummary,
   AutomationLoadIssue,
@@ -216,6 +217,7 @@ type AutomationRunPayload = {
   skipReason?: AutomationRunSkipReason;
   coalescedCount?: number;
   source?: AutomationRunSourceMetadata;
+  usage?: AutomationRunUsage;
 };
 
 type AutomationRunArtifactPayload = {
@@ -1012,6 +1014,28 @@ export class AutomationStore {
       );
   }
 
+  setRunUsage(params: {
+    runId: string;
+    usage: AutomationRunUsage;
+    now?: number;
+  }): AutomationRunSummary | undefined {
+    const row = this.stateDb.raw
+      .prepare("SELECT * FROM automation_runs WHERE run_id = ?")
+      .get(params.runId) as AutomationRunRow | undefined;
+    if (!row) return undefined;
+    const run = this.runFromRow(row);
+    if (!run) return undefined;
+    const payload = parseJson<AutomationRunPayload>(row.payload);
+    if (!payload) return undefined;
+    const updated: AutomationRunPayload = { ...payload, usage: params.usage };
+    this.stateDb.raw
+      .prepare(
+        "UPDATE automation_runs SET payload = ?, updated_at = ? WHERE run_id = ?",
+      )
+      .run(JSON.stringify(updated), params.now ?? Date.now(), params.runId);
+    return { ...run, usage: params.usage };
+  }
+
   private upsertRun(
     run: AutomationRunSummary,
     metadata: {
@@ -1029,6 +1053,7 @@ export class AutomationStore {
       skipReason: run.skipReason,
       coalescedCount: run.coalescedCount,
       source: run.source,
+      usage: run.usage,
     };
     this.stateDb.raw
       .prepare(
@@ -1205,6 +1230,7 @@ export class AutomationStore {
       errorMessage: payload.errorMessage,
       skipReason: payload.skipReason,
       coalescedCount: payload.coalescedCount,
+      usage: payload.usage,
     };
   }
 

--- a/apps/desktop/src/main/automations/automation-trigger-matcher.ts
+++ b/apps/desktop/src/main/automations/automation-trigger-matcher.ts
@@ -4,7 +4,9 @@ import {
 } from "@pwragent/shared";
 import type {
   AutomationInboundMessageTriggerDefinition,
+  AutomationReplayCandidate,
   AutomationRunSourceMetadata,
+  InboundPreviewMessage,
 } from "@pwragent/shared";
 import type { MessagingInboundEvent } from "@pwragent/messaging-interface";
 import type { AutomationRecord } from "./automation-store.js";
@@ -153,6 +155,71 @@ function boundSourceText(
   return {
     text: `${text.slice(0, MAX_SOURCE_TEXT_CHARS)}\n[truncated]`,
     truncated: true,
+  };
+}
+
+/**
+ * Judge recent conversation messages against a trigger's filter for the
+ * Replay picker. Uses the same shared evaluator as live matching and the
+ * editor preview, so a "matches" badge here is a promise about what the
+ * trigger would actually have done.
+ */
+export function buildAutomationReplayCandidates(
+  trigger: AutomationInboundMessageTriggerDefinition,
+  messages: InboundPreviewMessage[],
+): AutomationReplayCandidate[] {
+  const group = normalizeInboundTriggerConditions(trigger);
+  return messages.map((message) => ({
+    message,
+    matches: evaluateAutomationInboundConditions(group, {
+      text: message.text,
+      platformUserId: message.actor.platformUserId,
+      ...(message.actor.isBot === undefined ? {} : { isBot: message.actor.isBot }),
+    }),
+  }));
+}
+
+/**
+ * Source metadata for an operator-initiated replay of a captured message.
+ *
+ * The event key is namespaced with `replay:` plus a timestamp — never the
+ * original key — because inbound dispatch dedupes on `sourceEventKey`, and a
+ * replay run carrying the real key would make the scheduler treat a later
+ * genuine delivery of that message as already handled.
+ */
+export function buildReplayRunSourceMetadata(params: {
+  trigger: AutomationInboundMessageTriggerDefinition;
+  message: InboundPreviewMessage;
+  now?: number;
+}): AutomationRunSourceMetadata {
+  const { message, trigger } = params;
+  const bounded = boundSourceText(message.text);
+  return {
+    kind: "messaging",
+    eventId: message.id,
+    sourceEventKey: `replay:${message.id}:${params.now ?? Date.now()}`,
+    receivedAt: message.receivedAt,
+    matchedTriggerId: trigger.id,
+    matchedTriggerName: trigger.name,
+    actor: {
+      platformUserId: message.actor.platformUserId,
+      ...(message.actor.displayName
+        ? { displayName: message.actor.displayName }
+        : {}),
+      ...(message.actor.isBot ? { isBot: true } : {}),
+    },
+    conversation: {
+      channel: message.provider,
+      conversationId: message.conversationId,
+      ...(message.parentId ? { parentId: message.parentId } : {}),
+      ...(trigger.conversation.conversationId === message.conversationId
+        && trigger.conversation.title
+        ? { title: trigger.conversation.title }
+        : {}),
+    },
+    ...(bounded
+      ? { message: { text: bounded.text, textTruncated: bounded.truncated } }
+      : {}),
   };
 }
 

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -787,11 +787,15 @@ export class DesktopAutomationService {
    * final line is the one carrying the turn's full totals.
    */
   private captureRunUsageFromPricingEvent(event: AgentEvent): void {
+    // Event shape is `{ threadId, pricing: { lines, summaries } }` — the
+    // registry's emitThreadPricingUpdated nests readThreadPricing's result
+    // under `pricing`, it does not spread it.
     const params = event.notification.params as
-      | { lines?: Array<Record<string, unknown>> }
+      | { pricing?: { lines?: Array<Record<string, unknown>> } }
       | undefined;
-    if (!Array.isArray(params?.lines)) return;
-    for (const line of params.lines) {
+    const lines = params?.pricing?.lines;
+    if (!Array.isArray(lines)) return;
+    for (const line of lines) {
       if (line.scope !== "turn" || typeof line.turnId !== "string") continue;
       const run =
         this.options.store.findRunningRunByBackendTurnId({

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -10,6 +10,7 @@ import type {
   AutomationMutationResponse,
   AutomationRunSummary,
   AutomationRunStatus,
+  AutomationRunUsage,
   AutomationRunTranscriptEvent,
   AutomationTimelineCard,
   AutomationTriggerDefinition,
@@ -213,14 +214,38 @@ export class DesktopAutomationService {
             if (request.threadId && automation.threadId !== request.threadId) return false;
             return true;
           });
+    const startOfToday = new Date();
+    startOfToday.setHours(0, 0, 0, 0);
+    const todayMs = startOfToday.getTime();
     return {
       automations: automations.map((automation) =>
         toAutomationDetail(
           automation,
           this.options.store.getLatestRunForAutomation(automation.id),
+          this.sumRunCostSince(automation.id, todayMs),
         ),
       ),
     };
+  }
+
+  /**
+   * Summed run cost since `sinceMs`, from retained runs. This is honest only
+   * within the run-history window — a lifetime total needs a denormalized
+   * counter that survives pruning, which is a schema change deferred on
+   * purpose.
+   */
+  private sumRunCostSince(automationId: string, sinceMs: number): number | undefined {
+    let total = 0;
+    let sawCost = false;
+    for (const run of this.options.store.listRunsForAutomation(automationId, 200)) {
+      const at = run.completedAt ?? run.startedAt;
+      if (at === undefined || at < sinceMs) continue;
+      if (typeof run.usage?.totalCostMicros === "number") {
+        total += run.usage.totalCostMicros;
+        sawCost = true;
+      }
+    }
+    return sawCost ? total : undefined;
   }
 
   /**
@@ -723,7 +748,64 @@ export class DesktopAutomationService {
     return this.options.store.buildThreadSummaries();
   }
 
+  /**
+   * Distill the pricing pipeline's turn-scope usage lines onto their runs.
+   *
+   * The registry already computes tokens AND list-price cost for every
+   * headless automation turn (recordLiveThreadUsage) — this just correlates
+   * the line to a run by backend turn id and freezes the numbers on the run
+   * payload. Lookup is any-status, not running-only: the final line can land
+   * after the turn-completion event has marked the run completed, and that
+   * final line is the one carrying the turn's full totals.
+   */
+  private captureRunUsageFromPricingEvent(event: AgentEvent): void {
+    const params = event.notification.params as
+      | { lines?: Array<Record<string, unknown>> }
+      | undefined;
+    if (!Array.isArray(params?.lines)) return;
+    for (const line of params.lines) {
+      if (line.scope !== "turn" || typeof line.turnId !== "string") continue;
+      const run =
+        this.options.store.findRunningRunByBackendTurnId({
+          backend: event.backend,
+          backendTurnId: line.turnId,
+        })
+        ?? this.options.store.findRunByBackendTurnId?.({
+          backend: event.backend,
+          backendTurnId: line.turnId,
+        });
+      if (!run) continue;
+      const usage: AutomationRunUsage = {
+        ...(typeof line.model === "string" ? { model: line.model } : {}),
+        ...(typeof line.uncachedInputTokens === "number"
+          ? { uncachedInputTokens: line.uncachedInputTokens }
+          : {}),
+        ...(typeof line.cachedInputTokens === "number"
+          ? { cachedInputTokens: line.cachedInputTokens }
+          : {}),
+        ...(typeof line.outputTokens === "number"
+          ? { outputTokens: line.outputTokens }
+          : {}),
+        ...(typeof line.reasoningOutputTokens === "number"
+          ? { reasoningOutputTokens: line.reasoningOutputTokens }
+          : {}),
+        ...(typeof line.totalTokens === "number"
+          ? { totalTokens: line.totalTokens }
+          : {}),
+        ...(typeof line.totalCostMicros === "number"
+          ? { totalCostMicros: line.totalCostMicros }
+          : {}),
+        ...(typeof line.currency === "string" ? { currency: line.currency } : {}),
+      };
+      this.options.store.setRunUsage({ runId: run.id, usage });
+    }
+  }
+
   private async handleRegistryEvent(event: AgentEvent): Promise<void> {
+    if (event.notification.method === "thread/pricing/updated") {
+      this.captureRunUsageFromPricingEvent(event);
+      return;
+    }
     if (event.notification.method !== "thread/turnQueue/updated") {
       await this.captureAutomationRunTranscriptEvent(event);
       if (isTerminalTurnNotification(event.notification)) {
@@ -1171,6 +1253,7 @@ function automationInspectionFailure(
 function toAutomationDetail(
   record: AutomationRecord,
   latestRun?: AutomationRunSummary,
+  costTodayMicros?: number,
 ): AutomationDetail {
   const latestRunAt = latestRun ? automationRunActivityAt(latestRun) : undefined;
   const useLatestRun =
@@ -1191,6 +1274,7 @@ function toAutomationDetail(
     backlogPolicy: record.backlogPolicy,
     executionProfile: record.executionProfile,
     priorRunLookback: record.priorRunLookback,
+    ...(costTodayMicros !== undefined ? { costTodayMicros } : {}),
     outputActions: record.outputActions,
     inboundCoalesceWindowMs: record.inboundCoalesceWindowMs,
     maxRunsPerHour: record.maxRunsPerHour,

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -77,6 +77,14 @@ const RUN_ACTOR_CACHE_TTL_MS = 30_000;
 /** Runs scanned for distinct actors. Bounds the read on a long-lived automation. */
 const RUN_ACTOR_SCAN_LIMIT = 200;
 
+/**
+ * How long a changed usage snapshot may sit in memory before its sqlite
+ * write. One second matches the registry's live token-usage flush window:
+ * pricing stays responsive while a streaming turn's repeated updates share
+ * one payload rewrite instead of taking one commit each.
+ */
+const RUN_USAGE_FLUSH_INTERVAL_MS = 1_000;
+
 let service: DesktopAutomationService | null = null;
 let storeOverride: AutomationStore | null = null;
 
@@ -120,6 +128,16 @@ export class DesktopAutomationService {
     { actors: MessagingDirectoryActor[]; readAt: number }
   >();
   private readonly automationsChangedListeners = new Set<() => void>();
+  /**
+   * Latest usage snapshot per run, waiting for one sqlite write. Pricing
+   * events carry cumulative totals, so repeated observations for a run
+   * replace each other in memory and only the newest needs to be durable —
+   * the same shape as the registry's live token-usage batching (PR #1417),
+   * at automation scale. Best-effort, not banking: a crash inside the flush
+   * window loses at most the last in-flight snapshot of a cost estimate.
+   */
+  private readonly pendingRunUsage = new Map<string, AutomationRunUsage>();
+  private pendingRunUsageTimer: NodeJS.Timeout | undefined;
 
   constructor(
     private readonly options: {
@@ -191,6 +209,11 @@ export class DesktopAutomationService {
     this.scheduler.stop();
     this.unsubscribeRegistryEvents?.();
     this.unsubscribeRegistryEvents = undefined;
+    if (this.pendingRunUsageTimer) {
+      clearTimeout(this.pendingRunUsageTimer);
+      this.pendingRunUsageTimer = undefined;
+    }
+    this.flushPendingRunUsage();
     this.options.registry.setAutomationInspectionHandler?.(null);
   }
 
@@ -829,7 +852,41 @@ export class DesktopAutomationService {
           : {}),
         ...(typeof line.currency === "string" ? { currency: line.currency } : {}),
       };
-      this.options.store.setRunUsage({ runId: run.id, usage });
+      this.bufferRunUsage(run, usage);
+    }
+  }
+
+  /**
+   * Debounced write path for run usage. A streaming turn emits pricing
+   * updates repeatedly, and each setRunUsage rewrites the whole run payload
+   * row — so identical snapshots are dropped, changed ones wait out one flush
+   * window, and terminal events drain their run immediately.
+   */
+  private bufferRunUsage(run: AutomationRunSummary, usage: AutomationRunUsage): void {
+    const current = this.pendingRunUsage.get(run.id) ?? run.usage;
+    if (current && automationRunUsageEquals(current, usage)) return;
+    this.pendingRunUsage.set(run.id, usage);
+    if (this.pendingRunUsageTimer) return;
+    const timer = setTimeout(() => {
+      this.pendingRunUsageTimer = undefined;
+      this.flushPendingRunUsage();
+    }, RUN_USAGE_FLUSH_INTERVAL_MS);
+    timer.unref?.();
+    this.pendingRunUsageTimer = timer;
+  }
+
+  private flushPendingRunUsage(runId?: string): void {
+    if (runId !== undefined) {
+      const usage = this.pendingRunUsage.get(runId);
+      if (!usage) return;
+      this.pendingRunUsage.delete(runId);
+      this.options.store.setRunUsage({ runId, usage });
+      return;
+    }
+    const entries = [...this.pendingRunUsage.entries()];
+    this.pendingRunUsage.clear();
+    for (const [id, usage] of entries) {
+      this.options.store.setRunUsage({ runId: id, usage });
     }
   }
 
@@ -867,6 +924,15 @@ export class DesktopAutomationService {
       errorMessage: params.errorMessage,
     });
     if (params.automationRunId) {
+      if (
+        params.status === "failed"
+        || params.status === "cancelled"
+        || params.status === "terminal"
+      ) {
+        // The run just ended — make whatever usage we have durable now. A
+        // final pricing line landing after this still flushes on the timer.
+        this.flushPendingRunUsage(params.automationRunId);
+      }
       await this.publishAutomationRunUpdate({
         backend: event.backend,
         runId: params.automationRunId,
@@ -913,6 +979,9 @@ export class DesktopAutomationService {
 
     const finalText = finalTextFromTerminalTurnNotification(event.notification);
     const errorMessage = errorMessageFromTerminalTurnNotification(event.notification);
+    // Turn end is a durability boundary for the debounced usage snapshot. A
+    // final pricing line arriving afterwards still flushes on the timer.
+    this.flushPendingRunUsage(activeRun.id);
     await this.scheduler.handleTurnQueueUpdate({
       automationRunId: activeRun.id,
       status: "terminal",
@@ -1631,4 +1700,21 @@ function summarizeAutomationCard(params: {
 function firstLine(value: string | undefined): string | undefined {
   const line = value?.split(/\r?\n/).find((candidate) => candidate.trim());
   return line?.trim();
+}
+
+/** Field-wise equality so unchanged pricing snapshots never schedule a write. */
+function automationRunUsageEquals(
+  a: AutomationRunUsage,
+  b: AutomationRunUsage,
+): boolean {
+  return (
+    a.model === b.model
+    && a.uncachedInputTokens === b.uncachedInputTokens
+    && a.cachedInputTokens === b.cachedInputTokens
+    && a.outputTokens === b.outputTokens
+    && a.reasoningOutputTokens === b.reasoningOutputTokens
+    && a.totalTokens === b.totalTokens
+    && a.totalCostMicros === b.totalCostMicros
+    && a.currency === b.currency
+  );
 }

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -20,10 +20,14 @@ import type {
   ListAutomationCardsResponse,
   ListAutomationRunsRequest,
   ListAutomationRunsResponse,
+  ListAutomationReplayCandidatesRequest,
+  ListAutomationReplayCandidatesResponse,
   ListAutomationsRequest,
   ListAutomationsResponse,
+  InboundPreviewMessage,
   MessagingChannelKind,
   MessagingSenderSuggestion,
+  ReplayAutomationInboundRequest,
   RunAutomationNowResponse,
   SearchMessagingSendersRequest,
   SearchMessagingSendersResponse,
@@ -55,6 +59,8 @@ import { AutomationScheduler } from "./automation-scheduler.js";
 import type { AutomationRecord, AutomationStore } from "./automation-store.js";
 import {
   anyAutomationInboundMatch,
+  buildAutomationReplayCandidates,
+  buildReplayRunSourceMetadata,
   matchAutomationInboundEvent,
 } from "./automation-trigger-matcher.js";
 import { mergeTranscriptEvents } from "./transcript-merge.js";
@@ -565,6 +571,85 @@ export class DesktopAutomationService {
     await this.notifyThreadAutomationsUpdated(automation);
     this.startSchedulerIfEnabled();
     return { automation: toAutomationDetail(automation) };
+  }
+
+  /**
+   * Recent messages from an inbound automation's trigger conversation, each
+   * pre-judged against the trigger's filter so the Replay picker can offer
+   * both positive tests (replay a matching message) and negative ones (see
+   * that a message would NOT have fired the automation).
+   */
+  async listReplayCandidates(
+    request: ListAutomationReplayCandidatesRequest,
+    deps: {
+      fetchRecent: (params: {
+        provider: MessagingChannelKind;
+        conversationId: string;
+        parentId?: string;
+        limit?: number;
+      }) => Promise<InboundPreviewMessage[]>;
+      supportsHistory: (provider: MessagingChannelKind) => boolean;
+    },
+  ): Promise<ListAutomationReplayCandidatesResponse> {
+    const automation = this.options.store.getAutomation(request.automationId);
+    if (!automation) {
+      throw new Error("Automation not found.");
+    }
+    const trigger = automation.triggers.find(
+      (candidate) => candidate.kind === "inbound_message",
+    );
+    if (trigger?.kind !== "inbound_message") {
+      return { candidates: [], supported: false };
+    }
+    if (!deps.supportsHistory(trigger.conversation.channel)) {
+      return { candidates: [], supported: false };
+    }
+    const messages = await deps.fetchRecent({
+      provider: trigger.conversation.channel,
+      conversationId: trigger.conversation.conversationId,
+      ...(trigger.conversation.parentId
+        ? { parentId: trigger.conversation.parentId }
+        : {}),
+      limit: 15,
+    });
+    return {
+      candidates: buildAutomationReplayCandidates(trigger, messages),
+      supported: true,
+    };
+  }
+
+  async replayInbound(
+    request: ReplayAutomationInboundRequest,
+  ): Promise<RunAutomationNowResponse> {
+    this.assertAutomationsEnabled();
+    const automation = this.options.store.getAutomation(request.automationId);
+    if (!automation) {
+      throw new Error("Automation not found.");
+    }
+    const trigger = automation.triggers.find(
+      (candidate) => candidate.kind === "inbound_message",
+    );
+    if (trigger?.kind !== "inbound_message") {
+      throw new Error("This automation has no inbound trigger to replay.");
+    }
+    const result = await this.scheduler.replayInboundRun({
+      automation,
+      source: buildReplayRunSourceMetadata({
+        trigger,
+        message: request.message,
+      }),
+    });
+    const [run] = this.options.store.listRunsForAutomation(request.automationId, 1);
+    if (!run) {
+      throw new Error("Automation not found.");
+    }
+    await this.notifyThreadAutomationsUpdated(automation);
+    return {
+      run,
+      queueStatus: result?.status ?? "failed",
+      queueEntryId: result?.entry.id,
+      turnId: result?.status === "started" ? result.turnId : undefined,
+    };
   }
 
   async runNow(request: AutomationIdRequest): Promise<RunAutomationNowResponse> {

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -119,6 +119,7 @@ export class DesktopAutomationService {
     string,
     { actors: MessagingDirectoryActor[]; readAt: number }
   >();
+  private readonly automationsChangedListeners = new Set<() => void>();
 
   constructor(
     private readonly options: {
@@ -198,6 +199,28 @@ export class DesktopAutomationService {
    * or a schedule/trigger shape this build predates). Surfaced to the renderer
    * so the user sees a warning instead of silently missing automations.
    */
+  /**
+   * Fires after any mutation that can change which conversations inbound
+   * automations watch (create/update/pause/resume/delete). The messaging
+   * runtime subscribes to keep adapters' observed-conversation sets current.
+   */
+  onAutomationsChanged(listener: () => void): () => void {
+    this.automationsChangedListeners.add(listener);
+    return () => {
+      this.automationsChangedListeners.delete(listener);
+    };
+  }
+
+  private notifyAutomationsChanged(): void {
+    for (const listener of [...this.automationsChangedListeners]) {
+      try {
+        listener();
+      } catch {
+        // A broken listener must not break the mutation that fired it.
+      }
+    }
+  }
+
   getLoadIssues(): AutomationLoadIssue[] {
     return this.options.store.getAutomationLoadIssues();
   }
@@ -467,6 +490,7 @@ export class DesktopAutomationService {
     });
     await this.notifyThreadAutomationsUpdated(automation);
     this.startSchedulerIfEnabled();
+    this.notifyAutomationsChanged();
     return { automation: toAutomationDetail(automation) };
   }
 
@@ -551,6 +575,7 @@ export class DesktopAutomationService {
     }
     await this.notifyThreadAutomationsUpdated(updated);
     this.startSchedulerIfEnabled();
+    this.notifyAutomationsChanged();
     return { automation: toAutomationDetail(updated) };
   }
 
@@ -569,6 +594,7 @@ export class DesktopAutomationService {
     );
     await this.notifyThreadAutomationsUpdated(automation);
     this.startSchedulerIfEnabled();
+    this.notifyAutomationsChanged();
     return { automation: toAutomationDetail(automation) };
   }
 
@@ -583,6 +609,7 @@ export class DesktopAutomationService {
     if (!automation) throw new Error("Automation not found.");
     await this.notifyThreadAutomationsUpdated(automation);
     this.startSchedulerIfEnabled();
+    this.notifyAutomationsChanged();
     return { automation: toAutomationDetail(automation) };
   }
 
@@ -595,6 +622,7 @@ export class DesktopAutomationService {
     if (!automation) throw new Error("Automation not found.");
     await this.notifyThreadAutomationsUpdated(automation);
     this.startSchedulerIfEnabled();
+    this.notifyAutomationsChanged();
     return { automation: toAutomationDetail(automation) };
   }
 

--- a/apps/desktop/src/main/ipc/automation-ipc.ts
+++ b/apps/desktop/src/main/ipc/automation-ipc.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from "electron";
+import { BrowserWindow, ipcMain } from "electron";
 import type {
   AutomationIdRequest,
   DraftAutomationPromptRequest,
@@ -16,6 +16,7 @@ import type {
   ListAutomationsResponse,
   ListAutomationReplayCandidatesRequest,
   ListAutomationReplayCandidatesResponse,
+  OpenAutomationRunWindowRequest,
   ReplayAutomationInboundRequest,
   RunAutomationNowResponse,
   SearchMessagingSendersRequest,
@@ -34,6 +35,7 @@ import {
   AUTOMATIONS_ALLOCATE_WORKSPACE_CHANNEL,
   AUTOMATIONS_LIST_REPLAY_CANDIDATES_CHANNEL,
   AUTOMATIONS_REPLAY_INBOUND_CHANNEL,
+  AUTOMATION_RUN_WINDOW_OPEN_CHANNEL,
   AUTOMATIONS_SEARCH_SENDERS_CHANNEL,
   AUTOMATIONS_PAUSE_CHANNEL,
   AUTOMATIONS_RESUME_CHANNEL,
@@ -47,6 +49,7 @@ import {
 import { generateAutomationPromptDraft } from "../app-server/automation-prompt-draft-service";
 import { getDesktopMessagingRuntime } from "../messaging/messaging-runtime";
 import { createScratchProjectDirectory } from "../app-server/scratch-projects";
+import { showAutomationRunWindow } from "../automation-run-window";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 
 export function registerAutomationIpcHandlers(): void {
@@ -151,6 +154,20 @@ export function registerAutomationIpcHandlers(): void {
         supportsHistory: (provider) =>
           getDesktopMessagingRuntime().supportsPreviewHistory(provider),
       }),
+  );
+
+  ipcMain.removeHandler(AUTOMATION_RUN_WINDOW_OPEN_CHANNEL);
+  ipcMain.handle(
+    AUTOMATION_RUN_WINDOW_OPEN_CHANNEL,
+    async (
+      event,
+      request: OpenAutomationRunWindowRequest,
+    ): Promise<{ opened: true }> => {
+      showAutomationRunWindow(request, {
+        sourceWindow: BrowserWindow.fromWebContents(event.sender) ?? undefined,
+      });
+      return { opened: true };
+    },
   );
 
   ipcMain.removeHandler(AUTOMATIONS_REPLAY_INBOUND_CHANNEL);

--- a/apps/desktop/src/main/ipc/automation-ipc.ts
+++ b/apps/desktop/src/main/ipc/automation-ipc.ts
@@ -14,6 +14,9 @@ import type {
   ListAutomationRunsResponse,
   ListAutomationsRequest,
   ListAutomationsResponse,
+  ListAutomationReplayCandidatesRequest,
+  ListAutomationReplayCandidatesResponse,
+  ReplayAutomationInboundRequest,
   RunAutomationNowResponse,
   SearchMessagingSendersRequest,
   SearchMessagingSendersResponse,
@@ -29,6 +32,8 @@ import {
   AUTOMATIONS_LIST_RUNS_CHANNEL,
   AUTOMATIONS_LOAD_ISSUES_CHANNEL,
   AUTOMATIONS_ALLOCATE_WORKSPACE_CHANNEL,
+  AUTOMATIONS_LIST_REPLAY_CANDIDATES_CHANNEL,
+  AUTOMATIONS_REPLAY_INBOUND_CHANNEL,
   AUTOMATIONS_SEARCH_SENDERS_CHANNEL,
   AUTOMATIONS_PAUSE_CHANNEL,
   AUTOMATIONS_RESUME_CHANNEL,
@@ -131,6 +136,31 @@ export function registerAutomationIpcHandlers(): void {
     async (): Promise<{ path: string }> => ({
       path: await createScratchProjectDirectory(),
     }),
+  );
+
+  ipcMain.removeHandler(AUTOMATIONS_LIST_REPLAY_CANDIDATES_CHANNEL);
+  ipcMain.handle(
+    AUTOMATIONS_LIST_REPLAY_CANDIDATES_CHANNEL,
+    async (
+      _event,
+      request: ListAutomationReplayCandidatesRequest,
+    ): Promise<ListAutomationReplayCandidatesResponse> =>
+      getDesktopAutomationService().listReplayCandidates(request, {
+        fetchRecent: (params) =>
+          getDesktopMessagingRuntime().fetchRecentPreviewMessages(params),
+        supportsHistory: (provider) =>
+          getDesktopMessagingRuntime().supportsPreviewHistory(provider),
+      }),
+  );
+
+  ipcMain.removeHandler(AUTOMATIONS_REPLAY_INBOUND_CHANNEL);
+  ipcMain.handle(
+    AUTOMATIONS_REPLAY_INBOUND_CHANNEL,
+    async (
+      _event,
+      request: ReplayAutomationInboundRequest,
+    ): Promise<RunAutomationNowResponse> =>
+      getDesktopAutomationService().replayInbound(request),
   );
 
   ipcMain.removeHandler(AUTOMATIONS_SEARCH_SENDERS_CHANNEL);

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -773,12 +773,6 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   }
 
   /**
-   * Fetch recent messages for the Automations editor live preview. Delegates
-   * to the provider adapter's optional history fetch (Slack today), maps to the
-   * compact preview shape, and filters to the requested conversation scope.
-   * Returns `[]` when the provider has no history support or the call fails.
-   */
-  /**
    * Whether a provider's adapter can read recent conversation history (Slack
    * today). Callers use this to tell "no history support" apart from "the
    * conversation is simply empty", which fetchRecentPreviewMessages cannot.
@@ -788,6 +782,12 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     return Boolean(adapter?.fetchRecentMessages);
   }
 
+  /**
+   * Fetch recent messages for the Automations editor live preview. Delegates
+   * to the provider adapter's optional history fetch (Slack today), maps to the
+   * compact preview shape, and filters to the requested conversation scope.
+   * Returns `[]` when the provider has no history support or the call fails.
+   */
   async fetchRecentPreviewMessages(params: {
     provider: MessagingChannelKind;
     conversationId: string;

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -116,14 +116,20 @@ export type DesktopMessagingAdapter = {
    */
   searchDirectoryActors?: MessagingAdapter["searchDirectoryActors"];
   /**
+   * Push the set of conversations automations observe. Adapters forward all
+   * senders' messages there flagged observedOnly instead of dropping them at
+   * the per-user access gate.
+   */
+  updateObservedConversations?: (conversationIds: readonly string[]) => void;
+  /**
    * Optional history fetch for the Automations editor live preview. Providers
    * that can read recent conversation messages (e.g. Slack) implement this;
    * others omit it and the preview falls back to going-forward capture.
    */
-  fetchRecentMessages?(request: {
+  fetchRecentMessages?: (request: {
     conversationId: string;
     limit?: number;
-  }): Promise<MessagingInboundEvent[]>;
+  }) => Promise<MessagingInboundEvent[]>;
   /**
    * Optional subscription for serious runtime errors after a successful
    * start (e.g. Telegram's 409 Conflict when a second bot instance starts
@@ -341,6 +347,7 @@ export type CredentialValidationRequest =
 
 export class DesktopMessagingRuntime implements MessagingAgentToolService {
   private adapters: DesktopMessagingAdapter[] = [];
+  private automationsChangedUnsubscribe?: () => void;
   private controllers: MessagingController[] = [];
   private readonly runningAdapters = new Map<
     MessagingChannelKind,
@@ -481,6 +488,8 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   private async stopNow(
     options: { preserveStartupFailures?: boolean } = {},
   ): Promise<void> {
+    this.automationsChangedUnsubscribe?.();
+    this.automationsChangedUnsubscribe = undefined;
     if (!this.started) {
       if (!options.preserveStartupFailures) {
         this.clearRetainedStartupFailures();
@@ -811,6 +820,54 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       }
     }
     return messages;
+  }
+
+  /**
+   * Conversations an enabled inbound automation watches on this platform.
+   * These become the adapter's observed set: all senders' messages there are
+   * forwarded (flagged observedOnly) instead of dying at the per-user gate —
+   * which is what lets a sender filter see bot alerts at all.
+   */
+  private collectAutomationObservedConversations(
+    platform: MessagingChannelKind,
+  ): string[] {
+    try {
+      const ids = new Set<string>();
+      for (const automation of getDesktopAutomationService().list({}).automations) {
+        if (automation.status !== "enabled") continue;
+        for (const trigger of automation.triggers) {
+          if (trigger.kind !== "inbound_message") continue;
+          if (trigger.conversation.channel !== platform) continue;
+          ids.add(trigger.conversation.conversationId);
+          if (trigger.conversation.parentId) {
+            ids.add(trigger.conversation.parentId);
+          }
+        }
+      }
+      return [...ids];
+    } catch (error) {
+      messagingLog.warn("failed to collect observed conversations", {
+        platform,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
+  }
+
+  /** Re-push the observed-conversation sets to every running adapter. */
+  pushObservedConversations(): void {
+    for (const adapter of this.adapters) {
+      try {
+        adapter.updateObservedConversations?.(
+          this.collectAutomationObservedConversations(adapter.channel),
+        );
+      } catch (error) {
+        messagingLog.warn("failed to push observed conversations", {
+          platform: adapter.channel,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
   }
 
   /**
@@ -1239,6 +1296,19 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     if (this.options.automationInboundMatches?.(event)) {
       return false;
     }
+    // The message is about to be dropped by mention-only mode after matching
+    // no automation filter. This is the correct outcome for ordinary chatter,
+    // but it is also exactly where a misconfigured filter (wrong sender id,
+    // typo'd text) disappears without a trace — so leave a debug breadcrumb
+    // an operator can find in the profile log.
+    messagingLog.debug("mention-only drop: no automation filter matched", {
+      platform: event.channel.channel,
+      conversationId: event.channel.conversation.id,
+      actorId: event.actor.platformUserId,
+      actorIsBot: event.actor.isBot === true,
+      kind: event.kind,
+      textLength: "text" in event ? event.text?.length ?? 0 : 0,
+    });
     return true;
   }
 
@@ -1343,6 +1413,30 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         // the surface before actor and ambient-message gates so an approved
         // channel remains selectable even when this sender cannot steer Agents.
         await this.recordObservedSurface(store, event.channel, event.receivedAt);
+        if (
+          (event.kind === "text" || event.kind === "media")
+          && event.observedOnly === true
+        ) {
+          // Observed-only traffic exists for automations and the editor's
+          // live preview; it must never reach the controller's reply/command
+          // path — the sender did not clear the per-user access gate.
+          this.recordActivityFromInbound(adapter.channel, event, false);
+          publishInboundPreview(event);
+          if (this.options.automationInboundMatches?.(event)) {
+            await this.options.automationInboundHandler?.(event);
+          } else {
+            messagingLog.debug(
+              "observed-only message matched no automation filter",
+              {
+                platform: adapter.channel,
+                conversationId: event.channel.conversation.id,
+                actorId: event.actor.platformUserId,
+                actorIsBot: event.actor.isBot === true,
+              },
+            );
+          }
+          return;
+        }
         const authorized = authorization.actorIdSet.has(event.actor.platformUserId);
         if (
           authorized &&
@@ -1727,6 +1821,20 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     const running = [...this.runningAdapters.values()];
     this.adapters = running.map((record) => record.adapter);
     this.controllers = running.map((record) => record.controller);
+    // The automation service may be unavailable (unit harnesses, an app
+    // instance with automations disabled); messaging must start regardless —
+    // observed sets simply stay empty.
+    try {
+      this.pushObservedConversations();
+      if (!this.automationsChangedUnsubscribe) {
+        this.automationsChangedUnsubscribe = getDesktopAutomationService()
+          .onAutomationsChanged(() => this.pushObservedConversations());
+      }
+    } catch (error) {
+      messagingLog.debug("observed-conversation sync unavailable", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   private async dispatchRevokeToControllers(

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -769,6 +769,16 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
    * compact preview shape, and filters to the requested conversation scope.
    * Returns `[]` when the provider has no history support or the call fails.
    */
+  /**
+   * Whether a provider's adapter can read recent conversation history (Slack
+   * today). Callers use this to tell "no history support" apart from "the
+   * conversation is simply empty", which fetchRecentPreviewMessages cannot.
+   */
+  supportsPreviewHistory(provider: MessagingChannelKind): boolean {
+    const adapter = this.adapters.find((entry) => entry.channel === provider);
+    return Boolean(adapter?.fetchRecentMessages);
+  }
+
   async fetchRecentPreviewMessages(params: {
     provider: MessagingChannelKind;
     conversationId: string;

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -816,9 +816,19 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         message.conversationId === params.conversationId ||
         message.parentId === params.conversationId
       ) {
-        messages.push(message);
+        messages.push({ ...message, origin: "history" });
       }
     }
+    // Breadcrumb for "why is the preview showing X": records exactly which
+    // conversation the provider was asked for and how much survived the
+    // conversation-scope check, so a suspected cross-channel leak can be
+    // ruled in or out from the profile log.
+    messagingLog.debug("preview history backfill", {
+      provider: params.provider,
+      conversationId: params.conversationId,
+      fetched: events.length,
+      forwarded: messages.length,
+    });
     return messages;
   }
 

--- a/apps/desktop/src/main/window-channels.ts
+++ b/apps/desktop/src/main/window-channels.ts
@@ -39,6 +39,7 @@ export const WINDOW_KIND_LICENSE_DOCUMENT = "license-document" as const;
 export const WINDOW_KIND_APP_LOGS = "app-logs" as const;
 export const WINDOW_KIND_MARKDOWN_FILES = "markdown-files" as const;
 export const WINDOW_KIND_SUB_AGENT_TRANSCRIPT = "sub-agent-transcript" as const;
+export const WINDOW_KIND_AUTOMATION_RUN = "automation-run" as const;
 export type WindowKind =
   | typeof WINDOW_KIND_MAIN
   | typeof WINDOW_KIND_MESSAGING_ACTIVITY
@@ -46,6 +47,7 @@ export type WindowKind =
   | typeof WINDOW_KIND_LICENSE_DOCUMENT
   | typeof WINDOW_KIND_APP_LOGS
   | typeof WINDOW_KIND_MARKDOWN_FILES
+  | typeof WINDOW_KIND_AUTOMATION_RUN
   | typeof WINDOW_KIND_SUB_AGENT_TRANSCRIPT;
 
 interface Entry {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -35,6 +35,7 @@ import type {
   ListAutomationCardsResponse,
   ListAutomationReplayCandidatesRequest,
   ListAutomationReplayCandidatesResponse,
+  OpenAutomationRunWindowRequest,
   ReplayAutomationInboundRequest,
   SearchMessagingSendersRequest,
   SearchMessagingSendersResponse,
@@ -454,6 +455,7 @@ import {
   AUTOMATIONS_ALLOCATE_WORKSPACE_CHANNEL,
   AUTOMATIONS_LIST_REPLAY_CANDIDATES_CHANNEL,
   AUTOMATIONS_REPLAY_INBOUND_CHANNEL,
+  AUTOMATION_RUN_WINDOW_OPEN_CHANNEL,
   AUTOMATIONS_SEARCH_SENDERS_CHANNEL,
   AUTOMATIONS_PAUSE_CHANNEL,
   AUTOMATIONS_RESUME_CHANNEL,
@@ -911,6 +913,10 @@ const desktopApi = Object.freeze({
     request: ReplayAutomationInboundRequest,
   ): Promise<RunAutomationNowResponse> =>
     await ipcRenderer.invoke(AUTOMATIONS_REPLAY_INBOUND_CHANNEL, request),
+  openAutomationRunWindow: async (
+    request: OpenAutomationRunWindowRequest,
+  ): Promise<{ opened: true }> =>
+    await ipcRenderer.invoke(AUTOMATION_RUN_WINDOW_OPEN_CHANNEL, request),
   getAutomationRunArtifact: async (
     request: GetAutomationRunArtifactRequest,
   ): Promise<GetAutomationRunArtifactResponse> =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -33,6 +33,9 @@ import type {
   StopSubAgentResponse,
   ListAutomationCardsRequest,
   ListAutomationCardsResponse,
+  ListAutomationReplayCandidatesRequest,
+  ListAutomationReplayCandidatesResponse,
+  ReplayAutomationInboundRequest,
   SearchMessagingSendersRequest,
   SearchMessagingSendersResponse,
   ListAutomationLoadIssuesResponse,
@@ -449,6 +452,8 @@ import {
   AUTOMATIONS_LIST_RUNS_CHANNEL,
   AUTOMATIONS_LOAD_ISSUES_CHANNEL,
   AUTOMATIONS_ALLOCATE_WORKSPACE_CHANNEL,
+  AUTOMATIONS_LIST_REPLAY_CANDIDATES_CHANNEL,
+  AUTOMATIONS_REPLAY_INBOUND_CHANNEL,
   AUTOMATIONS_SEARCH_SENDERS_CHANNEL,
   AUTOMATIONS_PAUSE_CHANNEL,
   AUTOMATIONS_RESUME_CHANNEL,
@@ -898,6 +903,14 @@ const desktopApi = Object.freeze({
     await ipcRenderer.invoke(AUTOMATIONS_SEARCH_SENDERS_CHANNEL, request),
   allocateAutomationWorkspace: async (): Promise<{ path: string }> =>
     await ipcRenderer.invoke(AUTOMATIONS_ALLOCATE_WORKSPACE_CHANNEL),
+  listAutomationReplayCandidates: async (
+    request: ListAutomationReplayCandidatesRequest,
+  ): Promise<ListAutomationReplayCandidatesResponse> =>
+    await ipcRenderer.invoke(AUTOMATIONS_LIST_REPLAY_CANDIDATES_CHANNEL, request),
+  replayAutomationInbound: async (
+    request: ReplayAutomationInboundRequest,
+  ): Promise<RunAutomationNowResponse> =>
+    await ipcRenderer.invoke(AUTOMATIONS_REPLAY_INBOUND_CHANNEL, request),
   getAutomationRunArtifact: async (
     request: GetAutomationRunArtifactRequest,
   ): Promise<GetAutomationRunArtifactResponse> =>

--- a/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
@@ -43,6 +43,7 @@ import {
 import { copyText } from "../../lib/copy-text";
 import { HelpCircleIcon } from "../../icons";
 import { AutomationConditionEditor } from "./AutomationConditionEditor";
+import { formatAutomationRelative } from "./automation-format";
 import { AutomationMcpPicker } from "./AutomationMcpPicker";
 import { ProjectPicker } from "../composer/ProjectPicker";
 import { ComposerDropdown } from "../composer/ComposerDropdown";
@@ -1569,8 +1570,9 @@ export function AutomationEditor(props: AutomationEditorProps) {
                       {previewOpen && previewConversationId ? (
                         <div className="automation-preview__panel" role="status">
                           <p className="automation-field__hint">
-                            Showing messages as they arrive (no history). Messages your
-                            filter would match are highlighted.
+                            Showing recent history where the platform allows it, then
+                            messages as they arrive. Messages your filter would match
+                            are highlighted.
                           </p>
                           {previewMessages.length === 0 ? (
                             <p className="automation-preview__empty">
@@ -1598,6 +1600,13 @@ export function AutomationEditor(props: AutomationEditorProps) {
                                           {message.actor.platformUserId}
                                         </span>
                                       ) : null}
+                                      <span className="automation-preview__time">
+                                        {message.origin === "history"
+                                          ? `history · ${formatAutomationRelative(
+                                              message.receivedAt,
+                                            )}`
+                                          : formatAutomationRelative(message.receivedAt)}
+                                      </span>
                                     </span>
                                     <span className="automation-preview__text">
                                       {message.text || "(no text)"}
@@ -2125,7 +2134,7 @@ export function AutomationEditor(props: AutomationEditorProps) {
 
         <AutomationStage verb="Deliver" title="Where results go">
           <div className="automation-lanes">
-            <div className="automation-lane automation-lane--agent">
+            <div className="automation-lane automation-lane--active">
               <span className="automation-lane__tag">Agent thread · always</span>
               {shouldShowAgentPicker(props) ? (
                 <div className="automation-field automation-agent-field">
@@ -2304,7 +2313,13 @@ export function AutomationEditor(props: AutomationEditorProps) {
               </p>
             </div>
             {triggerKind === "inbound_message" ? (
-              <div className="automation-lane">
+              <div
+                className={
+                  resultMode === "agent_only"
+                    ? "automation-lane"
+                    : "automation-lane automation-lane--active"
+                }
+              >
                 <span className="automation-lane__tag">Messaging · optional</span>
                       <div className="automation-field-group">
                         <label className="automation-field">

--- a/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
@@ -424,6 +424,47 @@ export function AutomationEditor(props: AutomationEditorProps) {
   const selectedGroup = telegramGroups.find(
     (group) => group.id === groupSelection,
   );
+
+  // Same reconciliation the destination picker does below: `groupSelection`
+  // starts at MANUAL_GROUP_VALUE when editing (the catalog loads async), so
+  // without this, reopening an automation shows "Enter Channel ID manually…"
+  // with the raw platform id even though the catalog lists the channel by
+  // name. Runs once on the first catalog load that contains the initial id,
+  // and bails the moment the operator changes the conversation.
+  const inboundSelectionReconciledRef = useRef(false);
+  const initialInboundGroupId = initialIsTopic
+    ? initialConversation?.parentId
+    : initialConversation?.conversationId;
+  useEffect(() => {
+    if (inboundSelectionReconciledRef.current) return;
+    if (!initialConversation || !initialInboundGroupId) return;
+    if (inboundProvider !== initialConversation.channel) return;
+    if (inboundGroupId !== initialInboundGroupId) return;
+    const match = telegramGroups.find(
+      (group) => group.id === initialInboundGroupId,
+    );
+    if (!match) return;
+    setGroupSelection(match.id);
+    inboundSelectionReconciledRef.current = true;
+  }, [
+    telegramGroups,
+    inboundGroupId,
+    inboundProvider,
+    initialConversation,
+    initialInboundGroupId,
+  ]);
+
+  // The title snapshot stored on the trigger keeps naming the conversation
+  // even when the settings catalog does not list it (or has not loaded yet),
+  // as long as the operator has not pointed the trigger elsewhere.
+  const storedGroupTitle =
+    initialConversation
+    && inboundProvider === initialConversation.channel
+    && inboundGroupId.trim() === initialInboundGroupId
+      ? (initialIsTopic
+          ? initialConversation.parentTitle
+          : initialConversation.title)
+      : undefined;
   const destGroups = useMemo(
     () => providerGroups[destProvider] ?? [],
     [destProvider, providerGroups],
@@ -748,6 +789,7 @@ export function AutomationEditor(props: AutomationEditorProps) {
   const inboundConversationLabel =
     selectedGroup?.title
     ?? capturedGroupTitle
+    ?? storedGroupTitle
     ?? (inboundGroupId.trim() || "this conversation");
 
   const inboundFilterSummary =
@@ -1053,7 +1095,7 @@ export function AutomationEditor(props: AutomationEditorProps) {
       broadcast: sourceReplyBroadcast,
       conditionGroup: stampConditionLabels(inboundConditions, senderLabels),
       groupId: inboundGroupId,
-      groupTitle: selectedGroup?.title ?? capturedGroupTitle,
+      groupTitle: selectedGroup?.title ?? capturedGroupTitle ?? storedGroupTitle,
       includeThreadReplies: inboundIncludeReplies,
       provider: inboundProvider,
       replyDestination,

--- a/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
@@ -256,7 +256,19 @@ export function AutomationEditor(props: AutomationEditorProps) {
             ],
           },
     );
-  const [senderLabels, setSenderLabels] = useState<Record<string, string>>({});
+  // Seeded from the persisted valueLabels so reopening the editor shows
+  // "datadog", not the opaque platform id captured at selection time.
+  const [senderLabels, setSenderLabels] = useState<Record<string, string>>(() => {
+    if (!initialInboundTrigger) return {};
+    const labels: Record<string, string> = {};
+    for (const condition of normalizeInboundTriggerConditions(initialInboundTrigger)
+      .conditions) {
+      for (const [value, label] of Object.entries(condition.valueLabels ?? {})) {
+        labels[value] = label;
+      }
+    }
+    return labels;
+  });
   const [inboundIncludeReplies, setInboundIncludeReplies] = useState(
     initialInboundTrigger?.includeThreadReplies ?? false,
   );
@@ -1038,7 +1050,7 @@ export function AutomationEditor(props: AutomationEditorProps) {
     }
     const triggerConfig = buildTriggerConfig({
       broadcast: sourceReplyBroadcast,
-      conditionGroup: inboundConditions,
+      conditionGroup: stampConditionLabels(inboundConditions, senderLabels),
       groupId: inboundGroupId,
       groupTitle: selectedGroup?.title ?? capturedGroupTitle,
       includeThreadReplies: inboundIncludeReplies,
@@ -2739,6 +2751,32 @@ function includeCurrentOption(
   return trimmed && !options.includes(trimmed)
     ? [trimmed, ...options]
     : [...options];
+}
+
+/**
+ * Persist the display names the picker resolved onto the conditions
+ * themselves. Without this the labels die with the editor session, and every
+ * later surface — reopening the editor, the list screen's trigger summary —
+ * falls back to raw platform ids.
+ */
+function stampConditionLabels(
+  group: AutomationInboundConditionGroup,
+  senderLabels: Record<string, string>,
+): AutomationInboundConditionGroup {
+  return {
+    ...group,
+    conditions: group.conditions.map((condition) => {
+      if (condition.field !== "sender") return condition;
+      const valueLabels: Record<string, string> = {};
+      for (const value of condition.values) {
+        const label = senderLabels[value] ?? condition.valueLabels?.[value];
+        if (label && label !== value) valueLabels[value] = label;
+      }
+      return Object.keys(valueLabels).length > 0
+        ? { ...condition, valueLabels }
+        : condition;
+    }),
+  };
 }
 
 function buildTriggerConfig(params: {

--- a/apps/desktop/src/renderer/src/features/automations/AutomationRunWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationRunWindow.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useState } from "react";
+import type { AutomationDetail, AutomationRunSummary } from "@pwragent/shared";
+import { CloseIcon } from "../../icons";
+import { useDesktopApi } from "../../lib/desktop-api";
+import { AutomationRunArtifactDetails } from "./ThreadAutomationsPanel";
+import { useAutomationRunArtifact } from "./useAutomations";
+import {
+  formatAutomationRunUsage,
+  formatAutomationTimestamp,
+  formatRunStatus,
+} from "./automation-format";
+
+type AutomationRunTarget = {
+  automationId: string;
+  runId: string;
+};
+
+/**
+ * Inspection-only window for one automation run's captured events.
+ *
+ * Hash contract: `automation-run/<automationId>/<runId>`, each segment
+ * URI-encoded (see main-process automation-run-window.ts). The window fetches
+ * authoritative run + artifact data over normal IPC rather than trusting
+ * anything beyond the two ids.
+ */
+export function AutomationRunWindow() {
+  const desktopApi = useDesktopApi();
+  const target = useMemo(() => automationRunTargetFromHash(), []);
+  const [automation, setAutomation] = useState<AutomationDetail>();
+  const [run, setRun] = useState<AutomationRunSummary>();
+  const [error, setError] = useState<string>();
+  const [loading, setLoading] = useState(Boolean(target));
+  const artifact = useAutomationRunArtifact(desktopApi, target?.runId);
+
+  useEffect(() => {
+    if (!target) {
+      setError("This automation run address is invalid.");
+      setLoading(false);
+      return;
+    }
+    const listAutomations = desktopApi?.listAutomations;
+    const listRuns = desktopApi?.listAutomationRuns;
+    if (!listAutomations || !listRuns) {
+      setError("The desktop bridge is unavailable.");
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [automationsResponse, runsResponse] = await Promise.all([
+          listAutomations({}),
+          listRuns({ automationId: target.automationId }),
+        ]);
+        if (cancelled) return;
+        setAutomation(
+          automationsResponse.automations.find(
+            (candidate) => candidate.id === target.automationId,
+          ),
+        );
+        setRun(
+          runsResponse.runs.find((candidate) => candidate.id === target.runId),
+        );
+      } catch (caught) {
+        if (!cancelled) {
+          setError(caught instanceof Error ? caught.message : String(caught));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [desktopApi, target]);
+
+  const usageLine = formatAutomationRunUsage(run?.usage);
+
+  return (
+    <div className="automation-run-window">
+      <section aria-label="Automation run" className="activity-screen">
+        <header className="activity-titlebar">
+          <p className="activity-titlebar__brand">
+            Pwr<span className="activity-titlebar__brand-accent">Agent</span>
+          </p>
+          <div
+            className="activity-titlebar__breadcrumb"
+            aria-label="Automations > Run"
+          >
+            <span className="activity-titlebar__eyebrow">Automations</span>
+            <span aria-hidden="true" className="activity-titlebar__separator">
+              ›
+            </span>
+            <span className="activity-titlebar__current">
+              {automation?.name ?? "Run"}
+            </span>
+          </div>
+          <div className="activity-titlebar__spacer" />
+        </header>
+
+        <main className="automation-run-window__content">
+          <header className="automation-run-window__header">
+            <div className="automation-run-window__identity">
+              <h1>{automation?.name ?? "Automation run"}</h1>
+              {run ? (
+                <p>
+                  <span
+                    className={`automation-run-status automation-run-status--${run.status}`}
+                  >
+                    {formatRunStatus(run.status)}
+                  </span>
+                  <span>
+                    {run.trigger} ·{" "}
+                    {formatAutomationTimestamp(
+                      run.completedAt ?? run.startedAt ?? run.queuedAt,
+                    )}
+                  </span>
+                  {usageLine ? <span>{usageLine}</span> : null}
+                </p>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              className="automation-run-window__close"
+              aria-label="Close window"
+              title="Close"
+              onClick={() => window.close()}
+            >
+              <CloseIcon size={18} aria-hidden="true" />
+            </button>
+          </header>
+
+          {error ? (
+            <p className="automations-error" role="alert">
+              {error}
+            </p>
+          ) : loading ? (
+            <p className="automation-run-history__time">Loading run…</p>
+          ) : !run ? (
+            <p className="automation-run-history__time">
+              This run is no longer in the retained history.
+            </p>
+          ) : (
+            <div className="automation-run-history">
+              <AutomationRunArtifactDetails
+                backendThreadId={run.backendThreadId}
+                backendTurnId={run.backendTurnId}
+                error={artifact.error}
+                finalText={artifact.artifact?.finalText}
+                loading={artifact.loading}
+                outputDecision={artifact.artifact?.outputDecision?.kind}
+                rollout={artifact.rollout}
+                scheduledWindows={run.scheduledWindows}
+                status={run.status}
+                transcriptEvents={artifact.artifact?.transcriptEvents ?? []}
+              />
+            </div>
+          )}
+        </main>
+      </section>
+    </div>
+  );
+}
+
+function automationRunTargetFromHash(): AutomationRunTarget | undefined {
+  const hash = window.location.hash.replace(/^#/, "");
+  if (!hash.startsWith("automation-run/")) return undefined;
+  const segments = hash.split("/").slice(1);
+  const automationId = segments[0] ? decodeURIComponent(segments[0]) : "";
+  const runId = segments[1] ? decodeURIComponent(segments[1]) : "";
+  if (!automationId || !runId) return undefined;
+  return { automationId, runId };
+}

--- a/apps/desktop/src/renderer/src/features/automations/AutomationSenderPicker.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationSenderPicker.tsx
@@ -212,6 +212,13 @@ export function AutomationSenderPicker(
                     type="button"
                     className="automation-sender-picker__option"
                     key={actor.platformUserId}
+                    title={[
+                      actor.displayName ?? actor.username ?? actor.platformUserId,
+                      actor.username ? `@${actor.username}` : undefined,
+                      actor.platformUserId,
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")}
                     onClick={() => select(actor)}
                   >
                     <span
@@ -225,6 +232,11 @@ export function AutomationSenderPicker(
                     <span className="automation-sender-picker__name">
                       {actor.displayName ?? actor.username ?? actor.platformUserId}
                     </span>
+                    {actor.username && actor.username !== actor.displayName ? (
+                      <span className="automation-sender-picker__username">
+                        @{actor.username}
+                      </span>
+                    ) : undefined}
                     {actor.isBot ? (
                       <span className="automation-sender-picker__badge">BOT</span>
                     ) : undefined}

--- a/apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from "react";
 import type {
   AutomationDetail,
+  AutomationReplayCandidate,
+  ListAutomationReplayCandidatesResponse,
   MessagingChannelKind,
   NavigationDirectorySummary,
   NavigationThreadSummary,
@@ -224,6 +226,11 @@ export function AutomationsScreen(props: AutomationsScreenProps) {
                       setExpandedAutomationId(automation.id);
                       await props.onRefreshNavigation?.();
                     }}
+                    onReplayed={async () => {
+                      await automations.refresh();
+                      setExpandedAutomationId(automation.id);
+                      await props.onRefreshNavigation?.();
+                    }}
                     onSelectThread={
                       thread && props.onSelectThread
                         ? () => props.onSelectThread?.(thread)
@@ -248,11 +255,50 @@ function AutomationTableRow(props: {
   onEdit: () => void;
   onExpand: () => void;
   onPauseResume: () => Promise<void>;
+  onReplayed?: () => Promise<void>;
   onRunNow: () => Promise<void>;
   onSelectThread?: () => void;
   thread?: NavigationThreadSummary;
 }) {
   const [busy, setBusy] = useState<string>();
+  const [replayOpen, setReplayOpen] = useState(false);
+  const [replayCandidates, setReplayCandidates] =
+    useState<ListAutomationReplayCandidatesResponse>();
+  const [replayError, setReplayError] = useState<string>();
+  const inboundTriggered = props.automation.triggers.some(
+    (trigger) => trigger.kind === "inbound_message",
+  );
+
+  const toggleReplay = async (): Promise<void> => {
+    if (replayOpen) {
+      setReplayOpen(false);
+      return;
+    }
+    setReplayOpen(true);
+    setReplayError(undefined);
+    setReplayCandidates(undefined);
+    try {
+      const response = await props.desktopApi?.listAutomationReplayCandidates?.({
+        automationId: props.automation.id,
+      });
+      setReplayCandidates(
+        response ?? { candidates: [], supported: false },
+      );
+    } catch (caught) {
+      setReplayError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const replayMessage = async (
+    candidate: AutomationReplayCandidate,
+  ): Promise<void> => {
+    await props.desktopApi?.replayAutomationInbound?.({
+      automationId: props.automation.id,
+      message: candidate.message,
+    });
+    setReplayOpen(false);
+    await props.onReplayed?.();
+  };
   const runAction = async (
     action: string,
     callback: () => Promise<void>,
@@ -297,14 +343,25 @@ function AutomationTableRow(props: {
           <p>{formatAutomationLatestRun(props.automation)}</p>
         </div>
         <div className="automations-table__actions" role="cell">
-          <button
-            className="context-list__action"
-            disabled={Boolean(busy)}
-            type="button"
-            onClick={() => void runAction("run", props.onRunNow)}
-          >
-            Run
-          </button>
+          {inboundTriggered ? (
+            <button
+              className="context-list__action"
+              disabled={Boolean(busy)}
+              type="button"
+              onClick={() => void toggleReplay()}
+            >
+              Replay
+            </button>
+          ) : (
+            <button
+              className="context-list__action"
+              disabled={Boolean(busy)}
+              type="button"
+              onClick={() => void runAction("run", props.onRunNow)}
+            >
+              Run
+            </button>
+          )}
           <button className="context-list__action" type="button" onClick={props.onEdit}>
             Edit
           </button>
@@ -329,6 +386,70 @@ function AutomationTableRow(props: {
           </button>
         </div>
       </article>
+      {replayOpen ? (
+        <div className="automations-table__replay">
+          <p className="automations-table__replay-lead">
+            Replay a recent message from the trigger conversation. The badge is
+            the filter&rsquo;s live verdict — replaying a non-matching message
+            is a way to test what the automation would do if the filter let it
+            through.
+          </p>
+          {replayError ? (
+            <p className="automations-error" role="alert">
+              {replayError}
+            </p>
+          ) : replayCandidates === undefined ? (
+            <p className="automation-field__hint">Loading recent messages…</p>
+          ) : !replayCandidates.supported ? (
+            <p className="automation-field__hint">
+              This provider can&rsquo;t serve conversation history, so there is
+              nothing to replay. Use &ldquo;Preview live messages&rdquo; in the
+              editor to test against new traffic instead.
+            </p>
+          ) : replayCandidates.candidates.length === 0 ? (
+            <p className="automation-field__hint">
+              No recent messages in the trigger conversation.
+            </p>
+          ) : (
+            <ul className="automation-preview__list">
+              {replayCandidates.candidates.map((candidate) => (
+                <li
+                  className={`automation-preview__item${candidate.matches ? " is-match" : ""}`}
+                  key={candidate.message.id}
+                >
+                  <span className="automation-preview__meta">
+                    {new Date(candidate.message.receivedAt).toLocaleTimeString()}{" "}
+                    · {candidate.message.actor.displayName
+                      ?? candidate.message.actor.platformUserId}
+                  </span>
+                  <span className="automation-preview__row-text">
+                    {candidate.message.text || "(no text)"}
+                  </span>
+                  <span className="automation-preview__row-actions">
+                    {candidate.matches ? (
+                      <span className="automation-preview__badge">matches</span>
+                    ) : (
+                      <span className="automation-preview__badge automation-preview__badge--muted">
+                        no match
+                      </span>
+                    )}
+                    <button
+                      className="automation-preview__use-sender"
+                      disabled={Boolean(busy)}
+                      type="button"
+                      onClick={() =>
+                        void runAction("replay", () => replayMessage(candidate))
+                      }
+                    >
+                      {candidate.matches ? "Replay" : "Replay anyway"}
+                    </button>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ) : null}
       {props.expanded ? (
         <AutomationTableHistory
           automationId={props.automation.id}

--- a/apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx
@@ -15,6 +15,7 @@ import {
 import type { DesktopApi } from "../../lib/desktop-api";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import {
+  formatCostTodayMicros,
   formatAutomationRelative,
   formatAutomationStatus,
   formatBacklogPolicy,
@@ -341,6 +342,9 @@ function AutomationTableRow(props: {
             {formatAutomationStatus(props.automation.status)}
           </span>
           <p>{formatAutomationLatestRun(props.automation)}</p>
+          {formatCostTodayMicros(props.automation.costTodayMicros) ? (
+            <p>{formatCostTodayMicros(props.automation.costTodayMicros)}</p>
+          ) : null}
         </div>
         <div className="automations-table__actions" role="cell">
           {inboundTriggered ? (

--- a/apps/desktop/src/renderer/src/features/automations/ThreadAutomationsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/ThreadAutomationsPanel.tsx
@@ -10,6 +10,7 @@ import type {
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import {
+  formatAutomationRunUsage,
   formatAutomationRelative,
   formatAutomationStatus,
   formatAutomationTimestamp,
@@ -321,9 +322,31 @@ export function AutomationRunHistoryItem(props: {
       {props.run.errorMessage ? (
         <span className="automation-run-history__error">{props.run.errorMessage}</span>
       ) : null}
+      {formatAutomationRunUsage(props.run.usage) ? (
+        <span className="automation-run-history__time">
+          {formatAutomationRunUsage(props.run.usage)}
+        </span>
+      ) : null}
       <button className="context-list__action" type="button" onClick={props.onToggle}>
         {props.expanded ? "Hide details" : "Details"}
       </button>
+      {props.desktopApi?.openAutomationRunWindow ? (
+        <button
+          className="context-list__action"
+          type="button"
+          onClick={() =>
+            void props.desktopApi?.openAutomationRunWindow?.({
+              automationId: props.run.automationId,
+              runId: props.run.id,
+              title: formatAutomationTimestamp(
+                props.run.completedAt ?? props.run.startedAt ?? props.run.queuedAt,
+              ),
+            })
+          }
+        >
+          Open ↗
+        </button>
+      ) : null}
       {props.expanded ? (
         <AutomationRunArtifactDetails
           backendThreadId={props.run.backendThreadId}
@@ -342,7 +365,7 @@ export function AutomationRunHistoryItem(props: {
   );
 }
 
-function AutomationRunArtifactDetails(props: {
+export function AutomationRunArtifactDetails(props: {
   backendThreadId?: string;
   backendTurnId?: string;
   error?: string;

--- a/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
@@ -1070,6 +1070,89 @@ describe("AutomationEditor", () => {
     );
   });
 
+  it("preselects the saved trigger channel on edit so its title survives re-save", async () => {
+    const onSubmit = vi.fn(async () => undefined);
+    const automation: AutomationDetail = {
+      backend: "codex",
+      threadId: "thread-1",
+      id: "auto-1",
+      name: "Search bots",
+      status: "enabled",
+      triggers: [
+        {
+          id: "t",
+          kind: "inbound_message",
+          conversation: {
+            channel: "slack",
+            conversationId: "C2LE02620",
+            conversationKind: "channel",
+            title: "t-search-bots",
+          },
+          conditionGroup: {
+            join: "any",
+            conditions: [
+              {
+                id: "c1",
+                field: "sender",
+                operator: "is_one_of",
+                values: ["B1"],
+                valueLabels: { B1: "spinnaker" },
+              },
+            ],
+          },
+        },
+      ],
+      scheduleSummary: "On inbound message",
+      backlogPolicy: "coalesce",
+      updatedAt: 1,
+      createdAt: 1,
+      taskPrompt: "Investigate.",
+      outputActions: [{ id: "agent-context", kind: "agent_context" }],
+    };
+
+    render(
+      <AutomationEditor
+        desktopApi={fakeDesktopApi(
+          fakeSettings({
+            enabled: { slack: true },
+            slackChannels: [{ displayName: "t-search-bots", id: "C2LE02620" }],
+          }),
+        )}
+        mode={{ kind: "edit", automation }}
+        onCancel={() => undefined}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    // Once the channel catalog loads, the saved trigger conversation is
+    // preselected by name — not left on "Enter Channel ID manually…" showing
+    // the raw platform id.
+    await waitFor(() =>
+      expect((screen.getByLabelText("Channel") as HTMLSelectElement).value).toBe(
+        "C2LE02620",
+      ),
+    );
+
+    // Re-saving without touching the channel must keep its friendly title.
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "update",
+        request: expect.objectContaining({
+          triggers: [
+            expect.objectContaining({
+              conversation: expect.objectContaining({
+                conversationId: "C2LE02620",
+                title: "t-search-bots",
+              }),
+            }),
+          ],
+        }),
+      }),
+    );
+  });
+
   it("offers Agents first and regular threads on the Threads tab", async () => {
     const onSubmit = vi.fn(async () => undefined);
 

--- a/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
@@ -638,6 +638,7 @@ describe("AutomationEditor", () => {
         return () => undefined;
       },
     } as unknown as DesktopApi;
+    const onSubmit = vi.fn(async () => undefined);
 
     render(
       <AutomationEditor
@@ -647,7 +648,7 @@ describe("AutomationEditor", () => {
           kind: "create",
         }}
         onCancel={() => undefined}
-        onSubmit={vi.fn(async () => undefined)}
+        onSubmit={onSubmit}
       />,
     );
 
@@ -707,6 +708,34 @@ describe("AutomationEditor", () => {
     );
     expect(senderChips).toHaveLength(1);
     expect(senderChips[0]).toHaveTextContent("Datadog");
+
+    // The resolved display name must survive the round trip: it is stamped
+    // onto the condition at submit so reopening the editor (and the list
+    // screen's trigger summary) shows "Datadog", not the raw platform id.
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Label persistence" },
+    });
+    fireEvent.change(screen.getByLabelText("Task prompt"), {
+      target: { value: "Investigate." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const submitted = (onSubmit.mock.calls[0] as unknown[])[0] as {
+      request: {
+        triggers: Array<{
+          name?: string;
+          conditionGroup?: {
+            conditions: Array<{ field: string; valueLabels?: Record<string, string> }>;
+          };
+        }>;
+      };
+    };
+    const senderCondition =
+      submitted.request.triggers[0]?.conditionGroup?.conditions.find(
+        (entry) => entry.field === "sender",
+      );
+    expect(senderCondition?.valueLabels).toEqual({ B1: "Datadog" });
+    expect(submitted.request.triggers[0]?.name).toContain("Datadog");
     // The plain-language summary lives on the funnel connector below the
     // Filters stage, so it states what survives into the next stage.
     expect(

--- a/apps/desktop/src/renderer/src/features/automations/__tests__/automations-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/__tests__/automations-screen.test.tsx
@@ -331,3 +331,38 @@ describe("AutomationsScreen", () => {
     expect(screen.getByText("It will rain at 4 PM.")).toBeInTheDocument();
   });
 });
+
+describe("run vs replay actions", () => {
+  it("offers Replay instead of Run for inbound-triggered automations", async () => {
+    const inbound = {
+      ...automation,
+      id: "automation-2",
+      triggers: [
+        {
+          id: "inbound-message",
+          kind: "inbound_message" as const,
+          conversation: { channel: "slack" as const, conversationId: "C123" },
+        },
+      ],
+    };
+    render(
+      <AutomationsScreen
+        desktopApi={{
+          listAutomations: vi.fn(async () => ({
+            automations: [automation, inbound],
+          })),
+          listAutomationRuns: vi.fn(async () => ({ runs: [] })),
+        } as unknown as DesktopApi}
+        threads={[]}
+        onClose={() => undefined}
+      />,
+    );
+
+    // The scheduled automation runs on demand; the inbound one has no
+    // triggering message to fabricate, so it replays a captured one instead.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Replay" })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: "Run" })).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/automations/automation-format.ts
+++ b/apps/desktop/src/renderer/src/features/automations/automation-format.ts
@@ -4,6 +4,7 @@ import type {
   AutomationScheduleDefinition,
   AutomationStatus,
 } from "@pwragent/shared";
+import { formatUsd } from "../thread-detail/context-panels/subagent-format";
 
 export function formatAutomationTimestamp(timestamp: number | undefined): string {
   if (!timestamp) {
@@ -63,8 +64,9 @@ export function formatScheduleKind(schedule: AutomationScheduleDefinition): stri
 
 /**
  * One-line run cost/usage summary: "$0.38 · 6.4k in · 1.2k out". Cost is the
- * list price frozen at run time (micros). Returns undefined when the run has
- * no recorded usage, so callers can omit the line entirely.
+ * list price frozen at run time (micros), rendered with the same sub-ten-cent
+ * extra decimal the sub-agent cost line uses. Returns undefined when the run
+ * has no recorded usage, so callers can omit the line entirely.
  */
 export function formatAutomationRunUsage(
   usage:
@@ -79,7 +81,7 @@ export function formatAutomationRunUsage(
   if (!usage) return undefined;
   const parts: string[] = [];
   if (typeof usage.totalCostMicros === "number") {
-    parts.push(`$${(usage.totalCostMicros / 1_000_000).toFixed(2)}`);
+    parts.push(formatUsd(usage.totalCostMicros / 1_000_000));
   }
   const inputTokens =
     (usage.uncachedInputTokens ?? 0) + (usage.cachedInputTokens ?? 0);
@@ -98,5 +100,5 @@ function formatTokenCount(count: number): string {
 
 export function formatCostTodayMicros(micros: number | undefined): string | undefined {
   if (micros === undefined) return undefined;
-  return `$${(micros / 1_000_000).toFixed(2)} today`;
+  return `${formatUsd(micros / 1_000_000)} today`;
 }

--- a/apps/desktop/src/renderer/src/features/automations/automation-format.ts
+++ b/apps/desktop/src/renderer/src/features/automations/automation-format.ts
@@ -60,3 +60,43 @@ export function formatScheduleKind(schedule: AutomationScheduleDefinition): stri
   }
   return "Weekly";
 }
+
+/**
+ * One-line run cost/usage summary: "$0.38 · 6.4k in · 1.2k out". Cost is the
+ * list price frozen at run time (micros). Returns undefined when the run has
+ * no recorded usage, so callers can omit the line entirely.
+ */
+export function formatAutomationRunUsage(
+  usage:
+    | {
+        uncachedInputTokens?: number;
+        cachedInputTokens?: number;
+        outputTokens?: number;
+        totalCostMicros?: number;
+      }
+    | undefined,
+): string | undefined {
+  if (!usage) return undefined;
+  const parts: string[] = [];
+  if (typeof usage.totalCostMicros === "number") {
+    parts.push(`$${(usage.totalCostMicros / 1_000_000).toFixed(2)}`);
+  }
+  const inputTokens =
+    (usage.uncachedInputTokens ?? 0) + (usage.cachedInputTokens ?? 0);
+  if (inputTokens > 0) parts.push(`${formatTokenCount(inputTokens)} in`);
+  if (usage.outputTokens !== undefined && usage.outputTokens > 0) {
+    parts.push(`${formatTokenCount(usage.outputTokens)} out`);
+  }
+  return parts.length > 0 ? parts.join(" \u00b7 ") : undefined;
+}
+
+function formatTokenCount(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
+  return String(count);
+}
+
+export function formatCostTodayMicros(micros: number | undefined): string | undefined {
+  if (micros === undefined) return undefined;
+  return `$${(micros / 1_000_000).toFixed(2)} today`;
+}

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -91,6 +91,7 @@ import type {
   ListAutomationCardsResponse,
   ListAutomationReplayCandidatesRequest,
   ListAutomationReplayCandidatesResponse,
+  OpenAutomationRunWindowRequest,
   ReplayAutomationInboundRequest,
   SearchMessagingSendersRequest,
   SearchMessagingSendersResponse,
@@ -474,6 +475,9 @@ export type DesktopApi = {
   replayAutomationInbound?: (
     request: ReplayAutomationInboundRequest,
   ) => Promise<RunAutomationNowResponse>;
+  openAutomationRunWindow?: (
+    request: OpenAutomationRunWindowRequest,
+  ) => Promise<{ opened: true }>;
   getAutomationRunArtifact?: (
     request: GetAutomationRunArtifactRequest,
   ) => Promise<GetAutomationRunArtifactResponse>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -89,6 +89,9 @@ import type {
   LatestCodexConfigWarningResponse,
   ListAutomationCardsRequest,
   ListAutomationCardsResponse,
+  ListAutomationReplayCandidatesRequest,
+  ListAutomationReplayCandidatesResponse,
+  ReplayAutomationInboundRequest,
   SearchMessagingSendersRequest,
   SearchMessagingSendersResponse,
   ListAutomationLoadIssuesResponse,
@@ -465,6 +468,12 @@ export type DesktopApi = {
     request: SearchMessagingSendersRequest,
   ) => Promise<SearchMessagingSendersResponse>;
   allocateAutomationWorkspace?: () => Promise<{ path: string }>;
+  listAutomationReplayCandidates?: (
+    request: ListAutomationReplayCandidatesRequest,
+  ) => Promise<ListAutomationReplayCandidatesResponse>;
+  replayAutomationInbound?: (
+    request: ReplayAutomationInboundRequest,
+  ) => Promise<RunAutomationNowResponse>;
   getAutomationRunArtifact?: (
     request: GetAutomationRunArtifactRequest,
   ) => Promise<GetAutomationRunArtifactResponse>;

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -123,6 +123,10 @@ const SubAgentTranscriptWindow = lazy(async () => ({
   default: (await import("./features/thread-detail/SubAgentTranscriptWindow"))
     .SubAgentTranscriptWindow,
 }));
+const AutomationRunWindow = lazy(async () => ({
+  default: (await import("./features/automations/AutomationRunWindow"))
+    .AutomationRunWindow,
+}));
 
 /**
  * Routes recognized by `chooseRoot` below. The Messaging Activity
@@ -163,6 +167,10 @@ const routes: Array<{
   {
     match: (hash) => hash.startsWith("sub-agent/"),
     render: () => <SubAgentTranscriptWindow />,
+  },
+  {
+    match: (hash) => hash.startsWith("automation-run/"),
+    render: () => <AutomationRunWindow />,
   },
 ];
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6464,6 +6464,20 @@ textarea,
   color: var(--text-muted);
 }
 
+/* Replay rows reuse the preview item grid with their own first two cells:
+   a muted time+sender line, then the message text. */
+.automation-preview__meta {
+  color: var(--text-muted);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.automation-preview__row-text {
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
 .automations-error {
   margin: 0;
   color: var(--danger-text);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6376,6 +6376,29 @@ textarea,
   background: var(--bg-panel);
 }
 
+/* Replay panel under an inbound automation's row: recent conversation
+   messages with the filter's live verdict, reusing the editor preview's
+   row/badge styling so match state reads identically in both places. */
+.automations-table__replay {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+}
+
+.automations-table__replay-lead {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.automation-preview__badge--muted {
+  color: var(--text-muted);
+}
+
 .automations-error {
   margin: 0;
   color: var(--danger-text);
@@ -18222,9 +18245,14 @@ a.transcript-message__messaging-origin:focus-visible {
 .automation-sender-picker__menu {
   position: absolute;
   top: 100%;
-  right: 0;
   left: 0;
   z-index: 30;
+  /* Grow to the widest suggestion rather than clipping "spinnaker-…" at the
+     input's width — the anchor column can be much narrower than the names in
+     it. Bounded so a pathological display name can't span the window. */
+  min-width: 100%;
+  width: max-content;
+  max-width: min(560px, 80vw);
   max-height: 280px;
   overflow-y: auto;
   border: 1px solid var(--border-strong);
@@ -18267,6 +18295,14 @@ a.transcript-message__messaging-origin:focus-visible {
 .automation-sender-picker__name {
   min-width: 0;
   overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.automation-sender-picker__username {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -17540,6 +17540,15 @@ a.transcript-message__messaging-origin:focus-visible {
   white-space: nowrap;
 }
 
+/* Message age. History backfill can surface months-old posts in a quiet
+   channel; without a visible age they read as live traffic. */
+.automation-preview__time {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 400;
+  white-space: nowrap;
+}
+
 .automation-preview__text {
   color: var(--text-primary);
   word-break: break-word;
@@ -18096,7 +18105,7 @@ a.transcript-message__messaging-origin:focus-visible {
   background: var(--bg-input);
 }
 
-.automation-lane--agent {
+.automation-lane--active {
   border-color: var(--accent-border);
 }
 
@@ -18108,7 +18117,7 @@ a.transcript-message__messaging-origin:focus-visible {
   text-transform: uppercase;
 }
 
-.automation-lane--agent .automation-lane__tag {
+.automation-lane--active .automation-lane__tag {
   color: var(--accent);
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6376,6 +6376,71 @@ textarea,
   background: var(--bg-panel);
 }
 
+/* Automation run window: activity-window chrome around one run's captured
+   events, so a long transcript stops competing with the table for space. */
+.automation-run-window {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.automation-run-window .activity-screen {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+}
+
+.automation-run-window__content {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.automation-run-window__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.automation-run-window__identity h1 {
+  margin: 0 0 4px;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.automation-run-window__identity p {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.automation-run-window__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.automation-run-window__close:hover {
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+}
+
 /* Replay panel under an inbound automation's row: recent conversation
    messages with the filter's live verdict, reusing the editor preview's
    row/badge styling so match state reads identically in both places. */

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -233,6 +233,7 @@ export const AUTOMATIONS_ALLOCATE_WORKSPACE_CHANNEL =
 export const AUTOMATIONS_LIST_REPLAY_CANDIDATES_CHANNEL =
   "automations:list-replay-candidates";
 export const AUTOMATIONS_REPLAY_INBOUND_CHANNEL = "automations:replay-inbound";
+export const AUTOMATION_RUN_WINDOW_OPEN_CHANNEL = "automation-run:open-window";
 export const AUTOMATIONS_LIST_CARDS_CHANNEL = "automations:list-cards";
 export const AUTOMATIONS_GET_RUN_ARTIFACT_CHANNEL =
   "automations:get-run-artifact";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -230,6 +230,9 @@ export const AUTOMATIONS_LIST_RUNS_CHANNEL = "automations:list-runs";
 export const AUTOMATIONS_SEARCH_SENDERS_CHANNEL = "automations:search-senders";
 export const AUTOMATIONS_ALLOCATE_WORKSPACE_CHANNEL =
   "automations:allocate-workspace";
+export const AUTOMATIONS_LIST_REPLAY_CANDIDATES_CHANNEL =
+  "automations:list-replay-candidates";
+export const AUTOMATIONS_REPLAY_INBOUND_CHANNEL = "automations:replay-inbound";
 export const AUTOMATIONS_LIST_CARDS_CHANNEL = "automations:list-cards";
 export const AUTOMATIONS_GET_RUN_ARTIFACT_CHANNEL =
   "automations:get-run-artifact";

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1232,6 +1232,15 @@ export type MessagingInboundBaseEvent = {
   channel: MessagingChannelRef;
   receivedAt: number;
   /**
+   * True when the adapter forwarded this event ONLY because its conversation
+   * is being observed (an enabled inbound automation watches it), while the
+   * sender would otherwise fail the per-user access gate. Observed-only
+   * events must never reach the reply/command path — they exist so
+   * automations and the editor's live preview can see channel traffic (bot
+   * alerts especially) without widening who may command the bot.
+   */
+  observedOnly?: boolean;
+  /**
    * Provider-generated HTTPS destination for the original message or, when
    * the platform cannot expose a message permalink, its conversation.
    */

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -1261,7 +1261,7 @@ describe("SlackAdapter", () => {
     ).toEqual([]);
   });
 
-  it("preview mirrors the live message filter (skips own posts, keeps file_share, drops bot_message)", async () => {
+  it("preview mirrors the live message filter (skips own posts, keeps file_share and bot_message)", async () => {
     const adapter = new SlackAdapter({
       config: baseConfig,
       callbackHandleStore: fakeStore(),
@@ -1296,11 +1296,103 @@ describe("SlackAdapter", () => {
       conversationId: "C012ABCDEF0",
     });
 
-    // Own posts and bot_message subtypes are filtered (the live tap skips them);
-    // file_share and plain user messages survive, oldest-first.
+    // Own posts stay filtered. Other bots' bot_message posts survive — they
+    // are the alert senders inbound automations exist to watch — alongside
+    // file_share and plain user messages, oldest-first.
     expect(
       events.map((event) => (event.kind === "text" ? event.text : undefined)),
-    ).toEqual(["normal message", "shared a file"]);
+    ).toEqual([
+      "normal message",
+      "shared a file",
+      "other bot via bot_message",
+    ]);
+  });
+
+  it("delivers classic bot_message posts with attachment text folded in", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+    // The channel-user gate defaults to authorized_users, and the bot isn't an
+    // authorized actor — the desktop runtime marks the conversation observed
+    // because an enabled automation watches it, which is what lets the alert
+    // through (flagged observedOnly).
+    adapter.updateObservedConversations(["C012ABCDEF0"]);
+
+    // A classic integration alert: subtype bot_message, empty top-level text,
+    // content entirely in attachments — the exact shape Spinnaker and Datadog
+    // post. The actor must be the B… bot id, because that is what the event
+    // carries (sender filters must be able to match it).
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "message",
+        subtype: "bot_message",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        bot_id: "B012SPINNKR",
+        ts: "1712023032.000600",
+        text: "",
+        attachments: [
+          {
+            title: "Pipeline failed for SEARCHGRPC",
+            text: "Searchgrpc's searchgrpc-prod pipeline has failed",
+          },
+        ],
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    const [event] = events;
+    expect(event?.kind).toBe("text");
+    expect(event?.actor.platformUserId).toBe("B012SPINNKR");
+    expect(event?.actor.isBot).toBe(true);
+    expect(event?.observedOnly).toBe(true);
+    if (event?.kind === "text") {
+      expect(event.text).toContain("Pipeline failed for SEARCHGRPC");
+      expect(event.text).toContain("searchgrpc-prod pipeline has failed");
+    }
+  });
+
+  it("drops unauthorized-sender messages in conversations nothing observes", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "message",
+        subtype: "bot_message",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        bot_id: "B012SPINNKR",
+        ts: "1712023032.000700",
+        text: "unwatched alert",
+      },
+    });
+
+    // Fail-closed stands: no observation grant means no forwarding.
+    expect(events).toEqual([]);
   });
 
   it("keeps fan-out callback records scoped per routed binding", async () => {

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -57,6 +57,8 @@ function conversationKey(channel: MessagingChannelRef): string {
 function fakeApi(spies: {
   assistantStatusError?: Error;
   assistantStatuses?: Array<{ channelId: string; status: string; threadTs: string }>;
+  bots?: Record<string, string>;
+  botsInfoCalls?: string[];
   conversations?: Record<string, string>;
   mpimChannels?: string[];
   permalinks?: Record<string, string>;
@@ -117,6 +119,11 @@ function fakeApi(spies: {
     updateMessage: async (params) => {
       spies.updated?.push(params);
       return { channel: params.channel, ts: params.ts };
+    },
+    botsInfo: async (params) => {
+      spies.botsInfoCalls?.push(params.bot);
+      const name = spies.bots?.[params.bot];
+      return name ? { name } : undefined;
     },
     usersInfo: async (params) => {
       const user = spies.users?.[params.user];
@@ -1361,6 +1368,83 @@ describe("SlackAdapter", () => {
       expect(event.text).toContain("Pipeline failed for SEARCHGRPC");
       expect(event.text).toContain("searchgrpc-prod pipeline has failed");
     }
+  });
+
+  it("names bot senders from the event's bot_profile without an API lookup", async () => {
+    const socket = fakeSocket();
+    const botsInfoCalls: string[] = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ botsInfoCalls }),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+    adapter.updateObservedConversations(["C012ABCDEF0"]);
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "message",
+        subtype: "bot_message",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        bot_id: "B012SPINNKR",
+        bot_profile: { name: "Spinnaker" },
+        ts: "1712023032.000800",
+        text: "Pipeline complete",
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.actor.platformUserId).toBe("B012SPINNKR");
+    expect(events[0]?.actor.displayName).toBe("Spinnaker");
+    expect(botsInfoCalls).toEqual([]);
+  });
+
+  it("falls back to bots.info for bot names and caches the answer", async () => {
+    const socket = fakeSocket();
+    const botsInfoCalls: string[] = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ bots: { B012DATADOG: "Datadog" }, botsInfoCalls }),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+    adapter.updateObservedConversations(["C012ABCDEF0"]);
+
+    for (const ts of ["1712023032.000900", "1712023032.001000"]) {
+      await socket.emitEvent("slack_event", {
+        ack: async () => undefined,
+        event: {
+          type: "message",
+          subtype: "bot_message",
+          channel: "C012ABCDEF0",
+          channel_type: "channel",
+          team: "T012ABCDEF0",
+          bot_id: "B012DATADOG",
+          ts,
+          text: "Monitor triggered",
+        },
+      });
+    }
+
+    expect(events).toHaveLength(2);
+    expect(events[0]?.actor.displayName).toBe("Datadog");
+    expect(events[1]?.actor.displayName).toBe("Datadog");
+    // One lookup, then the cache answers — bots.info is rate-limited and the
+    // same integrations post repeatedly.
+    expect(botsInfoCalls).toEqual(["B012DATADOG"]);
   });
 
   it("drops unauthorized-sender messages in conversations nothing observes", async () => {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -150,6 +150,7 @@ export type SlackUserListMember = SlackUserInfo & {
   deleted?: boolean;
   is_app_user?: boolean;
   is_bot?: boolean;
+  profile?: SlackUserInfo["profile"] & { bot_id?: string };
 };
 
 export type SlackSocketClient = {
@@ -282,6 +283,7 @@ type SlackEventsApiBody = {
 };
 
 type SlackMessageEvent = {
+  attachments?: SlackMessageAttachment[];
   bot_id?: string;
   channel?: string;
   channel_type?: string;
@@ -294,6 +296,12 @@ type SlackMessageEvent = {
   ts?: string;
   type: "app_mention" | "message";
   user?: string;
+};
+
+type SlackMessageAttachment = {
+  fallback?: string;
+  text?: string;
+  title?: string;
 };
 
 type SlackAppHomeOpenedEvent = {
@@ -404,6 +412,10 @@ export class SlackAdapter implements SlackProviderAdapter {
   private directoryRosterFetchedAt = 0;
   private directoryRosterInFlight: Promise<MessagingDirectoryActor[]> | undefined;
   private directoryLookupDisabled = false;
+  // Conversations with an enabled inbound automation: all senders' messages
+  // there are forwarded flagged observedOnly instead of being dropped by the
+  // per-user access gate. Pushed by the desktop runtime; empty by default.
+  private observedConversationIds = new Set<string>();
   // Per-stream posted surfaces, keyed by `intent.stream.key`. Slack has no
   // "create-or-edit" primitive, so the first chunk posts a new message and
   // records its `ts` here; later chunks (and the final) edit it in place — the
@@ -464,6 +476,10 @@ export class SlackAdapter implements SlackProviderAdapter {
       ...(this.botAccount ? { account: this.botAccount } : {}),
       ...(this.botAccountDetail ? { detail: this.botAccountDetail } : {}),
     };
+  }
+
+  updateObservedConversations(conversationIds: readonly string[]): void {
+    this.observedConversationIds = new Set(conversationIds);
   }
 
   async updateAuthorization(update: MessagingAdapterAuthorizationUpdate): Promise<void> {
@@ -1006,7 +1022,18 @@ export class SlackAdapter implements SlackProviderAdapter {
     ) {
       return;
     }
-    if (event.subtype && event.subtype !== "file_share") return;
+    // "bot_message" is the subtype classic app integrations (Spinnaker,
+    // Datadog, PagerDuty) post with — exactly the senders inbound automations
+    // exist to watch. The subtype gate is for channel noise (joins, edits,
+    // deletes), not for authored messages. Our own bot is already excluded by
+    // the identity check above, so loops stay impossible.
+    if (
+      event.subtype
+      && event.subtype !== "file_share"
+      && event.subtype !== "bot_message"
+    ) {
+      return;
+    }
 
     const ids = this.validateInboundMessageIds({
       botId: event.bot_id,
@@ -1034,7 +1061,13 @@ export class SlackAdapter implements SlackProviderAdapter {
       teamId: ids.teamId,
       ts: ids.ts,
     });
-    const rawText = event.text ?? "";
+    // Classic app messages carry their content in attachments (title/text)
+    // with an empty top-level text — "Pipeline failed for SEARCHGRPC" lives
+    // there. Fold it in so text filters and automation prompts see what the
+    // operator sees in Slack.
+    const rawText = [event.text ?? "", slackAttachmentText(event.attachments)]
+      .filter((part) => part.length > 0)
+      .join("\n");
     const strippedText = stripBotMention(rawText, this.botUserId);
     // Slack's app_mention event is the authoritative addressed-to-us signal.
     // Also inspect message text because Slack can deliver the same post as both
@@ -1060,7 +1093,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     // are explicit invocations and are exempt.
     if (isGroupDm && !isMention && !command && !isPairingMessage) return;
 
-    if (!this.authorizeInbound({
+    const authorization = this.authorizeInbound({
       actor,
       botMention: isMention,
       channel,
@@ -1074,7 +1107,12 @@ export class SlackAdapter implements SlackProviderAdapter {
         || channel.conversation.isDirectMessage === true,
       routingState,
       teamId: ids.teamId,
-    })) return;
+    });
+    if (authorization === false) return;
+    const observedOnly = authorization === "observed";
+    // Observation is not authorization: a command from a sender who only
+    // passed the observed-conversation gate must not execute.
+    if (observedOnly && command) return;
 
     const sourceUrl = await this.sourceUrlForSlackMessage(ids);
 
@@ -1088,6 +1126,7 @@ export class SlackAdapter implements SlackProviderAdapter {
         routingState,
         sourceUrl,
         ...(isMention ? { botMention: true } : {}),
+        ...(observedOnly ? { observedOnly: true } : {}),
         text: text || undefined,
         disposition: "available",
         attachments: event.files.flatMap((file) => this.describeFile(file)),
@@ -1122,6 +1161,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       routingState,
       sourceUrl,
       ...(isMention ? { botMention: true } : {}),
+      ...(observedOnly ? { observedOnly: true } : {}),
       text,
     });
   }
@@ -1187,7 +1227,8 @@ export class SlackAdapter implements SlackProviderAdapter {
       teamId: ids.teamId,
       ts: ids.ts,
     });
-    if (!this.authorizeInbound({
+    // Observation is not authorization: only strict `true` may run a callback.
+    if (this.authorizeInbound({
       actor,
       channel,
       kind: "callback",
@@ -1196,7 +1237,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       }),
       routingState,
       teamId: ids.teamId,
-    })) {
+    }) !== true) {
       return;
     }
 
@@ -1261,7 +1302,8 @@ export class SlackAdapter implements SlackProviderAdapter {
       teamId: ids.teamId,
       ...(body.thread_ts ? { ts: ids.ts } : {}),
     });
-    if (!this.authorizeInbound({
+    // Observation is not authorization: only strict `true` may run a command.
+    if (this.authorizeInbound({
       actor,
       channel,
       kind: "command",
@@ -1270,7 +1312,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       }),
       routingState,
       teamId: ids.teamId,
-    })) {
+    }) !== true) {
       return;
     }
     const command = normalizeSlackSlashCommand(
@@ -1933,7 +1975,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     reportRejection?: boolean;
     routingState?: MessagingAdapterState;
     teamId?: string;
-  }): boolean {
+  }): boolean | "observed" {
     if (params.pairing) return true;
 
     const actorAuthorized = this.authorizedActorIds.includes(
@@ -1999,9 +2041,19 @@ export class SlackAdapter implements SlackProviderAdapter {
     }
 
     const channelUserMode = slackChannelUserAccessMode(this.config);
-    if (channelUserMode === "none") return reject("unauthorized-conversation");
+    const observed =
+      this.observedConversationIds.has(params.channel.conversation.id)
+      || (params.channel.conversation.parentId !== undefined
+        && this.observedConversationIds.has(params.channel.conversation.parentId));
+    if (channelUserMode === "none") {
+      return observed ? "observed" : reject("unauthorized-conversation");
+    }
     if (channelUserMode === "authorized_users" && !actorAuthorized) {
-      return reject("unauthorized-actor");
+      // The sender may not command the bot, but an enabled automation watches
+      // this conversation — forward for observation only. This is what lets a
+      // sender filter match Spinnaker/Datadog alerts without granting every
+      // channel member the right to steer Agents.
+      return observed ? "observed" : reject("unauthorized-actor");
     }
     return true;
   }
@@ -2383,7 +2435,13 @@ export class SlackAdapter implements SlackProviderAdapter {
       ) {
         continue;
       }
-      if (message.subtype && message.subtype !== "file_share") continue;
+      if (
+        message.subtype
+        && message.subtype !== "file_share"
+        && message.subtype !== "bot_message"
+      ) {
+        continue;
+      }
       const actor = message.bot_id
         ? this.actorForSlackBot(message.bot_id)
         : message.user
@@ -2740,12 +2798,37 @@ function toDirectoryActor(
     || member.profile?.display_name?.trim()
     || undefined;
   const username = member.name?.trim().replace(/^@/, "") || undefined;
+  const isBot = Boolean(member.is_bot || member.is_app_user);
+  // Inbound bot messages carry the app's BOT id (B…) as the actor, not the
+  // bot's user id (U…) — so a sender filter built from the user id would never
+  // match a single event. Suggest the id events actually carry.
+  const botId = member.profile?.bot_id?.trim();
   return {
-    platformUserId,
+    platformUserId: isBot && botId ? botId : platformUserId,
     ...(displayName ? { displayName } : {}),
     ...(username ? { username } : {}),
-    ...(member.is_bot || member.is_app_user ? { isBot: true } : {}),
+    ...(isBot ? { isBot: true } : {}),
   };
+}
+
+/** Attachment content, bounded — a runaway integration can attach a lot. */
+const MAX_ATTACHMENT_TEXT_CHARS = 4_000;
+
+function slackAttachmentText(
+  attachments: SlackMessageAttachment[] | undefined,
+): string {
+  if (!attachments || attachments.length === 0) return "";
+  const parts: string[] = [];
+  for (const attachment of attachments) {
+    const title = attachment.title?.trim();
+    const body = (attachment.text ?? attachment.fallback ?? "").trim();
+    if (title) parts.push(title);
+    if (body && body !== title) parts.push(body);
+  }
+  const joined = parts.join("\n");
+  return joined.length > MAX_ATTACHMENT_TEXT_CHARS
+    ? joined.slice(0, MAX_ATTACHMENT_TEXT_CHARS)
+    : joined;
 }
 
 function hostFromUrl(url: string | undefined): string | undefined {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -139,6 +139,7 @@ export type SlackApi = {
     cursor?: string;
     limit?: number;
   }): Promise<SlackUserListPage>;
+  botsInfo?(params: { bot: string }): Promise<{ name?: string } | undefined>;
 };
 
 export type SlackUserListPage = {
@@ -189,6 +190,7 @@ export type SlackThreadMessageInfo = {
 
 export type SlackHistoryMessageInfo = {
   bot_id?: string;
+  bot_profile?: { name?: string };
   subtype?: string;
   text?: string;
   ts?: string;
@@ -285,6 +287,7 @@ type SlackEventsApiBody = {
 type SlackMessageEvent = {
   attachments?: SlackMessageAttachment[];
   bot_id?: string;
+  bot_profile?: SlackBotProfile;
   channel?: string;
   channel_type?: string;
   event_ts?: string;
@@ -302,6 +305,10 @@ type SlackMessageAttachment = {
   fallback?: string;
   text?: string;
   title?: string;
+};
+
+type SlackBotProfile = {
+  name?: string;
 };
 
 type SlackAppHomeOpenedEvent = {
@@ -416,6 +423,11 @@ export class SlackAdapter implements SlackProviderAdapter {
   // there are forwarded flagged observedOnly instead of being dropped by the
   // per-user access gate. Pushed by the desktop runtime; empty by default.
   private observedConversationIds = new Set<string>();
+  // Bot display names, keyed by B… id. Seeded free from bot_profile on the
+  // event when Slack includes it; otherwise lazily via bots.info (cached, and
+  // self-disabling on missing_scope like the user-profile lookup above it).
+  private readonly botNameCache = new Map<string, string | undefined>();
+  private botInfoLookupDisabled = false;
   // Per-stream posted surfaces, keyed by `intent.stream.key`. Slack has no
   // "create-or-edit" primitive, so the first chunk posts a new message and
   // records its `ts` here; later chunks (and the final) edit it in place — the
@@ -1046,7 +1058,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     if (this.isDuplicateMessageEvent(event, ids)) return;
 
     const actor = ids.botId
-      ? this.actorForSlackBot(ids.botId)
+      ? await this.actorForSlackBot(ids.botId, event.bot_profile?.name)
       : await this.actorForSlackUser(ids.userId);
     const channel = await this.channelRefForSlack({
       channelId: ids.channelId,
@@ -2140,13 +2152,52 @@ export class SlackAdapter implements SlackProviderAdapter {
     };
   }
 
-  private actorForSlackBot(botId: string): MessagingActorIdentity {
+  private async actorForSlackBot(
+    botId: string,
+    eventProfileName?: string,
+  ): Promise<MessagingActorIdentity> {
+    const profileName = eventProfileName?.trim();
+    if (profileName) {
+      this.botNameCache.set(botId, profileName);
+    }
     const contact = this.config.authorizedActorIds.find((item) => item.id === botId);
+    const displayName =
+      profileName
+      ?? contact?.displayName
+      ?? (await this.lookupSlackBotName(botId));
     return {
       platformUserId: botId,
-      displayName: contact?.displayName ?? botId,
+      // The raw B… id is the last resort — an operator recognizes
+      // "Spinnaker", not "B01TZS7V371".
+      displayName: displayName ?? botId,
       isBot: true,
     };
+  }
+
+  private async lookupSlackBotName(botId: string): Promise<string | undefined> {
+    if (this.botNameCache.has(botId)) {
+      return this.botNameCache.get(botId);
+    }
+    if (this.botInfoLookupDisabled || !this.api.botsInfo) {
+      this.botNameCache.set(botId, undefined);
+      return undefined;
+    }
+    try {
+      const bot = await this.api.botsInfo({ bot: botId });
+      const name = bot?.name?.trim() || undefined;
+      this.botNameCache.set(botId, name);
+      return name;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      if (reason.includes("missing_scope")) {
+        this.botInfoLookupDisabled = true;
+        this.logger.warn?.("slack bot name lookup unavailable", {
+          reason: "missing_scope",
+        });
+      }
+      this.botNameCache.set(botId, undefined);
+      return undefined;
+    }
   }
 
   /**
@@ -2443,7 +2494,7 @@ export class SlackAdapter implements SlackProviderAdapter {
         continue;
       }
       const actor = message.bot_id
-        ? this.actorForSlackBot(message.bot_id)
+        ? await this.actorForSlackBot(message.bot_id, message.bot_profile?.name)
         : message.user
           ? await this.actorForSlackUser(message.user, message.username)
           : undefined;
@@ -2734,6 +2785,11 @@ export function createSlackApi(botToken: string): SlackApi {
     async usersInfo(params) {
       const response = await client.users.info(params);
       return response.user as SlackUserInfo | undefined;
+    },
+    async botsInfo(params) {
+      const response = await client.bots.info({ bot: params.bot });
+      const bot = response.bot as { name?: string } | undefined;
+      return bot ? { name: bot.name } : undefined;
     },
     async usersList(params) {
       const response = await client.users.list({

--- a/packages/shared/src/contracts/automations.ts
+++ b/packages/shared/src/contracts/automations.ts
@@ -5,6 +5,7 @@ import type {
   ThreadExecutionMode,
 } from "./normalized-app-server";
 import type {
+  InboundPreviewMessage,
   MessagingChannelKind,
   MessagingConversationKind,
 } from "./messaging";
@@ -245,6 +246,15 @@ export type AutomationInboundCondition = {
   operator: AutomationInboundConditionOperator;
   values: string[];
   caseSensitive?: boolean;
+  /**
+   * Display names for opaque platform values, keyed by value — "U041ZGYG07Q"
+   * → "datadog". Pure presentation metadata captured at selection time (the
+   * same snapshot-at-selection pattern conversation titles use): the matcher
+   * never reads it, and a missing entry just renders the raw id. Without it,
+   * reopening the editor or reading the list screen shows ids nobody can
+   * recognize.
+   */
+  valueLabels?: Record<string, string>;
 };
 
 /** How the condition rows combine. Flat by design — there is no nesting. */
@@ -469,7 +479,13 @@ export function isSupportedAutomationInboundConditionGroup(
       && AUTOMATION_INBOUND_CONDITION_FIELDS.includes(condition.field)
       && AUTOMATION_INBOUND_CONDITION_OPERATORS.includes(condition.operator)
       && Array.isArray(condition.values)
-      && condition.values.every((value) => typeof value === "string"),
+      && condition.values.every((value) => typeof value === "string")
+      && (condition.valueLabels === undefined
+        || (typeof condition.valueLabels === "object"
+          && condition.valueLabels !== null
+          && Object.values(condition.valueLabels).every(
+            (label) => typeof label === "string",
+          ))),
   );
 }
 
@@ -525,9 +541,16 @@ export function formatAutomationInboundConditionGroup(
     .map((condition) => {
       const values = condition.values.filter((value) => value.length > 0);
       if (values.length === 0) return undefined;
-      const rendered = values.map((value) =>
-        options.resolveLabel ? options.resolveLabel(value, condition) : `"${value}"`,
-      );
+      const rendered = values.map((value) => {
+        if (options.resolveLabel) return options.resolveLabel(value, condition);
+        // Sender values are opaque platform ids; the stored display name (or
+        // the raw id, unquoted) reads better than a quoted id. Text values
+        // keep their quotes so literal match strings stay visually distinct.
+        if (condition.field === "sender" || condition.field === "sender_type") {
+          return condition.valueLabels?.[value] ?? value;
+        }
+        return `"${value}"`;
+      });
       const joined =
         rendered.length === 1
           ? rendered[0]
@@ -969,6 +992,31 @@ export type AutomationTimelineCard = AutomationAgentAssignment & {
   summary: string;
   details?: string;
   occurredAt: number;
+};
+
+export type ListAutomationReplayCandidatesRequest = {
+  automationId: string;
+};
+
+/** One recent conversation message, pre-judged against the trigger's filter. */
+export type AutomationReplayCandidate = {
+  message: InboundPreviewMessage;
+  matches: boolean;
+};
+
+export type ListAutomationReplayCandidatesResponse = {
+  candidates: AutomationReplayCandidate[];
+  /**
+   * False when the provider cannot serve conversation history (only Slack can
+   * today) — the UI says so instead of rendering an empty list that reads as
+   * "the channel is silent".
+   */
+  supported: boolean;
+};
+
+export type ReplayAutomationInboundRequest = {
+  automationId: string;
+  message: InboundPreviewMessage;
 };
 
 export type CreateAutomationRequest = AutomationAgentAssignment & {

--- a/packages/shared/src/contracts/automations.ts
+++ b/packages/shared/src/contracts/automations.ts
@@ -875,6 +875,12 @@ export type AutomationDetail = AutomationListItemSummary & {
   gate?: AutomationGateConfig;
   executionProfile?: AutomationExecutionProfile;
   priorRunLookback?: AutomationPriorRunLookback;
+  /**
+   * Summed run cost since local midnight, computed from retained runs at read
+   * time. A durable lifetime total needs a denormalized counter (schema
+   * migration) and is deliberately not attempted here.
+   */
+  costTodayMicros?: number;
   outputActions: AutomationOutputActionDefinition[];
   /**
    * Inbound coalescing window in milliseconds. 0 disables coalescing (one run
@@ -914,6 +920,24 @@ export type AutomationRunWindow = {
  */
 export type AutomationRunSkipReason = "lane_busy" | "rate_limited";
 
+/**
+ * Token/cost accounting for one run's headless turn, distilled from the
+ * turn-scope ThreadUsageLineRecord the pricing pipeline computes. Cost is the
+ * list price at the time the run happened (micros, USD) — deliberately frozen
+ * rather than recomputed, so later pricing-table changes don't rewrite the
+ * history an operator already read.
+ */
+export type AutomationRunUsage = {
+  model?: string;
+  uncachedInputTokens?: number;
+  cachedInputTokens?: number;
+  outputTokens?: number;
+  reasoningOutputTokens?: number;
+  totalTokens?: number;
+  totalCostMicros?: number;
+  currency?: string;
+};
+
 export type AutomationRunSummary = {
   id: string;
   automationId: string;
@@ -937,6 +961,7 @@ export type AutomationRunSummary = {
    */
   coalescedCount?: number;
   source?: AutomationRunSourceMetadata;
+  usage?: AutomationRunUsage;
 };
 
 export type AutomationRunOutputDecision =
@@ -992,6 +1017,13 @@ export type AutomationTimelineCard = AutomationAgentAssignment & {
   summary: string;
   details?: string;
   occurredAt: number;
+};
+
+export type OpenAutomationRunWindowRequest = {
+  automationId: string;
+  runId: string;
+  /** Window-title hint; the window fetches authoritative data itself. */
+  title?: string;
 };
 
 export type ListAutomationReplayCandidatesRequest = {

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -545,8 +545,9 @@ export type RejectMessagingPairingResponse = {
 /**
  * A compact, bounded view of a single inbound message, surfaced live to the
  * Automations editor so an operator can see which recent messages their
- * trigger filter would match. Capture is going-forward only (messages that
- * arrive while the preview is open); provider history backfill is not implied.
+ * trigger filter would match. Providers that support it backfill recent
+ * conversation history when the preview opens (marked `origin: "history"`);
+ * everything else is captured going-forward while the preview is open.
  */
 export type InboundPreviewMessage = {
   id: string;
@@ -554,6 +555,12 @@ export type InboundPreviewMessage = {
   conversationId: string;
   parentId?: string;
   receivedAt: number;
+  /**
+   * Absent for live-captured messages. History rows can be arbitrarily old —
+   * a quiet channel's "recent 15" may reach back months — so the editor
+   * shows their age instead of letting stale posts read as live traffic.
+   */
+  origin?: "history";
   actor: {
     platformUserId: string;
     displayName?: string;


### PR DESCRIPTION
## Summary

Follow-up to #1484 from first live use of a messaging automation.

- **Sender display names persist.** The picker resolved "datadog" from the Slack directory, but the name lived only in editor state — reopening the editor showed the raw platform id on the chip, and the list screen's trigger summary read `sender is "U041ZGYG07Q"`. Conditions now carry `valueLabels` (display metadata captured at selection; the matcher never reads it). The editor stamps them at submit and hydrates chips from them on edit, and the shared formatter defaults to them for sender fields — the stored trigger name, the list screen, and the funnel caption all read `sender is datadog or spinnaker`. Automations saved before this change still show ids until re-saved.
- **Directory suggestions are legible.** The menu grows to its content (bounded at 560px) instead of clipping at the anchor column's width, shows `@username` when it adds information (two bots with the same display prefix are only tellable apart by handle), and every option carries a title tooltip with name, handle, and id.
- **Inbound automations replace Run with Replay.** Run on a messaging-driven automation had no triggering message to offer the prompt. Replay lists recent messages from the trigger conversation (Slack history), badges each with the filter's live verdict via the same shared evaluator the matcher and editor preview use — positive test replays a matching message; negative test shows a message the filter would reject, with "Replay anyway" to force it through — and dispatches the pick as a manual run carrying the message as its source. Scheduled automations keep Run unchanged. Providers without history support get an explanation instead of an empty list.

## Verification

- `pnpm test` — 7,564 passed; only the pre-existing `codex-environment-runtime` failures (5) remain.
- `pnpm typecheck` clean; `lint:eslint` 0 errors; `lint:boundaries`, `lint:colors`, `lint:sql` clean.
- New tests: replay-candidate judging + replay source-key namespacing (matcher), operator-replay prompt block, scheduler replay creating a manual run with source (and queueing a second replay behind the serial lane), valueLabels surviving submit, and Run-vs-Replay per trigger kind.
- Rendered the list screen with an open replay panel against the real stylesheet and verified visually: named trigger summary, match/no-match badges, Replay / Replay anyway actions.

## Notes

- The replay's source-event key is namespaced (`replay:<id>:<ts>`), never the original message's key — inbound dispatch dedupes on that key, and a replay carrying the real key would make the scheduler treat a later genuine delivery of the same message as already handled.
- Replays deliberately bypass the inbound rate limit, coalescing, and dedupe: those police unattended traffic, not an operator pressing a button. The serial lane still applies — a second replay queues behind an active run.
- The prompt labels a replayed source as "replayed by the operator for testing" so the model knows it is a test, not live traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
