### PR TITLE
ci: backport lifecycle cache to 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         timeout-minutes: 10
         with:
           node-version: 24.x
+          cache-electron: "true"
           lookup-only: "true"
 
   lint:
@@ -49,6 +50,7 @@ jobs:
         timeout-minutes: 10
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: License metadata
         timeout-minutes: 10
@@ -102,6 +104,7 @@ jobs:
         timeout-minutes: 10
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: Build
         timeout-minutes: 10
@@ -121,6 +124,7 @@ jobs:
         timeout-minutes: 10
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: Install ripgrep
         uses: ./.github/actions/install-ripgrep
@@ -246,6 +250,7 @@ jobs:
         timeout-minutes: 10
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: Run desktop replay-backed Electron tests
         timeout-minutes: 10
@@ -314,6 +319,7 @@ jobs:
         timeout-minutes: 10
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: Install ripgrep
         if: steps.changes.outputs.relevant == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,10 @@ jobs:
           persist-credentials: false
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@7c109865ae9af59c6fcd2f2a0e8cc851f6ded26a # v1
+        uses: pwrdrvr/configure-nodejs@v1
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: Check release metadata
         env:
@@ -177,9 +178,10 @@ jobs:
           persist-credentials: false
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@7c109865ae9af59c6fcd2f2a0e8cc851f6ded26a # v1
+        uses: pwrdrvr/configure-nodejs@v1
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: Check release metadata
         env:


### PR DESCRIPTION
## Summary

- Backport the Electron lifecycle-download cache opt-in from source PR #1548 to `releases/1.0`.
- Add `cache-electron: "true"` to every existing POSIX `pwrdrvr/configure-nodejs@v1` CI primer and consumer, plus the macOS release-preparation and Linux-package jobs.
- Leave the 1.0 Windows setup action unchanged; that workflow documents `configure-nodejs` as POSIX-only.

## Source

- Source PR: #1548
- Source squash commit: `7c92351a12530d9c973432a390ba0036ba037df7`

## Adaptation

The source squash could not apply cleanly because `releases/1.0` has a simpler CI layout with no main-only Windows dependency primer/consumer split or macOS E2E jobs. This backport applies the same cache contract to 1.0's six existing POSIX CI action calls, then updates its two older pinned release-workflow calls to the released `@v1` action and opts them in too.

`pwrdrvr/configure-nodejs@v1` is already used by the branch. The released `v1` ref currently resolves to the `v1.4.0` release commit (`e1bd1cc1494a20f0ee91dae622b0d2523b6fb53c`), which includes the opt-in `cache-electron` input. No action tags or releases were changed.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color .github/workflows/ci.yml .github/workflows/release.yml`
- Structural workflow checks: all six POSIX CI action calls opt in; the lookup-only primer and consumer dependencies remain intact; the Windows action remains untouched; both release calls use `@v1` and opt in.
- `git diff --check`

No application code, SQLite files, database migrations, or schema changes are included.
