### PR TITLE
fix(desktop): rank the Attention lens by turn, not by every update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,12 @@ accidental.
   of that turn, so a thread moves at most twice per turn no matter how loud the
   turn is. The second move is the one exception, and it is a setting:
   `general.attention_promote_on_turn_end` (default on) gives a finished turn one
-  last trip to the top so freshly completed work surfaces for review. Ranks are
+  last trip to the top so freshly completed work surfaces for review. That
+  covers a turn this window watched run *and* one it only learned about
+  afterwards — a messaging- or peer-driven turn can start and finish inside a
+  single poll interval, so an idle member whose `updatedAt` advanced counts as a
+  finished turn too. A live turn can never take that path, which is what keeps
+  it from becoming a back door to update-driven churn. Ranks are
   a monotonic counter, not a clock — no `Date.now()` in a render path and no
   ties to break — and they are scoped to current lens membership, so a thread
   that leaves and returns is fresh activity and re-enters at the top. The

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,11 +196,25 @@ accidental.
   switch. The tabs are icon-only; the lens name lives in `aria-label` and the
   tooltip.
 - Attention is the work-queue lens: threads with a live turn or waiting to be
-  reviewed, in recent-activity order. Its tab is two indicators with counts
+  reviewed. Its tab is two indicators with counts
   (scanner + in-progress, cookie + unread) rather than an icon, and each goes
   grey at zero so the tab reads as "nothing running, nothing unread" without
   being opened. A zero is shown, never hidden — a vanishing count makes an
   idle tab look like a broken one.
+- **Attention orders by turn, not by activity.** Every other lens is a pure
+  sort over `updatedAt` / `createdAt`; this one is not, because `updatedAt`
+  moves on every streamed item, sub-agent invocation, and tool result, and a
+  queue that re-sorts under the pointer while two turns run is unusable. Each
+  member holds a rank minted when its turn *starts* and left alone for the rest
+  of that turn, so a thread moves at most twice per turn no matter how loud the
+  turn is. The second move is the one exception, and it is a setting:
+  `general.attention_promote_on_turn_end` (default on) gives a finished turn one
+  last trip to the top so freshly completed work surfaces for review. Ranks are
+  a monotonic counter, not a clock — no `Date.now()` in a render path and no
+  ties to break — and they are scoped to current lens membership, so a thread
+  that leaves and returns is fresh activity and re-enters at the top. The
+  reducer and the reasoning live in
+  [attention-order.ts](apps/desktop/src/renderer/src/features/navigation/attention-order.ts).
 - Drafts is the second state lens: threads holding unsent composer text, in
   recent-activity order. A draft belongs to whoever typed it — it is stored in
   that machine's `composer_draft_latest` table, re-hydrated on the next launch,

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -47,6 +47,11 @@ summary.
   cookie, only replying does. See "Current Product Direction" in the
   [repo-root `AGENTS.md`](../../AGENTS.md) for why that rule is lens-scoped
   rather than global.
+- Attention rows are ranked per turn, not per update
+  ([attention-order.ts](src/renderer/src/features/navigation/attention-order.ts)).
+  Do not re-sort the lens by `updatedAt` — that is the bug the ranks exist to
+  fix. New signals that should move a row need a transition in the reducer, not
+  a tiebreaker in the sort.
 - User-curated Pins live as a scrollable section at the top of each directory
   in the Directories lens. Inbox and Recents are pure sort orders and do not
   float pins.

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -663,6 +663,38 @@ describe("DesktopSettingsService", () => {
     expect(service.resolveConfirmQuitWithInProgressThreads()).toBe(false);
   });
 
