### PR TITLE
fix(desktop): backport repeat-quit prompt recovery

### DIFF
--- a/apps/desktop/e2e/app-quit-lifecycle.spec.ts
+++ b/apps/desktop/e2e/app-quit-lifecycle.spec.ts
@@ -1,0 +1,267 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type ElectronApplication } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+/**
+ * Quit-path gate.
+ *
+ * `closeElectronApplication` force-kills the process tree when a graceful
+ * close doesn't land, which means a product quit path that never reaches
+ * process exit looks green in every other spec. These tests remove that
+ * cover: they ask the app to quit exactly the way a user does (`app.quit()`,
+ * the same call the macOS Quit menu item and Playwright's own
+ * `electronApp.close()` make) and assert the process actually exits.
+ *
+ * The wizard case is called out separately because it boots into a different
+ * app-state mode (`bootstrap`) with no profile on disk, so nothing about the
+ * profile-backed path proves it.
+ */
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The product's own shutdown ceiling: renderer window close
+ * (`RENDERER_WINDOW_SHUTDOWN_TIMEOUT_MS`, 2s) plus the main-process shutdown
+ * barrier (`MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS`, 12s), plus slack for a loaded
+ * VM. Every phase inside those is individually bounded, so a run that blows
+ * this budget is a quit path that never completes, not a slow one.
+ */
+const QUIT_BUDGET_MS = 20_000;
+
+/**
+ * Launch, the quit budget, and `close()`'s own bounded force-kill fallback
+ * (~5s) all have to fit, or a genuinely wedged app fails on Playwright's
+ * default 30s timeout instead of on `describeOutcome` — losing the main-process
+ * log tail in the exact case this spec exists to diagnose.
+ */
+const TEST_TIMEOUT_MS = 60_000;
+
+type QuitOutcome = {
+  elapsedMs: number;
+  exited: boolean;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  output: string;
+};
+
+/**
+ * Ask the app to quit, the same call the macOS Quit menu item makes.
+ *
+ * Deliberately not awaited for its result: a healthy quit tears the Playwright
+ * connection down before the round trip resolves, and a quit that stops at the
+ * confirmation prompt does not resolve either. Process exit is the signal.
+ */
+function requestQuit(electronApp: ElectronApplication): void {
+  void electronApp
+    .evaluate(({ app }) => {
+      app.quit();
+    })
+    .catch(() => undefined);
+}
+
+/** Wait for real process exit, bounded by the product's own shutdown ceiling. */
+async function awaitExit(
+  electronApp: ElectronApplication,
+  captured: () => string,
+): Promise<QuitOutcome> {
+  const child = electronApp.process();
+  const startedAt = Date.now();
+  const exited = new Promise<void>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve();
+      return;
+    }
+    child.once("exit", () => resolve());
+  });
+
+  let timer: NodeJS.Timeout | undefined;
+  await Promise.race([
+    exited,
+    new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, QUIT_BUDGET_MS);
+    }),
+  ]);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+  }
+
+  return {
+    elapsedMs: Date.now() - startedAt,
+    exited: child.exitCode !== null || child.signalCode !== null,
+    exitCode: child.exitCode,
+    signalCode: child.signalCode,
+    output: captured(),
+  };
+}
+
+/**
+ * Mirror the main process's console transport into a buffer. electron-log
+ * keeps its console transport enabled outside Vitest, so every `mainLog` line
+ * the quit path emits ("quit in progress", "shutdown barrier completed", …)
+ * shows up here — which is what turns a failure into a diagnosis instead of a
+ * timeout.
+ */
+function captureMainProcessOutput(electronApp: ElectronApplication): () => string {
+  const chunks: string[] = [];
+  const child = electronApp.process();
+  child.stdout?.on("data", (chunk: Buffer) => chunks.push(chunk.toString()));
+  child.stderr?.on("data", (chunk: Buffer) => chunks.push(chunk.toString()));
+  return () => chunks.join("");
+}
+
+function describeOutcome(label: string, outcome: QuitOutcome): string {
+  return [
+    `${label} did not exit within ${QUIT_BUDGET_MS}ms after app.quit().`,
+    `elapsedMs=${outcome.elapsedMs} exitCode=${String(outcome.exitCode)} signal=${String(outcome.signalCode)}`,
+    "--- main process output ---",
+    outcome.output.slice(-16_000),
+  ].join("\n");
+}
+
+test("exits the process when a profile-backed session is asked to quit", async () => {
+  test.setTimeout(TEST_TIMEOUT_MS);
+
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
+  });
+  const captured = captureMainProcessOutput(app.electronApp);
+
+  try {
+    requestQuit(app.electronApp);
+    const outcome = await awaitExit(app.electronApp, captured);
+    expect(outcome.exited, describeOutcome("profile-backed app", outcome)).toBe(
+      true,
+    );
+    expect(outcome.signalCode).toBeNull();
+  } finally {
+    await app.close();
+  }
+});
+
+/**
+ * The path a real operator hits, and the one every other spec seeds away: quit
+ * confirmation ON, with work running. Any deliberate interaction cancels the
+ * prompt's countdown for good, so from that point the dialog is the only thing
+ * that can settle the quit — and a repeat request has to reach it rather than
+ * collapse silently onto the pending prompt.
+ *
+ * What this asserts is the acknowledgement (the main-process log line) and that
+ * answering the prompt reaches process exit, not that the window was actually
+ * raised: real focus assertions are not dependable in a VM. The restore / show
+ * / focus calls are pinned in `quit-confirmation-dialog.test.ts` instead.
+ */
+test("acknowledges a repeat quit request and exits once the prompt is answered", async () => {
+  // Spawning a real login shell plus a second BrowserWindow outruns the default.
+  test.setTimeout(120_000);
+
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
+  });
+  const captured = captureMainProcessOutput(app.electronApp);
+
+  try {
+    // The shared harness seeds confirmation OFF so specs close cleanly. This
+    // spec is about the confirmation, so turn it back on the way the app does.
+    await app.window.evaluate(async () => {
+      await (
+        window as unknown as {
+          pwragent: {
+            writeSettingsConfig: (request: unknown) => Promise<unknown>;
+          };
+        }
+      ).pwragent.writeSettingsConfig({
+        patch: { general: { confirmQuitWithInProgressThreads: true } },
+      });
+    });
+
+    await app.window
+      .getByRole("button", { name: /Replay smoke thread/i })
+      .first()
+      .click();
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "Replay smoke thread" }),
+    ).toBeVisible();
+
+    // An idle shell is not a quit blocker; a foreground command is.
+    await app.window
+      .getByRole("button", { name: "Open integrated terminal" })
+      .click();
+    await expect(
+      app.window.getByLabel("Integrated terminal", { exact: true }),
+    ).toBeVisible();
+    await expect(app.window.locator(".integrated-terminal__status")).not.toHaveText(
+      "Starting shell...",
+    );
+    await app.window.locator(".integrated-terminal__viewport").click();
+    await app.window.keyboard.type("echo PWRAGENT_QUIT_BLOCKER_READY; sleep 120");
+    await app.window.keyboard.press("Enter");
+    await expect(
+      app.window.locator(".integrated-terminal .xterm-rows"),
+    ).toContainText("PWRAGENT_QUIT_BLOCKER_READY");
+
+    const dialogPromise = app.electronApp.waitForEvent("window");
+    requestQuit(app.electronApp);
+    const dialog = await dialogPromise;
+    await expect(
+      dialog.getByRole("heading", { name: "Quit PwrAgent?" }),
+    ).toBeVisible();
+
+    // Stand in for the impatient operator's second Cmd+Q: a keystroke on the
+    // dialog cancels the auto-quit permanently, so nothing but the dialog will
+    // ever settle this request.
+    await dialog.keyboard.press("ArrowDown");
+    await expect
+      .poll(async () => await dialog.locator("#countdown").innerText())
+      .toBe("Auto-quit cancelled. Choose an option below.");
+
+    requestQuit(app.electronApp);
+    await expect
+      .poll(() => captured())
+      .toContain("quit requested while confirmation is open");
+    // The repeat request raises the existing prompt; it must not stack a second
+    // dialog on top of it.
+    expect(
+      app.electronApp.windows().filter((page) => page !== app.window).length,
+    ).toBe(1);
+
+    // Answering it has to actually reach process exit — the countdown is gone,
+    // so this is the only remaining path out.
+    await dialog.locator("#quit").dispatchEvent("click");
+    const outcome = await awaitExit(app.electronApp, captured);
+    expect(
+      outcome.exited,
+      describeOutcome("app with quit confirmation answered", outcome),
+    ).toBe(true);
+    expect(outcome.signalCode).toBeNull();
+  } finally {
+    await app.close();
+  }
+});
+
+test("exits the process when the first-run wizard is asked to quit", async () => {
+  test.setTimeout(TEST_TIMEOUT_MS);
+
+  // No profile dir, no onboarding seed: the boot decision resolves to
+  // `no-profile-configured` and app state comes up in bootstrap mode with the
+  // wizard on screen — the state that hung a full E2E run for an hour.
+  const app = await launchElectronApp({
+    suppressOnboarding: false,
+    requiresReplayDriver: false,
+  });
+  const captured = captureMainProcessOutput(app.electronApp);
+
+  try {
+    await expect(
+      app.window.getByRole("heading", { name: /A few short choices/i }),
+    ).toBeVisible();
+    requestQuit(app.electronApp);
+    const outcome = await awaitExit(app.electronApp, captured);
+    expect(outcome.exited, describeOutcome("first-run wizard app", outcome)).toBe(
+      true,
+    );
+    expect(outcome.signalCode).toBeNull();
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
@@ -1,8 +1,83 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type FakeDialogWindow = {
+  /** Listeners the dialog registers, so tests can fire `ready-to-show` / `closed`. */
+  listeners: Map<string, (...args: unknown[]) => void>;
+  destroyed: boolean;
+  minimized: boolean;
+  shown: number;
+  focused: number;
+  restored: number;
+  closed: number;
+  once: (event: string, handler: (...args: unknown[]) => void) => void;
+  webContents: { on: () => void; setWindowOpenHandler: () => void };
+  /** Stays pending unless a test settles it — the real load is async too. */
+  loadURL: () => Promise<void>;
+  rejectLoad: (error: Error) => void;
+  isDestroyed: () => boolean;
+  isMinimized: () => boolean;
+  restore: () => void;
+  show: () => void;
+  focus: () => void;
+  close: () => void;
+};
+
+function createFakeDialogWindow(): FakeDialogWindow {
+  let rejectLoad!: (error: Error) => void;
+  const loaded = new Promise<void>((_resolve, reject) => {
+    rejectLoad = reject;
+  });
+  const window: FakeDialogWindow = {
+    listeners: new Map(),
+    destroyed: false,
+    minimized: false,
+    shown: 0,
+    focused: 0,
+    restored: 0,
+    closed: 0,
+    once: (event, handler) => {
+      window.listeners.set(event, handler);
+    },
+    webContents: {
+      on: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+    },
+    loadURL: () => loaded,
+    rejectLoad: (error) => rejectLoad(error),
+    isDestroyed: () => window.destroyed,
+    isMinimized: () => window.minimized,
+    restore: () => {
+      window.minimized = false;
+      window.restored += 1;
+    },
+    show: () => {
+      window.shown += 1;
+    },
+    focus: () => {
+      window.focused += 1;
+    },
+    close: () => {
+      window.closed += 1;
+      window.destroyed = true;
+    },
+  };
+  return window;
+}
+
+const dialogWindows: FakeDialogWindow[] = [];
 
 vi.mock("electron", () => ({
-  BrowserWindow: vi.fn(),
+  // `new BrowserWindow(...)`: an arrow function is not constructible.
+  BrowserWindow: vi.fn(function BrowserWindowMock() {
+    const window = createFakeDialogWindow();
+    dialogWindows.push(window);
+    return window;
+  }),
   nativeTheme: { shouldUseDarkColors: true },
+}));
+
+vi.mock("../log", () => ({
+  getMainLogger: () => ({ info: vi.fn(), warn: vi.fn() }),
 }));
 
 vi.mock("../ipc/integrated-terminal", () => ({
@@ -19,8 +94,10 @@ vi.mock("../settings/appearance-bootstrap", () => ({
 
 import { parseThreadIdentityKey } from "@pwragent/shared";
 import {
+  focusActiveQuitConfirmationDialog,
   formatQuitItemAction,
   parseQuitItemAction,
+  showQuitConfirmationDialog,
   type QuitBlockerItem,
 } from "../quit-confirmation-dialog";
 
@@ -67,5 +144,111 @@ describe("quit dialog row links", () => {
   it("ignores actions that are not row links", () => {
     expect(parseQuitItemAction("manual-confirm")).toBeUndefined();
     expect(parseQuitItemAction("countdown-cancel")).toBeUndefined();
+  });
+});
+
+/**
+ * Once the countdown is cancelled — which any deliberate interaction does, for
+ * good — the only thing that settles the quit is the user answering this
+ * dialog. So the dialog has to remain reachable: a repeat quit request asks the
+ * quit manager to raise it, and a dialog that has already been answered must
+ * not report itself as raisable.
+ *
+ * The subject holds the open dialog in module state, so each test here has to
+ * leave it empty for the next one — see the `afterEach`.
+ */
+describe("raising the open quit dialog", () => {
+  /** Open a dialog and drive it to the state a user would see it in. */
+  function openDialog(options?: { ready?: boolean }) {
+    const pending = showQuitConfirmationDialog({
+      countdownSeconds: 10,
+      inProgressThreadCount: 0,
+      terminalSessionCount: 1,
+    });
+    const window = dialogWindows.at(-1)!;
+    if (options?.ready ?? true) {
+      window.listeners.get("ready-to-show")?.();
+    }
+    return { pending, window };
+  }
+
+  afterEach(async () => {
+    // Close anything still open so module state does not leak into the next
+    // test, then drop the fakes this test created.
+    for (const window of dialogWindows) {
+      if (!window.destroyed) {
+        window.listeners.get("closed")?.();
+      }
+    }
+    await Promise.resolve();
+    dialogWindows.length = 0;
+  });
+
+  it("reports nothing to raise when no dialog is open", () => {
+    expect(focusActiveQuitConfirmationDialog()).toBe(false);
+  });
+
+  it("restores, shows, and focuses the dialog that is on screen", async () => {
+    const { pending, window } = openDialog();
+    // `ready-to-show` shows and focuses it once; a raise is the second of each.
+    window.minimized = true;
+
+    expect(focusActiveQuitConfirmationDialog()).toBe(true);
+    expect(window.restored).toBe(1);
+    expect(window.shown).toBe(2);
+    expect(window.focused).toBe(2);
+
+    // Answering it clears the handle: a later request must not try to raise a
+    // window that is gone.
+    window.listeners.get("closed")?.();
+    await expect(pending).resolves.toBe("manual-cancel");
+    expect(focusActiveQuitConfirmationDialog()).toBe(false);
+  });
+
+  // The window is created hidden. Showing it before its first paint puts a
+  // themed empty rectangle on screen, and its own `ready-to-show` handler is
+  // about to show it anyway — so report the prompt as open and leave it alone.
+  it("does not show a dialog that has not painted yet", async () => {
+    const { pending, window } = openDialog({ ready: false });
+
+    expect(focusActiveQuitConfirmationDialog()).toBe(true);
+    expect(window.shown).toBe(0);
+    expect(window.focused).toBe(0);
+
+    window.listeners.get("closed")?.();
+    await expect(pending).resolves.toBe("manual-cancel");
+  });
+
+  // No page means no controls, so there is no consent left to collect and
+  // nothing for the user to answer. Settle it rather than park an unusable
+  // window on screen until the hard ceiling fires.
+  it("settles the request when the dialog page fails to load", async () => {
+    const pending = showQuitConfirmationDialog({
+      countdownSeconds: 10,
+      inProgressThreadCount: 0,
+      terminalSessionCount: 1,
+    });
+    const window = dialogWindows.at(-1)!;
+    window.rejectLoad(new Error("ERR_ABORTED"));
+
+    await expect(pending).resolves.toBe("countdown-expired");
+    expect(window.shown).toBe(0);
+    expect(window.closed).toBe(1);
+    expect(focusActiveQuitConfirmationDialog()).toBe(false);
+  });
+
+  // Once the page has painted the prompt is up and the decision is the user's.
+  // A late rejection there is noise — a superseded navigation, say — and must
+  // not quit out from under someone reading the list.
+  it("leaves a painted dialog alone when a late load rejection arrives", async () => {
+    const { pending, window } = openDialog();
+    window.rejectLoad(new Error("ERR_ABORTED"));
+    await Promise.resolve();
+
+    expect(window.closed).toBe(0);
+    expect(focusActiveQuitConfirmationDialog()).toBe(true);
+
+    window.listeners.get("closed")?.();
+    await expect(pending).resolves.toBe("manual-cancel");
   });
 });

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -213,6 +213,93 @@ describe("createQuitManager", () => {
     expect(installUpdateAndQuit).toHaveBeenCalledTimes(1);
   });
 
+  // A repeat quit request while the prompt is open collapses onto the same
+  // pending promise, which is fine only if it still reaches the user: any
+  // deliberate interaction cancels the prompt's countdown for good, so from
+  // then on nothing but the dialog settles the quit — and a dialog sitting
+  // behind the main window reads as an app that refuses to quit.
+  it("raises the open confirmation when a quit is requested again", async () => {
+    const { createQuitManager } = await import("../quit-manager");
+    const performQuit = vi.fn();
+    const info = vi.fn();
+    const focusPendingConfirmation = vi.fn(() => true);
+    let resolveConfirm!: (value: "manual-confirm") => void;
+    const confirm = vi.fn(
+      async () =>
+        await new Promise<"manual-confirm">((resolve) => {
+          resolveConfirm = resolve;
+        }),
+    );
+    const manager = createQuitManager({
+      confirm,
+      focusPendingConfirmation,
+      getConfirmationEnabled: () => true,
+      getQuitBlockers: () => ({
+        count: 1,
+        terminalSessionCount: 1,
+        terminalThreadKeys: ["codex:thread-terminal"],
+        threadIds: [],
+        actionRunCount: 0,
+        items: [],
+      }),
+      log: { info },
+      performQuit,
+    });
+
+    const first = manager.requestQuit({ source: "before-quit" });
+    const second = manager.requestQuit({ source: "before-quit" });
+
+    expect(focusPendingConfirmation).toHaveBeenCalledTimes(1);
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(info).toHaveBeenCalledWith(
+      "quit requested while confirmation is open",
+      expect.objectContaining({ raisedConfirmation: true }),
+    );
+
+    resolveConfirm("manual-confirm");
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(true);
+    expect(performQuit).toHaveBeenCalledTimes(1);
+  });
+
+  it("records a repeat request with nothing to raise", async () => {
+    const { createQuitManager } = await import("../quit-manager");
+    const info = vi.fn();
+    let resolveConfirm!: (value: "manual-cancel") => void;
+    const confirm = vi.fn(
+      async () =>
+        await new Promise<"manual-cancel">((resolve) => {
+          resolveConfirm = resolve;
+        }),
+    );
+    const manager = createQuitManager({
+      confirm,
+      getConfirmationEnabled: () => true,
+      getQuitBlockers: () => ({
+        count: 1,
+        terminalSessionCount: 1,
+        terminalThreadKeys: ["codex:thread-terminal"],
+        threadIds: [],
+        actionRunCount: 0,
+        items: [],
+      }),
+      log: { info },
+      performQuit: vi.fn(),
+    });
+
+    const first = manager.requestQuit({ source: "menu" });
+    const second = manager.requestQuit({ source: "menu" });
+
+    expect(info).toHaveBeenCalledWith(
+      "quit requested while confirmation is open",
+      expect.objectContaining({ raisedConfirmation: false }),
+    );
+
+    resolveConfirm("manual-cancel");
+    await expect(first).resolves.toBe(false);
+    await expect(second).resolves.toBe(false);
+  });
+
   it("quits without prompting when confirmation is disabled", async () => {
     const { createQuitManager } = await import("../quit-manager");
     const performQuit = vi.fn();

--- a/apps/desktop/src/main/quit-confirmation-dialog.ts
+++ b/apps/desktop/src/main/quit-confirmation-dialog.ts
@@ -1,8 +1,11 @@
 import { BrowserWindow, nativeTheme } from "electron";
 import { parseThreadIdentityKey } from "@pwragent/shared";
 import { revealIntegratedTerminal } from "./ipc/integrated-terminal";
+import { getMainLogger } from "./log";
 import { readBootstrapAppearance } from "./settings/appearance-bootstrap";
 import { requestShowThread } from "./window-show-thread";
+
+const quitDialogLog = getMainLogger("pwragent:quit-dialog");
 
 export type QuitConfirmationDialogResult =
   | "manual-confirm"
@@ -96,6 +99,49 @@ function resolveQuitDialogTheme(): "dark" | "light" {
   return nativeTheme.shouldUseDarkColors ? "dark" : "light";
 }
 
+/**
+ * The dialog currently open, if any.
+ *
+ * The quit manager collapses concurrent quit requests onto one prompt, so a
+ * later request while this dialog is open resolves to the same pending promise.
+ * That is only acceptable if the later request can still *reach* the dialog:
+ * it is a small frameless window that a user can lose behind the main window or
+ * on another Space, and once the countdown has been cancelled nothing else will
+ * ever settle the quit. Keeping the handle here is what lets a repeat request
+ * raise it instead of doing nothing at all.
+ *
+ * `ready` tracks `ready-to-show`, because the window is created hidden: showing
+ * it before its first paint puts a themed empty rectangle on screen. Until then
+ * the prompt is still "open" — its own `ready-to-show` handler shows it — so a
+ * raise reports success without touching the window.
+ */
+type ActiveQuitDialog = {
+  window: BrowserWindow;
+  ready: boolean;
+};
+
+let activeDialog: ActiveQuitDialog | undefined;
+
+/**
+ * Bring the open quit prompt back in front of the user. Returns false when
+ * there is no prompt to raise.
+ */
+export function focusActiveQuitConfirmationDialog(): boolean {
+  const active = activeDialog;
+  if (!active || active.window.isDestroyed()) {
+    return false;
+  }
+  if (!active.ready) {
+    return true;
+  }
+  if (active.window.isMinimized()) {
+    active.window.restore();
+  }
+  active.window.show();
+  active.window.focus();
+  return true;
+}
+
 export async function showQuitConfirmationDialog(
   options: QuitConfirmationDialogOptions,
 ): Promise<QuitConfirmationDialogResult> {
@@ -145,6 +191,19 @@ export async function showQuitConfirmationDialog(
     },
   });
 
+  const active: ActiveQuitDialog = { window, ready: false };
+  activeDialog = active;
+
+  /** Drop the shared handle and the window, whichever way this call ends. */
+  const releaseDialog = (): void => {
+    if (activeDialog === active) {
+      activeDialog = undefined;
+    }
+    if (!window.isDestroyed()) {
+      window.close();
+    }
+  };
+
   return await new Promise<QuitConfirmationDialogResult>((resolve) => {
     let settled = false;
     let hardCeiling: NodeJS.Timeout | undefined;
@@ -153,9 +212,7 @@ export async function showQuitConfirmationDialog(
       if (settled) return;
       settled = true;
       if (hardCeiling) clearTimeout(hardCeiling);
-      if (!window.isDestroyed()) {
-        window.close();
-      }
+      releaseDialog();
       resolve(result);
     };
 
@@ -212,24 +269,44 @@ export async function showQuitConfirmationDialog(
       countdownSeconds * 1000 + HARD_CEILING_GRACE_MS,
     );
 
-    void window.loadURL(
-      `data:text/html;charset=utf-8,${encodeURIComponent(
-        buildQuitConfirmationHtml({
-          countdownSeconds,
-          inProgressThreadCount: options.inProgressThreadCount,
-          terminalSessionCount: options.terminalSessionCount,
-          actionRunCount: options.actionRunCount ?? 0,
-          items,
-          navigationPrefix,
-          colorScheme,
-          palette,
-        }),
-      )}`,
-    );
+    const dialogUrl = `data:text/html;charset=utf-8,${encodeURIComponent(
+      buildQuitConfirmationHtml({
+        countdownSeconds,
+        inProgressThreadCount: options.inProgressThreadCount,
+        terminalSessionCount: options.terminalSessionCount,
+        actionRunCount: options.actionRunCount ?? 0,
+        items,
+        navigationPrefix,
+        colorScheme,
+        palette,
+      }),
+    )}`;
+    // A rejected load leaves a window that never emits `ready-to-show` and never
+    // renders a control, so there is no consent to collect and nothing for the
+    // user to answer — showing the empty window would only park an unusable box
+    // on screen until the hard ceiling fires. Settle the request the same way
+    // that ceiling would, immediately, and record why. A rejection that arrives
+    // *after* the page painted is noise (a superseded navigation, say): the
+    // prompt is up and the user owns the decision, so only log it.
+    void window.loadURL(dialogUrl).catch((error: unknown) => {
+      quitDialogLog.warn("quit confirmation dialog failed to load", {
+        error: error instanceof Error ? error.message : String(error),
+        painted: active.ready,
+      });
+      if (!active.ready) {
+        finish("countdown-expired");
+      }
+    });
     window.once("ready-to-show", () => {
+      active.ready = true;
       window.show();
       window.focus();
     });
+  }).catch((error: unknown) => {
+    // An executor that throws would otherwise strand the shared handle on a
+    // window nobody closes, and a later raise would surface an orphan dialog.
+    releaseDialog();
+    throw error;
   });
 }
 

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -13,6 +13,7 @@ import { getIntegratedTerminalQuitSnapshot } from "./ipc/integrated-terminal";
 import { getMainLogger } from "./log";
 import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
 import {
+  focusActiveQuitConfirmationDialog,
   showQuitConfirmationDialog,
   type QuitBlockerItem,
   type QuitConfirmationDialogResult,
@@ -55,6 +56,11 @@ export type QuitManagerDependencies = {
     items?: QuitBlockerItem[];
     parent?: BrowserWindow | null;
   }) => Promise<QuitConfirmationDialogResult>;
+  /**
+   * Raise the confirmation prompt that is already open. Returns false when
+   * there is nothing to raise. See the `promptPromise` branch in `requestQuit`.
+   */
+  focusPendingConfirmation?: () => boolean;
   getConfirmationEnabled: () => boolean;
   getFocusedWindow?: () => BrowserWindow | null;
   getQuitBlockers: () => QuitBlockerSnapshot;
@@ -122,6 +128,18 @@ export function createQuitManager(
       if (options.performQuit) {
         pendingPerformQuit = options.performQuit;
       }
+      // Asking again has to do *something*. Any deliberate interaction with the
+      // prompt — a click, a scroll, a keystroke — cancels its countdown for
+      // good and clears the main-process ceiling with it, so from that point the
+      // only thing that ever settles this quit is the user answering the dialog.
+      // It is a small frameless window that can end up behind the main window or
+      // on another Space, and a repeat request that silently returns this
+      // pending promise reads as an app that refuses to quit. Raise it instead.
+      const raised = dependencies.focusPendingConfirmation?.() ?? false;
+      dependencies.log.info?.("quit requested while confirmation is open", {
+        raisedConfirmation: raised,
+        source: options.source,
+      });
       return await promptPromise;
     }
 
@@ -289,6 +307,7 @@ function splitQuitThreadKey(threadKey: string): {
 const quitLog = getMainLogger("pwragent:quit");
 
 export const appQuitManager = createQuitManager({
+  focusPendingConfirmation: () => focusActiveQuitConfirmationDialog(),
   getConfirmationEnabled: () =>
     getDesktopSettingsService().resolveConfirmQuitWithInProgressThreads(),
   getFocusedWindow: () => BrowserWindow.getFocusedWindow(),


### PR DESCRIPTION
## Summary

Backports #1362 to `releases/1.0`:

- tracks the single active quit-confirmation dialog
- restores, shows, and focuses that existing dialog when quit is requested again
- avoids showing the hidden window before `ready-to-show`
- clears the shared handle when the prompt settles, so later requests cannot raise a dead window
- catches dialog page-load rejection and settles an unusable pre-paint prompt without weakening the bounded shutdown path
- adds a real-process lifecycle E2E regression alongside focused manager/dialog unit coverage

## Source provenance

- PwrAgent #1362 — squash `059a42c6961b489a8a66426a616d914734f65301`

## Manual adaptation

The release branch has later light-theme palette values in `quit-confirmation-dialog.ts`; those values are preserved. The fix reuses the existing prompt promise and dialog only—no competing dialog is created, countdown-cancel semantics remain unchanged, and the bounded shutdown lifecycle already backported through #1509 is not weakened. Federation-only behavior is excluded.

## Root cause and impact

Any deliberate interaction cancels the quit prompt countdown and its main-process hard ceiling. A repeated quit request then collapsed onto the existing pending promise without surfacing the small frameless dialog, leaving the only remaining decision UI behind another window or on another Space. Repeat requests now bring that same prompt back to the user.

## SQLite migration audit

- `CURRENT_STATE_DB_USER_VERSION` remains **32**
- no state DB, DDL, schema, config, or migration changes

## Validation

- 21 focused quit manager/dialog unit tests passed
- Playwright collected all 3 `app-quit-lifecycle.spec.ts` cases
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; 136 existing warnings)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

No headed desktop E2E was run on the host. Real Electron focus/Space behavior and process exit remain CI/platform verification items.
