### PR TITLE
fix(desktop): preserve questionnaire answers in transcripts

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1307,6 +1307,40 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    appendQuestionnaireActivity: async ({
+      backend,
+      threadId,
+      activity,
+    }: {
+      backend: AppServerBackendKind;
+      threadId: string;
+      activity: NonNullable<ThreadOverlayState["questionnaireActivityLog"]>[number];
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current: ThreadOverlayState = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      if (
+        (current.questionnaireActivityLog ?? []).some(
+          (entry) => entry.requestId === activity.requestId,
+        )
+      ) {
+        return current;
+      }
+      const nextLog = [
+        ...(current.questionnaireActivityLog ?? []),
+        activity,
+      ].sort((left, right) => left.createdAt - right.createdAt);
+      const next = {
+        ...current,
+        questionnaireActivityLog: nextLog,
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
   } as unknown as OverlayStoreLike;
 }
 
@@ -22184,6 +22218,113 @@ command = "pnpm dev"
           requestId: "approval-1",
         },
       },
+    });
+
+    unsubscribe();
+    await registry.close();
+  });
+
+  it("persists completed questionnaire answers with secret values redacted", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    const request: AppServerPendingRequestNotification = {
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "input-1",
+        requestId: "input-1",
+        questions: [
+          {
+            id: "public",
+            header: "Public",
+            question: "Breakfast?",
+            isOther: true,
+            options: null,
+          },
+          {
+            id: "secret",
+            header: "Secret",
+            question: "Token?",
+            isOther: true,
+            isSecret: true,
+            options: null,
+          },
+        ],
+      },
+    } as AppServerPendingRequestNotification;
+    const responsePromise = codexClient.emitRequest(request);
+    await waitForCondition(() => events.length === 1);
+
+    await registry.submitServerRequest({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      requestId: "input-1",
+      response: {
+        answers: {
+          public: {
+            answers: ["Moon Waffles"],
+          },
+          secret: {
+            answers: ["sk-secret"],
+          },
+        },
+      },
+    });
+
+    await expect(responsePromise).resolves.toEqual({
+      answers: {
+        public: {
+          answers: ["Moon Waffles"],
+        },
+        secret: {
+          answers: ["sk-secret"],
+        },
+      },
+    });
+    expect(events.map((event) => event.notification.method)).toEqual([
+      "item/tool/requestUserInput",
+      "serverRequest/resolved",
+      "thread/questionnaireActivity/updated",
+    ]);
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      questionnaireActivityLog: [
+        {
+          requestId: "input-1",
+          status: "submitted",
+          questions: [
+            {
+              id: "public",
+            },
+            {
+              id: "secret",
+              isSecret: true,
+            },
+          ],
+          answers: {
+            public: {
+              answers: ["Moon Waffles"],
+            },
+            secret: {
+              answers: ["[REDACTED]"],
+            },
+          },
+        },
+      ],
     });
 
     unsubscribe();

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -13,6 +13,13 @@
     "rowsChanged": 49,
     "statements": 45
   },
