### PR TITLE
fix(release): gate publication on Windows signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,6 +363,12 @@ jobs:
           test "${#debs[@]}" -eq 4
           sha256sum "${debs[@]}" > SHA256SUMS
 
+      # The Windows package stage also writes SHA256SUMS. Keep the stable Linux
+      # alias for its documented download URL while giving the Windows manifest
+      # a platform-specific asset name; GitHub Releases rejects duplicate names.
+      - name: Name Windows checksum manifest
+        run: mv windows-dist/SHA256SUMS windows-dist/PwrAgent-windows-SHA256SUMS
+
       - name: Create release and publish all platform assets
         env:
           GH_TOKEN: ${{ secrets.RELEASES_PAT || github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,13 +83,13 @@ jobs:
           retention-days: 7
 
   sign:
-    name: Sign, notarize, publish
+    name: Sign, notarize, package macOS
     runs-on: macos-15
     needs: prepare
     timeout-minutes: 60
     environment: apple-signing
     permissions:
-      contents: write # publish releases to the same repo
+      contents: read
       id-token: none
     steps:
       - name: Download signing input
@@ -111,7 +111,7 @@ jobs:
       - name: Expand signing input
         run: tar -xzf .release-input/desktop-release-signing-input.tgz
 
-      - name: Sign, notarize, publish
+      - name: Sign, notarize, package macOS
         env:
           # Code signing (Developer ID Application: PwrDrvr LLC, T44CNHC4UH).
           # Store these in the apple-signing GitHub Environment, not as repo secrets.
@@ -127,30 +127,20 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_TEAM_ID: T44CNHC4UH
 
-          # Publish to the existing private pwrdrvr/PwrAgent repo.
-          # Phase 1 (solo dogfooding). Phase 2 channel migration is in
-          # docs/desktop-distribution-phase-2-runbook.md.
-          GH_TOKEN: ${{ secrets.RELEASES_PAT || github.token }}
-        run: node apps/desktop/scripts/release.mjs --sign-stage-only
+        run: node apps/desktop/scripts/release.mjs --sign-stage-only --no-publish
 
-      - name: Publish stable-name DMG alias
-        env:
-          GH_TOKEN: ${{ secrets.RELEASES_PAT || github.token }}
-          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+      - name: Prepare stable-name DMG alias
         run: |
           set -euo pipefail
           cd apps/desktop/release-stage/dist
           versioned=$(ls PwrAgent-*-universal.dmg | head -n 1)
           cp "$versioned" PwrAgent.dmg
-          gh release upload "$RELEASE_TAG" \
-            PwrAgent.dmg \
-            --repo pwrdrvr/PwrAgent \
-            --clobber
 
-      - name: Upload release artifacts (debug retention)
+      # This is the macOS release payload consumed by publish-release-assets.
+      # It is intentionally not a best-effort debug upload: publishing must
+      # wait until every signed platform payload is available.
+      - name: Upload macOS release assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: ${{ !cancelled() }}
-        continue-on-error: true
         with:
           name: desktop-release-artifacts
           path: |
@@ -328,17 +318,36 @@ jobs:
             apps/desktop/release-stage/dist/SHA256SUMS
           retention-days: 7
 
-  linux-publish:
-    name: Publish Linux DEB artifacts
+  publish-release-assets:
+    name: Publish release assets
     runs-on: ubuntu-24.04
     needs:
       - linux-package
       - sign
+      - windows-sign
     timeout-minutes: 15
     permissions:
       contents: write
       id-token: none
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+          persist-credentials: false
+
+      - name: Download macOS release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: desktop-release-artifacts
+          path: mac-dist
+
+      - name: Download Windows installer artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: windows-installer
+          path: windows-dist
+
       - name: Download Linux package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -354,26 +363,52 @@ jobs:
           test "${#debs[@]}" -eq 4
           sha256sum "${debs[@]}" > SHA256SUMS
 
-      - name: Publish Linux release assets
+      - name: Create release and publish all platform assets
         env:
           GH_TOKEN: ${{ secrets.RELEASES_PAT || github.token }}
           RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          cd linux-dist
-          gh release upload "$RELEASE_TAG" \
-            *.deb \
-            SHA256SUMS \
-            --repo pwrdrvr/PwrAgent \
-            --clobber
+          RELEASE_TAG="${RELEASE_TAG:?}"
+          notes="$RUNNER_TEMP/RELEASE_NOTES.md"
 
-      - name: Upload Linux artifacts (debug retention)
+          node scripts/extract-release-notes.mjs \
+            --tag "$RELEASE_TAG" \
+            --out "$notes"
+
+          if [ ! -s "$notes" ]; then
+            echo "::error::No CHANGELOG.md notes found for $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          release_args=(
+            "$RELEASE_TAG"
+            --repo pwrdrvr/PwrAgent
+            --verify-tag
+            --title "$RELEASE_TAG"
+            --notes-file "$notes"
+          )
+          if [[ "$RELEASE_TAG" == *-* ]]; then
+            release_args+=(--prerelease)
+          else
+            release_args+=(--latest)
+          fi
+
+          gh release create "${release_args[@]}" \
+            mac-dist/* \
+            windows-dist/* \
+            linux-dist/*.deb \
+            linux-dist/SHA256SUMS
+
+      - name: Upload assembled release artifacts (debug retention)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         continue-on-error: true
         with:
-          name: linux-release-artifacts
+          name: release-publish-artifacts
           path: |
+            mac-dist/*
+            windows-dist/*
             linux-dist/*.deb
             linux-dist/SHA256SUMS
           retention-days: 30
@@ -382,8 +417,7 @@ jobs:
     name: Publish release notes
     runs-on: ubuntu-24.04
     needs:
-      - sign
-      - linux-publish
+      - publish-release-assets
     timeout-minutes: 10
     permissions:
       contents: write

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -122,11 +122,12 @@ seven job definitions (the Linux package job fans out across two architectures):
    `id-token: none`, no Apple secrets, and checkout credentials disabled. It
    installs dependencies, runs release metadata checks, typecheck, tests, and
    `apps/desktop/scripts/release.mjs --prepare-only`.
-2. `Sign, notarize, publish`, gated by the protected `apple-signing`
-   environment, with `contents: write` and explicit `id-token: none`. It does
+2. `Sign, notarize, package macOS`, gated by the protected `apple-signing`
+   environment, with `contents: read` and explicit `id-token: none`. It does
    not check out the repository or run dependency installation/postinstall
    scripts. It downloads the prepared artifact, verifies its SHA-256 digest,
-   expands it, and runs `apps/desktop/scripts/release.mjs --sign-stage-only`
+   expands it, and runs `apps/desktop/scripts/release.mjs --sign-stage-only
+   --no-publish`
    with the environment-scoped Apple secrets.
 3. `Package Linux DEB`, running on native Ubuntu x64 and arm64 GitHub-hosted
    runners. Each job runs `apps/desktop/scripts/release.mjs --linux
@@ -146,12 +147,13 @@ seven job definitions (the Linux package job fans out across two architectures):
    verifier resolves from the staged toolchain, not the workspace. The Azure
    service-principal secrets are injected only into this signing-aware packaging
    step.
-6. `Publish Linux DEB artifacts`, which waits for the macOS publish job so the
-   GitHub Release exists, combines both Linux architecture artifacts, generates
-   `SHA256SUMS`, and uploads the `.deb` files plus checksums to the same
-   release.
-7. `Publish release notes`, which waits for successful macOS and Linux release
-   asset publishing, extracts the matching `CHANGELOG.md` section, updates the
+6. `Publish release assets`, which waits for successful macOS signing, both
+   Linux packages, and the signed Windows installer. Only then does it create
+   the GitHub Release (as `Pre-release` for prerelease tags and normal/Latest
+   for stable tags), upload every platform's assets, and generate Linux
+   `SHA256SUMS`.
+7. `Publish release notes`, which waits for successful all-platform asset
+   publishing, extracts the matching `CHANGELOG.md` section, updates the
    GitHub Release body, and fails the workflow if the body still reads back as
    empty.
 
@@ -174,15 +176,20 @@ The macOS environment-gated signing job:
    package version: versions with a prerelease suffix such as `-beta.41` are
    born as GitHub `Pre-release`, while stable versions are born as normal
    releases.
-4. Runs `electron-builder --mac --universal --publish always` from the
+4. Runs `electron-builder --mac --universal --publish never` from the
    downloaded artifact, without invoking `pnpm install`, `npx`, or dependency
    lifecycle scripts. `electron-builder` signs every
    helper bundle individually, signs the main `.app`, submits to Apple's
    notarization service via `notarytool`, staples the ticket, builds the DMG
-   and universal updater ZIP, generates `latest-mac.yml`, and uploads
-   everything to a GitHub Release on `pwrdrvr/PwrAgent`.
-5. Uploads the stable-name `PwrAgent.dmg` alias for landing-page download
-   links.
+   and universal updater ZIP, and generates `latest-mac.yml` without creating
+   a GitHub Release.
+5. Prepares the stable-name `PwrAgent.dmg` alias and transfers the signed
+   macOS assets to the all-platform publishing job.
+
+The all-platform publishing job creates the GitHub Release only after the
+signed macOS, Windows, and Linux payloads are all available. It uploads the
+signed Windows installer alongside the macOS and Linux assets; a failed or
+unapproved Windows signing job therefore cannot leave a partial public release.
 
 The Windows jobs use the same trust boundary with a platform-specific final
 step. The no-secret job prepares the stage on Windows, because its native
@@ -197,16 +204,16 @@ coverage.
 
 Cycle time target: ≤ 12 minutes.
 
-Do not approve the `apple-signing` environment unless the tag, commit, and
-metadata are the intended release. Do not create the GitHub Release manually
-before the build succeeds. A manually created release appears before
-signing/notarization finishes. The current flow lets electron-builder create or
-update the release from the successful CI build, then the workflow replaces the
-generated/empty notes with the matching `CHANGELOG.md` content after release
-assets are published. The release is not complete at the `apple-signing`
+Do not approve the `apple-signing` or `windows-signing` environment unless the
+tag, commit, and metadata are the intended release. Do not create the GitHub
+Release manually before the build succeeds. A manually created release appears
+before all required platform builds have completed. The workflow creates the
+release only after it has received the signed macOS and Windows payloads plus
+both Linux packages, then the release-notes job verifies and writes the
+matching `CHANGELOG.md` content. The release is not complete at either signing
 approval gate: after approval, continue watching the run through `Publish
 release notes`, then verify the final GitHub Release body is non-empty. If a
-monitor or handoff stops at the approval gate, resume after approval rather than
+monitor or handoff stops at an approval gate, resume after approval rather than
 treating the release as done.
 Prerelease-tagged versions such as `v1.0.0-beta.41` must be born as GitHub
 `Pre-release`, not edited afterward. Stable versions such as `v1.0.0` are born

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -151,7 +151,8 @@ seven job definitions (the Linux package job fans out across two architectures):
    Linux packages, and the signed Windows installer. Only then does it create
    the GitHub Release (as `Pre-release` for prerelease tags and normal/Latest
    for stable tags), upload every platform's assets, and generate Linux
-   `SHA256SUMS`.
+   `SHA256SUMS`. The Windows package checksum manifest is uploaded as
+   `PwrAgent-windows-SHA256SUMS` so GitHub Release assets have unique names.
 7. `Publish release notes`, which waits for successful all-platform asset
    publishing, extracts the matching `CHANGELOG.md` section, updates the
    GitHub Release body, and fails the workflow if the body still reads back as

--- a/scripts/check-desktop-release-metadata.mjs
+++ b/scripts/check-desktop-release-metadata.mjs
@@ -405,12 +405,14 @@ for (const expected of [
   "Checkout repository",
   "Download macOS release artifacts",
   "Download Windows installer artifact",
+  "Name Windows checksum manifest",
   "Create release and publish all platform assets",
   "gh release create",
   "--verify-tag",
   "--prerelease",
   "--latest",
   "windows-dist/*",
+  "PwrAgent-windows-SHA256SUMS",
 ]) {
   assertWorkflowJobContainsText(
     releaseWorkflow,
@@ -419,6 +421,13 @@ for (const expected of [
     expected,
   );
 }
+assertWorkflowJobOrdersText(
+  releaseWorkflow,
+  ".github/workflows/release.yml",
+  "publish-release-assets",
+  "Name Windows checksum manifest",
+  "Create release and publish all platform assets",
+);
 assertWorkflowJobContainsText(
   releaseWorkflow,
   ".github/workflows/release.yml",

--- a/scripts/check-desktop-release-metadata.mjs
+++ b/scripts/check-desktop-release-metadata.mjs
@@ -300,7 +300,7 @@ for (const unexpected of [
 for (const expected of [
   "ubuntu-24.04-arm",
   "Package Linux DEB",
-  "Publish Linux DEB artifacts",
+  "Publish release assets",
   "Publish release notes",
   "scripts/extract-release-notes.mjs",
   "--notes-file",
@@ -308,6 +308,7 @@ for (const expected of [
   "PWRAGENT_LINUX_ARCH",
   "SHA256SUMS",
   "windows-release-signing-input",
+  "windows-installer",
   "EXPECTED_SHA256",
   "scripts/release/install-trusted-signing.ps1",
   "--win --sign-stage-only --no-publish --require-signing",
@@ -375,6 +376,55 @@ for (const expected of [
     expected,
   );
 }
+for (const expected of [
+  "--sign-stage-only --no-publish",
+  "Upload macOS release assets",
+]) {
+  assertWorkflowJobContainsText(
+    releaseWorkflow,
+    ".github/workflows/release.yml",
+    "sign",
+    expected,
+  );
+}
+for (const unexpected of [
+  "gh release upload",
+  "continue-on-error: true",
+]) {
+  assertWorkflowJobExcludesText(
+    releaseWorkflow,
+    ".github/workflows/release.yml",
+    "sign",
+    unexpected,
+  );
+}
+for (const expected of [
+  "linux-package",
+  "sign",
+  "windows-sign",
+  "Checkout repository",
+  "Download macOS release artifacts",
+  "Download Windows installer artifact",
+  "Create release and publish all platform assets",
+  "gh release create",
+  "--verify-tag",
+  "--prerelease",
+  "--latest",
+  "windows-dist/*",
+]) {
+  assertWorkflowJobContainsText(
+    releaseWorkflow,
+    ".github/workflows/release.yml",
+    "publish-release-assets",
+    expected,
+  );
+}
+assertWorkflowJobContainsText(
+  releaseWorkflow,
+  ".github/workflows/release.yml",
+  "publish-release-notes",
+  "publish-release-assets",
+);
 for (const unexpected of [
   "actions/checkout@",
   "configure-nodejs@",
@@ -456,8 +506,7 @@ for (const expected of [
   }
 }
 for (const stepName of [
-  "Upload release artifacts (debug retention)",
-  "Upload Linux artifacts (debug retention)",
+  "Upload assembled release artifacts (debug retention)",
 ]) {
   assertWorkflowStepContinuesOnError(
     releaseWorkflow,


### PR DESCRIPTION
## Summary

- I forward-ported the release-publication gate from `releases/1.0` to `main`.
- I keep macOS signing/notarization inside the protected `apple-signing` environment, but prevent it from creating or publishing a GitHub Release.
- I publish the GitHub Release only after signed macOS, both Linux DEB packages, and signed Windows packaging succeed; the publish job uploads all platform assets and checksums before release notes verify a nonempty body.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML parsed"'`
- `RELEASE_TAG=v1.1.0-beta.1 pnpm release:check`
- `pnpm lint:eslint` (passed with 34 pre-existing warnings and no errors)

## Notes

- I preserved the protected `apple-signing` and `windows-signing` approval gates and did not create a release, approve an environment, change version metadata, or modify a tag.
- I retained `main`'s newer `pwrdrvr/configure-nodejs@v1.2.0` setup while applying the maintenance branch's release-publication behavior.
