### PR TITLE
fix(desktop): preserve questionnaire transcript activity

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1024,6 +1024,40 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    appendQuestionnaireActivity: async ({
+      backend,
+      threadId,
+      activity,
+    }: {
+      backend: AppServerBackendKind;
+      threadId: string;
+      activity: NonNullable<ThreadOverlayState["questionnaireActivityLog"]>[number];
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current: ThreadOverlayState = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      if (
+        (current.questionnaireActivityLog ?? []).some(
+          (entry) => entry.requestId === activity.requestId,
+        )
+      ) {
+        return current;
+      }
+      const nextLog = [
+        ...(current.questionnaireActivityLog ?? []),
+        activity,
+      ].sort((left, right) => left.createdAt - right.createdAt);
+      const next = {
+        ...current,
+        questionnaireActivityLog: nextLog,
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
   } as unknown as OverlayStoreLike;
 }
 
@@ -17236,6 +17270,113 @@ command = "pnpm dev"
           requestId: "approval-1",
         },
       },
+    });
+
+    unsubscribe();
+    await registry.close();
+  });
+
+  it("persists completed questionnaire answers with secret values redacted", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore,
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    const request: AppServerPendingRequestNotification = {
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "input-1",
+        requestId: "input-1",
+        questions: [
+          {
+            id: "public",
+            header: "Public",
+            question: "Breakfast?",
+            isOther: true,
+            options: null,
+          },
+          {
+            id: "secret",
+            header: "Secret",
+            question: "Token?",
+            isOther: true,
+            isSecret: true,
+            options: null,
+          },
+        ],
+      },
+    } as AppServerPendingRequestNotification;
+    const responsePromise = codexClient.emitRequest(request);
+    await waitForCondition(() => events.length === 1);
+
+    await registry.submitServerRequest({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      requestId: "input-1",
+      response: {
+        answers: {
+          public: {
+            answers: ["Moon Waffles"],
+          },
+          secret: {
+            answers: ["sk-secret"],
+          },
+        },
+      },
+    });
+
+    await expect(responsePromise).resolves.toEqual({
+      answers: {
+        public: {
+          answers: ["Moon Waffles"],
+        },
+        secret: {
+          answers: ["sk-secret"],
+        },
+      },
+    });
+    expect(events.map((event) => event.notification.method)).toEqual([
+      "item/tool/requestUserInput",
+      "serverRequest/resolved",
+      "thread/questionnaireActivity/updated",
+    ]);
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      questionnaireActivityLog: [
+        {
+          requestId: "input-1",
+          status: "submitted",
+          questions: [
+            {
+              id: "public",
+            },
+            {
+              id: "secret",
+              isSecret: true,
+            },
+          ],
+          answers: {
+            public: {
+              answers: ["Moon Waffles"],
+            },
+            secret: {
+              answers: ["[REDACTED]"],
+            },
+          },
+        },
+      ],
     });
 
     unsubscribe();

