### PR TITLE
fix(desktop): backport transient monitor heartbeat filtering

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1933,7 +1933,7 @@ describe("useThreadSessionState", () => {
     expect(readThread).toHaveBeenCalledTimes(1);
   });
 
-  it("renders task monitor usage metadata as a sibling activity entry", async () => {
+  it("keeps transient task monitor progress out of the transcript", async () => {
     let agentEventHandler:
       | ((event: {
           backend: "codex" | "grok";
@@ -2009,6 +2009,36 @@ describe("useThreadSessionState", () => {
                     reasoningOutputTokens: 10,
                   },
                 },
+                transient: true,
+              },
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "monitor:monitor-1",
+            item: {
+              id: "monitor-progress-usage-1",
+              type: "taskMonitorUsage",
+              data: {
+                source: "pwragent_task_monitor",
+                monitorId: "monitor-1",
+                monitorUsage: {
+                  phase: "progress",
+                  model: "gpt-5.4-mini",
+                  tokenUsage: {
+                    inputTokens: 2_000,
+                    cachedInputTokens: 400,
+                    outputTokens: 100,
+                    reasoningOutputTokens: 20,
+                  },
+                },
+                transient: true,
               },
             },
           },
@@ -2016,10 +2046,7 @@ describe("useThreadSessionState", () => {
       });
     });
 
-    expect(transcriptLabels(result.current.entries)).toEqual([
-      "message:Still running.",
-      "activity:Monitor usage so far: 800 uncached in · 200 cached · 50 out (10 reasoning) · <$0.001 list price",
-    ]);
+    expect(transcriptLabels(result.current.entries)).toEqual([]);
   });
 
   it("keeps completion monitor usage as top-level activity after hydration", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3008,6 +3008,21 @@ function assistantMessageEntryFromCompletedItem(params: {
   };
 }
 
+function isTransientTaskMonitorItem(
+  item: Record<string, unknown> | undefined,
+): boolean {
+  if (!item) {
+    return false;
+  }
+
+  const data = readRecord(item.data);
+  return (
+    (data?.source === "pwragent_task_monitor"
+      || item.source === "pwragent_task_monitor")
+    && (data?.transient === true || item.transient === true)
+  );
+}
+
 function hasReviewEntryForTurn(
   response: AppServerReadThreadResponse | undefined,
   turnId: string | undefined
@@ -4095,12 +4110,15 @@ export function useThreadSessionState(params: {
             fallbackStartedAt: current.activeTurnStartedAt,
             fallbackStatus: "in_progress",
           });
-          const assistantMessageEntry = assistantMessageEntryFromCompletedItem({
-            itemParams: event.notification.params,
-            turn: assistantTurn,
-          });
           const item = getNotificationItem(event.notification.params);
-          const taskMonitorUsageEntry = item
+          const transientTaskMonitorItem = isTransientTaskMonitorItem(item);
+          const assistantMessageEntry = transientTaskMonitorItem
+            ? undefined
+            : assistantMessageEntryFromCompletedItem({
+                itemParams: event.notification.params,
+                turn: assistantTurn,
+              });
+          const taskMonitorUsageEntry = item && !transientTaskMonitorItem
             ? buildTaskMonitorUsageActivityEntry({
                 id: `${item.id ?? event.notification.params.turnId ?? "monitor"}:usage`,
                 item,


### PR DESCRIPTION
## Summary

Backports transient task-monitor heartbeat filtering to `releases/1.0`.

Transient monitor progress agent messages and transient monitor-usage items are kept out of the parent transcript, while durable completion usage remains visible and persisted through the existing path.

## Source

- PR #1496, **fix(desktop): hide transient monitor heartbeats from transcript**
- squash commit `183f670a512545d14dc4ca5cfa9e021ef31fe623`

## 1.0 adaptations

- Preserved the 1.0 renderer event backend types (`codex | grok`) instead of importing mainline ACP/federation naming.
- Kept the change isolated to the session-state renderer and its focused test.
- No federation or Star Map changes were imported.

## Migration audit

Renderer/test-only change. `CURRENT_STATE_DB_USER_VERSION` remains **32**. No DDL, schema, config, or state migration was added.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
  - 1 file, 87 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

The source change has no replay-backed E2E fixture or spec, so no Electron run was needed for this isolated renderer-state fix. No headed Electron run was used.
