### PR TITLE
fix(desktop): backport Windows agent shim compatibility

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts
@@ -44,44 +44,37 @@ function createDescriptor(overrides: Partial<AcpLaunchDescriptor> = {}): AcpLaun
 }
 
 describe("AcpStdioJsonRpcTransport", () => {
-  it("routes a Windows ACP batch shim through ComSpec", async () => {
-    const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    vi.stubEnv("ComSpec", "C:\\Windows\\System32\\cmd.exe");
-    try {
-      const child = new MockAcpChildProcess();
-      const spawnCalls: Array<Parameters<AcpStdioSpawn>> = [];
-      const spawn: AcpStdioSpawn = (command, args, options) => {
-        spawnCalls.push([command, args, options]);
-        return child;
-      };
-      const transport = new AcpStdioJsonRpcTransport({
-        launchDescriptor: createDescriptor({
-          distributionKind: "local",
-          command:
-            "C:\\Users\\Ops & Dev\\AppData\\Roaming\\npm\\gemini.cmd",
-          args: ["--acp"],
-        }),
-        spawn,
-      });
+  it("launches a resolved Windows batch shim through ComSpec", async () => {
+    const child = new MockAcpChildProcess();
+    const spawnCalls: Array<Parameters<AcpStdioSpawn>> = [];
+    const spawn: AcpStdioSpawn = (command, args, options) => {
+      spawnCalls.push([command, args, options]);
+      return child;
+    };
+    const transport = new AcpStdioJsonRpcTransport({
+      launchDescriptor: createDescriptor({
+        command: "C:\\npm & tools\\qwen.cmd",
+        args: ["--acp", "value & whoami"],
+        env: { ComSpec: "C:\\Windows\\System32\\cmd.exe" },
+      }),
+      platform: "win32",
+      spawn,
+    });
 
-      await transport.connect();
+    await transport.connect();
 
-      expect(spawnCalls[0]?.[0]).toBe("C:\\Windows\\System32\\cmd.exe");
-      expect(spawnCalls[0]?.[1]).toEqual([
-        "/d",
-        "/s",
-        "/c",
-        expect.stringMatching(/gemini\.cmd.*--acp/i),
-      ]);
-      expect(spawnCalls[0]?.[2]).toMatchObject({
-        detached: false,
-        windowsVerbatimArguments: true,
-      });
-      await transport.close();
-    } finally {
-      platform.mockRestore();
-      vi.unstubAllEnvs();
-    }
+    expect(spawnCalls[0]?.[0]).toMatch(/^C:\\Windows\\System32\\cmd\.exe$/i);
+    expect(spawnCalls[0]?.[1].slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+    expect(spawnCalls[0]?.[1][3]).toContain(
+      "C:\\npm^ ^&^ tools\\qwen.cmd ^\"--acp^\"",
+    );
+    expect(spawnCalls[0]?.[1][3]).toContain("^\"value^ ^&^ whoami^\"");
+    expect(spawnCalls[0]?.[2]).toMatchObject({
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsVerbatimArguments: true,
+    });
+
+    await transport.close();
   });
 
   it("launches the descriptor command directly and writes newline JSON-RPC", async () => {

--- a/apps/desktop/src/main/__tests__/command-invocation.test.ts
+++ b/apps/desktop/src/main/__tests__/command-invocation.test.ts
@@ -1,0 +1,93 @@
+import { execFile as execFileCallback } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { createCommandInvocation } from "@pwrdrvr/agent-transport";
+
+const execFile = promisify(execFileCallback);
+
+describe("createCommandInvocation", () => {
+  it("preserves direct argv launches for native executables", () => {
+    expect(
+      createCommandInvocation({
+        command: "C:\\tools\\codex.exe",
+        args: ["app-server", "value & whoami"],
+        env: {},
+        platform: "win32",
+      }),
+    ).toEqual({
+      command: "C:\\tools\\codex.exe",
+      args: ["app-server", "value & whoami"],
+    });
+  });
+
+  it("escapes Windows batch commands and arguments for ComSpec", () => {
+    const invocation = createCommandInvocation({
+      command: "C:\\nvm4w & tools\\nodejs\\codex.cmd",
+      args: ["app-server", "value & whoami"],
+      env: { COMSPEC: "C:\\Windows\\System32\\cmd.exe" },
+      platform: "win32",
+    });
+
+    expect(invocation.command).toBe("C:\\Windows\\System32\\cmd.exe");
+    expect(invocation.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+    expect(invocation.args[3]).toContain(
+      "C:\\nvm4w^ ^&^ tools\\nodejs\\codex.cmd",
+    );
+    expect(invocation.args[3]).toContain("^\"value^ ^&^ whoami^\"");
+    expect(invocation.windowsVerbatimArguments).toBe(true);
+  });
+
+  it.runIf(process.platform === "win32")(
+    "executes an npm-style batch shim without evaluating argument metacharacters",
+    async () => {
+      const tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-shim-&-"));
+      try {
+        const scriptPath = path.join(tempDir, "codex.js");
+        const shimPath = path.join(tempDir, "codex.cmd");
+        const injectedFile = path.join(tempDir, "injected.txt");
+        writeFileSync(
+          scriptPath,
+          "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n",
+          "utf8",
+        );
+        writeFileSync(
+          shimPath,
+          "@ECHO off\r\n\"%NODE_EXE%\" \"%~dp0\\codex.js\" %*\r\n",
+          "utf8",
+        );
+        const injectionShapedArgument = `value & echo injected > ${injectedFile}`;
+        const env = {
+          ...process.env,
+          NODE_EXE: process.execPath,
+        };
+        const invocation = createCommandInvocation({
+          command: shimPath,
+          args: ["app-server", injectionShapedArgument],
+          env,
+        });
+
+        const result = await execFile(invocation.command, invocation.args, {
+          env,
+          windowsHide: true,
+          windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+        });
+
+        expect(JSON.parse(result.stdout)).toEqual([
+          "app-server",
+          injectionShapedArgument,
+        ]);
+        expect(existsSync(injectedFile)).toBe(false);
+      } finally {
+        rmSync(tempDir, { force: true, recursive: true });
+      }
+    },
+  );
+});

--- a/apps/desktop/src/main/__tests__/stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/stdio-transport.test.ts
@@ -72,40 +72,47 @@ describe("stdio transport Codex CLI resolution", () => {
 });
 
 describe("StdioJsonRpcTransport", () => {
-  it("routes a Windows Codex batch shim through ComSpec", async () => {
-    const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    vi.stubEnv("ComSpec", "C:\\Windows\\System32\\cmd.exe");
-    try {
-      const child = new MockCodexChildProcess();
-      spawnMock.mockReturnValue(child);
-      const transport = new StdioJsonRpcTransport({
-        command: "C:\\Users\\Ops & Dev\\AppData\\Roaming\\npm\\codex.cmd",
-        env: {
-          ComSpec: "C:\\Windows\\System32\\cmd.exe",
-          PATH: "C:\\Windows\\System32",
-        },
-      });
+  it("launches a resolved Windows batch shim through ComSpec", async () => {
+    const child = new MockCodexChildProcess();
+    spawnMock.mockReturnValue(child);
+    const command = "C:\\nvm4w & tools\\nodejs\\codex.cmd";
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      args: ["--feature", "value & whoami"],
+      env: {
+        ComSpec: "C:\\Windows\\System32\\cmd.exe",
+        PATH: "C:\\nvm4w & tools\\nodejs",
+      },
+      platform: "win32",
+      resolveCommand: async () => ({
+        command,
+        source: "path",
+        version: "0.126.0",
+      }),
+    });
 
-      await transport.connect();
+    await transport.connect();
 
-      expect(spawnMock).toHaveBeenCalledWith(
-        "C:\\Windows\\System32\\cmd.exe",
-        [
-          "/d",
-          "/s",
-          "/c",
-          expect.stringMatching(/codex\.cmd.*app-server/i),
-        ],
-        expect.objectContaining({
-          detached: false,
-          windowsVerbatimArguments: true,
-        }),
-      );
-      await transport.close();
-    } finally {
-      platform.mockRestore();
-      vi.unstubAllEnvs();
-    }
+    expect(spawnMock).toHaveBeenCalledWith(
+      "C:\\Windows\\System32\\cmd.exe",
+      [
+        "/d",
+        "/s",
+        "/c",
+        expect.stringContaining(
+          "C:\\nvm4w^ ^&^ tools\\nodejs\\codex.cmd ^\"app-server^\"",
+        ),
+      ],
+      expect.objectContaining({
+        windowsVerbatimArguments: true,
+        stdio: ["pipe", "pipe", "pipe"],
+      }),
+    );
+    expect(spawnMock.mock.calls[0]?.[1]?.[3]).toContain(
+      "^\"value^ ^&^ whoami^\"",
+    );
+
+    await transport.close();
   });
 
   it("does not pass PwrAgent's renderer URL to the Codex app server", async () => {

--- a/apps/desktop/src/main/acp/acp-stdio-transport.ts
+++ b/apps/desktop/src/main/acp/acp-stdio-transport.ts
@@ -44,6 +44,7 @@ export type AcpStdioJsonRpcTransportOptions = {
   requestTimeoutMs?: number;
   observer?: JsonRpcObserver;
   spawn?: AcpStdioSpawn;
+  platform?: NodeJS.Platform;
 };
 
 function appendExecutableSearchPaths(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
@@ -91,6 +92,7 @@ export class AcpStdioJsonRpcTransport implements AcpJsonRpcTransport {
     this.lineTransport = new AcpLineStdioTransport({
       launchDescriptor: options.launchDescriptor,
       spawn: options.spawn,
+      platform: options.platform,
     });
     this.connection = new JsonRpcConnection(
       this.lineTransport,
@@ -184,6 +186,7 @@ class AcpLineStdioTransport implements JsonRpcTransport {
     private readonly options: {
       launchDescriptor: AcpLaunchDescriptor;
       spawn?: AcpStdioSpawn;
+      platform?: NodeJS.Platform;
     },
   ) {}
 
@@ -222,6 +225,7 @@ class AcpLineStdioTransport implements JsonRpcTransport {
       command: descriptor.command,
       args: descriptor.args,
       env,
+      platform: this.options.platform,
     });
     const child = spawnProcess(invocation.command, invocation.args, {
       stdio: ["pipe", "pipe", "pipe"],

--- a/apps/desktop/src/main/codex-app-server/stdio-transport.ts
+++ b/apps/desktop/src/main/codex-app-server/stdio-transport.ts
@@ -39,6 +39,7 @@ export type StdioJsonRpcTransportOptions = {
     env: NodeJS.ProcessEnv;
   }) => Promise<ResolvedCodexCommandCandidate>;
   resolveEnv?: () => Promise<NodeJS.ProcessEnv>;
+  platform?: NodeJS.Platform;
 };
 
 export { compareCodexCliVersions };
@@ -137,6 +138,7 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
       command: command.command,
       args: ["app-server", ...args],
       env: childEnv,
+      platform: this.options.platform,
     });
     const child = spawn(invocation.command, invocation.args, {
       stdio: ["pipe", "pipe", "pipe"],


### PR DESCRIPTION
## Summary

Completes the Windows agent-shim compatibility backport to `releases/1.0`:

- adds deterministic platform injection at the Codex and ACP stdio launch boundaries
- verifies native executables retain direct argv launches
- verifies Windows `.cmd`/`.bat` shims use escaped `ComSpec /d /s /c` invocations with `windowsVerbatimArguments`
- verifies command and argument metacharacters such as `&` cannot escape into a second command
- adds a Windows-only real-process regression using an npm-style shim in a path containing `&`

## Source provenance

- PwrAgent #1511 — squash merge `a64903db1fb2eaa8b36dc72dc7287a69a5e97d5a`

The backport commit message records the source PR and squash SHA.

## Manual adaptation

The functional runtime portion of #1511 already landed on `releases/1.0` through the merged #1509 backport (`350f533e95f31bbe3d432d31f8f92e09f931d386`):

- `@pwrdrvr/agent-acp` `0.13.1`
- `@pwrdrvr/agent-transport` `0.1.7`
- `@pwrdrvr/codex-discovery` `0.1.6`
- both PwrAgent-owned stdio transports already route launches through `createCommandInvocation`

This PR therefore does not reapply package, lockfile, license, or duplicate runtime changes. It carries only #1511's remaining deterministic platform seam and hardened tests.

The repository's Windows process-lifecycle guidance was audited. These provider stdio launches remain non-detached on Windows and retain the existing `terminateOwnedProcessTree` graceful/forced cleanup. This backport does not add a caller-specific process registry, PID loop, timeout increase, or shutdown redesign.

## SQLite migration audit

- `CURRENT_STATE_DB_USER_VERSION` remains **32**.
- No `state-db.ts` or `migration.ts` changes.
- No DDL or schema migration.

## Validation

- `pnpm install --frozen-lockfile`
- 50 focused discovery/transport/invocation tests passed; 1 Windows-only real-process test skipped on macOS and remains enabled for Windows CI
- `pnpm --filter @pwragent/desktop typecheck`
- scoped ESLint: 0 errors
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm licenses:check`
- `git diff --check`

No headed E2E was run on the host. The real npm-style `.cmd` execution assertion requires the Windows CI lane before this backport can be considered platform-verified.
