### PR TITLE
fix(release): forward-port Windows signing input repair

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,9 +357,35 @@ jobs:
           node-version: 24.14.1
           working-directory: .
 
-      - name: Package Windows installer (unsigned, no publish)
+      - name: Prepare Windows installer signing input
         timeout-minutes: 25
-        run: node apps/desktop/scripts/release.mjs --win --no-publish
+        run: node apps/desktop/scripts/release.mjs --win --prepare-only
+
+      # Exercise the same archive boundary as the protected release job without
+      # granting this PR job signing credentials.
+      - name: Archive and expand Windows installer signing input
+        timeout-minutes: 10
+        shell: pwsh
+        run: |
+          $archive = Join-Path $env:RUNNER_TEMP "windows-installer-pr-input.tgz"
+          ./scripts/release/archive-windows-signing-input.ps1 -ArchivePath $archive
+          $input = Join-Path $env:RUNNER_TEMP "windows-installer-pr-input"
+          New-Item -ItemType Directory -Path $input -Force | Out-Null
+          Push-Location $input
+          & tar.exe -xzf $archive
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to expand Windows installer signing input (exit code $LASTEXITCODE)."
+          }
+          Pop-Location
+
+      - name: Package Windows installer from prepared input (unsigned, no publish)
+        timeout-minutes: 25
+        shell: pwsh
+        run: |
+          $input = Join-Path $env:RUNNER_TEMP "windows-installer-pr-input"
+          Push-Location $input
+          node apps/desktop/scripts/release.mjs --win --sign-stage-only --no-publish
+          Pop-Location
 
       - name: Upload Windows installer artifact
         uses: actions/upload-artifact@v7
@@ -368,9 +394,9 @@ jobs:
         with:
           name: windows-installer-pr
           path: |
