### PR TITLE
fix(desktop): backport ACP branch adoption to 1.0

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1773,6 +1773,7 @@ function createKimiAcpRegistry(options?: {
   startPrompt?: KimiStartPrompt;
   overlayStore?: ReturnType<typeof createOverlayStoreMock>;
   codexClient?: MockBackendClient;
+  grokClient?: MockBackendClient;
   codexEnvironmentCommandRunner?: CodexEnvironmentCommandRunner;
   gitDirectoryService?: unknown;
   gitWorkspaceHandoffService?: unknown;
@@ -1841,7 +1842,7 @@ function createKimiAcpRegistry(options?: {
   };
   const registry = new DesktopBackendRegistry({
     codexClient: options?.codexClient ?? new MockBackendClient({ threads: [] }),
-    grokClient: new MockBackendClient({ threads: [] }),
+    grokClient: options?.grokClient ?? new MockBackendClient({ threads: [] }),
     overlayStore: options?.overlayStore ?? createOverlayStoreMock(),
     acpAgentStore: createAcpAgentStoreMock([
       createKimiAgentRecord(acpBackendId, options?.runtimeCapabilities),
@@ -29685,6 +29686,130 @@ script = "printf setup"
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   });
+
+  it.each(["terminal", "idle"] as const)(
+    "adopts a named branch change from an ACP turn at the %s boundary",
+    async (boundary) => {
+      const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-acp-turn-branch-"));
+      const repo = path.join(root, "app");
+      await mkdir(repo, { recursive: true });
+      await git(repo, ["init", "-b", "feature/old"]);
+      await git(repo, [
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=Test User",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "init",
+      ]);
+
+      const acpBackendId = "acp:kimi" as AcpBackendId;
+      const overlayStore = createOverlayStoreMock({
+        overlays: {
+          "acp:kimi:thread-branch": {
+            backend: acpBackendId,
+            threadId: "thread-branch",
+            executionMode: "default",
+            gitBranch: "feature/old",
+            observedGitBranch: "feature/old",
+            extraLinkedDirectories: [],
+          },
+        },
+      });
+      const grokClient = new MockBackendClient({ threads: [] });
+      const { registry } = createKimiAcpRegistry({
+        acpBackendId,
+        sessionId: "thread-branch",
+        sessions: [
+          {
+            backendId: acpBackendId,
+            sessionId: "thread-branch",
+            title: "Active ACP branch turn",
+            cwd: repo,
+            createdAt: 1_000,
+            updatedAt: 2_000,
+            executionMode: "default",
+            status: "idle",
+          },
+        ],
+        grokClient,
+        overlayStore,
+      });
+      const eventMethods: string[] = [];
+      const unsubscribe = registry.onEvent((event) => {
+        eventMethods.push(event.notification.method);
+      });
+
+      try {
+        await registry.publishLocalEvent({
+          backend: acpBackendId,
+          notification: {
+            method: "turn/started",
+            params: {
+              threadId: "thread-branch",
+              turnId: "pending:started-turn",
+              turn: {
+                id: "pending:started-turn",
+                status: "in_progress",
+              },
+            },
+          },
+        });
+        await git(repo, ["switch", "-c", "fix/acp-branch-adoption"]);
+
+        if (boundary === "terminal") {
+          await registry.publishLocalEvent({
+            backend: acpBackendId,
+            notification: {
+              method: "turn/completed",
+              params: {
+                threadId: "thread-branch",
+                turnId: "pending:terminal-turn",
+                turn: {
+                  id: "pending:terminal-turn",
+                  status: "completed",
+                  output: [],
+                },
+              },
+            },
+          });
+        } else {
+          await registry.publishLocalEvent({
+            backend: acpBackendId,
+            notification: {
+              method: "thread/status/changed",
+              params: {
+                threadId: "thread-branch",
+                status: { type: "idle" },
+              },
+            },
+          });
+        }
+
+        await expect(
+          overlayStore.getThreadOverlayState({
+            backend: acpBackendId,
+            threadId: "thread-branch",
+          }),
+        ).resolves.toMatchObject({
+          gitBranch: "fix/acp-branch-adoption",
+          observedGitBranch: "fix/acp-branch-adoption",
+        });
+        expect(eventMethods).toEqual([
+          "turn/started",
+          "thread/branch/updated",
+          boundary === "terminal" ? "turn/completed" : "thread/status/changed",
+        ]);
+        expect(grokClient.lastUpdateThreadMetadataParams).toBeUndefined();
+      } finally {
+        unsubscribe();
+        await registry.close();
+        await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      }
+    },
+  );
 
   it("notifies listeners when the renderer adopts a new expected branch", async () => {
     const overlayStore = createOverlayStoreMock();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -29743,20 +29743,12 @@ script = "printf setup"
       });
 
       try {
-        await registry.publishLocalEvent({
+        const startedTurn = await registry.startTurn({
           backend: acpBackendId,
-          notification: {
-            method: "turn/started",
-            params: {
-              threadId: "thread-branch",
-              turnId: "pending:started-turn",
-              turn: {
-                id: "pending:started-turn",
-                status: "in_progress",
-              },
-            },
-          },
+          threadId: "thread-branch",
+          input: [{ type: "text", text: "Switch to a named branch" }],
         });
+        expect(startedTurn.turnId).toBe("turn-1");
         await git(repo, ["switch", "-c", "fix/acp-branch-adoption"]);
 
         if (boundary === "terminal") {
@@ -29766,9 +29758,9 @@ script = "printf setup"
               method: "turn/completed",
               params: {
                 threadId: "thread-branch",
-                turnId: "pending:terminal-turn",
+                turnId: startedTurn.turnId,
                 turn: {
-                  id: "pending:terminal-turn",
+                  id: startedTurn.turnId,
                   status: "completed",
                   output: [],
                 },
@@ -29810,6 +29802,61 @@ script = "printf setup"
       }
     },
   );
+
+  it("keeps a newer ACP turn active when an older terminal event arrives", async () => {
+    const acpBackendId = "acp:kimi" as AcpBackendId;
+    const { registry } = createKimiAcpRegistry({ acpBackendId });
+
+    try {
+      for (const turnId of ["turn-old", "turn-new"]) {
+        await registry.publishLocalEvent({
+          backend: acpBackendId,
+          notification: {
+            method: "turn/started",
+            params: {
+              threadId: "thread-race",
+              turnId,
+              turn: {
+                id: turnId,
+                status: "in_progress",
+              },
+            },
+          },
+        });
+      }
+
+      for (let duplicate = 0; duplicate < 2; duplicate += 1) {
+        await registry.publishLocalEvent({
+          backend: acpBackendId,
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-race",
+              turnId: "turn-old",
+              turn: {
+                id: "turn-old",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+
+        expect(
+          registry.getActiveTurnForThread({
+            backend: acpBackendId,
+            threadId: "thread-race",
+          }),
+        ).toEqual({
+          backend: acpBackendId,
+          threadId: "thread-race",
+          turnId: "turn-new",
+        });
+      }
+    } finally {
+      await registry.close();
+    }
+  });
 
   it("notifies listeners when the renderer adopts a new expected branch", async () => {
     const overlayStore = createOverlayStoreMock();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7162,6 +7162,22 @@ export class DesktopBackendRegistry {
         parts: promptPayload.parts,
         turnId: syntheticStartedTurnId,
       });
+      const syntheticActiveTurnKey = buildActiveTurnKey(
+        params.backend,
+        params.threadId,
+        syntheticStartedTurnId,
+      );
+      const resolvedActiveTurnKey = buildActiveTurnKey(
+        params.backend,
+        result.sessionId,
+        result.turnId,
+      );
+      if (
+        syntheticActiveTurnKey !== resolvedActiveTurnKey
+        && this.activeTurnKeys.delete(syntheticActiveTurnKey)
+      ) {
+        this.activeTurnKeys.add(resolvedActiveTurnKey);
+      }
       this.invalidateThreadListCache(params.backend);
       return {
         backend: params.backend,
@@ -22330,24 +22346,11 @@ export class DesktopBackendRegistry {
           turnId,
         });
       }
-      const genericActiveTurnKeyPrefix =
-        `${event.backend}:${notification.params.threadId}:`;
-      const hadGenericActiveTurn = Array.from(this.activeTurnKeys).some((key) =>
-        key.startsWith(genericActiveTurnKeyPrefix),
-      );
-      if (turnId) {
-        if (isAcpBackendId(event.backend)) {
-          for (const key of Array.from(this.activeTurnKeys)) {
-            if (key.startsWith(genericActiveTurnKeyPrefix)) {
-              this.activeTurnKeys.delete(key);
-            }
-          }
-        } else {
-          this.activeTurnKeys.delete(
+      const hadGenericActiveTurn = turnId
+        ? this.activeTurnKeys.delete(
             buildActiveTurnKey(event.backend, notification.params.threadId, turnId),
-          );
-        }
-      }
+          )
+        : false;
       if (isAcpBackendId(event.backend) && hadGenericActiveTurn) {
         await this.adoptThreadBranchChangeFromActiveTurn({
           backend: event.backend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -17103,7 +17103,7 @@ export class DesktopBackendRegistry {
         await this.withCodexThreadClient(params.threadId, async (client) => {
           await updateWithClient(client);
         });
-      } else {
+      } else if (params.backend === "grok") {
         await updateWithClient(this.grokClient);
       }
     } catch (error) {
@@ -22330,10 +22330,29 @@ export class DesktopBackendRegistry {
           turnId,
         });
       }
+      const genericActiveTurnKeyPrefix =
+        `${event.backend}:${notification.params.threadId}:`;
+      const hadGenericActiveTurn = Array.from(this.activeTurnKeys).some((key) =>
+        key.startsWith(genericActiveTurnKeyPrefix),
+      );
       if (turnId) {
-        this.activeTurnKeys.delete(
-          buildActiveTurnKey(event.backend, notification.params.threadId, turnId),
-        );
+        if (isAcpBackendId(event.backend)) {
+          for (const key of Array.from(this.activeTurnKeys)) {
+            if (key.startsWith(genericActiveTurnKeyPrefix)) {
+              this.activeTurnKeys.delete(key);
+            }
+          }
+        } else {
+          this.activeTurnKeys.delete(
+            buildActiveTurnKey(event.backend, notification.params.threadId, turnId),
+          );
+        }
+      }
+      if (isAcpBackendId(event.backend) && hadGenericActiveTurn) {
+        await this.adoptThreadBranchChangeFromActiveTurn({
+          backend: event.backend,
+          threadId: notification.params.threadId,
+        });
       }
       if (event.backend === "codex" && turnId) {
         const activeTurnModeKey = buildActiveTurnModeKey(
@@ -22489,6 +22508,7 @@ export class DesktopBackendRegistry {
         this.threadHasActiveCodexReviewTurn(threadId);
       const endedTurnIds = new Set<string>();
       const genericKeyPrefix = `${event.backend}:${event.notification.params.threadId}:`;
+      let hadGenericActiveTurn = false;
       for (const key of Array.from(this.activeTurnKeys)) {
         if (key.startsWith(genericKeyPrefix)) {
           const parsed = parseActiveTurnKey(key);
@@ -22501,6 +22521,7 @@ export class DesktopBackendRegistry {
           ) {
             continue;
           }
+          hadGenericActiveTurn = true;
           if (parsed?.turnId && !parsed.turnId.startsWith("pending:")) {
             endedTurnIds.add(parsed.turnId);
           }
@@ -22509,6 +22530,12 @@ export class DesktopBackendRegistry {
       }
       if (event.backend !== "codex") {
         if (isAcpBackendId(event.backend)) {
+          if (hadGenericActiveTurn) {
+            await this.adoptThreadBranchChangeFromActiveTurn({
+              backend: event.backend,
+              threadId: event.notification.params.threadId,
+            });
+          }
           if (this.usesSlashControlledAcpExecutionModes(event.backend)) {
             await this.flushQueuedExecutionModeIfPresent(
               event.notification.params.threadId,


### PR DESCRIPTION
## Summary

Backports ACP branch adoption correctness to `releases/1.0`:

- adopts named Git branch changes at terminal-turn and idle-status boundaries
- tracks ACP through generic active-turn keys, including `pending:` IDs
- re-keys synthetic ACP starts to the resolved provider turn ID before terminal handling
- clears only the exact completed ACP turn, so delayed or duplicate terminal events cannot erase a newer active turn
- avoids routing ACP metadata through the legacy Grok client

## Source provenance

- #1368 — `88a908698345f892c449bb45d0acaef13652f48c`

The cherry-picked commit retains `-x` provenance. Commit `29dbeddaa` is a review follow-up that preserves #1368 turn-ID drift support while making terminal cleanup turn-specific.

## Scope decision

#1372 (`cea91f8ffdfde61427c05eb5a7ba057aab535da8`) was audited but is intentionally not included. It removes in-repo `@pwragent/agent-core` and the bundled Grok app-server while retaining external `@pwrdrvr/agent-core`. On `releases/1.0`, it conflicts with release-modified legacy code and 23 surviving main-only/federation/settings/test files. A safe removal needs a dedicated redesign-level backport; federation must not be imported into 1.0.

This PR keeps the release legacy backend and lands the independently useful ACP fix only.

## SQLite migration audit

- `CURRENT_STATE_DB_USER_VERSION` remains **32**.
- No `state-db.ts` or `migration.ts` changes.
- No DDL or schema migration.

## Validation

- backend registry: 402 tests passed
- focused ACP branch/race regression: 3 tests passed
- `pnpm --filter @pwragent/desktop typecheck`
- scoped ESLint: 0 errors; existing warnings only
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

No headed E2E was run on the host.
