### PR TITLE
fix(desktop): preserve Markdown tables on paste

### DIFF
--- a/apps/desktop/e2e/composer-markdown-paste.spec.ts
+++ b/apps/desktop/e2e/composer-markdown-paste.spec.ts
@@ -5,6 +5,15 @@ import path from "node:path";
 import { expect, test, type Page } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 
+const TABLE_MARKDOWN = [
+  "## Quick matrix",
+  "",
+  "| Harness | Exe | Auth |",
+  "|---|---|---|",
+  "| Alpha | `alpha` | Browser sign-in |",
+  "| Beta | `beta` | API key |",
+].join("\n");
+
 // Regression coverage for composer markdown paste. The bug these guard against:
 // a code fence used to flip paste off Tiptap's HTML-aware default path onto a
 // plain-text-only markdown reparse. When a clipboard's text/plain flattens
@@ -56,9 +65,22 @@ async function createPasteFixture(): Promise<{
   const threadReadResult = {
     entries: [
       { type: "message", id: "existing-message-1", role: "assistant", text: "Ready." },
+      {
+        type: "message",
+        id: "existing-message-2",
+        role: "assistant",
+        text: TABLE_MARKDOWN,
+      },
     ],
-    messages: [{ id: "existing-message-1", role: "assistant", text: "Ready." }],
-    lastAssistantMessage: "Ready.",
+    messages: [
+      { id: "existing-message-1", role: "assistant", text: "Ready." },
+      {
+        id: "existing-message-2",
+        role: "assistant",
+        text: TABLE_MARKDOWN,
+      },
+    ],
+    lastAssistantMessage: TABLE_MARKDOWN,
     pagination: { supportsPagination: false, hasPreviousPage: false },
   };
 
@@ -80,6 +102,15 @@ async function createPasteFixture(): Promise<{
           { id: "thread-list-1", kind: "response", method: "thread/list", result: [existingThread] },
           { id: "thread-read-1", kind: "response", method: "thread/read", result: threadReadResult },
           { id: "thread-read-2", kind: "response", method: "thread/read", result: threadReadResult },
+          {
+            id: "turn-start-1",
+            kind: "response",
+            method: "turn/start",
+            result: {
+              threadId: "thread-existing",
+              turnId: "turn-table-paste",
+            },
+          },
         ],
       },
       null,
@@ -241,6 +272,77 @@ test("a code fence is upgraded from text/plain even when HTML is present but has
     await expect(
       tiptapInput.locator(".composer-tiptap-input__editor > pre"),
     ).toHaveCount(1);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("a copied transcript table pastes and sends as Markdown source", async () => {
+  const fixture = await createPasteFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+
+  try {
+    await openExistingThread(app);
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    const sourceMessage = transcript
+      .locator(".transcript-message--assistant")
+      .filter({ hasText: "Quick matrix" })
+      .first();
+    await expect(sourceMessage.locator("table")).toBeVisible();
+    await expect(
+      sourceMessage.getByRole("columnheader", { name: "Harness" }),
+    ).toBeVisible();
+
+    const reply = app.window.getByRole("textbox", { name: "Reply" });
+    const composerInput = app.window.getByTestId("composer-tiptap-input");
+    await app.electronApp.evaluate(({ clipboard }, markdown) => {
+      clipboard.writeText(markdown);
+    }, TABLE_MARKDOWN);
+    await reply.focus();
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+V" : "Control+V",
+    );
+    await expect(composerInput).toHaveAttribute("data-value", TABLE_MARKDOWN);
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+A" : "Control+A",
+    );
+    await app.window.keyboard.press("Delete");
+    await expect(composerInput).toHaveAttribute("data-value", "");
+
+    await sourceMessage.getByRole("button", { name: "Copy message" }).click();
+    await expect
+      .poll(async () =>
+        await app.electronApp.evaluate(({ clipboard }) => clipboard.readText())
+      )
+      .toBe(TABLE_MARKDOWN);
+    const clipboardSnapshot = await app.electronApp.evaluate(({ clipboard }) => ({
+      formats: clipboard.availableFormats(),
+      html: clipboard.readHTML(),
+    }));
+    expect(clipboardSnapshot.formats).toContain("text/plain");
+    expect(clipboardSnapshot.formats).toContain("text/html");
+    expect(clipboardSnapshot.html).toContain("<table>");
+
+    await reply.focus();
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+V" : "Control+V",
+    );
+
+    await expect(composerInput).toHaveAttribute("data-value", TABLE_MARKDOWN);
+    await expect(
+      composerInput.locator(".composer-tiptap-input__editor table"),
+    ).toHaveCount(0);
+
+    await app.window.getByRole("button", { name: "Send", exact: true }).click();
+    const sentMessage = transcript
+      .locator(".transcript-message--user")
+      .filter({ hasText: "Quick matrix" })
+      .first();
+    await expect(sentMessage.locator("table")).toBeVisible();
+    await expect(
+      sentMessage.getByRole("columnheader", { name: "Harness" }),
+    ).toBeVisible();
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/composer-markdown-paste.spec.ts
+++ b/apps/desktop/e2e/composer-markdown-paste.spec.ts
@@ -9,7 +9,7 @@ const TABLE_MARKDOWN = [
   "## Quick matrix",
   "",
   "| Harness | Exe | Auth |",
-  "|---|---|---|",
+  "|-|--|---|",
   "| Alpha | `alpha` | Browser sign-in |",
   "| Beta | `beta` | API key |",
 ].join("\n");

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -455,6 +455,29 @@ function containsBlockMarkdown(text: string): boolean {
   return text.split("\n").some((line) => isMarkdownBlockStart(line));
 }
 
+function isMarkdownTableDelimiterRow(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed.includes("|")) {
+    return false;
+  }
+
+  const cells = trimmed
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+  return cells.length >= 2 && cells.every((cell) => /^:?-{3,}:?$/.test(cell));
+}
+
+function containsMarkdownTable(text: string): boolean {
+  const lines = text.split("\n");
+  return lines.some(
+    (line, index) =>
+      line.includes("|")
+      && isMarkdownTableDelimiterRow(lines[index + 1] ?? ""),
+  );
+}
+
 function isMarkdownSectionLabelLine(line: string): boolean {
   return /^[^\s].*:\s*$/.test(line);
 }
