### PR TITLE
feat(messaging): add Slack live working cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Messaging - Render Slack Working Updates as one live Thinking Steps task card per turn, with sequenced updates, terminal/waiting state handling, and text fallback when Slack streaming is unavailable.
+- Messaging - Add opt-in Slack Live Working Cards that render Working Updates as one rate-aware Thinking Steps task card per turn, with ordered/coalesced stream calls, terminal/waiting state handling, cancellation, and classic text fallback when native streaming is off or unavailable.
 
 ## v1.1.0-beta.1 - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Messaging - Add opt-in Slack Live Working Updates cards that render Working Updates as one rate-aware Thinking Steps task card per turn, with ordered/coalesced stream calls, terminal/waiting state handling, cancellation, classic text fallback when native streaming is off or unavailable, and profile-wide plus per-route Working Updates controls for Default Agent routes. Cards show the tool that is currently running as an in-progress step, without adding any text-surface traffic.
+- Messaging - Add opt-in Slack Live Working Updates cards that render Working Updates as one rate-aware Thinking Steps task card per turn, with ordered/coalesced stream calls, terminal/waiting state handling, cancellation, classic text fallback when native streaming is off or unavailable, and profile-wide plus per-route Working Updates controls for Default Agent routes.
 
 ## v1.1.0-beta.1 - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Messaging - Add opt-in Slack Live Working Cards that render Working Updates as one rate-aware Thinking Steps task card per turn, with ordered/coalesced stream calls, terminal/waiting state handling, cancellation, and classic text fallback when native streaming is off or unavailable.
+- Messaging - Add opt-in Slack Live Working Cards that render Working Updates as one rate-aware Thinking Steps task card per turn, with ordered/coalesced stream calls, terminal/waiting state handling, cancellation, classic text fallback when native streaming is off or unavailable, and profile-wide plus per-route Working Updates controls for Default Agent routes.
 
 ## v1.1.0-beta.1 - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Messaging - Add opt-in Slack Live Working Cards that render Working Updates as one rate-aware Thinking Steps task card per turn, with ordered/coalesced stream calls, terminal/waiting state handling, cancellation, classic text fallback when native streaming is off or unavailable, and profile-wide plus per-route Working Updates controls for Default Agent routes.
+- Messaging - Add opt-in Slack Live Working Updates cards that render Working Updates as one rate-aware Thinking Steps task card per turn, with ordered/coalesced stream calls, terminal/waiting state handling, cancellation, classic text fallback when native streaming is off or unavailable, and profile-wide plus per-route Working Updates controls for Default Agent routes.
 
 ## v1.1.0-beta.1 - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Messaging - Render Slack Working Updates as one live Thinking Steps task card per turn, with sequenced updates, terminal/waiting state handling, and text fallback when Slack streaming is unavailable.
+
 ## v1.1.0-beta.1 - 2026-08-09
 
 - Federation and Star Map - Added secure remote-instance federation, live remote thread and terminal access, and the Star Map mission-control surface with project lenses, filters, arrangement controls, load visibility, and drag, snap, and multi-select interactions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Messaging - Add opt-in Slack Live Working Updates cards that render Working Updates as one rate-aware Thinking Steps task card per turn, with ordered/coalesced stream calls, terminal/waiting state handling, cancellation, classic text fallback when native streaming is off or unavailable, and profile-wide plus per-route Working Updates controls for Default Agent routes.
+- Messaging - Add opt-in Slack Live Working Updates cards that render Working Updates as one rate-aware Thinking Steps task card per turn, with ordered/coalesced stream calls, terminal/waiting state handling, cancellation, classic text fallback when native streaming is off or unavailable, and profile-wide plus per-route Working Updates controls for Default Agent routes. Cards show the tool that is currently running as an in-progress step, without adding any text-surface traffic.
 
 ## v1.1.0-beta.1 - 2026-08-09
 

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1145,6 +1145,36 @@ describe("DesktopSettingsService", () => {
     ]);
   });
 