--- a/apps/desktop/src/main/__tests__/overlay-store-questionnaires.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-questionnaires.test.ts
@@ -1,0 +1,101 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: SqliteOverlayStore;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-questionnaire-test-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new SqliteOverlayStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("SqliteOverlayStore - questionnaire activity log", () => {
+  it("persists completed questionnaire answers across sqlite handles", async () => {
+    const activity = {
+      id: "questionnaire:request-1",
+      requestId: "request-1",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "input-1",
+      status: "submitted" as const,
+      createdAt: 2_000,
+      updatedAt: 2_000,
+      questions: [
+        {
+          id: "food",
+          header: "Food",
+          question: "What should breakfast feature?",
+          isOther: true,
+          options: [{ label: "Waffles", description: "Crisp and golden" }],
+        },
+        {
+          id: "token",
+          header: "Secret",
+          question: "What is the token?",
+          isOther: true,
+          isSecret: true,
+        },
+      ],
+      answers: {
+        food: { answers: ["Waffles"] },
+        token: { answers: ["[REDACTED]"] },
+      },
+    };
+    const first = await store.appendQuestionnaireActivity({
+      backend: "codex",
+      threadId: "thread-1",
+      activity,
+    });
+    const duplicate = await store.appendQuestionnaireActivity({
+      backend: "codex",
+      threadId: "thread-1",
+      activity,
+    });
+    expect(duplicate).toEqual(first);
+
+    stateDb.close();
+    const reopenedDb = StateDb.open(path.join(tempDir, "state.db"));
+    const reopenedStore = new SqliteOverlayStore(reopenedDb);
+
+    await expect(
+      reopenedStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      questionnaireActivityLog: [
+        {
+          requestId: "request-1",
+          status: "submitted",
+          updatedAt: 2_000,
+          questions: [
+            {
+              id: "food",
+            },
+            {
+              id: "token",
+              isSecret: true,
+            },
+          ],
+          answers: {
+            food: { answers: ["Waffles"] },
+            token: { answers: ["[REDACTED]"] },
+          },
+        },
+      ],
+    });
+
+    reopenedDb.close();
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -123,7 +123,9 @@ import {
   type CancelThreadExecutionModeQueueResponse,
   type ThreadMessagingBindingTransition,
   type ThreadPermissionTransition,
+  type ThreadQuestionnaireActivity,
   type ThreadTurnFailure,
+  type AppServerToolRequestUserInputNotification,
   type ThreadAgentMetadata,
   type MessagingThreadBindingSummary,
   DEFAULT_MOVE_THREAD_WORKSPACE_STRATEGY,
@@ -1425,6 +1427,7 @@ function normalizePositivePullRequestNumber(value: unknown): number | undefined 
 }
 
 type PendingServerRequest = {
+  notification: AppServerPendingRequestNotification;
   resolve: (response: SubmitServerRequestRequest["response"]) => void;
   reject: (error: Error) => void;
 };
@@ -2222,6 +2225,66 @@ function buildHeadlessAutomationRequestCancelResponse(
   }
 
   return { decision: "cancel" };
+}
+
+function questionnaireAnswerHasValue(answer: unknown): boolean {
+  if (!answer || typeof answer !== "object" || Array.isArray(answer)) {
+    return false;
+  }
+
+  const values = (answer as { answers?: unknown }).answers;
+  return (
+    Array.isArray(values) &&
+    values.some((value) => typeof value === "string" && value.trim().length > 0)
+  );
+}
+
+function sanitizeQuestionnaireResponseForOverlay(params: {
+  activity: ThreadQuestionnaireActivity;
+  response: unknown;
+}): AppServerToolRequestUserInputResponse["answers"] {
+  if (
+    !params.response ||
+    typeof params.response !== "object" ||
+    Array.isArray(params.response)
+  ) {
+    return {};
+  }
+  const rawAnswers = (params.response as { answers?: unknown }).answers;
+  if (!rawAnswers || typeof rawAnswers !== "object" || Array.isArray(rawAnswers)) {
+    return {};
+  }
+
+  const secretQuestionIds = new Set(
+    params.activity.questions
+      .filter((question) => question.isSecret === true)
+      .map((question) => question.id),
+  );
+  const sanitized: AppServerToolRequestUserInputResponse["answers"] = {};
+  for (const [questionId, rawAnswer] of Object.entries(
+    rawAnswers as Record<string, unknown>,
+  )) {
+    if (!rawAnswer || typeof rawAnswer !== "object" || Array.isArray(rawAnswer)) {
+      sanitized[questionId] = undefined;
+      continue;
+    }
+    const values = (rawAnswer as { answers?: unknown }).answers;
+    if (!Array.isArray(values)) {
+      sanitized[questionId] = undefined;
+      continue;
+    }
+    const answers = values
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+    sanitized[questionId] = {
+      answers:
+        secretQuestionIds.has(questionId) && answers.length > 0
+          ? ["[REDACTED]"]
+          : answers,
+    };
+  }
+  return sanitized;
 }
 
 function readStatusType(value: unknown): string | undefined {
@@ -11057,6 +11120,70 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private async recordQuestionnaireActivity(params: {
+    backend: AppServerBackendKind;
+    notification: AppServerToolRequestUserInputNotification;
+    response: SubmitServerRequestRequest["response"];
+  }): Promise<boolean> {
+    const notificationParams = params.notification.params;
+    const questions = Array.isArray(notificationParams.questions)
+      ? notificationParams.questions
+      : [];
+    if (questions.length === 0) {
+      return false;
+    }
+    const now = Date.now();
+    const pendingActivity: ThreadQuestionnaireActivity = {
+      id: `questionnaire:${notificationParams.requestId}`,
+      requestId: notificationParams.requestId,
+      threadId: notificationParams.threadId,
+      turnId: notificationParams.turnId,
+      itemId: notificationParams.itemId,
+      status: "pending",
+      questions: questions.map((question) => ({
+        id: question.id,
+        header: question.header,
+        question: question.question,
+        isOther: question.isOther,
+        isSecret: question.isSecret,
+        options:
+          question.options?.map((option) => ({
+            label: option.label,
+            description: option.description,
+          })) ?? undefined,
+      })),
+      createdAt: now,
+      updatedAt: now,
+    };
+    const answers = sanitizeQuestionnaireResponseForOverlay({
+      activity: pendingActivity,
+      response: params.response,
+    });
+    const hasAnswers = Object.values(answers).some(questionnaireAnswerHasValue);
+    const activity: ThreadQuestionnaireActivity = {
+      ...pendingActivity,
+      status: hasAnswers ? "submitted" : "cancelled",
+      answers,
+    };
+
+    try {
+      await this.overlayStore.appendQuestionnaireActivity({
+        backend: params.backend,
+        threadId: notificationParams.threadId,
+        activity,
+      });
+      return true;
+    } catch (error) {
+      backendRegistryLog.error("failed to record questionnaire activity", {
+        backend: params.backend,
+        error: error instanceof Error ? error.message : String(error),
+        requestId: notificationParams.requestId,
+        threadId: notificationParams.threadId,
+      });
+      return false;
+    }
+  }
+
   /**
    * Flush any queued permission-mode change for the given thread.
    * Called from two places:
@@ -11761,6 +11888,15 @@ export class DesktopBackendRegistry {
       throw new Error(`No pending server request found for ${params.requestId}`);
     }
 
+    const recordedQuestionnaire =
+      pending.notification.method === "item/tool/requestUserInput"
+        ? await this.recordQuestionnaireActivity({
+            backend: params.backend,
+            notification:
+              pending.notification as AppServerToolRequestUserInputNotification,
+            response: params.response,
+          })
+        : false;
     this.pendingServerRequests.delete(key);
     pending.resolve(params.response);
     await this.emit({
@@ -11774,6 +11910,18 @@ export class DesktopBackendRegistry {
         },
       },
     });
+    if (recordedQuestionnaire) {
+      await this.emit({
+        backend: params.backend,
+        notification: {
+          method: "thread/questionnaireActivity/updated",
+          params: {
+            threadId: params.threadId,
+            requestId: params.requestId,
+          },
+        },
+      });
+    }
 
     return {
       backend: params.backend,
@@ -11800,44 +11948,45 @@ export class DesktopBackendRegistry {
       threadId: params.threadId,
       requestId,
     });
+    const notification: AppServerPendingRequestNotification = {
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: params.threadId,
+        ...(params.turnId ? { turnId: params.turnId } : {}),
+        ...(params.itemId ? { itemId: params.itemId } : {}),
+        requestId,
+        questions: [
+          {
+            id: HANDOFF_CWD_TRUST_QUESTION_ID,
+            header: "Trust directory",
+            question: `Trust ${normalizedCwd} and allow Default Access agent threads to read, write, and delete files in it?`,
+            isOther: false,
+            isSecret: false,
+            options: [
+              {
+                label: HANDOFF_CWD_TRUST_APPROVE_LABEL,
+                description:
+                  "Trust this directory for future Default Access agent work.",
+              },
+              {
+                label: params.cancelLabel ?? "Cancel handoff",
+                description:
+                  params.cancelDescription ??
+                  "Do not add this directory or start the handoff.",
+              },
+            ],
+          },
+        ],
+      },
+    };
 
     const response = await new Promise<SubmitServerRequestRequest["response"]>(
       (resolve, reject) => {
-        this.pendingServerRequests.set(key, { resolve, reject });
+        this.pendingServerRequests.set(key, { notification, resolve, reject });
 
         void this.emit({
           backend: params.backend,
-          notification: {
-            method: "item/tool/requestUserInput",
-            params: {
-              threadId: params.threadId,
-              ...(params.turnId ? { turnId: params.turnId } : {}),
-              ...(params.itemId ? { itemId: params.itemId } : {}),
-              requestId,
-              questions: [
-                {
-                  id: HANDOFF_CWD_TRUST_QUESTION_ID,
-                  header: "Trust directory",
-                  question: `Trust ${normalizedCwd} and allow Default Access agent threads to read, write, and delete files in it?`,
-                  isOther: false,
-                  isSecret: false,
-                  options: [
-                    {
-                      label: HANDOFF_CWD_TRUST_APPROVE_LABEL,
-                      description:
-                        "Trust this directory for future Default Access agent work.",
-                    },
-                    {
-                      label: params.cancelLabel ?? "Cancel handoff",
-                      description:
-                        params.cancelDescription ??
-                        "Do not add this directory or start the handoff.",
-                    },
-                  ],
-                },
-              ],
-            },
-          },
+          notification,
         }).catch((error) => {
           backendRegistryLog.error(
             "failed to publish handoff cwd trust request; keeping request pending",
@@ -17935,7 +18084,7 @@ export class DesktopBackendRegistry {
     });
 
     return await new Promise<SubmitServerRequestRequest["response"]>((resolve, reject) => {
-      this.pendingServerRequests.set(key, { resolve, reject });
+      this.pendingServerRequests.set(key, { notification: request, resolve, reject });
 
       void this.emit({
         backend,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -25,6 +25,7 @@ import type {
   ThreadToolInvocationSummary,
   ThreadPermissionTransition,
   ThreadPricingSummary,
+  ThreadQuestionnaireActivity,
   ThreadSubAgentSummary,
   ThreadTurnFailure,
   ThreadUsageLineRecord,
@@ -36,6 +37,7 @@ import {
   MAX_MESSAGING_BINDING_TRANSITION_LOG_ENTRIES,
   MAX_IMMUTABLE_USAGE_ACTIVITY_ENTRIES,
   MAX_PERMISSION_TRANSITION_LOG_ENTRIES,
+  MAX_QUESTIONNAIRE_ACTIVITY_LOG_ENTRIES,
   MAX_TURN_FAILURE_LOG_ENTRIES,
   buildPullRequestStatusKey,
   buildThreadIdentityKey,
@@ -2278,6 +2280,38 @@ export class SqliteOverlayStore {
     return nextState;
   }
 
+  async appendQuestionnaireActivity(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    activity: ThreadQuestionnaireActivity;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const existing = current.questionnaireActivityLog ?? [];
+    if (existing.some((entry) => entry.requestId === params.activity.requestId)) {
+      return current;
+    }
+    const nextLog = [
+      ...existing,
+      params.activity,
+    ].sort((left, right) => left.createdAt - right.createdAt);
+    const trimmed =
+      nextLog.length > MAX_QUESTIONNAIRE_ACTIVITY_LOG_ENTRIES
+        ? nextLog.slice(nextLog.length - MAX_QUESTIONNAIRE_ACTIVITY_LOG_ENTRIES)
+        : nextLog;
+    const nextState: ThreadOverlayState = {
+      ...current,
+      questionnaireActivityLog: trimmed,
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
   async setThreadModelSettings(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;
@@ -3883,6 +3917,7 @@ export type OverlayStoreLike = Pick<
   | "appendPermissionTransition"
   | "appendMessagingBindingTransition"
   | "appendTurnFailure"
+  | "appendQuestionnaireActivity"
   | "getLaunchpadDefaults"
   | "setLaunchpadDefaults"
   | "getNavigationBrowseMode"

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2782,6 +2782,9 @@ export function ThreadView(props: ThreadViewProps) {
               messagingBindingTransitions={
                 selectedThread!.messagingBindingTransitionLog
               }
+              questionnaireActivities={
+                selectedThread!.questionnaireActivityLog
+              }
               turnFailures={selectedThread!.turnFailureLog}
               activeTurnId={props.activeTurnId}
               activeTurnStartedAt={props.activeTurnStartedAt}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -25,6 +25,7 @@ import type {
   PendingRequestApprovalFileContext,
   ThreadMessagingBindingTransition,
   ThreadPermissionTransition,
+  ThreadQuestionnaireActivity,
   ThreadTurnFailure,
   MarkdownFileViewerContext,
 } from "@pwragent/shared";
@@ -35,6 +36,7 @@ import {
 import { injectAutomationCards } from "./automation-card-entries";
 import { injectMessagingBindingTransitions } from "./messaging-binding-transition-entries";
 import { injectPermissionTransitions } from "./permission-transition-entries";
+import { injectQuestionnaireActivities } from "./questionnaire-activity-entries";
 import { injectTurnFailures } from "./turn-failure-entries";
 import type { DesktopApi } from "../../lib/desktop-api";
 import {
@@ -96,6 +98,7 @@ type TranscriptListProps = {
   pagination?: AppServerThreadReplayPagination;
   permissionTransitions?: ThreadPermissionTransition[];
   messagingBindingTransitions?: ThreadMessagingBindingTransition[];
+  questionnaireActivities?: ThreadQuestionnaireActivity[];
   turnFailures?: ThreadTurnFailure[];
   restoredViewport?: TranscriptViewport;
   reglueRequestKey?: number;
@@ -693,12 +696,15 @@ export function TranscriptList(props: TranscriptListProps) {
       insertPendingEntry(entries, pendingEntry);
     }
     return injectTurnFailures(
-      injectAutomationCards(
-        injectMessagingBindingTransitions(
-          injectPermissionTransitions(entries, props.permissionTransitions),
-          props.messagingBindingTransitions,
+      injectQuestionnaireActivities(
+        injectAutomationCards(
+          injectMessagingBindingTransitions(
+            injectPermissionTransitions(entries, props.permissionTransitions),
+            props.messagingBindingTransitions,
+          ),
+          automationCards,
         ),
-        automationCards,
+        props.questionnaireActivities,
       ),
       props.turnFailures,
     );
@@ -712,6 +718,7 @@ export function TranscriptList(props: TranscriptListProps) {
     props.pendingPlanEntry,
     props.messagingBindingTransitions,
     props.permissionTransitions,
+    props.questionnaireActivities,
     props.turnFailures,
   ]);
   const pendingApprovalContext = useMemo(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/questionnaire-activity-entries.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/questionnaire-activity-entries.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { AppServerThreadMessageEntry } from "@pwragent/shared";
+import { buildTranscriptRenderItems } from "../transcript-render-items";
+import { injectQuestionnaireActivities } from "../questionnaire-activity-entries";
+
+describe("questionnaire activity transcript entries", () => {
+  it("hydrates answered questionnaires into collapsed previous work", () => {
+    const finalAnswer: AppServerThreadMessageEntry = {
+      type: "message",
+      id: "final-1",
+      role: "assistant",
+      phase: "final",
+      text: "Breakfast is ready.",
+      createdAt: 3_000,
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        completedAt: 3_000,
+      },
+    };
+
+    const entries = injectQuestionnaireActivities([finalAnswer], [
+      {
+        id: "questionnaire:request-1",
+        requestId: "request-1",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        status: "submitted",
+        createdAt: 1_000,
+        updatedAt: 2_000,
+        questions: [
+          {
+            id: "food",
+            header: "Food",
+            question: "What should breakfast feature?",
+            isOther: true,
+          },
+          {
+            id: "drink",
+            header: "Drink",
+            question: "What should fill the cup?",
+            isOther: true,
+          },
+        ],
+        answers: {
+          food: { answers: ["Waffles"] },
+          drink: { answers: ["Coffee"] },
+        },
+      },
+    ]);
+
+    expect(entries[0]).toMatchObject({
+      type: "activity",
+      id: "questionnaire:request-1",
+      summary: "Questionnaire answered",
+      status: "completed",
+      details: [
+        {
+          label: "Submitted answers",
+          markdown:
+            "1. Food: What should breakfast feature?\nAnswer: Waffles\n\n2. Drink: What should fill the cup?\nAnswer: Coffee",
+        },
+      ],
+    });
+
+    const renderItems = buildTranscriptRenderItems({ entries });
+    expect(renderItems).toMatchObject([
+      {
+        type: "workPhaseGroup",
+        label: "Previous work",
+        entries: [
+          {
+            id: "questionnaire:request-1",
+          },
+        ],
+      },
+      {
+        type: "entry",
+        entry: finalAnswer,
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/questionnaire-activity-entries.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/questionnaire-activity-entries.ts
@@ -1,0 +1,128 @@
+import type {
+  AppServerThreadActivityEntry,
+  AppServerThreadEntry,
+  ThreadQuestionnaireActivity,
+} from "@pwragent/shared";
+
+export const QUESTIONNAIRE_ACTIVITY_ENTRY_PREFIX = "questionnaire:";
+
+export function buildQuestionnaireActivityEntries(
+  activities: ThreadQuestionnaireActivity[] | undefined,
+): AppServerThreadActivityEntry[] {
+  if (!activities || activities.length === 0) {
+    return [];
+  }
+  return activities.map((activity) => {
+    const completed =
+      activity.status === "submitted" || activity.status === "cancelled";
+    return {
+      type: "activity",
+      id: `${QUESTIONNAIRE_ACTIVITY_ENTRY_PREFIX}${activity.requestId}`,
+      summary: summarizeQuestionnaireActivity(activity),
+      createdAt: activity.updatedAt || activity.createdAt,
+      status: completed ? "completed" : "in_progress",
+      turn: activity.turnId
+        ? {
+            id: activity.turnId,
+            status: completed ? "completed" : "in_progress",
+            completedAt: completed ? activity.updatedAt : undefined,
+          }
+        : undefined,
+      details: [
+        {
+          id: `${QUESTIONNAIRE_ACTIVITY_ENTRY_PREFIX}${activity.requestId}:details`,
+          kind: "read",
+          label:
+            activity.status === "cancelled"
+              ? "Questionnaire cancelled"
+              : activity.status === "submitted"
+                ? "Submitted answers"
+                : "Questionnaire requested",
+          markdown: buildQuestionnaireMarkdown(activity),
+          status: completed ? "completed" : "in_progress",
+        },
+      ],
+    };
+  });
+}
+
+export function injectQuestionnaireActivities(
+  entries: AppServerThreadEntry[],
+  activities: ThreadQuestionnaireActivity[] | undefined,
+): AppServerThreadEntry[] {
+  const synthetic = buildQuestionnaireActivityEntries(activities);
+  if (synthetic.length === 0) {
+    return entries;
+  }
+  const existingIds = new Set(entries.map((entry) => entry.id));
+  const additions = synthetic.filter((entry) => !existingIds.has(entry.id));
+  if (additions.length === 0) {
+    return entries;
+  }
+  const merged: AppServerThreadEntry[] = [...entries, ...additions];
+  merged.sort((left, right) => {
+    const leftAt = left.createdAt ?? 0;
+    const rightAt = right.createdAt ?? 0;
+    if (leftAt !== rightAt) {
+      return leftAt - rightAt;
+    }
+    const leftIsQuestionnaire = left.id.startsWith(
+      QUESTIONNAIRE_ACTIVITY_ENTRY_PREFIX,
+    );
+    const rightIsQuestionnaire = right.id.startsWith(
+      QUESTIONNAIRE_ACTIVITY_ENTRY_PREFIX,
+    );
+    if (leftIsQuestionnaire === rightIsQuestionnaire) {
+      return 0;
+    }
+    return leftIsQuestionnaire ? 1 : -1;
+  });
+  return merged;
+}
+
+function summarizeQuestionnaireActivity(
+  activity: ThreadQuestionnaireActivity,
+): string {
+  if (activity.status === "cancelled") {
+    return "Questionnaire cancelled";
+  }
+  if (activity.status === "submitted") {
+    return "Questionnaire answered";
+  }
+  const count = activity.questions.length;
+  return `Asked ${count} ${count === 1 ? "question" : "questions"}`;
+}
+
+function buildQuestionnaireMarkdown(activity: ThreadQuestionnaireActivity): string {
+  const blocks = activity.questions.map((question, index) => {
+    const prompt = [
+      `${index + 1}. ${question.header}: ${question.question}`,
+      formatAnswerLine(activity, question.id),
+    ].filter(Boolean);
+    if (activity.status === "pending" && question.options?.length) {
+      prompt.push(
+        ...question.options.map((option) =>
+          option.description
+            ? `- ${option.label}: ${option.description}`
+            : `- ${option.label}`,
+        ),
+      );
+    }
+    return prompt.join("\n");
+  });
+  return blocks.join("\n\n");
+}
+
+function formatAnswerLine(
+  activity: ThreadQuestionnaireActivity,
+  questionId: string,
+): string | undefined {
+  if (activity.status === "pending") {
+    return undefined;
+  }
+  const answers = activity.answers?.[questionId]?.answers ?? [];
+  if (answers.length === 0) {
+    return activity.status === "cancelled" ? "Answer: Cancelled" : "Answer: None";
+  }
+  return `Answer: ${answers.join(", ")}`;
+}

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -904,7 +904,7 @@ describe("useThreadNavigation", () => {
     });
   });
 
-  it("coalesces repeated turn lifecycle notifications into one navigation refresh", async () => {
+  it("coalesces transcript-affecting notifications into one navigation refresh", async () => {
     const listeners = new Set<(event: any) => void>();
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,
@@ -957,7 +957,12 @@ describe("useThreadNavigation", () => {
     expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      for (const method of ["turn/completed", "turn/failed", "turn/cancelled"] as const) {
+      for (const method of [
+        "turn/completed",
+        "turn/failed",
+        "turn/cancelled",
+        "thread/questionnaireActivity/updated",
+      ] as const) {
         for (const listener of listeners) {
           listener({
             backend: "codex",

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -692,6 +692,13 @@ function messagingBindingTransitionLogsEqual(
   });
 }
 
+function questionnaireActivityLogsEqual(
+  left: NavigationThreadSummary["questionnaireActivityLog"],
+  right: NavigationThreadSummary["questionnaireActivityLog"]
+): boolean {
+  return JSON.stringify(left ?? []) === JSON.stringify(right ?? []);
+}
+
 function threadSummariesEqual(
   left: NavigationThreadSummary,
   right: NavigationThreadSummary
@@ -756,6 +763,10 @@ function threadSummariesEqual(
     messagingBindingTransitionLogsEqual(
       left.messagingBindingTransitionLog,
       right.messagingBindingTransitionLog
+    ) &&
+    questionnaireActivityLogsEqual(
+      left.questionnaireActivityLog,
+      right.questionnaireActivityLog
     )
   );
 }
@@ -3314,6 +3325,14 @@ export function useThreadNavigation(
         // thread overlay before broadcasting this event. Refresh so the
         // navigation snapshot carries `turnFailureLog` into the transcript;
         // without it the failure would never surface as a durable entry.
+        scheduleRefresh();
+        return;
+      }
+
+      if (method === "thread/questionnaireActivity/updated") {
+        // Completed questionnaire answers are persisted in the thread overlay
+        // because App Server replay does not include request-user-input items.
+        // Refresh so the sanitized Q/A summary appears in the transcript now.
         scheduleRefresh();
         return;
       }

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -106,6 +106,13 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
    * visible across reconciliation and restart.
    */
   turnFailureLog?: ThreadTurnFailure[];
+  /**
+   * Per-thread questionnaire audit log. Persisted via the overlay store
+   * and rendered as synthetic "Previous work" transcript activity so
+   * request-user-input interactions stay visible even when the backend
+   * rollout omits them from durable transcript items.
+   */
+  questionnaireActivityLog?: ThreadQuestionnaireActivity[];
   optimisticUserMessage?: {
     text: string;
     imageParts?: AppServerThreadImagePart[];
@@ -1394,6 +1401,14 @@ export type ThreadOverlayState = {
    * a synthetic `turn-failed:<turnId>` transcript activity entry.
    */
   turnFailureLog?: ThreadTurnFailure[];
+  /**
+   * Per-thread questionnaire audit log. Persisted to the overlay store,
+   * capped at `MAX_QUESTIONNAIRE_ACTIVITY_LOG_ENTRIES` (oldest-first
+   * eviction). Each entry records a request-user-input questionnaire and
+   * its terminal answer/cancel state so cross-surface input remains visible
+   * in the transcript after hydration.
+   */
+  questionnaireActivityLog?: ThreadQuestionnaireActivity[];
 };
 
 /**
@@ -1504,6 +1519,52 @@ export type ThreadTurnFailure = {
    * transcript entry timestamp so the warning lands where it happened.
    */
   occurredAt: number;
+};
+
+/**
+ * Maximum number of questionnaire interactions retained per thread.
+ * Kept separate from the other audit streams so a thread with many
+ * user-input turns does not evict permission or messaging history.
+ */
+export const MAX_QUESTIONNAIRE_ACTIVITY_LOG_ENTRIES = 100;
+
+export type ThreadQuestionnaireActivityStatus =
+  | "pending"
+  | "submitted"
+  | "cancelled";
+
+export type ThreadQuestionnaireActivityQuestion = {
+  id: string;
+  header: string;
+  question: string;
+  isOther: boolean;
+  isSecret?: boolean;
+  options?: Array<{
+    label: string;
+    description?: string;
+  }>;
+};
+
+export type ThreadQuestionnaireActivityAnswer = {
+  answers: string[];
+};
+
+/**
+ * One entry in the per-thread questionnaire audit log. `requestId`
+ * is the durable deduplication key. Answers are already redacted for
+ * secret questions before they are persisted here.
+ */
+export type ThreadQuestionnaireActivity = {
+  id: string;
+  requestId: string;
+  threadId: ThreadIdentifier;
+  turnId?: string;
+  itemId?: string;
+  status: ThreadQuestionnaireActivityStatus;
+  questions: ThreadQuestionnaireActivityQuestion[];
+  answers?: Record<string, ThreadQuestionnaireActivityAnswer | undefined>;
+  createdAt: number;
+  updatedAt: number;
 };
 
 export type ThreadBranchDriftPair = {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1091,6 +1091,13 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "thread/questionnaireActivity/updated";
+      params: {
+        threadId: string;
+        requestId: string;
+      };
+    }
+  | {
       method: "thread/tokenUsage/updated";
       params: {
         threadId: string;

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -230,6 +230,7 @@ export function materializeNavigationThreads(params: {
       permissionTransitionLog: overlay?.permissionTransitionLog,
       messagingBindingTransitionLog: overlay?.messagingBindingTransitionLog,
       turnFailureLog: overlay?.turnFailureLog,
+      questionnaireActivityLog: overlay?.questionnaireActivityLog,
       model: overlay?.model ?? thread.model,
       reasoningEffort: overlay?.reasoningEffort ?? thread.reasoningEffort,
       modelMigrationRevision: overlay?.modelMigrationRevision,
@@ -406,6 +407,39 @@ export function buildNavigationSnapshotHash(params: {
         error: entry.error,
         occurredAt: entry.occurredAt,
       })),
+      questionnaireActivityLog: (thread.questionnaireActivityLog ?? []).map(
+        (entry) => ({
+          id: entry.id,
+          requestId: entry.requestId,
+          threadId: entry.threadId,
+          turnId: entry.turnId ?? null,
+          itemId: entry.itemId ?? null,
+          status: entry.status,
+          createdAt: entry.createdAt,
+          updatedAt: entry.updatedAt,
+          questions: entry.questions.map((question) => ({
+            id: question.id,
+            header: question.header,
+            question: question.question,
+            isOther: question.isOther,
+            isSecret: question.isSecret ?? null,
+            options: (question.options ?? []).map((option) => ({
+              label: option.label,
+              description: option.description ?? null,
+            })),
+          })),
+          answers: Object.fromEntries(
+            Object.entries(entry.answers ?? {}).map(([questionId, answer]) => [
+              questionId,
+              answer
+                ? {
+                    answers: answer.answers,
+                  }
+                : null,
+            ]),
+          ),
+        }),
+      ),
       model: thread.model ?? null,
       reasoningEffort: thread.reasoningEffort ?? null,
       serviceTier: thread.serviceTier ?? null,


### PR DESCRIPTION
## Summary

- Backport the durable, sanitized questionnaire transcript activity from #1520 to the 1.0 release branch.
- Completed `request_user_input` prompts and answers now survive refresh/restart, redact secret values, deduplicate by request ID, and render in Previous work.

## Provenance

- Source PR: #1520
- Source squash commit on `main`: `371f6e012eebfbd75bea08e56f0e1c56ab9142f1`

## 1.0 adaptation

- The source squash commit did not apply cleanly because `releases/1.0` predates native-subagent, Codex recovery, and SQLite write-metrics work. This backport retains only the questionnaire feature.
- `main` source dependency #1383 (`d7add7cd972a9982ae7f022f5b25106c24c4bd63`) stores the original pending-request notification. It is not on `releases/1.0`; this backport includes only the minimal equivalent record field needed to identify submitted questionnaires.
- Omitted the source's SQLite write-metrics test and budget fixture because that harness is absent from `releases/1.0`.
- No SQLite schema/database migration is introduced; questionnaire activity remains in the existing overlay payload.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/overlay-store-questionnaires.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/questionnaire-activity-entries.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (497 passed)
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
- `pnpm lint:eslint` (0 errors; existing warnings remain)
- `pnpm lint:boundaries`
- `pnpm typecheck`
- `pnpm --filter @pwragent/desktop build`
