### PR TITLE
fix(agent-core): improve Grok ACP working updates

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -824,6 +824,10 @@ describe("AcpBackendAdapter", () => {
       status: "completed",
     };
     transport.emitSessionUpdate(session.sessionId, completedToolUpdate);
+    transport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_message_chunk",
+      content: { type: "text", text: "\n" },
+    });
     for (const [index, text] of [
       "So ",
       "the ",

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -3940,6 +3940,67 @@ describe("AcpAgentClient", () => {
     ).toBe(false);
   });
 
+  it("does not allocate a live assistant item for whitespace after a tool", async () => {
+    const assistantMessageItemIds: Array<string | undefined> = [];
+    const transport = new FakeAcpAgentTransport();
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      store,
+      transport,
+      now: () => 1000,
+      onSessionUpdate: ({ assistantMessageItemId, update }) => {
+        if (update.sessionUpdate === "agent_message_chunk") {
+          assistantMessageItemIds.push(assistantMessageItemId);
+        }
+      },
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Inspect this",
+      turnId: "turn-1",
+    });
+
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "Before the tool." },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "tool_call",
+      toolCallId: "read-1",
+      kind: "read",
+      title: "Read `README.md`",
+      status: "completed",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "\n" },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "After the tool." },
+    });
+
+    expect(assistantMessageItemIds).toEqual([
+      "assistant:turn-1:0",
+      undefined,
+      "assistant:turn-1:1",
+    ]);
+    expect(
+      client
+        .readReplay(session.sessionId)
+        .messages.filter((message) => message.role === "assistant"),
+    ).toEqual([
+      expect.objectContaining({ role: "assistant", text: "Before the tool." }),
+      expect.objectContaining({ role: "assistant", text: "After the tool." }),
+    ]);
+  });
+
   it("strips legacy transcript updates when upserting stored sessions", () => {
     store.upsertSession({
       backendId: "acp:kimi",

--- a/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
@@ -361,6 +361,84 @@ describe("acpToolUpdateNotifications", () => {
     ]);
   });
 
+  it("maps Grok open-page output to a concrete web fetch", () => {
+    const notifications = acpToolUpdateNotifications({
+      threadId: "session-1",
+      turnId: "turn-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "ws_grok-open-1",
+        status: "completed",
+        title: "Web search:",
+        rawOutput: {
+          id: "ws_grok-open-1",
+          action: {
+            type: "open_page",
+            url: "https://api.slack.com/methods/chat.update",
+          },
+        },
+      },
+    });
+
+    expect(notifications).toEqual([
+      expect.objectContaining({
+        method: "item/completed",
+        params: expect.objectContaining({
+          item: expect.objectContaining({
+            id: "ws_grok-open-1",
+            type: "commandExecution",
+            toolName: "web_fetch",
+            command:
+              'web_fetch(url="https://api.slack.com/methods/chat.update")',
+            commandActions: [
+              {
+                type: "read",
+                name: "Fetched https://api.slack.com/methods/chat.update",
+              },
+            ],
+          }),
+        }),
+      }),
+    ]);
+  });
+
+  it("maps Grok find-in-page output to its pattern and page", () => {
+    const notifications = acpToolUpdateNotifications({
+      threadId: "session-1",
+      turnId: "turn-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "ws_grok-find-1",
+        status: "completed",
+        title: "Web search:",
+        rawOutput: {
+          id: "ws_grok-find-1",
+          action: {
+            type: "find_in_page",
+            url: "https://api.slack.com/methods/chat.update",
+            pattern: "blocks",
+          },
+        },
+      },
+    });
+
+    expect(notifications).toEqual([
+      expect.objectContaining({
+        method: "item/completed",
+        params: expect.objectContaining({
+          item: {
+            id: "ws_grok-find-1",
+            type: "webSearch",
+            toolName: "search_web",
+            status: "completed",
+            arguments: { query: "blocks" },
+            sources: [{ url: "https://api.slack.com/methods/chat.update" }],
+          },
+        }),
+      }),
+    ]);
+  });
+
   it("does not classify a generic ACP search action as Grok web search", () => {
     const notifications = acpToolUpdateNotifications({
       threadId: "session-1",

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -141,6 +141,55 @@ describe("AcpSessionReplayNormalizer", () => {
     expect(replay.lastAssistantMessage).toBe("Hello world");
   });
 
+  it("drops a whitespace-only assistant chunk after a tool boundary", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { kind: "agent_message_chunk", content: "Before the tool." },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "read-1",
+        kind: "read",
+        title: "Read `README.md`",
+        status: "completed",
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1002,
+      update: { kind: "agent_message_chunk", content: "\n" },
+    });
+
+    expect(replay.messages).toEqual([
+      expect.objectContaining({ role: "assistant", text: "Before the tool." }),
+    ]);
+    expect(replay.lastAssistantMessage).toBe("Before the tool.");
+  });
+
+  it("preserves whitespace chunks inside an active assistant message", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    for (const [receivedAt, content] of [
+      [1000, "Hello"],
+      [1001, " "],
+      [1002, "world"],
+    ] as const) {
+      normalizer.apply({
+        sessionId: "session-1",
+        receivedAt,
+        update: { kind: "agent_message_chunk", content },
+      });
+    }
+
+    expect(normalizer.replay().lastAssistantMessage).toBe("Hello world");
+  });
+
   it("prefers a provider timestamp extension over local receipt time", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 
@@ -737,6 +786,50 @@ describe("AcpSessionReplayNormalizer", () => {
     ]);
   });
 
