### PR TITLE
fix(messaging): backport bounded adapter startup

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -1153,14 +1153,9 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
-  it("preserves a stop request that arrives before adapters register", async () => {
+  it("skips adapter startup when a stop request arrives before adapters register", async () => {
     await prepareRuntimeStore();
-    const telegramStart = createDeferred<void>();
     const slowTelegramAdapter = createAdapter("telegram");
-    slowTelegramAdapter.start.mockImplementation(async (listener) => {
-      slowTelegramAdapter.listener = listener;
-      await telegramStart.promise;
-    });
     const workingDiscordAdapter = createAdapter("discord");
     const { DesktopMessagingRuntime: Runtime } = await import(
       "../messaging/messaging-runtime"
@@ -1186,12 +1181,10 @@ describe("DesktopMessagingRuntime", () => {
     const stopPromise = runtime.stop();
     await Promise.all([startPromise, stopPromise]);
 
-    expect(slowTelegramAdapter.start).toHaveBeenCalledTimes(1);
-    expect(workingDiscordAdapter.start).toHaveBeenCalledTimes(1);
-    expect(slowTelegramAdapter.stop).toHaveBeenCalledTimes(1);
-    // The fast adapter settles after cancellation wins the race, so it gets
-    // both immediate failed-start cleanup and the late-start zombie guard.
-    expect(workingDiscordAdapter.stop).toHaveBeenCalledTimes(2);
+    expect(slowTelegramAdapter.start).not.toHaveBeenCalled();
+    expect(workingDiscordAdapter.start).not.toHaveBeenCalled();
+    expect(slowTelegramAdapter.stop).not.toHaveBeenCalled();
+    expect(workingDiscordAdapter.stop).not.toHaveBeenCalled();
     expect(runtime.isEnabled()).toBe(false);
     expect(runtime.getPlatformStatuses()).toEqual(
       expect.arrayContaining([
@@ -1204,6 +1197,46 @@ describe("DesktopMessagingRuntime", () => {
           health: "suspended",
         }),
       ]),
+    );
+  });
+
+  it("cleans up again when a cancelled adapter start rejects late", async () => {
+    await prepareRuntimeStore();
+    const discordStart = createDeferred<void>();
+    const discordAdapter = createAdapter("discord", {
+      start: vi.fn(async () => {
+        await discordStart.promise;
+      }),
+    });
+    const factory = vi.fn<DesktopMessagingAdapterFactory>(({ config }) =>
+      config.discord ? [discordAdapter] : []
+    );
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = trackRuntime(new Runtime({
+      adapterFactory: factory,
+      backendBridge: createBackendBridge(),
+      config: {
+        discord: {
+          channel: "discord",
+          botToken: "discord-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    }));
+
+    const startPromise = runtime.start();
+    await waitFor(() => discordAdapter.start.mock.calls.length === 1);
+    const applyPromise = runtime.applyConfig({});
+    await Promise.all([startPromise, applyPromise]);
+
+    expect(discordAdapter.stop).toHaveBeenCalledTimes(1);
+    discordStart.reject(new Error("login rejected after cancellation"));
+    await waitFor(() => discordAdapter.stop.mock.calls.length === 2);
+    expect(messagingLog.info).toHaveBeenCalledWith(
+      "discord: stopped adapter after late startup",
+      { channel: "discord" },
     );
   });
 
@@ -1241,6 +1274,7 @@ describe("DesktopMessagingRuntime", () => {
     }));
 
     const startPromise = runtime.start();
+    await waitFor(() => discordAdapter.start.mock.calls.length === 1);
     const applyPromise = runtime.applyConfig({
       telegram: {
         channel: "telegram",

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -995,6 +995,61 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
+  it("times out a stuck adapter start and reports an error without blocking other adapters", async () => {
+    await prepareRuntimeStore();
+    const stuckStart = createDeferred<void>();
+    const stuckAdapter = createAdapter("discord", {
+      start: vi.fn(async () => {
+        await stuckStart.promise;
+      }),
+    });
+    const workingAdapter = createAdapter("telegram");
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = trackRuntime(new Runtime({
+      adapterFactory: () => [stuckAdapter, workingAdapter],
+      adapterStartTimeoutMs: 1,
+      backendBridge: createBackendBridge(),
+      config: {
+        discord: {
+          channel: "discord",
+          botToken: "discord-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    }));
+
+    await runtime.start();
+
+    expect(stuckAdapter.stop).toHaveBeenCalledTimes(1);
+    expect(runtime.getPlatformStatuses()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          platform: "discord",
+          health: "errored",
+          reason: "discord adapter startup did not complete within 1 ms.",
+        }),
+        expect.objectContaining({
+          platform: "telegram",
+          health: "enabled",
+        }),
+      ]),
+    );
+    expect(messagingLog.info).toHaveBeenCalledWith(
+      "messaging runtime config applied",
+      expect.objectContaining({
+        started: ["telegram"],
+        failed: ["discord"],
+      }),
+    );
+  });
+
   it("starts adapters in parallel and reports pending adapters as loading", async () => {
     await prepareRuntimeStore();
     const telegramStart = createDeferred<void>();
@@ -1039,6 +1094,9 @@ describe("DesktopMessagingRuntime", () => {
         health: "unknown",
       }),
     );
+    await waitFor(() => runtime.getPlatformStatuses().some(
+      (status) => status.platform === "discord" && status.health === "enabled",
+    ));
     expect(runtime.getPlatformStatuses()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -1095,7 +1153,7 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
-  it("serializes stop requests behind pending startup", async () => {
+  it("preserves a stop request that arrives before adapters register", async () => {
     await prepareRuntimeStore();
     const telegramStart = createDeferred<void>();
     const slowTelegramAdapter = createAdapter("telegram");
@@ -1125,19 +1183,15 @@ describe("DesktopMessagingRuntime", () => {
     });
 
     const startPromise = runtime.start();
-    await flushMicrotasks();
     const stopPromise = runtime.stop();
-    await flushMicrotasks();
+    await Promise.all([startPromise, stopPromise]);
 
     expect(slowTelegramAdapter.start).toHaveBeenCalledTimes(1);
     expect(workingDiscordAdapter.start).toHaveBeenCalledTimes(1);
-    expect(slowTelegramAdapter.stop).not.toHaveBeenCalled();
-
-    telegramStart.resolve();
-    await Promise.all([startPromise, stopPromise]);
-
     expect(slowTelegramAdapter.stop).toHaveBeenCalledTimes(1);
-    expect(workingDiscordAdapter.stop).toHaveBeenCalledTimes(1);
+    // The fast adapter settles after cancellation wins the race, so it gets
+    // both immediate failed-start cleanup and the late-start zombie guard.
+    expect(workingDiscordAdapter.stop).toHaveBeenCalledTimes(2);
     expect(runtime.isEnabled()).toBe(false);
     expect(runtime.getPlatformStatuses()).toEqual(
       expect.arrayContaining([
@@ -1150,6 +1204,76 @@ describe("DesktopMessagingRuntime", () => {
           health: "suspended",
         }),
       ]),
+    );
+  });
+
+  it("cancels a pending adapter start when that platform is disabled", async () => {
+    await prepareRuntimeStore();
+    const discordStart = createDeferred<void>();
+    const discordAdapter = createAdapter("discord");
+    discordAdapter.start.mockImplementation(async (listener) => {
+      discordAdapter.listener = listener;
+      await discordStart.promise;
+    });
+    const telegramAdapter = createAdapter("telegram");
+    const factory = vi.fn<DesktopMessagingAdapterFactory>(({ config }) => [
+      ...(config.discord ? [discordAdapter] : []),
+      ...(config.telegram ? [telegramAdapter] : []),
+    ]);
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = trackRuntime(new Runtime({
+      adapterFactory: factory,
+      backendBridge: createBackendBridge(),
+      config: {
+        discord: {
+          channel: "discord",
+          botToken: "discord-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    }));
+
+    const startPromise = runtime.start();
+    const applyPromise = runtime.applyConfig({
+      telegram: {
+        channel: "telegram",
+        botToken: "telegram-token",
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+      },
+    });
+    await Promise.all([startPromise, applyPromise]);
+
+    expect(discordAdapter.stop).toHaveBeenCalledTimes(1);
+    expect(runtime.getPlatformStatuses()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          platform: "discord",
+          health: "suspended",
+          reason: "discord was disabled while adapter startup was still pending.",
+        }),
+        expect.objectContaining({
+          platform: "telegram",
+          health: "enabled",
+        }),
+      ]),
+    );
+    expect(messagingLog.info).toHaveBeenCalledWith(
+      "discord: adapter startup cancelled",
+      expect.objectContaining({ channel: "discord" }),
+    );
+
+    discordStart.resolve();
+    await waitFor(() => discordAdapter.stop.mock.calls.length === 2);
+    expect(messagingLog.info).toHaveBeenCalledWith(
+      "discord: stopped adapter after late startup",
+      { channel: "discord" },
     );
   });
 

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -190,6 +190,28 @@ type RunningMessagingAuthorization = {
   actorIdSet: Set<string>;
 };
 
+type PendingAdapterStart = {
+  cancel(reason: string): void;
+};
+
+type AdapterStartOutcome = "cancelled" | "failed" | "started";
+
+class AdapterStartCancelledError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AdapterStartCancelledError";
+  }
+}
+
+class AdapterStartTimeoutError extends Error {
+  constructor(channel: MessagingChannelKind, timeoutMs: number) {
+    super(
+      `${channel} adapter startup did not complete within ${formatDuration(timeoutMs)}.`,
+    );
+    this.name = "AdapterStartTimeoutError";
+  }
+}
+
 const messagingLog = getMainLogger("pwragent:messaging");
 const PAIRING_INSTANCE_ID = "default";
 const DEFAULT_PAIRING_TTL_MS = 5 * 60 * 1000;
@@ -201,6 +223,16 @@ const PAIRING_TOKEN_ALPHABET =
 const RATE_LIMIT_HEALTH_BUFFER_MS = 2_000;
 const DELIVERY_BUDGET_WARNING_TTL_MS = 30_000;
 const DELIVERY_BUDGET_DIAGNOSTIC_THROTTLE_MS = 30_000;
+const DEFAULT_ADAPTER_START_TIMEOUT_MS = 90_000;
+const FAILED_START_STOP_TIMEOUT_MS = 3_000;
+const CONFIGURABLE_MESSAGING_CHANNELS = [
+  "discord",
+  "feishu",
+  "line",
+  "mattermost",
+  "slack",
+  "telegram",
+] as const satisfies readonly MessagingChannelKind[];
 
 export type MessagingPairingChangedEvent = {
   at: number;
@@ -310,6 +342,15 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   private readonly platformStatusListeners = new Set<
     (event: MessagingPlatformStatusEvent) => void
   >();
+  private readonly pendingAdapterStarts = new Map<
+    MessagingChannelKind,
+    PendingAdapterStart
+  >();
+  private readonly pendingAdapterStartCancellationReasons = new Map<
+    MessagingChannelKind,
+    string
+  >();
+  private pendingAdapterStopReason?: string;
   private lifecycleQueue: Promise<void> = Promise.resolve();
   /**
    * Listeners notified whenever any controller mutates a binding
@@ -331,10 +372,13 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       config: DesktopMessagingConfig | DesktopMessagingConfigLoader;
       automationInboundHandler?: MessagingAutomationInboundHandler;
       automationInboundMatches?: MessagingAutomationInboundMatcher;
+      adapterStartTimeoutMs?: number;
     },
   ) {}
 
   async start(): Promise<void> {
+    this.pendingAdapterStopReason = undefined;
+    this.pendingAdapterStartCancellationReasons.clear();
     await this.enqueueLifecycle(async () => {
       const config = await this.loadConfig({ logStartupEligibility: true });
       await this.applyConfigNow(config);
@@ -342,6 +386,9 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   }
 
   async stop(): Promise<void> {
+    const reason = "Messaging was stopped while adapter startup was still pending.";
+    this.pendingAdapterStopReason = reason;
+    this.cancelPendingAdapterStarts(reason);
     await this.enqueueLifecycle(async () => {
       await this.stopNow();
     });
@@ -400,6 +447,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     config: DesktopMessagingConfig,
     options: { allowStart?: boolean } = {},
   ): Promise<void> {
+    this.updatePendingAdapterStartIntent(config);
     await this.enqueueLifecycle(async () => {
       await this.applyConfigNow(config, options);
     });
@@ -492,22 +540,25 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     const startResults = await Promise.all(
       [...nextAdapters.entries()].map(async ([channel, adapter]) => {
         if (this.runningAdapters.has(channel)) {
-          return { channel, started: false, unchanged: true };
+          return { channel, unchanged: true };
         }
 
-        const started = await this.startRunningAdapter({
+        const outcome = await this.startRunningAdapter({
           adapter,
           config,
           store,
         });
-        return { channel, started, unchanged: false };
+        return { channel, outcome, unchanged: false };
       }),
     );
     const startedChannels = startResults
-      .filter((result) => result.started)
+      .filter((result) => !result.unchanged && result.outcome === "started")
       .map((result) => result.channel);
     const failedChannels = startResults
-      .filter((result) => !result.unchanged && !result.started)
+      .filter((result) => !result.unchanged && result.outcome === "failed")
+      .map((result) => result.channel);
+    const cancelledChannels = startResults
+      .filter((result) => !result.unchanged && result.outcome === "cancelled")
       .map((result) => result.channel);
 
     this.syncRunningAdapterLists();
@@ -523,9 +574,11 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       startedChannels.length > 0
       || stoppedChannels.length > 0
       || failedChannels.length > 0
+      || cancelledChannels.length > 0
       || hotUpdatedChannels.length > 0
     ) {
       messagingLog.info("messaging runtime config applied", {
+        cancelled: cancelledChannels.length > 0 ? cancelledChannels : undefined,
         hotUpdated: hotUpdatedChannels.length > 0 ? hotUpdatedChannels : undefined,
         started: startedChannels.length > 0 ? startedChannels : undefined,
         stopped: stoppedChannels.length > 0 ? stoppedChannels : undefined,
@@ -927,6 +980,35 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     await run;
   }
 
+  private cancelPendingAdapterStarts(reason: string): void {
+    for (const pending of this.pendingAdapterStarts.values()) {
+      pending.cancel(reason);
+    }
+  }
+
+  private updatePendingAdapterStartIntent(
+    config: DesktopMessagingConfig,
+  ): void {
+    if (config.enabled === false) {
+      const reason =
+        "Messaging was disabled while adapter startup was still pending.";
+      this.pendingAdapterStopReason = reason;
+      this.cancelPendingAdapterStarts(reason);
+      return;
+    }
+
+    this.pendingAdapterStopReason = undefined;
+    for (const channel of CONFIGURABLE_MESSAGING_CHANNELS) {
+      if (messagingChannelConfig(config, channel)) {
+        this.pendingAdapterStartCancellationReasons.delete(channel);
+        continue;
+      }
+      const reason = `${channel} was disabled while adapter startup was still pending.`;
+      this.pendingAdapterStartCancellationReasons.set(channel, reason);
+      this.pendingAdapterStarts.get(channel)?.cancel(reason);
+    }
+  }
+
   private async shouldDropAmbientSharedMessage(params: {
     channel: MessagingChannelKind;
     event: MessagingInboundEvent;
@@ -987,7 +1069,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     adapter: DesktopMessagingAdapter;
     config: DesktopMessagingConfig;
     store: MessagingStoreLike;
-  }): Promise<boolean> {
+  }): Promise<AdapterStartOutcome> {
     const { adapter, config, store } = params;
     const authorizedActorIds = [...adapter.authorizedActorIds];
     const authorization: RunningMessagingAuthorization = {
@@ -1080,7 +1162,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         });
       });
       this.setPlatformHealth(adapter.channel, "unknown");
-      await adapter.start?.(async (event) => {
+      await this.startAdapterWithDeadline(adapter, async (event) => {
         // Activity ping fires on every inbound, before authorization checks.
         this.emitPlatformActivity(adapter.channel);
         if (await this.handlePairingInbound(adapter, event)) {
@@ -1142,22 +1224,26 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         // Best effort cleanup after startup failure.
       }
       controller.dispose();
-      try {
-        await adapter.stop?.();
-      } catch (stopError) {
-        messagingLog.warn(`${adapter.channel}: adapter stop after failed start threw`, {
+      const cancelled = error instanceof AdapterStartCancelledError;
+      if (cancelled) {
+        messagingLog.info(`${adapter.channel}: adapter startup cancelled`, {
           channel: adapter.channel,
-          error: stopError instanceof Error ? stopError.message : String(stopError),
+          reason: error.message,
+        });
+        this.setPlatformHealth(adapter.channel, "suspended", {
+          reason: error.message,
+        });
+      } else {
+        messagingLog.error(`${adapter.channel}: failed to start adapter`, {
+          channel: adapter.channel,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        this.setPlatformHealth(adapter.channel, "errored", {
+          reason: error instanceof Error ? error.message : String(error),
         });
       }
-      messagingLog.error(`${adapter.channel}: failed to start adapter`, {
-        channel: adapter.channel,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      this.setPlatformHealth(adapter.channel, "errored", {
-        reason: error instanceof Error ? error.message : String(error),
-      });
-      return false;
+      await this.stopAdapterAfterFailedStart(adapter);
+      return cancelled ? "cancelled" : "failed";
     }
 
     const unsubscribeRuntimeError = adapter.onRuntimeError?.((reason) => {
@@ -1203,7 +1289,98 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     messagingLog.info(`${adapter.channel}: adapter started successfully`, {
       channel: adapter.channel,
     });
-    return true;
+    return "started";
+  }
+
+  private async startAdapterWithDeadline(
+    adapter: DesktopMessagingAdapter,
+    listener: (event: MessagingInboundEvent) => Promise<void>,
+  ): Promise<void> {
+    const timeoutMs = Math.max(
+      1,
+      this.options.adapterStartTimeoutMs ?? DEFAULT_ADAPTER_START_TIMEOUT_MS,
+    );
+    let cancel: ((reason: string) => void) | undefined;
+    let cancelled = false;
+    const cancellation = new Promise<never>((_resolve, reject) => {
+      cancel = (reason) => {
+        if (cancelled) return;
+        cancelled = true;
+        reject(new AdapterStartCancelledError(reason));
+      };
+    });
+    const startPromise = Promise.resolve().then(async () => {
+      await adapter.start?.(listener);
+    });
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timeoutHandle = setTimeout(() => {
+        reject(new AdapterStartTimeoutError(adapter.channel, timeoutMs));
+      }, timeoutMs);
+      if (timeoutHandle.unref) timeoutHandle.unref();
+    });
+    const pending: PendingAdapterStart = {
+      cancel: (reason) => cancel?.(reason),
+    };
+    this.pendingAdapterStarts.set(adapter.channel, pending);
+    const queuedCancellationReason = this.pendingAdapterStopReason
+      ?? this.pendingAdapterStartCancellationReasons.get(adapter.channel);
+    if (queuedCancellationReason) {
+      pending.cancel(queuedCancellationReason);
+    }
+
+    try {
+      await Promise.race([startPromise, cancellation, timeout]);
+    } catch (error) {
+      if (
+        error instanceof AdapterStartCancelledError
+        || error instanceof AdapterStartTimeoutError
+      ) {
+        void startPromise.then(
+          async () => this.stopAdapterAfterLateStart(adapter),
+          () => undefined,
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutHandle);
+      if (this.pendingAdapterStarts.get(adapter.channel) === pending) {
+        this.pendingAdapterStarts.delete(adapter.channel);
+      }
+    }
+  }
+
+  private async stopAdapterAfterFailedStart(
+    adapter: DesktopMessagingAdapter,
+  ): Promise<void> {
+    try {
+      await promiseWithTimeout(
+        Promise.resolve().then(async () => adapter.stop?.()),
+        FAILED_START_STOP_TIMEOUT_MS,
+        `${adapter.channel} adapter cleanup after failed startup`,
+      );
+    } catch (stopError) {
+      messagingLog.warn(`${adapter.channel}: adapter stop after failed start threw`, {
+        channel: adapter.channel,
+        error: stopError instanceof Error ? stopError.message : String(stopError),
+      });
+    }
+  }
+
+  private async stopAdapterAfterLateStart(
+    adapter: DesktopMessagingAdapter,
+  ): Promise<void> {
+    try {
+      await adapter.stop?.();
+      messagingLog.info(`${adapter.channel}: stopped adapter after late startup`, {
+        channel: adapter.channel,
+      });
+    } catch (error) {
+      messagingLog.warn(`${adapter.channel}: adapter stop after late start threw`, {
+        channel: adapter.channel,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   private async hotApplyRunningAdapter(
@@ -2344,6 +2521,57 @@ function degradationKey(
   id: string,
 ): string {
   return `${platform}:${kind}:${id}`;
+}
+
+function messagingChannelConfig(
+  config: DesktopMessagingConfig,
+  channel: MessagingChannelKind,
+): unknown {
+  switch (channel) {
+    case "discord":
+      return config.discord;
+    case "feishu":
+      return config.feishu;
+    case "line":
+      return config.line;
+    case "mattermost":
+      return config.mattermost;
+    case "slack":
+      return config.slack;
+    case "telegram":
+      return config.telegram;
+    default:
+      return undefined;
+  }
+}
+
+async function promiseWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  operation: string,
+): Promise<T> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(
+        new Error(`${operation} did not complete within ${formatDuration(timeoutMs)}.`),
+      );
+    }, timeoutMs);
+    if (timeoutHandle.unref) timeoutHandle.unref();
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
+function formatDuration(durationMs: number): string {
+  if (durationMs % 1000 === 0) {
+    const seconds = durationMs / 1000;
+    return `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
+  }
+  return `${durationMs} ms`;
 }
 
 function streamingResponsesDefaultForChannel(

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -197,7 +197,10 @@ type PendingAdapterStart = {
 type AdapterStartOutcome = "cancelled" | "failed" | "started";
 
 class AdapterStartCancelledError extends Error {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    readonly startInvoked = true,
+  ) {
     super(message);
     this.name = "AdapterStartCancelledError";
   }
@@ -1242,7 +1245,9 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
           reason: error instanceof Error ? error.message : String(error),
         });
       }
-      await this.stopAdapterAfterFailedStart(adapter);
+      if (!(error instanceof AdapterStartCancelledError && !error.startInvoked)) {
+        await this.stopAdapterAfterFailedStart(adapter);
+      }
       return cancelled ? "cancelled" : "failed";
     }
 
@@ -1309,6 +1314,17 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         reject(new AdapterStartCancelledError(reason));
       };
     });
+    const pending: PendingAdapterStart = {
+      cancel: (reason) => cancel?.(reason),
+    };
+    this.pendingAdapterStarts.set(adapter.channel, pending);
+    const queuedCancellationReason = this.pendingAdapterStopReason
+      ?? this.pendingAdapterStartCancellationReasons.get(adapter.channel);
+    if (queuedCancellationReason) {
+      this.pendingAdapterStarts.delete(adapter.channel);
+      throw new AdapterStartCancelledError(queuedCancellationReason, false);
+    }
+
     const startPromise = Promise.resolve().then(async () => {
       await adapter.start?.(listener);
     });
@@ -1319,15 +1335,6 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       }, timeoutMs);
       if (timeoutHandle.unref) timeoutHandle.unref();
     });
-    const pending: PendingAdapterStart = {
-      cancel: (reason) => cancel?.(reason),
-    };
-    this.pendingAdapterStarts.set(adapter.channel, pending);
-    const queuedCancellationReason = this.pendingAdapterStopReason
-      ?? this.pendingAdapterStartCancellationReasons.get(adapter.channel);
-    if (queuedCancellationReason) {
-      pending.cancel(queuedCancellationReason);
-    }
 
     try {
       await Promise.race([startPromise, cancellation, timeout]);
@@ -1338,7 +1345,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       ) {
         void startPromise.then(
           async () => this.stopAdapterAfterLateStart(adapter),
-          () => undefined,
+          async () => this.stopAdapterAfterLateStart(adapter),
         );
       }
       throw error;

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -60,6 +60,21 @@ authorized bot messages as ordinary `text` or `media` events with
 provider alerts such as Slack posts from monitoring bots without looping on
 PwrAgent's own replies.
 
+## Lifecycle
+
+`stop()` is valid as soon as `start()` has been invoked, not only after the
+adapter reports a fully started state. It must close or detach every resource
+created by a partial start, including callback servers, SDK listeners,
+websockets, gateway clients, and polling loops. A stop that arrives during an
+awaited identity or connection step must also prevent later startup steps from
+opening new external resources.
+
+Startup cleanup is idempotent. The desktop runtime may call `stop()` once when
+cancellation or a deadline wins and again after the original `start()` promise
+settles, whether that promise resolves or rejects. Providers must therefore not
+gate cleanup solely on a final `started` flag, and repeated cleanup must not
+leave listeners or connections behind.
+
 ## Opaque State
 
 Adapters own routing and surface state. PwrAgent may persist and echo

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -10,6 +10,7 @@ import {
 import { describe, expect, it, vi } from "vitest";
 import {
   DiscordAdapter,
+  DiscordJsGatewayConnection,
   stripDiscordBotMention,
   type DiscordApi,
   type DiscordGatewayConnection,
@@ -32,6 +33,81 @@ const TEST_OTHER_USER_ID = "1480556454498009356";
 const TEST_AUTHORIZED_GUILD_IDS = [{ id: TEST_GUILD_ID, displayName: "" }];
 
 describe("discord adapter", () => {
+  it("cancels gateway discovery before a stopped login can connect", async () => {
+    let resolveGateway!: (value: unknown) => void;
+    const pendingGateway = new Promise<unknown>((resolve) => {
+      resolveGateway = resolve;
+    });
+    const connect = vi.fn();
+    const getGateway = vi.fn(async () => await pendingGateway);
+    const rest = { get: getGateway };
+    const client = {
+      destroy: vi.fn(async () => undefined),
+      login: vi.fn(async () => {
+        await rest.get();
+        connect();
+        return "token";
+      }),
+      on: vi.fn(),
+      removeAllListeners: vi.fn(),
+      rest,
+    };
+    const gateway = new DiscordJsGatewayConnection(
+      {
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+        botToken: "token",
+        channel: "discord",
+      },
+      client as never,
+    );
+
+    const startPromise = gateway.start();
+    await vi.waitFor(() => {
+      expect(getGateway).toHaveBeenCalledTimes(1);
+    });
+    await gateway.close();
+    resolveGateway({ url: "wss://gateway.example.test" });
+
+    await expect(startPromise).rejects.toThrow(
+      "Discord gateway startup was cancelled.",
+    );
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it("does not open the gateway after a stop during command reconciliation", async () => {
+    let resolveCommands!: (value: DiscordApplicationCommand[]) => void;
+    const pendingCommands = new Promise<DiscordApplicationCommand[]>((resolve) => {
+      resolveCommands = resolve;
+    });
+    const listApplicationCommands = vi.fn(async () => await pendingCommands);
+    const gateway: DiscordGatewayConnection = {
+      close: vi.fn(async () => undefined),
+      onEvent: vi.fn(() => () => undefined),
+      start: vi.fn(async () => undefined),
+    };
+    const adapter = new DiscordAdapter({
+      api: createApi({ listApplicationCommands }),
+      config: {
+        applicationId: TEST_CHANNEL_ID,
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+        botToken: "token",
+        channel: "discord",
+      },
+      gateway,
+    });
+
+    const startPromise = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(listApplicationCommands).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+    resolveCommands([]);
+    await startPromise;
+
+    expect(gateway.start).not.toHaveBeenCalled();
+    expect(gateway.close).toHaveBeenCalledTimes(2);
+  });
+
   it("declares Monitor as a desired Discord application command", () => {
     expect(DISCORD_APPLICATION_COMMANDS.map((command) => command.name)).toEqual([
       "resume",

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -338,6 +338,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private typingSignalSequence = 0;
   private typingSignals = new Map<string, DiscordTypingSignal>();
   private unsubscribeGateway?: () => void;
+  private lifecycleGeneration = 0;
 
   constructor(options: DiscordAdapterOptions) {
     this.options = options;
@@ -386,15 +387,24 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   }
 
   async start(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void> {
+    const lifecycleGeneration = ++this.lifecycleGeneration;
     await this.reconcileApplicationCommands();
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
     this.listener = listener;
     this.unsubscribeGateway = this.gateway.onEvent(async (event) => {
       await this.handleGatewayEvent(event);
     });
     await this.gateway.start();
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+    }
   }
 
   async stop(): Promise<void> {
+    this.lifecycleGeneration += 1;
     this.stopTypingSignals();
     this.unsubscribeGateway?.();
     this.unsubscribeGateway = undefined;
@@ -2180,14 +2190,18 @@ class DiscordRestApi implements DiscordApi {
   }
 }
 
-class DiscordJsGatewayConnection implements DiscordGatewayConnection {
+export class DiscordJsGatewayConnection implements DiscordGatewayConnection {
   private readonly client: Client;
   private readonly config: DiscordMessagingConfig;
   private readonly listeners = new Set<DiscordGatewayListener>();
+  private lifecycleGeneration = 0;
 
-  constructor(config: DiscordMessagingConfig) {
+  constructor(
+    config: DiscordMessagingConfig,
+    client?: Client,
+  ) {
     this.config = config;
-    this.client = new Client({
+    this.client = client ?? new Client({
       intents: [
         GatewayIntentBits.DirectMessages,
         GatewayIntentBits.GuildMessages,
@@ -2196,22 +2210,44 @@ class DiscordJsGatewayConnection implements DiscordGatewayConnection {
       ],
       partials: [Partials.Channel],
     });
+    this.guardGatewayDiscovery();
     this.registerHandlers();
   }
 
   async start(): Promise<void> {
+    this.lifecycleGeneration += 1;
     await this.client.login(this.config.botToken);
   }
 
   async close(): Promise<void> {
+    this.lifecycleGeneration += 1;
     this.client.removeAllListeners();
-    this.client.destroy();
+    await this.client.destroy();
   }
 
   onEvent(listener: DiscordGatewayListener): () => void {
     this.listeners.add(listener);
     return () => {
       this.listeners.delete(listener);
+    };
+  }
+
+  private guardGatewayDiscovery(): void {
+    // discord.js fetches /gateway/bot before its internal manager opens any
+    // websocket shards. `Client.destroy()` cannot cancel that REST request;
+    // without this post-fetch guard, the suspended login continuation can
+    // still call the internal websocket manager after close() has returned.
+    const rest = this.client.rest as unknown as {
+      get(...args: unknown[]): Promise<unknown>;
+    };
+    const get = rest.get.bind(rest);
+    rest.get = async (...args: unknown[]) => {
+      const lifecycleGeneration = this.lifecycleGeneration;
+      const response = await get(...args);
+      if (lifecycleGeneration !== this.lifecycleGeneration) {
+        throw new Error("Discord gateway startup was cancelled.");
+      }
+      return response;
     };
   }
 

--- a/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
+++ b/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
@@ -104,6 +104,37 @@ describe("FeishuAdapter", () => {
     vi.unstubAllGlobals();
   });
 
+  it("closes a persistent connection while startup is still pending", async () => {
+    let rejectStart!: (reason?: unknown) => void;
+    const pendingStart = new Promise<never>((_resolve, reject) => {
+      rejectStart = reject;
+    });
+    const close = vi.fn();
+    const startConnection = vi.fn(async () => await pendingStart);
+    const { inboundMode: _inboundMode, ...persistentConfig } = baseConfig;
+    const adapter = new FeishuAdapter({
+      config: persistentConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      wsClientFactory: () => ({
+        close,
+        start: startConnection,
+      }),
+    });
+
+    const startPromise = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(startConnection).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+
+    expect(close).toHaveBeenCalledWith({ force: true });
+    rejectStart(new Error("persistent connection rejected after stop"));
+    await expect(startPromise).rejects.toThrow(
+      "persistent connection rejected after stop",
+    );
+  });
+
   it("declares Feishu capabilities", () => {
     const adapter = new FeishuAdapter({
       config: baseConfig,

--- a/packages/messaging/providers/feishu/src/feishu-adapter.ts
+++ b/packages/messaging/providers/feishu/src/feishu-adapter.ts
@@ -323,6 +323,7 @@ export class FeishuAdapter implements FeishuProviderAdapter {
   private started = false;
   private webhookListening = false;
   private wsClient: FeishuWsClient | undefined;
+  private lifecycleGeneration = 0;
   private readonly diagnosticListeners = new Set<MessagingAdapterDiagnosticListener>();
   private readonly inboundRejectedListeners = new Set<MessagingInboundRejectedListener>();
   private readonly rateLimitListeners = new Set<(info: MessagingRateLimitInfo) => void>();
@@ -434,24 +435,37 @@ export class FeishuAdapter implements FeishuProviderAdapter {
 
   async start(listener: FeishuInboundListener): Promise<void> {
     if (this.started) return;
+    const lifecycleGeneration = ++this.lifecycleGeneration;
     this.listener = listener;
     const botInfo = await this.api.getBotInfo();
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
     this.botAccount = botInfo.appName ?? botInfo.openId;
     this.botAccountDetail = botInfo.tenantKey ?? hostFromUrl(this.config.tenantUrl);
     this.botOpenId = botInfo.openId;
     if (this.config.inboundMode === "webhook") {
       await this.listenForCallbacks();
     } else {
-      await this.startPersistentConnection();
+      await this.startPersistentConnection(lifecycleGeneration);
+    }
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
     }
     this.started = true;
   }
 
   async stop(): Promise<void> {
-    if (!this.started) return;
-    this.wsClient?.close({ force: true });
+    this.lifecycleGeneration += 1;
+    try {
+      this.wsClient?.close({ force: true });
+    } catch (error) {
+      this.logger.warn?.("feishu persistent connection close failed", { error });
+    }
     this.wsClient = undefined;
-    if (this.webhookListening) {
+    if (this.webhookListening || this.server.listening) {
       await new Promise<void>((resolve, reject) => {
         this.server.close((error) => {
           if (error) reject(error);
@@ -1610,8 +1624,13 @@ export class FeishuAdapter implements FeishuProviderAdapter {
     this.webhookListening = true;
   }
 
-  private async startPersistentConnection(): Promise<void> {
+  private async startPersistentConnection(
+    lifecycleGeneration: number,
+  ): Promise<void> {
     const lark = await import("@larksuiteoapi/node-sdk");
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      return;
+    }
     const sdkEventDispatcher = new lark.EventDispatcher({
       ...(this.config.encryptKey ? { encryptKey: this.config.encryptKey } : {}),
       logger: larkLoggerFromProviderLogger(this.logger),
@@ -1648,8 +1667,36 @@ export class FeishuAdapter implements FeishuProviderAdapter {
       appSecret: this.config.appSecret,
       domain: this.config.tenantRegion === "lark" ? "lark" : "feishu",
     });
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      wsClient.close({ force: true });
+      return;
+    }
     this.wsClient = wsClient;
-    await wsClient.start({ eventDispatcher });
+    try {
+      await wsClient.start({ eventDispatcher });
+    } catch (error) {
+      try {
+        wsClient.close({ force: true });
+      } catch (closeError) {
+        this.logger.warn?.("feishu persistent connection close failed", {
+          error: closeError,
+        });
+      }
+      if (this.wsClient === wsClient) {
+        this.wsClient = undefined;
+      }
+      throw error;
+    }
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      try {
+        wsClient.close({ force: true });
+      } catch (error) {
+        this.logger.warn?.("feishu persistent connection close failed", { error });
+      }
+      if (this.wsClient === wsClient) {
+        this.wsClient = undefined;
+      }
+    }
   }
 
   private async handleWebhookRequest(

--- a/packages/messaging/providers/line/src/__tests__/line-adapter.test.ts
+++ b/packages/messaging/providers/line/src/__tests__/line-adapter.test.ts
@@ -19,6 +19,43 @@ describe("LineAdapter", () => {
     adapters.length = 0;
   });
 
+  it("does not bind a webhook after startup is stopped during identity lookup", async () => {
+    const port = await getFreePort();
+    let resolveBotInfo!: (value: {
+      displayName?: string;
+      userId: string;
+    }) => void;
+    const pendingBotInfo = new Promise<{
+      displayName?: string;
+      userId: string;
+    }>((resolve) => {
+      resolveBotInfo = resolve;
+    });
+    const api = createApi();
+    api.getBotInfo = vi.fn(async () => await pendingBotInfo);
+    const adapter = new LineAdapter({
+      api,
+      callbackHandleStore: createCallbackStore(),
+      config: createConfig({ callbackBaseUrl: `http://127.0.0.1:${port}/` }),
+    });
+    adapters.push(adapter);
+
+    const startPromise = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(api.getBotInfo).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+    resolveBotInfo({ userId: "Uffffffffffffffffffffffffffffffff" });
+    await startPromise;
+
+    const probe = createServer();
+    await new Promise<void>((resolve, reject) => {
+      probe.once("error", reject);
+      probe.listen(port, "127.0.0.1", () => resolve());
+    });
+    await new Promise<void>((resolve) => probe.close(() => resolve()));
+  });
+
   it("verifies X-Line-Signature before processing webhook bodies", () => {
     const body = Buffer.from(JSON.stringify({ events: [] }));
     const signature = createHmac("sha256", "secret").update(body).digest("base64");

--- a/packages/messaging/providers/line/src/line-adapter.ts
+++ b/packages/messaging/providers/line/src/line-adapter.ts
@@ -202,6 +202,7 @@ export class LineAdapter implements LineProviderAdapter {
   private listener: LineInboundListener | undefined;
   private botUserId: string | undefined;
   private started = false;
+  private lifecycleGeneration = 0;
   private readonly inboundRejectedListeners = new Set<MessagingInboundRejectedListener>();
 
   constructor(options: LineAdapterOptions) {
@@ -253,6 +254,7 @@ export class LineAdapter implements LineProviderAdapter {
 
   async start(listener: LineInboundListener): Promise<void> {
     if (this.started) return;
+    const lifecycleGeneration = ++this.lifecycleGeneration;
     this.listener = listener;
     if (!this.botUserId && this.api) {
       try {
@@ -264,6 +266,10 @@ export class LineAdapter implements LineProviderAdapter {
         });
       }
     }
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
     const bindAddress = bindAddressFromCallbackUrl(this.config.callbackBaseUrl);
     await new Promise<void>((resolve, reject) => {
       this.server.once("error", reject);
@@ -272,6 +278,10 @@ export class LineAdapter implements LineProviderAdapter {
         resolve();
       });
     });
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
     this.started = true;
     this.logger.info?.("line webhook listener started", {
       host: bindAddress.host,
@@ -283,15 +293,20 @@ export class LineAdapter implements LineProviderAdapter {
   }
 
   async stop(): Promise<void> {
-    if (!this.started) return;
-    await new Promise<void>((resolve, reject) => {
-      this.server.close((error) => {
-        if (error) reject(error);
-        else resolve();
-      });
-    });
-    this.listener = undefined;
-    this.started = false;
+    this.lifecycleGeneration += 1;
+    try {
+      if (this.server.listening) {
+        await new Promise<void>((resolve, reject) => {
+          this.server.close((error) => {
+            if (error) reject(error);
+            else resolve();
+          });
+        });
+      }
+    } finally {
+      this.listener = undefined;
+      this.started = false;
+    }
   }
 
   onInboundRejected(listener: MessagingInboundRejectedListener): () => void {

--- a/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
+++ b/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MattermostAdapter, stripBotMention, summarizeThreadRoot } from "../mattermost-adapter.ts";
 import type {
   MessagingCallbackHandleRecord,
@@ -142,6 +142,40 @@ function fakeClient4(spies: {
 }
 
 describe("MattermostAdapter — capability profile", () => {
+  it("stops a callback server while bot identity startup is still pending", async () => {
+    let rejectGetMe!: (reason?: unknown) => void;
+    const getMe = new Promise<never>((_resolve, reject) => {
+      rejectGetMe = reject;
+    });
+    const client = fakeClient4({ createdPosts: [], patchedPosts: [] });
+    client.getMe = vi.fn(async () => await getMe) as never;
+    const callbackServer = {
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+      signContext: () => ({ hmac: "x", issuedAt: 0 }),
+    };
+    const websocketClient = fakeWebSocketClient();
+    const adapter = new MattermostAdapter({
+      callbackHandleStore: fakeStore,
+      callbackServer: callbackServer as never,
+      client,
+      config: baseConfig,
+      logger: silentLogger,
+      websocketClient,
+    });
+
+    const startPromise = adapter.start(async () => {});
+    await vi.waitFor(() => {
+      expect(callbackServer.start).toHaveBeenCalledTimes(1);
+      expect(client.getMe).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+
+    expect(callbackServer.stop).toHaveBeenCalledTimes(1);
+    rejectGetMe(new Error("identity rejected after stop"));
+    await expect(startPromise).rejects.toThrow("identity rejected after stop");
+  });
+
   it("declares Mattermost capability profile with documented limits", () => {
     const adapter = new MattermostAdapter({
       callbackHandleStore: fakeStore,

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -300,6 +300,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
   private botUserId: string | undefined;
   private botUsername: string | undefined;
   private started = false;
+  private lifecycleGeneration = 0;
   /**
    * `true` once `stop()` has been called. Suppresses the runtime-error
    * fan-out for any websocket-close / -error events that fire as part
@@ -445,11 +446,20 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     if (this.started) {
       return;
     }
+    const lifecycleGeneration = ++this.lifecycleGeneration;
     this.listener = listener;
     await this.callbackServer.start();
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
 
     try {
       const me = (await this.client.getMe()) as { id: string; username?: string };
+      if (lifecycleGeneration !== this.lifecycleGeneration) {
+        await this.stop();
+        return;
+      }
       this.botUserId = me.id;
       this.botUsername = me.username;
     } catch (error) {
@@ -538,6 +548,10 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     // tradeoff.
     if (this.config.registerSlashCommands === true) {
       await this.reconcileSlashCommandsAcrossTeams();
+      if (lifecycleGeneration !== this.lifecycleGeneration) {
+        await this.stop();
+        return;
+      }
     } else {
       this.logger.info(
         "mattermost adapter: slash-command registration disabled (registerSlashCommands=false)",
@@ -555,9 +569,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
   }
 
   async stop(): Promise<void> {
-    if (!this.started) {
-      return;
-    }
+    this.lifecycleGeneration += 1;
     this.stopping = true;
     this.started = false;
     this.listener = undefined;
@@ -568,13 +580,16 @@ export class MattermostAdapter implements MattermostProviderAdapter {
         error: error instanceof Error ? error.message : String(error),
       });
     }
-    await this.callbackServer.stop();
-    // Reset latch + drop listeners so a subsequent `start()` re-arms.
-    this.runtimeErrorListeners.clear();
-    this.reconnectListeners.clear();
-    this.wsErroredLatched = false;
-    this.websocketReconnectActive = false;
-    this.stopping = false;
+    try {
+      await this.callbackServer.stop();
+    } finally {
+      // Reset latch + drop listeners so a subsequent `start()` re-arms.
+      this.runtimeErrorListeners.clear();
+      this.reconnectListeners.clear();
+      this.wsErroredLatched = false;
+      this.websocketReconnectActive = false;
+      this.stopping = false;
+    }
     this.logger.info("mattermost adapter stopped", {});
   }
 

--- a/packages/messaging/providers/mattermost/src/mattermost-callback-server.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-callback-server.ts
@@ -435,7 +435,7 @@ export function createMattermostCallbackServer(
       if (server) {
         return;
       }
-      server = createServer((req, res) => {
+      const current = createServer((req, res) => {
         handleRequest(req, res).catch((error) => {
           config.logger.error("mattermost callback request crashed", {
             error: error instanceof Error ? error.message : String(error),
@@ -447,6 +447,7 @@ export function createMattermostCallbackServer(
           }
         });
       });
+      server = current;
       await new Promise<void>((resolve, reject) => {
         const errorHandler = (error: Error): void => {
           config.logger.error("mattermost callback listener failed to bind", {
@@ -455,9 +456,9 @@ export function createMattermostCallbackServer(
           });
           reject(error);
         };
-        server!.once("error", errorHandler);
-        server!.listen(config.port, "127.0.0.1", () => {
-          server!.off("error", errorHandler);
+        current.once("error", errorHandler);
+        current.listen(config.port, "127.0.0.1", () => {
+          current.off("error", errorHandler);
           config.logger.info?.("mattermost callback listener bound", {
             port: config.port,
             host: "127.0.0.1",

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { SlackAdapter, type SlackApi, type SlackSocketClient } from "../slack-adapter.ts";
+import {
+  SlackAdapter,
+  SlackSocketModeConnection,
+  type SlackApi,
+  type SlackSocketClient,
+} from "../slack-adapter.ts";
 import type {
   MessagingChannelRef,
   MessagingCallbackHandleRecord,
@@ -139,6 +144,69 @@ function fakeSocket(): SlackSocketClient & {
 }
 
 describe("SlackAdapter", () => {
+  it("cancels URL discovery before a stopped Socket Mode client can connect", async () => {
+    let resolveUrl!: (value: string) => void;
+    const pendingUrl = new Promise<string>((resolve) => {
+      resolveUrl = resolve;
+    });
+    const connect = vi.fn();
+    const retrieveWSSURL = vi.fn(async () => await pendingUrl);
+    const client = {
+      disconnect: vi.fn(async () => undefined),
+      off: vi.fn(),
+      on: vi.fn(),
+      removeAllListeners: vi.fn(),
+      retrieveWSSURL,
+      start: vi.fn(async function(this: { retrieveWSSURL(): Promise<string> }) {
+        const url = await this.retrieveWSSURL();
+        connect(url);
+      }),
+    };
+    const socket = new SlackSocketModeConnection(client);
+
+    const startPromise = socket.start();
+    await vi.waitFor(() => {
+      expect(retrieveWSSURL).toHaveBeenCalledTimes(1);
+    });
+    await socket.disconnect();
+    resolveUrl("wss://socket-mode.example.test");
+
+    await expect(startPromise).rejects.toThrow(
+      "Slack Socket Mode startup was cancelled.",
+    );
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it("detaches socket listeners when startup is stopped before connecting", async () => {
+    let rejectStart!: (reason?: unknown) => void;
+    const pendingStart = new Promise<never>((_resolve, reject) => {
+      rejectStart = reject;
+    });
+    const socket: SlackSocketClient = {
+      disconnect: vi.fn(async () => undefined),
+      off: vi.fn(),
+      on: vi.fn(),
+      start: vi.fn(async () => await pendingStart),
+    };
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+    });
+
+    const startPromise = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(socket.start).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+
+    expect(socket.off).toHaveBeenCalledTimes(3);
+    expect(socket.disconnect).toHaveBeenCalledTimes(1);
+    rejectStart(new Error("socket rejected after stop"));
+    await expect(startPromise).rejects.toThrow("socket rejected after stop");
+  });
+
   it("declares Slack capabilities", () => {
     const adapter = new SlackAdapter({
       config: baseConfig,

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -366,6 +366,9 @@ export class SlackAdapter implements SlackProviderAdapter {
   private userInfoLookupDisabled = false;
   private listener: SlackInboundListener | undefined;
   private started = false;
+  private lifecycleGeneration = 0;
+  private socketListenersAttached = false;
+  private socketStartPending = false;
 
   constructor(options: SlackAdapterOptions) {
     this.config = options.config;
@@ -477,8 +480,13 @@ export class SlackAdapter implements SlackProviderAdapter {
 
   async start(listener: SlackInboundListener): Promise<void> {
     if (this.started) return;
+    const lifecycleGeneration = ++this.lifecycleGeneration;
     this.listener = listener;
     const auth = await this.api.authTest();
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
     this.botId = auth.bot_id;
     this.botUserId = auth.user_id;
     this.botAccount = auth.user ?? auth.user_id;
@@ -494,18 +502,38 @@ export class SlackAdapter implements SlackProviderAdapter {
     this.socketClient.on("slack_event", this.handleSlackEvent);
     this.socketClient.on("interactive", this.handleInteractive);
     this.socketClient.on("slash_commands", this.handleSlashCommand);
+    this.socketListenersAttached = true;
+    this.socketStartPending = true;
     await this.socketClient.start();
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      this.socketStartPending = false;
+      return;
+    }
+    this.socketStartPending = false;
     this.started = true;
   }
 
   async stop(): Promise<void> {
-    if (!this.started) return;
-    this.socketClient?.off?.("slack_event", this.handleSlackEvent);
-    this.socketClient?.off?.("interactive", this.handleInteractive);
-    this.socketClient?.off?.("slash_commands", this.handleSlashCommand);
-    await this.socketClient?.disconnect();
-    this.started = false;
-    this.listener = undefined;
+    this.lifecycleGeneration += 1;
+    const shouldDisconnect =
+      this.started
+      || this.socketListenersAttached
+      || this.socketStartPending;
+    try {
+      if (this.socketListenersAttached) {
+        this.socketClient?.off?.("slack_event", this.handleSlackEvent);
+        this.socketClient?.off?.("interactive", this.handleInteractive);
+        this.socketClient?.off?.("slash_commands", this.handleSlashCommand);
+        this.socketListenersAttached = false;
+      }
+      if (shouldDisconnect) {
+        await this.socketClient?.disconnect();
+      }
+    } finally {
+      this.started = false;
+      this.listener = undefined;
+    }
   }
 
   async deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult> {
@@ -2278,10 +2306,58 @@ export function createSlackSocketClient(
   if (!appToken?.trim()) {
     return undefined;
   }
-  return new SocketModeClient({
+  return new SlackSocketModeConnection(new SocketModeClient({
     appToken,
     autoReconnectEnabled: true,
-  }) as SlackSocketClient;
+  }) as unknown as SlackSocketModeClientWithDiscovery);
+}
+
+type SlackSocketModeClientWithDiscovery = SlackSocketClient & {
+  retrieveWSSURL(): Promise<string>;
+};
+
+export class SlackSocketModeConnection implements SlackSocketClient {
+  private lifecycleGeneration = 0;
+
+  constructor(
+    private readonly client: SlackSocketModeClientWithDiscovery,
+  ) {
+    // SocketModeClient.start() awaits apps.connections.open before it creates
+    // `websocket`. Its public disconnect() cannot close anything during that
+    // gap, so guard the SDK's discovery seam and reject before the suspended
+    // start continuation can construct and connect a SlackWebSocket.
+    const retrieveWSSURL = client.retrieveWSSURL.bind(client);
+    client.retrieveWSSURL = async () => {
+      const lifecycleGeneration = this.lifecycleGeneration;
+      const url = await retrieveWSSURL();
+      if (lifecycleGeneration !== this.lifecycleGeneration) {
+        throw new Error("Slack Socket Mode startup was cancelled.");
+      }
+      return url;
+    };
+  }
+
+  disconnect(): Promise<void> {
+    this.lifecycleGeneration += 1;
+    return this.client.disconnect();
+  }
+
+  off(event: string, listener: (payload: unknown) => void): unknown {
+    return this.client.off?.(event, listener);
+  }
+
+  on(event: string, listener: (payload: unknown) => void): unknown {
+    return this.client.on(event, listener);
+  }
+
+  removeAllListeners(event?: string): unknown {
+    return this.client.removeAllListeners?.(event);
+  }
+
+  async start(): Promise<unknown> {
+    this.lifecycleGeneration += 1;
+    return await this.client.start();
+  }
 }
 
 function hostFromUrl(url: string | undefined): string | undefined {

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
@@ -164,6 +164,46 @@ describe("adaptGrammyBot", () => {
   });
 });
 
+describe("TelegramAdapter lifecycle", () => {
+  it("does not continue webhook startup after a stop during identity lookup", async () => {
+    let resolveGetMe!: (value: {
+      id: number;
+      is_bot: true;
+      username: string;
+    }) => void;
+    const pendingGetMe = new Promise<{
+      id: number;
+      is_bot: true;
+      username: string;
+    }>((resolve) => {
+      resolveGetMe = resolve;
+    });
+    const api = fakeTelegramApi();
+    api.getMe = vi.fn(async () => await pendingGetMe);
+    api.getWebhookInfo = vi.fn(async () => ({ url: "" }));
+    const adapter = new TelegramAdapter({
+      api,
+      config: {
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        botToken: "token",
+        channel: "telegram",
+      },
+      pollOnStart: false,
+      store: fakeCallbackStore(),
+    });
+
+    const startPromise = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(api.getMe).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+    resolveGetMe({ id: 123, is_bot: true, username: "TestBot" });
+    await startPromise;
+
+    expect(api.getWebhookInfo).not.toHaveBeenCalled();
+  });
+});
+
 describe("TelegramAdapter callback persistence", () => {
   it("registers Monitor with Telegram bot commands", async () => {
     const grammyBot = createGrammyBot();

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -544,6 +544,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     store?: MessagingCallbackHandleStore;
   };
   private startPromise?: Promise<void>;
+  private lifecycleGeneration = 0;
   /**
    * `true` once `stop()` has been called; suppresses the runtime-error
    * fan-out for the polling-loop rejection that grammy raises as part
@@ -627,6 +628,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   }
 
   async start(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void> {
+    const lifecycleGeneration = ++this.lifecycleGeneration;
     this.listener = listener;
 
     this.registerBotErrorHandler();
@@ -653,6 +655,10 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         error: errorMessage(error),
       });
     }
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
 
     try {
       await this.bot.api.getWebhookInfo();
@@ -664,9 +670,17 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       });
       throw error;
     }
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
     await this.bot.api.deleteWebhook({
       drop_pending_updates: false,
     });
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
     await this.bot.api.setMyCommands({
       commands: [
         {
@@ -691,6 +705,10 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         },
       ],
     });
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
 
     if (this.options.pollOnStart !== false) {
       this.startPromise = this.bot.start?.({
@@ -736,6 +754,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   }
 
   async stop(): Promise<void> {
+    this.lifecycleGeneration += 1;
     this.stopping = true;
     this.stopTypingSignals();
     try {


### PR DESCRIPTION
## Summary

- bound each messaging adapter startup to a 90-second deadline
- cancel pending startup immediately when messaging or that platform is disabled, or when the runtime stops
- skip `adapter.start()` entirely when cancellation is already queued
- clean partially initialized provider resources across Mattermost, Slack, Feishu, LINE, Telegram, and Discord
- prevent Discord gateway and Slack Socket Mode discovery from opening connections after stop has completed
- stop adapters after late startup settlement, including late rejection, so they cannot return as zombie connections

## Backport provenance

- Original lifecycle backport: source PR #1197, squash commit `fd221c6832716830ef520e2f8267c2bd938ecabb`
- Cancellation cleanup follow-up: source PR #1542, squash commit `1753fb2cefeeda0e4e19c1080f75a5e25b260736`

Both were manually adapted onto current `releases/1.0`. The lifecycle orchestration remains provider-neutral. The #1542 adaptation retains the release branch's existing Discord command catalog and omits main-only Slack App Home publishing while preserving all startup-cancellation and connection-containment behavior.

## Root cause and impact

The release lifecycle queue previously waited forever for `adapter.start()`. Disable and stop requests serialized behind that pending promise, leaving Settings stuck in Loading and allowing a late-finishing adapter to return after the operator turned it off.

The initial backport still had two gaps found during review: already-queued cancellation could invoke provider startup, and several provider `stop()` implementations returned before cleaning partial startup. The follow-up closes both gaps and contains Discord/Slack SDK connection discovery races.

## Migration audit

No DB or config change is required. `CURRENT_STATE_DB_USER_VERSION` remains 32; this PR adds no DDL or schema migration.

## Validation

- Focused messaging runtime and affected-provider suites — 271 tests passed
- Mattermost, Slack, Feishu, LINE, Telegram, and Discord provider typechecks
- Targeted ESLint — 0 errors; 2 existing warnings
- `pnpm lint` — SQL, Codex-storage, color, license, full ESLint, full workspace typecheck, and dependency boundaries passed (existing warning baseline only)
- `git diff --check`

No headed E2E was run on the host.
