### PR TITLE
feat(desktop): center the thread-jump palette over a scrim

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -470,7 +470,8 @@ function DesktopAppShell(props: {
       }
     });
   }, [desktopApi]);
-  // `instant` is for callers that are about to hide the sidebar (the ⌘K peek):
+  // `instant` is for callers that are about to hide the sidebar (a ⌘K landing
+  // peek):
   // a smooth scroll is animated over several frames, and hiding the sidebar
   // mid-animation abandons it wherever it got to. An instant scroll lands in one
   // frame, and Chromium keeps the offset across `display: none` — so the row is
@@ -499,14 +500,14 @@ function DesktopAppShell(props: {
   // writeConfig call is fire-and-forget; a failed write just means the
   // preference isn't remembered next launch.
   const writeConfig = settings.writeConfig;
-  // Thread-list quick search (⌘K anywhere, ⌘F while the sidebar is focused).
-  // Owns its own open state and the sidebar peek it needs to render.
+  // Thread-jump palette (⌘K anywhere, ⌘F while the sidebar is focused). Owns
+  // its own open state and the sidebar peek a jump's landing scroll needs.
   const threadJump = useThreadJump({ sidebarHidden, setSidebarHidden });
   const endSidebarPeek = threadJump.endPeek;
   const setSidebarHiddenPersisted = useCallback(
     (next: boolean) => {
       // An explicit toggle (⌘B, the chips) is the operator stating a preference,
-      // so it ends any quick-search peek in flight.
+      // so it ends any jump-landing peek in flight.
       endSidebarPeek();
       setSidebarHidden(next);
       void writeConfig({ ui: { sidebarHidden: next } });
@@ -1352,8 +1353,8 @@ function DesktopAppShell(props: {
           }}
           threadJumpOpen={threadJump.open}
           onThreadJumpOpenChange={(open) => {
-            // Every close (Escape, outside click, picking a thread) goes through
-            // closeJump so a peeked-open sidebar goes back to hidden.
+            // Every close (Escape, scrim click, picking a thread) goes through
+            // closeJump, so the toggle state cannot drift from the surface.
             if (open) {
               threadJump.openJump();
               return;
@@ -1364,14 +1365,14 @@ function DesktopAppShell(props: {
             setMainView("thread");
             navigation.selectThread(thread);
             // Reveal on the next frame, once the new selection has rendered.
-            // Do it even when the sidebar is only peeked open (⌘K over a hidden
-            // sidebar) — the popup is closing and taking the sidebar with it,
-            // but the scroll offset survives, so bringing the sidebar back later
-            // shows the thread we jumped to instead of stranding it off-screen.
-            // That reveal must be instant: an animated scroll wouldn't finish
-            // before the sidebar hides.
-            const instant = threadJump.isPeeking();
-            requestAnimationFrame(() => revealSelectedThreadInList({ instant }));
+            // If the sidebar is hidden (⌘B), peek it open for this landing only:
+            // scrollIntoView needs a laid-out row, and Chromium preserves the
+            // resulting offset after the sidebar returns to display: none.
+            const instant = threadJump.beginRevealPeek();
+            requestAnimationFrame(() => {
+              revealSelectedThreadInList({ instant });
+              threadJump.completePeekRestore();
+            });
           }}
           onArchiveThread={navigation.archiveThread}
           onRenameThread={navigation.renameThread}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -504,6 +504,10 @@ function DesktopAppShell(props: {
   // its own open state and the sidebar peek a jump's landing scroll needs.
   const threadJump = useThreadJump({ sidebarHidden, setSidebarHidden });
   const endSidebarPeek = threadJump.endPeek;
+  const toggleGlobalThreadSearch = () => {
+    threadJump.closeJump();
+    setMainView((current) => current === "search" ? "thread" : "search");
+  };
   const setSidebarHiddenPersisted = useCallback(
     (next: boolean) => {
       // An explicit toggle (⌘B, the chips) is the operator stating a preference,
@@ -698,7 +702,7 @@ function DesktopAppShell(props: {
   // ⌘⇧F / ⌃⇧F opens the global thread search screen; ⌘F is the focus-sensitive
   // context find; ⌘K always lands on the thread-list quick search.
   useFindHotkeys({
-    onOpenSearch: () => setMainView(mainView === "search" ? "thread" : "search"),
+    onOpenSearch: toggleGlobalThreadSearch,
     onFind: () => {
       // The thread-list quick search claims ⌘F while the sidebar is focused;
       // anywhere else ⌘F finds within the open thread. Focus decides — which is
@@ -971,7 +975,7 @@ function DesktopAppShell(props: {
       setMainView("settings");
     },
     onToggleThreadSearch: () => {
-      setMainView(mainView === "search" ? "thread" : "search");
+      toggleGlobalThreadSearch();
     },
     onCreateThread: async () => {
       setMainView("thread");
@@ -1336,7 +1340,7 @@ function DesktopAppShell(props: {
             setMainView("automations");
           }}
           onOpenThreadSearch={() => {
-            setMainView(mainView === "search" ? "thread" : "search");
+            toggleGlobalThreadSearch();
           }}
           onOpenLaunchpad={async (directory, preferredBackend) => {
             setMainView("thread");

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -206,6 +206,61 @@ describe("App", () => {
     expect(getNavigationSnapshot).not.toHaveBeenCalled();
   });
 
+  it("dismisses quick thread search before opening global search", async () => {
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        platform: "darwin",
+        listBackends: async () => ({ fetchedAt: Date.now(), backends: [] }),
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        readSettings: async () =>
+          await new Promise<never>(() => {
+            // Keep the shell mounted without needing a full settings fixture.
+          }),
+      },
+    });
+
+    render(<App />);
+
+    fireEvent.keyDown(window, {
+      metaKey: true,
+      code: "KeyK",
+      key: "k",
+    });
+    const quickSearch = await screen.findByRole("dialog", {
+      name: "Jump to thread",
+    });
+    fireEvent.change(
+      within(quickSearch).getByRole("textbox", { name: "Jump to thread" }),
+      { target: { value: "something" } },
+    );
+
+    fireEvent.keyDown(window, {
+      metaKey: true,
+      shiftKey: true,
+      code: "KeyF",
+      key: "F",
+    });
+
+    expect(
+      screen.queryByRole("dialog", { name: "Jump to thread" }),
+    ).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { level: 2, name: "Search" }),
+    ).toBeInTheDocument();
+  });
+
   it("surfaces Codex config warnings and can trust the indicated project", async () => {
     const agentEventListeners = new Set<(event: AgentEvent) => void>();
     const trustCodexProject = vi.fn(

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -770,6 +770,9 @@ export function Sidebar(props: SidebarProps) {
 
   return (
     <aside className="sidebar" aria-label="Threads">
+      {/* Mounted here because the thread set and jump handlers already live
+          here, but it portals onto document.body so the sidebar's container
+          query and hidden state cannot clip or suppress the modal. */}
       {props.threadJumpOpen ? (
         <SidebarSearchPopup
           threads={props.threads}
@@ -803,7 +806,13 @@ export function Sidebar(props: SidebarProps) {
         <div className="sidebar__masthead-actions">
           <MastheadActionButton
             ariaLabel="Search threads"
-            tooltipText={`Search threads  (${formatPrimaryAccel("F", { shift: true })})`}
+            // ⌘K leads because the palette is the surface this button most
+            // closely resembles and the global shortcut operators reach for.
+            tooltipText={[
+              `Quick Thread List Search  (${formatPrimaryAccel("K")})`,
+              `Open Search All  (${formatPrimaryAccel("F", { shift: true })})`,
+              `Context Search  (${formatPrimaryAccel("F")}) — Thread List in sidebar, Thread Chat elsewhere`,
+            ].join("\n")}
             ariaPressed={props.threadSearchActive}
             className={`sidebar__icon-button${props.threadSearchActive ? " is-active" : ""}`}
             onClick={props.onOpenThreadSearch}

--- a/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
@@ -1,17 +1,24 @@
 import {
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
   type KeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
   type ReactElement,
 } from "react";
+import { createPortal } from "react-dom";
 import {
   buildThreadIdentityKey,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
 import { SearchIcon } from "../../icons";
-import { threadMatchesQuery } from "../thread-search/thread-match";
+import {
+  parsePrNumberQuery,
+  threadMatchesQuery,
+} from "../thread-search/thread-match";
 
 const MAX_RESULTS = 8;
 
@@ -22,59 +29,95 @@ type SidebarSearchPopupProps = {
 };
 
 /**
- * Quick-jump popup over the thread list (⌘F while the sidebar is focused).
- * Filters the in-memory thread set by title, PR number, branch, and linked
- * directory; ↑/↓ move the active row, Enter (or click) jumps, Escape closes.
+ * Quick-jump palette (⌘K, or ⌘F while the sidebar is focused). Filters the
+ * in-memory local thread set by title, Agent metadata, PR number, branch, and
+ * linked directory; ↑/↓ move the active row, Enter (or click) jumps, and
+ * Escape closes.
+ *
+ * It renders through a PORTAL onto `document.body`, and that is load-bearing
+ * twice over. `.sidebar` declares `container: sidebar / inline-size`, and an
+ * element with a `container-type` is a containing block for fixed-position
+ * descendants — a scrim left inside the rail would size itself to the sidebar
+ * rather than the window, and the rail's `overflow: hidden` would clip it.
+ * The portal also survives `⌘B`, which hides the sidebar with `display: none`,
+ * so the palette does not need the sidebar revealed underneath it.
  */
 export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement {
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
-  const rootRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const idPrefix = useId();
+  const listId = `${idPrefix}-results`;
+  const rowId = (index: number): string => `${idPrefix}-row-${index}`;
 
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
 
+  const trimmed = query.trim();
   const results = useMemo(() => {
-    const trimmed = query.trim();
     if (!trimmed) {
       return [];
     }
     return props.threads
-      .filter((thread) => threadMatchesQuery(thread, trimmed))
+      .filter(
+        (thread) =>
+          threadMatchesQuery(thread, trimmed)
+          || agentMetadataMatchesQuery(thread, trimmed),
+      )
+      .sort(
+        (left, right) =>
+          Number(threadHasExactPrNumberMatch(right, trimmed))
+          - Number(threadHasExactPrNumberMatch(left, trimmed)),
+      )
       .slice(0, MAX_RESULTS);
-  }, [query, props.threads]);
+  }, [trimmed, props.threads]);
 
   useEffect(() => {
     setActiveIndex(0);
   }, [query]);
 
-  // Dismiss when focus or a click lands outside the popup.
   useEffect(() => {
-    const onPointerDown = (event: PointerEvent): void => {
-      if (!rootRef.current?.contains(event.target as Node)) {
-        props.onClose();
-      }
-    };
-    document.addEventListener("pointerdown", onPointerDown);
-    return () => document.removeEventListener("pointerdown", onPointerDown);
-  }, [props]);
+    setActiveIndex((index) =>
+      results.length === 0 ? 0 : Math.min(index, results.length - 1),
+    );
+  }, [results.length]);
+
+  // Keyboard steering is the point of this surface, so the active row has to
+  // stay on screen once the list scrolls past its own height.
+  useEffect(() => {
+    const row = listRef.current?.querySelector(".jump-palette__row.is-active");
+    // jsdom has no layout and so no scrollIntoView; guard the same way the
+    // selected-thread reveal does.
+    if (typeof row?.scrollIntoView !== "function") {
+      return;
+    }
+    row.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, results.length]);
 
   const jump = (thread: NavigationThreadSummary): void => {
     props.onJumpToThread(thread);
     props.onClose();
   };
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
     if (event.key === "Escape") {
       event.preventDefault();
       props.onClose();
       return;
     }
+    // The palette is modal: the only tab stop inside it is the field (rows are
+    // driven by aria-activedescendant), so Tab must not walk into the dimmed app.
+    if (event.key === "Tab") {
+      event.preventDefault();
+      return;
+    }
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      setActiveIndex((index) => Math.min(index + 1, results.length - 1));
+      setActiveIndex((index) =>
+        results.length === 0 ? 0 : Math.min(index + 1, results.length - 1),
+      );
       return;
     }
     if (event.key === "ArrowUp") {
@@ -91,70 +134,204 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
     }
   };
 
-  const trimmed = query.trim();
-  return (
-    <div className="sidebar-search" ref={rootRef} role="dialog" aria-label="Jump to thread">
-      <div className="sidebar-search__field">
-        <span className="sidebar-search__icon" aria-hidden>
-          <SearchIcon size={14} />
-        </span>
-        <input
-          ref={inputRef}
-          className="sidebar-search__input"
-          aria-label="Jump to thread"
-          placeholder="Jump to thread, PR #, branch…"
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          onKeyDown={handleKeyDown}
-        />
-      </div>
-      {trimmed ? (
-        results.length > 0 ? (
-          <ul className="sidebar-search__results" role="listbox">
-            {results.map((thread, index) => (
-              <li
-                key={buildThreadIdentityKey(thread.source, thread.id)}
-                role="option"
-                aria-selected={index === activeIndex}
-              >
-                <button
-                  type="button"
-                  className={`sidebar-search__result${
-                    index === activeIndex ? " is-active" : ""
-                  }`}
-                  onMouseEnter={() => setActiveIndex(index)}
-                  onClick={() => jump(thread)}
-                >
-                  <span className="sidebar-search__result-title">{thread.title}</span>
-                  {describeThread(thread) ? (
-                    <span className="sidebar-search__result-meta">
-                      {describeThread(thread)}
-                    </span>
-                  ) : null}
-                </button>
-              </li>
-            ))}
+  const renderRow = (
+    thread: NavigationThreadSummary,
+    index: number,
+  ): ReactElement => {
+    const description = describeThread(thread, trimmed);
+    return (
+      <li
+        key={buildThreadIdentityKey(thread.source, thread.id)}
+        id={rowId(index)}
+        role="option"
+        aria-selected={index === activeIndex}
+      >
+        <button
+          type="button"
+          className={`jump-palette__row${
+            index === activeIndex ? " is-active" : ""
+          }`}
+          // Focus stays in the field so typing never breaks; the active row is
+          // published to assistive technology through aria-activedescendant.
+          tabIndex={-1}
+          onMouseEnter={() => setActiveIndex(index)}
+          onClick={() => jump(thread)}
+        >
+          <span className="jump-palette__row-title">{thread.title}</span>
+          {thread.agent ? (
+            <span
+              className="jump-palette__row-agent"
+              aria-label="Agent thread"
+            >
+              Agent
+            </span>
+          ) : null}
+          {description.pr ? (
+            <span className="jump-palette__row-pr">{description.pr}</span>
+          ) : null}
+          {description.branch ? (
+            // Clipped from the LEFT (`direction: rtl` in CSS) so a long
+            // `agent/…` prefix gives way and the disambiguating leaf survives.
+            <span className="jump-palette__row-branch">
+              {description.branch}
+            </span>
+          ) : null}
+          {description.directory ? (
+            <span className="jump-palette__row-repo">
+              {description.directory}
+            </span>
+          ) : null}
+        </button>
+      </li>
+    );
+  };
+
+  const showEmpty = Boolean(trimmed) && results.length === 0;
+  // The listbox is only in the DOM once it has rows, so `aria-controls` has to
+  // come and go with it instead of leaving behind a dangling id reference.
+  const listVisible = Boolean(trimmed) && results.length > 0;
+
+  return createPortal(
+    <div
+      className="jump-palette"
+      onPointerDown={(event: ReactPointerEvent<HTMLDivElement>) => {
+        // Scrim press only. A drag that starts inside the panel and releases
+        // outside it must not count as a dismissal.
+        if (event.target === event.currentTarget) {
+          props.onClose();
+        }
+      }}
+    >
+      <div
+        className="jump-palette__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Jump to thread"
+        // Keep keyboard handling on the dialog: pressing non-input chrome can
+        // otherwise leave Escape, arrows, and Enter in a dead state.
+        onKeyDown={handleKeyDown}
+        // Suppress focus movement everywhere except the input itself. Click
+        // still fires, so result rows remain directly clickable.
+        onMouseDown={(event: ReactMouseEvent<HTMLDivElement>) => {
+          if (event.target === inputRef.current) {
+            return;
+          }
+          event.preventDefault();
+          inputRef.current?.focus();
+        }}
+      >
+        <div className="jump-palette__field">
+          <span className="jump-palette__icon" aria-hidden>
+            <SearchIcon size={16} />
+          </span>
+          <input
+            ref={inputRef}
+            className="jump-palette__input"
+            aria-label="Jump to thread"
+            aria-controls={listVisible ? listId : undefined}
+            aria-activedescendant={
+              listVisible ? rowId(activeIndex) : undefined
+            }
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="Jump to thread, PR #, branch, repo…"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <span className="jump-palette__esc" aria-hidden>
+            esc
+          </span>
+        </div>
+        {listVisible ? (
+          <ul
+            className="jump-palette__results"
+            id={listId}
+            ref={listRef}
+            role="listbox"
+            aria-label="Threads"
+          >
+            {results.map((thread, index) => renderRow(thread, index))}
           </ul>
-        ) : (
-          <p className="sidebar-search__empty">No threads match</p>
-        )
-      ) : null}
-    </div>
+        ) : showEmpty ? (
+          <p className="jump-palette__empty">No threads match</p>
+        ) : null}
+        <div className="jump-palette__foot">
+          <span>↑↓ navigate</span>
+          <span>↵ open</span>
+          <span>esc close</span>
+          <span className="jump-palette__foot-spacer" />
+          {trimmed ? (
+            <span className="jump-palette__foot-count">
+              {results.length}
+              {results.length === 1 ? " result" : " results"}
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </div>,
+    document.body,
   );
 }
 
-function describeThread(thread: NavigationThreadSummary): string {
-  const parts: string[] = [];
-  const pr = (thread.prs ?? [])[0];
+function threadHasExactPrNumberMatch(
+  thread: NavigationThreadSummary,
+  query: string,
+): boolean {
+  const prNumber = parsePrNumberQuery(query);
+  return (
+    prNumber !== null
+    && (thread.prs ?? []).some((candidate) => candidate.number === prNumber)
+  );
+}
+
+function agentMetadataMatchesQuery(
+  thread: NavigationThreadSummary,
+  query: string,
+): boolean {
+  if (!thread.agent) {
+    return false;
+  }
+  const tokens = query
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+  const haystack = [
+    "agent",
+    "agent thread",
+    thread.agent.name,
+    thread.agent.instructions,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ")
+    .toLowerCase();
+  return tokens.length > 0 && tokens.every((token) => haystack.includes(token));
+}
+
+type ThreadDescription = {
+  pr?: string;
+  branch?: string;
+  directory?: string;
+};
+
+function describeThread(
+  thread: NavigationThreadSummary,
+  query: string,
+): ThreadDescription {
+  const description: ThreadDescription = {};
+  const exactPrNumber = parsePrNumberQuery(query);
+  const pr = exactPrNumber !== null
+    ? (thread.prs ?? []).find((candidate) => candidate.number === exactPrNumber)
+    : (thread.prs ?? [])[0];
   if (pr) {
-    parts.push(`#${pr.number}`);
+    description.pr = `#${pr.number}`;
   }
   if (thread.gitBranch) {
-    parts.push(thread.gitBranch);
+    description.branch = thread.gitBranch;
   }
   const directory = (thread.linkedDirectories ?? [])[0];
   if (directory?.label) {
-    parts.push(directory.label);
+    description.directory = directory.label;
   }
-  return parts.join(" · ");
+  return description;
 }

--- a/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
@@ -320,9 +320,10 @@ function describeThread(
 ): ThreadDescription {
   const description: ThreadDescription = {};
   const exactPrNumber = parsePrNumberQuery(query);
-  const pr = exactPrNumber !== null
+  const exactPr = exactPrNumber !== null
     ? (thread.prs ?? []).find((candidate) => candidate.number === exactPrNumber)
-    : (thread.prs ?? [])[0];
+    : undefined;
+  const pr = exactPr ?? (thread.prs ?? [])[0];
   if (pr) {
     description.pr = `#${pr.number}`;
   }

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
@@ -1,0 +1,294 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type NavigationThreadSummary,
+  type PrSummary,
+} from "@pwragent/shared";
+import { SidebarSearchPopup } from "../SidebarSearchPopup";
+
+function localThread(
+  partial: Partial<NavigationThreadSummary>,
+): NavigationThreadSummary {
+  return {
+    id: "local-1",
+    title: "Local thread",
+    titleSource: "explicit",
+    source: "codex",
+    inbox: { inInbox: true },
+    linkedDirectories: [],
+    ...partial,
+  } as NavigationThreadSummary;
+}
+
+function pr(number: number, repo = "PwrAgent"): PrSummary {
+  return {
+    provider: "github.com",
+    org: "pwrdrvr",
+    repo,
+    number,
+    state: "pending",
+    url: `https://github.com/pwrdrvr/${repo}/pull/${number}`,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SidebarSearchPopup", () => {
+  it("finds local Agent threads by metadata and marks the result", () => {
+    render(
+      <SidebarSearchPopup
+        threads={[
+          localThread({
+            id: "agent-1",
+            title: "Housekeeping",
+            agent: {
+              name: "Jeeves",
+              instructions: "Help people decide what to do next.",
+              instructionLineCount: 1,
+              instructionsTooLong: false,
+              updatedAt: 1_000,
+            },
+          }),
+        ]}
+        onJumpToThread={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Jump to thread" }), {
+      target: { value: "Agent Jeeves" },
+    });
+
+    expect(screen.getByText("Housekeeping")).toBeInTheDocument();
+    expect(screen.getByLabelText("Agent thread")).toHaveTextContent("Agent");
+  });
+
+  it("prioritizes the exact PR and renders local metadata columns", () => {
+    const exact = localThread({
+      id: "exact",
+      title: "Stacked PRs",
+      agent: {
+        name: "Release Agent",
+        instructionLineCount: 0,
+        instructionsTooLong: false,
+        updatedAt: 1_000,
+      },
+      prs: [pr(44, "PwrGit"), pr(49, "PwrGit")],
+      gitBranch: "agent/backports/preserve-identifying-leaf",
+      linkedDirectories: [
+        {
+          id: "pwr-git",
+          label: "PwrGit",
+          path: "/src/PwrGit",
+          kind: "local",
+        },
+      ],
+    });
+    const substring = localThread({
+      id: "substring",
+      title: "Newer substring",
+      prs: [pr(349)],
+    });
+
+    render(
+      <SidebarSearchPopup
+        threads={[substring, exact]}
+        onJumpToThread={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Jump to thread" }), {
+      target: { value: "49" },
+    });
+
+    const rows = screen.getAllByRole("option");
+    expect(rows[0]).toHaveTextContent("Stacked PRs");
+    expect(rows[0]).toHaveTextContent("Agent");
+    expect(rows[0]).toHaveTextContent("#49");
+    expect(rows[0]).toHaveTextContent("agent/backports/preserve-identifying-leaf");
+    expect(rows[0]).toHaveTextContent("PwrGit");
+  });
+
+  it("portals a modal dialog out of whatever mounted it", () => {
+    render(
+      <aside className="sidebar">
+        <SidebarSearchPopup
+          threads={[localThread({})]}
+          onJumpToThread={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </aside>,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Jump to thread" });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog.closest(".sidebar")).toBeNull();
+  });
+
+  it("closes on a scrim press but not on a press inside the panel", () => {
+    const onClose = vi.fn();
+    render(
+      <SidebarSearchPopup
+        threads={[localThread({})]}
+        onJumpToThread={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Jump to thread" });
+    fireEvent.pointerDown(dialog);
+    expect(onClose).not.toHaveBeenCalled();
+
+    const scrim = dialog.parentElement;
+    expect(scrim).not.toBeNull();
+    fireEvent.pointerDown(scrim as HTMLElement);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("conditionally publishes list ownership and the active row", () => {
+    render(
+      <SidebarSearchPopup
+        threads={[
+          localThread({ id: "one", title: "First fix" }),
+          localThread({ id: "two", title: "Second fix" }),
+        ]}
+        onJumpToThread={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Jump to thread" });
+    expect(input).not.toHaveAttribute("aria-controls");
+    expect(input).not.toHaveAttribute("aria-activedescendant");
+
+    fireEvent.change(input, { target: { value: "fix" } });
+    const list = screen.getByRole("listbox", { name: "Threads" });
+    const rows = screen.getAllByRole("option");
+    expect(input).toHaveAttribute("aria-controls", list.id);
+    expect(input).toHaveAttribute("aria-activedescendant", rows[0]?.id);
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input).toHaveAttribute("aria-activedescendant", rows[1]?.id);
+
+    fireEvent.change(input, { target: { value: "missing" } });
+    expect(input).not.toHaveAttribute("aria-controls");
+    expect(input).not.toHaveAttribute("aria-activedescendant");
+  });
+
+  it("handles Escape, arrows, Enter, and Tab on the dialog", () => {
+    const onClose = vi.fn();
+    const onJumpToThread = vi.fn();
+    render(
+      <SidebarSearchPopup
+        threads={[
+          localThread({ id: "one", title: "First fix" }),
+          localThread({ id: "two", title: "Second fix" }),
+        ]}
+        onJumpToThread={onJumpToThread}
+        onClose={onClose}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Jump to thread" });
+    const dialog = screen.getByRole("dialog", { name: "Jump to thread" });
+    fireEvent.change(input, { target: { value: "fix" } });
+
+    expect(fireEvent.keyDown(input, { key: "Tab" })).toBe(false);
+    fireEvent.keyDown(dialog, { key: "ArrowDown" });
+    fireEvent.keyDown(dialog, { key: "Enter" });
+    expect(onJumpToThread.mock.calls[0][0].id).toBe("two");
+
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps keyboard focus after chrome presses without breaking row clicks", () => {
+    const onJumpToThread = vi.fn();
+    render(
+      <SidebarSearchPopup
+        threads={[
+          localThread({ id: "one", title: "First fix" }),
+          localThread({ id: "two", title: "Second fix" }),
+        ]}
+        onJumpToThread={onJumpToThread}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Jump to thread" });
+    fireEvent.change(input, { target: { value: "fix" } });
+    expect(fireEvent.mouseDown(screen.getByText("↑↓ navigate"))).toBe(false);
+    expect(input).toHaveFocus();
+
+    fireEvent.click(screen.getAllByRole("option")[1]!.querySelector("button")!);
+    expect(onJumpToThread.mock.calls[0][0].id).toBe("two");
+  });
+
+  it("scrolls the keyboard-active row into view", () => {
+    const scrollIntoView = vi.fn();
+    const original = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollIntoView",
+    );
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+
+    try {
+      render(
+        <SidebarSearchPopup
+          threads={[
+            localThread({ id: "one", title: "First fix" }),
+            localThread({ id: "two", title: "Second fix" }),
+          ]}
+          onJumpToThread={vi.fn()}
+          onClose={vi.fn()}
+        />,
+      );
+      const input = screen.getByRole("textbox", { name: "Jump to thread" });
+      fireEvent.change(input, { target: { value: "fix" } });
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+
+      expect(scrollIntoView).toHaveBeenLastCalledWith({ block: "nearest" });
+    } finally {
+      if (original) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollIntoView",
+          original,
+        );
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, "scrollIntoView");
+      }
+    }
+  });
+
+  it("shows local result counts for singular, plural, and empty matches", () => {
+    render(
+      <SidebarSearchPopup
+        threads={[
+          localThread({ id: "one", title: "First fix" }),
+          localThread({ id: "two", title: "Second fix" }),
+        ]}
+        onJumpToThread={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Jump to thread" });
+    fireEvent.change(input, { target: { value: "First" } });
+    expect(screen.getByText("1 result")).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "fix" } });
+    expect(screen.getByText("2 results")).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "missing" } });
+    expect(screen.getByText("0 results")).toBeInTheDocument();
+    expect(screen.getByText("No threads match")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
@@ -66,7 +66,7 @@ describe("SidebarSearchPopup", () => {
     expect(screen.getByLabelText("Agent thread")).toHaveTextContent("Agent");
   });
 
-  it("prioritizes the exact PR and renders local metadata columns", () => {
+  it("prioritizes exact PRs and describes numeric substring matches", () => {
     const exact = localThread({
       id: "exact",
       title: "Stacked PRs",
@@ -111,6 +111,8 @@ describe("SidebarSearchPopup", () => {
     expect(rows[0]).toHaveTextContent("#49");
     expect(rows[0]).toHaveTextContent("agent/backports/preserve-identifying-leaf");
     expect(rows[0]).toHaveTextContent("PwrGit");
+    expect(rows[1]).toHaveTextContent("Newer substring");
+    expect(rows[1]).toHaveTextContent("#349");
   });
 
   it("portals a modal dialog out of whatever mounted it", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -529,6 +529,7 @@ describe("Sidebar", () => {
   });
 
   it("shows masthead action tooltips and preserves button handlers", async () => {
+    const onOpenThreadSearch = vi.fn();
     const onOpenAutomations = vi.fn();
     const onOpenSettings = vi.fn();
     const onCreateThread = vi.fn(async () => undefined);
@@ -547,12 +548,23 @@ describe("Sidebar", () => {
         threads={[sharedThread]}
         onBrowseModeChange={() => undefined}
         onCreateThread={onCreateThread}
+        onOpenThreadSearch={onOpenThreadSearch}
         onOpenAutomations={onOpenAutomations}
         onOpenLaunchpad={async () => undefined}
         onOpenSettings={onOpenSettings}
         onSelectThread={() => undefined}
       />
     );
+
+    const searchButton = screen.getByRole("button", { name: "Search threads" });
+    fireEvent.mouseEnter(searchButton);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Quick Thread List Search  (Ctrl+K)\nOpen Search All  (Ctrl+Shift+F)\nContext Search  (Ctrl+F) — Thread List in sidebar, Thread Chat elsewhere",
+    );
+    fireEvent.mouseLeave(searchButton);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    fireEvent.click(searchButton);
+    expect(onOpenThreadSearch).toHaveBeenCalledTimes(1);
 
     const automationsButton = screen.getByRole("button", { name: "Open automations" });
     fireEvent.mouseEnter(automationsButton);

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadJump.test.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadJump.test.ts
@@ -1,29 +1,8 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useThreadJump } from "../useThreadJump";
 
-// The peek restore is deliberately deferred a frame (a jump's scroll-into-view
-// has to land while the sidebar still has layout), so drive frames by hand.
-let frames: FrameRequestCallback[] = [];
-
-beforeEach(() => {
-  frames = [];
-  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
-    frames.push(callback),
-  );
-});
-
-function flushFrame(): void {
-  const queued = frames.splice(0);
-  act(() => {
-    for (const callback of queued) {
-      callback(0);
-    }
-  });
-}
-
 afterEach(() => {
-  vi.unstubAllGlobals();
   cleanup();
 });
 
@@ -47,109 +26,89 @@ function renderThreadJump(initialSidebarHidden: boolean): {
 }
 
 describe("useThreadJump", () => {
-  it("opens without touching a sidebar that's already showing", () => {
-    const { hook, setSidebarHidden } = renderThreadJump(false);
+  it("opens without touching the sidebar, hidden or not", () => {
+    const shown = renderThreadJump(false);
+    act(() => shown.hook.result.current.openJump());
+    expect(shown.hook.result.current.open).toBe(true);
+    expect(shown.setSidebarHidden).not.toHaveBeenCalled();
 
-    act(() => hook.result.current.openJump());
-
-    expect(hook.result.current.open).toBe(true);
-    expect(setSidebarHidden).not.toHaveBeenCalled();
+    const hidden = renderThreadJump(true);
+    act(() => hidden.hook.result.current.openJump());
+    expect(hidden.hook.result.current.open).toBe(true);
+    expect(hidden.setSidebarHidden).not.toHaveBeenCalled();
+    expect(hidden.sidebarHidden()).toBe(true);
   });
 
-  it("peeks a hidden sidebar open, then puts it back when the search closes", () => {
-    // ⌘K over a hidden sidebar has to reveal it — the popup renders inside it.
-    // But hiding the sidebar is a deliberate choice, so the reveal is temporary.
+  it("closes without touching the sidebar", () => {
     const { hook, setSidebarHidden, sidebarHidden } = renderThreadJump(true);
 
     act(() => hook.result.current.openJump());
-    expect(setSidebarHidden).toHaveBeenLastCalledWith(false);
-    expect(sidebarHidden()).toBe(false);
-    expect(hook.result.current.isPeeking()).toBe(true);
-
     act(() => hook.result.current.closeJump());
-    flushFrame();
 
     expect(hook.result.current.open).toBe(false);
-    expect(setSidebarHidden).toHaveBeenLastCalledWith(true);
+    expect(setSidebarHidden).not.toHaveBeenCalled();
     expect(sidebarHidden()).toBe(true);
   });
 
-  it("holds the sidebar for a frame on close, so a jump's scroll can land first", () => {
-    // Picking a thread closes the popup AND schedules the scroll that centers
-    // the chosen row. `scrollIntoView` does nothing inside a `display: none`
-    // subtree, so re-hiding in the same commit would eat the scroll and strand
-    // the row off-screen the next time the sidebar came back.
+  it("peeks a hidden sidebar open for the selected row's landing scroll", () => {
     const { hook, setSidebarHidden, sidebarHidden } = renderThreadJump(true);
-    act(() => hook.result.current.openJump());
-    setSidebarHidden.mockClear();
 
-    act(() => hook.result.current.closeJump());
+    let peeked = false;
+    act(() => {
+      peeked = hook.result.current.beginRevealPeek();
+    });
 
-    // Still laid out: this is the frame the reveal runs in.
-    expect(setSidebarHidden).not.toHaveBeenCalled();
+    expect(peeked).toBe(true);
+    expect(setSidebarHidden).toHaveBeenLastCalledWith(false);
     expect(sidebarHidden()).toBe(false);
+  });
 
-    flushFrame();
+  it("restores a landing-scroll peek when the scroll completes", () => {
+    const { hook, setSidebarHidden, sidebarHidden } = renderThreadJump(true);
+
+    act(() => {
+      hook.result.current.beginRevealPeek();
+    });
+    setSidebarHidden.mockClear();
+    act(() => hook.result.current.completePeekRestore());
 
     expect(setSidebarHidden).toHaveBeenCalledWith(true);
+    expect(sidebarHidden()).toBe(true);
   });
 
-  it("reports the peek to callers before the popup's close clears it", () => {
-    // App reads isPeeking() inside onJumpToThread to choose an instant scroll —
-    // and the popup calls onJumpToThread BEFORE onClose, so the peek must still
-    // be readable at that moment.
-    const { hook } = renderThreadJump(true);
-    act(() => hook.result.current.openJump());
-
-    expect(hook.result.current.isPeeking()).toBe(true);
-
-    act(() => hook.result.current.closeJump());
-    flushFrame();
-
-    expect(hook.result.current.isPeeking()).toBe(false);
-  });
-
-  it("leaves a visible sidebar alone when the search closes", () => {
+  it("starts no peek when the sidebar is already showing", () => {
     const { hook, setSidebarHidden } = renderThreadJump(false);
 
-    act(() => hook.result.current.openJump());
-    act(() => hook.result.current.closeJump());
-    flushFrame();
+    let peeked = true;
+    act(() => {
+      peeked = hook.result.current.beginRevealPeek();
+    });
 
-    expect(hook.result.current.open).toBe(false);
+    expect(peeked).toBe(false);
+    act(() => hook.result.current.completePeekRestore());
     expect(setSidebarHidden).not.toHaveBeenCalled();
   });
 
   it("lets an explicit sidebar preference win over a peek in flight", () => {
-    // If anything persists a sidebar preference while a peek is open, that's the
-    // operator stating what they want and the peek must not revert it on close.
-    // No path in today's UI reaches this (clicking a toggle chip dismisses the
-    // popup first, and ⌘B is inert while the caret is in the popup's field) —
-    // this pins the contract so a future one can't silently undo a saved
-    // preference.
     const { hook, setSidebarHidden } = renderThreadJump(true);
-    act(() => hook.result.current.openJump());
+    act(() => {
+      hook.result.current.beginRevealPeek();
+    });
     setSidebarHidden.mockClear();
 
     act(() => hook.result.current.endPeek());
-    act(() => hook.result.current.closeJump());
-    flushFrame();
+    act(() => hook.result.current.completePeekRestore());
 
-    expect(hook.result.current.open).toBe(false);
     expect(setSidebarHidden).not.toHaveBeenCalled();
   });
 
-  it("toggles closed on a second ⌘K, restoring the peek", () => {
-    const { hook, setSidebarHidden, sidebarHidden } = renderThreadJump(true);
+  it("toggles closed on a second ⌘K", () => {
+    const { hook } = renderThreadJump(true);
 
     act(() => hook.result.current.toggleJump());
     expect(hook.result.current.open).toBe(true);
 
     act(() => hook.result.current.toggleJump());
-    flushFrame();
-
     expect(hook.result.current.open).toBe(false);
-    expect(setSidebarHidden).toHaveBeenLastCalledWith(true);
-    expect(sidebarHidden()).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/useThreadJump.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/useThreadJump.ts
@@ -1,15 +1,15 @@
 import { useCallback, useRef, useState } from "react";
 
 /**
- * Owns the thread-list quick search — the popup opened by ⌘K from anywhere, or
- * by ⌘F while the sidebar holds focus.
+ * Owns the thread-jump palette — the modal opened by ⌘K from anywhere, or by
+ * ⌘F while the sidebar holds focus.
  *
- * The popup renders inside the sidebar, and a hidden sidebar (⌘B) is
- * `display: none`, so opening the search over a hidden sidebar has to reveal it
- * first. That reveal is a PEEK, not a preference change: it never writes
- * config.toml, and closing the search puts the sidebar back. Someone who
- * deliberately hides their sidebar shouldn't have it silently — and permanently
- * — reopened just because they reached for a thread.
+ * The palette portals onto `document.body`, so opening it no longer requires a
+ * sidebar. Picking a thread still scrolls its sidebar row into view, and
+ * `scrollIntoView` is a no-op inside the `display: none` subtree that ⌘B leaves
+ * behind. A hidden sidebar is therefore revealed at PICK time, not open time:
+ * a temporary peek that writes nothing to config.toml and ends as soon as the
+ * selected row's landing scroll completes.
  */
 export function useThreadJump(options: {
   sidebarHidden: boolean;
@@ -20,22 +20,15 @@ export function useThreadJump(options: {
   openJump: () => void;
   closeJump: () => void;
   /**
-   * Whether the sidebar on screen right now is a peek — i.e. it's about to be
-   * hidden again when the search closes. Callers that scroll the thread list on
-   * the way out need this: the scroll has to be instant, not animated, to land
-   * before the sidebar goes away. Read it at event time, not during render.
+   * Reveal a hidden sidebar so a jump's scroll-into-view has layout to land in.
+   * Returns whether a peek started, which selects an instant landing scroll.
    */
-  isPeeking: () => boolean;
-  /** ⌘K again backs out of a jump you didn't mean to start. */
+  beginRevealPeek: () => boolean;
+  /** Restore a peek after the selected row's landing scroll completes. */
+  completePeekRestore: () => void;
+  /** ⌘K again backs out of a jump you did not mean to start. */
   toggleJump: () => void;
-  /**
-   * Call from whatever persists the sidebar preference (⌘B, the toggle chips).
-   * An explicit preference outranks a peek: ending it here means the closing
-   * search can't revert what the operator just chose. Nothing in today's UI can
-   * actually toggle the sidebar while the popup is up — a click dismisses the
-   * popup first, and ⌘B is inert while the caret sits in its field — so this is
-   * a rail, not a live path.
-   */
+  /** End any pending peek when the operator explicitly changes the preference. */
   endPeek: () => void;
 } {
   const { sidebarHidden, setSidebarHidden } = options;
@@ -43,43 +36,45 @@ export function useThreadJump(options: {
   const peekedRef = useRef(false);
 
   const openJump = useCallback(() => {
-    if (sidebarHidden) {
-      peekedRef.current = true;
-      setSidebarHidden(false);
-    }
     setOpen(true);
-  }, [sidebarHidden, setSidebarHidden]);
+  }, []);
 
   const closeJump = useCallback(() => {
     setOpen(false);
+  }, []);
+
+  const beginRevealPeek = useCallback(() => {
+    if (!sidebarHidden) {
+      return false;
+    }
+    peekedRef.current = true;
+    setSidebarHidden(false);
+    return true;
+  }, [sidebarHidden, setSidebarHidden]);
+
+  const completePeekRestore = useCallback(() => {
     if (!peekedRef.current) {
       return;
     }
     peekedRef.current = false;
-    // Restore on the NEXT frame, not in this commit. Picking a thread closes the
-    // popup and schedules a scroll-the-selected-row-into-view for that same
-    // frame (App's onJumpToThread), and `scrollIntoView` inside a
-    // `display: none` subtree is a no-op — so re-hiding here would silently eat
-    // the scroll and the row would be off-screen when the sidebar came back.
-    // Chromium restores a scroll offset across `display: none`, so all we owe
-    // the reveal is a laid-out sidebar for the frame it runs in. Its rAF was
-    // queued first, so it runs before ours.
-    requestAnimationFrame(() => setSidebarHidden(true));
+    setSidebarHidden(true);
   }, [setSidebarHidden]);
 
   const toggleJump = useCallback(() => {
-    if (open) {
-      closeJump();
-      return;
-    }
-    openJump();
-  }, [open, closeJump, openJump]);
+    setOpen((current) => !current);
+  }, []);
 
   const endPeek = useCallback(() => {
     peekedRef.current = false;
   }, []);
 
-  const isPeeking = useCallback(() => peekedRef.current, []);
-
-  return { open, openJump, closeJump, isPeeking, toggleJump, endPeek };
+  return {
+    open,
+    openJump,
+    closeJump,
+    beginRevealPeek,
+    completePeekRestore,
+    toggleJump,
+    endPeek,
+  };
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -830,67 +830,122 @@ textarea,
   container: sidebar / inline-size;
 }
 
-/* Thread-list quick-jump popup (⌘F while the sidebar is focused). Floats below
-   the masthead, over the thread list. */
-.sidebar-search {
-  position: absolute;
-  z-index: 40;
-  top: 52px;
-  left: 10px;
-  right: 10px;
+/* Thread-jump palette (⌘K, or ⌘F while the sidebar is focused). A centered
+   modal over a scrim, portalled onto document.body so the sidebar's containing
+   block, overflow, and hidden state cannot constrain it. */
+.jump-palette {
+  position: fixed;
+  inset: 0;
+  z-index: 140;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 11vh 16px 16px;
+  background: var(--scrim-strong);
+  animation: jump-palette-fade 110ms ease both;
+}
+
+/* The app shell is already offset below Windows' draggable title strip. This
+   body-level portal must reproduce that offset so the strip remains usable. */
+:root[data-platform="win32"] .jump-palette {
+  top: var(--win-titlebar-h);
+}
+
+.jump-palette__panel {
   display: flex;
   flex-direction: column;
-  max-height: calc(100% - 64px);
+  width: min(640px, 92vw);
+  max-height: 66vh;
   overflow: hidden;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
   background: var(--bg-panel-elevated);
   box-shadow: var(--shadow-popover);
+  animation: jump-palette-rise 130ms cubic-bezier(0.2, 0.7, 0.3, 1) both;
 }
 
-.sidebar-search__field {
+@keyframes jump-palette-fade {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes jump-palette-rise {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .jump-palette,
+  .jump-palette__panel {
+    animation: none;
+  }
+}
+
+.jump-palette__field {
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 10px;
+  gap: 10px;
+  padding: 13px 15px;
   border-bottom: 1px solid var(--border-subtle);
 }
 
-.sidebar-search__icon {
+.jump-palette__icon {
   display: inline-flex;
   color: var(--text-muted);
 }
 
-.sidebar-search__input {
+.jump-palette__input {
   flex: 1;
   min-width: 0;
   border: none;
   background: transparent;
   color: var(--text-primary);
-  font: inherit;
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 500;
   outline: none;
 }
 
-.sidebar-search__input::placeholder {
+.jump-palette__input::placeholder {
   color: var(--text-muted);
 }
 
-.sidebar-search__results {
+.jump-palette__esc {
+  flex: none;
+  padding: 3px 7px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.jump-palette__results {
+  flex: 1 1 auto;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 2px;
   margin: 0;
-  padding: 4px;
+  padding: 6px;
   overflow-y: auto;
   list-style: none;
 }
 
-.sidebar-search__result {
+/* One line per thread: the title flexes while metadata rides the right edge in
+   compact columns. */
+.jump-palette__row {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: center;
+  gap: 10px;
   width: 100%;
-  padding: 6px 8px;
+  padding: 8px 10px;
   border: none;
   border-radius: 6px;
   background: transparent;
@@ -899,34 +954,100 @@ textarea,
   cursor: pointer;
 }
 
-.sidebar-search__result.is-active {
+.jump-palette__row.is-active {
   background: var(--bg-row-active);
+  box-shadow: inset 0 0 0 1px var(--accent-border);
 }
 
-.sidebar-search__result-title {
+.jump-palette__row-title {
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
+  color: var(--text-primary);
   font-size: 13px;
   font-weight: 600;
-  color: var(--text-primary);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.sidebar-search__result-meta {
-  overflow: hidden;
+.jump-palette__row-agent,
+.jump-palette__row-repo {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  height: 19px;
+  padding: 0 7px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+}
+
+.jump-palette__row-agent {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.jump-palette__row-pr {
+  flex: none;
+  color: var(--text-muted);
   font-family: var(--font-mono);
   font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Put the ellipsis at the START so a long `agent/…` prefix gives way before
+   the branch leaf. The title remains the primary identifier and shrinks less. */
+.jump-palette__row-branch {
+  flex: 0 2 auto;
+  min-width: 0;
+  max-width: 40%;
+  overflow: hidden;
+  direction: rtl;
   color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-align: right;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.sidebar-search__empty {
+.jump-palette__row-repo {
+  background: var(--bg-panel);
+  color: var(--accent);
+}
+
+.jump-palette__empty {
   margin: 0;
-  padding: 12px;
+  padding: 34px 20px;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: 13px;
   text-align: center;
+}
+
+.jump-palette__foot {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  padding: 9px 15px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-panel);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 500;
+}
+
+.jump-palette__foot-spacer {
+  flex: 1;
+}
+
+.jump-palette__foot-count {
+  font-variant-numeric: tabular-nums;
 }
 
 .sidebar__resize-handle,


### PR DESCRIPTION
## Backport

Backports [PwrAgent PR #1489](https://github.com/pwrdrvr/PwrAgent/pull/1489), **feat(desktop): center the thread-jump palette over a scrim**, to `releases/1.0`.

Source squash commit: `91b91e070d202ef1657c5fd3755ec0f19fc41afe`

Also includes the search-interaction follow-ups from [PwrAgent PR #1541](https://github.com/pwrdrvr/PwrAgent/pull/1541).

Follow-up squash commit: `22f97a18c8b6bc3efc32a41ad247a021bb1fcd79`

## What changed

- Portals the Cmd+K thread-jump palette onto `document.body`, centered at `min(640px, 92vw)` over the existing `--scrim-strong` token.
- Uses one-line local result rows with title, Agent marker, exact/local PR, branch, and repository/directory columns. Long branches clip from the left so the identifying leaf survives.
- Adds the active-row `--accent-border` hairline, token-only light/dark styling, the input/esc pill, footer legend, result count, and active-row scroll-into-view behavior.
- Adds modal accessibility and interaction behavior: `aria-modal`, `aria-activedescendant`, conditional `aria-controls`, a Tab trap, dialog-level Escape/arrows/Enter handling, guarded mousedown focus, clickable rows, and scrim dismissal.
- Preserves the 8px radius cap and Windows `--win-titlebar-h` drag-strip offset.
- Moves hidden-sidebar reveal from palette open to the selected thread's landing scroll, then restores the hidden preference.
- Leads the search tooltip with Cmd+K.
- Closes the Cmd+K palette before every transition into Search All, including Cmd/Ctrl+Shift+F and masthead actions.
- Preserves the first PR as metadata for numeric substring matches when no exact PR exists, while continuing to prioritize exact PR hits.

## 1.0-specific adaptations

- Keeps the existing local-only popup contract: `threads`, `onJumpToThread`, and `onClose`.
- Uses the Agent metadata already present on 1.0's `NavigationThreadSummary` for local matching and a compact local marker. It does not import the newer `AgentThreadChip` or related navigation architecture.
- Implements exact-PR prioritization and substring fallback in the palette using 1.0's existing PR-query parser rather than importing newer shared/federated search helpers.
- Restores a hidden-sidebar landing peek after the release branch's next-frame row scroll; 1.0 does not carry mainline's newer asynchronous reveal-completion plumbing.

## Explicit exclusions

No federation or remote-thread functionality was added: no federation imports or identity keys, remote search/debounce/loading/latency state, peer sections or chips, remote jump/pin/navigation handlers, federation tests, or Star Map code.

## Migration audit

- `CURRENT_STATE_DB_USER_VERSION` remains **32**.
- No DDL, SQLite schema/config migration, database file, mainline-only state, or schema test changed.
- The diff remains renderer/navigation/style/test-only; PR #1541 adds focused app-shell coverage.

## Validation

- Focused Vitest: SidebarSearchPopup, Sidebar, useThreadJump, theme-contract, and app-shell — **172 passed**.
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors (existing warning baseline only)
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:sql`
- `git diff --check`

Desktop E2E was not launched locally: `releases/1.0` has no Cmd+K/thread-title-reveal E2E target, and headed Electron was intentionally avoided. Platform visual/E2E confirmation is left to CI.
