### PR TITLE
fix(desktop): preserve viewer-owned federated pin order

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2120,6 +2120,7 @@ describe("app server ipc", () => {
     // The unread remote row bumps the group's "N to review" badge past the
     // reconcile-computed local count.
     expect(appDirectory?.needsAttentionCount).toBe(2);
+    expect(rememberCompleteNavigationSnapshot).toHaveBeenCalledWith(response);
   });
 
   it("marks a pinned remote snapshot changed when only reactions change", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6710,7 +6710,7 @@ describe("DesktopBackendRegistry", () => {
       },
       // Viewer-owned remote ranks live outside the local thread overlay but
       // participate in the same user-curated order.
-      remotePinnedRanks: ["2048"],
+      remotePinnedRanks: ["2048", "3072"],
     });
     const codexClient = new MockBackendClient({
       threads: [
@@ -6764,21 +6764,21 @@ describe("DesktopBackendRegistry", () => {
     expect(response).toMatchObject({
       backend: "codex",
       threadId: "thread-1",
-      pinnedRank: "3072",
+      pinnedRank: "4096",
     });
     await expect(
       overlayStore.getThreadOverlayState({
         backend: "codex",
         threadId: "thread-1",
       }),
-    ).resolves.toMatchObject({ pinnedRank: "3072" });
+    ).resolves.toMatchObject({ pinnedRank: "4096" });
     expect(events).toContainEqual({
       backend: "codex",
       notification: {
         method: "thread/pin/added",
         params: {
           threadId: "thread-1",
-          pinnedRank: "3072",
+          pinnedRank: "4096",
         },
       },
     });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -17,6 +17,7 @@ import { promisify } from "node:util";
 import { describe, expect, it, vi } from "vitest";
 import {
   applyNavigationLaunchpadProviderSettingsPatch,
+  buildFederatedThreadRef,
   buildNavigationSnapshot,
   buildThreadIdentityKey,
   PWRAGENT_MESSAGING_PDF_TOOL_CATALOG_VERSION,
@@ -327,6 +328,7 @@ function createOverlayStoreMock(params?: {
   executionMode?: "default" | "full-access";
   launchpadDefaults?: NavigationLaunchpadDefaults;
   overlays?: Record<string, ThreadOverlayState>;
+  remotePinnedRanks?: string[];
   toolAccounting?: ThreadToolAccounting;
 }) {
   const toolAccounting: ThreadToolAccounting = params?.toolAccounting ?? {
@@ -372,6 +374,17 @@ function createOverlayStoreMock(params?: {
   }
 
   return {
+    listRemoteThreadPins: async () =>
+      (params?.remotePinnedRanks ?? []).map((localPinnedRank, index) => ({
+        ref: buildFederatedThreadRef({
+          backend: "codex",
+          instanceId: "peer-laptop",
+          threadId: `remote-${index + 1}`,
+        }),
+        addedAt: 1_000 + index,
+        instanceLabel: "Laptop",
+        localPinnedRank,
+      })),
     getThreadOverlayState: async ({
       backend,
       threadId,
@@ -6674,7 +6687,7 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
-  it("auto-pins a top-level thread created through the shared launchpad materialization path", async () => {
+  it("auto-pins a new local thread after the existing local and remote pins", async () => {
     const directoryPath = expectedDir(
       path.join(os.tmpdir(), "pwragent-auto-pin-project"),
     );
@@ -6695,6 +6708,9 @@ describe("DesktopBackendRegistry", () => {
           pinnedRank: "1024",
         },
       },
+      // Viewer-owned remote ranks live outside the local thread overlay but
+      // participate in the same user-curated order.
+      remotePinnedRanks: ["2048"],
     });
     const codexClient = new MockBackendClient({
       threads: [
@@ -6748,21 +6764,21 @@ describe("DesktopBackendRegistry", () => {
     expect(response).toMatchObject({
       backend: "codex",
       threadId: "thread-1",
-      pinnedRank: "2048",
+      pinnedRank: "3072",
     });
     await expect(
       overlayStore.getThreadOverlayState({
         backend: "codex",
         threadId: "thread-1",
       }),
-    ).resolves.toMatchObject({ pinnedRank: "2048" });
+    ).resolves.toMatchObject({ pinnedRank: "3072" });
     expect(events).toContainEqual({
       backend: "codex",
       notification: {
         method: "thread/pin/added",
         params: {
           threadId: "thread-1",
-          pinnedRank: "2048",
+          pinnedRank: "3072",
         },
       },
     });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6710,7 +6710,7 @@ describe("DesktopBackendRegistry", () => {
       },
       // Viewer-owned remote ranks live outside the local thread overlay but
       // participate in the same user-curated order.
-      remotePinnedRanks: ["2048", "3072"],
+      remotePinnedRanks: ["64512", "65536"],
     });
     const codexClient = new MockBackendClient({
       threads: [
@@ -6764,21 +6764,21 @@ describe("DesktopBackendRegistry", () => {
     expect(response).toMatchObject({
       backend: "codex",
       threadId: "thread-1",
-      pinnedRank: "4096",
+      pinnedRank: "66560",
     });
     await expect(
       overlayStore.getThreadOverlayState({
         backend: "codex",
         threadId: "thread-1",
       }),
-    ).resolves.toMatchObject({ pinnedRank: "4096" });
+    ).resolves.toMatchObject({ pinnedRank: "66560" });
     expect(events).toContainEqual({
       backend: "codex",
       notification: {
         method: "thread/pin/added",
         params: {
           threadId: "thread-1",
-          pinnedRank: "4096",
+          pinnedRank: "66560",
         },
       },
     });

--- a/apps/desktop/src/main/__tests__/remote-thread-pins-store.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-pins-store.test.ts
@@ -243,11 +243,15 @@ describe("SqliteOverlayStore — remote thread pins", () => {
     expect(listed[0].pinnedVia).toBe("companion");
   });
 
-  it("reorders mixed local and remote pins atomically from the full order", async () => {
+  it("reorders colliding local and remote pins atomically from the full order", async () => {
     await store.addRemoteThreadPin({
       ref: ref("remote-1"),
       summary: summary({ id: "remote-1" }),
       instanceLabel: "Laptop",
+    });
+    await store.setRemoteThreadLocalPin({
+      ref: ref("remote-1"),
+      pinnedRank: "9999",
     });
     await store.setThreadPin({
       backend: "codex",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6259,6 +6259,7 @@ type BackendRegistryOverlayStoreLike = OverlayStoreLike & Partial<
   Pick<
     SqliteOverlayStore,
     | "readThreadGitWorkingStateCache"
+    | "listRemoteThreadPins"
     | "upsertThreadUsageLines"
     | "writeThreadGitWorkingStateCacheEntry"
   >
@@ -10594,8 +10595,31 @@ export class DesktopBackendRegistry {
     }
 
     return await this.createdThreadVisibilityLock.run("global-pin-order", async () => {
+      // Remote rows pinned into this viewer's main window own ranks in
+      // `remote_thread_pins`, not the local thread overlay. New local threads
+      // still join the same user-curated list, so rank allocation must include
+      // both stores or it can reuse a remote rank and strand the two rows at
+      // the local/remote boundary.
+      let remotePinnedRanks: Array<string | undefined> = [];
+      try {
+        remotePinnedRanks =
+          typeof this.overlayStore.listRemoteThreadPins === "function"
+            ? (await this.overlayStore.listRemoteThreadPins())
+                .map((pin) => pin.localPinnedRank)
+            : [];
+      } catch (error) {
+        // Auto-pinning is a visibility enhancement. A read failure should not
+        // turn a successfully created thread into a failed creation response.
+        backendRegistryLog.warn("remote pin ranks unavailable during auto-pin", {
+          error: error instanceof Error ? error.message : String(error),
+          threadId: params.threadId,
+        });
+      }
       const pinnedRank = buildAppendPinRank(
-        this.createdThreadVisibilityPinnedRanks,
+        [
+          ...this.createdThreadVisibilityPinnedRanks,
+          ...remotePinnedRanks,
+        ],
       );
       try {
         await this.overlayStore.setThreadPin({

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2056,13 +2056,6 @@ class DesktopAppServerService {
       threads,
       workspaceRoots: resolveScratchProjectsRoots(),
     });
-    if (
-      backend === "all"
-      && !request.filter?.trim()
-      && !activeRecentRefresh
-    ) {
-      getDesktopBackendRegistry().rememberCompleteNavigationSnapshot(snapshot);
-    }
     await this.loadPrStatusRegistry();
     await this.loadPrLookupRegistry();
     this.seedPrStatusRegistryFromThreads(snapshot.threads);
@@ -2128,7 +2121,7 @@ class DesktopAppServerService {
 
     const remotePins = await this.mergePinnedRemoteThreads();
 
-    return {
+    const response = {
       ...snapshot,
       threads: [...threadsWithWorkingState, ...remotePins.threads],
       // One unified ranking over local + remote rows: the local keys were
@@ -2154,6 +2147,16 @@ class DesktopAppServerService {
         && !primaryGitRepositoriesChanged
         && !remotePins.changed,
     };
+    if (
+      backend === "all"
+      && !request.filter?.trim()
+      && !activeRecentRefresh
+    ) {
+      // Creation-time visibility and append-rank decisions must see the same
+      // merged local + viewer-owned remote pin list the renderer sees.
+      getDesktopBackendRegistry().rememberCompleteNavigationSnapshot(response);
+    }
+    return response;
   }
 
   private async applyRemoteDirectoryViewerOverlays(

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -5694,11 +5694,10 @@ describe("Sidebar thread pinning Move items", () => {
     threadKeys,
   });
 
-  it("moves a pin across backends — pin order is global, not per-backend", async () => {
-    // Pin order is global across backends (mirrors directory pinning). The
-    // top global pin can Move Down past another backend's pins, producing an
-    // interleaved cross-backend order. This is exactly the behavior the old
-    // per-backend slice blocked.
+  it("moves a colliding remote pin above a newer local pin", async () => {
+    // A local auto-pin used to reuse a viewer-owned remote rank. Recency then
+    // put the newer local row first, but Move Up must still submit one global
+    // order that places the remote row above it.
     const onReorderThreadPins = vi.fn(async () => undefined);
     const codexTop = {
       ...sharedThread,
@@ -5706,13 +5705,25 @@ describe("Sidebar thread pinning Move items", () => {
       title: "Codex top pin",
       source: "codex" as const,
       pinnedRank: "1024",
+      updatedAt: 2_000,
     };
     const grokMiddle = {
       ...sharedThread,
       id: "grok-middle",
       title: "Grok middle pin",
       source: "acp:grok" as const,
-      pinnedRank: "2048",
+      pinnedRank: "1024",
+      updatedAt: 1_000,
+      federation: {
+        ref: {
+          backend: "acp:grok" as const,
+          target: { scope: "remote" as const, instanceId: "peer-laptop" },
+          threadId: "grok-middle",
+        },
+        instanceLabel: "Laptop",
+        peerStatus: "connected" as const,
+        capabilities: [],
+      },
     };
     const grokBottom = {
       ...sharedThread,
@@ -5749,24 +5760,21 @@ describe("Sidebar thread pinning Move items", () => {
       />,
     );
 
-    // Codex's pin is the GLOBAL top (rank 1024). Move Up is disabled (nothing
-    // above it), but Move Down is enabled and crosses into grok's pins.
-    const codexRow = screen
-      .getByRole("button", { name: /Codex top pin/i })
+    const remoteRow = screen
+      .getByRole("button", { name: /Grok middle pin/i })
       .closest(".thread-row-shell") as HTMLElement;
     fireEvent.click(
-      codexRow.querySelector(".thread-row__overflow-button") as HTMLButtonElement,
+      remoteRow.querySelector(".thread-row__overflow-button") as HTMLButtonElement,
     );
 
     const moveUp = await screen.findByRole("menuitem", { name: /Move Up/i });
     const moveDown = await screen.findByRole("menuitem", {
       name: /Move Down/i,
     });
-    expect(moveUp).toBeDisabled();
+    expect(moveUp).toBeEnabled();
     expect(moveDown).toBeEnabled();
 
-    fireEvent.click(moveDown);
-    // Global, interleaved new order: grok-middle now above the codex pin.
+    fireEvent.click(moveUp);
     expect(onReorderThreadPins).toHaveBeenCalledWith([
       "acp:grok:grok-middle",
       "codex:codex-top",


### PR DESCRIPTION
## Ownership model

Each instance owns its own pinned-list order. A remote thread therefore has two completely independent possible ranks:

- the owner instance's `summary.pinnedRank`, used only on that owner's surfaces
- the viewing instance's `remote_thread_pins.payload.localPinnedRank`, used when that remote identity appears in the viewer's local pinned list

This PR does not import, preserve, or synchronize the remote owner's order. The main-window merge explicitly strips the owner's `summary.pinnedRank` and stamps only the local viewer's `localPinnedRank` onto the merged row. Sidebar and Star Map then consume that same viewer-local rank, so both local surfaces show one consistent operator-controlled order.

## What changed

- include this viewer's `localPinnedRank` values for mounted remote identities when allocating the next local auto-pin rank
- cache the fully merged viewer snapshot for creation-time visibility decisions
- cover allocation after multiple viewer-ranked remote rows, existing mixed-rank collision recovery, the renderer Move Up path, and the merged snapshot contract

## Root cause

Automatic local pin allocation only considered ranks stored in local thread overlays. It omitted the viewing instance's ranks stored on `remote_thread_pins`, so a new local thread could reuse a rank already assigned locally to a mounted remote identity. Equal ranks then fell back to recency, making remote and local rows appear to form separate ordering blocks.

The reported profile contained two independent viewer-local collisions:

- a local thread and mounted `PwrAgent - Release` both had rank `64512`
- local `Fix thread sorting across federation` and mounted `Propose 1.0 Branch Backports` both had rank `65536`

The remote owners' own pin ranks were not involved. `PwrAgent - Release` was already present as an explicitly mounted, viewer-ranked root; its mounted child was correctly unranked.

## User impact

The viewing instance remains the sole authority for its local pinned list. Newly auto-pinned local threads append after every viewer-ranked row, whether the row identity is local or remote. Reordering an existing tied local/remote pair rewrites that viewer's full order to distinct local ranks. No rank mutation is sent to a remote owner.

Star Map intentionally shares the same viewer-local snapshot and order as the sidebar, so locally rearranging a mounted remote identity is reflected consistently on both surfaces without changing the owner instance.

## Validation

- focused renderer + main-process suites: 763 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`