### PR TITLE
fix(desktop): backport Markdown table UX fixes

### DIFF
--- a/apps/desktop/e2e/composer-markdown-paste.spec.ts
+++ b/apps/desktop/e2e/composer-markdown-paste.spec.ts
@@ -5,6 +5,15 @@ import path from "node:path";
 import { expect, test, type Page } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 
+const TABLE_MARKDOWN = [
+  "## Quick matrix",
+  "",
+  "| Harness | Exe | Auth |",
+  "|-|--|---|",
+  "| Alpha | `alpha` | Browser sign-in |",
+  "| Beta | `beta` | API key |",
+].join("\n");
+
 // Regression coverage for composer markdown paste. The bug these guard against:
 // a code fence used to flip paste off Tiptap's HTML-aware default path onto a
 // plain-text-only markdown reparse. When a clipboard's text/plain flattens
@@ -56,9 +65,22 @@ async function createPasteFixture(): Promise<{
   const threadReadResult = {
     entries: [
       { type: "message", id: "existing-message-1", role: "assistant", text: "Ready." },
+      {
+        type: "message",
+        id: "existing-message-2",
+        role: "assistant",
+        text: TABLE_MARKDOWN,
+      },
     ],
-    messages: [{ id: "existing-message-1", role: "assistant", text: "Ready." }],
-    lastAssistantMessage: "Ready.",
+    messages: [
+      { id: "existing-message-1", role: "assistant", text: "Ready." },
+      {
+        id: "existing-message-2",
+        role: "assistant",
+        text: TABLE_MARKDOWN,
+      },
+    ],
+    lastAssistantMessage: TABLE_MARKDOWN,
     pagination: { supportsPagination: false, hasPreviousPage: false },
   };
 
@@ -80,6 +102,15 @@ async function createPasteFixture(): Promise<{
           { id: "thread-list-1", kind: "response", method: "thread/list", result: [existingThread] },
           { id: "thread-read-1", kind: "response", method: "thread/read", result: threadReadResult },
           { id: "thread-read-2", kind: "response", method: "thread/read", result: threadReadResult },
+          {
+            id: "turn-start-1",
+            kind: "response",
+            method: "turn/start",
+            result: {
+              threadId: "thread-existing",
+              turnId: "turn-table-paste",
+            },
+          },
         ],
       },
       null,
