### PR TITLE
fix(messaging): backport Slack mention detection

### DIFF
--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -1178,6 +1178,78 @@ describe("SlackAdapter", () => {
     ]);
   });
 
+  it("routes app mentions that appear after other message content", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "app_mention",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        ts: "1712023032.123456",
+        user: "U012ABCDEF0",
+        text: ":thread: <@U0BOTUSERID> attach the search thread",
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        kind: "text",
+        botMention: true,
+        text: ":thread: attach the search thread",
+      }),
+    ]);
+  });
+
+  it("preserves line breaks around a mid-message app mention", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "app_mention",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        ts: "1712023032.123456",
+        user: "U012ABCDEF0",
+        text: "context:\n<@U0BOTUSERID> explain this",
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        kind: "text",
+        botMention: true,
+        text: "context:\nexplain this",
+      }),
+    ]);
+  });
+
   it("routes bare leading app mentions as the help command", async () => {
     const socket = fakeSocket();
     const adapter = new SlackAdapter({
@@ -1300,7 +1372,7 @@ describe("SlackAdapter", () => {
     ]);
   });
 
-  it("deduplicates app_mention and message events for the same Slack post", async () => {
+  it("preserves mention detection when message arrives before app_mention", async () => {
     const socket = fakeSocket();
     const adapter = new SlackAdapter({
       config: baseConfig,
@@ -1319,16 +1391,9 @@ describe("SlackAdapter", () => {
       team: "T012ABCDEF0",
       ts: "1712023032.123456",
       user: "U012ABCDEF0",
-      text: "<@U0BOTUSERID> help",
+      text: "show `<@U0BOTUSERID>` literally, then <@U0BOTUSERID> help",
     };
 
-    await socket.emitEvent("slack_event", {
-      ack: async () => undefined,
-      event: {
-        ...event,
-        type: "app_mention",
-      },
-    });
     await socket.emitEvent("slack_event", {
       ack: async () => undefined,
       event: {
@@ -1336,14 +1401,57 @@ describe("SlackAdapter", () => {
         type: "message",
       },
     });
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        ...event,
+        type: "app_mention",
+      },
+    });
 
     expect(events).toEqual([
       expect.objectContaining({
         kind: "text",
         botMention: true,
-        text: "help",
+        text: "show `<@U0BOTUSERID>` literally, then help",
       }),
     ]);
+  });
+
+  it.each([
+    ["inline", "show `<@U0BOTUSERID>` literally"],
+    ["fenced", "```\n<@U0BOTUSERID>\n```"],
+  ])("does not treat bot tokens in %s code as mentions", async (_kind, text) => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: { ...baseConfig, responseMode: "mention_only" },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "message",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        ts: "1712023032.123456",
+        user: "U012ABCDEF0",
+        text,
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({ kind: "text", text }),
+    ]);
+    expect(events[0]).not.toHaveProperty("botMention");
   });
 
   it("strips the configured prefix from Slack slash commands", async () => {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -831,7 +831,10 @@ export class SlackAdapter implements SlackProviderAdapter {
     });
     const rawText = event.text ?? "";
     const strippedText = stripBotMention(rawText, this.botUserId);
-    const isMention = strippedText !== rawText;
+    // Slack's app_mention event is the authoritative addressed-to-us signal.
+    // Also inspect message text because Slack can deliver the same post as both
+    // app_mention and message, and either copy may win our deduplication race.
+    const isMention = event.type === "app_mention" || strippedText !== rawText;
     const text = strippedText.trim();
     const isPairingMessage = Boolean(extractMessagingPairingToken(rawText));
     const command = isMention && text.length === 0
@@ -2301,7 +2304,44 @@ function slackConversationUrl(channelId: string, teamId?: string): string {
 
 export function stripBotMention(text: string, botUserId: string | undefined): string {
   if (!botUserId) return text;
-  return text.replace(new RegExp(`^\\s*<@${escapeRegex(botUserId)}>\\s*`), "");
+  const mention = `<@${botUserId}>`;
+  const mentionIndex = findSlackMentionOutsideCode(text, mention);
+  if (mentionIndex < 0) return text;
+
+  const before = text.slice(0, mentionIndex);
+  const after = text.slice(mentionIndex + mention.length);
+  const trailingWhitespace = before.match(/[ \t]+$/u)?.[0] ?? "";
+  const leadingWhitespace = after.match(/^[ \t]+/u)?.[0] ?? "";
+  const prefix = before.slice(0, before.length - trailingWhitespace.length);
+  const suffix = after.slice(leadingWhitespace.length);
+  const prefixEndsLine = prefix.length === 0 || /[\r\n]$/u.test(prefix);
+  const suffixStartsLine = suffix.length === 0 || /^[\r\n]/u.test(suffix);
+  const needsSpace = !prefixEndsLine
+    && !suffixStartsLine
+    && Boolean(trailingWhitespace || leadingWhitespace);
+  return `${prefix}${needsSpace ? " " : ""}${suffix}`;
+}
+
+function findSlackMentionOutsideCode(text: string, mention: string): number {
+  let inFencedCode = false;
+  let inInlineCode = false;
+  for (let index = 0; index < text.length;) {
+    if (!inInlineCode && text.startsWith("```", index)) {
+      inFencedCode = !inFencedCode;
+      index += 3;
+      continue;
+    }
+    if (!inFencedCode && text[index] === "`") {
+      inInlineCode = !inInlineCode;
+      index += 1;
+      continue;
+    }
+    if (!inFencedCode && !inInlineCode && text.startsWith(mention, index)) {
+      return index;
+    }
+    index += 1;
+  }
+  return -1;
 }
 
 function parseCommand(text: string): { command: string; args: string[] } | undefined {
@@ -2609,8 +2649,4 @@ function safeEqual(left: string, right: string): boolean {
   const rightBuffer = Buffer.from(right);
   return leftBuffer.byteLength === rightBuffer.byteLength
     && timingSafeEqual(leftBuffer, rightBuffer);
-}
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }


### PR DESCRIPTION
## Summary

- treat Slack `app_mention` as an authoritative addressed-to-bot signal
- recognize the exact `<@BOT_USER_ID>` token anywhere outside inline or fenced code
- remove the mention without collapsing surrounding line breaks
- preserve mention classification when Slack's duplicate `message` event arrives before `app_mention`

## Backport provenance

Manual backport of source PR #1460, squash commit `f143c18d32698467e5c71e02252bfb97fd06d97d`, onto `releases/1.0`.

The source patch applied as the same stable patch ID while retaining the older release branch's Slack implementation. It does not depend on backport PR #1527 and does not include any of #1527's changes.

## Root cause and impact

The release adapter inferred `botMention` only when a bot token was stripped from the start of the text. Slack emits `app_mention` for a mention anywhere, but duplicate `message` / `app_mention` delivery meant the first event could incorrectly win deduplication. Mention-only bindings now receive mid-message mentions with clean forwarded text.

## Migration audit

No DB or config change is required. `CURRENT_STATE_DB_USER_VERSION` remains 32; this PR adds no DDL or schema migration.

## Validation

- `pnpm test packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts` — 57 passed
- `pnpm --filter @pwragent/messaging-provider-slack typecheck`
- `pnpm lint` — SQL, Codex-storage, color, license, ESLint, workspace typecheck, and dependency boundaries passed (existing warning baseline only)
- `git diff --check`
