### PR TITLE
fix(desktop): preserve ACP session client ownership

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -3026,13 +3026,6 @@ describe("AcpBackendAdapter", () => {
         args: ["acp"],
         env: {},
       },
-      runtimeCapabilities: {
-        schemaVersion: 1,
-        status: "discovered",
-        agentCapabilities: {
-          loadSession: false,
-        },
-      },
     };
     const overrideAgent: AcpInstalledAgentRecord = {
       ...firstAgent,
@@ -3048,9 +3041,10 @@ describe("AcpBackendAdapter", () => {
       dispose: firstDispose,
       hasActiveOperations: () => false,
       hasActiveTurns: () => false,
-      hasOwnedSessions: () => true,
+      hasRetainableSessions: () => true,
       initialize: vi.fn(async () => undefined),
       ownsSession: (sessionId: string) => sessionId === "session-1",
+      supportsSessionLoad: () => false,
     };
     const secondOwnedSessions = new Set<string>();
     const secondDispose = vi.fn(async () => undefined);
@@ -3058,9 +3052,10 @@ describe("AcpBackendAdapter", () => {
       dispose: secondDispose,
       hasActiveOperations: () => false,
       hasActiveTurns: () => false,
-      hasOwnedSessions: () => secondOwnedSessions.size > 0,
+      hasRetainableSessions: () => secondOwnedSessions.size > 0,
       initialize: vi.fn(async () => undefined),
       ownsSession: (sessionId: string) => secondOwnedSessions.has(sessionId),
+      supportsSessionLoad: () => false,
       startSession: vi.fn(async () => {
         secondOwnedSessions.add("session-2");
         return { sessionId: "session-2" };
@@ -3136,18 +3131,20 @@ describe("AcpBackendAdapter", () => {
       dispose: firstDispose,
       hasActiveOperations: () => false,
       hasActiveTurns: () => false,
-      hasOwnedSessions: () => true,
+      hasRetainableSessions: () => true,
       initialize: vi.fn(async () => undefined),
       ownsSession: (sessionId: string) => sessionId === "session-1",
+      supportsSessionLoad: () => true,
     };
     const secondDispose = vi.fn(async () => undefined);
     const secondClient = {
       dispose: secondDispose,
       hasActiveOperations: () => false,
       hasActiveTurns: () => false,
-      hasOwnedSessions: () => false,
+      hasRetainableSessions: () => false,
       initialize: vi.fn(async () => undefined),
       ownsSession: () => false,
+      supportsSessionLoad: () => true,
     };
     const adapter = new AcpBackendAdapter({
       acpAgentStore: null,

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -3010,6 +3010,170 @@ describe("AcpBackendAdapter", () => {
     }
   });
 
+  it("keeps non-loadable sessions on their owner while new sessions use a replacement client", async () => {
+    const backendId = "acp:kimi" as AcpBackendId;
+    const firstAgent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      activeCommand: "/path/kimi",
+      launchDescriptor: {
+        backendId,
+        registryId: "kimi",
+        distributionKind: "local",
+        command: "/path/kimi",
+        args: ["acp"],
+        env: {},
+      },
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        agentCapabilities: {
+          loadSession: false,
+        },
+      },
+    };
+    const overrideAgent: AcpInstalledAgentRecord = {
+      ...firstAgent,
+      activeCommand: "/override/kimi",
+      launchDescriptor: {
+        ...firstAgent.launchDescriptor!,
+        command: "/override/kimi",
+      },
+    };
+    let discovered = firstAgent;
+    const firstDispose = vi.fn(async () => undefined);
+    const firstClient = {
+      dispose: firstDispose,
+      hasActiveOperations: () => false,
+      hasActiveTurns: () => false,
+      hasOwnedSessions: () => true,
+      initialize: vi.fn(async () => undefined),
+      ownsSession: (sessionId: string) => sessionId === "session-1",
+    };
+    const secondOwnedSessions = new Set<string>();
+    const secondDispose = vi.fn(async () => undefined);
+    const secondClient = {
+      dispose: secondDispose,
+      hasActiveOperations: () => false,
+      hasActiveTurns: () => false,
+      hasOwnedSessions: () => secondOwnedSessions.size > 0,
+      initialize: vi.fn(async () => undefined),
+      ownsSession: (sessionId: string) => secondOwnedSessions.has(sessionId),
+      startSession: vi.fn(async () => {
+        secondOwnedSessions.add("session-2");
+        return { sessionId: "session-2" };
+      }),
+    };
+    const createAcpClient = vi
+      .fn()
+      .mockReturnValueOnce(firstClient)
+      .mockReturnValueOnce(secondClient);
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: null,
+      captureStores: [],
+      createAcpClient: createAcpClient as never,
+      discoverLocalAcpAgents: async () => [discovered],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    discovered = overrideAgent;
+    adapter.invalidateLocalAgentDiscovery();
+
+    await expect(
+      adapter.getClientForSession(backendId, "session-1"),
+    ).resolves.toBe(firstClient);
+    expect(firstDispose).not.toHaveBeenCalled();
+    await expect(adapter.getClient(backendId)).resolves.toBe(secondClient);
+    expect(createAcpClient).toHaveBeenNthCalledWith(2, overrideAgent);
+
+    await secondClient.startSession();
+    await expect(
+      adapter.getClientForSession(backendId, "session-2"),
+    ).resolves.toBe(secondClient);
+
+    await adapter.close();
+    await adapter.close();
+    expect(firstDispose).toHaveBeenCalledOnce();
+    expect(secondDispose).toHaveBeenCalledOnce();
+  });
+
+  it("replaces the owner of a loadable session after launch identity changes", async () => {
+    const backendId = "acp:gemini" as AcpBackendId;
+    const firstAgent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      activeCommand: "/path/gemini",
+      launchDescriptor: {
+        backendId,
+        registryId: "gemini",
+        distributionKind: "local",
+        command: "/path/gemini",
+        args: ["--acp", "--skip-trust"],
+        env: {},
+      },
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        agentCapabilities: {
+          loadSession: true,
+        },
+      },
+    };
+    const overrideAgent: AcpInstalledAgentRecord = {
+      ...firstAgent,
+      activeCommand: "/override/gemini",
+      launchDescriptor: {
+        ...firstAgent.launchDescriptor!,
+        command: "/override/gemini",
+      },
+    };
+    let discovered = firstAgent;
+    const firstDispose = vi.fn(async () => undefined);
+    const firstClient = {
+      dispose: firstDispose,
+      hasActiveOperations: () => false,
+      hasActiveTurns: () => false,
+      hasOwnedSessions: () => true,
+      initialize: vi.fn(async () => undefined),
+      ownsSession: (sessionId: string) => sessionId === "session-1",
+    };
+    const secondDispose = vi.fn(async () => undefined);
+    const secondClient = {
+      dispose: secondDispose,
+      hasActiveOperations: () => false,
+      hasActiveTurns: () => false,
+      hasOwnedSessions: () => false,
+      initialize: vi.fn(async () => undefined),
+      ownsSession: () => false,
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: null,
+      captureStores: [],
+      createAcpClient: vi
+        .fn()
+        .mockReturnValueOnce(firstClient)
+        .mockReturnValueOnce(secondClient) as never,
+      discoverLocalAcpAgents: async () => [discovered],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    discovered = overrideAgent;
+    adapter.invalidateLocalAgentDiscovery();
+
+    await expect(
+      adapter.getClientForSession(backendId, "session-1"),
+    ).resolves.toBe(secondClient);
+    expect(firstDispose).toHaveBeenCalledOnce();
+
+    await adapter.close();
+    expect(secondDispose).toHaveBeenCalledOnce();
+  });
+
   it("keeps a stale client alive until its active turn finishes", async () => {
     const backendId = "acp:gemini" as AcpBackendId;
     const firstAgent: AcpInstalledAgentRecord = {

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -76,7 +76,7 @@ describe("AcpAgentClient", () => {
 
     await client.initialize();
     expect(client.hasActiveOperations()).toBe(false);
-    expect(client.hasOwnedSessions()).toBe(false);
+    expect(client.hasRetainableSessions()).toBe(false);
     expect(client.ownsSession("session-1")).toBe(false);
 
     const session = client.startSession({
@@ -88,7 +88,7 @@ describe("AcpAgentClient", () => {
     sessionResponse.resolve({ sessionId: "session-1" });
     await expect(session).resolves.toMatchObject({ sessionId: "session-1" });
     expect(client.hasActiveOperations()).toBe(false);
-    expect(client.hasOwnedSessions()).toBe(true);
+    expect(client.hasRetainableSessions()).toBe(true);
     expect(client.ownsSession("session-1")).toBe(true);
 
     const runtimeOption = client.setRuntimeOption({
@@ -103,8 +103,30 @@ describe("AcpAgentClient", () => {
     expect(client.hasActiveOperations()).toBe(false);
 
     await client.dispose();
-    expect(client.hasOwnedSessions()).toBe(false);
+    expect(client.hasRetainableSessions()).toBe(false);
     expect(client.ownsSession("session-1")).toBe(false);
+  });
+
+  it("does not retain the client solely for hidden helper sessions", async () => {
+    const client = new AcpAgentClient({
+      backendId: "acp:gemini",
+      store,
+      transport: new FakeAcpAgentTransport({
+        "session/new": { sessionId: "hidden-session" },
+      }),
+      now: () => 1000,
+    });
+
+    await client.initialize();
+    await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+      hidden: true,
+      mcpServers: "none",
+    });
+
+    expect(client.ownsSession("hidden-session")).toBe(true);
+    expect(client.hasRetainableSessions()).toBe(false);
   });
 
   it("initializes, starts sessions, sends prompts, and normalizes updates", async () => {
@@ -2438,6 +2460,7 @@ describe("AcpAgentClient", () => {
     });
 
     await client.initialize();
+    expect(client.supportsSessionLoad()).toBe(false);
     const replay = await client.loadSession(
       store.getSession("acp:gemini", "session-1")!,
     );

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -76,6 +76,8 @@ describe("AcpAgentClient", () => {
 
     await client.initialize();
     expect(client.hasActiveOperations()).toBe(false);
+    expect(client.hasOwnedSessions()).toBe(false);
+    expect(client.ownsSession("session-1")).toBe(false);
 
     const session = client.startSession({
       cwd: "/repo",
@@ -86,6 +88,8 @@ describe("AcpAgentClient", () => {
     sessionResponse.resolve({ sessionId: "session-1" });
     await expect(session).resolves.toMatchObject({ sessionId: "session-1" });
     expect(client.hasActiveOperations()).toBe(false);
+    expect(client.hasOwnedSessions()).toBe(true);
+    expect(client.ownsSession("session-1")).toBe(true);
 
     const runtimeOption = client.setRuntimeOption({
       sessionId: "session-1",
@@ -97,6 +101,10 @@ describe("AcpAgentClient", () => {
     runtimeOptionResponse.resolve({});
     await runtimeOption;
     expect(client.hasActiveOperations()).toBe(false);
+
+    await client.dispose();
+    expect(client.hasOwnedSessions()).toBe(false);
+    expect(client.ownsSession("session-1")).toBe(false);
   });
 
   it("initializes, starts sessions, sends prompts, and normalizes updates", async () => {

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -231,6 +231,7 @@ export class AcpAgentClient {
   private readonly sessionLoadReplays = new Map<string, AcpSessionLoadReplay>();
   private readonly agentSessionIdsByAppSessionId = new Map<string, string>();
   private readonly appSessionIdsByAgentSessionId = new Map<string, string>();
+  private readonly retainableSessionIds = new Set<string>();
   private readonly now: () => number;
   private readonly approvalRequesterName: string;
   private unsubscribe?: () => void;
@@ -323,8 +324,12 @@ export class AcpAgentClient {
     return this.agentSessionIdsByAppSessionId.has(sessionId);
   }
 
-  hasOwnedSessions(): boolean {
-    return this.agentSessionIdsByAppSessionId.size > 0;
+  hasRetainableSessions(): boolean {
+    return this.retainableSessionIds.size > 0;
+  }
+
+  supportsSessionLoad(): boolean {
+    return acpRuntimeSupportsSessionLoad(this.runtimeCapabilities);
   }
 
   // Count the whole public operation, including setup before the transport
@@ -347,6 +352,7 @@ export class AcpAgentClient {
     this.unsubscribeRequest = undefined;
     this.agentSessionIdsByAppSessionId.clear();
     this.appSessionIdsByAgentSessionId.clear();
+    this.retainableSessionIds.clear();
     this.loadedSessionCwds.clear();
     await this.options.transport.close?.();
   }
@@ -1394,10 +1400,6 @@ export class AcpAgentClient {
     return result;
   }
 
-  private supportsSessionLoad(): boolean {
-    return acpRuntimeSupportsSessionLoad(this.runtimeCapabilities);
-  }
-
   private isSessionLoaded(metadata: AcpSessionMetadata): boolean {
     const cwd = metadata.cwd ?? process.cwd();
     const protocolSessionId = protocolSessionIdForMetadata(metadata);
@@ -1594,6 +1596,9 @@ export class AcpAgentClient {
     const protocolSessionId = protocolSessionIdForMetadata(metadata);
     this.agentSessionIdsByAppSessionId.set(metadata.sessionId, protocolSessionId);
     this.appSessionIdsByAgentSessionId.set(protocolSessionId, metadata.sessionId);
+    if (metadata.hidden !== true) {
+      this.retainableSessionIds.add(metadata.sessionId);
+    }
   }
 
   private protocolSessionIdFor(sessionId: string): string {

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -319,6 +319,14 @@ export class AcpAgentClient {
     return this.activeOperations > 0;
   }
 
+  ownsSession(sessionId: string): boolean {
+    return this.agentSessionIdsByAppSessionId.has(sessionId);
+  }
+
+  hasOwnedSessions(): boolean {
+    return this.agentSessionIdsByAppSessionId.size > 0;
+  }
+
   // Count the whole public operation, including setup before the transport
   // request and state updates after it, so launch replacement cannot dispose
   // this client at either edge of an in-flight RPC.

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -130,11 +130,12 @@ export type AcpRuntimeClient = Pick<
       | "didSessionLoadReplayHistory"
       | "hasActiveOperations"
       | "hasActiveTurns"
-      | "hasOwnedSessions"
+      | "hasRetainableSessions"
       | "ownsSession"
       | "readProviderStatus"
       | "sendControlPrompt"
       | "setRuntimeOption"
+      | "supportsSessionLoad"
     >
   >;
 
@@ -1458,9 +1459,11 @@ export class AcpBackendAdapter {
         return await cached.promise;
       }
       this.acpClients.delete(backend);
+      const supportsSessionLoad =
+        cached.client.supportsSessionLoad?.() ?? cached.supportsSessionLoad;
       if (
-        !cached.supportsSessionLoad
-        && cached.client.hasOwnedSessions?.() === true
+        !supportsSessionLoad
+        && cached.client.hasRetainableSessions?.() === true
       ) {
         // Replace the launch target without replacing ownership of sessions
         // that the new process has no protocol method to recover.

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -130,6 +130,8 @@ export type AcpRuntimeClient = Pick<
       | "didSessionLoadReplayHistory"
       | "hasActiveOperations"
       | "hasActiveTurns"
+      | "hasOwnedSessions"
+      | "ownsSession"
       | "readProviderStatus"
       | "sendControlPrompt"
       | "setRuntimeOption"
@@ -150,6 +152,7 @@ type AcpClientEntry = {
   client: AcpRuntimeClient;
   launchIdentity: string;
   promise: Promise<AcpRuntimeClient>;
+  supportsSessionLoad: boolean;
   disposePromise?: Promise<void>;
 };
 
@@ -941,6 +944,13 @@ export class AcpBackendAdapter {
     request: AppServerPendingRequestNotification,
   ) => Promise<unknown>;
   private readonly acpClients = new Map<AcpBackendId, AcpClientEntry>();
+  // A non-loadable ACP session belongs to the process that created it. Launch
+  // selection may replace the current client, but these owners must remain
+  // addressable until adapter shutdown so later turns keep using that process.
+  private readonly retainedAcpClients = new Map<
+    AcpBackendId,
+    Set<AcpClientEntry>
+  >();
   private readonly acpClientResolutions = new Map<
     AcpBackendId,
     Promise<AcpRuntimeClient>
@@ -1276,8 +1286,9 @@ export class AcpBackendAdapter {
     sessionId: string,
   ): Promise<AppServerThreadReplay> {
     const session = this.getSession(backend, sessionId);
-    const cachedClient = await this.acpClients
-      .get(backend)
+    const cachedClient = await (
+      this.findSessionOwner(backend, sessionId) ?? this.acpClients.get(backend)
+    )
       ?.promise.catch(() => undefined);
     if (cachedClient) {
       const replay = cachedClient.readReplay(sessionId);
@@ -1403,6 +1414,29 @@ export class AcpBackendAdapter {
     }
   }
 
+  async getClientForSession(
+    backend: AcpBackendId,
+    sessionId: string,
+  ): Promise<AcpRuntimeClient> {
+    let current: AcpRuntimeClient;
+    try {
+      current = await this.getClient(backend);
+    } catch (error) {
+      // A broken replacement path must not strand a session whose original
+      // process is still alive. New sessions still observe the launch failure.
+      const owner = this.findSessionOwner(backend, sessionId);
+      if (owner) {
+        return await owner.promise;
+      }
+      throw error;
+    }
+    if (current.ownsSession?.(sessionId) === true) {
+      return current;
+    }
+    const owner = this.findSessionOwner(backend, sessionId);
+    return owner ? await owner.promise : current;
+  }
+
   private async resolveClient(backend: AcpBackendId): Promise<AcpRuntimeClient> {
     const agent = await this.resolveInstalledAgent(backend);
     if (this.closed) {
@@ -1424,7 +1458,16 @@ export class AcpBackendAdapter {
         return await cached.promise;
       }
       this.acpClients.delete(backend);
-      await this.disposeAcpClient(cached);
+      if (
+        !cached.supportsSessionLoad
+        && cached.client.hasOwnedSessions?.() === true
+      ) {
+        // Replace the launch target without replacing ownership of sessions
+        // that the new process has no protocol method to recover.
+        this.retainAcpClient(backend, cached);
+      } else {
+        await this.disposeAcpClient(cached);
+      }
       if (this.closed) {
         throw new Error("ACP backend adapter is closed");
       }
@@ -1435,6 +1478,9 @@ export class AcpBackendAdapter {
       client,
       launchIdentity,
       promise: Promise.resolve(client),
+      supportsSessionLoad: acpRuntimeSupportsSessionLoad(
+        agent.runtimeCapabilities,
+      ),
     };
     entry.promise = (async () => {
       await client.initialize();
@@ -1764,8 +1810,16 @@ export class AcpBackendAdapter {
       return await this.closePromise;
     }
     this.closed = true;
-    const acpClients = [...this.acpClients.entries()];
+    const acpClients = [
+      ...this.acpClients.entries(),
+      ...[...this.retainedAcpClients.entries()].flatMap(([backend, entries]) =>
+        [...entries].map(
+          (entry): [AcpBackendId, AcpClientEntry] => [backend, entry],
+        ),
+      ),
+    ];
     this.acpClients.clear();
+    this.retainedAcpClients.clear();
     this.acpClientResolutions.clear();
     this.liveNotificationFingerprints.clear();
     this.providerStatuses.clear();
@@ -1831,6 +1885,28 @@ export class AcpBackendAdapter {
   private disposeAcpClient(entry: AcpClientEntry): Promise<void> {
     entry.disposePromise ??= Promise.resolve().then(() => entry.client.dispose());
     return entry.disposePromise;
+  }
+
+  private retainAcpClient(
+    backend: AcpBackendId,
+    entry: AcpClientEntry,
+  ): void {
+    const retained = this.retainedAcpClients.get(backend) ?? new Set();
+    retained.add(entry);
+    this.retainedAcpClients.set(backend, retained);
+  }
+
+  private findSessionOwner(
+    backend: AcpBackendId,
+    sessionId: string,
+  ): AcpClientEntry | undefined {
+    const current = this.acpClients.get(backend);
+    if (current?.client.ownsSession?.(sessionId) === true) {
+      return current;
+    }
+    return [...(this.retainedAcpClients.get(backend) ?? [])].find(
+      (entry) => entry.client.ownsSession?.(sessionId) === true,
+    );
   }
 
   private shouldEmitLiveToolNotification(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8818,7 +8818,10 @@ export class DesktopBackendRegistry {
       throw new Error("ACP turns require text or image input");
     }
 
-    const client = await this.acpBackend.getClient(params.backend);
+    const client = await this.acpBackend.getClientForSession(
+      params.backend,
+      params.threadId,
+    );
     const session = this.acpBackend.getSession(params.backend, params.threadId);
     if (!session) {
       throw new Error(`ACP session not found: ${params.threadId}`);
@@ -9064,7 +9067,10 @@ export class DesktopBackendRegistry {
     if (!session) {
       throw new Error(`ACP session not found: ${params.threadId}`);
     }
-    const client = await this.acpBackend.getClient(params.backend);
+    const client = await this.acpBackend.getClientForSession(
+      params.backend,
+      params.threadId,
+    );
     await client.ensureSession?.(session);
     const fromValue =
       options?.fromValue ?? this.readAcpRuntimeOptionValue(session.acpRuntime, params);
@@ -13474,7 +13480,10 @@ export class DesktopBackendRegistry {
     if (!isAcpBackendId(params.backend)) {
       throw new Error(`Backend ${params.backend} is not an ACP backend.`);
     }
-    const client = await this.acpBackend.getClient(params.backend);
+    const client = await this.acpBackend.getClientForSession(
+      params.backend,
+      params.threadId,
+    );
     if (validateActiveTurn) {
       const active = this.getActiveTurnForThread(params);
       if (!active) {
@@ -14525,7 +14534,10 @@ export class DesktopBackendRegistry {
       throw new Error(`ACP session not found: ${params.threadId}`);
     }
     const previousApplied = session.executionMode ?? "default";
-    const client = await this.acpBackend.getClient(params.backend);
+    const client = await this.acpBackend.getClientForSession(
+      params.backend,
+      params.threadId,
+    );
     await client.ensureSession?.(session);
     const registryId = this.acpBackend.getInstalledAgent(params.backend)
       ?.registryId;
@@ -15237,7 +15249,10 @@ export class DesktopBackendRegistry {
             if (!session) {
               throw new Error(`ACP session not found: ${params.threadId}`);
             }
-            const client = await this.acpBackend.getClient(acpBackend);
+            const client = await this.acpBackend.getClientForSession(
+              acpBackend,
+              params.threadId,
+            );
             await client.ensureSession?.(session);
             await client.setRuntimeOption?.({
               sessionId: params.threadId,


### PR DESCRIPTION
## Summary

- retain ACP clients that own user sessions for agents advertising `loadSession: false` when launch selection changes
- derive load support from the initialized client so uncached launch identities retain non-loadable session owners correctly
- exclude throwaway hidden command-discovery and title-helper sessions from process retention
- route existing-session turns, cancellation, runtime changes, execution-mode controls, and replay reads to the owning client
- keep the newly resolved launch identity as the current client for new threads
- preserve the existing active-turn / active-operation replacement guard and dispose both current and retained clients exactly once on close

## Root cause

The launch-identity replacement added by #1540 treated the backend client as a single replaceable slot. Once the old client became idle, a CLI path change disposed it even when it owned sessions that the replacement process could not load. Later turns then sent the old ACP session ID to the replacement process.

This change separates current launch selection from in-process user-session ownership. Loadable sessions continue to use replacement clients; non-loadable user sessions remain pinned to the process that created them for the adapter lifetime. Load support is read from the initialized client, while hidden helper sessions remain known locally without retaining their process. The implementation is shared desktop ACP behavior and does not add a release-only path.

Regression provenance: squash merge `c1b1f7abb55f70624f7fd761c604e7c37d7c91ee` (#1540).

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts apps/desktop/src/main/__tests__/acp-runtime-override-launch.test.ts` (117 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`