+  it("defaults Slack Live Working Cards off without persisting the default", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const snapshot = await service.readSettings();
+    expect(snapshot.messaging.slack.liveWorkingCards).toEqual({
+      value: false,
+      source: "default",
+    });
+
+    await service.writeConfigPatch({
+      messaging: { slack: { workspaceUrl: "https://example.slack.com" } },
+    });
+    expect(fs.readFileSync(configPath, "utf8")).not.toContain(
+      "live_working_cards",
+    );
+
+    await service.writeConfigPatch({
+      messaging: { slack: { liveWorkingCards: true } },
+    });
+    expect(fs.readFileSync(configPath, "utf8")).toContain(
+      "live_working_cards = true",
+    );
+  });
+
   it("migrates legacy authorized user arrays when the list is next saved", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -119,6 +119,7 @@ describe("desktop messaging config", () => {
       "enabled",
       "groupDmAccessMode",
       "inboundMode",
+      "liveWorkingCards",
       "registerSlashCommands",
       "responseMode",
       "signingSecret",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3200,7 +3200,10 @@ describe("MessagingController", () => {
       toolUpdateDefaultMode: "show_all",
       deliver: async (intent) => {
         delivered.push(intent);
-        if (intent.id.startsWith("tool-update")) {
+        if (
+          intent.id.startsWith("tool-update")
+          || intent.id.startsWith("working-card")
+        ) {
           resolveWorkingUpdateStarted();
           await workingUpdateRelease;
           return {
@@ -3261,7 +3264,10 @@ describe("MessagingController", () => {
     const recordDelivery = harness.store.recordDelivery.bind(harness.store);
     vi.spyOn(harness.store, "recordDelivery").mockImplementation(async (delivery) => {
       const recorded = await recordDelivery(delivery);
-      if (delivery.intentId?.startsWith("tool-update:")) {
+      if (
+        delivery.intentId?.startsWith("tool-update:")
+        || delivery.intentId?.startsWith("working-card:")
+      ) {
         resolveWorkingUpdateRecorded();
         await workingUpdateRecordRelease;
       }

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -51,6 +51,7 @@ import {
   MessagingController,
   messagingDeliveryPriority,
   shouldConsumeDeliveryBudget,
+  updateWorkingCardActivities,
   type MessagingControllerOptions,
 } from "../messaging/core/messaging-controller";
 import type { MessagingRbacPolicyProvider } from "../messaging/rbac-policy-service";
@@ -15084,6 +15085,55 @@ describe("MessagingController", () => {
       "user_command",
     );
     expect(messagingDeliveryPriority(finalAssistant)).toBe("final_turn");
+  });
+
+  it("reserves final-turn delivery priority for terminal working cards", () => {
+    const workingCard = {
+      id: "working-card-1",
+      kind: "working_card",
+      createdAt: 1_000,
+      card: {
+        displayHint: "plan",
+        isFinal: false,
+        key: "binding-1\0turn-1",
+        phase: "working",
+        sequence: 1,
+        tasks: [],
+      },
+    } satisfies MessagingSurfaceIntent;
+
+    expect(messagingDeliveryPriority(workingCard)).toBe("tool_progress");
+    expect(messagingDeliveryPriority({
+      ...workingCard,
+      id: "working-card-final-1",
+      card: {
+        ...workingCard.card,
+        isFinal: true,
+        phase: "completed",
+        sequence: 2,
+      },
+    })).toBe("final_turn");
+  });
+
+  it("bounds accumulated working-card tasks and collapses the oldest entries", () => {
+    const state = {
+      activities: new Map(),
+      omittedTaskCount: 0,
+      sequence: 0,
+    };
+    for (let index = 1; index <= 14; index += 1) {
+      updateWorkingCardActivities(state, [{
+        id: `tool-${index}`,
+        kind: "tool",
+        status: "completed",
+        title: `Ran tool ${index}`,
+      }]);
+    }
+
+    expect([...state.activities.keys()]).toEqual(
+      Array.from({ length: 12 }, (_, index) => `tool-${index + 3}`),
+    );
+    expect(state.omittedTaskCount).toBe(2);
   });
 
   it("treats user-initiated status renders as user command budget traffic", () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -51,7 +51,6 @@ import {
   MessagingController,
   messagingDeliveryPriority,
   rememberWorkingCardState,
-  settleStartedActivities,
   shouldConsumeDeliveryBudget,
   updateWorkingCardActivities,
   type MessagingControllerOptions,
@@ -15125,7 +15124,6 @@ describe("MessagingController", () => {
   it("bounds accumulated working-card tasks and collapses the oldest entries", () => {
     const state = {
       activities: new Map(),
-      displayHint: "plan" as const,
       omittedTaskCount: 0,
       sequence: 0,
     };
@@ -15144,47 +15142,10 @@ describe("MessagingController", () => {
     expect(state.omittedTaskCount).toBe(2);
   });
 
-  it("replaces a started activity in place when the tool completes", () => {
-    const state = {
-      activities: new Map(),
-      displayHint: "plan" as const,
-      omittedTaskCount: 0,
-      sequence: 0,
-    };
-    updateWorkingCardActivities(state, [
-      { id: "tool-1", kind: "tool", status: "started", title: "Ran tool" },
-      { id: "tool-2", kind: "tool", status: "started", title: "Other tool" },
-    ]);
-    updateWorkingCardActivities(state, [
-      { id: "tool-1", kind: "tool", status: "completed", title: "Ran tool" },
-    ]);
-
-    // Same key updates the row without moving it behind tool-2.
-    expect([...state.activities.keys()]).toEqual(["tool-1", "tool-2"]);
-    expect(state.activities.get("tool-1")?.status).toBe("completed");
-    expect(state.omittedTaskCount).toBe(0);
-  });
-
-  it("settles steps still running when the turn reaches a terminal phase", () => {
-    const activities = [
-      { id: "done", kind: "tool" as const, status: "completed" as const, title: "Done" },
-      { id: "running", kind: "tool" as const, status: "started" as const, title: "Running" },
-      { id: "broke", kind: "tool" as const, status: "failed" as const, title: "Broke" },
-    ];
-
-    expect(settleStartedActivities(activities, "completed").map((a) => a.status))
-      .toEqual(["completed", "completed", "failed"]);
-    // A failed turn cannot claim the in-flight step succeeded.
-    expect(settleStartedActivities(activities, "cancelled").map((a) => a.status))
-      .toEqual(["completed", "cancelled", "failed"]);
-    expect(activities[1]?.status).toBe("started");
-  });
-
   it("bounds per-turn working-card state when terminal events are missing", () => {
     const states = new Map();
     const state = () => ({
       activities: new Map(),
-      displayHint: "plan" as const,
       omittedTaskCount: 0,
       sequence: 0,
     });
@@ -16326,83 +16287,6 @@ describe("MessagingController", () => {
     expect(cards).toHaveLength(2);
     expect(cards[0]?.card).toMatchObject({ isFinal: false, phase: "working" });
     expect(cards[1]?.card).toMatchObject({ isFinal: true, phase: "completed" });
-  });
-
-  it("shows a running tool on an open Slack card without sending text", async () => {
-    const harness = await createHarness({
-      channel: "slack",
-      toolUpdateDefaultMode: "show_all",
-    });
-    await harness.store.upsertBinding({
-      id: "binding-slack-running",
-      authorizedActorIds: ["user-1"],
-      backend: "codex",
-      channel: {
-        channel: "slack",
-        conversation: {
-          id: "C012RUNNING",
-          kind: "thread",
-          parentId: "1700000000.000001",
-          workspaceId: "T012WORKSPACE",
-        },
-      },
-      createdAt: 1000,
-      routingState: {
-        opaque: {
-          channelId: "C012RUNNING",
-          threadTs: "1700000000.000001",
-        },
-      },
-      targetKind: "thread",
-      threadId: "thread-1",
-      updatedAt: 1000,
-    });
-
-    const toolEvent = (
-      method: "item/started" | "item/completed",
-      item: { id: string; type: string } & Record<string, unknown>,
-    ): AgentEvent => ({
-      backend: "codex",
-      notification: {
-        method,
-        params: { threadId: "thread-1", turnId: "turn-1", item },
-      },
-    } satisfies AgentEvent);
-
-    // A start with no card open yet must not create one — the dial owns that.
-    await harness.controller.handleBackendEvent(toolEvent("item/started", {
-      id: "tool-1",
-      type: "commandExecution",
-      command: "rg --files",
-    }));
-    expect(harness.delivered.filter((i) => i.kind === "working_card")).toEqual([]);
-
-    await harness.controller.handleBackendEvent(toolEvent("item/completed", {
-      id: "tool-1",
-      type: "commandExecution",
-      command: "rg --files",
-      durationMs: 900,
-    }));
-    harness.delivered.length = 0;
-
-    await harness.controller.handleBackendEvent(toolEvent("item/started", {
-      id: "tool-2",
-      type: "commandExecution",
-      command: "npm test",
-    }));
-
-    const cards = harness.delivered.filter(
-      (intent): intent is Extract<MessagingSurfaceIntent, { kind: "working_card" }> =>
-        intent.kind === "working_card",
-    );
-    expect(cards).toHaveLength(1);
-    expect(cards[0]?.card.tasks).toEqual([
-      expect.objectContaining({ id: "tool-1", status: "complete" }),
-      expect.objectContaining({ id: "tool-2", status: "in_progress" }),
-    ]);
-    // The start bypasses the dial entirely: no batched text, no fallback text.
-    expect(cards[0]?.fallbackText).toBe("");
-    expect(harness.delivered.filter((i) => i.kind === "message")).toEqual([]);
   });
 
   it("discards a coalesced monitor heartbeat when the monitor completes", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1692,7 +1692,7 @@ describe("MessagingController", () => {
     const harness = await createHarness({
       createManagedConversation,
       navigation,
-      toolUpdateDefaultMode: "show_all",
+      toolUpdateDefaultMode: "show_none",
     });
     const channel = buildTopicChannel("13056");
     const event = buildTextEvent("find the thread for 13056", {
@@ -1705,7 +1705,12 @@ describe("MessagingController", () => {
         },
       },
     });
-    await seedConversationDefaultAgent(harness.store, channel);
+    await seedConversationDefaultAgent(
+      harness.store,
+      channel,
+      "codex",
+      "show_all",
+    );
 
     await harness.controller.handleInboundEvent(event);
 
@@ -23276,6 +23281,7 @@ async function seedConversationDefaultAgent(
   store: MessagingStore,
   channel: MessagingInboundEvent["channel"],
   backend: AppServerBackendKind = "codex",
+  toolUpdateMode?: MessagingToolUpdateMode,
 ): Promise<void> {
   await store.upsertDefaultAgentAssignment({
     id: `default-agent:${channel.channel}:${channel.conversation.id}`,
@@ -23288,6 +23294,7 @@ async function seedConversationDefaultAgent(
       backend,
       threadId: "thread-1",
     },
+    ...(toolUpdateMode ? { toolUpdateMode } : {}),
     createdAt: 1000,
     updatedAt: 1000,
   });

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1807,6 +1807,69 @@ describe("MessagingController", () => {
     expect(JSON.stringify(harness.delivered)).toContain("find the thread");
   });
 
+  it("anchors Slack Agent Route working cards to the inbound channel message", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      agent: {
+        name: "Signals Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1500,
+      },
+    };
+    const harness = await createHarness({
+      channel: "slack",
+      navigation,
+      toolUpdateDefaultMode: "show_none",
+    });
+    const channel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012SIGNALS",
+        kind: "channel" as const,
+        title: "p-search-signals-project",
+        workspaceId: "T012WORKSPACE",
+      },
+    };
+    const routingState = {
+      opaque: {
+        channelId: "C012SIGNALS",
+        teamId: "T012WORKSPACE",
+        ts: "1700000000.000099",
+      },
+    };
+    await seedConversationDefaultAgent(
+      harness.store,
+      channel,
+      "codex",
+      "show_some",
+    );
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("check the latest signals", {
+        botMention: true,
+        channel,
+        routingState,
+      }),
+    );
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent(
+      buildToolCompletedEvent("tool-1", "check automation run"),
+    );
+
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        kind: "working_card",
+        targetSurface: {
+          channel: "slack",
+          id: "event-text",
+          state: routingState,
+        },
+      }),
+    );
+  });
+
   it("routes an accepted every-message topic to its default Agent without binding it", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0] = {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -50,6 +50,7 @@ import { PERMISSIVE_CAPABILITY_PROFILE } from "@pwragent/messaging-interface/tes
 import {
   MessagingController,
   messagingDeliveryPriority,
+  rememberWorkingCardState,
   shouldConsumeDeliveryBudget,
   updateWorkingCardActivities,
   type MessagingControllerOptions,
@@ -15136,6 +15137,26 @@ describe("MessagingController", () => {
     expect(state.omittedTaskCount).toBe(2);
   });
 
+  it("bounds per-turn working-card state when terminal events are missing", () => {
+    const states = new Map();
+    const state = () => ({
+      activities: new Map(),
+      omittedTaskCount: 0,
+      sequence: 0,
+    });
+
+    expect(rememberWorkingCardState(states, "binding\0turn-1", state(), 2))
+      .toEqual([]);
+    expect(rememberWorkingCardState(states, "binding\0turn-2", state(), 2))
+      .toEqual([]);
+    expect(rememberWorkingCardState(states, "binding\0turn-3", state(), 2))
+      .toEqual(["binding\0turn-1"]);
+    expect([...states.keys()]).toEqual([
+      "binding\0turn-2",
+      "binding\0turn-3",
+    ]);
+  });
+
   it("treats user-initiated status renders as user command budget traffic", () => {
     const status = {
       id: "status-1",
@@ -16181,6 +16202,86 @@ describe("MessagingController", () => {
         ],
       }),
     );
+  });
+
+  it("finalizes a Slack working card before task-monitor state is cleared", async () => {
+    const harness = await createHarness({
+      channel: "slack",
+      toolUpdateDefaultMode: "show_all",
+    });
+    await harness.store.upsertBinding({
+      id: "binding-slack-monitor",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: {
+        channel: "slack",
+        conversation: {
+          id: "C012MONITOR",
+          kind: "thread",
+          parentId: "1700000000.000001",
+          workspaceId: "T012WORKSPACE",
+        },
+      },
+      createdAt: 1000,
+      routingState: {
+        opaque: {
+          channelId: "C012MONITOR",
+          threadTs: "1700000000.000001",
+        },
+      },
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "monitor:monitor-1",
+          item: {
+            id: "monitor-1:progress:1000",
+            type: "agentMessage",
+            text: "Monitor · PR checks\nLint is still running.",
+            data: {
+              source: "pwragent_task_monitor",
+              monitorId: "monitor-1",
+              transient: true,
+            },
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "monitor:monitor-1",
+          item: {
+            id: "monitor-1:completion:2000",
+            type: "taskMonitorCompletion",
+            data: {
+              source: "pwragent_task_monitor",
+              monitorId: "monitor-1",
+              outcome: "success",
+              transient: false,
+            },
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    const cards = harness.delivered.filter(
+      (intent): intent is Extract<MessagingSurfaceIntent, { kind: "working_card" }> =>
+        intent.kind === "working_card",
+    );
+    expect(cards).toHaveLength(2);
+    expect(cards[0]?.card).toMatchObject({ isFinal: false, phase: "working" });
+    expect(cards[1]?.card).toMatchObject({ isFinal: true, phase: "completed" });
   });
 
   it("discards a coalesced monitor heartbeat when the monitor completes", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -51,6 +51,7 @@ import {
   MessagingController,
   messagingDeliveryPriority,
   rememberWorkingCardState,
+  settleStartedActivities,
   shouldConsumeDeliveryBudget,
   updateWorkingCardActivities,
   type MessagingControllerOptions,
@@ -15124,6 +15125,7 @@ describe("MessagingController", () => {
   it("bounds accumulated working-card tasks and collapses the oldest entries", () => {
     const state = {
       activities: new Map(),
+      displayHint: "plan" as const,
       omittedTaskCount: 0,
       sequence: 0,
     };
@@ -15142,10 +15144,47 @@ describe("MessagingController", () => {
     expect(state.omittedTaskCount).toBe(2);
   });
 
+  it("replaces a started activity in place when the tool completes", () => {
+    const state = {
+      activities: new Map(),
+      displayHint: "plan" as const,
+      omittedTaskCount: 0,
+      sequence: 0,
+    };
+    updateWorkingCardActivities(state, [
+      { id: "tool-1", kind: "tool", status: "started", title: "Ran tool" },
+      { id: "tool-2", kind: "tool", status: "started", title: "Other tool" },
+    ]);
+    updateWorkingCardActivities(state, [
+      { id: "tool-1", kind: "tool", status: "completed", title: "Ran tool" },
+    ]);
+
+    // Same key updates the row without moving it behind tool-2.
+    expect([...state.activities.keys()]).toEqual(["tool-1", "tool-2"]);
+    expect(state.activities.get("tool-1")?.status).toBe("completed");
+    expect(state.omittedTaskCount).toBe(0);
+  });
+
+  it("settles steps still running when the turn reaches a terminal phase", () => {
+    const activities = [
+      { id: "done", kind: "tool" as const, status: "completed" as const, title: "Done" },
+      { id: "running", kind: "tool" as const, status: "started" as const, title: "Running" },
+      { id: "broke", kind: "tool" as const, status: "failed" as const, title: "Broke" },
+    ];
+
+    expect(settleStartedActivities(activities, "completed").map((a) => a.status))
+      .toEqual(["completed", "completed", "failed"]);
+    // A failed turn cannot claim the in-flight step succeeded.
+    expect(settleStartedActivities(activities, "cancelled").map((a) => a.status))
+      .toEqual(["completed", "cancelled", "failed"]);
+    expect(activities[1]?.status).toBe("started");
+  });
+
   it("bounds per-turn working-card state when terminal events are missing", () => {
     const states = new Map();
     const state = () => ({
       activities: new Map(),
+      displayHint: "plan" as const,
       omittedTaskCount: 0,
       sequence: 0,
     });
@@ -16287,6 +16326,83 @@ describe("MessagingController", () => {
     expect(cards).toHaveLength(2);
     expect(cards[0]?.card).toMatchObject({ isFinal: false, phase: "working" });
     expect(cards[1]?.card).toMatchObject({ isFinal: true, phase: "completed" });
+  });
+
+  it("shows a running tool on an open Slack card without sending text", async () => {
+    const harness = await createHarness({
+      channel: "slack",
+      toolUpdateDefaultMode: "show_all",
+    });
+    await harness.store.upsertBinding({
+      id: "binding-slack-running",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: {
+        channel: "slack",
+        conversation: {
+          id: "C012RUNNING",
+          kind: "thread",
+          parentId: "1700000000.000001",
+          workspaceId: "T012WORKSPACE",
+        },
+      },
+      createdAt: 1000,
+      routingState: {
+        opaque: {
+          channelId: "C012RUNNING",
+          threadTs: "1700000000.000001",
+        },
+      },
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+
+    const toolEvent = (
+      method: "item/started" | "item/completed",
+      item: { id: string; type: string } & Record<string, unknown>,
+    ): AgentEvent => ({
+      backend: "codex",
+      notification: {
+        method,
+        params: { threadId: "thread-1", turnId: "turn-1", item },
+      },
+    } satisfies AgentEvent);
+
+    // A start with no card open yet must not create one — the dial owns that.
+    await harness.controller.handleBackendEvent(toolEvent("item/started", {
+      id: "tool-1",
+      type: "commandExecution",
+      command: "rg --files",
+    }));
+    expect(harness.delivered.filter((i) => i.kind === "working_card")).toEqual([]);
+
+    await harness.controller.handleBackendEvent(toolEvent("item/completed", {
+      id: "tool-1",
+      type: "commandExecution",
+      command: "rg --files",
+      durationMs: 900,
+    }));
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent(toolEvent("item/started", {
+      id: "tool-2",
+      type: "commandExecution",
+      command: "npm test",
+    }));
+
+    const cards = harness.delivered.filter(
+      (intent): intent is Extract<MessagingSurfaceIntent, { kind: "working_card" }> =>
+        intent.kind === "working_card",
+    );
+    expect(cards).toHaveLength(1);
+    expect(cards[0]?.card.tasks).toEqual([
+      expect.objectContaining({ id: "tool-1", status: "complete" }),
+      expect.objectContaining({ id: "tool-2", status: "in_progress" }),
+    ]);
+    // The start bypasses the dial entirely: no batched text, no fallback text.
+    expect(cards[0]?.fallbackText).toBe("");
+    expect(harness.delivered.filter((i) => i.kind === "message")).toEqual([]);
   });
 
   it("discards a coalesced monitor heartbeat when the monitor completes", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-routes-service.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-routes-service.test.ts
@@ -153,7 +153,9 @@ function buildDependencies(options: {
 
 describe("messaging routes service", () => {
   it("lists default Agents, active bindings, and eligible Agent choices", async () => {
-    const dependencies = buildDependencies();
+    const dependencies = buildDependencies({
+      assignments: [buildAssignment({ toolUpdateMode: "show_some" })],
+    });
 
     const result = await listDesktopMessagingRoutes(dependencies);
 
@@ -174,6 +176,7 @@ describe("messaging routes service", () => {
           platform: "slack",
         }),
         target: expect.objectContaining({ label: "Search Signals Agent" }),
+        toolUpdateMode: "show_some",
       }),
     ]);
     expect(result.bindings).toEqual([
@@ -321,6 +324,64 @@ describe("messaging routes service", () => {
         dependencies,
       ),
     ).rejects.toThrow("not an eligible default Agent");
+  });
+
+  it("sets, preserves, and clears per-route Working Updates overrides", async () => {
+    const existing = buildAssignment({ toolUpdateMode: "show_more" });
+    const dependencies = buildDependencies({ assignments: [existing] });
+
+    await setDesktopMessagingDefaultAgent(
+      {
+        assignmentId: existing.id,
+        scope: { kind: "profile" },
+        target: { backend: "codex", threadId: "agent-1" },
+      },
+      { ...dependencies, now: () => 3000 },
+    );
+    expect(dependencies.store.upsertDefaultAgentAssignment).toHaveBeenLastCalledWith(
+      expect.objectContaining({ toolUpdateMode: "show_more" }),
+    );
+
+    await setDesktopMessagingDefaultAgent(
+      {
+        assignmentId: existing.id,
+        scope: { kind: "profile" },
+        target: { backend: "codex", threadId: "agent-1" },
+        toolUpdateMode: "show_all",
+      },
+      { ...dependencies, now: () => 4000 },
+    );
+    expect(dependencies.store.upsertDefaultAgentAssignment).toHaveBeenLastCalledWith(
+      expect.objectContaining({ toolUpdateMode: "show_all" }),
+    );
+
+    await setDesktopMessagingDefaultAgent(
+      {
+        assignmentId: existing.id,
+        scope: { kind: "profile" },
+        target: { backend: "codex", threadId: "agent-1" },
+        toolUpdateMode: null,
+      },
+      { ...dependencies, now: () => 5000 },
+    );
+    expect(dependencies.store.upsertDefaultAgentAssignment).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ toolUpdateMode: expect.anything() }),
+    );
+  });
+
+  it("rejects an invalid per-route Working Updates override", async () => {
+    const dependencies = buildDependencies();
+
+    await expect(
+      setDesktopMessagingDefaultAgent(
+        {
+          scope: { kind: "profile" },
+          target: { backend: "codex", threadId: "agent-1" },
+          toolUpdateMode: "show_everything" as never,
+        },
+        dependencies,
+      ),
+    ).rejects.toThrow("Working Updates mode is invalid");
   });
 
   it("clears assignments by id", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-store.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store.test.ts
@@ -646,6 +646,27 @@ describe("MessagingStore", () => {
     expect(migrated.version).toBe(3);
   });
 
+  it("preserves valid per-route Working Updates overrides and rejects invalid ones", () => {
+    const valid = buildDefaultAgentAssignment({ toolUpdateMode: "show_more" });
+    const migrated = migrateMessagingStoreData({
+      version: 3,
+      defaultAgentAssignments: {
+        valid,
+        invalid: {
+          ...valid,
+          id: "invalid",
+          toolUpdateMode: "show_everything",
+        },
+      },
+    });
+
+    expect(migrated.defaultAgentAssignments.valid).toMatchObject({
+      id: valid.id,
+      toolUpdateMode: "show_more",
+    });
+    expect(migrated.defaultAgentAssignments.invalid).toBeUndefined();
+  });
+
   it("migrates pre-merge default Agent assignment records", () => {
     const channel = buildBinding().channel;
     const migrated = migrateMessagingStoreData({

--- a/apps/desktop/src/main/__tests__/messaging-tool-activity.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-tool-activity.test.ts
@@ -27,6 +27,36 @@ describe("messaging tool activity", () => {
     expect(formatToolActivityLine(activity!)).toBe("npm view dive (1.2s)");
   });
 
+  it("summarizes a started item as started, ignoring its in_progress status", () => {
+    const activity = summarizeToolActivityFromBackendEvent(
+      buildStartedItem({
+        id: "tool-1",
+        type: "commandExecution",
+        command: "/bin/zsh -lc 'npm view dive'",
+        status: "in_progress",
+      }),
+    );
+
+    // Same id as the later item/completed event, so the card updates the row
+    // in place instead of appending a duplicate.
+    expect(activity).toMatchObject({
+      id: "tool-1",
+      kind: "command",
+      status: "started",
+      title: "npm view dive",
+    });
+    expect(activity?.durationMs).toBeUndefined();
+    expect(formatToolActivityLine(activity!)).toBe("npm view dive");
+  });
+
+  it("ignores lifecycle events that are neither started nor completed", () => {
+    const event = buildCompletedItem({ id: "t", type: "commandExecution" });
+    expect(summarizeToolActivityFromBackendEvent({
+      ...event,
+      notification: { ...event.notification, method: "item/updated" },
+    } as AgentEvent)).toBeUndefined();
+  });
+
   it("keeps Codex command action summaries stable", () => {
     const activity = summarizeToolActivityFromBackendEvent(
       buildCompletedItem({
@@ -290,6 +320,14 @@ describe("messaging tool activity", () => {
     expect(activity?.title).not.toContain("abc123");
   });
 });
+
+function buildStartedItem(item: Record<string, unknown>): AgentEvent {
+  const event = buildCompletedItem(item);
+  return {
+    ...event,
+    notification: { ...event.notification, method: "item/started" },
+  } as AgentEvent;
+}
 
 function buildCompletedItem(item: Record<string, unknown>): AgentEvent {
   return {

--- a/apps/desktop/src/main/__tests__/messaging-tool-activity.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-tool-activity.test.ts
@@ -27,36 +27,6 @@ describe("messaging tool activity", () => {
     expect(formatToolActivityLine(activity!)).toBe("npm view dive (1.2s)");
   });
 
-  it("summarizes a started item as started, ignoring its in_progress status", () => {
-    const activity = summarizeToolActivityFromBackendEvent(
-      buildStartedItem({
-        id: "tool-1",
-        type: "commandExecution",
-        command: "/bin/zsh -lc 'npm view dive'",
-        status: "in_progress",
-      }),
-    );
-
-    // Same id as the later item/completed event, so the card updates the row
-    // in place instead of appending a duplicate.
-    expect(activity).toMatchObject({
-      id: "tool-1",
-      kind: "command",
-      status: "started",
-      title: "npm view dive",
-    });
-    expect(activity?.durationMs).toBeUndefined();
-    expect(formatToolActivityLine(activity!)).toBe("npm view dive");
-  });
-
-  it("ignores lifecycle events that are neither started nor completed", () => {
-    const event = buildCompletedItem({ id: "t", type: "commandExecution" });
-    expect(summarizeToolActivityFromBackendEvent({
-      ...event,
-      notification: { ...event.notification, method: "item/updated" },
-    } as AgentEvent)).toBeUndefined();
-  });
-
   it("keeps Codex command action summaries stable", () => {
     const activity = summarizeToolActivityFromBackendEvent(
       buildCompletedItem({
@@ -320,14 +290,6 @@ describe("messaging tool activity", () => {
     expect(activity?.title).not.toContain("abc123");
   });
 });
-
-function buildStartedItem(item: Record<string, unknown>): AgentEvent {
-  const event = buildCompletedItem(item);
-  return {
-    ...event,
-    notification: { ...event.notification, method: "item/started" },
-  } as AgentEvent;
-}
 
 function buildCompletedItem(item: Record<string, unknown>): AgentEvent {
   return {

--- a/apps/desktop/src/main/__tests__/messaging-tool-update-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-tool-update-renderer.test.ts
@@ -88,7 +88,8 @@ describe("tool-update renderer prose handling", () => {
       id: "cancelled-1",
       kind: "tool",
       status: "cancelled",
-      title: "Cancelled deployment",
+      title: "Deploy production",
+      durationMs: 1_200,
     };
     const latest = tool("latest-1", "Ran focused tests");
     const intent = buildWorkingCardIntent({
@@ -104,11 +105,15 @@ describe("tool-update renderer prose handling", () => {
     });
 
     expect(intent.card.tasks).toEqual([
-      expect.objectContaining({ status: "complete", title: "Earlier: 3 tools" }),
-      expect.objectContaining({ id: "cancelled-1", status: "cancelled" }),
+      expect.objectContaining({
+        detail: "3 earlier steps · Cancelled · 1.2s",
+        id: "cancelled-1",
+        status: "cancelled",
+        title: "Deploy production",
+      }),
       expect.objectContaining({ id: "latest-1", status: "complete" }),
     ]);
     expect(intent.fallbackText).toContain("Ran focused tests");
-    expect(intent.fallbackText).not.toContain("Cancelled deployment");
+    expect(intent.fallbackText).not.toContain("Deploy production");
   });
 });

--- a/apps/desktop/src/main/__tests__/messaging-tool-update-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-tool-update-renderer.test.ts
@@ -4,6 +4,7 @@ import type { MessagingToolActivity } from "../messaging/core/messaging-tool-act
 import {
   buildToolUpdateBatchMessageIntent,
   buildToolUpdateMessageIntent,
+  buildWorkingCardIntent,
 } from "../messaging/core/messaging-renderer.js";
 
 const tool = (id: string, title: string): MessagingToolActivity => ({
@@ -80,5 +81,34 @@ describe("tool-update renderer prose handling", () => {
       "Looking into the failing test.\n\nTool updates: ran 1 tool\n- Ran tests",
     );
     expect(part).toMatchObject({ markdown: "markdown" });
+  });
+
+  it("preserves cancelled tasks and separates card history from fallback text", () => {
+    const cancelled: MessagingToolActivity = {
+      id: "cancelled-1",
+      kind: "tool",
+      status: "cancelled",
+      title: "Cancelled deployment",
+    };
+    const latest = tool("latest-1", "Ran focused tests");
+    const intent = buildWorkingCardIntent({
+      activities: [cancelled, latest],
+      bindingId: "b1",
+      createdAt: 1,
+      displayHint: "plan",
+      fallbackActivities: [latest],
+      id: "working-1",
+      key: "b1\0turn-1",
+      omittedTaskCount: 3,
+      sequence: 4,
+    });
+
+    expect(intent.card.tasks).toEqual([
+      expect.objectContaining({ status: "complete", title: "Earlier: 3 tools" }),
+      expect.objectContaining({ id: "cancelled-1", status: "cancelled" }),
+      expect.objectContaining({ id: "latest-1", status: "complete" }),
+    ]);
+    expect(intent.fallbackText).toContain("Ran focused tests");
+    expect(intent.fallbackText).not.toContain("Cancelled deployment");
   });
 });

--- a/apps/desktop/src/main/__tests__/messaging-tool-update-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-tool-update-renderer.test.ts
@@ -116,4 +116,30 @@ describe("tool-update renderer prose handling", () => {
     expect(intent.fallbackText).toContain("Ran focused tests");
     expect(intent.fallbackText).not.toContain("Deploy production");
   });
+
+  it("renders a started activity as an in-progress task with no duration", () => {
+    const running: MessagingToolActivity = {
+      id: "running-1",
+      kind: "command",
+      status: "started",
+      title: "rg --files",
+    };
+    const intent = buildWorkingCardIntent({
+      activities: [tool("done-1", "Read config"), running],
+      bindingId: "b1",
+      createdAt: 1,
+      displayHint: "plan",
+      fallbackActivities: [],
+      id: "working-2",
+      key: "b1\0turn-1",
+      sequence: 2,
+    });
+
+    expect(intent.card.tasks).toEqual([
+      expect.objectContaining({ id: "done-1", status: "complete" }),
+      { id: "running-1", status: "in_progress", title: "rg --files" },
+    ]);
+    // No fallback activities: a degraded card must not post "started" as text.
+    expect(intent.fallbackText).toBe("");
+  });
 });

--- a/apps/desktop/src/main/__tests__/messaging-tool-update-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-tool-update-renderer.test.ts
@@ -116,30 +116,4 @@ describe("tool-update renderer prose handling", () => {
     expect(intent.fallbackText).toContain("Ran focused tests");
     expect(intent.fallbackText).not.toContain("Deploy production");
   });
-
-  it("renders a started activity as an in-progress task with no duration", () => {
-    const running: MessagingToolActivity = {
-      id: "running-1",
-      kind: "command",
-      status: "started",
-      title: "rg --files",
-    };
-    const intent = buildWorkingCardIntent({
-      activities: [tool("done-1", "Read config"), running],
-      bindingId: "b1",
-      createdAt: 1,
-      displayHint: "plan",
-      fallbackActivities: [],
-      id: "working-2",
-      key: "b1\0turn-1",
-      sequence: 2,
-    });
-
-    expect(intent.card.tasks).toEqual([
-      expect.objectContaining({ id: "done-1", status: "complete" }),
-      { id: "running-1", status: "in_progress", title: "rg --files" },
-    ]);
-    // No fallback activities: a degraded card must not post "started" as text.
-    expect(intent.fallbackText).toBe("");
-  });
 });

--- a/apps/desktop/src/main/__tests__/messaging-tool-update-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-tool-update-renderer.test.ts
@@ -115,5 +115,31 @@ describe("tool-update renderer prose handling", () => {
     ]);
     expect(intent.fallbackText).toContain("Ran focused tests");
     expect(intent.fallbackText).not.toContain("Deploy production");
+    expect(intent.card.fallbackPresentation).toEqual({
+      markdown: "light",
+      role: "system",
+    });
+  });
+
+  it("preserves assistant Markdown presentation for card fallbacks", () => {
+    const intent = buildWorkingCardIntent({
+      activities: [{
+        id: "prose-1",
+        kind: "prose",
+        status: "completed",
+        title: "| Result |\n| --- |\n| Passed |",
+      }],
+      bindingId: "b1",
+      createdAt: 1,
+      displayHint: "plan",
+      id: "working-prose-1",
+      key: "b1\0turn-1",
+      sequence: 1,
+    });
+
+    expect(intent.card.fallbackPresentation).toEqual({
+      markdown: "markdown",
+      role: "assistant",
+    });
   });
 });

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -109,7 +109,6 @@ import type {
   MessagingSurfaceIntent,
   MessagingTopicCleanupProposalItem,
   MessagingTopicCleanupProposalRecord,
-  MessagingWorkingCardIntent,
 } from "@pwragent/messaging-interface";
 import {
   applyActionCapabilityLimits,
@@ -310,12 +309,6 @@ type MessagingTurnProseState = {
 
 export type MessagingWorkingCardState = {
   activities: Map<string, MessagingToolActivity>;
-  /**
-   * Last hint chosen from the dial. Remembered so a refresh that carries no
-   * dial delivery of its own — an in-progress step, a waiting headline — keeps
-   * the card in the layout the operator's mode selected.
-   */
-  displayHint: MessagingWorkingCardIntent["card"]["displayHint"];
   omittedTaskCount: number;
   sequence: number;
 };
@@ -15682,59 +15675,6 @@ export class MessagingController {
     }
   }
 
-  private ensureWorkingCardState(key: string): MessagingWorkingCardState {
-    let state = this.workingCards.get(key);
-    if (!state) {
-      state = {
-        activities: new Map(),
-        displayHint: "plan",
-        omittedTaskCount: 0,
-        sequence: 0,
-      };
-      rememberWorkingCardState(this.workingCards, key, state);
-    }
-    return state;
-  }
-
-  /**
-   * Show a tool as running on an already-open working card. Returns without
-   * delivering when no card exists for the turn: the dial has not produced one
-   * yet (or is set to None), and a started step must not be the thing that
-   * opens a card the operator did not ask for.
-   */
-  private async refreshWorkingCardWithStartedActivity(
-    binding: MessagingBindingRecord,
-    turnId: string,
-    activity: MessagingToolActivity,
-  ): Promise<void> {
-    if (binding.channel.channel !== "slack") {
-      return;
-    }
-    const key = this.turnProseKey(binding.id, turnId);
-    const state = this.workingCards.get(key);
-    if (!state) {
-      return;
-    }
-    updateWorkingCardActivities(state, [activity]);
-    state.sequence += 1;
-    await this.deliver(
-      buildWorkingCardIntent({
-        activities: [...state.activities.values()],
-        bindingId: binding.id,
-        createdAt: this.now(),
-        displayHint: state.displayHint,
-        // No text fallback: a degraded card must not post "started" lines as
-        // messages, which is exactly the per-tool spam the dial exists to stop.
-        fallbackActivities: [],
-        id: this.newIntentId("working-card-started"),
-        key,
-        omittedTaskCount: state.omittedTaskCount,
-        sequence: state.sequence,
-      }),
-      binding,
-    );
-  }
-
   private async markWorkingCardWaiting(
     binding: MessagingBindingRecord,
   ): Promise<void> {
@@ -15753,7 +15693,7 @@ export class MessagingController {
       activities: [...state.activities.values()],
       bindingId: binding.id,
       createdAt: this.now(),
-      displayHint: state.displayHint,
+      displayHint: "plan",
       fallbackActivities: [],
       id: this.newIntentId("working-card-waiting"),
       key,
@@ -15864,16 +15804,6 @@ export class MessagingController {
       return;
     }
     if (this.isAutomationTurnEvent(event, binding, activeTurnId)) {
-      return;
-    }
-
-    if (activity.status === "started") {
-      // Deliberately bypasses the dial. A started tool is not a Working Update
-      // — it reports no outcome — so it must never batch into a text message or
-      // consume the policy's budget. It only refreshes a card that the dial has
-      // already opened for this turn, which keeps None silent and means the
-      // live spinner costs nothing on surfaces that render text.
-      await this.refreshWorkingCardWithStartedActivity(binding, turnId, activity);
       return;
     }
 
@@ -16127,19 +16057,22 @@ export class MessagingController {
     activities: MessagingToolActivity[],
   ): MessagingSurfaceIntent {
     const key = this.turnProseKey(bindingId, delivery.turnId);
-    const state = this.ensureWorkingCardState(key);
-    state.displayHint = delivery.mode === "show_all"
-      ? "timeline"
-      : delivery.mode === "show_less"
-        ? "dense"
-        : "plan";
+    let state = this.workingCards.get(key);
+    if (!state) {
+      state = { activities: new Map(), omittedTaskCount: 0, sequence: 0 };
+      rememberWorkingCardState(this.workingCards, key, state);
+    }
     updateWorkingCardActivities(state, activities);
     state.sequence += 1;
     return buildWorkingCardIntent({
       activities: [...state.activities.values()],
       bindingId,
       createdAt: this.now(),
-      displayHint: state.displayHint,
+      displayHint: delivery.mode === "show_all"
+        ? "timeline"
+        : delivery.mode === "show_less"
+          ? "dense"
+          : "plan",
       fallbackActivities: activities,
       id: this.newIntentId("working-card"),
       key,
@@ -16163,16 +16096,10 @@ export class MessagingController {
     }
     state.sequence += 1;
     const intent = buildWorkingCardIntent({
-      // A step still in progress when the turn ends never reports an outcome
-      // of its own. Settle it here so the stopped stream cannot keep a live
-      // spinner: a finished turn completes it, a failed one cancels it.
-      activities: settleStartedActivities(
-        [...state.activities.values()],
-        phase === "failed" ? "cancelled" : "completed",
-      ),
+      activities: [...state.activities.values()],
       bindingId: binding.id,
       createdAt: this.now(),
-      displayHint: state.displayHint,
+      displayHint: "plan",
       fallbackActivities: [],
       id: this.newIntentId("working-card-final"),
       key,
@@ -20155,14 +20082,6 @@ export function updateWorkingCardActivities(
     }
     state.activities.set(activity.id, activity);
   }
-}
-
-export function settleStartedActivities(
-  activities: readonly MessagingToolActivity[],
-  status: "completed" | "cancelled",
-): MessagingToolActivity[] {
-  return activities.map((activity) =>
-    activity.status === "started" ? { ...activity, status } : activity);
 }
 
 export function rememberWorkingCardState(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -306,6 +306,12 @@ type MessagingTurnProseState = {
   latest?: { activityId: string; text: string };
   deliveredIds: Set<string>;
 };
+
+export type MessagingWorkingCardState = {
+  activities: Map<string, MessagingToolActivity>;
+  omittedTaskCount: number;
+  sequence: number;
+};
 const DEFAULT_MESSAGING_AGENT_NAME = "Messaging Agent";
 const DEFAULT_MESSAGING_AGENT_INSTRUCTIONS =
   "You are an Agent thread created from messaging. Keep shared context for the attached messaging surfaces and use available Agent tools when they are relevant.";
@@ -920,7 +926,7 @@ export class MessagingController {
   private readonly turnProse = new Map<string, MessagingTurnProseState>();
   private readonly workingCards = new Map<
     string,
-    { activities: Map<string, MessagingToolActivity>; sequence: number }
+    MessagingWorkingCardState
   >();
   private readonly completedTaskMonitorTurns = new Set<string>();
   private readonly turnAdmission: MessagingTurnAdmission;
@@ -15677,8 +15683,10 @@ export class MessagingController {
       bindingId: binding.id,
       createdAt: this.now(),
       displayHint: "plan",
+      fallbackActivities: [],
       id: this.newIntentId("working-card-waiting"),
       key,
+      omittedTaskCount: state.omittedTaskCount,
       sequence: state.sequence,
     });
     card.card.phase = "waiting";
@@ -16040,12 +16048,10 @@ export class MessagingController {
     const key = this.turnProseKey(bindingId, delivery.turnId);
     let state = this.workingCards.get(key);
     if (!state) {
-      state = { activities: new Map(), sequence: 0 };
+      state = { activities: new Map(), omittedTaskCount: 0, sequence: 0 };
       this.workingCards.set(key, state);
     }
-    for (const activity of activities) {
-      state.activities.set(activity.id, activity);
-    }
+    updateWorkingCardActivities(state, activities);
     state.sequence += 1;
     return buildWorkingCardIntent({
       activities: [...state.activities.values()],
@@ -16056,8 +16062,10 @@ export class MessagingController {
         : delivery.mode === "show_less"
           ? "dense"
           : "plan",
+      fallbackActivities: activities,
       id: this.newIntentId("working-card"),
       key,
+      omittedTaskCount: state.omittedTaskCount,
       sequence: state.sequence,
     });
   }
@@ -16081,8 +16089,10 @@ export class MessagingController {
       bindingId: binding.id,
       createdAt: this.now(),
       displayHint: "plan",
+      fallbackActivities: [],
       id: this.newIntentId("working-card-final"),
       key,
+      omittedTaskCount: state.omittedTaskCount,
       sequence: state.sequence,
     });
     intent.card.phase = phase;
@@ -20006,7 +20016,7 @@ export function messagingDeliveryPriority(
     case "stream_update":
       return intent.stream.isFinal ? "final_turn" : "stream_partial";
     case "working_card":
-      return "tool_progress";
+      return intent.card.isFinal ? "final_turn" : "tool_progress";
     case "message":
       if (intent.id.startsWith("assistant-resume-repost-important")) {
         return "user_command";
@@ -20040,6 +20050,26 @@ export function messagingDeliveryPriority(
     case "confirmation":
     case "error":
       return "user_command";
+  }
+}
+
+export function updateWorkingCardActivities(
+  state: MessagingWorkingCardState,
+  activities: readonly MessagingToolActivity[],
+  maxVisibleTasks = 12,
+): void {
+  for (const activity of activities) {
+    if (
+      !state.activities.has(activity.id)
+      && state.activities.size >= maxVisibleTasks
+    ) {
+      const oldestId = state.activities.keys().next().value;
+      if (oldestId !== undefined) {
+        state.activities.delete(oldestId);
+        state.omittedTaskCount += 1;
+      }
+    }
+    state.activities.set(activity.id, activity);
   }
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -109,6 +109,7 @@ import type {
   MessagingSurfaceIntent,
   MessagingTopicCleanupProposalItem,
   MessagingTopicCleanupProposalRecord,
+  MessagingWorkingCardIntent,
 } from "@pwragent/messaging-interface";
 import {
   applyActionCapabilityLimits,
@@ -309,6 +310,12 @@ type MessagingTurnProseState = {
 
 export type MessagingWorkingCardState = {
   activities: Map<string, MessagingToolActivity>;
+  /**
+   * Last hint chosen from the dial. Remembered so a refresh that carries no
+   * dial delivery of its own — an in-progress step, a waiting headline — keeps
+   * the card in the layout the operator's mode selected.
+   */
+  displayHint: MessagingWorkingCardIntent["card"]["displayHint"];
   omittedTaskCount: number;
   sequence: number;
 };
@@ -15675,6 +15682,59 @@ export class MessagingController {
     }
   }
 
+  private ensureWorkingCardState(key: string): MessagingWorkingCardState {
+    let state = this.workingCards.get(key);
+    if (!state) {
+      state = {
+        activities: new Map(),
+        displayHint: "plan",
+        omittedTaskCount: 0,
+        sequence: 0,
+      };
+      rememberWorkingCardState(this.workingCards, key, state);
+    }
+    return state;
+  }
+
+  /**
+   * Show a tool as running on an already-open working card. Returns without
+   * delivering when no card exists for the turn: the dial has not produced one
+   * yet (or is set to None), and a started step must not be the thing that
+   * opens a card the operator did not ask for.
+   */
+  private async refreshWorkingCardWithStartedActivity(
+    binding: MessagingBindingRecord,
+    turnId: string,
+    activity: MessagingToolActivity,
+  ): Promise<void> {
+    if (binding.channel.channel !== "slack") {
+      return;
+    }
+    const key = this.turnProseKey(binding.id, turnId);
+    const state = this.workingCards.get(key);
+    if (!state) {
+      return;
+    }
+    updateWorkingCardActivities(state, [activity]);
+    state.sequence += 1;
+    await this.deliver(
+      buildWorkingCardIntent({
+        activities: [...state.activities.values()],
+        bindingId: binding.id,
+        createdAt: this.now(),
+        displayHint: state.displayHint,
+        // No text fallback: a degraded card must not post "started" lines as
+        // messages, which is exactly the per-tool spam the dial exists to stop.
+        fallbackActivities: [],
+        id: this.newIntentId("working-card-started"),
+        key,
+        omittedTaskCount: state.omittedTaskCount,
+        sequence: state.sequence,
+      }),
+      binding,
+    );
+  }
+
   private async markWorkingCardWaiting(
     binding: MessagingBindingRecord,
   ): Promise<void> {
@@ -15693,7 +15753,7 @@ export class MessagingController {
       activities: [...state.activities.values()],
       bindingId: binding.id,
       createdAt: this.now(),
-      displayHint: "plan",
+      displayHint: state.displayHint,
       fallbackActivities: [],
       id: this.newIntentId("working-card-waiting"),
       key,
@@ -15804,6 +15864,16 @@ export class MessagingController {
       return;
     }
     if (this.isAutomationTurnEvent(event, binding, activeTurnId)) {
+      return;
+    }
+
+    if (activity.status === "started") {
+      // Deliberately bypasses the dial. A started tool is not a Working Update
+      // — it reports no outcome — so it must never batch into a text message or
+      // consume the policy's budget. It only refreshes a card that the dial has
+      // already opened for this turn, which keeps None silent and means the
+      // live spinner costs nothing on surfaces that render text.
+      await this.refreshWorkingCardWithStartedActivity(binding, turnId, activity);
       return;
     }
 
@@ -16057,22 +16127,19 @@ export class MessagingController {
     activities: MessagingToolActivity[],
   ): MessagingSurfaceIntent {
     const key = this.turnProseKey(bindingId, delivery.turnId);
-    let state = this.workingCards.get(key);
-    if (!state) {
-      state = { activities: new Map(), omittedTaskCount: 0, sequence: 0 };
-      rememberWorkingCardState(this.workingCards, key, state);
-    }
+    const state = this.ensureWorkingCardState(key);
+    state.displayHint = delivery.mode === "show_all"
+      ? "timeline"
+      : delivery.mode === "show_less"
+        ? "dense"
+        : "plan";
     updateWorkingCardActivities(state, activities);
     state.sequence += 1;
     return buildWorkingCardIntent({
       activities: [...state.activities.values()],
       bindingId,
       createdAt: this.now(),
-      displayHint: delivery.mode === "show_all"
-        ? "timeline"
-        : delivery.mode === "show_less"
-          ? "dense"
-          : "plan",
+      displayHint: state.displayHint,
       fallbackActivities: activities,
       id: this.newIntentId("working-card"),
       key,
@@ -16096,10 +16163,16 @@ export class MessagingController {
     }
     state.sequence += 1;
     const intent = buildWorkingCardIntent({
-      activities: [...state.activities.values()],
+      // A step still in progress when the turn ends never reports an outcome
+      // of its own. Settle it here so the stopped stream cannot keep a live
+      // spinner: a finished turn completes it, a failed one cancels it.
+      activities: settleStartedActivities(
+        [...state.activities.values()],
+        phase === "failed" ? "cancelled" : "completed",
+      ),
       bindingId: binding.id,
       createdAt: this.now(),
-      displayHint: "plan",
+      displayHint: state.displayHint,
       fallbackActivities: [],
       id: this.newIntentId("working-card-final"),
       key,
@@ -20082,6 +20155,14 @@ export function updateWorkingCardActivities(
     }
     state.activities.set(activity.id, activity);
   }
+}
+
+export function settleStartedActivities(
+  activities: readonly MessagingToolActivity[],
+  status: "completed" | "cancelled",
+): MessagingToolActivity[] {
+  return activities.map((activity) =>
+    activity.status === "started" ? { ...activity, status } : activity);
 }
 
 export function rememberWorkingCardState(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -161,6 +161,7 @@ import {
   buildStatusIntent,
   buildToolUpdateBatchMessageIntent,
   buildToolUpdateMessageIntent,
+  buildWorkingCardIntent,
 } from "./messaging-renderer.js";
 import {
   artifactFromPlanEntry,
@@ -917,6 +918,10 @@ export class MessagingController {
   // Bounded so a turn that ends without a clean terminal event to clear it
   // cannot grow the map without limit.
   private readonly turnProse = new Map<string, MessagingTurnProseState>();
+  private readonly workingCards = new Map<
+    string,
+    { activities: Map<string, MessagingToolActivity>; sequence: number }
+  >();
   private readonly completedTaskMonitorTurns = new Set<string>();
   private readonly turnAdmission: MessagingTurnAdmission;
   private readonly pendingNewThreadPrompts = new Map<string, PendingNewThreadPromptWindow>();
@@ -1664,6 +1669,13 @@ export class MessagingController {
           });
         }
         if (terminalTurnId) {
+          await this.finalizeWorkingCard(
+            binding,
+            terminalTurnId,
+            lifecycle?.status === "failed" || lifecycle?.status === "interrupted"
+              ? "failed"
+              : "completed",
+          );
           this.clearTurnProse(binding.id, terminalTurnId);
           if (!privateResponseFallback) {
             const workingUpdateKey = this.turnProseKey(
@@ -15464,6 +15476,9 @@ export class MessagingController {
   ): Promise<MessagingDeliveryResult> {
     if (binding && shouldFlushToolUpdatesBeforeIntent(intent)) {
       await this.flushToolUpdatesForBinding(binding, { clear: false });
+      if (intent.kind === "approval" || intent.kind === "questionnaire") {
+        await this.markWorkingCardWaiting(binding);
+      }
     }
     const displayIntent = binding?.backend === "codex"
       ? stripCodexGitActionDirectivesFromMessagingIntent(intent)
@@ -15641,6 +15656,40 @@ export class MessagingController {
       }
       return result;
     }
+  }
+
+  private async markWorkingCardWaiting(
+    binding: MessagingBindingRecord,
+  ): Promise<void> {
+    if (binding.channel.channel !== "slack") {
+      return;
+    }
+    const entry = [...this.workingCards.entries()].find(([key]) =>
+      key.startsWith(`${binding.id}\0`)
+    );
+    if (!entry) {
+      return;
+    }
+    const [key, state] = entry;
+    state.sequence += 1;
+    const card = buildWorkingCardIntent({
+      activities: [...state.activities.values()],
+      bindingId: binding.id,
+      createdAt: this.now(),
+      displayHint: "plan",
+      id: this.newIntentId("working-card-waiting"),
+      key,
+      sequence: state.sequence,
+    });
+    card.card.phase = "waiting";
+    await this.deliver(card, binding);
+    await this.deliver(buildActivityIntent({
+      activity: "typing",
+      bindingId: binding.id,
+      createdAt: this.now(),
+      id: this.newIntentId("working-card-waiting-idle"),
+      state: "idle",
+    }), binding);
   }
 
   private async deliverArtifactForBinding(params: {
@@ -15841,7 +15890,9 @@ export class MessagingController {
   }
 
   private clearTurnProse(bindingId: string, turnId: string): void {
-    this.turnProse.delete(this.turnProseKey(bindingId, turnId));
+    const key = this.turnProseKey(bindingId, turnId);
+    this.turnProse.delete(key);
+    this.workingCards.delete(key);
   }
 
   private rememberCompletedTaskMonitorTurn(
@@ -15909,8 +15960,9 @@ export class MessagingController {
       return;
     }
 
-    const intent =
-      delivery.kind === "individual"
+    const intent = binding.channel.channel === "slack"
+      ? this.buildWorkingCardDeliveryIntent(delivery, binding.id, activities)
+      : delivery.kind === "individual"
         ? buildToolUpdateMessageIntent({
             activity: activities[0]!,
             bindingId: binding.id,
@@ -15978,6 +16030,65 @@ export class MessagingController {
         this.workingUpdateDeliveries.delete(cancellationKey);
       }
     }
+  }
+
+  private buildWorkingCardDeliveryIntent(
+    delivery: MessagingToolUpdatePolicyDelivery,
+    bindingId: string,
+    activities: MessagingToolActivity[],
+  ): MessagingSurfaceIntent {
+    const key = this.turnProseKey(bindingId, delivery.turnId);
+    let state = this.workingCards.get(key);
+    if (!state) {
+      state = { activities: new Map(), sequence: 0 };
+      this.workingCards.set(key, state);
+    }
+    for (const activity of activities) {
+      state.activities.set(activity.id, activity);
+    }
+    state.sequence += 1;
+    return buildWorkingCardIntent({
+      activities: [...state.activities.values()],
+      bindingId,
+      createdAt: this.now(),
+      displayHint: delivery.mode === "show_all"
+        ? "timeline"
+        : delivery.mode === "show_less"
+          ? "dense"
+          : "plan",
+      id: this.newIntentId("working-card"),
+      key,
+      sequence: state.sequence,
+    });
+  }
+
+  private async finalizeWorkingCard(
+    binding: MessagingBindingRecord,
+    turnId: string,
+    phase: "completed" | "failed",
+  ): Promise<void> {
+    if (binding.channel.channel !== "slack") {
+      return;
+    }
+    const key = this.turnProseKey(binding.id, turnId);
+    const state = this.workingCards.get(key);
+    if (!state) {
+      return;
+    }
+    state.sequence += 1;
+    const intent = buildWorkingCardIntent({
+      activities: [...state.activities.values()],
+      bindingId: binding.id,
+      createdAt: this.now(),
+      displayHint: "plan",
+      id: this.newIntentId("working-card-final"),
+      key,
+      sequence: state.sequence,
+    });
+    intent.card.phase = phase;
+    intent.card.isFinal = true;
+    await this.deliver(intent, binding);
+    this.workingCards.delete(key);
   }
 
   private filterUndeliveredProseActivities(
@@ -19894,6 +20005,8 @@ export function messagingDeliveryPriority(
       return "critical_interactive";
     case "stream_update":
       return intent.stream.isFinal ? "final_turn" : "stream_partial";
+    case "working_card":
+      return "tool_progress";
     case "message":
       if (intent.id.startsWith("assistant-resume-repost-important")) {
         return "user_command";

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3394,6 +3394,7 @@ export class MessagingController {
     const binding = this.defaultAgentRouteBinding(event, {
       backend: selected.assignment.target.backend,
       threadId: selected.assignment.target.threadId,
+      toolUpdateMode: selected.assignment.toolUpdateMode,
     });
     await this.turnAdmission.append({
       binding,
@@ -15351,6 +15352,7 @@ export class MessagingController {
     target: {
       backend: AppServerBackendKind;
       threadId: ThreadIdentifier;
+      toolUpdateMode?: MessagingToolUpdateMode;
     },
   ): MessagingBindingRecord {
     const now = this.now();
@@ -15362,6 +15364,14 @@ export class MessagingController {
       targetKind: "agent_thread",
       backend: target.backend,
       threadId: target.threadId,
+      ...(target.toolUpdateMode
+        ? {
+            preferences: {
+              toolUpdateMode: target.toolUpdateMode,
+              updatedAt: now,
+            },
+          }
+        : {}),
       authorizedActorIds: [event.actor.platformUserId],
       routingState: event.routingState,
       createdAt: now,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1654,6 +1654,7 @@ export class MessagingController {
           clear: true,
           turnId: eventTurnId,
         });
+        await this.finalizeWorkingCard(binding, eventTurnId, "completed");
         this.clearTurnProse(binding.id, eventTurnId);
       }
       if (
@@ -15670,13 +15671,13 @@ export class MessagingController {
     if (binding.channel.channel !== "slack") {
       return;
     }
-    const entry = [...this.workingCards.entries()].find(([key]) =>
-      key.startsWith(`${binding.id}\0`)
-    );
-    if (!entry) {
+    const turnId = this.getActiveTurn(binding)?.turnId;
+    if (!turnId) {
       return;
     }
-    const [key, state] = entry;
+    const key = this.turnProseKey(binding.id, turnId);
+    const state = this.workingCards.get(key);
+    if (!state) return;
     state.sequence += 1;
     const card = buildWorkingCardIntent({
       activities: [...state.activities.values()],
@@ -16049,7 +16050,7 @@ export class MessagingController {
     let state = this.workingCards.get(key);
     if (!state) {
       state = { activities: new Map(), omittedTaskCount: 0, sequence: 0 };
-      this.workingCards.set(key, state);
+      rememberWorkingCardState(this.workingCards, key, state);
     }
     updateWorkingCardActivities(state, activities);
     state.sequence += 1;
@@ -20071,6 +20072,23 @@ export function updateWorkingCardActivities(
     }
     state.activities.set(activity.id, activity);
   }
+}
+
+export function rememberWorkingCardState(
+  states: Map<string, MessagingWorkingCardState>,
+  key: string,
+  state: MessagingWorkingCardState,
+  maxStates = MAX_TRACKED_TURN_PROSE,
+): string[] {
+  states.set(key, state);
+  const evicted: string[] = [];
+  while (states.size > maxStates) {
+    const oldest = states.keys().next().value;
+    if (oldest === undefined) break;
+    states.delete(oldest);
+    evicted.push(oldest);
+  }
+  return evicted;
 }
 
 function isUserInitiatedDeliveryEvent(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -15701,7 +15701,11 @@ export class MessagingController {
       sequence: state.sequence,
     });
     card.card.phase = "waiting";
-    await this.deliver(card, binding);
+    await this.deliver(
+      card,
+      binding,
+      this.agentMessagingOriginEvent(binding, turnId),
+    );
     await this.deliver(buildActivityIntent({
       activity: "typing",
       bindingId: binding.id,
@@ -16002,25 +16006,30 @@ export class MessagingController {
     const guardedIsCancelled = () =>
       isTaskMonitorCancelled() || cancellation.isCancelled();
     const deliveryPromise = (async (): Promise<MessagingDeliveryResult> => {
-      const result = await this.deliver(intent, binding, undefined, {
-        isCancelled: guardedIsCancelled,
-        whenCancelled: cancellation.whenCancelled,
-        onCancelledDelivery: async (cancelledResult) => {
-          if (
-            cancelledResult.surface
-            && isVisibleAssistantStreamDelivery(cancelledResult)
-          ) {
-            const dismissed = await this.dismissTerminalPrivateResponseSurface(
-              binding,
-              delivery.turnId,
-              cancelledResult.surface,
-            );
-            if (!dismissed) {
-              this.workingUpdateCancellationFailures.add(cancellationKey);
+      const result = await this.deliver(
+        intent,
+        binding,
+        this.agentMessagingOriginEvent(binding, delivery.turnId),
+        {
+          isCancelled: guardedIsCancelled,
+          whenCancelled: cancellation.whenCancelled,
+          onCancelledDelivery: async (cancelledResult) => {
+            if (
+              cancelledResult.surface
+              && isVisibleAssistantStreamDelivery(cancelledResult)
+            ) {
+              const dismissed = await this.dismissTerminalPrivateResponseSurface(
+                binding,
+                delivery.turnId,
+                cancelledResult.surface,
+              );
+              if (!dismissed) {
+                this.workingUpdateCancellationFailures.add(cancellationKey);
+              }
             }
-          }
+          },
         },
-      });
+      );
       if (
         !guardedIsCancelled()
         && result.surface
@@ -16108,8 +16117,21 @@ export class MessagingController {
     });
     intent.card.phase = phase;
     intent.card.isFinal = true;
-    await this.deliver(intent, binding);
+    await this.deliver(
+      intent,
+      binding,
+      this.agentMessagingOriginEvent(binding, turnId),
+    );
     this.workingCards.delete(key);
+  }
+
+  private agentMessagingOriginEvent(
+    binding: MessagingBindingRecord,
+    turnId: string,
+  ): MessagingInboundEvent | undefined {
+    return this.activeAgentMessagingOriginsByTurnKey.get(
+      agentMessagingTurnKey(binding.backend, binding.threadId, turnId),
+    )?.event;
   }
 
   private filterUndeliveredProseActivities(

--- a/apps/desktop/src/main/messaging/core/messaging-migrations.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-migrations.ts
@@ -12,7 +12,10 @@ import type {
   MessagingThreadTopicLinkRecord,
   MessagingTopicCleanupProposalRecord,
 } from "@pwragent/messaging-interface";
-import { normalizeMessagingBindingTargetKind } from "@pwragent/shared";
+import {
+  MESSAGING_TOOL_UPDATE_MODES,
+  normalizeMessagingBindingTargetKind,
+} from "@pwragent/shared";
 
 // SCHEMA-DRIFT-CHECKPOINT: when bumping CURRENT_MESSAGING_STORE_VERSION,
 // also audit `apps/desktop/e2e/fixtures/readme-state-seeding.ts`. Its
@@ -102,7 +105,13 @@ export function migrateMessagingDefaultAgentAssignmentRecord(
     typeof target.backend === "string" &&
     typeof target.threadId === "string" &&
     typeof record.createdAt === "number" &&
-    typeof record.updatedAt === "number"
+    typeof record.updatedAt === "number" &&
+    (
+      record.toolUpdateMode === undefined
+      || MESSAGING_TOOL_UPDATE_MODES.some(
+        (mode) => mode === record.toolUpdateMode,
+      )
+    )
   ) {
     return value as MessagingDefaultAgentAssignmentRecord;
   }

--- a/apps/desktop/src/main/messaging/core/messaging-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-renderer.ts
@@ -19,6 +19,7 @@ import {
   type MessagingCapabilityProfile,
 } from "@pwragent/messaging-interface";
 import {
+  formatToolActivityDuration,
   formatToolActivityLine,
   type MessagingToolActivity,
 } from "./messaging-tool-activity.js";
@@ -188,6 +189,30 @@ export function buildWorkingCardIntent(params: {
     id: `${params.id}:fallback`,
   });
   const fallbackPart = fallback.parts[0];
+  const tasks = params.activities.map((activity) => {
+    const detail = workingCardTaskDetail(activity);
+    return {
+      id: activity.id,
+      status: activity.status === "failed"
+        ? "error" as const
+        : activity.status === "cancelled"
+          ? "cancelled" as const
+          : "complete" as const,
+      title: activity.title,
+      ...(detail ? { detail } : {}),
+    };
+  });
+  if (params.omittedTaskCount && params.omittedTaskCount > 0 && tasks[0]) {
+    tasks[0] = {
+      ...tasks[0],
+      detail: [
+        `${params.omittedTaskCount} earlier step${
+          params.omittedTaskCount === 1 ? "" : "s"
+        }`,
+        tasks[0].detail,
+      ].filter(Boolean).join(" · "),
+    };
+  }
   return {
     id: params.id,
     kind: "working_card",
@@ -202,28 +227,20 @@ export function buildWorkingCardIntent(params: {
       key: params.key,
       phase: "working",
       sequence: params.sequence,
-      tasks: [
-        ...(params.omittedTaskCount && params.omittedTaskCount > 0
-          ? [{
-              id: `${params.key}:earlier`,
-              status: "complete" as const,
-              title: `Earlier: ${params.omittedTaskCount} tool${
-                params.omittedTaskCount === 1 ? "" : "s"
-              }`,
-            }]
-          : []),
-        ...params.activities.map((activity) => ({
-          id: activity.id,
-          status: activity.status === "failed"
-            ? "error" as const
-            : activity.status === "cancelled"
-              ? "cancelled" as const
-              : "complete" as const,
-          title: formatToolActivityLine(activity),
-        })),
-      ],
+      tasks,
     },
   };
+}
+
+function workingCardTaskDetail(
+  activity: MessagingToolActivity,
+): string | undefined {
+  return [
+    activity.status === "cancelled" ? "Cancelled" : undefined,
+    activity.durationMs !== undefined
+      ? formatToolActivityDuration(activity.durationMs)
+      : undefined,
+  ].filter(Boolean).join(" · ") || undefined;
 }
 
 export function buildConfirmationIntent(params: {

--- a/apps/desktop/src/main/messaging/core/messaging-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-renderer.ts
@@ -223,6 +223,12 @@ export function buildWorkingCardIntent(params: {
       : "Working update",
     card: {
       displayHint: params.displayHint,
+      fallbackPresentation: {
+        markdown: fallbackPart?.type === "text"
+          ? fallbackPart.markdown ?? "light"
+          : "light",
+        role: fallback.role === "assistant" ? "assistant" : "system",
+      },
       isFinal: false,
       key: params.key,
       phase: "working",

--- a/apps/desktop/src/main/messaging/core/messaging-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-renderer.ts
@@ -175,12 +175,14 @@ export function buildWorkingCardIntent(params: {
   bindingId: string;
   createdAt: number;
   displayHint: MessagingWorkingCardIntent["card"]["displayHint"];
+  fallbackActivities?: MessagingToolActivity[];
   id: string;
   key: string;
+  omittedTaskCount?: number;
   sequence: number;
 }): MessagingWorkingCardIntent {
   const fallback = buildToolUpdateBatchMessageIntent({
-    activities: params.activities,
+    activities: params.fallbackActivities ?? params.activities,
     bindingId: params.bindingId,
     createdAt: params.createdAt,
     id: `${params.id}:fallback`,
@@ -200,11 +202,26 @@ export function buildWorkingCardIntent(params: {
       key: params.key,
       phase: "working",
       sequence: params.sequence,
-      tasks: params.activities.map((activity) => ({
-        id: activity.id,
-        status: activity.status === "failed" ? "error" : "complete",
-        title: formatToolActivityLine(activity),
-      })),
+      tasks: [
+        ...(params.omittedTaskCount && params.omittedTaskCount > 0
+          ? [{
+              id: `${params.key}:earlier`,
+              status: "complete" as const,
+              title: `Earlier: ${params.omittedTaskCount} tool${
+                params.omittedTaskCount === 1 ? "" : "s"
+              }`,
+            }]
+          : []),
+        ...params.activities.map((activity) => ({
+          id: activity.id,
+          status: activity.status === "failed"
+            ? "error" as const
+            : activity.status === "cancelled"
+              ? "cancelled" as const
+              : "complete" as const,
+          title: formatToolActivityLine(activity),
+        })),
+      ],
     },
   };
 }

--- a/apps/desktop/src/main/messaging/core/messaging-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-renderer.ts
@@ -11,6 +11,7 @@ import type {
   MessagingSurfaceAction,
   MessagingMessageIntent,
   MessagingThreadPickerIntent,
+  MessagingWorkingCardIntent,
 } from "@pwragent/messaging-interface";
 import {
   applyActionCapabilityLimits,
@@ -166,6 +167,45 @@ export function buildToolUpdateBatchMessageIntent(params: {
         markdown: hasProse ? "markdown" : "light",
       },
     ],
+  };
+}
+
+export function buildWorkingCardIntent(params: {
+  activities: MessagingToolActivity[];
+  bindingId: string;
+  createdAt: number;
+  displayHint: MessagingWorkingCardIntent["card"]["displayHint"];
+  id: string;
+  key: string;
+  sequence: number;
+}): MessagingWorkingCardIntent {
+  const fallback = buildToolUpdateBatchMessageIntent({
+    activities: params.activities,
+    bindingId: params.bindingId,
+    createdAt: params.createdAt,
+    id: `${params.id}:fallback`,
+  });
+  const fallbackPart = fallback.parts[0];
+  return {
+    id: params.id,
+    kind: "working_card",
+    bindingId: params.bindingId,
+    createdAt: params.createdAt,
+    fallbackText: fallbackPart?.type === "text"
+      ? fallbackPart.text
+      : "Working update",
+    card: {
+      displayHint: params.displayHint,
+      isFinal: false,
+      key: params.key,
+      phase: "working",
+      sequence: params.sequence,
+      tasks: params.activities.map((activity) => ({
+        id: activity.id,
+        status: activity.status === "failed" ? "error" : "complete",
+        title: formatToolActivityLine(activity),
+      })),
+    },
   };
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-renderer.ts
@@ -197,7 +197,9 @@ export function buildWorkingCardIntent(params: {
         ? "error" as const
         : activity.status === "cancelled"
           ? "cancelled" as const
-          : "complete" as const,
+          : activity.status === "started"
+            ? "in_progress" as const
+            : "complete" as const,
       title: activity.title,
       ...(detail ? { detail } : {}),
     };

--- a/apps/desktop/src/main/messaging/core/messaging-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-renderer.ts
@@ -197,9 +197,7 @@ export function buildWorkingCardIntent(params: {
         ? "error" as const
         : activity.status === "cancelled"
           ? "cancelled" as const
-          : activity.status === "started"
-            ? "in_progress" as const
-            : "complete" as const,
+          : "complete" as const,
       title: activity.title,
       ...(detail ? { detail } : {}),
     };

--- a/apps/desktop/src/main/messaging/core/messaging-tool-activity.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-tool-activity.ts
@@ -8,16 +8,7 @@ import {
   safeCommandTitle as safeRedactedCommandTitle,
 } from "../../util/redact-command-text";
 
-/**
- * `started` is a *live* status: it only ever reaches surfaces that render a
- * single updating card (today, Slack working cards), never the text Working
- * Updates batches, which stay terminal-only so a tool is reported once.
- */
-export type MessagingToolActivityStatus =
-  | "started"
-  | "completed"
-  | "failed"
-  | "cancelled";
+export type MessagingToolActivityStatus = "completed" | "failed" | "cancelled";
 
 export type MessagingToolActivityKind =
   | "command"
@@ -39,8 +30,7 @@ export type MessagingToolActivity = {
 export function summarizeToolActivityFromBackendEvent(
   event: AgentEvent,
 ): MessagingToolActivity | undefined {
-  const method = event.notification.method;
-  if (method !== "item/completed" && method !== "item/started") {
+  if (event.notification.method !== "item/completed") {
     return undefined;
   }
 
@@ -63,12 +53,8 @@ export function summarizeToolActivityFromBackendEvent(
     readString(item, "itemId") ??
     readString(item, "item_id") ??
     `${event.backend}:${String(params.turnId ?? "turn")}:${itemType}`;
-  // A started item carries no outcome and no duration yet; its own `status`
-  // field ("in_progress") must not be read through `normalizeToolStatus`,
-  // which would fall through to "completed".
-  const started = method === "item/started";
-  const status = started ? "started" : normalizeToolStatus(item);
-  const durationMs = started ? undefined : readDurationMs(item);
+  const status = normalizeToolStatus(item);
+  const durationMs = readDurationMs(item);
 
   if (itemType === "commandexecution") {
     return {

--- a/apps/desktop/src/main/messaging/core/messaging-tool-activity.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-tool-activity.ts
@@ -114,8 +114,18 @@ export function formatToolActivityLine(activity: MessagingToolActivity): string 
       : activity.status === "cancelled"
         ? `Cancelled: ${activity.title}`
         : activity.title,
-    activity.durationMs !== undefined ? ` (${formatDuration(activity.durationMs)})` : "",
+    activity.durationMs !== undefined
+      ? ` (${formatToolActivityDuration(activity.durationMs)})`
+      : "",
   ].join("");
+}
+
+export function formatToolActivityDuration(durationMs: number): string {
+  if (durationMs < 1_000) {
+    return `${durationMs}ms`;
+  }
+  const seconds = durationMs / 1_000;
+  return seconds >= 10 ? `${seconds.toFixed(0)}s` : `${seconds.toFixed(1)}s`;
 }
 
 function isRecognizedToolItemType(itemType: string): boolean {
@@ -408,14 +418,6 @@ function normalizeTimestamp(value: number | undefined): number | undefined {
     return undefined;
   }
   return value < 10_000_000_000 ? value * 1000 : value;
-}
-
-function formatDuration(durationMs: number): string {
-  if (durationMs < 1_000) {
-    return `${durationMs}ms`;
-  }
-  const seconds = durationMs / 1_000;
-  return seconds >= 10 ? `${seconds.toFixed(0)}s` : `${seconds.toFixed(1)}s`;
 }
 
 function truncateTitle(title: string, limit = 72): string {

--- a/apps/desktop/src/main/messaging/core/messaging-tool-activity.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-tool-activity.ts
@@ -8,7 +8,16 @@ import {
   safeCommandTitle as safeRedactedCommandTitle,
 } from "../../util/redact-command-text";
 
-export type MessagingToolActivityStatus = "completed" | "failed" | "cancelled";
+/**
+ * `started` is a *live* status: it only ever reaches surfaces that render a
+ * single updating card (today, Slack working cards), never the text Working
+ * Updates batches, which stay terminal-only so a tool is reported once.
+ */
+export type MessagingToolActivityStatus =
+  | "started"
+  | "completed"
+  | "failed"
+  | "cancelled";
 
 export type MessagingToolActivityKind =
   | "command"
@@ -30,7 +39,8 @@ export type MessagingToolActivity = {
 export function summarizeToolActivityFromBackendEvent(
   event: AgentEvent,
 ): MessagingToolActivity | undefined {
-  if (event.notification.method !== "item/completed") {
+  const method = event.notification.method;
+  if (method !== "item/completed" && method !== "item/started") {
     return undefined;
   }
 
@@ -53,8 +63,12 @@ export function summarizeToolActivityFromBackendEvent(
     readString(item, "itemId") ??
     readString(item, "item_id") ??
     `${event.backend}:${String(params.turnId ?? "turn")}:${itemType}`;
-  const status = normalizeToolStatus(item);
-  const durationMs = readDurationMs(item);
+  // A started item carries no outcome and no duration yet; its own `status`
+  // field ("in_progress") must not be read through `normalizeToolStatus`,
+  // which would fall through to "completed".
+  const started = method === "item/started";
+  const status = started ? "started" : normalizeToolStatus(item);
+  const durationMs = started ? undefined : readDurationMs(item);
 
   if (itemType === "commandexecution") {
     return {

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -272,6 +272,7 @@ export const DESKTOP_MESSAGING_CHANNEL_CONFIG_FIELD_IMPACTS = {
     groupDmAccessMode: "authorization",
     enabled: "connection",
     inboundMode: "connection",
+    liveWorkingCards: "rendering",
     registerSlashCommands: "connection",
     responseMode: "authorization",
     signingSecret: "connection",
@@ -633,6 +634,7 @@ export function loadDesktopMessagingConfig(
             ...(slackSigningSecret ? { signingSecret: slackSigningSecret } : {}),
             ...(slackWorkspaceUrl ? { workspaceUrl: slackWorkspaceUrl } : {}),
             inboundMode: slackInboundMode,
+            liveWorkingCards: false,
             ...(slackSlashCommandPrefix !== undefined
               ? { slashCommandPrefix: slackSlashCommandPrefix }
               : {}),
@@ -1034,6 +1036,7 @@ export async function loadDesktopMessagingConfigFromSettings(
             ...(slackSigningSecret ? { signingSecret: slackSigningSecret } : {}),
             ...(slackWorkspaceUrl ? { workspaceUrl: slackWorkspaceUrl } : {}),
             inboundMode: slackInboundMode,
+            liveWorkingCards: snapshot.messaging.slack.liveWorkingCards.value,
             ...(slackSlashCommandPrefix !== undefined
               ? { slashCommandPrefix: slackSlashCommandPrefix }
               : {}),
@@ -1276,6 +1279,7 @@ export function redactDesktopMessagingConfig(
           signingSecret: config.slack.signingSecret ? "[REDACTED]" : undefined,
           workspaceUrl: config.slack.workspaceUrl,
           inboundMode: config.slack.inboundMode ?? "socket",
+          liveWorkingCards: config.slack.liveWorkingCards ?? false,
           slashCommandPrefix: config.slack.slashCommandPrefix ?? "[default]",
           registerSlashCommands: config.slack.registerSlashCommands ?? false,
           streamingResponses: config.slack.streamingResponses ?? false,
@@ -1517,7 +1521,10 @@ function renderingPreferencesForChannelConfig(
     case "mattermost":
       return { streamingResponses: config.mattermost?.streamingResponses };
     case "slack":
-      return { streamingResponses: config.slack?.streamingResponses };
+      return {
+        liveWorkingCards: config.slack?.liveWorkingCards,
+        streamingResponses: config.slack?.streamingResponses,
+      };
     case "feishu":
       return { streamingResponses: config.feishu?.streamingResponses };
     case "line":

--- a/apps/desktop/src/main/messaging/messaging-routes-service.ts
+++ b/apps/desktop/src/main/messaging/messaging-routes-service.ts
@@ -18,6 +18,7 @@ import type {
 } from "@pwragent/shared";
 import {
   buildThreadIdentityKey,
+  MESSAGING_TOOL_UPDATE_MODES,
   normalizeMessagingBindingTargetKind,
 } from "@pwragent/shared";
 import type {
@@ -109,6 +110,9 @@ export async function listDesktopMessagingRoutes(
       return {
         assignmentId: assignment.id,
         scope: toDesktopScope(assignment.scope),
+        ...(assignment.toolUpdateMode
+          ? { toolUpdateMode: assignment.toolUpdateMode }
+          : {}),
         target: eligible ?? {
           backend: assignment.target.backend,
           threadId: assignment.target.threadId,
@@ -216,6 +220,13 @@ export async function setDesktopMessagingDefaultAgent(
   request: SetMessagingDefaultAgentRequest,
   dependencies: MessagingRoutesServiceDependencies = {},
 ): Promise<SetMessagingDefaultAgentResponse> {
+  if (
+    request.toolUpdateMode !== undefined
+    && request.toolUpdateMode !== null
+    && !MESSAGING_TOOL_UPDATE_MODES.includes(request.toolUpdateMode)
+  ) {
+    throw new Error("The selected Working Updates mode is invalid.");
+  }
   const store = dependencies.store ?? getDesktopMessagingStore();
   const routes = await listDesktopMessagingRoutes(dependencies);
   const target = routes.eligibleAgents.find(
@@ -233,6 +244,9 @@ export async function setDesktopMessagingDefaultAgent(
     throw new Error("The default Agent assignment no longer exists.");
   }
   const now = (dependencies.now ?? Date.now)();
+  const toolUpdateMode = request.toolUpdateMode === undefined
+    ? existing?.toolUpdateMode
+    : request.toolUpdateMode ?? undefined;
   const assignment: MessagingDefaultAgentAssignmentRecord = {
     id:
       existing?.id
@@ -243,6 +257,7 @@ export async function setDesktopMessagingDefaultAgent(
       backend: request.target.backend,
       threadId: request.target.threadId,
     },
+    ...(toolUpdateMode ? { toolUpdateMode } : {}),
     createdAt: existing?.createdAt ?? now,
     updatedAt: now,
   };

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -193,6 +193,7 @@ export type DesktopSettingsConfig = {
     };
     slack?: {
       enabled?: boolean;
+      liveWorkingCards?: boolean;
       responseMode?: DesktopMessagingResponseMode;
       streamingResponses?: boolean;
       workspaceUrl?: string;
@@ -1149,6 +1150,9 @@ export function desktopSettingsPatchToEdits(
   if (slack?.enabled !== undefined) {
     set(["messaging", "slack", "enabled"], slack.enabled);
   }
+  if (slack?.liveWorkingCards !== undefined) {
+    set(["messaging", "slack", "live_working_cards"], slack.liveWorkingCards);
+  }
   if (slack?.responseMode !== undefined) {
     set(["messaging", "slack", "response_mode"], slack.responseMode);
   }
@@ -1704,6 +1708,7 @@ function normalizeDesktopConfig(
       },
       slack: {
         enabled: readBoolean(slack?.enabled),
+        liveWorkingCards: readBoolean(slack?.live_working_cards),
         responseMode: readMessagingResponseMode(slack?.response_mode),
         streamingResponses: readBoolean(slack?.streaming_responses),
         workspaceUrl: readString(slack?.workspace_url),

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -921,6 +921,10 @@ export class DesktopSettingsService {
             false,
             SLACK_ENABLED_ENV,
           ),
+          liveWorkingCards: this.resolveConfigBoolean(
+            config.messaging?.slack?.liveWorkingCards,
+            false,
+          ),
           responseMode: this.resolveConfigMessagingResponseMode(
             config.messaging?.slack?.responseMode,
             "mention_only",

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -911,6 +911,7 @@ describe("App", () => {
         },
         slack: {
           enabled: { value: false, source: "default" },
+          liveWorkingCards: { value: false, source: "default" },
           responseMode: { value: "mention_only", source: "default" },
           streamingResponses: { value: false, source: "default" },
           botToken: { configured: false, source: "unset", writable: true },

--- a/apps/desktop/src/renderer/src/features/settings/MessagingRoutesSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingRoutesSettings.tsx
@@ -486,7 +486,7 @@ function DefaultAgentRow(props: {
                 className="chip chip--backend messaging-route-row__provider-chip"
                 title={`Working Updates override: ${toolUpdateOverride}`}
               >
-                Updates override: {toolUpdateOverride}
+                Updates: {toolUpdateOverride}
               </span>
             ) : null}
             {!props.route.target.available

--- a/apps/desktop/src/renderer/src/features/settings/MessagingRoutesSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingRoutesSettings.tsx
@@ -25,7 +25,7 @@ import {
   formatMessagingPlatformName,
 } from "../../lib/messaging-platform-branding";
 import type { DesktopApi } from "../../lib/desktop-api";
-import { SettingsField, SettingsSection } from "./SettingsLayout";
+import { SettingsSection } from "./SettingsLayout";
 
 const EMPTY_ROUTES: ListMessagingRoutesResponse = {
   defaultAgents: [],
@@ -45,14 +45,13 @@ const ROUTE_PLATFORMS: MessagingChannelKind[] = [
 
 const ROUTE_TOOL_UPDATE_MODE_OPTIONS: Array<{
   label: string;
-  shortLabel: string;
   value: MessagingToolUpdateMode;
 }> = [
-  { label: "Show None", shortLabel: "None", value: "show_none" },
-  { label: "Show Less", shortLabel: "Few", value: "show_less" },
-  { label: "Show Some", shortLabel: "Some", value: "show_some" },
-  { label: "Show More", shortLabel: "More", value: "show_more" },
-  { label: "Show All", shortLabel: "All", value: "show_all" },
+  { label: "Show None", value: "show_none" },
+  { label: "Show Less", value: "show_less" },
+  { label: "Show Some", value: "show_some" },
+  { label: "Show More", value: "show_more" },
+  { label: "Show All", value: "show_all" },
 ];
 
 type DefaultScopeKind = DesktopMessagingDefaultAgentScope["kind"];
@@ -175,13 +174,8 @@ function useMessagingRoutes(): MessagingRoutesContextValue {
 
 export function MessagingRoutesSettings(props: {
   agentRouteToolUpdateMode?: MessagingToolUpdateMode;
-  agentRouteToolUpdateModeSource?: string;
   configuredPlatforms?: readonly MessagingChannelKind[];
   desktopApi?: DesktopApi;
-  saving?: boolean;
-  onAgentRouteToolUpdateModeChange?: (
-    mode: MessagingToolUpdateMode,
-  ) => void | Promise<void>;
   onOpenThread?: (target: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -264,16 +258,6 @@ export function MessagingRoutesSettings(props: {
       chipKind={routeCount > 0 ? "ok" : "muted"}
     >
       <div className="messaging-routes" ref={routesRef}>
-        <div className="settings-fields">
-          <RouteWorkingUpdatesControl
-            disabled={props.saving || !props.onAgentRouteToolUpdateModeChange}
-            mode={agentRouteToolUpdateMode}
-            source={props.agentRouteToolUpdateModeSource}
-            onChange={(mode) => {
-              void props.onAgentRouteToolUpdateModeChange?.(mode);
-            }}
-          />
-        </div>
         <div className="messaging-routes__toolbar">
           <div>
             <strong>Default Agents</strong>
@@ -352,7 +336,6 @@ export function MessagingRoutesSettings(props: {
               <DefaultAgentRow
                 key={route.assignmentId}
                 route={route}
-                inheritedToolUpdateMode={agentRouteToolUpdateMode}
                 busy={busyId === route.assignmentId}
                 onChange={() => {
                   setShowAdd(false);
@@ -445,7 +428,6 @@ export function MessagingRoutesSettings(props: {
 
 function DefaultAgentRow(props: {
   route: DesktopMessagingDefaultAgentRoute;
-  inheritedToolUpdateMode: MessagingToolUpdateMode;
   busy: boolean;
   onChange: () => void;
   onClear: () => void;
@@ -456,10 +438,18 @@ function DefaultAgentRow(props: {
 }) {
   const platform = platformForScope(props.route.scope);
   const Icon = platform ? MESSAGING_PLATFORM_ICONS[platform] : undefined;
+  const toolUpdateOverride = props.route.toolUpdateMode
+    ? routeToolUpdateModeLabel(props.route.toolUpdateMode)
+    : undefined;
   return (
     <div className="messaging-route-row">
       <button
-        aria-label={`Open thread ${props.route.target.label}`}
+        aria-label={[
+          `Open thread ${props.route.target.label}`,
+          toolUpdateOverride
+            ? `Working Updates override ${toolUpdateOverride}`
+            : undefined,
+        ].filter(Boolean).join(", ")}
         className="messaging-route-row__open"
         disabled={!props.onOpenThread}
         title={props.onOpenThread ? `Open ${props.route.target.label}` : undefined}
@@ -491,13 +481,14 @@ function DefaultAgentRow(props: {
               available={props.route.target.backendAvailable}
               label={props.route.target.backendLabel}
             />
-            <span className="chip chip--backend">
-              Working Updates: {props.route.toolUpdateMode
-                ? routeToolUpdateModeLabel(props.route.toolUpdateMode)
-                : `Default (${routeToolUpdateModeLabel(
-                    props.inheritedToolUpdateMode,
-                  )})`}
-            </span>
+            {toolUpdateOverride ? (
+              <span
+                className="chip chip--backend messaging-route-row__provider-chip"
+                title={`Working Updates override: ${toolUpdateOverride}`}
+              >
+                Updates override: {toolUpdateOverride}
+              </span>
+            ) : null}
             {!props.route.target.available
               && props.route.target.backendAvailable ? (
                 <span className="messaging-route-row__target-warning">
@@ -868,7 +859,7 @@ function DefaultAgentEditor(props: {
           ) : null}
         </div>
       ) : null}
-      <label className="messaging-route-editor__agent">
+      <label className="messaging-route-editor__field">
         <span>Agent</span>
         <select
           aria-label="Default Agent"
@@ -884,7 +875,7 @@ function DefaultAgentEditor(props: {
           ))}
         </select>
       </label>
-      <label className="messaging-route-editor__agent">
+      <label className="messaging-route-editor__field">
         <span>Working Updates</span>
         <select
           aria-label="Route Working Updates"
@@ -896,13 +887,13 @@ function DefaultAgentEditor(props: {
             )}
         >
           <option value="">
-            Use profile default ({routeToolUpdateModeLabel(
+            Use manager-agent default ({routeToolUpdateModeLabel(
               props.inheritedToolUpdateMode,
             )})
           </option>
           {ROUTE_TOOL_UPDATE_MODE_OPTIONS.map((option) => (
             <option key={option.value} value={option.value}>
-              {option.shortLabel}
+              {option.label}
             </option>
           ))}
         </select>
@@ -930,48 +921,10 @@ function DefaultAgentEditor(props: {
   );
 }
 
-function RouteWorkingUpdatesControl(props: {
-  disabled?: boolean;
-  mode: MessagingToolUpdateMode;
-  source?: string;
-  onChange: (mode: MessagingToolUpdateMode) => void;
-}) {
-  return (
-    <SettingsField
-      label="Agent route Working Updates"
-      sub="Profile default for Default Agent routes. Individual routes can override it when they need a different level of detail."
-      source={props.source}
-      control={
-        <div
-          aria-label="Agent route Working Updates"
-          className="settings-segmented"
-          role="radiogroup"
-        >
-          {ROUTE_TOOL_UPDATE_MODE_OPTIONS.map((option) => (
-            <button
-              key={option.value}
-              aria-checked={props.mode === option.value}
-              className={`settings-segmented__button${
-                props.mode === option.value ? " is-active" : ""
-              }`}
-              disabled={props.disabled}
-              role="radio"
-              type="button"
-              onClick={() => props.onChange(option.value)}
-            >
-              {option.label}
-            </button>
-          ))}
-        </div>
-      }
-    />
-  );
-}
-
 function routeToolUpdateModeLabel(mode: MessagingToolUpdateMode): string {
   return ROUTE_TOOL_UPDATE_MODE_OPTIONS.find(
     (option) => option.value === mode,
-  )?.shortLabel ?? "None";
+  )?.label ?? "Show None";
 }
 
 function newDefaultForm(

--- a/apps/desktop/src/renderer/src/features/settings/MessagingRoutesSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingRoutesSettings.tsx
@@ -17,6 +17,7 @@ import type {
   ListMessagingRoutesResponse,
   MessagingChannelKind,
   MessagingConversationKind,
+  MessagingToolUpdateMode,
 } from "@pwragent/shared";
 import { PlusIcon } from "../../icons";
 import {
@@ -24,7 +25,7 @@ import {
   formatMessagingPlatformName,
 } from "../../lib/messaging-platform-branding";
 import type { DesktopApi } from "../../lib/desktop-api";
-import { SettingsSection } from "./SettingsLayout";
+import { SettingsField, SettingsSection } from "./SettingsLayout";
 
 const EMPTY_ROUTES: ListMessagingRoutesResponse = {
   defaultAgents: [],
@@ -40,6 +41,18 @@ const ROUTE_PLATFORMS: MessagingChannelKind[] = [
   "mattermost",
   "feishu",
   "line",
+];
+
+const ROUTE_TOOL_UPDATE_MODE_OPTIONS: Array<{
+  label: string;
+  shortLabel: string;
+  value: MessagingToolUpdateMode;
+}> = [
+  { label: "Show None", shortLabel: "None", value: "show_none" },
+  { label: "Show Less", shortLabel: "Few", value: "show_less" },
+  { label: "Show Some", shortLabel: "Some", value: "show_some" },
+  { label: "Show More", shortLabel: "More", value: "show_more" },
+  { label: "Show All", shortLabel: "All", value: "show_all" },
 ];
 
 type DefaultScopeKind = DesktopMessagingDefaultAgentScope["kind"];
@@ -161,8 +174,14 @@ function useMessagingRoutes(): MessagingRoutesContextValue {
 }
 
 export function MessagingRoutesSettings(props: {
+  agentRouteToolUpdateMode?: MessagingToolUpdateMode;
+  agentRouteToolUpdateModeSource?: string;
   configuredPlatforms?: readonly MessagingChannelKind[];
   desktopApi?: DesktopApi;
+  saving?: boolean;
+  onAgentRouteToolUpdateModeChange?: (
+    mode: MessagingToolUpdateMode,
+  ) => void | Promise<void>;
   onOpenThread?: (target: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -170,6 +189,8 @@ export function MessagingRoutesSettings(props: {
 }) {
   const routeState = useMessagingRoutes();
   const { routes, loading, loadRoutes } = routeState;
+  const agentRouteToolUpdateMode =
+    props.agentRouteToolUpdateMode ?? "show_none";
   const configuredPlatforms = props.configuredPlatforms ?? ROUTE_PLATFORMS;
   const emptyForm = props.configuredPlatforms
     ? newDefaultForm(configuredPlatforms)
@@ -243,6 +264,16 @@ export function MessagingRoutesSettings(props: {
       chipKind={routeCount > 0 ? "ok" : "muted"}
     >
       <div className="messaging-routes" ref={routesRef}>
+        <div className="settings-fields">
+          <RouteWorkingUpdatesControl
+            disabled={props.saving || !props.onAgentRouteToolUpdateModeChange}
+            mode={agentRouteToolUpdateMode}
+            source={props.agentRouteToolUpdateModeSource}
+            onChange={(mode) => {
+              void props.onAgentRouteToolUpdateModeChange?.(mode);
+            }}
+          />
+        </div>
         <div className="messaging-routes__toolbar">
           <div>
             <strong>Default Agents</strong>
@@ -289,6 +320,7 @@ export function MessagingRoutesSettings(props: {
               await loadRoutes();
             }}
             desktopApi={props.desktopApi}
+            inheritedToolUpdateMode={agentRouteToolUpdateMode}
           />
         ) : null}
 
@@ -306,6 +338,7 @@ export function MessagingRoutesSettings(props: {
               await loadRoutes();
             }}
             desktopApi={props.desktopApi}
+            inheritedToolUpdateMode={agentRouteToolUpdateMode}
           />
         ) : null}
 
@@ -319,6 +352,7 @@ export function MessagingRoutesSettings(props: {
               <DefaultAgentRow
                 key={route.assignmentId}
                 route={route}
+                inheritedToolUpdateMode={agentRouteToolUpdateMode}
                 busy={busyId === route.assignmentId}
                 onChange={() => {
                   setShowAdd(false);
@@ -411,6 +445,7 @@ export function MessagingRoutesSettings(props: {
 
 function DefaultAgentRow(props: {
   route: DesktopMessagingDefaultAgentRoute;
+  inheritedToolUpdateMode: MessagingToolUpdateMode;
   busy: boolean;
   onChange: () => void;
   onClear: () => void;
@@ -456,6 +491,13 @@ function DefaultAgentRow(props: {
               available={props.route.target.backendAvailable}
               label={props.route.target.backendLabel}
             />
+            <span className="chip chip--backend">
+              Working Updates: {props.route.toolUpdateMode
+                ? routeToolUpdateModeLabel(props.route.toolUpdateMode)
+                : `Default (${routeToolUpdateModeLabel(
+                    props.inheritedToolUpdateMode,
+                  )})`}
+            </span>
             {!props.route.target.available
               && props.route.target.backendAvailable ? (
                 <span className="messaging-route-row__target-warning">
@@ -566,6 +608,7 @@ function DefaultAgentEditor(props: {
   agents: DesktopMessagingAgentRouteTarget[];
   assignment?: DesktopMessagingDefaultAgentRoute;
   desktopApi?: DesktopApi;
+  inheritedToolUpdateMode: MessagingToolUpdateMode;
   initialForm?: NewDefaultForm;
   observedSurfaces: DesktopMessagingObservedSurface[];
   platforms: readonly MessagingChannelKind[];
@@ -586,6 +629,9 @@ function DefaultAgentEditor(props: {
       ? encodeTarget(props.assignment.target)
       : "",
   );
+  const [toolUpdateMode, setToolUpdateMode] = useState<
+    MessagingToolUpdateMode | ""
+  >(props.assignment?.toolUpdateMode ?? "");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const editing = Boolean(props.assignment);
@@ -622,6 +668,11 @@ function DefaultAgentEditor(props: {
           : {}),
         scope,
         target,
+        ...(toolUpdateMode
+          ? { toolUpdateMode }
+          : props.assignment?.toolUpdateMode
+            ? { toolUpdateMode: null }
+            : {}),
       });
       await props.onSaved();
     } catch (saveError) {
@@ -833,6 +884,29 @@ function DefaultAgentEditor(props: {
           ))}
         </select>
       </label>
+      <label className="messaging-route-editor__agent">
+        <span>Working Updates</span>
+        <select
+          aria-label="Route Working Updates"
+          className="settings-select"
+          value={toolUpdateMode}
+          onChange={(event) =>
+            setToolUpdateMode(
+              event.target.value as MessagingToolUpdateMode | "",
+            )}
+        >
+          <option value="">
+            Use profile default ({routeToolUpdateModeLabel(
+              props.inheritedToolUpdateMode,
+            )})
+          </option>
+          {ROUTE_TOOL_UPDATE_MODE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.shortLabel}
+            </option>
+          ))}
+        </select>
+      </label>
       {error ? <p className="messaging-route-editor__error" role="alert">{error}</p> : null}
       <div className="messaging-route-editor__actions">
         <button
@@ -854,6 +928,50 @@ function DefaultAgentEditor(props: {
       </div>
     </div>
   );
+}
+
+function RouteWorkingUpdatesControl(props: {
+  disabled?: boolean;
+  mode: MessagingToolUpdateMode;
+  source?: string;
+  onChange: (mode: MessagingToolUpdateMode) => void;
+}) {
+  return (
+    <SettingsField
+      label="Agent route Working Updates"
+      sub="Profile default for Default Agent routes. Individual routes can override it when they need a different level of detail."
+      source={props.source}
+      control={
+        <div
+          aria-label="Agent route Working Updates"
+          className="settings-segmented"
+          role="radiogroup"
+        >
+          {ROUTE_TOOL_UPDATE_MODE_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              aria-checked={props.mode === option.value}
+              className={`settings-segmented__button${
+                props.mode === option.value ? " is-active" : ""
+              }`}
+              disabled={props.disabled}
+              role="radio"
+              type="button"
+              onClick={() => props.onChange(option.value)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      }
+    />
+  );
+}
+
+function routeToolUpdateModeLabel(mode: MessagingToolUpdateMode): string {
+  return ROUTE_TOOL_UPDATE_MODE_OPTIONS.find(
+    (option) => option.value === mode,
+  )?.shortLabel ?? "None";
 }
 
 function newDefaultForm(

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -1354,6 +1354,22 @@ export function MessagingSettings(props: {
             />
           </div>
           <ToggleField
+            checked={slack.liveWorkingCards.value}
+            disabled={props.saving}
+            label="Live Working Cards"
+            sub="Shows Working Updates as one live Slack task card per turn. Off by default."
+            source={sourceBadge(slack.liveWorkingCards)}
+            onChange={(liveWorkingCards) => {
+              void props.onSaveSlack({
+                ...slack,
+                liveWorkingCards: {
+                  ...slack.liveWorkingCards,
+                  value: liveWorkingCards,
+                },
+              });
+            }}
+          />
+          <ToggleField
             checked={slack.streamingResponses.value}
             disabled={props.saving}
             label="Streaming responses"

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -497,8 +497,12 @@ export function MessagingSettings(props: {
       </SettingsSection>
 
       <MessagingRoutesSettings
+        agentRouteToolUpdateMode={managerToolUpdateMode.value}
+        agentRouteToolUpdateModeSource={sourceBadge(managerToolUpdateMode)}
         configuredPlatforms={configuredRoutePlatforms}
         desktopApi={props.desktopApi}
+        saving={props.saving}
+        onAgentRouteToolUpdateModeChange={props.onManagerToolUpdateModeChange}
         onOpenThread={props.onOpenThread}
       />
 

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -498,11 +498,8 @@ export function MessagingSettings(props: {
 
       <MessagingRoutesSettings
         agentRouteToolUpdateMode={managerToolUpdateMode.value}
-        agentRouteToolUpdateModeSource={sourceBadge(managerToolUpdateMode)}
         configuredPlatforms={configuredRoutePlatforms}
         desktopApi={props.desktopApi}
-        saving={props.saving}
-        onAgentRouteToolUpdateModeChange={props.onManagerToolUpdateModeChange}
         onOpenThread={props.onOpenThread}
       />
 
@@ -1360,8 +1357,8 @@ export function MessagingSettings(props: {
           <ToggleField
             checked={slack.liveWorkingCards.value}
             disabled={props.saving}
-            label="Live Working Cards"
-            sub="Shows Working Updates as one live Slack task card per turn. Off by default."
+            label="Live Working Updates card"
+            sub="Shows Working Updates in one Slack task card per turn when Slack stream APIs are available; otherwise uses text updates."
             source={sourceBadge(slack.liveWorkingCards)}
             onChange={(liveWorkingCards) => {
               void props.onSaveSlack({

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/messaging-routes-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/messaging-routes-settings.test.tsx
@@ -209,7 +209,9 @@ describe("MessagingRoutesSettings", () => {
     expect(screen.getByText("Issue 13056")).toBeInTheDocument();
     expect(screen.getAllByText("Codex")).toHaveLength(2);
     expect(screen.getByText("3 active")).toBeInTheDocument();
-    expect(screen.queryByText(/Updates override:/)).not.toBeInTheDocument();
+    // Routes that inherit the default carry no chip at all — the marker is
+    // for the exception, not for repeating the profile default on every row.
+    expect(screen.queryByText(/^Updates:/)).not.toBeInTheDocument();
   });
 
   it("sets and clears a per-route Working Updates override", async () => {
@@ -229,7 +231,9 @@ describe("MessagingRoutesSettings", () => {
       </MessagingRoutesProvider>,
     );
 
-    expect(await screen.findByText("Updates override: Show More")).toHaveClass(
+    // Kept short so the chip survives the narrow target column; the full
+    // phrase stays in the row's aria-label and the chip's title.
+    expect(await screen.findByText("Updates: Show More")).toHaveClass(
       "messaging-route-row__provider-chip",
     );
     expect(

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/messaging-routes-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/messaging-routes-settings.test.tsx
@@ -209,6 +209,85 @@ describe("MessagingRoutesSettings", () => {
     expect(screen.getByText("Issue 13056")).toBeInTheDocument();
     expect(screen.getAllByText("Codex")).toHaveLength(2);
     expect(screen.getByText("3 active")).toBeInTheDocument();
+    expect(screen.getAllByText("Working Updates: Default (None)")).toHaveLength(2);
+  });
+
+  it("repeats the Agent-route Working Updates default in Routes", async () => {
+    const api = buildDesktopApi();
+    const onModeChange = vi.fn();
+
+    render(
+      <MessagingRoutesProvider desktopApi={api.desktopApi}>
+        <MessagingRoutesSettings
+          agentRouteToolUpdateMode="show_none"
+          desktopApi={api.desktopApi}
+          onAgentRouteToolUpdateModeChange={onModeChange}
+        />
+      </MessagingRoutesProvider>,
+    );
+
+    const group = await screen.findByRole("radiogroup", {
+      name: "Agent route Working Updates",
+    });
+    expect(group).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Show None" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: "Show Some" }));
+    expect(onModeChange).toHaveBeenCalledWith("show_some");
+  });
+
+  it("sets and clears a per-route Working Updates override", async () => {
+    const routes = buildRoutes();
+    routes.defaultAgents[0] = {
+      ...routes.defaultAgents[0]!,
+      toolUpdateMode: "show_more",
+    };
+    const api = buildDesktopApi(routes);
+
+    render(
+      <MessagingRoutesProvider desktopApi={api.desktopApi}>
+        <MessagingRoutesSettings
+          agentRouteToolUpdateMode="show_none"
+          desktopApi={api.desktopApi}
+        />
+      </MessagingRoutesProvider>,
+    );
+
+    expect(await screen.findByText("Working Updates: More")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Change" })[0]!);
+    expect(screen.getByLabelText("Route Working Updates")).toHaveValue(
+      "show_more",
+    );
+
+    fireEvent.change(screen.getByLabelText("Route Working Updates"), {
+      target: { value: "show_all" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save default" }));
+    await waitFor(() => {
+      expect(api.setMessagingDefaultAgent).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          assignmentId: "assignment-1",
+          toolUpdateMode: "show_all",
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Change" })[0]!);
+    fireEvent.change(screen.getByLabelText("Route Working Updates"), {
+      target: { value: "" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save default" }));
+    await waitFor(() => {
+      expect(api.setMessagingDefaultAgent).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          assignmentId: "assignment-1",
+          toolUpdateMode: null,
+        }),
+      );
+    });
   });
 
   it("distinguishes untitled topics in the same messaging group", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/messaging-routes-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/messaging-routes-settings.test.tsx
@@ -209,34 +209,7 @@ describe("MessagingRoutesSettings", () => {
     expect(screen.getByText("Issue 13056")).toBeInTheDocument();
     expect(screen.getAllByText("Codex")).toHaveLength(2);
     expect(screen.getByText("3 active")).toBeInTheDocument();
-    expect(screen.getAllByText("Working Updates: Default (None)")).toHaveLength(2);
-  });
-
-  it("repeats the Agent-route Working Updates default in Routes", async () => {
-    const api = buildDesktopApi();
-    const onModeChange = vi.fn();
-
-    render(
-      <MessagingRoutesProvider desktopApi={api.desktopApi}>
-        <MessagingRoutesSettings
-          agentRouteToolUpdateMode="show_none"
-          desktopApi={api.desktopApi}
-          onAgentRouteToolUpdateModeChange={onModeChange}
-        />
-      </MessagingRoutesProvider>,
-    );
-
-    const group = await screen.findByRole("radiogroup", {
-      name: "Agent route Working Updates",
-    });
-    expect(group).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "Show None" })).toHaveAttribute(
-      "aria-checked",
-      "true",
-    );
-
-    fireEvent.click(screen.getByRole("radio", { name: "Show Some" }));
-    expect(onModeChange).toHaveBeenCalledWith("show_some");
+    expect(screen.queryByText(/Updates override:/)).not.toBeInTheDocument();
   });
 
   it("sets and clears a per-route Working Updates override", async () => {
@@ -256,11 +229,27 @@ describe("MessagingRoutesSettings", () => {
       </MessagingRoutesProvider>,
     );
 
-    expect(await screen.findByText("Working Updates: More")).toBeInTheDocument();
+    expect(await screen.findByText("Updates override: Show More")).toHaveClass(
+      "messaging-route-row__provider-chip",
+    );
+    expect(
+      screen.getByRole("button", {
+        name: /Working Updates override Show More/,
+      }),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getAllByRole("button", { name: "Change" })[0]!);
     expect(screen.getByLabelText("Route Working Updates")).toHaveValue(
       "show_more",
     );
+    expect(screen.getByLabelText("Route Working Updates")).toHaveDisplayValue(
+      "Show More",
+    );
+    expect(screen.getByRole("option", { name: "Show Less" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", {
+        name: "Use manager-agent default (Show None)",
+      }),
+    ).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Route Working Updates"), {
       target: { value: "show_all" },

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -986,22 +986,11 @@ describe("SettingsScreen", () => {
         },
       });
     });
-    const routeWorkingUpdates = screen.getByRole("radiogroup", {
-      name: "Agent route Working Updates",
-    });
     expect(
-      within(routeWorkingUpdates).getByRole("radio", { name: "Show None" }),
-    ).toHaveAttribute("aria-checked", "true");
-    fireEvent.click(
-      within(routeWorkingUpdates).getByRole("radio", { name: "Show Some" }),
-    );
-    await waitFor(() => {
-      expect(settings.writeConfig).toHaveBeenCalledWith({
-        messaging: {
-          managerToolUpdateMode: "show_some",
-        },
-      });
-    });
+      screen.queryByRole("radiogroup", {
+        name: "Agent route Working Updates",
+      }),
+    ).not.toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Input debounce"), {
       target: { value: "750" },
     });
@@ -1018,6 +1007,23 @@ describe("SettingsScreen", () => {
     expect(
       screen.getByRole("radio", { name: "Group/supergroup chat" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Shows Working Updates in one Slack task card per turn when Slack stream APIs are available; otherwise uses text updates.",
+      ),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Live Working Updates card" }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: {
+          slack: {
+            liveWorkingCards: true,
+          },
+        },
+      });
+    });
     // Five providers expose a streaming toggle; LINE has no message-edit API so
     // it deliberately has none.
     expect(screen.getAllByText(/does not make turns finish sooner/)).toHaveLength(5);

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -986,6 +986,22 @@ describe("SettingsScreen", () => {
         },
       });
     });
+    const routeWorkingUpdates = screen.getByRole("radiogroup", {
+      name: "Agent route Working Updates",
+    });
+    expect(
+      within(routeWorkingUpdates).getByRole("radio", { name: "Show None" }),
+    ).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(
+      within(routeWorkingUpdates).getByRole("radio", { name: "Show Some" }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: {
+          managerToolUpdateMode: "show_some",
+        },
+      });
+    });
     fireEvent.change(screen.getByLabelText("Input debounce"), {
       target: { value: "750" },
     });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -283,6 +283,7 @@ function createSnapshot(
       },
       slack: {
         enabled: { value: false, source: "default" },
+        liveWorkingCards: { value: false, source: "default" },
         responseMode: { value: "mention_only", source: "default" },
         streamingResponses: { value: false, source: "default" },
         botToken: { configured: false, source: "unset", writable: true },

--- a/apps/desktop/src/renderer/src/features/settings/settings-patch-delta.ts
+++ b/apps/desktop/src/renderer/src/features/settings/settings-patch-delta.ts
@@ -162,6 +162,9 @@ export function buildSlackPatchDelta(
   if (snapshot.enabled.value !== candidate.enabled.value) {
     patch.enabled = candidate.enabled.value;
   }
+  if (snapshot.liveWorkingCards.value !== candidate.liveWorkingCards.value) {
+    patch.liveWorkingCards = candidate.liveWorkingCards.value;
+  }
   if (snapshot.responseMode.value !== candidate.responseMode.value) {
     patch.responseMode = candidate.responseMode.value;
   }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7764,7 +7764,7 @@ textarea,
   font-weight: 650;
 }
 
-.messaging-route-editor__agent {
+.messaging-route-editor__field {
   max-width: 520px;
 }
 

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -107,14 +107,32 @@ controller owns the dial policy and emits only admitted, redacted tasks with a
 stable `key` and monotonic `sequence`. Adapters must discard stale sequences.
 Slack renders the intent with Thinking Steps (`chat.startStream`,
 `chat.appendStream`, and `chat.stopStream`) when a thread target is available;
-stream state stays in memory. If native streaming is unavailable, the adapter
-delivers `fallbackText` as the existing Working Update. Providers without a
-native live-card surface continue to use that text fallback.
+stream state stays in memory. Slack Live Working Cards are opt-in through
+`messaging.slack.live_working_cards`; an absent setting currently means off and
+must remain absent during unrelated config writes so a future default change
+can apply to untouched profiles. If native streaming is disabled or
+unavailable, the adapter delivers `fallbackText` as the existing Working
+Update. Providers without a native live-card surface continue to use that text
+fallback.
+
+Provider-native live surfaces may have API budgets orthogonal to ordinary
+message delivery. Adapters may use `MessagingRateLimitGate` to account for
+multiple workspace/method buckets independently. Slack maintains ordered,
+per-card queues over workspace-wide `chat.startStream`, `chat.appendStream`,
+and `chat.stopStream` buckets: start is a barrier, intermediate snapshots are
+coalesced while waiting, and terminal stop remains queued until admitted.
+These queues must not block approval, questionnaire, final-answer, or other
+ordinary message delivery. A platform 429 extends the affected bucket from
+`Retry-After`; it is not permission to discard a terminal stop.
 
 An open native card replaces classic tool-update posts for those activities.
 Task titles and details must be clamped to provider limits and must never add
 raw command output or secrets. Waiting and terminal phases clear transient
 working indicators; the final assistant message remains authoritative.
+Adapters return a retractable surface as soon as a native card is queued so
+turn cancellation and terminal private-response routing can cancel pending
+work or remove an already-mounted card. Completed keys retain a bounded
+sequence tombstone so delayed events cannot reopen a terminal card.
 
 - chunk long messages according to platform limits
 - preserve inline code and fenced code when supported

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -100,6 +100,22 @@ long-lived sqlite records:
 
 Adapters own platform limits and degradation:
 
+### Working cards
+
+`working_card` is a channel-neutral, turn-scoped Working Updates surface. The
+controller owns the dial policy and emits only admitted, redacted tasks with a
+stable `key` and monotonic `sequence`. Adapters must discard stale sequences.
+Slack renders the intent with Thinking Steps (`chat.startStream`,
+`chat.appendStream`, and `chat.stopStream`) when a thread target is available;
+stream state stays in memory. If native streaming is unavailable, the adapter
+delivers `fallbackText` as the existing Working Update. Providers without a
+native live-card surface continue to use that text fallback.
+
+An open native card replaces classic tool-update posts for those activities.
+Task titles and details must be clamped to provider limits and must never add
+raw command output or secrets. Waiting and terminal phases clear transient
+working indicators; the final assistant message remains authoritative.
+
 - chunk long messages according to platform limits
 - preserve inline code and fenced code when supported
 - escape or neutralize markdown dialect hazards

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -145,7 +145,17 @@ Task titles use the already-redacted activity title, while duration and other
 secondary context belong in task details; both fields must be clamped to
 provider limits and must never add raw command output or secrets. Because Slack
 has no cancelled task status, cancelled tasks close neutrally with cancellation
-called out in their details instead of rendering as errors. Waiting phases add
+called out in their details instead of rendering as errors.
+
+A tool that has started but not finished is reported as an `in_progress` task
+so the card shows what is running now rather than a list of finished steps.
+Started activities deliberately bypass the Working Updates dial: they carry no
+outcome, so they never batch into text messages, never consume policy budget,
+and never open a card the dial has not already opened — None stays silent, and
+surfaces that render text are unaffected. A started task carries no duration,
+updates its row in place when the same item completes, and is settled by the
+terminal render (completed on success, cancelled on failure) so a stopped
+stream cannot keep a live indicator. Waiting phases add
 a visible stream headline and waiting and terminal phases clear transient
 working indicators; the final assistant message remains authoritative.
 Adapters return a retractable surface as soon as a native card is queued so

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -127,18 +127,24 @@ stream state stays in memory. Slack Live Working Updates cards are opt-in throug
 must remain absent during unrelated config writes so a future default change
 can apply to untouched profiles. If native streaming is disabled or
 unavailable, the adapter delivers `fallbackText` as the existing Working
-Update. Providers without a native live-card surface continue to use that text
-fallback.
+Update using the intent's `fallbackPresentation` role and Markdown policy.
+Providers without a native live-card surface continue to use that text
+fallback. Terminal fallback intents are no-ops and must not consume or wait on
+ordinary message-delivery capacity.
 
 Provider-native live surfaces may have API budgets orthogonal to ordinary
 message delivery. Adapters may use `MessagingRateLimitGate` to account for
-multiple workspace/method buckets independently. Slack maintains ordered,
-per-card queues over workspace-wide `chat.startStream`, `chat.appendStream`,
-and `chat.stopStream` buckets: start is a barrier, intermediate snapshots are
-coalesced while waiting, and terminal stop remains queued until admitted.
-These queues must not block approval, questionnaire, final-answer, or other
-ordinary message delivery. A platform 429 extends the affected bucket from
-`Retry-After`; it is not permission to discard a terminal stop.
+multiple workspace/method buckets independently. Slack maintains ordered
+per-card lifecycle state over workspace-wide `chat.startStream`,
+`chat.appendStream`, and `chat.stopStream` buckets. Start is a barrier and
+terminal stop remains queued until admitted. Intermediate appends are
+disposable: when their local bucket or Slack 429 cool-off blocks them, the
+adapter drops them without a timer or text fallback. A later admitted update
+reconciles directly to the newest controller-bounded snapshot. This prevents a
+multi-thread append backlog while keeping start/stop lifecycle ordering. These
+card lanes must not block approval, questionnaire, final-answer, or other
+ordinary message delivery. A platform 429 extends only the affected method
+bucket from `Retry-After`; it is not permission to discard a terminal stop.
 
 An open native card replaces classic tool-update posts for those activities.
 Task titles use the already-redacted activity title, while duration and other
@@ -148,6 +154,8 @@ has no cancelled task status, cancelled tasks close neutrally with cancellation
 called out in their details instead of rendering as errors. Waiting phases add
 a visible stream headline and waiting and terminal phases clear transient
 working indicators; the final assistant message remains authoritative.
+Slack renderers reuse a bounded set of positional task IDs so controller
+history eviction replaces mounted rows instead of growing the native card.
 Adapters return a retractable surface as soon as a native card is queued so
 turn cancellation and terminal private-response routing can cancel pending
 work or remove an already-mounted card. Completed keys retain a bounded

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -122,7 +122,7 @@ controller owns the dial policy and emits only admitted, redacted tasks with a
 stable `key` and monotonic `sequence`. Adapters must discard stale sequences.
 Slack renders the intent with Thinking Steps (`chat.startStream`,
 `chat.appendStream`, and `chat.stopStream`) when a thread target is available;
-stream state stays in memory. Slack Live Working Cards are opt-in through
+stream state stays in memory. Slack Live Working Updates cards are opt-in through
 `messaging.slack.live_working_cards`; an absent setting currently means off and
 must remain absent during unrelated config writes so a future default change
 can apply to untouched profiles. If native streaming is disabled or
@@ -141,8 +141,12 @@ ordinary message delivery. A platform 429 extends the affected bucket from
 `Retry-After`; it is not permission to discard a terminal stop.
 
 An open native card replaces classic tool-update posts for those activities.
-Task titles and details must be clamped to provider limits and must never add
-raw command output or secrets. Waiting and terminal phases clear transient
+Task titles use the already-redacted activity title, while duration and other
+secondary context belong in task details; both fields must be clamped to
+provider limits and must never add raw command output or secrets. Because Slack
+has no cancelled task status, cancelled tasks close neutrally with cancellation
+called out in their details instead of rendering as errors. Waiting phases add
+a visible stream headline and waiting and terminal phases clear transient
 working indicators; the final assistant message remains authoritative.
 Adapters return a retractable surface as soon as a native card is queued so
 turn cancellation and terminal private-response routing can cancel pending

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -145,17 +145,7 @@ Task titles use the already-redacted activity title, while duration and other
 secondary context belong in task details; both fields must be clamped to
 provider limits and must never add raw command output or secrets. Because Slack
 has no cancelled task status, cancelled tasks close neutrally with cancellation
-called out in their details instead of rendering as errors.
-
-A tool that has started but not finished is reported as an `in_progress` task
-so the card shows what is running now rather than a list of finished steps.
-Started activities deliberately bypass the Working Updates dial: they carry no
-outcome, so they never batch into text messages, never consume policy budget,
-and never open a card the dial has not already opened — None stays silent, and
-surfaces that render text are unaffected. A started task carries no duration,
-updates its row in place when the same item completes, and is settled by the
-terminal render (completed on success, cancelled on failure) so a stopped
-stream cannot keep a live indicator. Waiting phases add
+called out in their details instead of rendering as errors. Waiting phases add
 a visible stream headline and waiting and terminal phases clear transient
 working indicators; the final assistant message remains authoritative.
 Adapters return a retractable surface as soon as a native card is queued so

--- a/docs/plans/2026-08-12-001-feat-slack-live-working-cards-plan.md
+++ b/docs/plans/2026-08-12-001-feat-slack-live-working-cards-plan.md
@@ -294,10 +294,16 @@ no thread_ts, channel without recipient identity):
 - Prefer appendStream (Tier 4) over chat.update for in-flight ticks
 - Coalesce controller-side first (existing windows); then adapter min-interval
   (~500–1000ms) for appends
-- Respect existing delivery budget + Slow Mode: working_card is low priority vs
-  final answer / approvals
-- On 429: Cool Off; drop intermediate card ticks; keep final stopStream attempt
-  once
+- Keep native stream calls in provider-owned, workspace/method buckets that are
+  orthogonal to the ordinary visible-message budget. `startStream`,
+  `appendStream`, and `stopStream` do not consume each other's quota.
+- Maintain one ordered queue per mounted card. Start is a barrier, waiting
+  intermediate snapshots coalesce to latest, and terminal stop remains queued
+  until its method bucket admits it.
+- Queue processing must be non-blocking to the controller so final answers,
+  approvals, and questionnaires bypass a jammed live-card lane.
+- On 429: honor `Retry-After` for that method bucket; drop superseded
+  intermediate ticks, but retain and retry the terminal stop.
 - Do not count setStatus against the same message budget as posts if Slack
   treats it separately; still throttle status text churn (update status string
   only on phase change)
@@ -336,11 +342,14 @@ no thread_ts, channel without recipient identity):
 | Item | Persist? |
 | --- | --- |
 | Dial preference (`toolUpdateMode`) | Yes (existing) |
+| Slack Live Working Cards opt-in | Yes, optional TOML field; absent defaults off |
 | Live stream ts / open stream id | **No** (memory only) |
 | Working card sequence | Memory only |
 | Delivery audit for final messages | Existing delivery records |
 
-No schema migration required for v1 if preferences stay the same.
+No database migration is required. Unrelated config writes must not materialize
+`live_working_cards = false`; absence remains meaningful so changing the
+default later moves untouched profiles together.
 
 ## Concrete implementation plan
 

--- a/docs/plans/2026-08-12-001-feat-slack-live-working-cards-plan.md
+++ b/docs/plans/2026-08-12-001-feat-slack-live-working-cards-plan.md
@@ -1,0 +1,445 @@
+---
+title: "feat: Slack Live Working Cards for Working Updates"
+type: feat
+status: planned
+date: 2026-08-12
+origin: handoff research from Linear Slack live-card signal
+sources:
+  - https://x.com/linear/status/2087277719130165435
+  - https://docs.slack.dev/ai/developing-agents
+  - https://docs.slack.dev/changelog/2026/02/11/task-cards-plan-blocks
+  - https://slack.dev/slack-thinking-steps-ai-agents/
+  - https://docs.slack.dev/reference/block-kit/blocks/task-card-block
+  - https://docs.slack.dev/reference/block-kit/blocks/plan-block
+  - https://docs.slack.dev/reference/methods/chat.startStream
+  - https://docs.slack.dev/reference/methods/chat.appendStream
+  - https://docs.slack.dev/reference/methods/assistant.threads.setStatus
+  - docs/plans/2026-07-04-001-feat-messaging-working-updates-dial-plan.md
+  - docs/plans/2026-05-02-001-feat-messaging-tool-update-verbosity-plan.md
+---
+
+# feat: Slack Live Working Cards for Working Updates
+
+## Summary
+
+Linear's 2026-08-11 product post demonstrates **live cards in Slack** for agent
+coding sessions: operators follow investigation/tool steps in place, then open
+a review/diff when the agent is ready. Linear's public Slack docs still
+describe issue filing and unfurls; they do **not** document the card protocol.
+The implementable Slack surface is Slack's own **Thinking Steps** stack:
+
+1. **Chat Streaming** — `chat.startStream` / `chat.appendStream` / `chat.stopStream`
+2. **Task cards** — Block Kit `task_card` (+ `plan` container)
+3. **Task display mode** — `timeline` | `plan` | `dense` on stream start
+4. **Thread status shimmer** — `assistant.threads.setStatus` (already used)
+
+PwrAgent should map **Working Updates** onto that stack for Slack only, without
+changing the dial semantics (None / Few / Some / More / All) or flooding other
+providers.
+
+This note is research + design. Product code ships in a follow-up implementation
+thread/PR.
+
+## Signal analysis (what Linear showed)
+
+| Claim from Linear post | What we can verify from primary sources |
+| --- | --- |
+| "Live cards in Slack" for coding sessions | Product marketing language; not a separate Slack product API named "Live Cards" |
+| Follow agent investigation + changes in Slack | Matches Slack Thinking Steps: streamed `task_update` / `task_card` with statuses |
+| Open diff from Slack when ready for review | Action buttons / links on final message (existing PwrAgent status/PR surfaces can cover) |
+
+**Do not reverse-engineer Linear's private payload.** Build on Slack's published
+APIs and PwrAgent's existing Working Updates controller.
+
+## Slack platform facts (constraints)
+
+### Streaming + Thinking Steps
+
+- Start: `chat.startStream` (scope `chat:write`, Tier 2 ≈ 20+/min)
+- Append: `chat.appendStream` (Tier 4 ≈ 100+/min) — good for frequent task ticks
+- Stop: `chat.stopStream`
+- Streamed messages **must** be thread replies (`thread_ts` required)
+- Channel streams require `recipient_user_id` + `recipient_team_id`
+- Chunk types: `markdown_text`, `task_update`, `plan_update`, `blocks`
+- `task_update` / `plan_update` title/details are limited (**256 chars**)
+- Blocks may be finalized on stop; unfurling disabled on streaming messages
+- Task display modes:
+  - `timeline` — sequential tasks as they happen
+  - `plan` — grouped task list (collapsed by default)
+  - `dense` — collapse consecutive tool calls into summarized cards
+
+### Task card model
+
+`task_card` fields (from Slack Block Kit):
+
+| Field | Notes |
+| --- | --- |
+| `task_id` | Stable id for update-in-place |
+| `title` | Plain text |
+| `status` | `pending` \| `in_progress` \| `complete` \| `error` |
+| `details` / `output` | Optional rich_text |
+| `sources` | Optional URL source elements |
+
+`plan` groups multiple task cards under a title.
+
+### Status shimmer
+
+`assistant.threads.setStatus` shows "is working…" next to the bot. PwrAgent
+already maps `activity: typing` → this API when thread_ts is known. Clear with
+empty status. Needs Agents feature / `assistant:write` or compatible `chat:write`
+path; adapter already degrades when unsupported.
+
+### Message edits outside streaming
+
+Slack agent guidance: for longer messages, call `chat.update` **at most once
+every 3 seconds**. Prefer streaming APIs for live work; reserve `chat.update`
+for non-stream fallbacks and final polish.
+
+### Visibility / privacy
+
+- Stream content is ordinary channel/DM message visibility (not ephemeral).
+- In public channels, Working Updates are visible to everyone in the channel.
+- Do **not** put secrets, raw command output, env values, or private reply
+  content into task titles/details (existing controller redaction rules).
+- Prefer basenames / safe titles already produced by
+  `messaging-tool-activity.ts`.
+
+### Accessibility
+
+- Task cards are collapsed by default in plan/timeline modes; provide a
+  plain-text `fallbackText` / top-level message text so screen readers and
+  notification previews still get a one-line status.
+- Status shimmer is supplementary, not a substitute for a durable final answer.
+- Voice readers may miss mid-stream edits; final assistant message remains
+  authoritative (same rule as existing streaming responses).
+
+### Install / scopes
+
+| Capability | Scope / feature |
+| --- | --- |
+| Stream + post/update | `chat:write` (already required) |
+| Agent status / suggested prompts | Agents feature → `assistant:write` |
+| SDK floor | Node Slack SDK ≥ 7.14.0 (repo has `@slack/web-api` ^7.15.2) |
+
+No new marketplace capability is strictly required for `chat.*Stream` beyond
+`chat:write`, but Agents feature remains needed for the shimmer status path
+PwrAgent already uses.
+
+## Current PwrAgent state
+
+### Working Updates (controller)
+
+- Dial modes: `show_none` | `show_less` | `show_some` | `show_more` | `show_all`
+  (labels None / Few / Some / More / All)
+- Policy: `MessagingToolUpdatePolicy` batches by binding+turn
+- Sources: completed tool items + in-turn assistant prose
+- Delivery: **new `message` intents** per individual/batch (not a single live card)
+- Final answers / approvals / questionnaires are **not** gated by the dial
+- Cancellation + rate budget + Slow Mode already drop stale low-priority traffic
+
+### Slack adapter today
+
+| Intent | Behavior |
+| --- | --- |
+| `activity` typing | `assistant.threads.setStatus` |
+| `stream_update` | `chat.postMessage` then `chat.update` (not native streams) |
+| tool Working Updates | ordinary `message` posts ("Tool update: …") |
+| status card | Block Kit actions / pinned-style status message |
+
+**Gap:** Slack posts many small system messages for Working Updates instead of
+one updating Thinking Steps card, so the Linear-like live-card UX is missing
+even though the dial and tool summaries already exist.
+
+## Goals / non-goals
+
+### Goals
+
+1. Slack bindings render Working Updates as **one live stream card per turn**
+   (Thinking Steps), updating in place.
+2. Preserve dial semantics and budgets; None stays silent; All is densest.
+3. Map turn UX states: queued → working → waiting → completed / failed.
+4. Keep controller channel-agnostic; Slack owns native rendering; other
+   providers keep text Working Updates.
+5. Fail closed on privacy (redacted titles only) and degrade gracefully when
+   stream APIs/status are unavailable.
+
+### Non-goals (v1)
+
+- Recreating Linear's exact product UI or private protocols
+- Enabling native `chat.*Stream` for full assistant answer streaming (separate
+  from Working Updates; can share plumbing later)
+- Cross-provider live cards
+- Streaming raw tool stdout into Slack
+- Marketplace Agent-view migration as a hard dependency for Working Updates
+- Changing persisted preference keys
+
+## Recommended architecture (smallest coherent path)
+
+### Principle
+
+**Controller still decides *whether* and *what* to surface. Slack adapter
+decides *how* to render a live card.**
+
+Do not teach `MessagingController` about `task_card` JSON. Extend the semantic
+surface just enough for multi-task progress, then specialize in the Slack
+adapter.
+
+### 1) Semantic model (shared)
+
+Extend Working Update delivery beyond pure text messages with a **turn-scoped
+progress surface** that can be updated:
+
+```ts
+// Directional shape — implementer may name/place carefully
+type MessagingWorkingCardIntent = {
+  kind: "working_card"; // new intent kind OR specialized progress payload
+  key: string;          // bindingId + turnId (stable stream key)
+  sequence: number;     // monotonic; drop stale
+  phase: "queued" | "working" | "waiting" | "completed" | "failed";
+  headline: string;     // plain fallback, e.g. "Working: 3 tools…"
+  tasks: Array<{
+    id: string;         // tool activity id or synthetic batch id
+    title: string;      // already redacted/safe
+    status: "pending" | "in_progress" | "complete" | "error" | "cancelled";
+    detail?: string;    // ≤256 chars after clamp
+  }>;
+  displayHint?: "timeline" | "plan" | "dense";
+  isFinal: boolean;
+};
+```
+
+**Minimal alternative (preferred if intent surface bloat is a concern):**
+
+Keep delivering tool activities through the existing policy, but add an
+optional `deliveryPresentation: "live_card" | "message"` + `cardKey` on the
+message/progress path, and let Slack coalesce those deliveries into one stream
+surface in-adapter. Controller still emits discrete activities; Slack owns the
+live-card fold.
+
+**Recommendation:** use a first-class `working_card` intent. It makes sequence,
+phase, and multi-task updates explicit and prevents other adapters from
+mis-rendering Slack-shaped blocks. Non-Slack adapters map `working_card` →
+existing text batch (`Tool updates: …`) so behavior stays parity.
+
+### 2) Event lifecycle
+
+```
+turn/start
+  → activity typing active (setStatus)
+  → optional working_card phase=queued (if dial ≠ None)
+
+item starts (optional v1.1) / item/completed
+  → MessagingToolActivity (extend status to include in_progress later)
+  → MessagingToolUpdatePolicy (unchanged thresholds)
+  → if delivery admitted:
+       emit working_card upsert (sequence++)
+     else:
+       buffer / drop per dial
+
+approval / questionnaire / waiting_input
+  → flush policy
+  → working_card phase=waiting (isFinal=false)
+  → deliver interactive surface separately (existing)
+
+turn complete / fail / cancel
+  → flush policy
+  → working_card phase=completed|failed, isFinal=true
+  → activity typing idle (clear setStatus)
+  → final assistant message (authoritative)
+```
+
+### 3) Dial → Slack presentation
+
+| Mode | Task stream behavior | setStatus | Fallback text posts |
+| --- | --- | --- | --- |
+| None | No working_card | Optional brief shimmer only if already used for typing | None |
+| Few (`show_less`) | One stream; `dense`; batches only | Yes while working | Suppress individual tool messages |
+| Some | One stream; `plan` or `dense`; first 3 individual tasks then batch | Yes | Suppress tool messages when card open |
+| More | One stream; `timeline`/`plan`; more tasks before dense collapse | Yes | Suppress tool messages when card open |
+| All | One stream; `timeline`; every admitted activity as its own task update | Yes | Suppress tool messages when card open |
+
+**Critical anti-noise rule:** when a live card is open for a turn, **do not also
+post classic "Tool update:" messages** for the same activities. The card
+replaces them on Slack. Other providers keep text messages.
+
+### 4) Slack adapter delivery
+
+For each `working_card` key:
+
+1. Ensure target has `channel` + `thread_ts` (post a lightweight root or use
+   binding root). If no thread context, fall back to text Working Updates.
+2. If stream not open: `chat.startStream` with `task_display_mode` from dial
+   and initial `task_update` / markdown headline.
+3. On sequence advances: `chat.appendStream` with `task_update` chunks
+   (upsert by `task_id`). Clamp titles/details to 256.
+4. Cap tasks (e.g. last N=12 visible; older collapse into one "Earlier: N tools"
+   synthetic complete task) to stay under 50-block and UX limits.
+5. On `isFinal`: `chat.stopStream` with optional terminal markdown
+   ("Ready for review" / "Failed"). Attach actions (Open thread / Open PR)
+   via stop-stream blocks if available; else follow-up message.
+6. Track stream state only in memory (`streamSurfaces`-like map keyed by
+   `working_card.key`). Restart-safe: if memory lost, either open a new stream
+   or fall back to a single final text summary — never duplicate by guessing.
+
+**Fallback ladder** when stream APIs fail (`missing_scope`, method unavailable,
+no thread_ts, channel without recipient identity):
+
+1. Single editable message with `plan`/`task_card` blocks via
+   `chat.postMessage` + `chat.update` (≤1 update / 3s, coalesce)
+2. Existing text Working Update messages
+3. setStatus-only + final answer
+
+### 5) Rate-limit strategy
+
+- Prefer appendStream (Tier 4) over chat.update for in-flight ticks
+- Coalesce controller-side first (existing windows); then adapter min-interval
+  (~500–1000ms) for appends
+- Respect existing delivery budget + Slow Mode: working_card is low priority vs
+  final answer / approvals
+- On 429: Cool Off; drop intermediate card ticks; keep final stopStream attempt
+  once
+- Do not count setStatus against the same message budget as posts if Slack
+  treats it separately; still throttle status text churn (update status string
+  only on phase change)
+
+### 6) Ordering / staleness / duplicates
+
+- Monotonic `sequence` per card key; ignore older sequences
+- `seenActivityIds` remains in policy (already)
+- Cancel in-flight card deliveries on turn cancel (mirror workingUpdate
+  cancellation maps)
+- Terminal phase always wins even if intermediate appends fail
+- Never re-open a completed card for a new turn; new turn → new key
+
+### 7) UX state mapping
+
+| PwrAgent state | Card phase | Task statuses | Status shimmer |
+| --- | --- | --- | --- |
+| Bound turn admitted, not started work | `queued` | pending | "is starting…" / working |
+| Tools/prose running | `working` | in_progress → complete/error | "is working on your request…" |
+| Approval / questionnaire / elicitation | `waiting` | last task complete; headline waiting | clear or "is waiting for input…" |
+| Turn success | `completed` | all terminal | clear |
+| Turn failure / cancel | `failed` | error/cancelled | clear |
+
+### 8) Security / privacy
+
+- Titles only from existing redactors (`redactCommandText`, safe path basenames)
+- Never stream private-reply / sensitive commentary (existing controller bans)
+- Public channel: Working Updates are shared; None default for `agent_thread`
+  bindings remains correct
+- Do not put full PR diffs into the card; link out
+- Log stream open/fail without logging task titles that might include paths
+  operators consider sensitive in audit logs if policy requires
+
+### 9) Data model / persistence
+
+| Item | Persist? |
+| --- | --- |
+| Dial preference (`toolUpdateMode`) | Yes (existing) |
+| Live stream ts / open stream id | **No** (memory only) |
+| Working card sequence | Memory only |
+| Delivery audit for final messages | Existing delivery records |
+
+No schema migration required for v1 if preferences stay the same.
+
+## Concrete implementation plan
+
+### PR slice A — Contract + controller
+
+1. Add `working_card` to `MESSAGING_SURFACE_INTENT_KINDS` and types in
+   `packages/messaging/interface`.
+2. Map dial deliveries in `MessagingController.deliverToolUpdateDelivery` for
+   Slack-capable path:
+   - Prefer `working_card` when binding channel is Slack **or** when a
+     capability flag says live cards supported.
+   - Keep text message path for other providers.
+3. Emit phase transitions from existing turn lifecycle hooks (start, waiting,
+   complete, fail, cancel).
+4. Tests:
+   - dial None → no working_card
+   - Some → batched card updates, no duplicate text on Slack path
+   - sequence monotonic / stale drop
+   - cancel drops pending card updates
+   - non-Slack still gets text batches
+
+### PR slice B — Slack adapter Thinking Steps
+
+1. Wrap `chat.startStream` / `appendStream` / `stopStream` on `SlackApi`.
+2. Implement `deliverWorkingCard` with stream state map + fallback ladder.
+3. Clamp task fields; choose `task_display_mode` from dial/mode hint.
+4. Capture `recipient_user_id` / `recipient_team_id` from inbound actor when
+   posting in channels.
+5. Tests (adapter unit):
+   - start → append task complete → stop
+   - no thread_ts → text fallback
+   - rate limit error → cool-off fields
+   - final phase after missing intermediate still stops stream
+   - duplicate task_id updates in place (same id, new status)
+
+### PR slice C — Polish + docs
+
+1. Optional actions on completed card: Open in PwrAgent / PR link (reuse
+   existing surfaces).
+2. Operator docs note: Working Updates on Slack use live cards when the bot can
+   stream in-thread.
+3. Changelog entry.
+
+### Suggested file touch list
+
+- `packages/messaging/interface/src/index.ts`
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `apps/desktop/src/main/messaging/core/messaging-renderer.ts`
+- `apps/desktop/src/main/messaging/core/messaging-tool-activity.ts` (optional
+  in_progress later)
+- `packages/messaging/providers/slack/src/slack-adapter.ts`
+- `packages/messaging/providers/slack/src/slack-formatting.ts`
+- adapter + controller tests
+- `docs/messaging-adapter-contract.md` (working_card section)
+- `CHANGELOG.md`
+
+## Acceptance criteria
+
+1. With Working Updates = Some on a Slack thread binding, a multi-tool turn
+   shows **one** live updating card (not N "Tool update:" messages).
+2. Working Updates = None posts **no** live card and no tool text updates;
+   final answer still arrives.
+3. Working Updates = All surfaces each completed tool as a task on the card
+   without violating rate budget / Slow Mode.
+4. Waiting for approval updates the card phase to waiting and does not leave a
+   permanent "is working" shimmer.
+5. Completed turn finalizes the stream; failed turn marks error; cancel stops
+   shimmer and does not leave dangling in_progress tasks.
+6. If stream APIs are unavailable, adapter falls back to text Working Updates
+   without failing the turn.
+7. Non-Slack providers unchanged in behavior.
+8. Unit tests cover policy mapping + Slack stream lifecycle + fallback.
+9. No secrets/raw command output in task titles.
+10. Draft PR only when tests pass and behavior is reviewable.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Stream APIs behave differently in channel vs DM | Require recipient ids for channels; test both; fallback |
+| Card noise in public channels | Keep dial; agent_thread default None; dense mode |
+| SDK method typing gaps | Local typed wrappers like existing setStatus cast |
+| Double delivery (card + text) | Explicit suppress of text tool messages when card open |
+| Stuck shimmer | Always clear status on terminal + lease idle activity |
+
+## Decision
+
+**Implement Slack Thinking Steps live cards as the Slack rendering of Working
+Updates**, driven by a channel-agnostic `working_card` (or equivalent) intent,
+preserving the existing dial, budgets, redaction, and final-answer authority.
+
+Do **not** rename product settings to "Live Cards"; keep **Working Updates**.
+Internally document Slack's name as Thinking Steps / task cards.
+
+## Out of scope follow-ups
+
+- Native assistant answer streaming via `chat.*Stream` (separate feature;
+  Working Updates card should not be the final answer surface)
+- In-progress tool start events (v1 can stay completion-driven; optional v1.1
+  sets `in_progress` on start)
+- Linear-style "Open diff" deep link package until PR attachment APIs already
+  used by status cards are wired into card actions

--- a/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
+++ b/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
@@ -27,6 +27,7 @@ describe("messaging surface contract", () => {
       "activity",
       "message",
       "stream_update",
+      "working_card",
       "status",
       "progress",
       "thread_picker",

--- a/packages/messaging/interface/src/__tests__/rate-limit-gate.test.ts
+++ b/packages/messaging/interface/src/__tests__/rate-limit-gate.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { MessagingRateLimitGate } from "../rate-limit-gate";
+
+describe("MessagingRateLimitGate", () => {
+  it("tracks independent provider method budgets", () => {
+    let now = 1_000;
+    const gate = new MessagingRateLimitGate(() => now);
+    const start = { id: "slack:start", limit: 1, intervalMs: 60_000 };
+    const append = { id: "slack:append", limit: 2, intervalMs: 60_000 };
+
+    expect(gate.admit(start)).toEqual({ admitted: true });
+    expect(gate.admit(start)).toEqual({ admitted: false, retryAt: 61_000 });
+    expect(gate.admit(append)).toEqual({ admitted: true });
+    expect(gate.admit(append)).toEqual({ admitted: true });
+    expect(gate.admit(append)).toEqual({ admitted: false, retryAt: 61_000 });
+
+    now = 61_000;
+    expect(gate.admit(start)).toEqual({ admitted: true });
+    expect(gate.admit(append)).toEqual({ admitted: true });
+  });
+
+  it("honors method spacing and provider Retry-After cooldowns separately", () => {
+    let now = 10_000;
+    const gate = new MessagingRateLimitGate(() => now);
+    const start = {
+      id: "slack:start",
+      limit: 20,
+      intervalMs: 60_000,
+      minIntervalMs: 1_000,
+    };
+    const stop = { ...start, id: "slack:stop" };
+
+    expect(gate.admit(start)).toEqual({ admitted: true });
+    expect(gate.admit(start)).toEqual({ admitted: false, retryAt: 11_000 });
+    gate.recordRateLimit("slack:start", 5_000);
+    expect(gate.admit(start)).toEqual({ admitted: false, retryAt: 15_000 });
+    expect(gate.admit(stop)).toEqual({ admitted: true });
+
+    now = 15_000;
+    expect(gate.admit(start)).toEqual({ admitted: true });
+  });
+});

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -66,6 +66,7 @@ export const MESSAGING_SURFACE_INTENT_KINDS = [
   "activity",
   "message",
   "stream_update",
+  "working_card",
   "status",
   "progress",
   "thread_picker",
@@ -845,6 +846,23 @@ export type MessagingStreamUpdateIntent = MessagingBaseSurfaceIntent & {
   text: string;
 };
 
+export type MessagingWorkingCardIntent = MessagingBaseSurfaceIntent & {
+  kind: "working_card";
+  card: {
+    displayHint: "timeline" | "plan" | "dense";
+    isFinal: boolean;
+    key: string;
+    phase: "queued" | "working" | "waiting" | "completed" | "failed";
+    sequence: number;
+    tasks: Array<{
+      detail?: string;
+      id: string;
+      status: "pending" | "in_progress" | "complete" | "error" | "cancelled";
+      title: string;
+    }>;
+  };
+};
+
 export type MessagingActivityIntent = MessagingBaseSurfaceIntent & {
   kind: "activity";
   activity: "typing";
@@ -1170,6 +1188,7 @@ export type MessagingSurfaceIntent =
   | MessagingActivityIntent
   | MessagingMessageIntent
   | MessagingStreamUpdateIntent
+  | MessagingWorkingCardIntent
   | MessagingStatusIntent
   | MessagingProgressIntent
   | MessagingThreadPickerIntent

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -856,6 +856,10 @@ export type MessagingWorkingCardIntent = MessagingBaseSurfaceIntent & {
   kind: "working_card";
   card: {
     displayHint: "timeline" | "plan" | "dense";
+    fallbackPresentation?: {
+      markdown: MessagingMarkdownPolicy;
+      role: "assistant" | "system";
+    };
     isFinal: boolean;
     key: string;
     phase: "queued" | "working" | "waiting" | "completed" | "failed";

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -26,6 +26,11 @@ export {
 } from "./text-splitting";
 export { evictStaleStreamAnchors } from "./stream-anchors";
 export {
+  MessagingRateLimitGate,
+  type MessagingRateLimitAdmission,
+  type MessagingRateLimitBucket,
+} from "./rate-limit-gate";
+export {
   MESSAGING_COMMAND_CATALOG,
   MESSAGING_HELP_ACTION_COMMANDS,
   matchMessagingCommandVerb,
@@ -400,6 +405,7 @@ export type MessagingConversationResponseMode = {
 };
 
 export type MessagingAdapterRenderingPreferencesUpdate = {
+  liveWorkingCards?: boolean;
   streamingResponses?: boolean;
   toolUpdateDefaultMode?: MessagingToolUpdateMode;
 };

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1657,6 +1657,8 @@ export type MessagingDefaultAgentAssignmentRecord = {
   id: string;
   scope: MessagingDefaultAgentScope;
   target: MessagingDefaultAgentTarget;
+  /** Per-route override. Omitted assignments inherit the Agent-route default. */
+  toolUpdateMode?: MessagingToolUpdateMode;
   createdAt: number;
   updatedAt: number;
   revokedAt?: number;

--- a/packages/messaging/interface/src/rate-limit-gate.ts
+++ b/packages/messaging/interface/src/rate-limit-gate.ts
@@ -1,0 +1,81 @@
+export type MessagingRateLimitBucket = {
+  id: string;
+  intervalMs: number;
+  limit: number;
+  minIntervalMs?: number;
+};
+
+export type MessagingRateLimitAdmission =
+  | { admitted: true }
+  | { admitted: false; retryAt: number };
+
+type MessagingRateLimitBucketState = {
+  blockedUntil: number;
+  timestamps: number[];
+};
+
+/**
+ * In-memory, multi-bucket rate accounting for provider-specific API lanes.
+ * Providers may track independent method/workspace budgets without coupling
+ * those limits to the controller's visible-message delivery budget.
+ */
+export class MessagingRateLimitGate {
+  private readonly states = new Map<string, MessagingRateLimitBucketState>();
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  admit(bucket: MessagingRateLimitBucket): MessagingRateLimitAdmission {
+    const now = this.now();
+    const state = this.stateFor(bucket.id);
+    this.prune(state, bucket, now);
+    const lastTimestamp = state.timestamps.at(-1);
+    const intervalReadyAt = lastTimestamp === undefined
+      ? now
+      : lastTimestamp + Math.max(0, bucket.minIntervalMs ?? 0);
+    const windowReadyAt = state.timestamps.length < bucket.limit
+      ? now
+      : (state.timestamps[0] ?? now) + bucket.intervalMs;
+    const retryAt = Math.max(state.blockedUntil, intervalReadyAt, windowReadyAt);
+    if (retryAt > now) {
+      return { admitted: false, retryAt };
+    }
+    state.timestamps.push(now);
+    return { admitted: true };
+  }
+
+  recordRateLimit(bucketId: string, retryAfterMs: number): void {
+    const state = this.stateFor(bucketId);
+    state.blockedUntil = Math.max(
+      state.blockedUntil,
+      this.now() + Math.max(0, retryAfterMs),
+    );
+  }
+
+  clear(bucketId?: string): void {
+    if (bucketId === undefined) {
+      this.states.clear();
+      return;
+    }
+    this.states.delete(bucketId);
+  }
+
+  private stateFor(id: string): MessagingRateLimitBucketState {
+    let state = this.states.get(id);
+    if (!state) {
+      state = { blockedUntil: 0, timestamps: [] };
+      this.states.set(id, state);
+    }
+    return state;
+  }
+
+  private prune(
+    state: MessagingRateLimitBucketState,
+    bucket: MessagingRateLimitBucket,
+    now: number,
+  ): void {
+    const cutoff = now - bucket.intervalMs;
+    while (state.timestamps.length > 0 && (state.timestamps[0] ?? now) <= cutoff) {
+      state.timestamps.shift();
+    }
+  }
+}

--- a/packages/messaging/providers/discord/src/discord-formatting.ts
+++ b/packages/messaging/providers/discord/src/discord-formatting.ts
@@ -79,6 +79,8 @@ export function textForDiscordIntent(intent: MessagingSurfaceIntent): string {
       return intent.parts.map(renderContentPart).filter(Boolean).join("\n\n");
     case "stream_update":
       return intent.text;
+    case "working_card":
+      return intent.fallbackText ?? "Working update";
     case "status":
       return intent.text;
     case "progress":

--- a/packages/messaging/providers/feishu/src/feishu-formatting.ts
+++ b/packages/messaging/providers/feishu/src/feishu-formatting.ts
@@ -179,6 +179,8 @@ export function textForFeishuIntent(intent: MessagingSurfaceIntent): string {
       return renderContentParts(intent.parts);
     case "stream_update":
       return intent.text;
+    case "working_card":
+      return intent.fallbackText ?? "Working update";
     case "status":
       return intent.text;
     case "progress":

--- a/packages/messaging/providers/line/src/line-formatting.ts
+++ b/packages/messaging/providers/line/src/line-formatting.ts
@@ -183,6 +183,8 @@ export function textForLineIntent(intent: MessagingSurfaceIntent): string {
       return renderContentParts(intent.parts);
     case "stream_update":
       return intent.stream.isFinal ? intent.text : "";
+    case "working_card":
+      return intent.fallbackText ?? "Working update";
     case "status":
       return intent.text;
     case "progress":

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -633,6 +633,8 @@ export class MattermostAdapter implements MattermostProviderAdapter {
           return await this.deliverDismiss(intent);
         case "stream_update":
           return await this.deliverStreamUpdate(intent);
+        case "working_card":
+          return await this.deliverPostIntent(intent);
         case "message":
         case "status":
         case "progress":

--- a/packages/messaging/providers/mattermost/src/mattermost-formatting.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-formatting.ts
@@ -240,6 +240,8 @@ export function textForMattermostIntent(intent: MessagingSurfaceIntent): string 
       return renderContentParts(intent.parts);
     case "stream_update":
       return intent.text;
+    case "working_card":
+      return intent.fallbackText ?? "Working update";
     case "status":
       return intent.text;
     case "progress":

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -4160,11 +4160,20 @@ describe("SlackAdapter", () => {
     expect(stoppedStreams).toHaveLength(1);
     expect(JSON.stringify(startedStreams[0])).not.toContain("x".repeat(257));
     expect((startedStreams[0] as { chunks: SlackStreamChunk[] }).chunks)
-      .toEqual([expect.objectContaining({ id: "task-1", details: "0ms" })]);
+      .toEqual([expect.objectContaining({
+        id: expect.stringMatching(/^pwragent:[a-f0-9]{16}:1$/),
+        details: "0ms",
+      })]);
     expect((appendedStreams[0] as { chunks: SlackStreamChunk[] }).chunks)
-      .toEqual([expect.objectContaining({ id: "task-2", details: "0ms" })]);
+      .toEqual([expect.objectContaining({
+        id: expect.stringMatching(/^pwragent:[a-f0-9]{16}:2$/),
+        details: "0ms",
+      })]);
     expect((stoppedStreams[0] as { chunks: SlackStreamChunk[] }).chunks)
-      .toEqual([expect.objectContaining({ id: "task-3", details: "0ms" })]);
+      .toEqual([expect.objectContaining({
+        id: expect.stringMatching(/^pwragent:[a-f0-9]{16}:3$/),
+        details: "0ms",
+      })]);
   });
 
   it("anchors a channel-root Agent Route card to its inbound user message", async () => {
@@ -4372,7 +4381,7 @@ describe("SlackAdapter", () => {
     await expect(adapter.deliver(waiting)).resolves.toMatchObject({
       outcome: "discarded",
     });
-    await expect(adapter.deliver({
+    const terminal = {
       ...waiting,
       id: "working-card-terminal-fallback",
       card: {
@@ -4381,7 +4390,11 @@ describe("SlackAdapter", () => {
         phase: "completed",
         sequence: 3,
       },
-    })).resolves.toMatchObject({ outcome: "discarded" });
+    } satisfies MessagingSurfaceIntent;
+    expect(adapter.resolveDeliveryScope(terminal)).toBeUndefined();
+    await expect(adapter.deliver(terminal)).resolves.toMatchObject({
+      outcome: "discarded",
+    });
     expect(posted).toEqual([]);
   });
 
@@ -4417,11 +4430,70 @@ describe("SlackAdapter", () => {
     });
     expect(posted).toHaveLength(2);
 
+    const terminal = slackWorkingCardIntent(3, {
+      isFinal: true,
+      key: "degraded-turn",
+    });
+    expect(adapter.resolveDeliveryScope(terminal)).toBeUndefined();
+
     await adapter.deliver(slackWorkingCardIntent(1, { key: "second-degraded-turn" }));
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
     expect(posted).toHaveLength(2);
+  });
+
+  it("falls back with the latest snapshot when a pending start fails", async () => {
+    const posted: Array<{ text?: string }> = [];
+    let rejectStart!: (error: Error) => void;
+    const startResult = new Promise<never>((_resolve, reject) => {
+      rejectStart = reject;
+    });
+    const api = fakeApi({ posted });
+    api.startStream = async () => await startResult;
+    const adapter = new SlackAdapter({
+      config: { ...baseConfig, liveWorkingCards: true },
+      callbackHandleStore: fakeStore(),
+      api,
+      socketClient: fakeSocket(),
+    });
+
+    await adapter.deliver(slackWorkingCardIntent(1, { key: "slow-start" }));
+    await adapter.deliver(slackWorkingCardIntent(2, { key: "slow-start" }));
+    rejectStart(new Error("missing_scope"));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(posted).toHaveLength(1);
+    expect(posted[0]?.text).toContain("activity 2");
+    expect(posted[0]?.text).not.toContain("activity 1");
+  });
+
+  it("preserves assistant standard Markdown in classic card fallbacks", async () => {
+    const posted: Array<{
+      blocks?: Array<{ type: string }>;
+      text?: string;
+    }> = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ posted }),
+      socketClient: fakeSocket(),
+    });
+    const intent = slackWorkingCardIntent(1);
+    if (intent.kind !== "working_card") throw new Error("expected working card");
+    intent.fallbackText = "| Result |\n| --- |\n| Passed |";
+    intent.card.fallbackPresentation = {
+      markdown: "markdown",
+      role: "assistant",
+    };
+
+    await adapter.deliver(intent);
+
+    expect(posted[0]?.blocks).toEqual([
+      expect.objectContaining({ type: "markdown" }),
+    ]);
   });
 
   it("returns a retractable surface and cancels an open working card", async () => {
@@ -4526,6 +4598,132 @@ describe("SlackAdapter", () => {
     expect(startedStreams).toHaveLength(1);
   });
 
+  it("deletes and tombstones a card after bounded terminal stop failures", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    try {
+      const deleted: Array<{ channel: string; ts: string }> = [];
+      let stopAttempts = 0;
+      const api = fakeApi({ deleted });
+      api.stopStream = async () => {
+        stopAttempts += 1;
+        throw new Error("service_unavailable");
+      };
+      const adapter = new SlackAdapter({
+        config: { ...baseConfig, liveWorkingCards: true },
+        callbackHandleStore: fakeStore(),
+        api,
+        socketClient: fakeSocket(),
+      });
+
+      await adapter.deliver(slackWorkingCardIntent(1));
+      await Promise.resolve();
+      await Promise.resolve();
+      await adapter.deliver(slackWorkingCardIntent(2, { isFinal: true }));
+      await Promise.resolve();
+      expect(stopAttempts).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(stopAttempts).toBe(2);
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(stopAttempts).toBe(3);
+      expect(deleted).toEqual([{
+        channel: "C012ABCDEF0",
+        ts: "1700000000.900001",
+      }]);
+      await expect(adapter.deliver(slackWorkingCardIntent(1))).resolves
+        .toMatchObject({ outcome: "discarded" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("drops rate-limited card appends without retrying or posting text", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    try {
+      const posted: unknown[] = [];
+      let appendAttempts = 0;
+      const api = fakeApi({ posted });
+      api.appendStream = async () => {
+        appendAttempts += 1;
+        throw Object.assign(new Error("rate_limited"), {
+          status: 429,
+          retryAfterMs: 60_000,
+        });
+      };
+      const adapter = new SlackAdapter({
+        config: { ...baseConfig, liveWorkingCards: true },
+        callbackHandleStore: fakeStore(),
+        api,
+        socketClient: fakeSocket(),
+      });
+
+      await adapter.deliver(slackWorkingCardIntent(1));
+      await Promise.resolve();
+      await Promise.resolve();
+      await adapter.deliver(slackWorkingCardIntent(2));
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(appendAttempts).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(appendAttempts).toBe(1);
+      expect(posted).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reuses twelve mounted task slots when older card history is collapsed", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    try {
+      const appendedStreams: Array<{ chunks: SlackStreamChunk[] }> = [];
+      const startedStreams: Array<{ chunks: SlackStreamChunk[] }> = [];
+      const adapter = new SlackAdapter({
+        config: { ...baseConfig, liveWorkingCards: true },
+        callbackHandleStore: fakeStore(),
+        api: fakeApi({ appendedStreams, startedStreams }),
+        socketClient: fakeSocket(),
+      });
+
+      for (let sequence = 1; sequence <= 13; sequence += 1) {
+        const intent = slackWorkingCardIntent(sequence, { key: "bounded-card" });
+        if (intent.kind !== "working_card") throw new Error("expected working card");
+        const firstVisible = Math.max(1, sequence - 11);
+        intent.card.tasks = Array.from(
+          { length: sequence - firstVisible + 1 },
+          (_, index) => ({
+            id: `activity-${firstVisible + index}`,
+            title: `Activity ${firstVisible + index}`,
+            status: "complete" as const,
+            ...(sequence > 12 && index === 0
+              ? { detail: `${sequence - 12} earlier step` }
+              : {}),
+          }),
+        );
+        await adapter.deliver(intent);
+        await Promise.resolve();
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(1_000);
+      }
+
+      const allChunks = [
+        ...(startedStreams[0]?.chunks ?? []),
+        ...appendedStreams.flatMap((call) => call.chunks),
+      ].filter((chunk) => chunk.type === "task_update");
+      expect(new Set(allChunks.map((chunk) => chunk.id)).size).toBe(12);
+      expect(appendedStreams.at(-1)?.chunks).toHaveLength(12);
+      expect(appendedStreams.at(-1)?.chunks[0]).toMatchObject({
+        details: "1 earlier step",
+        title: "Activity 2",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("queues a rate-limited card start while approvals and questionnaires bypass it", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_700_000_000_000);
@@ -4596,7 +4794,7 @@ describe("SlackAdapter", () => {
     }
   });
 
-  it("coalesces queued card updates and lets the terminal stop supersede them", async () => {
+  it("drops locally throttled card updates and lets terminal stop supersede them", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_700_000_000_000);
     try {
@@ -4622,12 +4820,12 @@ describe("SlackAdapter", () => {
 
       expect(appendedStreams).toHaveLength(1);
       await vi.advanceTimersByTimeAsync(1_000);
-      expect(appendedStreams).toHaveLength(2);
-      expect(appendedStreams[1]?.chunks).toEqual([
-        expect.objectContaining({ id: "task-4" }),
-      ]);
+      expect(appendedStreams).toHaveLength(1);
 
       await adapter.deliver(slackWorkingCardIntent(5));
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(appendedStreams).toHaveLength(2);
       await adapter.deliver(slackWorkingCardIntent(6, { isFinal: true }));
       await Promise.resolve();
       await Promise.resolve();
@@ -4690,8 +4888,8 @@ describe("SlackAdapter", () => {
       await Promise.resolve();
 
       // Stop has its own workspace budget, so one terminal call proceeds even
-      // while the second append is queued. Each method still serializes calls
-      // shared by all cards on this adapter.
+      // though the second append was discarded. Each lifecycle method still
+      // serializes calls shared by all cards on this adapter.
       expect(stoppedStreams).toHaveLength(1);
       expect(appendedStreams).toHaveLength(1);
 

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { SlackAdapter, type SlackApi, type SlackSocketClient } from "../slack-adapter.ts";
 import type { SlackHomeView } from "../slack-home.ts";
 import type {
@@ -24,6 +24,42 @@ const baseConfig = {
   teamAuthorizationMode: "allow_all" as const,
   channelAuthorizationMode: "allow_all" as const,
 };
+
+function slackWorkingCardIntent(
+  sequence: number,
+  options: { isFinal?: boolean; key?: string; phase?: "completed" | "failed" } = {},
+): MessagingSurfaceIntent {
+  const isFinal = options.isFinal ?? false;
+  return {
+    id: `working-card-${sequence}`,
+    kind: "working_card",
+    bindingId: "slack-binding-1",
+    createdAt: sequence,
+    fallbackText: `Tool update: activity ${sequence}`,
+    card: {
+      displayHint: "plan",
+      isFinal,
+      key: options.key ?? "slack-binding-1\0turn-1",
+      phase: options.phase ?? (isFinal ? "completed" : "working"),
+      sequence,
+      tasks: [{ id: `task-${sequence}`, title: `Activity ${sequence}`, status: "complete" }],
+    },
+    audit: {
+      actor: { platformUserId: "U012ABCDEF0" },
+      bindingId: "slack-binding-1",
+      channel: {
+        channel: "slack",
+        conversation: {
+          id: "C012ABCDEF0",
+          kind: "thread",
+          parentId: "1700000000.000001",
+          workspaceId: "T012ABCDEF0",
+        },
+      },
+      occurredAt: sequence,
+    },
+  };
+}
 
 function fakeStore(): MessagingCallbackHandleStore & {
   records: MessagingCallbackHandleRecord[];
@@ -4001,7 +4037,7 @@ describe("SlackAdapter", () => {
     const startedStreams: unknown[] = [];
     const stoppedStreams: unknown[] = [];
     const adapter = new SlackAdapter({
-      config: baseConfig,
+      config: { ...baseConfig, liveWorkingCards: true },
       callbackHandleStore: fakeStore(),
       api: fakeApi({ appendedStreams, startedStreams, stoppedStreams }),
       socketClient: fakeSocket(),
@@ -4041,6 +4077,9 @@ describe("SlackAdapter", () => {
     await expect(adapter.deliver(intent(1))).resolves.toMatchObject({ outcome: "discarded" });
     await expect(adapter.deliver(intent(2))).resolves.toMatchObject({ outcome: "updated" });
     await expect(adapter.deliver(intent(3, true))).resolves.toMatchObject({ outcome: "updated" });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
 
     expect(startedStreams).toHaveLength(1);
     expect(appendedStreams).toHaveLength(1);
@@ -4055,7 +4094,7 @@ describe("SlackAdapter", () => {
     api.appendStream = undefined;
     api.stopStream = undefined;
     const adapter = new SlackAdapter({
-      config: baseConfig,
+      config: { ...baseConfig, liveWorkingCards: true },
       callbackHandleStore: fakeStore(),
       api,
       socketClient: fakeSocket(),
@@ -4091,6 +4130,264 @@ describe("SlackAdapter", () => {
 
     expect(posted).toHaveLength(1);
     expect(JSON.stringify(posted[0])).toContain("Tool update: searched files");
+  });
+
+  it("keeps Live Working Cards opt-in and uses classic updates when unspecified", async () => {
+    const posted: unknown[] = [];
+    const startedStreams: unknown[] = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ posted, startedStreams }),
+      socketClient: fakeSocket(),
+    });
+
+    await expect(adapter.deliver(slackWorkingCardIntent(1))).resolves.toMatchObject({
+      outcome: "presented",
+    });
+
+    expect(posted).toHaveLength(1);
+    expect(startedStreams).toEqual([]);
+  });
+
+  it("keeps native card calls off the ordinary message budget but budgets fallback text", () => {
+    const nativeAdapter = new SlackAdapter({
+      config: { ...baseConfig, liveWorkingCards: true },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: fakeSocket(),
+    });
+    const fallbackApi = fakeApi({});
+    fallbackApi.startStream = undefined;
+    fallbackApi.appendStream = undefined;
+    fallbackApi.stopStream = undefined;
+    const fallbackAdapter = new SlackAdapter({
+      config: { ...baseConfig, liveWorkingCards: true },
+      callbackHandleStore: fakeStore(),
+      api: fallbackApi,
+      socketClient: fakeSocket(),
+    });
+    const intent = slackWorkingCardIntent(1);
+
+    expect(nativeAdapter.resolveDeliveryScope(intent)).toBeUndefined();
+    expect(fallbackAdapter.resolveDeliveryScope(intent)).toMatchObject({
+      id: "slack:channel:C012ABCDEF0",
+      budget: { limit: 30, intervalMs: 60_000, reserved: 5 },
+    });
+  });
+
+  it("returns a retractable surface and cancels an open working card", async () => {
+    const deleted: Array<{ channel: string; ts: string }> = [];
+    const adapter = new SlackAdapter({
+      config: { ...baseConfig, liveWorkingCards: true },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ deleted }),
+      socketClient: fakeSocket(),
+    });
+
+    const result = await adapter.deliver(slackWorkingCardIntent(1));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(result).toMatchObject({
+      outcome: "presented",
+      surface: {
+        state: { opaque: { workingCardKey: "slack-binding-1\0turn-1" } },
+      },
+    });
+    await expect(adapter.deliver({
+      id: "dismiss-working-card",
+      kind: "dismiss",
+      createdAt: 2,
+      reason: "terminal_private_response",
+      targetSurface: result.surface!,
+    })).resolves.toMatchObject({ outcome: "dismissed" });
+    expect(deleted).toEqual([{
+      channel: "C012ABCDEF0",
+      ts: "1700000000.900001",
+    }]);
+  });
+
+  it("retracts a card whose queued start resolves after cancellation", async () => {
+    const deleted: Array<{ channel: string; ts: string }> = [];
+    let resolveStart!: () => void;
+    const startRelease = new Promise<void>((resolve) => {
+      resolveStart = resolve;
+    });
+    const api = fakeApi({ deleted });
+    api.startStream = async (params) => {
+      await startRelease;
+      return { channel: params.channel, ts: "1700000000.900002" };
+    };
+    const adapter = new SlackAdapter({
+      config: { ...baseConfig, liveWorkingCards: true },
+      callbackHandleStore: fakeStore(),
+      api,
+      socketClient: fakeSocket(),
+    });
+
+    const result = await adapter.deliver(slackWorkingCardIntent(1, {
+      key: "pending-start-turn",
+    }));
+    await expect(adapter.deliver({
+      id: "dismiss-pending-working-card",
+      kind: "dismiss",
+      createdAt: 2,
+      reason: "terminal_private_response",
+      targetSurface: result.surface!,
+    })).resolves.toMatchObject({ outcome: "dismissed" });
+    expect(deleted).toEqual([]);
+
+    resolveStart();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deleted).toEqual([{
+      channel: "C012ABCDEF0",
+      ts: "1700000000.900002",
+    }]);
+  });
+
+  it("keeps a terminal sequence tombstone and renders failed turns as errors", async () => {
+    const startedStreams: unknown[] = [];
+    const stoppedStreams: Array<{ chunks?: Array<{ status: string; title: string }> }> = [];
+    const adapter = new SlackAdapter({
+      config: { ...baseConfig, liveWorkingCards: true },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ startedStreams, stoppedStreams }),
+      socketClient: fakeSocket(),
+    });
+
+    await adapter.deliver(slackWorkingCardIntent(1));
+    await adapter.deliver(slackWorkingCardIntent(3, {
+      isFinal: true,
+      phase: "failed",
+    }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(stoppedStreams[0]?.chunks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ status: "error", title: "Turn failed" }),
+      ]),
+    );
+    await expect(adapter.deliver(slackWorkingCardIntent(2))).resolves.toMatchObject({
+      outcome: "discarded",
+    });
+    expect(startedStreams).toHaveLength(1);
+  });
+
+  it("queues a rate-limited card start while approvals and questionnaires bypass it", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    try {
+      const posted: unknown[] = [];
+      let startAttempts = 0;
+      const api = fakeApi({ posted });
+      api.startStream = async (params) => {
+        startAttempts += 1;
+        if (startAttempts === 1) {
+          throw Object.assign(new Error("rate_limited"), {
+            status: 429,
+            retryAfterMs: 5_000,
+          });
+        }
+        return { channel: params.channel, ts: "1700000000.900001" };
+      };
+      const adapter = new SlackAdapter({
+        config: { ...baseConfig, liveWorkingCards: true },
+        callbackHandleStore: fakeStore(),
+        api,
+        socketClient: fakeSocket(),
+      });
+
+      await adapter.deliver(slackWorkingCardIntent(1));
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(startAttempts).toBe(1);
+
+      await adapter.deliver({
+        id: "approval-during-card-cooldown",
+        kind: "approval",
+        bindingId: "slack-binding-1",
+        createdAt: 2,
+        title: "Approve command",
+        body: "Run the requested command?",
+        decisions: [{
+          id: "approve",
+          label: "Approve",
+          decision: "accept",
+        }],
+        audit: slackWorkingCardIntent(1).audit,
+      });
+      await adapter.deliver({
+        id: "questionnaire-during-card-cooldown",
+        kind: "questionnaire",
+        bindingId: "slack-binding-1",
+        createdAt: 3,
+        answers: [null],
+        currentIndex: 0,
+        phase: "answering",
+        questions: [{
+          id: "mode",
+          question: "Which mode?",
+          options: [{ id: "safe", label: "Safe" }],
+        }],
+        audit: slackWorkingCardIntent(1).audit,
+      });
+
+      expect(posted).toHaveLength(2);
+      expect(startAttempts).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(startAttempts).toBe(2);
+      await adapter.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("coalesces queued card updates and lets the terminal stop supersede them", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    try {
+      const appendedStreams: Array<{
+        chunks: Array<{ id: string }>;
+      }> = [];
+      const stoppedStreams: unknown[] = [];
+      const adapter = new SlackAdapter({
+        config: { ...baseConfig, liveWorkingCards: true },
+        callbackHandleStore: fakeStore(),
+        api: fakeApi({ appendedStreams, stoppedStreams }),
+        socketClient: fakeSocket(),
+      });
+
+      await adapter.deliver(slackWorkingCardIntent(1));
+      await Promise.resolve();
+      await Promise.resolve();
+      await adapter.deliver(slackWorkingCardIntent(2));
+      await Promise.resolve();
+      await Promise.resolve();
+      await adapter.deliver(slackWorkingCardIntent(3));
+      await adapter.deliver(slackWorkingCardIntent(4));
+
+      expect(appendedStreams).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(appendedStreams).toHaveLength(2);
+      expect(appendedStreams[1]?.chunks).toEqual([
+        expect.objectContaining({ id: "task-4" }),
+      ]);
+
+      await adapter.deliver(slackWorkingCardIntent(5));
+      await adapter.deliver(slackWorkingCardIntent(6, { isFinal: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(stoppedStreams).toHaveLength(1);
+      expect(appendedStreams).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("splits long Markdown with images and attaches them to the final post", async () => {

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -4176,6 +4176,74 @@ describe("SlackAdapter", () => {
     });
   });
 
+  it("does not post empty waiting or terminal text fallbacks", async () => {
+    const posted: unknown[] = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ posted }),
+      socketClient: fakeSocket(),
+    });
+    const waiting = slackWorkingCardIntent(2);
+    if (waiting.kind !== "working_card") throw new Error("expected working card");
+    waiting.card.phase = "waiting";
+    waiting.fallbackText = "";
+
+    await expect(adapter.deliver(waiting)).resolves.toMatchObject({
+      outcome: "discarded",
+    });
+    await expect(adapter.deliver({
+      ...waiting,
+      id: "working-card-terminal-fallback",
+      card: {
+        ...waiting.card,
+        isFinal: true,
+        phase: "completed",
+        sequence: 3,
+      },
+    })).resolves.toMatchObject({ outcome: "discarded" });
+    expect(posted).toEqual([]);
+  });
+
+  it("moves native-degraded cards back onto the channel budget", async () => {
+    const posted: unknown[] = [];
+    const api = fakeApi({ posted });
+    api.startStream = async () => {
+      throw new Error("missing_scope");
+    };
+    const adapter = new SlackAdapter({
+      config: { ...baseConfig, liveWorkingCards: true },
+      callbackHandleStore: fakeStore(),
+      api,
+      socketClient: fakeSocket(),
+      now: () => 1_700_000_000_000,
+    });
+    const first = slackWorkingCardIntent(1, { key: "degraded-turn" });
+
+    expect(adapter.resolveDeliveryScope(first)).toBeUndefined();
+    await adapter.deliver(first);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(posted).toHaveLength(1);
+
+    const second = slackWorkingCardIntent(2, { key: "degraded-turn" });
+    expect(adapter.resolveDeliveryScope(second)).toMatchObject({
+      id: "slack:channel:C012ABCDEF0",
+      budget: { limit: 30, intervalMs: 60_000, reserved: 5 },
+    });
+    await expect(adapter.deliver(second)).resolves.toMatchObject({
+      outcome: "presented",
+    });
+    expect(posted).toHaveLength(2);
+
+    await adapter.deliver(slackWorkingCardIntent(1, { key: "second-degraded-turn" }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(posted).toHaveLength(2);
+  });
+
   it("returns a retractable surface and cancels an open working card", async () => {
     const deleted: Array<{ channel: string; ts: string }> = [];
     const adapter = new SlackAdapter({

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -4124,7 +4124,12 @@ describe("SlackAdapter", () => {
         key: "slack-binding-1\0turn-1",
         phase: isFinal ? "completed" : "working",
         sequence,
-        tasks: [{ id: "task-1", title: "x".repeat(300), status: "complete" }],
+        tasks: Array.from({ length: sequence }, (_, index) => ({
+          detail: "0ms",
+          id: `task-${index + 1}`,
+          title: `Activity ${index + 1}: ${"x".repeat(300)}`,
+          status: "complete" as const,
+        })),
       },
       audit: {
         actor: { platformUserId: "U012ABCDEF0" },
@@ -4154,6 +4159,12 @@ describe("SlackAdapter", () => {
     expect(appendedStreams).toHaveLength(1);
     expect(stoppedStreams).toHaveLength(1);
     expect(JSON.stringify(startedStreams[0])).not.toContain("x".repeat(257));
+    expect((startedStreams[0] as { chunks: SlackStreamChunk[] }).chunks)
+      .toEqual([expect.objectContaining({ id: "task-1", details: "0ms" })]);
+    expect((appendedStreams[0] as { chunks: SlackStreamChunk[] }).chunks)
+      .toEqual([expect.objectContaining({ id: "task-2", details: "0ms" })]);
+    expect((stoppedStreams[0] as { chunks: SlackStreamChunk[] }).chunks)
+      .toEqual([expect.objectContaining({ id: "task-3", details: "0ms" })]);
   });
 
   it("anchors a channel-root Agent Route card to its inbound user message", async () => {

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -3,6 +3,7 @@ import {
   SlackAdapter,
   SlackSocketModeConnection,
   type SlackApi,
+  type SlackStreamChunk,
   type SlackSocketClient,
 } from "../slack-adapter.ts";
 import type { SlackHomeView } from "../slack-home.ts";
@@ -4153,6 +4154,57 @@ describe("SlackAdapter", () => {
     expect(appendedStreams).toHaveLength(1);
     expect(stoppedStreams).toHaveLength(1);
     expect(JSON.stringify(startedStreams[0])).not.toContain("x".repeat(257));
+  });
+
+  it("renders waiting visibly and closes cancelled tasks without an error state", async () => {
+    const appendedStreams: unknown[] = [];
+    const startedStreams: unknown[] = [];
+    const adapter = new SlackAdapter({
+      config: { ...baseConfig, liveWorkingCards: true },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ appendedStreams, startedStreams }),
+      socketClient: fakeSocket(),
+    });
+    const first = slackWorkingCardIntent(1);
+    if (first.kind !== "working_card") throw new Error("expected working card");
+    first.card.tasks = [{
+      detail: "Cancelled · 1.2s",
+      id: "task-cancelled",
+      status: "cancelled",
+      title: "Deploy production",
+    }];
+    const waiting = {
+      ...first,
+      id: "working-card-waiting",
+      card: {
+        ...first.card,
+        phase: "waiting" as const,
+        sequence: 2,
+      },
+    };
+
+    await adapter.deliver(first);
+    await adapter.deliver(waiting);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const startedChunks = (startedStreams[0] as {
+      chunks: SlackStreamChunk[];
+    }).chunks;
+    expect(startedChunks).toContainEqual(expect.objectContaining({
+      details: "Cancelled · 1.2s",
+      status: "complete",
+      title: "Deploy production",
+      type: "task_update",
+    }));
+    const appendedChunks = (appendedStreams[0] as {
+      chunks: SlackStreamChunk[];
+    }).chunks;
+    expect(appendedChunks).toContainEqual({
+      markdown_text: "*Waiting for your input*",
+      type: "markdown_text",
+    });
   });
 
   it("falls back to the classic text Working Update without stream APIs", async () => {

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -4458,6 +4458,71 @@ describe("SlackAdapter", () => {
     }
   });
 
+  it("shares method budgets across simultaneous working cards", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    try {
+      const startedStreams: Array<{
+        chunks: Array<{ id: string }>;
+      }> = [];
+      const appendedStreams: Array<{
+        chunks: Array<{ id: string }>;
+      }> = [];
+      const stoppedStreams: Array<{
+        chunks: Array<{ id: string }>;
+      }> = [];
+      const adapter = new SlackAdapter({
+        config: { ...baseConfig, liveWorkingCards: true },
+        callbackHandleStore: fakeStore(),
+        api: fakeApi({ appendedStreams, startedStreams, stoppedStreams }),
+        socketClient: fakeSocket(),
+      });
+      const first = (sequence: number, isFinal = false) =>
+        slackWorkingCardIntent(sequence, {
+          isFinal,
+          key: "slack-binding-1\0turn-1",
+        });
+      const second = (sequence: number, isFinal = false) =>
+        slackWorkingCardIntent(sequence, {
+          isFinal,
+          key: "slack-binding-1\0turn-2",
+        });
+
+      await adapter.deliver(first(1));
+      await adapter.deliver(second(1));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(startedStreams).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(startedStreams).toHaveLength(2);
+
+      await adapter.deliver(first(2));
+      await adapter.deliver(second(2));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(appendedStreams).toHaveLength(1);
+
+      await adapter.deliver(first(3, true));
+      await adapter.deliver(second(3, true));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Stop has its own workspace budget, so one terminal call proceeds even
+      // while the second append is queued. Each method still serializes calls
+      // shared by all cards on this adapter.
+      expect(stoppedStreams).toHaveLength(1);
+      expect(appendedStreams).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(stoppedStreams).toHaveLength(2);
+      expect(appendedStreams).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("splits long Markdown with images and attaches them to the final post", async () => {
     const posted: Array<{
       blocks?: Array<{ image_url?: string; text?: string; type: string }>;

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -57,6 +57,7 @@ function conversationKey(channel: MessagingChannelRef): string {
 function fakeApi(spies: {
   assistantStatusError?: Error;
   assistantStatuses?: Array<{ channelId: string; status: string; threadTs: string }>;
+  appendedStreams?: unknown[];
   bots?: Record<string, string>;
   botsInfoCalls?: string[];
   conversations?: Record<string, string>;
@@ -70,9 +71,21 @@ function fakeApi(spies: {
   postedTimestamps?: string[];
   replies?: Record<string, string>;
   updated?: unknown[];
+  startedStreams?: unknown[];
+  stoppedStreams?: unknown[];
   users?: Record<string, { displayName?: string; realName?: string; username?: string }>;
 }): SlackApi {
   return {
+    startStream: async (params) => {
+      spies.startedStreams?.push(params);
+      return { channel: params.channel, ts: "1700000000.900001" };
+    },
+    appendStream: async (params) => {
+      spies.appendedStreams?.push(params);
+    },
+    stopStream: async (params) => {
+      spies.stoppedStreams?.push(params);
+    },
     authTest: async () => ({
       bot_id: "B0PWRAGENT",
       user: "pwragent",
@@ -3981,6 +3994,103 @@ describe("SlackAdapter", () => {
         .messageTimestamps
         .map((ts) => ({ channel: "D012ABCDEF0", ts })),
     );
+  });
+
+  it("streams one sequenced Thinking Steps card and drops stale updates", async () => {
+    const appendedStreams: unknown[] = [];
+    const startedStreams: unknown[] = [];
+    const stoppedStreams: unknown[] = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ appendedStreams, startedStreams, stoppedStreams }),
+      socketClient: fakeSocket(),
+      now: () => 1_700_000_000_000,
+    });
+    const intent = (sequence: number, isFinal = false): MessagingSurfaceIntent => ({
+      id: `working-card-${sequence}`,
+      kind: "working_card",
+      bindingId: "slack-binding-1",
+      createdAt: sequence,
+      fallbackText: "Tool update: searched files",
+      card: {
+        displayHint: "plan",
+        isFinal,
+        key: "slack-binding-1\0turn-1",
+        phase: isFinal ? "completed" : "working",
+        sequence,
+        tasks: [{ id: "task-1", title: "x".repeat(300), status: "complete" }],
+      },
+      audit: {
+        actor: { platformUserId: "U012ABCDEF0" },
+        bindingId: "slack-binding-1",
+        channel: {
+          channel: "slack",
+          conversation: {
+            id: "C012ABCDEF0",
+            kind: "thread",
+            parentId: "1700000000.000001",
+            workspaceId: "T012ABCDEF0",
+          },
+        },
+        occurredAt: sequence,
+      },
+    });
+
+    await expect(adapter.deliver(intent(1))).resolves.toMatchObject({ outcome: "presented" });
+    await expect(adapter.deliver(intent(1))).resolves.toMatchObject({ outcome: "discarded" });
+    await expect(adapter.deliver(intent(2))).resolves.toMatchObject({ outcome: "updated" });
+    await expect(adapter.deliver(intent(3, true))).resolves.toMatchObject({ outcome: "updated" });
+
+    expect(startedStreams).toHaveLength(1);
+    expect(appendedStreams).toHaveLength(1);
+    expect(stoppedStreams).toHaveLength(1);
+    expect(JSON.stringify(startedStreams[0])).not.toContain("x".repeat(257));
+  });
+
+  it("falls back to the classic text Working Update without stream APIs", async () => {
+    const posted: unknown[] = [];
+    const api = fakeApi({ posted });
+    api.startStream = undefined;
+    api.appendStream = undefined;
+    api.stopStream = undefined;
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api,
+      socketClient: fakeSocket(),
+      now: () => 1_700_000_000_000,
+    });
+
+    await expect(adapter.deliver({
+      id: "working-card-fallback",
+      kind: "working_card",
+      createdAt: 1,
+      fallbackText: "Tool update: searched files",
+      card: {
+        displayHint: "plan",
+        isFinal: false,
+        key: "fallback-turn",
+        phase: "working",
+        sequence: 1,
+        tasks: [{ id: "task-1", title: "Searched files", status: "complete" }],
+      },
+      audit: {
+        actor: { platformUserId: "U012ABCDEF0" },
+        channel: {
+          channel: "slack",
+          conversation: {
+            id: "C012ABCDEF0",
+            kind: "thread",
+            parentId: "1700000000.000001",
+          },
+        },
+        occurredAt: 1,
+      },
+    })).resolves.toMatchObject({ outcome: "presented" });
+
+    expect(posted).toHaveLength(1);
+    expect(JSON.stringify(posted[0])).toContain("Tool update: searched files");
   });
 
   it("splits long Markdown with images and attaches them to the final post", async () => {

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -4156,6 +4156,55 @@ describe("SlackAdapter", () => {
     expect(JSON.stringify(startedStreams[0])).not.toContain("x".repeat(257));
   });
 
+  it("anchors a channel-root Agent Route card to its inbound user message", async () => {
+    const startedStreams: unknown[] = [];
+    const adapter = new SlackAdapter({
+      config: { ...baseConfig, liveWorkingCards: true },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ startedStreams }),
+      socketClient: fakeSocket(),
+    });
+    const intent = slackWorkingCardIntent(1);
+    if (intent.kind !== "working_card") throw new Error("expected working card");
+    intent.audit = {
+      ...intent.audit!,
+      channel: {
+        channel: "slack",
+        conversation: {
+          id: "C012ABCDEF0",
+          kind: "channel",
+          workspaceId: "T012ABCDEF0",
+        },
+      },
+    };
+    intent.targetSurface = {
+      channel: "slack",
+      id: "slack-inbound-1",
+      state: {
+        opaque: {
+          channelId: "C012ABCDEF0",
+          teamId: "T012ABCDEF0",
+          ts: "1700000000.000099",
+        },
+      },
+    };
+
+    await expect(adapter.deliver(intent)).resolves.toMatchObject({
+      outcome: "presented",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(startedStreams).toEqual([
+      expect.objectContaining({
+        channel: "C012ABCDEF0",
+        recipientTeamId: "T012ABCDEF0",
+        recipientUserId: "U012ABCDEF0",
+        threadTs: "1700000000.000099",
+      }),
+    ]);
+  });
+
   it("renders waiting visibly and closes cancelled tasks without an error state", async () => {
     const appendedStreams: unknown[] = [];
     const startedStreams: unknown[] = [];

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -169,13 +169,18 @@ export type SlackApi = {
   botsInfo?(params: { bot: string }): Promise<{ name?: string } | undefined>;
 };
 
-export type SlackStreamChunk = {
-  details?: string;
-  id: string;
-  status: "pending" | "in_progress" | "complete" | "error";
-  title: string;
-  type: "task_update";
-};
+export type SlackStreamChunk =
+  | {
+      details?: string;
+      id: string;
+      status: "pending" | "in_progress" | "complete" | "error";
+      title: string;
+      type: "task_update";
+    }
+  | {
+      markdown_text: string;
+      type: "markdown_text";
+    };
 
 export type SlackUserListPage = {
   members?: SlackUserListMember[];
@@ -2074,13 +2079,25 @@ export class SlackAdapter implements SlackProviderAdapter {
   private workingCardChunks(
     intent: Extract<MessagingSurfaceIntent, { kind: "working_card" }>,
   ): SlackStreamChunk[] {
-    const chunks = intent.card.tasks.map((task): SlackStreamChunk => ({
-      type: "task_update",
-      id: clampSlackTaskField(task.id),
-      title: clampSlackTaskField(task.title),
-      status: task.status === "cancelled" ? "error" : task.status,
-      ...(task.detail ? { details: clampSlackTaskField(task.detail) } : {}),
-    }));
+    const chunks = intent.card.tasks.map((task): SlackStreamChunk => {
+      const details = [
+        task.status === "cancelled" && !task.detail ? "Cancelled" : undefined,
+        task.detail,
+      ].filter(Boolean).join(" · ");
+      return {
+        type: "task_update",
+        id: clampSlackTaskField(task.id),
+        title: clampSlackTaskField(task.title),
+        status: task.status === "cancelled" ? "complete" : task.status,
+        ...(details ? { details: clampSlackTaskField(details) } : {}),
+      };
+    });
+    if (intent.card.phase === "waiting") {
+      chunks.unshift({
+        type: "markdown_text",
+        markdown_text: "*Waiting for your input*",
+      });
+    }
     if (intent.card.isFinal && intent.card.phase === "failed") {
       chunks.push({
         type: "task_update",

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -91,6 +91,7 @@ const SLACK_DIRECTORY_PAGE_SIZE = 200;
 const SLACK_DIRECTORY_MAX_PAGES = 10;
 const SLACK_WORKING_CARD_TOMBSTONE_MAX = 200;
 const SLACK_WORKING_CARD_RETRY_MS = 3_000;
+const SLACK_WORKING_CARD_STOP_MAX_FAILURES = 3;
 const SLACK_WORKING_CARD_BUCKETS = {
   start: { method: "chat.startStream", limit: 20 },
   append: { method: "chat.appendStream", limit: 100 },
@@ -313,6 +314,11 @@ type SlackSurfaceOpaqueState = {
 };
 
 type SlackWorkingCardMethod = keyof typeof SLACK_WORKING_CARD_BUCKETS;
+type SlackWorkingCardIntent = Extract<
+  MessagingSurfaceIntent,
+  { kind: "working_card" }
+>;
+type SlackWorkingCardTask = SlackWorkingCardIntent["card"]["tasks"][number];
 
 type SlackWorkingCardTarget = {
   channelId: string;
@@ -322,13 +328,13 @@ type SlackWorkingCardTarget = {
 
 type SlackWorkingCardQueueState = {
   cancelled: boolean;
-  deliveredTaskIds: Set<string>;
+  deliveredTaskSlots: Map<number, string>;
   fallbackSurface?: MessagingSurfaceRef;
   lastDeliveredPhase?: Extract<
     MessagingSurfaceIntent,
     { kind: "working_card" }
   >["card"]["phase"];
-  latest: Extract<MessagingSurfaceIntent, { kind: "working_card" }>;
+  latest: SlackWorkingCardIntent;
   lastDeliveredSequence: number;
   nativeUnavailable?: boolean;
   nonRateFailureCount: number;
@@ -655,18 +661,24 @@ export class SlackAdapter implements SlackProviderAdapter {
   }
 
   resolveDeliveryScope(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined {
-    if (intent.kind === "working_card" && this.config.liveWorkingCards === true) {
+    if (intent.kind === "working_card") {
       const target = this.resolveTarget(intent);
       const state = this.workingCardStreams.get(intent.card.key);
+      const nativeAvailable =
+        this.config.liveWorkingCards === true
+        && Boolean(target?.threadTs)
+        && Boolean(this.api.startStream)
+        && Boolean(this.api.appendStream)
+        && Boolean(this.api.stopStream);
+      // A terminal fallback is intentionally a no-op. Do not reserve ordinary
+      // Slack message capacity or defer the authoritative final response for it.
+      if (intent.card.isFinal && (!nativeAvailable || state?.nativeUnavailable)) {
+        return undefined;
+      }
       if (state?.nativeUnavailable) {
         return target ? this.rateLimitScopeForTarget(target) : undefined;
       }
-      if (
-        target?.threadTs
-        && this.api.startStream
-        && this.api.appendStream
-        && this.api.stopStream
-      ) {
+      if (nativeAvailable) {
         return undefined;
       }
       return target ? this.rateLimitScopeForTarget(target) : undefined;
@@ -1881,7 +1893,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     };
     const state: SlackWorkingCardQueueState = current ?? {
       cancelled: false,
-      deliveredTaskIds: new Set(),
+      deliveredTaskSlots: new Map(),
       latest: intent,
       lastDeliveredSequence: 0,
       nonRateFailureCount: 0,
@@ -1951,6 +1963,14 @@ export class SlackAdapter implements SlackProviderAdapter {
         const bucket = this.workingCardBucket(method, state.target);
         const admission = this.workingCardRateLimits.admit(bucket);
         if (!admission.admitted) {
+          if (method === "append") {
+            // Working Updates are disposable under pressure. Remember that
+            // this sequence was considered without mutating the mounted slot
+            // snapshot; a later admitted update can still reconcile directly
+            // to its newest bounded card state. Never queue an append backlog.
+            state.lastDeliveredSequence = intent.card.sequence;
+            return;
+          }
           this.scheduleWorkingCardPump(
             key,
             state,
@@ -2021,6 +2041,10 @@ export class SlackAdapter implements SlackProviderAdapter {
           if (retryAfterMs !== undefined) {
             this.workingCardRateLimits.recordRateLimit(bucket.id, retryAfterMs);
             this.emitWorkingCardRateLimit(error, bucket, state.target, retryAfterMs);
+            if (method === "append") {
+              state.lastDeliveredSequence = intent.card.sequence;
+              return;
+            }
             this.scheduleWorkingCardPump(key, state, retryAfterMs, method);
             return;
           }
@@ -2030,26 +2054,35 @@ export class SlackAdapter implements SlackProviderAdapter {
               "Slack Thinking Steps stream unavailable; using text Working Update",
               { error: error instanceof Error ? error.message : String(error) },
             );
-            const fallback = await this.deliverWorkingCardFallback(intent, {
+            // Flip the mode before awaiting the fallback so newer updates use
+            // the classic path instead of being accepted into a dead stream.
+            state.nativeUnavailable = true;
+            const fallbackIntent = state.latest;
+            const fallback = await this.deliverWorkingCardFallback(fallbackIntent, {
               controllerBudgeted: false,
             });
             state.fallbackSurface = fallback.surface;
-            state.lastDeliveredSequence = intent.card.sequence;
-            state.nativeUnavailable = true;
+            state.lastDeliveredSequence = fallbackIntent.card.sequence;
             return;
           }
           this.logger.warn?.("Slack Thinking Steps stream call failed; preserving open card", {
             error: error instanceof Error ? error.message : String(error),
             method: SLACK_WORKING_CARD_BUCKETS[method].method,
           });
-          if (state.nonRateFailureCount === 1) {
+          if (method === "append") {
+            state.lastDeliveredSequence = intent.card.sequence;
+            return;
+          }
+          if (state.nonRateFailureCount < SLACK_WORKING_CARD_STOP_MAX_FAILURES) {
             this.scheduleWorkingCardPump(
               key,
               state,
-              SLACK_WORKING_CARD_RETRY_MS,
+              SLACK_WORKING_CARD_RETRY_MS * state.nonRateFailureCount,
               method,
             );
+            return;
           }
+          await this.abandonWorkingCardAfterStopFailure(key, state, intent);
           return;
         }
       }
@@ -2088,24 +2121,16 @@ export class SlackAdapter implements SlackProviderAdapter {
   }
 
   private workingCardChunks(
-    intent: Extract<MessagingSurfaceIntent, { kind: "working_card" }>,
+    intent: SlackWorkingCardIntent,
     state: SlackWorkingCardQueueState,
   ): SlackStreamChunk[] {
     const chunks = intent.card.tasks
-      .filter((task) => !state.deliveredTaskIds.has(task.id))
-      .map((task): SlackStreamChunk => {
-        const details = [
-          task.status === "cancelled" && !task.detail ? "Cancelled" : undefined,
-          task.detail,
-        ].filter(Boolean).join(" · ");
-        return {
-          type: "task_update",
-          id: clampSlackTaskField(task.id),
-          title: clampSlackTaskField(task.title),
-          status: task.status === "cancelled" ? "complete" : task.status,
-          ...(details ? { details: clampSlackTaskField(details) } : {}),
-        };
-      });
+      .map((task, index) => this.workingCardTaskSlot(intent, task, index))
+      .filter(
+        (slot, index) =>
+          state.deliveredTaskSlots.get(index) !== slot.fingerprint,
+      )
+      .map(({ fingerprint: _fingerprint, ...chunk }) => chunk);
     if (
       intent.card.phase === "waiting"
       && state.lastDeliveredPhase !== "waiting"
@@ -2118,7 +2143,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     if (intent.card.isFinal && intent.card.phase === "failed") {
       chunks.push({
         type: "task_update",
-        id: clampSlackTaskField(`${intent.card.key}:terminal`),
+        id: workingCardTaskSlotId(intent.card.key, "terminal"),
         status: "error",
         title: "Turn failed",
       });
@@ -2128,13 +2153,63 @@ export class SlackAdapter implements SlackProviderAdapter {
 
   private recordWorkingCardSnapshot(
     state: SlackWorkingCardQueueState,
-    intent: Extract<MessagingSurfaceIntent, { kind: "working_card" }>,
+    intent: SlackWorkingCardIntent,
   ): void {
-    for (const task of intent.card.tasks) {
-      state.deliveredTaskIds.add(task.id);
+    state.deliveredTaskSlots.clear();
+    for (const [index, task] of intent.card.tasks.entries()) {
+      state.deliveredTaskSlots.set(index, this.workingCardTaskSlot(
+        intent,
+        task,
+        index,
+      ).fingerprint);
     }
     state.lastDeliveredPhase = intent.card.phase;
     state.lastDeliveredSequence = intent.card.sequence;
+  }
+
+  private workingCardTaskSlot(
+    intent: SlackWorkingCardIntent,
+    task: SlackWorkingCardTask,
+    index: number,
+  ): SlackStreamChunk & { fingerprint: string } {
+    const details = [
+      task.status === "cancelled" && !task.detail ? "Cancelled" : undefined,
+      task.detail,
+    ].filter(Boolean).join(" · ");
+    const chunk: SlackStreamChunk = {
+      type: "task_update",
+      // Stable positional slots let a bounded controller snapshot replace
+      // evicted tasks without leaving the old rows mounted in Slack.
+      id: workingCardTaskSlotId(intent.card.key, index + 1),
+      title: clampSlackTaskField(task.title),
+      status: task.status === "cancelled" ? "complete" : task.status,
+      ...(details ? { details: clampSlackTaskField(details) } : {}),
+    };
+    return {
+      ...chunk,
+      fingerprint: JSON.stringify([task.id, chunk]),
+    };
+  }
+
+  private async abandonWorkingCardAfterStopFailure(
+    key: string,
+    state: SlackWorkingCardQueueState,
+    intent: SlackWorkingCardIntent,
+  ): Promise<void> {
+    if (state.ts) {
+      try {
+        await this.api.deleteMessage({
+          channel: state.target.channelId,
+          ts: state.ts,
+        });
+      } catch (error) {
+        this.logger.warn?.("Slack terminal Thinking Steps card could not be removed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    this.workingCardStreams.delete(key);
+    this.recordWorkingCardTombstone(key, intent.card.sequence);
   }
 
   private workingCardBucket(
@@ -2269,11 +2344,11 @@ export class SlackAdapter implements SlackProviderAdapter {
     return await this.deliver({
       ...intent,
       kind: "message",
-      role: "system",
+      role: intent.card.fallbackPresentation?.role ?? "system",
       parts: [{
         type: "text",
         text: fallbackText,
-        markdown: "light",
+        markdown: intent.card.fallbackPresentation?.markdown ?? "light",
       }],
     });
   }
@@ -3661,6 +3736,14 @@ function findSlackMentionOutsideCode(text: string, mention: string): number {
 
 function clampSlackTaskField(value: string): string {
   return value.length <= 256 ? value : `${value.slice(0, 255)}…`;
+}
+
+function workingCardTaskSlotId(
+  key: string,
+  slot: number | "terminal",
+): string {
+  const keyHash = createHash("sha256").update(key).digest("hex").slice(0, 16);
+  return `pwragent:${keyHash}:${slot}`;
 }
 
 function parseCommand(text: string): { command: string; args: string[] } | undefined {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -2263,6 +2263,14 @@ export class SlackAdapter implements SlackProviderAdapter {
     const channelId = surfaceState?.channelId ?? auditChannel?.conversation.id;
     if (!channelId) return undefined;
     const sourceRelative = intent.delivery?.sourceRelative;
+    // Slack requires every stream to reply to the user message that prompted
+    // it. Channel-root Agent Route requests are not themselves thread
+    // conversations, so their inbound message timestamp lives in the opaque
+    // source surface rather than channel.parentId. Use that timestamp only for
+    // Working Cards; ordinary and final replies keep their existing placement.
+    const workingCardAnchorTs = intent.kind === "working_card"
+      ? surfaceState?.ts
+      : undefined;
     const threadTs =
       sourceRelative === "source_channel"
         ? undefined
@@ -2270,6 +2278,7 @@ export class SlackAdapter implements SlackProviderAdapter {
           ? surfaceState?.threadTs ?? surfaceState?.ts ?? auditChannel?.conversation.parentId
           : surfaceState?.threadTs
             ?? auditChannel?.conversation.parentId
+            ?? workingCardAnchorTs
             ?? (auditChannel?.conversation.kind === "thread"
               ? auditChannel.conversation.parentId
               : undefined);

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -96,6 +96,11 @@ export type SlackProviderLogger = {
 };
 
 export type SlackApi = {
+  appendStream?(params: {
+    channel: string;
+    chunks: SlackStreamChunk[];
+    ts: string;
+  }): Promise<void>;
   setAssistantThreadStatus?(params: {
     channelId: string;
     loadingMessages?: string[];
@@ -121,6 +126,19 @@ export type SlackApi = {
   downloadFile(params: { url: string; maxBytes: number }): Promise<Uint8Array>;
   filesInfo(params: { file: string }): Promise<SlackFileInfo | undefined>;
   postMessage(params: SlackPostBody): Promise<SlackMessageResult>;
+  startStream?(params: {
+    channel: string;
+    chunks: SlackStreamChunk[];
+    recipientTeamId?: string;
+    recipientUserId?: string;
+    taskDisplayMode: "timeline" | "plan" | "dense";
+    threadTs: string;
+  }): Promise<SlackMessageResult>;
+  stopStream?(params: {
+    channel: string;
+    chunks?: SlackStreamChunk[];
+    ts: string;
+  }): Promise<void>;
   publishHomeView?(params: {
     userId: string;
     view: SlackHomeView;
@@ -140,6 +158,14 @@ export type SlackApi = {
     limit?: number;
   }): Promise<SlackUserListPage>;
   botsInfo?(params: { bot: string }): Promise<{ name?: string } | undefined>;
+};
+
+export type SlackStreamChunk = {
+  details?: string;
+  id: string;
+  status: "pending" | "in_progress" | "complete" | "error";
+  title: string;
+  type: "task_update";
 };
 
 export type SlackUserListPage = {
@@ -446,6 +472,10 @@ export class SlackAdapter implements SlackProviderAdapter {
       text: string;
     }>
   >();
+  private readonly workingCardStreams = new Map<
+    string,
+    { channelId: string; sequence: number; ts: string }
+  >();
   private botAccount: string | undefined;
   private botAccountDetail: string | undefined;
   private botId: string | undefined;
@@ -625,6 +655,9 @@ export class SlackAdapter implements SlackProviderAdapter {
     }
     if (intent.kind === "stream_update") {
       return await this.deliverStreamUpdate(intent);
+    }
+    if (intent.kind === "working_card") {
+      return await this.deliverWorkingCard(intent);
     }
 
     const target = this.resolveTarget(intent);
@@ -1658,6 +1691,90 @@ export class SlackAdapter implements SlackProviderAdapter {
         ...(rateLimit ? { rateLimit } : {}),
       };
     }
+  }
+
+  private async deliverWorkingCard(
+    intent: Extract<MessagingSurfaceIntent, { kind: "working_card" }>,
+  ): Promise<MessagingDeliveryResult> {
+    const deliveredAt = this.now();
+    const target = this.resolveTarget(intent);
+    const current = this.workingCardStreams.get(intent.card.key);
+    if (current && intent.card.sequence <= current.sequence) {
+      return { outcome: "discarded", channel: this.channel, deliveredAt };
+    }
+    if (
+      !target?.threadTs
+      || !this.api.startStream
+      || !this.api.appendStream
+      || !this.api.stopStream
+    ) {
+      return await this.deliverWorkingCardFallback(intent);
+    }
+    const chunks = intent.card.tasks.map((task): SlackStreamChunk => ({
+      type: "task_update",
+      id: clampSlackTaskField(task.id),
+      title: clampSlackTaskField(task.title),
+      status: task.status === "cancelled" ? "error" : task.status,
+      ...(task.detail ? { details: clampSlackTaskField(task.detail) } : {}),
+    }));
+    try {
+      if (!current) {
+        const result = await this.api.startStream({
+          channel: target.channelId,
+          chunks,
+          taskDisplayMode: intent.card.displayHint,
+          threadTs: target.threadTs,
+          ...(intent.audit?.actor.platformUserId
+            ? { recipientUserId: intent.audit.actor.platformUserId }
+            : {}),
+          ...(target.channelRef.conversation.workspaceId
+            ? { recipientTeamId: target.channelRef.conversation.workspaceId }
+            : {}),
+        });
+        if (!result.ts) {
+          throw new Error("Slack chat.startStream returned no timestamp");
+        }
+        this.workingCardStreams.set(intent.card.key, {
+          channelId: target.channelId,
+          sequence: intent.card.sequence,
+          ts: result.ts,
+        });
+        if (intent.card.isFinal) {
+          await this.api.stopStream({ channel: target.channelId, ts: result.ts });
+          this.workingCardStreams.delete(intent.card.key);
+        }
+        return { outcome: "presented", channel: this.channel, deliveredAt };
+      }
+      if (intent.card.isFinal) {
+        await this.api.stopStream({ channel: current.channelId, chunks, ts: current.ts });
+        this.workingCardStreams.delete(intent.card.key);
+      } else {
+        await this.api.appendStream({ channel: current.channelId, chunks, ts: current.ts });
+        current.sequence = intent.card.sequence;
+      }
+      return { outcome: "updated", channel: this.channel, deliveredAt };
+    } catch (error) {
+      this.workingCardStreams.delete(intent.card.key);
+      this.logger.warn?.("Slack Thinking Steps stream unavailable; using text Working Update", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return await this.deliverWorkingCardFallback(intent);
+    }
+  }
+
+  private async deliverWorkingCardFallback(
+    intent: Extract<MessagingSurfaceIntent, { kind: "working_card" }>,
+  ): Promise<MessagingDeliveryResult> {
+    return await this.deliver({
+      ...intent,
+      kind: "message",
+      role: "system",
+      parts: [{
+        type: "text",
+        text: intent.fallbackText ?? "Working update",
+        markdown: "light",
+      }],
+    });
   }
 
   private resolveTarget(intent: MessagingSurfaceIntent):
@@ -2701,6 +2818,43 @@ export function createSlackAdapter(
 export function createSlackApi(botToken: string): SlackApi {
   const client = new WebClient(botToken, { rejectRateLimitedCalls: true });
   return {
+    async startStream(params) {
+      const chat = client.chat as unknown as {
+        startStream(input: Record<string, unknown>): Promise<SlackMessageResult>;
+      };
+      return await chat.startStream({
+        channel: params.channel,
+        chunks: params.chunks,
+        thread_ts: params.threadTs,
+        task_display_mode: params.taskDisplayMode,
+        ...(params.recipientUserId
+          ? { recipient_user_id: params.recipientUserId }
+          : {}),
+        ...(params.recipientTeamId
+          ? { recipient_team_id: params.recipientTeamId }
+          : {}),
+      });
+    },
+    async appendStream(params) {
+      const chat = client.chat as unknown as {
+        appendStream(input: Record<string, unknown>): Promise<unknown>;
+      };
+      await chat.appendStream({
+        channel: params.channel,
+        chunks: params.chunks,
+        ts: params.ts,
+      });
+    },
+    async stopStream(params) {
+      const chat = client.chat as unknown as {
+        stopStream(input: Record<string, unknown>): Promise<unknown>;
+      };
+      await chat.stopStream({
+        channel: params.channel,
+        ts: params.ts,
+        ...(params.chunks ? { chunks: params.chunks } : {}),
+      });
+    },
     async authTest() {
       return (await client.auth.test()) as SlackAuthTestResult;
     },
@@ -2945,6 +3099,10 @@ function findSlackMentionOutsideCode(text: string, mention: string): number {
     index += 1;
   }
   return -1;
+}
+
+function clampSlackTaskField(value: string): string {
+  return value.length <= 256 ? value : `${value.slice(0, 255)}…`;
 }
 
 function parseCommand(text: string): { command: string; args: string[] } | undefined {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -34,6 +34,7 @@ import type {
   MessagingManagedConversationRightsResult,
   MessagingPrivateConversationResolveRequest,
   MessagingPrivateConversationResolveResult,
+  MessagingRateLimitBucket,
   MessagingRateLimitInfo,
   MessagingRejectedInboundEvent,
   MessagingSurfaceAction,
@@ -43,6 +44,7 @@ import type {
 import {
   evictStaleStreamAnchors,
   extractMessagingPairingToken,
+  MessagingRateLimitGate,
   SLACK_CHANNEL_AUTHORIZATION_MODE_DEFAULT,
   SLACK_CHANNEL_USER_ACCESS_MODE_DEFAULT,
   SLACK_DM_ACCESS_MODE_DEFAULT,
@@ -87,6 +89,13 @@ const SLACK_DIRECTORY_PAGE_SIZE = 200;
 // Bounds a very large workspace: 10 pages x 200 = 2,000 people, past which a
 // name search is the wrong interaction anyway.
 const SLACK_DIRECTORY_MAX_PAGES = 10;
+const SLACK_WORKING_CARD_TOMBSTONE_MAX = 200;
+const SLACK_WORKING_CARD_RETRY_MS = 3_000;
+const SLACK_WORKING_CARD_BUCKETS = {
+  start: { method: "chat.startStream", limit: 20 },
+  append: { method: "chat.appendStream", limit: 100 },
+  stop: { method: "chat.stopStream", limit: 20 },
+} as const;
 
 export type SlackProviderLogger = {
   debug?: (message: string, data?: Record<string, unknown>) => void;
@@ -295,6 +304,29 @@ type SlackSurfaceOpaqueState = {
   messageTimestamps?: string[];
   threadTs?: string;
   ts?: string;
+  workingCardKey?: string;
+};
+
+type SlackWorkingCardMethod = keyof typeof SLACK_WORKING_CARD_BUCKETS;
+
+type SlackWorkingCardTarget = {
+  channelId: string;
+  channelRef: MessagingChannelRef;
+  threadTs: string;
+};
+
+type SlackWorkingCardQueueState = {
+  cancelled: boolean;
+  fallbackSurface?: MessagingSurfaceRef;
+  latest: Extract<MessagingSurfaceIntent, { kind: "working_card" }>;
+  lastDeliveredSequence: number;
+  nativeUnavailable?: boolean;
+  nonRateFailureCount: number;
+  pumping: boolean;
+  retryMethod?: SlackWorkingCardMethod;
+  retryTimer?: ReturnType<typeof setTimeout>;
+  target: SlackWorkingCardTarget;
+  ts?: string;
 };
 
 type SlackInboundListener = (event: MessagingInboundEvent) => Promise<void>;
@@ -472,14 +504,14 @@ export class SlackAdapter implements SlackProviderAdapter {
       text: string;
     }>
   >();
-  private readonly workingCardStreams = new Map<
-    string,
-    { channelId: string; sequence: number; ts: string }
-  >();
+  private readonly workingCardStreams = new Map<string, SlackWorkingCardQueueState>();
+  private readonly workingCardTombstones = new Map<string, number>();
+  private readonly workingCardRateLimits: MessagingRateLimitGate;
   private botAccount: string | undefined;
   private botAccountDetail: string | undefined;
   private botId: string | undefined;
   private botUserId: string | undefined;
+  private workspaceId: string | undefined;
   private assistantThreadStatusDisabled = false;
   private conversationInfoLookupDisabled = false;
   private threadInfoLookupDisabled = false;
@@ -491,6 +523,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     this.config = options.config;
     this.logger = options.logger ?? {};
     this.now = options.now ?? Date.now;
+    this.workingCardRateLimits = new MessagingRateLimitGate(this.now);
     this.callbackHandleStore = options.callbackHandleStore;
     this.authorizedActorIdsValue = options.config.authorizedActorIds.map(
       (actor) => actor.id,
@@ -583,6 +616,12 @@ export class SlackAdapter implements SlackProviderAdapter {
   async updateRenderingPreferences(
     update: MessagingAdapterRenderingPreferencesUpdate,
   ): Promise<void> {
+    if (update.liveWorkingCards !== undefined) {
+      this.config.liveWorkingCards = update.liveWorkingCards;
+      if (!update.liveWorkingCards) {
+        await this.cancelAllWorkingCards();
+      }
+    }
     if (update.streamingResponses !== undefined) {
       this.config.streamingResponses = update.streamingResponses;
     }
@@ -603,6 +642,18 @@ export class SlackAdapter implements SlackProviderAdapter {
   }
 
   resolveDeliveryScope(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined {
+    if (intent.kind === "working_card" && this.config.liveWorkingCards === true) {
+      const target = this.resolveTarget(intent);
+      if (
+        target?.threadTs
+        && this.api.startStream
+        && this.api.appendStream
+        && this.api.stopStream
+      ) {
+        return undefined;
+      }
+      return target ? this.rateLimitScopeForTarget(target) : undefined;
+    }
     const target = this.resolveTarget(intent);
     return target ? this.rateLimitScopeForTarget(target) : undefined;
   }
@@ -615,6 +666,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     this.botUserId = auth.user_id;
     this.botAccount = auth.user ?? auth.user_id;
     this.botAccountDetail = auth.team ?? hostFromUrl(auth.url) ?? auth.team_id;
+    this.workspaceId = auth.team_id;
 
     if (this.config.inboundMode === "events") {
       throw new Error("Slack Events API mode is not implemented yet; use Socket Mode");
@@ -636,6 +688,13 @@ export class SlackAdapter implements SlackProviderAdapter {
   }
 
   async stop(): Promise<void> {
+    for (const state of this.workingCardStreams.values()) {
+      state.cancelled = true;
+      if (state.retryTimer) clearTimeout(state.retryTimer);
+    }
+    this.workingCardStreams.clear();
+    this.workingCardTombstones.clear();
+    this.workingCardRateLimits.clear();
     if (!this.started) return;
     this.socketClient?.off?.("slack_event", this.handleSlackEvent);
     this.socketClient?.off?.("interactive", this.handleInteractive);
@@ -1383,6 +1442,50 @@ export class SlackAdapter implements SlackProviderAdapter {
     intent: Extract<MessagingSurfaceIntent, { kind: "dismiss" }>,
   ): Promise<MessagingDeliveryResult> {
     const target = readSlackSurfaceState(intent.targetSurface);
+    if (target?.workingCardKey) {
+      const state = this.workingCardStreams.get(target.workingCardKey);
+      if (state) {
+        state.cancelled = true;
+        if (state.retryTimer) clearTimeout(state.retryTimer);
+        this.workingCardStreams.delete(target.workingCardKey);
+        this.recordWorkingCardTombstone(
+          target.workingCardKey,
+          state.latest.card.sequence,
+        );
+        const fallbackState = readSlackSurfaceState(state.fallbackSurface);
+        const deleteTarget = state.ts
+          ? { channelId: state.target.channelId, ts: state.ts }
+          : fallbackState?.channelId && fallbackState.ts
+            ? { channelId: fallbackState.channelId, ts: fallbackState.ts }
+            : undefined;
+        if (deleteTarget) {
+          try {
+            await this.api.deleteMessage({
+              channel: deleteTarget.channelId,
+              ts: deleteTarget.ts,
+            });
+          } catch (error) {
+            const rateLimit = this.emitRateLimitFromError(
+              error,
+              state.target,
+              { retryable: true },
+            );
+            return {
+              outcome: "failed",
+              channel: this.channel,
+              deliveredAt: this.now(),
+              errorMessage: error instanceof Error ? error.message : String(error),
+              ...(rateLimit ? { rateLimit } : {}),
+            };
+          }
+        }
+      }
+      return {
+        outcome: "dismissed",
+        channel: this.channel,
+        deliveredAt: this.now(),
+      };
+    }
     const messageTimestamps = target?.messageTimestamps?.length
       ? target.messageTimestamps
       : target?.ts
@@ -1697,10 +1800,26 @@ export class SlackAdapter implements SlackProviderAdapter {
     intent: Extract<MessagingSurfaceIntent, { kind: "working_card" }>,
   ): Promise<MessagingDeliveryResult> {
     const deliveredAt = this.now();
+    if (this.config.liveWorkingCards !== true) {
+      return await this.deliverWorkingCardFallback(intent);
+    }
     const target = this.resolveTarget(intent);
-    const current = this.workingCardStreams.get(intent.card.key);
-    if (current && intent.card.sequence <= current.sequence) {
+    const terminalSequence = this.workingCardTombstones.get(intent.card.key);
+    if (terminalSequence !== undefined && intent.card.sequence <= terminalSequence) {
       return { outcome: "discarded", channel: this.channel, deliveredAt };
+    }
+    const current = this.workingCardStreams.get(intent.card.key);
+    if (current && intent.card.sequence <= current.latest.card.sequence) {
+      return { outcome: "discarded", channel: this.channel, deliveredAt };
+    }
+    if (current?.nativeUnavailable) {
+      current.latest = intent;
+      if (intent.card.isFinal) {
+        this.workingCardStreams.delete(intent.card.key);
+        this.recordWorkingCardTombstone(intent.card.key, intent.card.sequence);
+        return { outcome: "discarded", channel: this.channel, deliveredAt };
+      }
+      return await this.deliverWorkingCardFallback(intent);
     }
     if (
       !target?.threadTs
@@ -1710,6 +1829,214 @@ export class SlackAdapter implements SlackProviderAdapter {
     ) {
       return await this.deliverWorkingCardFallback(intent);
     }
+    const workingTarget: SlackWorkingCardTarget = {
+      channelId: target.channelId,
+      channelRef: target.channelRef,
+      threadTs: target.threadTs,
+    };
+    const state: SlackWorkingCardQueueState = current ?? {
+      cancelled: false,
+      latest: intent,
+      lastDeliveredSequence: 0,
+      nonRateFailureCount: 0,
+      pumping: false,
+      target: workingTarget,
+    };
+    if (!current) {
+      this.workingCardStreams.set(intent.card.key, state);
+    } else {
+      state.latest = intent;
+      state.nonRateFailureCount = 0;
+      if (intent.card.isFinal && state.retryMethod === "append" && state.retryTimer) {
+        clearTimeout(state.retryTimer);
+        state.retryTimer = undefined;
+        state.retryMethod = undefined;
+      }
+    }
+    this.startWorkingCardPump(intent.card.key, state);
+    return {
+      outcome: current ? "updated" : "presented",
+      channel: this.channel,
+      deliveredAt,
+      surface: this.workingCardSurface(intent.card.key, state),
+    };
+  }
+
+  private startWorkingCardPump(
+    key: string,
+    state: SlackWorkingCardQueueState,
+  ): void {
+    if (state.pumping || state.cancelled || state.retryTimer) return;
+    void this.pumpWorkingCard(key, state).catch((error) => {
+      this.logger.error?.("Slack Thinking Steps queue failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+
+  private async pumpWorkingCard(
+    key: string,
+    state: SlackWorkingCardQueueState,
+  ): Promise<void> {
+    if (state.pumping || state.cancelled) return;
+    state.pumping = true;
+    try {
+      while (
+        !state.cancelled
+        && this.workingCardStreams.get(key) === state
+      ) {
+        const intent = state.latest;
+        const method: SlackWorkingCardMethod = !state.ts
+          ? "start"
+          : intent.card.isFinal
+            ? "stop"
+            : "append";
+        if (
+          method === "append"
+          && intent.card.sequence <= state.lastDeliveredSequence
+        ) {
+          return;
+        }
+        const bucket = this.workingCardBucket(method, state.target);
+        const admission = this.workingCardRateLimits.admit(bucket);
+        if (!admission.admitted) {
+          this.scheduleWorkingCardPump(
+            key,
+            state,
+            Math.max(0, admission.retryAt - this.now()),
+            method,
+          );
+          return;
+        }
+        try {
+          if (method === "start") {
+            const result = await this.api.startStream!({
+              channel: state.target.channelId,
+              chunks: this.workingCardChunks(intent),
+              taskDisplayMode: intent.card.displayHint,
+              threadTs: state.target.threadTs,
+              ...(intent.audit?.actor.platformUserId
+                ? { recipientUserId: intent.audit.actor.platformUserId }
+                : {}),
+              ...(state.target.channelRef.conversation.workspaceId
+                ? {
+                    recipientTeamId:
+                      state.target.channelRef.conversation.workspaceId,
+                  }
+                : {}),
+            });
+            if (!result.ts) {
+              throw new Error("Slack chat.startStream returned no timestamp");
+            }
+            if (state.cancelled) {
+              try {
+                await this.api.deleteMessage({
+                  channel: state.target.channelId,
+                  ts: result.ts,
+                });
+              } catch (error) {
+                this.logger.warn?.("Slack cancelled Thinking Steps card could not be removed", {
+                  error: error instanceof Error ? error.message : String(error),
+                });
+              }
+              return;
+            }
+            state.ts = result.ts;
+            state.lastDeliveredSequence = intent.card.sequence;
+            state.nonRateFailureCount = 0;
+            continue;
+          }
+          if (method === "append") {
+            await this.api.appendStream!({
+              channel: state.target.channelId,
+              chunks: this.workingCardChunks(intent),
+              ts: state.ts!,
+            });
+            state.lastDeliveredSequence = intent.card.sequence;
+            state.nonRateFailureCount = 0;
+            continue;
+          }
+          await this.api.stopStream!({
+            channel: state.target.channelId,
+            chunks: this.workingCardChunks(intent),
+            ts: state.ts!,
+          });
+          this.workingCardStreams.delete(key);
+          this.recordWorkingCardTombstone(key, intent.card.sequence);
+          return;
+        } catch (error) {
+          if (state.cancelled) return;
+          const retryAfterMs = retryAfterMsFromError(error);
+          if (retryAfterMs !== undefined) {
+            this.workingCardRateLimits.recordRateLimit(bucket.id, retryAfterMs);
+            this.emitWorkingCardRateLimit(error, bucket, state.target, retryAfterMs);
+            this.scheduleWorkingCardPump(key, state, retryAfterMs, method);
+            return;
+          }
+          state.nonRateFailureCount += 1;
+          if (method === "start") {
+            this.logger.warn?.(
+              "Slack Thinking Steps stream unavailable; using text Working Update",
+              { error: error instanceof Error ? error.message : String(error) },
+            );
+            const fallback = await this.deliverWorkingCardFallback(intent);
+            state.fallbackSurface = fallback.surface;
+            state.lastDeliveredSequence = intent.card.sequence;
+            state.nativeUnavailable = true;
+            return;
+          }
+          this.logger.warn?.("Slack Thinking Steps stream call failed; preserving open card", {
+            error: error instanceof Error ? error.message : String(error),
+            method: SLACK_WORKING_CARD_BUCKETS[method].method,
+          });
+          if (state.nonRateFailureCount === 1) {
+            this.scheduleWorkingCardPump(
+              key,
+              state,
+              SLACK_WORKING_CARD_RETRY_MS,
+              method,
+            );
+          }
+          return;
+        }
+      }
+    } finally {
+      state.pumping = false;
+      if (
+        !state.cancelled
+        && !state.nativeUnavailable
+        && !state.retryTimer
+        && state.nonRateFailureCount < 2
+        && this.workingCardStreams.get(key) === state
+        && (
+          !state.ts
+          || state.latest.card.isFinal
+          || state.latest.card.sequence > state.lastDeliveredSequence
+        )
+      ) {
+        this.startWorkingCardPump(key, state);
+      }
+    }
+  }
+
+  private scheduleWorkingCardPump(
+    key: string,
+    state: SlackWorkingCardQueueState,
+    delayMs: number,
+    method: SlackWorkingCardMethod,
+  ): void {
+    if (state.cancelled || state.retryTimer) return;
+    state.retryMethod = method;
+    state.retryTimer = setTimeout(() => {
+      state.retryTimer = undefined;
+      state.retryMethod = undefined;
+      this.startWorkingCardPump(key, state);
+    }, delayMs);
+  }
+
+  private workingCardChunks(
+    intent: Extract<MessagingSurfaceIntent, { kind: "working_card" }>,
+  ): SlackStreamChunk[] {
     const chunks = intent.card.tasks.map((task): SlackStreamChunk => ({
       type: "task_update",
       id: clampSlackTaskField(task.id),
@@ -1717,54 +2044,116 @@ export class SlackAdapter implements SlackProviderAdapter {
       status: task.status === "cancelled" ? "error" : task.status,
       ...(task.detail ? { details: clampSlackTaskField(task.detail) } : {}),
     }));
-    try {
-      if (!current) {
-        const result = await this.api.startStream({
-          channel: target.channelId,
-          chunks,
-          taskDisplayMode: intent.card.displayHint,
-          threadTs: target.threadTs,
-          ...(intent.audit?.actor.platformUserId
-            ? { recipientUserId: intent.audit.actor.platformUserId }
-            : {}),
-          ...(target.channelRef.conversation.workspaceId
-            ? { recipientTeamId: target.channelRef.conversation.workspaceId }
-            : {}),
-        });
-        if (!result.ts) {
-          throw new Error("Slack chat.startStream returned no timestamp");
-        }
-        this.workingCardStreams.set(intent.card.key, {
-          channelId: target.channelId,
-          sequence: intent.card.sequence,
-          ts: result.ts,
-        });
-        if (intent.card.isFinal) {
-          await this.api.stopStream({ channel: target.channelId, ts: result.ts });
-          this.workingCardStreams.delete(intent.card.key);
-        }
-        return { outcome: "presented", channel: this.channel, deliveredAt };
-      }
-      if (intent.card.isFinal) {
-        await this.api.stopStream({ channel: current.channelId, chunks, ts: current.ts });
-        this.workingCardStreams.delete(intent.card.key);
-      } else {
-        await this.api.appendStream({ channel: current.channelId, chunks, ts: current.ts });
-        current.sequence = intent.card.sequence;
-      }
-      return { outcome: "updated", channel: this.channel, deliveredAt };
-    } catch (error) {
-      this.workingCardStreams.delete(intent.card.key);
-      this.logger.warn?.("Slack Thinking Steps stream unavailable; using text Working Update", {
-        error: error instanceof Error ? error.message : String(error),
+    if (intent.card.isFinal && intent.card.phase === "failed") {
+      chunks.push({
+        type: "task_update",
+        id: clampSlackTaskField(`${intent.card.key}:terminal`),
+        status: "error",
+        title: "Turn failed",
       });
-      return await this.deliverWorkingCardFallback(intent);
     }
+    return chunks;
+  }
+
+  private workingCardBucket(
+    method: SlackWorkingCardMethod,
+    target: SlackWorkingCardTarget,
+  ): MessagingRateLimitBucket {
+    const definition = SLACK_WORKING_CARD_BUCKETS[method];
+    const workspaceId =
+      this.workspaceId
+      ?? target.channelRef.conversation.workspaceId
+      ?? this.botAccountDetail
+      ?? "configured-workspace";
+    return {
+      id: `slack:workspace:${workspaceId}:${definition.method}`,
+      intervalMs: 60_000,
+      limit: definition.limit,
+      minIntervalMs: 1_000,
+    };
+  }
+
+  private emitWorkingCardRateLimit(
+    error: unknown,
+    bucket: MessagingRateLimitBucket,
+    target: SlackWorkingCardTarget,
+    retryAfterMs: number,
+  ): void {
+    this.emitRateLimit({
+      scope: {
+        platform: this.channel,
+        id: bucket.id,
+        kind: "workspace",
+        label: `Slack ${bucket.id.split(":").at(-1) ?? "stream"}`,
+        budget: { limit: bucket.limit, intervalMs: bucket.intervalMs },
+        parentId: this.rateLimitScopeForTarget(target).id,
+      },
+      retryAfterMs,
+      message: error instanceof Error ? error.message : String(error),
+      observedAt: this.now(),
+      retryable: false,
+    });
+  }
+
+  private workingCardSurface(
+    key: string,
+    state: SlackWorkingCardQueueState,
+  ): MessagingSurfaceRef {
+    return {
+      channel: this.channel,
+      id: `working-card:${key}`,
+      state: {
+        opaque: {
+          channelId: state.target.channelId,
+          threadTs: state.target.threadTs,
+          workingCardKey: key,
+          ...(state.ts ? { ts: state.ts } : {}),
+        },
+      },
+    };
+  }
+
+  private recordWorkingCardTombstone(key: string, sequence: number): void {
+    this.workingCardTombstones.delete(key);
+    this.workingCardTombstones.set(key, sequence);
+    while (this.workingCardTombstones.size > SLACK_WORKING_CARD_TOMBSTONE_MAX) {
+      const oldest = this.workingCardTombstones.keys().next().value;
+      if (oldest === undefined) break;
+      this.workingCardTombstones.delete(oldest);
+    }
+  }
+
+  private async cancelAllWorkingCards(): Promise<void> {
+    const removals: Promise<void>[] = [];
+    for (const [key, state] of this.workingCardStreams) {
+      state.cancelled = true;
+      if (state.retryTimer) clearTimeout(state.retryTimer);
+      this.recordWorkingCardTombstone(key, state.latest.card.sequence);
+      if (state.ts) {
+        removals.push(
+          this.api.deleteMessage({ channel: state.target.channelId, ts: state.ts })
+            .catch((error) => {
+              this.logger.warn?.("Slack disabled Thinking Steps card could not be removed", {
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }),
+        );
+      }
+    }
+    this.workingCardStreams.clear();
+    await Promise.all(removals);
   }
 
   private async deliverWorkingCardFallback(
     intent: Extract<MessagingSurfaceIntent, { kind: "working_card" }>,
   ): Promise<MessagingDeliveryResult> {
+    if (intent.card.isFinal) {
+      return {
+        outcome: "discarded",
+        channel: this.channel,
+        deliveredAt: this.now(),
+      };
+    }
     return await this.deliver({
       ...intent,
       kind: "message",
@@ -3155,6 +3544,9 @@ function readSlackOpaqueState(
     ...(typeof record.teamId === "string" ? { teamId: record.teamId } : {}),
     ...(typeof record.threadTs === "string" ? { threadTs: record.threadTs } : {}),
     ...(typeof record.ts === "string" ? { ts: record.ts } : {}),
+    ...(typeof record.workingCardKey === "string"
+      ? { workingCardKey: record.workingCardKey }
+      : {}),
   };
 }
 
@@ -3427,10 +3819,13 @@ function slackTimestampToMs(ts: string | undefined): number | undefined {
 }
 
 function retryAfterMsFromError(error: unknown): number | undefined {
+  const explicitMilliseconds = readNumberProperty(error, "retryAfterMs");
+  if (explicitMilliseconds !== undefined) {
+    return Math.ceil(explicitMilliseconds);
+  }
   const retryAfter =
-    readNumberProperty(error, "retryAfter") ??
-    readNumberProperty(error, "retry_after") ??
-    readNumberProperty(error, "retryAfterMs");
+    readNumberProperty(error, "retryAfter")
+    ?? readNumberProperty(error, "retry_after");
   if (retryAfter !== undefined) {
     return retryAfter > 1_000 ? Math.ceil(retryAfter) : Math.ceil(retryAfter * 1000);
   }

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -644,6 +644,10 @@ export class SlackAdapter implements SlackProviderAdapter {
   resolveDeliveryScope(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined {
     if (intent.kind === "working_card" && this.config.liveWorkingCards === true) {
       const target = this.resolveTarget(intent);
+      const state = this.workingCardStreams.get(intent.card.key);
+      if (state?.nativeUnavailable) {
+        return target ? this.rateLimitScopeForTarget(target) : undefined;
+      }
       if (
         target?.threadTs
         && this.api.startStream
@@ -1979,7 +1983,9 @@ export class SlackAdapter implements SlackProviderAdapter {
               "Slack Thinking Steps stream unavailable; using text Working Update",
               { error: error instanceof Error ? error.message : String(error) },
             );
-            const fallback = await this.deliverWorkingCardFallback(intent);
+            const fallback = await this.deliverWorkingCardFallback(intent, {
+              controllerBudgeted: false,
+            });
             state.fallbackSurface = fallback.surface;
             state.lastDeliveredSequence = intent.card.sequence;
             state.nativeUnavailable = true;
@@ -2146,13 +2152,43 @@ export class SlackAdapter implements SlackProviderAdapter {
 
   private async deliverWorkingCardFallback(
     intent: Extract<MessagingSurfaceIntent, { kind: "working_card" }>,
+    options: { controllerBudgeted?: boolean } = {},
   ): Promise<MessagingDeliveryResult> {
-    if (intent.card.isFinal) {
+    const fallbackText = intent.fallbackText?.trim();
+    if (intent.card.isFinal || !fallbackText) {
       return {
         outcome: "discarded",
         channel: this.channel,
         deliveredAt: this.now(),
       };
+    }
+    const target = this.resolveTarget(intent);
+    if (!target) {
+      return {
+        outcome: "failed",
+        channel: this.channel,
+        deliveredAt: this.now(),
+        errorMessage: "Slack delivery target is missing",
+      };
+    }
+    if (options.controllerBudgeted === false) {
+      const scope = this.rateLimitScopeForTarget(target);
+      const admission = this.workingCardRateLimits.admit({
+        id: `${scope.id}:working-card-fallback`,
+        intervalMs: scope.budget?.intervalMs ?? 60_000,
+        // The first fallback happens asynchronously after controller
+        // admission, so it gets one emergency write per channel/minute.
+        // Later updates expose the degraded state through resolveDeliveryScope
+        // and return to the controller's ordinary channel budget.
+        limit: 1,
+      });
+      if (!admission.admitted) {
+        return {
+          outcome: "discarded",
+          channel: this.channel,
+          deliveredAt: this.now(),
+        };
+      }
     }
     return await this.deliver({
       ...intent,
@@ -2160,7 +2196,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       role: "system",
       parts: [{
         type: "text",
-        text: intent.fallbackText ?? "Working update",
+        text: fallbackText,
         markdown: "light",
       }],
     });

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -322,7 +322,12 @@ type SlackWorkingCardTarget = {
 
 type SlackWorkingCardQueueState = {
   cancelled: boolean;
+  deliveredTaskIds: Set<string>;
   fallbackSurface?: MessagingSurfaceRef;
+  lastDeliveredPhase?: Extract<
+    MessagingSurfaceIntent,
+    { kind: "working_card" }
+  >["card"]["phase"];
   latest: Extract<MessagingSurfaceIntent, { kind: "working_card" }>;
   lastDeliveredSequence: number;
   nativeUnavailable?: boolean;
@@ -1876,6 +1881,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     };
     const state: SlackWorkingCardQueueState = current ?? {
       cancelled: false,
+      deliveredTaskIds: new Set(),
       latest: intent,
       lastDeliveredSequence: 0,
       nonRateFailureCount: 0,
@@ -1937,6 +1943,11 @@ export class SlackAdapter implements SlackProviderAdapter {
         ) {
           return;
         }
+        const chunks = this.workingCardChunks(intent, state);
+        if (method === "append" && chunks.length === 0) {
+          this.recordWorkingCardSnapshot(state, intent);
+          continue;
+        }
         const bucket = this.workingCardBucket(method, state.target);
         const admission = this.workingCardRateLimits.admit(bucket);
         if (!admission.admitted) {
@@ -1952,7 +1963,7 @@ export class SlackAdapter implements SlackProviderAdapter {
           if (method === "start") {
             const result = await this.api.startStream!({
               channel: state.target.channelId,
-              chunks: this.workingCardChunks(intent),
+              chunks,
               taskDisplayMode: intent.card.displayHint,
               threadTs: state.target.threadTs,
               ...(intent.audit?.actor.platformUserId
@@ -1982,23 +1993,23 @@ export class SlackAdapter implements SlackProviderAdapter {
               return;
             }
             state.ts = result.ts;
-            state.lastDeliveredSequence = intent.card.sequence;
+            this.recordWorkingCardSnapshot(state, intent);
             state.nonRateFailureCount = 0;
             continue;
           }
           if (method === "append") {
             await this.api.appendStream!({
               channel: state.target.channelId,
-              chunks: this.workingCardChunks(intent),
+              chunks,
               ts: state.ts!,
             });
-            state.lastDeliveredSequence = intent.card.sequence;
+            this.recordWorkingCardSnapshot(state, intent);
             state.nonRateFailureCount = 0;
             continue;
           }
           await this.api.stopStream!({
             channel: state.target.channelId,
-            chunks: this.workingCardChunks(intent),
+            ...(chunks.length > 0 ? { chunks } : {}),
             ts: state.ts!,
           });
           this.workingCardStreams.delete(key);
@@ -2078,21 +2089,27 @@ export class SlackAdapter implements SlackProviderAdapter {
 
   private workingCardChunks(
     intent: Extract<MessagingSurfaceIntent, { kind: "working_card" }>,
+    state: SlackWorkingCardQueueState,
   ): SlackStreamChunk[] {
-    const chunks = intent.card.tasks.map((task): SlackStreamChunk => {
-      const details = [
-        task.status === "cancelled" && !task.detail ? "Cancelled" : undefined,
-        task.detail,
-      ].filter(Boolean).join(" · ");
-      return {
-        type: "task_update",
-        id: clampSlackTaskField(task.id),
-        title: clampSlackTaskField(task.title),
-        status: task.status === "cancelled" ? "complete" : task.status,
-        ...(details ? { details: clampSlackTaskField(details) } : {}),
-      };
-    });
-    if (intent.card.phase === "waiting") {
+    const chunks = intent.card.tasks
+      .filter((task) => !state.deliveredTaskIds.has(task.id))
+      .map((task): SlackStreamChunk => {
+        const details = [
+          task.status === "cancelled" && !task.detail ? "Cancelled" : undefined,
+          task.detail,
+        ].filter(Boolean).join(" · ");
+        return {
+          type: "task_update",
+          id: clampSlackTaskField(task.id),
+          title: clampSlackTaskField(task.title),
+          status: task.status === "cancelled" ? "complete" : task.status,
+          ...(details ? { details: clampSlackTaskField(details) } : {}),
+        };
+      });
+    if (
+      intent.card.phase === "waiting"
+      && state.lastDeliveredPhase !== "waiting"
+    ) {
       chunks.unshift({
         type: "markdown_text",
         markdown_text: "*Waiting for your input*",
@@ -2107,6 +2124,17 @@ export class SlackAdapter implements SlackProviderAdapter {
       });
     }
     return chunks;
+  }
+
+  private recordWorkingCardSnapshot(
+    state: SlackWorkingCardQueueState,
+    intent: Extract<MessagingSurfaceIntent, { kind: "working_card" }>,
+  ): void {
+    for (const task of intent.card.tasks) {
+      state.deliveredTaskIds.add(task.id);
+    }
+    state.lastDeliveredPhase = intent.card.phase;
+    state.lastDeliveredSequence = intent.card.sequence;
   }
 
   private workingCardBucket(

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -667,9 +667,9 @@ export class SlackAdapter implements SlackProviderAdapter {
       const nativeAvailable =
         this.config.liveWorkingCards === true
         && Boolean(target?.threadTs)
-        && Boolean(this.api.startStream)
-        && Boolean(this.api.appendStream)
-        && Boolean(this.api.stopStream);
+        && this.api.startStream !== undefined
+        && this.api.appendStream !== undefined
+        && this.api.stopStream !== undefined;
       // A terminal fallback is intentionally a no-op. Do not reserve ordinary
       // Slack message capacity or defer the authoritative final response for it.
       if (intent.card.isFinal && (!nativeAvailable || state?.nativeUnavailable)) {

--- a/packages/messaging/providers/slack/src/slack-config.ts
+++ b/packages/messaging/providers/slack/src/slack-config.ts
@@ -28,6 +28,7 @@ export type SlackMessagingConfig = {
   channel: "slack";
   enabled?: boolean;
   inboundMode?: SlackInboundMode;
+  liveWorkingCards?: boolean;
   registerSlashCommands?: boolean;
   responseMode?: MessagingResponseMode;
   signingSecret?: string;

--- a/packages/messaging/providers/slack/src/slack-formatting.ts
+++ b/packages/messaging/providers/slack/src/slack-formatting.ts
@@ -260,6 +260,8 @@ export function textForSlackIntent(intent: MessagingSurfaceIntent): string {
       return renderContentParts(intent.parts);
     case "stream_update":
       return intent.text;
+    case "working_card":
+      return intent.fallbackText ?? "Working update";
     case "status":
       return intent.text;
     case "progress":

--- a/packages/messaging/providers/telegram/src/telegram-formatting.ts
+++ b/packages/messaging/providers/telegram/src/telegram-formatting.ts
@@ -85,6 +85,8 @@ export function textForTelegramIntent(intent: MessagingSurfaceIntent): string {
       return intent.parts.map(renderContentPart).filter(Boolean).join("\n\n");
     case "stream_update":
       return renderTelegramHtml(intent.text, intent.markdown ?? "plain");
+    case "working_card":
+      return renderTelegramHtml(intent.fallbackText ?? "Working update", "plain");
     case "status":
       return renderTelegramHtml(intent.text, "plain");
     case "progress":

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -264,6 +264,7 @@ describe("desktop settings contracts", () => {
         },
         slack: {
           enabled: { value: false, source: "default" },
+          liveWorkingCards: { value: false, source: "default" },
           responseMode: { value: "mention_only", source: "default" },
           streamingResponses: { value: false, source: "default" },
           botToken: {

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -347,6 +347,7 @@ export type DesktopMessagingDefaultAgentRoute = {
   assignmentId: string;
   scope: DesktopMessagingDefaultAgentScope;
   target: DesktopMessagingAgentRouteTarget;
+  toolUpdateMode?: MessagingToolUpdateMode;
   createdAt: number;
   updatedAt: number;
 };
@@ -403,6 +404,8 @@ export type SetMessagingDefaultAgentRequest = {
     backend: AppServerBackendKind;
     threadId: ThreadIdentifier;
   };
+  /** `null` clears an existing override; omitted preserves it when editing. */
+  toolUpdateMode?: MessagingToolUpdateMode | null;
 };
 
 export type SetMessagingDefaultAgentResponse = {

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -734,6 +734,7 @@ export type DesktopSettingsSnapshot = {
     };
     slack: {
       enabled: DesktopSettingsValue<boolean>;
+      liveWorkingCards: DesktopSettingsValue<boolean>;
       responseMode: DesktopSettingsValue<DesktopMessagingResponseMode>;
       streamingResponses: DesktopSettingsValue<boolean>;
       botToken: DesktopSettingsSecretState;
@@ -991,6 +992,7 @@ export type DesktopSettingsConfigPatch = {
     };
     slack?: {
       enabled?: boolean;
+      liveWorkingCards?: boolean;
       responseMode?: DesktopMessagingResponseMode;
       streamingResponses?: boolean;
       workspaceUrl?: string;


### PR DESCRIPTION
## What changed

- Adds a channel-neutral `working_card` intent driven by the existing Working Updates policy.
- Folds Slack tool/prose updates into one sequenced Thinking Steps stream per turn using `chat.startStream`, `chat.appendStream`, and `chat.stopStream`.
- Handles waiting and terminal phases, stale sequences, 256-character task limits, in-memory stream state, and classic text fallback.
- Keeps non-Slack providers on their existing text rendering path.
- Adds the Phase 1 design artifact, adapter contract documentation, tests, and changelog entry.

## Why

Slack Thinking Steps is the public native equivalent of the live coding-session cards demonstrated by Linear. Rendering policy-admitted Working Updates through one native stream reduces message noise while preserving the existing None/Few/Some/More/All dial, cancellation, budgets, redaction, and authoritative final answer.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-tool-update-policy.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts` (486 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; 34 existing warnings)
- `pnpm lint:boundaries`
- `git diff --check`
