### PR TITLE
ci: align 1.0 platform test lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         timeout-minutes: 10
+        with:
+          sparse-checkout: |
+            **/package.json
+            .npmrc
+            .pnpmfile.cjs
+            pnpm-lock.yaml
+            pnpm-workspace.yaml
+            apps/desktop/scripts/ensure-electron-runtime.mjs
+            apps/desktop/scripts/rebuild-native-for-electron.mjs
+          sparse-checkout-cone-mode: false
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
@@ -134,28 +144,50 @@ jobs:
         timeout-minutes: 10
         run: pnpm run test
 
-  windows:
-    name: Windows (build + test)
+  windows-install-deps:
+    name: Setup Windows Dependencies
     runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        timeout-minutes: 10
+        with:
+          sparse-checkout: |
+            **/package.json
+            .npmrc
+            .pnpmfile.cjs
+            pnpm-lock.yaml
+            pnpm-workspace.yaml
+            apps/desktop/scripts/ensure-electron-runtime.mjs
+            apps/desktop/scripts/rebuild-native-for-electron.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Install Node.js and dependencies
+        uses: pwrdrvr/configure-nodejs@v1
+        timeout-minutes: 10
+        with:
+          node-version: 24.14.1
+          working-directory: .
+          cache-electron: "true"
+          lookup-only: "true"
+
+  windows-verify:
+    name: Windows verify
+    runs-on: windows-latest
+    needs: windows-install-deps
     timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         timeout-minutes: 10
 
-      # pwrdrvr/configure-nodejs is POSIX-only, so use a Windows-specific
-      # setup action that activates the repo-pinned pnpm through Corepack.
-      - name: Setup Node.js and pnpm
-        uses: ./.github/actions/configure-windows-nodejs
+      - name: Install Node.js and dependencies
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
-
-      - name: Install dependencies
-        timeout-minutes: 15
-        run: pnpm install --frozen-lockfile
-
-      - name: Install ripgrep
-        timeout-minutes: 5
-        uses: ./.github/actions/install-ripgrep
+        with:
+          node-version: 24.14.1
+          working-directory: .
+          cache-electron: "true"
 
       - name: Type check
         timeout-minutes: 10
@@ -165,9 +197,59 @@ jobs:
         timeout-minutes: 15
         run: pnpm run build
 
+  windows-desktop-main:
+    name: Windows desktop-main
+    runs-on: windows-latest
+    needs: windows-install-deps
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        timeout-minutes: 10
+
+      - name: Install Node.js and dependencies
+        uses: pwrdrvr/configure-nodejs@v1
+        timeout-minutes: 10
+        with:
+          node-version: 24.14.1
+          working-directory: .
+          cache-electron: "true"
+
       - name: Test
         timeout-minutes: 20
-        run: pnpm run test
+        run: pnpm exec vitest run --config vitest.workspace.ts --project desktop-main
+
+  windows-renderer-packages:
+    name: Windows renderer + packages
+    runs-on: windows-latest
+    needs: windows-install-deps
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        timeout-minutes: 10
+
+      - name: Install Node.js and dependencies
+        uses: pwrdrvr/configure-nodejs@v1
+        timeout-minutes: 10
+        with:
+          node-version: 24.14.1
+          working-directory: .
+          cache-electron: "true"
+
+      - name: Install ripgrep
+        timeout-minutes: 5
+        uses: ./.github/actions/install-ripgrep
+
+      - name: Test
+        timeout-minutes: 20
+        run: >-
+          pnpm exec vitest run --config vitest.workspace.ts
+          --project desktop-renderer
+          --project agent-core
+          --project grok-app-server
+          --project messaging
+          --project shared
 
   windows-package:
     name: Windows installer (label-gated)
@@ -236,14 +318,27 @@ jobs:
           retention-days: 7
 
   desktop-e2e:
-    name: Desktop E2E
+    name: Linux Desktop E2E (lane ${{ matrix.lane }} of 2)
     runs-on: ubuntu-latest
     needs: install-deps
+    strategy:
+      # GitHub-hosted Linux capacity can run both halves concurrently. Keep
+      # the other shard running after a failure so its artifacts still show
+      # whether the failure is isolated or suite-wide.
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        lane: [1, 2]
     timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         timeout-minutes: 10
+        # macOS visual baselines are LFS objects. The Linux suite currently
+        # skips that platform-specific visual spec, but fetching them here
+        # keeps checkout behavior ready for future Linux coverage too.
+        with:
+          lfs: true
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
@@ -254,14 +349,148 @@ jobs:
 
       - name: Run desktop replay-backed Electron tests
         timeout-minutes: 10
-        run: xvfb-run --auto-servernum pnpm run test:desktop-e2e
+        run: >-
+          xvfb-run --auto-servernum
+          pnpm --filter @pwragent/desktop test:e2e
+          --shard=${{ matrix.lane }}/2
 
       - name: Upload desktop Playwright artifacts
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         timeout-minutes: 10
         with:
