### PR TITLE
fix(desktop): reserve concurrent worktree paths

### DIFF
--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -1261,6 +1261,73 @@ describe("GitDirectoryService", () => {
     expect(path.basename(path.dirname(second))).toMatch(/-2$/);
   });
 
+  it("reserves distinct paths for concurrent allocations in the same millisecond", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const fixedTimestamp = 1730000000000;
+
+    const [first, second] = await Promise.all([
+      computeWorktreePath({
+        repoRoot: repoDir,
+        storage: "in-repo",
+        timestamp: fixedTimestamp,
+      }),
+      computeWorktreePath({
+        repoRoot: repoDir,
+        storage: "in-repo",
+        timestamp: fixedTimestamp,
+      }),
+    ]);
+
+    expect(first).not.toBe(second);
+    expect(path.basename(first)).toBe(path.basename(second));
+    expect(
+      [path.basename(path.dirname(first)), path.basename(path.dirname(second))].sort(),
+    ).toEqual([
+      fixedTimestamp.toString(36),
+      `${fixedTimestamp.toString(36)}-2`,
+    ]);
+  });
+
+  it("creates distinct worktrees for concurrent launchpads in the same millisecond", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1730000000000);
+
+    try {
+      const [first, second] = await Promise.all([
+        service.prepareLaunchpadWorkspace({
+          directoryKind: "directory",
+          directoryLabel: "FixtureRepo",
+          directoryPath: repoDir,
+          workMode: "worktree",
+          branchName: "main",
+        }),
+        service.prepareLaunchpadWorkspace({
+          directoryKind: "directory",
+          directoryLabel: "FixtureRepo",
+          directoryPath: repoDir,
+          workMode: "worktree",
+          branchName: "main",
+        }),
+      ]);
+
+      expect(first.workMode).toBe("worktree");
+      expect(second.workMode).toBe("worktree");
+      expect(first.cwd).toBeDefined();
+      expect(second.cwd).toBeDefined();
+      expect(first.cwd).not.toBe(second.cwd);
+      expect(runGit(first.cwd!, ["rev-parse", "HEAD"])).toBe(
+        runGit(second.cwd!, ["rev-parse", "HEAD"]),
+      );
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   it("removes the worktree and prunes the empty hash parent on cleanup", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -1239,7 +1239,7 @@ describe("GitDirectoryService", () => {
     });
   });
 
