### PR TITLE
feat(desktop): keep remote thread links in current window

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -927,30 +927,70 @@ function DesktopAppShell(props: {
   }, [mainView, navigation.selectedLaunchpad, navigation.selectedThreadKey]);
   const showThread = navigation.showThread;
   const selectDirectoryLaunchpad = navigation.selectDirectoryLaunchpad;
-  // Target of `pwragent://thread/…` chips in the transcript. Navigation-only:
-  // the scheme never carries an action, so this is the entire surface it can
-  // reach. Mirrors the tray/notification `onShowThreadRequested` path below.
+  // A remote thread link joins the main window's local list before opening,
+  // matching Cmd+K federated results. A separate chip action owns the
+  // instance-wide remote viewer window, so an ordinary click stays here.
   const showThreadFromLink = useCallback(
     (request: {
       backend: AppServerBackendKind;
       instanceId?: FederationInstanceId;
+      instanceLabel?: string;
+      inThreadList?: boolean;
       threadId: string;
     }): void => {
       if (request.instanceId) {
         const windowTarget = readRendererFederationTarget();
         if (windowTarget?.instanceId !== request.instanceId) {
+          // A remote viewer is already scoped to another owner. Keep its
+          // cross-instance navigation window-scoped; viewer-owned local pins
+          // belong to the unscoped main window only.
+          if (windowTarget) {
+            const target = {
+              scope: "remote" as const,
+              instanceId: request.instanceId,
+            };
+            void desktopApi?.openFederationWindow?.({
+              target,
+              initialThread: {
+                backend: request.backend,
+                target,
+                threadId: request.threadId,
+              },
+            });
+            return;
+          }
+          if (request.inThreadList) {
+            setMainView("thread");
+            void showThread({
+              backend: request.backend,
+              threadId: request.threadId,
+            });
+            return;
+          }
           const target = {
             scope: "remote" as const,
             instanceId: request.instanceId,
           };
-          void desktopApi?.openFederationWindow?.({
-            target,
-            initialThread: {
+          void (async () => {
+            try {
+              await desktopApi?.addRemoteThreadPin?.({
+                ref: {
+                  backend: request.backend,
+                  target,
+                  threadId: request.threadId,
+                },
+                instanceLabel: request.instanceLabel,
+              });
+            } catch (error) {
+              console.warn("Adding the remote thread to this PwrAgent failed.", error);
+              return;
+            }
+            setMainView("thread");
+            await showThread({
               backend: request.backend,
-              target,
               threadId: request.threadId,
-            },
-          });
+            });
+          })();
           return;
         }
       }
@@ -958,6 +998,27 @@ function DesktopAppShell(props: {
       void showThread({ backend: request.backend, threadId: request.threadId });
     },
     [desktopApi, showThread],
+  );
+  const openRemoteViewerFromLink = useCallback(
+    (request: {
+      backend: AppServerBackendKind;
+      instanceId: FederationInstanceId;
+      threadId: string;
+    }): void => {
+      const target = {
+        scope: "remote" as const,
+        instanceId: request.instanceId,
+      };
+      void desktopApi?.openFederationWindow?.({
+        target,
+        initialThread: {
+          backend: request.backend,
+          target,
+          threadId: request.threadId,
+        },
+      });
+    },
+    [desktopApi],
   );
   const restoreHistoryLocation = useCallback(
     (location: NavigationHistoryLocation): void => {
@@ -1713,6 +1774,7 @@ function DesktopAppShell(props: {
   return (
     <TranscriptLinkProvider
       activeThread={navigation.selectedThread}
+      onOpenRemoteViewer={openRemoteViewerFromLink}
       onShowThread={showThreadFromLink}
       threads={navigation.threads}
     >

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -3312,6 +3312,201 @@ describe("App", () => {
     });
   });
 
+  it("adds a remote transcript link to this window while its pop-out opens the viewer", async () => {
+    const remoteTarget = {
+      scope: "remote" as const,
+      instanceId: "studio-mac",
+    };
+    const localThread = {
+      id: "thread-local",
+      title: "Local planning thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: true, reason: "new-thread" as const },
+      updatedAt: 2_000,
+    };
+    const remoteThread = {
+      id: "thread-remote",
+      title: "M4 Mac Mini runner-host conversion preflight",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: true, reason: "new-thread" as const },
+      updatedAt: 1_000,
+      federation: {
+        ref: {
+          backend: "codex" as const,
+          target: remoteTarget,
+          threadId: "thread-remote",
+        },
+        instanceLabel: "Studio Mac",
+        peerStatus: "connected" as const,
+      },
+    };
+    let remotePinned = false;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: remotePinned
+        ? ["codex:thread-local", "codex:thread-remote"]
+        : ["codex:thread-local"],
+      threads: remotePinned ? [localThread, remoteThread] : [localThread],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const addRemoteThreadPin = vi.fn(async (request: {
+      ref: typeof remoteThread.federation.ref;
+    }) => {
+      remotePinned = true;
+      return {
+        pin: {
+          ref: request.ref,
+          addedAt: Date.now(),
+          instanceLabel: "Studio Mac",
+        },
+      };
+    });
+    const openFederationWindow = vi.fn(async () => ({ windowId: 2 }));
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        addRemoteThreadPin,
+        getNavigationSnapshot,
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [
+            {
+              kind: "codex",
+              label: "Codex app server",
+              available: true,
+              methods: ["thread/list", "thread/read"],
+              capabilities: {
+                listThreads: true,
+                createThread: false,
+                resumeThread: true,
+                renameThread: false,
+                readThread: true,
+                startTurn: false,
+                interruptTurn: false,
+                steerTurn: false,
+                transcriptPagination: false,
+                toolUse: false,
+                approvalRequests: false,
+                multiDirectoryThreads: true,
+              },
+              executionModes: [
+                {
+                  mode: "default",
+                  label: "Default Access",
+                  available: true,
+                  isDefault: true,
+                },
+              ],
+            },
+          ],
+        }),
+        listSkills: async () => ({
+          backend: "codex" as const,
+          fetchedAt: Date.now(),
+          data: [],
+        }),
+        markThreadSeen: async (request: {
+          backend: AppServerBackendKind;
+          threadId: string;
+        }) => ({ ...request, seenAt: Date.now() }),
+        onAgentEvent: () => () => undefined,
+        onWindowFocus: () => () => undefined,
+        openFederationWindow,
+        platform: "darwin",
+        readThread: async (request: {
+          backend: AppServerBackendKind;
+          threadId: string;
+        }) => ({
+          ...request,
+          fetchedAt: Date.now(),
+          replay: {
+            entries: request.threadId === "thread-local"
+              ? [
+                  {
+                    type: "message" as const,
+                    id: "message-link",
+                    role: "assistant" as const,
+                    text:
+                      "Open [runner preflight](pwragent://thread/thread-remote"
+                      + "?backend=codex&instanceId=studio-mac)",
+                  },
+                ]
+              : [],
+            messages: request.threadId === "thread-local"
+              ? [
+                  {
+                    id: "message-link",
+                    role: "assistant" as const,
+                    text:
+                      "Open [runner preflight](pwragent://thread/thread-remote"
+                      + "?backend=codex&instanceId=studio-mac)",
+                  },
+                ]
+              : [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        }),
+        versions: { electron: "41.2.1" },
+      },
+    });
+
+    render(<App />);
+    await screen.findByRole("heading", { level: 2, name: localThread.title });
+
+    fireEvent.click(screen.getByRole("button", {
+      name: "Open remote viewer for studio-mac",
+    }));
+    expect(openFederationWindow).toHaveBeenCalledWith({
+      target: remoteTarget,
+      initialThread: {
+        backend: "codex",
+        target: remoteTarget,
+        threadId: "thread-remote",
+      },
+    });
+    expect(addRemoteThreadPin).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", {
+      name: "Open thread runner preflight",
+    }));
+
+    await waitFor(() => expect(addRemoteThreadPin).toHaveBeenCalledWith({
+      ref: remoteThread.federation.ref,
+      instanceLabel: undefined,
+    }));
+    expect(openFederationWindow).toHaveBeenCalledTimes(1);
+    expect(await screen.findByRole("heading", {
+      level: 2,
+      name: remoteThread.title,
+    })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Local planning thread/i }));
+    await screen.findByRole("heading", { level: 2, name: localThread.title });
+    fireEvent.click(screen.getByRole("button", {
+      name: "Open thread M4 Mac Mini runner-host conversion preflight",
+    }));
+
+    expect(await screen.findByRole("heading", {
+      level: 2,
+      name: remoteThread.title,
+    })).toBeInTheDocument();
+    expect(addRemoteThreadPin).toHaveBeenCalledTimes(1);
+  });
+
   it("reuses cached thread history when reselecting an unchanged thread", async () => {
     const readThread = vi.fn(
       async ({

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState, type KeyboardEvent, type MouseEvent } from "react";
-import { ThreadIcon } from "../../icons";
-import { useLiveThreadLink } from "../../lib/thread-links";
+import { PopoutIcon, ThreadIcon } from "../../icons";
+import { useLiveThreadLink, useThreadLinks } from "../../lib/thread-links";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import type { ResolvedThreadLink } from "../../lib/thread-links";
 import {
@@ -25,10 +25,14 @@ type ThreadChipProps = {
 
 export function ThreadChip(props: ThreadChipProps) {
   const link = useLiveThreadLink(props.link);
+  const threadLinks = useThreadLinks();
   const contextMenuInvokerRef = useRef<HTMLSpanElement>(null);
   const [contextMenuPosition, setContextMenuPosition] =
     useState<ChipContextMenuPosition>();
   const tooltipController = useViewportTooltip({ className: "viewport-tooltip" });
+  const popoutTooltipController = useViewportTooltip({
+    className: "viewport-tooltip",
+  });
 
   const liveTitle = link.title.trim();
   const fallbackLabel = props.fallbackLabel?.trim();
@@ -38,6 +42,10 @@ export function ThreadChip(props: ThreadChipProps) {
   const tooltip = link.gitBranch
     ? `${label}\n${link.gitBranch} — open thread`
     : `${label}\nOpen thread`;
+  const remoteInstanceLabel = link.instanceLabel ?? link.instanceId;
+  const remoteViewerTooltip = remoteInstanceLabel
+    ? `Open this thread in the remote viewer window for ${remoteInstanceLabel}`
+    : undefined;
 
   // role="button" span rather than a real <button>: the chip renders inside
   // markdown that may already sit within a clickable surface, and a nested
@@ -54,43 +62,81 @@ export function ThreadChip(props: ThreadChipProps) {
 
   return (
     <>
-      <span
-        aria-label={`Open thread ${label}`}
-        aria-haspopup="menu"
-        className="chip thread-chip"
-        data-thread-chip=""
-        draggable={false}
-        role="button"
-        tabIndex={0}
-        onBlur={tooltipController.hide}
-        onClick={handleActivate}
-        onContextMenu={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          window.getSelection()?.removeAllRanges();
-          tooltipController.hide();
-          const rect = event.currentTarget.getBoundingClientRect();
-          contextMenuInvokerRef.current = event.currentTarget;
-          setContextMenuPosition({
-            x: event.clientX,
-            y: event.clientY,
-            anchorTop: rect.top,
-          });
-        }}
-        onDragStart={(event) => event.preventDefault()}
-        onFocus={(event) => tooltipController.show(event.currentTarget, tooltip)}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            handleActivate(event);
-          }
-        }}
-        onMouseEnter={(event) => tooltipController.show(event.currentTarget, tooltip)}
-        onMouseLeave={tooltipController.hide}
-      >
-        <ThreadIcon className="thread-chip__icon" size={12} />
-        <span className="thread-chip__label">#{label.replace(/^#/, "")}</span>
+      <span className="thread-chip-group">
+        <span
+          aria-label={`Open thread ${label}`}
+          aria-haspopup="menu"
+          className="chip thread-chip"
+          data-thread-chip=""
+          draggable={false}
+          role="button"
+          tabIndex={0}
+          onBlur={tooltipController.hide}
+          onClick={handleActivate}
+          onContextMenu={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            window.getSelection()?.removeAllRanges();
+            tooltipController.hide();
+            const rect = event.currentTarget.getBoundingClientRect();
+            contextMenuInvokerRef.current = event.currentTarget;
+            setContextMenuPosition({
+              x: event.clientX,
+              y: event.clientY,
+              anchorTop: rect.top,
+            });
+          }}
+          onDragStart={(event) => event.preventDefault()}
+          onFocus={(event) => tooltipController.show(event.currentTarget, tooltip)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              handleActivate(event);
+            }
+          }}
+          onMouseEnter={(event) => tooltipController.show(event.currentTarget, tooltip)}
+          onMouseLeave={tooltipController.hide}
+        >
+          <ThreadIcon className="thread-chip__icon" size={12} />
+          <span className="thread-chip__label">#{label.replace(/^#/, "")}</span>
+        </span>
+        {link.instanceId && remoteViewerTooltip ? (
+          <span
+            aria-label={`Open remote viewer for ${remoteInstanceLabel}`}
+            className="thread-chip__popout"
+            role="button"
+            tabIndex={0}
+            onBlur={popoutTooltipController.hide}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              popoutTooltipController.hide();
+              event.currentTarget.blur();
+              threadLinks?.openRemoteViewer(link);
+            }}
+            onFocus={(event) =>
+              popoutTooltipController.show(event.currentTarget, remoteViewerTooltip)
+            }
+            onKeyDown={(event) => {
+              if (event.key !== "Enter" && event.key !== " ") {
+                return;
+              }
+              event.preventDefault();
+              event.stopPropagation();
+              popoutTooltipController.hide();
+              event.currentTarget.blur();
+              threadLinks?.openRemoteViewer(link);
+            }}
+            onMouseEnter={(event) =>
+              popoutTooltipController.show(event.currentTarget, remoteViewerTooltip)
+            }
+            onMouseLeave={popoutTooltipController.hide}
+          >
+            <PopoutIcon size={11} aria-hidden="true" />
+          </span>
+        ) : null}
       </span>
       {tooltipController.tooltipNode}
+      {popoutTooltipController.tooltipNode}
       {contextMenuPosition && contextMenuInvokerRef.current ? (
         <ChipContextMenu
           className={props.contextMenuClassName}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
@@ -31,13 +31,20 @@ function threadSummary(
 function renderWithLinks(
   text: string,
   options: {
+    onOpenRemoteViewer?: (request: {
+      backend: AppServerBackendKind;
+      instanceId: string;
+      threadId: string;
+    }) => void;
     onShowThread?: (request: { backend: AppServerBackendKind; threadId: string }) => void;
     threads?: NavigationThreadSummary[];
   } = {},
 ) {
+  const onOpenRemoteViewer = options.onOpenRemoteViewer ?? vi.fn();
   const onShowThread = options.onShowThread ?? vi.fn();
   return render(
     <ThreadLinkProvider
+      onOpenRemoteViewer={onOpenRemoteViewer}
       onShowThread={onShowThread}
       threads={options.threads ?? [threadSummary()]}
     >
@@ -243,9 +250,11 @@ describe("thread links in transcript markdown", () => {
 
   it("keeps an arbitrary remote thread actionable with its owning instance", () => {
     const onShowThread = vi.fn();
+    const onOpenRemoteViewer = vi.fn();
     renderWithLinks(
       `See [Remote handoff](pwragent://thread/${CHILD_THREAD_ID}?backend=codex&instanceId=pwr_harold)`,
       {
+        onOpenRemoteViewer,
         onShowThread,
         threads: [],
       },
@@ -260,6 +269,48 @@ describe("thread links in transcript markdown", () => {
       instanceId: "pwr_harold",
       threadId: CHILD_THREAD_ID,
     });
+    expect(onOpenRemoteViewer).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", {
+      name: "Open remote viewer for pwr_harold",
+    }));
+
+    expect(onOpenRemoteViewer).toHaveBeenCalledWith({
+      backend: "codex",
+      instanceId: "pwr_harold",
+      threadId: CHILD_THREAD_ID,
+    });
+    expect(onShowThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("labels a remote thread's pop-out action with its instance name", () => {
+    const onOpenRemoteViewer = vi.fn();
+    renderWithLinks(
+      `See [Remote handoff](pwragent://thread/${CHILD_THREAD_ID}?backend=codex&instanceId=pwr_harold)`,
+      {
+        onOpenRemoteViewer,
+        threads: [threadSummary({
+          federation: {
+            ref: {
+              backend: "codex",
+              target: { scope: "remote", instanceId: "pwr_harold" },
+              threadId: CHILD_THREAD_ID,
+            },
+            instanceLabel: "Studio Mac",
+            peerStatus: "connected",
+          },
+        })],
+      },
+    );
+
+    const popout = screen.getByRole("button", {
+      name: "Open remote viewer for Studio Mac",
+    });
+    fireEvent.mouseEnter(popout);
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Open this thread in the remote viewer window for Studio Mac",
+    );
   });
 
   it("drops live metadata when a federated thread leaves the snapshot", () => {

--- a/apps/desktop/src/renderer/src/lib/thread-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/thread-links.tsx
@@ -22,7 +22,9 @@ import {
 
 export type ResolvedThreadLink = {
   backend: AppServerBackendKind;
+  inThreadList?: boolean;
   instanceId?: FederationInstanceId;
+  instanceLabel?: string;
   threadId: string;
   title: string;
   titleSource?: AppServerThreadTitleSource;
@@ -37,6 +39,7 @@ export type ThreadLinkContextValue = {
    * rather than a chip that goes nowhere.
    */
   resolve: (ref: ThreadLinkRef) => ResolvedThreadLink | undefined;
+  openRemoteViewer: (link: ResolvedThreadLink) => void;
   show: (link: ResolvedThreadLink) => void;
   getSnapshot: (link: ResolvedThreadLink) => ResolvedThreadLink;
   subscribe: (link: ResolvedThreadLink, listener: () => void) => () => void;
@@ -55,7 +58,11 @@ function threadSummaryLink(thread: NavigationThreadSummary): ResolvedThreadLink 
   const target = thread.federation?.ref.target;
   return {
     backend: thread.source,
+    inThreadList: true,
     ...(target?.scope === "remote" ? { instanceId: target.instanceId } : {}),
+    ...(thread.federation?.instanceLabel
+      ? { instanceLabel: thread.federation.instanceLabel }
+      : {}),
     threadId: thread.id,
     title: thread.title,
     titleSource: thread.titleSource,
@@ -72,6 +79,7 @@ function sameThreadLink(
     left
     && left.title === right.title
     && left.titleSource === right.titleSource
+    && left.instanceLabel === right.instanceLabel
     && left.gitBranch === right.gitBranch
     && linkedDirectoryMetadata(left.linkedDirectories)
       === linkedDirectoryMetadata(right.linkedDirectories)
@@ -102,6 +110,7 @@ function threadLinkMetadataKey(threads: NavigationThreadSummary[]): string {
       thread.id,
       thread.title,
       thread.titleSource,
+      thread.federation?.instanceLabel ?? null,
       thread.gitBranch ?? null,
       linkedDirectoryMetadata(thread.linkedDirectories),
     ]),
@@ -207,9 +216,17 @@ export function useLiveThreadLink(link: ResolvedThreadLink): ResolvedThreadLink 
 
 export function ThreadLinkProvider(props: {
   children: ReactNode;
+  onOpenRemoteViewer?: (request: {
+    backend: AppServerBackendKind;
+    instanceId: FederationInstanceId;
+    instanceLabel?: string;
+    threadId: string;
+  }) => void;
   onShowThread: (request: {
     backend: AppServerBackendKind;
     instanceId?: FederationInstanceId;
+    instanceLabel?: string;
+    inThreadList?: boolean;
     threadId: string;
   }) => void;
   threads: NavigationThreadSummary[];
@@ -248,6 +265,8 @@ export function ThreadLinkProvider(props: {
   // current data at each membership change without listing them as deps.
   const onShowThreadRef = useRef(onShowThread);
   onShowThreadRef.current = onShowThread;
+  const onOpenRemoteViewerRef = useRef(props.onOpenRemoteViewer);
+  onOpenRemoteViewerRef.current = props.onOpenRemoteViewer;
 
   const value = useMemo<ThreadLinkContextValue>(() => {
     const byThreadId = new Map<string, ResolvedThreadLink>();
@@ -269,6 +288,17 @@ export function ThreadLinkProvider(props: {
     }
 
     return {
+      openRemoteViewer(link) {
+        if (!link.instanceId) {
+          return;
+        }
+        onOpenRemoteViewerRef.current?.({
+          backend: link.backend,
+          instanceId: link.instanceId,
+          ...(link.instanceLabel ? { instanceLabel: link.instanceLabel } : {}),
+          threadId: link.threadId,
+        });
+      },
       resolve(ref) {
         let resolved: ResolvedThreadLink | undefined;
         if (ref.instanceId) {
@@ -308,6 +338,8 @@ export function ThreadLinkProvider(props: {
         onShowThreadRef.current({
           backend: link.backend,
           ...(link.instanceId ? { instanceId: link.instanceId } : {}),
+          ...(link.instanceLabel ? { instanceLabel: link.instanceLabel } : {}),
+          ...(link.instanceId && link.inThreadList ? { inThreadList: true } : {}),
           threadId: link.threadId,
         });
       },

--- a/apps/desktop/src/renderer/src/lib/transcript-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/transcript-links.tsx
@@ -10,15 +10,24 @@ import { ThreadLinkProvider } from "./thread-links";
 export function TranscriptLinkProvider(props: {
   activeThread?: NavigationThreadSummary;
   children: ReactNode;
+  onOpenRemoteViewer?: (request: {
+    backend: AppServerBackendKind;
+    instanceId: FederationInstanceId;
+    instanceLabel?: string;
+    threadId: string;
+  }) => void;
   onShowThread: (request: {
     backend: AppServerBackendKind;
     instanceId?: FederationInstanceId;
+    instanceLabel?: string;
+    inThreadList?: boolean;
     threadId: string;
   }) => void;
   threads: NavigationThreadSummary[];
 }) {
   return (
     <ThreadLinkProvider
+      onOpenRemoteViewer={props.onOpenRemoteViewer}
       onShowThread={props.onShowThread}
       threads={props.threads}
     >

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16080,6 +16080,15 @@ a.transcript-message__messaging-origin:focus-visible {
    `pwragent://thread/…` link (or a bare thread id an agent wrote as code).
    Sits on the `.chip` primitive so it carries the same pill geometry as the
    skill chip; the interactive states are what set it apart. */
+.thread-chip-group {
+  display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
+  align-items: center;
+  gap: 2px;
+  vertical-align: middle;
+}
+
 .thread-chip {
   max-width: 100%;
   height: 22px;
@@ -16109,6 +16118,33 @@ a.transcript-message__messaging-origin:focus-visible {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.thread-chip__popout {
+  display: inline-flex;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 20px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  color: var(--text-muted);
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.thread-chip__popout:hover,
+.thread-chip__popout:focus-visible {
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
+  color: var(--accent);
+}
+
+.thread-chip__popout:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
 }
 
 .context-rail {


### PR DESCRIPTION
## Summary

- make a remote thread chip's primary action add the thread to this PwrAgent's local list and open it in the current window
- add a dedicated pop-out action that opens the thread in the remote viewer for its owning instance
- preserve direct navigation for remote threads already mounted in the local list and avoid re-pinning them
- carry the remote instance label into the chip so the pop-out action and tooltip name the target machine

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx` (119 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with the existing 30-warning baseline)
- `pnpm lint:boundaries`
- `pnpm lint:colors`
- `pnpm lint:codex-storage`

## Notes

- The pop-out tooltip reads “Open this thread in the remote viewer window for <instance>”.
- I verified the regression test fails against the prior behavior because the pop-out action is absent, then passes with this change.