-          name: desktop-e2e-artifacts
+          name: desktop-e2e-linux-lane-${{ matrix.lane }}-artifacts
+          path: |
+            apps/desktop/playwright-report/
+            apps/desktop/test-results/
+          retention-days: 30
+
+  desktop-e2e-result:
+    # Preserve the required status-check context while the work runs as two
+    # independently named matrix jobs. `always()` is required so a failed
+    # lane reaches this job and cannot turn the aggregate check into a skip.
+    name: Desktop E2E
+    runs-on: ubuntu-latest
+    needs: desktop-e2e
+    if: always()
+    timeout-minutes: 5
+    steps:
+      - name: Require both Linux Desktop E2E lanes
+        env:
+          LINUX_E2E_RESULT: ${{ needs.desktop-e2e.result }}
+        run: |
+          if [[ "$LINUX_E2E_RESULT" != "success" ]]; then
+            echo "Linux Desktop E2E matrix result: $LINUX_E2E_RESULT"
+            exit 1
+          fi
+
+  macos-install-deps:
+    name: Setup macOS Dependencies
+    # Keep the same fork guard as the macOS E2E consumer. A public fork must
+    # never execute arbitrary code on the self-hosted runner.
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: [self-hosted, macOS, ARM64, pwrdrvr-macos]
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        timeout-minutes: 10
+        # Keep this checkout full: sparse state can persist on the self-hosted
+        # macOS runner and break a later job's checkout.
+
+      - name: Install Node.js and dependencies
+        uses: pwrdrvr/configure-nodejs@v1
+        timeout-minutes: 10
+        with:
+          node-version: 24.x
+          cache-electron: "true"
+          lookup-only: "true"
+
+  desktop-e2e-macos:
+    name: macOS Desktop E2E (lane ${{ matrix.lane }} of 2)
+    # The restricted PwrDrvr organization runner group exposes this label only
+    # to PwrAgent and PwrSnap. The host Tart VM runs Electron on its virtual
+    # display, so neither CI nor manual test work takes over an operator's Mac.
+    #
+    # Never relax this fork guard: a public fork must not execute arbitrary
+    # code on a self-hosted machine, even when the VM is softnet-isolated.
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: [self-hosted, macOS, ARM64, pwrdrvr-macos]
+    needs: macos-install-deps
+    strategy:
+      # Keep both lab VMs busy when they are idle, while avoiding a third
+      # queued lane when one is already serving another job. Do not cancel the
+      # other shard on failure: its artifacts can distinguish a real failure
+      # from a flaky one and make the follow-up rerun smaller.
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        lane: [1, 2]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        timeout-minutes: 10
+        with:
+          lfs: true
+
+      - name: Materialize Git LFS assets
+        # These jobs reuse persistent runner workspaces. A previous checkout
+        # can leave an LFS pointer at an unchanged path, and checkout --force
+        # does not necessarily rewrite it after fetching the LFS object.
+        # Pull explicitly so Playwright always receives PNG bytes rather than
+        # the pointer text, even when this runner served another job first.
+        timeout-minutes: 5
+        run: git lfs pull
+
+      - name: Install Node.js and dependencies
+        uses: pwrdrvr/configure-nodejs@v1
+        timeout-minutes: 10
+        with:
+          node-version: 24.x
+          cache-electron: "true"
+
+      - name: Clear leftover Electron state from previous jobs
+        # This runner is a persistent Tart guest, not a fresh VM per job, so a
+        # previous job's leaked Electron tree and its macOS saved application
+        # state both survive into this one. The saved state is the harmful
+        # half: after an abnormal exit AppKit puts up a modal "unexpectedly
+        # quit while reopening windows" alert before any window exists, which
+        # is exactly how this lane times out having run 0 tests. Force-killing
+        # an orphan is itself what arms that alert, so the reap and the state
+        # clearing ship together. The step always reports what it found (zero
+        # included) so the log carries evidence next time. Process matching is
+        # scoped to this runner's own workspace: the guest is shared with
+        # PwrSnap and with operator work, and neither may become collateral.
+        # Windows lanes are GitHub-hosted (fresh VM per job), so they need no
+        # equivalent.
+        shell: bash
+        timeout-minutes: 5
+        run: bash ./scripts/ci/macos-e2e-pre-run-cleanup.sh
+
+      - name: Run desktop replay-backed Electron tests
+        # Tart's AppleParavirtGPU can reset under Electron load. The early
+        # PWRAGENT_E2E_DISABLE_GPU gate selects software rendering before
+        # Electron initializes, while ordinary host E2E keeps GPU coverage.
+        timeout-minutes: 20
+        env:
+          PWRAGENT_E2E_DISABLE_GPU: "1"
+        run: >-
+          pnpm --filter @pwragent/desktop test:e2e
+          --shard=${{ matrix.lane }}/2
+
+      - name: Upload macOS Playwright artifacts
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        timeout-minutes: 10
+        with:
+          name: desktop-e2e-macos-lane-${{ matrix.lane }}-artifacts
           path: |
             apps/desktop/playwright-report/
             apps/desktop/test-results/

--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -512,12 +512,14 @@ test("thread environment Run command uses the current cwd after workspace handof
             const runs = thread?.codexEnvironmentRuntime?.actionRuns ?? [];
             // Take the most recently started run's status, which is the
             // one the Run-button click just kicked off. (Multi-instance
-            // refactor: see PR #505.)
+            // refactor: see PR #505.) This action is intentionally short,
+            // so assert its stable terminal state instead of racing to
+            // observe the transient "started" state.
             return runs.at(-1)?.status ?? "missing";
           }),
         { timeout: 5_000 },
       )
-      .toBe("started");
+      .toBe("exited");
     await expect
       .poll(
         async () =>

--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -774,6 +774,10 @@ test("new-thread picker starts a newly added directory in local checkout by defa
     await app.window.getByRole("button", { name: /^(Project:|Choose a project)/ }).click();
     await app.window.getByRole("button", { name: /Add directory/ }).click();
 
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "PickedRepo" }),
+    ).toBeVisible();
+
     const settings = app.window.getByLabel("New thread settings");
     const workspaceMode = settings.getByLabel("Workspace mode");
     await expect(workspaceMode).toBeEnabled();

--- a/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
+++ b/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
@@ -37,19 +37,6 @@ async function getActiveOptionIndex(
   );
 }
 
