### PR TITLE
fix(desktop): make automation-aware quit safe

### DIFF
--- a/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
@@ -538,6 +538,121 @@ describe("AutomationScheduler", () => {
     });
   });
 
+  it("starts a queued run once when duplicate terminal signals release the lane", async () => {
+    const automation = store.createAutomation({
+      id: "automation-duplicate-terminal",
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Search Bots",
+      taskPrompt: "Investigate.",
+      inboundCoalesceWindowMs: 0,
+      triggers: [
+        {
+          id: "inbound",
+          kind: "inbound_message",
+          conversation: { channel: "slack", conversationId: "C123" },
+        },
+      ],
+      now: 0,
+    });
+    const scheduler = buildScheduler();
+    const source = (sourceEventKey: string) => ({
+      kind: "messaging" as const,
+      sourceEventKey,
+      receivedAt: now,
+      matchedTriggerId: "inbound",
+      actor: { platformUserId: "B123", isBot: true },
+      conversation: { channel: "slack" as const, conversationId: "C123" },
+      message: { text: "ERROR" },
+    });
+
+    now = 1_000;
+    await scheduler.runFromInboundEvent({
+      automation,
+      source: source("first"),
+      now,
+    });
+    const activeRun = store.findActiveRunForAutomation(automation.id)!;
+
+    now = 2_000;
+    await scheduler.runFromInboundEvent({
+      automation,
+      source: source("queued"),
+      now,
+    });
+
+    now = 3_000;
+    await Promise.all([
+      scheduler.handleTurnQueueUpdate({
+        automationRunId: activeRun.id,
+        status: "terminal",
+        terminalStatus: "turn/completed",
+        now,
+      }),
+      scheduler.handleTurnQueueUpdate({
+        automationRunId: activeRun.id,
+        status: "terminal",
+        terminalStatus: "turn/completed",
+        now,
+      }),
+    ]);
+
+    expect(queue.submitted).toHaveLength(2);
+    expect(
+      queue.submitted.filter((entry) => entry.automationRunId !== activeRun.id),
+    ).toHaveLength(1);
+  });
+
+  it("queues automation dispatch while quit confirmation is open and resumes it", async () => {
+    const automation = store.createAutomation({
+      id: "automation-quit-wait",
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Search Bots",
+      taskPrompt: "Investigate.",
+      inboundCoalesceWindowMs: 0,
+      triggers: [
+        {
+          id: "inbound",
+          kind: "inbound_message",
+          conversation: { channel: "slack", conversationId: "C123" },
+        },
+      ],
+      now: 0,
+    });
+    const scheduler = buildScheduler();
+    scheduler.start();
+    const resume = scheduler.quiesceDispatch();
+
+    now = 1_000;
+    const result = await scheduler.runFromInboundEvent({
+      automation,
+      source: {
+        kind: "messaging",
+        sourceEventKey: "held-while-quitting",
+        receivedAt: now,
+        matchedTriggerId: "inbound",
+        actor: { platformUserId: "B123", isBot: true },
+        conversation: { channel: "slack", conversationId: "C123" },
+        message: { text: "ERROR" },
+      },
+      now,
+    });
+
+    expect(result?.status).toBe("queued");
+    expect(queue.submitted).toHaveLength(0);
+    expect(store.findActiveRunForAutomation(automation.id)).toMatchObject({
+      status: "queued",
+    });
+
+    await resume();
+
+    expect(queue.submitted).toHaveLength(1);
+    expect(store.findActiveRunForAutomation(automation.id)).toMatchObject({
+      status: "running",
+    });
+  });
+
   it("ignores a redelivered inbound event with the same source-event key", async () => {
     const automation = store.createAutomation({
       id: "automation-1",

--- a/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
@@ -653,6 +653,63 @@ describe("AutomationScheduler", () => {
     });
   });
 
+  it("queues a run when quit quiescing begins while its gate is in progress", async () => {
+    createIntervalAutomation({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      gate: { command: "echo ready" },
+      schedule: {
+        kind: "interval",
+        every: 5,
+        unit: "minutes",
+        anchorAt: 0,
+      },
+      nextRunAt: 5 * 60 * 1000,
+    });
+    let gateCalls = 0;
+    let releaseFirstGate!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirstGate = resolve;
+    });
+    const scheduler = buildSchedulerWithGate({
+      runGate: async (config) => {
+        gateCalls += 1;
+        if (gateCalls === 1) {
+          await firstGate;
+        }
+        return {
+          status: "proceed",
+          command: config.command,
+          durationMs: 5,
+          output: "ready\n",
+        };
+      },
+    });
+    scheduler.start();
+    now = 5 * 60 * 1000;
+
+    const evaluating = scheduler.evaluateDueAutomations();
+    await Promise.resolve();
+    const resume = scheduler.quiesceDispatch();
+    releaseFirstGate();
+    await evaluating;
+
+    expect(queue.submitted).toHaveLength(0);
+    expect(store.findActiveRunForAutomation("automation-1")).toMatchObject({
+      status: "queued",
+    });
+
+    await resume();
+
+    expect(gateCalls).toBe(2);
+    expect(queue.submitted).toHaveLength(1);
+    expect(store.findActiveRunForAutomation("automation-1")).toMatchObject({
+      status: "running",
+    });
+  });
+
   it("ignores a redelivered inbound event with the same source-event key", async () => {
     const automation = store.createAutomation({
       id: "automation-1",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -21793,6 +21793,19 @@ command = "pnpm dev"
         },
       },
     ]);
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: [],
+      automationRuns: [
+        {
+          agentThreadId: "agent-thread-1",
+          automationName: "Check email",
+          automationRunId: "run-1",
+          backend: "codex",
+          startedAt: expect.any(Number),
+        },
+      ],
+    });
 
     await codexClient.emit({
       method: "turn/completed",
@@ -21847,8 +21860,59 @@ command = "pnpm dev"
         },
       },
     ]);
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 0,
+      threadIds: [],
+    });
 
     unsubscribe();
