### PR TITLE
fix(desktop): serialize ACP launch selection

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -3081,6 +3081,227 @@ describe("AcpBackendAdapter", () => {
     expect(secondDispose).toHaveBeenCalledOnce();
   });
 
+  it("keeps a stale client alive until its non-turn RPCs finish", async () => {
+    const backendId = "acp:gemini" as AcpBackendId;
+    const firstAgent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      activeCommand: "/path/gemini",
+      launchDescriptor: {
+        backendId,
+        registryId: "gemini",
+        distributionKind: "local",
+        command: "/path/gemini",
+        args: ["--acp", "--skip-trust"],
+        env: {},
+      },
+    };
+    const overrideAgent: AcpInstalledAgentRecord = {
+      ...firstAgent,
+      activeCommand: "/override/gemini",
+      launchDescriptor: {
+        ...firstAgent.launchDescriptor!,
+        command: "/override/gemini",
+      },
+    };
+    let discovered = firstAgent;
+    let activeOperations = 0;
+    let finishSession!: () => void;
+    let finishRuntimeOption!: () => void;
+    const firstDispose = vi.fn(async () => undefined);
+    const firstClient = {
+      dispose: firstDispose,
+      hasActiveOperations: () => activeOperations > 0,
+      hasActiveTurns: () => false,
+      initialize: vi.fn(async () => undefined),
+      startSession: vi.fn(() => {
+        activeOperations += 1;
+        return new Promise<void>((resolve) => {
+          finishSession = resolve;
+        }).finally(() => {
+          activeOperations -= 1;
+        });
+      }),
+      setRuntimeOption: vi.fn(() => {
+        activeOperations += 1;
+        return new Promise<void>((resolve) => {
+          finishRuntimeOption = resolve;
+        }).finally(() => {
+          activeOperations -= 1;
+        });
+      }),
+    };
+    const secondClient = {
+      dispose: vi.fn(async () => undefined),
+      hasActiveOperations: () => false,
+      hasActiveTurns: () => false,
+      initialize: vi.fn(async () => undefined),
+    };
+    const createAcpClient = vi
+      .fn()
+      .mockReturnValueOnce(firstClient)
+      .mockReturnValueOnce(secondClient);
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: null,
+      captureStores: [],
+      createAcpClient: createAcpClient as never,
+      discoverLocalAcpAgents: async () => [discovered],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    const session = firstClient.startSession();
+    const runtimeOption = firstClient.setRuntimeOption();
+    discovered = overrideAgent;
+    adapter.invalidateLocalAgentDiscovery();
+
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    expect(firstDispose).not.toHaveBeenCalled();
+
+    finishSession();
+    await session;
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    expect(firstDispose).not.toHaveBeenCalled();
+
+    finishRuntimeOption();
+    await runtimeOption;
+    await expect(adapter.getClient(backendId)).resolves.toBe(secondClient);
+    expect(firstDispose).toHaveBeenCalledOnce();
+
+    await adapter.close();
+  });
+
+  it("restarts invalidated discovery before returning or persisting results", async () => {
+    const staleAgent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      activeCommand: "/stale/gemini",
+      launchDescriptor: {
+        backendId: "acp:gemini" as AcpBackendId,
+        registryId: "gemini",
+        distributionKind: "local",
+        command: "/stale/gemini",
+        args: ["--acp", "--skip-trust"],
+        env: {},
+      },
+    };
+    const currentAgent: AcpInstalledAgentRecord = {
+      ...staleAgent,
+      activeCommand: "/current/gemini",
+      launchDescriptor: {
+        ...staleAgent.launchDescriptor!,
+        command: "/current/gemini",
+      },
+    };
+    const discoveries: Array<{
+      resolve: (agents: AcpInstalledAgentRecord[]) => void;
+      promise: Promise<AcpInstalledAgentRecord[]>;
+    }> = [];
+    const discoverLocalAcpAgents = vi.fn(() => {
+      let resolve!: (agents: AcpInstalledAgentRecord[]) => void;
+      const promise = new Promise<AcpInstalledAgentRecord[]>((done) => {
+        resolve = done;
+      });
+      discoveries.push({ promise, resolve });
+      return promise;
+    });
+    const upsertInstalledAgent = vi.fn();
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => undefined,
+        listInstalledAgents: () => [],
+        upsertInstalledAgent,
+      },
+      captureStores: [],
+      discoverLocalAcpAgents,
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    const preInvalidationListing = adapter.listAvailableAgents();
+    await vi.waitFor(() => expect(discoveries).toHaveLength(1));
+    adapter.invalidateLocalAgentDiscovery();
+    const postInvalidationListing = adapter.listAvailableAgents();
+    await vi.waitFor(() => expect(discoveries).toHaveLength(2));
+
+    discoveries[0]!.resolve([staleAgent]);
+    await Promise.resolve();
+    expect(upsertInstalledAgent).not.toHaveBeenCalled();
+
+    discoveries[1]!.resolve([currentAgent]);
+    await expect(preInvalidationListing).resolves.toEqual([currentAgent]);
+    await expect(postInvalidationListing).resolves.toEqual([currentAgent]);
+    expect(upsertInstalledAgent).toHaveBeenCalled();
+    expect(upsertInstalledAgent).not.toHaveBeenCalledWith(staleAgent);
+    for (const [persisted] of upsertInstalledAgent.mock.calls) {
+      expect(persisted).toEqual(currentAgent);
+    }
+
+    await adapter.close();
+  });
+
+  it("rechecks discovery after invalidation queued behind its completion", async () => {
+    const staleAgent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      activeCommand: "/stale/gemini",
+      launchDescriptor: {
+        backendId: "acp:gemini" as AcpBackendId,
+        registryId: "gemini",
+        distributionKind: "local",
+        command: "/stale/gemini",
+        args: ["--acp", "--skip-trust"],
+        env: {},
+      },
+    };
+    const currentAgent: AcpInstalledAgentRecord = {
+      ...staleAgent,
+      activeCommand: "/current/gemini",
+      launchDescriptor: {
+        ...staleAgent.launchDescriptor!,
+        command: "/current/gemini",
+      },
+    };
+    const discoveries: Array<{
+      resolve: (agents: AcpInstalledAgentRecord[]) => void;
+      promise: Promise<AcpInstalledAgentRecord[]>;
+    }> = [];
+    const discoverLocalAcpAgents = vi.fn(() => {
+      let resolve!: (agents: AcpInstalledAgentRecord[]) => void;
+      const promise = new Promise<AcpInstalledAgentRecord[]>((done) => {
+        resolve = done;
+      });
+      discoveries.push({ promise, resolve });
+      return promise;
+    });
+    const upsertInstalledAgent = vi.fn();
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => undefined,
+        listInstalledAgents: () => [],
+        upsertInstalledAgent,
+      },
+      captureStores: [],
+      discoverLocalAcpAgents,
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    const listing = adapter.listAvailableAgents();
+    await vi.waitFor(() => expect(discoveries).toHaveLength(1));
+    discoveries[0]!.resolve([staleAgent]);
+    await Promise.resolve();
+    queueMicrotask(() => adapter.invalidateLocalAgentDiscovery());
+
+    await vi.waitFor(() => expect(discoveries).toHaveLength(2));
+    expect(upsertInstalledAgent).not.toHaveBeenCalled();
+    discoveries[1]!.resolve([currentAgent]);
+
+    await expect(listing).resolves.toEqual([currentAgent]);
+    expect(upsertInstalledAgent).toHaveBeenCalledOnce();
+    expect(upsertInstalledAgent).toHaveBeenCalledWith(currentAgent);
+
+    await adapter.close();
+  });
+
   it("merges discovery with agent metadata written while discovery was pending", async () => {
     const backendId = "acp:gemini" as AcpBackendId;
     const launchDescriptor = {

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -60,6 +60,45 @@ function readRawAcpSessionPayload(
 }
 
 describe("AcpAgentClient", () => {
+  it("tracks non-turn RPCs until their transport requests settle", async () => {
+    const sessionResponse = createDeferred<unknown>();
+    const runtimeOptionResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/new": sessionResponse.promise,
+      "session/set_model": runtimeOptionResponse.promise,
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:gemini",
+      store,
+      transport,
+      now: () => 1000,
+    });
+
+    await client.initialize();
+    expect(client.hasActiveOperations()).toBe(false);
+
+    const session = client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+      mcpServers: "none",
+    });
+    expect(client.hasActiveOperations()).toBe(true);
+    sessionResponse.resolve({ sessionId: "session-1" });
+    await expect(session).resolves.toMatchObject({ sessionId: "session-1" });
+    expect(client.hasActiveOperations()).toBe(false);
+
+    const runtimeOption = client.setRuntimeOption({
+      sessionId: "session-1",
+      source: "model",
+      optionId: "model",
+      value: "gemini-2.5-pro",
+    });
+    expect(client.hasActiveOperations()).toBe(true);
+    runtimeOptionResponse.resolve({});
+    await runtimeOption;
+    expect(client.hasActiveOperations()).toBe(false);
+  });
+
   it("initializes, starts sessions, sends prompts, and normalizes updates", async () => {
     const promptResponse = createDeferred<unknown>();
     const transport = new FakeAcpAgentTransport({

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -237,6 +237,7 @@ export class AcpAgentClient {
   private unsubscribeRequest?: () => void;
   private runtimeCapabilities?: BackendAcpRuntimeCapabilities;
   private readonly surfaceThoughtsAsMessages: boolean;
+  private activeOperations = 0;
 
   constructor(private readonly options: AcpAgentClientOptions) {
     this.now = options.now ?? Date.now;
@@ -314,6 +315,22 @@ export class AcpAgentClient {
     return this.activeTurns.size > 0;
   }
 
+  hasActiveOperations(): boolean {
+    return this.activeOperations > 0;
+  }
+
+  // Count the whole public operation, including setup before the transport
+  // request and state updates after it, so launch replacement cannot dispose
+  // this client at either edge of an in-flight RPC.
+  private async withOperation<T>(operation: () => Promise<T>): Promise<T> {
+    this.activeOperations += 1;
+    try {
+      return await operation();
+    } finally {
+      this.activeOperations -= 1;
+    }
+  }
+
   async dispose(): Promise<void> {
     this.options.rolloutStore?.flushAll?.();
     this.unsubscribe?.();
@@ -327,6 +344,14 @@ export class AcpAgentClient {
   }
 
   async readProviderStatus(): Promise<AcpProviderStatus | undefined> {
+    return await this.withOperation(
+      async () => await this.readProviderStatusOperation(),
+    );
+  }
+
+  private async readProviderStatusOperation(): Promise<
+    AcpProviderStatus | undefined
+  > {
     if (this.options.backendId !== "acp:grok") {
       return undefined;
     }
@@ -353,6 +378,14 @@ export class AcpAgentClient {
     additionalMcpRegistration?: AcpMcpServerRegistration;
     sessionMeta?: Record<string, unknown>;
   }): Promise<AcpSessionMetadata> {
+    return await this.withOperation(
+      async () => await this.startSessionOperation(params),
+    );
+  }
+
+  private async startSessionOperation(
+    params: Parameters<AcpAgentClient["startSession"]>[0],
+  ): Promise<AcpSessionMetadata> {
     const cwd = params.cwd ?? process.cwd();
     const defaultMcpRegistration =
       params.mcpServers === "none"
@@ -477,6 +510,14 @@ export class AcpAgentClient {
   }
 
   async loadSession(metadata: AcpSessionMetadata): Promise<AppServerThreadReplay> {
+    return await this.withOperation(
+      async () => await this.loadSessionOperation(metadata),
+    );
+  }
+
+  private async loadSessionOperation(
+    metadata: AcpSessionMetadata,
+  ): Promise<AppServerThreadReplay> {
     this.rememberSessionIds(metadata);
     const storedMetadata =
       this.options.store.getSession(this.options.backendId, metadata.sessionId) ??
@@ -529,12 +570,21 @@ export class AcpAgentClient {
   }
 
   async refreshSession(metadata: AcpSessionMetadata): Promise<void> {
-    await this.ensureSession(metadata);
+    await this.withOperation(async () => await this.ensureSession(metadata));
   }
 
   async ensureSession(
     metadata: AcpSessionMetadata,
     options: { suppressTranscriptReplay?: boolean } = {},
+  ): Promise<void> {
+    await this.withOperation(
+      async () => await this.ensureSessionOperation(metadata, options),
+    );
+  }
+
+  private async ensureSessionOperation(
+    metadata: AcpSessionMetadata,
+    options: { suppressTranscriptReplay?: boolean },
   ): Promise<void> {
     this.rememberSessionIds(metadata);
     if (this.supportsSessionLoad() && this.isSessionLoaded(metadata)) {
@@ -620,6 +670,12 @@ export class AcpAgentClient {
   }
 
   async cancelSession(sessionId: string): Promise<void> {
+    await this.withOperation(
+      async () => await this.cancelSessionOperation(sessionId),
+    );
+  }
+
+  private async cancelSessionOperation(sessionId: string): Promise<void> {
     if (!this.options.transport.notify) {
       throw new Error("ACP transport does not support notifications");
     }
@@ -629,6 +685,19 @@ export class AcpAgentClient {
   }
 
   async sendControlPrompt(params: {
+    sessionId: string;
+    prompt: string;
+  }): Promise<{
+    text: string;
+    model?: string;
+    tokenUsage?: AcpSuppressedControlPrompt["tokenUsage"];
+  }> {
+    return await this.withOperation(
+      async () => await this.sendControlPromptOperation(params),
+    );
+  }
+
+  private async sendControlPromptOperation(params: {
     sessionId: string;
     prompt: string;
   }): Promise<{
@@ -671,6 +740,18 @@ export class AcpAgentClient {
   }
 
   async setRuntimeOption(params: {
+    sessionId: string;
+    source: BackendAcpRuntimeOptionSource;
+    optionId: string;
+    value: string;
+    reasoningEffort?: string;
+  }): Promise<BackendAcpSessionRuntimeState | undefined> {
+    return await this.withOperation(
+      async () => await this.setRuntimeOptionOperation(params),
+    );
+  }
+
+  private async setRuntimeOptionOperation(params: {
     sessionId: string;
     source: BackendAcpRuntimeOptionSource;
     optionId: string;

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -128,6 +128,7 @@ export type AcpRuntimeClient = Pick<
     Pick<
       AcpAgentClient,
       | "didSessionLoadReplayHistory"
+      | "hasActiveOperations"
       | "hasActiveTurns"
       | "readProviderStatus"
       | "sendControlPrompt"
@@ -954,6 +955,7 @@ export class AcpBackendAdapter {
   private closePromise?: Promise<void>;
   private readonly closeTimeoutMs: number;
   private readonly liveTurnUsage = new Map<string, AcpLiveTurnUsage>();
+  private localAcpAgentsRevision = 0;
   private localAcpAgentsPromise?: Promise<AcpInstalledAgentRecord[]>;
 
   constructor(options: AcpBackendAdapterOptions) {
@@ -1182,6 +1184,7 @@ export class AcpBackendAdapter {
   }
 
   invalidateLocalAgentDiscovery(): void {
+    this.localAcpAgentsRevision += 1;
     this.localAcpAgentsPromise = undefined;
   }
 
@@ -1411,10 +1414,13 @@ export class AcpBackendAdapter {
       return await cached.promise;
     }
     if (cached) {
-      // One ACP client owns every live turn for this backend. Keep routing
-      // control and session operations to that process until its last turn
-      // reaches a terminal state; the next idle lookup adopts the new path.
-      if (cached.client.hasActiveTurns?.() === true) {
+      // One ACP client owns every live turn and RPC for this backend. Keep
+      // routing to that process until its last operation reaches a terminal
+      // state; the next idle lookup adopts the new path.
+      if (
+        cached.client.hasActiveTurns?.() === true
+        || cached.client.hasActiveOperations?.() === true
+      ) {
         return await cached.promise;
       }
       this.acpClients.delete(backend);
@@ -1675,7 +1681,22 @@ export class AcpBackendAdapter {
   }
 
   async listAvailableAgents(): Promise<AcpInstalledAgentRecord[]> {
-    const discoveredAgents = (await this.readLocalAgentsOnce())
+    while (true) {
+      const discovery = await this.readLocalAgentsOnce();
+      if (discovery.revision !== this.localAcpAgentsRevision) {
+        continue;
+      }
+      // Keep the revision check and all consumption synchronous. An
+      // invalidation queued after discovery settles must run before this
+      // point or after stale results have been fully merged and persisted.
+      return this.mergeAndPersistDiscoveredAgents(discovery.agents);
+    }
+  }
+
+  private mergeAndPersistDiscoveredAgents(
+    agents: AcpInstalledAgentRecord[],
+  ): AcpInstalledAgentRecord[] {
+    const discoveredAgents = agents
       .map(normalizeInstalledAcpAgent)
       .filter((agent) => !isBannedAcpRegistryId(agent.registryId));
     // Discovery probes are asynchronous and can overlap runtime-capability or
@@ -1842,14 +1863,21 @@ export class AcpBackendAdapter {
     }
   }
 
-  private async readLocalAgentsOnce(): Promise<AcpInstalledAgentRecord[]> {
+  private async readLocalAgentsOnce(): Promise<{
+    agents: AcpInstalledAgentRecord[];
+    revision: number;
+  }> {
+    const revision = this.localAcpAgentsRevision;
     this.localAcpAgentsPromise ??= this.discoverLocalAcpAgents().catch((error) => {
       acpBackendAdapterLog.debug("local_acp_discovery_failed", {
         error: error instanceof Error ? error.message : String(error),
       });
       return [];
     });
-    return await this.localAcpAgentsPromise;
+    return {
+      agents: await this.localAcpAgentsPromise,
+      revision,
+    };
   }
 
   private createDefaultClient(agent: AcpInstalledAgentRecord): AcpRuntimeClient {

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -56,6 +56,7 @@ function enabledSnapshotFor(
  * siblings of the Codex section inside one "Backends & credentials" stack.
  */
 export function AcpAgentsSettings(props: {
+  catalogRefreshing?: boolean;
   desktopApi?: DesktopApi;
   saving?: boolean;
   snapshot?: DesktopSettingsSnapshot;
@@ -138,7 +139,7 @@ export function AcpAgentsSettings(props: {
             cliPathSnapshot={cliPathSnapshotFor(props.snapshot, entry.registryId)}
             enabled={enabledSnapshotFor(props.snapshot, entry.registryId)}
             saving={props.saving}
-            refreshing={refreshing || loading}
+            refreshing={refreshing || loading || props.catalogRefreshing}
             onCliPathChange={
               props.onCliPathChange
                 ? async (registryId, cliPath) => {

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -356,6 +356,7 @@ export function ModelsSettings(props: {
       </SettingsSection>
 
       <AcpAgentsSettings
+        catalogRefreshing={refreshingCatalog}
         desktopApi={props.desktopApi}
         saving={props.saving}
         snapshot={props.snapshot}
@@ -751,7 +752,7 @@ function ProviderModelDefaultsSettings(props: {
             control={
               <button
                 className="button button--secondary"
-                disabled={props.refreshing}
+                disabled={props.refreshing || props.saving}
                 type="button"
                 onClick={() => void props.onRefresh()}
               >
@@ -770,7 +771,7 @@ function ProviderModelDefaultsSettings(props: {
             control={
               <button
                 className="button button--secondary"
-                disabled={props.refreshing}
+                disabled={props.refreshing || props.saving}
                 type="button"
                 onClick={() => void props.onRefresh()}
               >

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -11,6 +11,7 @@ import {
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
+  AcpAgentSettingsEntry,
   AgentEvent,
   AppServerListThreadsResponse,
   AppServerThreadSummary,
@@ -507,7 +508,7 @@ function createArchivedSnapshot(
 }
 
 describe("SettingsScreen", () => {
-  it("renders cached provider models while refreshing the catalog", async () => {
+  it("renders cached provider models and locks ACP paths while refreshing the catalog", async () => {
     const cachedBackends: BackendSummary[] = [
       {
         kind: "codex",
@@ -544,11 +545,38 @@ describe("SettingsScreen", () => {
     const listBackends = vi.fn(
       async () => await new Promise<never>(() => undefined),
     );
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [
+        {
+          backendId: "acp:grok",
+          registryId: "grok",
+          name: "Grok",
+          authors: ["xAI"],
+          distributionKind: "local",
+          distributionSource: "/usr/bin/grok",
+          installable: false,
+          installed: true,
+          installStatus: "installed",
+          authStatus: "not-required",
+          verificationStatus: "not-applicable",
+          activeCommand: "/usr/bin/grok",
+          instances: [
+            { command: "/usr/bin/grok", version: "1.0.0", source: "path" },
+            {
+              command: "/opt/homebrew/bin/grok",
+              version: "0.9.0",
+              source: "path",
+            },
+          ],
+        } satisfies AcpAgentSettingsEntry,
+      ],
+    }));
 
     render(
       <SettingsScreen
         cachedBackends={cachedBackends}
-        desktopApi={{ listBackends }}
+        desktopApi={{ listAcpAgents, listBackends }}
         initialSection="models"
         settings={createSettingsState()}
         onClose={() => undefined}
@@ -568,6 +596,37 @@ describe("SettingsScreen", () => {
         includeUnavailable: true,
         refreshModels: true,
       });
+    });
+    await waitFor(() => expect(listAcpAgents).toHaveBeenCalledTimes(2));
+    expect(screen.getByLabelText("Grok manual path")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(
+      within(screen.getByLabelText("Grok installs")).getByRole("button", {
+        name: "Use",
+      }),
+    ).toBeDisabled();
+  });
+
+  it("locks catalog refresh while settings are saving", async () => {
+    const listBackends = vi.fn(async () => ({
+      fetchedAt: 1000,
+      backends: [],
+    }));
+    const settings = createSettingsState();
+    settings.saving = true;
+
+    render(
+      <SettingsScreen
+        desktopApi={{ listBackends }}
+        initialSection="models"
+        settings={settings}
+        onClose={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Refresh models" }))
+        .toBeDisabled();
     });
   });
 


### PR DESCRIPTION
## Summary

This is the mainline correctness fix discovered while reviewing release backport PR #1530. The release branch should backport this commit instead of carrying a divergent implementation.

- Add a discovery revision to the ACP backend adapter and carry it through the awaited probe. `listAvailableAgents()` revalidates the revision immediately before a synchronous merge-and-persist step, so invalidation queued after discovery settles cannot let a stale executable be returned or overwrite the newer settings-discovery record.
- Track complete non-turn ACP client operations at the client boundary, including setup before transport requests and state updates after responses. Launch-identity replacement now retains the cached client while either an active turn or a non-turn operation is still using it. Coverage exercises concurrent session/new-style and runtime-option operations while preserving the existing active-turn behavior.
- Make top-level model catalog refresh and ACP CLI-path saves mutually exclusive. Catalog refresh state now disables ACP path, enablement, and re-probe controls, while the top-level Refresh models action is disabled during settings saves. This prevents post-save forced verification from coalescing with a pre-write refresh.

The change is limited to ACP launch selection and Settings serialization. It does not change provider onboarding, Windows shims, the external @pwrdrvr/agent-core dependency, federation behavior, database schemas, or user_version.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts apps/desktop/src/main/__tests__/acp-runtime-override-launch.test.ts apps/desktop/src/main/__tests__/settings-ipc.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx` — 210 tests passed
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "reads persisted ACP sessions locally and refreshes the agent in the background|preserves ACP launchpad model selections when starting sessions|serializes Kimi control prompts before starting the next ACP turn|applies model settings from the selected thread overlay when starting turns"` — 4 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — zero errors (34 existing warnings)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

Headed E2E was intentionally not run, per scope.

