### PR TITLE
feat(desktop): select federation target for new threads

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-load-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-load-ipc.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { FederationLoadStatus } from "@pwragent/shared";
-import { FEDERATION_READ_INSTANCE_LOAD_CHANNEL } from "../../shared/ipc";
+import {
+  FEDERATION_OPEN_WINDOW_CHANNEL,
+  FEDERATION_READ_INSTANCE_LOAD_CHANNEL,
+} from "../../shared/ipc";
 
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 
@@ -23,6 +26,7 @@ const runtime = {
   connectedPeerTargets: vi.fn(),
   remoteBackend: vi.fn(),
 };
+const createFederationWindow = vi.hoisted(() => vi.fn());
 
 vi.mock("../federation/federation-runtime", () => ({
   getDesktopFederationRuntime: () => runtime,
@@ -31,7 +35,7 @@ vi.mock("../federation/federation-tailscale", () => ({
   getFederationTailscaleService: () => ({}),
 }));
 vi.mock("../federation/federation-window", () => ({
-  createFederationWindow: vi.fn(),
+  createFederationWindow,
 }));
 
 const localLoad: FederationLoadStatus = {
@@ -69,6 +73,7 @@ describe("federation read-instance-load ipc", () => {
       .mockReturnValue({ getLoadStatus: async () => localLoad });
     runtime.connectedPeerTargets.mockReset().mockReturnValue([]);
     runtime.remoteBackend.mockReset();
+    createFederationWindow.mockReset().mockReturnValue({ id: 7 });
   });
 
   it("samples locally when no instance id is given", async () => {
@@ -152,5 +157,32 @@ describe("federation read-instance-load ipc", () => {
       invokeReadInstanceLoad({ instanceId: "not a valid id!" }),
     ).rejects.toThrow("Invalid federation instance id");
     expect(runtime.health).not.toHaveBeenCalled();
+  });
+
+  it("opens a connected instance directly into its new-thread launchpad", async () => {
+    const peer = {
+      target: { scope: "remote" as const, instanceId: "pwr_studio" },
+      label: "Studio Mac / work",
+      capabilities: ["remote_window", "thread_navigation"],
+    };
+    runtime.connectedPeerTargets.mockReturnValue([peer]);
+    const { registerFederationIpcHandlers } = await import("../ipc/federation");
+    registerFederationIpcHandlers();
+
+    await expect(
+      handlers.get(FEDERATION_OPEN_WINDOW_CHANNEL)!({}, {
+        target: peer.target,
+        initialLaunchpad: true,
+      }),
+    ).resolves.toEqual({
+      opened: true,
+      windowId: 7,
+      target: peer.target,
+    });
+    expect(createFederationWindow).toHaveBeenCalledWith({
+      peer,
+      initialLaunchpad: true,
+      initialThread: undefined,
+    });
   });
 });

--- a/apps/desktop/src/main/federation/federation-window.ts
+++ b/apps/desktop/src/main/federation/federation-window.ts
@@ -14,6 +14,7 @@ export type FederationWindowPeer = {
 
 export function createFederationWindow(options: {
   peer: FederationWindowPeer;
+  initialLaunchpad?: boolean;
   initialThread?: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -29,6 +30,7 @@ export function createFederationWindow(options: {
   const window = createMainWindow({
     federationLabel: peer.label,
     federationTarget: peer.target,
+    ...(options.initialLaunchpad ? { initialLaunchpad: true } : {}),
     initialThread: options.initialThread,
   });
   const runtime = getDesktopFederationRuntime();

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -211,6 +211,7 @@ export function registerFederationIpcHandlers(): void {
       }
       const window = createFederationWindow({
         peer,
+        ...(request.initialLaunchpad ? { initialLaunchpad: true } : {}),
         initialThread: request.initialThread
           ? {
               backend: request.initialThread.backend,

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -324,6 +324,7 @@ export function createMainWindow(options?: {
   onShown?: () => void;
   federationLabel?: string;
   federationTarget?: FederationRemoteTarget;
+  initialLaunchpad?: boolean;
   initialThread?: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -473,6 +474,8 @@ export function createMainWindow(options?: {
         WINDOW_SHOW_THREAD_CHANNEL,
         options.initialThread,
       );
+    } else if (options?.initialLaunchpad) {
+      window.webContents.send(WINDOW_OPEN_NEW_THREAD_CHANNEL);
     }
   });
   if (!isMac) {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -15,6 +15,7 @@ import {
   buildThreadIdentityKey,
   DEFAULT_BACKGROUND_PR_POLLING,
   DEFAULT_PR_AUTO_DISPATCH_ALLOWED,
+  formatFederationPeerDisplayLabel,
   isRemoteFederationTarget,
   parseThreadIdentityKey,
   type AppServerBackendKind,
@@ -337,6 +338,53 @@ function DesktopAppShell(props: {
   const [ThreadViewComponent, setThreadViewComponent] =
     useState<ComponentType<ThreadViewProps>>();
   const desktopApi = props.desktopApi;
+  const [newThreadFederationTargets, setNewThreadFederationTargets] = useState<
+    Array<{ instanceId: string; label: string }>
+  >([]);
+  const refreshNewThreadFederationTargets = useCallback(async (): Promise<void> => {
+    if (
+      readRendererFederationTarget()
+      || !desktopApi?.openFederationWindow
+      || !desktopApi.readFederationHealth
+    ) {
+      setNewThreadFederationTargets([]);
+      return;
+    }
+    const { health } = await desktopApi.readFederationHealth({});
+    const visibleInstances = [
+      ...health.peers,
+      ...(health.localLabel
+        ? [{
+            label: health.localLabel,
+            profileName: health.localProfileName,
+          }]
+        : []),
+    ];
+    setNewThreadFederationTargets(
+      health.peers
+        .filter(
+          (peer) =>
+            peer.status === "connected"
+            && !peer.revokedAt
+            && peer.capabilities.includes("remote_window")
+            && peer.capabilities.includes("thread_navigation"),
+        )
+        .map((peer) => ({
+          instanceId: peer.id,
+          label: formatFederationPeerDisplayLabel(peer, visibleInstances),
+        })),
+    );
+  }, [desktopApi]);
+  useEffect(() => {
+    void refreshNewThreadFederationTargets().catch(() => {
+      setNewThreadFederationTargets([]);
+    });
+    return desktopApi?.onWindowFocus?.(() => {
+      void refreshNewThreadFederationTargets().catch(() => {
+        setNewThreadFederationTargets([]);
+      });
+    });
+  }, [desktopApi, refreshNewThreadFederationTargets]);
   const resumePrAutoDispatchBudget = useCallback(() => {
     void desktopApi?.resumePrAutoDispatchBudget?.()
       .then((status) => {
@@ -1859,6 +1907,23 @@ function DesktopAppShell(props: {
             await navigation.createThread(undefined, "default", {
               forceWorkspace: true,
             });
+          }}
+          newThreadFederationTargets={newThreadFederationTargets}
+          onCreateThreadOnFederationTarget={async (instanceId) => {
+            try {
+              await desktopApi?.openFederationWindow?.({
+                target: { scope: "remote", instanceId },
+                initialLaunchpad: true,
+              });
+            } catch (error) {
+              showAppNotice({
+                id: `new-thread-federation-target:${instanceId}`,
+                title: "Could not open new thread",
+                message: error instanceof Error ? error.message : String(error),
+                tone: "error",
+                transientSlot: "new-thread-federation-target",
+              });
+            }
           }}
           onAddProjectDirectory={readRendererFederationTarget()
             ? undefined

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -64,6 +64,7 @@ import {
   readRendererFederationTarget,
 } from "./lib/federation-window";
 import { useFederationPeerConnectivity } from "./lib/useFederationPeerConnectivity";
+import { useFederationHealth } from "./lib/useFederationHealth";
 import { useFederationThreadEventSubscriptions } from "./lib/useFederationThreadEventSubscriptions";
 import { scopeDesktopApiToFederationTarget } from "./lib/federation-desktop-api";
 import { federationTargetsEqual } from "./lib/federated-thread-events";
@@ -338,19 +339,18 @@ function DesktopAppShell(props: {
   const [ThreadViewComponent, setThreadViewComponent] =
     useState<ComponentType<ThreadViewProps>>();
   const desktopApi = props.desktopApi;
-  const [newThreadFederationTargets, setNewThreadFederationTargets] = useState<
-    Array<{ instanceId: string; label: string }>
-  >([]);
-  const refreshNewThreadFederationTargets = useCallback(async (): Promise<void> => {
-    if (
-      readRendererFederationTarget()
-      || !desktopApi?.openFederationWindow
-      || !desktopApi.readFederationHealth
-    ) {
-      setNewThreadFederationTargets([]);
-      return;
+  const {
+    health: liveFederationHealth,
+    refresh: refreshFederationHealth,
+  } = useFederationHealth({
+    desktopApi,
+    enabled: !readRendererFederationTarget(),
+  });
+  const newThreadFederationTargets = useMemo(() => {
+    const health = liveFederationHealth;
+    if (!health || !desktopApi?.openFederationWindow) {
+      return [];
     }
-    const { health } = await desktopApi.readFederationHealth({});
     const visibleInstances = [
       ...health.peers,
       ...(health.localLabel
@@ -360,31 +360,25 @@ function DesktopAppShell(props: {
           }]
         : []),
     ];
-    setNewThreadFederationTargets(
-      health.peers
-        .filter(
-          (peer) =>
-            peer.status === "connected"
-            && !peer.revokedAt
-            && peer.capabilities.includes("remote_window")
-            && peer.capabilities.includes("thread_navigation"),
-        )
-        .map((peer) => ({
-          instanceId: peer.id,
-          label: formatFederationPeerDisplayLabel(peer, visibleInstances),
-        })),
-    );
-  }, [desktopApi]);
+    return health.peers
+      .filter(
+        (peer) =>
+          peer.status === "connected"
+          && !peer.revokedAt
+          && peer.capabilities.includes("remote_window")
+          && peer.capabilities.includes("thread_navigation")
+          && peer.capabilities.includes("environment_actions"),
+      )
+      .map((peer) => ({
+        instanceId: peer.id,
+        label: formatFederationPeerDisplayLabel(peer, visibleInstances),
+      }));
+  }, [desktopApi?.openFederationWindow, liveFederationHealth]);
   useEffect(() => {
-    void refreshNewThreadFederationTargets().catch(() => {
-      setNewThreadFederationTargets([]);
-    });
     return desktopApi?.onWindowFocus?.(() => {
-      void refreshNewThreadFederationTargets().catch(() => {
-        setNewThreadFederationTargets([]);
-      });
+      refreshFederationHealth();
     });
-  }, [desktopApi, refreshNewThreadFederationTargets]);
+  }, [desktopApi, refreshFederationHealth]);
   const resumePrAutoDispatchBudget = useCallback(() => {
     void desktopApi?.resumePrAutoDispatchBudget?.()
       .then((status) => {
@@ -1440,6 +1434,24 @@ function DesktopAppShell(props: {
     }
     await navigation.addProjectDirectory();
   };
+  const createThreadOnFederationTarget = async (
+    instanceId: string,
+  ): Promise<void> => {
+    try {
+      await desktopApi?.openFederationWindow?.({
+        target: { scope: "remote", instanceId },
+        initialLaunchpad: true,
+      });
+    } catch (error) {
+      showAppNotice({
+        id: `new-thread-federation-target:${instanceId}`,
+        title: "Could not open new thread",
+        message: error instanceof Error ? error.message : String(error),
+        tone: "error",
+        transientSlot: "new-thread-federation-target",
+      });
+    }
+  };
   const mastheadActions = {
     addingProjectDirectory: navigation.pickingDirectory,
     automationsActive: mainView === "automations",
@@ -1447,6 +1459,7 @@ function DesktopAppShell(props: {
     threadSearchActive: mainView === "search",
     creatingThread: Boolean(navigation.creatingThread),
     newThreadDirectoryLabel: navigation.newThreadDirectoryLabel,
+    newThreadFederationTargets,
     onAddProjectDirectory: readRendererFederationTarget()
       ? undefined
       : addProjectDirectory,
@@ -1468,6 +1481,7 @@ function DesktopAppShell(props: {
       setMainView("thread");
       await navigation.createThread(undefined, "default", { forceWorkspace: true });
     },
+    onCreateThreadOnFederationTarget: createThreadOnFederationTarget,
   };
   // The Star Map is a whole-federation surface owned by the primary window;
   // federation remote-viewer windows never render its toggle.
@@ -1909,22 +1923,7 @@ function DesktopAppShell(props: {
             });
           }}
           newThreadFederationTargets={newThreadFederationTargets}
-          onCreateThreadOnFederationTarget={async (instanceId) => {
-            try {
-              await desktopApi?.openFederationWindow?.({
-                target: { scope: "remote", instanceId },
-                initialLaunchpad: true,
-              });
-            } catch (error) {
-              showAppNotice({
-                id: `new-thread-federation-target:${instanceId}`,
-                title: "Could not open new thread",
-                message: error instanceof Error ? error.message : String(error),
-                tone: "error",
-                transientSlot: "new-thread-federation-target",
-              });
-            }
-          }}
+          onCreateThreadOnFederationTarget={createThreadOnFederationTarget}
           onAddProjectDirectory={readRendererFederationTarget()
             ? undefined
             : addProjectDirectory}

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -14,6 +14,7 @@ import type {
   CreateScheduledThreadActionRequest,
   DesktopPwrAgentProfileSummary,
   DesktopSettingsSnapshot,
+  FederationPeerSummary,
   NavigationSnapshot,
   OpenFederationWindowRequest,
   StartTurnRequest,
@@ -318,11 +319,33 @@ describe("App", () => {
   });
 
   it("starts a new thread on a selected federation machine and profile", async () => {
+    const federationListeners = new Set<(event: AgentEvent) => void>();
     const openFederationWindow = vi.fn(async (request: OpenFederationWindowRequest) => ({
       opened: true,
       target: request.target,
       windowId: 7,
     }));
+    let peers: FederationPeerSummary[] = [
+      {
+        id: "studio-work",
+        label: "Studio Mac",
+        profileName: "work",
+        role: "client" as const,
+        status: "connected" as const,
+        capabilities: [
+          "remote_window",
+          "thread_navigation",
+          "environment_actions",
+        ] as const,
+      },
+      {
+        id: "read-only",
+        label: "Read-only peer",
+        role: "client" as const,
+        status: "connected" as const,
+        capabilities: ["remote_window", "thread_navigation"] as const,
+      },
+    ];
     const readFederationHealth = vi.fn(async () => ({
       health: {
         enabled: true,
@@ -331,16 +354,7 @@ describe("App", () => {
         instanceId: "local-instance",
         localLabel: "Studio Mac",
         localProfileName: "default",
-        peers: [
-          {
-            id: "studio-work",
-            label: "Studio Mac",
-            profileName: "work",
-            role: "client" as const,
-            status: "connected" as const,
-            capabilities: ["remote_window", "thread_navigation"] as const,
-          },
-        ],
+        peers,
       },
     }));
     Object.defineProperty(window, "pwragent", {
@@ -359,6 +373,10 @@ describe("App", () => {
           },
         }),
         listBackends: async () => ({ fetchedAt: Date.now(), backends: [] }),
+        onAgentEvent: (listener: (event: AgentEvent) => void) => {
+          federationListeners.add(listener);
+          return () => federationListeners.delete(listener);
+        },
         onWindowFocus: () => () => undefined,
         openFederationWindow,
         readFederationHealth,
@@ -370,6 +388,9 @@ describe("App", () => {
 
     const button = screen.getByRole("button", { name: "New thread" });
     fireEvent.mouseEnter(button.parentElement as HTMLElement);
+    expect(screen.queryByRole("menuitem", {
+      name: "New chat on Read-only peer",
+    })).not.toBeInTheDocument();
     fireEvent.click(await screen.findByRole("menuitem", {
       name: "New chat on Studio Mac / work",
     }));
@@ -378,6 +399,43 @@ describe("App", () => {
       target: { scope: "remote", instanceId: "studio-work" },
       initialLaunchpad: true,
     });
+
+    peers = [
+      {
+        id: "laptop-default",
+        label: "Laptop",
+        role: "client" as const,
+        status: "connected" as const,
+        capabilities: [
+          "remote_window",
+          "thread_navigation",
+          "environment_actions",
+        ] as const,
+      },
+    ];
+    act(() => {
+      for (const listener of federationListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "federation/peerStatus/changed",
+            params: {
+              instanceId: "laptop-default",
+              status: "connected",
+            },
+          },
+        });
+      }
+    });
+    await waitFor(() => expect(readFederationHealth).toHaveBeenCalledTimes(2));
+
+    fireEvent.mouseEnter(button.parentElement as HTMLElement);
+    expect(await screen.findByRole("menuitem", {
+      name: "New chat on Laptop",
+    })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", {
+      name: "New chat on Studio Mac / work",
+    })).not.toBeInTheDocument();
   });
 
   it("surfaces GitHub organization SAML enforcement as a sticky error toast", async () => {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -15,6 +15,7 @@ import type {
   DesktopPwrAgentProfileSummary,
   DesktopSettingsSnapshot,
   NavigationSnapshot,
+  OpenFederationWindowRequest,
   StartTurnRequest,
   StartTurnResponse,
 } from "@pwragent/shared";
@@ -314,6 +315,69 @@ describe("App", () => {
     expect(
       await screen.findByRole("heading", { level: 2, name: "Search" }),
     ).toBeInTheDocument();
+  });
+
+  it("starts a new thread on a selected federation machine and profile", async () => {
+    const openFederationWindow = vi.fn(async (request: OpenFederationWindowRequest) => ({
+      opened: true,
+      target: request.target,
+      windowId: 7,
+    }));
+    const readFederationHealth = vi.fn(async () => ({
+      health: {
+        enabled: true,
+        role: "gateway" as const,
+        status: "connected" as const,
+        instanceId: "local-instance",
+        localLabel: "Studio Mac",
+        localProfileName: "default",
+        peers: [
+          {
+            id: "studio-work",
+            label: "Studio Mac",
+            profileName: "work",
+            role: "client" as const,
+            status: "connected" as const,
+            capabilities: ["remote_window", "thread_navigation"] as const,
+          },
+        ],
+      },
+    }));
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        listBackends: async () => ({ fetchedAt: Date.now(), backends: [] }),
+        onWindowFocus: () => () => undefined,
+        openFederationWindow,
+        readFederationHealth,
+      },
+    });
+
+    render(<App />);
+    await waitFor(() => expect(readFederationHealth).toHaveBeenCalled());
+
+    const button = screen.getByRole("button", { name: "New thread" });
+    fireEvent.mouseEnter(button.parentElement as HTMLElement);
+    fireEvent.click(await screen.findByRole("menuitem", {
+      name: "New chat on Studio Mac / work",
+    }));
+
+    expect(openFederationWindow).toHaveBeenCalledWith({
+      target: { scope: "remote", instanceId: "studio-work" },
+      initialLaunchpad: true,
+    });
   });
 
   it("surfaces GitHub organization SAML enforcement as a sticky error toast", async () => {

--- a/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
@@ -42,6 +42,10 @@ export function AppTitleBar(props: {
     addingProjectDirectory?: boolean;
     automationsActive: boolean;
     newThreadDirectoryLabel?: string;
+    newThreadFederationTargets?: readonly {
+      instanceId: string;
+      label: string;
+    }[];
     settingsActive: boolean;
     creatingThread: boolean;
     onAddProjectDirectory?: () => void | Promise<void>;
@@ -49,6 +53,9 @@ export function AppTitleBar(props: {
     onOpenSettings: () => void;
     onCreateThread: () => void | Promise<void>;
     onCreateThreadWithoutDirectory?: () => void | Promise<void>;
+    onCreateThreadOnFederationTarget?: (
+      instanceId: string,
+    ) => void | Promise<void>;
   };
 }): ReactElement | null {
   const isWindows = getDesktopApi()?.platform === "win32";
@@ -103,6 +110,10 @@ export function AppTitleBar(props: {
               onCreateThreadWithoutDirectory={
                 actions.onCreateThreadWithoutDirectory
               }
+              onCreateThreadOnTarget={
+                actions.onCreateThreadOnFederationTarget
+              }
+              remoteTargets={actions.newThreadFederationTargets}
             />
           </div>
         ) : null}

--- a/apps/desktop/src/renderer/src/features/chrome/MastheadActions.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/MastheadActions.tsx
@@ -18,12 +18,19 @@ export type MastheadActionsProps = {
   creatingThread?: boolean;
   /** Directory the default New Thread action resolves to (flyout label). */
   newThreadDirectoryLabel?: string;
+  newThreadFederationTargets?: readonly {
+    instanceId: string;
+    label: string;
+  }[];
   onAddProjectDirectory?: () => void | Promise<void>;
   onOpenAutomations?: () => void;
   onOpenSettings?: () => void;
   onToggleThreadSearch?: () => void;
   onCreateThread?: () => void | Promise<void>;
   onCreateThreadWithoutDirectory?: () => void | Promise<void>;
+  onCreateThreadOnFederationTarget?: (
+    instanceId: string,
+  ) => void | Promise<void>;
 };
 
 export function MastheadActions(props: MastheadActionsProps): ReactElement {
@@ -75,6 +82,8 @@ export function MastheadActions(props: MastheadActionsProps): ReactElement {
         onAddProjectDirectory={props.onAddProjectDirectory}
         onCreateThread={() => props.onCreateThread?.()}
         onCreateThreadWithoutDirectory={props.onCreateThreadWithoutDirectory}
+        onCreateThreadOnTarget={props.onCreateThreadOnFederationTarget}
+        remoteTargets={props.newThreadFederationTargets}
       />
     </div>
   );

--- a/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
@@ -18,7 +18,8 @@ import { useViewportTooltip } from "../../lib/useViewportTooltip";
  *
  *   1. New chat in <directory>     → `onCreateThread` (context default)
  *   2. New chat without a directory → `onCreateThreadWithoutDirectory`
- *   3. Add a Project Directory…     → track a repo without starting a chat
+ *   3. New chat on <instance>        → open that owner's launchpad
+ *   4. Add a Project Directory…     → track a repo without starting a chat
  *
  * The flyout renders when there's either a meaningful directory choice or an
  * explicit project-registration action. That keeps "Add a Project Directory…"
@@ -38,6 +39,11 @@ export type NewThreadButtonProps = {
   onAddProjectDirectory?: () => void | Promise<void>;
   onCreateThread: () => void | Promise<void>;
   onCreateThreadWithoutDirectory?: () => void | Promise<void>;
+  onCreateThreadOnTarget?: (instanceId: string) => void | Promise<void>;
+  remoteTargets?: readonly {
+    instanceId: string;
+    label: string;
+  }[];
 };
 
 export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
@@ -50,7 +56,13 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
   const hasDirectoryChoice = Boolean(
     props.directoryLabel && props.onCreateThreadWithoutDirectory,
   );
-  const hasFlyout = hasDirectoryChoice || Boolean(props.onAddProjectDirectory);
+  const hasRemoteTargets = Boolean(
+    props.onCreateThreadOnTarget && props.remoteTargets?.length,
+  );
+  const hasFlyout =
+    hasDirectoryChoice
+    || hasRemoteTargets
+    || Boolean(props.onAddProjectDirectory);
   const menuOpen = open && hasFlyout && !props.creatingThread;
 
   // With no flyout to reveal, keep a plain "New thread" tooltip so the button
@@ -176,6 +188,28 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
                 New chat without a directory
               </button>
             )}
+            {hasRemoteTargets ? (
+              <>
+                <div className="new-thread-menu__separator" role="separator" />
+                <div className="new-thread-menu__section-label" role="presentation">
+                  Other instances
+                </div>
+                {props.remoteTargets?.map((target) => (
+                  <button
+                    key={target.instanceId}
+                    type="button"
+                    role="menuitem"
+                    className="new-thread-menu__item"
+                    onClick={() => {
+                      setOpen(false);
+                      void props.onCreateThreadOnTarget?.(target.instanceId);
+                    }}
+                  >
+                    New chat on {target.label}
+                  </button>
+                ))}
+              </>
+            ) : null}
             {props.onAddProjectDirectory ? (
               <>
                 <div className="new-thread-menu__separator" role="separator" />

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
@@ -82,6 +82,34 @@ describe("NewThreadButton", () => {
     expect(onCreateThread).not.toHaveBeenCalled();
   });
 
+  it("offers connected federation instances before composition starts", async () => {
+    const onCreateThread = vi.fn();
+    const onCreateThreadOnTarget = vi.fn();
+    render(
+      <NewThreadButton
+        onCreateThread={onCreateThread}
+        onCreateThreadOnTarget={onCreateThreadOnTarget}
+        remoteTargets={[
+          { instanceId: "studio-work", label: "Studio Mac / work" },
+          { instanceId: "laptop-default", label: "Laptop" },
+        ]}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "New thread" });
+    fireEvent.mouseEnter(button.parentElement as HTMLElement);
+
+    expect(await screen.findByText("Other instances")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("menuitem", {
+        name: "New chat on Studio Mac / work",
+      }),
+    );
+
+    expect(onCreateThreadOnTarget).toHaveBeenCalledWith("studio-work");
+    expect(onCreateThread).not.toHaveBeenCalled();
+  });
+
   it("closes the flyout on Escape while a menu item is focused (regression)", async () => {
     render(
       <NewThreadButton

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/new-thread-placements.test.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/new-thread-placements.test.tsx
@@ -1,0 +1,68 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppTitleBar } from "../AppTitleBar";
+import { MastheadActions } from "../MastheadActions";
+
+const remoteTargets = [
+  { instanceId: "studio-work", label: "Studio Mac / work" },
+];
+
+afterEach(() => {
+  cleanup();
+  Object.defineProperty(window, "pwragent", {
+    configurable: true,
+    value: undefined,
+  });
+});
+
+describe("federation New Thread placements", () => {
+  it("offers targets from the hidden-sidebar masthead placement", () => {
+    const onCreateThreadOnFederationTarget = vi.fn();
+    render(
+      <MastheadActions
+        newThreadFederationTargets={remoteTargets}
+        onCreateThread={vi.fn()}
+        onCreateThreadOnFederationTarget={onCreateThreadOnFederationTarget}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "New thread" });
+    fireEvent.mouseEnter(button.parentElement as HTMLElement);
+    fireEvent.click(screen.getByRole("menuitem", {
+      name: "New chat on Studio Mac / work",
+    }));
+
+    expect(onCreateThreadOnFederationTarget).toHaveBeenCalledWith("studio-work");
+  });
+
+  it("offers targets from the Windows title-bar placement", () => {
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: { platform: "win32" },
+    });
+    const onCreateThreadOnFederationTarget = vi.fn();
+    render(
+      <AppTitleBar
+        actions={{
+          automationsActive: false,
+          creatingThread: false,
+          newThreadFederationTargets: remoteTargets,
+          onCreateThread: vi.fn(),
+          onCreateThreadOnFederationTarget,
+          onOpenAutomations: vi.fn(),
+          onOpenSettings: vi.fn(),
+          settingsActive: false,
+        }}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "New thread" });
+    fireEvent.mouseEnter(button.parentElement as HTMLElement);
+    fireEvent.click(screen.getByRole("menuitem", {
+      name: "New chat on Studio Mac / work",
+    }));
+
+    expect(onCreateThreadOnFederationTarget).toHaveBeenCalledWith("studio-work");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -141,6 +141,11 @@ type SidebarProps = {
   onBrowseModeChange: (browseMode: BrowseMode) => void;
   onCreateThread: () => Promise<void>;
   onCreateThreadWithoutDirectory?: () => Promise<void>;
+  onCreateThreadOnFederationTarget?: (instanceId: string) => Promise<void>;
+  newThreadFederationTargets?: readonly {
+    instanceId: string;
+    label: string;
+  }[];
   onAddProjectDirectory?: () => Promise<void>;
   addingProjectDirectory?: boolean;
   /** Directory the default New Thread action resolves to (flyout label). */
@@ -1615,6 +1620,8 @@ export function Sidebar(props: SidebarProps) {
             onAddProjectDirectory={props.onAddProjectDirectory}
             onCreateThread={() => props.onCreateThread()}
             onCreateThreadWithoutDirectory={props.onCreateThreadWithoutDirectory}
+            onCreateThreadOnTarget={props.onCreateThreadOnFederationTarget}
+            remoteTargets={props.newThreadFederationTargets}
           />
         </div>
       </header>

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -698,6 +698,13 @@ textarea,
   background: var(--border-subtle);
 }
 
+.new-thread-menu__section-label {
+  padding: 4px 10px 2px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+}
+
 /* macOS floats the traffic lights over the cluster's left. Match the sidebar
    masthead's wordmark offset exactly — its 16px sidebar gutter + 80px
    stoplight reservation — so the wordmark sits in the same spot whether the

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -582,6 +582,8 @@ export type ResetFederationEnrollmentResponse = {
 export type OpenFederationWindowRequest = {
   target: FederationRemoteTarget;
   initialThread?: FederatedThreadRef;
+  /** Open the target instance's ordinary new-thread launchpad on arrival. */
+  initialLaunchpad?: boolean;
 };
 
 export type OpenFederationWindowResponse = {


### PR DESCRIPTION
## Summary

- add connected federation machine/profile targets to the New Thread flyout
- open the selected owner's new-thread launchpad before composition begins
- preserve owner-scoped projects, providers, models, reasoning, environments, and launchpad defaults
- disambiguate profiles sharing a machine label and surface launch failures without silently falling back locally

## Why

New threads were previously created only on the instance implied by the current window. Operators connected to a federation had to navigate through Federation settings or another remote surface before they could create work on a different machine/profile.

The launch target determines every downstream launchpad choice, so this change moves that decision before composition while retaining the existing federation-window ownership boundary.

## Implementation

The ordinary New Thread menu reads connected peers from federation health and shows only peers supporting both remote windows and thread navigation. Selecting a target opens a scoped federation window with an `initialLaunchpad` request. Once the remote renderer is ready, it enters its existing launchpad flow, which already sources directories, backend catalogs, model settings, environments, and materialization from the owner.

## Validation

- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx apps/desktop/src/main/__tests__/federation-load-ipc.test.ts`
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/main/__tests__/index.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `pnpm lint:colors`
- `git diff --check`

Headed Electron E2E was not run because repository guidance requires an operator-provided off-desktop lab.