-async function seedComposerDraft(input: Locator, value: string): Promise<void> {
-  await input.evaluate((element, nextValue) => {
-    const editor = element as HTMLElement & {
-      setSelectionRange: (start: number, end: number) => void;
-      value: string;
-    };
-    editor.value = nextValue;
-    editor.dispatchEvent(new Event("change", { bubbles: true }));
-    editor.setSelectionRange(nextValue.length, nextValue.length);
-  }, value);
-  await input.focus();
-}
-
 test("thread reply Tiptap skill autocomplete filters and commits the reported multi-line draft", async () => {
   const app = await launchElectronApp({
     fixturePath,
@@ -65,10 +52,23 @@ test("thread reply Tiptap skill autocomplete filters and commits the reported mu
     const tiptapInput = app.window.getByTestId("composer-tiptap-input");
     const textbox = app.window.getByRole("textbox", { name: "Reply" });
     await textbox.fill(reportedDraftPrefix);
-    await textbox.focus();
-    await app.window.keyboard.press("End");
+    await expect(tiptapInput).toHaveAttribute("data-value", /Let's use $/);
     const seededDraft = await tiptapInput.getAttribute("data-value");
-    expect(seededDraft).toMatch(/Let's use $/);
+    expect(seededDraft).toBeTruthy();
+    await textbox.focus();
+    const selectionRange = await textbox.evaluate((element, selectionIndex) => {
+      const editor = element as HTMLElement & {
+        selectionEnd: number;
+        selectionStart: number;
+        setSelectionRange: (start: number, end: number) => void;
+      };
+      editor.setSelectionRange(selectionIndex, selectionIndex);
+      return [editor.selectionStart, editor.selectionEnd];
+    }, seededDraft!.length);
+    expect(selectionRange).toEqual([
+      seededDraft!.length,
+      seededDraft!.length,
+    ]);
 
     await app.window.keyboard.type("$ce");
     await expect(app.window.getByRole("listbox", { name: "Skills" })).toBeVisible();

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2282,13 +2282,14 @@ describe("app server ipc", () => {
       state: "passing",
       url: "https://github.com/pwrdrvr/PwrAgent/pull/922",
     });
+    const fetchedAt = Date.now();
     readPrLookupCache.mockResolvedValueOnce({
       [lookupKey]: {
         lookupKey,
         provider: "github.com",
         branch: "feat/cached-detached-pr",
         directoryPaths: ["/repo"],
-        fetchedAt: Date.now(),
+        fetchedAt,
         prs: [detachedPr, cachedPr],
       },
     });
@@ -2299,7 +2300,7 @@ describe("app server ipc", () => {
       extraLinkedDirectories: [],
       detachedPrKeys: ["github.com/pwrdrvr/pwragent#921"],
       prs: [previousPr],
-      prsFetchedAt: Date.now() - 120_000,
+      prsFetchedAt: fetchedAt - 120_000,
       prsRefreshKey: "old-refresh-key",
     });
     setThreadPullRequests.mockResolvedValueOnce({
@@ -2308,7 +2309,7 @@ describe("app server ipc", () => {
       executionMode: "default",
       extraLinkedDirectories: [],
       prs: [previousPr, cachedPr],
-      prsFetchedAt: Date.now(),
+      prsFetchedAt: fetchedAt,
       prsRefreshKey: requestKey,
     });
 

--- a/scripts/ci/macos-e2e-pre-run-cleanup.sh
+++ b/scripts/ci/macos-e2e-pre-run-cleanup.sh
@@ -1,0 +1,405 @@
+#!/usr/bin/env bash
+# Clear the two kinds of state a previous job leaves behind on the persistent
+# macOS E2E guest: orphaned Electron process trees, and macOS saved
+# application state for the Electron bundle. Report what was found either way.
+#
+# The macOS Desktop E2E lane runs on a persistent Tart guest, not a fresh VM
+# per job, so anything a previous job left behind survives into the next one.
+# The E2E fixture's teardown (apps/desktop/e2e/fixtures/electron-app.ts)
+# routinely falls back from a graceful close to killProcessTree plus a fixed
+# one-second wait, and that wait is not proof of reaping: Electron helper
+# processes can outlive the main pid.
+#
+# Of the two, the saved application state is the one tied to an observed
+# failure — see clear_saved_application_state below. The process reap is
+# hygiene: a healthy runner starts a job with zero leftovers, so a non-zero
+# count is evidence worth surfacing, and starting a job with orphans is wrong
+# regardless. Note that force-killing an Electron is itself what creates the
+# saved-state trigger, so the reap must not ship without the state clearing.
+#
+# Scope, because this machine is shared:
+#   * The runner group is shared with PwrSnap, and an operator may be working
+#     on the guest. A bare `pkill -f Electron` would take out their work.
+#   * Only processes whose command line lives under this runner's own
+#     RUNNER_WORKSPACE are eligible. A runner executes one job at a time, so
+#     everything matching that path at pre-run time is a leftover, and nothing
+#     belonging to PwrSnap or to the operator can match it.
+#   * Electron found elsewhere on the guest is counted for the log and left
+#     completely alone.
+#   * This script runs before the lane launches anything, and it excludes its
+#     own process tree, so it cannot kill the current job's processes.
+#   * Every pid is re-checked against the scope immediately before it is
+#     signalled, so a pid that exits and gets recycled between the scan and
+#     the kill cannot be hit by mistake.
+#
+# Test seams (see macos-e2e-pre-run-cleanup.test.mjs):
+#   REAP_PS_SNAPSHOT_FILE  Read the process table from this file instead of
+#                          running ps. Forces report-only mode: with an
+#                          injected table the script signals nothing.
+#   REAP_SELF_PID          Override the pid used for self-exclusion.
+#   REAP_STATE_HOME        Look for saved application state under this
+#                          directory instead of $HOME, and never touch
+#                          cfprefsd defaults. Lets the destructive delete run
+#                          against a throwaway tree under test; without it a
+#                          report-only run deletes nothing at all.
+
+set -euo pipefail
+
+# Log prefix on every line, so the step's output is greppable in a job log.
+LOG="macos-e2e-cleanup"
+
+# The E2E suite runs the unsigned dev Electron binary, whose bundle id is
+# com.github.Electron (node_modules/electron/dist/Electron.app). The packaged
+# PwrAgent id is not listed: this lane never launches it.
+ELECTRON_BUNDLE_IDS=("com.github.Electron")
+
+# `RUNNER_WORKSPACE` is <runner>/_work/<repo>; GITHUB_WORKSPACE is the checkout
+# beneath it. Prefer the former so a leftover from a previous job's build
+# directory still matches, and refuse to run rather than guess a kill scope.
+scope="${RUNNER_WORKSPACE:-${GITHUB_WORKSPACE:-}}"
+if [[ -z "$scope" ]]; then
+  echo "$LOG: neither RUNNER_WORKSPACE nor GITHUB_WORKSPACE is set;" >&2
+  echo "$LOG: refusing to guess a kill scope on a shared machine." >&2
+  exit 1
+fi
+# Anchor the scope with a trailing slash. A bare substring test would also
+# match a sibling workspace that merely shares the prefix (`_work/PwrAgent2`
+# against a scope of `_work/PwrAgent`).
+scope="${scope%/}"
+scope_prefix="$scope/"
+
+# Electron main, every helper, and the crashpad handler all carry
+# /Electron.app/ in argv[0], because the framework lives inside the bundle and
+# the bundle lives under node_modules. That marker plus the scope prefix
+# identify exactly this lane's E2E processes.
+marker="/Electron.app/"
+
+self_pid="${REAP_SELF_PID:-$$}"
+injected_table="${REAP_PS_SNAPSHOT_FILE:-}"
+
+# Spell the template out rather than using `mktemp -t NAME`. BSD mktemp
+# appends the X's for you; GNU mktemp treats the argument as the template and
+# fails with "too few X's". The script only ever runs for real on macOS, but
+# its unit tests run on every platform's Test job.
+tmp_root="${TMPDIR:-/tmp}"
+tmp_root="${tmp_root%/}"
+snapshot_file=$(mktemp "$tmp_root/macos-e2e-cleanup.XXXXXXXX")
+matches_file=$(mktemp "$tmp_root/macos-e2e-cleanup-matches.XXXXXXXX")
+trap 'rm -f "$snapshot_file" "$matches_file"' EXIT
+
+summary() {
+  [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+  printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"
+}
+
+# Classify the current process table into `$matches_file`. Emits one
+# `pid|ppid|state|etime|command` line per in-scope orphan, then a final
+# `OUTSIDE_SCOPE|<count>` line for Electron seen elsewhere on the guest.
+scan() {
+  if [[ -n "$injected_table" ]]; then
+    cat "$injected_table" >"$snapshot_file"
+  else
+    # -ww keeps full argument vectors; the helper processes are identified by
+    # the framework path in argv[0], which would otherwise be truncated.
+    ps -Awwo pid=,ppid=,state=,etime=,command= >"$snapshot_file"
+  fi
+
+  # The marker and the scope both travel through the environment rather than
+  # as awk arguments: awk's own command line is in the very table it is
+  # classifying, so a marker plus a scope in argv would make awk match itself.
+  # The process-tree exclusion below would still catch it, but a self-match is
+  # not a thing to leave one guard away from.
+  REAP_MARKER="$marker" REAP_SCOPE_PREFIX="$scope_prefix" \
+  awk -v self="$self_pid" '
+    # True when `pid` sits anywhere beneath this script in the process tree.
+    function descends_from_self(pid,   walked) {
+      while (pid > 1) {
+        if (pid == self) return 1
+        if (pid in walked) return 0
+        walked[pid] = 1
+        if (!(pid in parent)) return 0
+        pid = parent[pid]
+      }
+      return 0
+    }
+    # The Electron bundle path itself must live under this workspace. Testing
+    # the whole command line for the scope would also match a foreign Electron
+    # that merely mentions this checkout in an argument, and testing only
+    # argv[0] would miss a bundle launched through a wrapper. So: some single
+    # argument has to both start with the scope and name the bundle.
+    function bundle_under_scope(command,   i, count, token) {
+      if (index(command, marker) == 0) return 0
+      if (index(command, scope_prefix) == 1) return 1
+      count = split(command, token, " ")
+      for (i = 1; i <= count; i++) {
+        if (index(token[i], scope_prefix) == 1 && index(token[i], marker) > 0) return 1
+      }
+      return 0
+    }
+    BEGIN {
+      marker = ENVIRON["REAP_MARKER"]
+      scope_prefix = ENVIRON["REAP_SCOPE_PREFIX"]
+    }
+    {
+      command = ""
+      for (i = 5; i <= NF; i++) command = command (i > 5 ? " " : "") $i
+      pids[NR] = $1
+      ppids[NR] = $2
+      states[NR] = $3
+      etimes[NR] = $4
+      commands[NR] = command
+      parent[$1] = $2
+      rows = NR
+    }
+    END {
+      # Ancestors of this script (the step shell, the runner worker, launchd)
+      # can never be orphans, and killing one would take down the job. The
+      # snapshot covers every process, so walk them straight out of the
+      # parent map rather than shelling out per generation.
+      for (pid = self; pid > 1 && (pid in parent) && !(pid in ancestor); pid = parent[pid]) {
+        ancestor[pid] = 1
+      }
+      ancestor[self] = 1
+
+      outside = 0
+      for (row = 1; row <= rows; row++) {
+        if (index(commands[row], marker) == 0) continue
+        if (pids[row] in ancestor || descends_from_self(pids[row])) continue
+        if (!bundle_under_scope(commands[row])) { outside++; continue }
+        # A zombie has already exited and is waiting to be reaped by its
+        # parent; there is nothing to kill and nothing leaking.
+        if (substr(states[row], 1, 1) == "Z") continue
+        print pids[row] "|" ppids[row] "|" states[row] "|" etimes[row] "|" commands[row]
+      }
+      print "OUTSIDE_SCOPE|" outside
+    }
+  ' "$snapshot_file" >"$matches_file"
+
+  outside_count=$(sed -n 's/^OUTSIDE_SCOPE|//p' "$matches_file")
+  orphan_lines=$(grep -v '^OUTSIDE_SCOPE|' "$matches_file" || true)
+  orphan_count=0
+  if [[ -n "$orphan_lines" ]]; then
+    orphan_count=$(printf '%s\n' "$orphan_lines" | wc -l | tr -d '[:space:]')
+  fi
+}
+
+# Elapsed time is the correlation handle: it dates a leftover to a specific
+# previous job on this runner.
+print_orphans() {
+  printf '%s\n' "$orphan_lines" | while IFS='|' read -r pid ppid state etime command; do
+    printf '  %-7s ppid=%-7s state=%-4s elapsed=%-14s %.200s\n' \
+      "$pid" "$ppid" "$state" "$etime" "$command"
+  done
+}
+
+# A pid captured by a scan can exit before it is signalled, and macOS will
+# eventually hand that number to something else. Re-read the command line and
+# re-apply both tests, so the signal can only ever land on a process that is
+# still an in-scope Electron leftover.
+still_in_scope() {
+  local pid="$1" command token
+  local -a tokens
+  command=$(ps -ww -o command= -p "$pid" 2>/dev/null || true)
+  [[ -n "$command" ]] || return 1
+  [[ "$command" == *"$marker"* ]] || return 1
+  [[ "$command" == "$scope_prefix"* ]] && return 0
+  # Same rule as the awk classifier: the bundle path, not just any mention of
+  # the workspace. `read -a` rather than word splitting so a `*` in a path
+  # cannot glob.
+  IFS=' ' read -r -a tokens <<<"$command"
+  for token in "${tokens[@]}"; do
+    if [[ "$token" == "$scope_prefix"* && "$token" == *"$marker"* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Takes the pid list explicitly rather than reading a caller's variable, so
+# what gets signalled is visible at the call site.
+signal_orphans() {
+  local signal="$1" pid
+  shift
+  for pid in "$@"; do
+    if still_in_scope "$pid"; then
+      kill "-$signal" "$pid" 2>/dev/null || true
+    fi
+  done
+}
+
+# Reap every in-scope leftover. Returns 1 only when something is still alive
+# after two full rounds.
+reap_orphans() {
+  local round first_count survivors
+
+  if [[ "$orphan_count" -eq 0 ]]; then
+    echo "$LOG: nothing to reap; the runner started this job clean."
+    summary "### Orphaned Electron check: clean"
+    summary ""
+    summary "No leftover Electron processes under \`$scope\` before the E2E run."
+    summary "(\`$outside_count\` Electron process(es) elsewhere on the guest, left alone.)"
+    return 0
+  fi
+
+  first_count="$orphan_count"
+  echo "$LOG: leftovers (pid, ppid, state, elapsed, command):"
+  print_orphans
+
+  echo "::warning title=Orphaned Electron processes on macOS runner::Found $first_count leftover Electron process(es) under $scope before this job's E2E run. A healthy runner starts clean; these came from a previous job whose teardown did not reap its process tree."
+
+  summary "### Orphaned Electron check: $first_count leftover process(es) reaped"
+  summary ""
+  summary "A healthy runner starts a job with zero leftovers under \`$scope\`."
+  summary ""
+  summary '```'
+  printf '%s\n' "$orphan_lines" | while IFS='|' read -r pid ppid state etime command; do
+    summary "$(printf '%-7s ppid=%-7s state=%-4s elapsed=%-14s %.200s' \
+      "$pid" "$ppid" "$state" "$etime" "$command")"
+  done
+  summary '```'
+
+  # Two rounds, because a leftover Electron main can spawn a helper after the
+  # scan that captured it. Round two catches that child; anything still
+  # standing after it is not losing a race, it is refusing to die.
+  local -a orphan_pids
+  for round in 1 2; do
+    IFS=$'\n' read -r -d '' -a orphan_pids \
+      < <(printf '%s\n' "$orphan_lines" | cut -d'|' -f1 && printf '\0')
+    if [[ "$round" -gt 1 ]]; then
+      echo "$LOG: round $round — $orphan_count still present after round $((round - 1)):"
+      print_orphans
+    fi
+
+    # TERM first so anything still capable of an orderly exit takes it, then
+    # KILL whatever ignored it. Both are best-effort: a pid that exits in
+    # between is a success, not an error.
+    signal_orphans TERM "${orphan_pids[@]}"
+    sleep 2
+    signal_orphans KILL "${orphan_pids[@]}"
+    sleep 2
+
+    # Re-scan rather than re-checking only the pids just signalled: that is
+    # the only way to prove the scope is actually clean, and it also surfaces
+    # helpers born after the previous scan.
+    scan
+    # Not `[[ ... ]] && break`: under `set -e` a false test as the last
+    # command in the body would exit the script instead of running round two.
+    if [[ "$orphan_count" -eq 0 ]]; then
+      break
+    fi
+  done
+
+  if [[ "$orphan_count" -ne 0 ]]; then
+    survivors=$(printf '%s\n' "$orphan_lines" | cut -d'|' -f1 | tr '\n' ' ')
+    # SIGKILL is not refusable in user space. A survivor means the process is
+    # stuck in the kernel — the vmapple paravirt driver has wedged Electron
+    # helpers at birth before — and no amount of retrying here will clear it.
+    # Fail now with an actionable message instead of burning the lane's
+    # 20-minute cap on a suite that cannot launch a window.
+    echo "$LOG: still present after two reap rounds:"
+    print_orphans
+    echo "::error title=Unkillable Electron processes on macOS runner::pid(s) $survivors survived SIGKILL. The guest is wedged at the kernel level and needs to be recycled before this lane can pass."
+    summary ""
+    summary "**pid(s) \`$survivors\` survived SIGKILL — recycle the guest.**"
+    return 1
+  fi
+
+  echo "$LOG: reaped $first_count process(es); a follow-up scan found the scope clean."
+  return 0
+}
+
+# Clear macOS saved application state for the Electron bundle.
+#
+# This is the half of the cleanup that addresses an actually-observed failure.
+# A runner screenshot caught the AppKit alert "The last time you opened
+# Electron, it unexpectedly quit while reopening windows. Do you want to try
+# to reopen its windows again?" sitting on the guest. That alert is modal and
+# it appears before the app creates any window, which is exactly the
+# 2026-08-07 signature: `Launch electron` completes, `Wait for event "window"`
+# never returns, 0 tests, full 20-minute cap.
+#
+# The trigger is an abnormal termination of the same bundle id — precisely
+# what the E2E teardown's killProcessTree fallback produces, and what the
+# reap above produces too. So the reap alone does not fix this and can even
+# feed it; the two have to ship together.
+#
+# Preferences and saved state for the dev Electron binary are keyed on the
+# bundle id under the real user, via cfprefsd. The fixture's per-test `HOME`
+# override (apps/desktop/e2e/fixtures/electron-app.ts) does NOT isolate them,
+# which is why this state survives from job to job on a persistent guest.
+clear_saved_application_state() {
+  local bundle_id state_dir state_home
+
+  # `set -u` catches an unset HOME but not an empty one, and an empty one
+  # would aim the rm at /Library/Saved Application State. This is the only
+  # destructive line in the script; it does not get to run on a guess.
+  state_home="${REAP_STATE_HOME:-${HOME:-}}"
+  if [[ -z "$state_home" ]]; then
+    echo "$LOG: no home directory resolved; leaving saved application state alone." >&2
+    return 0
+  fi
+
+  for bundle_id in "${ELECTRON_BUNDLE_IDS[@]}"; do
+    state_dir="$state_home/Library/Saved Application State/$bundle_id.savedState"
+    if [[ -d "$state_dir" ]]; then
+      rm -rf "$state_dir"
+      echo "$LOG: removed saved application state for $bundle_id"
+      echo "::warning title=Stale Electron saved state on macOS runner::Removed $bundle_id.savedState before this job's E2E run. That state is what produces the modal \"unexpectedly quit while reopening windows\" alert, which blocks window creation and makes the suite time out having run 0 tests."
+      summary ""
+      summary "Removed stale \`$bundle_id.savedState\` (source of the \"reopen windows\" modal)."
+    else
+      echo "$LOG: no saved application state for $bundle_id"
+    fi
+
+    # Belt and braces: tell AppKit not to restore windows for this bundle at
+    # all. Deleting the directory removes today's trigger; these two keys stop
+    # it being recreated by the next abnormal exit. Scoped to the dev Electron
+    # bundle id, idempotent, and reversible with `defaults delete`.
+    #
+    # CI only, and never under a test state home. These go through cfprefsd,
+    # which is keyed on the logged-in user and ignores $HOME, so there is no
+    # way to scope them to a throwaway profile — running this script by hand
+    # on a workstation, or from the unit tests, would silently change that
+    # operator's own Electron behavior. On the runner guest the same user also
+    # runs PwrSnap's E2E, which wants this suppressed too.
+    if [[ -n "${REAP_STATE_HOME:-}" ]]; then
+      echo "$LOG: test state home in use; leaving $bundle_id defaults untouched"
+      continue
+    fi
+    if [[ -z "${GITHUB_ACTIONS:-}" ]]; then
+      echo "$LOG: not on GitHub Actions; leaving $bundle_id defaults untouched"
+      continue
+    fi
+    defaults write "$bundle_id" ApplePersistenceIgnoreState -bool true 2>/dev/null || true
+    defaults write "$bundle_id" NSQuitAlwaysKeepsWindows -bool false 2>/dev/null || true
+  done
+}
+
+scan
+echo "$LOG: scope        $scope"
+echo "$LOG: in scope     $orphan_count orphaned Electron process(es)"
+echo "$LOG: out of scope $outside_count Electron process(es) elsewhere on this guest (not touched)"
+
+if [[ -n "$injected_table" ]]; then
+  echo "$LOG: report-only (process table injected); nothing was signalled."
+  [[ "$orphan_count" -eq 0 ]] || print_orphans
+  # The saved-state clearing is the one destructive path here, so it does get
+  # exercised under test — but only against an explicitly supplied throwaway
+  # home. Without REAP_STATE_HOME a stray report-only run cannot delete the
+  # invoking user's real state.
+  if [[ -n "${REAP_STATE_HOME:-}" ]]; then
+    clear_saved_application_state
+  else
+    echo "$LOG: report-only; REAP_STATE_HOME unset, saved application state left alone."
+  fi
+  exit 0
+fi
+
+reap_status=0
+reap_orphans || reap_status=$?
+
+# After the reap, never before: signalling an Electron can make AppKit write
+# fresh saved state on the way out.
+clear_saved_application_state
+
+exit "$reap_status"

--- a/scripts/ci/macos-e2e-pre-run-cleanup.test.mjs
+++ b/scripts/ci/macos-e2e-pre-run-cleanup.test.mjs
@@ -1,0 +1,225 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// The script kills processes on a shared, persistent CI guest, so the part
+// worth locking down is which rows it selects. `REAP_PS_SNAPSHOT_FILE` feeds
+// it a synthetic `ps` table and forces report-only mode, so these tests
+// exercise the real classifier without a single signal being sent.
+const scriptPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "macos-e2e-pre-run-cleanup.sh",
+);
+
+const SCOPE = "/Users/admin/actions-runner/_work/PwrAgent";
+const BUNDLE = `${SCOPE}/PwrAgent/node_modules/.pnpm/electron@41.10.3/node_modules/electron/dist/Electron.app`;
+
+/** One `ps -Ao pid=,ppid=,state=,etime=,command=` row. */
+const row = (pid, ppid, state, command, etime = "01:23") =>
+  `${pid} ${ppid} ${state} ${etime} ${command}`;
+
+// argv[1] is the app entry point, which lives in the same checkout as the
+// bundle — deriving it keeps foreign-bundle rows realistic instead of
+// accidentally sprinkling our own workspace path into someone else's argv.
+const electronMain = (pid, ppid = 1, state = "S", bundle = BUNDLE) =>
+  row(
+    pid,
+    ppid,
+    state,
+    `${bundle}/Contents/MacOS/Electron ${bundle.replace(/\/node_modules\/.*$/, "")}/apps/desktop/out/main/index.js`,
+  );
+
+const electronHelper = (pid, ppid, state = "S", bundle = BUNDLE) =>
+  row(
+    pid,
+    ppid,
+    state,
+    `${bundle}/Contents/Frameworks/Electron Helper.app/Contents/MacOS/Electron Helper --type=renderer`,
+  );
+
+let workDir;
+
+beforeAll(() => {
+  workDir = mkdtempSync(path.join(tmpdir(), "reap-orphan-electron-test-"));
+});
+afterAll(() => {
+  rmSync(workDir, { force: true, recursive: true });
+});
+
+let tableCounter = 0;
+
+function run(rows, { scope = SCOPE, selfPid = "9000", env = {}, stderr = "inherit" } = {}) {
+  const tableFile = path.join(workDir, `table-${tableCounter++}.txt`);
+  writeFileSync(tableFile, `${rows.join("\n")}\n`, "utf8");
+  return execFileSync("bash", [scriptPath], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", stderr],
+    env: {
+      ...process.env,
+      RUNNER_WORKSPACE: scope,
+      REAP_PS_SNAPSHOT_FILE: tableFile,
+      REAP_SELF_PID: selfPid,
+      GITHUB_STEP_SUMMARY: "",
+      ...env,
+    },
+  });
+}
+
+const inScopeCount = (output) =>
+  Number(/in scope\s+(\d+) orphaned/.exec(output)?.[1]);
+const outOfScopeCount = (output) =>
+  Number(/out of scope\s+(\d+) Electron/.exec(output)?.[1]);
+
+// Every row a real runner would show while sitting idle between jobs.
+const BASELINE = [
+  row(1, 0, "Ss", "/sbin/launchd", "21-22:28:55"),
+  row(9000, 8000, "S", "bash /Users/admin/actions-runner/_work/_temp/step.sh"),
+  row(8000, 500, "S", "/Users/admin/actions-runner/bin/Runner.Worker"),
+];
+
+describe.skipIf(process.platform === "win32")("macos-e2e-pre-run-cleanup.sh", () => {
+  it("reports a clean runner when no Electron is running", () => {
+    const output = run(BASELINE);
+    expect(inScopeCount(output)).toBe(0);
+    expect(outOfScopeCount(output)).toBe(0);
+    expect(output).toContain("report-only");
+  });
+
+  it("selects an orphaned Electron main and its helper", () => {
+    const output = run([...BASELINE, electronMain(4100), electronHelper(4101, 4100)]);
+    expect(inScopeCount(output)).toBe(2);
+    expect(output).toContain("4100");
+    expect(output).toContain("4101");
+  });
+
+  it("counts but never selects Electron outside the runner workspace", () => {
+    // PwrSnap on the shared guest, and an operator's own checkout. Killing
+    // either would be exactly the collateral this scope exists to prevent.
+    const pwrSnap = "/Users/admin/actions-runner/_work/PwrSnap/PwrSnap/node_modules/electron/dist/Electron.app";
+    const operator = "/Users/admin/dev/scratch/node_modules/electron/dist/Electron.app";
+    const output = run([
+      ...BASELINE,
+      electronMain(5100, 1, "S", pwrSnap),
+      electronHelper(5101, 5100, "S", pwrSnap),
+      electronMain(5200, 1, "S", operator),
+    ]);
+    expect(inScopeCount(output)).toBe(0);
+    expect(outOfScopeCount(output)).toBe(3);
+    expect(output).not.toContain("5100");
+  });
+
+  it("does not select a workspace whose path merely shares the scope prefix", () => {
+    const sibling = "/Users/admin/actions-runner/_work/PwrAgent2/PwrAgent2/node_modules/electron/dist/Electron.app";
+    const output = run([...BASELINE, electronMain(6100, 1, "S", sibling)]);
+    expect(inScopeCount(output)).toBe(0);
+    expect(outOfScopeCount(output)).toBe(1);
+  });
+
+  it("does not select a foreign Electron that merely mentions our workspace", () => {
+    // A PwrSnap job comparing against this checkout, or an operator's shell
+    // history landing in argv. The scope has to be a prefix of argv[0].
+    const foreign = "/Users/admin/actions-runner/_work/PwrSnap/PwrSnap/node_modules/electron/dist/Electron.app";
+    const output = run([
+      ...BASELINE,
+      row(6200, 1, "S", `${foreign}/Contents/MacOS/Electron --compare-to=${SCOPE}/PwrAgent/out`),
+    ]);
+    expect(inScopeCount(output)).toBe(0);
+    expect(outOfScopeCount(output)).toBe(1);
+  });
+
+  it("selects a bundle launched through a wrapper, where argv[0] is the interpreter", () => {
+    const output = run([
+      ...BASELINE,
+      row(6300, 1, "S", `/bin/sh ${BUNDLE}/Contents/MacOS/Electron --type=renderer`),
+    ]);
+    expect(inScopeCount(output)).toBe(1);
+    expect(output).toContain("6300");
+  });
+
+  it("never selects its own process tree", () => {
+    // An Electron launched by this job would descend from the step shell.
+    // Nothing beneath the running script may ever be signalled.
+    const output = run([
+      ...BASELINE,
+      electronMain(7100, 9000),
+      electronHelper(7101, 7100),
+    ]);
+    expect(inScopeCount(output)).toBe(0);
+  });
+
+  it("ignores zombies, which are already dead and hold nothing", () => {
+    const output = run([...BASELINE, electronMain(7200, 1, "Z"), electronMain(7201, 1, "S")]);
+    expect(inScopeCount(output)).toBe(1);
+    expect(output).toContain("7201");
+    expect(output).not.toContain("7200");
+  });
+
+  it("reports elapsed time so a leftover can be dated to a previous job", () => {
+    const output = run([
+      ...BASELINE,
+      row(
+        7300,
+        1,
+        "S",
+        `${BUNDLE}/Contents/MacOS/Electron ${SCOPE}/PwrAgent/apps/desktop/out/main/index.js`,
+        "2:14:07",
+      ),
+    ]);
+    expect(output).toContain("elapsed=2:14:07");
+  });
+
+  // The delete is the only destructive line in the script, so it gets covered
+  // rather than left to manual testing. REAP_STATE_HOME points it at a
+  // throwaway tree and also blocks the cfprefsd writes, which are user-scoped
+  // and could not be undone by a test.
+  const savedStatePath = (home) =>
+    path.join(home, "Library", "Saved Application State", "com.github.Electron.savedState");
+
+  it("deletes stale saved application state for the Electron bundle", () => {
+    const stateHome = mkdtempSync(path.join(workDir, "home-"));
+    const stateDir = savedStatePath(stateHome);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(path.join(stateDir, "windows.plist"), "stale", "utf8");
+
+    const output = run(BASELINE, { env: { REAP_STATE_HOME: stateHome } });
+
+    expect(existsSync(stateDir)).toBe(false);
+    expect(output).toContain("removed saved application state for com.github.Electron");
+    // cfprefsd is keyed on the logged-in user, not $HOME — a test must never
+    // reach it.
+    expect(output).toContain("leaving com.github.Electron defaults untouched");
+  });
+
+  it("reports when there is no saved application state to remove", () => {
+    const stateHome = mkdtempSync(path.join(workDir, "home-"));
+    const output = run(BASELINE, { env: { REAP_STATE_HOME: stateHome } });
+    expect(output).toContain("no saved application state for com.github.Electron");
+  });
+
+  it("leaves saved application state alone when no throwaway home is given", () => {
+    // A report-only run without REAP_STATE_HOME must not touch the invoking
+    // user's real state, even though $HOME is set.
+    const stateHome = mkdtempSync(path.join(workDir, "home-"));
+    const stateDir = savedStatePath(stateHome);
+    mkdirSync(stateDir, { recursive: true });
+
+    const output = run(BASELINE, { env: { HOME: stateHome } });
+
+    expect(existsSync(stateDir)).toBe(true);
+    expect(output).toContain("REAP_STATE_HOME unset, saved application state left alone");
+  });
+
+  it("refuses to run when no workspace is set rather than guessing a scope", () => {
+    let failure;
+    try {
+      run(BASELINE, { scope: "", env: { GITHUB_WORKSPACE: "" }, stderr: "pipe" });
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure?.status).toBe(1);
+    expect(String(failure?.stderr)).toContain("refusing to guess a kill scope");
+  });
+});


### PR DESCRIPTION
## Summary

- Align regular `releases/1.0` CI with main's platform-primer and parallel-lane topology, using the released `configure-nodejs@v1` Electron lifecycle cache contract from #1550.
- Add one cache-primer each for Linux, Windows, and protected macOS; every ordinary platform consumer depends on its corresponding primer.
- Split Windows into verify, desktop-main, and renderer/packages lanes, preserving all six 1.0 Vitest projects.
- Shard Linux and macOS Desktop E2E into two lanes. Keep the aggregate `Desktop E2E` required-check context for Linux.
- Add the proven, workspace-scoped macOS Electron cleanup helper and its focused test, required because this older branch did not yet contain the runner-stability implementation.

## Provenance

Adapted deliberately, rather than cherry-picked, from:

- #1334 — Windows lane split
- #1336 — platform dependency primers
- #1361 — macOS persistent-runner Electron cleanup helper
- #1382 — macOS E2E lanes
- #1470 — Linux E2E lanes and aggregate required check
- #1474 — sparse dependency-primer checkouts
- #1550 — released `configure-nodejs@v1` Electron lifecycle cache backport

## Deliberate 1.0 deviations

- The branch does not have main's later `changes` classifier/docs-only gating, so this PR preserves existing 1.0 trigger behavior rather than importing unrelated workflow restructuring. The macOS guard retains main's exact push-or-same-repository-PR safety predicate; fork code never reaches the self-hosted runner.
- The Windows renderer/packages lane includes `desktop-renderer`, `agent-core`, `grok-app-server`, `messaging`, and `shared`. Main no longer has the two former components; 1.0 does, so omitting them would reduce coverage.
- The label-gated Windows installer stays independent and continues using its existing Windows-local setup path. It is not a regular consumer of the Windows dependency primer.
- The macOS cleanup helper from #1361 is included because 1.0 lacks it; its process matching is scoped to the current runner workspace and leaves PwrSnap/operator processes alone.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color -ignore 'label "pwrdrvr-macos" is unknown' .github/workflows/ci.yml`
- Structural workflow assertion covering platform-primer dependencies, one-time Windows project coverage, Linux aggregate result, macOS fork guard, LFS/GPU/cleanup handling, and the independent installer job.
- `bash -n scripts/ci/macos-e2e-pre-run-cleanup.sh`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main scripts/ci/macos-e2e-pre-run-cleanup.test.mjs` — 13 passed.
- Listed the exact Windows project lane commands and both E2E shards locally.
- `git diff --check`

No product, federation, release-signing, SQLite/database migration, or schema changes are included.

## Follow-up stability fixes

- Adapted the test-only lookup-cache timestamp stabilization from #1085 (`5a1e24342dd003188af670d751afc81f774c5da9`).
- Adapted the stable terminal-status assertion for the short workspace-handoff environment action from #1146 (`eeb8e922ca4c0ffe75b93e09875bd0688a1430d8`).

Additional validation: `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts` (65 passed); focused workspace-handoff E2E (1 passed); targeted ESLint (0 errors, 2 pre-existing warnings).