+  "completed-questionnaire-transcript": {
+    "commits": 1,
+    "note": "persist one completed questionnaire transcript summary",
+    "observedWalBytes": 16480,
+    "rowsChanged": 1,
+    "statements": 1
+  },
   "composer-draft-typing": {
     "commits": 70,
     "note": "70 direct store saves (a stress case for prefix collapse, NOT the app's typing cadence \u2014 the renderer coalesces to one save per 5s): exactly one journal row survives, and commits track save calls because each save is its own transaction",

--- a/apps/desktop/src/main/__tests__/overlay-store-questionnaires.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-questionnaires.test.ts
@@ -1,0 +1,101 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: SqliteOverlayStore;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-questionnaire-test-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new SqliteOverlayStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("SqliteOverlayStore - questionnaire activity log", () => {
+  it("persists completed questionnaire answers across sqlite handles", async () => {
+    const activity = {
+      id: "questionnaire:request-1",
+      requestId: "request-1",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "input-1",
+      status: "submitted" as const,
+      createdAt: 2_000,
+      updatedAt: 2_000,
+      questions: [
+        {
+          id: "food",
+          header: "Food",
+          question: "What should breakfast feature?",
+          isOther: true,
+          options: [{ label: "Waffles", description: "Crisp and golden" }],
+        },
+        {
+          id: "token",
+          header: "Secret",
+          question: "What is the token?",
+          isOther: true,
+          isSecret: true,
+        },
+      ],
+      answers: {
+        food: { answers: ["Waffles"] },
+        token: { answers: ["[REDACTED]"] },
+      },
+    };
+    const first = await store.appendQuestionnaireActivity({
+      backend: "codex",
+      threadId: "thread-1",
+      activity,
+    });
+    const duplicate = await store.appendQuestionnaireActivity({
+      backend: "codex",
+      threadId: "thread-1",
+      activity,
+    });
+    expect(duplicate).toEqual(first);
+
+    stateDb.close();
+    const reopenedDb = StateDb.open(path.join(tempDir, "state.db"));
+    const reopenedStore = new SqliteOverlayStore(reopenedDb);
+
+    await expect(
+      reopenedStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      questionnaireActivityLog: [
+        {
+          requestId: "request-1",
+          status: "submitted",
+          updatedAt: 2_000,
+          questions: [
+            {
+              id: "food",
+            },
+            {
+              id: "token",
+              isSecret: true,
+            },
+          ],
+          answers: {
+            food: { answers: ["Waffles"] },
+            token: { answers: ["[REDACTED]"] },
+          },
+        },
+      ],
+    });
+
+    reopenedDb.close();
+  });
+});

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -89,6 +89,45 @@ describe("sqlite write metrics", () => {
     expect(metrics?.commits).toBe(1);
   });
 
