### PR TITLE
fix(desktop): use the searchable branch picker in the handoff dialog

### DIFF
--- a/apps/desktop/e2e/workspace-handoff-dialog.inspect.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-dialog.inspect.spec.ts
@@ -31,7 +31,11 @@ test("opens the local-to-worktree handoff dialog until Electron is closed manual
     await expect(dialog).toContainText("Handoff to Detached HEAD");
     await expect(dialog).toContainText("main");
     await dialog.getByRole("radio", { name: /Handoff Current Branch/ }).click();
-    await expect(dialog.getByLabel("Leave current checkout on")).toHaveValue("HEAD");
+    // `exact` matters: the branch picker's listbox is labelled
+    // "Leave current checkout on options", and getByLabel matches substrings.
+    await expect(
+      dialog.getByLabel("Leave current checkout on", { exact: true }),
+    ).toHaveAttribute("data-value", "HEAD");
     await expect(dialog).toContainText("Ignored files are not moved by handoff.");
 
     console.log(

--- a/apps/desktop/e2e/workspace-handoff-dialog.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-dialog.spec.ts
@@ -43,7 +43,11 @@ test("centers the local-to-worktree handoff dialog in the window", async () => {
     await expect(dialog).toContainText("main");
 
     await dialog.getByRole("radio", { name: /Handoff Current Branch/ }).click();
-    await expect(dialog.getByLabel("Leave current checkout on")).toHaveValue("HEAD");
+    // `exact` matters: the branch picker's listbox is labelled
+    // "Leave current checkout on options", and getByLabel matches substrings.
+    await expect(
+      dialog.getByLabel("Leave current checkout on", { exact: true }),
+    ).toHaveAttribute("data-value", "HEAD");
 
     await dialog.getByRole("radio", { name: /Handoff to New Branch/ }).click();
     await expect(dialog.getByLabel("New branch name")).toHaveValue(

--- a/apps/desktop/e2e/workspace-handoff-flows.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-flows.spec.ts
@@ -213,6 +213,23 @@ async function openLocalHandoffDialog(page: Page, title: string) {
   return dialog;
 }
 
+/**
+ * Picks a row in the handoff dialog's "leave current checkout on" branch
+ * picker. `optionLabel` is the row's visible text, so the detached-HEAD
+ * sentinel is "Detached HEAD" rather than the "HEAD" value it submits.
+ */
+async function chooseLeaveLocalBranch(page: Page, optionLabel: string) {
+  const dialog = page.getByRole("dialog", { name: "Handoff to New Worktree" });
+  // `exact` matters: the picker's listbox is labelled "<name> options" and
+  // getByLabel matches substrings, so a bare name resolves to two elements
+  // once the popover opens.
+  await dialog.getByLabel("Leave current checkout on", { exact: true }).click();
+  await dialog
+    .getByRole("listbox", { name: "Leave current checkout on options" })
+    .getByRole("option", { name: optionLabel, exact: true })
+    .click();
+}
+
 async function handoffBackToLocal(page: Page) {
   await page.getByLabel("Workspace mode").click();
   await page.getByRole("menuitem", { name: "Handoff to Local" }).click();
@@ -256,7 +273,7 @@ test.describe("workspace handoff git flows", () => {
       configure: async (page: Page) => {
         const dialog = page.getByRole("dialog", { name: "Handoff to New Worktree" });
         await dialog.getByRole("radio", { name: /Handoff Current Branch/ }).click();
-        await dialog.getByLabel("Leave current checkout on").selectOption("main");
+        await chooseLeaveLocalBranch(page, "main");
       },
       expectedLocalBranchAfterLocalHandoff: "main",
       expectedLocalBranchAfterReturn: "feature/handoff",
@@ -267,7 +284,7 @@ test.describe("workspace handoff git flows", () => {
       configure: async (page: Page) => {
         const dialog = page.getByRole("dialog", { name: "Handoff to New Worktree" });
         await dialog.getByRole("radio", { name: /Handoff Current Branch/ }).click();
-        await dialog.getByLabel("Leave current checkout on").selectOption("HEAD");
+        await chooseLeaveLocalBranch(page, "Detached HEAD");
       },
       expectedLocalBranchAfterLocalHandoff: "",
       expectedLocalBranchAfterReturn: "feature/handoff",

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2037,6 +2037,17 @@ type LaunchpadBranchOption = {
   current?: boolean;
   /** The repository's default branch (origin/HEAD, or main/master/...). */
   isDefault?: boolean;
+  /**
+   * Display text for rows whose `name` is a sentinel rather than a branch
+   * (the handoff dialog's `"HEAD"` → "Detached HEAD"). Falls back to `name`.
+   */
+  label?: string;
+  /**
+   * Hold the row above the recency-ordered list no matter what is selected.
+   * A sentinel row has no commit date, so recency ordering would drop it in
+   * an arbitrary spot once the operator picks a real branch.
+   */
+  pinned?: boolean;
 };
 
 /**
@@ -2069,10 +2080,11 @@ function BranchPicker(props: {
   const ref = useDismissableMenu<HTMLDivElement>(open, () => setOpen(false));
 
   const normalizedQuery = query.trim().toLowerCase();
-  // Pin the anchor branches — the one you'll branch off (selected), the repo
-  // default, and the checked-out branch — to the top, deduped in that
-  // priority order. Everything else follows in recency order. When the three
-  // anchors are the same branch (the common case) this is a single pinned row.
+  // Pin the anchor branches — caller-pinned sentinels, the one you'll branch
+  // off (selected), the repo default, and the checked-out branch — to the top,
+  // deduped in that priority order. Everything else follows in recency order.
+  // When the three anchors are the same branch (the common case) this is a
+  // single pinned row.
   const { pinnedOptions, restOptions } = useMemo(() => {
     const byName = new Map(props.options.map((option) => [option.name, option]));
     const pinnedNames = new Set<string>();
@@ -2083,6 +2095,11 @@ function BranchPicker(props: {
         pinned.push(option);
       }
     };
+    for (const option of props.options) {
+      if (option.pinned) {
+        addPin(option);
+      }
+    }
     addPin(byName.get(props.value));
     addPin(props.options.find((option) => option.isDefault));
     addPin(props.options.find((option) => option.current));
@@ -2091,7 +2108,9 @@ function BranchPicker(props: {
   }, [props.options, props.value]);
 
   const matchesQuery = (option: LaunchpadBranchOption): boolean =>
-    !normalizedQuery || option.name.toLowerCase().includes(normalizedQuery);
+    !normalizedQuery
+    || option.name.toLowerCase().includes(normalizedQuery)
+    || Boolean(option.label?.toLowerCase().includes(normalizedQuery));
   const visiblePinned = pinnedOptions.filter(matchesQuery);
   const visibleRest = restOptions.filter(matchesQuery);
   const flatVisible = [...visiblePinned, ...visibleRest];
@@ -2182,7 +2201,7 @@ function BranchPicker(props: {
     const relativeTime = formatBranchRelativeTime(option.lastCommitAt, nowMs);
     return (
       <button
-        aria-label={option.name}
+        aria-label={option.label ?? option.name}
         aria-selected={isSelected}
         className={[
           "branch-picker__option",
@@ -2203,7 +2222,9 @@ function BranchPicker(props: {
         <span aria-hidden="true" className="branch-picker__option-icon">
           <BranchIcon size={12} />
         </span>
-        <span className="branch-picker__option-name">{option.name}</span>
+        <span className="branch-picker__option-name">
+          {option.label ?? option.name}
+        </span>
         {option.current ? (
           <span
             aria-hidden="true"
@@ -2265,7 +2286,7 @@ function BranchPicker(props: {
           <BranchIcon size={13} />
         </span>
         <span className="composer-dropdown__label">
-          {selectedOption?.name ?? props.value}
+          {selectedOption?.label ?? selectedOption?.name ?? props.value}
         </span>
         <span aria-hidden="true" className="composer-dropdown__chevron">
           ⌄
@@ -2303,7 +2324,10 @@ function BranchPicker(props: {
             </div>
           ) : null}
           <div
-            aria-label={props.ariaLabel}
+            // Not bare `ariaLabel` — that name belongs to the trigger, and
+            // duplicating it makes every by-name query ambiguous while the
+            // menu is open. Mirrors ReviewBranchPicker.
+            aria-label={`${props.ariaLabel} options`}
             className="branch-picker__list"
             id={listboxId}
             role="listbox"
@@ -9301,10 +9325,15 @@ export function Composer(props: ComposerProps) {
       : props.directory?.gitStatus?.currentBranch ??
         props.thread?.observedGitBranch ??
         props.thread?.gitBranch;
-  const branchOptions = getLeaveLocalBranchOptions({
-    currentBranch: sourceBranch,
-    directory: props.directory,
-  });
+  const leaveLocalBranchOptions = useMemo(
+    () =>
+      buildLeaveLocalBranchPickerOptions({
+        currentBranch: sourceBranch,
+        directory: props.directory,
+      }),
+    [sourceBranch, props.directory],
+  );
+  const branchOptions = leaveLocalBranchOptions.map((option) => option.name);
   const canHandoffThreadWorkspace = Boolean(
     props.thread &&
       threadWorkspace &&
@@ -10016,22 +10045,17 @@ export function Composer(props: ComposerProps) {
                     </button>
                   </div>
                   {localHandoffStrategy === "move-branch" ? (
-                    <label className="workspace-handoff-dialog__field">
-                      Leave current checkout on
-                      <select
-                        aria-label="Leave current checkout on"
-                        className="composer__select"
-                        disabled={handoffSubmitting || branchOptions.length === 0}
+                    <div className="workspace-handoff-dialog__field">
+                      <span aria-hidden="true">Leave current checkout on</span>
+                      <BranchPicker
+                        ariaLabel="Leave current checkout on"
+                        className="branch-picker--dialog"
+                        disabled={handoffSubmitting}
+                        options={leaveLocalBranchOptions}
                         value={leaveLocalBranch}
-                        onChange={(event) => setLeaveLocalBranch(event.target.value)}
-                      >
-                        {branchOptions.map((branch) => (
-                          <option key={branch} value={branch}>
-                            {formatLeaveLocalBranchOption(branch)}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
+                        onChange={setLeaveLocalBranch}
+                      />
+                    </div>
                   ) : null}
                   {localHandoffStrategy === "new-branch" ? (
                     <label className="workspace-handoff-dialog__field">
@@ -13119,6 +13143,36 @@ function getLeaveLocalBranchOptions(params: {
   return ["HEAD", ...new Set(ordered)];
 }
 
-function formatLeaveLocalBranchOption(branch: string): string {
-  return branch === "HEAD" ? "Detached HEAD" : branch;
+/**
+ * Options for the handoff dialog's "leave current checkout on" picker.
+ *
+ * `getLeaveLocalBranchOptions` decides *which* refs are offered — it already
+ * drops the branch being moved and (via `handoffBranches`) anything another
+ * worktree holds. This only enriches those names with the recency and
+ * default-branch metadata the picker renders, so the two stay in sync.
+ *
+ * The leading `"HEAD"` sentinel is a checkout state rather than a branch, so
+ * it carries a display label and stays pinned above the recency list.
+ */
+function buildLeaveLocalBranchPickerOptions(params: {
+  currentBranch?: string;
+  directory?: NavigationDirectorySummary;
+}): LaunchpadBranchOption[] {
+  const details = params.directory?.gitStatus?.branchDetails ?? [];
+  const detailByName = new Map(details.map((detail) => [detail.name, detail]));
+  const defaultBranch = params.directory?.gitStatus?.defaultBranch;
+  return getLeaveLocalBranchOptions(params).map((name) => {
+    if (name === "HEAD") {
+      return { name, label: "Detached HEAD", pinned: true };
+    }
+    const detail = detailByName.get(name);
+    return {
+      name,
+      lastCommitAt: detail?.lastCommitAt,
+      // Only reachable on the `branches` fallback path — `handoffBranches`
+      // has already filtered in-use branches out.
+      inUse: detail?.inUse,
+      isDefault: defaultBranch ? name === defaultBranch : false,
+    };
+  });
 }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2075,6 +2075,7 @@ function BranchPicker(props: {
   const [activeIndex, setActiveIndex] = useState(0);
   const [menuShift, setMenuShift] = useState(0);
   const listboxId = useId();
+  const selectedLabelId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const ref = useDismissableMenu<HTMLDivElement>(open, () => setOpen(false));
@@ -2271,6 +2272,11 @@ function BranchPicker(props: {
     >
       <button
         aria-controls={open ? listboxId : undefined}
+        // `aria-label` is the field name and overrides the button's content in
+        // the accessible-name computation, so without this the selected branch
+        // is never announced — the native <select> this replaced did announce
+        // its value. Describes rather than renames so by-name queries hold.
+        aria-describedby={selectedLabelId}
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-label={props.ariaLabel}
@@ -2285,7 +2291,7 @@ function BranchPicker(props: {
         <span aria-hidden="true" className="composer-dropdown__icon">
           <BranchIcon size={13} />
         </span>
-        <span className="composer-dropdown__label">
+        <span className="composer-dropdown__label" id={selectedLabelId}>
           {selectedOption?.label ?? selectedOption?.name ?? props.value}
         </span>
         <span aria-hidden="true" className="composer-dropdown__chevron">

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -12883,6 +12883,9 @@ describe("Composer", () => {
     const leaveOn = screen.getByLabelText("Leave current checkout on");
     expect(leaveOn).toHaveAttribute("data-value", "HEAD");
     expect(leaveOn).toHaveTextContent("Detached HEAD");
+    // The aria-label names the field and suppresses the button's content, so
+    // the selection has to reach assistive tech as a description instead.
+    expect(leaveOn).toHaveAccessibleDescription("Detached HEAD");
     fireEvent.click(screen.getByRole("button", { name: "Handoff" }));
 
     await waitFor(() => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -12880,7 +12880,9 @@ describe("Composer", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: "Handoff to New Worktree" }));
     fireEvent.click(screen.getByRole("radio", { name: /Handoff Current Branch/ }));
 
-    expect(screen.getByLabelText("Leave current checkout on")).toHaveValue("HEAD");
+    const leaveOn = screen.getByLabelText("Leave current checkout on");
+    expect(leaveOn).toHaveAttribute("data-value", "HEAD");
+    expect(leaveOn).toHaveTextContent("Detached HEAD");
     fireEvent.click(screen.getByRole("button", { name: "Handoff" }));
 
     await waitFor(() => {
@@ -12891,6 +12893,103 @@ describe("Composer", () => {
         sourcePath: "/repo",
         sourceBranch: "feature/handoff",
         leaveLocalBranch: "HEAD",
+      });
+    });
+  });
+
+  it("filters the handoff leave-branch picker and shows branch metadata", async () => {
+    const onHandoffThreadWorkspace = vi.fn(async () => undefined);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        disabled={false}
+        directory={{
+          key: "directory:/repo",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/repo",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "feature/handoff",
+            defaultBranch: "main",
+            branches: ["feature/handoff", "main", "release"],
+            branchDetails: [
+              { name: "release", lastCommitAt: nowSeconds - 3600 },
+              { name: "main", lastCommitAt: nowSeconds - 172800 },
+            ],
+            handoffBranches: ["main", "release"],
+            syncState: "untracked",
+          },
+        }}
+        onHandoffThreadWorkspace={onHandoffThreadWorkspace}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          gitBranch: "feature/handoff",
+          linkedDirectories: [
+            { id: "dir-1", label: "PwrAgent", path: "/repo", kind: "local" },
+          ],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Workspace mode"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Handoff to New Worktree" }));
+    fireEvent.click(screen.getByRole("radio", { name: /Handoff Current Branch/ }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Leave current checkout on" })
+    );
+
+    const listbox = screen.getByRole("listbox", {
+      name: "Leave current checkout on options",
+    });
+    // Pinned rows lead: the sentinel (it has no commit date to sort by), then
+    // the default branch. Everything else follows in handoffBranches order.
+    expect(
+      within(listbox)
+        .getAllByRole("option")
+        .map((option) => option.getAttribute("aria-label"))
+    ).toEqual(["Detached HEAD", "main", "release"]);
+    expect(within(listbox).getByRole("option", { name: "main" })).toHaveTextContent(
+      "Default"
+    );
+    expect(
+      within(listbox).getByRole("option", { name: "release" })
+    ).toHaveTextContent("1h ago");
+
+    fireEvent.change(screen.getByLabelText("Find a branch"), {
+      target: { value: "rel" },
+    });
+    expect(
+      within(listbox)
+        .getAllByRole("option")
+        .map((option) => option.getAttribute("aria-label"))
+    ).toEqual(["release"]);
+
+    fireEvent.click(within(listbox).getByRole("option", { name: "release" }));
+    expect(screen.getByLabelText("Leave current checkout on")).toHaveAttribute(
+      "data-value",
+      "release"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Handoff" }));
+
+    await waitFor(() => {
+      expect(onHandoffThreadWorkspace).toHaveBeenCalledWith({
+        direction: "local-to-worktree",
+        strategy: "move-branch",
+        repositoryPath: "/repo",
+        sourcePath: "/repo",
+        sourceBranch: "feature/handoff",
+        leaveLocalBranch: "release",
       });
     });
   });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -21650,25 +21650,36 @@ a.transcript-message__messaging-origin:focus-visible {
   max-height: min(440px, calc(100dvh - 128px));
 }
 
-.branch-picker--review {
-  width: min(100%, 640px);
+/* Dialog variant: the picker stands in for a form field (the handoff dialog's
+   "leave current checkout on"), so it fills the field row and squares off to
+   match the sibling text input instead of hugging a toolbar as a pill. */
+.branch-picker--dialog {
+  width: 100%;
   max-width: 100%;
 }
 
-.branch-picker--review .composer-dropdown__button {
+.branch-picker--dialog .composer-dropdown__button {
   min-height: 34px;
-  justify-content: flex-start;
   border-radius: 6px;
-  font-weight: 700;
+  font-weight: 500;
 }
 
-.branch-picker--review .branch-picker__menu {
+.branch-picker--dialog .composer-dropdown__label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Anchor to the field's left edge and match its width — the trigger spans the
+   dialog rather than sitting near the right gutter. */
+.branch-picker--dialog .branch-picker__menu {
   right: auto;
   left: 0;
-  z-index: 45;
-  min-width: min(100%, 420px);
-  width: min(640px, calc(100vw - 32px));
-  max-width: calc(100vw - 32px);
+  min-width: 100%;
+  max-width: 100%;
 }
 
 .review-branch-picker {


### PR DESCRIPTION
## Summary

- The **"Leave current checkout on"** control in the *Handoff to New Worktree* dialog was a native `<select>` — an unsorted, unfiltered list with no branch metadata that covered the whole dialog once it grew past a few entries. Every other branch-selection surface in the app already uses the searchable `BranchPicker` popover; this reuses it here.
- `LaunchpadBranchOption` gains two optional fields so the picker can carry a row that is not a branch:
  - `label` — display text when `name` is a sentinel (`"HEAD"` → "Detached HEAD"). Drives the row text, the trigger text, the `aria-label`, and the search filter.
  - `pinned` — holds a row above the recency list. The sentinel has no commit date, so without this it would land in an arbitrary spot as soon as a real branch was selected.
- New `buildLeaveLocalBranchPickerOptions` **wraps** `getLeaveLocalBranchOptions` rather than replacing it. That helper already decides *which* refs are legal — it drops the branch being moved, and via `handoffBranches` anything another worktree holds. The new builder only enriches those names with `lastCommitAt` / `isDefault` / `inUse` from `gitStatus.branchDetails`, so the picker cannot drift into offering a branch that would fail to check out.
- Net effect: type-to-filter, "1h ago" recency, Default / In use badges, ✓ on the selection, keyboard nav, and a scroll-capped 440px menu. The last one is what fixes the overlap complaint — `.branch-picker__list` scrolls *inside* the popover instead of growing over the dialog.

Two adjacent cleanups:

- Repurposed the **dead** `.branch-picker--review` CSS block as `.branch-picker--dialog` instead of adding a near-duplicate. Nothing in the tree referenced `--review`; `ReviewBranchPicker` had moved to its own `.review-branch-picker__menu`.
- Gave `BranchPicker`'s listbox the `aria-label` `` `<name> options` ``, matching `ReviewBranchPicker`. The trigger and the listbox previously shared one accessible name — the substring-matching trap [`apps/desktop/AGENTS.md`](https://github.com/pwrdrvr/PwrAgent/blob/main/apps/desktop/AGENTS.md) documents. `getByLabel("Leave current checkout on")` resolved to two elements the moment the popover opened.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx` — **352 passed**, including a new test covering filter → metadata → select → submit for this picker.
- `pnpm test` on the adjacent picker-touching suites (`thread-view`, `automation-editor`, `ProjectPicker`) — **105 passed**.
- `npx eslint` on the changed files — **0 errors** (14 warnings, all the pre-existing `Composer.tsx` baseline).
- `pnpm lint:colors` — passes; no new color literals.
- `tsc --noEmit -p apps/desktop/tsconfig.json` — only 3 pre-existing errors in untouched main-process files (`createCommandInvocation` from an unbuilt `@pwrdrvr/agent-transport`); confirmed identical on a stashed tree.

## Notes

**The three E2E specs in this diff were updated blind** (desktop E2E is not run on my machine), but **CI has since verified them** — the macOS Desktop E2E lane ran all three and passed, 89 passed / 0 failed:

```
✓  94 workspace-handoff-dialog.spec.ts › centers the local-to-worktree handoff dialog
✓  95 workspace-handoff-dialog.spec.ts › centers the worktree-to-local handoff dialog
✓  98 workspace-handoff-flows.spec.ts › round trips dirty WIP through move-leave-main
✓  99 workspace-handoff-flows.spec.ts › round trips dirty WIP through move-leave-detached
```

`move-leave-main` and `move-leave-detached` are the two cases that exercise the changed call sites:

- `workspace-handoff-dialog.spec.ts` / `.inspect.spec.ts`: `toHaveValue("HEAD")` → `toHaveAttribute("data-value", "HEAD")`, since the trigger is now a button.
- `workspace-handoff-flows.spec.ts`: two `selectOption(...)` calls → a new `chooseLeaveLocalBranch` helper that opens the popover and clicks the row. The detached case targets the visible label **"Detached HEAD"**, not the `"HEAD"` value it submits.

The four `getByLabel("Base branch")` assertions in `directory-launchpad-workspace.spec.ts` were checked and are safe — they run with the menu closed, so the new `"... options"` listbox is not in the DOM to collide with.

**One judgment call to eyeball.** The picker opens *upward* (the shared `.branch-picker__menu` default). The field sits low in the dialog so there is more room above, but that came from layout arithmetic rather than from seeing it render. There is an existing inspect spec for a headed look:

```
pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/workspace-handoff-dialog.inspect.spec.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

