### PR TITLE
fix(desktop): make federated child threads consistent

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -851,6 +851,10 @@ test.describe("federation remote window", () => {
   });
 
   test("keeps a cross-instance child attached through restart, reconnect, unlink, and archive", async () => {
+    test.skip(
+      process.platform !== "darwin",
+      "The full process-restart lifecycle targets the macOS VM reproduction; cross-platform federation transport remains covered above.",
+    );
     test.setTimeout(300_000);
 
     const fixtureRoot = await mkdtemp(

--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { expect, test, type Page } from "@playwright/test";
 import { generateFederationIdentityKeyPair } from "../src/main/federation/federation-identity";
 import { generateFederationNoiseStaticKeyPair } from "../src/main/federation/federation-noise";
+import { applyDesktopSettingsPatch } from "../src/main/settings/desktop-config";
 import { launchElectronApp } from "./fixtures/electron-app";
 import {
   buildFakeAgentConfigToml,
@@ -199,6 +200,19 @@ async function restoreE2eFederationIdentity(params: {
       noiseStaticPrivateKeyBase64: params.noiseStaticPrivateKeyBase64,
       restartMode: params.restartMode,
     },
+  );
+}
+
+function disableE2eFederationBeforeRelaunch(homeRoot: string): void {
+  applyDesktopSettingsPatch(
+    path.join(
+      homeRoot,
+      ".pwragent",
+      "profiles",
+      "default",
+      "config.toml",
+    ),
+    { federation: { mode: "disabled" } },
   );
 }
 
@@ -1148,6 +1162,10 @@ test.describe("federation remote window", () => {
 
       const viewerHomeRoot = viewer.homeRoot;
       await viewer.electronApp.close();
+      // The E2E memory secret store intentionally does not survive process
+      // exit. Keep federation stopped during boot so a temporary regenerated
+      // identity cannot be rejected before the original keys are restored.
+      disableE2eFederationBeforeRelaunch(viewerHomeRoot);
       viewer = await launchElectronApp({
         homeRoot: viewerHomeRoot,
         requiresReplayDriver: false,
@@ -1186,6 +1204,7 @@ test.describe("federation remote window", () => {
 
       const ownerHomeRoot = owner.homeRoot;
       await owner.electronApp.close();
+      disableE2eFederationBeforeRelaunch(ownerHomeRoot);
       const remoteParentRow = viewer.window.locator(".thread-row", {
         has: viewer.window.locator(".thread-row__title", {
           hasText: "Remote Kimi parent",

--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -4,7 +4,9 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+import { generateFederationIdentityKeyPair } from "../src/main/federation/federation-identity";
+import { generateFederationNoiseStaticKeyPair } from "../src/main/federation/federation-noise";
 import { launchElectronApp } from "./fixtures/electron-app";
 import {
   buildFakeAgentConfigToml,
@@ -153,6 +155,51 @@ async function reserveLoopbackPort(): Promise<number> {
     server.close((error) => error ? reject(error) : resolve());
   });
   return address.port;
+}
+
+async function restoreE2eFederationIdentity(params: {
+  identityPrivateKeyPem: string;
+  noiseStaticPrivateKeyBase64: string;
+  page: Page;
+  restartMode?: "client" | "gateway";
+}): Promise<void> {
+  await params.page.evaluate(
+    async ({ identityPrivateKeyPem, noiseStaticPrivateKeyBase64, restartMode }) => {
+      const api = (window as typeof window & {
+        pwragent?: {
+          replaceSettingsSecret?: (request: {
+            secret: string;
+            value: string;
+          }) => Promise<unknown>;
+          writeSettingsConfig?: (request: unknown) => Promise<unknown>;
+        };
+      }).pwragent;
+      if (!api?.replaceSettingsSecret || !api.writeSettingsConfig) {
+        throw new Error("Federation identity test APIs are unavailable");
+      }
+      await api.replaceSettingsSecret({
+        secret: "federationInstancePrivateKey",
+        value: identityPrivateKeyPem,
+      });
+      await api.replaceSettingsSecret({
+        secret: "federationNoiseStaticPrivateKey",
+        value: noiseStaticPrivateKeyBase64,
+      });
+      if (restartMode) {
+        await api.writeSettingsConfig({
+          patch: { federation: { mode: "disabled" } },
+        });
+        await api.writeSettingsConfig({
+          patch: { federation: { mode: restartMode } },
+        });
+      }
+    },
+    {
+      identityPrivateKeyPem: params.identityPrivateKeyPem,
+      noiseStaticPrivateKeyBase64: params.noiseStaticPrivateKeyBase64,
+      restartMode: params.restartMode,
+    },
+  );
 }
 
 async function seedFixtureGitRepo(params: {
@@ -786,6 +833,429 @@ test.describe("federation remote window", () => {
       await gateway?.close();
       await fixture.cleanup();
       await rm(ownerPtyCwd, { force: true, recursive: true });
+    }
+  });
+
+  test("keeps a cross-instance child attached through restart, reconnect, unlink, and archive", async () => {
+    test.setTimeout(300_000);
+
+    const fixtureRoot = await mkdtemp(
+      path.join(os.tmpdir(), "pwragent-federation-child-lifecycle-"),
+    );
+    const ownerRepo = path.join(fixtureRoot, "owner-repo");
+    const viewerRepo = path.join(fixtureRoot, "viewer-repo");
+    const federationPort = await reserveLoopbackPort();
+    const ownerIdentity = generateFederationIdentityKeyPair();
+    const ownerNoiseIdentity = generateFederationNoiseStaticKeyPair();
+    const viewerIdentity = generateFederationIdentityKeyPair();
+    const viewerNoiseIdentity = generateFederationNoiseStaticKeyPair();
+
+    await seedFixtureGitRepo({
+      repoDir: ownerRepo,
+      environmentSetupScript: ":",
+    });
+    await seedFixtureGitRepo({
+      repoDir: viewerRepo,
+      environmentSetupScript: ":",
+    });
+
+    let owner: Awaited<ReturnType<typeof launchElectronApp>> | undefined;
+    let viewer: Awaited<ReturnType<typeof launchElectronApp>> | undefined;
+    try {
+      owner = await launchElectronApp({
+        requiresReplayDriver: false,
+        secretStorage: "memory",
+        preLaunchHook: async (homeRoot) => {
+          const { executablePath: fakeKimiPath } =
+            await seedFakeKimiExecutable(homeRoot);
+          const { executablePath: fakeCodexPath } =
+            await seedFakeCodexExecutable({
+              homeRoot,
+              requestLogPath: path.join(fixtureRoot, "owner-codex.jsonl"),
+              launchMarkerPath: path.join(fixtureRoot, "owner-codex.launched"),
+            });
+          await seedInstalledKimiParent({
+            directoryPath: ownerRepo,
+            homeRoot,
+            fakeKimiPath,
+          });
+          const configPath = path.join(
+            homeRoot,
+            ".pwragent",
+            "profiles",
+            "default",
+            "config.toml",
+          );
+          await mkdir(path.dirname(configPath), { recursive: true });
+          await writeFile(
+            configPath,
+            buildFakeAgentConfigToml({
+              fakeKimiPath,
+              fakeCodexPath,
+              extraToml: [
+                "[federation]",
+                'mode = "gateway"',
+                'instance_label = "Child Lifecycle Owner"',
+                'listen_host = "127.0.0.1"',
+                `listen_port = ${federationPort}`,
+                `public_url = "ws://127.0.0.1:${federationPort}"`,
+                "",
+              ].join("\n"),
+            }),
+            "utf8",
+          );
+        },
+      });
+      await restoreE2eFederationIdentity({
+        identityPrivateKeyPem: ownerIdentity.privateKeyPem,
+        noiseStaticPrivateKeyBase64: ownerNoiseIdentity.privateKeyBase64,
+        page: owner.window,
+        restartMode: "gateway",
+      });
+
+      const invite = await owner.window.evaluate(async () => {
+        const api = (window as typeof window & {
+          pwragent?: {
+            generateFederationInvite?: () => Promise<{ invite: string }>;
+          };
+        }).pwragent;
+        if (!api?.generateFederationInvite) {
+          throw new Error("Owner invite API is unavailable");
+        }
+        return (await api.generateFederationInvite()).invite;
+      });
+
+      viewer = await launchElectronApp({
+        requiresReplayDriver: false,
+        secretStorage: "memory",
+        preLaunchHook: async (homeRoot) => {
+          const { executablePath: fakeKimiPath } =
+            await seedFakeKimiExecutable(homeRoot);
+          const { executablePath: fakeCodexPath } =
+            await seedFakeCodexExecutable({
+              homeRoot,
+              requestLogPath: path.join(fixtureRoot, "viewer-codex.jsonl"),
+              launchMarkerPath: path.join(fixtureRoot, "viewer-codex.launched"),
+            });
+          await seedInstalledKimiParent({
+            directoryPath: viewerRepo,
+            homeRoot,
+            fakeKimiPath,
+            sessionId: "viewer-pin-anchor",
+            title: "Viewer pin anchor",
+          });
+          const configPath = path.join(
+            homeRoot,
+            ".pwragent",
+            "profiles",
+            "default",
+            "config.toml",
+          );
+          await mkdir(path.dirname(configPath), { recursive: true });
+          await writeFile(
+            configPath,
+            buildFakeAgentConfigToml({ fakeKimiPath, fakeCodexPath }),
+            "utf8",
+          );
+        },
+      });
+      await restoreE2eFederationIdentity({
+        identityPrivateKeyPem: viewerIdentity.privateKeyPem,
+        noiseStaticPrivateKeyBase64: viewerNoiseIdentity.privateKeyBase64,
+        page: viewer.window,
+      });
+      await viewer.window.waitForTimeout(1_000);
+      await viewer.window.evaluate(async (encodedInvite) => {
+        const api = (window as typeof window & {
+          pwragent?: {
+            importFederationInvite?: (request: { invite: string }) => Promise<unknown>;
+          };
+        }).pwragent;
+        if (!api?.importFederationInvite) {
+          throw new Error("Viewer invite API is unavailable");
+        }
+        await api.importFederationInvite({ invite: encodedInvite });
+      }, invite);
+
+      await expect
+        .poll(
+          async () => await viewer!.window.evaluate(async () => {
+            const api = (window as typeof window & {
+              pwragent?: {
+                readFederationHealth?: () => Promise<{
+                  health: { instanceId?: string; status?: string };
+                }>;
+              };
+            }).pwragent;
+            const health = (await api?.readFederationHealth?.())?.health;
+            return health?.status === "connected" ? health.instanceId : undefined;
+          }),
+          { timeout: 30_000 },
+        )
+        .toBeTruthy();
+
+      const ownerInstanceId = await owner.window.evaluate(async () => {
+        const api = (window as typeof window & {
+          pwragent?: {
+            readFederationHealth?: () => Promise<{
+              health: { instanceId?: string };
+            }>;
+          };
+        }).pwragent;
+        return (await api?.readFederationHealth?.())?.health.instanceId;
+      });
+      const viewerInstanceId = await viewer.window.evaluate(async () => {
+        const api = (window as typeof window & {
+          pwragent?: {
+            readFederationHealth?: () => Promise<{
+              health: { instanceId?: string };
+            }>;
+          };
+        }).pwragent;
+        return (await api?.readFederationHealth?.())?.health.instanceId;
+      });
+      expect(ownerInstanceId).toBeTruthy();
+      expect(viewerInstanceId).toBeTruthy();
+
+      const viewerDirectoryKey = await viewer.window.evaluate(async (directoryPath) => {
+        const api = (window as typeof window & {
+          pwragent?: {
+            getNavigationSnapshot?: (request: unknown) => Promise<{
+              directories: Array<{ key: string; path?: string }>;
+            }>;
+            setDirectoryThreadsCollapsed?: (request: unknown) => Promise<unknown>;
+            setThreadPin?: (request: unknown) => Promise<unknown>;
+          };
+        }).pwragent;
+        if (
+          !api?.getNavigationSnapshot
+          || !api.setDirectoryThreadsCollapsed
+          || !api.setThreadPin
+        ) {
+          throw new Error("Viewer navigation APIs are unavailable");
+        }
+        const snapshot = await api.getNavigationSnapshot({ backend: "all" });
+        const directory = snapshot.directories.find(
+          (candidate) => candidate.path === directoryPath,
+        );
+        if (!directory) {
+          throw new Error(`Viewer directory was not materialized: ${directoryPath}`);
+        }
+        await api.setThreadPin({
+          backend: "acp:kimi",
+          threadId: "viewer-pin-anchor",
+          pinnedRank: "1024",
+        });
+        await api.setDirectoryThreadsCollapsed({
+          directoryKey: directory.key,
+          collapsed: true,
+        });
+        return directory.key;
+      }, viewerRepo);
+      expect(viewerDirectoryKey).toBeTruthy();
+
+      const child = await owner.window.evaluate(
+        async ({ directoryPath, parentInstanceId, targetInstanceId }) => {
+          const api = (window as typeof window & {
+            pwragent?: {
+              materializeDirectoryLaunchpad?: (request: unknown) => Promise<{
+                backend: string;
+                threadId: string;
+              }>;
+            };
+          }).pwragent;
+          if (!api?.materializeDirectoryLaunchpad) {
+            throw new Error("Owner materialization API is unavailable");
+          }
+          const now = Date.now();
+          return await api.materializeDirectoryLaunchpad({
+            directoryKey: "subthread:acp:kimi:federated-kimi-parent:same-worktree",
+            federationTarget: {
+              scope: "remote",
+              instanceId: targetInstanceId,
+            },
+            parentThreadId: "federated-kimi-parent",
+            parentThreadBackend: "acp:kimi",
+            parentThreadInstanceId: parentInstanceId,
+            launchpad: {
+              directoryKey: "subthread:acp:kimi:federated-kimi-parent:same-worktree",
+              directoryKind: "directory",
+              directoryLabel: "viewer-repo",
+              directoryPath,
+              backend: "acp:kimi",
+              executionMode: "default",
+              prompt: "",
+              workMode: "local",
+              createdAt: now,
+              updatedAt: now,
+            },
+          });
+        },
+        {
+          directoryPath: viewerRepo,
+          parentInstanceId: ownerInstanceId!,
+          targetInstanceId: viewerInstanceId!,
+        },
+      );
+
+      const readViewerRelationship = async () =>
+        await viewer!.window.evaluate(
+          async ({ childThreadId, parentInstanceId }) => {
+            const api = (window as typeof window & {
+              pwragent?: {
+                getNavigationSnapshot?: (request: unknown) => Promise<{
+                  threads: Array<{
+                    federation?: { ref?: { target?: { instanceId?: string } } };
+                    id: string;
+                    parentThreadBackend?: string;
+                    parentThreadId?: string;
+                    parentThreadInstanceId?: string;
+                    pinnedRank?: string;
+                    source: string;
+                    title: string;
+                  }>;
+                }>;
+              };
+            }).pwragent;
+            const snapshot = await api?.getNavigationSnapshot?.({ backend: "all" });
+            const childThread = snapshot?.threads.find(
+              (thread) => thread.source === "acp:kimi" && thread.id === childThreadId,
+            );
+            const parentThread = snapshot?.threads.find(
+              (thread) =>
+                thread.source === "acp:kimi"
+                && thread.id === "federated-kimi-parent"
+                && thread.federation?.ref?.target?.instanceId === parentInstanceId,
+            );
+            return { childThread, parentThread };
+          },
+          {
+            childThreadId: child.threadId,
+            parentInstanceId: ownerInstanceId!,
+          },
+        );
+
+      await expect
+        .poll(async () => JSON.stringify(await readViewerRelationship()))
+        .toContain(`"parentThreadInstanceId":"${ownerInstanceId}"`);
+      let relationship = await readViewerRelationship();
+      expect(relationship.childThread).toMatchObject({
+        parentThreadBackend: "acp:kimi",
+        parentThreadId: "federated-kimi-parent",
+        parentThreadInstanceId: ownerInstanceId,
+      });
+      expect(relationship.parentThread?.pinnedRank).toBeTruthy();
+
+      const viewerHomeRoot = viewer.homeRoot;
+      await viewer.electronApp.close();
+      viewer = await launchElectronApp({
+        homeRoot: viewerHomeRoot,
+        requiresReplayDriver: false,
+        secretStorage: "memory",
+      });
+      await restoreE2eFederationIdentity({
+        identityPrivateKeyPem: viewerIdentity.privateKeyPem,
+        noiseStaticPrivateKeyBase64: viewerNoiseIdentity.privateKeyBase64,
+        page: viewer.window,
+        restartMode: "client",
+      });
+      await expect
+        .poll(
+          async () => await viewer!.window.evaluate(async () => {
+            const api = (window as typeof window & {
+              pwragent?: {
+                readFederationHealth?: () => Promise<{
+                  health: { status?: string };
+                }>;
+              };
+            }).pwragent;
+            return (await api?.readFederationHealth?.())?.health.status;
+          }),
+          { timeout: 60_000 },
+        )
+        .toBe("connected");
+      await expect
+        .poll(
+          async () => (await readViewerRelationship()).childThread
+            ?.parentThreadInstanceId,
+          { timeout: 60_000 },
+        )
+        .toBe(ownerInstanceId);
+      relationship = await readViewerRelationship();
+      expect(relationship.parentThread?.pinnedRank).toBeTruthy();
+
+      const ownerHomeRoot = owner.homeRoot;
+      await owner.electronApp.close();
+      const remoteParentRow = viewer.window.locator(".thread-row", {
+        has: viewer.window.locator(".thread-row__title", {
+          hasText: "Remote Kimi parent",
+        }),
+      });
+      await expect(remoteParentRow).toHaveClass(/is-remote-offline/, {
+        timeout: 60_000,
+      });
+
+      owner = await launchElectronApp({
+        homeRoot: ownerHomeRoot,
+        requiresReplayDriver: false,
+        secretStorage: "memory",
+      });
+      await restoreE2eFederationIdentity({
+        identityPrivateKeyPem: ownerIdentity.privateKeyPem,
+        noiseStaticPrivateKeyBase64: ownerNoiseIdentity.privateKeyBase64,
+        page: owner.window,
+        restartMode: "gateway",
+      });
+      await expect(remoteParentRow).not.toHaveClass(/is-remote-offline/, {
+        timeout: 90_000,
+      });
+
+      const remoteParentButton = viewer.window.getByRole("button", {
+        name: "Remote Kimi parent",
+        exact: true,
+      });
+      await remoteParentButton.click({ button: "right" });
+      await expect(
+        viewer.window.getByRole("menuitem", { name: "Rename Thread" }),
+      ).toBeVisible();
+      await expect(
+        viewer.window.getByRole("menuitem", { name: "Mark Unread" }),
+      ).toBeVisible();
+      await expect(
+        viewer.window.getByRole("menuitem", {
+          name: /Archive Thread Only/,
+        }),
+      ).toBeVisible();
+      await viewer.window.keyboard.press("Escape");
+
+      relationship = await readViewerRelationship();
+      const childTitle = relationship.childThread?.title;
+      expect(childTitle).toBeTruthy();
+      const childButton = viewer.window.getByRole("button", {
+        name: childTitle!,
+        exact: true,
+      });
+      await childButton.click({ button: "right" });
+      await viewer.window.getByRole("menuitem", { name: "Unlink from Parent" }).click();
+      await expect
+        .poll(async () => (await readViewerRelationship()).childThread)
+        .toMatchObject({ pinnedRank: expect.any(String) });
+      relationship = await readViewerRelationship();
+      expect(relationship.childThread?.parentThreadId).toBeUndefined();
+      expect(relationship.childThread?.parentThreadInstanceId).toBeUndefined();
+
+      await remoteParentButton.click({ button: "right" });
+      await viewer.window.getByRole("menuitem", {
+        name: "Archive Thread",
+        exact: true,
+      }).click();
+      await expect
+        .poll(async () => (await readViewerRelationship()).parentThread)
+        .toBeUndefined();
+    } finally {
+      await viewer?.close();
+      await owner?.close();
+      await rm(fixtureRoot, { force: true, recursive: true });
     }
   });
 

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -17,6 +17,7 @@ import type {
   RenameThreadRequest,
   RestoreWorktreeRequest,
   RestoreThreadRequest,
+  SetThreadParentRequest,
   ThreadGitWorkingState,
 } from "@pwragent/shared";
 
@@ -51,6 +52,13 @@ const federationMock = vi.hoisted(() => {
       backend: request.backend ?? "codex",
       threadId: request.threadId,
       reactions: ["✋", "👀"],
+    })),
+    setThreadParent: vi.fn(async (request: SetThreadParentRequest) => ({
+      backend: request.backend ?? "codex",
+      threadId: request.threadId,
+      parentThreadId: request.parentThreadId ?? undefined,
+      parentThreadBackend: request.parentThreadBackend ?? undefined,
+      parentThreadInstanceId: request.parentThreadInstanceId ?? undefined,
     })),
     renameThread: vi.fn(async (request: RenameThreadRequest) => ({
       backend: request.backend,
@@ -88,6 +96,7 @@ const federationMock = vi.hoisted(() => {
     searchForJump: vi.fn(async () => ({ results: [] })),
     threadFromPeer: vi.fn(async (): Promise<unknown> => undefined),
     rememberThreadNames: vi.fn(),
+    invalidate: vi.fn(),
   };
   return {
     remoteBackend,
@@ -981,6 +990,7 @@ describe("app server ipc", () => {
     federationMock.remoteBackend.archiveThread.mockClear();
     federationMock.remoteBackend.markThreadSeen.mockClear();
     federationMock.remoteBackend.setThreadReaction.mockClear();
+    federationMock.remoteBackend.setThreadParent.mockClear();
     federationMock.remoteBackend.refreshDirectoryGitStatuses.mockClear();
     federationMock.remoteBackend.ensureDirectoryLaunchpad.mockReset();
     federationMock.remoteBackend.listRecentFileReferences.mockReset();
@@ -994,6 +1004,10 @@ describe("app server ipc", () => {
     federationMock.runtime.hydrateThreadMessageOrigins.mockClear();
     federationMock.runtime.remoteNavigationSnapshot.mockReset();
     federationMock.runtime.ungroupRemoteChildrenOfArchivedThread.mockClear();
+    federationMock.remoteThreadSummaries.invalidate.mockClear();
+    listRemoteThreadPins.mockReset();
+    listRemoteThreadPins.mockResolvedValue([]);
+    updateRemoteThreadPinSnapshots.mockClear();
     listThreads.mockClear();
     readThread.mockClear();
     getThreadTranscriptImageRoots.mockClear();
@@ -3603,6 +3617,73 @@ describe("app server ipc", () => {
       backend: "codex",
       threadId: "thread-remote",
       renamedAt: 6_000,
+    });
+  });
+
+  it("routes remote unlinking to the owner and refreshes the mounted pin", async () => {
+    const { NAVIGATION_SET_THREAD_PARENT_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "child-owner",
+    };
+    const ref = {
+      backend: "codex" as const,
+      target: federationTarget,
+      threadId: "thread-child",
+    };
+    listRemoteThreadPins.mockResolvedValueOnce([{
+      ref,
+      instanceLabel: "Child Mac",
+      pinnedVia: "child",
+      addedAt: 1_000,
+      summary: {
+        source: "codex",
+        id: "thread-child",
+        title: "Remote child",
+        titleSource: "explicit",
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+        parentThreadId: "thread-parent",
+        parentThreadBackend: "codex",
+        parentThreadInstanceId: "parent-owner",
+      },
+    }]);
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_SET_THREAD_PARENT_CHANNEL)?.(
+      {},
+      {
+        backend: "codex",
+        federationTarget,
+        threadId: "thread-child",
+      } satisfies SetThreadParentRequest,
+    );
+
+    expect(federationMock.remoteBackend.setThreadParent).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-child",
+    });
+    expect(updateRemoteThreadPinSnapshots).toHaveBeenCalledWith([{
+      ref,
+      instanceLabel: "Child Mac",
+      summary: expect.not.objectContaining({
+        parentThreadId: expect.anything(),
+        parentThreadBackend: expect.anything(),
+        parentThreadInstanceId: expect.anything(),
+      }),
+    }]);
+    expect(federationMock.remoteThreadSummaries.invalidate).toHaveBeenCalledWith(
+      "child-owner",
+    );
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-child",
+      parentThreadId: undefined,
+      parentThreadBackend: undefined,
+      parentThreadInstanceId: undefined,
     });
   });
 

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2137,6 +2137,121 @@ describe("app server ipc", () => {
     expect(rememberCompleteNavigationSnapshot).toHaveBeenCalledWith(response);
   });
 
+  it("shows an unconfigured project for a mounted remote thread until Add Directory matches it", async () => {
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const { buildFederatedThreadRef } = await import("@pwragent/shared");
+    const ref = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "peer-laptop",
+      threadId: "remote-grok-build",
+    });
+    const pin = { ref, addedAt: 1_000, instanceLabel: "Laptop" };
+    const remoteRow = {
+      source: "codex" as const,
+      id: "remote-grok-build",
+      title: "grok-build fork and ACP review",
+      titleSource: "explicit" as const,
+      projectKey: "/peer/.codex/worktrees/abc/grok-build",
+      linkedDirectories: [
+        {
+          id: "/peer/repos/grok-build",
+          label: "grok-build",
+          path: "/peer/repos/grok-build",
+          worktreePath: "/peer/.codex/worktrees/abc/grok-build",
+          kind: "worktree" as const,
+        },
+        {
+          id: "/peer/repos/PwrAgent",
+          label: "PwrAgent",
+          path: "/peer/repos/PwrAgent",
+          kind: "local" as const,
+        },
+      ],
+      inbox: { inInbox: true, reason: "updated-since-seen" as const },
+      federation: {
+        ref,
+        instanceLabel: "Laptop",
+        peerStatus: "connected" as const,
+        capabilities: [],
+      },
+    };
+    const localSnapshot = (directories: Array<{
+      key: string;
+      kind: "directory";
+      label: string;
+      path: string;
+      threadKeys: string[];
+      needsAttentionCount: number;
+      latestUpdatedAt: number;
+    }>) => ({
+      backend: "all" as const,
+      fetchedAt: 1_234,
+      unchanged: false,
+      threads: [],
+      inboxThreadKeys: [],
+      directories,
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    });
+    reconcileNavigationSnapshot
+      .mockResolvedValueOnce(localSnapshot([]))
+      .mockResolvedValueOnce(localSnapshot([
+        {
+          key: "directory:/viewer/repos/grok-build",
+          kind: "directory" as const,
+          label: "grok-build",
+          path: "/viewer/repos/grok-build",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          latestUpdatedAt: 2_000,
+        },
+      ]));
+    listRemoteThreadPins.mockResolvedValue([pin]);
+    federationMock.remoteThreadSummaries.resolvePinnedThreads.mockResolvedValue({
+      threads: [remoteRow],
+      refreshed: [],
+      archived: [],
+    });
+    registerAppServerIpcHandlers();
+
+    const first = (await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.(
+      {},
+      {} satisfies GetNavigationSnapshotRequest,
+    )) as { directories: Array<{
+      key: string;
+      label: string;
+      localAvailability?: string;
+      threadKeys: string[];
+      needsAttentionCount: number;
+    }> };
+    expect(first.directories).toContainEqual({
+      key: "unconfigured-directory:grok-build",
+      kind: "directory",
+      label: "grok-build",
+      localAvailability: "unconfigured",
+      threadKeys: ["codex:remote-grok-build"],
+      needsAttentionCount: 1,
+    });
+
+    // Registering the same project locally gives the next snapshot a real
+    // directory row. The mounted thread converges into it by project identity;
+    // the temporary owner-path-free placeholder does not survive beside it.
+    const second = (await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.(
+      {},
+      {} satisfies GetNavigationSnapshotRequest,
+    )) as typeof first;
+    expect(second.directories).toContainEqual(expect.objectContaining({
+      key: "directory:/viewer/repos/grok-build",
+      label: "grok-build",
+      threadKeys: ["codex:remote-grok-build"],
+    }));
+    expect(second.directories).not.toContainEqual(expect.objectContaining({
+      localAvailability: "unconfigured",
+    }));
+  });
+
   it("marks a pinned remote snapshot changed when only reactions change", async () => {
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
     const { buildFederatedThreadRef } = await import("@pwragent/shared");

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -38,6 +38,80 @@ describe("federation backend bridge", () => {
     );
   });
 
+  it("rejects grouping RPCs from a legacy thread-navigation peer", async () => {
+    const backend = {
+      updateSubthreadOrder: vi.fn(),
+      setSubthreadsCollapsed: vi.fn(),
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "legacy_viewer",
+      capabilities: ["thread_navigation"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    for (const [id, method, params] of [
+      [
+        "order",
+        FEDERATION_BACKEND_METHODS.updateSubthreadOrder,
+        {
+          backend: "codex",
+          parentThreadId: "thread-parent",
+          threadIds: ["thread-child"],
+        },
+      ],
+      [
+        "collapse",
+        FEDERATION_BACKEND_METHODS.setSubthreadsCollapsed,
+        {
+          backend: "codex",
+          parentThreadId: "thread-parent",
+          collapsed: true,
+        },
+      ],
+    ] as const) {
+      await router.routeEnvelope({
+        sourcePeerId: "legacy_viewer",
+        envelope: {
+          id,
+          kind: "request",
+          method,
+          params,
+          protocolVersion: 1,
+          sourceInstanceId: "legacy_viewer",
+          targetInstanceId: "owner_one",
+          createdAt: 1_000,
+        },
+      });
+    }
+
+    expect(backend.updateSubthreadOrder).not.toHaveBeenCalled();
+    expect(backend.setSubthreadsCollapsed).not.toHaveBeenCalled();
+    expect(replies).toMatchObject([
+      {
+        kind: "error",
+        requestId: "order",
+        error: {
+          code: "capability_denied",
+          message: expect.stringContaining("thread_grouping"),
+        },
+      },
+      {
+        kind: "error",
+        requestId: "collapse",
+        error: {
+          code: "capability_denied",
+          message: expect.stringContaining("thread_grouping"),
+        },
+      },
+    ]);
+  });
+
   it("preserves encoded ACP navigation keys on the protocol-v1 wire", async () => {
     const backend = {
       getNavigationSnapshot: vi.fn(async () => ({
@@ -1452,12 +1526,12 @@ describe("federation backend bridge", () => {
       FEDERATION_BACKEND_METHOD_CAPABILITIES[
         FEDERATION_BACKEND_METHODS.updateSubthreadOrder
       ],
-    ).toBe("thread_navigation");
+    ).toBe("thread_grouping");
     expect(
       FEDERATION_BACKEND_METHOD_CAPABILITIES[
         FEDERATION_BACKEND_METHODS.setSubthreadsCollapsed
       ],
-    ).toBe("thread_navigation");
+    ).toBe("thread_grouping");
   });
 
   it("routes PR detach over RPC with turn_control authorization", async () => {

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1374,6 +1374,70 @@ describe("federation backend bridge", () => {
       backend: "codex",
       threadId: "thread-child",
     });
+
+    const orderPending = client.updateSubthreadOrder({
+      backend: "codex",
+      parentThreadId: "thread-root",
+      threadIds: ["thread-child", "thread-sibling"],
+    });
+    const orderRequest = sent.at(-1)!;
+    expect(orderRequest).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.updateSubthreadOrder,
+      params: {
+        backend: "codex",
+        parentThreadId: "thread-root",
+        threadIds: ["thread-child", "thread-sibling"],
+      },
+    });
+    rpc.receiveEnvelope({
+      id: "response-order-children",
+      kind: "response",
+      requestId: orderRequest.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_300,
+      result: {
+        backend: "codex",
+        parentThreadId: "thread-root",
+        threadIds: ["thread-child", "thread-sibling"],
+      },
+    });
+    await expect(orderPending).resolves.toMatchObject({
+      threadIds: ["thread-child", "thread-sibling"],
+    });
+
+    const collapsedPending = client.setSubthreadsCollapsed({
+      backend: "codex",
+      parentThreadId: "thread-root",
+      collapsed: false,
+    });
+    const collapsedRequest = sent.at(-1)!;
+    expect(collapsedRequest).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.setSubthreadsCollapsed,
+      params: {
+        backend: "codex",
+        parentThreadId: "thread-root",
+        collapsed: false,
+      },
+    });
+    rpc.receiveEnvelope({
+      id: "response-expand-children",
+      kind: "response",
+      requestId: collapsedRequest.id,
+      protocolVersion: 1,
+      sourceInstanceId: "owner_one",
+      targetInstanceId: "viewer_one",
+      createdAt: 1_400,
+      result: {
+        backend: "codex",
+        parentThreadId: "thread-root",
+        collapsed: false,
+      },
+    });
+    await expect(collapsedPending).resolves.toMatchObject({ collapsed: false });
     expect(
       FEDERATION_BACKEND_METHOD_CAPABILITIES[
         FEDERATION_BACKEND_METHODS.mountRemoteChild
@@ -1382,6 +1446,16 @@ describe("federation backend bridge", () => {
     expect(
       FEDERATION_BACKEND_METHOD_CAPABILITIES[
         FEDERATION_BACKEND_METHODS.setThreadParent
+      ],
+    ).toBe("thread_navigation");
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.updateSubthreadOrder
+      ],
+    ).toBe("thread_navigation");
+    expect(
+      FEDERATION_BACKEND_METHOD_CAPABILITIES[
+        FEDERATION_BACKEND_METHODS.setSubthreadsCollapsed
       ],
     ).toBe("thread_navigation");
   });
@@ -2327,6 +2401,8 @@ describe("federation backend bridge", () => {
       reorderThreadPins: vi.fn(),
       mountRemoteChild: vi.fn(),
       setThreadParent: vi.fn(),
+      updateSubthreadOrder: vi.fn(),
+      setSubthreadsCollapsed: vi.fn(),
       detachThreadPullRequest: vi.fn(),
       setThreadPrAutoDispatch: vi.fn(),
       cancelThreadPrAutoDispatch: vi.fn(),
@@ -2710,6 +2786,8 @@ describe("federation backend bridge", () => {
       reorderThreadPins: vi.fn(),
         mountRemoteChild: vi.fn(),
         setThreadParent: vi.fn(),
+        updateSubthreadOrder: vi.fn(),
+        setSubthreadsCollapsed: vi.fn(),
         detachThreadPullRequest: vi.fn(),
         setThreadPrAutoDispatch: vi.fn(),
         cancelThreadPrAutoDispatch: vi.fn(),

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -18,13 +18,21 @@ import {
   FEDERATION_PROTOCOL_VERSION,
   MAX_CELESTIAL_ASSIGNMENTS,
   buildFederatedThreadRef,
+  buildThreadIdentityKey,
   findPreferredReviewWorkspaceCwd,
 } from "@pwragent/shared";
 import {
   FEDERATION_BACKEND_EVENT_METHOD,
   FEDERATION_ENVIRONMENT_SETUP_PROGRESS_METHOD,
 } from "../federation/federation-backend-bridge";
-import { DesktopFederationRuntime } from "../federation/federation-runtime";
+import {
+  DesktopFederationRuntime,
+  disposeDesktopFederationRuntime,
+  getDesktopFederationRuntime,
+} from "../federation/federation-runtime";
+import { getDesktopBackendRegistry } from "../app-server/backend-registry";
+import { DesktopMessagingBackendBridge } from "../messaging/desktop-backend-bridge";
+import * as desktopSettingsSingleton from "../settings/desktop-settings-singleton";
 import {
   resetDesktopOverlayStoreForTests,
   setDesktopOverlayStoreForTests,
@@ -665,6 +673,137 @@ describe("DesktopFederationRuntime", () => {
     } finally {
       resetDesktopOverlayStoreForTests();
       stateDb.close();
+    }
+  });
+
+  it("mounts a remote parent when accepting a cross-instance child", async () => {
+    await disposeDesktopFederationRuntime();
+    const stateDb = openInMemoryStateDb();
+    const overlayStore = new SqliteOverlayStore(stateDb);
+    setDesktopOverlayStoreForTests(overlayStore);
+    const runtime = getDesktopFederationRuntime();
+    const settings = vi.spyOn(
+      desktopSettingsSingleton,
+      "getDesktopSettingsService",
+    ).mockReturnValue(new Proxy({}, {
+      get: (_target, property) =>
+        property === "resolveCodexCommandPreference"
+        || property === "resolveCodexSpawnEnv"
+          ? () => undefined
+          : () => false,
+    }) as never);
+    const registry = getDesktopBackendRegistry();
+    const parentSummary = {
+      source: "codex" as const,
+      id: "parent",
+      title: "Remote parent",
+      titleSource: "explicit" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: true },
+      pinnedRank: "1024",
+    };
+    const materializeResponse = {
+      backend: "codex" as const,
+      threadId: "child",
+      executionMode: "default" as const,
+      workMode: "local" as const,
+    };
+    const materialize = vi.spyOn(registry, "materializeDirectoryLaunchpad")
+      .mockResolvedValue(materializeResponse as never);
+    const publish = vi.spyOn(registry, "publishLocalEvent")
+      .mockResolvedValue(undefined);
+    const navigationSnapshot = vi.spyOn(
+      DesktopMessagingBackendBridge.prototype,
+      "getNavigationSnapshot",
+    ).mockResolvedValue({
+      backend: "all",
+      fetchedAt: 1_000,
+      unchanged: false,
+      browseMode: "directories",
+      directories: [
+        {
+          key: "directory:/repo",
+          kind: "directory",
+          label: "Repo",
+          path: "/repo",
+          threadKeys: [buildThreadIdentityKey("codex", "child")],
+          directoryThreadsCollapsed: true,
+        },
+      ],
+      threads: [
+        {
+          source: "codex",
+          id: "existing-pin",
+          title: "Existing pin",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          inbox: { inInbox: true, reason: "active" },
+          pinnedRank: "1024",
+        },
+      ],
+      launchpadDefaults: {} as never,
+      federationPeers: [],
+    } as never);
+    vi.spyOn(runtime, "health").mockResolvedValue({
+      instanceId: "child-peer",
+    } as never);
+    const threadFromPeer = vi.spyOn(
+      runtime.remoteThreadSummaries(),
+      "threadFromPeer",
+    ).mockResolvedValue(parentSummary);
+
+    try {
+      await runtime.localBackend().materializeDirectoryLaunchpad({
+        directoryKey: "directory:/repo",
+        parentThreadId: "parent",
+        parentThreadBackend: "codex",
+        parentThreadInstanceId: "parent-peer",
+        launchpad: {
+          directoryKey: "directory:/repo",
+          directoryKind: "directory",
+          directoryLabel: "Repo",
+          directoryPath: "/repo",
+        },
+      } as never, {
+        sourceInstanceId: "parent-peer",
+      });
+
+      expect(materialize).toHaveBeenCalledTimes(1);
+      expect(threadFromPeer).toHaveBeenCalledWith({
+        target: { scope: "remote", instanceId: "parent-peer" },
+        backend: "codex",
+        threadId: "parent",
+      });
+      const [pin] = await overlayStore.listRemoteThreadPins();
+      expect(pin).toMatchObject({
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "parent-peer" },
+          threadId: "parent",
+        },
+        pinnedVia: "companion",
+        summary: parentSummary,
+      });
+      expect(pin?.localPinnedRank).toBeTruthy();
+      expect(publish).toHaveBeenCalledWith({
+        backend: "codex",
+        notification: {
+          method: "navigation/remoteThreadPins/changed",
+          params: {
+            instanceId: "parent-peer",
+            threadId: "parent",
+            pinned: true,
+          },
+        },
+      });
+    } finally {
+      materialize.mockRestore();
+      publish.mockRestore();
+      navigationSnapshot.mockRestore();
+      settings.mockRestore();
+      resetDesktopOverlayStoreForTests();
+      stateDb.close();
+      await disposeDesktopFederationRuntime();
     }
   });
 
@@ -2022,6 +2161,10 @@ describe("DesktopFederationRuntime", () => {
 
   it.each([
     "thread/status/changed",
+    "thread/parent/cleared",
+    "thread/parent/set",
+    "thread/subthreadOrder/updated",
+    "thread/subthreadsCollapsed/updated",
     "turn/cancelled",
     "turn/completed",
     "turn/failed",
@@ -2115,7 +2258,6 @@ describe("DesktopFederationRuntime", () => {
 
     expect(invalidated).toEqual([]);
   });
-
   it("subscribes Cmd+K snapshot peers to navigation updates for the cache TTL", async () => {
     vi.useFakeTimers();
     const sent: FederationProtocolEnvelope[] = [];

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -774,12 +774,16 @@ describe("DesktopFederationRuntime", () => {
         pinnedRank: "1024",
       });
       await runtime.localBackend().materializeDirectoryLaunchpad({
-        directoryKey: "directory:/repo",
+        // Inline subthread composers use a synthetic launchpad key rather
+        // than the materialized directory summary key. The launchpad path is
+        // the authoritative bridge back to the directory whose collapsed
+        // state determines whether the companion parent must be pinned.
+        directoryKey: "subthread:codex:parent:same-worktree",
         parentThreadId: "parent",
         parentThreadBackend: "codex",
         parentThreadInstanceId: "parent-peer",
         launchpad: {
-          directoryKey: "directory:/repo",
+          directoryKey: "subthread:codex:parent:same-worktree",
           directoryKind: "directory",
           directoryLabel: "Repo",
           directoryPath: "/repo",

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -722,6 +722,14 @@ describe("DesktopFederationRuntime", () => {
       browseMode: "directories",
       directories: [
         {
+          key: "directory:/other",
+          kind: "directory",
+          label: "Other",
+          path: "/other",
+          threadKeys: [buildThreadIdentityKey("codex", "child")],
+          directoryThreadsCollapsed: false,
+        },
+        {
           key: "directory:/repo",
           kind: "directory",
           label: "Repo",
@@ -730,17 +738,7 @@ describe("DesktopFederationRuntime", () => {
           directoryThreadsCollapsed: true,
         },
       ],
-      threads: [
-        {
-          source: "codex",
-          id: "existing-pin",
-          title: "Existing pin",
-          titleSource: "explicit",
-          linkedDirectories: [],
-          inbox: { inInbox: true, reason: "active" },
-          pinnedRank: "1024",
-        },
-      ],
+      threads: [],
       launchpadDefaults: {} as never,
       federationPeers: [],
     } as never);
@@ -753,6 +751,28 @@ describe("DesktopFederationRuntime", () => {
     ).mockResolvedValue(parentSummary);
 
     try {
+      const existingRemoteRef = buildFederatedThreadRef({
+        backend: "codex",
+        instanceId: "other-peer",
+        threadId: "existing-pin",
+      });
+      await overlayStore.addRemoteThreadPin({
+        ref: existingRemoteRef,
+        instanceLabel: "Other Mac",
+        pinnedVia: "explicit",
+        summary: {
+          source: "codex",
+          id: "existing-pin",
+          title: "Existing remote pin",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        },
+      });
+      await overlayStore.setRemoteThreadLocalPin({
+        ref: existingRemoteRef,
+        pinnedRank: "1024",
+      });
       await runtime.localBackend().materializeDirectoryLaunchpad({
         directoryKey: "directory:/repo",
         parentThreadId: "parent",
@@ -774,7 +794,9 @@ describe("DesktopFederationRuntime", () => {
         backend: "codex",
         threadId: "parent",
       });
-      const [pin] = await overlayStore.listRemoteThreadPins();
+      const pin = (await overlayStore.listRemoteThreadPins()).find(
+        (candidate) => candidate.ref.threadId === "parent",
+      );
       expect(pin).toMatchObject({
         ref: {
           backend: "codex",
@@ -784,7 +806,43 @@ describe("DesktopFederationRuntime", () => {
         pinnedVia: "companion",
         summary: parentSummary,
       });
-      expect(pin?.localPinnedRank).toBeTruthy();
+      // The raw backend snapshot contains no viewer-owned remote pins. The
+      // visibility calculation still sees that Pins is active and appends
+      // after its existing rank without colliding.
+      expect(pin?.localPinnedRank).toBe("2048");
+
+      await overlayStore.addRemoteThreadPin({
+        ref: pin!.ref,
+        instanceLabel: "Parent Mac",
+        pinnedVia: "explicit",
+        summary: { ...parentSummary, title: "Older cached parent" },
+      });
+      await overlayStore.setRemoteThreadLocalPin({
+        ref: pin!.ref,
+        pinnedRank: "4096",
+      });
+      await runtime.localBackend().materializeDirectoryLaunchpad({
+        directoryKey: "directory:/repo",
+        parentThreadId: "parent",
+        parentThreadBackend: "codex",
+        parentThreadInstanceId: "parent-peer",
+        launchpad: {
+          directoryKey: "directory:/repo",
+          directoryKind: "directory",
+          directoryLabel: "Repo",
+          directoryPath: "/repo",
+        },
+      } as never, {
+        sourceInstanceId: "parent-peer",
+      });
+      const preserved = (await overlayStore.listRemoteThreadPins()).find(
+        (candidate) => candidate.ref.threadId === "parent",
+      );
+      expect(preserved).toMatchObject({
+        pinnedVia: "explicit",
+        localPinnedRank: "4096",
+        summary: parentSummary,
+      });
       expect(publish).toHaveBeenCalledWith({
         backend: "codex",
         notification: {

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type {
   AgentEvent,
@@ -38,6 +41,13 @@ import {
   setDesktopOverlayStoreForTests,
 } from "../app-server/desktop-overlay-store";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import { StateDb } from "../state/state-db";
+import {
+  measureSqliteWrites,
+  resetSqliteWriteMetrics,
+  SQLITE_WRITE_METRICS_ENV,
+} from "../state/sqlite-write-metrics";
+import { expectSqliteWriteBudget } from "./fixtures/sqlite-write-budget";
 import { openInMemoryStateDb } from "./sqlite-test-utils";
 import {
   FEDERATION_PEER_UNAVAILABLE_ERROR_CODE,
@@ -678,7 +688,12 @@ describe("DesktopFederationRuntime", () => {
 
   it("mounts a remote parent when accepting a cross-instance child", async () => {
     await disposeDesktopFederationRuntime();
-    const stateDb = openInMemoryStateDb();
+    process.env[SQLITE_WRITE_METRICS_ENV] = "1";
+    const tempDir = mkdtempSync(path.join(
+      os.tmpdir(),
+      "pwragent-federated-parent-mount-",
+    ));
+    const stateDb = StateDb.open(path.join(tempDir, "state.db"));
     const overlayStore = new SqliteOverlayStore(stateDb);
     setDesktopOverlayStoreForTests(overlayStore);
     const runtime = getDesktopFederationRuntime();
@@ -773,23 +788,34 @@ describe("DesktopFederationRuntime", () => {
         ref: existingRemoteRef,
         pinnedRank: "1024",
       });
-      await runtime.localBackend().materializeDirectoryLaunchpad({
-        // Inline subthread composers use a synthetic launchpad key rather
-        // than the materialized directory summary key. The launchpad path is
-        // the authoritative bridge back to the directory whose collapsed
-        // state determines whether the companion parent must be pinned.
-        directoryKey: "subthread:codex:parent:same-worktree",
-        parentThreadId: "parent",
-        parentThreadBackend: "codex",
-        parentThreadInstanceId: "parent-peer",
-        launchpad: {
+      resetSqliteWriteMetrics();
+      const { writes } = await measureSqliteWrites(async () => {
+        await runtime.localBackend().materializeDirectoryLaunchpad({
+          // Inline subthread composers use a synthetic launchpad key rather
+          // than the materialized directory summary key. The launchpad path is
+          // the authoritative bridge back to the directory whose collapsed
+          // state determines whether the companion parent must be pinned.
           directoryKey: "subthread:codex:parent:same-worktree",
-          directoryKind: "directory",
-          directoryLabel: "Repo",
-          directoryPath: "/repo",
-        },
-      } as never, {
-        sourceInstanceId: "parent-peer",
+          parentThreadId: "parent",
+          parentThreadBackend: "codex",
+          parentThreadInstanceId: "parent-peer",
+          launchpad: {
+            directoryKey: "subthread:codex:parent:same-worktree",
+            directoryKind: "directory",
+            directoryLabel: "Repo",
+            directoryPath: "/repo",
+          },
+        } as never, {
+          sourceInstanceId: "parent-peer",
+        });
+      });
+      expectSqliteWriteBudget({
+        note:
+          "materialize one cross-instance child, mount its companion parent, "
+          + "persist the route, and add a viewer rank because Directory "
+          + "Threads is collapsed while Pins is active",
+        scenario: "federated-child-materialization-with-parent-mount",
+        writes,
       });
 
       expect(materialize).toHaveBeenCalledTimes(1);
@@ -865,6 +891,8 @@ describe("DesktopFederationRuntime", () => {
       settings.mockRestore();
       resetDesktopOverlayStoreForTests();
       stateDb.close();
+      rmSync(tempDir, { recursive: true, force: true });
+      delete process.env[SQLITE_WRITE_METRICS_ENV];
       await disposeDesktopFederationRuntime();
     }
   });

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -34,6 +34,13 @@
     "rowsChanged": 2,
     "statements": 2
   },
+  "federated-child-materialization-with-parent-mount": {
+    "commits": 3,
+    "note": "materialize one cross-instance child, mount its companion parent, persist the route, and add a viewer rank because Directory Threads is collapsed while Pins is active",
+    "observedWalBytes": 28840,
+    "rowsChanged": 3,
+    "statements": 3
+  },
   "federated-child-mount": {
     "commits": 2,
     "note": "persist one cross-instance child mount and its routing target",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -16033,6 +16033,9 @@ export class DesktopBackendRegistry {
         request.parentThreadId ?? normalizedExisting.parentThreadId;
       const requestParentThreadBackend =
         request.parentThreadBackend ?? normalizedExisting.parentThreadBackend;
+      const requestParentThreadInstanceId =
+        request.parentThreadInstanceId
+        ?? normalizedExisting.parentThreadInstanceId;
       const requestParentThreadTitle =
         request.parentThreadTitle ?? normalizedExisting.parentThreadTitle;
       const identityChanged =
@@ -16043,6 +16046,8 @@ export class DesktopBackendRegistry {
         request.parentThreadId !== undefined &&
         (normalizedExisting.parentThreadId !== request.parentThreadId ||
           normalizedExisting.parentThreadBackend !== request.parentThreadBackend ||
+          normalizedExisting.parentThreadInstanceId
+            !== request.parentThreadInstanceId ||
           normalizedExisting.parentThreadTitle !== request.parentThreadTitle);
 
       if (isEmptyDirectoryLaunchpadDraft(existing)) {
@@ -16064,6 +16069,7 @@ export class DesktopBackendRegistry {
           branchName: existing.branchName ?? request.currentBranch,
           parentThreadId: requestParentThreadId,
           parentThreadBackend: requestParentThreadBackend,
+          parentThreadInstanceId: requestParentThreadInstanceId,
           parentThreadTitle: requestParentThreadTitle,
           registeredAt,
           updatedAt: Date.now(),
@@ -16097,6 +16103,7 @@ export class DesktopBackendRegistry {
               directoryPath: request.directoryPath,
               parentThreadId: requestParentThreadId,
               parentThreadBackend: requestParentThreadBackend,
+              parentThreadInstanceId: requestParentThreadInstanceId,
               parentThreadTitle: requestParentThreadTitle,
               registeredAt,
               updatedAt: Date.now(),
@@ -16133,6 +16140,7 @@ export class DesktopBackendRegistry {
       branchName: request.currentBranch,
       parentThreadId: request.parentThreadId,
       parentThreadBackend: request.parentThreadBackend,
+      parentThreadInstanceId: request.parentThreadInstanceId,
       parentThreadTitle: request.parentThreadTitle,
       createdAt: Date.now(),
       updatedAt: Date.now(),

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -362,8 +362,8 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.reorderThreadPins]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.mountRemoteChild]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.setThreadParent]: "thread_navigation",
-  [FEDERATION_BACKEND_METHODS.updateSubthreadOrder]: "thread_navigation",
-  [FEDERATION_BACKEND_METHODS.setSubthreadsCollapsed]: "thread_navigation",
+  [FEDERATION_BACKEND_METHODS.updateSubthreadOrder]: "thread_grouping",
+  [FEDERATION_BACKEND_METHODS.setSubthreadsCollapsed]: "thread_grouping",
   // PR detach cancels pending auto-dispatch work and auto-dispatch arms
   // automatic repair turns, so both sit with the turn-control grants
   // (like archiveThread) rather than the browse-level navigation grants.

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -25,6 +25,7 @@ import type {
   DetachThreadPullRequestRequest,
   DetachThreadPullRequestResponse,
   FederationCapability,
+  FederationInstanceId,
   FederatedThreadRef,
   FederationLoadStatus,
   FederationRequestEnvelope,
@@ -113,6 +114,8 @@ import type {
   SetThreadModelSettingsResponse,
   SetThreadParentRequest,
   SetThreadParentResponse,
+  SetSubthreadsCollapsedRequest,
+  SetSubthreadsCollapsedResponse,
   SteerTurnRequest,
   SteerTurnResponse,
   StartTurnRequest,
@@ -129,6 +132,8 @@ import type {
   SubmitServerRequestResponse,
   TrustCodexProjectRequest,
   TrustCodexProjectResponse,
+  UpdateSubthreadOrderRequest,
+  UpdateSubthreadOrderResponse,
   UpdateScheduledThreadActionRequest,
   UpdateThreadExpectedBranchRequest,
   UpdateThreadExpectedBranchResponse,
@@ -264,6 +269,8 @@ export const FEDERATION_BACKEND_METHODS = {
   reorderThreadPins: "backend.reorderThreadPins",
   mountRemoteChild: "backend.mountRemoteChild",
   setThreadParent: "backend.setThreadParent",
+  updateSubthreadOrder: "backend.updateSubthreadOrder",
+  setSubthreadsCollapsed: "backend.setSubthreadsCollapsed",
   detachThreadPullRequest: "backend.detachThreadPullRequest",
   setThreadPrAutoDispatch: "backend.setThreadPrAutoDispatch",
   cancelThreadPrAutoDispatch: "backend.cancelThreadPrAutoDispatch",
@@ -355,6 +362,8 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.reorderThreadPins]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.mountRemoteChild]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.setThreadParent]: "thread_navigation",
+  [FEDERATION_BACKEND_METHODS.updateSubthreadOrder]: "thread_navigation",
+  [FEDERATION_BACKEND_METHODS.setSubthreadsCollapsed]: "thread_navigation",
   // PR detach cancels pending auto-dispatch work and auto-dispatch arms
   // automatic repair turns, so both sit with the turn-control grants
   // (like archiveThread) rather than the browse-level navigation grants.
@@ -471,6 +480,12 @@ export type FederationBackendOperations = {
   setThreadParent(
     request: SetThreadParentRequest,
   ): Promise<SetThreadParentResponse>;
+  updateSubthreadOrder(
+    request: UpdateSubthreadOrderRequest,
+  ): Promise<UpdateSubthreadOrderResponse>;
+  setSubthreadsCollapsed(
+    request: SetSubthreadsCollapsedRequest,
+  ): Promise<SetSubthreadsCollapsedResponse>;
   detachThreadPullRequest(
     request: DetachThreadPullRequestRequest,
   ): Promise<DetachThreadPullRequestResponse>;
@@ -591,7 +606,9 @@ export type FederationBackendOperations = {
   ): Promise<GetWorktreeUnpublishedCommitDiffResponse>;
   materializeDirectoryLaunchpad(
     request: MaterializeDirectoryLaunchpadRequest,
-    options?: MaterializeDirectoryLaunchpadOptions,
+    options?: MaterializeDirectoryLaunchpadOptions & {
+      sourceInstanceId?: FederationInstanceId;
+    },
   ): Promise<MaterializeDirectoryLaunchpadResponse>;
   handoffThreadWorkspace(
     request: HandoffThreadWorkspaceRequest,
@@ -800,6 +817,20 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.setThreadParent(
         envelope.params as SetThreadParentRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.updateSubthreadOrder,
+    async (envelope) =>
+      await params.backend.updateSubthreadOrder(
+        envelope.params as UpdateSubthreadOrderRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.setSubthreadsCollapsed,
+    async (envelope) =>
+      await params.backend.setSubthreadsCollapsed(
+        envelope.params as SetSubthreadsCollapsedRequest,
       ),
   );
   params.router.registerHandler(
@@ -1151,6 +1182,7 @@ export function registerFederationBackendHandlers(params: {
       await params.backend.materializeDirectoryLaunchpad(
         envelope.params as MaterializeDirectoryLaunchpadRequest,
         {
+          sourceInstanceId: envelope.sourceInstanceId,
           onCodexEnvironmentSetupProgress: (event) => {
             params.onEnvironmentSetupProgress?.(
               event,
@@ -1358,6 +1390,24 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<SetThreadParentResponse> {
     return await this.rpc.request<SetThreadParentResponse>({
       method: FEDERATION_BACKEND_METHODS.setThreadParent,
+      params: request,
+    });
+  }
+
+  async updateSubthreadOrder(
+    request: UpdateSubthreadOrderRequest,
+  ): Promise<UpdateSubthreadOrderResponse> {
+    return await this.rpc.request<UpdateSubthreadOrderResponse>({
+      method: FEDERATION_BACKEND_METHODS.updateSubthreadOrder,
+      params: request,
+    });
+  }
+
+  async setSubthreadsCollapsed(
+    request: SetSubthreadsCollapsedRequest,
+  ): Promise<SetSubthreadsCollapsedResponse> {
+    return await this.rpc.request<SetSubthreadsCollapsedResponse>({
+      method: FEDERATION_BACKEND_METHODS.setSubthreadsCollapsed,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -82,6 +82,7 @@ import {
   applyNavigationSnapshotTransportResponse,
   buildAppendPinRank,
   buildFederatedThreadRef,
+  buildThreadIdentityKey,
   encodeLegacyThreadIdentityKey,
   federationEndpointAcceptsCloudflareCredentials,
   isCelestialIconAssignment,

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -4520,8 +4520,20 @@ async function mountRemoteParentForLocalChild(
     .getNavigationSnapshot({});
   const launchpadDirectoryKey =
     request.launchpad?.directoryKey ?? request.directoryKey;
+  const launchpadDirectoryPath = request.launchpad?.directoryPath?.trim();
+  const normalizedLaunchpadDirectoryPath = launchpadDirectoryPath
+    ? path.resolve(launchpadDirectoryPath)
+    : undefined;
   const childDirectory = snapshot.directories.find(
     (directory) => directory.key === launchpadDirectoryKey,
+  ) ?? (
+    normalizedLaunchpadDirectoryPath
+      ? snapshot.directories.find(
+          (directory) =>
+            directory.path
+            && path.resolve(directory.path) === normalizedLaunchpadDirectoryPath,
+        )
+      : undefined
   );
   const localRanks = await overlayStore.listPinnedThreadOverlayRanks();
   const remotePins = await overlayStore.listRemoteThreadPins();

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -80,6 +80,7 @@ import {
   FEDERATION_PROTOCOL_VERSION,
   MAX_CELESTIAL_ASSIGNMENTS,
   applyNavigationSnapshotTransportResponse,
+  buildAppendPinRank,
   buildFederatedThreadRef,
   buildThreadIdentityKey,
   encodeLegacyThreadIdentityKey,
@@ -165,6 +166,8 @@ import {
   type SetThreadExecutionModeRequest,
   type SetThreadModelSettingsRequest,
   type SetThreadParentRequest,
+  type SetSubthreadsCollapsedRequest,
+  type SetSubthreadsCollapsedResponse,
   type StartReviewRequest,
   type StartThreadRequest,
   type SteerTurnRequest,
@@ -173,6 +176,8 @@ import {
   type StopCodexEnvironmentActionRequest,
   type StopSubAgentRequest,
   type TrustCodexProjectRequest,
+  type UpdateSubthreadOrderRequest,
+  type UpdateSubthreadOrderResponse,
   type UpdateThreadExpectedBranchRequest,
 } from "@pwragent/shared";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
@@ -494,6 +499,10 @@ const NAVIGATION_EVENT_METHODS = new Set<string>([
  */
 const REMOTE_THREAD_SUMMARY_LIFECYCLE_METHODS = new Set<string>([
   "thread/status/changed",
+  "thread/parent/cleared",
+  "thread/parent/set",
+  "thread/subthreadOrder/updated",
+  "thread/subthreadsCollapsed/updated",
   "turn/cancelled",
   "turn/completed",
   "turn/failed",
@@ -4415,6 +4424,110 @@ async function resolveFederatedWorktreeGitReadContext(request: {
   return context;
 }
 
+/**
+ * A cross-instance child is not legible on its owning instance unless the
+ * remote parent is mounted beside it. Import that parent as part of accepting
+ * the child creation request, then mirror the normal created-thread visibility
+ * rule when the child's Directory Threads section is collapsed.
+ */
+async function mountRemoteParentForLocalChild(
+  request: MaterializeDirectoryLaunchpadRequest,
+  response: MaterializeDirectoryLaunchpadResponse,
+  sourceInstanceId?: FederationInstanceId,
+): Promise<void> {
+  const parentThreadId = request.parentThreadId?.trim();
+  const parentInstanceId = request.parentThreadInstanceId?.trim();
+  if (!parentThreadId || !parentInstanceId) {
+    return;
+  }
+  const runtime = getDesktopFederationRuntime();
+  const localInstanceId = (await runtime.health()).instanceId;
+  if (!localInstanceId || parentInstanceId === localInstanceId) {
+    return;
+  }
+  const parentBackend = request.parentThreadBackend ?? response.backend;
+  const target = {
+    scope: "remote" as const,
+    instanceId: parentInstanceId,
+  };
+  const parentSummary = await runtime.remoteThreadSummaries().threadFromPeer({
+    target,
+    backend: parentBackend,
+    threadId: parentThreadId,
+  });
+  if (!parentSummary && parentInstanceId !== sourceInstanceId) {
+    return;
+  }
+  const fallbackLinkedDirectory = response.linkedDirectory
+    ?? (
+      request.launchpad?.directoryPath
+      && request.launchpad.directoryKind !== "workspace"
+        ? {
+            id: `federated-parent:${request.launchpad.directoryKey}`,
+            label: request.launchpad.directoryLabel,
+            path: request.launchpad.directoryPath,
+            kind: response.workMode === "worktree"
+              ? "worktree" as const
+              : "local" as const,
+          }
+        : undefined
+    );
+  const fallbackParent: NavigationThreadSummary = {
+    source: parentBackend,
+    id: parentThreadId,
+    title: parentThreadId,
+    titleSource: "fallback",
+    linkedDirectories: fallbackLinkedDirectory
+      ? [fallbackLinkedDirectory]
+      : [],
+    inbox: { inInbox: false },
+  };
+  const summary = parentSummary ?? fallbackParent;
+  const ref = buildFederatedThreadRef({
+    backend: parentBackend,
+    instanceId: parentInstanceId,
+    threadId: parentThreadId,
+  });
+  const overlayStore = getDesktopOverlayStore();
+  await overlayStore.addRemoteThreadPin({
+    ref,
+    summary,
+    instanceLabel:
+      parentSummary?.federation?.instanceLabel ?? parentInstanceId,
+    pinnedVia: "companion",
+  });
+
+  const snapshot = await new DesktopMessagingBackendBridge()
+    .getNavigationSnapshot({});
+  const childKey = buildThreadIdentityKey(response.backend, response.threadId);
+  const childDirectory = snapshot.directories.find(
+    (directory) => directory.threadKeys.includes(childKey),
+  );
+  const hasPinnedTopLevelThread = snapshot.threads.some(
+    (thread) => thread.pinnedRank && !thread.parentThreadId,
+  );
+  if (childDirectory?.directoryThreadsCollapsed && hasPinnedTopLevelThread) {
+    await overlayStore.setRemoteThreadLocalPin({
+      ref,
+      pinnedRank: buildAppendPinRank(
+        snapshot.threads.map((thread) => thread.pinnedRank),
+      ),
+    });
+  }
+
+  await getDesktopBackendRegistry().publishLocalEvent({
+    backend: parentBackend,
+    notification: {
+      method: "navigation/remoteThreadPins/changed",
+      params: {
+        instanceId: parentInstanceId,
+        threadId: parentThreadId,
+        pinned: true,
+      },
+    },
+  });
+}
+
 function localBackendOperations(): FederationBackendOperations {
   return {
     async getNavigationSnapshot(request = {}): Promise<NavigationSnapshot> {
@@ -4664,6 +4777,57 @@ function localBackendOperations(): FederationBackendOperations {
         parentThreadId: overlay.parentThreadId,
         parentThreadBackend: overlay.parentThreadBackend,
         parentThreadInstanceId: overlay.parentThreadInstanceId,
+      };
+    },
+    async updateSubthreadOrder(
+      request: UpdateSubthreadOrderRequest,
+    ): Promise<UpdateSubthreadOrderResponse> {
+      const backend = request.backend ?? "codex";
+      const threadIds = await getDesktopOverlayStore().updateSubthreadOrder({
+        backend,
+        parentThreadId: request.parentThreadId,
+        threadIds: request.threadIds,
+      });
+      await getDesktopBackendRegistry().publishLocalEvent({
+        backend,
+        notification: {
+          method: "thread/subthreadOrder/updated",
+          params: {
+            parentThreadId: request.parentThreadId,
+            threadIds,
+          },
+        },
+      });
+      return {
+        backend,
+        parentThreadId: request.parentThreadId,
+        threadIds,
+      };
+    },
+    async setSubthreadsCollapsed(
+      request: SetSubthreadsCollapsedRequest,
+    ): Promise<SetSubthreadsCollapsedResponse> {
+      const backend = request.backend ?? "codex";
+      const overlay = await getDesktopOverlayStore().setSubthreadsCollapsed({
+        backend,
+        parentThreadId: request.parentThreadId,
+        collapsed: request.collapsed,
+      });
+      const collapsed = overlay.subthreadsCollapsed === true;
+      await getDesktopBackendRegistry().publishLocalEvent({
+        backend,
+        notification: {
+          method: "thread/subthreadsCollapsed/updated",
+          params: {
+            parentThreadId: request.parentThreadId,
+            collapsed,
+          },
+        },
+      });
+      return {
+        backend,
+        parentThreadId: request.parentThreadId,
+        collapsed,
       };
     },
     async archiveThread(request) {
@@ -4998,10 +5162,27 @@ function localBackendOperations(): FederationBackendOperations {
     },
     async materializeDirectoryLaunchpad(
       request: MaterializeDirectoryLaunchpadRequest,
-      options?: MaterializeDirectoryLaunchpadOptions,
+      options?: MaterializeDirectoryLaunchpadOptions & {
+        sourceInstanceId?: FederationInstanceId;
+      },
     ): Promise<MaterializeDirectoryLaunchpadResponse> {
-      return await getDesktopBackendRegistry()
+      const response = await getDesktopBackendRegistry()
         .materializeDirectoryLaunchpad(request, options);
+      try {
+        await mountRemoteParentForLocalChild(
+          request,
+          response,
+          options?.sourceInstanceId,
+        );
+      } catch (error) {
+        log.warn("failed to mount remote parent for local child", {
+          error: error instanceof Error ? error.message : String(error),
+          parentInstanceId: request.parentThreadInstanceId,
+          parentThreadId: request.parentThreadId,
+          threadId: response.threadId,
+        });
+      }
+      return response;
     },
     async handoffThreadWorkspace(
       request: HandoffThreadWorkspaceRequest,

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -370,6 +370,7 @@ const DEFAULT_CAPABILITIES: FederationCapability[] = [
   "remote_window",
   "thread_navigation",
   "navigation_snapshot_deltas",
+  "thread_grouping",
   "thread_detail",
   "turn_control",
   "scheduled_actions",

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -82,7 +82,6 @@ import {
   applyNavigationSnapshotTransportResponse,
   buildAppendPinRank,
   buildFederatedThreadRef,
-  buildThreadIdentityKey,
   encodeLegacyThreadIdentityKey,
   federationEndpointAcceptsCloudflareCredentials,
   isCelestialIconAssignment,
@@ -4489,28 +4488,67 @@ async function mountRemoteParentForLocalChild(
     threadId: parentThreadId,
   });
   const overlayStore = getDesktopOverlayStore();
-  await overlayStore.addRemoteThreadPin({
-    ref,
-    summary,
-    instanceLabel:
-      parentSummary?.federation?.instanceLabel ?? parentInstanceId,
-    pinnedVia: "companion",
-  });
+  const instanceLabel =
+    parentSummary?.federation?.instanceLabel ?? parentInstanceId;
+  const existingPins = await overlayStore.listRemoteThreadPins();
+  const existingPin = existingPins.find(
+    (pin) =>
+      pin.ref.backend === ref.backend
+      && pin.ref.threadId === ref.threadId
+      && isRemoteFederationTarget(pin.ref.target)
+      && pin.ref.target.instanceId === parentInstanceId,
+  );
+  if (existingPin) {
+    // Snapshot refreshes must not replace viewer-owned rank or provenance.
+    // In particular, creating another child cannot demote an explicit pin to
+    // a companion or remove it from the viewer's Pins section.
+    await overlayStore.updateRemoteThreadPinSnapshots([{
+      ref,
+      summary,
+      instanceLabel,
+    }]);
+  } else {
+    await overlayStore.addRemoteThreadPin({
+      ref,
+      summary,
+      instanceLabel,
+      pinnedVia: "companion",
+    });
+  }
 
   const snapshot = await new DesktopMessagingBackendBridge()
     .getNavigationSnapshot({});
-  const childKey = buildThreadIdentityKey(response.backend, response.threadId);
+  const launchpadDirectoryKey =
+    request.launchpad?.directoryKey ?? request.directoryKey;
   const childDirectory = snapshot.directories.find(
-    (directory) => directory.threadKeys.includes(childKey),
+    (directory) => directory.key === launchpadDirectoryKey,
   );
-  const hasPinnedTopLevelThread = snapshot.threads.some(
-    (thread) => thread.pinnedRank && !thread.parentThreadId,
+  const localRanks = await overlayStore.listPinnedThreadOverlayRanks();
+  const remotePins = await overlayStore.listRemoteThreadPins();
+  const parentPin = remotePins.find(
+    (pin) =>
+      pin.ref.backend === ref.backend
+      && pin.ref.threadId === ref.threadId
+      && isRemoteFederationTarget(pin.ref.target)
+      && pin.ref.target.instanceId === parentInstanceId,
   );
-  if (childDirectory?.directoryThreadsCollapsed && hasPinnedTopLevelThread) {
+  const hasPinnedTopLevelThread =
+    localRanks.some((entry) => !entry.parentThreadId)
+    || remotePins.some(
+      (pin) => pin.localPinnedRank && !pin.summary?.parentThreadId,
+    );
+  if (
+    childDirectory?.directoryThreadsCollapsed
+    && hasPinnedTopLevelThread
+    && !parentPin?.localPinnedRank
+  ) {
     await overlayStore.setRemoteThreadLocalPin({
       ref,
       pinnedRank: buildAppendPinRank(
-        snapshot.threads.map((thread) => thread.pinnedRank),
+        [
+          ...localRanks.map((entry) => entry.pinnedRank),
+          ...remotePins.map((pin) => pin.localPinnedRank),
+        ],
       ),
     });
   }

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -6179,6 +6179,55 @@ class DesktopAppServerService {
   async setThreadParent(
     request: SetThreadParentRequest,
   ): Promise<SetThreadParentResponse> {
+    if (
+      request.federationTarget
+      && isRemoteFederationTarget(request.federationTarget)
+    ) {
+      const { federationTarget, ...ownerRequest } = request;
+      const federationRuntime = getDesktopFederationRuntime();
+      const response = await federationRuntime
+        .remoteBackend(federationTarget)
+        .setThreadParent(ownerRequest);
+      try {
+        const pins = await this.getOverlayStore().listRemoteThreadPins();
+        const pin = pins.find(
+          (candidate) =>
+            candidate.ref.backend === response.backend
+            && candidate.ref.threadId === response.threadId
+            && isRemoteFederationTarget(candidate.ref.target)
+            && candidate.ref.target.instanceId === federationTarget.instanceId,
+        );
+        if (pin?.summary) {
+          const summary = { ...pin.summary };
+          if (response.parentThreadId) {
+            summary.parentThreadId = response.parentThreadId;
+            summary.parentThreadBackend = response.parentThreadBackend;
+            summary.parentThreadInstanceId = response.parentThreadInstanceId;
+          } else {
+            delete summary.parentThreadId;
+            delete summary.parentThreadBackend;
+            delete summary.parentThreadInstanceId;
+          }
+          await this.getOverlayStore().updateRemoteThreadPinSnapshots([{
+            ref: pin.ref,
+            summary,
+            instanceLabel: pin.instanceLabel,
+          }]);
+        }
+      } catch (error) {
+        // The relationship mutation already committed on the owner. Keep that
+        // success authoritative even if this viewer's cached pin cannot patch.
+        appServerLog.warn("Remote parent change cache update failed.", {
+          error: error instanceof Error ? error.message : String(error),
+          instanceId: federationTarget.instanceId,
+          threadId: response.threadId,
+        });
+      }
+      federationRuntime.remoteThreadSummaries().invalidate(
+        federationTarget.instanceId,
+      );
+      return response;
+    }
     const backend = request.backend ?? "codex";
     const overlay = await this.getOverlayStore().setThreadParent({
       backend,
@@ -6228,6 +6277,15 @@ class DesktopAppServerService {
   async updateSubthreadOrder(
     request: UpdateSubthreadOrderRequest,
   ): Promise<UpdateSubthreadOrderResponse> {
+    if (
+      request.federationTarget
+      && isRemoteFederationTarget(request.federationTarget)
+    ) {
+      const { federationTarget, ...ownerRequest } = request;
+      return await getDesktopFederationRuntime()
+        .remoteBackend(federationTarget)
+        .updateSubthreadOrder(ownerRequest);
+    }
     const backend = request.backend ?? "codex";
     const threadIds = await this.getOverlayStore().updateSubthreadOrder({
       backend,
@@ -6258,6 +6316,15 @@ class DesktopAppServerService {
   async setSubthreadsCollapsed(
     request: SetSubthreadsCollapsedRequest,
   ): Promise<SetSubthreadsCollapsedResponse> {
+    if (
+      request.federationTarget
+      && isRemoteFederationTarget(request.federationTarget)
+    ) {
+      const { federationTarget, ...ownerRequest } = request;
+      return await getDesktopFederationRuntime()
+        .remoteBackend(federationTarget)
+        .setSubthreadsCollapsed(ownerRequest);
+    }
     const backend = request.backend ?? "codex";
     const overlay = await this.getOverlayStore().setSubthreadsCollapsed({
       backend,
@@ -6479,6 +6546,7 @@ class DesktopAppServerService {
         ...localResponse,
         launchpad: {
           ...localResponse.launchpad,
+          federationTarget,
           directoryKind:
             ownerResponse?.launchpad.directoryKind ?? request.directoryKind,
           directoryLabel:

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -85,6 +85,7 @@ import {
   type RegisterDirectoryFromDiskResponse,
   type MarkThreadSeenRequest,
   type MarkThreadSeenResponse,
+  type NavigationDirectorySummary,
   type NavigationDirectoryGitStatus,
   type NavigationDirectoryGitStatusUpdatedNotification,
   type NavigationThreadGitWorkingStateUpdatedNotification,
@@ -550,8 +551,9 @@ async function renderExplicitComposerPdfPreview(
  * when it identifies a linked directory; fallback preference is a local
  * checkout before a worktree, then linked-directory order.
  *
- * Remote threads whose project has no local counterpart stay ungrouped and
- * surface only in the Updated / Created lenses.
+ * Remote threads whose project has no local counterpart receive an
+ * unconfigured placeholder group. That keeps Cmd+K-mounted rows discoverable
+ * in the Directories lens until Add Directory registers a matching checkout.
  */
 /**
  * The single local directory group a remote thread belongs to, by project
@@ -579,21 +581,7 @@ function findRemoteHomeDirectoryIndex(
       }
     }
   });
-  const projectKey = thread.projectKey;
-  const linkedDirectories = thread.linkedDirectories ?? [];
-  const primaryProjectDirectory = projectKey
-    ? linkedDirectories.find((directory) =>
-        linkedDirectoryMatchesProjectKey(directory, projectKey)
-      )
-    : undefined;
-  const linkedByHomePreference = primaryProjectDirectory
-    ? [primaryProjectDirectory]
-    : [...linkedDirectories].sort((left, right) => {
-      if (left.kind !== right.kind) {
-        return left.kind === "worktree" ? 1 : -1;
-      }
-      return 0;
-    });
+  const linkedByHomePreference = remoteLinkedDirectoriesByHomePreference(thread);
   for (const linked of linkedByHomePreference) {
     const names = [linked.label, path.basename(linked.path)]
       .map((name) => (name ?? "").trim().toLowerCase())
@@ -606,6 +594,50 @@ function findRemoteHomeDirectoryIndex(
     }
   }
   return undefined;
+}
+
+function remoteLinkedDirectoriesByHomePreference(
+  thread: Pick<NavigationThreadSummary, "linkedDirectories" | "projectKey">,
+): LinkedDirectorySummary[] {
+  const linkedDirectories = thread.linkedDirectories ?? [];
+  const projectKey = thread.projectKey;
+  const primaryProjectDirectory = projectKey
+    ? linkedDirectories.find((directory) =>
+        linkedDirectoryMatchesProjectKey(directory, projectKey)
+      )
+    : undefined;
+  if (primaryProjectDirectory) {
+    return [primaryProjectDirectory];
+  }
+
+  return [...linkedDirectories].sort((left, right) => {
+    if (left.kind !== right.kind) {
+      return left.kind === "worktree" ? 1 : -1;
+    }
+    return 0;
+  });
+}
+
+function remoteDirectoryPlaceholder(
+  thread: Pick<NavigationThreadSummary, "linkedDirectories" | "projectKey">,
+): NavigationDirectorySummary | undefined {
+  const home = remoteLinkedDirectoriesByHomePreference(thread)[0];
+  if (!home) {
+    return undefined;
+  }
+  const label = home.label.trim() || path.basename(home.path).trim();
+  if (!label) {
+    return undefined;
+  }
+
+  return {
+    key: `unconfigured-directory:${encodeURIComponent(label.toLowerCase())}`,
+    kind: "directory",
+    label,
+    localAvailability: "unconfigured",
+    threadKeys: [],
+    needsAttentionCount: 0,
+  };
 }
 
 function linkedDirectoryMatchesProjectKey(
@@ -633,18 +665,28 @@ function attachRemoteThreadsToLocalDirectories(
   if (remoteThreads.length === 0) {
     return directories;
   }
+  const mergedDirectories = [...directories];
   const addedByDirectoryIndex = new Map<
     number,
     Array<{ threadKey: string; inInbox: boolean }>
   >();
   for (const thread of remoteThreads) {
     const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-    const homeIndex = findRemoteHomeDirectoryIndex(
-      directories,
+    let homeIndex = findRemoteHomeDirectoryIndex(
+      mergedDirectories,
       thread,
     );
     if (homeIndex === undefined) {
-      continue;
+      const placeholder = remoteDirectoryPlaceholder(thread);
+      if (!placeholder) {
+        continue;
+      }
+      homeIndex = mergedDirectories.findIndex(
+        (directory) => directory.key === placeholder.key,
+      );
+      if (homeIndex === -1) {
+        homeIndex = mergedDirectories.push(placeholder) - 1;
+      }
     }
     const added = addedByDirectoryIndex.get(homeIndex) ?? [];
     added.push({ threadKey, inInbox: Boolean(thread.inbox?.inInbox) });
@@ -653,7 +695,7 @@ function attachRemoteThreadsToLocalDirectories(
   if (addedByDirectoryIndex.size === 0) {
     return directories;
   }
-  return directories.map((directory, index) => {
+  return mergedDirectories.map((directory, index) => {
     const added = addedByDirectoryIndex
       .get(index)
       ?.filter((entry) => !directory.threadKeys.includes(entry.threadKey));

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1965,6 +1965,7 @@ function DesktopAppShell(props: {
           onSetThreadPin={navigation.setThreadPin}
           onReorderThreadPins={navigation.reorderThreadPins}
           onSetThreadParent={navigation.setThreadParent}
+          onUnlinkThreads={navigation.unlinkThreads}
           onUpdateSubthreadOrder={navigation.updateSubthreadOrder}
           onSetSubthreadsCollapsed={navigation.setSubthreadsCollapsed}
           onSetDirectoryPin={navigation.setDirectoryPin}

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -197,9 +197,10 @@ const EMPTY_EXPANDED_DIRECTORY_THREAD_MODEL: ExpandedDirectoryThreadRenderModel 
  * apart. See plan 2026-05-09-002 Unit K.
  */
 function isPinnableDirectoryKind(
-  directory: Pick<NavigationDirectorySummary, "kind">,
+  directory: Pick<NavigationDirectorySummary, "kind" | "localAvailability">,
 ): boolean {
-  return directory.kind === "directory" || directory.kind === "workspace";
+  return directory.localAvailability !== "unconfigured"
+    && (directory.kind === "directory" || directory.kind === "workspace");
 }
 
 /**
@@ -446,6 +447,9 @@ function DirectoryCount(props: {
 
 export function DirectoriesList(props: DirectoriesListProps) {
   const [expandedByKey, setExpandedByKey] = useState<Record<string, boolean>>({});
+  const unavailableDirectoryTooltip = useViewportTooltip({
+    className: "viewport-tooltip",
+  });
   // Per-directory "show all unpinned threads" toggle, keyed by directory.key.
   const [unpinnedExpandedByKey, setUnpinnedExpandedByKey] = useState<
     Record<string, boolean>
@@ -1068,6 +1072,8 @@ export function DirectoriesList(props: DirectoriesListProps) {
   const renderDirectoryRow = (
     directory: NavigationDirectorySummary,
   ): ReactElement => {
+    const directoryUnconfigured =
+      directory.localAvailability === "unconfigured";
     const directoryPinned = isPinnedDirectory(directory);
     const directoryDraggable =
       directoryDragEnabled &&
@@ -1102,6 +1108,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
     } = threadModel;
     const directorySummaryLabel = [
       directory.label,
+      directoryUnconfigured ? "not configured on this instance" : undefined,
       activeThreadCount > 0 ? formatActiveThreadCount(activeThreadCount) : undefined,
       reviewThreadCount > 0 ? formatReviewThreadCount(reviewThreadCount) : undefined,
     ]
@@ -1494,8 +1501,11 @@ export function DirectoriesList(props: DirectoriesListProps) {
             aria-pressed={selectedDirectory}
             className={`thread-row thread-row--compact directory-row__summary${
               selectedDirectory ? " is-selected" : ""
+            }${
+              directoryUnconfigured ? " directory-row__summary--unconfigured" : ""
             }`}
             type="button"
+            onBlur={directoryUnconfigured ? unavailableDirectoryTooltip.hide : undefined}
             onClick={(event) => {
               // Suppress the synthetic post-drop click that the
               // browser fires on the element under the mouse when
@@ -1541,6 +1551,25 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 });
               };
             })()}
+            onFocus={
+              directoryUnconfigured
+                ? (event) => unavailableDirectoryTooltip.show(
+                    event.currentTarget,
+                    "This project directory isn't configured on this instance. Use Add Directory to connect it.",
+                  )
+                : undefined
+            }
+            onMouseEnter={
+              directoryUnconfigured
+                ? (event) => unavailableDirectoryTooltip.show(
+                    event.currentTarget,
+                    "This project directory isn't configured on this instance. Use Add Directory to connect it.",
+                  )
+                : undefined
+            }
+            onMouseLeave={
+              directoryUnconfigured ? unavailableDirectoryTooltip.hide : undefined
+            }
           >
             <span className="directory-row__summary-main">
               <span
@@ -1585,18 +1614,20 @@ export function DirectoriesList(props: DirectoriesListProps) {
             </span>
           </button>
 
-          <button
-            aria-label={`Open new thread launchpad for ${directory.label}`}
-            className={`directory-row__launchpad-button${
-              hasPendingLaunchpadState(directory) ? " has-draft" : ""
-            }`}
-            type="button"
-            onClick={() => {
-              void props.onOpenLaunchpad(directory, directory.launchpad?.backend);
-            }}
-          >
-            <NewThreadIcon size={16} />
-          </button>
+          {directoryUnconfigured ? null : (
+            <button
+              aria-label={`Open new thread launchpad for ${directory.label}`}
+              className={`directory-row__launchpad-button${
+                hasPendingLaunchpadState(directory) ? " has-draft" : ""
+              }`}
+              type="button"
+              onClick={() => {
+                void props.onOpenLaunchpad(directory, directory.launchpad?.backend);
+              }}
+            >
+              <NewThreadIcon size={16} />
+            </button>
+          )}
         </div>
 
             {expanded ? (
@@ -1705,11 +1736,15 @@ export function DirectoriesList(props: DirectoriesListProps) {
                         aria-label={`${
                           directoryThreadsCollapsed ? "Show" : "Hide"
                         } directory threads for ${directory.label}`}
-                        disabled={!props.onSetDirectoryThreadsCollapsed}
+                        disabled={
+                          directoryUnconfigured
+                          || !props.onSetDirectoryThreadsCollapsed
+                        }
                         onClick={() => {
                           if (
-                            Date.now() - lastDirectoryThreadDropAtRef.current <
-                            POST_DRAG_CLICK_SUPPRESS_MS
+                            directoryUnconfigured
+                            || Date.now() - lastDirectoryThreadDropAtRef.current <
+                              POST_DRAG_CLICK_SUPPRESS_MS
                           ) {
                             return;
                           }
@@ -1833,6 +1868,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
         </div>
       ) : null}
       {unpinnedDirectories.map(renderDirectoryRow)}
+      {unavailableDirectoryTooltip.tooltipNode}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -40,6 +40,7 @@ import {
   useDropIndicatorController,
 } from "./drag-drop";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
+import { threadSupportsFederationCapability } from "../../lib/federated-thread-events";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
   beginNativeDragInteraction,
@@ -1128,7 +1129,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
         buildThreadIdentityKey(child.source, child.id),
       );
       const reorderable =
-        children.length > 1 && Boolean(props.onUpdateSubthreadOrder);
+        threadSupportsFederationCapability(parent, "thread_grouping")
+        && children.length > 1
+        && Boolean(props.onUpdateSubthreadOrder);
       return (
         <div className="subthread-list subthread-list--compact" role="list" aria-label={`Sub-threads of ${parent.title}`}>
           {children.map((child) => {
@@ -1296,7 +1299,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
             thread={thread}
             threadPinState="unpinned"
             onToggleSubthreads={
-              subthreadCount > 0 && props.onSetSubthreadsCollapsed
+              subthreadCount > 0
+                && threadSupportsFederationCapability(thread, "thread_grouping")
+                && props.onSetSubthreadsCollapsed
                 ? () =>
                     void props.onSetSubthreadsCollapsed!(
                       thread,
@@ -1632,7 +1637,12 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           thread={thread}
                           threadPinState="pinned"
                               onToggleSubthreads={
-                                subthreadCount > 0 && props.onSetSubthreadsCollapsed
+                                subthreadCount > 0
+                                  && threadSupportsFederationCapability(
+                                    thread,
+                                    "thread_grouping",
+                                  )
+                                  && props.onSetSubthreadsCollapsed
                                   ? () =>
                                       void props.onSetSubthreadsCollapsed!(
                                         thread,

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -17,6 +17,7 @@ import {
   useDropIndicatorController,
 } from "./drag-drop";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
+import { threadSupportsFederationCapability } from "../../lib/federated-thread-events";
 import {
   getSubthreadDisclosureCount,
   isSubthreadSectionCollapsed,
@@ -122,6 +123,10 @@ export function RecentsList(props: RecentsListProps) {
     const children = sortSubthreadSummaries(parent, childrenByParentKey.get(parentKey) ?? []);
     const nativeSubAgentCount = parent.codexNativeSubAgents?.length ?? 0;
     const subthreadsCollapsed = isSubthreadSectionCollapsed(parent);
+    const canManageSubthreads = threadSupportsFederationCapability(
+      parent,
+      "thread_grouping",
+    );
     if (
       (children.length === 0 && nativeSubAgentCount === 0)
       || subthreadsCollapsed
@@ -146,7 +151,11 @@ export function RecentsList(props: RecentsListProps) {
               queuedMessageThreadKeys={props.queuedMessageThreadKeys}
               draftThreadKeys={props.draftThreadKeys}
               composerSourceThreadKey={props.composerSourceThreadKey}
-              draggable={children.length > 1 && Boolean(props.onUpdateSubthreadOrder)}
+              draggable={
+                canManageSubthreads
+                && children.length > 1
+                && Boolean(props.onUpdateSubthreadOrder)
+              }
               includeLinkedDirectories
               nested
               revealSelectedThreadRequest={props.revealSelectedThreadRequest}
@@ -284,7 +293,9 @@ export function RecentsList(props: RecentsListProps) {
           thinkingThreadKeys={props.thinkingThreadKeys}
           thread={thread}
           onToggleSubthreads={
-            subthreadCount > 0 && props.onSetSubthreadsCollapsed
+            subthreadCount > 0
+              && threadSupportsFederationCapability(thread, "thread_grouping")
+              && props.onSetSubthreadsCollapsed
               ? () =>
                   void props.onSetSubthreadsCollapsed!(
                     thread,

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -196,6 +196,9 @@ type SidebarProps = {
     thread: NavigationThreadSummary,
     parentThreadId?: string,
   ) => Promise<void>;
+  onUnlinkThreads?: (
+    threads: NavigationThreadSummary[],
+  ) => Promise<void>;
   onUpdateSubthreadOrder?: (
     parent: NavigationThreadSummary,
     threadIds: string[],
@@ -1018,6 +1021,10 @@ export function Sidebar(props: SidebarProps) {
 
   const unlinkSubthreadFromContextMenu = (thread: NavigationThreadSummary): void => {
     setContextMenu(undefined);
+    if (props.onUnlinkThreads) {
+      void props.onUnlinkThreads([thread]);
+      return;
+    }
     void props.onSetThreadParent?.(thread, undefined);
   };
 
@@ -1183,9 +1190,15 @@ export function Sidebar(props: SidebarProps) {
     threads: NavigationThreadSummary[],
   ): void => {
     setContextMenu(undefined);
-    void Promise.all(
-      threads.map((thread) => props.onSetThreadParent?.(thread, undefined)),
-    );
+    if (props.onUnlinkThreads) {
+      void props.onUnlinkThreads(threads);
+      return;
+    }
+    void (async () => {
+      for (const thread of threads) {
+        await props.onSetThreadParent?.(thread, undefined);
+      }
+    })();
   };
 
   const pinThreadsFromContextMenu = (
@@ -1257,10 +1270,8 @@ export function Sidebar(props: SidebarProps) {
 
   const contextMenuThreads = contextMenu?.threads ?? [];
   const contextMenuIsBulk = contextMenuThreads.length > 1;
-  // A remote-owned row pinned into the main window's list: local overlay
-  // actions (pin, archive, rename, sub-thread/fork) don't apply — the only
-  // management action is removing the viewer-side pin. Federation windows
-  // keep their existing behavior (every row there is remote).
+  // A remote-owned row pinned into the main window's list can be removed from
+  // this viewer independently of owner-routed thread actions.
   const contextMenuIsMainWindowRemoteRow = Boolean(
     contextMenu &&
       !contextMenuIsBulk &&
@@ -1272,20 +1283,31 @@ export function Sidebar(props: SidebarProps) {
     && !contextMenu?.thread.federation?.derivedFromMountedParent
     && props.onRemoveRemoteThreadPin,
   );
+  const contextMenuCanRouteRemoteCapability = (
+    capability: "environment_actions" | "launchpad_metadata" |
+      "thread_navigation" | "turn_control",
+  ): boolean =>
+    !contextMenuIsMainWindowRemoteRow
+    || Boolean(
+      contextMenu?.thread.federation?.peerStatus === "connected"
+      && contextMenu.thread.federation.capabilities?.includes(capability),
+    );
   const contextMenuCanRename =
-    contextMenu && !contextMenuIsBulk && !contextMenuIsMainWindowRemoteRow
+    contextMenu && !contextMenuIsBulk
       ? canRenameThread(contextMenu.thread)
+        && contextMenuCanRouteRemoteCapability("turn_control")
       : false;
   const contextMenuCanArchive =
-    contextMenu && !contextMenuIsBulk && !contextMenuIsMainWindowRemoteRow
+    contextMenu && !contextMenuIsBulk
       ? canArchiveThread(contextMenu.thread)
+        && contextMenuCanRouteRemoteCapability("turn_control")
       : false;
   const contextMenuCanMarkUnread = Boolean(
     contextMenu &&
       !contextMenuIsBulk &&
-      !contextMenuIsMainWindowRemoteRow &&
       !contextMenu.thread.inbox.inInbox &&
       contextMenu.thread.updatedAt !== undefined &&
+      contextMenuCanRouteRemoteCapability("thread_navigation") &&
       props.onMarkThreadUnread,
   );
   const contextMenuCanMarkRead = Boolean(
@@ -1329,23 +1351,24 @@ export function Sidebar(props: SidebarProps) {
   const contextMenuCanCreateSubthread = Boolean(
     contextMenu &&
       !contextMenuIsBulk &&
-      !contextMenuIsMainWindowRemoteRow &&
       contextMenuHasWorkspace &&
+      contextMenuCanRouteRemoteCapability("launchpad_metadata") &&
+      contextMenuCanRouteRemoteCapability("environment_actions") &&
       props.onCreateSubthread,
   );
   const contextMenuCanFork = Boolean(
     contextMenu &&
       !contextMenuIsBulk &&
-      !contextMenuIsMainWindowRemoteRow &&
       contextMenu.thread.source === "codex" &&
       contextMenuHasWorkspace &&
+      contextMenuCanRouteRemoteCapability("turn_control") &&
       canForkThread(contextMenu.thread) &&
       props.onForkThread,
   );
   const contextMenuCanUnlinkSubthread = Boolean(
     contextMenuIsSubthread
-    && !contextMenuIsMainWindowRemoteRow
-    && props.onSetThreadParent,
+    && contextMenuCanRouteRemoteCapability("thread_navigation")
+    && (props.onUnlinkThreads || props.onSetThreadParent),
   );
   // Remote rows CAN pin here: the rank is viewer-owned (stored on the
   // remote_thread_pins row), so the owner's list never learns about it.
@@ -1426,7 +1449,8 @@ export function Sidebar(props: SidebarProps) {
     bulkCanPin &&
     (bulkPinnedThreads.length > 0 || bulkUnpinnedThreads.length > 0);
   const bulkHasManagementActions = Boolean(
-    (bulkUnlinkableThreads.length > 0 && props.onSetThreadParent) ||
+    (bulkUnlinkableThreads.length > 0
+      && (props.onUnlinkThreads || props.onSetThreadParent)) ||
       bulkArchivableThreads.length > 0,
   );
   const bulkThreadLinks = uniqueContextMenuValues(
@@ -1864,7 +1888,8 @@ export function Sidebar(props: SidebarProps) {
               ) : null}
               {bulkHasManagementActions ? (
                 <div className="thread-context-menu__section">
-                  {bulkUnlinkableThreads.length > 0 && props.onSetThreadParent ? (
+                  {bulkUnlinkableThreads.length > 0
+                    && (props.onUnlinkThreads || props.onSetThreadParent) ? (
                     <button
                       role="menuitem"
                       type="button"

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -266,7 +266,7 @@ export function ThreadRow(props: ThreadRowProps) {
         });
       }}
     >
-      {props.subthreadCount ? (
+      {props.subthreadCount && props.onToggleSubthreads ? (
         <button
           aria-expanded={!props.subthreadsCollapsed}
           aria-label={`${props.subthreadsCollapsed ? "Expand" : "Collapse"} sub-threads for ${props.thread.title}`}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1335,6 +1335,84 @@ describe("Sidebar", () => {
     ).toBeNull();
   });
 
+  it("offers owner-routed actions for a connected remote child", () => {
+    const remoteBackends: BackendSummary[] = [{
+      ...backends[0]!,
+      capabilities: {
+        ...backends[0]!.capabilities,
+        forkThread: true,
+      },
+    }];
+    const remoteChild: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "thread-remote-child",
+      title: "Remote child",
+      inbox: { inInbox: false },
+      parentThreadId: "thread-local-parent",
+      parentThreadBackend: "codex",
+      parentThreadInstanceId: "local-instance",
+      federation: {
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "peer-mini" },
+          threadId: "thread-remote-child",
+        },
+        instanceLabel: "Mac Mini",
+        peerStatus: "connected",
+        capabilities: [
+          "environment_actions",
+          "launchpad_metadata",
+          "thread_navigation",
+          "turn_control",
+        ],
+      },
+    };
+    render(
+      <Sidebar
+        backends={remoteBackends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[remoteChild]}
+        loading={false}
+        selectedItemKey="codex:thread-remote-child"
+        threads={[remoteChild]}
+        onArchiveThread={async () => undefined}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onCreateSubthread={async () => undefined}
+        onForkThread={async () => undefined}
+        onMarkThreadUnread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onRenameThread={async () => undefined}
+        onSelectThread={() => undefined}
+        onUnlinkThreads={async () => undefined}
+      />,
+    );
+
+    fireEvent.contextMenu(
+      screen.getByRole("button", { name: "Remote child" }),
+    );
+
+    expect(screen.getByRole("menuitem", {
+      name: "Sub-thread in Same Worktree",
+    })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", {
+      name: "Fork into Same Worktree",
+    })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", {
+      name: "Unlink from Parent",
+    })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", {
+      name: "Rename Thread",
+    })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", {
+      name: "Mark Unread",
+    })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", {
+      name: "Archive Thread",
+    })).toBeInTheDocument();
+  });
+
   it("closes its context menu when another renderer menu opens", () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2037,6 +2037,49 @@ describe("Sidebar", () => {
     expect(onOpenLaunchpad).toHaveBeenCalledWith(directories[0], undefined);
   });
 
+  it("shows mounted projects that are not configured on this instance", async () => {
+    const unconfiguredDirectory: NavigationDirectorySummary = {
+      key: "unconfigured-directory:grok-build",
+      kind: "directory",
+      label: "grok-build",
+      localAvailability: "unconfigured",
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={[unconfiguredDirectory]}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    const summary = screen.getByRole("button", {
+      name: /^grok-build, not configured on this instance/,
+    });
+    expect(summary).toHaveClass("directory-row__summary--unconfigured");
+    expect(screen.queryByRole("button", {
+      name: "Open new thread launchpad for grok-build",
+    })).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(summary);
+    expect(await screen.findByText(
+      "This project directory isn't configured on this instance. Use Add Directory to connect it.",
+    )).toBeInTheDocument();
+  });
+
   it("does not highlight an opened-only launchpad as a pending draft", () => {
     const openedOnlyDirectories: NavigationDirectorySummary[] = [
       {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -988,6 +988,55 @@ describe("Sidebar", () => {
     expect(onSetSubthreadsCollapsed).toHaveBeenCalledWith(sharedThread, true);
   });
 
+  it("does not expose sub-thread disclosure controls for an older remote peer", () => {
+    const remoteParent: NavigationThreadSummary = {
+      ...sharedThread,
+      federation: {
+        capabilities: ["thread_navigation"],
+        instanceLabel: "Older Mac",
+        peerStatus: "connected",
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "older-peer" },
+          threadId: sharedThread.id,
+        },
+      },
+    };
+    const childThread: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "thread-review",
+      title: "Adversarial review",
+      parentThreadId: remoteParent.id,
+    };
+    const onSetSubthreadsCollapsed = vi.fn(async () => undefined);
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[childThread, remoteParent]}
+        loading={false}
+        selectedItemKey="codex:thread-1"
+        threads={[childThread, remoteParent]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+        onSetSubthreadsCollapsed={onSetSubthreadsCollapsed}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", {
+        name: "Collapse sub-threads for Cross-project cleanup",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Adversarial review" }),
+    ).toBeInTheDocument();
+  });
+
   it("groups a Codex child under its pinned ACP parent in Inbox", () => {
     const parentThread: NavigationThreadSummary = {
       ...sharedThread,

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -1685,6 +1685,7 @@ const FEDERATION_CAPABILITY_LABELS: Record<FederationCapability, string> = {
   remote_window: "open a remote workspace",
   thread_navigation: "browse and create threads",
   navigation_snapshot_deltas: "exchange compact navigation updates",
+  thread_grouping: "reorder and collapse sub-threads",
   thread_detail: "read transcripts",
   turn_control: "prompt, steer, and interrupt",
   scheduled_actions: "schedule and manage messages",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2688,10 +2688,12 @@ describe("useThreadNavigation", () => {
       archivedAt: 2_000,
       cleanup: [],
     }));
+    const removeRemoteThreadPin = vi.fn(async () => ({ removed: true }));
     const desktopApi: DesktopApi = {
       archiveThread,
       getNavigationSnapshot,
       onAgentEvent: () => () => undefined,
+      removeRemoteThreadPin,
     };
     const { result } = renderHook(() => useThreadNavigation(desktopApi));
 
@@ -2706,6 +2708,13 @@ describe("useThreadNavigation", () => {
       backend: "codex",
       threadId: "thread-remote",
       federationTarget,
+    });
+    expect(removeRemoteThreadPin).toHaveBeenCalledWith({
+      ref: {
+        backend: "codex",
+        target: federationTarget,
+        threadId: "thread-remote",
+      },
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -3744,6 +3744,7 @@ describe("useThreadNavigation", () => {
       inbox: { inInbox: false },
       subthreadOrder: ["thread-local-child"],
       federation: {
+        capabilities: ["thread_navigation", "thread_grouping"],
         ref: {
           backend: "codex",
           target: rootTarget,
@@ -3859,6 +3860,68 @@ describe("useThreadNavigation", () => {
         parentThreadId: "thread-root",
       }),
     );
+  });
+
+  it("does not route grouping mutations to a legacy remote peer", async () => {
+    const target = {
+      scope: "remote" as const,
+      instanceId: "legacy-owner",
+    };
+    const remoteParent: NavigationThreadSummary = {
+      id: "thread-root",
+      title: "Legacy remote root",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      subthreadOrder: ["thread-a", "thread-b"],
+      subthreadsCollapsed: false,
+      federation: {
+        capabilities: ["thread_navigation"],
+        instanceLabel: "Legacy Mac",
+        ref: {
+          backend: "codex",
+          target,
+          threadId: "thread-root",
+        },
+      },
+    };
+    const updateSubthreadOrder = vi.fn();
+    const setSubthreadsCollapsed = vi.fn();
+    const desktopApi = {
+      getNavigationSnapshot: vi.fn(async () => ({
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        inboxThreadKeys: [],
+        threads: [remoteParent],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      })),
+      onAgentEvent: () => () => undefined,
+      updateSubthreadOrder,
+      setSubthreadsCollapsed,
+    } as unknown as DesktopApi;
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => expect(result.current.threads).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.updateSubthreadOrder(remoteParent, [
+        "thread-b",
+        "thread-a",
+      ]);
+      await result.current.setSubthreadsCollapsed(remoteParent, true);
+    });
+
+    expect(updateSubthreadOrder).not.toHaveBeenCalled();
+    expect(setSubthreadsCollapsed).not.toHaveBeenCalled();
+    expect(result.current.threads[0]).toMatchObject({
+      subthreadOrder: ["thread-a", "thread-b"],
+      subthreadsCollapsed: false,
+    });
   });
 
   it("pins unlinked siblings together immediately above their pinned parent", async () => {
@@ -10915,6 +10978,138 @@ describe("useThreadNavigation", () => {
       expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
       expect(result.current.threads[0]?.updatedAt).toBe(2_000);
     });
+  });
+
+  it("applies remote relationship events only to mounted rows from that peer", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const localParent: NavigationThreadSummary = {
+      id: "shared-parent",
+      title: "Local parent",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      subthreadOrder: ["local-child"],
+      subthreadsCollapsed: false,
+    };
+    const remoteParent: NavigationThreadSummary = {
+      ...localParent,
+      title: "Remote parent",
+      federation: {
+        capabilities: ["thread_navigation", "thread_grouping"],
+        instanceLabel: "Remote Mac",
+        ref: {
+          backend: "codex",
+          target: federationTarget,
+          threadId: localParent.id,
+        },
+      },
+    };
+    const localChild: NavigationThreadSummary = {
+      ...localParent,
+      id: "shared-child",
+      title: "Local child",
+      subthreadOrder: undefined,
+      subthreadsCollapsed: undefined,
+    };
+    const remoteChild: NavigationThreadSummary = {
+      ...localChild,
+      title: "Remote child",
+      federation: {
+        capabilities: ["thread_navigation", "thread_grouping"],
+        instanceLabel: "Remote Mac",
+        ref: {
+          backend: "codex",
+          target: federationTarget,
+          threadId: localChild.id,
+        },
+      },
+    };
+    const desktopApi = {
+      getNavigationSnapshot: vi.fn(async () => ({
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        inboxThreadKeys: [],
+        threads: [localParent, remoteParent, localChild, remoteChild],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      })),
+      onAgentEvent: (
+        callback: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0],
+      ) => {
+        agentEventHandler = callback;
+        return () => {
+          agentEventHandler = undefined;
+        };
+      },
+    } as unknown as DesktopApi;
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => expect(result.current.threads).toHaveLength(4));
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        federationTarget,
+        notification: {
+          method: "thread/subthreadOrder/updated",
+          params: {
+            parentThreadId: "shared-parent",
+            threadIds: ["remote-child"],
+          },
+        },
+      } as never);
+      agentEventHandler?.({
+        backend: "codex",
+        federationTarget,
+        notification: {
+          method: "thread/subthreadsCollapsed/updated",
+          params: {
+            parentThreadId: "shared-parent",
+            collapsed: true,
+          },
+        },
+      } as never);
+      agentEventHandler?.({
+        backend: "codex",
+        federationTarget,
+        notification: {
+          method: "thread/parent/set",
+          params: {
+            threadId: "shared-child",
+            parentThreadId: "shared-parent",
+            parentThreadBackend: "codex",
+          },
+        },
+      } as never);
+    });
+
+    const localRows = result.current.threads.filter((thread) => !thread.federation);
+    const remoteRows = result.current.threads.filter((thread) => thread.federation);
+    expect(localRows.find((thread) => thread.id === "shared-parent")).toMatchObject({
+      subthreadOrder: ["local-child"],
+      subthreadsCollapsed: false,
+    });
+    expect(localRows.find((thread) => thread.id === "shared-child"))
+      .not.toHaveProperty("parentThreadId");
+    expect(remoteRows.find((thread) => thread.id === "shared-parent")).toMatchObject({
+      subthreadOrder: ["remote-child"],
+      subthreadsCollapsed: true,
+    });
+    expect(remoteRows.find((thread) => thread.id === "shared-child"))
+      .toMatchObject({
+        parentThreadId: "shared-parent",
+        parentThreadBackend: "codex",
+      });
   });
 
   describe("pickAndRegisterDirectory (issue #223)", () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -3714,6 +3714,144 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("records remote-root ownership for locally created children and forks", async () => {
+    const rootTarget = {
+      scope: "remote" as const,
+      instanceId: "root-owner",
+    };
+    const worktree = {
+      id: "wt",
+      label: "Repo",
+      path: "/repo",
+      worktreePath: "/wt/repo",
+      kind: "worktree" as const,
+    };
+    const remoteRoot: NavigationThreadSummary = {
+      id: "thread-root",
+      title: "Remote root",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [worktree],
+      inbox: { inInbox: false },
+      subthreadOrder: ["thread-local-child"],
+      federation: {
+        ref: {
+          backend: "codex",
+          target: rootTarget,
+          threadId: "thread-root",
+        },
+        instanceLabel: "Root Mac",
+      },
+    };
+    const localChild: NavigationThreadSummary = {
+      ...remoteRoot,
+      id: "thread-local-child",
+      title: "Local child",
+      parentThreadId: "thread-root",
+      parentThreadBackend: "codex",
+      parentThreadInstanceId: "root-owner",
+      federation: undefined,
+    };
+    const directoryKey =
+      "subthread:codex:thread-local-child:same-worktree";
+    const launchpad = {
+      directoryKey,
+      directoryKind: "directory" as const,
+      directoryLabel: "Repo",
+      directoryPath: "/wt/repo",
+      workMode: "local" as const,
+      backend: "codex" as const,
+      executionMode: "default" as const,
+      prompt: "",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad,
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const updateDirectoryLaunchpad = vi.fn(async (request) => ({
+      launchpad: { ...launchpad, ...request.patch, updatedAt: 2 },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const forkThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      sourceThreadId: "thread-local-child",
+      threadId: "thread-fork",
+      executionMode: "default" as const,
+      workMode: "local" as const,
+    }));
+    const updateSubthreadOrder = vi.fn(async (request) => ({
+      backend: "codex" as const,
+      parentThreadId: request.parentThreadId,
+      threadIds: request.threadIds,
+    }));
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      forkThread,
+      getNavigationSnapshot: vi.fn(async () => ({
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        inboxThreadKeys: [],
+        threads: [remoteRoot, localChild],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      })),
+      onAgentEvent: () => () => undefined,
+      updateDirectoryLaunchpad,
+      updateSubthreadOrder,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => expect(result.current.threads).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.createSubthread(localChild, "same-worktree");
+    });
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        federationTarget: undefined,
+        parentThreadId: "thread-root",
+        parentThreadInstanceId: "root-owner",
+      }),
+    );
+    expect(updateDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        patch: expect.objectContaining({
+          federationTarget: undefined,
+          parentThreadId: "thread-root",
+          parentThreadInstanceId: "root-owner",
+        }),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.forkThread(localChild, "same-worktree");
+    });
+    expect(forkThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        federationTarget: undefined,
+        parentThreadId: "thread-root",
+        parentThreadInstanceId: "root-owner",
+      }),
+    );
+    expect(updateSubthreadOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        federationTarget: rootTarget,
+        parentThreadId: "thread-root",
+      }),
+    );
+  });
+
   it("pins unlinked siblings together immediately above their pinned parent", async () => {
     const pinnedBefore = {
       id: "thread-before",
@@ -3829,6 +3967,7 @@ describe("useThreadNavigation", () => {
           threadId: "thread-child",
         },
         instanceLabel: "Child Mac",
+        derivedFromMountedParent: true,
       },
     };
     const snapshot: NavigationSnapshot = {
@@ -3844,10 +3983,20 @@ describe("useThreadNavigation", () => {
       backend: "codex" as const,
       threadId: "thread-child",
     }));
+    const addRemoteThreadPin = vi.fn(async () => ({
+      pin: {
+        ref: child.federation!.ref,
+        instanceLabel: "Child Mac",
+        pinnedVia: "explicit" as const,
+        addedAt: Date.now(),
+      },
+    }));
+    const reorderThreadPins = vi.fn(async () => ({ pinnedRanks: {} }));
     const desktopApi: DesktopApi = {
+      addRemoteThreadPin,
       getNavigationSnapshot: vi.fn(async () => snapshot),
       onAgentEvent: () => () => undefined,
-      reorderThreadPins: vi.fn(async () => ({ pinnedRanks: {} })),
+      reorderThreadPins,
       setThreadParent,
     };
     const { result } = renderHook(() => useThreadNavigation(desktopApi));
@@ -3861,6 +4010,18 @@ describe("useThreadNavigation", () => {
       backend: "codex",
       federationTarget: remoteTarget,
       threadId: "thread-child",
+    });
+    expect(addRemoteThreadPin).toHaveBeenCalledWith({
+      ref: child.federation?.ref,
+      instanceLabel: "Child Mac",
+      summary: child,
+    });
+    expect(addRemoteThreadPin.mock.invocationCallOrder[0]).toBeLessThan(
+      setThreadParent.mock.invocationCallOrder[0]!,
+    );
+    expect(reorderThreadPins).toHaveBeenCalledWith({
+      federationTarget: undefined,
+      threadKeys: ["codex:thread-child", "codex:thread-parent"],
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -10,6 +10,7 @@ import type {
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
   NavigationSnapshot,
+  NavigationThreadSummary,
   PrSummary,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
@@ -3710,6 +3711,156 @@ describe("useThreadNavigation", () => {
     expect(updateSubthreadOrder.mock.calls[0]![0]).toMatchObject({
       parentThreadId: "thread-root",
       threadIds: ["thread-a", "thread-fork", "thread-b"],
+    });
+  });
+
+  it("pins unlinked siblings together immediately above their pinned parent", async () => {
+    const pinnedBefore = {
+      id: "thread-before",
+      title: "Pinned before",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      pinnedRank: "1024",
+    };
+    const parent = {
+      ...pinnedBefore,
+      id: "thread-parent",
+      title: "Pinned parent",
+      pinnedRank: "2048",
+      subthreadOrder: ["thread-child-a", "thread-child-b"],
+      federation: {
+        ref: {
+          backend: "codex" as const,
+          target: { scope: "remote" as const, instanceId: "parent-owner" },
+          threadId: "thread-parent",
+        },
+        instanceLabel: "Parent Mac",
+      },
+    };
+    const childA = {
+      ...pinnedBefore,
+      id: "thread-child-a",
+      title: "Child A",
+      pinnedRank: undefined,
+      parentThreadId: "thread-parent",
+      parentThreadBackend: "codex" as const,
+      parentThreadInstanceId: "parent-owner",
+    };
+    const childB = { ...childA, id: "thread-child-b", title: "Child B" };
+    const snapshot = {
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [pinnedBefore, parent, childA, childB],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    };
+    const setThreadParent = vi.fn(async (request: { threadId: string }) => ({
+      backend: "codex" as const,
+      threadId: request.threadId,
+    }));
+    const reorderThreadPins = vi.fn(async () => ({
+      pinnedRanks: {
+        "codex:thread-before": "1024",
+        "codex:thread-child-a": "2048",
+        "codex:thread-child-b": "3072",
+        "codex:thread-parent": "4096",
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot: vi.fn(async () => snapshot),
+      onAgentEvent: () => () => undefined,
+      reorderThreadPins,
+      setThreadParent,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => expect(result.current.threads).toHaveLength(4));
+
+    await act(async () => {
+      await result.current.unlinkThreads([childB, childA]);
+    });
+
+    expect(setThreadParent.mock.calls.map(([request]) => request)).toEqual([
+      { backend: "codex", federationTarget: undefined, threadId: "thread-child-b" },
+      { backend: "codex", federationTarget: undefined, threadId: "thread-child-a" },
+    ]);
+    expect(reorderThreadPins).toHaveBeenCalledWith({
+      federationTarget: undefined,
+      threadKeys: [
+        "codex:thread-before",
+        "codex:thread-child-a",
+        "codex:thread-child-b",
+        "codex:thread-parent",
+      ],
+    });
+  });
+
+  it("routes remote-child unlinking to its owner", async () => {
+    const remoteTarget = {
+      scope: "remote" as const,
+      instanceId: "child-owner",
+    };
+    const parent = {
+      id: "thread-parent",
+      title: "Local parent",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      pinnedRank: "1024",
+    };
+    const child: NavigationThreadSummary = {
+      ...parent,
+      id: "thread-child",
+      title: "Remote child",
+      pinnedRank: undefined,
+      parentThreadId: "thread-parent",
+      parentThreadBackend: "codex",
+      federation: {
+        ref: {
+          backend: "codex",
+          target: remoteTarget,
+          threadId: "thread-child",
+        },
+        instanceLabel: "Child Mac",
+      },
+    };
+    const snapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [parent, child],
+      directories: [],
+      launchpadDefaults: { backend: "codex", executionMode: "default" },
+    };
+    const setThreadParent = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-child",
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot: vi.fn(async () => snapshot),
+      onAgentEvent: () => () => undefined,
+      reorderThreadPins: vi.fn(async () => ({ pinnedRanks: {} })),
+      setThreadParent,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => expect(result.current.threads).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.unlinkThreads([child]);
+    });
+
+    expect(setThreadParent).toHaveBeenCalledWith({
+      backend: "codex",
+      federationTarget: remoteTarget,
+      threadId: "thread-child",
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -11518,7 +11518,9 @@ describe("useThreadNavigation", () => {
 
     it("addProjectDirectory tracks an empty repo and reveals the Directories lens", async () => {
       const launchpad = buildPickedLaunchpad({ registeredAt: 1_500 });
+      const getNavigationSnapshot = vi.fn(async () => buildSnapshot());
       const desktopApi = buildBaseDesktopApi({
+        getNavigationSnapshot,
         pickDirectoryFromDisk: vi.fn(async () => ({
           canceled: false as const,
           path: "/Users/me/repos/PwrAgent",
@@ -11542,6 +11544,7 @@ describe("useThreadNavigation", () => {
       });
 
       expect(result.current.browseMode).toBe("directories");
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
       expect(result.current.selectedItemKey).toBeUndefined();
       expect(result.current.directories).toEqual(
         expect.arrayContaining([

--- a/apps/desktop/src/renderer/src/lib/federated-thread-events.ts
+++ b/apps/desktop/src/renderer/src/lib/federated-thread-events.ts
@@ -1,5 +1,6 @@
 import type {
   AgentEvent,
+  FederationCapability,
   FederationTarget,
   NavigationThreadSummary,
   ThreadIdentifier,
@@ -17,6 +18,14 @@ export function federationTargetsEqual(
     return !right || right.scope === "local";
   }
   return right?.scope === "remote" && right.instanceId === left.instanceId;
+}
+
+export function threadSupportsFederationCapability(
+  thread: NavigationThreadSummary,
+  capability: FederationCapability,
+): boolean {
+  return !thread.federation
+    || thread.federation.capabilities?.includes(capability) === true;
 }
 
 export function threadSummaryIdentityKey(thread: NavigationThreadSummary): string {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -5796,8 +5796,9 @@ export function useThreadNavigation(
     const picked = await pickDirectoryForReference();
     if (picked) {
       updateBrowseMode("directories");
+      await refresh();
     }
-  }, [pickDirectoryForReference, updateBrowseMode]);
+  }, [pickDirectoryForReference, refresh, updateBrowseMode]);
 
   const pickAndAttachDirectoryToSelectedThread = useCallback(async (): Promise<void> => {
     if (rendererFederationTarget) {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -61,6 +61,7 @@ import {
   agentEventMatchesThread,
   agentEventThreadIdentityKey,
   federationTargetsEqual,
+  threadSupportsFederationCapability,
   threadSummaryIdentityKey,
 } from "./federated-thread-events";
 import {
@@ -1192,6 +1193,7 @@ function updateThreadParentInSnapshot(
   snapshot: NavigationSnapshot | undefined,
   params: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
     parentThreadId?: string;
     parentThreadBackend?: AppServerBackendKind;
@@ -1205,6 +1207,14 @@ function updateThreadParentInSnapshot(
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
     if (thread.source !== params.backend || thread.id !== params.threadId) {
+      return thread;
+    }
+    if (
+      !federationTargetsEqual(
+        thread.federation?.ref.target,
+        params.federationTarget,
+      )
+    ) {
       return thread;
     }
     if (
@@ -1310,6 +1320,7 @@ function updateSubthreadOrderInSnapshot(
   snapshot: NavigationSnapshot | undefined,
   params: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     parentThreadId: string;
     threadIds: string[];
   },
@@ -1321,6 +1332,14 @@ function updateSubthreadOrderInSnapshot(
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
     if (thread.source !== params.backend || thread.id !== params.parentThreadId) {
+      return thread;
+    }
+    if (
+      !federationTargetsEqual(
+        thread.federation?.ref.target,
+        params.federationTarget,
+      )
+    ) {
       return thread;
     }
     if (JSON.stringify(thread.subthreadOrder ?? []) === JSON.stringify(params.threadIds)) {
@@ -1337,6 +1356,7 @@ function updateSubthreadsCollapsedInSnapshot(
   snapshot: NavigationSnapshot | undefined,
   params: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     parentThreadId: string;
     collapsed: boolean;
   },
@@ -1348,6 +1368,14 @@ function updateSubthreadsCollapsedInSnapshot(
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
     if (thread.source !== params.backend || thread.id !== params.parentThreadId) {
+      return thread;
+    }
+    if (
+      !federationTargetsEqual(
+        thread.federation?.ref.target,
+        params.federationTarget,
+      )
+    ) {
       return thread;
     }
     if (thread.subthreadsCollapsed === params.collapsed) {
@@ -3676,7 +3704,11 @@ export function useThreadNavigation(
           || method === "thread/status/changed"
           || method === "turn/cancelled"
           || method === "turn/completed"
-          || method === "turn/failed");
+          || method === "turn/failed"
+          || method === "thread/parent/set"
+          || method === "thread/parent/cleared"
+          || method === "thread/subthreadOrder/updated"
+          || method === "thread/subthreadsCollapsed/updated");
       if (
         !remoteThreadStatePassthrough
         && !federationTargetsEqual(event.federationTarget, windowTarget)
@@ -4318,6 +4350,7 @@ export function useThreadNavigation(
           ...current,
           response: updateThreadParentInSnapshot(current.response, {
             backend: event.backend,
+            federationTarget: event.federationTarget,
             threadId,
             parentThreadId,
             parentThreadBackend,
@@ -4336,6 +4369,7 @@ export function useThreadNavigation(
           ...current,
           response: updateThreadParentInSnapshot(current.response, {
             backend: event.backend,
+            federationTarget: event.federationTarget,
             threadId,
             parentThreadId: undefined,
             parentThreadBackend: undefined,
@@ -4354,6 +4388,7 @@ export function useThreadNavigation(
           ...current,
           response: updateSubthreadOrderInSnapshot(current.response, {
             backend: event.backend,
+            federationTarget: event.federationTarget,
             parentThreadId,
             threadIds,
           }),
@@ -4370,6 +4405,7 @@ export function useThreadNavigation(
           ...current,
           response: updateSubthreadsCollapsedInSnapshot(current.response, {
             backend: event.backend,
+            federationTarget: event.federationTarget,
             parentThreadId,
             collapsed,
           }),
@@ -5125,6 +5161,15 @@ export function useThreadNavigation(
       );
       const rootKey = buildThreadIdentityKey(parentBackend, rootThreadId);
       const root = threadByKey.get(rootKey);
+      if (
+        federationTarget
+        && (
+          !root
+          || !threadSupportsFederationCapability(root, "thread_grouping")
+        )
+      ) {
+        return;
+      }
       const currentChildIds = sortSubthreadSummaries(
         root ?? { subthreadOrder: undefined },
         snapshot.threads.filter(
@@ -5141,6 +5186,7 @@ export function useThreadNavigation(
         ...current,
         response: updateSubthreadOrderInSnapshot(current.response, {
           backend: parentBackend,
+          federationTarget,
           parentThreadId: rootThreadId,
           threadIds: nextOrder,
         }),
@@ -5161,6 +5207,7 @@ export function useThreadNavigation(
             ...current,
             response: updateSubthreadOrderInSnapshot(current.response, {
               backend: result.backend,
+              federationTarget,
               parentThreadId: result.parentThreadId,
               threadIds: result.threadIds,
             }),
@@ -5175,6 +5222,7 @@ export function useThreadNavigation(
           ...current,
           response: updateSubthreadsCollapsedInSnapshot(current.response, {
             backend: parentBackend,
+            federationTarget,
             parentThreadId: rootThreadId,
             collapsed: false,
           }),
@@ -6931,11 +6979,14 @@ export function useThreadNavigation(
       if (!setThreadParentRequest) {
         return;
       }
+      const federationTarget = thread.federation?.ref.target
+        ?? readRendererFederationTarget();
 
       setState((current) => ({
         ...current,
         response: updateThreadParentInSnapshot(current.response, {
           backend: thread.source,
+          federationTarget,
           threadId: thread.id,
           parentThreadId,
           parentThreadBackend,
@@ -6945,8 +6996,7 @@ export function useThreadNavigation(
       try {
         const result = await setThreadParentRequest({
           backend: thread.source,
-          federationTarget: thread.federation?.ref.target ??
-            readRendererFederationTarget(),
+          federationTarget,
           threadId: thread.id,
           parentThreadId,
           parentThreadBackend,
@@ -6955,6 +7005,7 @@ export function useThreadNavigation(
           ...current,
           response: updateThreadParentInSnapshot(current.response, {
             backend: result.backend,
+            federationTarget,
             threadId: result.threadId,
             parentThreadId: result.parentThreadId,
             parentThreadBackend: result.parentThreadBackend,
@@ -7033,6 +7084,8 @@ export function useThreadNavigation(
           threadsToUnlink.reduce(
             (response, thread) => updateThreadParentInSnapshot(response, {
               backend: thread.source,
+              federationTarget: thread.federation?.ref.target
+                ?? readRendererFederationTarget(),
               threadId: thread.id,
               parentThreadId: undefined,
             }),
@@ -7109,14 +7162,20 @@ export function useThreadNavigation(
       parent: NavigationThreadSummary,
       threadIds: string[],
     ): Promise<void> => {
-      if (!updateSubthreadOrderRequest) {
+      if (
+        !updateSubthreadOrderRequest
+        || !threadSupportsFederationCapability(parent, "thread_grouping")
+      ) {
         return;
       }
+      const federationTarget = parent.federation?.ref.target
+        ?? readRendererFederationTarget();
 
       setState((current) => ({
         ...current,
         response: updateSubthreadOrderInSnapshot(current.response, {
           backend: parent.source,
+          federationTarget,
           parentThreadId: parent.id,
           threadIds,
         }),
@@ -7125,8 +7184,7 @@ export function useThreadNavigation(
       try {
         const result = await updateSubthreadOrderRequest({
           backend: parent.source,
-          federationTarget: parent.federation?.ref.target ??
-            readRendererFederationTarget(),
+          federationTarget,
           parentThreadId: parent.id,
           threadIds,
         });
@@ -7134,6 +7192,7 @@ export function useThreadNavigation(
           ...current,
           response: updateSubthreadOrderInSnapshot(current.response, {
             backend: result.backend,
+            federationTarget,
             parentThreadId: result.parentThreadId,
             threadIds: result.threadIds,
           }),
@@ -7150,14 +7209,20 @@ export function useThreadNavigation(
       parent: NavigationThreadSummary,
       collapsed: boolean,
     ): Promise<void> => {
-      if (!setSubthreadsCollapsedRequest) {
+      if (
+        !setSubthreadsCollapsedRequest
+        || !threadSupportsFederationCapability(parent, "thread_grouping")
+      ) {
         return;
       }
+      const federationTarget = parent.federation?.ref.target
+        ?? readRendererFederationTarget();
 
       setState((current) => ({
         ...current,
         response: updateSubthreadsCollapsedInSnapshot(current.response, {
           backend: parent.source,
+          federationTarget,
           parentThreadId: parent.id,
           collapsed,
         }),
@@ -7166,8 +7231,7 @@ export function useThreadNavigation(
       try {
         const result = await setSubthreadsCollapsedRequest({
           backend: parent.source,
-          federationTarget: parent.federation?.ref.target ??
-            readRendererFederationTarget(),
+          federationTarget,
           parentThreadId: parent.id,
           collapsed,
         });
@@ -7175,6 +7239,7 @@ export function useThreadNavigation(
           ...current,
           response: updateSubthreadsCollapsedInSnapshot(current.response, {
             backend: result.backend,
+            federationTarget,
             parentThreadId: result.parentThreadId,
             collapsed: result.collapsed,
           }),

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2889,6 +2889,7 @@ export function useThreadNavigation(
   const markThreadSeen = desktopApi?.markThreadSeen;
   const forkThreadRequest = desktopApi?.forkThread;
   const archiveThreadRequest = desktopApi?.archiveThread;
+  const removeRemoteThreadPinRequest = desktopApi?.removeRemoteThreadPin;
   const archiveWorktreeRequest = desktopApi?.archiveWorktree;
   const restoreWorktreeRequest = desktopApi?.restoreWorktree;
   const handoffThreadWorkspaceRequest = desktopApi?.handoffThreadWorkspace;
@@ -6555,6 +6556,14 @@ export function useThreadNavigation(
           if (cleanupNotice) {
             setArchiveThreadNotice(cleanupNotice);
           }
+          if (target.federation?.ref && removeRemoteThreadPinRequest) {
+            // Archiving succeeds on the owner, but viewer-owned remote pins
+            // are deliberately local state. Remove that cached mount too or
+            // the next refresh resurrects the archived row from its snapshot.
+            await removeRemoteThreadPinRequest({
+              ref: target.federation.ref,
+            });
+          }
         }
         await refresh();
       } catch (error) {
@@ -6565,7 +6574,14 @@ export function useThreadNavigation(
         await refresh(threadKey, undefined, true);
       }
     },
-    [archiveThreadRequest, optimisticThread, refresh, state.response, threads]
+    [
+      archiveThreadRequest,
+      optimisticThread,
+      refresh,
+      removeRemoteThreadPinRequest,
+      state.response,
+      threads,
+    ]
   );
 
   const archiveWorktree = useCallback(

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -5215,11 +5215,13 @@ export function useThreadNavigation(
         && isRemoteFederationTarget(groupRoot.federation.ref.target)
         ? groupRoot.federation.ref.target.instanceId
         : parent.parentThreadInstanceId;
-      const parentThreadInstanceId =
-        federationTarget
+      const childOwnerInstanceId = federationTarget
         && isRemoteFederationTarget(federationTarget)
-        && groupRootInstanceId
-        && groupRootInstanceId !== federationTarget.instanceId
+        ? federationTarget.instanceId
+        : undefined;
+      const parentThreadInstanceId =
+        groupRootInstanceId
+        && groupRootInstanceId !== childOwnerInstanceId
           ? groupRootInstanceId
           : undefined;
       setCreatingThread({
@@ -5364,11 +5366,13 @@ export function useThreadNavigation(
         && isRemoteFederationTarget(groupRoot.federation.ref.target)
         ? groupRoot.federation.ref.target.instanceId
         : parent.parentThreadInstanceId;
-      const parentThreadInstanceId =
-        federationTarget
+      const childOwnerInstanceId = federationTarget
         && isRemoteFederationTarget(federationTarget)
-        && groupRootInstanceId
-        && groupRootInstanceId !== federationTarget.instanceId
+        ? federationTarget.instanceId
+        : undefined;
+      const parentThreadInstanceId =
+        groupRootInstanceId
+        && groupRootInstanceId !== childOwnerInstanceId
           ? groupRootInstanceId
           : undefined;
       const executionMode = parent.executionMode ?? "default";
@@ -7025,6 +7029,24 @@ export function useThreadNavigation(
       const successfullyUnlinkedPinnedKeys = new Set<string>();
       for (const thread of threadsToUnlink) {
         try {
+          if (
+            thread.federation?.derivedFromMountedParent
+            && !readRendererFederationTarget()
+          ) {
+            if (!desktopApi?.addRemoteThreadPin) {
+              throw new Error(
+                "Desktop bridge cannot preserve this derived remote child.",
+              );
+            }
+            // Derived children ride along with a mounted parent and have no
+            // viewer-side pin row of their own. Persist one before clearing the
+            // owner relationship or the next refresh would drop the child.
+            await desktopApi.addRemoteThreadPin({
+              ref: thread.federation.ref,
+              instanceLabel: thread.federation.instanceLabel,
+              summary: thread,
+            });
+          }
           await setThreadParentRequest({
             backend: thread.source,
             federationTarget: thread.federation?.ref.target ??
@@ -7063,7 +7085,7 @@ export function useThreadNavigation(
       }
       await refresh();
     },
-    [refresh, reorderThreadPinsRequest, setThreadParentRequest],
+    [desktopApi, refresh, reorderThreadPinsRequest, setThreadParentRequest],
   );
 
   const updateSubthreadOrder = useCallback(

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -33,6 +33,7 @@ import {
   buildPinnedRanks,
   buildPullRequestStatusKey,
   buildThreadIdentityKey,
+  comparePinnedThreads,
   compareThreadsByCreatedAtDesc,
   DEFAULT_NAVIGATION_BROWSE_MODE,
   federatedThreadIdentityKey,
@@ -2306,7 +2307,10 @@ function mergeLaunchpadUpdateResponse(
   preserveSetting("fastMode");
   preserveSetting("workMode");
   preserveSetting("branchName");
+  preserveSetting("federationTarget");
   preserveSetting("parentThreadId");
+  preserveSetting("parentThreadBackend");
+  preserveSetting("parentThreadInstanceId");
   preserveSetting("parentThreadTitle");
   preserveEnvironment("codexEnvironmentId");
   preserveEnvironment("codexEnvironmentExecutionTarget");
@@ -2482,6 +2486,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
   optimisticActiveTurn?: NavigationThreadSummary["optimisticActiveTurn"];
   parentThreadId?: string;
   parentThreadBackend?: AppServerBackendKind;
+  parentThreadInstanceId?: string;
   pinnedRank?: string;
   scheduledStart?: NavigationThreadSummary["scheduledStart"];
   federation?: NavigationThreadSummary["federation"];
@@ -2521,6 +2526,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
       : {}),
     parentThreadId: params.parentThreadId,
     parentThreadBackend: params.parentThreadBackend,
+    parentThreadInstanceId: params.parentThreadInstanceId,
     pinnedRank: params.pinnedRank,
     federation: params.federation,
     acpRuntime: params.launchpad.acpRuntime,
@@ -2858,6 +2864,7 @@ export function useThreadNavigation(
     thread: NavigationThreadSummary,
     parentThreadId?: string,
   ) => Promise<void>;
+  unlinkThreads: (threads: NavigationThreadSummary[]) => Promise<void>;
   updateSubthreadOrder: (
     parent: NavigationThreadSummary,
     threadIds: string[],
@@ -5103,6 +5110,7 @@ export function useThreadNavigation(
       rootThreadId: string,
       sourceThreadId: string,
       newThreadId: string,
+      federationTarget?: FederationTarget,
     ): Promise<void> => {
       const snapshot = stateRef.current.response;
       if (!snapshot) {
@@ -5144,6 +5152,7 @@ export function useThreadNavigation(
         try {
           const result = await persistOrder({
             backend: parentBackend,
+            federationTarget,
             parentThreadId: rootThreadId,
             threadIds: nextOrder,
           });
@@ -5171,6 +5180,7 @@ export function useThreadNavigation(
         }));
         void desktopApi?.setSubthreadsCollapsed?.({
           backend: parentBackend,
+          federationTarget,
           parentThreadId: rootThreadId,
           collapsed: false,
         }).catch(() => {});
@@ -5199,6 +5209,19 @@ export function useThreadNavigation(
       // thread to the group root and remember the source for in-place insertion.
       const directoryKey = buildSubthreadLaunchpadKey(parent, mode);
       const groupRoot = resolveGroupRoot(parent);
+      const federationTarget =
+        parent.federation?.ref.target ?? rendererFederationTarget;
+      const groupRootInstanceId = groupRoot.federation?.ref.target
+        && isRemoteFederationTarget(groupRoot.federation.ref.target)
+        ? groupRoot.federation.ref.target.instanceId
+        : parent.parentThreadInstanceId;
+      const parentThreadInstanceId =
+        federationTarget
+        && isRemoteFederationTarget(federationTarget)
+        && groupRootInstanceId
+        && groupRootInstanceId !== federationTarget.instanceId
+          ? groupRootInstanceId
+          : undefined;
       setCreatingThread({
         backend: parent.source,
         executionMode: parent.executionMode ?? "default",
@@ -5210,8 +5233,7 @@ export function useThreadNavigation(
 
       try {
         const response = await desktopApi.ensureDirectoryLaunchpad({
-          federationTarget:
-            parent.federation?.ref.target ?? rendererFederationTarget,
+          federationTarget,
           directoryKey,
           directoryKind: directory.directoryKind,
           directoryLabel: directory.directoryLabel,
@@ -5229,13 +5251,16 @@ export function useThreadNavigation(
           currentBranch: directory.branchName,
           parentThreadId: groupRoot.id,
           parentThreadBackend: groupRoot.source,
+          ...(parentThreadInstanceId ? { parentThreadInstanceId } : {}),
           parentThreadTitle: groupRoot.title,
           preferredBackend: parent.source,
         });
         let launchpad: NavigationLaunchpadDraft = {
           ...response.launchpad,
+          federationTarget,
           parentThreadId: groupRoot.id,
           parentThreadBackend: groupRoot.source,
+          parentThreadInstanceId,
           parentThreadTitle: groupRoot.title,
           sourceThreadId: parent.id,
         };
@@ -5246,9 +5271,11 @@ export function useThreadNavigation(
           workMode: directory.workMode,
           directoryLabel: directory.directoryLabel,
           directoryPath: launchpadDirectoryPath,
+          federationTarget,
           ...(directory.branchName ? { branchName: directory.branchName } : {}),
           parentThreadId: groupRoot.id,
           parentThreadBackend: groupRoot.source,
+          parentThreadInstanceId,
           parentThreadTitle: groupRoot.title,
         };
         if (desktopApi.updateDirectoryLaunchpad) {
@@ -5263,6 +5290,7 @@ export function useThreadNavigation(
             ),
             parentThreadId: groupRoot.id,
             parentThreadBackend: groupRoot.source,
+            parentThreadInstanceId,
             parentThreadTitle: groupRoot.title,
             sourceThreadId: parent.id,
           };
@@ -5279,6 +5307,7 @@ export function useThreadNavigation(
             ),
             parentThreadId: groupRoot.id,
             parentThreadBackend: groupRoot.source,
+            parentThreadInstanceId,
             parentThreadTitle: groupRoot.title,
             sourceThreadId: parent.id,
           };
@@ -5329,6 +5358,19 @@ export function useThreadNavigation(
 
       const directory = selectThreadWorkspace(parent, mode);
       const groupRoot = resolveGroupRoot(parent);
+      const federationTarget = parent.federation?.ref.target ??
+        readRendererFederationTarget();
+      const groupRootInstanceId = groupRoot.federation?.ref.target
+        && isRemoteFederationTarget(groupRoot.federation.ref.target)
+        ? groupRoot.federation.ref.target.instanceId
+        : parent.parentThreadInstanceId;
+      const parentThreadInstanceId =
+        federationTarget
+        && isRemoteFederationTarget(federationTarget)
+        && groupRootInstanceId
+        && groupRootInstanceId !== federationTarget.instanceId
+          ? groupRootInstanceId
+          : undefined;
       const executionMode = parent.executionMode ?? "default";
       const pendingForkEnvironmentSetup = buildPendingForkEnvironmentSetup({
         directoryLabel: directory.directoryLabel,
@@ -5350,11 +5392,11 @@ export function useThreadNavigation(
       try {
         const response = await forkThreadRequest({
           backend: parent.source,
-          federationTarget: parent.federation?.ref.target ??
-            readRendererFederationTarget(),
+          federationTarget,
           sourceThreadId: parent.id,
           parentThreadId: groupRoot.id,
           parentThreadBackend: groupRoot.source,
+          ...(parentThreadInstanceId ? { parentThreadInstanceId } : {}),
           executionMode,
           directoryKind: directory.directoryKind,
           directoryLabel: directory.directoryLabel,
@@ -5407,6 +5449,19 @@ export function useThreadNavigation(
           linkedDirectories,
           parentThreadId: groupRoot.id,
           parentThreadBackend: groupRoot.source,
+          parentThreadInstanceId,
+          federation: federationTarget
+            && isRemoteFederationTarget(federationTarget)
+            ? {
+                ref: {
+                  backend: response.backend,
+                  target: federationTarget,
+                  threadId: response.threadId,
+                },
+                instanceLabel:
+                  parent.federation?.instanceLabel ?? federationTarget.instanceId,
+              }
+            : undefined,
         };
         const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
         // Drop the fork directly below the card it was spawned from, and let
@@ -5416,7 +5471,30 @@ export function useThreadNavigation(
           groupRoot.id,
           parent.id,
           response.threadId,
+          groupRoot.federation?.ref.target,
         );
+        if (
+          federationTarget
+          && isRemoteFederationTarget(federationTarget)
+          && !readRendererFederationTarget()
+        ) {
+          try {
+            await desktopApi?.addRemoteThreadPin?.({
+              ref: {
+                backend: response.backend,
+                target: federationTarget,
+                threadId: response.threadId,
+              },
+              summary: optimisticFork,
+              instanceLabel:
+                parent.federation?.instanceLabel ?? federationTarget.instanceId,
+            });
+          } catch (error) {
+            // The owner already created the fork. A viewer-side pin failure
+            // must not report the whole fork as failed and invite a duplicate.
+            console.warn("Could not add the remote fork to this thread list:", error);
+          }
+        }
         setOptimisticThread(optimisticFork);
         setSelectedItemKey(nextThreadKey);
         setPendingSeenThreadKey(nextThreadKey);
@@ -5427,7 +5505,13 @@ export function useThreadNavigation(
         setCreatingThread(undefined);
       }
     },
-    [forkThreadRequest, insertSubthreadBelowSource, refresh, resolveGroupRoot],
+    [
+      desktopApi,
+      forkThreadRequest,
+      insertSubthreadBelowSource,
+      refresh,
+      resolveGroupRoot,
+    ],
   );
 
   const openDirectoryLaunchpad = useCallback(
@@ -6073,7 +6157,10 @@ export function useThreadNavigation(
         getParentThreadIdFromSubthreadLaunchpadKey(directoryKey);
       const materializeParentThreadBackend =
         launchpad.parentThreadBackend ?? launchpad.backend;
-      const federationTarget = readRendererFederationTarget();
+      const materializeParentThreadInstanceId =
+        launchpad.parentThreadInstanceId;
+      const federationTarget =
+        launchpad.federationTarget ?? readRendererFederationTarget();
       let response: Awaited<ReturnType<NonNullable<DesktopApi["materializeDirectoryLaunchpad"]>>>;
       try {
         response = await desktopApi.materializeDirectoryLaunchpad({
@@ -6088,6 +6175,9 @@ export function useThreadNavigation(
             ? {
                 parentThreadId: materializeParentThreadId,
                 parentThreadBackend: materializeParentThreadBackend,
+                ...(materializeParentThreadInstanceId
+                  ? { parentThreadInstanceId: materializeParentThreadInstanceId }
+                  : {}),
               }
             : {}),
         });
@@ -6115,6 +6205,7 @@ export function useThreadNavigation(
         backend: response.backend,
         threadId: response.threadId,
         federation: federationTarget
+          && isRemoteFederationTarget(federationTarget)
           ? {
               ref: {
                 backend: response.backend,
@@ -6150,6 +6241,9 @@ export function useThreadNavigation(
         parentThreadBackend: materializeParentThreadId
           ? materializeParentThreadBackend
           : undefined,
+        parentThreadInstanceId: materializeParentThreadId
+          ? materializeParentThreadInstanceId
+          : undefined,
         pinnedRank: response.pinnedRank,
         scheduledStart: response.scheduledAction
           ? {
@@ -6175,16 +6269,53 @@ export function useThreadNavigation(
             titleSource: "explicit" as const,
           }
         : optimisticMaterializedThread;
+      if (
+        federationTarget
+        && isRemoteFederationTarget(federationTarget)
+        && !readRendererFederationTarget()
+      ) {
+        try {
+          await desktopApi.addRemoteThreadPin?.({
+            ref: {
+              backend: response.backend,
+              target: federationTarget,
+              threadId: response.threadId,
+            },
+            summary: namedOptimisticMaterializedThread,
+            instanceLabel:
+              namedOptimisticMaterializedThread.federation?.instanceLabel
+              ?? federationTarget.instanceId,
+          });
+        } catch (error) {
+          // Materialization already succeeded on the owner. Keep the created
+          // thread selected even if this viewer cannot persist its list entry.
+          console.warn("Could not add the remote thread to this thread list:", error);
+        }
+      }
       const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
       // Sub-thread launchpads drop the new child directly below their source
       // card. Plain new-thread launchpads have no parent and skip this. Await
       // so the order write commits before the refresh below reads it back.
       if (materializeParentThreadId) {
+        const groupRoot = stateRef.current.response?.threads.find(
+          (thread) =>
+            thread.source === materializeParentThreadBackend
+            && thread.id === materializeParentThreadId,
+        );
+        const subthreadOrderTarget = groupRoot
+          ? groupRoot.federation?.ref.target
+          : materializeParentThreadInstanceId
+            ? {
+                scope: "remote" as const,
+                instanceId: materializeParentThreadInstanceId,
+              }
+            : federationTarget;
         await insertSubthreadBelowSource(
           materializeParentThreadBackend,
           materializeParentThreadId,
           launchpad.sourceThreadId ?? materializeParentThreadId,
           response.threadId,
+          subthreadOrderTarget,
         );
       }
       setLocalLaunchpads((current) => {
@@ -6794,6 +6925,8 @@ export function useThreadNavigation(
       try {
         const result = await setThreadParentRequest({
           backend: thread.source,
+          federationTarget: thread.federation?.ref.target ??
+            readRendererFederationTarget(),
           threadId: thread.id,
           parentThreadId,
           parentThreadBackend,
@@ -6805,6 +6938,7 @@ export function useThreadNavigation(
             threadId: result.threadId,
             parentThreadId: result.parentThreadId,
             parentThreadBackend: result.parentThreadBackend,
+            parentThreadInstanceId: result.parentThreadInstanceId,
           }),
         }));
       } catch {
@@ -6812,6 +6946,124 @@ export function useThreadNavigation(
       }
     },
     [refresh, setThreadParentRequest],
+  );
+
+  const unlinkThreads = useCallback(
+    async (threadsToUnlink: NavigationThreadSummary[]): Promise<void> => {
+      if (!setThreadParentRequest || threadsToUnlink.length === 0) {
+        return;
+      }
+      const snapshot = stateRef.current.response;
+      if (!snapshot) {
+        return;
+      }
+      const threadByKey = new Map(
+        snapshot.threads.map((thread) => [
+          buildThreadIdentityKey(thread.source, thread.id),
+          thread,
+        ]),
+      );
+      const childKeysByPinnedParent = new Map<string, string[]>();
+      for (const thread of threadsToUnlink) {
+        const parentKey = resolveThreadParentKey(thread, threadByKey);
+        const parent = parentKey ? threadByKey.get(parentKey) : undefined;
+        if (!parentKey || !parent?.pinnedRank) {
+          continue;
+        }
+        const childKeys = childKeysByPinnedParent.get(parentKey) ?? [];
+        childKeys.push(buildThreadIdentityKey(thread.source, thread.id));
+        childKeysByPinnedParent.set(parentKey, childKeys);
+      }
+      for (const [parentKey, childKeys] of childKeysByPinnedParent) {
+        const parent = threadByKey.get(parentKey);
+        const selectedChildren = childKeys
+          .map((threadKey) => threadByKey.get(threadKey))
+          .filter(
+            (thread): thread is NavigationThreadSummary => Boolean(thread),
+          );
+        if (parent) {
+          childKeysByPinnedParent.set(
+            parentKey,
+            sortSubthreadSummaries(parent, selectedChildren).map((thread) =>
+              buildThreadIdentityKey(thread.source, thread.id)
+            ),
+          );
+        }
+      }
+      const selectedKeys = new Set(
+        threadsToUnlink.map((thread) =>
+          buildThreadIdentityKey(thread.source, thread.id)
+        ),
+      );
+      const currentPinnedKeys = snapshot.threads
+        .filter((thread) => thread.pinnedRank && !selectedKeys.has(
+          buildThreadIdentityKey(thread.source, thread.id),
+        ))
+        .sort(comparePinnedThreads)
+        .map((thread) => buildThreadIdentityKey(thread.source, thread.id));
+      const nextPinnedKeys = currentPinnedKeys.flatMap((threadKey) => [
+        ...(childKeysByPinnedParent.get(threadKey) ?? []),
+        threadKey,
+      ]);
+      const pinnedRanksByThreadKey = buildPinnedRanks(nextPinnedKeys);
+
+      setState((current) => ({
+        ...current,
+        response: updateThreadPinsInSnapshot(
+          threadsToUnlink.reduce(
+            (response, thread) => updateThreadParentInSnapshot(response, {
+              backend: thread.source,
+              threadId: thread.id,
+              parentThreadId: undefined,
+            }),
+            current.response,
+          ),
+          { pinnedRanksByThreadKey },
+        ),
+      }));
+
+      const successfullyUnlinkedPinnedKeys = new Set<string>();
+      for (const thread of threadsToUnlink) {
+        try {
+          await setThreadParentRequest({
+            backend: thread.source,
+            federationTarget: thread.federation?.ref.target ??
+              readRendererFederationTarget(),
+            threadId: thread.id,
+          });
+          const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+          const parentKey = resolveThreadParentKey(thread, threadByKey);
+          if (parentKey && childKeysByPinnedParent.has(parentKey)) {
+            successfullyUnlinkedPinnedKeys.add(threadKey);
+          }
+        } catch (error) {
+          console.warn(`Could not unlink thread ${thread.id}:`, error);
+        }
+      }
+      const nextSuccessfulPinnedKeys = currentPinnedKeys.flatMap(
+        (threadKey) => [
+          ...(childKeysByPinnedParent.get(threadKey) ?? []).filter(
+            (childKey) => successfullyUnlinkedPinnedKeys.has(childKey),
+          ),
+          threadKey,
+        ],
+      );
+      try {
+        if (
+          successfullyUnlinkedPinnedKeys.size > 0
+          && reorderThreadPinsRequest
+        ) {
+          await reorderThreadPinsRequest({
+            federationTarget: readRendererFederationTarget(),
+            threadKeys: nextSuccessfulPinnedKeys,
+          });
+        }
+      } catch (error) {
+        console.warn("Could not pin the unlinked threads above their parent:", error);
+      }
+      await refresh();
+    },
+    [refresh, reorderThreadPinsRequest, setThreadParentRequest],
   );
 
   const updateSubthreadOrder = useCallback(
@@ -6835,6 +7087,8 @@ export function useThreadNavigation(
       try {
         const result = await updateSubthreadOrderRequest({
           backend: parent.source,
+          federationTarget: parent.federation?.ref.target ??
+            readRendererFederationTarget(),
           parentThreadId: parent.id,
           threadIds,
         });
@@ -6874,6 +7128,8 @@ export function useThreadNavigation(
       try {
         const result = await setSubthreadsCollapsedRequest({
           backend: parent.source,
+          federationTarget: parent.federation?.ref.target ??
+            readRendererFederationTarget(),
           parentThreadId: parent.id,
           collapsed,
         });
@@ -7430,6 +7686,7 @@ export function useThreadNavigation(
     setThreadAgent,
     reorderThreadPins,
     setThreadParent,
+    unlinkThreads,
     updateSubthreadOrder,
     setSubthreadsCollapsed,
     setDirectoryPin,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5237,6 +5237,15 @@ textarea,
   outline-offset: -2px;
 }
 
+.directory-row__summary--unconfigured .directory-row__icon,
+.directory-row__summary--unconfigured .thread-row__title {
+  color: var(--text-muted);
+}
+
+.directory-row__summary--unconfigured .directory-row__icon {
+  opacity: 0.72;
+}
+
 .directory-row__summary-main,
 .directory-row__summary-meta,
 .directory-row__title-wrap {

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -785,6 +785,7 @@ export type EnsureDirectoryLaunchpadRequest = {
   currentBranch?: string;
   parentThreadId?: string;
   parentThreadBackend?: AppServerBackendKind;
+  parentThreadInstanceId?: FederationInstanceId;
   parentThreadTitle?: string;
   preferredBackend?: AppServerBackendKind;
   registeredAt?: number;
@@ -821,8 +822,10 @@ export type UpdateDirectoryLaunchpadRequest = {
       | "messagingToolUpdateMode"
       | "workMode"
       | "branchName"
+      | "federationTarget"
       | "parentThreadId"
       | "parentThreadBackend"
+      | "parentThreadInstanceId"
       | "parentThreadTitle"
       | "codexEnvironmentId"
       | "codexEnvironmentExecutionTarget"

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -14,6 +14,7 @@ export const FEDERATION_CAPABILITIES = [
   "remote_window",
   "thread_navigation",
   "navigation_snapshot_deltas",
+  "thread_grouping",
   "thread_detail",
   "turn_control",
   "scheduled_actions",

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -737,6 +737,8 @@ export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
   prAutoDispatchEnabled?: boolean;
   workMode: LaunchpadWorkMode;
   branchName?: string;
+  /** Instance that owns the thread this viewer-side launchpad will create. */
+  federationTarget?: FederationTarget;
   parentThreadId?: string;
   parentThreadBackend?: AppServerBackendKind;
   parentThreadInstanceId?: FederationInstanceId;
@@ -1481,6 +1483,7 @@ export type ReorderThreadPinsResponse = {
 };
 
 export type SetThreadParentRequest = {
+  federationTarget?: FederationTarget;
   backend?: AppServerBackendKind;
   threadId: ThreadIdentifier;
   parentThreadId?: ThreadIdentifier | null;
@@ -1497,6 +1500,7 @@ export type SetThreadParentResponse = {
 };
 
 export type UpdateSubthreadOrderRequest = {
+  federationTarget?: FederationTarget;
   backend?: AppServerBackendKind;
   parentThreadId: ThreadIdentifier;
   threadIds: ThreadIdentifier[];
@@ -1509,6 +1513,7 @@ export type UpdateSubthreadOrderResponse = {
 };
 
 export type SetSubthreadsCollapsedRequest = {
+  federationTarget?: FederationTarget;
   backend?: AppServerBackendKind;
   parentThreadId: ThreadIdentifier;
   collapsed: boolean;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -846,6 +846,14 @@ export type NavigationDirectorySummary = {
   kind: DirectorySummaryKind;
   label: string;
   path?: string;
+  /**
+   * The row was derived from a mounted remote thread, but this viewer has not
+   * registered a matching local checkout yet. The Directories lens keeps the
+   * thread discoverable under this placeholder while suppressing actions that
+   * require a local path. Registering the project replaces the placeholder on
+   * the next snapshot.
+   */
+  localAvailability?: "unconfigured";
   threadKeys: string[];
   needsAttentionCount: number;
   latestUpdatedAt?: number;


### PR DESCRIPTION
## Summary

- mount a cross-instance parent on the child-owning instance when a federated child is created, including the normal folded-directory visibility pin
- expose connected, capability-backed owner actions for main-window remote rows: sub-thread, fork, unlink, rename, mark unread, and archive
- route parent/order/collapse mutations to the owning peer and keep viewer-side mounted summaries coherent
- when unlinking one or more children from a pinned parent, pin them immediately above the parent while preserving their tray order

## Validation

- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- focused Vitest coverage: 6 files, 465 tests passed

## Notes

- remote mutation actions remain hidden while the owner is disconnected or does not advertise the required capability
- viewer-side pin/cache failures are best-effort after an owner has already committed a create or relationship mutation, avoiding duplicate retries