@@ -1515,12 +1538,17 @@ function pastePlainMarkdownText(
   event: ClipboardEvent<HTMLDivElement>,
 ): boolean {
   const text = getPlainTextFromPaste(event);
+  const preserveMarkdownTableSource = containsMarkdownTable(text);
   // Only reroute through the markdown parser when the text carries block
-  // structure the default paste won't rebuild (fences, bullet/ordered lists).
+  // structure the default paste won't rebuild (fences, bullet/ordered lists),
+  // or when text/plain contains a GFM table. In that table case, text/plain is
+  // the lossless Markdown source: ProseMirror adds blank paragraphs between
+  // rows for plain-only paste, while the rich HTML path flattens adjacent cell
+  // text because the composer schema deliberately has no table node.
   // Pure prose — and inline-only markdown like **bold** / `code`, which paste
   // rules already handle — stays on the default path so we don't disturb
   // mid-sentence pastes.
-  if (!containsBlockMarkdown(text)) {
+  if (!containsBlockMarkdown(text) && !preserveMarkdownTableSource) {
     return false;
   }
 
@@ -1542,7 +1570,10 @@ function pastePlainMarkdownText(
   // this targets — one rendered message copied with both flavors — and is not
   // meant to be a general markdown/HTML merge. Note <p> alone does NOT count:
   // bare paragraph HTML around a text/plain fence must still reach the parser.
-  if (clipboardHtmlHasStructuredBlocks(event)) {
+  if (
+    !preserveMarkdownTableSource
+    && clipboardHtmlHasStructuredBlocks(event)
+  ) {
     return false;
   }
 

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -455,27 +455,65 @@ function containsBlockMarkdown(text: string): boolean {
   return text.split("\n").some((line) => isMarkdownBlockStart(line));
 }
 
-function isMarkdownTableDelimiterRow(line: string): boolean {
+function splitMarkdownTableCells(line: string): string[] {
   const trimmed = line.trim();
-  if (!trimmed.includes("|")) {
-    return false;
+  let content = trimmed.startsWith("|") ? trimmed.slice(1) : trimmed;
+  let trailingBackslashes = 0;
+  for (
+    let index = content.length - 2;
+    index >= 0 && content[index] === "\\";
+    index -= 1
+  ) {
+    trailingBackslashes += 1;
+  }
+  if (content.endsWith("|") && trailingBackslashes % 2 === 0) {
+    content = content.slice(0, -1);
   }
 
-  const cells = trimmed
-    .replace(/^\|/, "")
-    .replace(/\|$/, "")
-    .split("|")
-    .map((cell) => cell.trim());
-  return cells.length >= 2 && cells.every((cell) => /^:?-{3,}:?$/.test(cell));
+  const cells: string[] = [];
+  let cell = "";
+  let escaped = false;
+  for (const character of content) {
+    if (escaped) {
+      cell += character;
+      escaped = false;
+    } else if (character === "\\") {
+      cell += character;
+      escaped = true;
+    } else if (character === "|") {
+      cells.push(cell.trim());
+      cell = "";
+    } else {
+      cell += character;
+    }
+  }
+  cells.push(cell.trim());
+  return cells;
+}
+
+// Mirrors micromark-extension-gfm-table's delimiter grammar: each cell is an
+// optional colon, one or more hyphens, and an optional colon. The header and
+// delimiter must have the same cell count, while a pipe or colon distinguishes
+// a one-column table from a setext heading.
+function parseMarkdownTableDelimiterRow(line: string): string[] | undefined {
+  const cells = splitMarkdownTableCells(line);
+  const hasTableMarker =
+    line.includes("|")
+    || cells.some((cell) => cell.includes(":"));
+  return hasTableMarker && cells.every((cell) => /^:?-+:?$/.test(cell))
+    ? cells
+    : undefined;
 }
 
 function containsMarkdownTable(text: string): boolean {
   const lines = text.split("\n");
-  return lines.some(
-    (line, index) =>
-      line.includes("|")
-      && isMarkdownTableDelimiterRow(lines[index + 1] ?? ""),
-  );
+  return lines.some((line, index) => {
+    if (!line.trim()) {
+      return false;
+    }
+    const delimiterCells = parseMarkdownTableDelimiterRow(lines[index + 1] ?? "");
+    return delimiterCells?.length === splitMarkdownTableCells(line).length;
+  });
 }
 
 function isMarkdownSectionLabelLine(line: string): boolean {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -283,7 +283,7 @@ describe("ComposerTiptapInput", () => {
       "## Quick matrix",
       "",
       "| Harness | Exe | Auth |",
-      "|---|---|---|",
+      "|-|--|---|",
       "| Alpha | `alpha` | Browser sign-in |",
       "| Beta | `beta` | API key |",
     ].join("\n");
@@ -319,7 +319,64 @@ describe("ComposerTiptapInput", () => {
     });
     expect(container.querySelector("table")).not.toBeInTheDocument();
     expect(container.querySelector(".composer-tiptap-input__editor"))
-      .toHaveTextContent("|---|---|---|");
+      .toHaveTextContent("|-|--|---|");
+  });
+
+  it("keeps a one-column rendered table as Markdown source", async () => {
+    const markdown = [
+      "| Harness |",
+      "| - |",
+      "| Alpha |",
+    ].join("\n");
+    const { container, onChange } = renderTiptapInput();
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return [
+              "<table>",
+              "<thead><tr><th>Harness</th></tr></thead>",
+              "<tbody><tr><td>Alpha</td></tr></tbody>",
+              "</table>",
+            ].join("");
+          }
+          return type === "text/plain" ? markdown : "";
+        },
+        items: [],
+        types: ["text/html", "text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(markdown, []);
+    });
+    expect(container.querySelector("table")).not.toBeInTheDocument();
+  });
+
+  it("does not treat a setext heading as a one-column table", async () => {
+    const { container } = renderTiptapInput();
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return "<h2>Quick matrix</h2>";
+          }
+          return type === "text/plain" ? "Quick matrix\n-" : "";
+        },
+        items: [],
+        types: ["text/html", "text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector("h2")).toHaveTextContent("Quick matrix");
+    });
   });
 
   it("keeps HTML-only double-blank-line SQL paste inside an active code block", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -278,6 +278,50 @@ describe("ComposerTiptapInput", () => {
     ).toBe(false);
   });
 
