### PR TITLE
fix(messaging): clean up cancelled adapter startup

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -1536,14 +1536,9 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
-  it("preserves a stop request that arrives before adapters register", async () => {
+  it("skips adapter startup when a stop request arrives before adapters register", async () => {
     await prepareRuntimeStore();
-    const telegramStart = createDeferred<void>();
     const slowTelegramAdapter = createAdapter("telegram");
-    slowTelegramAdapter.start.mockImplementation(async (listener) => {
-      slowTelegramAdapter.listener = listener;
-      await telegramStart.promise;
-    });
     const workingDiscordAdapter = createAdapter("discord");
     const { DesktopMessagingRuntime: Runtime } = await import(
       "../messaging/messaging-runtime"
@@ -1569,12 +1564,10 @@ describe("DesktopMessagingRuntime", () => {
     const stopPromise = runtime.stop();
     await Promise.all([startPromise, stopPromise]);
 
-    expect(slowTelegramAdapter.start).toHaveBeenCalledTimes(1);
-    expect(workingDiscordAdapter.start).toHaveBeenCalledTimes(1);
-    expect(slowTelegramAdapter.stop).toHaveBeenCalledTimes(1);
-    // The fast adapter settles after cancellation wins the race, so it gets
-    // both immediate failed-start cleanup and the late-start zombie guard.
-    expect(workingDiscordAdapter.stop).toHaveBeenCalledTimes(2);
+    expect(slowTelegramAdapter.start).not.toHaveBeenCalled();
+    expect(workingDiscordAdapter.start).not.toHaveBeenCalled();
+    expect(slowTelegramAdapter.stop).not.toHaveBeenCalled();
+    expect(workingDiscordAdapter.stop).not.toHaveBeenCalled();
     expect(runtime.isEnabled()).toBe(false);
     expect(runtime.getPlatformStatuses()).toEqual(
       expect.arrayContaining([
@@ -1587,6 +1580,46 @@ describe("DesktopMessagingRuntime", () => {
           health: "suspended",
         }),
       ]),
+    );
+  });
+
+  it("cleans up again when a cancelled adapter start rejects late", async () => {
+    await prepareRuntimeStore();
+    const discordStart = createDeferred<void>();
+    const discordAdapter = createAdapter("discord", {
+      start: vi.fn(async () => {
+        await discordStart.promise;
+      }),
+    });
+    const factory = vi.fn<DesktopMessagingAdapterFactory>(({ config }) =>
+      config.discord ? [discordAdapter] : []
+    );
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = trackRuntime(new Runtime({
+      adapterFactory: factory,
+      backendBridge: createBackendBridge(),
+      config: {
+        discord: {
+          channel: "discord",
+          botToken: "discord-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    }));
+
+    const startPromise = runtime.start();
+    await waitFor(() => discordAdapter.start.mock.calls.length === 1);
+    const applyPromise = runtime.applyConfig({});
+    await Promise.all([startPromise, applyPromise]);
+
+    expect(discordAdapter.stop).toHaveBeenCalledTimes(1);
+    discordStart.reject(new Error("login rejected after cancellation"));
+    await waitFor(() => discordAdapter.stop.mock.calls.length === 2);
+    expect(messagingLog.info).toHaveBeenCalledWith(
+      "discord: stopped adapter after late startup",
+      { channel: "discord" },
     );
   });
 
@@ -1624,6 +1657,7 @@ describe("DesktopMessagingRuntime", () => {
     }));
 
     const startPromise = runtime.start();
+    await waitFor(() => discordAdapter.start.mock.calls.length === 1);
     const applyPromise = runtime.applyConfig({
       telegram: {
         channel: "telegram",

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -234,7 +234,10 @@ type PendingAdapterStart = {
 type AdapterStartOutcome = "cancelled" | "failed" | "started";
 
 class AdapterStartCancelledError extends Error {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    readonly startInvoked = true,
+  ) {
     super(message);
     this.name = "AdapterStartCancelledError";
   }
@@ -1521,7 +1524,9 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
           reason: error instanceof Error ? error.message : String(error),
         });
       }
-      await this.stopAdapterAfterFailedStart(adapter);
+      if (!(error instanceof AdapterStartCancelledError && !error.startInvoked)) {
+        await this.stopAdapterAfterFailedStart(adapter);
+      }
       return cancelled ? "cancelled" : "failed";
     }
 
@@ -1588,6 +1593,17 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         reject(new AdapterStartCancelledError(reason));
       };
     });
+    const pending: PendingAdapterStart = {
+      cancel: (reason) => cancel?.(reason),
+    };
+    this.pendingAdapterStarts.set(adapter.channel, pending);
+    const queuedCancellationReason = this.pendingAdapterStopReason
+      ?? this.pendingAdapterStartCancellationReasons.get(adapter.channel);
+    if (queuedCancellationReason) {
+      this.pendingAdapterStarts.delete(adapter.channel);
+      throw new AdapterStartCancelledError(queuedCancellationReason, false);
+    }
+
     const startPromise = Promise.resolve().then(async () => {
       await adapter.start?.(listener);
     });
@@ -1598,15 +1614,6 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       }, timeoutMs);
       if (timeoutHandle.unref) timeoutHandle.unref();
     });
-    const pending: PendingAdapterStart = {
-      cancel: (reason) => cancel?.(reason),
-    };
-    this.pendingAdapterStarts.set(adapter.channel, pending);
-    const queuedCancellationReason = this.pendingAdapterStopReason
-      ?? this.pendingAdapterStartCancellationReasons.get(adapter.channel);
-    if (queuedCancellationReason) {
-      pending.cancel(queuedCancellationReason);
-    }
 
     try {
       await Promise.race([startPromise, cancellation, timeout]);
@@ -1617,7 +1624,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       ) {
         void startPromise.then(
           async () => this.stopAdapterAfterLateStart(adapter),
-          () => undefined,
+          async () => this.stopAdapterAfterLateStart(adapter),
         );
       }
       throw error;

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -60,6 +60,21 @@ authorized bot messages as ordinary `text` or `media` events with
 provider alerts such as Slack posts from monitoring bots without looping on
 PwrAgent's own replies.
 
+## Lifecycle
+
+`stop()` is valid as soon as `start()` has been invoked, not only after the
+adapter reports a fully started state. It must close or detach every resource
+created by a partial start, including callback servers, SDK listeners,
+websockets, gateway clients, and polling loops. A stop that arrives during an
+awaited identity or connection step must also prevent later startup steps from
+opening new external resources.
+
+Startup cleanup is idempotent. The desktop runtime may call `stop()` once when
+cancellation or a deadline wins and again after the original `start()` promise
+settles, whether that promise resolves or rejects. Providers must therefore not
+gate cleanup solely on a final `started` flag, and repeated cleanup must not
+leave listeners or connections behind.
+
 ## Opaque State
 
 Adapters own routing and surface state. PwrAgent may persist and echo

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -32,6 +32,40 @@ const TEST_OTHER_USER_ID = "1480556454498009356";
 const TEST_AUTHORIZED_GUILD_IDS = [{ id: TEST_GUILD_ID, displayName: "" }];
 
 describe("discord adapter", () => {
+  it("does not open the gateway after a stop during command reconciliation", async () => {
+    let resolveCommands!: (value: DiscordApplicationCommand[]) => void;
+    const pendingCommands = new Promise<DiscordApplicationCommand[]>((resolve) => {
+      resolveCommands = resolve;
+    });
+    const listApplicationCommands = vi.fn(async () => await pendingCommands);
+    const gateway: DiscordGatewayConnection = {
+      close: vi.fn(async () => undefined),
+      onEvent: vi.fn(() => () => undefined),
+      start: vi.fn(async () => undefined),
+    };
+    const adapter = new DiscordAdapter({
+      api: createApi({ listApplicationCommands }),
+      config: {
+        applicationId: TEST_CHANNEL_ID,
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+        botToken: "token",
+        channel: "discord",
+      },
+      gateway,
+    });
+
+    const startPromise = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(listApplicationCommands).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+    resolveCommands([]);
+    await startPromise;
+
+    expect(gateway.start).not.toHaveBeenCalled();
+    expect(gateway.close).toHaveBeenCalledTimes(2);
+  });
+
   it("declares backend-owned scheduling as Discord application commands", () => {
     expect(DISCORD_APPLICATION_COMMANDS.map((command) => command.name)).toEqual([
       "resume",

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -10,6 +10,7 @@ import {
 import { describe, expect, it, vi } from "vitest";
 import {
   DiscordAdapter,
+  DiscordJsGatewayConnection,
   stripDiscordBotMention,
   type DiscordApi,
   type DiscordGatewayConnection,
@@ -32,6 +33,47 @@ const TEST_OTHER_USER_ID = "1480556454498009356";
 const TEST_AUTHORIZED_GUILD_IDS = [{ id: TEST_GUILD_ID, displayName: "" }];
 
 describe("discord adapter", () => {
+  it("cancels gateway discovery before a stopped login can connect", async () => {
+    let resolveGateway!: (value: unknown) => void;
+    const pendingGateway = new Promise<unknown>((resolve) => {
+      resolveGateway = resolve;
+    });
+    const connect = vi.fn();
+    const getGateway = vi.fn(async () => await pendingGateway);
+    const rest = { get: getGateway };
+    const client = {
+      destroy: vi.fn(async () => undefined),
+      login: vi.fn(async () => {
+        await rest.get();
+        connect();
+        return "token";
+      }),
+      on: vi.fn(),
+      removeAllListeners: vi.fn(),
+      rest,
+    };
+    const gateway = new DiscordJsGatewayConnection(
+      {
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+        botToken: "token",
+        channel: "discord",
+      },
+      client as never,
+    );
+
+    const startPromise = gateway.start();
+    await vi.waitFor(() => {
+      expect(getGateway).toHaveBeenCalledTimes(1);
+    });
+    await gateway.close();
+    resolveGateway({ url: "wss://gateway.example.test" });
+
+    await expect(startPromise).rejects.toThrow(
+      "Discord gateway startup was cancelled.",
+    );
+    expect(connect).not.toHaveBeenCalled();
+  });
+
   it("does not open the gateway after a stop during command reconciliation", async () => {
     let resolveCommands!: (value: DiscordApplicationCommand[]) => void;
     const pendingCommands = new Promise<DiscordApplicationCommand[]>((resolve) => {

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -339,6 +339,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private typingSignalSequence = 0;
   private typingSignals = new Map<string, DiscordTypingSignal>();
   private unsubscribeGateway?: () => void;
+  private lifecycleGeneration = 0;
 
   constructor(options: DiscordAdapterOptions) {
     this.options = options;
@@ -387,15 +388,24 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   }
 
   async start(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void> {
+    const lifecycleGeneration = ++this.lifecycleGeneration;
     await this.reconcileApplicationCommands();
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
     this.listener = listener;
     this.unsubscribeGateway = this.gateway.onEvent(async (event) => {
       await this.handleGatewayEvent(event);
     });
     await this.gateway.start();
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+    }
   }
 
   async stop(): Promise<void> {
+    this.lifecycleGeneration += 1;
     this.stopTypingSignals();
     this.unsubscribeGateway?.();
     this.unsubscribeGateway = undefined;

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -2153,14 +2153,18 @@ class DiscordRestApi implements DiscordApi {
   }
 }
 
-class DiscordJsGatewayConnection implements DiscordGatewayConnection {
+export class DiscordJsGatewayConnection implements DiscordGatewayConnection {
   private readonly client: Client;
   private readonly config: DiscordMessagingConfig;
   private readonly listeners = new Set<DiscordGatewayListener>();
+  private lifecycleGeneration = 0;
 
-  constructor(config: DiscordMessagingConfig) {
+  constructor(
+    config: DiscordMessagingConfig,
+    client?: Client,
+  ) {
     this.config = config;
-    this.client = new Client({
+    this.client = client ?? new Client({
       intents: [
         GatewayIntentBits.DirectMessages,
         GatewayIntentBits.GuildMessages,
@@ -2169,22 +2173,44 @@ class DiscordJsGatewayConnection implements DiscordGatewayConnection {
       ],
       partials: [Partials.Channel],
     });
+    this.guardGatewayDiscovery();
     this.registerHandlers();
   }
 
   async start(): Promise<void> {
+    this.lifecycleGeneration += 1;
     await this.client.login(this.config.botToken);
   }
 
   async close(): Promise<void> {
+    this.lifecycleGeneration += 1;
     this.client.removeAllListeners();
-    this.client.destroy();
+    await this.client.destroy();
   }
 
   onEvent(listener: DiscordGatewayListener): () => void {
     this.listeners.add(listener);
     return () => {
       this.listeners.delete(listener);
+    };
+  }
+
+  private guardGatewayDiscovery(): void {
+    // discord.js fetches /gateway/bot before its internal manager opens any
+    // websocket shards. `Client.destroy()` cannot cancel that REST request;
+    // without this post-fetch guard, the suspended login continuation can
+    // still call the internal websocket manager after close() has returned.
+    const rest = this.client.rest as unknown as {
+      get(...args: unknown[]): Promise<unknown>;
+    };
+    const get = rest.get.bind(rest);
+    rest.get = async (...args: unknown[]) => {
+      const lifecycleGeneration = this.lifecycleGeneration;
+      const response = await get(...args);
+      if (lifecycleGeneration !== this.lifecycleGeneration) {
+        throw new Error("Discord gateway startup was cancelled.");
+      }
+      return response;
     };
   }
 

--- a/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
+++ b/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
@@ -109,6 +109,37 @@ describe("FeishuAdapter", () => {
     vi.unstubAllGlobals();
   });
 
+  it("closes a persistent connection while startup is still pending", async () => {
+    let rejectStart!: (reason?: unknown) => void;
+    const pendingStart = new Promise<never>((_resolve, reject) => {
+      rejectStart = reject;
+    });
+    const close = vi.fn();
+    const startConnection = vi.fn(async () => await pendingStart);
+    const { inboundMode: _inboundMode, ...persistentConfig } = baseConfig;
+    const adapter = new FeishuAdapter({
+      config: persistentConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      wsClientFactory: () => ({
+        close,
+        start: startConnection,
+      }),
+    });
+
+    const startPromise = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(startConnection).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+
+    expect(close).toHaveBeenCalledWith({ force: true });
+    rejectStart(new Error("persistent connection rejected after stop"));
+    await expect(startPromise).rejects.toThrow(
+      "persistent connection rejected after stop",
+    );
+  });
+
   it("declares Feishu capabilities", () => {
     const adapter = new FeishuAdapter({
       config: baseConfig,

--- a/packages/messaging/providers/feishu/src/feishu-adapter.ts
+++ b/packages/messaging/providers/feishu/src/feishu-adapter.ts
@@ -327,6 +327,7 @@ export class FeishuAdapter implements FeishuProviderAdapter {
   private started = false;
   private webhookListening = false;
   private wsClient: FeishuWsClient | undefined;
+  private lifecycleGeneration = 0;
   private readonly diagnosticListeners = new Set<MessagingAdapterDiagnosticListener>();
   private readonly inboundRejectedListeners = new Set<MessagingInboundRejectedListener>();
   private readonly rateLimitListeners = new Set<(info: MessagingRateLimitInfo) => void>();
@@ -438,24 +439,37 @@ export class FeishuAdapter implements FeishuProviderAdapter {
 
   async start(listener: FeishuInboundListener): Promise<void> {
     if (this.started) return;
+    const lifecycleGeneration = ++this.lifecycleGeneration;
     this.listener = listener;
     const botInfo = await this.api.getBotInfo();
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
     this.botAccount = botInfo.appName ?? botInfo.openId;
     this.botAccountDetail = botInfo.tenantKey ?? hostFromUrl(this.config.tenantUrl);
     this.botOpenId = botInfo.openId;
     if (this.config.inboundMode === "webhook") {
       await this.listenForCallbacks();
     } else {
-      await this.startPersistentConnection();
+      await this.startPersistentConnection(lifecycleGeneration);
+    }
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
     }
     this.started = true;
   }
 
   async stop(): Promise<void> {
-    if (!this.started) return;
-    this.wsClient?.close({ force: true });
+    this.lifecycleGeneration += 1;
+    try {
+      this.wsClient?.close({ force: true });
+    } catch (error) {
+      this.logger.warn?.("feishu persistent connection close failed", { error });
+    }
     this.wsClient = undefined;
-    if (this.webhookListening) {
+    if (this.webhookListening || this.server.listening) {
       await new Promise<void>((resolve, reject) => {
         this.server.close((error) => {
           if (error) reject(error);
@@ -1662,8 +1676,13 @@ export class FeishuAdapter implements FeishuProviderAdapter {
     this.webhookListening = true;
   }
 
-  private async startPersistentConnection(): Promise<void> {
+  private async startPersistentConnection(
+    lifecycleGeneration: number,
+  ): Promise<void> {
     const lark = await import("@larksuiteoapi/node-sdk");
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      return;
+    }
     const sdkEventDispatcher = new lark.EventDispatcher({
       ...(this.config.encryptKey ? { encryptKey: this.config.encryptKey } : {}),
       logger: larkLoggerFromProviderLogger(this.logger),
@@ -1700,8 +1719,36 @@ export class FeishuAdapter implements FeishuProviderAdapter {
       appSecret: this.config.appSecret,
       domain: this.config.tenantRegion === "lark" ? "lark" : "feishu",
     });
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      wsClient.close({ force: true });
+      return;
+    }
     this.wsClient = wsClient;
-    await wsClient.start({ eventDispatcher });
+    try {
+      await wsClient.start({ eventDispatcher });
+    } catch (error) {
+      try {
+        wsClient.close({ force: true });
+      } catch (closeError) {
+        this.logger.warn?.("feishu persistent connection close failed", {
+          error: closeError,
+        });
+      }
+      if (this.wsClient === wsClient) {
+        this.wsClient = undefined;
+      }
+      throw error;
+    }
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      try {
+        wsClient.close({ force: true });
+      } catch (error) {
+        this.logger.warn?.("feishu persistent connection close failed", { error });
+      }
+      if (this.wsClient === wsClient) {
+        this.wsClient = undefined;
+      }
+    }
   }
 
   private async handleWebhookRequest(

--- a/packages/messaging/providers/line/src/__tests__/line-adapter.test.ts
+++ b/packages/messaging/providers/line/src/__tests__/line-adapter.test.ts
@@ -19,6 +19,43 @@ describe("LineAdapter", () => {
     adapters.length = 0;
   });
 
+  it("does not bind a webhook after startup is stopped during identity lookup", async () => {
+    const port = await getFreePort();
+    let resolveBotInfo!: (value: {
+      displayName?: string;
+      userId: string;
+    }) => void;
+    const pendingBotInfo = new Promise<{
+      displayName?: string;
+      userId: string;
+    }>((resolve) => {
+      resolveBotInfo = resolve;
+    });
+    const api = createApi();
+    api.getBotInfo = vi.fn(async () => await pendingBotInfo);
+    const adapter = new LineAdapter({
+      api,
+      callbackHandleStore: createCallbackStore(),
+      config: createConfig({ callbackBaseUrl: `http://127.0.0.1:${port}/` }),
+    });
+    adapters.push(adapter);
+
+    const startPromise = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(api.getBotInfo).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+    resolveBotInfo({ userId: "Uffffffffffffffffffffffffffffffff" });
+    await startPromise;
+
+    const probe = createServer();
+    await new Promise<void>((resolve, reject) => {
+      probe.once("error", reject);
+      probe.listen(port, "127.0.0.1", () => resolve());
+    });
+    await new Promise<void>((resolve) => probe.close(() => resolve()));
+  });
+
   it("verifies X-Line-Signature before processing webhook bodies", () => {
     const body = Buffer.from(JSON.stringify({ events: [] }));
     const signature = createHmac("sha256", "secret").update(body).digest("base64");

--- a/packages/messaging/providers/line/src/line-adapter.ts
+++ b/packages/messaging/providers/line/src/line-adapter.ts
@@ -202,6 +202,7 @@ export class LineAdapter implements LineProviderAdapter {
   private listener: LineInboundListener | undefined;
   private botUserId: string | undefined;
   private started = false;
+  private lifecycleGeneration = 0;
   private readonly inboundRejectedListeners = new Set<MessagingInboundRejectedListener>();
 
   constructor(options: LineAdapterOptions) {
@@ -253,6 +254,7 @@ export class LineAdapter implements LineProviderAdapter {
 
   async start(listener: LineInboundListener): Promise<void> {
     if (this.started) return;
+    const lifecycleGeneration = ++this.lifecycleGeneration;
     this.listener = listener;
     if (!this.botUserId && this.api) {
       try {
@@ -264,6 +266,10 @@ export class LineAdapter implements LineProviderAdapter {
         });
       }
     }
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
     const bindAddress = bindAddressFromCallbackUrl(this.config.callbackBaseUrl);
     await new Promise<void>((resolve, reject) => {
       this.server.once("error", reject);
@@ -272,6 +278,10 @@ export class LineAdapter implements LineProviderAdapter {
         resolve();
       });
     });
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
     this.started = true;
     this.logger.info?.("line webhook listener started", {
       host: bindAddress.host,
@@ -283,15 +293,20 @@ export class LineAdapter implements LineProviderAdapter {
   }
 
   async stop(): Promise<void> {
-    if (!this.started) return;
-    await new Promise<void>((resolve, reject) => {
-      this.server.close((error) => {
-        if (error) reject(error);
-        else resolve();
-      });
-    });
-    this.listener = undefined;
-    this.started = false;
+    this.lifecycleGeneration += 1;
+    try {
+      if (this.server.listening) {
+        await new Promise<void>((resolve, reject) => {
+          this.server.close((error) => {
+            if (error) reject(error);
+            else resolve();
+          });
+        });
+      }
+    } finally {
+      this.listener = undefined;
+      this.started = false;
+    }
   }
 
   onInboundRejected(listener: MessagingInboundRejectedListener): () => void {

--- a/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
+++ b/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MattermostAdapter, stripBotMention, summarizeThreadRoot } from "../mattermost-adapter.ts";
 import type {
   MessagingCallbackHandleRecord,
@@ -143,6 +143,40 @@ function fakeClient4(spies: {
 }
 
 describe("MattermostAdapter — capability profile", () => {
+  it("stops a callback server while bot identity startup is still pending", async () => {
+    let rejectGetMe!: (reason?: unknown) => void;
+    const getMe = new Promise<never>((_resolve, reject) => {
+      rejectGetMe = reject;
+    });
+    const client = fakeClient4({ createdPosts: [], patchedPosts: [] });
+    client.getMe = vi.fn(async () => await getMe) as never;
+    const callbackServer = {
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+      signContext: () => ({ hmac: "x", issuedAt: 0 }),
+    };
+    const websocketClient = fakeWebSocketClient();
+    const adapter = new MattermostAdapter({
+      callbackHandleStore: fakeStore,
+      callbackServer: callbackServer as never,
+      client,
+      config: baseConfig,
+      logger: silentLogger,
+      websocketClient,
+    });
+
+    const startPromise = adapter.start(async () => {});
+    await vi.waitFor(() => {
+      expect(callbackServer.start).toHaveBeenCalledTimes(1);
+      expect(client.getMe).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+
+    expect(callbackServer.stop).toHaveBeenCalledTimes(1);
+    rejectGetMe(new Error("identity rejected after stop"));
+    await expect(startPromise).rejects.toThrow("identity rejected after stop");
+  });
+
   it("declares Mattermost capability profile with documented limits", () => {
     const adapter = new MattermostAdapter({
       callbackHandleStore: fakeStore,

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -302,6 +302,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
   private botUserId: string | undefined;
   private botUsername: string | undefined;
   private started = false;
+  private lifecycleGeneration = 0;
   /**
    * `true` once `stop()` has been called. Suppresses the runtime-error
    * fan-out for any websocket-close / -error events that fire as part
@@ -447,11 +448,20 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     if (this.started) {
       return;
     }
+    const lifecycleGeneration = ++this.lifecycleGeneration;
     this.listener = listener;
     await this.callbackServer.start();
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
 
     try {
       const me = (await this.client.getMe()) as { id: string; username?: string };
+      if (lifecycleGeneration !== this.lifecycleGeneration) {
+        await this.stop();
+        return;
+      }
       this.botUserId = me.id;
       this.botUsername = me.username;
     } catch (error) {
@@ -540,6 +550,10 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     // tradeoff.
     if (this.config.registerSlashCommands === true) {
       await this.reconcileSlashCommandsAcrossTeams();
+      if (lifecycleGeneration !== this.lifecycleGeneration) {
+        await this.stop();
+        return;
+      }
     } else {
       this.logger.info(
         "mattermost adapter: slash-command registration disabled (registerSlashCommands=false)",
@@ -557,9 +571,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
   }
 
   async stop(): Promise<void> {
-    if (!this.started) {
-      return;
-    }
+    this.lifecycleGeneration += 1;
     this.stopping = true;
     this.started = false;
     this.listener = undefined;
@@ -570,13 +582,16 @@ export class MattermostAdapter implements MattermostProviderAdapter {
         error: error instanceof Error ? error.message : String(error),
       });
     }
-    await this.callbackServer.stop();
-    // Reset latch + drop listeners so a subsequent `start()` re-arms.
-    this.runtimeErrorListeners.clear();
-    this.reconnectListeners.clear();
-    this.wsErroredLatched = false;
-    this.websocketReconnectActive = false;
-    this.stopping = false;
+    try {
+      await this.callbackServer.stop();
+    } finally {
+      // Reset latch + drop listeners so a subsequent `start()` re-arms.
+      this.runtimeErrorListeners.clear();
+      this.reconnectListeners.clear();
+      this.wsErroredLatched = false;
+      this.websocketReconnectActive = false;
+      this.stopping = false;
+    }
     this.logger.info("mattermost adapter stopped", {});
   }
 

--- a/packages/messaging/providers/mattermost/src/mattermost-callback-server.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-callback-server.ts
@@ -435,7 +435,7 @@ export function createMattermostCallbackServer(
       if (server) {
         return;
       }
-      server = createServer((req, res) => {
+      const current = createServer((req, res) => {
         handleRequest(req, res).catch((error) => {
           config.logger.error("mattermost callback request crashed", {
             error: error instanceof Error ? error.message : String(error),
@@ -447,6 +447,7 @@ export function createMattermostCallbackServer(
           }
         });
       });
+      server = current;
       await new Promise<void>((resolve, reject) => {
         const errorHandler = (error: Error): void => {
           config.logger.error("mattermost callback listener failed to bind", {
@@ -455,9 +456,9 @@ export function createMattermostCallbackServer(
           });
           reject(error);
         };
-        server!.once("error", errorHandler);
-        server!.listen(config.port, "127.0.0.1", () => {
-          server!.off("error", errorHandler);
+        current.once("error", errorHandler);
+        current.listen(config.port, "127.0.0.1", () => {
+          current.off("error", errorHandler);
           config.logger.info?.("mattermost callback listener bound", {
             port: config.port,
             host: "127.0.0.1",

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { SlackAdapter, type SlackApi, type SlackSocketClient } from "../slack-adapter.ts";
+import {
+  SlackAdapter,
+  SlackSocketModeConnection,
+  type SlackApi,
+  type SlackSocketClient,
+} from "../slack-adapter.ts";
 import type { SlackHomeView } from "../slack-home.ts";
 import type {
   MessagingChannelRef,
@@ -161,6 +166,39 @@ function fakeSocket(): SlackSocketClient & {
 }
 
 describe("SlackAdapter", () => {
+  it("cancels URL discovery before a stopped Socket Mode client can connect", async () => {
+    let resolveUrl!: (value: string) => void;
+    const pendingUrl = new Promise<string>((resolve) => {
+      resolveUrl = resolve;
+    });
+    const connect = vi.fn();
+    const retrieveWSSURL = vi.fn(async () => await pendingUrl);
+    const client = {
+      disconnect: vi.fn(async () => undefined),
+      off: vi.fn(),
+      on: vi.fn(),
+      removeAllListeners: vi.fn(),
+      retrieveWSSURL,
+      start: vi.fn(async function(this: { retrieveWSSURL(): Promise<string> }) {
+        const url = await this.retrieveWSSURL();
+        connect(url);
+      }),
+    };
+    const socket = new SlackSocketModeConnection(client);
+
+    const startPromise = socket.start();
+    await vi.waitFor(() => {
+      expect(retrieveWSSURL).toHaveBeenCalledTimes(1);
+    });
+    await socket.disconnect();
+    resolveUrl("wss://socket-mode.example.test");
+
+    await expect(startPromise).rejects.toThrow(
+      "Slack Socket Mode startup was cancelled.",
+    );
+    expect(connect).not.toHaveBeenCalled();
+  });
+
   it("detaches socket listeners when startup is stopped before connecting", async () => {
     let rejectStart!: (reason?: unknown) => void;
     const pendingStart = new Promise<never>((_resolve, reject) => {

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -161,6 +161,36 @@ function fakeSocket(): SlackSocketClient & {
 }
 
 describe("SlackAdapter", () => {
+  it("detaches socket listeners when startup is stopped before connecting", async () => {
+    let rejectStart!: (reason?: unknown) => void;
+    const pendingStart = new Promise<never>((_resolve, reject) => {
+      rejectStart = reject;
+    });
+    const socket: SlackSocketClient = {
+      disconnect: vi.fn(async () => undefined),
+      off: vi.fn(),
+      on: vi.fn(),
+      start: vi.fn(async () => await pendingStart),
+    };
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+    });
+
+    const startPromise = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(socket.start).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+
+    expect(socket.off).toHaveBeenCalledTimes(3);
+    expect(socket.disconnect).toHaveBeenCalledTimes(1);
+    rejectStart(new Error("socket rejected after stop"));
+    await expect(startPromise).rejects.toThrow("socket rejected after stop");
+  });
+
   it("declares Slack capabilities", () => {
     const adapter = new SlackAdapter({
       config: baseConfig,

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -456,6 +456,9 @@ export class SlackAdapter implements SlackProviderAdapter {
   private userInfoLookupDisabled = false;
   private listener: SlackInboundListener | undefined;
   private started = false;
+  private lifecycleGeneration = 0;
+  private socketListenersAttached = false;
+  private socketStartPending = false;
 
   constructor(options: SlackAdapterOptions) {
     this.config = options.config;
@@ -579,8 +582,13 @@ export class SlackAdapter implements SlackProviderAdapter {
 
   async start(listener: SlackInboundListener): Promise<void> {
     if (this.started) return;
+    const lifecycleGeneration = ++this.lifecycleGeneration;
     this.listener = listener;
     const auth = await this.api.authTest();
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
     this.botId = auth.bot_id;
     this.botUserId = auth.user_id;
     this.botAccount = auth.user ?? auth.user_id;
@@ -596,23 +604,46 @@ export class SlackAdapter implements SlackProviderAdapter {
     this.socketClient.on("slack_event", this.handleSlackEvent);
     this.socketClient.on("interactive", this.handleInteractive);
     this.socketClient.on("slash_commands", this.handleSlashCommand);
+    this.socketListenersAttached = true;
+    this.socketStartPending = true;
     await this.socketClient.start();
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      this.socketStartPending = false;
+      return;
+    }
+    this.socketStartPending = false;
     this.started = true;
     // Existing PwrAgent Slack apps may have the Home tab enabled without an
     // `app_home_opened` subscription. Pre-publishing for configured users
     // replaces Slack's indefinite loading state as soon as the adapter starts;
     // the event handler below keeps the view fresh for apps that do subscribe.
     await this.publishAppHomes(this.authorizedActorIdsValue);
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+    }
   }
 
   async stop(): Promise<void> {
-    if (!this.started) return;
-    this.socketClient?.off?.("slack_event", this.handleSlackEvent);
-    this.socketClient?.off?.("interactive", this.handleInteractive);
-    this.socketClient?.off?.("slash_commands", this.handleSlashCommand);
-    await this.socketClient?.disconnect();
-    this.started = false;
-    this.listener = undefined;
+    this.lifecycleGeneration += 1;
+    const shouldDisconnect =
+      this.started
+      || this.socketListenersAttached
+      || this.socketStartPending;
+    try {
+      if (this.socketListenersAttached) {
+        this.socketClient?.off?.("slack_event", this.handleSlackEvent);
+        this.socketClient?.off?.("interactive", this.handleInteractive);
+        this.socketClient?.off?.("slash_commands", this.handleSlashCommand);
+        this.socketListenersAttached = false;
+      }
+      if (shouldDisconnect) {
+        await this.socketClient?.disconnect();
+      }
+    } finally {
+      this.started = false;
+      this.listener = undefined;
+    }
   }
 
   async deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult> {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -2858,10 +2858,58 @@ export function createSlackSocketClient(
   if (!appToken?.trim()) {
     return undefined;
   }
-  return new SocketModeClient({
+  return new SlackSocketModeConnection(new SocketModeClient({
     appToken,
     autoReconnectEnabled: true,
-  }) as SlackSocketClient;
+  }) as unknown as SlackSocketModeClientWithDiscovery);
+}
+
+type SlackSocketModeClientWithDiscovery = SlackSocketClient & {
+  retrieveWSSURL(): Promise<string>;
+};
+
+export class SlackSocketModeConnection implements SlackSocketClient {
+  private lifecycleGeneration = 0;
+
+  constructor(
+    private readonly client: SlackSocketModeClientWithDiscovery,
+  ) {
+    // SocketModeClient.start() awaits apps.connections.open before it creates
+    // `websocket`. Its public disconnect() cannot close anything during that
+    // gap, so guard the SDK's discovery seam and reject before the suspended
+    // start continuation can construct and connect a SlackWebSocket.
+    const retrieveWSSURL = client.retrieveWSSURL.bind(client);
+    client.retrieveWSSURL = async () => {
+      const lifecycleGeneration = this.lifecycleGeneration;
+      const url = await retrieveWSSURL();
+      if (lifecycleGeneration !== this.lifecycleGeneration) {
+        throw new Error("Slack Socket Mode startup was cancelled.");
+      }
+      return url;
+    };
+  }
+
+  disconnect(): Promise<void> {
+    this.lifecycleGeneration += 1;
+    return this.client.disconnect();
+  }
+
+  off(event: string, listener: (payload: unknown) => void): unknown {
+    return this.client.off?.(event, listener);
+  }
+
+  on(event: string, listener: (payload: unknown) => void): unknown {
+    return this.client.on(event, listener);
+  }
+
+  removeAllListeners(event?: string): unknown {
+    return this.client.removeAllListeners?.(event);
+  }
+
+  async start(): Promise<unknown> {
+    this.lifecycleGeneration += 1;
+    return await this.client.start();
+  }
 }
 
 /**

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
@@ -164,6 +164,46 @@ describe("adaptGrammyBot", () => {
   });
 });
 
+describe("TelegramAdapter lifecycle", () => {
+  it("does not continue webhook startup after a stop during identity lookup", async () => {
+    let resolveGetMe!: (value: {
+      id: number;
+      is_bot: true;
+      username: string;
+    }) => void;
+    const pendingGetMe = new Promise<{
+      id: number;
+      is_bot: true;
+      username: string;
+    }>((resolve) => {
+      resolveGetMe = resolve;
+    });
+    const api = fakeTelegramApi();
+    api.getMe = vi.fn(async () => await pendingGetMe);
+    api.getWebhookInfo = vi.fn(async () => ({ url: "" }));
+    const adapter = new TelegramAdapter({
+      api,
+      config: {
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        botToken: "token",
+        channel: "telegram",
+      },
+      pollOnStart: false,
+      store: fakeCallbackStore(),
+    });
+
+    const startPromise = adapter.start(async () => undefined);
+    await vi.waitFor(() => {
+      expect(api.getMe).toHaveBeenCalledTimes(1);
+    });
+    await adapter.stop();
+    resolveGetMe({ id: 123, is_bot: true, username: "TestBot" });
+    await startPromise;
+
+    expect(api.getWebhookInfo).not.toHaveBeenCalled();
+  });
+});
+
 describe("TelegramAdapter callback persistence", () => {
   it("sends every assistant image", async () => {
     const api = fakeTelegramApi();

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -558,6 +558,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     store?: MessagingCallbackHandleStore;
   };
   private startPromise?: Promise<void>;
+  private lifecycleGeneration = 0;
   /**
    * `true` once `stop()` has been called; suppresses the runtime-error
    * fan-out for the polling-loop rejection that grammy raises as part
@@ -641,6 +642,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   }
 
   async start(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void> {
+    const lifecycleGeneration = ++this.lifecycleGeneration;
     this.listener = listener;
 
     this.registerBotErrorHandler();
@@ -667,6 +669,10 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         error: errorMessage(error),
       });
     }
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
 
     try {
       await this.bot.api.getWebhookInfo();
@@ -678,15 +684,27 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       });
       throw error;
     }
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
     await this.bot.api.deleteWebhook({
       drop_pending_updates: false,
     });
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
     await this.bot.api.setMyCommands({
       commands: MESSAGING_COMMAND_CATALOG.map(({ verb }) => ({
         command: verb,
         description: TELEGRAM_COMMAND_DESCRIPTIONS[verb],
       })),
     });
+    if (lifecycleGeneration !== this.lifecycleGeneration) {
+      await this.stop();
+      return;
+    }
 
     if (this.options.pollOnStart !== false) {
       this.startPromise = this.bot.start?.({
@@ -732,6 +750,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   }
 
   async stop(): Promise<void> {
+    this.lifecycleGeneration += 1;
     this.stopping = true;
     this.stopTypingSignals();
     try {


### PR DESCRIPTION
## Summary

- skip adapter `start()` entirely when a stop or per-platform cancellation is already queued
- make deadline/cancellation cleanup run again after late startup settlement, including late rejection
- make Mattermost, Slack, Feishu, and LINE clean partially initialized callback servers, listeners, sockets, and persistent connections without relying on a final `started` flag
- add startup-generation guards to Telegram and Discord as well, so cancellation stops later external startup steps across every current provider
- document the adapter lifecycle cleanup contract and add focused runtime/provider regressions

## Context

This follows up #1197. During review of the `releases/1.0` backport, two lifecycle gaps were identified that also remained on `main`:

1. runtime cancellation called `stop()`, but several providers returned early until startup had fully completed, leaving partial-start resources outside the cleanup guarantee
2. `startAdapterWithDeadline` scheduled `adapter.start()` before checking queued stop/cancellation intent

This PR resolves both gaps on `main`; it does not modify or depend on `releases/1.0`.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-runtime.test.ts packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts packages/messaging/providers/mattermost/src/__tests__/mattermost-callback-server.test.ts packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts packages/messaging/providers/line/src/__tests__/line-adapter.test.ts packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts` (317 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

## Migration audit

No database, DDL, schema, config-shape, or migration changes are required.
