### PR TITLE
fix(desktop): preserve ACP fallback after failed replay

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -2532,6 +2532,101 @@ describe("AcpAgentClient", () => {
     expect(rolloutStore.appendUpdate).toHaveBeenCalled();
   });
 
+  it("retains fallback history after a rejected partial session replay", async () => {
+    const rolloutStore = {
+      appendUpdate: vi.fn(),
+      readUpdates: vi.fn(() => []),
+      flushAll: vi.fn(),
+    };
+    const transport = new FakeAcpAgentTransport({
+      initialize: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: true,
+        },
+      },
+    });
+    let loadAttempts = 0;
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      rolloutStore,
+      store,
+      transport: {
+        request: async (method, params) => {
+          if (method === "session/load") {
+            loadAttempts += 1;
+            if (loadAttempts === 1) {
+              transport.emitSessionUpdate(
+                "session-1",
+                {
+                  session_update: "agent_message_chunk",
+                  content: { type: "text", text: "Partial replay" },
+                },
+                { agentTimestampMs: 1_700_000_000_000, isReplay: true },
+              );
+              throw new Error("session/load failed");
+            }
+            return {};
+          }
+          return await transport.request(method, params);
+        },
+        notify: (method, params) => transport.notify(method, params),
+        close: () => transport.close(),
+        onNotification: (listener) => transport.onNotification(listener),
+      },
+      now: () => 1_800_000_000_000,
+    });
+    store.upsertSession({
+      backendId: "acp:grok",
+      sessionId: "session-1",
+      title: "Grok session",
+      cwd: "/repo",
+      createdAt: 1_600_000_000_000,
+      updatedAt: 1_600_000_000_000,
+      executionMode: "default",
+      status: "idle",
+      hasConversationHistory: true,
+    });
+
+    await client.initialize();
+    const metadata = store.getSession("acp:grok", "session-1")!;
+    await expect(client.loadSession(metadata)).rejects.toThrow(
+      "session/load failed",
+    );
+    expect(client.didSessionLoadReplayHistory("session-1")).toBe(false);
+
+    await client.refreshSession(metadata);
+    expect(loadAttempts).toBe(2);
+    expect(client.didSessionLoadReplayHistory("session-1")).toBe(false);
+
+    rolloutStore.appendUpdate.mockClear();
+    client.startPrompt({
+      sessionId: "session-1",
+      prompt: "Continue after retry",
+      turnId: "turn-2",
+    });
+    transport.emitSessionUpdate("session-1", {
+      session_update: "agent_message_chunk",
+      content: { type: "text", text: "Fallback remains active." },
+    });
+
+    expect(rolloutStore.appendUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          kind: "pwragent_user_prompt",
+          prompt: "Continue after retry",
+        }),
+      }),
+    );
+    expect(rolloutStore.appendUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          session_update: "agent_message_chunk",
+        }),
+      }),
+    );
+  });
+
   it("does not call session/load when the ACP agent says loading is unsupported", async () => {
     const transport = new FakeAcpAgentTransport({
       initialize: {

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -1266,16 +1266,16 @@ export class AcpAgentClient {
       });
     } finally {
       this.loadingSessions.delete(protocolSessionId);
-      if (loadState.replayedTranscript) {
-        this.sessionLoadReplays.set(protocolSessionId, {
-          ...(loadState.lastTimestampedTranscriptAt !== undefined
-            ? {
-                lastTimestampedTranscriptAt:
-                  loadState.lastTimestampedTranscriptAt,
-              }
-            : {}),
-        });
-      }
+    }
+    if (loadState.replayedTranscript) {
+      this.sessionLoadReplays.set(protocolSessionId, {
+        ...(loadState.lastTimestampedTranscriptAt !== undefined
+          ? {
+              lastTimestampedTranscriptAt:
+                loadState.lastTimestampedTranscriptAt,
+            }
+          : {}),
+      });
     }
     const runtimeCapabilities = this.captureRuntimeCapabilities({
       source: "session-load",


### PR DESCRIPTION
## Summary

- commit ACP `session/load` replay verification only after the load request succeeds
- keep `loadingSessions` cleanup on both success and failure
- add regression coverage for a timestamped partial replay emitted before a rejected load, a successful retry with no replay, and continued fallback rollout persistence on the next turn

## Root cause and impact

`loadSessionFromAgent` previously recorded `sessionLoadReplays` from its `finally` block. A provider could emit timestamped transcript history and then reject `session/load`, causing PwrAgent to treat the failed partial replay as verified. If a later retry succeeded without replaying history, that stale marker could suppress durable fallback writes and lose later turns after restart.

This is the mainline counterpart to the review finding on backport PR #1528.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-client.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint` (zero errors; existing unrelated warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`