+    await registry.close();
+  });
+
+  it("reports duplicate executions of one automation run as one quit blocker", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+      startTurnResults: [
+        { threadId: "ephemeral-1", turnId: "turn-1" },
+        { threadId: "ephemeral-2", turnId: "turn-2" },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await Promise.all([
+      registry.startAutomationHeadlessTurn({
+        backend: "codex",
+        agentThreadId: "agent-thread-1",
+        automationName: "Search Bots",
+        automationRunId: "run-1",
+        input: [{ type: "text", text: "Run the task." }],
+      }),
+      registry.startAutomationHeadlessTurn({
+        backend: "codex",
+        agentThreadId: "agent-thread-1",
+        automationName: "Search Bots",
+        automationRunId: "run-1",
+        input: [{ type: "text", text: "Run the task." }],
+      }),
+    ]);
+
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: [],
+      automationRuns: [
+        {
+          agentThreadId: "agent-thread-1",
+          automationName: "Search Bots",
+          automationRunId: "run-1",
+          backend: "codex",
+          startedAt: expect.any(Number),
+        },
+      ],
+    });
+
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
@@ -76,6 +76,21 @@ function createFakeDialogWindow(): FakeDialogWindow {
 
 const dialogWindows: FakeDialogWindow[] = [];
 
+function sendDialogAction(window: FakeDialogWindow, action: string): void {
+  const on = window.webContents.on as unknown as {
+    mock: { calls: Array<[string, (event: unknown, url: string) => void]> };
+  };
+  const willNavigate = on.mock.calls.find(
+    ([event]) => event === "will-navigate",
+  )?.[1];
+  if (!willNavigate) throw new Error("dialog registered no will-navigate handler");
+  const prefix = /pwragent-quit-confirmation:\/\/[^/]+\//.exec(
+    decodeURIComponent(window.loadedUrl ?? ""),
+  )?.[0];
+  if (!prefix) throw new Error("dialog page carries no navigation prefix");
+  willNavigate({ preventDefault: vi.fn() }, `${prefix}${action}`);
+}
+
 vi.mock("electron", () => ({
   // `new BrowserWindow(...)`: an arrow function is not constructible.
   BrowserWindow: vi.fn(function BrowserWindowMock() {
@@ -317,6 +332,7 @@ describe("raising the open quit dialog", () => {
       });
       const window = dialogWindows.at(-1)!;
       window.listeners.get("ready-to-show")?.();
+      sendDialogAction(window, "wait-for-work");
 
       await vi.advanceTimersByTimeAsync(0);
 
@@ -328,6 +344,9 @@ describe("raising the open quit dialog", () => {
         "Wait for Work",
       );
       expect(decodeURIComponent(window.loadedUrl ?? "")).toContain(
+        'send("wait-for-work")',
+      );
+      expect(decodeURIComponent(window.loadedUrl ?? "")).toContain(
         "1 automation is running",
       );
       expect(decodeURIComponent(window.loadedUrl ?? "")).toContain(
@@ -335,6 +354,79 @@ describe("raising the open quit dialog", () => {
       );
       await vi.advanceTimersByTimeAsync(1_250);
       await expect(pending).resolves.toBe("work-completed");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not quit when work finishes after interaction only cancelled the countdown", async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = showQuitConfirmationDialog({
+        countdownSeconds: 10,
+        inProgressThreadCount: 1,
+        terminalSessionCount: 0,
+        refresh: async () => ({
+          inProgressThreadCount: 0,
+          automationRunCount: 0,
+          terminalSessionCount: 0,
+          actionRunCount: 0,
+          items: [],
+        }),
+      });
+      const window = dialogWindows.at(-1)!;
+      sendDialogAction(window, "countdown-cancel");
+      window.listeners.get("ready-to-show")?.();
+
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(window.closed).toBe(0);
+      window.listeners.get("closed")?.();
+      await expect(pending).resolves.toBe("manual-cancel");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels wait completion when new work appears during the grace period", async () => {
+    vi.useFakeTimers();
+    try {
+      let refreshCount = 0;
+      const pending = showQuitConfirmationDialog({
+        countdownSeconds: 10,
+        inProgressThreadCount: 1,
+        terminalSessionCount: 0,
+        refresh: async () => {
+          refreshCount += 1;
+          const active = refreshCount > 1;
+          return {
+            inProgressThreadCount: active ? 1 : 0,
+            automationRunCount: 0,
+            terminalSessionCount: 0,
+            actionRunCount: 0,
+            items: active
+              ? [
+                  {
+                    kind: "turn" as const,
+                    backend: "codex",
+                    threadId: "new-thread",
+                    threadKey: "codex:new-thread",
+                  },
+                ]
+              : [],
+          };
+        },
+      });
+      const window = dialogWindows.at(-1)!;
+      window.listeners.get("ready-to-show")?.();
+      sendDialogAction(window, "wait-for-work");
+
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(refreshCount).toBeGreaterThan(1);
+      expect(window.closed).toBe(0);
+      window.listeners.get("closed")?.();
+      await expect(pending).resolves.toBe("manual-cancel");
     } finally {
       vi.useRealTimers();
     }
@@ -358,18 +450,7 @@ describe("clicking a quit dialog row", () => {
    * the per-dialog navigation prefix the page was actually built with.
    */
   function clickRow(window: (typeof dialogWindows)[number], action: string) {
-    const on = window.webContents.on as unknown as {
-      mock: { calls: Array<[string, (event: unknown, url: string) => void]> };
-    };
-    const willNavigate = on.mock.calls.find(
-      ([event]) => event === "will-navigate",
-    )?.[1];
-    if (!willNavigate) throw new Error("dialog registered no will-navigate handler");
-    const prefix = /pwragent-quit-confirmation:\/\/[^/]+\//.exec(
-      decodeURIComponent(window.loadedUrl ?? ""),
-    )?.[0];
-    if (!prefix) throw new Error("dialog page carries no navigation prefix");
-    willNavigate({ preventDefault: vi.fn() }, `${prefix}${action}`);
+    sendDialogAction(window, action);
   }
 
   it("routes the show-thread request to the window that owns a remote terminal", async () => {

--- a/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
@@ -10,7 +10,11 @@ type FakeDialogWindow = {
   restored: number;
   closed: number;
   once: (event: string, handler: (...args: unknown[]) => void) => void;
-  webContents: { on: () => void; setWindowOpenHandler: () => void };
+  webContents: {
+    executeJavaScript: (script: string) => Promise<void>;
+    on: () => void;
+    setWindowOpenHandler: () => void;
+  };
   /** The data: URL the dialog loaded, so tests can read the page it built. */
   loadedUrl?: string;
   /** Stays pending unless a test settles it — the real load is async too. */
@@ -41,6 +45,7 @@ function createFakeDialogWindow(): FakeDialogWindow {
       window.listeners.set(event, handler);
     },
     webContents: {
+      executeJavaScript: vi.fn(async () => undefined),
       on: vi.fn(),
       setWindowOpenHandler: vi.fn(),
     },
@@ -282,6 +287,57 @@ describe("raising the open quit dialog", () => {
 
     window.listeners.get("closed")?.();
     await expect(pending).resolves.toBe("manual-cancel");
+  });
+
+  it("reports finished work before completing the quit", async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = showQuitConfirmationDialog({
+        countdownSeconds: 10,
+        inProgressThreadCount: 0,
+        automationRunCount: 1,
+        terminalSessionCount: 0,
+        items: [
+          {
+            kind: "automation",
+            backend: "codex",
+            threadId: "agent-thread-1",
+            threadKey: "codex:agent-thread-1",
+            title: "Search Bots",
+            detail: "Started 8:29:31 PM",
+          },
+        ],
+        refresh: async () => ({
+          inProgressThreadCount: 0,
+          automationRunCount: 0,
+          terminalSessionCount: 0,
+          actionRunCount: 0,
+          items: [],
+        }),
+      });
+      const window = dialogWindows.at(-1)!;
+      window.listeners.get("ready-to-show")?.();
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(window.webContents.executeJavaScript).toHaveBeenCalledWith(
+        expect.stringContaining("All running work finished"),
+        true,
+      );
+      expect(decodeURIComponent(window.loadedUrl ?? "")).toContain(
+        "Wait for Work",
+      );
+      expect(decodeURIComponent(window.loadedUrl ?? "")).toContain(
+        "1 automation is running",
+      );
+      expect(decodeURIComponent(window.loadedUrl ?? "")).toContain(
+        "Search Bots",
+      );
+      await vi.advanceTimersByTimeAsync(1_250);
+      await expect(pending).resolves.toBe("work-completed");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -455,9 +455,71 @@ describe("createQuitManager", () => {
       expect.objectContaining({ error: "app-server unavailable" }),
     );
   });
+
+  it("resumes automation dispatch when the operator stays open", async () => {
+    const { createQuitManager } = await import("../quit-manager");
+    const resumeDispatch = vi.fn(async () => undefined);
+    const quiesceAutomationDispatch = vi.fn(() => resumeDispatch);
+    const manager = createQuitManager({
+      confirm: vi.fn(async () => "manual-cancel" as const),
+      getConfirmationEnabled: () => true,
+      getQuitBlockers: () => ({
+        count: 1,
+        terminalSessionCount: 0,
+        terminalThreadKeys: [],
+        threadIds: [],
+        automationRunCount: 1,
+        actionRunCount: 0,
+        items: [],
+      }),
+      quiesceAutomationDispatch,
+      log: {},
+      performQuit: vi.fn(),
+    });
+
+    await expect(manager.requestQuit({ source: "menu" })).resolves.toBe(false);
+
+    expect(quiesceAutomationDispatch).toHaveBeenCalledTimes(1);
+    expect(resumeDispatch).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("buildQuitBlockerSnapshot", () => {
+  it("collapses an ephemeral automation execution onto its named Agent run", async () => {
+    const { buildQuitBlockerSnapshot } = await import("../quit-manager");
+
+    const snapshot = buildQuitBlockerSnapshot({
+      inProgressThreads: {
+        count: 1,
+        threadIds: [],
+        automationRuns: [
+          {
+            agentThreadId: "agent-thread-1",
+            automationName: "Search Bots",
+            automationRunId: "automation-run:1",
+            backend: "codex",
+            startedAt: new Date("2026-08-12T20:29:31-04:00").getTime(),
+          },
+        ],
+      },
+      terminalSessions: { count: 0, threads: [] },
+    });
+
+    expect(snapshot.count).toBe(1);
+    expect(snapshot.threadIds).toEqual([]);
+    expect(snapshot.automationRunCount).toBe(1);
+    expect(snapshot.items).toEqual([
+      expect.objectContaining({
+        kind: "automation",
+        backend: "codex",
+        threadId: "agent-thread-1",
+        threadKey: "codex:agent-thread-1",
+        title: "Search Bots",
+        detail: expect.stringMatching(/^Started /),
+      }),
+    ]);
+  });
+
   it("turns every kind of running work into a linkable item", async () => {
     const { buildQuitBlockerSnapshot } = await import("../quit-manager");
 

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -482,6 +482,46 @@ describe("createQuitManager", () => {
     expect(quiesceAutomationDispatch).toHaveBeenCalledTimes(1);
     expect(resumeDispatch).toHaveBeenCalledTimes(1);
   });
+
+  it("allows a new quit prompt while queued automation dispatch is still resuming", async () => {
+    const { createQuitManager } = await import("../quit-manager");
+    let finishResume!: () => void;
+    const resumePending = new Promise<void>((resolve) => {
+      finishResume = resolve;
+    });
+    const resumeDispatch = vi.fn(() => resumePending);
+    const confirm = vi
+      .fn()
+      .mockResolvedValueOnce("manual-cancel" as const)
+      .mockResolvedValueOnce("manual-confirm" as const);
+    const performQuit = vi.fn();
+    const manager = createQuitManager({
+      confirm,
+      getConfirmationEnabled: () => true,
+      getQuitBlockers: () => ({
+        count: 1,
+        terminalSessionCount: 0,
+        terminalThreadKeys: [],
+        threadIds: [],
+        automationRunCount: 1,
+        actionRunCount: 0,
+        items: [],
+      }),
+      quiesceAutomationDispatch: () => resumeDispatch,
+      log: {},
+      performQuit,
+    });
+
+    await expect(manager.requestQuit({ source: "menu" })).resolves.toBe(false);
+    expect(resumeDispatch).toHaveBeenCalledTimes(1);
+
+    await expect(manager.requestQuit({ source: "menu" })).resolves.toBe(true);
+
+    expect(confirm).toHaveBeenCalledTimes(2);
+    expect(performQuit).toHaveBeenCalledTimes(1);
+    finishResume();
+    await resumePending;
+  });
 });
 
 describe("buildQuitBlockerSnapshot", () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6720,10 +6720,13 @@ export class DesktopBackendRegistry {
     string,
     {
       agentThreadId: string;
+      backend: AppServerBackendKind;
       automationName?: string;
       automationRunId: string;
       executionMode: ThreadExecutionMode;
+      executionThreadId: string;
       queueEntryId: string;
+      startedAt: number;
       suppressBindingBroadcast?: boolean;
     }
   >();
@@ -7673,10 +7676,13 @@ export class DesktopBackendRegistry {
       buildHeadlessAutomationTurnKey(params.backend, turn.threadId, turn.turnId),
       {
         agentThreadId: params.agentThreadId,
+        backend: params.backend,
         automationName: params.automationName,
         automationRunId: params.automationRunId,
         executionMode,
+        executionThreadId: turn.threadId,
         queueEntryId,
+        startedAt: Date.now(),
         suppressBindingBroadcast: params.suppressBindingBroadcast,
       },
     );
@@ -11649,44 +11655,90 @@ export class DesktopBackendRegistry {
   getInProgressThreadSnapshotForQuit(): {
     count: number;
     threadIds: string[];
+    automationRuns?: Array<{
+      agentThreadId: string;
+      automationName?: string;
+      automationRunId: string;
+      backend: AppServerBackendKind;
+      startedAt: number;
+    }>;
   } {
     const threadKeys = new Set<string>();
+    const automationExecutionThreadKeys = new Set<string>();
+    const automationRunsByKey = new Map<
+      string,
+      {
+        agentThreadId: string;
+        automationName?: string;
+        automationRunId: string;
+        backend: AppServerBackendKind;
+        startedAt: number;
+      }
+    >();
+    for (const run of this.headlessAutomationTurns.values()) {
+      automationExecutionThreadKeys.add(
+        formatQuitThreadKey(run.backend, run.executionThreadId),
+      );
+      const key = `${run.backend}:${run.automationRunId}`;
+      const existing = automationRunsByKey.get(key);
+      if (!existing || run.startedAt < existing.startedAt) {
+        automationRunsByKey.set(key, {
+          agentThreadId: run.agentThreadId,
+          automationName: run.automationName,
+          automationRunId: run.automationRunId,
+          backend: run.backend,
+          startedAt: run.startedAt,
+        });
+      }
+    }
+    const addThread = (backend: AppServerBackendKind, threadId: string): void => {
+      const threadKey = formatQuitThreadKey(backend, threadId);
+      if (!automationExecutionThreadKeys.has(threadKey)) {
+        threadKeys.add(threadKey);
+      }
+    };
     for (const threadId of this.backendActiveCodexThreadIds) {
-      threadKeys.add(formatQuitThreadKey("codex", threadId));
+      addThread("codex", threadId);
     }
     for (const key of this.activeTurnKeys) {
       const parsed = parseActiveTurnKey(key);
       if (parsed) {
-        threadKeys.add(formatQuitThreadKey(parsed.backend, parsed.threadId));
+        addThread(parsed.backend, parsed.threadId);
       }
     }
     for (const key of this.activeCodexTurnModes.keys()) {
       const threadId = parseThreadIdFromThreadTurnKeyBody(key);
       if (threadId) {
-        threadKeys.add(formatQuitThreadKey("codex", threadId));
+        addThread("codex", threadId);
       }
     }
     for (const threadId of this.reservedCodexStartThreadIds) {
-      threadKeys.add(formatQuitThreadKey("codex", threadId));
+      addThread("codex", threadId);
     }
     for (const key of this.reservedAcpStartThreadKeys) {
       const parsed = parseReservedAcpStartThreadKey(key);
       if (parsed) {
-        threadKeys.add(formatQuitThreadKey(parsed.backend, parsed.threadId));
+        addThread(parsed.backend, parsed.threadId);
       }
     }
     for (const entry of this.threadTurnQueue.getAllQueuedEntries()) {
-      threadKeys.add(formatQuitThreadKey(entry.backend, entry.threadId));
+      addThread(entry.backend, entry.threadId);
     }
     for (const move of this.pendingThreadWorkspaceMoves.values()) {
       if (move.status === "queued" || move.status === "running") {
-        threadKeys.add(formatQuitThreadKey(move.backend, move.threadId));
+        addThread(move.backend, move.threadId);
       }
     }
     const threadIds = [...threadKeys].sort();
+    const automationRuns = [...automationRunsByKey.values()].sort(
+      (left, right) =>
+        left.startedAt - right.startedAt
+        || left.automationRunId.localeCompare(right.automationRunId),
+    );
     return {
-      count: threadIds.length,
+      count: threadIds.length + automationRuns.length,
       threadIds,
+      ...(automationRuns.length > 0 ? { automationRuns } : {}),
     };
   }
 

--- a/apps/desktop/src/main/automations/automation-scheduler.ts
+++ b/apps/desktop/src/main/automations/automation-scheduler.ts
@@ -621,6 +621,22 @@ export class AutomationScheduler {
       if (gateResult?.status === "skip" || gateResult?.status === "failed") {
         return undefined;
       }
+      // A gate can outlive the moment quit quiescing begins. Nothing awaits
+      // between this check and submitRun, so once it passes the launch is
+      // atomic with respect to another main-process event pausing dispatch.
+      if (this.dispatchPauseCount > 0) {
+        const queued = this.options.store.markRunQueued({
+          runId: run.id,
+          queueEntryId: run.queueEntryId ?? buildLaneQueueEntryId(run.id),
+          queuedAt: params.now,
+          now: params.now,
+        });
+        return buildLaneQueuedResult({
+          automation: params.automation,
+          run: queued ?? run,
+          position: 1,
+        });
+      }
       const result = await this.options.runner.submitRun({
         automation: params.automation,
         gateResult,

--- a/apps/desktop/src/main/automations/automation-scheduler.ts
+++ b/apps/desktop/src/main/automations/automation-scheduler.ts
@@ -61,8 +61,16 @@ export function throttleSkipMessage(droppedCount: number): string {
 export class AutomationScheduler {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private running = false;
+  private dispatchPauseCount = 0;
   private readonly sessionStartedAt: number;
   private readonly coalesceWindows = new Map<string, InboundCoalesceWindow>();
+  /**
+   * A run can reach terminal state through both the captured assistant-final
+   * fast path and the later backend lifecycle notification. Those handlers may
+   * race while releasing the same automation lane. Claim the queued successor
+   * before its async submission so one durable run never launches twice.
+   */
+  private readonly startingPendingRunIds = new Set<string>();
 
   constructor(private readonly options: AutomationSchedulerOptions) {
     this.sessionStartedAt = this.now();
@@ -87,6 +95,28 @@ export class AutomationScheduler {
       this.clearTimer(open.timer);
     }
     this.coalesceWindows.clear();
+  }
+
+  /**
+   * Hold new launches while the operator decides whether to quit. Existing
+   * turns continue, and triggers still become durable queued runs so staying
+   * open can resume them without losing inbound work.
+   */
+  quiesceDispatch(): () => Promise<void> {
+    this.dispatchPauseCount += 1;
+    if (this.timer) {
+      this.clearTimer(this.timer);
+      this.timer = null;
+    }
+    let released = false;
+    return async () => {
+      if (released) return;
+      released = true;
+      this.dispatchPauseCount = Math.max(0, this.dispatchPauseCount - 1);
+      if (this.dispatchPauseCount > 0) return;
+      this.scheduleNextTimer();
+      await this.resumePendingRuns();
+    };
   }
 
   async evaluateDueAutomations(): Promise<void> {
@@ -568,6 +598,20 @@ export class AutomationScheduler {
     const run = this.options.store.getRun(params.runId);
     if (!run) return undefined;
 
+    if (this.dispatchPauseCount > 0) {
+      const queued = this.options.store.markRunQueued({
+        runId: run.id,
+        queueEntryId: run.queueEntryId ?? buildLaneQueueEntryId(run.id),
+        queuedAt: params.now,
+        now: params.now,
+      });
+      return buildLaneQueuedResult({
+        automation: params.automation,
+        run: queued ?? run,
+        position: 1,
+      });
+    }
+
     try {
       const gateResult = await this.runGateIfNeeded({
         automation: params.automation,
@@ -738,17 +782,33 @@ export class AutomationScheduler {
     automationId: string | undefined,
     now: number,
   ): Promise<void> {
-    if (!automationId) return;
+    if (!automationId || this.dispatchPauseCount > 0) return;
     const automation = this.options.store.getAutomation(automationId);
     if (!automation) return;
     const pending = this.options.store.findPendingRunForAutomation(automationId);
     if (!pending) return;
-    await this.submitRun({
-      automation,
-      runId: pending.id,
-      windows: pending.scheduledWindows,
-      now,
-    });
+    if (this.startingPendingRunIds.has(pending.id)) return;
+    this.startingPendingRunIds.add(pending.id);
+    try {
+      await this.submitRun({
+        automation,
+        runId: pending.id,
+        windows: pending.scheduledWindows,
+        now,
+      });
+    } finally {
+      this.startingPendingRunIds.delete(pending.id);
+    }
+  }
+
+  private async resumePendingRuns(): Promise<void> {
+    if (!this.running || this.dispatchPauseCount > 0) return;
+    const now = this.now();
+    for (const automation of this.options.store.listAutomations()) {
+      const active = this.options.store.findActiveRunForAutomation(automation.id);
+      if (active?.status === "running") continue;
+      await this.startNextPendingRun(automation.id, now);
+    }
   }
 
   private scheduleNextTimer(): void {

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -214,6 +214,10 @@ export class DesktopAutomationService {
     this.options.registry.setAutomationInspectionHandler?.(null);
   }
 
+  quiesceDispatch(): () => Promise<void> {
+    return this.scheduler.quiesceDispatch();
+  }
+
   /**
    * Automations the store couldn't load this process lifetime (corrupt payload,
    * or a schedule/trigger shape this build predates). Surfaced to the renderer

--- a/apps/desktop/src/main/quit-confirmation-dialog.ts
+++ b/apps/desktop/src/main/quit-confirmation-dialog.ts
@@ -11,7 +11,8 @@ const quitDialogLog = getMainLogger("pwragent:quit-dialog");
 export type QuitConfirmationDialogResult =
   | "manual-confirm"
   | "manual-cancel"
-  | "countdown-expired";
+  | "countdown-expired"
+  | "work-completed";
 
 /**
  * One row in the dialog's "still running" list. Declared here rather than in
@@ -19,7 +20,7 @@ export type QuitConfirmationDialogResult =
  * be a dependency cycle.
  */
 export type QuitBlockerItem = {
-  kind: "turn" | "terminal" | "action";
+  kind: "turn" | "automation" | "terminal" | "action";
   backend: string;
   threadId: string;
   threadKey: string;
@@ -34,15 +35,27 @@ export type QuitBlockerItem = {
   title?: string;
   /** Secondary line — the owning peer, or an action's command and pid. */
   detail?: string;
+  /** Start time for live elapsed/completion reporting in the quit prompt. */
+  startedAt?: number;
 };
 
 export type QuitConfirmationDialogOptions = {
   countdownSeconds: number;
   inProgressThreadCount: number;
+  automationRunCount?: number;
   terminalSessionCount: number;
   actionRunCount?: number;
   items?: QuitBlockerItem[];
   parent?: BrowserWindow | null;
+  refresh?: () => Promise<QuitConfirmationDialogSnapshot>;
+};
+
+export type QuitConfirmationDialogSnapshot = {
+  inProgressThreadCount: number;
+  automationRunCount: number;
+  terminalSessionCount: number;
+  actionRunCount: number;
+  items: QuitBlockerItem[];
 };
 
 /**
@@ -222,13 +235,63 @@ export async function showQuitConfirmationDialog(
   return await new Promise<QuitConfirmationDialogResult>((resolve) => {
     let settled = false;
     let hardCeiling: NodeJS.Timeout | undefined;
+    let refreshTimer: NodeJS.Timeout | undefined;
+    let completionTimer: NodeJS.Timeout | undefined;
+    let refreshInFlight = false;
+    let lastRefreshSignature = JSON.stringify({
+      inProgressThreadCount: options.inProgressThreadCount,
+      automationRunCount: options.automationRunCount ?? 0,
+      terminalSessionCount: options.terminalSessionCount,
+      actionRunCount: options.actionRunCount ?? 0,
+      items,
+    });
 
     const finish = (result: QuitConfirmationDialogResult): void => {
       if (settled) return;
       settled = true;
       if (hardCeiling) clearTimeout(hardCeiling);
+      if (refreshTimer) clearInterval(refreshTimer);
+      if (completionTimer) clearTimeout(completionTimer);
       releaseDialog();
       resolve(result);
+    };
+
+    const refreshDialog = async (): Promise<void> => {
+      if (!options.refresh || settled || refreshInFlight) return;
+      refreshInFlight = true;
+      try {
+        const snapshot = await options.refresh();
+        const signature = JSON.stringify(snapshot);
+        if (signature === lastRefreshSignature) return;
+        lastRefreshSignature = signature;
+        const payload = buildQuitDialogUpdatePayload(snapshot, navigationPrefix);
+        if (!window.isDestroyed()) {
+          void window.webContents.executeJavaScript(
+            `window.__pwragentUpdateQuitSnapshot?.(${serializeForJavaScript(payload)})`,
+            true,
+          ).catch(() => undefined);
+        }
+        if (payload.totalCount === 0) {
+          if (hardCeiling) {
+            clearTimeout(hardCeiling);
+            hardCeiling = undefined;
+          }
+          if (refreshTimer) {
+            clearInterval(refreshTimer);
+            refreshTimer = undefined;
+          }
+          completionTimer = setTimeout(
+            () => finish("work-completed"),
+            COMPLETION_REPORT_MS,
+          );
+        }
+      } catch (error) {
+        quitDialogLog.warn("quit confirmation refresh failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      } finally {
+        refreshInFlight = false;
+      }
     };
 
     // This page interpolates model-generated thread titles and user-configured
@@ -297,6 +360,7 @@ export async function showQuitConfirmationDialog(
       buildQuitConfirmationHtml({
         countdownSeconds,
         inProgressThreadCount: options.inProgressThreadCount,
+        automationRunCount: options.automationRunCount ?? 0,
         terminalSessionCount: options.terminalSessionCount,
         actionRunCount: options.actionRunCount ?? 0,
         items,
@@ -325,6 +389,14 @@ export async function showQuitConfirmationDialog(
       active.ready = true;
       window.show();
       window.focus();
+      if (options.refresh) {
+        void refreshDialog();
+        refreshTimer = setInterval(
+          () => void refreshDialog(),
+          QUIT_REFRESH_INTERVAL_MS,
+        );
+        refreshTimer.unref?.();
+      }
     });
   }).catch((error: unknown) => {
     // An executor that throws would otherwise strand the shared handle on a
@@ -362,6 +434,8 @@ export function resolveQuitCountdownSeconds(
 /** The main-process ceiling must never beat the in-dialog cancel to the punch:
  *  a `countdown-cancel` fired in the final tick has to survive the round trip. */
 const HARD_CEILING_GRACE_MS = 1_500;
+const QUIT_REFRESH_INTERVAL_MS = 500;
+const COMPLETION_REPORT_MS = 1_250;
 
 function quitDialogHeight(itemCount: number): number {
   if (itemCount === 0) return DIALOG_BASE_HEIGHT;
@@ -375,6 +449,7 @@ const QUIT_ITEM_GROUPS: ReadonlyArray<{
   heading: string;
 }> = [
   { kind: "turn", heading: "Agent turns in progress" },
+  { kind: "automation", heading: "Automations in progress" },
   { kind: "terminal", heading: "Integrated terminals" },
   { kind: "action", heading: "Environment actions" },
 ];
@@ -459,6 +534,7 @@ function buildQuitItemListHtml(options: {
 export function buildQuitConfirmationHtml(options: {
   countdownSeconds: number;
   inProgressThreadCount: number;
+  automationRunCount?: number;
   terminalSessionCount: number;
   actionRunCount: number;
   items: QuitBlockerItem[];
@@ -468,11 +544,13 @@ export function buildQuitConfirmationHtml(options: {
 }): string {
   const countText = describeQuitBlockers({
     inProgressThreadCount: options.inProgressThreadCount,
+    automationRunCount: options.automationRunCount,
     terminalSessionCount: options.terminalSessionCount,
     actionRunCount: options.actionRunCount,
   });
   const interruptionText = describeQuitImpact({
     inProgressThreadCount: options.inProgressThreadCount,
+    automationRunCount: options.automationRunCount,
     terminalSessionCount: options.terminalSessionCount,
     actionRunCount: options.actionRunCount,
     hasItems: options.items.length > 0,
@@ -600,6 +678,9 @@ export function buildQuitConfirmationHtml(options: {
         border-color: var(--accent-border);
         background: var(--panel-hover);
       }
+      .row--finished {
+        opacity: 0.72;
+      }
       .row:focus-visible {
         outline: 2px solid var(--accent);
         outline-offset: 1px;
@@ -715,12 +796,13 @@ export function buildQuitConfirmationHtml(options: {
     </header>
     <main class="content">
       <h1>Quit PwrAgent?</h1>
-      <p>${escapeHtml(countText)}</p>
-      <p>${escapeHtml(interruptionText)}</p>
+      <p id="blocker-count">${escapeHtml(countText)}</p>
+      <p id="blocker-impact">${escapeHtml(interruptionText)}</p>
       ${listHtml}
       <p class="countdown" id="countdown"></p>
       <div class="actions">
         <button id="stay" class="secondary" type="button">Stay Open</button>
+        <button id="wait" class="secondary" type="button">Wait for Work</button>
         <button id="quit" class="primary" type="button" autofocus>Quit Now</button>
       </div>
     </main>
@@ -749,6 +831,43 @@ export function buildQuitConfirmationHtml(options: {
         countdown.textContent = "Auto-quit cancelled. Choose an option below.";
         send("countdown-cancel");
       }
+      window.__pwragentUpdateQuitSnapshot = (snapshot) => {
+        document.getElementById("blocker-count").textContent = snapshot.countText;
+        document.getElementById("blocker-impact").textContent = snapshot.impactText;
+        const currentList = document.getElementById("list");
+        if (snapshot.totalCount === 0) {
+          if (timer) {
+            clearInterval(timer);
+            timer = undefined;
+          }
+          const finishedAt = new Date().toLocaleTimeString([], {
+            hour: "numeric",
+            minute: "2-digit",
+            second: "2-digit",
+          });
+          for (const row of document.querySelectorAll(".row")) {
+            row.classList.add("row--finished");
+            let detail = row.querySelector(".row__detail");
+            if (!detail) {
+              detail = document.createElement("span");
+              detail.className = "row__detail";
+              row.append(detail);
+            }
+            detail.textContent = "Finished " + finishedAt;
+          }
+          countdown.textContent = "All running work finished. Quitting now...";
+          return;
+        }
+        if (snapshot.listHtml) {
+          if (currentList) {
+            currentList.outerHTML = snapshot.listHtml;
+          } else {
+            countdown.insertAdjacentHTML("beforebegin", snapshot.listHtml);
+          }
+        } else {
+          currentList?.remove();
+        }
+      };
       render();
       timer = setInterval(() => {
         remaining -= 1;
@@ -775,6 +894,10 @@ export function buildQuitConfirmationHtml(options: {
 
       document.getElementById("stay").addEventListener("click", () => send("manual-cancel"));
       document.getElementById("close").addEventListener("click", () => send("manual-cancel"));
+      document.getElementById("wait").addEventListener("click", () => {
+        cancelCountdown();
+        countdown.textContent = "Waiting for running work to finish...";
+      });
       document.getElementById("quit").addEventListener("click", () => send("manual-confirm"));
       window.addEventListener("keydown", (event) => {
         if (event.key === "Escape") send("manual-cancel");
@@ -789,8 +912,56 @@ export function buildQuitConfirmationHtml(options: {
 </html>`;
 }
 
+function buildQuitDialogUpdatePayload(
+  snapshot: QuitConfirmationDialogSnapshot,
+  navigationPrefix: string,
+): {
+  countText: string;
+  impactText: string;
+  listHtml: string;
+  totalCount: number;
+} {
+  const counts = {
+    inProgressThreadCount: snapshot.inProgressThreadCount,
+    automationRunCount: snapshot.automationRunCount,
+    terminalSessionCount: snapshot.terminalSessionCount,
+    actionRunCount: snapshot.actionRunCount,
+  };
+  const totalCount =
+    counts.inProgressThreadCount
+    + counts.automationRunCount
+    + counts.terminalSessionCount
+    + counts.actionRunCount;
+  return {
+    countText:
+      totalCount === 0
+        ? "All running work finished."
+        : describeQuitBlockers(counts),
+    impactText:
+      totalCount === 0
+        ? "PwrAgent can now quit without interrupting it."
+        : describeQuitImpact({
+            ...counts,
+            hasItems: snapshot.items.length > 0,
+          }),
+    listHtml: buildQuitItemListHtml({
+      items: snapshot.items,
+      navigationPrefix,
+    }),
+    totalCount,
+  };
+}
+
+function serializeForJavaScript(value: unknown): string {
+  return JSON.stringify(value)
+    .replaceAll("<", "\\u003c")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
+}
+
 function describeQuitBlockers(options: {
   inProgressThreadCount: number;
+  automationRunCount?: number;
   terminalSessionCount: number;
   actionRunCount: number;
 }): string {
@@ -799,6 +970,11 @@ function describeQuitBlockers(options: {
     parts.push("1 thread has an agent turn in progress");
   } else if (options.inProgressThreadCount > 1) {
     parts.push(`${options.inProgressThreadCount} threads have agent turns in progress`);
+  }
+  if (options.automationRunCount === 1) {
+    parts.push("1 automation is running");
+  } else if ((options.automationRunCount ?? 0) > 1) {
+    parts.push(`${options.automationRunCount} automations are running`);
   }
   if (options.terminalSessionCount === 1) {
     parts.push("1 integrated terminal is running");
@@ -822,6 +998,7 @@ function describeQuitBlockers(options: {
 
 function describeQuitImpact(options: {
   inProgressThreadCount: number;
+  automationRunCount?: number;
   terminalSessionCount: number;
   actionRunCount: number;
   hasItems: boolean;
@@ -829,6 +1006,9 @@ function describeQuitImpact(options: {
   const consequences: string[] = [];
   if (options.inProgressThreadCount > 0) {
     consequences.push("those turns will be interrupted");
+  }
+  if ((options.automationRunCount ?? 0) > 0) {
+    consequences.push("automation runs will be interrupted");
   }
   if (options.terminalSessionCount > 0) {
     consequences.push("terminal processes will be killed");

--- a/apps/desktop/src/main/quit-confirmation-dialog.ts
+++ b/apps/desktop/src/main/quit-confirmation-dialog.ts
@@ -238,6 +238,12 @@ export async function showQuitConfirmationDialog(
     let refreshTimer: NodeJS.Timeout | undefined;
     let completionTimer: NodeJS.Timeout | undefined;
     let refreshInFlight = false;
+    let waitForWork = false;
+    let lastTotalCount =
+      options.inProgressThreadCount
+      + (options.automationRunCount ?? 0)
+      + options.terminalSessionCount
+      + (options.actionRunCount ?? 0);
     let lastRefreshSignature = JSON.stringify({
       inProgressThreadCount: options.inProgressThreadCount,
       automationRunCount: options.automationRunCount ?? 0,
@@ -256,15 +262,39 @@ export async function showQuitConfirmationDialog(
       resolve(result);
     };
 
+    const cancelCompletion = (): void => {
+      if (!completionTimer) return;
+      clearTimeout(completionTimer);
+      completionTimer = undefined;
+    };
+
+    const scheduleCompletion = (): void => {
+      if (!waitForWork || lastTotalCount !== 0 || completionTimer || settled) {
+        return;
+      }
+      completionTimer = setTimeout(() => {
+        completionTimer = undefined;
+        if (waitForWork && lastTotalCount === 0) {
+          finish("work-completed");
+        }
+      }, COMPLETION_REPORT_MS);
+    };
+
     const refreshDialog = async (): Promise<void> => {
       if (!options.refresh || settled || refreshInFlight) return;
       refreshInFlight = true;
       try {
         const snapshot = await options.refresh();
         const signature = JSON.stringify(snapshot);
+        const payload = buildQuitDialogUpdatePayload(snapshot, navigationPrefix);
+        lastTotalCount = payload.totalCount;
+        if (lastTotalCount === 0) {
+          scheduleCompletion();
+        } else {
+          cancelCompletion();
+        }
         if (signature === lastRefreshSignature) return;
         lastRefreshSignature = signature;
-        const payload = buildQuitDialogUpdatePayload(snapshot, navigationPrefix);
         if (!window.isDestroyed()) {
           void window.webContents.executeJavaScript(
             `window.__pwragentUpdateQuitSnapshot?.(${serializeForJavaScript(payload)})`,
@@ -276,14 +306,6 @@ export async function showQuitConfirmationDialog(
             clearTimeout(hardCeiling);
             hardCeiling = undefined;
           }
-          if (refreshTimer) {
-            clearInterval(refreshTimer);
-            refreshTimer = undefined;
-          }
-          completionTimer = setTimeout(
-            () => finish("work-completed"),
-            COMPLETION_REPORT_MS,
-          );
         }
       } catch (error) {
         quitDialogLog.warn("quit confirmation refresh failed", {
@@ -316,6 +338,16 @@ export async function showQuitConfirmationDialog(
           clearTimeout(hardCeiling);
           hardCeiling = undefined;
         }
+        return;
+      }
+
+      if (action === "wait-for-work") {
+        waitForWork = true;
+        if (hardCeiling) {
+          clearTimeout(hardCeiling);
+          hardCeiling = undefined;
+        }
+        scheduleCompletion();
         return;
       }
 
@@ -811,6 +843,7 @@ export function buildQuitConfirmationHtml(options: {
       let remaining = ${JSON.stringify(options.countdownSeconds)};
       const countdown = document.getElementById("countdown");
       let timer;
+      let waitingForWork = false;
 
       function send(result) {
         window.location.href = navigationPrefix + result;
@@ -836,7 +869,7 @@ export function buildQuitConfirmationHtml(options: {
         document.getElementById("blocker-impact").textContent = snapshot.impactText;
         const currentList = document.getElementById("list");
         if (snapshot.totalCount === 0) {
-          if (timer) {
+          if (waitingForWork && timer) {
             clearInterval(timer);
             timer = undefined;
           }
@@ -855,7 +888,11 @@ export function buildQuitConfirmationHtml(options: {
             }
             detail.textContent = "Finished " + finishedAt;
           }
-          countdown.textContent = "All running work finished. Quitting now...";
+          if (waitingForWork) {
+            countdown.textContent = "All running work finished. Quitting now...";
+          } else if (!timer) {
+            countdown.textContent = "All running work finished. Choose an option below.";
+          }
           return;
         }
         if (snapshot.listHtml) {
@@ -896,7 +933,9 @@ export function buildQuitConfirmationHtml(options: {
       document.getElementById("close").addEventListener("click", () => send("manual-cancel"));
       document.getElementById("wait").addEventListener("click", () => {
         cancelCountdown();
+        waitingForWork = true;
         countdown.textContent = "Waiting for running work to finish...";
+        send("wait-for-work");
       });
       document.getElementById("quit").addEventListener("click", () => send("manual-confirm"));
       window.addEventListener("keydown", (event) => {

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -14,6 +14,7 @@ import {
   type DetachedCommandSummary,
 } from "./app-server/codex-environment-runtime";
 import { getDesktopOverlayStore } from "./app-server/desktop-overlay-store";
+import { getDesktopAutomationService } from "./automations/desktop-automation-service";
 import { getDesktopFederationRuntime } from "./federation/federation-runtime";
 import { getIntegratedTerminalQuitSnapshot } from "./ipc/integrated-terminal";
 import { getMainLogger } from "./log";
@@ -27,6 +28,7 @@ import {
   showQuitConfirmationDialog,
   type QuitBlockerItem,
   type QuitConfirmationDialogResult,
+  type QuitConfirmationDialogSnapshot,
 } from "./quit-confirmation-dialog";
 
 export type { QuitBlockerItem };
@@ -54,6 +56,7 @@ export type QuitBlockerSnapshot = {
   terminalThreadKeys: string[];
   threadIds: string[];
   actionRunCount: number;
+  automationRunCount?: number;
   items: QuitBlockerItem[];
 };
 
@@ -65,6 +68,7 @@ export type QuitManagerDependencies = {
     actionRunCount?: number;
     items?: QuitBlockerItem[];
     parent?: BrowserWindow | null;
+    refresh?: () => Promise<QuitConfirmationDialogSnapshot>;
   }) => Promise<QuitConfirmationDialogResult>;
   /**
    * Raise the confirmation prompt that is already open. Returns false when
@@ -74,6 +78,8 @@ export type QuitManagerDependencies = {
   getConfirmationEnabled: () => boolean;
   getFocusedWindow?: () => BrowserWindow | null;
   getQuitBlockers: () => QuitBlockerSnapshot;
+  /** Hold new automation launches until quitting proceeds or the prompt closes. */
+  quiesceAutomationDispatch?: () => () => Promise<void> | void;
   /**
    * Best-effort thread-title lookup for the dialog's links, keyed by
    * `quitBlockerTitleKey`. Takes whole items rather than thread keys because
@@ -127,6 +133,7 @@ export function createQuitManager(
         {
           count: snapshot.count,
           actionRunCount: snapshot.actionRunCount,
+          automationRunCount: snapshot.automationRunCount ?? 0,
           source: options.source,
           terminalSessionCount: snapshot.terminalSessionCount,
           terminalThreadKeys: snapshot.terminalThreadKeys,
@@ -160,6 +167,7 @@ export function createQuitManager(
     dependencies.log.warn?.("quit requested with active work", {
       count: snapshot.count,
       actionRunCount: snapshot.actionRunCount,
+      automationRunCount: snapshot.automationRunCount ?? 0,
       source: options.source,
       terminalSessionCount: snapshot.terminalSessionCount,
       terminalThreadKeys: snapshot.terminalThreadKeys,
@@ -168,6 +176,7 @@ export function createQuitManager(
 
     pendingPerformQuit = options.performQuit ?? dependencies.performQuit;
     promptPromise = (async () => {
+      const resumeAutomationDispatch = dependencies.quiesceAutomationDispatch?.();
       // Skip the round trip entirely when there is nothing to title, so the
       // no-resolver path reaches `confirm` without an extra microtask hop.
       const items =
@@ -178,17 +187,31 @@ export function createQuitManager(
               dependencies.log,
             )
           : snapshot.items;
-      const resolution = await (dependencies.confirm ?? showQuitConfirmationDialog)({
-        countdownSeconds: QUIT_CONFIRMATION_COUNTDOWN_SECONDS,
-        inProgressThreadCount: snapshot.threadIds.length,
-        terminalSessionCount: snapshot.terminalSessionCount,
-        actionRunCount: snapshot.actionRunCount,
-        items,
-        parent: dependencies.getFocusedWindow?.(),
-      });
+      let resolution: QuitConfirmationDialogResult;
+      try {
+        resolution = await (dependencies.confirm ?? showQuitConfirmationDialog)({
+          countdownSeconds: QUIT_CONFIRMATION_COUNTDOWN_SECONDS,
+          inProgressThreadCount: snapshot.threadIds.length,
+          automationRunCount: snapshot.automationRunCount ?? 0,
+          terminalSessionCount: snapshot.terminalSessionCount,
+          actionRunCount: snapshot.actionRunCount,
+          items,
+          parent: dependencies.getFocusedWindow?.(),
+          refresh: async () =>
+            await buildQuitConfirmationSnapshot(
+              dependencies.getQuitBlockers(),
+              dependencies.resolveThreadTitles,
+              dependencies.log,
+            ),
+        });
+      } catch (error) {
+        await resumeAutomationDispatch?.();
+        throw error;
+      }
       dependencies.log.warn?.("quit confirmation resolved", {
         count: snapshot.count,
         actionRunCount: snapshot.actionRunCount,
+        automationRunCount: snapshot.automationRunCount ?? 0,
         resolution,
         source: options.source,
         terminalSessionCount: snapshot.terminalSessionCount,
@@ -196,6 +219,7 @@ export function createQuitManager(
         threadIds: snapshot.threadIds,
       });
       if (resolution === "manual-cancel") {
+        await resumeAutomationDispatch?.();
         pendingPerformQuit = undefined;
         return false;
       }
@@ -219,10 +243,35 @@ export function createQuitManager(
   };
 }
 
+async function buildQuitConfirmationSnapshot(
+  snapshot: QuitBlockerSnapshot,
+  resolveThreadTitles: QuitManagerDependencies["resolveThreadTitles"],
+  log: QuitManagerDependencies["log"],
+): Promise<QuitConfirmationDialogSnapshot> {
+  const items =
+    resolveThreadTitles && snapshot.items.some((item) => !item.title)
+      ? await withResolvedTitles(snapshot.items, resolveThreadTitles, log)
+      : snapshot.items;
+  return {
+    inProgressThreadCount: snapshot.threadIds.length,
+    automationRunCount: snapshot.automationRunCount ?? 0,
+    terminalSessionCount: snapshot.terminalSessionCount,
+    actionRunCount: snapshot.actionRunCount,
+    items,
+  };
+}
+
 export function buildQuitBlockerSnapshot(params: {
   inProgressThreads: {
     count: number;
     threadIds: string[];
+    automationRuns?: Array<{
+      agentThreadId: string;
+      automationName?: string;
+      automationRunId: string;
+      backend: AppServerBackendKind;
+      startedAt: number;
+    }>;
   };
   terminalSessions: {
     count: number;
@@ -234,6 +283,7 @@ export function buildQuitBlockerSnapshot(params: {
   const terminalThreads = [...params.terminalSessions.threads].sort(byThreadKey);
   const terminalThreadKeys = terminalThreads.map((thread) => thread.threadKey);
   const actionRuns = params.actionRuns ?? [];
+  const automationRuns = params.inProgressThreads.automationRuns ?? [];
 
   const items: QuitBlockerItem[] = [
     // Turns and actions are driven by THIS instance's registry and runtime,
@@ -242,6 +292,15 @@ export function buildQuitBlockerSnapshot(params: {
       kind: "turn" as const,
       ...splitQuitThreadKey(threadKey),
       threadKey,
+    })),
+    ...automationRuns.map((run) => ({
+      kind: "automation" as const,
+      backend: run.backend,
+      threadId: run.agentThreadId,
+      threadKey: buildThreadIdentityKey(run.backend, run.agentThreadId),
+      title: run.automationName?.trim() || "Automation",
+      detail: formatAutomationRunStart(run.startedAt),
+      startedAt: run.startedAt,
     })),
     ...terminalThreads.map((thread) => ({
       kind: "terminal" as const,
@@ -269,13 +328,26 @@ export function buildQuitBlockerSnapshot(params: {
   ];
 
   return {
-    count: threadIds.length + params.terminalSessions.count + actionRuns.length,
+    count:
+      threadIds.length
+      + automationRuns.length
+      + params.terminalSessions.count
+      + actionRuns.length,
     terminalSessionCount: params.terminalSessions.count,
     terminalThreadKeys,
     threadIds,
     actionRunCount: actionRuns.length,
+    automationRunCount: automationRuns.length,
     items,
   };
+}
+
+export function formatAutomationRunStart(startedAt: number): string {
+  return `Started ${new Date(startedAt).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  })}`;
 }
 
 /**
@@ -291,8 +363,12 @@ async function withResolvedTitles(
   if (!resolve || items.length === 0) {
     return items;
   }
+  const unresolvedItems = items.filter((item) => !item.title?.trim());
+  if (unresolvedItems.length === 0) {
+    return items;
+  }
   const byTitleKey = new Map(
-    items.map((item) => [quitBlockerTitleKey(item), item]),
+    unresolvedItems.map((item) => [quitBlockerTitleKey(item), item]),
   );
   let titles: Map<string, string>;
   try {
@@ -498,6 +574,8 @@ export const appQuitManager = createQuitManager({
       terminalSessions: getIntegratedTerminalQuitSnapshot(),
       actionRuns: listRunningDetachedCommands(),
     }),
+  quiesceAutomationDispatch: () =>
+    getDesktopAutomationService().quiesceDispatch(),
   resolveThreadTitles: async (items) =>
     await resolveQuitBlockerThreadTitles(items, {
       listLocalThreads: async () =>

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -110,6 +110,21 @@ export function createQuitManager(
   let quitAllowed = false;
   let pendingPerformQuit: (() => void) | undefined;
   let promptPromise: Promise<boolean> | undefined;
+  let activePromptId = 0;
+  let nextPromptId = 0;
+
+  const resumeAutomationDispatchAfterPrompt = (
+    resumeAutomationDispatch: (() => Promise<void> | void) | undefined,
+  ): void => {
+    if (!resumeAutomationDispatch) return;
+    void Promise.resolve()
+      .then(() => resumeAutomationDispatch())
+      .catch((error: unknown) => {
+        dependencies.log.warn?.("automation dispatch resume failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+  };
 
   const requestQuit = async (options: RequestQuitOptions): Promise<boolean> => {
     if (quitAllowed) {
@@ -175,7 +190,15 @@ export function createQuitManager(
     });
 
     pendingPerformQuit = options.performQuit ?? dependencies.performQuit;
-    promptPromise = (async () => {
+    const promptId = nextPromptId + 1;
+    nextPromptId = promptId;
+    activePromptId = promptId;
+    const clearPrompt = (): void => {
+      if (activePromptId !== promptId) return;
+      activePromptId = 0;
+      promptPromise = undefined;
+    };
+    const currentPrompt = (async () => {
       const resumeAutomationDispatch = dependencies.quiesceAutomationDispatch?.();
       // Skip the round trip entirely when there is nothing to title, so the
       // no-resolver path reaches `confirm` without an extra microtask hop.
@@ -205,7 +228,8 @@ export function createQuitManager(
             ),
         });
       } catch (error) {
-        await resumeAutomationDispatch?.();
+        clearPrompt();
+        resumeAutomationDispatchAfterPrompt(resumeAutomationDispatch);
         throw error;
       }
       dependencies.log.warn?.("quit confirmation resolved", {
@@ -219,19 +243,26 @@ export function createQuitManager(
         threadIds: snapshot.threadIds,
       });
       if (resolution === "manual-cancel") {
-        await resumeAutomationDispatch?.();
         pendingPerformQuit = undefined;
+        // The dialog is already gone. Release this prompt before gates and
+        // backend submissions resume so a new quit request can open a visible
+        // confirmation instead of joining work nobody can see.
+        clearPrompt();
+        resumeAutomationDispatchAfterPrompt(resumeAutomationDispatch);
         return false;
       }
       quitAllowed = true;
       (pendingPerformQuit ?? dependencies.performQuit)();
       pendingPerformQuit = undefined;
       return true;
-    })().finally(() => {
-      promptPromise = undefined;
-    });
+    })();
+    promptPromise = currentPrompt;
 
-    return await promptPromise;
+    try {
+      return await currentPrompt;
+    } finally {
+      clearPrompt();
+    }
   };
 
   return {


### PR DESCRIPTION
## Summary

- represent active headless automation work in the quit dialog as one named automation run linked to its durable Agent thread, with its start time, instead of exposing ephemeral Codex UUIDs
- add an explicit **Wait for Work** path; refresh blockers while the prompt is open, report when the remaining work finishes, and then quit without interrupting it
- quiesce new automation launches while quit confirmation is open, persist new triggers as queued work, and resume dispatch if the operator chooses **Stay Open**
- serialize automation-lane release so the assistant-final fast path and the later `turn/completed` notification cannot launch the same queued run twice

## Root cause

The dogfood log showed two ephemeral Codex threads for the same `Search Bots` automation run. Both were genuinely active when quit was requested, then completed roughly 20–38 seconds later. They existed because two terminal signals for the preceding run released the same queued successor concurrently. The scheduler had no in-flight claim around that async lane transition, so one durable run launched twice while Automation History still had only one row.

Quit accounting then treated both ephemeral execution threads as ordinary user threads. Title resolution could not find ephemeral threads in the durable thread list, leaving two raw UUIDs in the dialog and counting one automation run twice.

## Impact

Operators can now tell which automation is keeping the app open and when it started. They can wait in place while current work drains; no new automation turn starts behind the dialog, and cancelling the quit resumes queued work. Duplicate terminal delivery no longer duplicates the next automation execution.

This intentionally does not change the Automations History UI. PR #1512 is already on `main` and owns that surface.

## Validation

- reproduced the lane race with a failing test: three submissions instead of the expected original + one queued successor
- 570 focused desktop-main tests across backend registry, scheduler, quit manager, and quit dialog
- `pnpm typecheck`
- `pnpm lint:eslint` (existing warning baseline only; zero errors)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:sql`
- `pnpm lint:colors`
- `git diff --check`
