### PR TITLE
ci: validate configure-nodejs lifecycle caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,11 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
         timeout-minutes: 10
         with:
           node-version: 24.x
+          cache-electron: "true"
           lookup-only: "true"
 
   lint:
@@ -127,10 +128,11 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
         timeout-minutes: 10
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: License metadata
         timeout-minutes: 10
@@ -194,10 +196,11 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
         timeout-minutes: 10
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: Build
         timeout-minutes: 10
@@ -214,10 +217,11 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
         timeout-minutes: 10
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: Install ripgrep
         uses: ./.github/actions/install-ripgrep
@@ -248,11 +252,12 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@e19a1a140ed1851a536fcc2cc116e9d3df6b0ce9 # v1.2.0
+        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
         timeout-minutes: 10
         with:
           node-version: 24.14.1
           working-directory: .
+          cache-electron: "true"
           lookup-only: "true"
 
   windows-verify:
@@ -267,11 +272,12 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@e19a1a140ed1851a536fcc2cc116e9d3df6b0ce9 # v1.2.0
+        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
         timeout-minutes: 10
         with:
           node-version: 24.14.1
           working-directory: .
+          cache-electron: "true"
 
       - name: Type check
         timeout-minutes: 10
@@ -293,11 +299,12 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@e19a1a140ed1851a536fcc2cc116e9d3df6b0ce9 # v1.2.0
+        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
         timeout-minutes: 10
         with:
           node-version: 24.14.1
           working-directory: .
+          cache-electron: "true"
 
       - name: Test
         timeout-minutes: 20
@@ -315,11 +322,12 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@e19a1a140ed1851a536fcc2cc116e9d3df6b0ce9 # v1.2.0
+        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
         timeout-minutes: 10
         with:
           node-version: 24.14.1
           working-directory: .
+          cache-electron: "true"
 
       - name: Install ripgrep
         timeout-minutes: 5
@@ -424,10 +432,11 @@ jobs:
           lfs: true
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
         timeout-minutes: 10
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: Run desktop replay-backed Electron tests
         timeout-minutes: 10
@@ -488,10 +497,11 @@ jobs:
         # macOS runner and break a later job's checkout.
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
         timeout-minutes: 10
         with:
           node-version: 24.x
+          cache-electron: "true"
           lookup-only: "true"
 
   desktop-e2e-macos:
@@ -536,10 +546,11 @@ jobs:
         run: git lfs pull
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
         timeout-minutes: 10
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: Clear leftover Electron state from previous jobs
         # This runner is a persistent Tart guest, not a fresh VM per job, so a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -128,7 +128,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -196,7 +196,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -217,7 +217,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -252,7 +252,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.14.1
@@ -272,7 +272,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.14.1
@@ -299,7 +299,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.14.1
@@ -322,7 +322,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.14.1
@@ -432,7 +432,7 @@ jobs:
           lfs: true
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -497,7 +497,7 @@ jobs:
         # macOS runner and break a later job's checkout.
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -546,7 +546,7 @@ jobs:
         run: git lfs pull
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x


### PR DESCRIPTION
## Summary

- exercise pwrdrvr/configure-nodejs#11 from the `agent/cache-lifecycle-downloads` feature branch
- enable `cache-electron: "true"` on the Linux, Windows, and macOS dependency primers and every consumer behind those primers
- keep each OS/architecture group's action ref and cache-key inputs aligned so a cold lookup-only primer installs and saves once, then consumers restore the pnpm store plus both lifecycle download caches before postinstall

## Why

PwrAgent's pnpm cache does not cover downloads performed by Electron lifecycle scripts. A warm pnpm store can therefore still require network downloads for the Electron runtime and Electron-ABI native prebuilds during postinstall. configure-nodejs PR #11 adds an opt-in, workspace-local cache contract for those artifacts.

This consumer PR validates that contract in PwrAgent without adding home-directory cache paths, standalone cache actions, or changes outside the CI consumer workflow.

Upstream feature ref observed while preparing this PR:

- `pwrdrvr/configure-nodejs@agent/cache-lifecycle-downloads`
- `3965f6271554f90e56c13b0fa3fe880d5f5fb6b9`
- https://github.com/pwrdrvr/configure-nodejs/pull/11

## Jobs changed

- Linux/x64: `install-deps` primer; `lint`, `build`, `test`, and `desktop-e2e` consumers
- Windows/x64: `windows-install-deps` primer; `windows-verify`, `windows-desktop-main`, and `windows-renderer-packages` consumers
- macOS/ARM64: `macos-install-deps` primer; `desktop-e2e-macos` consumer

The independent label-gated Windows installer job is intentionally unchanged because it is not a consumer of the Windows dependency primer.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color -ignore 'label "pwrdrvr-macos" is unknown' .github/workflows/ci.yml`
- structural YAML assertion that every primer/consumer group uses the same action ref and cache-key inputs, each primer remains lookup-only, and every consumer depends on its platform primer
- `git diff --check`
- verified the configure-nodejs feature ref resolves to `3965f6271554f90e56c13b0fa3fe880d5f5fb6b9`