+  it("holds each completed questionnaire transcript record to one commit", async () => {
+    // This path runs once per completed questionnaire, never per streamed
+    // event. At 100 questionnaires/day, one commit each is 100 commits/day;
+    // the measured WAL below keeps the corresponding disk cost reviewable.
+    const { writes } = await measureSqliteWrites(async () => {
+      await store.appendQuestionnaireActivity({
+        backend: "codex",
+        threadId: "questionnaire-thread",
+        activity: {
+          id: "questionnaire:request-1",
+          requestId: "request-1",
+          threadId: "questionnaire-thread",
+          turnId: "turn-1",
+          itemId: "input-1",
+          status: "submitted",
+          createdAt: 1_800_000_000_000,
+          updatedAt: 1_800_000_000_000,
+          questions: [
+            {
+              id: "food",
+              header: "Food",
+              question: "What should breakfast feature?",
+              isOther: true,
+            },
+          ],
+          answers: {
+            food: { answers: ["Waffles"] },
+          },
+        },
+      });
+    });
+
+    expectSqliteWriteBudget({
+      note: "persist one completed questionnaire transcript summary",
+      scenario: "completed-questionnaire-transcript",
+      writes,
+    });
+  });
+
   it("keeps the transaction variants callable and counted", () => {
     // better-sqlite3 hangs .default/.deferred/.immediate/.exclusive off the
     // callable it returns, and they are not enumerable. The first version of

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -190,7 +190,9 @@ import {
   type ThreadMessagingBindingTransition,
   type ThreadCodexInvalidIdRecovery,
   type ThreadPermissionTransition,
+  type ThreadQuestionnaireActivity,
   type ThreadTurnFailure,
+  type AppServerToolRequestUserInputNotification,
   type ThreadAgentMetadata,
   type MessagingThreadBindingSummary,
   DEFAULT_MOVE_THREAD_WORKSPACE_STRATEGY,
@@ -2496,6 +2498,66 @@ function buildHeadlessAutomationRequestCancelResponse(
   }
 
   return { decision: "cancel" };
+}
+
+function questionnaireAnswerHasValue(answer: unknown): boolean {
+  if (!answer || typeof answer !== "object" || Array.isArray(answer)) {
+    return false;
+  }
+
+  const values = (answer as { answers?: unknown }).answers;
+  return (
+    Array.isArray(values) &&
+    values.some((value) => typeof value === "string" && value.trim().length > 0)
+  );
+}
+
+function sanitizeQuestionnaireResponseForOverlay(params: {
+  activity: ThreadQuestionnaireActivity;
+  response: unknown;
+}): AppServerToolRequestUserInputResponse["answers"] {
+  if (
+    !params.response ||
+    typeof params.response !== "object" ||
+    Array.isArray(params.response)
+  ) {
+    return {};
+  }
+  const rawAnswers = (params.response as { answers?: unknown }).answers;
+  if (!rawAnswers || typeof rawAnswers !== "object" || Array.isArray(rawAnswers)) {
+    return {};
+  }
+
+  const secretQuestionIds = new Set(
+    params.activity.questions
+      .filter((question) => question.isSecret === true)
+      .map((question) => question.id),
+  );
+  const sanitized: AppServerToolRequestUserInputResponse["answers"] = {};
+  for (const [questionId, rawAnswer] of Object.entries(
+    rawAnswers as Record<string, unknown>,
+  )) {
+    if (!rawAnswer || typeof rawAnswer !== "object" || Array.isArray(rawAnswer)) {
+      sanitized[questionId] = undefined;
+      continue;
+    }
+    const values = (rawAnswer as { answers?: unknown }).answers;
+    if (!Array.isArray(values)) {
+      sanitized[questionId] = undefined;
+      continue;
+    }
+    const answers = values
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+    sanitized[questionId] = {
+      answers:
+        secretQuestionIds.has(questionId) && answers.length > 0
+          ? ["[REDACTED]"]
+          : answers,
+    };
+  }
+  return sanitized;
 }
 
 function readStatusType(value: unknown): string | undefined {
@@ -14812,6 +14874,70 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private async recordQuestionnaireActivity(params: {
+    backend: AppServerBackendKind;
+    notification: AppServerToolRequestUserInputNotification;
+    response: SubmitServerRequestRequest["response"];
+  }): Promise<boolean> {
+    const notificationParams = params.notification.params;
+    const questions = Array.isArray(notificationParams.questions)
+      ? notificationParams.questions
+      : [];
+    if (questions.length === 0) {
+      return false;
+    }
+    const now = Date.now();
+    const pendingActivity: ThreadQuestionnaireActivity = {
+      id: `questionnaire:${notificationParams.requestId}`,
+      requestId: notificationParams.requestId,
+      threadId: notificationParams.threadId,
+      turnId: notificationParams.turnId,
+      itemId: notificationParams.itemId,
+      status: "pending",
+      questions: questions.map((question) => ({
+        id: question.id,
+        header: question.header,
+        question: question.question,
+        isOther: question.isOther,
+        isSecret: question.isSecret,
+        options:
+          question.options?.map((option) => ({
+            label: option.label,
+            description: option.description,
+          })) ?? undefined,
+      })),
+      createdAt: now,
+      updatedAt: now,
+    };
+    const answers = sanitizeQuestionnaireResponseForOverlay({
+      activity: pendingActivity,
+      response: params.response,
+    });
+    const hasAnswers = Object.values(answers).some(questionnaireAnswerHasValue);
+    const activity: ThreadQuestionnaireActivity = {
+      ...pendingActivity,
+      status: hasAnswers ? "submitted" : "cancelled",
+      answers,
+    };
+
+    try {
+      await this.overlayStore.appendQuestionnaireActivity({
+        backend: params.backend,
+        threadId: notificationParams.threadId,
+        activity,
+      });
+      return true;
+    } catch (error) {
+      backendRegistryLog.error("failed to record questionnaire activity", {
+        backend: params.backend,
+        error: error instanceof Error ? error.message : String(error),
+        requestId: notificationParams.requestId,
+        threadId: notificationParams.threadId,
+      });
+      return false;
+    }
+  }
+
   /**
    * Flush any queued permission-mode change for the given thread.
    * Called from two places:
@@ -15584,6 +15710,15 @@ export class DesktopBackendRegistry {
       throw new Error(`No pending server request found for ${params.requestId}`);
     }
 
+    const recordedQuestionnaire =
+      pending.notification.method === "item/tool/requestUserInput"
+        ? await this.recordQuestionnaireActivity({
+            backend: params.backend,
+            notification:
+              pending.notification as AppServerToolRequestUserInputNotification,
+            response: params.response,
+          })
+        : false;
     this.pendingServerRequests.delete(key);
     pending.resolve(params.response);
     await this.emit({
@@ -15597,6 +15732,18 @@ export class DesktopBackendRegistry {
         },
       },
     });
+    if (recordedQuestionnaire) {
+      await this.emit({
+        backend: params.backend,
+        notification: {
+          method: "thread/questionnaireActivity/updated",
+          params: {
+            threadId: params.threadId,
+            requestId: params.requestId,
+          },
+        },
+      });
+    }
 
     return {
       backend: params.backend,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -35,6 +35,7 @@ import type {
   ThreadPullRequestWatchSummary,
   RemoteThreadPin,
   StarMapArrangementEntry,
+  ThreadQuestionnaireActivity,
   ThreadSubAgentSummary,
   ThreadTurnFailure,
   ThreadUsageLineRecord,
@@ -50,6 +51,7 @@ import {
   MAX_IMMUTABLE_USAGE_ACTIVITY_ENTRIES,
   MAX_MANAGED_REVIEW_ENTRIES,
   MAX_PERMISSION_TRANSITION_LOG_ENTRIES,
+  MAX_QUESTIONNAIRE_ACTIVITY_LOG_ENTRIES,
   MAX_TURN_FAILURE_LOG_ENTRIES,
   buildPullRequestStatusKey,
   buildFederatedThreadRef,
@@ -610,6 +612,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
           messagingBindingTransitionLog:
             current?.messagingBindingTransitionLog,
           turnFailureLog: current?.turnFailureLog,
+          questionnaireActivityLog: current?.questionnaireActivityLog,
         });
       }
     }
@@ -3263,6 +3266,38 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       ...current,
       codexInvalidIdRecoveryLastAttemptedAt: params.recovery.attemptedAt,
       turnFailureLog: nextLog,
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
+  async appendQuestionnaireActivity(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    activity: ThreadQuestionnaireActivity;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const existing = current.questionnaireActivityLog ?? [];
+    if (existing.some((entry) => entry.requestId === params.activity.requestId)) {
+      return current;
+    }
+    const nextLog = [
+      ...existing,
+      params.activity,
+    ].sort((left, right) => left.createdAt - right.createdAt);
+    const trimmed =
+      nextLog.length > MAX_QUESTIONNAIRE_ACTIVITY_LOG_ENTRIES
+        ? nextLog.slice(nextLog.length - MAX_QUESTIONNAIRE_ACTIVITY_LOG_ENTRIES)
+        : nextLog;
+    const nextState: ThreadOverlayState = {
+      ...current,
+      questionnaireActivityLog: trimmed,
     };
     this.putThread(threadKey, nextState);
     return nextState;
@@ -6529,6 +6564,7 @@ export type OverlayStoreLike = Pick<
   | "appendMessagingBindingTransition"
   | "appendTurnFailure"
   | "setTurnFailureCodexInvalidIdRecovery"
+  | "appendQuestionnaireActivity"
   | "getLaunchpadDefaults"
   | "setLaunchpadDefaults"
   | "getNavigationBrowseMode"

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -3195,6 +3195,9 @@ export function ThreadView(props: ThreadViewProps) {
               messagingBindingTransitions={
                 selectedThread!.messagingBindingTransitionLog
               }
+              questionnaireActivities={
+                selectedThread!.questionnaireActivityLog
+              }
               turnFailures={selectedThread!.turnFailureLog}
               activeTurnId={props.activeTurnId}
               activeTurnStartedAt={props.activeTurnStartedAt}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -27,6 +27,7 @@ import type {
   PendingRequestApprovalFileContext,
   ThreadMessagingBindingTransition,
   ThreadPermissionTransition,
+  ThreadQuestionnaireActivity,
   ThreadTurnFailure,
   ThreadSubAgentSummary,
   MarkdownFileViewerContext,
@@ -39,6 +40,7 @@ import {
 import { injectAutomationCards } from "./automation-card-entries";
 import { injectMessagingBindingTransitions } from "./messaging-binding-transition-entries";
 import { injectPermissionTransitions } from "./permission-transition-entries";
+import { injectQuestionnaireActivities } from "./questionnaire-activity-entries";
 import { injectTurnFailures } from "./turn-failure-entries";
 import type { DesktopApi } from "../../lib/desktop-api";
 import {
@@ -107,6 +109,7 @@ type TranscriptListProps = {
   parentThreadId?: string;
   permissionTransitions?: ThreadPermissionTransition[];
   messagingBindingTransitions?: ThreadMessagingBindingTransition[];
+  questionnaireActivities?: ThreadQuestionnaireActivity[];
   turnFailures?: ThreadTurnFailure[];
   restoredViewport?: TranscriptViewport;
   reglueRequestKey?: number;
@@ -864,12 +867,15 @@ export function TranscriptList(props: TranscriptListProps) {
       insertPendingEntry(entries, pendingEntry);
     }
     return injectTurnFailures(
-      injectAutomationCards(
-        injectMessagingBindingTransitions(
-          injectPermissionTransitions(entries, props.permissionTransitions),
-          props.messagingBindingTransitions,
+      injectQuestionnaireActivities(
+        injectAutomationCards(
+          injectMessagingBindingTransitions(
+            injectPermissionTransitions(entries, props.permissionTransitions),
+            props.messagingBindingTransitions,
+          ),
+          automationCards,
         ),
-        automationCards,
+        props.questionnaireActivities,
       ),
       props.turnFailures,
     );
@@ -885,6 +891,7 @@ export function TranscriptList(props: TranscriptListProps) {
     props.pendingPlanEntry,
     props.messagingBindingTransitions,
     props.permissionTransitions,
+    props.questionnaireActivities,
     props.turnFailures,
   ]);
   const alwaysVisibleTransientMessageIds = useMemo(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/questionnaire-activity-entries.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/questionnaire-activity-entries.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { AppServerThreadMessageEntry } from "@pwragent/shared";
+import { buildTranscriptRenderItems } from "../transcript-render-items";
+import { injectQuestionnaireActivities } from "../questionnaire-activity-entries";
+
+describe("questionnaire activity transcript entries", () => {
+  it("hydrates answered questionnaires into collapsed previous work", () => {
+    const finalAnswer: AppServerThreadMessageEntry = {
+      type: "message",
+      id: "final-1",
+      role: "assistant",
+      phase: "final",
+      text: "Breakfast is ready.",
+      createdAt: 3_000,
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        completedAt: 3_000,
+      },
+    };
+
+    const entries = injectQuestionnaireActivities([finalAnswer], [
+      {
+        id: "questionnaire:request-1",
+        requestId: "request-1",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        status: "submitted",
+        createdAt: 1_000,
+        updatedAt: 2_000,
+        questions: [
+          {
+            id: "food",
+            header: "Food",
+            question: "What should breakfast feature?",
+            isOther: true,
+          },
+          {
+            id: "drink",
+            header: "Drink",
+            question: "What should fill the cup?",
+            isOther: true,
+          },
+        ],
+        answers: {
+          food: { answers: ["Waffles"] },
+          drink: { answers: ["Coffee"] },
+        },
+      },
+    ]);
+
+    expect(entries[0]).toMatchObject({
+      type: "activity",
+      id: "questionnaire:request-1",
+      summary: "Questionnaire answered",
+      status: "completed",
+      details: [
+        {
+          label: "Submitted answers",
+          markdown:
+            "1. Food: What should breakfast feature?\nAnswer: Waffles\n\n2. Drink: What should fill the cup?\nAnswer: Coffee",
+        },
+      ],
+    });
+
+    const renderItems = buildTranscriptRenderItems({ entries });
+    expect(renderItems).toMatchObject([
+      {
+        type: "workPhaseGroup",
+        label: "Previous work",
+        entries: [
+          {
+            id: "questionnaire:request-1",
+          },
+        ],
+      },
+      {
+        type: "entry",
+        entry: finalAnswer,
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/questionnaire-activity-entries.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/questionnaire-activity-entries.ts
@@ -1,0 +1,128 @@
+import type {
+  AppServerThreadActivityEntry,
+  AppServerThreadEntry,
+  ThreadQuestionnaireActivity,
+} from "@pwragent/shared";
+
+export const QUESTIONNAIRE_ACTIVITY_ENTRY_PREFIX = "questionnaire:";
+
+export function buildQuestionnaireActivityEntries(
+  activities: ThreadQuestionnaireActivity[] | undefined,
+): AppServerThreadActivityEntry[] {
+  if (!activities || activities.length === 0) {
+    return [];
+  }
+  return activities.map((activity) => {
+    const completed =
+      activity.status === "submitted" || activity.status === "cancelled";
+    return {
+      type: "activity",
+      id: `${QUESTIONNAIRE_ACTIVITY_ENTRY_PREFIX}${activity.requestId}`,
+      summary: summarizeQuestionnaireActivity(activity),
+      createdAt: activity.updatedAt || activity.createdAt,
+      status: completed ? "completed" : "in_progress",
+      turn: activity.turnId
+        ? {
+            id: activity.turnId,
+            status: completed ? "completed" : "in_progress",
+            completedAt: completed ? activity.updatedAt : undefined,
+          }
+        : undefined,
+      details: [
+        {
+          id: `${QUESTIONNAIRE_ACTIVITY_ENTRY_PREFIX}${activity.requestId}:details`,
+          kind: "read",
+          label:
+            activity.status === "cancelled"
+              ? "Questionnaire cancelled"
+              : activity.status === "submitted"
+                ? "Submitted answers"
+                : "Questionnaire requested",
+          markdown: buildQuestionnaireMarkdown(activity),
+          status: completed ? "completed" : "in_progress",
+        },
+      ],
+    };
+  });
+}
+
+export function injectQuestionnaireActivities(
+  entries: AppServerThreadEntry[],
+  activities: ThreadQuestionnaireActivity[] | undefined,
+): AppServerThreadEntry[] {
+  const synthetic = buildQuestionnaireActivityEntries(activities);
+  if (synthetic.length === 0) {
+    return entries;
+  }
+  const existingIds = new Set(entries.map((entry) => entry.id));
+  const additions = synthetic.filter((entry) => !existingIds.has(entry.id));
+  if (additions.length === 0) {
+    return entries;
+  }
+  const merged: AppServerThreadEntry[] = [...entries, ...additions];
+  merged.sort((left, right) => {
+    const leftAt = left.createdAt ?? 0;
+    const rightAt = right.createdAt ?? 0;
+    if (leftAt !== rightAt) {
+      return leftAt - rightAt;
+    }
+    const leftIsQuestionnaire = left.id.startsWith(
+      QUESTIONNAIRE_ACTIVITY_ENTRY_PREFIX,
+    );
+    const rightIsQuestionnaire = right.id.startsWith(
+      QUESTIONNAIRE_ACTIVITY_ENTRY_PREFIX,
+    );
+    if (leftIsQuestionnaire === rightIsQuestionnaire) {
+      return 0;
+    }
+    return leftIsQuestionnaire ? 1 : -1;
+  });
+  return merged;
+}
+
+function summarizeQuestionnaireActivity(
+  activity: ThreadQuestionnaireActivity,
+): string {
+  if (activity.status === "cancelled") {
+    return "Questionnaire cancelled";
+  }
+  if (activity.status === "submitted") {
+    return "Questionnaire answered";
+  }
+  const count = activity.questions.length;
+  return `Asked ${count} ${count === 1 ? "question" : "questions"}`;
+}
+
+function buildQuestionnaireMarkdown(activity: ThreadQuestionnaireActivity): string {
+  const blocks = activity.questions.map((question, index) => {
+    const prompt = [
+      `${index + 1}. ${question.header}: ${question.question}`,
+      formatAnswerLine(activity, question.id),
+    ].filter(Boolean);
+    if (activity.status === "pending" && question.options?.length) {
+      prompt.push(
+        ...question.options.map((option) =>
+          option.description
+            ? `- ${option.label}: ${option.description}`
+            : `- ${option.label}`,
+        ),
+      );
+    }
+    return prompt.join("\n");
+  });
+  return blocks.join("\n\n");
+}
+
+function formatAnswerLine(
+  activity: ThreadQuestionnaireActivity,
+  questionId: string,
+): string | undefined {
+  if (activity.status === "pending") {
+    return undefined;
+  }
+  const answers = activity.answers?.[questionId]?.answers ?? [];
+  if (answers.length === 0) {
+    return activity.status === "cancelled" ? "Answer: Cancelled" : "Answer: None";
+  }
+  return `Answer: ${answers.join(", ")}`;
+}

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1663,7 +1663,7 @@ describe("useThreadNavigation", () => {
     });
   });
 
-  it("coalesces repeated turn lifecycle notifications into one navigation refresh", async () => {
+  it("coalesces transcript-affecting notifications into one navigation refresh", async () => {
     const listeners = new Set<(event: AgentEvent) => void>();
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,
@@ -1715,7 +1715,7 @@ describe("useThreadNavigation", () => {
 
     expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
 
-    const terminalNotifications: AgentEvent["notification"][] = [
+    const refreshNotifications: AgentEvent["notification"][] = [
       {
         method: "turn/completed",
         params: {
@@ -1753,10 +1753,17 @@ describe("useThreadNavigation", () => {
           },
         },
       },
+      {
+        method: "thread/questionnaireActivity/updated",
+        params: {
+          threadId: "thread-1",
+          requestId: "request-1",
+        },
+      },
     ];
 
     await act(async () => {
-      for (const notification of terminalNotifications) {
+      for (const notification of refreshNotifications) {
         for (const listener of listeners) {
           listener({
             backend: "codex",

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -747,6 +747,13 @@ function messagingBindingTransitionLogsEqual(
   });
 }
 
+function questionnaireActivityLogsEqual(
+  left: NavigationThreadSummary["questionnaireActivityLog"],
+  right: NavigationThreadSummary["questionnaireActivityLog"]
+): boolean {
+  return JSON.stringify(left ?? []) === JSON.stringify(right ?? []);
+}
+
 function threadSummariesEqual(
   left: NavigationThreadSummary,
   right: NavigationThreadSummary
@@ -825,6 +832,10 @@ function threadSummariesEqual(
     messagingBindingTransitionLogsEqual(
       left.messagingBindingTransitionLog,
       right.messagingBindingTransitionLog
+    ) &&
+    questionnaireActivityLogsEqual(
+      left.questionnaireActivityLog,
+      right.questionnaireActivityLog
     )
   );
 }
@@ -4135,6 +4146,14 @@ export function useThreadNavigation(
         // thread overlay before broadcasting this event. Refresh so the
         // navigation snapshot carries `turnFailureLog` into the transcript;
         // without it the failure would never surface as a durable entry.
+        scheduleRefresh();
+        return;
+      }
+
+      if (method === "thread/questionnaireActivity/updated") {
+        // Completed questionnaire answers are persisted in the thread overlay
+        // because App Server replay does not include request-user-input items.
+        // Refresh so the sanitized Q/A summary appears in the transcript now.
         scheduleRefresh();
         return;
       }

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -170,6 +170,13 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
    * visible across reconciliation and restart.
    */
   turnFailureLog?: ThreadTurnFailure[];
+  /**
+   * Per-thread questionnaire audit log. Persisted via the overlay store
+   * and rendered as synthetic "Previous work" transcript activity so
+   * request-user-input interactions stay visible even when the backend
+   * rollout omits them from durable transcript items.
+   */
+  questionnaireActivityLog?: ThreadQuestionnaireActivity[];
   optimisticUserMessage?: {
     text: string;
     imageParts?: AppServerThreadImagePart[];
@@ -1915,6 +1922,14 @@ export type ThreadOverlayState = {
    * five-minute cooldown guard.
    */
   codexInvalidIdRecoveryLastAttemptedAt?: number;
+  /**
+   * Per-thread questionnaire audit log. Persisted to the overlay store,
+   * capped at `MAX_QUESTIONNAIRE_ACTIVITY_LOG_ENTRIES` (oldest-first
+   * eviction). Each entry records a request-user-input questionnaire and
+   * its terminal answer/cancel state so cross-surface input remains visible
+   * in the transcript after hydration.
+   */
+  questionnaireActivityLog?: ThreadQuestionnaireActivity[];
 };
 
 /**
@@ -2054,6 +2069,52 @@ export type ThreadTurnFailure = {
    * transcript context survive process restarts.
    */
   codexInvalidIdRecovery?: ThreadCodexInvalidIdRecovery;
+};
+
+/**
+ * Maximum number of questionnaire interactions retained per thread.
+ * Kept separate from the other audit streams so a thread with many
+ * user-input turns does not evict permission or messaging history.
+ */
+export const MAX_QUESTIONNAIRE_ACTIVITY_LOG_ENTRIES = 100;
+
+export type ThreadQuestionnaireActivityStatus =
+  | "pending"
+  | "submitted"
+  | "cancelled";
+
+export type ThreadQuestionnaireActivityQuestion = {
+  id: string;
+  header: string;
+  question: string;
+  isOther: boolean;
+  isSecret?: boolean;
+  options?: Array<{
+    label: string;
+    description?: string;
+  }>;
+};
+
+export type ThreadQuestionnaireActivityAnswer = {
+  answers: string[];
+};
+
+/**
+ * One entry in the per-thread questionnaire audit log. `requestId`
+ * is the durable deduplication key. Answers are already redacted for
+ * secret questions before they are persisted here.
+ */
+export type ThreadQuestionnaireActivity = {
+  id: string;
+  requestId: string;
+  threadId: ThreadIdentifier;
+  turnId?: string;
+  itemId?: string;
+  status: ThreadQuestionnaireActivityStatus;
+  questions: ThreadQuestionnaireActivityQuestion[];
+  answers?: Record<string, ThreadQuestionnaireActivityAnswer | undefined>;
+  createdAt: number;
+  updatedAt: number;
 };
 
 export type ThreadBranchDriftPair = {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1313,6 +1313,13 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "thread/questionnaireActivity/updated";
+      params: {
+        threadId: string;
+        requestId: string;
+      };
+    }
+  | {
       method: "thread/tokenUsage/updated";
       params: {
         threadId: string;

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -260,6 +260,7 @@ export function materializeNavigationThreads(params: {
       permissionTransitionLog: overlay?.permissionTransitionLog,
       messagingBindingTransitionLog: overlay?.messagingBindingTransitionLog,
       turnFailureLog: overlay?.turnFailureLog,
+      questionnaireActivityLog: overlay?.questionnaireActivityLog,
       model: overlay?.model ?? thread.model,
       reasoningEffort: overlay?.reasoningEffort ?? thread.reasoningEffort,
       modelMigrationRevision: overlay?.modelMigrationRevision,
@@ -465,6 +466,39 @@ export function buildNavigationSnapshotHash(params: {
             }
           : null,
       })),
+      questionnaireActivityLog: (thread.questionnaireActivityLog ?? []).map(
+        (entry) => ({
+          id: entry.id,
+          requestId: entry.requestId,
+          threadId: entry.threadId,
+          turnId: entry.turnId ?? null,
+          itemId: entry.itemId ?? null,
+          status: entry.status,
+          createdAt: entry.createdAt,
+          updatedAt: entry.updatedAt,
+          questions: entry.questions.map((question) => ({
+            id: question.id,
+            header: question.header,
+            question: question.question,
+            isOther: question.isOther,
+            isSecret: question.isSecret ?? null,
+            options: (question.options ?? []).map((option) => ({
+              label: option.label,
+              description: option.description ?? null,
+            })),
+          })),
+          answers: Object.fromEntries(
+            Object.entries(entry.answers ?? {}).map(([questionId, answer]) => [
+              questionId,
+              answer
+                ? {
+                    answers: answer.answers,
+                  }
+                : null,
+            ]),
+          ),
+        }),
+      ),
       model: thread.model ?? null,
       reasoningEffort: thread.reasoningEffort ?? null,
       serviceTier: thread.serviceTier ?? null,


### PR DESCRIPTION
## Summary

- I preserve completed `request_user_input` questionnaires as sanitized, durable transcript activity because Codex App Server replay does not return the questionnaire request or its answers.
- I render each questionnaire's prompts and answers in Previous work after refresh or restart, and refresh navigation immediately when a response is accepted.
- I redact secret answers before persistence, deduplicate by request ID, cap the per-thread log at 100 entries, and retain one SQLite commit per completed questionnaire.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/overlay-store-questionnaires.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/questionnaire-activity-entries.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (654 tests passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings remain)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`

## Notes

- Root cause: Codex App Server `thread/read` includes ordinary user messages and steers but omits completed `request_user_input` interactions, so PwrAgent previously had no durable source from which to reconstruct questionnaire summaries.
- The checked write budget records one commit, one changed row, and 16,480 observed WAL bytes for one completed questionnaire.
- Questionnaires missing from existing transcripts cannot be backfilled because neither their prompts nor answers are available from App Server replay.