+  it("keeps a copied rendered table as Markdown source", async () => {
+    const markdown = [
+      "## Quick matrix",
+      "",
+      "| Harness | Exe | Auth |",
+      "|---|---|---|",
+      "| Alpha | `alpha` | Browser sign-in |",
+      "| Beta | `beta` | API key |",
+    ].join("\n");
+    const html = [
+      "<h2>Quick matrix</h2>",
+      "<table>",
+      "<thead><tr><th>Harness</th><th>Exe</th><th>Auth</th></tr></thead>",
+      "<tbody>",
+      "<tr><td>Alpha</td><td><code>alpha</code></td><td>Browser sign-in</td></tr>",
+      "<tr><td>Beta</td><td><code>beta</code></td><td>API key</td></tr>",
+      "</tbody>",
+      "</table>",
+    ].join("");
+    const { container, onChange } = renderTiptapInput();
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return html;
+          }
+          return type === "text/plain" ? markdown : "";
+        },
+        items: [],
+        types: ["text/html", "text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(markdown, []);
+    });
+    expect(container.querySelector("table")).not.toBeInTheDocument();
+    expect(container.querySelector(".composer-tiptap-input__editor"))
+      .toHaveTextContent("|---|---|---|");
+  });
+
   it("keeps HTML-only double-blank-line SQL paste inside an active code block", async () => {
     const { container, onChange } = renderTiptapInput({ value: "```\n```" });
     const textbox = await screen.findByRole("textbox", { name: "Reply" });


### PR DESCRIPTION
## Summary

- I preserve valid GFM table source when it is pasted into the Markdown composer from either a plain-text clipboard or a rendered transcript copy carrying both `text/plain` and `text/html`.
- I keep unsupported visual table nodes out of Tiptap while ensuring the exact Markdown source, including the header delimiter row, is sent and rendered back into a transcript table.
- I added focused component coverage and a real Electron native-clipboard copy, paste, send, and render regression using a small sanitized matrix.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx`
- `pnpm test:desktop-e2e e2e/composer-markdown-paste.spec.ts`
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`

## Notes

- The root cause was clipboard flavor arbitration: transcript copy correctly supplied raw Markdown as `text/plain` and a rendered `<table>` as `text/html`, but the composer preferred the HTML path. Its schema has no table node, so ProseMirror flattened the cells into adjacent text. Plain-only paste also inserted blank paragraphs between table rows.
- I made `text/plain` authoritative only when it contains a valid multi-column GFM delimiter row. Existing rich paste behavior remains unchanged for headings, lists, code blocks, blockquotes, and ordinary rich text.
- This is an independent follow-up to draft PR #1504 and is based on `origin/main`.
