### PR TITLE
fix(messaging): backport serialized status renders

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5318,6 +5318,100 @@ describe("MessagingController", () => {
     });
   });
 
+  it("reuses one status surface when initial and automatic renders race", async () => {
+    const statusIntents: Array<
+      Extract<MessagingSurfaceIntent, { kind: "status" }>
+    > = [];
+    let resolveFirstStatusDeliveryStarted: (() => void) | undefined;
+    const firstStatusDeliveryStarted = new Promise<void>((resolve) => {
+      resolveFirstStatusDeliveryStarted = resolve;
+    });
+    let firstStatusDelivery = true;
+    const harness = await createHarness({
+      deliver: async (intent) => {
+        if (intent.kind !== "status") {
+          return {
+            channel: "slack",
+            deliveredAt: 1000,
+            outcome: "presented",
+          };
+        }
+        statusIntents.push(intent);
+        if (firstStatusDelivery) {
+          firstStatusDelivery = false;
+          resolveFirstStatusDeliveryStarted?.();
+          await new Promise<void>((resolve) => setTimeout(resolve, 50));
+        }
+        const surface = intent.targetSurface ?? {
+          channel: "slack" as const,
+          id: "status-surface-1",
+        };
+        return {
+          channel: "slack",
+          deliveredAt: 1000,
+          outcome: intent.targetSurface ? "updated" as const : "presented" as const,
+          surface,
+        };
+      },
+    });
+    const event = buildTextEvent("delegate this", {
+      channel: {
+        channel: "slack",
+        conversation: {
+          id: "1786469165.289979",
+          kind: "thread",
+          parentId: "C05RKSBL1QF",
+          parentTitle: "giphy-services",
+        },
+      },
+    });
+    await harness.store.upsertBinding({
+      id: "binding:slack:thread:1786469165.289979:C05RKSBL1QF:codex:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: event.channel,
+      createdAt: 1000,
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+
+    const initialStatus = harness.controller.handleInboundEvent({
+      ...buildCommandEvent("/status"),
+      channel: event.channel,
+    });
+    await firstStatusDeliveryStarted;
+    await Promise.all([
+      initialStatus,
+      ...[
+        "Renamed title",
+        "Final title",
+      ].map(async (threadName) => {
+        await harness.controller.handleBackendEvent({
+          backend: "codex",
+          notification: {
+            method: "thread/name/updated",
+            params: {
+              threadId: "thread-1",
+              threadName,
+            },
+          },
+        });
+      }),
+    ]);
+
+    expect(statusIntents.map((intent) => intent.delivery?.mode)).toEqual([
+      "present",
+      "update",
+      "update",
+    ]);
+    expect(statusIntents.map((intent) => intent.targetSurface?.id)).toEqual([
+      undefined,
+      "status-surface-1",
+      "status-surface-1",
+    ]);
+  });
+
   it("refreshes the status card when a bound thread is renamed", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -147,6 +147,7 @@ import {
 } from "./messaging-markdown-file-attachment-selector.js";
 import { buildMessagingAuditContext } from "./messaging-audit.js";
 import { getMainLogger } from "../../log.js";
+import { PerKeyAsyncLock } from "../../util/per-key-async-lock.js";
 import { DeterministicInteractionMapper } from "./deterministic-interaction-mapper.js";
 import { actionsForIntent } from "./deterministic-interaction-mapper.js";
 import { parseReviewCommand } from "../../../shared/review-command.js";
@@ -633,6 +634,7 @@ export type MessagingControllerOptions = {
 export class MessagingController {
   private readonly authorizedActorIds: Set<string>;
   private readonly capabilityProfile: MessagingCapabilityProfile;
+  private readonly statusRenderLock = new PerKeyAsyncLock();
   private readonly deliveredAssistantMessageKeys = new Set<string>();
   private readonly assistantStreamBuffers = new Map<string, AssistantStreamBuffer>();
   private readonly assistantStreamDeliveryQueues = new Map<string, Promise<void>>();
@@ -11264,6 +11266,24 @@ export class MessagingController {
   }
 
   private async renderBindingStatus(
+    binding: MessagingBindingRecord,
+    event?: MessagingInboundEvent,
+    navigation?: NavigationSnapshot,
+  ): Promise<MessagingBindingRecord> {
+    return await this.statusRenderLock.run(binding.id, async () => {
+      const latestBinding = await this.options.store.getBinding(binding.id);
+      if (latestBinding?.revokedAt) {
+        return latestBinding;
+      }
+      return await this.renderBindingStatusUnlocked(
+        latestBinding ?? binding,
+        event,
+        navigation,
+      );
+    });
+  }
+
+  private async renderBindingStatusUnlocked(
     binding: MessagingBindingRecord,
     event?: MessagingInboundEvent,
     navigation?: NavigationSnapshot,


### PR DESCRIPTION
## Summary

- serialize status rendering independently for each messaging binding
- re-read the latest persisted binding before every queued render
- make automatic thread-name and lifecycle refreshes update the first created status surface instead of presenting duplicate cards
- add a timing-controlled regression for the initial-status/thread-name race

## Root cause

A newly attached messaging thread could start its initial status-card delivery while automatic backend events triggered additional renders. The renders ran concurrently, each read a binding without a status surface, and each emitted a present intent. Slack could therefore post multiple status cards.

## Backport provenance

- Original PR: #1501
- Original squash commit: 24d46479c58524fbbd06eb69b6b72de9144c0af3
- Target: releases/1.0
- Backport commit: 9b0271519

This is a manual two-file adaptation for release-line drift. The 1.0 test fixture omits two later Slack conversation metadata fields that are not part of its older shared messaging contract; runtime behavior is unchanged.

## Migration audit

- no SQLite schema or DDL changes
- CURRENT_STATE_DB_USER_VERSION remains 32
- no configuration migration

## Validation

- pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts — 305 passed
- pnpm typecheck
- pnpm lint:eslint — 0 errors; existing warnings only
- pnpm lint:boundaries
- pnpm lint:codex-storage
- git diff --check