### PR TITLE
fix(desktop): backport ACP scratch workspaces

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1778,6 +1778,7 @@ function createKimiAcpRegistry(options?: {
   gitDirectoryService?: unknown;
   gitWorkspaceHandoffService?: unknown;
   runtimeCapabilities?: BackendAcpRuntimeCapabilities;
+  createScratchProjectDirectory?: () => Promise<string>;
   acpWorktreeRepositoryResolver?: (
     cwd: string,
   ) => Promise<LinkedDirectorySummary | undefined>;
@@ -1855,6 +1856,9 @@ function createKimiAcpRegistry(options?: {
     gitWorkspaceHandoffService:
       options?.gitWorkspaceHandoffService as never,
     acpWorktreeRepositoryResolver: options?.acpWorktreeRepositoryResolver,
+    createScratchProjectDirectory:
+      options?.createScratchProjectDirectory
+      ?? (async () => "/Users/test/.pwragent/projects/acp-scratch"),
   });
   return {
     acpBackendId,
@@ -9500,6 +9504,32 @@ command = "pnpm grok"
     expectPwragentDynamicTools(codexClient.lastStartThreadParams?.dynamicTools, [
       "create_monitor_delegation",
     ]);
+
+    await registry.close();
+  });
+
+  it("creates a scratch workspace for ACP thread creation when cwd is omitted", async () => {
+    const scratchPath =
+      "/Users/test/.pwragent/projects/2026-08-10-a1b2c3";
+    const { acpBackendId, acpClient, registry } = createKimiAcpRegistry({
+      createScratchProjectDirectory: async () => scratchPath,
+    });
+
+    const response = await registry.startThread({
+      backend: acpBackendId,
+    });
+
+    expect(response).toEqual({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      executionMode: "default",
+    });
+    expect(acpClient.startSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: scratchPath,
+        executionMode: "default",
+      }),
+    );
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8478,8 +8478,8 @@ export class DesktopBackendRegistry {
       ...request
     } = params;
     const modelSettings = await this.resolveModelSettings(backend, request);
-    let cwd =
-      backend === "codex" && !request.cwd?.trim()
+    let cwd: string | undefined =
+      !request.cwd?.trim()
         ? await this.createScratchProjectDirectory()
         : request.cwd;
     let resolvedLinkedDirectories = linkedDirectories;


### PR DESCRIPTION
## Summary

Backports #1467, **fix(desktop): align ACP scratch workspace launches**, squash `d11dc63a243fc73896735a1c7e5653bbb6123523`, to `releases/1.0`.

ACP threads created without a supplied CWD now receive a generated profile scratch workspace, matching existing Codex behavior, instead of falling through to Electron's process CWD.

This is intentionally separate from the #1441/#1447 launch-selection backport for rollback clarity.

## Release-branch adaptations

- Applies at the release branch's existing shared `DesktopBackendRegistry.startThread` boundary.
- Adapts the regression setup to the release branch's `createKimiAcpRegistry` harness and supplies a deterministic default scratch path so tests never touch the operator profile.
- Preserves provider onboarding #1509, ACP branch adoption #1510, and Windows shim compatibility #1513 without re-importing them.
- Keeps the external `@pwrdrvr/agent-core` dependency and excludes federation-only behavior.

## Root cause

The shared thread-launch path created scratch workspaces only when `backend === "codex"`. Unscoped ACP launches therefore passed `cwd: undefined`; the ACP client then inherited Electron's process CWD.

## Migration audit

No state database migration, DDL, schema change, or `user_version` change is included. `CURRENT_STATE_DB_USER_VERSION` remains **32**.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` — **403 passed**
- Focused scratch-workspace filter — **2 passed** (Codex and ACP)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; baseline warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

No headed E2E was run on the host.
