### PR TITLE
fix(desktop): keep headings with wide table blocks

### DIFF
--- a/apps/desktop/e2e/fixtures/README.md
+++ b/apps/desktop/e2e/fixtures/README.md
@@ -145,6 +145,9 @@ desktop replay scenarios do not exercise Codex sidebar directory identity.
   hide low-signal hunks via the focused diff path
 - `thread-image-fit/`: pasted transcript image preview preserves its natural
   aspect ratio and fits within the preview container without cropping
+- `markdown-findings-table/`: wide markdown tables keep their headings and
+  separators inside the scrollable split block; table-block and full-message
+  clipboard actions retain their distinct scopes
 - `mcp-elicitation/`: Codex MCP elicitation request for Playwright
   `browser_tabs`, including MCP-shaped approval handling and progress rendering
 

--- a/apps/desktop/e2e/fixtures/markdown-findings-table/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/markdown-findings-table/replay.fixture.json
@@ -2,7 +2,7 @@
   "metadata": {
     "backend": "codex",
     "scenario": "markdown-findings-table",
-    "sourceCaptureId": "synthetic-sanitized-2026-05-11",
+    "sourceCaptureId": "synthetic-sanitized-2026-08-11",
     "threadId": "thread-markdown-findings-table"
   },
   "steps": [
@@ -78,6 +78,12 @@
             "id": "message-assistant-4",
             "role": "assistant",
             "text": "Alternate review header schema (proves the classifier is content-aware, not keyed to the literal `# / Sev / File / Issue / Fix` header). Same content shape, different labels — expect tag / label / prose / prose:\n\n| Severity | Module | Symptom | Fix |\n|:---:|---|---|---|\n| P0 | billing/dispatch | Duplicate-notice emission after retry suppression, observed in shadow rollouts at 0.3% rate. Caused by fallback path not respecting suppression flag. | Propagate suppression flag into the secondary provider path and gate the fallback emission behind it. Add an integration test that exercises the suppression interleaving. |\n| P1 | window/ledger | Tenant identity merging across cache normalization. Two tenants with the same period and bucket ids are indistinguishable to the cache key. | Add `tenantId` to the `LedgerIdentity` tuple, the `stableKey` serializer, and the sorting comparator. Regression test in `window/ledger.spec.ts`. |\n| P2 | window/observation | Failure-heavy buckets remain sparse indefinitely because the call-count threshold excludes failures from observed calls. | Switch the threshold input to total attempts, keep the win-ratio math on resolved auctions, and add a failure-heavy regression test. |"
+          },
+          {
+            "type": "message",
+            "id": "message-assistant-5",
+            "role": "assistant",
+            "text": "Research is complete. This is a compact cross-platform setup guide for the public harnesses.\n\n## Quick matrix\n\n---\n\n| Harness | Executable | Primary install | First run |\n|---|---|---|---|\n| Grok Build | `grok` | Shell installer on macOS/Linux; PowerShell installer on Windows | Browser sign-in or API key |\n| Kimi Code | `kimi` | Vendor installer, with Git for Windows on native Windows | Run `/login` in the TUI |\n| Qwen Code | `qwen` | Standalone installer; package-manager fallback needs Node 22+ | Run `/auth` in the session |\n| Codex CLI | `codex` | Standalone installer for macOS, Linux, and Windows | Sign in with ChatGPT or provide an API key |\n\nImplementation note: keep the matrix horizontally scrollable without widening the transcript."
           }
         ],
         "messages": [
@@ -105,6 +111,11 @@
             "id": "message-assistant-4",
             "role": "assistant",
             "text": "Alternate review header schema (proves the classifier is content-aware, not keyed to the literal `# / Sev / File / Issue / Fix` header). Same content shape, different labels — expect tag / label / prose / prose:\n\n| Severity | Module | Symptom | Fix |\n|:---:|---|---|---|\n| P0 | billing/dispatch | Duplicate-notice emission after retry suppression, observed in shadow rollouts at 0.3% rate. Caused by fallback path not respecting suppression flag. | Propagate suppression flag into the secondary provider path and gate the fallback emission behind it. Add an integration test that exercises the suppression interleaving. |\n| P1 | window/ledger | Tenant identity merging across cache normalization. Two tenants with the same period and bucket ids are indistinguishable to the cache key. | Add `tenantId` to the `LedgerIdentity` tuple, the `stableKey` serializer, and the sorting comparator. Regression test in `window/ledger.spec.ts`. |\n| P2 | window/observation | Failure-heavy buckets remain sparse indefinitely because the call-count threshold excludes failures from observed calls. | Switch the threshold input to total attempts, keep the win-ratio math on resolved auctions, and add a failure-heavy regression test. |"
+          },
+          {
+            "id": "message-assistant-5",
+            "role": "assistant",
+            "text": "Research is complete. This is a compact cross-platform setup guide for the public harnesses.\n\n## Quick matrix\n\n---\n\n| Harness | Executable | Primary install | First run |\n|---|---|---|---|\n| Grok Build | `grok` | Shell installer on macOS/Linux; PowerShell installer on Windows | Browser sign-in or API key |\n| Kimi Code | `kimi` | Vendor installer, with Git for Windows on native Windows | Run `/login` in the TUI |\n| Qwen Code | `qwen` | Standalone installer; package-manager fallback needs Node 22+ | Run `/auth` in the session |\n| Codex CLI | `codex` | Standalone installer for macOS, Linux, and Windows | Sign in with ChatGPT or provide an API key |\n\nImplementation note: keep the matrix horizontally scrollable without widening the transcript."
           }
         ],
         "lastUserMessage": "Review the billing pacing change and present the findings in a compact table.",

