### PR TITLE
fix(federation): sync live Codex thread names

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4447,6 +4447,57 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("exposes live Codex thread names while thread/list still returns the placeholder", async () => {
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-1",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await expect(
+      registry.listThreads({ backend: "codex" }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-1",
+        title: "Untitled thread",
+        titleSource: "fallback",
+      }),
+    ]);
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId: "thread-1",
+          threadName: "Sync generated names over federation",
+        },
+      },
+    });
+
+    await expect(
+      registry.listThreads({ backend: "codex" }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-1",
+        title: "Sync generated names over federation",
+        titleSource: "explicit",
+      }),
+    ]);
+
+    await registry.close();
+  });
+
   it("invalidates cached ACP thread summaries when runtime mode changes", async () => {
     const acpBackendId = "acp:gemini" as AcpBackendId;
     const sessions: AcpSessionMetadata[] = [

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1514,6 +1514,7 @@ class MockBackendClient {
       rateLimits?: BackendRateLimitSummary[];
       listThreadsError?: Error;
       listThreadsDelay?: Promise<unknown>;
+      respectThreadTitleFilter?: boolean;
       archivedThreads?: AppServerThreadSummary[];
       archiveThreadError?: Error;
       startThreadResult?: { threadId: string };
@@ -1572,10 +1573,14 @@ class MockBackendClient {
     if (this.options.listThreadsDelay) {
       await this.options.listThreadsDelay;
     }
-    if (params?.archived === true && this.options.archivedThreads) {
-      return this.options.archivedThreads;
-    }
-    return this.options.threads ?? [];
+    const threads =
+      params?.archived === true && this.options.archivedThreads
+        ? this.options.archivedThreads
+        : this.options.threads ?? [];
+    const filter = params?.filter?.trim().toLowerCase();
+    return this.options.respectThreadTitleFilter && filter
+      ? threads.filter((thread) => thread.title.toLowerCase().includes(filter))
+      : threads;
   }
 
   async listNativeSubAgentThreads(params?: {
@@ -4493,6 +4498,215 @@ describe("DesktopBackendRegistry", () => {
         title: "Sync generated names over federation",
         titleSource: "explicit",
       }),
+    ]);
+
+    await registry.close();
+  });
+
+  it("reconciles a Codex name update that arrives during list enrichment", async () => {
+    const enrichment = createDeferred<void>();
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-1",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock();
+    const getThreadOverlayStates = vi.spyOn(
+      overlayStore,
+      "getThreadOverlayStates",
+    ).mockImplementation(async () => {
+      await enrichment.promise;
+      return {};
+    });
+    const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+
+    const pendingList = registry.listThreads({ backend: "codex" });
+    await waitForCondition(() => getThreadOverlayStates.mock.calls.length === 1);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId: "thread-1",
+          threadName: "Sync generated names over federation",
+        },
+      },
+    });
+    enrichment.resolve();
+
+    await expect(pendingList).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-1",
+        title: "Sync generated names over federation",
+        titleSource: "explicit",
+      }),
+    ]);
+    await expect(
+      registry.listThreads({ backend: "codex" }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-1",
+        title: "Sync generated names over federation",
+      }),
+    ]);
+    expect(codexClient.listThreadsCallCount).toBe(2);
+
+    await registry.close();
+  });
+
+  it("includes live Codex name matches omitted by provider-side filtering", async () => {
+    const codexClient = new MockBackendClient({
+      respectThreadTitleFilter: true,
+      threads: [
+        {
+          id: "thread-1",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+    await registry.listThreads({ backend: "codex" });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId: "thread-1",
+          threadName: "Sync generated names over federation",
+        },
+      },
+    });
+
+    await expect(
+      registry.listThreads({
+        backend: "codex",
+        filter: "generated names",
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-1",
+        title: "Sync generated names over federation",
+      }),
+    ]);
+    expect(codexClient.listThreadsCalls.map(({ params }) => params?.filter))
+      .toEqual([undefined, "generated names", undefined]);
+
+    await registry.close();
+  });
+
+  it("retires observed Codex names when the provider acknowledges them", async () => {
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-1",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId: "thread-1",
+          threadName: "First generated name",
+        },
+      },
+    });
+    await expect(
+      registry.listThreads({ backend: "codex" }),
+    ).resolves.toEqual([
+      expect.objectContaining({ title: "First generated name" }),
+    ]);
+
+    codexClient.setThreads([
+      {
+        id: "thread-1",
+        title: "First generated name",
+        titleSource: "explicit",
+        linkedDirectories: [],
+        source: "codex",
+      },
+    ]);
+    await registry.listThreads({ backend: "codex", forceRefresh: true });
+    codexClient.setThreads([
+      {
+        id: "thread-1",
+        title: "New name from another process",
+        titleSource: "explicit",
+        linkedDirectories: [],
+        source: "codex",
+      },
+    ]);
+
+    await expect(
+      registry.listThreads({ backend: "codex", forceRefresh: true }),
+    ).resolves.toEqual([
+      expect.objectContaining({ title: "New name from another process" }),
+    ]);
+
+    await registry.close();
+  });
+
+  it("trusts a different explicit provider name over an unacknowledged observation", async () => {
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-1",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId: "thread-1",
+          threadName: "First generated name",
+        },
+      },
+    });
+    codexClient.setThreads([
+      {
+        id: "thread-1",
+        title: "New name from another process",
+        titleSource: "explicit",
+        linkedDirectories: [],
+        source: "codex",
+      },
+    ]);
+
+    await expect(
+      registry.listThreads({ backend: "codex", forceRefresh: true }),
+    ).resolves.toEqual([
+      expect.objectContaining({ title: "New name from another process" }),
     ]);
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -1666,6 +1666,50 @@ describe("DesktopFederationRuntime", () => {
     expect(invalidated).toEqual(["client_one"]);
   });
 
