### PR TITLE
fix(desktop): preserve tooltips across pane scrolls

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
@@ -1,0 +1,49 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useViewportTooltip } from "../useViewportTooltip";
+
+afterEach(cleanup);
+
+function TooltipFixture() {
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+
+  return (
+    <div>
+      <div data-testid="sidebar-scroll-region">
+        <button
+          type="button"
+          onMouseEnter={(event) =>
+            tooltip.show(event.currentTarget, "Branch details")
+          }
+        >
+          agent/keep-tooltip-open
+        </button>
+      </div>
+      <div data-testid="transcript-scroll-region" />
+      {tooltip.tooltipNode}
+    </div>
+  );
+}
+
+describe("useViewportTooltip", () => {
+  it("keeps a tooltip open when an unrelated pane scrolls", () => {
+    render(<TooltipFixture />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Branch details");
+
+    fireEvent.scroll(screen.getByTestId("transcript-scroll-region"));
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Branch details");
+  });
+
+  it("closes a tooltip when the scroll moves its anchor", () => {
+    render(<TooltipFixture />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    fireEvent.scroll(screen.getByTestId("sidebar-scroll-region"));
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -68,6 +68,7 @@ export function useViewportTooltip(options: {
   tooltipNode: ReactNode;
 } {
   const tooltipRef = useRef<HTMLDivElement>(null);
+  const targetRef = useRef<HTMLElement | null>(null);
   const tooltipId = useId();
   const [state, setState] = useState<TooltipState | undefined>(undefined);
 
@@ -102,6 +103,7 @@ export function useViewportTooltip(options: {
 
   const show = useCallback((target: HTMLElement, content: ReactNode): void => {
     const rect = target.getBoundingClientRect();
+    targetRef.current = target;
     setState({
       content,
       targetTop: rect.top,
@@ -115,6 +117,7 @@ export function useViewportTooltip(options: {
   }, []);
 
   const hide = useCallback((): void => {
+    targetRef.current = null;
     setState(undefined);
   }, []);
 
@@ -122,19 +125,31 @@ export function useViewportTooltip(options: {
   // us no dismissal signal when the window loses focus (cmd-tab away leaves
   // the pointer "over" the chip, so no `mouseleave` fires) or when the list
   // scrolls underneath the position:fixed portal (the tooltip detaches from
-  // its target and lingers). Tear it down on either, matching ReactionPicker's
-  // window-level teardown. Keyed on visibility so the measure pass doesn't
-  // resubscribe each render.
+  // its target and lingers). Tear it down when the viewport or an ancestor of
+  // the target scrolls. A captured scroll from an unrelated pane must not
+  // dismiss it — transcript auto-scrolls otherwise close sidebar tooltips.
+  // Keyed on visibility so the measure pass doesn't resubscribe each render.
   const visible = state !== undefined;
   useEffect(() => {
     if (!visible) {
       return;
     }
+    const onScroll = (event: Event): void => {
+      const scrollTarget = event.target;
+      const target = targetRef.current;
+      if (
+        scrollTarget === window
+        || scrollTarget === document
+        || (scrollTarget instanceof Node && target && scrollTarget.contains(target))
+      ) {
+        hide();
+      }
+    };
     window.addEventListener("blur", hide);
-    window.addEventListener("scroll", hide, { capture: true });
+    window.addEventListener("scroll", onScroll, { capture: true });
     return () => {
       window.removeEventListener("blur", hide);
-      window.removeEventListener("scroll", hide, { capture: true });
+      window.removeEventListener("scroll", onScroll, { capture: true });
     };
   }, [visible, hide]);
 


### PR DESCRIPTION
## Backport of #1544

This backports the viewport-tooltip scroll scoping fix so portal-rendered tooltips stay visible when an unrelated pane, such as the transcript, auto-scrolls. Tooltips still dismiss when their anchor's scroll ancestor or the viewport moves.

Source squash: `3bd7bcb6a0db3be5d7c15f19e29c3f5a87c8e62e`

## Adaptation notes

`releases/1.0` already has the shared tooltip hook but does not contain PR #1429's native-drag interaction layer. That is a separate drag-performance feature, not a prerequisite for anchor-aware scroll dismissal, so this backport intentionally carries only #1544's tooltip behavior and regression coverage.

## Database / migration audit

No SQLite schema, migration, or SQL files changed. No migration was introduced.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx` — 47 passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — 0 errors; 136 pre-existing warnings
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop build`
- `git diff --check`