-  it("computeWorktreePath suffixes the hash when the path already exists", async () => {
+  it("computeWorktreePath advances the timestamp when the path already exists", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);
     const fixedTimestamp = 1730000000000;
@@ -1258,7 +1258,38 @@ describe("GitDirectoryService", () => {
 
     expect(second).not.toBe(first);
     expect(path.basename(second)).toBe(path.basename(first));
-    expect(path.basename(path.dirname(second))).toMatch(/-2$/);
+    expect(path.basename(path.dirname(second))).toBe(
+      (fixedTimestamp + 1).toString(36),
+    );
+  });
+
+  it("probes at most ten timestamp increments", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const fixedTimestamp = 1730000000000;
+
+    for (
+      let timestampIncrement = 0;
+      timestampIncrement <= 10;
+      timestampIncrement += 1
+    ) {
+      const allocated = await computeWorktreePath({
+        repoRoot: repoDir,
+        storage: "in-repo",
+        timestamp: fixedTimestamp,
+      });
+      expect(path.basename(path.dirname(allocated))).toBe(
+        (fixedTimestamp + timestampIncrement).toString(36),
+      );
+    }
+
+    await expect(
+      computeWorktreePath({
+        repoRoot: repoDir,
+        storage: "in-repo",
+        timestamp: fixedTimestamp,
+      }),
+    ).rejects.toThrow("Unable to allocate a unique worktree path");
   });
 
   it("reserves distinct paths for concurrent allocations in the same millisecond", async () => {
@@ -1282,10 +1313,13 @@ describe("GitDirectoryService", () => {
     expect(first).not.toBe(second);
     expect(path.basename(first)).toBe(path.basename(second));
     expect(
-      [path.basename(path.dirname(first)), path.basename(path.dirname(second))].sort(),
+      [
+        path.basename(path.dirname(first)),
+        path.basename(path.dirname(second)),
+      ].sort(),
     ).toEqual([
       fixedTimestamp.toString(36),
-      `${fixedTimestamp.toString(36)}-2`,
+      (fixedTimestamp + 1).toString(36),
     ]);
   });
 
@@ -1295,7 +1329,8 @@ describe("GitDirectoryService", () => {
     const service = new GitDirectoryService({
       resolveWorktreeStorage: () => "in-repo",
     });
-    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1730000000000);
+    const fixedTimestamp = 1730000000000;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(fixedTimestamp);
 
     try {
       const [first, second] = await Promise.all([
@@ -1320,6 +1355,15 @@ describe("GitDirectoryService", () => {
       expect(first.cwd).toBeDefined();
       expect(second.cwd).toBeDefined();
       expect(first.cwd).not.toBe(second.cwd);
+      expect(
+        [
+          path.basename(path.dirname(first.cwd!)),
+          path.basename(path.dirname(second.cwd!)),
+        ].sort(),
+      ).toEqual([
+        fixedTimestamp.toString(36),
+        (fixedTimestamp + 1).toString(36),
+      ]);
       expect(runGit(first.cwd!, ["rev-parse", "HEAD"])).toBe(
         runGit(second.cwd!, ["rev-parse", "HEAD"]),
       );

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -996,6 +996,48 @@ describe("GitDirectoryService", () => {
     expect(runGit(sourceWorktree, ["branch", "--show-current"])).toBe("release");
   });
 
+  it("restores an excluded source branch when worktree reservation is exhausted", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const sourceWorktree = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "pwragent-exhausted-transfer-source-")),
+      "fixture",
+    );
+    cleanupPaths.push(path.dirname(sourceWorktree));
+    runGit(repoDir, ["worktree", "add", sourceWorktree, "release"]);
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+    const fixedTimestamp = 1730000000000;
+
+    for (let reservation = 0; reservation <= 10; reservation += 1) {
+      await computeWorktreePath({
+        repoRoot: repoDir,
+        storage: "in-repo",
+        timestamp: fixedTimestamp,
+      });
+    }
+
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(fixedTimestamp);
+    try {
+      await expect(
+        service.prepareLaunchpadWorkspace({
+          directoryKind: "directory",
+          directoryLabel: "FixtureRepo",
+          directoryPath: repoDir,
+          excludedWorktreePaths: [sourceWorktree],
+          workMode: "worktree",
+          branchName: "release",
+          worktreeBranchMode: "attached",
+        }),
+      ).rejects.toThrow("Unable to allocate a unique worktree path");
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(runGit(sourceWorktree, ["branch", "--show-current"])).toBe("release");
+  });
+
   it("rolls back a detached destination worktree", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -1320,23 +1320,49 @@ export class GitDirectoryService {
         });
       }
 
-      const storage = await this.resolveStorage();
-      const worktreePath = await computeWorktreePath({
-        backend: launchpad.backend,
-        codexHome: launchpad.backend === "codex" ? this.codexHome : undefined,
-        repoRoot,
-        storage,
-        homeDir: this.homeDir,
-      });
       try {
-        await mkdir(path.dirname(worktreePath), { recursive: true });
-        await this.runGitCommand(
+        const storage = await this.resolveStorage();
+        const worktreePath = await computeWorktreePath({
+          backend: launchpad.backend,
+          codexHome: launchpad.backend === "codex" ? this.codexHome : undefined,
           repoRoot,
-          ["worktree", "add", worktreePath, baseBranch],
-          this.gitEnv,
-        );
+          storage,
+          homeDir: this.homeDir,
+        });
+        try {
+          await mkdir(path.dirname(worktreePath), { recursive: true });
+          await this.runGitCommand(
+            repoRoot,
+            ["worktree", "add", worktreePath, baseBranch],
+            this.gitEnv,
+          );
+        } catch (error) {
+          await pruneEmptyWorktreeParents(worktreePath);
+          throw error;
+        }
+
+        return {
+          cwd: worktreePath,
+          repositoryPath: repoRoot,
+          rollback: async () => {
+            await removeWorktreeAndPrune({
+              gitEnv: this.gitEnv,
+              repoRoot,
+              runGit: this.runGitCommand,
+              worktreePath,
+            });
+            if (detachedSourceWorktreePath) {
+              await restoreDetachedWorktreeBranch({
+                branchName: baseBranch,
+                gitEnv: this.gitEnv,
+                runGit: this.runGitCommand,
+                worktreePath: detachedSourceWorktreePath,
+              });
+            }
+          },
+          workMode: "worktree",
+        };
       } catch (error) {
-        await pruneEmptyWorktreeParents(worktreePath);
         if (detachedSourceWorktreePath) {
           await restoreDetachedWorktreeBranch({
             branchName: baseBranch,
@@ -1347,28 +1373,6 @@ export class GitDirectoryService {
         }
         throw error;
       }
-
-      return {
-        cwd: worktreePath,
-        repositoryPath: repoRoot,
-        rollback: async () => {
-          await removeWorktreeAndPrune({
-            gitEnv: this.gitEnv,
-            repoRoot,
-            runGit: this.runGitCommand,
-            worktreePath,
-          });
-          if (detachedSourceWorktreePath) {
-            await restoreDetachedWorktreeBranch({
-              branchName: baseBranch,
-              gitEnv: this.gitEnv,
-              runGit: this.runGitCommand,
-              worktreePath: detachedSourceWorktreePath,
-            });
-          }
-        },
-        workMode: "worktree",
-      };
     }
 
     const storage = await this.resolveStorage();

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, realpath, rmdir, writeFile } from "node:fs/promises";
+import { mkdir, realpath, rmdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { IterableMapper } from "@shutterstock/p-map-iterable";
@@ -285,15 +285,6 @@ function codexHomeWorktreesRoot(options: {
   );
 }
 
-async function pathExists(target: string): Promise<boolean> {
-  try {
-    await access(target);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 async function normalizeFilesystemPath(target: string): Promise<string> {
   return realpath(target).catch(() => path.resolve(target));
 }
@@ -308,6 +299,12 @@ async function pruneEmptyWorktreeParents(worktreePath: string): Promise<void> {
   } catch {
     // Parent is non-empty or already gone; either is fine.
   }
+}
+
+export async function releaseWorktreePathReservation(
+  worktreePath: string,
+): Promise<void> {
+  await pruneEmptyWorktreeParents(worktreePath);
 }
 
 async function removeWorktreeAndPrune(params: {
@@ -339,12 +336,22 @@ export async function computeWorktreePath(params: {
   });
   const projectName = path.basename(path.resolve(params.repoRoot)) || "project";
   const baseHash = (params.timestamp ?? Date.now()).toString(36);
+  await mkdir(root, { recursive: true });
 
   for (let attempt = 0; attempt < 32; attempt += 1) {
     const hash = attempt === 0 ? baseHash : `${baseHash}-${attempt + 1}`;
-    const candidate = path.join(root, hash, projectName);
-    if (!(await pathExists(candidate))) {
-      return candidate;
+    const hashParent = path.join(root, hash);
+    try {
+      // Reserving the hash directory makes path allocation atomic across
+      // concurrent calls and separate PwrAgent processes. Git accepts the
+      // still-missing project directory beneath this empty parent.
+      await mkdir(hashParent);
+      return path.join(hashParent, projectName);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        continue;
+      }
+      throw error;
     }
   }
 
@@ -1325,6 +1332,7 @@ export class GitDirectoryService {
           this.gitEnv,
         );
       } catch (error) {
+        await pruneEmptyWorktreeParents(worktreePath);
         if (detachedSourceWorktreePath) {
           await restoreDetachedWorktreeBranch({
             branchName: baseBranch,
@@ -1368,11 +1376,16 @@ export class GitDirectoryService {
       homeDir: this.homeDir,
     });
     await mkdir(path.dirname(worktreePath), { recursive: true });
-    await this.runGitCommand(
-      repoRoot,
-      ["worktree", "add", "--detach", worktreePath, baseBranch],
-      this.gitEnv,
-    );
+    try {
+      await this.runGitCommand(
+        repoRoot,
+        ["worktree", "add", "--detach", worktreePath, baseBranch],
+        this.gitEnv,
+      );
+    } catch (error) {
+      await pruneEmptyWorktreeParents(worktreePath);
+      throw error;
+    }
 
     return {
       cwd: worktreePath,

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -335,11 +335,15 @@ export async function computeWorktreePath(params: {
     homeDir: params.homeDir,
   });
   const projectName = path.basename(path.resolve(params.repoRoot)) || "project";
-  const baseHash = (params.timestamp ?? Date.now()).toString(36);
+  const baseTimestamp = params.timestamp ?? Date.now();
   await mkdir(root, { recursive: true });
 
-  for (let attempt = 0; attempt < 32; attempt += 1) {
-    const hash = attempt === 0 ? baseHash : `${baseHash}-${attempt + 1}`;
+  for (
+    let timestampIncrement = 0;
+    timestampIncrement <= 10;
+    timestampIncrement += 1
+  ) {
+    const hash = (baseTimestamp + timestampIncrement).toString(36);
     const hashParent = path.join(root, hash);
     try {
       // Reserving the hash directory makes path allocation atomic across

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -14,7 +14,10 @@ import type {
 } from "@pwragent/shared";
 import { DESKTOP_WORKTREE_STORAGE_DEFAULT } from "@pwragent/shared";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
-import { computeWorktreePath } from "./git-directory-service";
+import {
+  computeWorktreePath,
+  releaseWorktreePathReservation,
+} from "./git-directory-service";
 import { WorktreeArchiveService } from "./worktree-archive-service";
 
 const execFileAsync = promisify(execFile);
@@ -34,6 +37,14 @@ function toForwardSlashesOptional(
   value: string | undefined,
 ): string | undefined {
   return value === undefined ? undefined : toForwardSlashes(value);
+}
+
+async function releaseReservationAndRethrow(
+  targetPath: string,
+  error: unknown,
+): Promise<never> {
+  await releaseWorktreePathReservation(targetPath);
+  throw error;
 }
 
 function normalizeHandoffResponseIdentifiers(
@@ -465,21 +476,25 @@ export class GitWorkspaceHandoffService {
       gitEnv: this.gitEnv,
       path: context.sourcePath,
       message: this.buildStashMessage(context, "source"),
-    });
+    }).catch((error) => releaseReservationAndRethrow(targetPath, error));
     await runGit(
       context.sourcePath,
       leaveLocalDetached
         ? ["switch", "--detach", context.headSha]
         : ["switch", leaveLocalBranch],
       this.gitEnv,
-    );
-
+    ).catch((error) => releaseReservationAndRethrow(targetPath, error));
     await mkdir(path.dirname(targetPath), { recursive: true });
-    await runGit(
-      context.repositoryPath,
-      ["worktree", "add", targetPath, context.branch],
-      this.gitEnv,
-    );
+    try {
+      await runGit(
+        context.repositoryPath,
+        ["worktree", "add", targetPath, context.branch],
+        this.gitEnv,
+      );
+    } catch (error) {
+      await releaseWorktreePathReservation(targetPath);
+      throw error;
+    }
     const appliedSourceStash = await applyVerifyAndDropStash(
       targetPath,
       sourceStash,
@@ -542,17 +557,22 @@ export class GitWorkspaceHandoffService {
       gitEnv: this.gitEnv,
       path: context.sourcePath,
       message: this.buildStashMessage(context, "source"),
-    });
+    }).catch((error) => releaseReservationAndRethrow(targetPath, error));
     if (!sourceStash) {
       warnings.push("No dirty non-ignored changes were available to move.");
     }
 
     await mkdir(path.dirname(targetPath), { recursive: true });
-    await runGit(
-      context.repositoryPath,
-      ["worktree", "add", "-b", newBranchName, targetPath, baseSha],
-      this.gitEnv,
-    );
+    try {
+      await runGit(
+        context.repositoryPath,
+        ["worktree", "add", "-b", newBranchName, targetPath, baseSha],
+        this.gitEnv,
+      );
+    } catch (error) {
+      await releaseWorktreePathReservation(targetPath);
+      throw error;
+    }
     const appliedSourceStash = await applyVerifyAndDropStash(
       targetPath,
       sourceStash,
@@ -604,17 +624,22 @@ export class GitWorkspaceHandoffService {
       gitEnv: this.gitEnv,
       path: context.sourcePath,
       message: this.buildStashMessage(context, "source"),
-    });
+    }).catch((error) => releaseReservationAndRethrow(targetPath, error));
     if (!sourceStash) {
       warnings.push("No dirty non-ignored changes were available to move.");
     }
 
     await mkdir(path.dirname(targetPath), { recursive: true });
-    await runGit(
-      context.repositoryPath,
-      ["worktree", "add", "--detach", targetPath, baseSha],
-      this.gitEnv,
-    );
+    try {
+      await runGit(
+        context.repositoryPath,
+        ["worktree", "add", "--detach", targetPath, baseSha],
+        this.gitEnv,
+      );
+    } catch (error) {
+      await releaseWorktreePathReservation(targetPath);
+      throw error;
+    }
     const appliedSourceStash = await applyVerifyAndDropStash(
       targetPath,
       sourceStash,


### PR DESCRIPTION
## What changed

- reserve each timestamp worktree directory atomically before returning its path
- probe the next millisecond-derived IDs, up to `timestamp + 10 ms`
- release empty reservations when Git worktree creation or pre-creation handoff steps fail
- restore an attached source branch if destination path allocation or worktree creation fails
- add deterministic concurrent allocator, real concurrent worktree, and allocation-rollback regressions

## Root cause

Two mainline handoffs started 452 ms apart on this machine:

- 12:02:55.053 — the ACP parent invoked `handoff_task`
- 12:02:55.505 — the messaging parent invoked `handoff_task`
- 12:02:57.434 — the only environment setup began in `msqa33k5/PwrAgnt`
- 12:03:03.439 — the messaging child started there
- 12:03:46.326 — the ACP parent retried
- 12:03:48.016 — the ACP child also started in `msqa33k5/PwrAgnt`, without a second setup

The path segment `msqa33k5` is the base-36 encoding of 2026-08-12T16:02:56.837Z, inside the concurrent allocation window.

`computeWorktreePath` used a check-then-return sequence: it tested whether the candidate existed, but did not claim it. Concurrent callers could both observe the same candidate as absent and both return it before either `git worktree add` created the directory. A deterministic regression reproduced both effects on unmodified main: two allocator calls returned the same path, and two real concurrent launchpad preparations raced on the same Git target.

The fix uses exclusive directory creation as the reservation. This is atomic at the filesystem boundary, so it protects concurrent calls in one process and separate PwrAgent processes. On collision, allocation tries the base millisecond and then `+1 ms` through `+10 ms`; it fails after that bounded search. All worktree creation paths retain the shared allocator and clean up reservations on failure. Attached branch transfers now keep storage resolution, path allocation, and destination creation inside the same rollback guard so any failure restores the source checkout's branch.

## Impact

Concurrent thread/environment launches for the same repository can no longer receive the same worktree path. One receives the timestamp path and the other receives `timestamp + 1 ms`, preserving isolated thread workspaces. Failed attached transfers no longer leave the source checkout on detached HEAD.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/git-directory-service.test.ts apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts` — 56 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors (34 existing warnings)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`