+  it("invalidates Cmd+K summaries when a peer names a thread", () => {
+    const invalidated: Array<string | undefined> = [];
+    const router = new FederationRouter({ localInstanceId: "gateway_one" });
+    router.registerConnection(createConnection({
+      peerId: "client_one",
+      capabilities: ["thread_navigation", "event_subscriptions"],
+    }));
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "gateway_one";
+    runtime.router = router;
+    runtime.setEventSubscriptions("viewer", [{
+      sourceInstanceId: "client_one",
+      eventClasses: ["navigation"],
+    }]);
+    runtime.remoteThreadSummaryCache = {
+      invalidate: (instanceId) => invalidated.push(instanceId),
+    };
+
+    runtime.publishRemoteBackendEvent(
+      {
+        id: "event-name",
+        kind: "notification",
+        method: FEDERATION_BACKEND_EVENT_METHOD,
+        params: {
+          backend: "codex",
+          notification: {
+            method: "thread/name/updated",
+            params: {
+              threadId: "thread-1",
+              threadName: "Sync generated names over federation",
+            },
+          },
+        },
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: "client_one",
+        targetInstanceId: "gateway_one",
+        createdAt: 2_000,
+      },
+      "client_one",
+    );
+
+    expect(invalidated).toEqual(["client_one"]);
+  });
+
   it("subscribes Cmd+K snapshot peers to navigation updates for the cache TTL", async () => {
     vi.useFakeTimers();
     const sent: FederationProtocolEnvelope[] = [];

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6571,6 +6571,13 @@ export class DesktopBackendRegistry {
    */
   private readonly notificationThreadTitles = new Map<string, string>();
   private readonly notificationThreadProjectLabels = new Map<string, string>();
+  /**
+   * Live `thread/name/updated` observations are newer than the provider's
+   * thread list during an active turn. Reconcile list rows through this map so
+   * federation snapshots and remote search do not regress to a placeholder
+   * after the local renderer has already received the generated name.
+   */
+  private readonly observedThreadNames = new Map<string, string>();
   private hasLoggedNotificationsEnabledError = false;
   private readonly threadTurnQueue: ThreadTurnQueue;
   private automationInspectionHandler?: AutomationInspectionHandler;
@@ -18715,7 +18722,7 @@ export class DesktopBackendRegistry {
       "codex",
       allThreads,
       params,
-    );
+    ).map((thread) => this.withObservedThreadName(thread));
 
     const overlaysByThreadId = await this.overlayStore.getThreadOverlayStates({
       backend: "codex",
@@ -28137,10 +28144,9 @@ export class DesktopBackendRegistry {
       if (typeof threadId === "string" && typeof threadName === "string") {
         const trimmed = threadName.trim();
         if (trimmed) {
-          this.notificationThreadTitles.set(
-            buildThreadIdentityKey(event.backend, threadId),
-            trimmed,
-          );
+          const key = buildThreadIdentityKey(event.backend, threadId);
+          this.notificationThreadTitles.set(key, trimmed);
+          this.observedThreadNames.set(key, trimmed);
         }
       }
       return;
@@ -28156,6 +28162,25 @@ export class DesktopBackendRegistry {
       }
       this.rememberThreadNotificationContext(event.backend, threadId, params.thread);
     }
+  }
+
+  private withObservedThreadName(
+    thread: AppServerThreadSummary,
+  ): AppServerThreadSummary {
+    const observedName = this.observedThreadNames.get(
+      buildThreadIdentityKey(thread.source, thread.id),
+    );
+    if (
+      !observedName
+      || (thread.title === observedName && thread.titleSource === "explicit")
+    ) {
+      return thread;
+    }
+    return {
+      ...thread,
+      title: observedName,
+      titleSource: "explicit",
+    };
   }
 
   private rememberThreadNotificationContext(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7841,31 +7841,38 @@ export class DesktopBackendRegistry {
       skipArchivedMetadataRefresh:
         normalizedParams.skipArchivedMetadataRefresh === true,
     });
+    // An event can invalidate or replace this entry while the read awaits
+    // enrichment. Only the promise that still owns the key may publish it.
+    const pendingState: ThreadListCacheState = {};
     const promise = this.readThreadList(normalizedParams)
       .then((threads) => {
-        this.threadListCache.set(cacheKey, {
-          expiresAt: Date.now() + THREAD_LIST_REUSE_WINDOW_MS,
-          threads,
-        });
-        logDebug("threadListCache:store", {
-          archived: normalizedParams.archived === true,
-          backend: normalizedParams.backend ?? "all",
-          callerReason: normalizedParams.callerReason ?? "thread-list",
-          durationMs: Date.now() - startedAt,
-          enrichDirectories: normalizedParams.enrichDirectories,
-          expiresInMs: THREAD_LIST_REUSE_WINDOW_MS,
-          filterPresent: Boolean(normalizedParams.filter?.trim()),
-          forceRefresh: normalizedParams.forceRefresh === true,
-          limit: normalizedParams.limit,
-          maxPages: normalizedParams.maxPages,
-          skipArchivedMetadataRefresh:
-            normalizedParams.skipArchivedMetadataRefresh === true,
-          threadCount: threads.length,
-        });
+        if (this.threadListCache.get(cacheKey) === pendingState) {
+          this.threadListCache.set(cacheKey, {
+            expiresAt: Date.now() + THREAD_LIST_REUSE_WINDOW_MS,
+            threads,
+          });
+          logDebug("threadListCache:store", {
+            archived: normalizedParams.archived === true,
+            backend: normalizedParams.backend ?? "all",
+            callerReason: normalizedParams.callerReason ?? "thread-list",
+            durationMs: Date.now() - startedAt,
+            enrichDirectories: normalizedParams.enrichDirectories,
+            expiresInMs: THREAD_LIST_REUSE_WINDOW_MS,
+            filterPresent: Boolean(normalizedParams.filter?.trim()),
+            forceRefresh: normalizedParams.forceRefresh === true,
+            limit: normalizedParams.limit,
+            maxPages: normalizedParams.maxPages,
+            skipArchivedMetadataRefresh:
+              normalizedParams.skipArchivedMetadataRefresh === true,
+            threadCount: threads.length,
+          });
+        }
         return threads;
       })
       .catch((error) => {
-        this.threadListCache.delete(cacheKey);
+        if (this.threadListCache.get(cacheKey) === pendingState) {
+          this.threadListCache.delete(cacheKey);
+        }
         logDebug("threadListCache:error", {
           archived: normalizedParams.archived === true,
           backend: normalizedParams.backend ?? "all",
@@ -7882,7 +7889,8 @@ export class DesktopBackendRegistry {
         });
         throw error;
       });
-    this.threadListCache.set(cacheKey, { promise });
+    pendingState.promise = promise;
+    this.threadListCache.set(cacheKey, pendingState);
     return await promise;
   }
 
@@ -18687,15 +18695,64 @@ export class DesktopBackendRegistry {
     callerReason?: string;
     ownerId?: string;
   }): Promise<AppServerThreadSummary[]> {
-    const defaultThreads = await this.codexClient
-      .listThreads(params, diagnostics)
-      .catch((error) => {
-        if (diagnostics?.callerReason === "archive-cleanup") {
-          throw error;
-        }
+    const observedFilterThreadIds =
+      this.observedCodexThreadIdsMatchingFilter(params.filter);
+    // Codex applies searchTerm before returning rows. During its naming lag,
+    // fetch unfiltered candidates only when a live observed title matches the
+    // query, then retain just those thread ids alongside provider matches.
+    const [providerFilteredThreads, observedFilterCandidates] =
+      await Promise.all([
+        this.codexClient
+          .listThreads(params, diagnostics)
+          .catch((error) => {
+            if (diagnostics?.callerReason === "archive-cleanup") {
+              throw error;
+            }
 
-        return [];
-      });
+            return [];
+          }),
+        observedFilterThreadIds.size > 0
+          ? this.codexClient.listThreads(
+              {
+                ...params,
+                filter: undefined,
+                limit: undefined,
+                maxPages: undefined,
+              },
+              diagnostics
+                ? {
+                    ...diagnostics,
+                    callerReason:
+                      `${diagnostics.callerReason ?? "thread-list"}:observed-name-filter`,
+                  }
+                : undefined,
+            ).catch((error) => {
+              backendRegistryLog.debug(
+                "live Codex name filter fallback failed",
+                {
+                  error: error instanceof Error ? error.message : String(error),
+                  filter: params.filter,
+                },
+              );
+              return [];
+            })
+          : Promise.resolve([]),
+      ]);
+    const providerFilteredThreadIds = new Set(
+      providerFilteredThreads.map((thread) => thread.id),
+    );
+    const defaultThreadsById = new Map(
+      providerFilteredThreads.map((thread) => [thread.id, thread]),
+    );
+    for (const thread of observedFilterCandidates) {
+      if (
+        observedFilterThreadIds.has(thread.id)
+        && !defaultThreadsById.has(thread.id)
+      ) {
+        defaultThreadsById.set(thread.id, thread);
+      }
+    }
+    const defaultThreads = [...defaultThreadsById.values()];
     const nativeSubAgentThreads =
       !params.archived &&
       !params.filter?.trim() &&
@@ -18722,7 +18779,7 @@ export class DesktopBackendRegistry {
       "codex",
       allThreads,
       params,
-    ).map((thread) => this.withObservedThreadName(thread));
+    );
 
     const overlaysByThreadId = await this.overlayStore.getThreadOverlayStates({
       backend: "codex",
@@ -18777,11 +18834,19 @@ export class DesktopBackendRegistry {
       }),
     );
 
-    const statusReconciledThreads = enrichedThreads.map((thread) =>
-      this.reconcileCodexThreadListStatus(thread)
-    );
+    const statusReconciledThreads = enrichedThreads
+      .map((thread) => this.reconcileCodexThreadListStatus(thread))
+      .map((thread) => this.withObservedThreadName(thread));
+    const normalizedFilter = params.filter?.trim().toLowerCase();
+    const filteredThreads = normalizedFilter && observedFilterThreadIds.size > 0
+      ? statusReconciledThreads.filter(
+          (thread) =>
+            providerFilteredThreadIds.has(thread.id)
+            || thread.title.toLowerCase().includes(normalizedFilter),
+        )
+      : statusReconciledThreads;
 
-    return statusReconciledThreads.sort(
+    return filteredThreads.sort(
       (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
     );
   }
@@ -28167,13 +28232,16 @@ export class DesktopBackendRegistry {
   private withObservedThreadName(
     thread: AppServerThreadSummary,
   ): AppServerThreadSummary {
-    const observedName = this.observedThreadNames.get(
-      buildThreadIdentityKey(thread.source, thread.id),
-    );
-    if (
-      !observedName
-      || (thread.title === observedName && thread.titleSource === "explicit")
-    ) {
+    const key = buildThreadIdentityKey(thread.source, thread.id);
+    const observedName = this.observedThreadNames.get(key);
+    if (!observedName) {
+      return thread;
+    }
+    if (thread.titleSource === "explicit") {
+      // Matching explicit text means the provider acknowledged our event.
+      // Different explicit text is durable provider truth from a rename this
+      // process may not have observed (profiles can be shared by processes).
+      this.observedThreadNames.delete(key);
       return thread;
     }
     return {
@@ -28181,6 +28249,24 @@ export class DesktopBackendRegistry {
       title: observedName,
       titleSource: "explicit",
     };
+  }
+
+  private observedCodexThreadIdsMatchingFilter(filter?: string): Set<string> {
+    const normalizedFilter = filter?.trim().toLowerCase();
+    const threadIds = new Set<string>();
+    if (!normalizedFilter) {
+      return threadIds;
+    }
+    const keyPrefix = buildThreadIdentityKey("codex", "");
+    for (const [key, observedName] of this.observedThreadNames) {
+      if (
+        key.startsWith(keyPrefix)
+        && observedName.toLowerCase().includes(normalizedFilter)
+      ) {
+        threadIds.add(key.slice(keyPrefix.length));
+      }
+    }
+    return threadIds;
   }
 
   private rememberThreadNotificationContext(
@@ -28736,6 +28822,7 @@ export class DesktopBackendRegistry {
       this.recordTaskMonitorActivity(event.notification);
     }
 
+    this.rememberThreadTitleFromEvent(event);
     if (this.shouldInvalidateThreadListCacheForNotification(event.notification.method)) {
       this.invalidateThreadListCache(event.backend);
     }
@@ -29196,7 +29283,6 @@ export class DesktopBackendRegistry {
     await this.recordCodexNativeSubAgentNames(event);
     await this.recordTaskMonitorUsage(event);
 
-    this.rememberThreadTitleFromEvent(event);
     this.notifyForAttentionRequired(event);
     await this.notifyForTerminalOutcome(event);
 

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -3911,6 +3911,7 @@ export class DesktopFederationRuntime {
     if (
       event.notification.method === "thread/pullRequests/updated"
       || event.notification.method === "thread/reactions/updated"
+      || event.notification.method === "thread/name/updated"
     ) {
       this.remoteThreadSummaryCache?.invalidate(sourceInstanceId);
     }


### PR DESCRIPTION
## What changed

- keep the latest `thread/name/updated` value as the thread-list high-water mark while Codex's `thread/list` response is still stale
- expose that reconciled name through federation navigation snapshots
- invalidate the viewer's cached Cmd+K remote summaries when a peer publishes a name update
- add regression coverage for both the owner-side list and viewer-side cache paths

## Root cause

The local renderer patches `thread/name/updated` immediately, but remote viewers and Cmd+K fetch navigation summaries from the owner's registry. The registry invalidated its list cache on the name event, then accepted Codex's still-stale `Untitled thread` row during the active turn. A viewer that had already cached a remote snapshot also kept that stale row until the 15-second TTL expired.

## Impact

Remote viewers now show and find a newly generated Codex thread name during the first running turn, matching the owning machine.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/federation-runtime.test.ts` (552 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with existing warning baseline)
- `pnpm lint:boundaries`
- `git diff --check`
