### PR TITLE
fix(desktop): prevent duplicate federated transcript tails

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -389,6 +389,263 @@ describe("useThreadSessionState", () => {
     );
   });
 
+  it("replaces an overlapping live tail when hydrated message ids change", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const activeTurn = {
+      id: "turn-current",
+      status: "in_progress" as const,
+      startedAt: 1_000,
+    };
+    const completedTurn = {
+      ...activeTurn,
+      status: "completed" as const,
+      completedAt: 2_000,
+    };
+    const initialTail = readThreadResponse({
+      entries: [
+        {
+          ...messageEntry({
+            id: "stable-tail-anchor",
+            role: "user",
+            text: "Earlier prompt",
+            createdAt: 500,
+          }),
+          turn: { id: "turn-earlier", status: "completed" },
+        },
+        {
+          ...messageEntry({
+            id: "current-user",
+            role: "user",
+            text: "Audit the backports",
+            createdAt: 1_000,
+          }),
+          turn: activeTurn,
+        },
+      ],
+      hasPreviousPage: true,
+      previousCursor: "stable-tail-anchor",
+      threadStatus: "active",
+    });
+    const olderPage = readThreadResponse({
+      entries: [
+        messageEntry({
+          id: "older-message",
+          role: "user",
+          text: "Older history",
+          createdAt: 100,
+        }),
+      ],
+      hasPreviousPage: false,
+    });
+    const refreshedTail = readThreadResponse({
+      entries: [
+        {
+          ...messageEntry({
+            id: "stable-tail-anchor",
+            role: "user",
+            text: "Earlier prompt",
+            createdAt: 500,
+          }),
+          turn: { id: "turn-earlier", status: "completed" },
+        },
+        {
+          ...messageEntry({
+            id: "current-user",
+            role: "user",
+            text: "Audit the backports",
+            createdAt: 1_000,
+          }),
+          turn: completedTurn,
+        },
+        {
+          ...messageEntry({
+            id: "item-57",
+            text: "First commentary.",
+            createdAt: 1_100,
+          }),
+          phase: "commentary" as const,
+          turn: completedTurn,
+        },
+        {
+          ...messageEntry({
+            id: "item-58",
+            text: "Second commentary.",
+            createdAt: 1_300,
+          }),
+          phase: "commentary" as const,
+          turn: completedTurn,
+        },
+        {
+          ...messageEntry({
+            id: "item-61",
+            text: "Final answer.",
+            createdAt: 2_000,
+          }),
+          phase: "final" as const,
+          turn: completedTurn,
+        },
+      ],
+      hasPreviousPage: true,
+      previousCursor: "stable-tail-anchor",
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(olderPage)
+      .mockResolvedValueOnce(refreshedTail);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turn: activeTurn,
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: "thread-1",
+            turnId: activeTurn.id,
+            itemId: "live-commentary-1",
+            delta: "First commentary.",
+            phase: "commentary",
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: activeTurn.id,
+            item: {
+              id: "read-1",
+              type: "commandExecution",
+              command: "rg -n backport src",
+              commandActions: [{ type: "search", path: "src" }],
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: "thread-1",
+            turnId: activeTurn.id,
+            itemId: "live-commentary-2",
+            delta: "Second commentary.",
+            phase: "commentary",
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: activeTurn.id,
+            item: {
+              id: "live-commentary-2",
+              type: "agentMessage",
+              phase: "commentary",
+              text: "Second commentary.",
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: activeTurn.id,
+            item: {
+              id: "live-final",
+              type: "agentMessage",
+              phase: "final_answer",
+              text: "Final answer.",
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: activeTurn.id,
+            turn: {
+              ...completedTurn,
+              output: [{ type: "text", text: "Final answer." }],
+            },
+          },
+        },
+      });
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Older history",
+      "message:Earlier prompt",
+      "message:Audit the backports",
+      "message:First commentary.",
+      "activity:Searched src",
+      "message:Second commentary.",
+      "message:Final answer.",
+    ]);
+
+    rerender({ updatedAt: 2_000 });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:Older history",
+        "message:Earlier prompt",
+        "message:Audit the backports",
+        "message:First commentary.",
+        "activity:Searched src",
+        "message:Second commentary.",
+        "message:Final answer.",
+      ]);
+    });
+  });
+
   it("releases older-history loading when a fresher hydration supersedes it", async () => {
     const initialTail = readThreadResponse({
       entries: [

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -644,6 +644,211 @@ describe("useThreadSessionState", () => {
         "message:Final answer.",
       ]);
     });
+
+  });
+
+  it("preserves completed live entries omitted by a stale tail refresh", async () => {
+    const turn = {
+      id: "completed-live-turn",
+      status: "completed" as const,
+      startedAt: 200,
+      completedAt: 400,
+    };
+    const anchor = {
+      ...messageEntry({
+        id: "tail-anchor",
+        role: "user" as const,
+        text: "Prompt",
+        createdAt: 200,
+      }),
+      turn,
+    };
+    const initialTail = readThreadResponse({
+      entries: [
+        anchor,
+        {
+          ...messageEntry({
+            id: "live-commentary",
+            text: "Completed commentary",
+            createdAt: 300,
+          }),
+          phase: "commentary" as const,
+          turn,
+        },
+        {
+          ...messageEntry({
+            id: "live-final",
+            text: "Completed final",
+            createdAt: 400,
+          }),
+          phase: "final" as const,
+          turn,
+        },
+      ],
+      hasPreviousPage: true,
+      previousCursor: "tail-anchor",
+    });
+    const olderPage = readThreadResponse({
+      entries: [
+        messageEntry({
+          id: "older-message",
+          role: "user",
+          text: "Older history",
+          createdAt: 100,
+        }),
+      ],
+      hasPreviousPage: false,
+    });
+    const staleTail = readThreadResponse({
+      entries: [anchor],
+      hasPreviousPage: true,
+      previousCursor: "tail-anchor",
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(olderPage)
+      .mockResolvedValueOnce(staleTail);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    rerender({ updatedAt: 2_000 });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:Older history",
+        "message:Prompt",
+        "message:Completed commentary",
+        "message:Completed final",
+      ]);
+    });
+  });
+
+  it("preserves a loaded prefix when the latest page starts mid-turn", async () => {
+    const turn = {
+      id: "split-turn",
+      status: "completed" as const,
+      startedAt: 100,
+      completedAt: 400,
+    };
+    const initialTail = readThreadResponse({
+      entries: [
+        {
+          ...messageEntry({
+            id: "middle-live-id",
+            text: "Middle of the turn",
+            createdAt: 200,
+          }),
+          phase: "commentary" as const,
+          turn,
+        },
+        {
+          ...messageEntry({
+            id: "turn-final",
+            text: "Turn final",
+            createdAt: 400,
+          }),
+          phase: "final" as const,
+          turn,
+        },
+      ],
+      hasPreviousPage: true,
+      previousCursor: "middle-live-id",
+    });
+    const olderPage = readThreadResponse({
+      entries: [
+        {
+          ...messageEntry({
+            id: "earlier-same-turn",
+            text: "Earlier in the same turn",
+            createdAt: 100,
+          }),
+          phase: "commentary" as const,
+          turn,
+        },
+      ],
+      hasPreviousPage: true,
+      previousCursor: "older-page",
+    });
+    const refreshedTail = readThreadResponse({
+      entries: [
+        {
+          ...messageEntry({
+            id: "middle-normalized-id",
+            text: "Middle of the turn",
+            createdAt: 200,
+          }),
+          phase: "commentary" as const,
+          turn,
+        },
+        {
+          ...messageEntry({
+            id: "turn-final",
+            text: "Turn final",
+            createdAt: 400,
+          }),
+          phase: "final" as const,
+          turn,
+        },
+      ],
+      hasPreviousPage: true,
+      previousCursor: "middle-normalized-id",
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(olderPage)
+      .mockResolvedValueOnce(refreshedTail);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    rerender({ updatedAt: 2_000 });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:Earlier in the same turn",
+        "message:Middle of the turn",
+        "message:Turn final",
+      ]);
+    });
   });
 
   it("releases older-history loading when a fresher hydration supersedes it", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -596,21 +596,60 @@ function preserveLoadedTranscriptHistory(
     return response;
   }
 
+  const retainedEntries = retainedTranscriptPrefix(
+    retainedResponse.replay.entries,
+    response.replay.entries
+  );
+  const retainedMessageIds = new Set(
+    retainedEntries.flatMap((entry) =>
+      entry.type === "message" ? [entry.id] : []
+    )
+  );
+
   return {
     ...response,
     replay: {
       ...response.replay,
       entries: mergeItems(
-        retainedResponse.replay.entries,
+        retainedEntries,
         response.replay.entries
       ),
       messages: mergeItems(
-        retainedResponse.replay.messages,
+        retainedResponse.replay.messages.filter((message) =>
+          retainedMessageIds.has(message.id)
+        ),
         response.replay.messages
       ),
       pagination: retainedResponse.replay.pagination,
     },
   };
+}
+
+function retainedTranscriptPrefix(
+  retainedEntries: AppServerThreadEntry[],
+  freshEntries: AppServerThreadEntry[]
+): AppServerThreadEntry[] {
+  // A latest-page refresh owns its whole overlap. Live notifications and a
+  // later thread/read can describe the same message with different item IDs,
+  // so an ID-only merge would append the coarse hydrated tail after the live
+  // interleaved transcript. Keep only the genuinely older page prefix.
+  for (const freshEntry of freshEntries) {
+    const exactOverlapIndex = retainedEntries.findIndex(
+      (retainedEntry) => retainedEntry.id === freshEntry.id
+    );
+    const overlapIndex = exactOverlapIndex !== -1
+      ? exactOverlapIndex
+      : freshEntry.turn?.id
+        ? retainedEntries.findIndex(
+            (retainedEntry) => retainedEntry.turn?.id === freshEntry.turn?.id
+          )
+        : -1;
+    if (overlapIndex !== -1) {
+      return retainedEntries.slice(0, overlapIndex);
+    }
+  }
+
+  return retainedEntries;
 }
 
 function isCodexImageBoundaryText(value: string): boolean {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -148,7 +148,7 @@ type ThreadSessionEntry = {
   initialLoadDurationMs?: number;
   interacted: boolean;
   lastTouchedAt: number;
-  loadedOlderHistory: boolean;
+  loadedHistoryEntryCount: number;
   loading: boolean;
   loadingMore: boolean;
   needsHydrationAfterCompletion: boolean;
@@ -200,7 +200,7 @@ function createEmptyThreadSessionEntry(): ThreadSessionEntry {
     expectOwnUpdate: false,
     interacted: false,
     lastTouchedAt: Date.now(),
-    loadedOlderHistory: false,
+    loadedHistoryEntryCount: 0,
     loading: false,
     loadingMore: false,
     needsHydrationAfterCompletion: false,
@@ -586,70 +586,128 @@ function mergeTranscriptMessages(
 function preserveLoadedTranscriptHistory(
   response: AppServerReadThreadResponse,
   retainedResponse: AppServerReadThreadResponse | undefined,
-  shouldPreserve: boolean
+  loadedHistoryEntryCount: number
 ): AppServerReadThreadResponse {
   if (
-    !shouldPreserve ||
+    loadedHistoryEntryCount === 0 ||
     !retainedResponse ||
     !response.replay.pagination.supportsPagination
   ) {
     return response;
   }
 
-  const retainedEntries = retainedTranscriptPrefix(
-    retainedResponse.replay.entries,
-    response.replay.entries
+  // The explicit boundary keeps a latest page that starts mid-turn from
+  // claiming entries that were loaded by an older-page request.
+  const retainedPrefix = retainedResponse.replay.entries.slice(
+    0,
+    loadedHistoryEntryCount
   );
-  const retainedMessageIds = new Set(
-    retainedEntries.flatMap((entry) =>
-      entry.type === "message" ? [entry.id] : []
-    )
+  const retainedTail = retainedResponse.replay.entries.slice(
+    loadedHistoryEntryCount
+  );
+  // A refresh can lag the live stream. Replace only exact or uniquely
+  // equivalent retained entries; keep anything the refresh omitted.
+  const matchedRetainedEntries = new Set<AppServerThreadEntry>();
+  for (const freshEntry of response.replay.entries) {
+    const retainedMatch = findUniqueTranscriptRefreshMatch(
+      freshEntry,
+      retainedTail.filter((entry) => !matchedRetainedEntries.has(entry))
+    );
+    if (retainedMatch) {
+      matchedRetainedEntries.add(retainedMatch);
+    }
+  }
+  const retainedTailRemainder = retainedTail.filter(
+    (entry) => !matchedRetainedEntries.has(entry)
+  );
+  const entries = mergeItems(
+    retainedPrefix,
+    mergeTranscriptEntries(response.replay.entries, retainedTailRemainder)
+  );
+  const messagesById = new Map(
+    [
+      ...retainedResponse.replay.messages,
+      ...response.replay.messages,
+    ].map((message) => [message.id, message] as const)
   );
 
   return {
     ...response,
     replay: {
       ...response.replay,
-      entries: mergeItems(
-        retainedEntries,
-        response.replay.entries
-      ),
-      messages: mergeItems(
-        retainedResponse.replay.messages.filter((message) =>
-          retainedMessageIds.has(message.id)
-        ),
-        response.replay.messages
-      ),
+      entries,
+      messages: entries.flatMap((entry) => {
+        if (entry.type !== "message") {
+          return [];
+        }
+
+        const message = messagesById.get(entry.id);
+        return message
+          ? [message]
+          : [{
+              id: entry.id,
+              role: entry.role,
+              text: entry.text,
+              ...(entry.parts ? { parts: entry.parts } : {}),
+              ...(entry.origin ? { origin: entry.origin } : {}),
+              ...(entry.createdAt !== undefined
+                ? { createdAt: entry.createdAt }
+                : {}),
+            }];
+      }),
       pagination: retainedResponse.replay.pagination,
     },
   };
 }
 
-function retainedTranscriptPrefix(
-  retainedEntries: AppServerThreadEntry[],
-  freshEntries: AppServerThreadEntry[]
-): AppServerThreadEntry[] {
-  // A latest-page refresh owns its whole overlap. Live notifications and a
-  // later thread/read can describe the same message with different item IDs,
-  // so an ID-only merge would append the coarse hydrated tail after the live
-  // interleaved transcript. Keep only the genuinely older page prefix.
-  for (const freshEntry of freshEntries) {
-    const exactOverlapIndex = retainedEntries.findIndex(
-      (retainedEntry) => retainedEntry.id === freshEntry.id
-    );
-    const overlapIndex = exactOverlapIndex !== -1
-      ? exactOverlapIndex
-      : freshEntry.turn?.id
-        ? retainedEntries.findIndex(
-            (retainedEntry) => retainedEntry.turn?.id === freshEntry.turn?.id
-          )
-        : -1;
-    if (overlapIndex !== -1) {
-      return retainedEntries.slice(0, overlapIndex);
-    }
+function findUniqueTranscriptRefreshMatch(
+  freshEntry: AppServerThreadEntry,
+  retainedEntries: AppServerThreadEntry[]
+): AppServerThreadEntry | undefined {
+  const exactMatch = retainedEntries.find(
+    (retainedEntry) => retainedEntry.id === freshEntry.id
+  );
+  if (exactMatch) {
+    return exactMatch;
   }
 
-  return retainedEntries;
+  const logicalMatches = retainedEntries.filter((retainedEntry) => {
+    if (
+      freshEntry.turn?.id &&
+      retainedEntry.turn?.id &&
+      freshEntry.turn.id !== retainedEntry.turn.id
+    ) {
+      return false;
+    }
+    if (
+      freshEntry.type === "message" &&
+      retainedEntry.type === "message" &&
+      freshEntry.phase &&
+      retainedEntry.phase &&
+      freshEntry.phase !== retainedEntry.phase
+    ) {
+      return false;
+    }
+
+    return transcriptEntriesMatch(freshEntry, retainedEntry);
+  });
+
+  return logicalMatches.length === 1 ? logicalMatches[0] : undefined;
+}
+
+function loadedHistoryPrefixGrowth(
+  currentEntries: AppServerThreadEntry[],
+  mergedEntries: AppServerThreadEntry[]
+): number {
+  const currentFirstEntryId = currentEntries[0]?.id;
+  if (!currentFirstEntryId) {
+    return mergedEntries.length;
+  }
+
+  const currentBoundaryIndex = mergedEntries.findIndex(
+    (entry) => entry.id === currentFirstEntryId
+  );
+  return currentBoundaryIndex === -1 ? 0 : currentBoundaryIndex;
 }
 
 function isCodexImageBoundaryText(value: string): boolean {
@@ -3888,7 +3946,7 @@ export function useThreadSessionState(params: {
           const responseWithLoadedHistory = preserveLoadedTranscriptHistory(
             orderedResponse,
             current.response,
-            current.loadedOlderHistory
+            current.loadedHistoryEntryCount
           );
           const hydratedPendingRequest = response.pendingRequest;
           const hydratedPendingUserInput =
@@ -5618,28 +5676,42 @@ export function useThreadSessionState(params: {
         return;
       }
 
-      updateSession(threadKey, (current) => ({
-        ...current,
-        lastTouchedAt: Date.now(),
-        loadingMore: false,
-        response: current.response
-          ? {
-              ...olderResponse,
-              replay: {
-                ...olderResponse.replay,
-                entries: mergeItems(
-                  olderResponse.replay.entries,
-                  current.response.replay.entries
-                ),
-                messages: mergeItems(
-                  olderResponse.replay.messages,
-                  current.response.replay.messages
-                ),
-              },
-            }
-          : olderResponse,
-        loadedOlderHistory: Boolean(current.response),
-      }));
+      updateSession(threadKey, (current) => {
+        if (!current.response) {
+          return {
+            ...current,
+            lastTouchedAt: Date.now(),
+            loadingMore: false,
+            response: olderResponse,
+          };
+        }
+
+        const mergedEntries = mergeItems(
+          olderResponse.replay.entries,
+          current.response.replay.entries
+        );
+        return {
+          ...current,
+          lastTouchedAt: Date.now(),
+          loadedHistoryEntryCount:
+            current.loadedHistoryEntryCount + loadedHistoryPrefixGrowth(
+              current.response.replay.entries,
+              mergedEntries
+            ),
+          loadingMore: false,
+          response: {
+            ...olderResponse,
+            replay: {
+              ...olderResponse.replay,
+              entries: mergedEntries,
+              messages: mergeItems(
+                olderResponse.replay.messages,
+                current.response.replay.messages
+              ),
+            },
+          },
+        };
+      });
     } catch (error) {
       if ((requestVersionsRef.current[threadKey] ?? 0) !== requestVersion) {
         return;


### PR DESCRIPTION
## Summary

- Treat the refreshed latest transcript page as authoritative from its first exact-ID or same-turn overlap.
- Preserve only genuinely older paginated history during completion hydration.
- Keep live tool activity interleaved while preventing normalized commentary and final messages from being appended a second time.
- Add regression coverage for differing live and hydrated message IDs.

## Root cause

When older transcript history had been loaded, the renderer retained the full live transcript and merged a completion hydration response by item ID. Live notification IDs can differ from the normalized IDs returned by a later `thread/read`.

The live tail contained commentary interleaved with tool activities, while the hydrated tail contained only normalized messages. Because the IDs differed, the old merge retained the rich live tail and appended the hydrated commentary and final again. This produced a collapsed duplicate commentary group followed by a duplicate final response.

Source-side investigation found one persisted turn, one completion event, no duplicate authoritative items, and no duplicate tool invocation IDs. A mid-turn federation outage likely exercised the mixed live-state and hydration path, but the source federation response itself contained each item once per projection.

## User impact

Completed federated turns no longer show duplicate commentary and final responses after completion hydration. Previously loaded history and live tool ordering remain intact.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx` — 110 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — zero errors
- `pnpm lint:boundaries` — no violations across 1,403 modules and 4,573 dependencies
- `git diff --check`