@@ -269,6 +300,70 @@ test("a code fence is upgraded from text/plain even when HTML is present but has
     await expect(
       tiptapInput.locator(".composer-tiptap-input__editor > pre"),
     ).toHaveCount(1);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("a copied transcript table pastes and sends as Markdown source", async () => {
+  const fixture = await createPasteFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+
+  try {
+    await openExistingThread(app);
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    const sourceMessage = transcript
+      .locator(".transcript-message--assistant")
+      .filter({ hasText: "Quick matrix" })
+      .first();
+    await expect(sourceMessage.locator("table")).toBeVisible();
+    await expect(
+      sourceMessage.getByRole("columnheader", { name: "Harness" }),
+    ).toBeVisible();
+
+    const reply = app.window.getByRole("textbox", { name: "Reply" });
+    const composerInput = app.window.getByTestId("composer-tiptap-input");
+    await app.electronApp.evaluate(({ clipboard }, markdown) => {
+      clipboard.writeText(markdown);
+    }, TABLE_MARKDOWN);
+    await reply.focus();
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+V" : "Control+V",
+    );
+    await expect(composerInput).toHaveAttribute("data-value", TABLE_MARKDOWN);
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+A" : "Control+A",
+    );
+    await app.window.keyboard.press("Delete");
+    await expect(composerInput).toHaveAttribute("data-value", "");
+
+    await sourceMessage.getByRole("button", { name: "Copy message" }).click();
+    await expect
+      .poll(async () =>
+        await app.electronApp.evaluate(({ clipboard }) => clipboard.readText())
+      )
+      .toBe(TABLE_MARKDOWN);
+
+    await reply.focus();
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+V" : "Control+V",
+    );
+
+    await expect(composerInput).toHaveAttribute("data-value", TABLE_MARKDOWN);
+    await expect(
+      composerInput.locator(".composer-tiptap-input__editor table"),
+    ).toHaveCount(0);
+
+    await app.window.getByRole("button", { name: "Send", exact: true }).click();
+    const sentMessage = transcript
+      .locator(".transcript-message--user")
+      .filter({ hasText: "Quick matrix" })
+      .first();
+    await expect(sentMessage.locator("table")).toBeVisible();
+    await expect(
+      sentMessage.getByRole("columnheader", { name: "Harness" }),
+    ).toBeVisible();
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/fixtures/README.md
+++ b/apps/desktop/e2e/fixtures/README.md
@@ -148,6 +148,9 @@ desktop replay scenarios do not exercise Codex sidebar directory identity.
   hide low-signal hunks via the focused diff path
 - `thread-image-fit/`: pasted transcript image preview preserves its natural
   aspect ratio and fits within the preview container without cropping
+- `markdown-findings-table/`: wide markdown tables keep their headings and
+  separators inside the scrollable split block; table-block and full-message
+  clipboard actions retain their distinct scopes
 - `mcp-elicitation/`: Codex MCP elicitation request for Playwright
   `browser_tabs`, including MCP-shaped approval handling and progress rendering
 

--- a/apps/desktop/e2e/fixtures/markdown-findings-table/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/markdown-findings-table/replay.fixture.json
@@ -2,7 +2,7 @@
   "metadata": {
     "backend": "codex",
     "scenario": "markdown-findings-table",
-    "sourceCaptureId": "synthetic-sanitized-2026-05-11",
+    "sourceCaptureId": "synthetic-sanitized-2026-08-11",
     "threadId": "thread-markdown-findings-table"
   },
   "steps": [
@@ -78,6 +78,12 @@
             "id": "message-assistant-4",
             "role": "assistant",
             "text": "Alternate review header schema (proves the classifier is content-aware, not keyed to the literal `# / Sev / File / Issue / Fix` header). Same content shape, different labels — expect tag / label / prose / prose:\n\n| Severity | Module | Symptom | Fix |\n|:---:|---|---|---|\n| P0 | billing/dispatch | Duplicate-notice emission after retry suppression, observed in shadow rollouts at 0.3% rate. Caused by fallback path not respecting suppression flag. | Propagate suppression flag into the secondary provider path and gate the fallback emission behind it. Add an integration test that exercises the suppression interleaving. |\n| P1 | window/ledger | Tenant identity merging across cache normalization. Two tenants with the same period and bucket ids are indistinguishable to the cache key. | Add `tenantId` to the `LedgerIdentity` tuple, the `stableKey` serializer, and the sorting comparator. Regression test in `window/ledger.spec.ts`. |\n| P2 | window/observation | Failure-heavy buckets remain sparse indefinitely because the call-count threshold excludes failures from observed calls. | Switch the threshold input to total attempts, keep the win-ratio math on resolved auctions, and add a failure-heavy regression test. |"
+          },
+          {
+            "type": "message",
+            "id": "message-assistant-5",
+            "role": "assistant",
+            "text": "Research is complete. This is a compact cross-platform setup guide for the public harnesses.\n\n## Quick matrix\n\n---\n\n| Harness | Executable | Primary install | First run |\n|---|---|---|---|\n| Grok Build | `grok` | Shell installer on macOS/Linux; PowerShell installer on Windows | Browser sign-in or API key |\n| Kimi Code | `kimi` | Vendor installer, with Git for Windows on native Windows | Run `/login` in the TUI |\n| Qwen Code | `qwen` | Standalone installer; package-manager fallback needs Node 22+ | Run `/auth` in the session |\n| Codex CLI | `codex` | Standalone installer for macOS, Linux, and Windows | Sign in with ChatGPT or provide an API key |\n\nImplementation note: keep the matrix horizontally scrollable without widening the transcript."
           }
         ],
         "messages": [
@@ -105,6 +111,11 @@
             "id": "message-assistant-4",
             "role": "assistant",
             "text": "Alternate review header schema (proves the classifier is content-aware, not keyed to the literal `# / Sev / File / Issue / Fix` header). Same content shape, different labels — expect tag / label / prose / prose:\n\n| Severity | Module | Symptom | Fix |\n|:---:|---|---|---|\n| P0 | billing/dispatch | Duplicate-notice emission after retry suppression, observed in shadow rollouts at 0.3% rate. Caused by fallback path not respecting suppression flag. | Propagate suppression flag into the secondary provider path and gate the fallback emission behind it. Add an integration test that exercises the suppression interleaving. |\n| P1 | window/ledger | Tenant identity merging across cache normalization. Two tenants with the same period and bucket ids are indistinguishable to the cache key. | Add `tenantId` to the `LedgerIdentity` tuple, the `stableKey` serializer, and the sorting comparator. Regression test in `window/ledger.spec.ts`. |\n| P2 | window/observation | Failure-heavy buckets remain sparse indefinitely because the call-count threshold excludes failures from observed calls. | Switch the threshold input to total attempts, keep the win-ratio math on resolved auctions, and add a failure-heavy regression test. |"
+          },
+          {
+            "id": "message-assistant-5",
+            "role": "assistant",
+            "text": "Research is complete. This is a compact cross-platform setup guide for the public harnesses.\n\n## Quick matrix\n\n---\n\n| Harness | Executable | Primary install | First run |\n|---|---|---|---|\n| Grok Build | `grok` | Shell installer on macOS/Linux; PowerShell installer on Windows | Browser sign-in or API key |\n| Kimi Code | `kimi` | Vendor installer, with Git for Windows on native Windows | Run `/login` in the TUI |\n| Qwen Code | `qwen` | Standalone installer; package-manager fallback needs Node 22+ | Run `/auth` in the session |\n| Codex CLI | `codex` | Standalone installer for macOS, Linux, and Windows | Sign in with ChatGPT or provide an API key |\n\nImplementation note: keep the matrix horizontally scrollable without widening the transcript."
           }
         ],
         "lastUserMessage": "Review the billing pacing change and present the findings in a compact table.",

