### PR TITLE
fix(desktop): preserve tooltips across pane scrolls

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
@@ -1,0 +1,49 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useViewportTooltip } from "../useViewportTooltip";
+
+afterEach(cleanup);
+
+function TooltipFixture() {
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+
+  return (
+    <div>
+      <div data-testid="sidebar-scroll-region">
+        <button
+          type="button"
+          onMouseEnter={(event) =>
+            tooltip.show(event.currentTarget, "Branch details")
+          }
+        >
+          agent/keep-tooltip-open
+        </button>
+      </div>
+      <div data-testid="transcript-scroll-region" />
+      {tooltip.tooltipNode}
+    </div>
+  );
+}
+
+describe("useViewportTooltip", () => {
+  it("keeps a tooltip open when an unrelated pane scrolls", () => {
+    render(<TooltipFixture />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Branch details");
+
+    fireEvent.scroll(screen.getByTestId("transcript-scroll-region"));
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Branch details");
+  });
+
+  it("closes a tooltip when the scroll moves its anchor", () => {
+    render(<TooltipFixture />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    fireEvent.scroll(screen.getByTestId("sidebar-scroll-region"));
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -79,6 +79,7 @@ export function useViewportTooltip(options: {
   tooltipNode: ReactNode;
 } {
   const tooltipRef = useRef<HTMLDivElement>(null);
+  const targetRef = useRef<HTMLElement | null>(null);
   const tooltipId = useId();
   const [state, setState] = useState<TooltipState | undefined>(undefined);
 
@@ -113,10 +114,12 @@ export function useViewportTooltip(options: {
 
   const show = useCallback((target: HTMLElement, content: ReactNode): void => {
     if (isNativeDragInteractionActive()) {
+      targetRef.current = null;
       setState(undefined);
       return;
     }
     const rect = target.getBoundingClientRect();
+    targetRef.current = target;
     setState({
       content,
       targetTop: rect.top,
@@ -130,6 +133,7 @@ export function useViewportTooltip(options: {
   }, []);
 
   const hide = useCallback((): void => {
+    targetRef.current = null;
     setState(undefined);
   }, []);
 
@@ -137,9 +141,10 @@ export function useViewportTooltip(options: {
   // us no dismissal signal when the window loses focus (cmd-tab away leaves
   // the pointer "over" the chip, so no `mouseleave` fires) or when the list
   // scrolls underneath the position:fixed portal (the tooltip detaches from
-  // its target and lingers). Tear it down on either, matching ReactionPicker's
-  // window-level teardown. Keyed on visibility so the measure pass doesn't
-  // resubscribe each render.
+  // its target and lingers). Tear it down when the viewport or an ancestor of
+  // the target scrolls. A captured scroll from an unrelated pane must not
+  // dismiss it — transcript auto-scrolls otherwise close sidebar tooltips.
+  // Keyed on visibility so the measure pass doesn't resubscribe each render.
   const visible = state !== undefined;
   useEffect(() => {
     if (!visible) {
@@ -148,12 +153,23 @@ export function useViewportTooltip(options: {
     const unsubscribeNativeDrag = subscribeNativeDragInteraction((active) => {
       if (active) hide();
     });
+    const onScroll = (event: Event): void => {
+      const scrollTarget = event.target;
+      const target = targetRef.current;
+      if (
+        scrollTarget === window
+        || scrollTarget === document
+        || (scrollTarget instanceof Node && target && scrollTarget.contains(target))
+      ) {
+        hide();
+      }
+    };
     window.addEventListener("blur", hide);
-    window.addEventListener("scroll", hide, { capture: true });
+    window.addEventListener("scroll", onScroll, { capture: true });
     return () => {
       unsubscribeNativeDrag();
       window.removeEventListener("blur", hide);
-      window.removeEventListener("scroll", hide, { capture: true });
+      window.removeEventListener("scroll", onScroll, { capture: true });
     };
   }, [visible, hide]);
 


### PR DESCRIPTION
## What changed

- keep viewport tooltips open when a different pane scrolls
- continue dismissing a tooltip when the viewport or one of its anchor's scroll ancestors moves
- add regression coverage for both behaviors

## Why

The shared viewport-tooltip hook captured every `scroll` event at `window` and treated it as movement of the tooltip anchor. Transcript and environment-setup paints auto-scroll the right detail pane, so hovering a branch or pull-request chip in the left sidebar was interrupted even though that chip never moved.

This is a shared event-scoping bug rather than a sidebar/detail-pane remount problem. The hook now records its anchor and only responds to scrolls that can move that anchor.

## User impact

Branch, PR, and other portal-rendered tooltips remain readable while transcript content paints or auto-scrolls elsewhere in the window.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx` (67 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`
