### PR TITLE
ci: cache Electron downloads in packaging workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,11 +359,12 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@e19a1a140ed1851a536fcc2cc116e9d3df6b0ce9 # v1.2.0
+        uses: pwrdrvr/configure-nodejs@e1bd1cc1494a20f0ee91dae622b0d2523b6fb53c # v1.4.0
         timeout-minutes: 15
         with:
           node-version: 24.14.1
           working-directory: .
+          cache-electron: "true"
 
       - name: Prepare Windows installer signing input
         timeout-minutes: 25

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -21,6 +21,7 @@ jobs:
         uses: pwrdrvr/configure-nodejs@v1
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: Compute preview version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,10 @@ jobs:
           persist-credentials: false
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@e19a1a140ed1851a536fcc2cc116e9d3df6b0ce9 # v1.2.0
+        uses: pwrdrvr/configure-nodejs@e1bd1cc1494a20f0ee91dae622b0d2523b6fb53c # v1.4.0
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: Check release metadata
         env:
@@ -187,9 +188,10 @@ jobs:
           persist-credentials: false
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@e19a1a140ed1851a536fcc2cc116e9d3df6b0ce9 # v1.2.0
+        uses: pwrdrvr/configure-nodejs@e1bd1cc1494a20f0ee91dae622b0d2523b6fb53c # v1.4.0
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: Check release metadata
         env:
@@ -229,10 +231,11 @@ jobs:
           persist-credentials: false
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@e19a1a140ed1851a536fcc2cc116e9d3df6b0ce9 # v1.2.0
+        uses: pwrdrvr/configure-nodejs@e1bd1cc1494a20f0ee91dae622b0d2523b6fb53c # v1.4.0
         with:
           node-version: 24.14.1
           working-directory: .
+          cache-electron: "true"
 
       - name: Prepare Windows release stage
         run: node apps/desktop/scripts/release.mjs --win --prepare-only


### PR DESCRIPTION
## Summary

- advance the four remaining exact `configure-nodejs` v1.2.0 pins to the published v1.4.0 commit
- enable `cache-electron: "true"` in the label-gated Windows installer, preview build, and macOS/Linux/Windows release preparation jobs
- preserve exact-SHA pinning in release-sensitive workflows while retaining floating `@v1` in the existing preview workflow

## Why

PR #1548 enabled lifecycle download caching in the dependency primers and their CI consumers, but five independent packaging/release invocation sites remained outside that change. Those jobs install the same Electron application dependencies and otherwise continue missing the workspace-local Electron runtime and native-prebuild caches added in configure-nodejs v1.4.0.

After this change, all 16 configure-nodejs invocations in PwrAgent set `cache-electron: "true"`.

## Scope

- `.github/workflows/ci.yml`: label-gated Windows installer
- `.github/workflows/preview-build.yml`: macOS preview DMG
- `.github/workflows/release.yml`: macOS preparation, Linux DEB matrix, and Windows preparation

No release was triggered and no tags were changed.

## Validation

- verified both `configure-nodejs@v1` and dereferenced `v1.4.0` resolve to `e1bd1cc1494a20f0ee91dae622b0d2523b6fb53c`
- `actionlint` v1.7.12 on all three changed workflows, suppressing only the repository's known custom `pwrdrvr-macos` runner-label warning
- structural assertion that all 16 configure-nodejs workflow invocations opt in, the four exact pins use the v1.4.0 commit, and the remaining 12 use `@v1`
- confirmed zero stale v1.2.0 or feature-branch references
- `git diff --check`