--- a/apps/desktop/e2e/markdown-findings-table.spec.ts
+++ b/apps/desktop/e2e/markdown-findings-table.spec.ts
@@ -4,6 +4,21 @@ import { expect, test } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 
 const specDir = path.dirname(fileURLToPath(import.meta.url));
+const harnessTableBlock = `## Quick matrix
+
+---
+
+| Harness | Executable | Primary install | First run |
+|---|---|---|---|
+| Grok Build | \`grok\` | Shell installer on macOS/Linux; PowerShell installer on Windows | Browser sign-in or API key |
+| Kimi Code | \`kimi\` | Vendor installer, with Git for Windows on native Windows | Run \`/login\` in the TUI |
+| Qwen Code | \`qwen\` | Standalone installer; package-manager fallback needs Node 22+ | Run \`/auth\` in the session |
+| Codex CLI | \`codex\` | Standalone installer for macOS, Linux, and Windows | Sign in with ChatGPT or provide an API key |`;
+const harnessMessage = `Research is complete. This is a compact cross-platform setup guide for the public harnesses.
+
+${harnessTableBlock}
+
+Implementation note: keep the matrix horizontally scrollable without widening the transcript.`;
 
 test("renders a wide assistant markdown findings table without crushing the columns", async () => {
   const app = await launchElectronApp({
@@ -52,6 +67,9 @@ test("renders a wide assistant markdown findings table without crushing the colu
     await expect(proseMessage).toBeVisible();
     await expect(proseMessage).not.toHaveClass(/transcript-message--table-wide/);
     await expect(wideTableMessage).toBeVisible();
+    await expect(
+      wideTableMessage.getByRole("heading", { level: 2, name: "Findings" })
+    ).toBeVisible();
     await expect(tableScroll).toBeVisible();
     await expect(table).toBeVisible();
     await expect(table.getByRole("columnheader", { name: "#" })).toBeVisible();
@@ -140,6 +158,42 @@ test("renders a wide assistant markdown findings table without crushing the colu
     expect(oversizedDimensions.northAmericaRight).toBeLessThanOrEqual(
       oversizedDimensions.europeLeft + 1
     );
+
+    const harnessProseMessage = transcript
+      .locator(".transcript-message--assistant")
+      .filter({ hasText: "Research is complete" })
+      .first();
+    const harnessTableMessage = transcript
+      .locator(".transcript-message--table-wide")
+      .filter({ hasText: "Quick matrix" })
+      .first();
+    await expect(harnessProseMessage).toBeVisible();
+    await expect(harnessProseMessage).not.toContainText("Quick matrix");
+    await expect(harnessTableMessage).toBeVisible();
+    await expect(
+      harnessTableMessage.getByRole("heading", { level: 2, name: "Quick matrix" })
+    ).toBeVisible();
+    await expect(harnessTableMessage.locator(".transcript-message__rule")).toBeVisible();
+    await expect(harnessTableMessage.locator("table")).toContainText("Grok Build");
+
+    await app.electronApp.evaluate(({ clipboard }) => clipboard.writeText(""));
+    await harnessTableMessage
+      .getByRole("button", { name: "Copy table block" })
+      .click();
+    await expect
+      .poll(async () =>
+        await app.electronApp.evaluate(({ clipboard }) => clipboard.readText())
+      )
+      .toBe(harnessTableBlock);
+
+    await harnessProseMessage
+      .getByRole("button", { name: "Copy message" })
+      .click();
+    await expect
+      .poll(async () =>
+        await app.electronApp.evaluate(({ clipboard }) => clipboard.readText())
+      )
+      .toBe(harnessMessage);
   } finally {
     await app.close();
   }

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -358,6 +358,67 @@ function containsBlockMarkdown(text: string): boolean {
   return text.split("\n").some((line) => isMarkdownBlockStart(line));
 }
 
+function splitMarkdownTableCells(line: string): string[] {
+  const trimmed = line.trim();
+  let content = trimmed.startsWith("|") ? trimmed.slice(1) : trimmed;
+  let trailingBackslashes = 0;
+  for (
+    let index = content.length - 2;
+    index >= 0 && content[index] === "\\";
+    index -= 1
+  ) {
+    trailingBackslashes += 1;
+  }
+  if (content.endsWith("|") && trailingBackslashes % 2 === 0) {
+    content = content.slice(0, -1);
+  }
+
+  const cells: string[] = [];
+  let cell = "";
+  let escaped = false;
+  for (const character of content) {
+    if (escaped) {
+      cell += character;
+      escaped = false;
+    } else if (character === "\\") {
+      cell += character;
+      escaped = true;
+    } else if (character === "|") {
+      cells.push(cell.trim());
+      cell = "";
+    } else {
+      cell += character;
+    }
+  }
+  cells.push(cell.trim());
+  return cells;
+}
+
+// Mirrors micromark-extension-gfm-table's delimiter grammar: each cell is an
+// optional colon, one or more hyphens, and an optional colon. The header and
+// delimiter must have the same cell count, while a pipe or colon distinguishes
+// a one-column table from a setext heading.
+function parseMarkdownTableDelimiterRow(line: string): string[] | undefined {
+  const cells = splitMarkdownTableCells(line);
+  const hasTableMarker =
+    line.includes("|")
+    || cells.some((cell) => cell.includes(":"));
+  return hasTableMarker && cells.every((cell) => /^:?-+:?$/.test(cell))
+    ? cells
+    : undefined;
+}
+
+function containsMarkdownTable(text: string): boolean {
+  const lines = text.split("\n");
+  return lines.some((line, index) => {
+    if (!line.trim()) {
+      return false;
+    }
+    const delimiterCells = parseMarkdownTableDelimiterRow(lines[index + 1] ?? "");
+    return delimiterCells?.length === splitMarkdownTableCells(line).length;
+  });
+}
+
 function isMarkdownSectionLabelLine(line: string): boolean {
   return /^[^\s].*:\s*$/.test(line);
 }
@@ -1415,12 +1476,17 @@ function pastePlainMarkdownText(
   event: ClipboardEvent<HTMLDivElement>,
 ): boolean {
   const text = getPlainTextFromPaste(event);
+  const preserveMarkdownTableSource = containsMarkdownTable(text);
   // Only reroute through the markdown parser when the text carries block
-  // structure the default paste won't rebuild (fences, bullet/ordered lists).
+  // structure the default paste won't rebuild (fences, bullet/ordered lists),
+  // or when text/plain contains a GFM table. In that table case, text/plain is
+  // the lossless Markdown source: ProseMirror adds blank paragraphs between
+  // rows for plain-only paste, while the rich HTML path flattens adjacent cell
+  // text because the composer schema deliberately has no table node.
   // Pure prose — and inline-only markdown like **bold** / `code`, which paste
   // rules already handle — stays on the default path so we don't disturb
   // mid-sentence pastes.
-  if (!containsBlockMarkdown(text)) {
+  if (!containsBlockMarkdown(text) && !preserveMarkdownTableSource) {
     return false;
   }
 
@@ -1442,7 +1508,10 @@ function pastePlainMarkdownText(
   // this targets — one rendered message copied with both flavors — and is not
   // meant to be a general markdown/HTML merge. Note <p> alone does NOT count:
   // bare paragraph HTML around a text/plain fence must still reach the parser.
-  if (clipboardHtmlHasStructuredBlocks(event)) {
+  if (
+    !preserveMarkdownTableSource
+    && clipboardHtmlHasStructuredBlocks(event)
+  ) {
     return false;
   }
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -278,6 +278,107 @@ describe("ComposerTiptapInput", () => {
     ).toBe(false);
   });
 
+  it("keeps a copied rendered table as Markdown source", async () => {
+    const markdown = [
+      "## Quick matrix",
+      "",
+      "| Harness | Exe | Auth |",
+      "|-|--|---|",
+      "| Alpha | `alpha` | Browser sign-in |",
+      "| Beta | `beta` | API key |",
+    ].join("\n");
+    const html = [
+      "<h2>Quick matrix</h2>",
+      "<table>",
+      "<thead><tr><th>Harness</th><th>Exe</th><th>Auth</th></tr></thead>",
+      "<tbody>",
+      "<tr><td>Alpha</td><td><code>alpha</code></td><td>Browser sign-in</td></tr>",
+      "<tr><td>Beta</td><td><code>beta</code></td><td>API key</td></tr>",
+      "</tbody>",
+      "</table>",
+    ].join("");
+    const { container, onChange } = renderTiptapInput();
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return html;
+          }
+          return type === "text/plain" ? markdown : "";
+        },
+        items: [],
+        types: ["text/html", "text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(markdown, []);
+    });
+    expect(container.querySelector("table")).not.toBeInTheDocument();
+    expect(container.querySelector(".composer-tiptap-input__editor"))
+      .toHaveTextContent("|-|--|---|");
+  });
+
+  it("keeps a one-column rendered table as Markdown source", async () => {
+    const markdown = [
+      "| Harness |",
+      "| - |",
+      "| Alpha |",
+    ].join("\n");
+    const { container, onChange } = renderTiptapInput();
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return [
+              "<table>",
+              "<thead><tr><th>Harness</th></tr></thead>",
+              "<tbody><tr><td>Alpha</td></tr></tbody>",
+              "</table>",
+            ].join("");
+          }
+          return type === "text/plain" ? markdown : "";
+        },
+        items: [],
+        types: ["text/html", "text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(markdown, []);
+    });
+    expect(container.querySelector("table")).not.toBeInTheDocument();
+  });
+
+  it("does not treat a setext heading as a one-column table", async () => {
+    const { container } = renderTiptapInput();
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return "<h2>Quick matrix</h2>";
+          }
+          return type === "text/plain" ? "Quick matrix\n-" : "";
+        },
+        items: [],
+        types: ["text/html", "text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector("h2")).toHaveTextContent("Quick matrix");
+    });
+  });
+
   it("keeps HTML-only double-blank-line SQL paste inside an active code block", async () => {
     const { container, onChange } = renderTiptapInput({ value: "```\n```" });
     const textbox = await screen.findByRole("textbox", { name: "Reply" });

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -94,6 +94,10 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
             continuation: index > 0,
             desktopApi: props.desktopApi,
             message: props.message,
+            segmentText:
+              segment.type === "table" && messageSegments.length > 1
+                ? segment.text
+                : undefined,
             sourceThreadLink,
             threadLinks,
             text: messageCopyText,
@@ -223,8 +227,14 @@ function splitMarkdownTableBlocks(markdown: string): MarkdownBlock[] {
       isMarkdownTableHeader(line) &&
       isMarkdownTableDelimiter(lines[index + 1] ?? "")
     ) {
+      const tableHeading = splitTrailingTableHeading(textBuffer);
+      textBuffer = tableHeading.remainingLines;
       flushText();
-      const tableLines = [line, lines[index + 1] ?? ""];
+      const tableLines = [
+        ...tableHeading.headingLines,
+        line,
+        lines[index + 1] ?? "",
+      ];
       index += 2;
       while (index < lines.length && isMarkdownTableRow(lines[index] ?? "")) {
         tableLines.push(lines[index] ?? "");
@@ -240,6 +250,39 @@ function splitMarkdownTableBlocks(markdown: string): MarkdownBlock[] {
 
   flushText();
   return blocks;
+}
+
+function splitTrailingTableHeading(lines: string[]): {
+  headingLines: string[];
+  remainingLines: string[];
+} {
+  let headingIndex = lines.length - 1;
+  while (
+    headingIndex >= 0
+    && (
+      lines[headingIndex]?.trim() === ""
+      || isMarkdownThematicBreak(lines[headingIndex] ?? "")
+    )
+  ) {
+    headingIndex -= 1;
+  }
+
+  if (!isMarkdownAtxHeading(lines[headingIndex] ?? "")) {
+    return { headingLines: [], remainingLines: lines };
+  }
+
+  return {
+    headingLines: lines.slice(headingIndex),
+    remainingLines: lines.slice(0, headingIndex),
+  };
+}
+
+function isMarkdownAtxHeading(line: string): boolean {
+  return /^\s{0,3}#{1,6}(?:\s+|$)/.test(line);
+}
+
+function isMarkdownThematicBreak(line: string): boolean {
+  return /^\s{0,3}(?:(?:\*\s*){3,}|(?:_\s*){3,}|(?:-\s*){3,})$/.test(line);
 }
 
 function isMarkdownTableHeader(line: string): boolean {
@@ -273,7 +316,14 @@ function splitTableCells(line: string): string[] {
 }
 
 function isWideMarkdownTable(table: string): boolean {
-  const [header = "", , ...rows] = table.split("\n");
+  const lines = table.split("\n");
+  const headerIndex = lines.findIndex(
+    (line, index) =>
+      isMarkdownTableHeader(line)
+      && isMarkdownTableDelimiter(lines[index + 1] ?? ""),
+  );
+  const header = lines[headerIndex] ?? "";
+  const rows = lines.slice(headerIndex + 2);
   const columnCount = splitTableCells(header).length;
   const longestRowLength = rows.reduce(
     (longest, row) => Math.max(longest, row.length),
@@ -466,12 +516,29 @@ function renderMessageHeader(params: {
   continuation: boolean;
   desktopApi?: Pick<DesktopApi, "copyText">;
   message: AppServerThreadMessageEntry;
+  segmentText?: string;
   sourceThreadLink?: ResolvedThreadLink;
   threadLinks: ReturnType<typeof useThreadLinks>;
   text: string;
 }): ReactNode {
+  const segmentCopyButton = params.segmentText ? (
+    <TranscriptCopyButton
+      className="transcript-copy-button--segment"
+      copiedLabel="Copied table block"
+      desktopApi={params.desktopApi}
+      label="Copy table block"
+      text={params.segmentText}
+    />
+  ) : null;
+
   if (params.continuation) {
-    return null;
+    return segmentCopyButton ? (
+      <header className="transcript-message__header transcript-message__header--continuation">
+        <span className="transcript-message__header-actions">
+          {segmentCopyButton}
+        </span>
+      </header>
+    ) : null;
   }
 
   return (
@@ -497,6 +564,7 @@ function renderMessageHeader(params: {
           ) : null}
       </span>
       <span className="transcript-message__header-actions">
+        {segmentCopyButton}
         {params.text ? (
           <TranscriptCopyButton
             className="transcript-copy-button--message"

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -560,6 +560,54 @@ describe("TranscriptList", () => {
     expect(screen.getByText("Follow-up prose should not inherit", { exact: false })).toBeInTheDocument();
   });
 
+  it("keeps a trailing heading and separators with its wide table split block", async () => {
+    const copyText = vi.fn(async () => undefined);
+    const tableBlock = `## Quick matrix
+
+---
+
+${wideMarkdownTable}`;
+    const messageText = `Research is complete. The concise guide follows.
+
+${tableBlock}
+
+Implementation notes remain in a readable bubble.`;
+
+    const { container } = render(
+      <TranscriptList
+        desktopApi={{ copyText }}
+        entries={[
+          {
+            type: "message",
+            id: "message-table-heading",
+            role: "assistant",
+            text: messageText,
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const articles = container.querySelectorAll("article.transcript-message--assistant");
+    const tableArticle = screen.getByRole("heading", { name: "Quick matrix" }).closest("article");
+    expect(articles).toHaveLength(3);
+    expect(articles[0]).toHaveTextContent("Research is complete");
+    expect(articles[0]).not.toHaveTextContent("Quick matrix");
+    expect(tableArticle).toHaveClass("transcript-message--table-wide");
+    expect(tableArticle?.querySelector(".transcript-message__rule")).toBeInTheDocument();
+    expect(tableArticle?.querySelector("table.thread-markdown__table")).toBeInTheDocument();
+    expect(articles[2]).toHaveTextContent("Implementation notes remain");
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy table block" }));
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(tableBlock);
+    });
+    expect(copyText).not.toHaveBeenCalledWith(messageText);
+  });
+
   it("copies the full original message when the rendered message is split into segments", async () => {
     const copyText = vi.fn(async () => undefined);
     const messageText = `Intro prose should stay in the normal readable assistant bubble.\n\n${wideMarkdownTable}\n\nFollow-up prose should not inherit the table width.`;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9073,6 +9073,10 @@ textarea,
   gap: 12px;
 }
 
+.transcript-message__header--continuation {
+  justify-content: flex-end;
+}
+
 .transcript-message__attribution {
   display: inline-flex;
   min-width: 0;
@@ -9221,7 +9225,10 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .transcript-message:hover .transcript-copy-button--message,
 .transcript-message:focus-within .transcript-copy-button--message,
-.transcript-copy-button--message[data-copied="true"] {
+.transcript-copy-button--message[data-copied="true"],
+.transcript-message:hover .transcript-copy-button--segment,
+.transcript-message:focus-within .transcript-copy-button--segment,
+.transcript-copy-button--segment[data-copied="true"] {
   opacity: 1;
 }
 
@@ -9387,6 +9394,7 @@ a.transcript-message__messaging-origin:focus-visible {
 
 @media (hover: none) {
   .transcript-copy-button--message,
+  .transcript-copy-button--segment,
   .transcript-copy-button--section,
   .transcript-copy-button--activity {
     opacity: 1;


### PR DESCRIPTION
## Summary

Backports the Markdown-table UX stack to `releases/1.0`:

- preserve valid GFM table source when pasted into the composer
- keep an ATX heading and intervening separators with its following wide-table split block
- add a table-block copy action while retaining full-message copy behavior

## Sources

- PR #1508, **fix(desktop): preserve Markdown tables on paste**
  - squash commit `6b2c142d10d84c503232634800b2149651b69922`
- PR #1504, **fix(desktop): keep headings with wide table blocks**
  - squash commit `75c8f8db549d8c67308aaf79c5030d2f0785ffdb`

## 1.0 adaptations

- Kept the `releases/1.0` renderer and theme structure.
- Retained the 1.0 plain-Markdown clipboard contract; did not import the newer rich-clipboard renderer dependency.
- Excluded federation, instance-chip, and Star Map code from the mainline transcript implementation.
- Reused the source replay fixture changes; no live fixture seeding or capture was performed.

## Migration audit

Renderer/E2E-only change. `CURRENT_STATE_DB_USER_VERSION` remains **32**. No DDL, schema, config, or state migration was added.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
  - 3 files, 150 tests passed
- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/composer-markdown-paste.spec.ts e2e/markdown-findings-table.spec.ts`
  - 14 tests passed, non-headed
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

No headed Electron run was used.
