### PR TITLE
fix(messaging): honor automation-scoped sender access

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -648,6 +648,127 @@ describe("DesktopMessagingRuntime", () => {
     ).toBe(false);
   });
 
+  it("records an automation-matched observed-only sender as routed", async () => {
+    await prepareRuntimeStore();
+    const automationInboundHandler = vi.fn(async () => true);
+    const automationInboundMatches = vi.fn(() => true);
+    const adapter = createAdapter("slack", {
+      authorizedActorIds: ["operator-1"],
+    });
+    const bridge = createBackendBridge();
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = trackRuntime(new Runtime({
+      adapterFactory: () => [adapter],
+      backendBridge: bridge,
+      automationInboundHandler,
+      automationInboundMatches,
+      config: {},
+    }));
+    await runtime.start();
+
+    await adapter.listener?.({
+      id: "slack:message:datadog-1",
+      kind: "text",
+      actor: {
+        platformUserId: "B012DATADOG",
+        displayName: "Datadog",
+        isBot: true,
+      },
+      channel: {
+        channel: "slack",
+        conversation: {
+          id: "C012SEARCHBOTS",
+          kind: "channel",
+          title: "t-search-bots",
+        },
+      },
+      observedOnly: true,
+      receivedAt: 1_000,
+      text: "Search pipeline alert",
+    });
+
+    expect(automationInboundMatches).toHaveBeenCalledTimes(1);
+    expect(automationInboundHandler).toHaveBeenCalledTimes(1);
+    expect(bridge.startTurn).not.toHaveBeenCalled();
+
+    const { getAppStateDb } = await import("../state/app-state");
+    const rows = getAppStateDb().raw
+      .prepare(
+        `SELECT kind, actor_id, conversation_id
+         FROM messaging_activity_log
+         WHERE actor_id = ?
+         ORDER BY id ASC`,
+      )
+      .all("B012DATADOG") as Array<{
+        actor_id: string;
+        conversation_id: string;
+        kind: string;
+      }>;
+    expect(rows).toEqual([{
+      actor_id: "B012DATADOG",
+      conversation_id: "C012SEARCHBOTS",
+      kind: "inbound-routed",
+    }]);
+  });
+
+  it("keeps unmatched observed-only senders rejected", async () => {
+    await prepareRuntimeStore();
+    const automationInboundHandler = vi.fn(async () => true);
+    const adapter = createAdapter("slack", {
+      authorizedActorIds: ["operator-1"],
+    });
+    const bridge = createBackendBridge();
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = trackRuntime(new Runtime({
+      adapterFactory: () => [adapter],
+      backendBridge: bridge,
+      automationInboundHandler,
+      automationInboundMatches: () => false,
+      config: {},
+    }));
+    await runtime.start();
+
+    await adapter.listener?.({
+      id: "slack:message:other-bot-1",
+      kind: "text",
+      actor: {
+        platformUserId: "B012OTHERBOT",
+        displayName: "Other Bot",
+        isBot: true,
+      },
+      channel: {
+        channel: "slack",
+        conversation: {
+          id: "C012SEARCHBOTS",
+          kind: "channel",
+          title: "t-search-bots",
+        },
+      },
+      observedOnly: true,
+      receivedAt: 1_000,
+      text: "Unrelated message",
+    });
+
+    expect(automationInboundHandler).not.toHaveBeenCalled();
+    expect(bridge.startTurn).not.toHaveBeenCalled();
+
+    const { getAppStateDb } = await import("../state/app-state");
+    const row = getAppStateDb().raw
+      .prepare(
+        `SELECT kind
+         FROM messaging_activity_log
+         WHERE actor_id = ?
+         ORDER BY id DESC
+         LIMIT 1`,
+      )
+      .get("B012OTHERBOT") as { kind: string } | undefined;
+    expect(row?.kind).toBe("inbound-rejected");
+  });
+
   it("drops ambient @mention-only messages no automation filter matches", async () => {
     const automationInboundHandler = vi.fn(async () => false);
     const automationInboundMatches = vi.fn(() => false);

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1433,9 +1433,18 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
           // Observed-only traffic exists for automations and the editor's
           // live preview; it must never reach the controller's reply/command
           // path — the sender did not clear the per-user access gate.
-          this.recordActivityFromInbound(adapter.channel, event, false);
+          // A matching automation is its own narrow authorization context:
+          // classify that event as routed without widening the sender's
+          // adapter or RBAC permissions for any interactive messaging path.
+          const automationMatched =
+            this.options.automationInboundMatches?.(event) === true;
+          this.recordActivityFromInbound(
+            adapter.channel,
+            event,
+            automationMatched,
+          );
           publishInboundPreview(event);
-          if (this.options.automationInboundMatches?.(event)) {
+          if (automationMatched) {
             await this.options.automationInboundHandler?.(event);
           } else {
             messagingLog.debug(


### PR DESCRIPTION
## What changed

- classify an observed-only inbound message as routed when an enabled inbound automation's full filter matches it
- keep that grant scoped to the automation path; the sender still cannot reach commands, replies, or controller/RBAC messaging actions
- preserve rejection activity for observed-only traffic that matches no automation
- add regression coverage for matched and unmatched bot senders

## Root cause

Slack intentionally forwards messages from otherwise unauthorized senders in automation-observed conversations with `observedOnly: true`. The desktop runtime correctly prevented those events from reaching the interactive controller, but it recorded every observed-only event as `inbound-rejected` before evaluating the automation matcher. A matching event was then processed by the automation, leaving contradictory activity history.

## Impact

Configured automation senders such as Datadog are now shown as routed when their event matches that automation. This does not widen the sender's general messaging access.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-runtime.test.ts` — 65 passed
- `pnpm lint:eslint` — passed with the existing warning baseline
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
