### PR TITLE
fix(desktop): backport ACP launch selection

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -2371,6 +2371,167 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
+  it("keeps non-loadable sessions on their owner while new sessions use a replacement client", async () => {
+    const backendId = "acp:kimi" as AcpBackendId;
+    const firstAgent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      activeCommand: "/path/kimi",
+      launchDescriptor: {
+        backendId,
+        registryId: "kimi",
+        distributionKind: "local",
+        command: "/path/kimi",
+        args: ["acp"],
+        env: {},
+      },
+    };
+    const overrideAgent: AcpInstalledAgentRecord = {
+      ...firstAgent,
+      activeCommand: "/override/kimi",
+      launchDescriptor: {
+        ...firstAgent.launchDescriptor!,
+        command: "/override/kimi",
+      },
+    };
+    let discovered = firstAgent;
+    const firstDispose = vi.fn(async () => undefined);
+    const firstClient = {
+      dispose: firstDispose,
+      hasActiveOperations: () => false,
+      hasActiveTurns: () => false,
+      hasRetainableSessions: () => true,
+      initialize: vi.fn(async () => undefined),
+      ownsSession: (sessionId: string) => sessionId === "session-1",
+      supportsSessionLoad: () => false,
+    };
+    const secondOwnedSessions = new Set<string>();
+    const secondDispose = vi.fn(async () => undefined);
+    const secondClient = {
+      dispose: secondDispose,
+      hasActiveOperations: () => false,
+      hasActiveTurns: () => false,
+      hasRetainableSessions: () => secondOwnedSessions.size > 0,
+      initialize: vi.fn(async () => undefined),
+      ownsSession: (sessionId: string) => secondOwnedSessions.has(sessionId),
+      supportsSessionLoad: () => false,
+      startSession: vi.fn(async () => {
+        secondOwnedSessions.add("session-2");
+        return { sessionId: "session-2" };
+      }),
+    };
+    const createAcpClient = vi
+      .fn()
+      .mockReturnValueOnce(firstClient)
+      .mockReturnValueOnce(secondClient);
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: null,
+      captureStores: [],
+      createAcpClient: createAcpClient as never,
+      discoverLocalAcpAgents: async () => [discovered],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    discovered = overrideAgent;
+    adapter.invalidateLocalAgentDiscovery();
+
+    await expect(
+      adapter.getClientForSession(backendId, "session-1"),
+    ).resolves.toBe(firstClient);
+    expect(firstDispose).not.toHaveBeenCalled();
+    await expect(adapter.getClient(backendId)).resolves.toBe(secondClient);
+    expect(createAcpClient).toHaveBeenNthCalledWith(2, overrideAgent);
+
+    await secondClient.startSession();
+    await expect(
+      adapter.getClientForSession(backendId, "session-2"),
+    ).resolves.toBe(secondClient);
+
+    await adapter.close();
+    await adapter.close();
+    expect(firstDispose).toHaveBeenCalledOnce();
+    expect(secondDispose).toHaveBeenCalledOnce();
+  });
+
+  it("replaces the owner of a loadable session after launch identity changes", async () => {
+    const backendId = "acp:gemini" as AcpBackendId;
+    const firstAgent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      activeCommand: "/path/gemini",
+      launchDescriptor: {
+        backendId,
+        registryId: "gemini",
+        distributionKind: "local",
+        command: "/path/gemini",
+        args: ["--acp", "--skip-trust"],
+        env: {},
+      },
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        agentCapabilities: {
+          loadSession: true,
+        },
+      },
+    };
+    const overrideAgent: AcpInstalledAgentRecord = {
+      ...firstAgent,
+      activeCommand: "/override/gemini",
+      launchDescriptor: {
+        ...firstAgent.launchDescriptor!,
+        command: "/override/gemini",
+      },
+    };
+    let discovered = firstAgent;
+    const firstDispose = vi.fn(async () => undefined);
+    const firstClient = {
+      dispose: firstDispose,
+      hasActiveOperations: () => false,
+      hasActiveTurns: () => false,
+      hasRetainableSessions: () => true,
+      initialize: vi.fn(async () => undefined),
+      ownsSession: (sessionId: string) => sessionId === "session-1",
+      supportsSessionLoad: () => true,
+    };
+    const secondDispose = vi.fn(async () => undefined);
+    const secondClient = {
+      dispose: secondDispose,
+      hasActiveOperations: () => false,
+      hasActiveTurns: () => false,
+      hasRetainableSessions: () => false,
+      initialize: vi.fn(async () => undefined),
+      ownsSession: () => false,
+      supportsSessionLoad: () => true,
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: null,
+      captureStores: [],
+      createAcpClient: vi
+        .fn()
+        .mockReturnValueOnce(firstClient)
+        .mockReturnValueOnce(secondClient) as never,
+      discoverLocalAcpAgents: async () => [discovered],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    discovered = overrideAgent;
+    adapter.invalidateLocalAgentDiscovery();
+
+    await expect(
+      adapter.getClientForSession(backendId, "session-1"),
+    ).resolves.toBe(secondClient);
+    expect(firstDispose).toHaveBeenCalledOnce();
+
+    await adapter.close();
+    expect(secondDispose).toHaveBeenCalledOnce();
+  });
+
   it("keeps a stale client alive until its active turn finishes", async () => {
     const backendId = "acp:gemini" as AcpBackendId;
     const firstAgent: AcpInstalledAgentRecord = {

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -2442,6 +2442,227 @@ describe("AcpBackendAdapter", () => {
     expect(secondDispose).toHaveBeenCalledOnce();
   });
 
+  it("keeps a stale client alive until its non-turn RPCs finish", async () => {
+    const backendId = "acp:gemini" as AcpBackendId;
+    const firstAgent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      activeCommand: "/path/gemini",
+      launchDescriptor: {
+        backendId,
+        registryId: "gemini",
+        distributionKind: "local",
+        command: "/path/gemini",
+        args: ["--acp", "--skip-trust"],
+        env: {},
+      },
+    };
+    const overrideAgent: AcpInstalledAgentRecord = {
+      ...firstAgent,
+      activeCommand: "/override/gemini",
+      launchDescriptor: {
+        ...firstAgent.launchDescriptor!,
+        command: "/override/gemini",
+      },
+    };
+    let discovered = firstAgent;
+    let activeOperations = 0;
+    let finishSession!: () => void;
+    let finishRuntimeOption!: () => void;
+    const firstDispose = vi.fn(async () => undefined);
+    const firstClient = {
+      dispose: firstDispose,
+      hasActiveOperations: () => activeOperations > 0,
+      hasActiveTurns: () => false,
+      initialize: vi.fn(async () => undefined),
+      startSession: vi.fn(() => {
+        activeOperations += 1;
+        return new Promise<void>((resolve) => {
+          finishSession = resolve;
+        }).finally(() => {
+          activeOperations -= 1;
+        });
+      }),
+      setRuntimeOption: vi.fn(() => {
+        activeOperations += 1;
+        return new Promise<void>((resolve) => {
+          finishRuntimeOption = resolve;
+        }).finally(() => {
+          activeOperations -= 1;
+        });
+      }),
+    };
+    const secondClient = {
+      dispose: vi.fn(async () => undefined),
+      hasActiveOperations: () => false,
+      hasActiveTurns: () => false,
+      initialize: vi.fn(async () => undefined),
+    };
+    const createAcpClient = vi
+      .fn()
+      .mockReturnValueOnce(firstClient)
+      .mockReturnValueOnce(secondClient);
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: null,
+      captureStores: [],
+      createAcpClient: createAcpClient as never,
+      discoverLocalAcpAgents: async () => [discovered],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    const session = firstClient.startSession();
+    const runtimeOption = firstClient.setRuntimeOption();
+    discovered = overrideAgent;
+    adapter.invalidateLocalAgentDiscovery();
+
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    expect(firstDispose).not.toHaveBeenCalled();
+
+    finishSession();
+    await session;
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    expect(firstDispose).not.toHaveBeenCalled();
+
+    finishRuntimeOption();
+    await runtimeOption;
+    await expect(adapter.getClient(backendId)).resolves.toBe(secondClient);
+    expect(firstDispose).toHaveBeenCalledOnce();
+
+    await adapter.close();
+  });
+
+  it("restarts invalidated discovery before returning or persisting results", async () => {
+    const staleAgent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      activeCommand: "/stale/gemini",
+      launchDescriptor: {
+        backendId: "acp:gemini" as AcpBackendId,
+        registryId: "gemini",
+        distributionKind: "local",
+        command: "/stale/gemini",
+        args: ["--acp", "--skip-trust"],
+        env: {},
+      },
+    };
+    const currentAgent: AcpInstalledAgentRecord = {
+      ...staleAgent,
+      activeCommand: "/current/gemini",
+      launchDescriptor: {
+        ...staleAgent.launchDescriptor!,
+        command: "/current/gemini",
+      },
+    };
+    const discoveries: Array<{
+      resolve: (agents: AcpInstalledAgentRecord[]) => void;
+      promise: Promise<AcpInstalledAgentRecord[]>;
+    }> = [];
+    const discoverLocalAcpAgents = vi.fn(() => {
+      let resolve!: (agents: AcpInstalledAgentRecord[]) => void;
+      const promise = new Promise<AcpInstalledAgentRecord[]>((done) => {
+        resolve = done;
+      });
+      discoveries.push({ promise, resolve });
+      return promise;
+    });
+    const upsertInstalledAgent = vi.fn();
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => undefined,
+        listInstalledAgents: () => [],
+        upsertInstalledAgent,
+      },
+      captureStores: [],
+      discoverLocalAcpAgents,
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    const preInvalidationListing = adapter.listAvailableAgents();
+    await vi.waitFor(() => expect(discoveries).toHaveLength(1));
+    adapter.invalidateLocalAgentDiscovery();
+    const postInvalidationListing = adapter.listAvailableAgents();
+    await vi.waitFor(() => expect(discoveries).toHaveLength(2));
+
+    discoveries[0]!.resolve([staleAgent]);
+    await Promise.resolve();
+    expect(upsertInstalledAgent).not.toHaveBeenCalled();
+
+    discoveries[1]!.resolve([currentAgent]);
+    await expect(preInvalidationListing).resolves.toEqual([currentAgent]);
+    await expect(postInvalidationListing).resolves.toEqual([currentAgent]);
+    expect(upsertInstalledAgent).toHaveBeenCalled();
+    expect(upsertInstalledAgent).not.toHaveBeenCalledWith(staleAgent);
+    for (const [persisted] of upsertInstalledAgent.mock.calls) {
+      expect(persisted).toEqual(currentAgent);
+    }
+
+    await adapter.close();
+  });
+
+  it("rechecks discovery after invalidation queued behind its completion", async () => {
+    const staleAgent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      activeCommand: "/stale/gemini",
+      launchDescriptor: {
+        backendId: "acp:gemini" as AcpBackendId,
+        registryId: "gemini",
+        distributionKind: "local",
+        command: "/stale/gemini",
+        args: ["--acp", "--skip-trust"],
+        env: {},
+      },
+    };
+    const currentAgent: AcpInstalledAgentRecord = {
+      ...staleAgent,
+      activeCommand: "/current/gemini",
+      launchDescriptor: {
+        ...staleAgent.launchDescriptor!,
+        command: "/current/gemini",
+      },
+    };
+    const discoveries: Array<{
+      resolve: (agents: AcpInstalledAgentRecord[]) => void;
+      promise: Promise<AcpInstalledAgentRecord[]>;
+    }> = [];
+    const discoverLocalAcpAgents = vi.fn(() => {
+      let resolve!: (agents: AcpInstalledAgentRecord[]) => void;
+      const promise = new Promise<AcpInstalledAgentRecord[]>((done) => {
+        resolve = done;
+      });
+      discoveries.push({ promise, resolve });
+      return promise;
+    });
+    const upsertInstalledAgent = vi.fn();
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => undefined,
+        listInstalledAgents: () => [],
+        upsertInstalledAgent,
+      },
+      captureStores: [],
+      discoverLocalAcpAgents,
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    const listing = adapter.listAvailableAgents();
+    await vi.waitFor(() => expect(discoveries).toHaveLength(1));
+    discoveries[0]!.resolve([staleAgent]);
+    await Promise.resolve();
+    queueMicrotask(() => adapter.invalidateLocalAgentDiscovery());
+
+    await vi.waitFor(() => expect(discoveries).toHaveLength(2));
+    expect(upsertInstalledAgent).not.toHaveBeenCalled();
+    discoveries[1]!.resolve([currentAgent]);
+
+    await expect(listing).resolves.toEqual([currentAgent]);
+    expect(upsertInstalledAgent).toHaveBeenCalledOnce();
+    expect(upsertInstalledAgent).toHaveBeenCalledWith(currentAgent);
+
+    await adapter.close();
+  });
+
   it("merges discovery with agent metadata written while discovery was pending", async () => {
     const backendId = "acp:gemini" as AcpBackendId;
     const launchDescriptor = {

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -2371,6 +2371,161 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
+  it("keeps a stale client alive until its active turn finishes", async () => {
+    const backendId = "acp:gemini" as AcpBackendId;
+    const firstAgent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      version: "1.0.0",
+      activeCommand: "/path/gemini",
+      launchDescriptor: {
+        backendId,
+        registryId: "gemini",
+        distributionKind: "local",
+        command: "/path/gemini",
+        args: ["--acp", "--skip-trust"],
+        env: {},
+      },
+    };
+    const overrideAgent: AcpInstalledAgentRecord = {
+      ...firstAgent,
+      activeCommand: "/override/gemini",
+      launchDescriptor: {
+        ...firstAgent.launchDescriptor!,
+        command: "/override/gemini",
+      },
+    };
+    let discovered = firstAgent;
+    let active = true;
+    const firstDispose = vi.fn(async () => undefined);
+    const secondDispose = vi.fn(async () => undefined);
+    const firstClient = {
+      dispose: firstDispose,
+      hasActiveTurns: () => active,
+      initialize: vi.fn(async () => undefined),
+    };
+    const secondClient = {
+      dispose: secondDispose,
+      hasActiveTurns: () => false,
+      initialize: vi.fn(async () => undefined),
+    };
+    const createAcpClient = vi
+      .fn()
+      .mockReturnValueOnce(firstClient)
+      .mockReturnValueOnce(secondClient);
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => firstAgent,
+        listInstalledAgents: () => [firstAgent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      captureStores: [],
+      createAcpClient: createAcpClient as never,
+      discoverLocalAcpAgents: async () => [discovered],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    discovered = overrideAgent;
+    adapter.invalidateLocalAgentDiscovery();
+
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    expect(firstDispose).not.toHaveBeenCalled();
+    expect(createAcpClient).toHaveBeenCalledOnce();
+
+    active = false;
+    await expect(adapter.getClient(backendId)).resolves.toBe(secondClient);
+    expect(firstDispose).toHaveBeenCalledOnce();
+    expect(createAcpClient).toHaveBeenCalledTimes(2);
+
+    await adapter.close();
+    expect(secondDispose).toHaveBeenCalledOnce();
+  });
+
+  it("merges discovery with agent metadata written while discovery was pending", async () => {
+    const backendId = "acp:gemini" as AcpBackendId;
+    const launchDescriptor = {
+      backendId,
+      registryId: "gemini",
+      distributionKind: "local" as const,
+      command: "/path/gemini",
+      args: ["--acp", "--skip-trust"],
+      env: {},
+    };
+    const discovered: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      version: "1.0.0",
+      activeCommand: launchDescriptor.command,
+      launchDescriptor,
+      updatedAt: 2000,
+    };
+    let cached: AcpInstalledAgentRecord = {
+      ...discovered,
+      updatedAt: 1000,
+    };
+    let finishDiscovery:
+      | ((agents: AcpInstalledAgentRecord[]) => void)
+      | undefined;
+    const upsertInstalledAgent = vi.fn((record: AcpInstalledAgentRecord) => {
+      cached = record;
+    });
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => cached,
+        listInstalledAgents: () => [cached],
+        upsertInstalledAgent,
+      },
+      captureStores: [],
+      discoverLocalAcpAgents: () =>
+        new Promise((resolve) => {
+          finishDiscovery = resolve;
+        }),
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    const listing = adapter.listAvailableAgents();
+    await vi.waitFor(() => expect(finishDiscovery).toBeDefined());
+    cached = {
+      ...cached,
+      updatedAt: 4000,
+      lastDiscoveredAt: 4000,
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        checkedAt: 4000,
+        models: {
+          currentModelId: "gemini-2.5-pro",
+          availableModels: [
+            { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+          ],
+        },
+      },
+      update: {
+        status: "up-to-date",
+        checkedAt: 4000,
+        currentVersion: "1.0.0",
+      },
+      updateCommand: launchDescriptor.command,
+    };
+    finishDiscovery?.([discovered]);
+
+    await expect(listing).resolves.toEqual([
+      expect.objectContaining({
+        updatedAt: 4000,
+        lastDiscoveredAt: 4000,
+        runtimeCapabilities: cached.runtimeCapabilities,
+        update: cached.update,
+        updateCommand: launchDescriptor.command,
+      }),
+    ]);
+    expect(upsertInstalledAgent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ updatedAt: 2000 }),
+    );
+
+    await adapter.close();
+  });
+
   it("bounds close while ACP initialization is pending", async () => {
     vi.useFakeTimers();
     try {

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -75,6 +75,8 @@ describe("AcpAgentClient", () => {
 
     await client.initialize();
     expect(client.hasActiveOperations()).toBe(false);
+    expect(client.hasRetainableSessions()).toBe(false);
+    expect(client.ownsSession("session-1")).toBe(false);
 
     const session = client.startSession({
       cwd: "/repo",
@@ -85,6 +87,8 @@ describe("AcpAgentClient", () => {
     sessionResponse.resolve({ sessionId: "session-1" });
     await expect(session).resolves.toMatchObject({ sessionId: "session-1" });
     expect(client.hasActiveOperations()).toBe(false);
+    expect(client.hasRetainableSessions()).toBe(true);
+    expect(client.ownsSession("session-1")).toBe(true);
 
     const runtimeOption = client.setRuntimeOption({
       sessionId: "session-1",
@@ -96,6 +100,32 @@ describe("AcpAgentClient", () => {
     runtimeOptionResponse.resolve({});
     await runtimeOption;
     expect(client.hasActiveOperations()).toBe(false);
+
+    await client.dispose();
+    expect(client.hasRetainableSessions()).toBe(false);
+    expect(client.ownsSession("session-1")).toBe(false);
+  });
+
+  it("does not retain the client solely for hidden helper sessions", async () => {
+    const client = new AcpAgentClient({
+      backendId: "acp:gemini",
+      store,
+      transport: new FakeAcpAgentTransport({
+        "session/new": { sessionId: "hidden-session" },
+      }),
+      now: () => 1000,
+    });
+
+    await client.initialize();
+    await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+      hidden: true,
+      mcpServers: "none",
+    });
+
+    expect(client.ownsSession("hidden-session")).toBe(true);
+    expect(client.hasRetainableSessions()).toBe(false);
   });
 
   it("initializes, starts sessions, sends prompts, and normalizes updates", async () => {
@@ -2382,6 +2412,7 @@ describe("AcpAgentClient", () => {
     });
 
     await client.initialize();
+    expect(client.supportsSessionLoad()).toBe(false);
     const replay = await client.loadSession(
       store.getSession("acp:gemini", "session-1")!,
     );

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -60,7 +60,10 @@ function readRawAcpSessionPayload(
 
 describe("AcpAgentClient", () => {
   it("initializes, starts sessions, sends prompts, and normalizes updates", async () => {
-    const transport = new FakeAcpAgentTransport();
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
     const sessionUpdates: string[] = [];
     const client = new AcpAgentClient({
       backendId: "acp:codex-acp",
@@ -73,19 +76,24 @@ describe("AcpAgentClient", () => {
     });
 
     await client.initialize();
+    expect(client.hasActiveTurns()).toBe(false);
     const session = await client.startSession({
       cwd: "/repo",
       executionMode: "default",
       title: "Test ACP",
     });
-    const prompt = await client.prompt({
+    const promptPromise = client.prompt({
       sessionId: session.sessionId,
       prompt: "hello",
     });
+    expect(client.hasActiveTurns()).toBe(true);
     transport.emitSessionUpdate(session.sessionId, {
       kind: "agent_message_chunk",
       content: "Done",
     });
+    promptResponse.resolve({ turnId: "turn-1" });
+    const prompt = await promptPromise;
+    expect(client.hasActiveTurns()).toBe(false);
 
     expect(transport.requests.map((request) => request.method)).toEqual([
       "initialize",
@@ -191,6 +199,7 @@ describe("AcpAgentClient", () => {
       prompt: "hello",
       turnId: "turn-1",
     });
+    expect(client.hasActiveTurns()).toBe(true);
     transport.emitSessionUpdate(session.sessionId, {
       session_update: "agent_message_chunk",
       content: { type: "text", text: "Kimi says hi." },
@@ -206,6 +215,7 @@ describe("AcpAgentClient", () => {
     });
 
     expect(sessionUpdates).toContain("agent_message_chunk");
+    expect(client.hasActiveTurns()).toBe(false);
     expect(transport.requests[2]?.timeoutMs).toBe(60 * 60_000);
   });
 

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -59,6 +59,45 @@ function readRawAcpSessionPayload(
 }
 
 describe("AcpAgentClient", () => {
+  it("tracks non-turn RPCs until their transport requests settle", async () => {
+    const sessionResponse = createDeferred<unknown>();
+    const runtimeOptionResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/new": sessionResponse.promise,
+      "session/set_model": runtimeOptionResponse.promise,
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:gemini",
+      store,
+      transport,
+      now: () => 1000,
+    });
+
+    await client.initialize();
+    expect(client.hasActiveOperations()).toBe(false);
+
+    const session = client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+      mcpServers: "none",
+    });
+    expect(client.hasActiveOperations()).toBe(true);
+    sessionResponse.resolve({ sessionId: "session-1" });
+    await expect(session).resolves.toMatchObject({ sessionId: "session-1" });
+    expect(client.hasActiveOperations()).toBe(false);
+
+    const runtimeOption = client.setRuntimeOption({
+      sessionId: "session-1",
+      source: "model",
+      optionId: "model",
+      value: "gemini-2.5-pro",
+    });
+    expect(client.hasActiveOperations()).toBe(true);
+    runtimeOptionResponse.resolve({});
+    await runtimeOption;
+    expect(client.hasActiveOperations()).toBe(false);
+  });
+
   it("initializes, starts sessions, sends prompts, and normalizes updates", async () => {
     const promptResponse = createDeferred<unknown>();
     const transport = new FakeAcpAgentTransport({

--- a/apps/desktop/src/main/__tests__/acp-runtime-override-launch.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-runtime-override-launch.test.ts
@@ -1,0 +1,294 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AcpBackendId } from "@pwragent/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AcpAgentStore } from "../acp/acp-agent-store";
+import { discoverLocalAcpAgentRecords } from "../acp/acp-instance-discovery";
+import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
+import { AcpSessionStore } from "../acp/acp-session-store";
+import {
+  createExecutableAcpProviderFixture,
+  type ExecutableAcpProviderFixture,
+} from "../acp/testing/executable-acp-agent-fixture";
+import { AcpBackendAdapter } from "../app-server/acp-backend-adapter";
+import { installedAcpAgentSettingsEntry } from "../ipc/settings";
+import { StateDb } from "../state/state-db";
+
+type ProviderCase = {
+  expectedArgs: string[];
+  registryId: "gemini" | "grok" | "kimi" | "qwen";
+};
+
+const PROVIDERS: ProviderCase[] = [
+  { registryId: "gemini", expectedArgs: ["--acp", "--skip-trust"] },
+  { registryId: "grok", expectedArgs: ["agent", "stdio"] },
+  { registryId: "kimi", expectedArgs: ["acp"] },
+  { registryId: "qwen", expectedArgs: ["--acp"] },
+];
+
+const tempDirs: string[] = [];
+
+// These fixtures intentionally exercise direct execution of Node shebang
+// files, matching the macOS/Linux CLI installations involved in this bug.
+// Windows cannot execute extensionless shebang files through execFile/spawn;
+// a Windows runtime test needs a real native executable fixture, not a .cmd
+// shim that would change the production launch semantics under test.
+const describeExecutableAcp = process.platform === "win32"
+  ? describe.skip
+  : describe;
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describeExecutableAcp("ACP runtime path overrides", () => {
+  it.each(PROVIDERS)(
+    "launches the $registryId absolute override after startup with a stale cached default",
+    async ({ expectedArgs, registryId }) => {
+      const tempDir = makeTempDir(`pwragent-${registryId}-override-`);
+      const fixture = createExecutableAcpProviderFixture({
+        rootDir: tempDir,
+        registryId,
+      });
+      const env = fixtureDiscoveryEnv(fixture);
+      const stateDb = StateDb.open(path.join(tempDir, "state.db"));
+      const agentStore = new AcpAgentStore(stateDb);
+      const sessionStore = new AcpSessionStore(stateDb);
+      let adapter: AcpBackendAdapter | undefined;
+
+      try {
+        adapter = createAdapter({
+          agentStore,
+          sessionStore,
+          discover: async () => [
+            await discoverSingleProvider({ env, registryId }),
+          ],
+        });
+        await adapter.listAvailableAgents();
+        await adapter.close();
+        adapter = undefined;
+
+        expect(
+          agentStore.getInstalledAgent(`acp:${registryId}` as AcpBackendId)
+            ?.activeCommand,
+        ).toBe(fixture.defaultCommand);
+        const persistDiscovered = vi.spyOn(agentStore, "upsertInstalledAgent");
+
+        adapter = createAdapter({
+          agentStore,
+          sessionStore,
+          discover: async () => [
+            await discoverSingleProvider({
+              env,
+              overridePath: fixture.overrideCommand,
+              registryId,
+            }),
+          ],
+        });
+
+        const client = await adapter.getClient(
+          `acp:${registryId}` as AcpBackendId,
+        );
+        await client.startSession({
+          cwd: tempDir,
+          executionMode: "default",
+          mcpServers: "none",
+        });
+
+        const persisted = agentStore.getInstalledAgent(
+          `acp:${registryId}` as AcpBackendId,
+        );
+        expect(persisted).toMatchObject({
+          activeCommand: fixture.overrideCommand,
+          launchDescriptor: {
+            command: fixture.overrideCommand,
+            args: expectedArgs,
+          },
+        });
+        expect(persisted?.instances).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              command: fixture.overrideCommand,
+              source: "override",
+            }),
+            expect.objectContaining({
+              command: fixture.defaultCommand,
+              source: "path",
+            }),
+          ]),
+        );
+
+        const settingsEntry = installedAcpAgentSettingsEntry(
+          persisted as AcpInstalledAgentRecord,
+        );
+        const settingsUsing = settingsEntry.instances?.find(
+          (instance) => instance.command === settingsEntry.activeCommand,
+        );
+        expect(settingsUsing).toMatchObject({
+          command: fixture.overrideCommand,
+          source: "override",
+        });
+
+        expect(acpLaunchMarkers(fixture)).toEqual([
+          expect.objectContaining({
+            argv: expectedArgs,
+            executable: fixture.overrideCommand,
+            id: `${registryId}-override`,
+            version: "0.2.0-override",
+          }),
+        ]);
+        const writesBeforeCachedLookup = persistDiscovered.mock.calls.length;
+        await adapter.listAvailableAgents();
+        expect(persistDiscovered).toHaveBeenCalledTimes(writesBeforeCachedLookup);
+      } finally {
+        await adapter?.close();
+        stateDb.close();
+      }
+    },
+    30_000,
+  );
+
+  it("disposes a memoized client when the Grok override changes", async () => {
+    const tempDir = makeTempDir("pwragent-grok-override-change-");
+    const first = createExecutableAcpProviderFixture({
+      rootDir: tempDir,
+      registryId: "grok",
+      suffix: "first",
+    });
+    const second = createExecutableAcpProviderFixture({
+      rootDir: tempDir,
+      registryId: "grok",
+      suffix: "second",
+    });
+    const env = fixtureDiscoveryEnv(first);
+    const stateDb = StateDb.open(path.join(tempDir, "state.db"));
+    const agentStore = new AcpAgentStore(stateDb);
+    const sessionStore = new AcpSessionStore(stateDb);
+    let overridePath = first.overrideCommand;
+    let adapter: AcpBackendAdapter | undefined;
+
+    try {
+      agentStore.upsertInstalledAgent(
+        await discoverSingleProvider({ env, registryId: "grok" }),
+      );
+      adapter = createAdapter({
+        agentStore,
+        sessionStore,
+        discover: async () => [
+          await discoverSingleProvider({
+            env,
+            overridePath,
+            registryId: "grok",
+          }),
+        ],
+      });
+
+      const firstClient = await adapter.getClient("acp:grok");
+      await firstClient.startSession({
+        cwd: tempDir,
+        executionMode: "default",
+        mcpServers: "none",
+      });
+
+      overridePath = second.overrideCommand;
+      adapter.invalidateLocalAgentDiscovery();
+      const secondClient = await adapter.getClient("acp:grok");
+      await secondClient.startSession({
+        cwd: tempDir,
+        executionMode: "default",
+        mcpServers: "none",
+      });
+
+      expect(secondClient).not.toBe(firstClient);
+      await vi.waitFor(() => {
+        expect(
+          first.readMarkers().some((marker) => marker.kind === "disposed"),
+        ).toBe(true);
+      });
+      expect(acpLaunchMarkers(first)).toEqual([
+        expect.objectContaining({
+          argv: ["agent", "stdio"],
+          executable: first.overrideCommand,
+        }),
+      ]);
+      expect(acpLaunchMarkers(second)).toEqual([
+        expect.objectContaining({
+          argv: ["agent", "stdio"],
+          executable: second.overrideCommand,
+        }),
+      ]);
+      expect(agentStore.getInstalledAgent("acp:grok")).toMatchObject({
+        activeCommand: second.overrideCommand,
+        launchDescriptor: { command: second.overrideCommand },
+      });
+    } finally {
+      await adapter?.close();
+      stateDb.close();
+    }
+  }, 30_000);
+});
+
+function createAdapter(params: {
+  agentStore: AcpAgentStore;
+  discover: () => Promise<AcpInstalledAgentRecord[]>;
+  sessionStore: AcpSessionStore;
+}): AcpBackendAdapter {
+  return new AcpBackendAdapter({
+    acpAgentStore: params.agentStore,
+    acpRolloutStore: null,
+    acpSessionStore: params.sessionStore,
+    captureStores: [],
+    checkGrokCliUpdate: null,
+    discoverLocalAcpAgents: params.discover,
+    emit: async () => undefined,
+    handleServerRequest: async () => ({ decision: "accept" }),
+  });
+}
+
+async function discoverSingleProvider(params: {
+  env: NodeJS.ProcessEnv;
+  overridePath?: string;
+  registryId: ProviderCase["registryId"];
+}): Promise<AcpInstalledAgentRecord> {
+  const records = await discoverLocalAcpAgentRecords({
+    enabledRegistryIds: [params.registryId],
+    env: params.env,
+    ...(params.overridePath
+      ? { preferences: { [params.registryId]: { overridePath: params.overridePath } } }
+      : {}),
+  });
+  const record = records.find(
+    (candidate) => candidate.registryId === params.registryId,
+  );
+  if (!record) {
+    throw new Error(`Fake ${params.registryId} executable was not discovered`);
+  }
+  return record;
+}
+
+function fixtureDiscoveryEnv(
+  fixture: ExecutableAcpProviderFixture,
+): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    PATH: [
+      path.dirname(fixture.defaultCommand),
+      path.dirname(process.execPath),
+      "/usr/bin",
+      "/bin",
+    ].join(path.delimiter),
+  };
+}
+
+function acpLaunchMarkers(fixture: ExecutableAcpProviderFixture) {
+  return fixture.readMarkers().filter((marker) => marker.kind === "acp");
+}
+
+function makeTempDir(prefix: string): string {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(tempDir);
+  return tempDir;
+}

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -220,6 +220,7 @@ export class AcpAgentClient {
   private unsubscribeRequest?: () => void;
   private runtimeCapabilities?: BackendAcpRuntimeCapabilities;
   private readonly surfaceThoughtsAsMessages: boolean;
+  private activeOperations = 0;
 
   constructor(private readonly options: AcpAgentClientOptions) {
     this.now = options.now ?? Date.now;
@@ -297,6 +298,22 @@ export class AcpAgentClient {
     return this.activeTurns.size > 0;
   }
 
+  hasActiveOperations(): boolean {
+    return this.activeOperations > 0;
+  }
+
+  // Count the whole public operation, including setup before the transport
+  // request and state updates after it, so launch replacement cannot dispose
+  // this client at either edge of an in-flight RPC.
+  private async withOperation<T>(operation: () => Promise<T>): Promise<T> {
+    this.activeOperations += 1;
+    try {
+      return await operation();
+    } finally {
+      this.activeOperations -= 1;
+    }
+  }
+
   async dispose(): Promise<void> {
     this.options.rolloutStore?.flushAll?.();
     this.unsubscribe?.();
@@ -310,6 +327,14 @@ export class AcpAgentClient {
   }
 
   async readProviderStatus(): Promise<AcpProviderStatus | undefined> {
+    return await this.withOperation(
+      async () => await this.readProviderStatusOperation(),
+    );
+  }
+
+  private async readProviderStatusOperation(): Promise<
+    AcpProviderStatus | undefined
+  > {
     if (this.options.backendId !== "acp:grok") {
       return undefined;
     }
@@ -335,6 +360,14 @@ export class AcpAgentClient {
     mcpServers?: "default" | "none";
     sessionMeta?: Record<string, unknown>;
   }): Promise<AcpSessionMetadata> {
+    return await this.withOperation(
+      async () => await this.startSessionOperation(params),
+    );
+  }
+
+  private async startSessionOperation(
+    params: Parameters<AcpAgentClient["startSession"]>[0],
+  ): Promise<AcpSessionMetadata> {
     const cwd = params.cwd ?? process.cwd();
     const mcpRegistration =
       params.mcpServers === "none"
@@ -454,6 +487,14 @@ export class AcpAgentClient {
   }
 
   async loadSession(metadata: AcpSessionMetadata): Promise<AppServerThreadReplay> {
+    return await this.withOperation(
+      async () => await this.loadSessionOperation(metadata),
+    );
+  }
+
+  private async loadSessionOperation(
+    metadata: AcpSessionMetadata,
+  ): Promise<AppServerThreadReplay> {
     this.rememberSessionIds(metadata);
     const storedMetadata =
       this.options.store.getSession(this.options.backendId, metadata.sessionId) ??
@@ -506,12 +547,21 @@ export class AcpAgentClient {
   }
 
   async refreshSession(metadata: AcpSessionMetadata): Promise<void> {
-    await this.ensureSession(metadata);
+    await this.withOperation(async () => await this.ensureSession(metadata));
   }
 
   async ensureSession(
     metadata: AcpSessionMetadata,
     options: { suppressTranscriptReplay?: boolean } = {},
+  ): Promise<void> {
+    await this.withOperation(
+      async () => await this.ensureSessionOperation(metadata, options),
+    );
+  }
+
+  private async ensureSessionOperation(
+    metadata: AcpSessionMetadata,
+    options: { suppressTranscriptReplay?: boolean },
   ): Promise<void> {
     this.rememberSessionIds(metadata);
     if (this.supportsSessionLoad() && this.isSessionLoaded(metadata)) {
@@ -596,6 +646,12 @@ export class AcpAgentClient {
   }
 
   async cancelSession(sessionId: string): Promise<void> {
+    await this.withOperation(
+      async () => await this.cancelSessionOperation(sessionId),
+    );
+  }
+
+  private async cancelSessionOperation(sessionId: string): Promise<void> {
     if (!this.options.transport.notify) {
       throw new Error("ACP transport does not support notifications");
     }
@@ -605,6 +661,19 @@ export class AcpAgentClient {
   }
 
   async sendControlPrompt(params: {
+    sessionId: string;
+    prompt: string;
+  }): Promise<{
+    text: string;
+    model?: string;
+    tokenUsage?: AcpSuppressedControlPrompt["tokenUsage"];
+  }> {
+    return await this.withOperation(
+      async () => await this.sendControlPromptOperation(params),
+    );
+  }
+
+  private async sendControlPromptOperation(params: {
     sessionId: string;
     prompt: string;
   }): Promise<{
@@ -647,6 +716,18 @@ export class AcpAgentClient {
   }
 
   async setRuntimeOption(params: {
+    sessionId: string;
+    source: BackendAcpRuntimeOptionSource;
+    optionId: string;
+    value: string;
+    reasoningEffort?: string;
+  }): Promise<BackendAcpSessionRuntimeState | undefined> {
+    return await this.withOperation(
+      async () => await this.setRuntimeOptionOperation(params),
+    );
+  }
+
+  private async setRuntimeOptionOperation(params: {
     sessionId: string;
     source: BackendAcpRuntimeOptionSource;
     optionId: string;

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -214,6 +214,7 @@ export class AcpAgentClient {
   private readonly sessionLoadReplays = new Map<string, AcpSessionLoadReplay>();
   private readonly agentSessionIdsByAppSessionId = new Map<string, string>();
   private readonly appSessionIdsByAgentSessionId = new Map<string, string>();
+  private readonly retainableSessionIds = new Set<string>();
   private readonly now: () => number;
   private readonly approvalRequesterName: string;
   private unsubscribe?: () => void;
@@ -302,6 +303,18 @@ export class AcpAgentClient {
     return this.activeOperations > 0;
   }
 
+  ownsSession(sessionId: string): boolean {
+    return this.agentSessionIdsByAppSessionId.has(sessionId);
+  }
+
+  hasRetainableSessions(): boolean {
+    return this.retainableSessionIds.size > 0;
+  }
+
+  supportsSessionLoad(): boolean {
+    return acpRuntimeSupportsSessionLoad(this.runtimeCapabilities);
+  }
+
   // Count the whole public operation, including setup before the transport
   // request and state updates after it, so launch replacement cannot dispose
   // this client at either edge of an in-flight RPC.
@@ -322,6 +335,7 @@ export class AcpAgentClient {
     this.unsubscribeRequest = undefined;
     this.agentSessionIdsByAppSessionId.clear();
     this.appSessionIdsByAgentSessionId.clear();
+    this.retainableSessionIds.clear();
     this.loadedSessionCwds.clear();
     await this.options.transport.close?.();
   }
@@ -1352,10 +1366,6 @@ export class AcpAgentClient {
     return result;
   }
 
-  private supportsSessionLoad(): boolean {
-    return acpRuntimeSupportsSessionLoad(this.runtimeCapabilities);
-  }
-
   private isSessionLoaded(metadata: AcpSessionMetadata): boolean {
     const cwd = metadata.cwd ?? process.cwd();
     const protocolSessionId = protocolSessionIdForMetadata(metadata);
@@ -1522,6 +1532,9 @@ export class AcpAgentClient {
     const protocolSessionId = protocolSessionIdForMetadata(metadata);
     this.agentSessionIdsByAppSessionId.set(metadata.sessionId, protocolSessionId);
     this.appSessionIdsByAgentSessionId.set(protocolSessionId, metadata.sessionId);
+    if (metadata.hidden !== true) {
+      this.retainableSessionIds.add(metadata.sessionId);
+    }
   }
 
   private protocolSessionIdFor(sessionId: string): string {

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -293,6 +293,10 @@ export class AcpAgentClient {
     });
   }
 
+  hasActiveTurns(): boolean {
+    return this.activeTurns.size > 0;
+  }
+
   async dispose(): Promise<void> {
     this.options.rolloutStore?.flushAll?.();
     this.unsubscribe?.();

--- a/apps/desktop/src/main/acp/testing/executable-acp-agent-fixture.ts
+++ b/apps/desktop/src/main/acp/testing/executable-acp-agent-fixture.ts
@@ -1,0 +1,149 @@
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+export type ExecutableAcpMarker = {
+  argv: string[];
+  executable: string;
+  id: string;
+  kind: "acp" | "disposed" | "probe";
+  version: string;
+};
+
+export type ExecutableAcpProviderFixture = {
+  defaultCommand: string;
+  markerPath: string;
+  overrideCommand: string;
+  readMarkers: () => ExecutableAcpMarker[];
+};
+
+export function createExecutableAcpProviderFixture(params: {
+  rootDir: string;
+  registryId: "gemini" | "grok" | "kimi" | "qwen";
+  suffix?: string;
+}): ExecutableAcpProviderFixture {
+  const suffix = params.suffix ? `-${params.suffix}` : "";
+  const defaultDir = path.join(params.rootDir, `path-bin${suffix}`);
+  const overrideDir = path.join(params.rootDir, `override-bin${suffix}`);
+  const markerPath = path.join(
+    params.rootDir,
+    `${params.registryId}${suffix}-invocations.jsonl`,
+  );
+  const defaultCommand = path.join(defaultDir, params.registryId);
+  const overrideCommand = path.join(
+    overrideDir,
+    `${params.registryId}-absolute-override`,
+  );
+  mkdirSync(defaultDir, { recursive: true });
+  mkdirSync(overrideDir, { recursive: true });
+  writeExecutable({
+    command: defaultCommand,
+    id: `${params.registryId}-default${suffix}`,
+    markerPath,
+    registryId: params.registryId,
+    version: "0.1.0-default",
+  });
+  writeExecutable({
+    command: overrideCommand,
+    id: `${params.registryId}-override${suffix}`,
+    markerPath,
+    registryId: params.registryId,
+    version: "0.2.0-override",
+  });
+
+  return {
+    defaultCommand,
+    markerPath,
+    overrideCommand,
+    readMarkers: () => readMarkers(markerPath),
+  };
+}
+
+function writeExecutable(params: {
+  command: string;
+  id: string;
+  markerPath: string;
+  registryId: "gemini" | "grok" | "kimi" | "qwen";
+  version: string;
+}): void {
+  const source = `#!/usr/bin/env node
+const fs = require("node:fs");
+const readline = require("node:readline");
+const argv = process.argv.slice(2);
+const executable = ${JSON.stringify(params.command)};
+const id = ${JSON.stringify(params.id)};
+const markerPath = ${JSON.stringify(params.markerPath)};
+const registryId = ${JSON.stringify(params.registryId)};
+const version = ${JSON.stringify(params.version)};
+const record = (kind) => {
+  fs.appendFileSync(markerPath, JSON.stringify({
+    argv,
+    executable,
+    id,
+    kind,
+    version,
+  }) + "\\n");
+};
+if (argv.includes("--version")) {
+  record("probe");
+  process.stdout.write(
+    registryId === "kimi"
+      ? "kimi-code " + version + "\\n"
+      : registryId + " " + version + "\\n",
+  );
+  process.exit(0);
+}
+if (argv.includes("--help")) {
+  record("probe");
+  const help = registryId === "grok"
+    ? "Run the agent over stdio"
+    : registryId === "qwen"
+      ? "Qwen Code --acp"
+      : registryId === "gemini"
+        ? "Usage: gemini --acp"
+        : "Agent Client Protocol server";
+  process.stdout.write(help + "\\n");
+  process.exit(0);
+}
+record("acp");
+process.on("SIGTERM", () => {
+  record("disposed");
+  process.exit(0);
+});
+const lines = readline.createInterface({ input: process.stdin });
+lines.on("line", (line) => {
+  const request = JSON.parse(line);
+  if (request.id === undefined) return;
+  const result = request.method === "initialize"
+    ? { protocolVersion: 1, agentCapabilities: {} }
+    : request.method === "session/new"
+      ? { sessionId: id + "-session" }
+      : {};
+  process.stdout.write(JSON.stringify({
+    jsonrpc: "2.0",
+    id: request.id,
+    result,
+  }) + "\\n");
+});
+`;
+  writeFileSync(params.command, source, "utf8");
+  chmodSync(params.command, 0o755);
+}
+
+function readMarkers(markerPath: string): ExecutableAcpMarker[] {
+  try {
+    return readFileSync(markerPath, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as ExecutableAcpMarker);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -126,6 +126,7 @@ export type AcpRuntimeClient = Pick<
     Pick<
       AcpAgentClient,
       | "didSessionLoadReplayHistory"
+      | "hasActiveOperations"
       | "hasActiveTurns"
       | "readProviderStatus"
       | "sendControlPrompt"
@@ -884,6 +885,7 @@ export class AcpBackendAdapter {
   private closePromise?: Promise<void>;
   private readonly closeTimeoutMs: number;
   private readonly liveTurnUsage = new Map<string, AcpLiveTurnUsage>();
+  private localAcpAgentsRevision = 0;
   private localAcpAgentsPromise?: Promise<AcpInstalledAgentRecord[]>;
 
   constructor(options: AcpBackendAdapterOptions) {
@@ -1111,6 +1113,7 @@ export class AcpBackendAdapter {
   }
 
   invalidateLocalAgentDiscovery(): void {
+    this.localAcpAgentsRevision += 1;
     this.localAcpAgentsPromise = undefined;
   }
 
@@ -1340,10 +1343,13 @@ export class AcpBackendAdapter {
       return await cached.promise;
     }
     if (cached) {
-      // One ACP client owns every live turn for this backend. Keep routing
-      // control and session operations to that process until its last turn
-      // reaches a terminal state; the next idle lookup adopts the new path.
-      if (cached.client.hasActiveTurns?.() === true) {
+      // One ACP client owns every live turn and RPC for this backend. Keep
+      // routing to that process until its last operation reaches a terminal
+      // state; the next idle lookup adopts the new path.
+      if (
+        cached.client.hasActiveTurns?.() === true
+        || cached.client.hasActiveOperations?.() === true
+      ) {
         return await cached.promise;
       }
       this.acpClients.delete(backend);
@@ -1597,7 +1603,22 @@ export class AcpBackendAdapter {
   }
 
   async listAvailableAgents(): Promise<AcpInstalledAgentRecord[]> {
-    const discoveredAgents = (await this.readLocalAgentsOnce())
+    while (true) {
+      const discovery = await this.readLocalAgentsOnce();
+      if (discovery.revision !== this.localAcpAgentsRevision) {
+        continue;
+      }
+      // Keep the revision check and all consumption synchronous. An
+      // invalidation queued after discovery settles must run before this
+      // point or after stale results have been fully merged and persisted.
+      return this.mergeAndPersistDiscoveredAgents(discovery.agents);
+    }
+  }
+
+  private mergeAndPersistDiscoveredAgents(
+    agents: AcpInstalledAgentRecord[],
+  ): AcpInstalledAgentRecord[] {
+    const discoveredAgents = agents
       .map(normalizeInstalledAcpAgent)
       .filter((agent) => !isBannedAcpRegistryId(agent.registryId));
     // Discovery probes are asynchronous and can overlap runtime-capability or
@@ -1764,14 +1785,21 @@ export class AcpBackendAdapter {
     }
   }
 
-  private async readLocalAgentsOnce(): Promise<AcpInstalledAgentRecord[]> {
+  private async readLocalAgentsOnce(): Promise<{
+    agents: AcpInstalledAgentRecord[];
+    revision: number;
+  }> {
+    const revision = this.localAcpAgentsRevision;
     this.localAcpAgentsPromise ??= this.discoverLocalAcpAgents().catch((error) => {
       acpBackendAdapterLog.debug("local_acp_discovery_failed", {
         error: error instanceof Error ? error.message : String(error),
       });
       return [];
     });
-    return await this.localAcpAgentsPromise;
+    return {
+      agents: await this.localAcpAgentsPromise,
+      revision,
+    };
   }
 
   private createDefaultClient(agent: AcpInstalledAgentRecord): AcpRuntimeClient {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -128,9 +128,12 @@ export type AcpRuntimeClient = Pick<
       | "didSessionLoadReplayHistory"
       | "hasActiveOperations"
       | "hasActiveTurns"
+      | "hasRetainableSessions"
+      | "ownsSession"
       | "readProviderStatus"
       | "sendControlPrompt"
       | "setRuntimeOption"
+      | "supportsSessionLoad"
     >
   >;
 
@@ -148,6 +151,7 @@ type AcpClientEntry = {
   client: AcpRuntimeClient;
   launchIdentity: string;
   promise: Promise<AcpRuntimeClient>;
+  supportsSessionLoad: boolean;
   disposePromise?: Promise<void>;
 };
 
@@ -871,6 +875,13 @@ export class AcpBackendAdapter {
     request: AppServerPendingRequestNotification,
   ) => Promise<unknown>;
   private readonly acpClients = new Map<AcpBackendId, AcpClientEntry>();
+  // A non-loadable ACP session belongs to the process that created it. Launch
+  // selection may replace the current client, but these owners must remain
+  // addressable until adapter shutdown so later turns keep using that process.
+  private readonly retainedAcpClients = new Map<
+    AcpBackendId,
+    Set<AcpClientEntry>
+  >();
   private readonly acpClientResolutions = new Map<
     AcpBackendId,
     Promise<AcpRuntimeClient>
@@ -1205,8 +1216,9 @@ export class AcpBackendAdapter {
     sessionId: string,
   ): Promise<AppServerThreadReplay> {
     const session = this.getSession(backend, sessionId);
-    const cachedClient = await this.acpClients
-      .get(backend)
+    const cachedClient = await (
+      this.findSessionOwner(backend, sessionId) ?? this.acpClients.get(backend)
+    )
       ?.promise.catch(() => undefined);
     if (cachedClient) {
       const replay = cachedClient.readReplay(sessionId);
@@ -1332,6 +1344,29 @@ export class AcpBackendAdapter {
     }
   }
 
+  async getClientForSession(
+    backend: AcpBackendId,
+    sessionId: string,
+  ): Promise<AcpRuntimeClient> {
+    let current: AcpRuntimeClient;
+    try {
+      current = await this.getClient(backend);
+    } catch (error) {
+      // A broken replacement path must not strand a session whose original
+      // process is still alive. New sessions still observe the launch failure.
+      const owner = this.findSessionOwner(backend, sessionId);
+      if (owner) {
+        return await owner.promise;
+      }
+      throw error;
+    }
+    if (current.ownsSession?.(sessionId) === true) {
+      return current;
+    }
+    const owner = this.findSessionOwner(backend, sessionId);
+    return owner ? await owner.promise : current;
+  }
+
   private async resolveClient(backend: AcpBackendId): Promise<AcpRuntimeClient> {
     const agent = await this.resolveInstalledAgent(backend);
     if (this.closed) {
@@ -1353,7 +1388,18 @@ export class AcpBackendAdapter {
         return await cached.promise;
       }
       this.acpClients.delete(backend);
-      await this.disposeAcpClient(cached);
+      const supportsSessionLoad =
+        cached.client.supportsSessionLoad?.() ?? cached.supportsSessionLoad;
+      if (
+        !supportsSessionLoad
+        && cached.client.hasRetainableSessions?.() === true
+      ) {
+        // Replace the launch target without replacing ownership of sessions
+        // that the new process has no protocol method to recover.
+        this.retainAcpClient(backend, cached);
+      } else {
+        await this.disposeAcpClient(cached);
+      }
       if (this.closed) {
         throw new Error("ACP backend adapter is closed");
       }
@@ -1364,6 +1410,9 @@ export class AcpBackendAdapter {
       client,
       launchIdentity,
       promise: Promise.resolve(client),
+      supportsSessionLoad: acpRuntimeSupportsSessionLoad(
+        agent.runtimeCapabilities,
+      ),
     };
     entry.promise = (async () => {
       await client.initialize();
@@ -1686,8 +1735,16 @@ export class AcpBackendAdapter {
       return await this.closePromise;
     }
     this.closed = true;
-    const acpClients = [...this.acpClients.entries()];
+    const acpClients = [
+      ...this.acpClients.entries(),
+      ...[...this.retainedAcpClients.entries()].flatMap(([backend, entries]) =>
+        [...entries].map(
+          (entry): [AcpBackendId, AcpClientEntry] => [backend, entry],
+        ),
+      ),
+    ];
     this.acpClients.clear();
+    this.retainedAcpClients.clear();
     this.acpClientResolutions.clear();
     this.liveNotificationFingerprints.clear();
     this.providerStatuses.clear();
@@ -1753,6 +1810,28 @@ export class AcpBackendAdapter {
   private disposeAcpClient(entry: AcpClientEntry): Promise<void> {
     entry.disposePromise ??= Promise.resolve().then(() => entry.client.dispose());
     return entry.disposePromise;
+  }
+
+  private retainAcpClient(
+    backend: AcpBackendId,
+    entry: AcpClientEntry,
+  ): void {
+    const retained = this.retainedAcpClients.get(backend) ?? new Set();
+    retained.add(entry);
+    this.retainedAcpClients.set(backend, retained);
+  }
+
+  private findSessionOwner(
+    backend: AcpBackendId,
+    sessionId: string,
+  ): AcpClientEntry | undefined {
+    const current = this.acpClients.get(backend);
+    if (current?.client.ownsSession?.(sessionId) === true) {
+      return current;
+    }
+    return [...(this.retainedAcpClients.get(backend) ?? [])].find(
+      (entry) => entry.client.ownsSession?.(sessionId) === true,
+    );
   }
 
   private shouldEmitLiveToolNotification(

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -126,6 +126,7 @@ export type AcpRuntimeClient = Pick<
     Pick<
       AcpAgentClient,
       | "didSessionLoadReplayHistory"
+      | "hasActiveTurns"
       | "readProviderStatus"
       | "sendControlPrompt"
       | "setRuntimeOption"
@@ -144,6 +145,7 @@ export type AcpSessionStoreLike =
 
 type AcpClientEntry = {
   client: AcpRuntimeClient;
+  launchIdentity: string;
   promise: Promise<AcpRuntimeClient>;
   disposePromise?: Promise<void>;
 };
@@ -388,6 +390,25 @@ function normalizeInstalledAcpAgent(
   return runtimeCapabilities === agent.runtimeCapabilities
     ? agent
     : { ...agent, runtimeCapabilities };
+}
+
+function acpAgentLaunchIdentity(agent: AcpInstalledAgentRecord): string {
+  const descriptor = agent.launchDescriptor;
+  return JSON.stringify({
+    activeCommand: agent.activeCommand,
+    launchDescriptor: descriptor
+      ? {
+          backendId: descriptor.backendId,
+          registryId: descriptor.registryId,
+          distributionKind: descriptor.distributionKind,
+          command: descriptor.command,
+          args: descriptor.args,
+          env: Object.fromEntries(Object.entries(descriptor.env).sort()),
+          cwd: descriptor.cwd,
+          installPath: descriptor.installPath,
+        }
+      : undefined,
+  });
 }
 
 function effectiveAcpAgentCapabilities(
@@ -849,6 +870,10 @@ export class AcpBackendAdapter {
     request: AppServerPendingRequestNotification,
   ) => Promise<unknown>;
   private readonly acpClients = new Map<AcpBackendId, AcpClientEntry>();
+  private readonly acpClientResolutions = new Map<
+    AcpBackendId,
+    Promise<AcpRuntimeClient>
+  >();
   private readonly liveNotificationFingerprints = new Map<string, string>();
   private readonly providerStatuses = new Map<AcpBackendId, AcpProviderStatus>();
   private readonly providerStatusRefreshAttempts = new Map<AcpBackendId, number>();
@@ -1288,18 +1313,50 @@ export class AcpBackendAdapter {
     if (this.closed) {
       throw new Error("ACP backend adapter is closed");
     }
-    const cached = this.acpClients.get(backend);
-    if (cached) {
-      return await cached.promise;
+    const resolving = this.acpClientResolutions.get(backend);
+    if (resolving) {
+      return await resolving;
     }
 
+    const resolution = this.resolveClient(backend);
+    this.acpClientResolutions.set(backend, resolution);
+    try {
+      return await resolution;
+    } finally {
+      if (this.acpClientResolutions.get(backend) === resolution) {
+        this.acpClientResolutions.delete(backend);
+      }
+    }
+  }
+
+  private async resolveClient(backend: AcpBackendId): Promise<AcpRuntimeClient> {
     const agent = await this.resolveInstalledAgent(backend);
     if (this.closed) {
       throw new Error("ACP backend adapter is closed");
     }
+    const launchIdentity = acpAgentLaunchIdentity(agent);
+    const cached = this.acpClients.get(backend);
+    if (cached?.launchIdentity === launchIdentity) {
+      return await cached.promise;
+    }
+    if (cached) {
+      // One ACP client owns every live turn for this backend. Keep routing
+      // control and session operations to that process until its last turn
+      // reaches a terminal state; the next idle lookup adopts the new path.
+      if (cached.client.hasActiveTurns?.() === true) {
+        return await cached.promise;
+      }
+      this.acpClients.delete(backend);
+      await this.disposeAcpClient(cached);
+      if (this.closed) {
+        throw new Error("ACP backend adapter is closed");
+      }
+    }
+
     const client = this.createAcpClient(agent);
     const entry: AcpClientEntry = {
       client,
+      launchIdentity,
       promise: Promise.resolve(client),
     };
     entry.promise = (async () => {
@@ -1540,24 +1597,65 @@ export class AcpBackendAdapter {
   }
 
   async listAvailableAgents(): Promise<AcpInstalledAgentRecord[]> {
-    const installedAgents = (this.acpAgentStore?.listInstalledAgents() ?? [])
-      .map(normalizeInstalledAcpAgent)
-      .filter((agent) => !isBannedAcpRegistryId(agent.registryId));
-    const installedBackendIds = new Set(
-      installedAgents.map((agent) => agent.backendId),
-    );
     const discoveredAgents = (await this.readLocalAgentsOnce())
       .map(normalizeInstalledAcpAgent)
       .filter((agent) => !isBannedAcpRegistryId(agent.registryId));
-    for (const agent of discoveredAgents) {
-      if (!installedBackendIds.has(agent.backendId)) {
+    // Discovery probes are asynchronous and can overlap runtime-capability or
+    // update-check writes. Read the durable cache only after discovery, then
+    // merge and persist synchronously so those newer fields cannot be rolled
+    // back by a snapshot captured before the probe started.
+    const installedAgents = (this.acpAgentStore?.listInstalledAgents() ?? [])
+      .map(normalizeInstalledAcpAgent)
+      .filter((agent) => !isBannedAcpRegistryId(agent.registryId));
+    const installedByBackendId = new Map(
+      installedAgents.map((agent) => [agent.backendId, agent]),
+    );
+    const effectiveDiscoveredAgents = discoveredAgents.map((agent) => {
+      const cached = installedByBackendId.get(agent.backendId);
+      const sameRuntime =
+        agent.installStatus === "installed"
+        && cached?.installStatus === "installed"
+        && cached.version === agent.version
+        && acpAgentLaunchIdentity(cached) === acpAgentLaunchIdentity(agent);
+      return {
+        ...agent,
+        installedAt: cached?.installedAt ?? agent.installedAt,
+        updatedAt:
+          sameRuntime && cached
+            ? Math.max(agent.updatedAt, cached.updatedAt)
+            : agent.updatedAt,
+        ...(sameRuntime && cached?.runtimeCapabilities
+          ? { runtimeCapabilities: cached.runtimeCapabilities }
+          : {}),
+        ...(sameRuntime && cached?.lastDiscoveredAt !== undefined
+          ? { lastDiscoveredAt: cached.lastDiscoveredAt }
+          : {}),
+        ...(sameRuntime && cached?.lastDiscoveryError !== undefined
+          ? { lastDiscoveryError: cached.lastDiscoveryError }
+          : {}),
+        ...(sameRuntime && cached?.update !== undefined
+          ? { update: cached.update }
+          : {}),
+        ...(sameRuntime && cached?.updateCommand !== undefined
+          ? { updateCommand: cached.updateCommand }
+          : {}),
+      };
+    });
+    for (const agent of effectiveDiscoveredAgents) {
+      const cached = installedByBackendId.get(agent.backendId);
+      if (!cached || JSON.stringify(cached) !== JSON.stringify(agent)) {
+        // Fresh discovery owns launch selection. The durable record is a cache
+        // of that result, never an authority that can suppress a new override.
         this.acpAgentStore?.upsertInstalledAgent(agent);
       }
     }
+    const discoveredBackendIds = new Set(
+      effectiveDiscoveredAgents.map((agent) => agent.backendId),
+    );
     return [
-      ...installedAgents,
-      ...discoveredAgents.filter(
-        (agent) => !installedBackendIds.has(agent.backendId),
+      ...effectiveDiscoveredAgents,
+      ...installedAgents.filter(
+        (agent) => !discoveredBackendIds.has(agent.backendId),
       ),
     ];
   }
@@ -1569,6 +1667,7 @@ export class AcpBackendAdapter {
     this.closed = true;
     const acpClients = [...this.acpClients.entries()];
     this.acpClients.clear();
+    this.acpClientResolutions.clear();
     this.liveNotificationFingerprints.clear();
     this.providerStatuses.clear();
     this.providerStatusRefreshAttempts.clear();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7148,7 +7148,10 @@ export class DesktopBackendRegistry {
       throw new Error("ACP turns require text or image input");
     }
 
-    const client = await this.acpBackend.getClient(params.backend);
+    const client = await this.acpBackend.getClientForSession(
+      params.backend,
+      params.threadId,
+    );
     const session = this.acpBackend.getSession(params.backend, params.threadId);
     if (!session) {
       throw new Error(`ACP session not found: ${params.threadId}`);
@@ -7410,7 +7413,10 @@ export class DesktopBackendRegistry {
     if (!session) {
       throw new Error(`ACP session not found: ${params.threadId}`);
     }
-    const client = await this.acpBackend.getClient(params.backend);
+    const client = await this.acpBackend.getClientForSession(
+      params.backend,
+      params.threadId,
+    );
     await client.ensureSession?.(session);
     const fromValue =
       options?.fromValue ?? this.readAcpRuntimeOptionValue(session.acpRuntime, params);
@@ -10157,7 +10163,10 @@ export class DesktopBackendRegistry {
     turnId: string;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
     if (isAcpBackendId(params.backend)) {
-      const client = await this.acpBackend.getClient(params.backend);
+      const client = await this.acpBackend.getClientForSession(
+        params.backend,
+        params.threadId,
+      );
       await client.cancelSession(params.threadId);
       await this.emit({
         backend: params.backend,
@@ -10823,7 +10832,10 @@ export class DesktopBackendRegistry {
       throw new Error(`ACP session not found: ${params.threadId}`);
     }
     const previousApplied = session.executionMode ?? "default";
-    const client = await this.acpBackend.getClient(params.backend);
+    const client = await this.acpBackend.getClientForSession(
+      params.backend,
+      params.threadId,
+    );
     await client.ensureSession?.(session);
     const registryId = this.acpBackend.getInstalledAgent(params.backend)
       ?.registryId;
@@ -11391,7 +11403,10 @@ export class DesktopBackendRegistry {
             if (!session) {
               throw new Error(`ACP session not found: ${params.threadId}`);
             }
-            const client = await this.acpBackend.getClient(acpBackend);
+            const client = await this.acpBackend.getClientForSession(
+              acpBackend,
+              params.threadId,
+            );
             await client.ensureSession?.(session);
             await client.setRuntimeOption?.({
               sessionId: params.threadId,

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -518,7 +518,7 @@ function acpAgentSettingsEntry(params: {
   };
 }
 
-function installedAcpAgentSettingsEntry(
+export function installedAcpAgentSettingsEntry(
   record: AcpInstalledAgentRecord,
   registryAgent?: AcpRegistryAgent,
 ): AcpAgentSettingsEntry {

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -11,6 +11,13 @@ import { SettingsPathRow, type SettingsPathRowChip } from "./SettingsPathRow";
 import { SettingsSwitch } from "./SettingsSwitch";
 import { acpStatusLabel } from "./acp-agent-copy";
 
+type AcpCliPathUpdateResult =
+  | { saved: false }
+  | {
+      saved: true;
+      verification: "verified" | "failed" | "deferred";
+    };
+
 /** Look up the persisted CLI-path override for an agent by its registry id. */
 function cliPathSnapshotFor(
   snapshot: DesktopSettingsSnapshot | undefined,
@@ -46,7 +53,7 @@ export function AcpAgentsSettings(props: {
   snapshot?: DesktopSettingsSnapshot;
   /** Persist a per-agent CLI-path override (also used to "pin" a discovered
    *  install — picking an install writes its command as the override). */
-  onCliPathChange?: (registryId: string, cliPath: string) => Promise<void>;
+  onCliPathChange?: (registryId: string, cliPath: string) => Promise<boolean>;
   /** Persist a per-agent enabled flag (off = hidden from the model picker). */
   onEnabledChange?: (registryId: string, enabled: boolean) => Promise<void>;
 }) {
@@ -58,11 +65,11 @@ export function AcpAgentsSettings(props: {
   async function refresh(
     refreshRegistry = false,
     force = false,
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (!props.desktopApi?.listAcpAgents) {
       setError("ACP registry controls are unavailable in this build.");
       setLoading(false);
-      return;
+      return false;
     }
     if (!refreshRegistry && entries.length === 0) {
       setLoading(true);
@@ -79,8 +86,10 @@ export function AcpAgentsSettings(props: {
       if (refreshRegistry) {
         window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
       }
+      return true;
     } catch (refreshError) {
       setError(refreshError instanceof Error ? refreshError.message : String(refreshError));
+      return false;
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -115,11 +124,30 @@ export function AcpAgentsSettings(props: {
           enabled={enabledSnapshotFor(props.snapshot, entry.registryId)}
           saving={props.saving}
           refreshing={refreshing || loading}
-          onCliPathChange={props.onCliPathChange}
+          onCliPathChange={
+            props.onCliPathChange
+              ? async (registryId, cliPath) => {
+                  const saved = await props.onCliPathChange?.(
+                    registryId,
+                    cliPath,
+                  );
+                  if (!saved) {
+                    return { saved: false };
+                  }
+                  if (!enabledSnapshotFor(props.snapshot, registryId)) {
+                    return { saved: true, verification: "deferred" };
+                  }
+                  return {
+                    saved: true,
+                    verification: await refresh(true, true)
+                      ? "verified"
+                      : "failed",
+                  };
+                }
+              : undefined
+          }
           onEnabledChange={props.onEnabledChange}
-          onRefresh={() => {
-            void refresh(true, true);
-          }}
+          onRefresh={() => refresh(true, true)}
         />
       ))}
       {!loading && entries.length === 0 ? (
@@ -143,20 +171,93 @@ function AcpAgentSection(props: {
   enabled: boolean;
   saving?: boolean;
   refreshing?: boolean;
-  onCliPathChange?: (registryId: string, cliPath: string) => Promise<void>;
+  onCliPathChange?: (
+    registryId: string,
+    cliPath: string,
+  ) => Promise<AcpCliPathUpdateResult>;
   onEnabledChange?: (registryId: string, enabled: boolean) => Promise<void>;
-  onRefresh: () => void;
+  onRefresh: () => Promise<boolean>;
 }) {
   const { entry, enabled } = props;
   const instances = entry.instances ?? [];
   const savedPath = props.cliPathSnapshot?.value ?? "";
   const [draft, setDraft] = useState(savedPath);
+  const [pathUpdating, setPathUpdating] = useState(false);
+  const [pathActionError, setPathActionError] = useState<string | undefined>();
   useEffect(() => {
     setDraft(savedPath);
   }, [savedPath]);
 
   const detail =
     entry.lastDiscoveryError ?? entry.lastError ?? entry.unavailableReason;
+  const normalizedSavedPath = savedPath.trim();
+  const envForced = props.cliPathSnapshot?.source === "env";
+  const checkingPath = pathUpdating || props.refreshing === true;
+  const overrideActive =
+    enabled
+    && normalizedSavedPath !== ""
+    && entry.activeCommand === normalizedSavedPath;
+  const activeOverrideInstance = overrideActive
+    ? instances.find((instance) => instance.command === normalizedSavedPath)
+    : undefined;
+  const overrideHelp = normalizedSavedPath === ""
+    ? undefined
+    : !enabled
+      ? "Enable this provider, then click Refresh to verify the saved path before use."
+      : checkingPath
+        ? "Checking this path and provider capabilities…"
+        : overrideActive
+          ? `Active for new threads${activeOverrideInstance?.version
+            ? ` · v${activeOverrideInstance.version}`
+            : ""}.`
+          : undefined;
+  const inactiveOverrideError =
+    enabled
+    && normalizedSavedPath !== ""
+    && !checkingPath
+    && !overrideActive
+      ? entry.activeCommand
+        ? `Saved override is not active. New threads currently use ${entry.activeCommand}.`
+        : "Saved override is not active. This provider cannot launch new threads."
+      : undefined;
+
+  async function commitPath(nextPath: string): Promise<void> {
+    if (!props.onCliPathChange) {
+      return;
+    }
+    setDraft(nextPath);
+    setPathActionError(undefined);
+    setPathUpdating(true);
+    try {
+      const result = await props.onCliPathChange(entry.registryId, nextPath);
+      if (!result.saved) {
+        setDraft(savedPath);
+        setPathActionError("PwrAgent couldn't save this path.");
+      } else if (result.verification === "failed") {
+        setPathActionError(
+          "Path was saved, but PwrAgent couldn't verify it. Click Refresh to try again.",
+        );
+      }
+    } catch (error) {
+      setDraft(savedPath);
+      setPathActionError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setPathUpdating(false);
+    }
+  }
+
+  async function refreshPathStatus(): Promise<void> {
+    setPathActionError(undefined);
+    const refreshed = await props.onRefresh();
+    if (!refreshed && normalizedSavedPath !== "") {
+      setPathActionError(
+        "PwrAgent couldn't verify the saved path. Click Refresh to try again.",
+      );
+    }
+  }
+
+  const pathControlsDisabled =
+    props.saving || pathUpdating || props.refreshing || envForced;
 
   return (
     <SettingsSection
@@ -174,7 +275,7 @@ function AcpAgentSection(props: {
             control={
               <SettingsSwitch
                 checked={enabled}
-                disabled={props.saving}
+                disabled={props.saving || pathUpdating || props.refreshing}
                 label={`Enable ${entry.name}`}
                 onChange={(next) => {
                   void props.onEnabledChange?.(entry.registryId, next);
@@ -186,7 +287,11 @@ function AcpAgentSection(props: {
 
         <SettingsField
           label="Installed paths"
-          sub="Binaries detected on this machine. The active one runs new threads — click Use to pick another."
+          sub={
+            enabled
+              ? "Binaries detected on this machine. The active one runs new threads — click Use to pick another."
+              : "Previously detected binaries. Enable this provider and Refresh before launching new threads."
+          }
           source={`${instances.length} found`}
           error={detail}
           control={
@@ -195,7 +300,8 @@ function AcpAgentSection(props: {
                 <p className="settings-empty">Not installed.</p>
               ) : (
                 instances.map((instance) => {
-                  const active = instance.command === entry.activeCommand;
+                  const active =
+                    enabled && instance.command === entry.activeCommand;
                   const chips: SettingsPathRowChip[] = [
                     {
                       label: instance.source === "override" ? "override" : "path",
@@ -219,14 +325,11 @@ function AcpAgentSection(props: {
                       selected={active}
                       selectedLabel="Using"
                       useLabel="Use"
-                      disabled={props.saving}
+                      disabled={pathControlsDisabled}
                       onUse={
                         props.onCliPathChange
                           ? () => {
-                              void props.onCliPathChange?.(
-                                entry.registryId,
-                                instance.command,
-                              );
+                              void commitPath(instance.command);
                             }
                           : undefined
                       }
@@ -241,13 +344,31 @@ function AcpAgentSection(props: {
         {props.onCliPathChange ? (
           <SettingsField
             label="Manual path"
-            sub="Override discovery with an absolute path. Save, then Refresh to re-probe."
+            sub={
+              envForced
+                ? "This path is controlled by an environment override set before PwrAgent launched."
+                : enabled
+                  ? "Enter an absolute path. Save checks it immediately and updates the binary used by new threads."
+                  : "Save an absolute path now. Enable this provider, then Refresh to verify it before use."
+            }
+            source={
+              envForced
+                ? "env override"
+                : overrideActive
+                  ? "active override"
+                  : normalizedSavedPath
+                    ? "saved override"
+                    : undefined
+            }
+            help={overrideHelp}
+            error={pathActionError ?? inactiveOverrideError}
             control={
               <div className="settings-secret">
                 <input
                   aria-label={`${entry.name} manual path`}
+                  aria-invalid={Boolean(pathActionError ?? inactiveOverrideError)}
                   className="settings-input"
-                  disabled={props.saving}
+                  disabled={pathControlsDisabled}
                   placeholder="Manual path — e.g. /Users/you/.local/bin/agent"
                   type="text"
                   value={draft}
@@ -255,22 +376,20 @@ function AcpAgentSection(props: {
                 />
                 <button
                   className="button button--secondary"
-                  disabled={props.saving || draft.trim() === savedPath.trim()}
-                  type="button"
-                  onClick={() =>
-                    props.onCliPathChange?.(entry.registryId, draft.trim())
+                  disabled={
+                    pathControlsDisabled
+                    || draft.trim() === normalizedSavedPath
                   }
+                  type="button"
+                  onClick={() => void commitPath(draft.trim())}
                 >
-                  Save
+                  {pathUpdating ? "Checking…" : "Save"}
                 </button>
                 <button
                   className="button button--ghost"
-                  disabled={props.saving || draft === ""}
+                  disabled={pathControlsDisabled || draft === ""}
                   type="button"
-                  onClick={() => {
-                    setDraft("");
-                    void props.onCliPathChange?.(entry.registryId, "");
-                  }}
+                  onClick={() => void commitPath("")}
                 >
                   Clear
                 </button>
@@ -286,9 +405,9 @@ function AcpAgentSection(props: {
             <div className="settings-inline-actions">
               <button
                 className="button button--secondary"
-                disabled={props.refreshing}
+                disabled={props.refreshing || pathUpdating}
                 type="button"
-                onClick={props.onRefresh}
+                onClick={() => void refreshPathStatus()}
               >
                 {props.refreshing ? "Discovering…" : "Refresh"}
               </button>

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -48,6 +48,7 @@ function enabledSnapshotFor(
  * siblings of the Codex section inside one "Backends & credentials" stack.
  */
 export function AcpAgentsSettings(props: {
+  catalogRefreshing?: boolean;
   desktopApi?: DesktopApi;
   saving?: boolean;
   snapshot?: DesktopSettingsSnapshot;
@@ -123,7 +124,7 @@ export function AcpAgentsSettings(props: {
           cliPathSnapshot={cliPathSnapshotFor(props.snapshot, entry.registryId)}
           enabled={enabledSnapshotFor(props.snapshot, entry.registryId)}
           saving={props.saving}
-          refreshing={refreshing || loading}
+          refreshing={refreshing || loading || props.catalogRefreshing}
           onCliPathChange={
             props.onCliPathChange
               ? async (registryId, cliPath) => {

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -98,7 +98,7 @@ export function ModelsSettings(props: {
   ) => Promise<boolean>;
   onSaveCodexFastAllowed: (allowed: boolean) => Promise<boolean>;
   /** Persist a per-ACP-agent CLI-path override (also pins a discovered install). */
-  onAcpCliPathChange: (registryId: string, cliPath: string) => Promise<void>;
+  onAcpCliPathChange: (registryId: string, cliPath: string) => Promise<boolean>;
   /** Persist a per-ACP-agent enabled flag (off = hidden from the model picker). */
   onAcpEnabledChange: (registryId: string, enabled: boolean) => Promise<void>;
 }) {

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -430,6 +430,7 @@ export function ModelsSettings(props: {
       ) : null}
 
       <AcpAgentsSettings
+        catalogRefreshing={refreshingCatalog}
         desktopApi={props.desktopApi}
         saving={props.saving}
         snapshot={props.snapshot}
@@ -825,7 +826,7 @@ function ProviderModelDefaultsSettings(props: {
             control={
               <button
                 className="button button--secondary"
-                disabled={props.refreshing}
+                disabled={props.refreshing || props.saving}
                 type="button"
                 onClick={() => void props.onRefresh()}
               >
@@ -844,7 +845,7 @@ function ProviderModelDefaultsSettings(props: {
             control={
               <button
                 className="button button--secondary"
-                disabled={props.refreshing}
+                disabled={props.refreshing || props.saving}
                 type="button"
                 onClick={() => void props.onRefresh()}
               >

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -693,7 +693,7 @@ function SettingsSectionBody(props: {
         });
       }}
       onAcpCliPathChange={async (registryId, cliPath) => {
-        await props.settings.writeConfig({
+        return await props.settings.writeConfig({
           acpAgents: { [registryId]: { cliPath } } as NonNullable<
             DesktopSettingsConfigPatch["acpAgents"]
           >,

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -1,8 +1,17 @@
 import "@testing-library/jest-dom/vitest";
-import { StrictMode } from "react";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { StrictMode, useState } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { AcpAgentSettingsEntry } from "@pwragent/shared";
+import type {
+  AcpAgentSettingsEntry,
+  DesktopSettingsSnapshot,
+} from "@pwragent/shared";
 import { AcpAgentsSettings } from "../AcpAgentsSettings";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../../lib/useBackendSummaries";
@@ -27,6 +36,47 @@ function geminiEntry(): AcpAgentSettingsEntry {
     authStatus: "not-required",
     verificationStatus: "not-applicable",
   } satisfies AcpAgentSettingsEntry;
+}
+
+function grokEntry(params?: {
+  activeCommand?: string;
+  instances?: AcpAgentSettingsEntry["instances"];
+}): AcpAgentSettingsEntry {
+  const activeCommand = params?.activeCommand ?? "/usr/bin/grok";
+  return {
+    backendId: "acp:grok",
+    registryId: "grok",
+    name: "Grok",
+    version: "1.0.0",
+    authors: [],
+    distributionKind: "local",
+    distributionSource: `${activeCommand} --acp`,
+    installable: false,
+    installed: true,
+    installStatus: "installed",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+    instances: params?.instances ?? [
+      { command: activeCommand, version: "1.0.0", source: "path" },
+    ],
+    activeCommand,
+  } satisfies AcpAgentSettingsEntry;
+}
+
+function acpSnapshot(
+  registryId: "grok" | "qwen",
+  cliPath: string,
+  source: "config" | "env" = "config",
+  enabled = true,
+): DesktopSettingsSnapshot {
+  return {
+    acpAgents: {
+      [registryId]: {
+        cliPath: { value: cliPath, source },
+        enabled,
+      },
+    },
+  } as unknown as DesktopSettingsSnapshot;
 }
 
 describe("AcpAgentsSettings", () => {
@@ -115,7 +165,7 @@ describe("AcpAgentsSettings", () => {
   });
 
   it("renders multiple installs with a 'Use' action and the active one as 'Using'", async () => {
-    const onCliPathChange = vi.fn(async () => undefined);
+    const onCliPathChange = vi.fn(async () => true);
     const desktopApi: DesktopApi = {
       listAcpAgents: vi.fn(async () => ({
         fetchedAt: 1000,
@@ -157,6 +207,302 @@ describe("AcpAgentsSettings", () => {
     expect(screen.getByText("Using")).toBeInTheDocument();
     screen.getByRole("button", { name: "Use" }).click();
     expect(onCliPathChange).toHaveBeenCalledWith("qwen", "/opt/homebrew/bin/qwen");
+    await waitFor(() => {
+      expect(desktopApi.listAcpAgents).toHaveBeenCalledWith({
+        refresh: true,
+        force: true,
+      });
+    });
+  });
+
+  it("blocks path changes while provider discovery is running", async () => {
+    const installed = grokEntry({
+      instances: [
+        { command: "/usr/bin/grok", version: "1.0.0", source: "path" },
+        { command: "/opt/homebrew/bin/grok", version: "0.9.0", source: "path" },
+      ],
+    });
+    let resolveManualRefresh:
+      | ((value: { fetchedAt: number; entries: AcpAgentSettingsEntry[] }) => void)
+      | undefined;
+    const manualRefresh = new Promise<{
+      fetchedAt: number;
+      entries: AcpAgentSettingsEntry[];
+    }>((resolve) => {
+      resolveManualRefresh = resolve;
+    });
+    const listAcpAgents = vi.fn(
+      async (request?: { refresh?: boolean; force?: boolean }) =>
+        request?.force
+          ? manualRefresh
+          : { fetchedAt: 1000, entries: [installed] },
+    );
+    const onCliPathChange = vi.fn(async () => true);
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        snapshot={acpSnapshot("grok", "")}
+        onCliPathChange={onCliPathChange}
+      />,
+    );
+
+    expect(await screen.findByText("Grok")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Refresh" })).toBeEnabled();
+    });
+    fireEvent.change(screen.getByLabelText("Grok manual path"), {
+      target: { value: "/Users/me/bin/grok-next" },
+    });
+    screen.getByRole("button", { name: "Refresh" }).click();
+
+    expect(
+      await screen.findByRole("button", { name: "Discovering…" }),
+    ).toBeDisabled();
+    expect(screen.getByLabelText("Grok manual path")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Clear" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Use" })).toBeDisabled();
+    expect(onCliPathChange).not.toHaveBeenCalled();
+
+    resolveManualRefresh?.({ fetchedAt: 2000, entries: [installed] });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+    });
+  });
+
+  it("saves and immediately verifies a manual path for new threads", async () => {
+    const overridePath = "/Users/me/.local/bin/grok-local";
+    const installed = grokEntry();
+    const overridden = grokEntry({
+      activeCommand: overridePath,
+      instances: [
+        { command: overridePath, version: "2.0.0", source: "override" },
+        { command: "/usr/bin/grok", version: "1.0.0", source: "path" },
+      ],
+    });
+    const listAcpAgents = vi.fn(
+      async (request?: { refresh?: boolean; force?: boolean }) => ({
+        fetchedAt: 1000,
+        entries: [request?.force ? overridden : installed],
+      }),
+    );
+
+    function Harness() {
+      const [snapshot, setSnapshot] = useState(acpSnapshot("grok", ""));
+      return (
+        <AcpAgentsSettings
+          desktopApi={{ listAcpAgents } as DesktopApi}
+          snapshot={snapshot}
+          onCliPathChange={async (registryId, cliPath) => {
+            setSnapshot(acpSnapshot(registryId as "grok", cliPath));
+            return true;
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    expect(await screen.findByText("Grok")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Refresh" })).toBeEnabled();
+    });
+    fireEvent.change(screen.getByLabelText("Grok manual path"), {
+      target: { value: overridePath },
+    });
+    screen.getByRole("button", { name: "Save" }).click();
+
+    await waitFor(() => {
+      expect(listAcpAgents).toHaveBeenCalledWith({ refresh: true, force: true });
+    });
+    expect(await screen.findByText("active override")).toBeInTheDocument();
+    expect(screen.getByText("override")).toBeInTheDocument();
+    expect(screen.getByText("v2.0.0")).toBeInTheDocument();
+    expect(
+      screen.getByText("Active for new threads · v2.0.0."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(overridePath)).toBeInTheDocument();
+    expect(screen.getByText("Using")).toBeInTheDocument();
+  });
+
+  it("shows when a saved manual path is not active and names the fallback", async () => {
+    const invalidPath = "/Users/me/bin/missing-grok";
+    const installed = grokEntry();
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [installed],
+    }));
+
+    function Harness() {
+      const [snapshot, setSnapshot] = useState(acpSnapshot("grok", ""));
+      return (
+        <AcpAgentsSettings
+          desktopApi={{ listAcpAgents } as DesktopApi}
+          snapshot={snapshot}
+          onCliPathChange={async (registryId, cliPath) => {
+            setSnapshot(acpSnapshot(registryId as "grok", cliPath));
+            return true;
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    expect(await screen.findByText("Grok")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Refresh" })).toBeEnabled();
+    });
+    fireEvent.change(screen.getByLabelText("Grok manual path"), {
+      target: { value: invalidPath },
+    });
+    screen.getByRole("button", { name: "Save" }).click();
+
+    expect(
+      await screen.findByText(
+        "Saved override is not active. New threads currently use /usr/bin/grok.",
+      ),
+    ).toHaveAttribute("role", "alert");
+    expect(screen.getByText("saved override")).toBeInTheDocument();
+    expect(screen.getByLabelText("Grok manual path")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  });
+
+  it("preserves a saved path when verification fails and supports retry", async () => {
+    const overridePath = "/Users/me/.local/bin/grok-local";
+    const installed = grokEntry();
+    const overridden = grokEntry({
+      activeCommand: overridePath,
+      instances: [
+        { command: overridePath, version: "2.0.0", source: "override" },
+        { command: "/usr/bin/grok", version: "1.0.0", source: "path" },
+      ],
+    });
+    let forcedAttempts = 0;
+    const listAcpAgents = vi.fn(
+      async (request?: { refresh?: boolean; force?: boolean }) => {
+        if (request?.force) {
+          forcedAttempts += 1;
+          if (forcedAttempts === 1) {
+            throw new Error("probe unavailable");
+          }
+          return { fetchedAt: 2000, entries: [overridden] };
+        }
+        return { fetchedAt: 1000, entries: [installed] };
+      },
+    );
+
+    function Harness() {
+      const [snapshot, setSnapshot] = useState(acpSnapshot("grok", ""));
+      return (
+        <AcpAgentsSettings
+          desktopApi={{ listAcpAgents } as DesktopApi}
+          snapshot={snapshot}
+          onCliPathChange={async (registryId, cliPath) => {
+            setSnapshot(acpSnapshot(registryId as "grok", cliPath));
+            return true;
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    expect(await screen.findByText("Grok")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Refresh" })).toBeEnabled();
+    });
+    fireEvent.change(screen.getByLabelText("Grok manual path"), {
+      target: { value: overridePath },
+    });
+    screen.getByRole("button", { name: "Save" }).click();
+
+    expect(
+      await screen.findByText(
+        "Path was saved, but PwrAgent couldn't verify it. Click Refresh to try again.",
+      ),
+    ).toHaveAttribute("role", "alert");
+    expect(screen.getByLabelText("Grok manual path")).toHaveValue(overridePath);
+    expect(screen.getByText("saved override")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+
+    screen.getByRole("button", { name: "Refresh" }).click();
+    expect(
+      await screen.findByText("Active for new threads · v2.0.0."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Path was saved, but PwrAgent couldn't verify it. Click Refresh to try again.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not claim a saved path is active while the provider is disabled", async () => {
+    const overridePath = "/Users/me/.local/bin/grok-local";
+    const entry = grokEntry({
+      activeCommand: overridePath,
+      instances: [
+        { command: overridePath, version: "2.0.0", source: "override" },
+      ],
+    });
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [entry],
+    }));
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        snapshot={acpSnapshot("grok", overridePath, "config", false)}
+        onCliPathChange={vi.fn(async () => true)}
+      />,
+    );
+
+    expect(await screen.findByText("Grok")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Refresh" })).toBeEnabled();
+    });
+    expect(screen.getByText("Disabled")).toBeInTheDocument();
+    expect(screen.getByText("saved override")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Enable this provider, then click Refresh to verify the saved path before use.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("active override")).not.toBeInTheDocument();
+    expect(screen.queryByText("Using")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Active for new threads · v2.0.0."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("makes environment-forced paths read-only and explains their source", async () => {
+    const envPath = "/opt/company/bin/grok";
+    const entry = grokEntry({
+      activeCommand: envPath,
+      instances: [{ command: envPath, version: "1.2.3", source: "override" }],
+    });
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [entry],
+    }));
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        snapshot={acpSnapshot("grok", envPath, "env")}
+        onCliPathChange={vi.fn(async () => true)}
+      />,
+    );
+
+    expect(await screen.findByText("Grok")).toBeInTheDocument();
+    expect(screen.getByText("env override")).toBeInTheDocument();
+    expect(screen.getByLabelText("Grok manual path")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Clear" })).toBeDisabled();
   });
 
   it("renders an undiscovered provider as a 'Not installed' section", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -11,6 +11,7 @@ import {
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
+  AcpAgentSettingsEntry,
   AppServerListThreadsResponse,
   AppServerThreadSummary,
   BackendSummary,
@@ -439,7 +440,7 @@ function createArchivedSnapshot(
 }
 
 describe("SettingsScreen", () => {
-  it("renders cached provider models while refreshing the catalog", async () => {
+  it("renders cached provider models and locks ACP paths while refreshing the catalog", async () => {
     const cachedBackends: BackendSummary[] = [
       {
         kind: "codex",
@@ -476,11 +477,38 @@ describe("SettingsScreen", () => {
     const listBackends = vi.fn(
       async () => await new Promise<never>(() => undefined),
     );
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [
+        {
+          backendId: "acp:grok",
+          registryId: "grok",
+          name: "Grok",
+          authors: ["xAI"],
+          distributionKind: "local",
+          distributionSource: "/usr/bin/grok",
+          installable: false,
+          installed: true,
+          installStatus: "installed",
+          authStatus: "not-required",
+          verificationStatus: "not-applicable",
+          activeCommand: "/usr/bin/grok",
+          instances: [
+            { command: "/usr/bin/grok", version: "1.0.0", source: "path" },
+            {
+              command: "/opt/homebrew/bin/grok",
+              version: "0.9.0",
+              source: "path",
+            },
+          ],
+        } satisfies AcpAgentSettingsEntry,
+      ],
+    }));
 
     render(
       <SettingsScreen
         cachedBackends={cachedBackends}
-        desktopApi={{ listBackends }}
+        desktopApi={{ listAcpAgents, listBackends }}
         initialSection="models"
         settings={createSettingsState()}
         onClose={() => undefined}
@@ -500,6 +528,37 @@ describe("SettingsScreen", () => {
         includeUnavailable: true,
         refreshModels: true,
       });
+    });
+    await waitFor(() => expect(listAcpAgents).toHaveBeenCalledTimes(2));
+    expect(screen.getByLabelText("Grok manual path")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(
+      within(screen.getByLabelText("Grok installs")).getByRole("button", {
+        name: "Use",
+      }),
+    ).toBeDisabled();
+  });
+
+  it("locks catalog refresh while settings are saving", async () => {
+    const listBackends = vi.fn(async () => ({
+      fetchedAt: 1000,
+      backends: [],
+    }));
+    const settings = createSettingsState();
+    settings.saving = true;
+
+    render(
+      <SettingsScreen
+        desktopApi={{ listBackends }}
+        initialSection="models"
+        settings={settings}
+        onClose={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Refresh models" }))
+        .toBeDisabled();
     });
   });
 


### PR DESCRIPTION
## Summary

Backports the ACP launch-selection correctness stack to `releases/1.0`:

- #1441, **fix(desktop): verify ACP path overrides** — squash `d0d3d1a6d7367ac06a40f34a3a16d9ba511dc6dc`
- #1447, **fix(agent-core): launch ACP path overrides at runtime** — squash `c01aeb039b302cfab50a771a7d95da4f0edb13da`
- #1540, **fix(desktop): serialize ACP launch selection** — mainline squash `c1b1f7abb55f70624f7fd761c604e7c37d7c91ee`
- #1553, **fix(desktop): preserve ACP session client ownership** — mainline squash `5535c4d758cd065266f90e5e6940ab747f56a3f0`

Settings immediately verifies saved, selected, or cleared Gemini/Grok/Kimi/Qwen CLI overrides and reports the exact active command. Runtime discovery is authoritative over stale installed-agent cache records, and new threads launch on the newly resolved CLI path.

The #1540 and #1553 correctness follow-ups are applied from their exact mainline squash commits with `-x`. Concurrent discovery results invalidated by a path change are discarded, ACP clients remain alive through in-flight operations, and Settings path verification cannot coalesce with a catalog refresh that predates the write. Existing process-bound sessions for agents without session loading remain routed to their owning clients, while new threads use the replacement launch client and loadable sessions continue moving to it.

## Release-branch adaptations

- Preserves the provider-onboarding implementation already present from #1509 instead of restoring mainline's older Kimi compatibility/install card.
- Adapts the runtime changes to the ACP branch-adoption implementation already present from #1510.
- Retains the Windows shim compatibility already present from #1513.
- Keeps the external `@pwrdrvr/agent-core` dependency; does not import legacy in-repo agent-core removal work.
- Excludes federation-only behavior.
- Resolves #1540's Settings conflict by retaining the release provider layout while taking the mainline catalog-refresh serialization prop and assertions.
- Resolves #1553's registry conflict by applying its five session-owner routing calls to the release registry layout without importing main-only active-turn control code.

## Root cause

Settings and runtime launch selection previously used different discovery/cache authority. Concurrent discovery could restore an invalidated executable, client replacement could interrupt in-flight RPCs, and post-save verification could join an older refresh. Replacing the backend-wide client also orphaned sessions created by agents that advertise `loadSession: false`; their old session IDs were then sent to a new process that had never created them.

## Migration audit

No state database migration, DDL, schema change, or `user_version` change is included. `CURRENT_STATE_DB_USER_VERSION` remains **32**.

## Validation

- Focused ACP Settings/client/backend/registry/discovery/runtime-launch suites: **17 files, 318 tests passed**
- Targeted backend-registry existing-session routing tests: **7 passed**
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; baseline warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

No headed E2E was run on the host.
