### PR TITLE
fix(desktop): dismiss quick search before global search

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -744,6 +744,10 @@ function DesktopAppShell(props: {
   // its own open state and the sidebar peek a jump's landing scroll needs.
   const threadJump = useThreadJump({ sidebarHidden, setSidebarHidden });
   const endSidebarPeek = threadJump.endPeek;
+  const toggleGlobalThreadSearch = () => {
+    threadJump.closeJump();
+    setMainView((current) => current === "search" ? "thread" : "search");
+  };
   const setSidebarHiddenPersisted = useCallback(
     (next: boolean) => {
       // An explicit toggle (⌘B, the chips) is the operator stating a preference,
@@ -1075,7 +1079,7 @@ function DesktopAppShell(props: {
   // ⌘⇧F / ⌃⇧F opens the global thread search screen; ⌘F is the focus-sensitive
   // context find; ⌘K always lands on the thread-list quick search.
   useFindHotkeys({
-    onOpenSearch: () => setMainView(mainView === "search" ? "thread" : "search"),
+    onOpenSearch: toggleGlobalThreadSearch,
     onFind: () => {
       // The thread-list quick search claims ⌘F while the sidebar is focused;
       // anywhere else ⌘F finds within the open thread. Focus decides — which is
@@ -1406,7 +1410,7 @@ function DesktopAppShell(props: {
       setMainView("settings");
     },
     onToggleThreadSearch: () => {
-      setMainView(mainView === "search" ? "thread" : "search");
+      toggleGlobalThreadSearch();
     },
     onCreateThread: async () => {
       setMainView("thread");
@@ -1865,7 +1869,7 @@ function DesktopAppShell(props: {
             setMainView("automations");
           }}
           onOpenThreadSearch={() => {
-            setMainView(mainView === "search" ? "thread" : "search");
+            toggleGlobalThreadSearch();
           }}
           onOpenLaunchpad={async (directory, preferredBackend) => {
             setMainView("thread");

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -261,6 +261,61 @@ describe("App", () => {
     expect(getNavigationSnapshot).not.toHaveBeenCalled();
   });
 
+  it("dismisses quick thread search before opening global search", async () => {
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        platform: "darwin",
+        listBackends: async () => ({ fetchedAt: Date.now(), backends: [] }),
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        readSettings: async () =>
+          await new Promise<never>(() => {
+            // Keep the shell mounted without needing a full settings fixture.
+          }),
+      },
+    });
+
+    render(<App />);
+
+    fireEvent.keyDown(window, {
+      metaKey: true,
+      code: "KeyK",
+      key: "k",
+    });
+    const quickSearch = await screen.findByRole("dialog", {
+      name: "Jump to thread",
+    });
+    fireEvent.change(
+      within(quickSearch).getByRole("textbox", { name: "Jump to thread" }),
+      { target: { value: "something" } },
+    );
+
+    fireEvent.keyDown(window, {
+      metaKey: true,
+      shiftKey: true,
+      code: "KeyF",
+      key: "F",
+    });
+
+    expect(
+      screen.queryByRole("dialog", { name: "Jump to thread" }),
+    ).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { level: 2, name: "Search" }),
+    ).toBeInTheDocument();
+  });
+
   it("surfaces GitHub organization SAML enforcement as a sticky error toast", async () => {
     let samlListener:
       | ((event: {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
@@ -162,7 +162,7 @@ describe("SidebarSearchPopup", () => {
     expect(screen.getByLabelText("Runs on Laptop")).toBeInTheDocument();
   });
 
-  it("prioritizes and describes the exact PR when a thread has several PRs", async () => {
+  it("prioritizes exact PRs and describes numeric substring matches", async () => {
     const exact = localThread({
       id: "exact",
       title: "Stacked PRs",
@@ -189,6 +189,8 @@ describe("SidebarSearchPopup", () => {
     const rows = screen.getAllByRole("option");
     expect(rows[0]).toHaveTextContent("Stacked PRs");
     expect(rows[0]).toHaveTextContent("#49");
+    expect(rows[1]).toHaveTextContent("Newer substring");
+    expect(rows[1]).toHaveTextContent("#349");
     await settleRemoteSearch();
   });
 


### PR DESCRIPTION
## What changed

- Close the Cmd+K quick thread search before toggling the global Search view.
- Route shortcut and button-based global-search toggles through the same close-first handler.
- Add an App-level regression test that types into Cmd+K, invokes Cmd+Shift+F, and verifies only global Search remains.
- Pin PR metadata for bare-number substring matches: querying `49` keeps `#349` visible on the substring result while an exact `#49` result remains first.

## Why

The quick-search palette owns independent open state from the main Search view. Cmd+Shift+F changed the main view without clearing that palette, leaving two search surfaces stacked and causing Escape to dismiss only the global view underneath.

Mainline already contains the correct PR-description fallback: exact metadata is selected only for a true exact-number match, otherwise the thread's first PR is retained. The added assertion protects that behavior from the regression found while backporting.

## Validation

- Search-surface regression test confirmed failing before the fix.
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/features/chrome/__tests__/useFindHotkeys.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadJump.test.ts` (42 passed)
- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx` (16 passed)
- `pnpm lint:eslint` (0 errors; existing baseline warnings only)
- Focused ESLint on the updated popup test
- `pnpm typecheck`
- Focused search-surface regression rerun after rebasing onto `origin/main`
