### PR TITLE
fix(desktop): allow marking Attention threads read

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1031,6 +1031,11 @@ export function Sidebar(props: SidebarProps) {
     void props.onMarkThreadUnread?.(thread);
   };
 
+  const markReadFromContextMenu = (thread: NavigationThreadSummary): void => {
+    setContextMenu(undefined);
+    void props.onMarkThreadsSeen?.([thread]);
+  };
+
   const removeRemotePinFromContextMenu = (
     thread: NavigationThreadSummary,
   ): void => {
@@ -1283,6 +1288,13 @@ export function Sidebar(props: SidebarProps) {
       contextMenu.thread.updatedAt !== undefined &&
       props.onMarkThreadUnread,
   );
+  const contextMenuCanMarkRead = Boolean(
+    contextMenu &&
+      !contextMenuIsBulk &&
+      !contextMenuIsMainWindowRemoteRow &&
+      contextMenu.thread.inbox.inInbox &&
+      props.onMarkThreadsSeen,
+  );
   const contextMenuChildThreadCount = contextMenu && !contextMenuIsBulk
     ? props.threads.filter(
         (thread) =>
@@ -1381,6 +1393,7 @@ export function Sidebar(props: SidebarProps) {
     contextMenuCanUnlinkSubthread ||
     contextMenuShowMoveItems ||
     contextMenuCanRename ||
+    contextMenuCanMarkRead ||
     contextMenuCanMarkUnread ||
     contextMenuCanArchive;
   const contextMenuHasTopActions =
@@ -2118,6 +2131,17 @@ export function Sidebar(props: SidebarProps) {
                       }
                     >
                       Mark Unread
+                    </button>
+                  ) : null}
+                  {contextMenuCanMarkRead ? (
+                    <button
+                      role="menuitem"
+                      type="button"
+                      onClick={() =>
+                        markReadFromContextMenu(contextMenu.thread)
+                      }
+                    >
+                      Mark Read
                     </button>
                   ) : null}
                   {contextMenuCanArchive && contextMenuHasChildThreads ? (

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -4505,6 +4505,37 @@ describe("Sidebar", () => {
       .not.toBeInTheDocument();
   });
 
+  it("marks an unread Attention thread read from the thread context menu", async () => {
+    const onMarkThreadsSeen = vi.fn(async () => undefined);
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="attention"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[updatedSinceSeenThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-updated"
+        threads={[updatedSinceSeenThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onMarkThreadsSeen={onMarkThreadsSeen}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open thread actions" }));
+    await clickElement(screen.getByRole("menuitem", { name: "Mark Read" }));
+
+    expect(onMarkThreadsSeen).toHaveBeenCalledWith([updatedSinceSeenThread]);
+    expect(screen.queryByRole("menuitem", { name: "Mark Read" }))
+      .not.toBeInTheDocument();
+  });
+
   it("omits Mark Unread for an already-unread thread", () => {
     render(
       <Sidebar


### PR DESCRIPTION
## Summary

- add `Mark Read` to the thread actions menu for unread threads, including rows in the Attention lens
- route the action through the existing seen-state callback so the row leaves the unread work queue
- add a regression test covering the Attention-lens menu action

## Root cause

The sidebar thread menu only modeled the inverse `Mark Unread` action. Although the existing `onMarkThreadsSeen` path already supported explicit read-state updates, unread thread rows never exposed it as a menu item.

## User impact

Operators can intentionally dismiss an unread thread from the Attention work queue without replying to it.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx` (126 passed)
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
