### PR TITLE
fix(desktop): catch up federated transcripts

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -1710,6 +1710,102 @@ describe("DesktopFederationRuntime", () => {
     expect(invalidated).toEqual(["client_one"]);
   });
 
+  it.each([
+    "thread/status/changed",
+    "turn/cancelled",
+    "turn/completed",
+    "turn/failed",
+    "turn/started",
+  ])("invalidates cached remote summaries on %s", (method) => {
+    const invalidated: Array<string | undefined> = [];
+    const router = new FederationRouter({ localInstanceId: "gateway_one" });
+    router.registerConnection(createConnection({
+      peerId: "client_one",
+      capabilities: ["thread_navigation", "event_subscriptions"],
+    }));
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "gateway_one";
+    runtime.router = router;
+    runtime.setEventSubscriptions("viewer", [{
+      sourceInstanceId: "client_one",
+      eventClasses: ["navigation"],
+    }]);
+    runtime.remoteThreadSummaryCache = {
+      invalidate: (instanceId) => invalidated.push(instanceId),
+    };
+
+    runtime.publishRemoteBackendEvent(
+      {
+        id: `event-${method}`,
+        kind: "notification",
+        method: FEDERATION_BACKEND_EVENT_METHOD,
+        params: {
+          backend: "codex",
+          notification: {
+            method,
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+            },
+          },
+        },
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: "client_one",
+        targetInstanceId: "gateway_one",
+        createdAt: 2_000,
+      },
+      "client_one",
+    );
+
+    expect(invalidated).toEqual(["client_one"]);
+  });
+
+  it("does not invalidate cached remote summaries for streamed transcript items", () => {
+    const invalidated: Array<string | undefined> = [];
+    const router = new FederationRouter({ localInstanceId: "gateway_one" });
+    router.registerConnection(createConnection({
+      peerId: "client_one",
+      capabilities: ["thread_detail", "event_subscriptions"],
+    }));
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "gateway_one";
+    runtime.router = router;
+    runtime.setEventSubscriptions("viewer", [{
+      sourceInstanceId: "client_one",
+      eventClasses: ["transcript"],
+    }]);
+    runtime.remoteThreadSummaryCache = {
+      invalidate: (instanceId) => invalidated.push(instanceId),
+    };
+
+    runtime.publishRemoteBackendEvent(
+      {
+        id: "event-agent-message-delta",
+        kind: "notification",
+        method: FEDERATION_BACKEND_EVENT_METHOD,
+        params: {
+          backend: "codex",
+          notification: {
+            method: "item/agentMessage/delta",
+            params: {
+              delta: "hello",
+              itemId: "item-1",
+              threadId: "thread-1",
+              turnId: "turn-1",
+            },
+          },
+        },
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: "client_one",
+        targetInstanceId: "gateway_one",
+        createdAt: 2_000,
+      },
+      "client_one",
+    );
+
+    expect(invalidated).toEqual([]);
+  });
+
   it("subscribes Cmd+K snapshot peers to navigation updates for the cache TTL", async () => {
     vi.useFakeTimers();
     const sent: FederationProtocolEnvelope[] = [];

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -467,6 +467,22 @@ const NAVIGATION_EVENT_METHODS = new Set<string>([
   "turn/started",
 ]);
 
+/**
+ * Live events patch renderer state, but pinned remote rows also come from a
+ * cached owner snapshot. Turn boundaries can advance `updatedAt` while that
+ * cache still holds the pre-turn value, leaving a previously hydrated
+ * transcript convinced it is current. Invalidate only at lifecycle
+ * boundaries — never for streamed transcript items — so the next pinned-row
+ * refresh catches up without turning every token into a snapshot fetch.
+ */
+const REMOTE_THREAD_SUMMARY_LIFECYCLE_METHODS = new Set<string>([
+  "thread/status/changed",
+  "turn/cancelled",
+  "turn/completed",
+  "turn/failed",
+  "turn/started",
+]);
+
 export function federationEventClassForMethod(
   method: string,
 ): FederationEventClass {
@@ -3912,6 +3928,9 @@ export class DesktopFederationRuntime {
       event.notification.method === "thread/pullRequests/updated"
       || event.notification.method === "thread/reactions/updated"
       || event.notification.method === "thread/name/updated"
+      || REMOTE_THREAD_SUMMARY_LIFECYCLE_METHODS.has(
+        event.notification.method,
+      )
     ) {
       this.remoteThreadSummaryCache?.invalidate(sourceInstanceId);
     }

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -10514,6 +10514,88 @@ describe("useThreadNavigation", () => {
     expect(result.current.threads[1]?.reactions).toEqual(["✋", "👀"]);
   });
 
+  it("refreshes pinned remote summaries when a peer turn completes", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    let updatedAt = 1_000;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+      threads: [
+        {
+          id: "remote-thread",
+          title: "Pinned remote thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          updatedAt,
+          federation: {
+            instanceLabel: "Remote Mac",
+            ref: {
+              backend: "codex" as const,
+              target: federationTarget,
+              threadId: "remote-thread",
+            },
+          },
+        },
+      ],
+    }));
+    const desktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (
+        callback: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0],
+      ) => {
+        agentEventHandler = callback;
+        return () => {
+          agentEventHandler = undefined;
+        };
+      },
+    } as unknown as DesktopApi;
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.updatedAt).toBe(1_000);
+    });
+
+    updatedAt = 2_000;
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        federationTarget,
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "remote-thread",
+            turnId: "remote-turn",
+            turn: {
+              id: "remote-turn",
+              status: "completed",
+              output: [{ type: "text", text: "Remote final answer." }],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+      expect(result.current.threads[0]?.updatedAt).toBe(2_000);
+    });
+  });
+
   describe("pickAndRegisterDirectory (issue #223)", () => {
     const launchpadDefaults = {
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -3645,9 +3645,9 @@ export function useThreadNavigation(
       const method = event.notification.method as string;
       // A peer's row-state events carry its own remote target, which never
       // matches the main window's absent target — yet this window
-      // hosts that peer's threads as viewer-side remote pins. Let PR and
-      // reaction updates past the target filter and into their origin-scoped
-      // appliers below.
+      // hosts that peer's threads as viewer-side remote pins. Let row-state
+      // and lifecycle updates past the target filter and into their
+      // origin-scoped appliers below.
       //
       // Safe against duelling monitors: the main process drops a peer
       // observation for any PR this instance monitors itself, so whatever
@@ -3659,7 +3659,11 @@ export function useThreadNavigation(
         && Boolean(event.federationTarget)
         && (method === "pullRequest/status/updated"
           || method === "thread/pullRequests/updated"
-          || method === "thread/reactions/updated");
+          || method === "thread/reactions/updated"
+          || method === "thread/status/changed"
+          || method === "turn/cancelled"
+          || method === "turn/completed"
+          || method === "turn/failed");
       if (
         !remoteThreadStatePassthrough
         && !federationTargetsEqual(event.federationTarget, windowTarget)


### PR DESCRIPTION
## Summary

- invalidate cached remote navigation summaries at thread/turn lifecycle boundaries
- let the main window process remote status and terminal-turn events for pinned threads
- refresh pinned summaries after remote completion so an advanced `updatedAt` triggers transcript hydration
- keep streamed transcript item events out of the invalidation path

## Root cause

Federated lifecycle notifications are live, best-effort events. The owner correctly persisted and exposed the reported CI repair turn, but the viewer's remote summary cache was invalidated only for PR, reaction, and name changes. A completion refresh could therefore reuse a pre-turn summary whose `updatedAt` still matched the renderer's hydrated transcript version. `useThreadSessionState` then correctly—but incorrectly for the stale input—declined another `thread/read`.

The main-window navigation hook also filtered remote lifecycle events because its window has no federation target, even though it hosts viewer-pinned remote rows. That prevented terminal events from scheduling the navigation refresh that would begin catch-up.

The observed owner turn started at 2026-08-12 19:01:39 EDT and completed at 19:02:55. The authoritative transcript and remote pin summary both reached `updatedAt=1786575775000`; the M2 renderer remained on the earlier transcript. Neither side logged a federation disconnect or route error in that window. Logs cannot distinguish a notification that never reached the renderer from one discarded there, so the fix restores both cache invalidation and renderer reconciliation at the durable lifecycle boundary.

## Impact

Pinned federated threads now converge on the owner's completed transcript after a remote turn ends. Invalidation happens only for status and turn boundaries—a small fixed number per turn—not for streamed deltas or tool output chunks.

This is separate from:

- #1515, which filters and deltas Federation navigation transport
- #1518, which makes cross-instance child grouping consistent
- #1514, which fixed duplicate hydrated transcript tails

## Validation

- `pnpm test apps/desktop/src/main/__tests__/federation-runtime.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` — 180 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; existing warnings only
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:colors`
- `git diff --check`

Regression coverage intentionally does not depend on `completedAt`; the reported completed owner transcript had a usage projection whose `completed_at` remained null.