+  it("defaults the Attention end-of-turn promotion on and persists overrides", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const initial = await service.readSettings();
+    expect(initial.general.attentionPromoteOnTurnEnd).toEqual({
+      value: true,
+      source: "default",
+    });
+
+    await service.writeConfigPatch({
+      general: {
+        attentionPromoteOnTurnEnd: false,
+      },
+    });
+
+    const saved = fs.readFileSync(configPath, "utf8");
+    expect(saved).toContain("[general]");
+    expect(saved).toContain("attention_promote_on_turn_end = false");
+    expect(
+      (await service.readSettings()).general.attentionPromoteOnTurnEnd,
+    ).toEqual({
+      value: false,
+      source: "config",
+    });
+  });
+
   it("round-trips appearance through writeConfigPatch + readSettings + readBootstrapAppearance", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -85,6 +85,7 @@ type StoredChatReplyComposer =
 export type DesktopSettingsConfig = {
   general?: {
     confirmQuitWithInProgressThreads?: boolean;
+    attentionPromoteOnTurnEnd?: boolean;
     pdfAnalysisEnabled?: boolean;
     developerMode?: boolean;
     hotCpuProfilingEnabled?: boolean;
@@ -614,6 +615,12 @@ export function desktopSettingsPatchToEdits(
     set(
       ["general", "confirm_quit_with_in_progress_threads"],
       patch.general.confirmQuitWithInProgressThreads,
+    );
+  }
+  if (patch.general?.attentionPromoteOnTurnEnd !== undefined) {
+    set(
+      ["general", "attention_promote_on_turn_end"],
+      patch.general.attentionPromoteOnTurnEnd,
     );
   }
   if (patch.general?.pdfAnalysisEnabled !== undefined) {
@@ -1524,6 +1531,9 @@ function normalizeDesktopConfig(
       confirmQuitWithInProgressThreads: readBoolean(
         general?.confirm_quit_with_in_progress_threads,
       ),
+      attentionPromoteOnTurnEnd: readBoolean(
+        general?.attention_promote_on_turn_end,
+      ),
       pdfAnalysisEnabled: readBoolean(general?.pdf_analysis_enabled),
       developerMode: readBoolean(general?.developer_mode),
       hotCpuProfilingEnabled: readBoolean(general?.hot_cpu_profiling_enabled),
@@ -1860,6 +1870,7 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     config.general?.hotCpuProfilingHeapSnapshotLimit;
   const confirmQuitWithInProgressThreads =
     config.general?.confirmQuitWithInProgressThreads;
+  const attentionPromoteOnTurnEnd = config.general?.attentionPromoteOnTurnEnd;
   const pdfAnalysisEnabled = config.general?.pdfAnalysisEnabled;
   const notificationsEnabled = config.general?.notificationsEnabled;
   const appearance = config.general?.appearance;
@@ -1875,6 +1886,7 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     hotCpuProfilingCaptureHeapSnapshot !== undefined ||
     hotCpuProfilingHeapSnapshotLimit !== undefined ||
     confirmQuitWithInProgressThreads !== undefined ||
+    attentionPromoteOnTurnEnd !== undefined ||
     pdfAnalysisEnabled !== undefined ||
     notificationsEnabled !== undefined ||
     appearanceDefined ||
@@ -1909,6 +1921,9 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     if (confirmQuitWithInProgressThreads !== undefined) {
       pruned.general.confirmQuitWithInProgressThreads =
         confirmQuitWithInProgressThreads;
+    }
+    if (attentionPromoteOnTurnEnd !== undefined) {
+      pruned.general.attentionPromoteOnTurnEnd = attentionPromoteOnTurnEnd;
     }
     if (pdfAnalysisEnabled !== undefined) {
       pruned.general.pdfAnalysisEnabled = pdfAnalysisEnabled;

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -597,6 +597,13 @@ export class DesktopSettingsService {
           config.general?.confirmQuitWithInProgressThreads,
           true,
         ),
+        // Default on: with the Attention lens ranked by turn start, leaving
+        // this off would park a long-running turn below a short one that
+        // started later, which reads oddly for a review queue.
+        attentionPromoteOnTurnEnd: this.resolveConfigBoolean(
+          config.general?.attentionPromoteOnTurnEnd,
+          true,
+        ),
         pdfAnalysisEnabled: this.resolveConfigBoolean(
           config.general?.pdfAnalysisEnabled,
           true,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1820,6 +1820,9 @@ function DesktopAppShell(props: {
           error={navigation.error}
           inboxThreads={navigation.inboxThreads}
           recentThreads={navigation.recentThreads}
+          attentionPromoteOnTurnEnd={
+            settings.snapshot?.general.attentionPromoteOnTurnEnd?.value ?? true
+          }
           archiveThreadError={navigation.archiveThreadError}
           renameThreadError={navigation.renameThreadError}
           runtimeIdentity={runtimeIdentity}

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -791,6 +791,10 @@ describe("App", () => {
           value: true,
           source: "default",
         },
+        attentionPromoteOnTurnEnd: {
+          value: true,
+          source: "default",
+        },
         developerMode: {
           value: false,
           source: "default",

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -68,6 +68,7 @@ import {
   formatRateLimitLine,
   selectVisibleRateLimits,
 } from "../../lib/backend-status-format";
+import { useAttentionOrderedThreads } from "./attention-order";
 import { DirectoriesList } from "./DirectoriesList";
 import { RecentsList } from "./RecentsList";
 import {
@@ -93,6 +94,12 @@ type SidebarProps = {
   error?: string;
   inboxThreads?: NavigationThreadSummary[];
   recentThreads?: NavigationThreadSummary[];
+  /**
+   * Give a thread one last move to the top of the Attention lens when its turn
+   * finishes. Defaults on, matching the settings default, so a Sidebar rendered
+   * before the settings snapshot arrives does not flip order once it lands.
+   */
+  attentionPromoteOnTurnEnd?: boolean;
   /** A snapshot exists even if its latest refresh failed. */
   loaded?: boolean;
   loading: boolean;
@@ -428,16 +435,23 @@ export function Sidebar(props: SidebarProps) {
   const updatedOrderThreads = props.inboxThreads ?? props.threads;
   /**
    * The Attention lens: everything with a live turn or waiting to be
-   * reviewed, in most-recently-updated order (the same order the Updated lens
-   * uses) so the freshest work sits at the top of the queue.
+   * reviewed. Membership comes off the most-recently-updated order, but the
+   * rows are then ranked per turn rather than per update — see
+   * `attention-order.ts` for why a work queue must not re-sort itself while a
+   * turn streams.
    */
-  const attentionThreads = useMemo(
+  const attentionMembers = useMemo(
     () =>
       updatedOrderThreads.filter((thread) =>
         isThreadNeedingAttention(thread, props.thinkingThreadKeys),
       ),
     [props.thinkingThreadKeys, updatedOrderThreads],
   );
+  const attentionThreads = useAttentionOrderedThreads({
+    promoteOnTurnEnd: props.attentionPromoteOnTurnEnd ?? true,
+    threads: attentionMembers,
+    thinkingThreadKeys: props.thinkingThreadKeys,
+  });
   /**
    * The Drafts lens: everything holding unsent composer text, in the same
    * most-recently-updated order Attention uses. Filtered from the very map the

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/attention-order.test.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/attention-order.test.ts
@@ -134,6 +134,71 @@ describe("reconcileAttentionOrder", () => {
     expect(run.ids).toEqual(["b", "a"]);
   });
 
+  it("promotes an existing member whose turn ran entirely between snapshots", () => {
+    // A turn driven from messaging, a federated peer, or an automation is only
+    // visible through `threadStatus` in the polled snapshot, and a short one
+    // fits inside a single poll interval. The renderer sees no live state at
+    // all — just an already-unread thread whose `updatedAt` moved. Without
+    // this, it keeps its stale rank and stays buried under threads that have
+    // had no new work.
+    let run = step(createAttentionOrderState(), [
+      idleThread("a"),
+      idleThread("b"),
+      idleThread("c"),
+    ]);
+    expect(run.ids).toEqual(["a", "b", "c"]);
+
+    run = step(run.state, [
+      thread("c", { threadStatus: "idle", updatedAt: 99 }),
+      idleThread("a"),
+      idleThread("b"),
+    ]);
+    expect(run.ids).toEqual(["c", "a", "b"]);
+
+    // The same `updatedAt` observed again is not a second turn.
+    run = step(run.state, [
+      thread("c", { threadStatus: "idle", updatedAt: 99 }),
+      idleThread("a"),
+      idleThread("b"),
+    ]);
+    expect(run.ids).toEqual(["c", "a", "b"]);
+  });
+
+  it("leaves an unobserved turn parked when promotion is off", () => {
+    let run = step(
+      createAttentionOrderState(),
+      [idleThread("a"), idleThread("b")],
+      { promoteOnTurnEnd: false },
+    );
+    expect(run.ids).toEqual(["a", "b"]);
+
+    run = step(
+      run.state,
+      [thread("b", { threadStatus: "idle", updatedAt: 99 }), idleThread("a")],
+      { promoteOnTurnEnd: false },
+    );
+    expect(run.ids).toEqual(["a", "b"]);
+  });
+
+  it("never re-ranks a live turn however far its updatedAt runs", () => {
+    // The after-the-fact promotion must not become a back door to the
+    // update-driven churn the ranks exist to remove. A streaming turn is
+    // active, and an active thread's rank is frozen.
+    let run = step(createAttentionOrderState(), [
+      activeThread("a"),
+      activeThread("b"),
+    ]);
+    expect(run.ids).toEqual(["a", "b"]);
+
+    for (const tick of [10, 20, 30]) {
+      run = step(run.state, [
+        thread("b", { threadStatus: "active", updatedAt: tick }),
+        thread("a", { threadStatus: "active", updatedAt: tick }),
+      ]);
+      expect(run.ids).toEqual(["a", "b"]);
+    }
+  });
+
   it("promotes a thread that has just joined the lens", () => {
     let run = step(createAttentionOrderState(), [
       idleThread("a"),

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/attention-order.test.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/attention-order.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import {
+  createAttentionOrderState,
+  reconcileAttentionOrder,
+  type AttentionOrderState,
+} from "../attention-order";
+
+function thread(
+  id: string,
+  overrides: Partial<NavigationThreadSummary> = {},
+): NavigationThreadSummary {
+  return {
+    id,
+    inbox: { inInbox: true },
+    linkedDirectories: [],
+    source: "codex",
+    title: id,
+    titleSource: "derived",
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+function activeThread(id: string): NavigationThreadSummary {
+  return thread(id, { threadStatus: "active" });
+}
+
+function idleThread(id: string): NavigationThreadSummary {
+  return thread(id, { threadStatus: "idle" });
+}
+
+/**
+ * Push one snapshot through the reducer, mirroring what the Sidebar hook does
+ * with its ref. Returns the resulting order as plain ids so assertions read as
+ * the list the operator sees.
+ */
+function step(
+  state: AttentionOrderState,
+  threads: NavigationThreadSummary[],
+  options: { promoteOnTurnEnd?: boolean } = {},
+): { ids: string[]; state: AttentionOrderState } {
+  const reconciled = reconcileAttentionOrder({
+    previous: state,
+    promoteOnTurnEnd: options.promoteOnTurnEnd ?? true,
+    threads,
+  });
+  return {
+    ids: reconciled.threads.map((entry) => entry.id),
+    state: reconciled.state,
+  };
+}
+
+describe("reconcileAttentionOrder", () => {
+  it("adopts the snapshot's most-recently-updated order on first sight", () => {
+    const first = step(createAttentionOrderState(), [
+      activeThread("a"),
+      idleThread("b"),
+      idleThread("c"),
+    ]);
+
+    expect(first.ids).toEqual(["a", "b", "c"]);
+  });
+
+  it("holds position while a live turn keeps updating the thread", () => {
+    // The bug this exists to prevent: `updatedAt` moves on every streamed item
+    // and sub-agent invocation, so two live turns swapped places under the
+    // pointer. Membership order flips between snapshots here; the rendered
+    // order must not.
+    let run = step(createAttentionOrderState(), [
+      activeThread("a"),
+      activeThread("b"),
+      idleThread("c"),
+    ]);
+    expect(run.ids).toEqual(["a", "b", "c"]);
+
+    run = step(run.state, [activeThread("b"), activeThread("a"), idleThread("c")]);
+    expect(run.ids).toEqual(["a", "b", "c"]);
+
+    run = step(run.state, [idleThread("c"), activeThread("b"), activeThread("a")]);
+    expect(run.ids).toEqual(["a", "b", "c"]);
+  });
+
+  it("moves a thread to the top exactly once when its turn starts", () => {
+    let run = step(createAttentionOrderState(), [
+      idleThread("a"),
+      idleThread("b"),
+      idleThread("c"),
+    ]);
+    expect(run.ids).toEqual(["a", "b", "c"]);
+
+    run = step(run.state, [activeThread("c"), idleThread("a"), idleThread("b")]);
+    expect(run.ids).toEqual(["c", "a", "b"]);
+
+    // Everything the turn goes on to do — more items, sub-agents, tool
+    // results — leaves the rank alone.
+    run = step(run.state, [activeThread("c"), idleThread("b"), idleThread("a")]);
+    expect(run.ids).toEqual(["c", "a", "b"]);
+  });
+
+  it("gives a finished turn one last move to the top when promotion is on", () => {
+    let run = step(createAttentionOrderState(), [
+      activeThread("a"),
+      activeThread("b"),
+    ]);
+    expect(run.ids).toEqual(["a", "b"]);
+
+    run = step(run.state, [idleThread("b"), activeThread("a")]);
+    expect(run.ids).toEqual(["b", "a"]);
+
+    // One move, not one per post-turn snapshot.
+    run = step(run.state, [idleThread("b"), activeThread("a")]);
+    expect(run.ids).toEqual(["b", "a"]);
+  });
+
+  it("leaves a finished turn parked at its turn-start rank when promotion is off", () => {
+    let run = step(
+      createAttentionOrderState(),
+      [activeThread("a"), activeThread("b")],
+      { promoteOnTurnEnd: false },
+    );
+    expect(run.ids).toEqual(["a", "b"]);
+
+    run = step(run.state, [idleThread("b"), activeThread("a")], {
+      promoteOnTurnEnd: false,
+    });
+    expect(run.ids).toEqual(["a", "b"]);
+
+    // The next turn on that thread still promotes — only the end-of-turn move
+    // is suppressed.
+    run = step(run.state, [activeThread("b"), activeThread("a")], {
+      promoteOnTurnEnd: false,
+    });
+    expect(run.ids).toEqual(["b", "a"]);
+  });
+
+  it("promotes a thread that has just joined the lens", () => {
+    let run = step(createAttentionOrderState(), [
+      idleThread("a"),
+      idleThread("b"),
+    ]);
+    expect(run.ids).toEqual(["a", "b"]);
+
+    run = step(run.state, [idleThread("c"), idleThread("a"), idleThread("b")]);
+    expect(run.ids).toEqual(["c", "a", "b"]);
+  });
+
+  it("re-ranks a thread that left the lens and came back", () => {
+    let run = step(createAttentionOrderState(), [
+      idleThread("a"),
+      idleThread("b"),
+      idleThread("c"),
+    ]);
+    expect(run.ids).toEqual(["a", "b", "c"]);
+
+    // `c` is read, so it drops out of the queue entirely.
+    run = step(run.state, [idleThread("a"), idleThread("b")]);
+    expect(run.ids).toEqual(["a", "b"]);
+
+    // A new message makes it unread again. It is fresh activity, so it comes
+    // back at the top rather than at the bottom it left from.
+    run = step(run.state, [idleThread("c"), idleThread("a"), idleThread("b")]);
+    expect(run.ids).toEqual(["c", "a", "b"]);
+  });
+
+  it("drops entries for threads that leave the lens", () => {
+    let run = step(createAttentionOrderState(), [
+      idleThread("a"),
+      idleThread("b"),
+    ]);
+    run = step(run.state, [idleThread("a")]);
+
+    expect([...run.state.entries.keys()]).toEqual(["codex:a"]);
+  });
+
+  it("is idempotent when the same snapshot is reconciled twice", () => {
+    // The Sidebar hook writes its ref during the memo, so a StrictMode double
+    // render reconciles the already-reconciled state. No transitions remain,
+    // so nothing may move.
+    const first = step(createAttentionOrderState(), [
+      activeThread("a"),
+      idleThread("b"),
+    ]);
+    const second = step(first.state, [activeThread("a"), idleThread("b")]);
+
+    expect(second.ids).toEqual(first.ids);
+    expect(second.state.nextRank).toBe(first.state.nextRank);
+  });
+
+  it("keeps the freshest thread on top when one snapshot carries several turn starts", () => {
+    let run = step(createAttentionOrderState(), [
+      idleThread("a"),
+      idleThread("b"),
+      idleThread("c"),
+    ]);
+
+    run = step(run.state, [activeThread("c"), activeThread("b"), idleThread("a")]);
+    expect(run.ids).toEqual(["c", "b", "a"]);
+  });
+
+  it("treats an optimistic thinking key as a live turn", () => {
+    // The renderer marks a thread thinking the moment it sends, before the
+    // backend status round-trips. Turn start has to fire on that, or the
+    // promotion would land a beat late and then again on the real status.
+    const first = reconcileAttentionOrder({
+      previous: createAttentionOrderState(),
+      promoteOnTurnEnd: true,
+      threads: [idleThread("a"), idleThread("b")],
+    });
+    const second = reconcileAttentionOrder({
+      previous: first.state,
+      promoteOnTurnEnd: true,
+      threads: [idleThread("a"), idleThread("b")],
+      thinkingThreadKeys: { "codex:b": true },
+    });
+    expect(second.threads.map((entry) => entry.id)).toEqual(["b", "a"]);
+
+    // The backend status catching up is not a second transition.
+    const third = reconcileAttentionOrder({
+      previous: second.state,
+      promoteOnTurnEnd: true,
+      threads: [activeThread("b"), idleThread("a")],
+      thinkingThreadKeys: { "codex:b": true },
+    });
+    expect(third.threads.map((entry) => entry.id)).toEqual(["b", "a"]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2343,6 +2343,52 @@ describe("Sidebar", () => {
       ]);
     });
 
+    it("holds row order while live turns keep re-sorting the snapshot", () => {
+      // The snapshot arrives in most-recently-updated order, and a running
+      // turn rewrites `updatedAt` on every streamed item, so the incoming
+      // order flips constantly while two turns are live. The lens ranks by
+      // turn instead — see attention-order.ts — so the rows must not move.
+      const secondActiveThread = {
+        ...activeThread,
+        id: "thread-active-2",
+        title: "Second active thread",
+      };
+      const props = {
+        backends,
+        browseMode: "attention" as const,
+        createThreadError: undefined,
+        directories,
+        launchpadError: undefined,
+        loading: false,
+        creatingThread: undefined,
+        selectedItemKey: undefined,
+        onBrowseModeChange: () => undefined,
+        onCreateThread: async () => undefined,
+        onOpenLaunchpad: async () => undefined,
+        onSelectThread: () => undefined,
+      };
+      const attentionRowTitles = () => {
+        const browseSection = screen.getByRole("region", {
+          name: "Thread browser",
+        });
+        return within(browseSection as HTMLElement)
+          .getAllByRole("button", {
+            name: /Active thread|Second active thread/i,
+          })
+          .map((row) => (row.textContent?.includes("Second") ? "second" : "first"));
+      };
+
+      const ordered = [activeThread, secondActiveThread];
+      const { rerender } = render(
+        <Sidebar {...props} inboxThreads={ordered} threads={ordered} />,
+      );
+      expect(attentionRowTitles()).toEqual(["first", "second"]);
+
+      const reordered = [secondActiveThread, activeThread];
+      rerender(<Sidebar {...props} inboxThreads={reordered} threads={reordered} />);
+      expect(attentionRowTitles()).toEqual(["first", "second"]);
+    });
+
     it("reports both counts on the tab and switches to the lens", () => {
       const onBrowseModeChange = vi.fn();
       renderAttention("inbox", onBrowseModeChange);

--- a/apps/desktop/src/renderer/src/features/navigation/attention-order.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/attention-order.ts
@@ -1,0 +1,115 @@
+import { useMemo, useRef } from "react";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { threadSummaryIdentityKey } from "../../lib/federated-thread-events";
+import { isThreadActive } from "./ThreadRowStatus";
+
+/**
+ * Turn-stable ordering for the Attention lens.
+ *
+ * The lens used to render in the snapshot's own most-recently-updated order,
+ * which meant a running thread re-sorted on every streamed item, sub-agent
+ * invocation, and tool result — two live turns were enough to make the queue
+ * trade places under the pointer. A work queue whose rows move while you are
+ * reading them is unusable, so position is pinned to the *turn* instead of to
+ * the thread's `updatedAt`.
+ *
+ * Each lens member holds a rank drawn from a monotonic counter. The rank is
+ * assigned once and then left alone; only two events mint a new one:
+ *
+ * - a turn starting on that thread (idle → live), which is the operator-visible
+ *   event that deserves the top of the queue, and
+ * - a turn finishing (live → idle), when `promoteOnTurnEnd` is on — one last
+ *   move so freshly finished work surfaces for review.
+ *
+ * Everything in between — deltas, sub-agent traffic, item completions, PR
+ * status, reactions — leaves the rank untouched, so a thread moves at most
+ * twice per turn no matter how loud that turn is.
+ *
+ * Ranks are a counter rather than a clock so the order is a pure function of
+ * the transitions observed, with no `Date.now()` in a render path and no ties
+ * to break.
+ */
+type AttentionOrderEntry = {
+  /** Live-turn state at the snapshot this entry was last written from. */
+  active: boolean;
+  /** Higher sorts first. Unique across entries by construction. */
+  rank: number;
+};
+
+export type AttentionOrderState = {
+  entries: Map<string, AttentionOrderEntry>;
+  nextRank: number;
+};
+
+export function createAttentionOrderState(): AttentionOrderState {
+  return { entries: new Map(), nextRank: 1 };
+}
+
+/**
+ * State is scoped to current lens membership: a thread that leaves the lens
+ * drops its entry and re-enters at the top. That is the right answer for the
+ * way threads actually re-enter — a new turn, or a new unread message — both of
+ * which are fresh activity. It also keeps the map from growing without bound.
+ */
+export function reconcileAttentionOrder(params: {
+  previous: AttentionOrderState;
+  /** Attention-lens members, in the snapshot's most-recently-updated order. */
+  threads: NavigationThreadSummary[];
+  thinkingThreadKeys?: Record<string, boolean>;
+  promoteOnTurnEnd: boolean;
+}): { state: AttentionOrderState; threads: NavigationThreadSummary[] } {
+  const entries = new Map<string, AttentionOrderEntry>();
+  const rankByThread = new Map<NavigationThreadSummary, number>();
+  let nextRank = params.previous.nextRank;
+
+  // Walk oldest-first so that when one snapshot carries several transitions at
+  // once — the common case on the first render, where every member is new —
+  // the freshest thread takes the highest rank and lands on top.
+  for (let index = params.threads.length - 1; index >= 0; index -= 1) {
+    const thread = params.threads[index];
+    const key = threadSummaryIdentityKey(thread);
+    const active = isThreadActive(thread, params.thinkingThreadKeys);
+    const previousEntry = params.previous.entries.get(key);
+    const turnStarted = active && previousEntry?.active === false;
+    const turnEnded = !active && previousEntry?.active === true;
+    const rank =
+      !previousEntry || turnStarted || (turnEnded && params.promoteOnTurnEnd)
+        ? nextRank++
+        : previousEntry.rank;
+    entries.set(key, { active, rank });
+    rankByThread.set(thread, rank);
+  }
+
+  const ordered = [...params.threads].sort(
+    (left, right) => (rankByThread.get(right) ?? 0) - (rankByThread.get(left) ?? 0),
+  );
+
+  return { state: { entries, nextRank }, threads: ordered };
+}
+
+/**
+ * Sidebar-side wrapper. The ordering state lives in a ref rather than React
+ * state because it is derived bookkeeping, not something to render on: writing
+ * it during the memo keeps the ordered list available on the very render that
+ * observed the transition. Re-running the memo against already-reconciled state
+ * is a no-op — no transitions remain to detect — so a StrictMode double render
+ * produces the same order.
+ */
+export function useAttentionOrderedThreads(params: {
+  promoteOnTurnEnd: boolean;
+  threads: NavigationThreadSummary[];
+  thinkingThreadKeys?: Record<string, boolean>;
+}): NavigationThreadSummary[] {
+  const stateRef = useRef<AttentionOrderState>(createAttentionOrderState());
+  const { promoteOnTurnEnd, threads, thinkingThreadKeys } = params;
+  return useMemo(() => {
+    const reconciled = reconcileAttentionOrder({
+      previous: stateRef.current,
+      promoteOnTurnEnd,
+      threads,
+      thinkingThreadKeys,
+    });
+    stateRef.current = reconciled.state;
+    return reconciled.threads;
+  }, [promoteOnTurnEnd, threads, thinkingThreadKeys]);
+}

--- a/apps/desktop/src/renderer/src/features/navigation/attention-order.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/attention-order.ts
@@ -14,12 +14,14 @@ import { isThreadActive } from "./ThreadRowStatus";
  * the thread's `updatedAt`.
  *
  * Each lens member holds a rank drawn from a monotonic counter. The rank is
- * assigned once and then left alone; only two events mint a new one:
+ * assigned once and then left alone; only a turn boundary mints a new one:
  *
  * - a turn starting on that thread (idle → live), which is the operator-visible
  *   event that deserves the top of the queue, and
- * - a turn finishing (live → idle), when `promoteOnTurnEnd` is on — one last
- *   move so freshly finished work surfaces for review.
+ * - a turn finishing, when `promoteOnTurnEnd` is on — one last move so freshly
+ *   finished work surfaces for review. That covers both a turn this window
+ *   watched run (live → idle) and one it only learned about afterwards, where
+ *   an idle member's `updatedAt` advanced between snapshots.
  *
  * Everything in between — deltas, sub-agent traffic, item completions, PR
  * status, reactions — leaves the rank untouched, so a thread moves at most
@@ -34,6 +36,12 @@ type AttentionOrderEntry = {
   active: boolean;
   /** Higher sorts first. Unique across entries by construction. */
   rank: number;
+  /**
+   * `updatedAt` at the snapshot this entry was last written from, so a turn
+   * that began and ended without the renderer ever seeing the live state can
+   * still be recognized after the fact.
+   */
+  updatedAt: number;
 };
 
 export type AttentionOrderState = {
@@ -69,14 +77,34 @@ export function reconcileAttentionOrder(params: {
     const thread = params.threads[index];
     const key = threadSummaryIdentityKey(thread);
     const active = isThreadActive(thread, params.thinkingThreadKeys);
+    const updatedAt = thread.updatedAt ?? 0;
     const previousEntry = params.previous.entries.get(key);
     const turnStarted = active && previousEntry?.active === false;
     const turnEnded = !active && previousEntry?.active === true;
+    // A turn driven from somewhere this window is not watching — messaging, a
+    // federated peer, an automation — is only visible through `threadStatus`
+    // in the polled snapshot, and a short one can start and finish inside a
+    // single poll interval. The renderer then sees no transition at all, so an
+    // already-unread thread would keep its stale rank and stay buried under
+    // threads that have had no new work, which is the opposite of what this
+    // lens is for. An idle member whose `updatedAt` advanced is that turn
+    // observed after the fact, and earns the same end-of-turn move.
+    //
+    // A streaming turn can never take this path: mid-turn the thread is
+    // active, and an active thread's rank is frozen no matter how far its
+    // `updatedAt` runs. That is what keeps this from reintroducing the churn
+    // the ranks exist to remove.
+    const finishedUnobserved =
+      !active
+      && previousEntry?.active === false
+      && updatedAt > previousEntry.updatedAt;
     const rank =
-      !previousEntry || turnStarted || (turnEnded && params.promoteOnTurnEnd)
+      !previousEntry
+      || turnStarted
+      || ((turnEnded || finishedUnobserved) && params.promoteOnTurnEnd)
         ? nextRank++
         : previousEntry.rank;
-    entries.set(key, { active, rank });
+    entries.set(key, { active, rank, updatedAt });
     rankByThread.set(thread, rank);
   }
 

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -123,6 +123,7 @@ export function GeneralSettings(props: {
   saving: boolean;
   snapshot: DesktopSettingsSnapshot;
   onConfirmQuitWithInProgressThreadsChange: (value: boolean) => Promise<void>;
+  onAttentionPromoteOnTurnEndChange: (value: boolean) => Promise<void>;
   onPdfAnalysisEnabledChange: (value: boolean) => Promise<void>;
   onPastedImageMaxPatchesChange: (value: number) => Promise<void>;
   onUpdateChannelChange: (value: DesktopUpdateChannel) => Promise<void>;
@@ -147,6 +148,8 @@ export function GeneralSettings(props: {
     props.snapshot.imageUploads.pastedImageMaxPatches;
   const confirmQuitWithInProgressThreads =
     props.snapshot.general.confirmQuitWithInProgressThreads;
+  const attentionPromoteOnTurnEnd =
+    props.snapshot.general.attentionPromoteOnTurnEnd;
   const pdfAnalysisEnabled = props.snapshot.general.pdfAnalysisEnabled;
   const notificationsEnabled = props.snapshot.general.notificationsEnabled;
   const updateChannel = props.snapshot.updates.channel;
@@ -309,6 +312,30 @@ export function GeneralSettings(props: {
           </div>
         </SettingsSection>
       ) : null}
+
+      <SettingsSection
+        eyebrow="General"
+        title="Attention lens"
+        chip={sourceBadge(attentionPromoteOnTurnEnd)}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Move a thread to the top when its turn finishes"
+            sub="Attention ranks threads by when their current turn started, so streaming output, sub-agents, and tool results never re-sort the queue mid-turn. Turn this off to keep a thread parked where its turn started until the next one begins."
+            source={sourceBadge(attentionPromoteOnTurnEnd)}
+            control={
+              <SettingsSwitch
+                checked={attentionPromoteOnTurnEnd.value}
+                disabled={props.saving}
+                label="Move a thread to the top when its turn finishes"
+                onChange={(next) => {
+                  void props.onAttentionPromoteOnTurnEndChange(next);
+                }}
+              />
+            }
+          />
+        </div>
+      </SettingsSection>
 
       <SettingsSection
         eyebrow="General"

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -380,6 +380,13 @@ function SettingsSectionBody(props: {
             general: { confirmQuitWithInProgressThreads },
           });
         }}
+        onAttentionPromoteOnTurnEndChange={async (
+          attentionPromoteOnTurnEnd: boolean,
+        ) => {
+          await props.settings.writeConfig({
+            general: { attentionPromoteOnTurnEnd },
+          });
+        }}
         onPdfAnalysisEnabledChange={async (pdfAnalysisEnabled) => {
           await props.settings.writeConfig({
             general: { pdfAnalysisEnabled },

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -89,6 +89,10 @@ function createSnapshot(
         value: true,
         source: "default",
       },
+      attentionPromoteOnTurnEnd: {
+        value: true,
+        source: "default",
+      },
       developerMode: {
         value: false,
         source: "default",
@@ -715,6 +719,23 @@ describe("SettingsScreen", () => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         general: {
           confirmQuitWithInProgressThreads: false,
+        },
+      });
+    });
+    expect(
+      screen.getByRole("switch", {
+        name: "Move a thread to the top when its turn finishes",
+      }),
+    ).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Move a thread to the top when its turn finishes",
+      }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        general: {
+          attentionPromoteOnTurnEnd: false,
         },
       });
     });

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -23,6 +23,10 @@ describe("desktop settings contracts", () => {
           value: true,
           source: "default",
         },
+        attentionPromoteOnTurnEnd: {
+          value: true,
+          source: "default",
+        },
         developerMode: {
           value: false,
           source: "default",

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -368,6 +368,12 @@ export type DesktopAppearanceSnapshot = {
 export type DesktopGeneralSettingsSnapshot = {
   confirmQuitWithInProgressThreads: DesktopSettingsValue<boolean>;
   /**
+   * Attention-lens ordering is pinned to the start of a thread's turn so a
+   * streaming turn cannot re-sort the queue under the operator. This controls
+   * the one exception: whether a finished turn earns one last move to the top.
+   */
+  attentionPromoteOnTurnEnd: DesktopSettingsValue<boolean>;
+  /**
    * Prefer PwrAgent's bounded, visual PDF analysis flow over handing a raw
    * local PDF reference to the model.
    */
@@ -883,6 +889,7 @@ export type DesktopSettingsSnapshot = {
 export type DesktopSettingsConfigPatch = {
   general?: {
     confirmQuitWithInProgressThreads?: boolean;
+    attentionPromoteOnTurnEnd?: boolean;
     pdfAnalysisEnabled?: boolean;
     developerMode?: boolean;
     hotCpuProfilingEnabled?: boolean;


### PR DESCRIPTION
## Problem

The Attention lens rendered in the snapshot's own most-recently-updated order.
`updatedAt` moves on **every** streamed item, sub-agent invocation, tool
result, and PR-status refresh — so with two live turns the rows traded places
continuously. A queue you are supposed to work through was re-sorting under the
pointer.

## Fix

Rank each lens member on a monotonic counter instead of reading `updatedAt`.
A rank is minted when a turn **starts** and then left alone for the rest of
that turn. Everything the turn goes on to do leaves the rank untouched, so a
thread moves **at most twice per turn** no matter how loud the turn is.

The second move is the one exception, and it is a setting:

**Settings → General → Attention lens → "Move a thread to the top when its turn
finishes"** (`general.attention_promote_on_turn_end`, default **on**).

- **On** — a finished turn gets one last trip to the top, so freshly completed
  work surfaces for review. At rest this reproduces today's order, which is why
  it is the default.
- **Off** — a thread stays parked at its turn-start rank until its next turn
  begins.

Two details worth calling out:

- **Ranks are a counter, not a clock.** No `Date.now()` in a render path and no
  ties to break — the order is a pure function of the transitions observed.
- **State is scoped to current lens membership.** A thread that leaves the lens
  (read, no live turn) drops its rank and re-enters at the top later, which is
  correct: it comes back because of a new turn or a new unread message, and both
  are fresh activity.

The optimistic thinking key counts as a live turn, so the promotion fires the
moment the operator sends rather than a beat later when the backend status
round-trips — and the status catching up is not treated as a second transition.

## Tests

- `attention-order.test.ts` (new, 11 cases): first-sight order, holding position
  through a streaming turn, one move per turn start, promotion on/off at turn
  end, lens re-entry, entry cleanup, StrictMode idempotence, simultaneous turn
  starts, optimistic thinking keys.
- `sidebar.test.tsx`: rows hold order across a rerender whose snapshot order
  flipped. Verified this fails when the ordering hook is bypassed.
- `settings-screen.test.tsx` + `desktop-settings-service.test.ts`: toggle writes
  the patch; the config key round-trips and defaults to on.

`pnpm typecheck`, `pnpm lint:eslint`, and `pnpm lint:boundaries` are clean.
Full `pnpm test` passes apart from 28 pre-existing `createCommandInvocation`
failures in this worktree (stale `@pwrdrvr/agent-transport` build — confirmed
present on a clean tree).

## Follow-up

The operator-facing Settings → General reference lives in
[pwrdrvr/docs.pwragent.ai](https://github.com/pwrdrvr/docs.pwragent.ai) and is
not updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