--- a/apps/desktop/e2e/markdown-findings-table.spec.ts
+++ b/apps/desktop/e2e/markdown-findings-table.spec.ts
@@ -4,6 +4,21 @@ import { expect, test } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 
 const specDir = path.dirname(fileURLToPath(import.meta.url));
+const harnessTableBlock = `## Quick matrix
+
+---
+
+| Harness | Executable | Primary install | First run |
+|---|---|---|---|
+| Grok Build | \`grok\` | Shell installer on macOS/Linux; PowerShell installer on Windows | Browser sign-in or API key |
+| Kimi Code | \`kimi\` | Vendor installer, with Git for Windows on native Windows | Run \`/login\` in the TUI |
+| Qwen Code | \`qwen\` | Standalone installer; package-manager fallback needs Node 22+ | Run \`/auth\` in the session |
+| Codex CLI | \`codex\` | Standalone installer for macOS, Linux, and Windows | Sign in with ChatGPT or provide an API key |`;
+const harnessMessage = `Research is complete. This is a compact cross-platform setup guide for the public harnesses.
+
+${harnessTableBlock}
+
+Implementation note: keep the matrix horizontally scrollable without widening the transcript.`;
 
 test("renders a wide assistant markdown findings table without crushing the columns", async () => {
   const app = await launchElectronApp({
@@ -52,6 +67,9 @@ test("renders a wide assistant markdown findings table without crushing the colu
     await expect(proseMessage).toBeVisible();
     await expect(proseMessage).not.toHaveClass(/transcript-message--table-wide/);
     await expect(wideTableMessage).toBeVisible();
+    await expect(
+      wideTableMessage.getByRole("heading", { level: 2, name: "Findings" })
+    ).toBeVisible();
     await expect(tableScroll).toBeVisible();
     await expect(table).toBeVisible();
     await expect(table.getByRole("columnheader", { name: "#" })).toBeVisible();
@@ -140,6 +158,42 @@ test("renders a wide assistant markdown findings table without crushing the colu
     expect(oversizedDimensions.northAmericaRight).toBeLessThanOrEqual(
       oversizedDimensions.europeLeft + 1
     );
+
+    const harnessProseMessage = transcript
+      .locator(".transcript-message--assistant")
+      .filter({ hasText: "Research is complete" })
+      .first();
+    const harnessTableMessage = transcript
+      .locator(".transcript-message--table-wide")
+      .filter({ hasText: "Quick matrix" })
+      .first();
+    await expect(harnessProseMessage).toBeVisible();
+    await expect(harnessProseMessage).not.toContainText("Quick matrix");
+    await expect(harnessTableMessage).toBeVisible();
+    await expect(
+      harnessTableMessage.getByRole("heading", { level: 2, name: "Quick matrix" })
+    ).toBeVisible();
+    await expect(harnessTableMessage.locator(".transcript-message__rule")).toBeVisible();
+    await expect(harnessTableMessage.locator("table")).toContainText("Grok Build");
+
+    await app.electronApp.evaluate(({ clipboard }) => clipboard.writeText(""));
+    await harnessTableMessage
+      .getByRole("button", { name: "Copy table block" })
+      .click();
+    await expect
+      .poll(async () =>
+        await app.electronApp.evaluate(({ clipboard }) => clipboard.readText())
+      )
+      .toBe(harnessTableBlock);
+
+    await harnessProseMessage
+      .getByRole("button", { name: "Copy message" })
+      .click();
+    await expect
+      .poll(async () =>
+        await app.electronApp.evaluate(({ clipboard }) => clipboard.readText())
+      )
+      .toBe(harnessMessage);
   } finally {
     await app.close();
   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -297,6 +297,10 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
             continuation: index > 0,
             desktopApi: props.desktopApi,
             message: props.message,
+            segmentText:
+              segment.type === "table" && messageSegments.length > 1
+                ? segment.text
+                : undefined,
             sourceThreadLink,
             threadLinks,
             text: messageCopyText,
@@ -442,8 +446,14 @@ function splitMarkdownTableBlocks(markdown: string): MarkdownBlock[] {
       isMarkdownTableHeader(line) &&
       isMarkdownTableDelimiter(lines[index + 1] ?? "")
     ) {
+      const tableHeading = splitTrailingTableHeading(textBuffer);
+      textBuffer = tableHeading.remainingLines;
       flushText();
-      const tableLines = [line, lines[index + 1] ?? ""];
+      const tableLines = [
+        ...tableHeading.headingLines,
+        line,
+        lines[index + 1] ?? "",
+      ];
       index += 2;
       while (index < lines.length && isMarkdownTableRow(lines[index] ?? "")) {
         tableLines.push(lines[index] ?? "");
@@ -459,6 +469,39 @@ function splitMarkdownTableBlocks(markdown: string): MarkdownBlock[] {
 
   flushText();
   return blocks;
+}
+
+function splitTrailingTableHeading(lines: string[]): {
+  headingLines: string[];
+  remainingLines: string[];
+} {
+  let headingIndex = lines.length - 1;
+  while (
+    headingIndex >= 0
+    && (
+      lines[headingIndex]?.trim() === ""
+      || isMarkdownThematicBreak(lines[headingIndex] ?? "")
+    )
+  ) {
+    headingIndex -= 1;
+  }
+
+  if (!isMarkdownAtxHeading(lines[headingIndex] ?? "")) {
+    return { headingLines: [], remainingLines: lines };
+  }
+
+  return {
+    headingLines: lines.slice(headingIndex),
+    remainingLines: lines.slice(0, headingIndex),
+  };
+}
+
+function isMarkdownAtxHeading(line: string): boolean {
+  return /^\s{0,3}#{1,6}(?:\s+|$)/.test(line);
+}
+
+function isMarkdownThematicBreak(line: string): boolean {
+  return /^\s{0,3}(?:(?:\*\s*){3,}|(?:_\s*){3,}|(?:-\s*){3,})$/.test(line);
 }
 
 function isMarkdownTableHeader(line: string): boolean {
@@ -492,7 +535,14 @@ function splitTableCells(line: string): string[] {
 }
 
 function isWideMarkdownTable(table: string): boolean {
-  const [header = "", , ...rows] = table.split("\n");
+  const lines = table.split("\n");
+  const headerIndex = lines.findIndex(
+    (line, index) =>
+      isMarkdownTableHeader(line)
+      && isMarkdownTableDelimiter(lines[index + 1] ?? ""),
+  );
+  const header = lines[headerIndex] ?? "";
+  const rows = lines.slice(headerIndex + 2);
   const columnCount = splitTableCells(header).length;
   const longestRowLength = rows.reduce(
     (longest, row) => Math.max(longest, row.length),
@@ -743,12 +793,30 @@ function renderMessageHeader(params: {
   continuation: boolean;
   desktopApi?: Pick<DesktopApi, "copyText" | "copyRichText">;
   message: AppServerThreadMessageEntry;
+  segmentText?: string;
   sourceThreadLink?: ResolvedThreadLink;
   threadLinks: ReturnType<typeof useThreadLinks>;
   text: string;
 }): ReactNode {
+  const segmentCopyButton = params.segmentText ? (
+    <TranscriptCopyButton
+      className="transcript-copy-button--segment"
+      copiedLabel="Copied table block"
+      desktopApi={params.desktopApi}
+      html={() => renderMarkdownToClipboardHtml(params.segmentText ?? "")}
+      label="Copy table block"
+      text={params.segmentText}
+    />
+  ) : null;
+
   if (params.continuation) {
-    return null;
+    return segmentCopyButton ? (
+      <header className="transcript-message__header transcript-message__header--continuation">
+        <span className="transcript-message__header-actions">
+          {segmentCopyButton}
+        </span>
+      </header>
+    ) : null;
   }
 
   const attributionClassName =
@@ -799,6 +867,7 @@ function renderMessageHeader(params: {
         {sourceInstanceChip}
       </span>
       <span className="transcript-message__header-actions">
+        {segmentCopyButton}
         {params.text ? (
           <TranscriptCopyButton
             className="transcript-copy-button--message"

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1156,6 +1156,54 @@ describe("TranscriptList", () => {
     expect(screen.getByText("Follow-up prose should not inherit", { exact: false })).toBeInTheDocument();
   });
 
+  it("keeps a trailing heading and separators with its wide table split block", async () => {
+    const copyText = vi.fn(async () => undefined);
+    const tableBlock = `## Quick matrix
+
+---
+
+${wideMarkdownTable}`;
+    const messageText = `Research is complete. The concise guide follows.
+
+${tableBlock}
+
+Implementation notes remain in a readable bubble.`;
+
+    const { container } = render(
+      <TranscriptList
+        desktopApi={{ copyText }}
+        entries={[
+          {
+            type: "message",
+            id: "message-table-heading",
+            role: "assistant",
+            text: messageText,
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const articles = container.querySelectorAll("article.transcript-message--assistant");
+    const tableArticle = screen.getByRole("heading", { name: "Quick matrix" }).closest("article");
+    expect(articles).toHaveLength(3);
+    expect(articles[0]).toHaveTextContent("Research is complete");
+    expect(articles[0]).not.toHaveTextContent("Quick matrix");
+    expect(tableArticle).toHaveClass("transcript-message--table-wide");
+    expect(tableArticle?.querySelector(".transcript-message__rule")).toBeInTheDocument();
+    expect(tableArticle?.querySelector("table.thread-markdown__table")).toBeInTheDocument();
+    expect(articles[2]).toHaveTextContent("Implementation notes remain");
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy table block" }));
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(tableBlock);
+    });
+    expect(copyText).not.toHaveBeenCalledWith(messageText);
+  });
+
   it("copies the full original message when the rendered message is split into segments", async () => {
     const copyText = vi.fn(async () => undefined);
     const messageText = `Intro prose should stay in the normal readable assistant bubble.\n\n${wideMarkdownTable}\n\nFollow-up prose should not inherit the table width.`;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12457,6 +12457,10 @@ textarea,
   gap: 12px;
 }
 
+.transcript-message__header--continuation {
+  justify-content: flex-end;
+}
+
 .transcript-message__attribution {
   display: inline-flex;
   min-width: 0;
@@ -12624,7 +12628,10 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .transcript-message:hover .transcript-copy-button--message,
 .transcript-message:focus-within .transcript-copy-button--message,
-.transcript-copy-button--message[data-copied="true"] {
+.transcript-copy-button--message[data-copied="true"],
+.transcript-message:hover .transcript-copy-button--segment,
+.transcript-message:focus-within .transcript-copy-button--segment,
+.transcript-copy-button--segment[data-copied="true"] {
   opacity: 1;
 }
 
@@ -12918,6 +12925,7 @@ a.transcript-message__messaging-origin:focus-visible {
 
 @media (hover: none) {
   .transcript-copy-button--message,
+  .transcript-copy-button--segment,
   .transcript-copy-button--section,
   .transcript-copy-button--inline,
   .transcript-copy-button--activity {


### PR DESCRIPTION
## Summary

- I keep a Markdown heading with its following wide-table split block when only blank lines or thematic breaks separate them.
- I added a per-table-block copy affordance that copies the heading, separators, and table while preserving the existing whole-response copy behavior.
- I extended the sanitized replay harness with a concise cross-platform agent matrix modeled on the public Grok research thread and pinned both clipboard scopes in Electron.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm test:desktop-e2e e2e/markdown-findings-table.spec.ts`
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:colors`
- `pnpm lint:boundaries`

## Notes

- I verified the response-level copy still copies the complete original message and the new split-block action copies only that table block with its heading.
- ESLint completes with the repository's existing warning baseline and no errors.