-            apps/desktop/release-stage/dist/*.exe
-            apps/desktop/release-stage/dist/*.exe.blockmap
-            apps/desktop/release-stage/dist/SHA256SUMS
+            ${{ runner.temp }}/windows-installer-pr-input/apps/desktop/release-stage/dist/*.exe
+            ${{ runner.temp }}/windows-installer-pr-input/apps/desktop/release-stage/dist/*.exe.blockmap
+            ${{ runner.temp }}/windows-installer-pr-input/apps/desktop/release-stage/dist/SHA256SUMS
           retention-days: 7
 
   desktop-e2e:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,22 +242,7 @@ jobs:
         shell: pwsh
         run: |
           $archive = Join-Path $env:RUNNER_TEMP "windows-release-signing-input.tgz"
-          $paths = @(
-            "package.json",
-            "pnpm-lock.yaml",
-            "pnpm-workspace.yaml",
-            "apps/desktop/release-stage",
-            "apps/desktop/scripts/release.mjs",
-            "apps/desktop/scripts/verify-asar-contents.mjs",
-            "apps/desktop/scripts/asar-entry-paths.mjs",
-            "apps/desktop/node_modules",
-            "scripts/release/install-trusted-signing.ps1",
-            "node_modules"
-          )
-          & tar.exe -czf $archive @paths
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to archive Windows signing input (exit code $LASTEXITCODE)."
-          }
+          ./scripts/release/archive-windows-signing-input.ps1 -ArchivePath $archive
           $sha256 = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
           "sha256=$sha256" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "$sha256  windows-release-signing-input.tgz" |

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -185,7 +185,12 @@ function resolveWindowsAzureSigning() {
 }
 
 function electronBuilderCli() {
-  const cli = join(desktopRoot, "node_modules", "electron-builder", "cli.js");
+  // Windows signing receives a self-contained, hoisted release-stage archive
+  // instead of the workspace's pnpm symlink graph. Its signing job must not
+  // install dependencies, so use the staged electron-builder toolchain there.
+  const cli = signStageOnly && win
+    ? join(stageDir, "node_modules", "electron-builder", "cli.js")
+    : join(desktopRoot, "node_modules", "electron-builder", "cli.js");
   if (!existsSync(cli)) {
     throw new Error(`electron-builder CLI is missing at ${cli}; signing jobs must use the prepared release artifact`);
   }
@@ -449,27 +454,33 @@ if (!signStageOnly) {
   step("electron-vite build");
   runChecked("pnpm", ["--filter", "@pwragent/desktop", "build"], { cwd: repoRoot });
 
-  // 3. Materialize a self-contained, flat node_modules under stage.
-  step("pnpm deploy --prod -> release-stage");
+  // 3. Materialize the release stage. Windows must include electron-builder in
+  // the staged tree: its protected signing job receives only this tree, and
+  // Windows tar follows pnpm's workspace junctions when the workspace
+  // node_modules directories are archived. A hoisted deploy avoids that
+  // junction graph while leaving package-manager work outside the credential
+  // boundary.
+  const deployArgs = [
+    ...(!linux && !win
+      ? ["--cpu=x64", "--cpu=arm64", "--os=darwin"]
+      : []),
+    "deploy",
+    "--filter",
+    "@pwragent/desktop",
+    "--legacy",
+  ];
+  if (win) {
+    deployArgs.push("--config.node-linker=hoisted");
+  } else {
+    deployArgs.push("--prod");
+  }
+  deployArgs.push(stageDir);
+  step(`pnpm ${win ? "deploy (hoisted)" : "deploy --prod"} -> release-stage`);
   if (existsSync(stageDir)) {
     rmSync(stageDir, { recursive: true, force: true });
   }
   mkdirSync(stageDir, { recursive: true });
-  runChecked(
-    "pnpm",
-    [
-      ...(!linux && !win
-        ? ["--cpu=x64", "--cpu=arm64", "--os=darwin"]
-        : []),
-      "deploy",
-      "--filter",
-      "@pwragent/desktop",
-      "--prod",
-      "--legacy",
-      stageDir,
-    ],
-    { cwd: repoRoot },
-  );
+  runChecked("pnpm", deployArgs, { cwd: repoRoot });
   patchStageDependencyManifests();
   if (win) {
     verifyWindowsCanvasBindingInStage();
@@ -575,7 +586,11 @@ if (win) {
   const builtApp = findWindowsUnpackedDir(dist);
 
   step("verify packaged asar contents");
-  runChecked("node", [join(desktopRoot, "scripts", "verify-asar-contents.mjs"), builtApp]);
+  runChecked(
+    "node",
+    [join(desktopRoot, "scripts", "verify-asar-contents.mjs"), builtApp],
+    { env: { PWRAGENT_ASAR_MODULE_ROOT: stageDir } },
+  );
 
   step("write Windows checksums");
   const checksumPath = writeWindowsChecksums(dist);

--- a/apps/desktop/scripts/verify-asar-contents.mjs
+++ b/apps/desktop/scripts/verify-asar-contents.mjs
@@ -42,9 +42,14 @@ if (!existsSync(asarPath)) {
   process.exit(1);
 }
 
-// @electron/asar is a transitive dependency of electron-builder, so it resolves
-// from the desktop package's node_modules without an extra install step.
-const require = createRequire(import.meta.url);
+// @electron/asar is a transitive dependency of electron-builder. The protected
+// Windows signing job receives a self-contained staged toolchain rather than
+// the workspace node_modules, so allow release.mjs to resolve from that stage
+// without reinstalling dependencies around signing credentials.
+const asarModuleRoot = process.env.PWRAGENT_ASAR_MODULE_ROOT?.trim();
+const require = asarModuleRoot
+  ? createRequire(resolve(asarModuleRoot, "package.json"))
+  : createRequire(import.meta.url);
 const asar = require("@electron/asar");
 const listing = normalizeAsarListing(
   asar.listPackage(asarPath, { isPack: false }),

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -133,15 +133,19 @@ seven job definitions (the Linux package job fans out across two architectures):
    --no-publish`, verifies the packaged ASAR, writes a stable download alias,
    and uploads the `.deb` files as short-retention workflow artifacts.
 4. `Prepare Windows signing input`, running on Windows without an environment
-   or signing credentials. It builds and deploys the Windows release stage,
-   archives that stage plus the already-resolved electron-builder toolchain,
-   records the archive SHA-256 as a job output, and uploads the archive.
+   or signing credentials. It builds a self-contained, hoisted Windows release
+   stage that includes the electron-builder toolchain, archives that stage and
+   the small signing scripts without workspace `node_modules` links, records
+   the archive SHA-256 as a job output, and uploads the archive. This avoids
+   Windows tar recursively following pnpm workspace junctions.
 5. `Sign and package Windows installer`, gated by the protected
    `windows-signing` environment. It does not check out source or install
    project dependencies/lifecycle scripts. It verifies and expands the exact
    prepared archive, installs `TrustedSigning`, and runs `release.mjs --win
-   --sign-stage-only --no-publish --require-signing`. The Azure service-principal
-   secrets are injected only into this signing-aware packaging step.
+   --sign-stage-only --no-publish --require-signing`. The post-package ASAR
+   verifier resolves from the staged toolchain, not the workspace. The Azure
+   service-principal secrets are injected only into this signing-aware packaging
+   step.
 6. `Publish Linux DEB artifacts`, which waits for the macOS publish job so the
    GitHub Release exists, combines both Linux architecture artifacts, generates
    `SHA256SUMS`, and uploads the `.deb` files plus checksums to the same

--- a/scripts/check-desktop-release-metadata.mjs
+++ b/scripts/check-desktop-release-metadata.mjs
@@ -18,6 +18,10 @@ const trustedSigningSetupPath = resolve(
   repoRoot,
   "scripts/release/install-trusted-signing.ps1",
 );
+const windowsArchiveScriptPath = resolve(
+  repoRoot,
+  "scripts/release/archive-windows-signing-input.ps1",
+);
 const desktopReleaseRunbookPath = resolve(repoRoot, "docs/desktop-release-runbook.md");
 const changelogPath = resolve(repoRoot, "CHANGELOG.md");
 
@@ -177,6 +181,11 @@ const releaseScript = readFileSync(releaseScriptPath, "utf8");
 const verifyAsarContents = readFileSync(verifyAsarContentsPath, "utf8");
 const releaseWorkflow = readFileSync(releaseWorkflowPath, "utf8");
 const trustedSigningSetup = readFileSync(trustedSigningSetupPath, "utf8");
+const windowsArchiveScript = readFileSync(windowsArchiveScriptPath, "utf8");
+const asarVerifier = readFileSync(
+  resolve(repoRoot, "apps/desktop/scripts/verify-asar-contents.mjs"),
+  "utf8",
+);
 const desktopReleaseRunbook = readFileSync(desktopReleaseRunbookPath, "utf8");
 
 const desktopScripts = desktopPackage.scripts || {};
@@ -250,7 +259,9 @@ for (const expected of [
 for (const expected of [
   "releases/**",
   "ci:windows-package",
-  "--win --no-publish",
+  "--win --prepare-only",
+  "--win --sign-stage-only --no-publish",
+  "archive-windows-signing-input.ps1",
 ]) {
   if (!ciWorkflow.includes(expected)) {
     fail(`.github/workflows/ci.yml must contain ${JSON.stringify(expected)}`);
@@ -324,6 +335,7 @@ for (const expected of [
   "signing-input-sha256: ${{ steps.archive.outputs.sha256 }}",
   "Archive Windows signing input",
   "Upload Windows signing input",
+  "archive-windows-signing-input.ps1",
 ]) {
   assertWorkflowJobContainsText(
     releaseWorkflow,
@@ -337,6 +349,8 @@ for (const unexpected of [
   "secrets.",
   "      - name: Install TrustedSigning",
   "--require-signing",
+  "apps/desktop/node_modules",
+  "            \"node_modules\"",
 ]) {
   assertWorkflowJobExcludesText(
     releaseWorkflow,
@@ -406,6 +420,29 @@ for (const credential of [
     "windows-sign",
     credential,
   );
+}
+for (const expected of [
+  "--config.node-linker=hoisted",
+  "signStageOnly && win",
+  "PWRAGENT_ASAR_MODULE_ROOT: stageDir",
+]) {
+  if (!releaseScript.includes(expected)) {
+    fail(`apps/desktop/scripts/release.mjs must contain ${JSON.stringify(expected)} for Windows signing input isolation`);
+  }
+}
+for (const expected of [
+  "apps/desktop/release-stage/node_modules/.pnpm/node_modules",
+  "apps/desktop/release-stage",
+  "apps/desktop/scripts/release.mjs",
+  "scripts/release/install-trusted-signing.ps1",
+  "tar.exe -czf",
+]) {
+  if (!windowsArchiveScript.includes(expected)) {
+    fail(`${windowsArchiveScriptPath} must contain ${JSON.stringify(expected)} for Windows signing input isolation`);
+  }
+}
+if (!asarVerifier.includes("PWRAGENT_ASAR_MODULE_ROOT")) {
+  fail("apps/desktop/scripts/verify-asar-contents.mjs must accept the staged ASAR module root");
 }
 for (const expected of [
   "Install-Module",

--- a/scripts/release/archive-windows-signing-input.ps1
+++ b/scripts/release/archive-windows-signing-input.ps1
@@ -1,0 +1,35 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ArchivePath
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+# A default pnpm deploy leaves .pnpm/node_modules as a workspace-link view.
+# Git for Windows' tar follows those directory junctions, which can re-enter
+# apps/desktop/release-stage indefinitely. The release script uses a hoisted
+# stage for Windows so this virtual-root directory must not be present.
+$workspaceLinkRoot = "apps/desktop/release-stage/node_modules/.pnpm/node_modules"
+if (Test-Path -LiteralPath $workspaceLinkRoot) {
+  throw "Windows release-stage must not contain $workspaceLinkRoot; archive only the hoisted signing input."
+}
+
+$paths = @(
+  "apps/desktop/release-stage",
+  "apps/desktop/scripts/release.mjs",
+  "apps/desktop/scripts/verify-asar-contents.mjs",
+  "apps/desktop/scripts/asar-entry-paths.mjs",
+  "scripts/release/install-trusted-signing.ps1"
+)
+foreach ($path in $paths) {
+  if (-not (Test-Path -LiteralPath $path)) {
+    throw "Required Windows signing input is missing: $path"
+  }
+}
+
+& tar.exe -czf $ArchivePath @paths
+if ($LASTEXITCODE -ne 0) {
+  throw "Failed to archive Windows signing input (exit code $LASTEXITCODE)."
+}


### PR DESCRIPTION
## Summary

- I forward-port the validated `releases/1.0` Windows signing-input repair to current `main`.
- I prepare a self-contained hoisted Windows stage, archive only that stage and its signing scripts, and resolve the post-package ASAR verifier from the staged toolchain.
- I make the label-gated PR package job exercise prepare → archive → extract → unsigned package without signing credentials, while keeping the protected signing job free of checkout and project dependency installation.

## Verification

- `pnpm release:check --tag v1.1.0-beta.1`
- `node --check apps/desktop/scripts/release.mjs`
- `node --check apps/desktop/scripts/verify-asar-contents.mjs`
- `node --check scripts/check-desktop-release-metadata.mjs`
- `pnpm lint:eslint` (passes with the existing 34 warnings)
- `pnpm typecheck`
- I verified the label-gated Windows prepare/archive/extract/package CI path. Run `31565041436` uploaded non-expired `windows-installer-pr` artifact `9129230172`.

## Notes

- This preserves the protected `windows-signing` environment boundary and does not request approval, create a tag, or create a release.
