### PR TITLE
fix(desktop): backport draft journal persistence controls

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
@@ -238,6 +238,235 @@ describe("ComposerDraftRecoveryStore", () => {
   });
 });
 
+describe("journal prefix collapse", () => {
+  const type = (text: string, index: number): void => {
+    store.save({
+      draft: buildDraft({
+        scopeKey: "thread:codex:typing",
+        threadId: "typing",
+        text,
+        updatedAt: 1000 + index,
+        // Hash the content, not its length. `composer_draft_journal` has a
+        // unique index on (scope_key, content_hash, status), so a
+        // length-derived hash makes two same-length drafts collide and the
+        // second silently replaces the first — which would quietly hide the
+        // very row this suite is counting.
+        contentHash: `hash-${text}`,
+        charCount: text.length,
+      }),
+      recordHistory: true,
+    });
+  };
+  const journalTexts = (): string[] =>
+    (
+      stateDb.raw
+        .prepare(
+          "SELECT payload FROM composer_draft_journal WHERE scope_key = ? ORDER BY id",
+        )
+        .all("thread:codex:typing") as { payload: string }[]
+    ).map((row) => (JSON.parse(row.payload) as { text: string }).text);
+
+  it("keeps one row while a message is extended", () => {
+    ["I like dogs", "I like dogs and cats", "I like dogs and cats and bears"]
+      .forEach(type);
+
+    expect(journalTexts()).toEqual(["I like dogs and cats and bears"]);
+  });
+
+  it("keeps one row across a space, which used to start a new one", () => {
+    // The regression this exists for. Both sides of the comparison are
+    // `trimEnd`ed, so the moment a space is typed the trimmed texts are equal
+    // — a strict "next must be longer" check then failed and inserted a fresh
+    // row. The journal grew by one row per WORD, so a sentence with fourteen
+    // spaces left fifteen near-identical rows.
+    ["I like", "I like ", "I like dogs"].forEach(type);
+
+    expect(journalTexts()).toEqual(["I like dogs"]);
+  });
+
+  it("keeps one row for a whole sentence typed character by character", () => {
+    const sentence = "I like dogs and cats and bears, and I have opinions.";
+    for (let index = 1; index <= sentence.length; index += 1) {
+      type(sentence.slice(0, index), index);
+    }
+
+    expect(journalTexts()).toEqual([sentence]);
+  });
+
+  it("starts a new row when the text stops being an extension", () => {
+    // Backspacing past what was already journalled is a real branch, not a
+    // continuation, and keeping it is the point of a recovery journal.
+    ["I like dogs", "I like cats"].forEach(type);
+
+    expect(journalTexts()).toEqual(["I like dogs", "I like cats"]);
+  });
+});
+
+// Fixed and recent, so the 30-day retention sweep running in the same
+// `cleanupExpired` pass never removes these fixtures out from under the
+// assertions.
+const NOW_FOR_COLLAPSE = 1_786_500_000_000;
+
+describe("journal prefix-chain collapse on the GC pass", () => {
+  /**
+   * Seeds rows in the shape the buggy runtime left behind — one per word —
+   * directly, since the point is what an EXISTING profile already carries.
+   */
+  const seedLegacyJournal = (
+    rows: Array<{
+      payload?: string;
+      scopeKey?: string;
+      status?: string;
+      text: string;
+    }>,
+  ): void => {
+    const insert = stateDb.raw.prepare(
+      `INSERT INTO composer_draft_journal(
+         scope_key, scope_kind, status, content_hash, char_count,
+         created_at, updated_at, payload
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    rows.forEach((row, index) => {
+      const scopeKey = row.scopeKey ?? "thread:codex:t1";
+      const status = row.status ?? "unsent";
+      insert.run(
+        scopeKey,
+        "thread",
+        status,
+        `hash-${scopeKey}-${status}-${row.text}`,
+        row.text.length,
+        1,
+        NOW_FOR_COLLAPSE + index,
+        row.payload ?? JSON.stringify({ scopeKey, status, text: row.text }),
+      );
+    });
+  };
+
+  const readJournal = (): Array<{ status: string; text: string }> =>
+    (
+      stateDb.raw
+        .prepare(
+          "SELECT status, payload FROM composer_draft_journal ORDER BY scope_key, updated_at, id",
+        )
+        .all() as { payload: string; status: string }[]
+    ).map((row) => ({
+      status: row.status,
+      text: (JSON.parse(row.payload) as { text: string }).text,
+    }));
+
+  it("collapses a chain left by the old per-word behaviour", () => {
+    seedLegacyJournal([
+      { text: "I" },
+      { text: "I like" },
+      { text: "I like dogs" },
+      { text: "I like dogs and" },
+      { text: "I like dogs and cats" },
+    ]);
+
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+
+    // The longest text survives — nothing an operator wrote is lost, only the
+    // redundant snapshots of the way there.
+    expect(readJournal()).toEqual([
+      { status: "unsent", text: "I like dogs and cats" },
+    ]);
+  });
+
+  it("collapses abandoned prefix chains too", () => {
+    seedLegacyJournal([
+      { status: "abandoned", text: "A recoverable" },
+      { status: "abandoned", text: "A recoverable abandoned draft" },
+    ]);
+
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+
+    expect(readJournal()).toEqual([
+      { status: "abandoned", text: "A recoverable abandoned draft" },
+    ]);
+  });
+
+  it("keeps a genuine branch rather than collapsing everything", () => {
+    seedLegacyJournal([
+      { text: "I like dogs" },
+      { text: "I like cats" },
+      { text: "I like cats a lot" },
+    ]);
+
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+
+    expect(readJournal()).toEqual([
+      { status: "unsent", text: "I like dogs" },
+      { status: "unsent", text: "I like cats a lot" },
+    ]);
+  });
+
+  it("never reads or deletes sent rows", () => {
+    // `sent` entries record what was actually submitted. The runtime's
+    // previous-row query excludes them, so this must too.
+    seedLegacyJournal([
+      { status: "sent", text: "I like dogs" },
+      { text: "I like dogs" },
+      { text: "I like dogs and cats" },
+    ]);
+
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+
+    expect(readJournal()).toEqual([
+      { status: "sent", text: "I like dogs" },
+      { status: "unsent", text: "I like dogs and cats" },
+    ]);
+  });
+
+  it("does not let one scope absorb another", () => {
+    seedLegacyJournal([
+      { scopeKey: "thread:codex:a", text: "Shared" },
+      { scopeKey: "thread:codex:b", text: "Shared prefix continues" },
+    ]);
+
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+
+    expect(readJournal()).toEqual([
+      { status: "unsent", text: "Shared" },
+      { status: "unsent", text: "Shared prefix continues" },
+    ]);
+  });
+
+  it("leaves malformed payloads alone and does not collapse across them", () => {
+    seedLegacyJournal([
+      { text: "I like" },
+      { payload: "{not-json", text: "malformed" },
+      { text: "I like dogs" },
+    ]);
+
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+
+    const payloads = (
+      stateDb.raw
+        .prepare(
+          "SELECT payload FROM composer_draft_journal ORDER BY updated_at, id",
+        )
+        .all() as Array<{ payload: string }>
+    ).map((row) => row.payload);
+    expect(payloads).toHaveLength(3);
+    expect(payloads[0]).toContain('"text":"I like"');
+    expect(payloads[1]).toBe("{not-json");
+    expect(payloads[2]).toContain('"text":"I like dogs"');
+  });
+
+  it("deletes nothing on a second pass", () => {
+    // Idempotency is what makes running this every GC pass safe rather than
+    // needing a one-shot schema migration to gate it.
+    seedLegacyJournal([{ text: "I like" }, { text: "I like dogs" }]);
+
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+    const afterFirst = readJournal();
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+
+    expect(readJournal()).toEqual(afterFirst);
+    expect(afterFirst).toEqual([{ status: "unsent", text: "I like dogs" }]);
+  });
+});
+
 function buildDraft(
   patch: Partial<ComposerDraftSnapshotRecord>,
 ): ComposerDraftSnapshotRecord {

--- a/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
@@ -10,6 +10,60 @@ let stateDb: StateDb;
 let store: ComposerDraftRecoveryStore;
 let tempDir: string;
 
+const RECOVERABLE_NON_TEXT_VARIANTS: Array<{
+  label: string;
+  patch: Partial<ComposerDraftSnapshotRecord>;
+}> = [
+  {
+    label: "editor document",
+    patch: {
+      editorDocument: {
+        type: "doc",
+        content: [{ type: "paragraph" }],
+      },
+    },
+  },
+  {
+    label: "skill tokens",
+    patch: {
+      skillTokens: [
+        {
+          id: "skill-1",
+          index: 0,
+          name: "review",
+          path: "/skills/review",
+        },
+      ],
+    },
+  },
+  {
+    label: "image attachments",
+    patch: {
+      imageAttachments: [
+        {
+          id: "image-1",
+          name: "reference.png",
+          size: 128,
+          type: "image/png",
+          url: "data:image/png;base64,abc",
+        },
+      ],
+    },
+  },
+  {
+    label: "file attachments",
+    patch: {
+      fileAttachments: [
+        {
+          id: "file-1",
+          label: "notes.txt",
+          path: "/tmp/notes.txt",
+        },
+      ],
+    },
+  },
+];
+
 beforeEach(() => {
   tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-composer-drafts-"));
   stateDb = StateDb.open(path.join(tempDir, "state.db"));
@@ -293,6 +347,52 @@ describe("journal prefix collapse", () => {
     expect(journalTexts()).toEqual([sentence]);
   });
 
+  it("keeps one row when editor text grows with the plain-text prefix", () => {
+    ["I like", "I like ", "I like dogs"].forEach((text, index) => {
+      store.save({
+        draft: buildDraft({
+          scopeKey: "thread:codex:typing",
+          threadId: "typing",
+          text,
+          editorDocument: buildEditorDocument(text),
+          updatedAt: 1000 + index,
+          contentHash: `editor-${text}`,
+        }),
+        recordHistory: true,
+      });
+    });
+
+    expect(journalTexts()).toEqual(["I like dogs"]);
+  });
+
+  it.each(RECOVERABLE_NON_TEXT_VARIANTS)(
+    "keeps equal-text rows with different $label",
+    ({ patch }) => {
+      const text = "A long draft whose non-text recovery state changed.";
+      store.save({
+        draft: buildDraft({
+          ...patch,
+          scopeKey: "thread:codex:typing",
+          threadId: "typing",
+          text,
+          contentHash: "",
+        }),
+        recordHistory: true,
+      });
+      store.save({
+        draft: buildDraft({
+          scopeKey: "thread:codex:typing",
+          threadId: "typing",
+          text,
+          contentHash: "",
+        }),
+        recordHistory: true,
+      });
+
+      expect(journalTexts()).toEqual([text, text]);
+    },
+  );
+
   it("starts a new row when the text stops being an extension", () => {
     // Backspacing past what was already journalled is a real branch, not a
     // continuation, and keeping it is the point of a recovery journal.
@@ -372,6 +472,31 @@ describe("journal prefix-chain collapse on the GC pass", () => {
     ]);
   });
 
+  it("collapses legacy editor documents that differ only by prefix text", () => {
+    seedLegacyJournal([
+      {
+        payload: JSON.stringify({
+          editorDocument: buildEditorDocument("I like"),
+          text: "I like",
+        }),
+        text: "I like",
+      },
+      {
+        payload: JSON.stringify({
+          editorDocument: buildEditorDocument("I like dogs"),
+          text: "I like dogs",
+        }),
+        text: "I like dogs",
+      },
+    ]);
+
+    stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+
+    expect(readJournal()).toEqual([
+      { status: "unsent", text: "I like dogs" },
+    ]);
+  });
+
   it("collapses abandoned prefix chains too", () => {
     seedLegacyJournal([
       { status: "abandoned", text: "A recoverable" },
@@ -431,6 +556,31 @@ describe("journal prefix-chain collapse on the GC pass", () => {
     ]);
   });
 
+  it.each(RECOVERABLE_NON_TEXT_VARIANTS)(
+    "does not collapse legacy prefixes across different $label",
+    ({ patch }) => {
+      seedLegacyJournal([
+        {
+          payload: JSON.stringify({
+            ...patch,
+            text: "I like dogs",
+          }),
+          text: "I like dogs",
+        },
+        { text: "I like dogs and cats" },
+      ]);
+
+      stateDb.cleanupExpired(NOW_FOR_COLLAPSE);
+
+      const payloads = stateDb.raw
+        .prepare(
+          "SELECT payload FROM composer_draft_journal ORDER BY updated_at, id",
+        )
+        .all() as Array<{ payload: string }>;
+      expect(payloads).toHaveLength(2);
+    },
+  );
+
   it("leaves malformed payloads alone and does not collapse across them", () => {
     seedLegacyJournal([
       { text: "I like" },
@@ -485,5 +635,19 @@ function buildDraft(
     contentHash: `hash-${text.length}-${patch.status ?? "unsent"}`,
     charCount: text.length,
     ...patch,
+  };
+}
+
+function buildEditorDocument(
+  text: string,
+): ComposerDraftSnapshotRecord["editorDocument"] {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text }],
+      },
+    ],
   };
 }

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -1,4 +1,11 @@
 {
+  "composer-draft-typing": {
+    "commits": 70,
+    "note": "70 direct store saves (a stress case for prefix collapse, NOT the app's typing cadence — the renderer coalesces to one save per 5s): exactly one journal row survives, and commits track save calls because each save is its own transaction",
+    "observedWalBytes": 1738640,
+    "rowsChanged": 140,
+    "statements": 209
+  },
   "live-thread-token-usage": {
     "commits": 1,
     "note": "500 cumulative usage observations across 10 turns, then one terminal flush",

--- a/apps/desktop/src/main/__tests__/sqlite-write-budgets.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-budgets.test.ts
@@ -8,6 +8,7 @@ import type {
 } from "@pwragent/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
+import { ComposerDraftRecoveryStore } from "../state/composer-draft-recovery-store";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import { StateDb } from "../state/state-db";
 import { expectSqliteWriteBudget } from "./fixtures/sqlite-write-budget";
@@ -53,6 +54,69 @@ describe("sqlite write budgets", () => {
       transaction.immediate("immediate");
     });
     expect(writes).toMatchObject({ commits: 2, rowsChanged: 2, statements: 2 });
+  });
+
+  it("keeps a typed message to one journal row, at one commit per direct store save", async () => {
+    // ROWS is what this pins, and it is deliberately measured under a save
+    // per keystroke — a stress case for the collapse rule, not a claim about
+    // how often the app saves. `shouldReplacePreviousUnsentDraft` compares
+    // `trimEnd`ed texts, so a strict "next must be longer" check failed on
+    // every typed space and inserted a fresh row: one journal row per WORD,
+    // fifteen near-identical rows for one sentence. It must stay at one
+    // however many saves arrive.
+    //
+    // COMMITS here is the per-save cost at the STORE — one save call, one
+    // transaction — and 70 of them because this test makes 70 calls. Do not
+    // read it as the cost of typing a sentence: the renderer coalesces edits
+    // into at most one save per `DURABLE_SAVE_INTERVAL_MS` (5s) and skips
+    // unchanged content entirely, so real typing reaches this store roughly
+    // once every five seconds, not once per character.
+    const drafts = new ComposerDraftRecoveryStore(stateDb);
+    const sentence =
+      "I like dogs and cats and bears, and I have opinions about all of them.";
+
+    // Seeding is nothing here — the typing IS the measured work.
+    const { writes } = await meter.measure(() => {
+      for (let index = 1; index <= sentence.length; index += 1) {
+        const text = sentence.slice(0, index);
+        drafts.save({
+          draft: {
+            scopeKey: "thread:codex:typing",
+            scopeKind: "thread",
+            backend: "codex",
+            threadId: "typing",
+            text,
+            skillTokens: [],
+            imageAttachments: [],
+            status: "unsent",
+            createdAt: 1,
+            updatedAt: 1_786_500_000_000 + index,
+            contentHash: `hash-${text}`,
+            charCount: text.length,
+          },
+          recordHistory: true,
+        });
+      }
+    });
+
+    const journalRows = (
+      stateDb.raw
+        .prepare(
+          "SELECT COUNT(*) AS n FROM composer_draft_journal WHERE scope_key = ?",
+        )
+        .get("thread:codex:typing") as { n: number }
+    ).n;
+    expect(journalRows).toBe(1);
+
+    expectSqliteWriteBudget({
+      note:
+        "70 direct store saves (a stress case for prefix collapse, NOT the "
+        + "app's typing cadence — the renderer coalesces to one save per 5s): "
+        + "exactly one journal row survives, and commits track save calls "
+        + "because each save is its own transaction",
+      scenario: "composer-draft-typing",
+      writes,
+    });
   });
 
   it("pins streamed command output to one delta batch plus completion", async () => {

--- a/apps/desktop/src/main/state/composer-draft-recovery-store.ts
+++ b/apps/desktop/src/main/state/composer-draft-recovery-store.ts
@@ -308,10 +308,30 @@ function parseDraftPayload(
   }
 }
 
-function hashDraftContent(draft: Pick<ComposerDraftSnapshotRecord, "text">): string {
+function hashDraftContent(
+  draft: Pick<
+    ComposerDraftSnapshotRecord,
+    | "editorDocument"
+    | "fileAttachments"
+    | "imageAttachments"
+    | "skillTokens"
+    | "text"
+  >,
+): string {
+  const content = JSON.stringify({
+    text: draft.text,
+    editorDocument: withoutEditorTextNodeContent(draft.editorDocument),
+    skillTokens: Array.isArray(draft.skillTokens) ? draft.skillTokens : [],
+    imageAttachments: Array.isArray(draft.imageAttachments)
+      ? draft.imageAttachments
+      : [],
+    fileAttachments: Array.isArray(draft.fileAttachments)
+      ? draft.fileAttachments
+      : [],
+  });
   let hash = 5381;
-  for (let index = 0; index < draft.text.length; index += 1) {
-    hash = (hash * 33) ^ draft.text.charCodeAt(index);
+  for (let index = 0; index < content.length; index += 1) {
+    hash = (hash * 33) ^ content.charCodeAt(index);
   }
   return `h${(hash >>> 0).toString(36)}`;
 }
@@ -416,8 +436,51 @@ function shouldReplacePreviousUnsentDraft(
   // WORD typed: a sentence with fourteen spaces left fifteen near-identical
   // rows, each a prefix of the next.
   //
-  // Equal trimmed text is deliberately replaced rather than skipped: it is the
-  // same content re-saved (trailing whitespace only), so updating the existing
-  // row in place is exactly right and keeps one row per continuous edit.
-  return previousText.length > 0 && nextText.startsWith(previousText);
+  // Equal trimmed text is deliberately replaced rather than skipped when the
+  // rest of the recoverable content is unchanged: it is the same draft
+  // re-saved with trailing whitespace only. Attachments, skill tokens, and the
+  // editor document are part of recovery state too, so a change to any of them
+  // must start a distinct branch even when the visible text is identical.
+  return previousText.length > 0
+    && nextText.startsWith(previousText)
+    && serializeRecoverableNonTextDraftContent(previous)
+      === serializeRecoverableNonTextDraftContent(next);
+}
+
+function serializeRecoverableNonTextDraftContent(
+  draft: Pick<
+    ComposerDraftSnapshotRecord,
+    | "editorDocument"
+    | "fileAttachments"
+    | "imageAttachments"
+    | "skillTokens"
+  >,
+): string {
+  return JSON.stringify({
+    // Plain text growth is already governed by the prefix predicate. Ignore
+    // only Tiptap text-node strings here so normal typing can collapse while
+    // document structure, marks, attributes, and other editor state cannot.
+    editorDocument: withoutEditorTextNodeContent(draft.editorDocument),
+    skillTokens: draft.skillTokens,
+    imageAttachments: draft.imageAttachments,
+    fileAttachments: draft.fileAttachments ?? [],
+  });
+}
+
+function withoutEditorTextNodeContent(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(withoutEditorTextNodeContent);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.entries(record).map(([key, child]) => [
+      key,
+      record.type === "text" && key === "text" && typeof child === "string"
+        ? ""
+        : withoutEditorTextNodeContent(child),
+    ]),
+  );
 }

--- a/apps/desktop/src/main/state/composer-draft-recovery-store.ts
+++ b/apps/desktop/src/main/state/composer-draft-recovery-store.ts
@@ -408,9 +408,16 @@ function shouldReplacePreviousUnsentDraft(
   }
   const previousText = previous.text.trimEnd();
   const nextText = next.text.trimEnd();
-  return (
-    previousText.length > 0 &&
-    nextText.length > previousText.length &&
-    nextText.startsWith(previousText)
-  );
+  // `startsWith` already implies next is at least as long, so no length
+  // comparison is needed — and a STRICT one was the bug this replaced. Both
+  // sides are `trimEnd`ed, so the moment an operator types a space the trimmed
+  // texts are equal, strict growth is false, and the entry gets inserted as a
+  // new row instead of collapsing. That made the journal grow by one row per
+  // WORD typed: a sentence with fourteen spaces left fifteen near-identical
+  // rows, each a prefix of the next.
+  //
+  // Equal trimmed text is deliberately replaced rather than skipped: it is the
+  // same content re-saved (trailing whitespace only), so updating the existing
+  // row in place is exactly right and keeps one row per continuous edit.
+  return previousText.length > 0 && nextText.startsWith(previousText);
 }

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -1055,6 +1055,8 @@ export class StateDb {
            )`,
         )
         .run(MESSAGING_ACTIVITY_LOG_PER_PLATFORM_CAP);
+      // Before the retention and cap sweeps, so both count post-collapse rows.
+      collapseComposerDraftJournalPrefixChains(this.db);
       this.db
         .prepare("DELETE FROM composer_draft_journal WHERE updated_at < ?")
         .run(now - COMPOSER_DRAFT_JOURNAL_RETENTION_MS);
@@ -1103,6 +1105,103 @@ export class StateDb {
 
   deleteSecret(key: string): void {
     this.db.prepare("DELETE FROM secrets WHERE key = ?").run(key);
+  }
+}
+
+/**
+ * Collapses prefix chains sitting in `composer_draft_journal`.
+ *
+ * Until the fix that ships alongside this, the runtime rule compared
+ * `trimEnd`ed texts with a strict "next must be longer" check, so every typed
+ * space inserted a fresh row instead of extending the previous one — roughly
+ * one row per WORD. Existing profiles carry long runs of near-identical rows,
+ * each a prefix of the next. The code fix only stops NEW ones; without this,
+ * what is already there drains only as the journal's 30-day retention and
+ * 300-row cap catch up.
+ *
+ * **Deliberately NOT a `user_version` migration.** Reserving a schema version
+ * for it would make this change unbackportable: a release branch that took the
+ * number would collide with whatever main assigns next. It needs no schema
+ * change, it is idempotent, and the journal is capped at 300 rows — so it runs
+ * from the hourly `cleanupExpired` pass instead, riding a transaction that is
+ * already open and therefore costing no additional commit. Existing profiles
+ * converge on their first launch after upgrading, and the sweep self-heals if
+ * anything ever reintroduces chains.
+ *
+ * **This deletes rows.** It is deliberately the same rule the runtime now
+ * applies, so it removes exactly what the fixed code would never have written
+ * and nothing else:
+ *
+ * - Only `unsent`/`abandoned` rows participate, matching the runtime's
+ *   previous-row query. `sent` rows are never read and never deleted.
+ * - Within a scope, rows are walked oldest-first and a row is dropped only
+ *   when the NEXT surviving row's trimmed text starts with it — i.e. the later
+ *   row already contains everything the earlier one held. The longest text in
+ *   each chain always survives, so no content is lost, only redundant
+ *   snapshots of the way there.
+ * - A row that is not an extension starts a new chain and both are kept.
+ *   Backspacing and retyping something different is a real branch, and keeping
+ *   it is what a recovery journal is for.
+ *
+ * Idempotent, which is what makes running it every pass safe: once collapsed
+ * there are no chains left, so every subsequent pass deletes nothing and costs
+ * one bounded scan.
+ */
+function collapseComposerDraftJournalPrefixChains(
+  db: BetterSqlite3.Database,
+): void {
+  if (!tableExists(db, "composer_draft_journal")) {
+    return;
+  }
+
+  const rows = db
+    .prepare(
+      `SELECT id, scope_key, payload
+       FROM composer_draft_journal
+       WHERE status IN ('unsent', 'abandoned')
+       ORDER BY scope_key, updated_at, id`,
+    )
+    .all() as Array<{ id: number; payload: string; scope_key: string }>;
+
+  const deleteRow = db.prepare("DELETE FROM composer_draft_journal WHERE id = ?");
+  const superseded: number[] = [];
+  let chainScopeKey: string | undefined;
+  let keeper: { id: number; text: string } | undefined;
+
+  for (const row of rows) {
+    let text: string;
+    try {
+      text = ((JSON.parse(row.payload) as { text?: unknown }).text ?? "") as string;
+    } catch {
+      // An unparseable payload is left strictly alone: it cannot be compared,
+      // so it can neither absorb a neighbour nor be absorbed.
+      chainScopeKey = row.scope_key;
+      keeper = undefined;
+      continue;
+    }
+    if (typeof text !== "string") {
+      chainScopeKey = row.scope_key;
+      keeper = undefined;
+      continue;
+    }
+    const trimmed = text.trimEnd();
+
+    if (row.scope_key !== chainScopeKey) {
+      chainScopeKey = row.scope_key;
+      keeper = { id: row.id, text: trimmed };
+      continue;
+    }
+
+    if (keeper && keeper.text.length > 0 && trimmed.startsWith(keeper.text)) {
+      // This row already contains everything the keeper held, so the keeper is
+      // a redundant waypoint rather than a distinct draft.
+      superseded.push(keeper.id);
+    }
+    keeper = { id: row.id, text: trimmed };
+  }
+
+  for (const id of superseded) {
+    deleteRow.run(id);
   }
 }
 

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -5,6 +5,7 @@ import type BetterSqlite3 from "better-sqlite3";
 import {
   estimateTokenUsageCost,
   resolveOpenAiPricingServiceTier,
+  type ComposerDraftSnapshotRecord,
   type ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
@@ -1135,10 +1136,11 @@ export class StateDb {
  * - Only `unsent`/`abandoned` rows participate, matching the runtime's
  *   previous-row query. `sent` rows are never read and never deleted.
  * - Within a scope, rows are walked oldest-first and a row is dropped only
- *   when the NEXT surviving row's trimmed text starts with it — i.e. the later
- *   row already contains everything the earlier one held. The longest text in
- *   each chain always survives, so no content is lost, only redundant
- *   snapshots of the way there.
+ *   when the NEXT surviving row's trimmed text starts with it AND its editor
+ *   document, skill tokens, image attachments, and file attachments match.
+ *   The later row therefore contains everything recoverable from the earlier
+ *   one. The longest text in each chain survives, so no content is lost, only
+ *   redundant snapshots of the way there.
  * - A row that is not an extension starts a new chain and both are kept.
  *   Backspacing and retyping something different is a real branch, and keeping
  *   it is what a recovery journal is for.
@@ -1166,43 +1168,109 @@ function collapseComposerDraftJournalPrefixChains(
   const deleteRow = db.prepare("DELETE FROM composer_draft_journal WHERE id = ?");
   const superseded: number[] = [];
   let chainScopeKey: string | undefined;
-  let keeper: { id: number; text: string } | undefined;
+  let keeper:
+    | { draft: ComposerDraftJournalCollapsePayload; id: number }
+    | undefined;
 
   for (const row of rows) {
-    let text: string;
-    try {
-      text = ((JSON.parse(row.payload) as { text?: unknown }).text ?? "") as string;
-    } catch {
+    const draft = parseComposerDraftJournalCollapsePayload(row.payload);
+    if (!draft) {
       // An unparseable payload is left strictly alone: it cannot be compared,
       // so it can neither absorb a neighbour nor be absorbed.
       chainScopeKey = row.scope_key;
       keeper = undefined;
       continue;
     }
-    if (typeof text !== "string") {
-      chainScopeKey = row.scope_key;
-      keeper = undefined;
-      continue;
-    }
-    const trimmed = text.trimEnd();
 
     if (row.scope_key !== chainScopeKey) {
       chainScopeKey = row.scope_key;
-      keeper = { id: row.id, text: trimmed };
+      keeper = { draft, id: row.id };
       continue;
     }
 
-    if (keeper && keeper.text.length > 0 && trimmed.startsWith(keeper.text)) {
+    if (keeper && shouldCollapseComposerDraftJournalPrefix(keeper.draft, draft)) {
       // This row already contains everything the keeper held, so the keeper is
       // a redundant waypoint rather than a distinct draft.
       superseded.push(keeper.id);
     }
-    keeper = { id: row.id, text: trimmed };
+    keeper = { draft, id: row.id };
   }
 
   for (const id of superseded) {
     deleteRow.run(id);
   }
+}
+
+type ComposerDraftJournalCollapsePayload = Pick<
+  ComposerDraftSnapshotRecord,
+  | "editorDocument"
+  | "fileAttachments"
+  | "imageAttachments"
+  | "skillTokens"
+  | "text"
+>;
+
+function parseComposerDraftJournalCollapsePayload(
+  payload: string,
+): ComposerDraftJournalCollapsePayload | undefined {
+  try {
+    const parsed = JSON.parse(payload) as Partial<ComposerDraftSnapshotRecord>;
+    if (!parsed || typeof parsed !== "object" || typeof parsed.text !== "string") {
+      return undefined;
+    }
+    return {
+      editorDocument: parsed.editorDocument,
+      fileAttachments: parsed.fileAttachments,
+      imageAttachments: parsed.imageAttachments ?? [],
+      skillTokens: parsed.skillTokens ?? [],
+      text: parsed.text,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function shouldCollapseComposerDraftJournalPrefix(
+  previous: ComposerDraftJournalCollapsePayload,
+  next: ComposerDraftJournalCollapsePayload,
+): boolean {
+  const previousText = previous.text.trimEnd();
+  const nextText = next.text.trimEnd();
+  return previousText.length > 0
+    && nextText.startsWith(previousText)
+    && serializeRecoverableNonTextDraftContent(previous)
+      === serializeRecoverableNonTextDraftContent(next);
+}
+
+function serializeRecoverableNonTextDraftContent(
+  draft: Omit<ComposerDraftJournalCollapsePayload, "text">,
+): string {
+  return JSON.stringify({
+    // Text-node strings are represented by `text` and checked as a prefix
+    // above. Keep every other part of the editor document in the comparison.
+    editorDocument: withoutEditorTextNodeContent(draft.editorDocument),
+    skillTokens: draft.skillTokens,
+    imageAttachments: draft.imageAttachments,
+    fileAttachments: draft.fileAttachments ?? [],
+  });
+}
+
+function withoutEditorTextNodeContent(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(withoutEditorTextNodeContent);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.entries(record).map(([key, child]) => [
+      key,
+      record.type === "text" && key === "text" && typeof child === "string"
+        ? ""
+        : withoutEditorTextNodeContent(child),
+    ]),
+  );
 }
 
 function ensureCurrentSchema(db: BetterSqlite3.Database): void {

--- a/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
@@ -493,9 +493,10 @@ describe("AutomationEditor", () => {
     expect(await screen.findByText(/Send this code: ABC123/)).toBeInTheDocument();
     // The code is copyable (the app root sets user-select: none).
     expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+    await waitFor(() => expect(pairingListener).toBeDefined());
 
     act(() => {
-      pairingListener?.({
+      pairingListener!({
         at: 1,
         entry: {
           id: "pair-1",

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import type { ComposerDraftSnapshot } from "../useComposerDraftStore";
@@ -7,11 +7,297 @@ import { useDurableComposerDraftStore } from "../useDurableComposerDraftStore";
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   vi.useRealTimers();
 });
 
 describe("useDurableComposerDraftStore", () => {
-  it("flushes pending debounced draft saves on teardown", () => {
+  it("does not rewrite a hydrated draft when a thread is merely opened and left", async () => {
+    // The PR's headline claim, and the one that depends on a fragile
+    // round-trip: hydration seeds the persisted-hash map from the STORED
+    // `contentHash`, so suppressing this write requires
+    // `snapshotFromDraftRecord` -> `hashDraftContent` to reproduce exactly the
+    // hash the record was written with. Add a field to the snapshot and update
+    // only one side and this silently either stops suppressing (harmless) or
+    // suppresses a real edit (not).
+    //
+    // The composer re-saves on unmount with no dirty check, so an unchanged
+    // snapshot arrives here just from opening a thread and navigating away.
+    vi.useFakeTimers();
+    const saveComposerDraft = vi.fn<NonNullable<DesktopApi["saveComposerDraft"]>>(
+      async (request) => ({ draft: request.draft }),
+    );
+
+    // Establish the hash the renderer itself produces for this content, so the
+    // fixture cannot drift from the real implementation.
+    const probeApi = { saveComposerDraft } as Partial<DesktopApi> as DesktopApi;
+    const probe = renderHook(() =>
+      useDurableComposerDraftStore(useComposerDraftStore(), probeApi),
+    );
+    act(() => {
+      probe.result.current.set(
+        "thread:codex:thread-1",
+        buildSnapshot("A draft from a previous launch."),
+      );
+      vi.advanceTimersByTime(5_000);
+    });
+    const storedHash = saveComposerDraft.mock.calls[0]![0].draft.contentHash;
+    probe.unmount();
+    saveComposerDraft.mockClear();
+
+    const hydratedApi = {
+      saveComposerDraft,
+      listComposerDraftLatest: async () => ({
+        drafts: [
+          {
+            scopeKey: "thread:codex:thread-1",
+            scopeKind: "thread" as const,
+            backend: "codex" as const,
+            threadId: "thread-1",
+            text: "A draft from a previous launch.",
+            skillTokens: [],
+            imageAttachments: [],
+            fileAttachments: [],
+            status: "unsent" as const,
+            createdAt: 1,
+            updatedAt: 2,
+            contentHash: storedHash,
+            charCount: 31,
+          },
+        ],
+      }),
+    } as Partial<DesktopApi> as DesktopApi;
+    // Hydration resolves a promise, and fake timers do not flush microtasks —
+    // so let it settle on real timers before measuring the cadence.
+    vi.useRealTimers();
+    const { result } = renderHook(() =>
+      useDurableComposerDraftStore(useComposerDraftStore(), hydratedApi),
+    );
+    await waitFor(() => {
+      expect(result.current.get("thread:codex:thread-1")).toBeDefined();
+    });
+    vi.useFakeTimers();
+
+    act(() => {
+      result.current.set(
+        "thread:codex:thread-1",
+        buildSnapshot("A draft from a previous launch."),
+      );
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(saveComposerDraft).not.toHaveBeenCalled();
+  });
+
+  describe("write cadence", () => {
+    const setup = () => {
+      vi.useFakeTimers();
+      const saveComposerDraft = vi.fn<
+        NonNullable<DesktopApi["saveComposerDraft"]>
+      >(async (request) => ({ draft: request.draft }));
+      const desktopApi = {
+        saveComposerDraft,
+      } as Partial<DesktopApi> as DesktopApi;
+      const rendered = renderHook(() =>
+        useDurableComposerDraftStore(useComposerDraftStore(), desktopApi),
+      );
+      return { ...rendered, saveComposerDraft };
+    };
+
+    it("coalesces a burst of typing into a single write", () => {
+      // The point of the change: this used to be one sqlite commit per 200ms,
+      // roughly five a second while typing, for a recovery feature that does
+      // not need per-keystroke granularity.
+      const { result, saveComposerDraft } = setup();
+      const sentence = "I like dogs and cats and bears.";
+
+      act(() => {
+        for (let index = 1; index <= sentence.length; index += 1) {
+          result.current.set(
+            "thread:codex:thread-1",
+            buildSnapshot(sentence.slice(0, index)),
+          );
+        }
+      });
+      expect(saveComposerDraft).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(5_000);
+      });
+
+      expect(saveComposerDraft).toHaveBeenCalledOnce();
+      expect(saveComposerDraft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          draft: expect.objectContaining({ text: sentence }),
+        }),
+      );
+    });
+
+    it("still writes while typing continuously, rather than waiting for a pause", () => {
+      // A trailing debounce would fail this: someone typing without a gap
+      // would never reach the quiet window and nothing would persist at all.
+      // Assert the count and the boundary, not merely that something happened
+      // — a per-keystroke implementation would satisfy `toHaveBeenCalled()`
+      // and this is the test standing between the two designs.
+      const { result, saveComposerDraft } = setup();
+
+      act(() => {
+        result.current.set("thread:codex:thread-1", buildSnapshot("a"));
+      });
+
+      // Keep editing across the whole window without ever pausing.
+      act(() => {
+        vi.advanceTimersByTime(2_500);
+        result.current.set("thread:codex:thread-1", buildSnapshot("ab"));
+      });
+      expect(saveComposerDraft).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(2_500);
+        result.current.set("thread:codex:thread-1", buildSnapshot("abc"));
+      });
+
+      // Exactly one write, at the 5s boundary, carrying the newest text —
+      // the edit that landed at 5s is coalesced into it rather than queued.
+      expect(saveComposerDraft).toHaveBeenCalledOnce();
+      expect(saveComposerDraft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          draft: expect.objectContaining({ text: "ab" }),
+        }),
+      );
+
+      // ...and the edit made after that write starts a fresh window.
+      act(() => {
+        vi.advanceTimersByTime(5_000);
+      });
+      expect(saveComposerDraft).toHaveBeenCalledTimes(2);
+      expect(saveComposerDraft).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          draft: expect.objectContaining({ text: "abc" }),
+        }),
+      );
+    });
+
+    it("does not write when nothing changed", () => {
+      // The composer re-saves on unmount with no dirty check, so an unchanged
+      // snapshot arrives here just from opening a thread and leaving.
+      const { result, saveComposerDraft } = setup();
+
+      act(() => {
+        result.current.set("thread:codex:thread-1", buildSnapshot("Same text."));
+        vi.advanceTimersByTime(5_000);
+      });
+      expect(saveComposerDraft).toHaveBeenCalledOnce();
+
+      act(() => {
+        result.current.set("thread:codex:thread-1", buildSnapshot("Same text."));
+        vi.advanceTimersByTime(60_000);
+      });
+
+      expect(saveComposerDraft).toHaveBeenCalledOnce();
+    });
+
+    it("flushes pending work when the window loses focus", () => {
+      // The unmount cleanup is a React lifecycle hook, and a renderer being
+      // torn down (window closed, app quit) does not run it. Blur lands well
+      // before teardown, so this is what keeps "typed for four seconds then
+      // quit" from losing the text now that the interval is 5s rather than
+      // 200ms.
+      const { result, saveComposerDraft } = setup();
+
+      act(() => {
+        result.current.set(
+          "thread:codex:thread-1",
+          buildSnapshot("Typed just before quitting."),
+        );
+      });
+      expect(saveComposerDraft).not.toHaveBeenCalled();
+
+      act(() => {
+        window.dispatchEvent(new Event("blur"));
+      });
+
+      expect(saveComposerDraft).toHaveBeenCalledOnce();
+      expect(saveComposerDraft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          draft: expect.objectContaining({ text: "Typed just before quitting." }),
+        }),
+      );
+    });
+
+    it("flushes pending work when the document becomes hidden", () => {
+      const { result, saveComposerDraft } = setup();
+      vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+
+      act(() => {
+        result.current.set(
+          "thread:codex:thread-1",
+          buildSnapshot("Typed before the window became hidden."),
+        );
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+
+      expect(saveComposerDraft).toHaveBeenCalledOnce();
+      expect(saveComposerDraft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          draft: expect.objectContaining({
+            text: "Typed before the window became hidden.",
+          }),
+        }),
+      );
+    });
+
+    it("best-effort flushes pending work before unload", () => {
+      const { result, saveComposerDraft } = setup();
+
+      act(() => {
+        result.current.set(
+          "thread:codex:thread-1",
+          buildSnapshot("Typed just before unload."),
+        );
+        window.dispatchEvent(new Event("beforeunload"));
+      });
+
+      expect(saveComposerDraft).toHaveBeenCalledOnce();
+      expect(saveComposerDraft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          draft: expect.objectContaining({ text: "Typed just before unload." }),
+        }),
+      );
+    });
+
+    it("writes nothing on blur when there is nothing pending", () => {
+      const { saveComposerDraft } = setup();
+
+      act(() => {
+        window.dispatchEvent(new Event("blur"));
+      });
+
+      expect(saveComposerDraft).not.toHaveBeenCalled();
+    });
+
+    it("writes again once the draft actually changes", () => {
+      const { result, saveComposerDraft } = setup();
+
+      act(() => {
+        result.current.set("thread:codex:thread-1", buildSnapshot("First."));
+        vi.advanceTimersByTime(5_000);
+      });
+      act(() => {
+        result.current.set("thread:codex:thread-1", buildSnapshot("Second."));
+        vi.advanceTimersByTime(5_000);
+      });
+
+      expect(saveComposerDraft).toHaveBeenCalledTimes(2);
+      expect(saveComposerDraft).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          draft: expect.objectContaining({ text: "Second." }),
+        }),
+      );
+    });
+  });
+
+  it("flushes pending scheduled draft saves on teardown", () => {
     vi.useFakeTimers();
     const saveComposerDraft = vi.fn<NonNullable<DesktopApi["saveComposerDraft"]>>(
       async (request) => ({ draft: request.draft }),

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
@@ -317,6 +317,57 @@ describe("useDurableComposerDraftStore", () => {
       expect(saveComposerDraft).toHaveBeenCalledTimes(2);
     });
 
+    it("does not let a stale save re-mark a cleared draft as durable", async () => {
+      vi.useFakeTimers();
+      let resolveFirstSave: (() => void) | undefined;
+      const saveComposerDraft = vi.fn<
+        NonNullable<DesktopApi["saveComposerDraft"]>
+      >(
+        (request) => new Promise((resolve) => {
+          resolveFirstSave = () => resolve({ draft: request.draft });
+        }),
+      );
+      const clearComposerDraft = vi.fn<
+        NonNullable<DesktopApi["clearComposerDraft"]>
+      >(async ({ scopeKey }) => ({ scopeKey }));
+      const desktopApi = {
+        clearComposerDraft,
+        saveComposerDraft,
+      } as Partial<DesktopApi> as DesktopApi;
+      const { result } = renderHook(() =>
+        useDurableComposerDraftStore(useComposerDraftStore(), desktopApi),
+      );
+      const scopeKey = "thread:codex:thread-1";
+      const snapshot = buildSnapshot("Restore this draft after submission fails.");
+
+      act(() => {
+        result.current.set(scopeKey, snapshot);
+        vi.advanceTimersByTime(5_000);
+      });
+      expect(saveComposerDraft).toHaveBeenCalledOnce();
+      expect(resolveFirstSave).toBeDefined();
+
+      act(() => {
+        result.current.delete(scopeKey);
+      });
+      expect(clearComposerDraft).toHaveBeenCalledWith({ scopeKey });
+
+      await act(async () => {
+        resolveFirstSave!();
+        await Promise.resolve();
+      });
+      saveComposerDraft.mockImplementation(
+        async (request) => ({ draft: request.draft }),
+      );
+
+      await act(async () => {
+        result.current.set(scopeKey, snapshot);
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+
+      expect(saveComposerDraft).toHaveBeenCalledTimes(2);
+    });
+
     it("flushes pending work when the window loses focus", () => {
       // The unmount cleanup is a React lifecycle hook, and a renderer being
       // torn down (window closed, app quit) does not run it. Blur lands well

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
@@ -11,6 +11,60 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+const RECOVERABLE_NON_TEXT_VARIANTS: Array<{
+  label: string;
+  patch: Partial<Omit<ComposerDraftSnapshot, "draft">>;
+}> = [
+  {
+    label: "editor document",
+    patch: {
+      editorDocument: {
+        type: "doc",
+        content: [{ type: "paragraph" }],
+      },
+    },
+  },
+  {
+    label: "skill tokens",
+    patch: {
+      skillTokens: [
+        {
+          id: "skill-1",
+          index: 0,
+          name: "review",
+          path: "/skills/review",
+        },
+      ],
+    },
+  },
+  {
+    label: "image attachments",
+    patch: {
+      imageAttachments: [
+        {
+          id: "image-1",
+          name: "reference.png",
+          size: 128,
+          type: "image/png",
+          url: "data:image/png;base64,abc",
+        },
+      ],
+    },
+  },
+  {
+    label: "file attachments",
+    patch: {
+      fileAttachments: [
+        {
+          id: "file-1",
+          label: "notes.txt",
+          path: "/tmp/notes.txt",
+        },
+      ],
+    },
+  },
+];
+
 describe("useDurableComposerDraftStore", () => {
   it("does not rewrite a hydrated draft when a thread is merely opened and left", async () => {
     // The PR's headline claim, and the one that depends on a fragile
@@ -178,23 +232,89 @@ describe("useDurableComposerDraftStore", () => {
       );
     });
 
-    it("does not write when nothing changed", () => {
+    it("does not write when nothing changed", async () => {
       // The composer re-saves on unmount with no dirty check, so an unchanged
       // snapshot arrives here just from opening a thread and leaving.
       const { result, saveComposerDraft } = setup();
 
-      act(() => {
+      await act(async () => {
         result.current.set("thread:codex:thread-1", buildSnapshot("Same text."));
-        vi.advanceTimersByTime(5_000);
+        await vi.advanceTimersByTimeAsync(5_000);
       });
       expect(saveComposerDraft).toHaveBeenCalledOnce();
 
-      act(() => {
+      await act(async () => {
         result.current.set("thread:codex:thread-1", buildSnapshot("Same text."));
-        vi.advanceTimersByTime(60_000);
+        await vi.advanceTimersByTimeAsync(60_000);
       });
 
       expect(saveComposerDraft).toHaveBeenCalledOnce();
+    });
+
+    it("writes when only recoverable non-text content changes", async () => {
+      const { result, saveComposerDraft } = setup();
+      const text = "The visible text stays the same.";
+
+      await act(async () => {
+        result.current.set("thread:codex:thread-1", buildSnapshot(text));
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+      await act(async () => {
+        result.current.set(
+          "thread:codex:thread-1",
+          buildSnapshot(text, RECOVERABLE_NON_TEXT_VARIANTS[2]!.patch),
+        );
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+
+      expect(saveComposerDraft).toHaveBeenCalledTimes(2);
+      expect(saveComposerDraft).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          draft: expect.objectContaining({
+            imageAttachments: expect.arrayContaining([
+              expect.objectContaining({ id: "image-1" }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it("retries unchanged content after a save fails", async () => {
+      vi.useFakeTimers();
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const saveComposerDraft = vi
+        .fn<NonNullable<DesktopApi["saveComposerDraft"]>>()
+        .mockRejectedValueOnce(new Error("database is busy"))
+        .mockImplementation(async (request) => ({ draft: request.draft }));
+      const desktopApi = {
+        saveComposerDraft,
+      } as Partial<DesktopApi> as DesktopApi;
+      const { result } = renderHook(() =>
+        useDurableComposerDraftStore(useComposerDraftStore(), desktopApi),
+      );
+
+      await act(async () => {
+        result.current.set(
+          "thread:codex:thread-1",
+          buildSnapshot("Retry this unchanged draft."),
+        );
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+      expect(saveComposerDraft).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledWith(
+        "Failed to save composer draft",
+        expect.any(Error),
+      );
+
+      await act(async () => {
+        result.current.set(
+          "thread:codex:thread-1",
+          buildSnapshot("Retry this unchanged draft."),
+        );
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+
+      expect(saveComposerDraft).toHaveBeenCalledTimes(2);
     });
 
     it("flushes pending work when the window loses focus", () => {
@@ -430,20 +550,23 @@ describe("useDurableComposerDraftStore", () => {
     const { result } = renderHook(() =>
       useDurableComposerDraftStore(useComposerDraftStore(), desktopApi),
     );
+    const shorter =
+      "the quick fox typed enough context to be treated as a complete recoverable draft before it grew past the minimum recovery threshold";
+    const longer = `${shorter} into a longer coherent prompt`;
 
     act(() => {
       result.current.recordHistory?.(
         "thread:codex:thread-1",
-        buildSnapshot(
-          "the quick fox typed enough context to be treated as a complete recoverable draft before it grew past the minimum recovery threshold",
-        ),
+        buildSnapshot(shorter, {
+          editorDocument: buildEditorDocument(shorter),
+        }),
         "abandoned",
       );
       result.current.recordHistory?.(
         "thread:codex:thread-1",
-        buildSnapshot(
-          "the quick fox typed enough context to be treated as a complete recoverable draft before it grew past the minimum recovery threshold into a longer coherent prompt",
-        ),
+        buildSnapshot(longer, {
+          editorDocument: buildEditorDocument(longer),
+        }),
         "abandoned",
       );
     });
@@ -456,17 +579,77 @@ describe("useDurableComposerDraftStore", () => {
 
     expect(candidates).toEqual([
       expect.objectContaining({
-        text: "the quick fox typed enough context to be treated as a complete recoverable draft before it grew past the minimum recovery threshold into a longer coherent prompt",
+        text: longer,
       }),
     ]);
   });
+
+  it.each(RECOVERABLE_NON_TEXT_VARIANTS)(
+    "keeps optimistic equal-text candidates with different $label",
+    async ({ patch }) => {
+      const recordComposerDraftHistory = vi.fn<
+        NonNullable<DesktopApi["recordComposerDraftHistory"]>
+      >(async (request) => ({ candidate: request.draft }));
+      const listComposerDraftRecoveryCandidates = vi.fn<
+        NonNullable<DesktopApi["listComposerDraftRecoveryCandidates"]>
+      >(async () => ({ candidates: [] }));
+      const desktopApi = {
+        listComposerDraftRecoveryCandidates,
+        recordComposerDraftHistory,
+      } as Partial<DesktopApi> as DesktopApi;
+      const { result } = renderHook(() =>
+        useDurableComposerDraftStore(useComposerDraftStore(), desktopApi),
+      );
+      const text =
+        "This prompt is intentionally longer than the recovery threshold so both equal-text snapshots enter history while their editor state, tokens, or attachments change independently.";
+
+      act(() => {
+        result.current.recordHistory?.(
+          "thread:codex:thread-1",
+          buildSnapshot(text, patch),
+          "abandoned",
+        );
+        result.current.recordHistory?.(
+          "thread:codex:thread-1",
+          buildSnapshot(text),
+          "abandoned",
+        );
+      });
+
+      const candidates = await result.current.listRecoveryCandidates?.({
+        backend: "codex",
+        scopeKey: "thread:codex:thread-1",
+        threadId: "thread-1",
+      });
+
+      expect(candidates).toHaveLength(2);
+    },
+  );
 });
 
-function buildSnapshot(draft: string): ComposerDraftSnapshot {
+function buildSnapshot(
+  draft: string,
+  patch: Partial<Omit<ComposerDraftSnapshot, "draft">> = {},
+): ComposerDraftSnapshot {
   return {
     draft,
     editorDocument: undefined,
     imageAttachments: [],
     skillTokens: [],
+    ...patch,
+  };
+}
+
+function buildEditorDocument(
+  text: string,
+): NonNullable<ComposerDraftSnapshot["editorDocument"]> {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text }],
+      },
+    ],
   };
 }

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -22,7 +22,22 @@ import type {
   ComposerDraftStore,
 } from "./useComposerDraftStore";
 
-const DURABLE_SAVE_DEBOUNCE_MS = 200;
+/**
+ * How often an edited draft is written to sqlite, at most.
+ *
+ * This is an INTERVAL, not a debounce: the first edit after a quiet period
+ * schedules a write this far out, and every edit inside that window is
+ * coalesced into it. A trailing debounce would be wrong in the other
+ * direction — someone typing continuously would never reach the quiet gap and
+ * nothing would be persisted at all until they stopped.
+ *
+ * It was 200ms, which meant roughly five sqlite commits per second of typing
+ * (~18,000/hour) for a feature whose purpose is shell-style draft RECOVERY —
+ * getting back a message you walked away from. Recovery does not need
+ * per-keystroke granularity; losing the last few seconds of typing on a hard
+ * crash is not what this exists to prevent.
+ */
+const DURABLE_SAVE_INTERVAL_MS = 5_000;
 const HISTORY_TEXT_THRESHOLD = 120;
 
 type SaveComposerDraft = NonNullable<DesktopApi["saveComposerDraft"]>;
@@ -43,6 +58,10 @@ export function useDurableComposerDraftStore(
 ): ComposerDraftStore {
   const pendingSavesRef = useRef(new Map<string, PendingDraftSave>());
   const createdAtRef = useRef(new Map<string, number>());
+  // Content hash of what is actually in sqlite for each scope. Guards the
+  // "edited" half of the rule: opening a thread and leaving, or any other
+  // re-save of identical content, must not cost a write.
+  const persistedHashRef = useRef(new Map<string, string>());
   const localRecoveryCandidatesRef = useRef<LocalRecoveryCandidate[]>([]);
   const localRecoverySequenceRef = useRef(0);
   const [hydrationVersion, setHydrationVersion] = useState(0);
@@ -83,6 +102,7 @@ export function useDurableComposerDraftStore(
         "unsent",
         createdAtRef,
       );
+      persistedHashRef.current.set(scopeKey, record.contentHash);
       if (shouldRecordHistory(pending.snapshot, "unsent")) {
         rememberLocalRecoveryCandidate(record);
       }
@@ -114,6 +134,7 @@ export function useDurableComposerDraftStore(
           if (!baseStore.get(draft.scopeKey)) {
             baseStore.set(draft.scopeKey, snapshotFromDraftRecord(draft));
             createdAtRef.current.set(draft.scopeKey, draft.createdAt);
+            persistedHashRef.current.set(draft.scopeKey, draft.contentHash);
             hydratedAny = true;
           }
         }
@@ -130,13 +151,56 @@ export function useDurableComposerDraftStore(
     };
   }, [baseStore, desktopApi]);
 
+  const flushAllPendingSaves = useCallback((): void => {
+    for (const [scopeKey, pending] of [...pendingSavesRef.current]) {
+      flushPendingSave(scopeKey, pending);
+    }
+  }, [flushPendingSave]);
+
   useEffect(() => {
     return () => {
-      for (const [scopeKey, pending] of [...pendingSavesRef.current]) {
-        flushPendingSave(scopeKey, pending);
+      flushAllPendingSaves();
+    };
+  }, [flushAllPendingSaves]);
+
+  /**
+   * Flush whenever the operator stops interacting with this window.
+   *
+   * The unmount cleanup above is a React lifecycle hook, and a renderer being
+   * torn down — window closed, app quit — does not run it. That was near
+   * enough to harmless while the write interval was 200ms; at 5s it would mean
+   * typing for four seconds, quitting, and losing it, which is precisely the
+   * failure a draft-recovery feature exists to prevent.
+   *
+   * Blur and `visibilitychange` both land well BEFORE teardown, so the async
+   * IPC has a normal amount of time to complete — unlike `beforeunload`, where
+   * an in-flight `invoke` may never be delivered. `beforeunload` is registered
+   * anyway as a last resort for paths that somehow skip the others; it is
+   * best-effort by nature, not the thing being relied on.
+   *
+   * Flushing on blur is cheap because the dirty check already gates it: a
+   * window that lost focus with nothing pending writes nothing.
+   */
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const flushIfHidden = (): void => {
+      if (document.visibilityState === "hidden") {
+        flushAllPendingSaves();
       }
     };
-  }, [flushPendingSave]);
+
+    window.addEventListener("blur", flushAllPendingSaves);
+    window.addEventListener("beforeunload", flushAllPendingSaves);
+    document.addEventListener("visibilitychange", flushIfHidden);
+    return () => {
+      window.removeEventListener("blur", flushAllPendingSaves);
+      window.removeEventListener("beforeunload", flushAllPendingSaves);
+      document.removeEventListener("visibilitychange", flushIfHidden);
+    };
+  }, [flushAllPendingSaves]);
 
   return useMemo(
     () => ({
@@ -145,6 +209,7 @@ export function useDurableComposerDraftStore(
       delete: (scopeKey) => {
         baseStore.delete(scopeKey);
         createdAtRef.current.delete(scopeKey);
+        persistedHashRef.current.delete(scopeKey);
         const pending = pendingSavesRef.current.get(scopeKey);
         if (pending) {
           window.clearTimeout(pending.timer);
@@ -194,7 +259,25 @@ export function useDurableComposerDraftStore(
 
         const existingPending = pendingSavesRef.current.get(scopeKey);
         if (existingPending) {
-          window.clearTimeout(existingPending.timer);
+          // A write is already scheduled. Take the newer snapshot but LEAVE
+          // the timer alone — resetting it here is what would turn this back
+          // into a debounce that never fires while someone keeps typing.
+          pendingSavesRef.current.set(scopeKey, {
+            ...existingPending,
+            snapshot,
+          });
+          return;
+        }
+
+        // Nothing scheduled, so this is the first edit of a new window — and
+        // only a real edit earns a write. An unchanged snapshot reaches here
+        // constantly: the composer re-saves on unmount without a dirty check,
+        // so merely opening a thread and navigating away would otherwise cost
+        // a write and restamp `updated_at`.
+        if (
+          hashDraftContent(snapshot) === persistedHashRef.current.get(scopeKey)
+        ) {
+          return;
         }
 
         const saveComposerDraft = desktopApi.saveComposerDraft;
@@ -203,7 +286,7 @@ export function useDurableComposerDraftStore(
           if (pending) {
             flushPendingSave(scopeKey, pending);
           }
-        }, DURABLE_SAVE_DEBOUNCE_MS);
+        }, DURABLE_SAVE_INTERVAL_MS);
         pendingSavesRef.current.set(scopeKey, {
           saveComposerDraft,
           snapshot,
@@ -416,13 +499,32 @@ function shouldReplacePreviousUnsentCandidate(
   }
   const previousText = previous.text.trimEnd();
   const nextText = next.text.trimEnd();
-  return (
-    previousText.length > 0 &&
-    nextText.length > previousText.length &&
-    nextText.startsWith(previousText)
-  );
+  // Must stay in step with `shouldReplacePreviousUnsentDraft` in
+  // composer-draft-recovery-store.ts — this is the in-memory half of the same
+  // rule, and it carried the same bug: both sides are `trimEnd`ed, so a
+  // strict length comparison failed on every typed space and left one
+  // candidate per word instead of one per edit.
+  return previousText.length > 0 && nextText.startsWith(previousText);
 }
 
+/**
+ * Content fingerprint for a snapshot.
+ *
+ * Note what this now decides. It started as a dedupe/ranking key for recovery
+ * candidates, where a collision merely merged two entries in a list. It is now
+ * also the dirty check that decides whether an edit is persisted AT ALL, so a
+ * collision means a draft change is silently never written. djb2/32-bit makes
+ * that vanishingly unlikely between successive edits of one document, and the
+ * consequence is bounded (the next distinct edit writes), but the risk class
+ * changed when the second caller arrived — do not widen its use further
+ * without swapping in something with real collision resistance.
+ *
+ * It must also stay in step with the record round-trip: hydration seeds the
+ * persisted-hash map straight from a stored `contentHash`, so if this function
+ * and `snapshotFromDraftRecord` ever disagree about which fields matter, the
+ * dirty check either stops suppressing (harmless) or suppresses a real edit
+ * (not). `useDurableComposerDraftStore.test.tsx` pins that round-trip.
+ */
 function hashDraftContent(snapshot: ComposerDraftSnapshot): string {
   const content = JSON.stringify({
     text: snapshot.draft,

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -102,7 +102,6 @@ export function useDurableComposerDraftStore(
         "unsent",
         createdAtRef,
       );
-      persistedHashRef.current.set(scopeKey, record.contentHash);
       if (shouldRecordHistory(pending.snapshot, "unsent")) {
         rememberLocalRecoveryCandidate(record);
       }
@@ -110,6 +109,15 @@ export function useDurableComposerDraftStore(
         .saveComposerDraft({
           draft: record,
           recordHistory: shouldRecordHistory(pending.snapshot, "unsent"),
+        })
+        .then((response) => {
+          // This map describes what is ACTUALLY durable, not what was merely
+          // attempted. Leaving the old hash in place on failure lets a later
+          // unchanged composer flush retry instead of suppressing the save.
+          persistedHashRef.current.set(
+            scopeKey,
+            response.draft.contentHash,
+          );
         })
         .catch((error) => {
           console.warn("Failed to save composer draft", error);
@@ -503,8 +511,12 @@ function shouldReplacePreviousUnsentCandidate(
   // composer-draft-recovery-store.ts — this is the in-memory half of the same
   // rule, and it carried the same bug: both sides are `trimEnd`ed, so a
   // strict length comparison failed on every typed space and left one
-  // candidate per word instead of one per edit.
-  return previousText.length > 0 && nextText.startsWith(previousText);
+  // candidate per word instead of one per edit. Non-text recovery content must
+  // also remain distinct when attachments, tokens, or editor state change.
+  return previousText.length > 0
+    && nextText.startsWith(previousText)
+    && serializeRecoverableNonTextDraftContent(previous)
+      === serializeRecoverableNonTextDraftContent(next);
 }
 
 /**
@@ -528,23 +540,63 @@ function shouldReplacePreviousUnsentCandidate(
 function hashDraftContent(snapshot: ComposerDraftSnapshot): string {
   const content = JSON.stringify({
     text: snapshot.draft,
-    editorDocument: snapshot.editorDocument,
-    skillTokens: snapshot.skillTokens.map((token) => ({
-      id: token.id,
-      index: token.index,
-      name: token.name,
-      path: token.path,
-    })),
-    imageAttachments: snapshot.imageAttachments.map((attachment) => ({
-      url: attachment.url,
-    })),
-    fileAttachments: (snapshot.fileAttachments ?? []).map((attachment) => ({
-      path: attachment.path,
-    })),
+    ...getRecoverableNonTextDraftContent(snapshot),
   });
   let hash = 5381;
   for (let index = 0; index < content.length; index += 1) {
     hash = (hash * 33) ^ content.charCodeAt(index);
   }
   return `h${(hash >>> 0).toString(36)}`;
+}
+
+function serializeRecoverableNonTextDraftContent(
+  draft: Pick<
+    ComposerDraftSnapshotRecord,
+    | "editorDocument"
+    | "fileAttachments"
+    | "imageAttachments"
+    | "skillTokens"
+  >,
+): string {
+  return JSON.stringify(getRecoverableNonTextDraftContent(draft));
+}
+
+function getRecoverableNonTextDraftContent(draft: {
+  editorDocument?: unknown;
+  fileAttachments?: readonly unknown[];
+  imageAttachments: readonly unknown[];
+  skillTokens: readonly unknown[];
+}): {
+  editorDocument: unknown;
+  fileAttachments: readonly unknown[];
+  imageAttachments: readonly unknown[];
+  skillTokens: readonly unknown[];
+} {
+  return {
+    // `draft` carries the changing plain text. Normalize only Tiptap text-node
+    // strings here so prefix typing remains collapsible while structure,
+    // marks, attributes, and every other editor-state field remain distinct.
+    editorDocument: withoutEditorTextNodeContent(draft.editorDocument),
+    skillTokens: draft.skillTokens,
+    imageAttachments: draft.imageAttachments,
+    fileAttachments: draft.fileAttachments ?? [],
+  };
+}
+
+function withoutEditorTextNodeContent(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(withoutEditorTextNodeContent);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.entries(record).map(([key, child]) => [
+      key,
+      record.type === "text" && key === "text" && typeof child === "string"
+        ? ""
+        : withoutEditorTextNodeContent(child),
+    ]),
+  );
 }

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -62,6 +62,10 @@ export function useDurableComposerDraftStore(
   // "edited" half of the rule: opening a thread and leaving, or any other
   // re-save of identical content, must not cost a write.
   const persistedHashRef = useRef(new Map<string, string>());
+  // A clear invalidates every save that started before it. Without this
+  // generation guard, a stale async completion can put the cleared hash back
+  // and suppress persistence when the composer restores the same snapshot.
+  const clearGenerationRef = useRef(new Map<string, number>());
   const localRecoveryCandidatesRef = useRef<LocalRecoveryCandidate[]>([]);
   const localRecoverySequenceRef = useRef(0);
   const [hydrationVersion, setHydrationVersion] = useState(0);
@@ -102,6 +106,7 @@ export function useDurableComposerDraftStore(
         "unsent",
         createdAtRef,
       );
+      const clearGeneration = clearGenerationRef.current.get(scopeKey) ?? 0;
       if (shouldRecordHistory(pending.snapshot, "unsent")) {
         rememberLocalRecoveryCandidate(record);
       }
@@ -111,6 +116,11 @@ export function useDurableComposerDraftStore(
           recordHistory: shouldRecordHistory(pending.snapshot, "unsent"),
         })
         .then((response) => {
+          if (
+            (clearGenerationRef.current.get(scopeKey) ?? 0) !== clearGeneration
+          ) {
+            return;
+          }
           // This map describes what is ACTUALLY durable, not what was merely
           // attempted. Leaving the old hash in place on failure lets a later
           // unchanged composer flush retry instead of suppressing the save.
@@ -215,6 +225,10 @@ export function useDurableComposerDraftStore(
       ...baseStore,
       hydrationVersion,
       delete: (scopeKey) => {
+        clearGenerationRef.current.set(
+          scopeKey,
+          (clearGenerationRef.current.get(scopeKey) ?? 0) + 1,
+        );
         baseStore.delete(scopeKey);
         createdAtRef.current.delete(scopeKey);
         persistedHashRef.current.delete(scopeKey);


### PR DESCRIPTION
## Summary

Manual backport of [#1494](https://github.com/pwrdrvr/PwrAgent/pull/1494), `fix(desktop): collapse draft journal rows and save every 5s, not every 200ms`, from squash commit [`bc4d919ea9fd389c2e5c2dbfa6b3d4ac922dcc82`](https://github.com/pwrdrvr/PwrAgent/commit/bc4d919ea9fd389c2e5c2dbfa6b3d4ac922dcc82). The original main CI passed in full.

This ports only the logical #1494 change onto the 1.0 maintenance line:

- fix both prefix-extension predicates so trailing spaces continue the current draft row while backspaced/divergent drafts still branch
- replace the trailing 200 ms debounce with a five-second interval, so edits coalesce without starving continuous typing
- seed and maintain a persisted-content hash so unchanged drafts and open-then-navigate-away flows do not write
- flush pending drafts on React cleanup, window blur, visibility transition to hidden, and best-effort before unload
- collapse legacy unsent/abandoned prefix chains during the existing `cleanupExpired` transaction before retention and cap sweeps
- pin the runtime behavior and direct-store SQLite write cost with focused tests and checked budgets

## 1.0-specific adaptations

- Manually ported onto the current `origin/releases/1.0`; no cherry-pick was used.
- Kept the release hook's existing `recordHistory` shape. Main's later `pushDraft` / `persistDraftHistory` refactor is not present and was not imported.
- Added the checked write scenario to `sqlite-write-budgets.test.ts`, the release-native infrastructure backported by #1446, instead of main's later `sqlite-write-metrics.test.ts` layout.
- Inserted the legacy collapse immediately before the release line's existing journal retention/cap statements; later main-only federation and PR-watch cleanup are absent.
- Added explicit release-line regression coverage for abandoned chains, malformed payload boundaries, visibility-hidden flush, and best-effort before-unload flush.
- Did not include #1479's 180-day `composer_draft_latest` TTL, federation, Star Map, or any unrelated main behavior.

## Database/version constraint

This deliberately remains cleanup logic, not a migration:

- `CURRENT_STATE_DB_USER_VERSION` remains **32**
- `CURRENT_MESSAGING_STORE_VERSION` remains **2**
- no DDL, migration number, schema definition, `PRAGMA user_version`, or messaging-store version changes
- the collapse performs a bounded read plus deletes inside the transaction already opened by `cleanupExpired`, so it adds **zero SQLite commits**
- sent rows are excluded; scopes cannot absorb one another; divergent branches and malformed payloads survive; the longest text in each prefix chain survives; a second pass is idempotent

The final diff was explicitly scanned for version/DDL additions and for #1479-only symbols.

## SQLite write budget and arithmetic

The checked `composer-draft-typing` scenario intentionally calls the main-process store once per character to stress the row-collapse rule; it does **not** model renderer cadence:

- 70 direct saves
- 70 commits
- 209 statements
- 140 changed rows
- 1 journal row survives
- 1,738,640 observed WAL bytes

That is `1,738,640 / 70 = 24,837.7` observed WAL bytes per direct-store commit in this fixture.

For one continuously edited, focused composer scope:

- old 200 ms cadence ceiling: `3,600 / 0.2 = 18,000 commits/hour` (`432,000/day`)
- new five-second cadence ceiling: `3,600 / 5 = 720 commits/hour` (`17,280/day`)
- cadence reduction: `5,000 / 200 = 25x`
- pathological WAL-only projection at the new ceiling: `24,837.7 × 17,280 = 429,195,703 bytes/day` (429 MB/day, 0.400 GiB/day), versus about 10.73 GB/day at the former cadence

Actual writes occur only while content is dirty. Unchanged saves schedule nothing, and blur/hidden/unload flushes write only when a draft is pending. WAL checkpoint copying can add device writes beyond this projection.

## Validation

Passed:

- `pnpm test apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx` — 31/31
- `UPDATE_SQLITE_WRITE_BUDGETS=1 pnpm test apps/desktop/src/main/__tests__/sqlite-write-budgets.test.ts -t "keeps a typed message to one journal row"` — prescribed budget recording flow, 1/1
- `pnpm test apps/desktop/src/main/__tests__/sqlite-write-budgets.test.ts` — 11/11
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors (existing release-line warning baseline only)
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
- `pnpm lint:boundaries`
- `git diff --check`

## Source audit

The final eight-file diff was compared with #1494 and its squash commit. It contains the two predicate fixes, interval/dirty/flush behavior, cleanup collapse, focused regressions, and the adapted release-line budget only. No #1479 TTL behavior or other later main changes leaked into the backport.


## Review follow-up

- Prefix rows now collapse only when skill tokens, image attachments, file attachments, and non-text editor structure/marks are equivalent. Tiptap text-node strings are normalized because plain-text growth is already governed by the prefix predicate, so normal typing still collapses.
- The runtime store, startup/hourly cleanup, mirrored renderer candidate list, and fallback content hash use the same recoverable-state rule.
- The persisted dirty hash advances only after `saveComposerDraft` succeeds. A rejected save leaves the prior durable hash in place, so a later unchanged flush retries.
- Focused coverage now includes every non-text field, normal editor-document text growth, legacy cleanup, attachment-only dirty writes, and failed-save retries: 48\/48 composer tests. SQLite budgets remain unchanged at 11/11.

## CI follow-up

- The automation pairing test now waits for its React subscription effect before emitting the simulated pairing event. Two CI runs exposed the prior race on different platforms: Linux first, then Windows after rebasing. This is test-only synchronization; AutomationEditor production behavior is unchanged.
- Validation after the fix: affected four files 80/80, the exact pairing test passed in ten fresh-process stress runs, typecheck passed, and ESLint reported zero errors.

## Stale-save review follow-up

- Each save captures a per-scope clear generation. A completion from before clear can no longer re-mark deleted content as durable or suppress persistence when an identical snapshot is restored after a failed submission.
- Regression coverage holds the first save in flight, clears the scope, resolves that stale save, restores identical content, and verifies a second durable write. Current focused validation is 81/81.