### PR TITLE
fix(desktop): match the Automations chrome to Settings

### DIFF
--- a/apps/desktop/src/renderer/src/features/automations/AutomationRunWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationRunWindow.tsx
@@ -83,10 +83,11 @@ export function AutomationRunWindow() {
           <p className="activity-titlebar__brand">
             Pwr<span className="activity-titlebar__brand-accent">Agent</span>
           </p>
-          <div
-            className="activity-titlebar__breadcrumb"
-            aria-label="Automations > Run"
-          >
+          {/* No aria-label: the Messaging Activity, License, and Changelog
+              windows all let this breadcrumb read its own content, and a
+              label here only overrode "Automations Run" with an ASCII ">"
+              that screen readers voice as "greater than". */}
+          <div className="activity-titlebar__breadcrumb">
             <span className="activity-titlebar__eyebrow">Automations</span>
             <span aria-hidden="true" className="activity-titlebar__separator">
               ›

--- a/apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx
@@ -114,8 +114,10 @@ export function AutomationsScreen(props: AutomationsScreenProps) {
             Pwr<span className="settings-nav__brand-accent">Agent</span>
           </p>
         </header>
+        {/* Same arrow glyph as Settings' Exit row — a bare "<" read as a
+            stray character next to the real ← one screen over. */}
         <button className="settings-nav__exit" type="button" onClick={props.onClose}>
-          <span aria-hidden="true">&lt;</span> Exit Automations
+          <span aria-hidden="true">←</span> Exit Automations
         </button>
         <button
           className="settings-nav__new"
@@ -140,7 +142,7 @@ export function AutomationsScreen(props: AutomationsScreenProps) {
           <div className="settings-titlebar__breadcrumb">
             <span className="settings-titlebar__eyebrow">Automations</span>
             <span aria-hidden="true" className="settings-titlebar__separator">
-              &gt;
+              ›
             </span>
             <span className="settings-titlebar__current">All Automations</span>
           </div>

--- a/apps/desktop/src/renderer/src/features/automations/__tests__/automations-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/__tests__/automations-screen.test.tsx
@@ -342,6 +342,37 @@ describe("AutomationsScreen", () => {
   });
 });
 
+describe("nav chrome parity with Settings", () => {
+  it("uses the same Exit row and breadcrumb glyphs Settings uses", async () => {
+    render(
+      <AutomationsScreen
+        desktopApi={
+          {
+            listAutomations: vi.fn(async () => ({ automations: [] })),
+            listAutomationRuns: vi.fn(async () => ({ runs: [] })),
+            onAgentEvent: () => () => undefined,
+          } as unknown as DesktopApi
+        }
+        threads={[]}
+        onClose={() => undefined}
+      />,
+    );
+
+    // Settings' contract test pins "← Exit Settings"; this is the same row on
+    // the other screen and drifted to a bare "<", which read as a stray
+    // character rather than an arrow.
+    const exit = await screen.findByRole("button", { name: /Exit Automations/i });
+    expect(exit).toHaveClass("settings-nav__exit");
+    expect(exit.closest(".settings-nav")).not.toBeNull();
+    expect(exit.textContent).toBe("← Exit Automations");
+
+    // Settings' breadcrumb uses "›"; this one used ">".
+    expect(
+      document.querySelector(".settings-titlebar__separator")?.textContent?.trim(),
+    ).toBe("›");
+  });
+});
+
 describe("row runtime and actions", () => {
   it("states the execution profile so a risky automation is spottable", async () => {
     const risky: AutomationDetail = {

--- a/apps/desktop/src/renderer/src/styles/__tests__/automations-chrome-parity.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/automations-chrome-parity.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(path.resolve(testDir, "../app.css"), "utf8");
+
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(
+    new RegExp(`(?:^|\\n)${escaped}\\s*\\{(?<body>[\\s\\S]*?)\\n\\}`),
+  );
+  if (!match?.groups?.body) {
+    throw new Error(`Expected app.css to define ${selector}`);
+  }
+  return match.groups.body;
+}
+
+/** The `padding` shorthand's parts, in source order. */
+function padding(selector: string): string[] {
+  const match = ruleBody(selector).match(/\n\s*padding:\s*([^;]+);/);
+  if (!match) {
+    throw new Error(`Expected ${selector} to set padding`);
+  }
+  return match[1].trim().split(/\s+/);
+}
+
+/**
+ * The Automations screen borrows Settings' nav, title bar, and grid, so the
+ * two are one chrome wearing two labels. Everywhere they diverge is an
+ * accident — and one already shipped: the content inset drifted to 20px
+ * against Settings' 24px and nothing failed, which is what these lock.
+ */
+describe("Automations chrome matches Settings", () => {
+  it("insets content from the window edge identically", () => {
+    const settings = padding(".settings-content"); // 20px 24px 24px
+    const automations = padding(".automations-content"); // 0 24px 24px
+    expect(settings).toHaveLength(3);
+    expect(automations).toHaveLength(3);
+    // Horizontal and bottom track Settings. Compared rather than hardcoded so
+    // that restyling Settings surfaces this screen as a decision to make.
+    expect(automations[1]).toBe(settings[1]);
+    expect(automations[2]).toBe(settings[2]);
+  });
+
+  it("keeps the Automations scrollport's top padding at zero", () => {
+    // Deliberately NOT matching Settings' 20px top: this padding is inside
+    // the scrollport, and rows would slide up through it and appear above the
+    // sticky column header. `.automations-toolbar` carries that space
+    // instead. Settings solves the same problem from the other side, with
+    // `--settings-section-sticky-top: -20px`.
+    expect(padding(".automations-content")[0]).toBe("0");
+    expect(ruleBody(".automations-toolbar")).toMatch(/padding-top:\s*20px;/);
+  });
+
+  it("gives the nav's create row the same rhythm Exit has in Settings", () => {
+    // `.settings-nav` is a flex column with `gap: 4px`, and `.settings-nav__exit`
+    // carries `margin: 8px 0 4px`. In Settings that yields exit → group label
+    // = 4 + 4 + 4 = 12px. Automations inserts this row into that gap, so it
+    // needs 4px on both sides to keep both halves at 12px; `0 0 8px` left 8px
+    // above and 16px below, clumping Exit and New together.
+    expect(ruleBody(".settings-nav")).toMatch(/gap:\s*4px;/);
+    expect(ruleBody(".settings-nav__exit")).toMatch(/margin:\s*8px 0 4px;/);
+    expect(ruleBody(".settings-nav__group-label")).toMatch(/margin:\s*4px 12px 6px;/);
+    expect(ruleBody(".settings-nav__new")).toMatch(/margin:\s*4px 0;/);
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6514,10 +6514,14 @@ textarea,
   flex: 1;
   flex-direction: column;
   gap: 14px;
-  /* No top padding: it is inside the scrollport, so rows would slide through
-     it and show above the sticky column header. The toolbar carries that
-     space instead, and scrolls away with the rest of the page. */
-  padding: 0 20px 20px;
+  /* Horizontal and bottom padding match `.settings-content` so the two
+     screens inset their content from the window edge identically.
+     No top padding, though: it is inside the scrollport, so rows would slide
+     through it and show above the sticky column header. The toolbar carries
+     that 20px instead, and scrolls away with the rest of the page. (Settings
+     solves the same problem the other way, cancelling its own top padding
+     with `--settings-section-sticky-top: -20px`.) */
+  padding: 0 24px 24px;
   overflow: auto;
 }
 
@@ -7157,6 +7161,11 @@ textarea,
    operator's eye already is when the screen opens (they arrived via the left
    rail) — a full-accent button across the empty canvas made the create action
    the farthest thing from the pointer. Only the plus carries accent. */
+/* Automations-only row, directly under Exit. The nav's 4px flex gap plus the
+   Exit row's 4px bottom margin left only 8px above this and 16px below it,
+   so two rows of identical size, weight, and color read as one clump with a
+   hole under them. 4px top and bottom puts both gaps at 12px — the same
+   Exit-to-next-thing rhythm Settings has. */
 .settings-nav__new {
   display: inline-flex;
   width: 100%;
@@ -7164,7 +7173,7 @@ textarea,
   appearance: none;
   cursor: pointer;
   gap: 6px;
-  margin: 0 0 8px;
+  margin: 4px 0;
   padding: 6px 12px;
   border: none;
   border-radius: 6px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7160,12 +7160,13 @@ textarea,
 /* Quiet create action in the Automations nav, under Exit. It sits where the
    operator's eye already is when the screen opens (they arrived via the left
    rail) — a full-accent button across the empty canvas made the create action
-   the farthest thing from the pointer. Only the plus carries accent. */
-/* Automations-only row, directly under Exit. The nav's 4px flex gap plus the
-   Exit row's 4px bottom margin left only 8px above this and 16px below it,
-   so two rows of identical size, weight, and color read as one clump with a
-   hole under them. 4px top and bottom puts both gaps at 12px — the same
-   Exit-to-next-thing rhythm Settings has. */
+   the farthest thing from the pointer. Only the plus carries accent.
+
+   The nav is a flex column with a 4px gap and Exit carries a 4px bottom
+   margin, so `margin: 4px 0` here puts both the Exit→New and New→group-label
+   gaps at 12px — the same Exit-to-next-thing rhythm Settings has. It was
+   `0 0 8px`, which left 8px above and 16px below: two rows of identical size,
+   weight, and color clumped together with a hole beneath them. */
 .settings-nav__new {
   display: inline-flex;
   width: 100%;


### PR DESCRIPTION
## Summary

A UI design review of the Automations nav against Settings. Both screens already share `.settings-nav`, `.settings-titlebar`, and the same two-column grid — so everywhere they disagree is an accident, not a decision. Four of them:

| | Settings | Automations (was) |
|---|---|---|
| Exit row glyph | `←` | `<` |
| Breadcrumb separator | `›` | `>` |
| Gap below the Exit row | 12px | 8px, then a 16px hole |
| Content inset | 24px | 20px |

**The Exit glyph** is the one that reads as broken. At 12px, a bare `<` next to the real `←` one screen over looks like a stray character rather than an arrow. Settings already pins its row's text as `"← Exit Settings"` in a design-contract test; this adds the matching lock for `"← Exit Automations"` and for the breadcrumb glyph.

**The nav rhythm** is the "ugly" in the screenshot. `.settings-nav` is a flex column with a 4px gap, and `.settings-nav__new` carried `margin: 0 0 8px` — so Exit → New was 8px while New → the group label was 16px. Two rows of identical size, weight, and color, 8px apart, clump into one blob with a hole underneath. `margin: 4px 0` puts both gaps at 12px, which is exactly the Exit-to-next-thing rhythm Settings has.

**The content inset** was the one I found by reading rather than looking: `.settings-content` is `padding: 20px 24px 24px` and `.automations-content` was `0 20px 20px`, so the two screens held their content at different distances from the window edge.

## What deliberately stays different

`.automations-content` keeps **no top padding**. That padding sits inside the scrollport, and the sticky column header needs rows not to slide up through it; the toolbar carries the 20px instead. The first content row therefore lands at the same offset Settings gets from its own 20px — Settings just solves the sticky problem the other way, cancelling its padding with `--settings-section-sticky-top: -20px`.

## Verification

- `pnpm typecheck`, `lint:eslint`, `lint:eslint:typed`, `lint:colors`, `lint:boundaries` clean; 2,727 renderer tests pass.
- New contract test asserts the Exit row's exact text and the breadcrumb glyph, mirroring the existing Settings lock so neither can drift again.
- **On the spacing numbers:** the browser pane could not open local files this session, so the gaps above are computed rather than measured on screen. Every value involved is a fixed margin in a flex column with a fixed gap, so the arithmetic is exact — but a second pair of eyes on the rendered result is welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)