+  it("lets a refined file-tool label replace Grok's raw tool name", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "read-file-1",
+        kind: "other",
+        title: "read_file",
+        status: "pending",
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "read-file-1",
+        kind: "read",
+        title: "Read `docs/messaging-adapter-contract.md`",
+        status: "completed",
+        locations: [{ path: "docs/messaging-adapter-contract.md" }],
+      },
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        id: "read-file-1",
+        summary: "Read `docs/messaging-adapter-contract.md`",
+        status: "completed",
+        details: [
+          expect.objectContaining({
+            kind: "read",
+            label: "Read `docs/messaging-adapter-contract.md`",
+            path: "docs/messaging-adapter-contract.md",
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("merges Kimi snake_case tool call updates into the original activity", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 
@@ -965,6 +1058,53 @@ describe("AcpSessionReplayNormalizer", () => {
             label: "Models",
             url: "https://docs.x.ai/developers/models",
           },
+        ],
+      }),
+    ]);
+  });
+
+  it("upgrades a historical Grok open-page search to a web fetch", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+    const url = "https://api.slack.com/methods/chat.update";
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "ws_grok-open-1",
+        title: "Web search:",
+        kind: "search",
+        status: "in_progress",
+        rawInput: { variant: "WebSearch", backend: true },
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "ws_grok-open-1",
+        title: "Web search:",
+        status: "completed",
+        rawOutput: {
+          id: "ws_grok-open-1",
+          action: { type: "open_page", url },
+        },
+      },
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        id: "ws_grok-open-1",
+        summary: `Fetched ${url}`,
+        status: "completed",
+        details: [
+          expect.objectContaining({
+            kind: "read",
+            label: `Fetched ${url}`,
+          }),
         ],
       }),
     ]);

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -1048,12 +1048,20 @@ export class AcpAgentClient {
       && toolCallId !== undefined
       && activeTurn?.knownToolCallIds.has(toolCallId) === true;
     let assistantMessageItemId: string | undefined;
-    if (shouldTrackAssistantTextUpdate && activeTurn && text) {
-      const phase: AppServerTranscriptPhase =
-        updateKind === "agent_thought_chunk" ? "commentary" : "final";
+    const assistantTextPhase: AppServerTranscriptPhase =
+      updateKind === "agent_thought_chunk" ? "commentary" : "final";
+    const continuesActiveAssistantMessage =
+      activeTurn?.activeAssistantMessageItemId !== undefined
+      && activeTurn.activeAssistantMessagePhase === assistantTextPhase;
+    if (
+      shouldTrackAssistantTextUpdate
+      && activeTurn
+      && text
+      && (text.trim() || continuesActiveAssistantMessage)
+    ) {
       assistantMessageItemId = assistantMessageItemIdForUpdate({
         activeTurn,
-        phase,
+        phase: assistantTextPhase,
         update,
       });
       if (updateKind === "agent_message_chunk") {

--- a/apps/desktop/src/main/acp/acp-command-extraction.ts
+++ b/apps/desktop/src/main/acp/acp-command-extraction.ts
@@ -116,8 +116,9 @@ export function readAcpWebSearch(
     readString(record, "toolCallId") ??
     readString(record, "tool_call_id");
   const outputId = readString(rawOutput ?? {}, "id");
+  const actionType = readString(action ?? {}, "type");
   const isGrokWebSearchOutput =
-    readString(action ?? {}, "type") === "search"
+    (actionType === "search" || actionType === "find_in_page")
     && [toolCallId, outputId].some((id) => id?.startsWith("ws_"));
   const isWebSearch =
     variant === "WebSearch"
@@ -130,8 +131,15 @@ export function readAcpWebSearch(
 
   const query =
     readString(action ?? {}, "query") ??
+    readString(action ?? {}, "pattern") ??
     readString(rawInput ?? {}, "query");
-  const rawSources = Array.isArray(action?.sources) ? action.sources : [];
+  const actionUrl = readString(action ?? {}, "url");
+  const rawSources = [
+    ...(Array.isArray(action?.sources) ? action.sources : []),
+    ...(actionType === "find_in_page" && actionUrl
+      ? [{ url: actionUrl }]
+      : []),
+  ];
   const sources = rawSources.flatMap((value): AcpWebSearch["sources"] => {
     const source = asRecord(value);
     if (!source) {
@@ -158,25 +166,36 @@ export function readAcpWebFetchUrl(
   record: Record<string, unknown>,
 ): string | undefined {
   const rawInput = asRecord(record.rawInput);
+  const rawOutput = asRecord(record.rawOutput);
+  const action = asRecord(rawOutput?.action);
   const metadata = readAcpToolMetadata(record);
   const variant = readString(rawInput ?? {}, "variant");
   const metadataName = readString(metadata ?? {}, "name");
   const metadataKind = readString(metadata ?? {}, "kind");
   const kind = readString(record, "kind");
   const title = readString(record, "title");
+  const toolCallId =
+    readString(record, "toolCallId") ??
+    readString(record, "tool_call_id");
+  const outputId = readString(rawOutput ?? {}, "id");
+  const isGrokOpenPage =
+    readString(action ?? {}, "type") === "open_page"
+    && [toolCallId, outputId].some((id) => id?.startsWith("ws_"));
   const isWebFetch =
     variant?.toLowerCase() === "webfetch"
     || metadataName === "web_fetch"
     || metadataKind === "web_fetch"
     || kind === "fetch"
     || /^web_fetch$/i.test(title ?? "")
-    || /^fetch:\s+/i.test(title ?? "");
+    || /^fetch:\s+/i.test(title ?? "")
+    || isGrokOpenPage;
   if (!isWebFetch) {
     return undefined;
   }
 
   return (
     readString(rawInput ?? {}, "url") ??
+    readString(action ?? {}, "url") ??
     readString(asRecord(metadata?.input) ?? {}, "url") ??
     /^fetch:\s+(.+)$/i.exec(title ?? "")?.[1]?.trim()
   );

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -342,7 +342,7 @@ export class AcpSessionReplayNormalizer {
         readContentText(update.update, "content") ??
         readString(update.update, "text") ??
         "";
-      if (text && !isModeUpdateMarker(text) && this.currentTurnId) {
+      if (text.trim() && !isModeUpdateMarker(text) && this.currentTurnId) {
         this.removeAgentWaitingActivity(this.currentTurnId);
       }
       if (kind === "agent_message_chunk") {
@@ -482,7 +482,11 @@ export class AcpSessionReplayNormalizer {
       readContentText(update.update, "content") ??
       readString(update.update, "text") ??
       "";
-    if (!text || isModeUpdateMarker(text)) {
+    if (
+      !text
+      || isModeUpdateMarker(text)
+      || (!this.activeAssistantMessageId && !text.trim())
+    ) {
       return;
     }
     const id = this.assistantMessageIdForChunk(update);
@@ -542,7 +546,7 @@ export class AcpSessionReplayNormalizer {
       readContentText(update.update, "content") ??
       readString(update.update, "text") ??
       "";
-    if (!text) {
+    if (!text || (!this.activeAssistantMessageId && !text.trim())) {
       return;
     }
     const id = this.assistantMessageIdForChunk(update);
@@ -1391,9 +1395,13 @@ function isGenericActivityLabel(value: string): boolean {
     "zsh",
     "execute",
     "read",
+    "read_file",
     "write",
     "search",
+    "web_search",
+    "x_search",
     "list",
+    "list_dir",
     "tool call",
     "tool_call",
     "tool call update",

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -2137,7 +2137,13 @@ export class AcpBackendAdapter {
               shouldSurfaceAcpThoughtsAsMessages(agent.backendId)))
         ) {
           const delta = agentMessageDelta ?? readAcpUpdateText(update);
-          if (delta) {
+          // The client deliberately leaves the item ID unset when a provider
+          // sends a whitespace-only chunk after a tool boundary. Do not revive
+          // that skipped chunk under the legacy fallback ID: doing so creates
+          // a blank live assistant card even though replay normalization drops
+          // the same artifact. Preserve whitespace only when it continues an
+          // already-active assistant item.
+          if (delta && (assistantMessageItemId || delta.trim())) {
             const phase =
               updateKind === "agent_thought_chunk" ? "commentary" : "final";
             await this.emit({


### PR DESCRIPTION
## Summary

- suppress whitespace-only ACP assistant chunks at tool boundaries without removing meaningful streamed spaces
- decode Grok `open_page` and `find_in_page` hosted-search payloads into concrete fetch/search activity
- let refined file-tool labels replace raw names such as `read_file` during live rendering and replay
- cover the exact historical event shapes observed in Slack Live Cards Working Updates

## Root cause

PwrAgent treated a standalone newline after a Grok tool boundary as a new assistant message. It also only understood Grok's hosted `search` action, so `open_page` and `find_in_page` completions remained blank `Web search:` rows. Finally, raw snake-case tool names were treated as specific labels and could win over later updates containing the real path.

## Impact

Existing Grok rollouts replay with useful search, page, and file context, while future live updates no longer create empty assistant cards. The ACP producer-side companion is [pwrdrvr/grok-build#6](https://github.com/pwrdrvr/grok-build/pull/6).

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-live-notifications.test.ts apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts apps/desktop/src/main/__tests__/acp-client.test.ts` — 148 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors
