### PR TITLE
fix(desktop): backport Windows git worktree reaping

### DIFF
--- a/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
@@ -18,8 +18,7 @@ function toForwardSlashes(value: string): string {
 }
 
 async function git(cwd: string, args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync("git", args, {
-    cwd,
+  const { stdout } = await execFileAsync("git", ["-C", cwd, ...args], {
     encoding: "utf8",
     maxBuffer: 1024 * 1024 * 10,
   });
@@ -66,7 +65,7 @@ async function createRepo(): Promise<string> {
 afterEach(async () => {
   await Promise.all(
     cleanupPaths.splice(0).map((target) =>
-      rm(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }),
+      rm(target, { recursive: true, force: true }),
     ),
   );
 });

--- a/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
+++ b/apps/desktop/src/main/__tests__/windows-job-wrapper.test.ts
@@ -1,0 +1,413 @@
+import { spawn } from "node:child_process";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  formatWindowsJobStartupTelemetry,
+  formatWindowsJobStartupTimeout,
+  readWindowsJobStartupTelemetry,
+  startWindowsJobReadyPoll,
+  type WindowsJobStartupTimeout,
+  WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS,
+  WINDOWS_JOB_POWERSHELL_START_TIMEOUT_MS,
+  WINDOWS_JOB_STARTUP_PROGRESS_TIMEOUT_MS,
+  wrapCommandInWindowsJob,
+} from "../windows-job-wrapper";
+import { runGitCommand } from "../app-server/git-executable";
+import { resolveWindowsBashShell } from "../windows-shell";
+
+function decodeBase64(value: string): string {
+  return Buffer.from(value, "base64").toString("utf8");
+}
+
+async function runWrappedCommand(params: {
+  args: string[];
+  command: string;
+  cwd: string;
+}): Promise<{
+  code: number | null;
+  stderr: string;
+  stdout: string;
+}> {
+  const wrapped = wrapCommandInWindowsJob({
+    ...params,
+    env: process.env,
+  });
+  try {
+    return await new Promise((resolve, reject) => {
+      const child = spawn(wrapped.command, wrapped.args, {
+        cwd: params.cwd,
+        env: wrapped.env,
+        windowsHide: true,
+      });
+      let stderr = "";
+      let stdout = "";
+      child.stderr.setEncoding("utf8");
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.once("error", reject);
+      child.once("close", (code) => {
+        resolve({ code, stderr, stdout });
+      });
+    });
+  } finally {
+    wrapped.cleanup();
+  }
+}
+
+describe("wrapCommandInWindowsJob", () => {
+  it("bounds host launch, phase progress, and overall readiness", () => {
+    expect(WINDOWS_JOB_POWERSHELL_START_TIMEOUT_MS).toBe(20_000);
+    expect(WINDOWS_JOB_STARTUP_PROGRESS_TIMEOUT_MS).toBe(10_000);
+    expect(WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS).toBe(28_000);
+    expect(WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS).toBeLessThan(30_000);
+  });
+
+  it("launches the shell through an atomic kill-on-close Job wrapper", () => {
+    const originalEnv = {
+      PATH: "C:\\tools",
+      SystemRoot: "C:\\Windows",
+    };
+    const command = [
+      "set -e",
+      'printf "quoted value"',
+      "while true; do sleep 1; done",
+    ].join("\n");
+
+    const wrapped = wrapCommandInWindowsJob({
+      args: ["-lc", command],
+      command: "C:\\Program Files\\Git\\usr\\bin\\bash.exe",
+      cwd: "C:\\work tree",
+      env: originalEnv,
+    });
+
+    expect(wrapped.command).toBe(
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
+    expect(wrapped.args.slice(0, -1)).toEqual([
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+    ]);
+    const wrapperScript = readFileSync(wrapped.args.at(-1)!, "utf8");
+    expect(wrapperScript).toContain("JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE");
+    expect(wrapperScript).toContain("CREATE_SUSPENDED | CREATE_NO_WINDOW");
+    expect(wrapperScript).toContain("AssignProcessToJobObject");
+    expect(wrapped.env.PWRAGENT_JOB_WRAPPER_EXECUTABLE).toBe(
+      "C:\\Program Files\\Git\\usr\\bin\\bash.exe",
+    );
+    expect(
+      JSON.parse(
+        decodeBase64(wrapped.env.PWRAGENT_JOB_WRAPPER_ARGUMENTS!),
+      ),
+    ).toEqual([
+      "-lc",
+      [
+        "trap 'pwragent_exit=$?; trap - EXIT; set +e; pwragent_exit_file=$(/usr/bin/cygpath.exe -u \"$PWRAGENT_JOB_WRAPPER_EXIT_FILE\"); if [ -n \"$pwragent_exit_file\" ]; then printf \"%s\" \"$pwragent_exit\" > \"$pwragent_exit_file\"; fi; exit \"$pwragent_exit\"' EXIT",
+        command,
+      ].join("\n"),
+    ]);
+    expect(wrapped.env.PWRAGENT_JOB_WRAPPER_CWD).toBe("C:\\work tree");
+    expect(wrapped.env.PWRAGENT_JOB_WRAPPER_READY_FILE).toBe(
+      wrapped.readyFilePath,
+    );
+    expect(wrapped.env.PWRAGENT_JOB_WRAPPER_EXIT_FILE).toMatch(
+      /pwragent-windows-job-.*[\\/]exit$/,
+    );
+    expect(wrapped.env.PWRAGENT_JOB_WRAPPER_STARTUP_STATUS_FILE).toBe(
+      wrapped.startupStatusFilePath,
+    );
+    expect(wrapped.env.PWRAGENT_JOB_WRAPPER_STARTED_AT).toBe(
+      String(wrapped.startupStartedAt),
+    );
+    expect(readWindowsJobStartupTelemetry(wrapped)).toEqual({
+      phases: [{ detail: undefined, elapsedMs: 0, phase: "wrapper-created" }],
+    });
+    expect(originalEnv).toEqual({
+      PATH: "C:\\tools",
+      SystemRoot: "C:\\Windows",
+    });
+    wrapped.cleanup();
+  });
+
+  it("preserves a native command's complete argument vector", () => {
+    const args = [
+      "-C",
+      "C:\\repo with spaces",
+      "worktree",
+      "remove",
+      "--force",
+      "C:\\worktrees\\feature with spaces",
+    ];
+    const wrapped = wrapCommandInWindowsJob({
+      args,
+      command: "C:\\Program Files\\Git\\cmd\\git.exe",
+      env: { SystemRoot: "C:\\Windows" },
+    });
+
+    expect(
+      JSON.parse(
+        decodeBase64(wrapped.env.PWRAGENT_JOB_WRAPPER_ARGUMENTS!),
+      ),
+    ).toEqual(args);
+    wrapped.cleanup();
+  });
+
+  it("honors journaled progress inside the overall readiness bound", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-07T00:00:00.000Z"));
+    const wrapped = wrapCommandInWindowsJob({
+      args: ["/c", "exit 0"],
+      command: "C:\\Windows\\System32\\cmd.exe",
+      env: { SystemRoot: "C:\\Windows" },
+    });
+    let readyPoll: ReturnType<typeof startWindowsJobReadyPoll> | undefined;
+    try {
+      const telemetryPromise = new Promise<
+        ReturnType<typeof readWindowsJobStartupTelemetry>
+      >((resolve, reject) => {
+        readyPoll = startWindowsJobReadyPoll({
+          launch: wrapped,
+          onReady: resolve,
+          onTimeout: ({ stage }) =>
+            reject(new Error(`Delayed readiness timed out during ${stage}`)),
+          overallReadyTimeoutMs: 350,
+          powershellStartTimeoutMs: 200,
+          progressTimeoutMs: 100,
+        });
+      });
+      await vi.advanceTimersByTimeAsync(150);
+      appendFileSync(
+        wrapped.startupStatusFilePath,
+        "150\tpowershell-started\t\n170\thelper-compile-started\t\n",
+      );
+      await vi.advanceTimersByTimeAsync(90);
+      appendFileSync(
+        wrapped.startupStatusFilePath,
+        "240\thelper-ready\t\n",
+      );
+      await vi.advanceTimersByTimeAsync(60);
+      appendFileSync(
+        wrapped.startupStatusFilePath,
+        "300\ttarget-assigned\t\n",
+      );
+      await vi.advanceTimersByTimeAsync(20);
+      appendFileSync(wrapped.startupStatusFilePath, "320\tready\t\n");
+      writeFileSync(wrapped.readyFilePath, "ready", "utf8");
+      await vi.advanceTimersByTimeAsync(5);
+      const telemetry = await telemetryPromise;
+
+      expect(telemetry.phases.map(({ phase }) => phase)).toEqual([
+        "wrapper-created",
+        "powershell-started",
+        "helper-compile-started",
+        "helper-ready",
+        "target-assigned",
+        "ready",
+      ]);
+      expect(formatWindowsJobStartupTelemetry(telemetry)).toBe(
+        "wrapper-created@0ms -> powershell-started@150ms -> helper-compile-started@170ms -> helper-ready@240ms -> target-assigned@300ms -> ready@320ms",
+      );
+    } finally {
+      readyPoll?.cancel();
+      wrapped.cleanup();
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports a PowerShell host-start timeout before wrapper code runs", async () => {
+    const wrapped = wrapCommandInWindowsJob({
+      args: ["/c", "exit 0"],
+      command: "C:\\Windows\\System32\\cmd.exe",
+      env: { SystemRoot: "C:\\Windows" },
+    });
+    try {
+      const startupTimeout = await new Promise<WindowsJobStartupTimeout>(
+        (resolve, reject) => {
+          startWindowsJobReadyPoll({
+            launch: wrapped,
+            onReady: () => reject(new Error("Unexpected readiness")),
+            onTimeout: resolve,
+            overallReadyTimeoutMs: 100,
+            powershellStartTimeoutMs: 40,
+            progressTimeoutMs: 100,
+          });
+        },
+      );
+      expect(startupTimeout).toMatchObject({
+        stage: "powershell-start",
+        timeoutMs: 40,
+        telemetry: {
+          phases: [{ elapsedMs: 0, phase: "wrapper-created" }],
+        },
+      });
+      expect(formatWindowsJobStartupTimeout(startupTimeout)).toBe(
+        "Windows Job PowerShell host did not begin executing within 40ms: wrapper-created@0ms",
+      );
+    } finally {
+      wrapped.cleanup();
+    }
+  });
+
+  it("reports the last startup phase when progress stalls", async () => {
+    const wrapped = wrapCommandInWindowsJob({
+      args: ["/c", "exit 0"],
+      command: "C:\\Windows\\System32\\cmd.exe",
+      env: { SystemRoot: "C:\\Windows" },
+    });
+    try {
+      appendFileSync(
+        wrapped.startupStatusFilePath,
+        "12\tpowershell-started\t\n18\thelper-compile-started\t\n",
+      );
+      const startupTimeout = await new Promise<WindowsJobStartupTimeout>(
+        (resolve, reject) => {
+          startWindowsJobReadyPoll({
+            launch: wrapped,
+            onReady: () => reject(new Error("Unexpected readiness")),
+            onTimeout: resolve,
+            overallReadyTimeoutMs: 200,
+            powershellStartTimeoutMs: 100,
+            progressTimeoutMs: 40,
+          });
+        },
+      );
+      expect(startupTimeout).toMatchObject({
+        stage: "progress-stall",
+        timeoutMs: 40,
+      });
+      expect(startupTimeout.telemetry.phases.at(-1)).toMatchObject({
+        elapsedMs: 18,
+        phase: "helper-compile-started",
+      });
+      expect(formatWindowsJobStartupTimeout(startupTimeout)).toBe(
+        "Windows Job startup made no progress for 40ms after helper-compile-started@18ms: wrapper-created@0ms -> powershell-started@12ms -> helper-compile-started@18ms",
+      );
+    } finally {
+      wrapped.cleanup();
+    }
+  });
+
+  it("keeps progress extensions inside the overall readiness bound", async () => {
+    const wrapped = wrapCommandInWindowsJob({
+      args: ["/c", "exit 0"],
+      command: "C:\\Windows\\System32\\cmd.exe",
+      env: { SystemRoot: "C:\\Windows" },
+    });
+    try {
+      appendFileSync(
+        wrapped.startupStatusFilePath,
+        "12\tpowershell-started\t\n18\thelper-compile-started\t\n25\thelper-ready\t\n",
+      );
+      const startupTimeout = await new Promise<WindowsJobStartupTimeout>(
+        (resolve, reject) => {
+          startWindowsJobReadyPoll({
+            launch: wrapped,
+            onReady: () => reject(new Error("Unexpected readiness")),
+            onTimeout: resolve,
+            overallReadyTimeoutMs: 40,
+            powershellStartTimeoutMs: 100,
+            progressTimeoutMs: 100,
+          });
+        },
+      );
+      expect(startupTimeout).toMatchObject({
+        stage: "overall-ready",
+        timeoutMs: 40,
+      });
+      expect(formatWindowsJobStartupTimeout(startupTimeout)).toBe(
+        "Windows Job shell ownership did not become ready within 40ms overall: wrapper-created@0ms -> powershell-started@12ms -> helper-compile-started@18ms -> helper-ready@25ms",
+      );
+    } finally {
+      wrapped.cleanup();
+    }
+  });
+
+  it.skipIf(process.platform !== "win32")(
+    "executes both native and Git Bash commands inside the Job",
+    async () => {
+      const root = await mkdtemp(
+        path.join(os.tmpdir(), "pwragent-windows-job-test-"),
+      );
+      try {
+        const nativeResult = await runWrappedCommand({
+          args: ["/c", "echo job-native"],
+          command: path.join(
+            process.env.SystemRoot ?? "C:\\Windows",
+            "System32",
+            "cmd.exe",
+          ),
+          cwd: root,
+        });
+        expect(nativeResult, nativeResult.stderr).toMatchObject({
+          code: 0,
+          stderr: "",
+        });
+        expect(nativeResult.stdout).toContain("job-native");
+
+        const gitResult = await runGitCommand(root, ["init", "-b", "main"], {
+          ownProcessTree: true,
+        });
+        expect(gitResult.stderr).toBe("");
+
+        const bashResult = await runWrappedCommand({
+          args: [
+            "-lc",
+            [
+              '[ -s "$HOME/.bashrc" ] && . "$HOME/.bashrc"',
+              '[ -n "${NVM_DIR:-}" ] && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"',
+              '[ -z "${NVM_DIR:-}" ] && [ -s "$HOME/.nvm/nvm.sh" ] && . "$HOME/.nvm/nvm.sh"',
+              "set -e",
+              ": pwragent-env-integration-test",
+              'printf "job-bash"',
+            ].join("\n"),
+          ],
+          command: resolveWindowsBashShell(),
+          cwd: root,
+        });
+        expect(bashResult, bashResult.stderr).toMatchObject({
+          code: 0,
+          stderr: "",
+          stdout: "job-bash",
+        });
+      } finally {
+        await rm(root, { force: true, recursive: true });
+      }
+    },
+    30_000,
+  );
+
+  it.skipIf(process.platform !== "win32")(
+    "preserves a nonzero Git Bash exit through the status side channel",
+    async () => {
+      const root = await mkdtemp(
+        path.join(os.tmpdir(), "pwragent-windows-job-exit-test-"),
+      );
+      try {
+        const result = await runWrappedCommand({
+          args: ["-lc", 'printf "job-bash-failure"; exit 23'],
+          command: resolveWindowsBashShell(),
+          cwd: root,
+        });
+        expect(result, result.stderr).toMatchObject({
+          code: 23,
+          stderr: "",
+          stdout: "job-bash-failure",
+        });
+      } finally {
+        await rm(root, { force: true, recursive: true });
+      }
+    },
+    30_000,
+  );
+});

--- a/apps/desktop/src/main/__tests__/worktree-archive-service.test.ts
+++ b/apps/desktop/src/main/__tests__/worktree-archive-service.test.ts
@@ -9,8 +9,7 @@ import { WorktreeArchiveService } from "../app-server/worktree-archive-service";
 const execFileAsync = promisify(execFile);
 
 async function git(cwd: string, args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync("git", args, {
-    cwd,
+  const { stdout } = await execFileAsync("git", ["-C", cwd, ...args], {
     encoding: "utf8",
     maxBuffer: 1024 * 1024 * 10,
   });

--- a/apps/desktop/src/main/app-server/git-executable.ts
+++ b/apps/desktop/src/main/app-server/git-executable.ts
@@ -1,7 +1,9 @@
 import { execFile as execFileCallback } from "node:child_process";
+import path from "node:path";
 import { promisify } from "node:util";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { gitCandidateInputs } from "../settings/git-discovery";
+import { wrapCommandInWindowsJob } from "../windows-job-wrapper";
 
 const execFile = promisify(execFileCallback);
 
@@ -56,6 +58,34 @@ async function canRunGit(
   }
 }
 
+async function resolveWindowsJobExecutable(
+  command: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string> {
+  if (path.win32.isAbsolute(command)) {
+    return command;
+  }
+
+  const systemRoot = Object.entries(env).find(
+    ([key]) => key.toUpperCase() === "SYSTEMROOT",
+  )?.[1];
+  const where = systemRoot
+    ? path.win32.join(systemRoot, "System32", "where.exe")
+    : "where.exe";
+  const { stdout } = await execFile(where, [command], {
+    encoding: "utf8",
+    env,
+  });
+  const resolved = stdout
+    .split(/\r?\n/)
+    .map((candidate) => candidate.trim())
+    .find((candidate) => path.win32.isAbsolute(candidate));
+  if (!resolved) {
+    throw new Error(`Unable to resolve an absolute executable path for ${command}.`);
+  }
+  return resolved;
+}
+
 export async function resolveGitExecutable(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<string> {
@@ -92,19 +122,46 @@ export async function resolveGitExecutable(
 export async function runGitCommand(
   cwd: string,
   args: string[],
-  options: { env?: NodeJS.ProcessEnv } = {},
+  options: {
+    env?: NodeJS.ProcessEnv;
+    ownProcessTree?: boolean;
+  } = {},
 ): Promise<{
   stdout: string;
   stderr: string;
 }> {
   const env = buildPwrAgentChildProcessEnv(options.env ?? process.env);
   const git = await resolveGitExecutable(env);
-  const { stdout, stderr } = await execFile(git, ["-C", cwd, ...args], {
-    encoding: "utf8",
+  const gitArgs = ["-C", cwd, ...args];
+  const jobExecutable =
+    process.platform === "win32" && options.ownProcessTree
+      ? await resolveWindowsJobExecutable(git, env)
+      : git;
+  const windowsJobLaunch =
+    process.platform === "win32" && options.ownProcessTree
+      ? wrapCommandInWindowsJob({
+          args: gitArgs,
+          command: jobExecutable,
+          env,
+        })
+      : undefined;
+  const launch = windowsJobLaunch ?? {
+    args: gitArgs,
+    command: git,
     env,
-  });
-  return {
-    stdout: stdout.trim(),
-    stderr: (stderr ?? "").trim(),
   };
+
+  try {
+    const { stdout, stderr } = await execFile(launch.command, launch.args, {
+      encoding: "utf8",
+      env: launch.env,
+      maxBuffer: 1024 * 1024 * 10,
+    });
+    return {
+      stdout: stdout.trim(),
+      stderr: (stderr ?? "").trim(),
+    };
+  } finally {
+    windowsJobLaunch?.cleanup();
+  }
 }

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -115,8 +115,7 @@ async function runGit(
   args: string[],
   env?: NodeJS.ProcessEnv,
 ): Promise<GitResult> {
-  return await execFileAsync("git", args, {
-    cwd,
+  return await execFileAsync("git", ["-C", cwd, ...args], {
     env: buildPwrAgentChildProcessEnv(env ?? process.env),
     maxBuffer: 1024 * 1024 * 10,
   });

--- a/apps/desktop/src/main/app-server/worktree-archive-service.ts
+++ b/apps/desktop/src/main/app-server/worktree-archive-service.ts
@@ -9,6 +9,7 @@ import type {
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
+import { runGitCommand } from "./git-executable";
 
 const execFileAsync = promisify(execFile);
 
@@ -60,11 +61,20 @@ type WorktreeArchiveServiceOptions = {
 async function runGit(
   cwd: string,
   args: string[],
-  options: { env?: NodeJS.ProcessEnv } = {},
+  options: {
+    env?: NodeJS.ProcessEnv;
+    ownProcessTree?: boolean;
+  } = {},
 ): Promise<GitResult> {
-  return await execFileAsync("git", args, {
-    cwd,
-    env: buildPwrAgentChildProcessEnv(process.env, options.env),
+  const env = buildPwrAgentChildProcessEnv(process.env, options.env);
+  if (process.platform === "win32" && options.ownProcessTree) {
+    return await runGitCommand(cwd, args, {
+      env,
+      ownProcessTree: true,
+    });
+  }
+  return await execFileAsync("git", ["-C", cwd, ...args], {
+    env,
     maxBuffer: 1024 * 1024 * 10,
   });
 }
@@ -180,7 +190,14 @@ export class WorktreeArchiveService {
     });
     const snapshotRef = snapshotRefForBackend(params.backend, worktreePath);
     await this.runGit(repositoryPath, ["update-ref", snapshotRef, snapshotCommit]);
-    await this.runGit(repositoryPath, ["worktree", "remove", "--force", worktreePath]);
+    await this.runGit(
+      repositoryPath,
+      ["worktree", "remove", "--force", worktreePath],
+      // Git for Windows can hand work to another git.exe after the launcher
+      // exits. Own that complete process tree atomically and do not report the
+      // archive complete until the Job's active-process count reaches zero.
+      { ownProcessTree: true },
+    );
 
     const archivedAt = params.now ?? Date.now();
     return {
@@ -416,13 +433,17 @@ export class WorktreeArchiveService {
   private async runGit(
     cwd: string,
     args: string[],
-    options: { env?: NodeJS.ProcessEnv } = {},
+    options: {
+      env?: NodeJS.ProcessEnv;
+      ownProcessTree?: boolean;
+    } = {},
   ): Promise<GitResult> {
     return await runGit(cwd, args, {
       env: {
         ...this.gitEnv,
         ...options.env,
       },
+      ownProcessTree: options.ownProcessTree,
     });
   }
 }

--- a/apps/desktop/src/main/windows-job-wrapper.ts
+++ b/apps/desktop/src/main/windows-job-wrapper.ts
@@ -1,0 +1,732 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const EXECUTABLE_ENV = "PWRAGENT_JOB_WRAPPER_EXECUTABLE";
+const ARGUMENTS_ENV = "PWRAGENT_JOB_WRAPPER_ARGUMENTS";
+const WORKING_DIRECTORY_ENV = "PWRAGENT_JOB_WRAPPER_CWD";
+const READY_FILE_ENV = "PWRAGENT_JOB_WRAPPER_READY_FILE";
+const EXIT_FILE_ENV = "PWRAGENT_JOB_WRAPPER_EXIT_FILE";
+const STARTED_AT_ENV = "PWRAGENT_JOB_WRAPPER_STARTED_AT";
+const STARTUP_STATUS_FILE_ENV = "PWRAGENT_JOB_WRAPPER_STARTUP_STATUS_FILE";
+const BASH_EXIT_TRAP =
+  "trap 'pwragent_exit=$?; trap - EXIT; set +e; pwragent_exit_file=$(/usr/bin/cygpath.exe -u \"$PWRAGENT_JOB_WRAPPER_EXIT_FILE\"); if [ -n \"$pwragent_exit_file\" ]; then printf \"%s\" \"$pwragent_exit\" > \"$pwragent_exit_file\"; fi; exit \"$pwragent_exit\"' EXIT";
+
+/**
+ * PowerShell hosts this small native launcher because Node does not expose the
+ * Windows Job Object APIs. The target starts suspended, enters a
+ * KILL_ON_JOB_CLOSE job, and only then resumes, so even MSYS fork descendants
+ * cannot escape between process creation and ownership assignment.
+ */
+const WINDOWS_JOB_WRAPPER_SCRIPT = String.raw`
+$ErrorActionPreference = 'Stop'
+$application = [string]$env:PWRAGENT_JOB_WRAPPER_EXECUTABLE
+$argumentsJson = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String([string]$env:PWRAGENT_JOB_WRAPPER_ARGUMENTS))
+$arguments = @((ConvertFrom-Json -InputObject $argumentsJson) | ForEach-Object { [string]$_ })
+$workingDirectory = [string]$env:PWRAGENT_JOB_WRAPPER_CWD
+$readyFile = [string]$env:PWRAGENT_JOB_WRAPPER_READY_FILE
+$exitFile = [string]$env:PWRAGENT_JOB_WRAPPER_EXIT_FILE
+$startupStartedAt = [long]$env:PWRAGENT_JOB_WRAPPER_STARTED_AT
+$startupStatusFile = [string]$env:PWRAGENT_JOB_WRAPPER_STARTUP_STATUS_FILE
+Remove-Item Env:PWRAGENT_JOB_WRAPPER_EXECUTABLE -ErrorAction SilentlyContinue
+Remove-Item Env:PWRAGENT_JOB_WRAPPER_ARGUMENTS -ErrorAction SilentlyContinue
+Remove-Item Env:PWRAGENT_JOB_WRAPPER_CWD -ErrorAction SilentlyContinue
+Remove-Item Env:PWRAGENT_JOB_WRAPPER_READY_FILE -ErrorAction SilentlyContinue
+Remove-Item Env:PWRAGENT_JOB_WRAPPER_STARTED_AT -ErrorAction SilentlyContinue
+Remove-Item Env:PWRAGENT_JOB_WRAPPER_STARTUP_STATUS_FILE -ErrorAction SilentlyContinue
+
+function Write-StartupPhase {
+  param(
+    [Parameter(Mandatory = $true)][string]$Phase,
+    [string]$Detail = ''
+  )
+  try {
+    $elapsedMs = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds() - $startupStartedAt
+    $encodedDetail = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Detail))
+    [IO.File]::AppendAllText(
+      $startupStatusFile,
+      ([string]$elapsedMs + [char]9 + $Phase + [char]9 + $encodedDetail + [Environment]::NewLine))
+  } catch {
+    # Startup telemetry is best-effort and must never weaken Job ownership.
+  }
+}
+
+Write-StartupPhase -Phase 'powershell-started'
+
+$source = @'
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+
+public static class PwrAgentWindowsJobRunner
+{
+    private const uint CREATE_SUSPENDED = 0x00000004;
+    private const uint CREATE_NO_WINDOW = 0x08000000;
+    private const uint HANDLE_FLAG_INHERIT = 0x00000001;
+    private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000;
+    private const int JobObjectExtendedLimitInformation = 9;
+    private const uint STARTF_USESTDHANDLES = 0x00000100;
+    private const uint INFINITE = 0xFFFFFFFF;
+    private const uint WAIT_FAILED = 0xFFFFFFFF;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct STARTUPINFO
+    {
+        public uint cb;
+        public IntPtr lpReserved;
+        public IntPtr lpDesktop;
+        public IntPtr lpTitle;
+        public uint dwX;
+        public uint dwY;
+        public uint dwXSize;
+        public uint dwYSize;
+        public uint dwXCountChars;
+        public uint dwYCountChars;
+        public uint dwFillAttribute;
+        public uint dwFlags;
+        public short wShowWindow;
+        public short cbReserved2;
+        public IntPtr lpReserved2;
+        public IntPtr hStdInput;
+        public IntPtr hStdOutput;
+        public IntPtr hStdError;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PROCESS_INFORMATION
+    {
+        public IntPtr hProcess;
+        public IntPtr hThread;
+        public uint dwProcessId;
+        public uint dwThreadId;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IO_COUNTERS
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+    {
+        public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+        public IO_COUNTERS IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_BASIC_ACCOUNTING_INFORMATION
+    {
+        public long TotalUserTime;
+        public long TotalKernelTime;
+        public long ThisPeriodTotalUserTime;
+        public long ThisPeriodTotalKernelTime;
+        public uint TotalPageFaultCount;
+        public uint TotalProcesses;
+        public uint ActiveProcesses;
+        public uint TotalTerminatedProcesses;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr CreateJobObject(IntPtr jobAttributes, string name);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetInformationJobObject(
+        IntPtr job,
+        int informationClass,
+        IntPtr information,
+        uint informationLength);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool QueryInformationJobObject(
+        IntPtr job,
+        int informationClass,
+        out JOBOBJECT_BASIC_ACCOUNTING_INFORMATION information,
+        uint informationLength,
+        out uint returnLength);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool CreateProcess(
+        string applicationName,
+        StringBuilder commandLine,
+        IntPtr processAttributes,
+        IntPtr threadAttributes,
+        bool inheritHandles,
+        uint creationFlags,
+        IntPtr environment,
+        string currentDirectory,
+        ref STARTUPINFO startupInfo,
+        out PROCESS_INFORMATION processInformation);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint ResumeThread(IntPtr thread);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool GetExitCodeProcess(IntPtr process, out uint exitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool TerminateProcess(IntPtr process, uint exitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CloseHandle(IntPtr handle);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr GetStdHandle(int standardHandle);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetHandleInformation(
+        IntPtr handle,
+        uint mask,
+        uint flags);
+
+    private static void ThrowLastWin32Error(string operation)
+    {
+        throw new Win32Exception(
+            Marshal.GetLastWin32Error(),
+            operation + " failed");
+    }
+
+    private static void WriteStartupPhase(
+        string startupStatusFile,
+        long startupStartedAt,
+        string phase)
+    {
+        try
+        {
+            long elapsedMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - startupStartedAt;
+            File.AppendAllText(
+                startupStatusFile,
+                elapsedMs.ToString() + "\t" + phase + "\t" + Environment.NewLine);
+        }
+        catch
+        {
+            // Startup telemetry is best-effort and must never weaken Job ownership.
+        }
+    }
+
+    private static void MakeInheritable(IntPtr handle)
+    {
+        if (handle == IntPtr.Zero || handle == new IntPtr(-1))
+        {
+            return;
+        }
+        if (!SetHandleInformation(handle, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT))
+        {
+            ThrowLastWin32Error("SetHandleInformation");
+        }
+    }
+
+    private static string QuoteArgument(string value)
+    {
+        if (value.Length > 0 && value.IndexOfAny(new char[] { ' ', '\t', '\n', '\v', '"' }) < 0)
+        {
+            return value;
+        }
+        StringBuilder quoted = new StringBuilder();
+        quoted.Append('"');
+        int backslashes = 0;
+        foreach (char character in value)
+        {
+            if (character == '\\')
+            {
+                backslashes += 1;
+                continue;
+            }
+            if (character == '"')
+            {
+                quoted.Append('\\', backslashes * 2 + 1);
+                quoted.Append('"');
+                backslashes = 0;
+                continue;
+            }
+            quoted.Append('\\', backslashes);
+            quoted.Append(character);
+            backslashes = 0;
+        }
+        quoted.Append('\\', backslashes * 2);
+        quoted.Append('"');
+        return quoted.ToString();
+    }
+
+    private static uint ReadActiveProcessCount(IntPtr job)
+    {
+        JOBOBJECT_BASIC_ACCOUNTING_INFORMATION accounting;
+        uint returnLength;
+        if (!QueryInformationJobObject(
+            job,
+            1,
+            out accounting,
+            (uint)Marshal.SizeOf(typeof(JOBOBJECT_BASIC_ACCOUNTING_INFORMATION)),
+            out returnLength))
+        {
+            ThrowLastWin32Error("QueryInformationJobObject");
+        }
+        return accounting.ActiveProcesses;
+    }
+
+    public static int Run(
+        string application,
+        string[] arguments,
+        string workingDirectory,
+        string readyFile,
+        string startupStatusFile,
+        long startupStartedAt)
+    {
+        WriteStartupPhase(startupStatusFile, startupStartedAt, "native-job-started");
+        IntPtr job = CreateJobObject(IntPtr.Zero, null);
+        if (job == IntPtr.Zero)
+        {
+            ThrowLastWin32Error("CreateJobObject");
+        }
+
+        PROCESS_INFORMATION processInformation = new PROCESS_INFORMATION();
+        bool processCreated = false;
+        try
+        {
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits =
+                new JOBOBJECT_EXTENDED_LIMIT_INFORMATION();
+            limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            int limitsSize = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+            IntPtr limitsPointer = Marshal.AllocHGlobal(limitsSize);
+            try
+            {
+                Marshal.StructureToPtr(limits, limitsPointer, false);
+                if (!SetInformationJobObject(
+                    job,
+                    JobObjectExtendedLimitInformation,
+                    limitsPointer,
+                    (uint)limitsSize))
+                {
+                    ThrowLastWin32Error("SetInformationJobObject");
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(limitsPointer);
+            }
+            WriteStartupPhase(startupStatusFile, startupStartedAt, "job-configured");
+
+            STARTUPINFO startupInfo = new STARTUPINFO();
+            startupInfo.cb = (uint)Marshal.SizeOf(typeof(STARTUPINFO));
+            startupInfo.dwFlags = STARTF_USESTDHANDLES;
+            startupInfo.hStdInput = GetStdHandle(-10);
+            startupInfo.hStdOutput = GetStdHandle(-11);
+            startupInfo.hStdError = GetStdHandle(-12);
+            MakeInheritable(startupInfo.hStdInput);
+            MakeInheritable(startupInfo.hStdOutput);
+            MakeInheritable(startupInfo.hStdError);
+
+            StringBuilder commandLine = new StringBuilder(QuoteArgument(application));
+            foreach (string argument in arguments)
+            {
+                commandLine.Append(' ');
+                commandLine.Append(QuoteArgument(argument));
+            }
+            if (!CreateProcess(
+                application,
+                commandLine,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                true,
+                CREATE_SUSPENDED | CREATE_NO_WINDOW,
+                IntPtr.Zero,
+                workingDirectory,
+                ref startupInfo,
+                out processInformation))
+            {
+                ThrowLastWin32Error("CreateProcess");
+            }
+            processCreated = true;
+            WriteStartupPhase(
+                startupStatusFile,
+                startupStartedAt,
+                "target-created-suspended");
+
+            if (!AssignProcessToJobObject(job, processInformation.hProcess))
+            {
+                TerminateProcess(processInformation.hProcess, 127);
+                ThrowLastWin32Error("AssignProcessToJobObject");
+            }
+            WriteStartupPhase(startupStatusFile, startupStartedAt, "target-assigned");
+            if (ResumeThread(processInformation.hThread) == UInt32.MaxValue)
+            {
+                TerminateProcess(processInformation.hProcess, 127);
+                ThrowLastWin32Error("ResumeThread");
+            }
+            WriteStartupPhase(startupStatusFile, startupStartedAt, "target-resumed");
+            File.WriteAllText(readyFile, "ready");
+            WriteStartupPhase(startupStatusFile, startupStartedAt, "ready");
+            if (WaitForSingleObject(processInformation.hProcess, INFINITE) == WAIT_FAILED)
+            {
+                ThrowLastWin32Error("WaitForSingleObject");
+            }
+            while (ReadActiveProcessCount(job) > 0)
+            {
+                Thread.Sleep(10);
+            }
+            uint exitCode;
+            if (!GetExitCodeProcess(processInformation.hProcess, out exitCode))
+            {
+                ThrowLastWin32Error("GetExitCodeProcess");
+            }
+            return unchecked((int)exitCode);
+        }
+        finally
+        {
+            if (processCreated)
+            {
+                CloseHandle(processInformation.hThread);
+                CloseHandle(processInformation.hProcess);
+            }
+            CloseHandle(job);
+        }
+    }
+}
+'@
+
+try {
+  Write-StartupPhase -Phase 'helper-compile-started'
+  Add-Type -TypeDefinition $source -Language CSharp -ErrorAction Stop
+  Write-StartupPhase -Phase 'helper-ready'
+  $exitCode = [PwrAgentWindowsJobRunner]::Run(
+    $application,
+    [string[]]$arguments,
+    $workingDirectory,
+    $readyFile,
+    $startupStatusFile,
+    $startupStartedAt)
+  if (Test-Path -LiteralPath $exitFile) {
+    $reportedExitCode = 0
+    if ([int]::TryParse(
+      (Get-Content -Raw -LiteralPath $exitFile),
+      [ref]$reportedExitCode)) {
+      $exitCode = $reportedExitCode
+    }
+  }
+  exit $exitCode
+} catch {
+  Write-StartupPhase -Phase 'failed' -Detail $_.Exception.Message
+  [Console]::Error.WriteLine('PwrAgent Windows job wrapper failed: ' + $_.Exception.Message)
+  exit 127
+}
+`;
+
+export type WindowsJobWrappedCommand = {
+  args: string[];
+  cleanup: () => void;
+  command: string;
+  env: NodeJS.ProcessEnv;
+  readyFilePath: string;
+  startupStartedAt: number;
+  startupStatusFilePath: string;
+};
+
+export type WindowsJobStartupPhase = {
+  detail?: string;
+  elapsedMs: number;
+  phase: string;
+};
+
+export type WindowsJobStartupTelemetry = {
+  phases: WindowsJobStartupPhase[];
+};
+
+export type WindowsJobReadyPoll = {
+  cancel: () => void;
+};
+
+export type WindowsJobStartupTimeout = {
+  stage: "overall-ready" | "powershell-start" | "progress-stall";
+  telemetry: WindowsJobStartupTelemetry;
+  timeoutMs: number;
+};
+
+// Keep cold PowerShell launch, forward progress, and overall readiness as
+// separate contracts. Hosted Windows CI has taken 16.7 seconds to enter the
+// wrapper and 7.1 seconds to compile its helper, but each journaled phase still
+// proved forward progress. A phase-relative stall watchdog keeps real hangs
+// bounded without letting one slow phase consume the next phase's allowance.
+// The 28-second overall maximum remains inside the existing 30-second Windows
+// test contract and does not weaken atomic Job ownership.
+export const WINDOWS_JOB_POWERSHELL_START_TIMEOUT_MS = 20_000;
+export const WINDOWS_JOB_STARTUP_PROGRESS_TIMEOUT_MS = 10_000;
+export const WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS = 28_000;
+const WINDOWS_JOB_READY_POLL_INTERVAL_MS = 25;
+
+export function readWindowsJobStartupTelemetry(
+  launch: Pick<WindowsJobWrappedCommand, "startupStatusFilePath">,
+): WindowsJobStartupTelemetry {
+  let content: string;
+  try {
+    content = readFileSync(launch.startupStatusFilePath, "utf8");
+  } catch {
+    return { phases: [] };
+  }
+  const phases: WindowsJobStartupPhase[] = [];
+  for (const line of content.split(/\r?\n/)) {
+    if (!line) continue;
+    const [elapsedValue, phase, encodedDetail = ""] = line.split("\t", 3);
+    const elapsedMs = Number(elapsedValue);
+    if (!phase || !Number.isFinite(elapsedMs) || elapsedMs < 0) {
+      continue;
+    }
+    let detail: string | undefined;
+    if (encodedDetail) {
+      try {
+        detail = Buffer.from(encodedDetail, "base64").toString("utf8");
+      } catch {
+        // Ignore a partial final telemetry line while the wrapper is appending.
+      }
+    }
+    phases.push({ detail, elapsedMs, phase });
+  }
+  return { phases };
+}
+
+export function formatWindowsJobStartupTelemetry(
+  telemetry: WindowsJobStartupTelemetry,
+): string {
+  if (telemetry.phases.length === 0) {
+    return "startup phases unavailable";
+  }
+  return telemetry.phases
+    .map(({ detail, elapsedMs, phase }) =>
+      `${phase}@${elapsedMs}ms${detail ? ` (${detail})` : ""}`,
+    )
+    .join(" -> ");
+}
+
+export function formatWindowsJobStartupTimeout(
+  timeout: WindowsJobStartupTimeout,
+): string {
+  let timeoutDescription: string;
+  if (timeout.stage === "powershell-start") {
+    timeoutDescription =
+      `PowerShell host did not begin executing within ${timeout.timeoutMs}ms`;
+  } else if (timeout.stage === "progress-stall") {
+    const lastPhase = timeout.telemetry.phases.at(-1);
+    timeoutDescription =
+      `startup made no progress for ${timeout.timeoutMs}ms`
+      + (lastPhase
+        ? ` after ${lastPhase.phase}@${lastPhase.elapsedMs}ms`
+        : " after the last recorded phase");
+  } else {
+    timeoutDescription =
+      `shell ownership did not become ready within ${timeout.timeoutMs}ms overall`;
+  }
+  return `Windows Job ${timeoutDescription}: ${formatWindowsJobStartupTelemetry(timeout.telemetry)}`;
+}
+
+export function startWindowsJobReadyPoll(params: {
+  launch: Pick<
+    WindowsJobWrappedCommand,
+    "readyFilePath" | "startupStartedAt" | "startupStatusFilePath"
+  >;
+  onReady: (telemetry: WindowsJobStartupTelemetry) => void;
+  onTimeout: (timeout: WindowsJobStartupTimeout) => void;
+  overallReadyTimeoutMs?: number;
+  powershellStartTimeoutMs?: number;
+  progressTimeoutMs?: number;
+}): WindowsJobReadyPoll {
+  const overallReadyTimeoutMs =
+    params.overallReadyTimeoutMs
+    ?? WINDOWS_JOB_OVERALL_READY_TIMEOUT_MS;
+  const powershellStartTimeoutMs =
+    params.powershellStartTimeoutMs
+    ?? WINDOWS_JOB_POWERSHELL_START_TIMEOUT_MS;
+  const progressTimeoutMs =
+    params.progressTimeoutMs
+    ?? WINDOWS_JOB_STARTUP_PROGRESS_TIMEOUT_MS;
+  const overallReadyDeadline =
+    params.launch.startupStartedAt + overallReadyTimeoutMs;
+  const powershellStartDeadline =
+    params.launch.startupStartedAt + powershellStartTimeoutMs;
+  let cancelled = false;
+  let timer: NodeJS.Timeout | undefined;
+  const cancel = () => {
+    cancelled = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+  const poll = () => {
+    timer = undefined;
+    if (cancelled) return;
+    const telemetry = readWindowsJobStartupTelemetry(params.launch);
+    if (existsSync(params.launch.readyFilePath)) {
+      cancelled = true;
+      params.onReady(telemetry);
+      return;
+    }
+    const powershellStarted = telemetry.phases.find(
+      ({ phase }) => phase === "powershell-started",
+    );
+    const now = Date.now();
+    if (!powershellStarted && now >= powershellStartDeadline) {
+      cancelled = true;
+      params.onTimeout({
+        stage: "powershell-start",
+        telemetry,
+        timeoutMs: powershellStartTimeoutMs,
+      });
+      return;
+    }
+    if (powershellStarted) {
+      if (powershellStarted.elapsedMs > powershellStartTimeoutMs) {
+        cancelled = true;
+        params.onTimeout({
+          stage: "powershell-start",
+          telemetry,
+          timeoutMs: powershellStartTimeoutMs,
+        });
+        return;
+      }
+      const lastPhase = telemetry.phases.at(-1) ?? powershellStarted;
+      const progressDeadline =
+        params.launch.startupStartedAt
+        + lastPhase.elapsedMs
+        + progressTimeoutMs;
+      if (now >= overallReadyDeadline) {
+        cancelled = true;
+        params.onTimeout({
+          stage: "overall-ready",
+          telemetry,
+          timeoutMs: overallReadyTimeoutMs,
+        });
+        return;
+      }
+      if (now >= progressDeadline) {
+        cancelled = true;
+        params.onTimeout({
+          stage: "progress-stall",
+          telemetry,
+          timeoutMs: progressTimeoutMs,
+        });
+        return;
+      }
+    }
+    timer = setTimeout(poll, WINDOWS_JOB_READY_POLL_INTERVAL_MS);
+  };
+  poll();
+  return { cancel };
+}
+
+function encodeArgument(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64");
+}
+
+export function wrapCommandInWindowsJob(params: {
+  args: string[];
+  command: string;
+  cwd?: string;
+  env: NodeJS.ProcessEnv;
+}): WindowsJobWrappedCommand {
+  const stateDirectory = mkdtempSync(
+    path.join(os.tmpdir(), "pwragent-windows-job-"),
+  );
+  const readyFilePath = path.join(stateDirectory, "ready");
+  const exitFilePath = path.join(stateDirectory, "exit");
+  const startupStatusFilePath = path.join(stateDirectory, "startup-status.tsv");
+  const scriptPath = path.join(stateDirectory, "wrapper.ps1");
+  const startupStartedAt = Date.now();
+  writeFileSync(startupStatusFilePath, "0\twrapper-created\t\n", {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  writeFileSync(scriptPath, WINDOWS_JOB_WRAPPER_SCRIPT, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  const systemRoot = Object.entries(params.env).find(
+    ([key]) => key.toUpperCase() === "SYSTEMROOT",
+  )?.[1];
+  const powershell = systemRoot
+    ? path.win32.join(
+        systemRoot,
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe",
+      )
+    : "powershell.exe";
+  // Git-for-Windows can hand execution between multiple MSYS processes. The
+  // native process created above is therefore not always the process whose
+  // exit code represents the shell script. Have every POSIX `-lc` invocation
+  // report its own exact status for the wrapper to return.
+  const wrappedArgs = [...params.args];
+  if (wrappedArgs[0] === "-lc" && wrappedArgs[1] !== undefined) {
+    wrappedArgs[1] = `${BASH_EXIT_TRAP}\n${wrappedArgs[1]}`;
+  }
+  return {
+    command: powershell,
+    args: [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+      scriptPath,
+    ],
+    cleanup: () => {
+      rmSync(stateDirectory, {
+        force: true,
+        maxRetries: 5,
+        recursive: true,
+        retryDelay: 100,
+      });
+    },
+    env: {
+      ...params.env,
+      [EXECUTABLE_ENV]: params.command,
+      [ARGUMENTS_ENV]: encodeArgument(JSON.stringify(wrappedArgs)),
+      [WORKING_DIRECTORY_ENV]: params.cwd ?? process.cwd(),
+      [READY_FILE_ENV]: readyFilePath,
+      [EXIT_FILE_ENV]: exitFilePath,
+      [STARTED_AT_ENV]: String(startupStartedAt),
+      [STARTUP_STATUS_FILE_ENV]: startupStatusFilePath,
+    },
+    readyFilePath,
+    startupStartedAt,
+    startupStatusFilePath,
+  };
+}

--- a/apps/desktop/src/main/windows-shell.ts
+++ b/apps/desktop/src/main/windows-shell.ts
@@ -16,16 +16,45 @@ export function windowsBashCandidates(): string[] {
   const localAppData = process.env.LOCALAPPDATA;
 
   const candidates = [
-    path.join(programFiles, "Git", "bin", "bash.exe"),
-    path.join(programFiles, "Git", "usr", "bin", "bash.exe"),
-    path.join(programFilesX86, "Git", "bin", "bash.exe"),
+    path.win32.join(programFiles, "Git", "usr", "bin", "bash.exe"),
+    path.win32.join(programFiles, "Git", "bin", "bash.exe"),
+    path.win32.join(programFilesX86, "Git", "usr", "bin", "bash.exe"),
+    path.win32.join(programFilesX86, "Git", "bin", "bash.exe"),
   ];
   if (localAppData) {
-    candidates.push(path.join(localAppData, "Programs", "Git", "bin", "bash.exe"));
+    candidates.push(
+      path.win32.join(localAppData, "Programs", "Git", "usr", "bin", "bash.exe"),
+      path.win32.join(localAppData, "Programs", "Git", "bin", "bash.exe"),
+    );
   }
   // Last resort: rely on PATH resolution.
   candidates.push("bash.exe");
   return candidates;
+}
+
+/**
+ * Prefer Git-for-Windows' stable MSYS bash over its `bin\\bash.exe` launcher.
+ * The launcher can exit after spawning a differently-pid'd `usr\\bin\\bash.exe`,
+ * which breaks process-tree ownership and leaves detached commands behind.
+ */
+export function preferStableWindowsBashPath(
+  shell: string,
+  pathExists: (candidate: string) => boolean = existsSync,
+): string {
+  const normalized = path.win32.normalize(shell);
+  if (path.win32.basename(normalized).toLowerCase() !== "bash.exe") {
+    return shell;
+  }
+  const binDir = path.win32.dirname(normalized);
+  if (path.win32.basename(binDir).toLowerCase() !== "bin") {
+    return shell;
+  }
+  const binParent = path.win32.dirname(binDir);
+  if (path.win32.basename(binParent).toLowerCase() === "usr") {
+    return normalized;
+  }
+  const stableBash = path.win32.join(binParent, "usr", "bin", "bash.exe");
+  return pathExists(stableBash) ? stableBash : shell;
 }
 
 /**


### PR DESCRIPTION
## Summary

Backports #1488 to `releases/1.0`:

- runs `git worktree remove` inside an atomic Windows Job Object boundary
- assigns the native `git.exe` process to `KILL_ON_JOB_CLOSE` before resuming it
- waits for the Job's active-process count to reach zero before archive completion
- invokes Git with `git -C` so temporary repositories are not inherited as process working directories
- resolves bare Git safely to an absolute executable for suspended native launch
- preserves complete native argument vectors through base64-encoded JSON transport

## Source provenance

- PwrAgent #1488 — squash `9738edb9bbe2a78d4db4faf430b36c15460e3b2d`
- prerequisite Job Object boundary from #1259 — squash `5ddd8ceaed8ce0600d247cd53d405f4d05156ba9`
- prerequisite readiness hardening retained from #1277 (`64b91c50e`) and #1301 (`eafb4d1ea`)

The release branch did not yet contain the atomic Job Object module used by #1488, so the mature shared boundary and its focused tests are included as a manual prerequisite adaptation. This does not replace or weaken the bounded shutdown and process-tree ownership already backported through #1509/#1513. Federation-only behavior is excluded.

## Root cause and impact

Git for Windows can hand execution from its launcher to another `git.exe`. Waiting only for the immediate child can report archive completion while a descendant still holds the worktree path open, causing intermittent `EBUSY` cleanup failures. The Job boundary makes ownership atomic and completion reflect real process quiescence.

## SQLite migration audit

- `CURRENT_STATE_DB_USER_VERSION` remains **32**
- no state DB, DDL, schema, config, or migration changes

## Validation

- 22 focused handoff/archive/Windows Job tests passed; 2 real Windows-only process tests skipped on macOS and remain enabled for Windows CI
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; 136 existing warnings)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

No headed desktop E2E was run on the host. The real Git-for-Windows Job Object and immediate directory-reap behavior require the Windows CI lane before platform verification is complete.
