### PR TITLE
feat(desktop): add federation targets to the directory launchpad button

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -15,7 +15,6 @@ import {
   buildThreadIdentityKey,
   DEFAULT_BACKGROUND_PR_POLLING,
   DEFAULT_PR_AUTO_DISPATCH_ALLOWED,
-  formatFederationPeerDisplayLabel,
   isRemoteFederationTarget,
   parseThreadIdentityKey,
   type AppServerBackendKind,
@@ -31,6 +30,7 @@ import {
 import { Sidebar } from "./features/navigation/Sidebar";
 import { useThreadJump } from "./features/navigation/useThreadJump";
 import { AppTitleBar } from "./features/chrome/AppTitleBar";
+import { buildFederationThreadTargets } from "./features/chrome/federation-thread-targets";
 import type { HistoryNavControls } from "./features/chrome/HistoryNavButtons";
 import { useFindHotkeys } from "./features/chrome/useFindHotkeys";
 import { useHistoryNavHotkeys } from "./features/chrome/useHistoryNavHotkeys";
@@ -346,34 +346,13 @@ function DesktopAppShell(props: {
     desktopApi,
     enabled: !readRendererFederationTarget(),
   });
-  const newThreadFederationTargets = useMemo(() => {
-    const health = liveFederationHealth;
-    if (!health || !desktopApi?.openFederationWindow) {
-      return [];
-    }
-    const visibleInstances = [
-      ...health.peers,
-      ...(health.localLabel
-        ? [{
-            label: health.localLabel,
-            profileName: health.localProfileName,
-          }]
-        : []),
-    ];
-    return health.peers
-      .filter(
-        (peer) =>
-          peer.status === "connected"
-          && !peer.revokedAt
-          && peer.capabilities.includes("remote_window")
-          && peer.capabilities.includes("thread_navigation")
-          && peer.capabilities.includes("environment_actions"),
-      )
-      .map((peer) => ({
-        instanceId: peer.id,
-        label: formatFederationPeerDisplayLabel(peer, visibleInstances),
-      }));
-  }, [desktopApi?.openFederationWindow, liveFederationHealth]);
+  const newThreadFederationTargets = useMemo(
+    () =>
+      desktopApi?.openFederationWindow
+        ? buildFederationThreadTargets(liveFederationHealth)
+        : [],
+    [desktopApi?.openFederationWindow, liveFederationHealth],
+  );
   useEffect(() => {
     return desktopApi?.onWindowFocus?.(() => {
       refreshFederationHealth();

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -388,11 +388,14 @@ describe("App", () => {
 
     const button = screen.getByRole("button", { name: "New thread" });
     fireEvent.mouseEnter(button.parentElement as HTMLElement);
-    expect(screen.queryByRole("menuitem", {
-      name: "New chat on Read-only peer",
-    })).not.toBeInTheDocument();
+    // A peer whose build cannot host a thread stays listed and disabled —
+    // vanishing from the list is indistinguishable from a bug, and Settings →
+    // Federation already keeps such a peer visible with a disabled action.
+    expect(
+      await screen.findByRole("menuitem", { name: /Read-only peer/ }),
+    ).toBeDisabled();
     fireEvent.click(await screen.findByRole("menuitem", {
-      name: "New chat on Studio Mac / work",
+      name: "Studio Mac / work",
     }));
 
     expect(openFederationWindow).toHaveBeenCalledWith({
@@ -431,10 +434,10 @@ describe("App", () => {
 
     fireEvent.mouseEnter(button.parentElement as HTMLElement);
     expect(await screen.findByRole("menuitem", {
-      name: "New chat on Laptop",
+      name: "Laptop",
     })).toBeInTheDocument();
     expect(screen.queryByRole("menuitem", {
-      name: "New chat on Studio Mac / work",
+      name: "Studio Mac / work",
     })).not.toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -393,7 +393,7 @@ describe("App", () => {
     // Federation already keeps such a peer visible with a disabled action.
     expect(
       await screen.findByRole("menuitem", { name: /Read-only peer/ }),
-    ).toBeDisabled();
+    ).toHaveAttribute("aria-disabled", "true");
     fireEvent.click(await screen.findByRole("menuitem", {
       name: "Studio Mac / work",
     }));

--- a/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from "react";
 import { getDesktopApi, type DesktopApi } from "../../lib/desktop-api";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { FederationRemoteBadge } from "./FederationRemoteBadge";
+import type { FederationThreadTarget } from "./federation-thread-targets";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { AppMenuBar } from "./AppMenuBar";
 import { NewThreadButton } from "./NewThreadButton";
@@ -42,10 +43,7 @@ export function AppTitleBar(props: {
     addingProjectDirectory?: boolean;
     automationsActive: boolean;
     newThreadDirectoryLabel?: string;
-    newThreadFederationTargets?: readonly {
-      instanceId: string;
-      label: string;
-    }[];
+    newThreadFederationTargets?: readonly FederationThreadTarget[];
     settingsActive: boolean;
     creatingThread: boolean;
     onAddProjectDirectory?: () => void | Promise<void>;

--- a/apps/desktop/src/renderer/src/features/chrome/FederationTargetMenuSection.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/FederationTargetMenuSection.tsx
@@ -1,0 +1,65 @@
+import { useId, type ReactElement } from "react";
+import {
+  describeFederationThreadTargetAvailability,
+  type FederationThreadTarget,
+} from "./federation-thread-targets";
+
+const AVAILABILITY_STATE_LABEL: Record<string, string> = {
+  offline: "Offline",
+  unsupported: "Unsupported",
+};
+
+/**
+ * The "New chat on <machine>" group shared by the New Thread flyout and the
+ * per-directory launchpad split button, so both surfaces read identically.
+ *
+ * The verb lives in the group label rather than on each row. Rows are
+ * `text-overflow: ellipsis` inside a card capped at 320px, and repeating
+ * "New chat on " per row spent about a quarter of that budget pushing the
+ * machine label — including the ` / <profile>` suffix that exists precisely
+ * to tell two entries apart — toward the clip.
+ *
+ * The label is a real `role="group"` with `aria-labelledby` rather than a
+ * presentational div: without it a screen reader hears one undifferentiated
+ * run of menu items and never learns that these ones start work on another
+ * machine.
+ */
+export function FederationTargetMenuSection(props: {
+  onSelect: (instanceId: string) => void;
+  targets: readonly FederationThreadTarget[];
+}): ReactElement {
+  const labelId = useId();
+  return (
+    <div role="group" aria-labelledby={labelId}>
+      <div className="new-thread-menu__section-label" id={labelId}>
+        New chat on
+      </div>
+      {props.targets.map((target) => {
+        const stateLabel = AVAILABILITY_STATE_LABEL[target.availability];
+        return (
+          <button
+            key={target.instanceId}
+            type="button"
+            role="menuitem"
+            className="new-thread-menu__item new-thread-menu__item--target"
+            disabled={target.availability !== "available"}
+            title={describeFederationThreadTargetAvailability(
+              target.availability,
+            )}
+            onClick={() => props.onSelect(target.instanceId)}
+          >
+            <span
+              aria-hidden="true"
+              className="new-thread-menu__target-dot"
+              data-availability={target.availability}
+            />
+            <span className="new-thread-menu__target-name">{target.label}</span>
+            {stateLabel ? (
+              <span className="new-thread-menu__target-state">{stateLabel}</span>
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/chrome/FederationTargetMenuSection.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/FederationTargetMenuSection.tsx
@@ -2,9 +2,12 @@ import { useId, type ReactElement } from "react";
 import {
   describeFederationThreadTargetAvailability,
   type FederationThreadTarget,
+  type FederationThreadTargetAvailability,
 } from "./federation-thread-targets";
 
-const AVAILABILITY_STATE_LABEL: Record<string, string> = {
+const AVAILABILITY_STATE_LABEL: Partial<
+  Record<FederationThreadTargetAvailability, string>
+> = {
   offline: "Offline",
   unsupported: "Unsupported",
 };
@@ -36,17 +39,28 @@ export function FederationTargetMenuSection(props: {
       </div>
       {props.targets.map((target) => {
         const stateLabel = AVAILABILITY_STATE_LABEL[target.availability];
+        const unavailable = target.availability !== "available";
         return (
           <button
             key={target.instanceId}
             type="button"
             role="menuitem"
             className="new-thread-menu__item new-thread-menu__item--target"
-            disabled={target.availability !== "available"}
+            // `aria-disabled`, not `disabled`: a disabled button leaves the tab
+            // order, and this menu has no arrow-key navigation, so the real
+            // `disabled` attribute would hide unreachable machines from
+            // keyboard and screen-reader users entirely — the opposite of why
+            // they are listed instead of filtered out.
+            aria-disabled={unavailable || undefined}
             title={describeFederationThreadTargetAvailability(
               target.availability,
             )}
-            onClick={() => props.onSelect(target.instanceId)}
+            onClick={() => {
+              if (unavailable) {
+                return;
+              }
+              props.onSelect(target.instanceId);
+            }}
           >
             <span
               aria-hidden="true"

--- a/apps/desktop/src/renderer/src/features/chrome/MastheadActions.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/MastheadActions.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from "react";
 import { AutomationsIcon, SearchIcon, SettingsIcon } from "../../icons";
 import { readRendererFederationTarget } from "../../lib/federation-window";
+import type { FederationThreadTarget } from "./federation-thread-targets";
 import { NewThreadButton } from "./NewThreadButton";
 
 /**
@@ -18,10 +19,7 @@ export type MastheadActionsProps = {
   creatingThread?: boolean;
   /** Directory the default New Thread action resolves to (flyout label). */
   newThreadDirectoryLabel?: string;
-  newThreadFederationTargets?: readonly {
-    instanceId: string;
-    label: string;
-  }[];
+  newThreadFederationTargets?: readonly FederationThreadTarget[];
   onAddProjectDirectory?: () => void | Promise<void>;
   onOpenAutomations?: () => void;
   onOpenSettings?: () => void;

--- a/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
@@ -7,6 +7,8 @@ import {
 } from "react";
 import { NewThreadIcon } from "../../icons";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import { FederationTargetMenuSection } from "./FederationTargetMenuSection";
+import type { FederationThreadTarget } from "./federation-thread-targets";
 
 /**
  * The masthead "New thread" button with a hover/focus flyout.
@@ -18,7 +20,7 @@ import { useViewportTooltip } from "../../lib/useViewportTooltip";
  *
  *   1. New chat in <directory>     → `onCreateThread` (context default)
  *   2. New chat without a directory → `onCreateThreadWithoutDirectory`
- *   3. New chat on <instance>        → open that owner's launchpad
+ *   3. New chat on → <instance>     → open that owner's launchpad
  *   4. Add a Project Directory…     → track a repo without starting a chat
  *
  * The flyout renders when there's either a meaningful directory choice or an
@@ -40,10 +42,7 @@ export type NewThreadButtonProps = {
   onCreateThread: () => void | Promise<void>;
   onCreateThreadWithoutDirectory?: () => void | Promise<void>;
   onCreateThreadOnTarget?: (instanceId: string) => void | Promise<void>;
-  remoteTargets?: readonly {
-    instanceId: string;
-    label: string;
-  }[];
+  remoteTargets?: readonly FederationThreadTarget[];
 };
 
 export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
@@ -188,26 +187,16 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
                 New chat without a directory
               </button>
             )}
-            {hasRemoteTargets ? (
+            {hasRemoteTargets && props.remoteTargets ? (
               <>
                 <div className="new-thread-menu__separator" role="separator" />
-                <div className="new-thread-menu__section-label" role="presentation">
-                  Other instances
-                </div>
-                {props.remoteTargets?.map((target) => (
-                  <button
-                    key={target.instanceId}
-                    type="button"
-                    role="menuitem"
-                    className="new-thread-menu__item"
-                    onClick={() => {
-                      setOpen(false);
-                      void props.onCreateThreadOnTarget?.(target.instanceId);
-                    }}
-                  >
-                    New chat on {target.label}
-                  </button>
-                ))}
+                <FederationTargetMenuSection
+                  targets={props.remoteTargets}
+                  onSelect={(instanceId) => {
+                    setOpen(false);
+                    void props.onCreateThreadOnTarget?.(instanceId);
+                  }}
+                />
               </>
             ) : null}
             {props.onAddProjectDirectory ? (

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { NewThreadButton } from "../NewThreadButton";
 
@@ -90,8 +90,16 @@ describe("NewThreadButton", () => {
         onCreateThread={onCreateThread}
         onCreateThreadOnTarget={onCreateThreadOnTarget}
         remoteTargets={[
-          { instanceId: "studio-work", label: "Studio Mac / work" },
-          { instanceId: "laptop-default", label: "Laptop" },
+          {
+            availability: "available",
+            instanceId: "studio-work",
+            label: "Studio Mac / work",
+          },
+          {
+            availability: "available",
+            instanceId: "laptop-default",
+            label: "Laptop",
+          },
         ]}
       />,
     );
@@ -99,15 +107,79 @@ describe("NewThreadButton", () => {
     const button = screen.getByRole("button", { name: "New thread" });
     fireEvent.mouseEnter(button.parentElement as HTMLElement);
 
-    expect(await screen.findByText("Other instances")).toBeInTheDocument();
+    expect(await screen.findByText("New chat on")).toBeInTheDocument();
     fireEvent.click(
-      screen.getByRole("menuitem", {
-        name: "New chat on Studio Mac / work",
-      }),
+      screen.getByRole("menuitem", { name: "Studio Mac / work" }),
     );
 
     expect(onCreateThreadOnTarget).toHaveBeenCalledWith("studio-work");
     expect(onCreateThread).not.toHaveBeenCalled();
+  });
+
+  it("carries the verb in the group label instead of repeating it per row", async () => {
+    render(
+      <NewThreadButton
+        onCreateThread={vi.fn()}
+        onCreateThreadOnTarget={vi.fn()}
+        remoteTargets={[
+          {
+            availability: "available",
+            instanceId: "studio-work",
+            label: "Studio Mac / work",
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.mouseEnter(
+      screen.getByRole("button", { name: "New thread" })
+        .parentElement as HTMLElement,
+    );
+
+    // The machine label is the whole row: rows are nowrap/ellipsis inside a
+    // 320px card, and a repeated "New chat on " prefix pushed the ` / profile`
+    // suffix — the only thing telling two rows apart — toward the clip.
+    const group = await screen.findByRole("group", { name: "New chat on" });
+    expect(
+      within(group).getByRole("menuitem", { name: "Studio Mac / work" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps unreachable instances visible and disabled rather than hiding them", async () => {
+    const onCreateThreadOnTarget = vi.fn();
+    render(
+      <NewThreadButton
+        onCreateThread={vi.fn()}
+        onCreateThreadOnTarget={onCreateThreadOnTarget}
+        remoteTargets={[
+          {
+            availability: "offline",
+            instanceId: "studio-work",
+            label: "Studio Mac",
+          },
+          {
+            availability: "unsupported",
+            instanceId: "old-build",
+            label: "Attic Mini",
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.mouseEnter(
+      screen.getByRole("button", { name: "New thread" })
+        .parentElement as HTMLElement,
+    );
+
+    const offline = await screen.findByRole("menuitem", { name: /Studio Mac/ });
+    expect(offline).toBeDisabled();
+    expect(offline).toHaveTextContent("Offline");
+    const unsupported = screen.getByRole("menuitem", { name: /Attic Mini/ });
+    expect(unsupported).toBeDisabled();
+    expect(unsupported).toHaveTextContent("Unsupported");
+
+    fireEvent.click(offline);
+    expect(onCreateThreadOnTarget).not.toHaveBeenCalled();
   });
 
   it("closes the flyout on Escape while a menu item is focused (regression)", async () => {

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
@@ -171,11 +171,15 @@ describe("NewThreadButton", () => {
         .parentElement as HTMLElement,
     );
 
+    // aria-disabled, not `disabled` — an unreachable machine has to stay
+    // focusable or keyboard users never learn it exists, which is the whole
+    // reason it is listed rather than filtered out.
     const offline = await screen.findByRole("menuitem", { name: /Studio Mac/ });
-    expect(offline).toBeDisabled();
+    expect(offline).toHaveAttribute("aria-disabled", "true");
+    expect(offline).not.toBeDisabled();
     expect(offline).toHaveTextContent("Offline");
     const unsupported = screen.getByRole("menuitem", { name: /Attic Mini/ });
-    expect(unsupported).toBeDisabled();
+    expect(unsupported).toHaveAttribute("aria-disabled", "true");
     expect(unsupported).toHaveTextContent("Unsupported");
 
     fireEvent.click(offline);

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/federation-thread-targets.test.ts
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/federation-thread-targets.test.ts
@@ -92,6 +92,27 @@ describe("buildFederationThreadTargets", () => {
     expect(targets.map((target) => target.instanceId)).toEqual(["b"]);
   });
 
+  it("breaks label ties by instance id so health order cannot reshuffle rows", () => {
+    // Same machine label, neither advertising a profile: the labels are equal,
+    // so without a tiebreak the order would follow health order and could flip
+    // between reads while the menu is open.
+    const forward = buildFederationThreadTargets(
+      health([
+        peer({ id: "b", label: "Studio Mac" }),
+        peer({ id: "a", label: "Studio Mac" }),
+      ]),
+    );
+    const reversed = buildFederationThreadTargets(
+      health([
+        peer({ id: "a", label: "Studio Mac" }),
+        peer({ id: "b", label: "Studio Mac" }),
+      ]),
+    );
+
+    expect(forward.map((target) => target.instanceId)).toEqual(["a", "b"]);
+    expect(reversed.map((target) => target.instanceId)).toEqual(["a", "b"]);
+  });
+
   it("keeps the profile suffix when a peer shares this machine's label", () => {
     const targets = buildFederationThreadTargets(
       health([peer({ id: "a", label: "Studio Mac", profileName: "default" })], {

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/federation-thread-targets.test.ts
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/federation-thread-targets.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type {
+  FederationCapability,
+  FederationHealthStatus,
+} from "@pwragent/shared";
+import { buildFederationThreadTargets } from "../federation-thread-targets";
+
+const ALL_CAPABILITIES: FederationCapability[] = [
+  "remote_window",
+  "thread_navigation",
+  "environment_actions",
+];
+
+function peer(
+  overrides: Partial<FederationHealthStatus["peers"][number]> & { id: string },
+): FederationHealthStatus["peers"][number] {
+  return {
+    capabilities: ALL_CAPABILITIES,
+    label: overrides.id,
+    role: "client",
+    status: "connected",
+    ...overrides,
+  } as FederationHealthStatus["peers"][number];
+}
+
+function health(
+  peers: FederationHealthStatus["peers"],
+  overrides: Partial<FederationHealthStatus> = {},
+): FederationHealthStatus {
+  return {
+    enabled: true,
+    role: "gateway",
+    status: "connected",
+    peers,
+    ...overrides,
+  } as FederationHealthStatus;
+}
+
+describe("buildFederationThreadTargets", () => {
+  it("returns nothing before health has been read", () => {
+    expect(buildFederationThreadTargets(undefined)).toEqual([]);
+  });
+
+  it("sorts by display label so hover-menu rows do not move under the pointer", () => {
+    const targets = buildFederationThreadTargets(
+      health([
+        peer({ id: "c", label: "Studio Mac" }),
+        peer({ id: "a", label: "Attic Mini" }),
+        peer({ id: "b", label: "Loft Laptop" }),
+      ]),
+    );
+
+    expect(targets.map((target) => target.label)).toEqual([
+      "Attic Mini",
+      "Loft Laptop",
+      "Studio Mac",
+    ]);
+  });
+
+  it("marks a disconnected peer offline instead of dropping it", () => {
+    const targets = buildFederationThreadTargets(
+      health([peer({ id: "a", label: "Studio Mac", status: "disconnected" })]),
+    );
+
+    expect(targets).toEqual([
+      { availability: "offline", instanceId: "a", label: "Studio Mac" },
+    ]);
+  });
+
+  it("marks a peer missing any required capability unsupported", () => {
+    const targets = buildFederationThreadTargets(
+      health([
+        peer({
+          id: "a",
+          label: "Attic Mini",
+          capabilities: ["remote_window", "thread_navigation"],
+        }),
+      ]),
+    );
+
+    expect(targets[0]?.availability).toBe("unsupported");
+  });
+
+  it("drops revoked peers, which are dead entries rather than offline ones", () => {
+    const targets = buildFederationThreadTargets(
+      health([
+        peer({ id: "a", label: "Studio Mac", revokedAt: 1 }),
+        peer({ id: "b", label: "Loft Laptop" }),
+      ]),
+    );
+
+    expect(targets.map((target) => target.instanceId)).toEqual(["b"]);
+  });
+
+  it("keeps the profile suffix when a peer shares this machine's label", () => {
+    const targets = buildFederationThreadTargets(
+      health([peer({ id: "a", label: "Studio Mac", profileName: "default" })], {
+        localLabel: "Studio Mac",
+        localProfileName: "work",
+      }),
+    );
+
+    expect(targets[0]?.label).toBe("Studio Mac / default");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/new-thread-placements.test.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/new-thread-placements.test.tsx
@@ -5,7 +5,11 @@ import { AppTitleBar } from "../AppTitleBar";
 import { MastheadActions } from "../MastheadActions";
 
 const remoteTargets = [
-  { instanceId: "studio-work", label: "Studio Mac / work" },
+  {
+    availability: "available" as const,
+    instanceId: "studio-work",
+    label: "Studio Mac / work",
+  },
 ];
 
 afterEach(() => {
@@ -30,7 +34,7 @@ describe("federation New Thread placements", () => {
     const button = screen.getByRole("button", { name: "New thread" });
     fireEvent.mouseEnter(button.parentElement as HTMLElement);
     fireEvent.click(screen.getByRole("menuitem", {
-      name: "New chat on Studio Mac / work",
+      name: "Studio Mac / work",
     }));
 
     expect(onCreateThreadOnFederationTarget).toHaveBeenCalledWith("studio-work");
@@ -60,7 +64,7 @@ describe("federation New Thread placements", () => {
     const button = screen.getByRole("button", { name: "New thread" });
     fireEvent.mouseEnter(button.parentElement as HTMLElement);
     fireEvent.click(screen.getByRole("menuitem", {
-      name: "New chat on Studio Mac / work",
+      name: "Studio Mac / work",
     }));
 
     expect(onCreateThreadOnFederationTarget).toHaveBeenCalledWith("studio-work");

--- a/apps/desktop/src/renderer/src/features/chrome/federation-thread-targets.ts
+++ b/apps/desktop/src/renderer/src/features/chrome/federation-thread-targets.ts
@@ -59,10 +59,10 @@ function resolveAvailability(
  * that reorders under the pointer turns a misclick into a thread created on
  * the wrong machine.
  *
- * Revoked peers are dropped — they are dead entries, not offline ones — but
- * they still count toward label disambiguation inside
- * `formatFederationPeerDisplayLabel`, alongside the local instance, so a peer
- * sharing this machine's label keeps its profile suffix.
+ * Revoked peers are dropped — they are dead entries, not offline ones. They
+ * are still passed to `formatFederationPeerDisplayLabel`, but only because it
+ * filters them out itself; what the local instance's presence in that list
+ * buys us is a peer sharing THIS machine's label keeping its profile suffix.
  */
 export function buildFederationThreadTargets(
   health: FederationHealthStatus | undefined,
@@ -83,7 +83,15 @@ export function buildFederationThreadTargets(
       label: formatFederationPeerDisplayLabel(peer, visibleInstances),
       availability: resolveAvailability(peer),
     }))
-    .sort((left, right) => left.label.localeCompare(right.label));
+    .sort(
+      (left, right) =>
+        left.label.localeCompare(right.label)
+        // Two peers can share a display label — same machine, neither
+        // advertising a profile. Without a tiebreak their order falls back to
+        // health order, which is exactly the under-the-pointer reshuffle this
+        // sort exists to prevent.
+        || left.instanceId.localeCompare(right.instanceId),
+    );
 }
 
 /** Tooltip/title text explaining a row the operator cannot click. */

--- a/apps/desktop/src/renderer/src/features/chrome/federation-thread-targets.ts
+++ b/apps/desktop/src/renderer/src/features/chrome/federation-thread-targets.ts
@@ -1,0 +1,100 @@
+import {
+  formatFederationPeerDisplayLabel,
+  type FederationCapability,
+  type FederationHealthStatus,
+} from "@pwragent/shared";
+
+/**
+ * Capabilities a peer must advertise before this window can start a thread on
+ * it. `remote_window` opens the scoped window, `thread_navigation` lets that
+ * window reach its own launchpad, and `environment_actions` covers the
+ * environment/script work the launchpad runs once composition begins.
+ */
+const REQUIRED_TARGET_CAPABILITIES: readonly FederationCapability[] = [
+  "remote_window",
+  "thread_navigation",
+  "environment_actions",
+];
+
+/**
+ * Why a target can or cannot host a new thread right now.
+ *
+ * `offline` is a state the peer recovers from on its own, so the row stays
+ * visible and explains itself. `unsupported` is a property of the build the
+ * peer is running and will not change without an upgrade — it stays visible
+ * for the same reason Settings → Federation keeps listing the peer with a
+ * disabled "Browse remote threads": a machine vanishing from the list is
+ * indistinguishable from a bug.
+ */
+export type FederationThreadTargetAvailability =
+  | "available"
+  | "offline"
+  | "unsupported";
+
+export type FederationThreadTarget = {
+  instanceId: string;
+  label: string;
+  availability: FederationThreadTargetAvailability;
+};
+
+function resolveAvailability(
+  peer: FederationHealthStatus["peers"][number],
+): FederationThreadTargetAvailability {
+  if (
+    !REQUIRED_TARGET_CAPABILITIES.every((capability) =>
+      peer.capabilities.includes(capability),
+    )
+  ) {
+    return "unsupported";
+  }
+  return peer.status === "connected" ? "available" : "offline";
+}
+
+/**
+ * Federation peers this window can offer as a launch target, in a stable
+ * display order.
+ *
+ * Sorted by label rather than left in health order: these rows live in
+ * hover-opened menus, health re-reads on every peer transition, and a list
+ * that reorders under the pointer turns a misclick into a thread created on
+ * the wrong machine.
+ *
+ * Revoked peers are dropped — they are dead entries, not offline ones — but
+ * they still count toward label disambiguation inside
+ * `formatFederationPeerDisplayLabel`, alongside the local instance, so a peer
+ * sharing this machine's label keeps its profile suffix.
+ */
+export function buildFederationThreadTargets(
+  health: FederationHealthStatus | undefined,
+): FederationThreadTarget[] {
+  if (!health) {
+    return [];
+  }
+  const visibleInstances = [
+    ...health.peers,
+    ...(health.localLabel
+      ? [{ label: health.localLabel, profileName: health.localProfileName }]
+      : []),
+  ];
+  return health.peers
+    .filter((peer) => !peer.revokedAt)
+    .map((peer) => ({
+      instanceId: peer.id,
+      label: formatFederationPeerDisplayLabel(peer, visibleInstances),
+      availability: resolveAvailability(peer),
+    }))
+    .sort((left, right) => left.label.localeCompare(right.label));
+}
+
+/** Tooltip/title text explaining a row the operator cannot click. */
+export function describeFederationThreadTargetAvailability(
+  availability: FederationThreadTargetAvailability,
+): string | undefined {
+  if (availability === "offline") {
+    return "Not connected";
+  }
+  if (availability === "unsupported") {
+    return "This instance's build cannot host a new thread";
+  }
+  return undefined;
+}

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1624,6 +1624,8 @@ export function DirectoriesList(props: DirectoriesListProps) {
             </span>
           </button>
 
+          {/* Guarded as a unit: an unconfigured row has no local launchpad, so
+              it gets no machine chevron either. */}
           {directoryUnconfigured ? null : (
             <span className="directory-row__launchpad-cluster">
               <button

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -105,6 +105,8 @@ type DirectoriesListProps = {
     directory: NavigationDirectorySummary,
     position: { x: number; y: number; anchorTop?: number },
   ) => void;
+  /** Directory key whose federation target menu is currently open, if any. */
+  openFederationTargetMenuDirectoryKey?: string;
   onRevealSelectedThreadComplete?: (request: number) => void;
   onSelectThread: (
     thread: NavigationThreadSummary,
@@ -1627,7 +1629,13 @@ export function DirectoriesList(props: DirectoriesListProps) {
           {/* Guarded as a unit: an unconfigured row has no local launchpad, so
               it gets no machine chevron either. */}
           {directoryUnconfigured ? null : (
-            <span className="directory-row__launchpad-cluster">
+            <span
+              className={`directory-row__launchpad-cluster${
+                props.onOpenFederationTargetMenu
+                  ? " directory-row__launchpad-cluster--split"
+                  : ""
+              }`}
+            >
               <button
                 aria-label={`Open new thread launchpad for ${directory.label}`}
                 className={`directory-row__launchpad-button${
@@ -1642,8 +1650,16 @@ export function DirectoriesList(props: DirectoriesListProps) {
               </button>
               {props.onOpenFederationTargetMenu ? (
                 <button
-                  aria-label={`Choose a machine for a new thread in ${directory.label}`}
+                  // Deliberately not "...for a new thread in <directory>": the
+                  // selected machine opens its OWN launchpad with its own
+                  // projects, so the local directory does not scope the result.
+                  // It stays in the name only as row context, which also keeps
+                  // the name unique per row for locators.
+                  aria-label={`Start a new thread on another machine (from ${directory.label})`}
                   aria-haspopup="menu"
+                  aria-expanded={
+                    props.openFederationTargetMenuDirectoryKey === directory.key
+                  }
                   className="directory-row__launchpad-targets-button"
                   type="button"
                   onClick={(event) => {

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -29,6 +29,7 @@ import {
   sortSubthreadSummaries,
 } from "@pwragent/shared";
 import {
+  ChevronDownIcon,
   FolderIcon,
   NewThreadIcon,
   UnlinkedDotIcon,
@@ -95,6 +96,15 @@ type DirectoriesListProps = {
     directory: NavigationDirectorySummary,
     preferredBackend?: AppServerBackendKind
   ) => Promise<void>;
+  /**
+   * Opens the "New chat on <machine>" menu for this row's launchpad button.
+   * Absent when the federation has no peers to offer, which is what keeps the
+   * split-button chevron from rendering on a single-instance install.
+   */
+  onOpenFederationTargetMenu?: (
+    directory: NavigationDirectorySummary,
+    position: { x: number; y: number; anchorTop?: number },
+  ) => void;
   onRevealSelectedThreadComplete?: (request: number) => void;
   onSelectThread: (
     thread: NavigationThreadSummary,
@@ -1615,18 +1625,43 @@ export function DirectoriesList(props: DirectoriesListProps) {
           </button>
 
           {directoryUnconfigured ? null : (
-            <button
-              aria-label={`Open new thread launchpad for ${directory.label}`}
-              className={`directory-row__launchpad-button${
-                hasPendingLaunchpadState(directory) ? " has-draft" : ""
-              }`}
-              type="button"
-              onClick={() => {
-                void props.onOpenLaunchpad(directory, directory.launchpad?.backend);
-              }}
-            >
-              <NewThreadIcon size={16} />
-            </button>
+            <span className="directory-row__launchpad-cluster">
+              <button
+                aria-label={`Open new thread launchpad for ${directory.label}`}
+                className={`directory-row__launchpad-button${
+                  hasPendingLaunchpadState(directory) ? " has-draft" : ""
+                }`}
+                type="button"
+                onClick={() => {
+                  void props.onOpenLaunchpad(directory, directory.launchpad?.backend);
+                }}
+              >
+                <NewThreadIcon size={16} />
+              </button>
+              {props.onOpenFederationTargetMenu ? (
+                <button
+                  aria-label={`Choose a machine for a new thread in ${directory.label}`}
+                  aria-haspopup="menu"
+                  className="directory-row__launchpad-targets-button"
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    const rect = event.currentTarget.getBoundingClientRect();
+                    // `x` is the chevron's RIGHT edge; the sidebar right-aligns
+                    // the card to it once the card has been measured. The card's
+                    // width is a range (220–320px), so subtracting a guess here
+                    // would misplace it on the wider end.
+                    props.onOpenFederationTargetMenu?.(directory, {
+                      x: rect.right,
+                      y: rect.bottom + 4,
+                      anchorTop: rect.top,
+                    });
+                  }}
+                >
+                  <ChevronDownIcon size={12} />
+                </button>
+              ) : null}
+            </span>
           )}
         </div>
 

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1660,7 +1660,11 @@ export function DirectoriesList(props: DirectoriesListProps) {
                     });
                   }}
                 >
-                  <ChevronDownIcon size={12} />
+                  {/* Heavier stroke at a smaller size: at the icon library's
+                      1.75 default a 12px chevron read washed out next to the
+                      16px launchpad glyph, so the pair looked like two
+                      different treatments rather than one control. */}
+                  <ChevronDownIcon size={14} strokeWidth={2} />
                 </button>
               ) : null}
             </span>

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -408,6 +408,7 @@ export function Sidebar(props: SidebarProps) {
     | {
         requestedPosition: ThreadContextMenuPosition;
         position?: { x: number; y: number };
+        directoryKey: string;
         directoryLabel: string;
       }
     | undefined
@@ -846,6 +847,15 @@ export function Sidebar(props: SidebarProps) {
   }, [directoryContextMenu]);
 
   useEffect(() => {
+    if (federationThreadTargets.length === 0) {
+      // The menu is also gated on this at render time, so without clearing the
+      // state a peer reconnecting would pop the menu back open at its old
+      // anchor with no operator input.
+      setDirectoryTargetMenu(undefined);
+    }
+  }, [federationThreadTargets.length]);
+
+  useEffect(() => {
     if (!directoryTargetMenu) {
       return;
     }
@@ -1149,9 +1159,11 @@ export function Sidebar(props: SidebarProps) {
   ): void => {
     setContextMenu(undefined);
     setDirectoryContextMenu(undefined);
+    setProfileMenuOpen(false);
     setRenameThread(undefined);
     setDirectoryTargetMenu({
       requestedPosition: position,
+      directoryKey: directory.key,
       directoryLabel: directory.label,
     });
   };
@@ -1868,6 +1880,9 @@ export function Sidebar(props: SidebarProps) {
                   ? openDirectoryTargetMenu
                   : undefined
               }
+              openFederationTargetMenuDirectoryKey={
+                directoryTargetMenu?.directoryKey
+              }
               onPrefetchPullRequests={props.onPrefetchPullRequests}
               onPrefetchGitWorkingState={props.onPrefetchGitWorkingState}
               onRevealSelectedThreadComplete={
@@ -2443,7 +2458,7 @@ export function Sidebar(props: SidebarProps) {
           ref={directoryTargetMenuRef}
           className="new-thread-menu__card new-thread-menu__card--anchored"
           role="menu"
-          aria-label={`New thread targets for ${directoryTargetMenu.directoryLabel}`}
+          aria-label="Start a new thread on another machine"
           style={{
             left:
               directoryTargetMenu.position?.x ??

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -43,6 +43,8 @@ import {
   type IconProps,
 } from "../../icons";
 import { FederationRemoteBadge } from "../chrome/FederationRemoteBadge";
+import type { FederationThreadTarget } from "../chrome/federation-thread-targets";
+import { FederationTargetMenuSection } from "../chrome/FederationTargetMenuSection";
 import { NewThreadButton } from "../chrome/NewThreadButton";
 import type {
   ArchiveThreadOptions,
@@ -142,10 +144,7 @@ type SidebarProps = {
   onCreateThread: () => Promise<void>;
   onCreateThreadWithoutDirectory?: () => Promise<void>;
   onCreateThreadOnFederationTarget?: (instanceId: string) => Promise<void>;
-  newThreadFederationTargets?: readonly {
-    instanceId: string;
-    label: string;
-  }[];
+  newThreadFederationTargets?: readonly FederationThreadTarget[];
   onAddProjectDirectory?: () => Promise<void>;
   addingProjectDirectory?: boolean;
   /** Directory the default New Thread action resolves to (flyout label). */
@@ -351,6 +350,8 @@ export function Sidebar(props: SidebarProps) {
   const federationTarget = readRendererFederationTarget();
   const contextMenuRef = useRef<HTMLDivElement>(null);
   const directoryContextMenuRef = useRef<HTMLDivElement>(null);
+  const directoryTargetMenuRef = useRef<HTMLDivElement>(null);
+  const federationThreadTargets = props.newThreadFederationTargets ?? [];
   const renameInputRef = useRef<HTMLInputElement>(null);
   const handledRevealRequestRef = useRef(0);
   const selectionAnchorKeyRef = useRef<string | undefined>(
@@ -394,6 +395,20 @@ export function Sidebar(props: SidebarProps) {
         position?: { x: number; y: number };
         directory: NavigationDirectorySummary;
         directories: NavigationDirectorySummary[];
+      }
+    | undefined
+  >();
+  /**
+   * "New chat on <machine>" for one directory row's launchpad button. Hoisted
+   * here rather than owned by the row for the same reason the two context
+   * menus are: the row lives inside the scrolling thread list, and a popover
+   * anchored inside it gets clipped by that scroll container.
+   */
+  const [directoryTargetMenu, setDirectoryTargetMenu] = useState<
+    | {
+        requestedPosition: ThreadContextMenuPosition;
+        position?: { x: number; y: number };
+        directoryLabel: string;
       }
     | undefined
   >();
@@ -831,6 +846,28 @@ export function Sidebar(props: SidebarProps) {
   }, [directoryContextMenu]);
 
   useEffect(() => {
+    if (!directoryTargetMenu) {
+      return;
+    }
+
+    const closeMenu = (): void => setDirectoryTargetMenu(undefined);
+    const closeOnEscape = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        closeMenu();
+      }
+    };
+
+    window.addEventListener("click", closeMenu);
+    window.addEventListener("contextmenu", closeMenu, true);
+    window.addEventListener("keydown", closeOnEscape);
+    return () => {
+      window.removeEventListener("click", closeMenu);
+      window.removeEventListener("contextmenu", closeMenu, true);
+      window.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [directoryTargetMenu]);
+
+  useEffect(() => {
     if (!profileMenuOpen) {
       return;
     }
@@ -909,6 +946,42 @@ export function Sidebar(props: SidebarProps) {
       position: nextPosition,
     });
   }, [directoryContextMenu]);
+
+  useLayoutEffect(() => {
+    if (!directoryTargetMenu) {
+      return;
+    }
+
+    const menu = directoryTargetMenuRef.current;
+    if (!menu) {
+      return;
+    }
+
+    // `requestedPosition.x` is the chevron's right edge. Right-align the card
+    // to it now that the card has been measured — the directory row sits at
+    // the sidebar's right edge, so a left-aligned card would hang over the
+    // thread pane instead of reading as this row's menu.
+    const menuRect = menu.getBoundingClientRect();
+    const nextPosition = placeThreadContextMenu(
+      {
+        ...directoryTargetMenu.requestedPosition,
+        x: directoryTargetMenu.requestedPosition.x - menuRect.width,
+      },
+      menuRect,
+    );
+
+    if (
+      directoryTargetMenu.position?.x === nextPosition.x &&
+      directoryTargetMenu.position.y === nextPosition.y
+    ) {
+      return;
+    }
+
+    setDirectoryTargetMenu({
+      ...directoryTargetMenu,
+      position: nextPosition,
+    });
+  }, [directoryTargetMenu]);
 
   useLayoutEffect(() => {
     if (!renameThread) {
@@ -1067,6 +1140,19 @@ export function Sidebar(props: SidebarProps) {
       requestedPosition: position,
       directory,
       directories: resolveDirectoryContextMenuDirectories(directory),
+    });
+  };
+
+  const openDirectoryTargetMenu = (
+    directory: NavigationDirectorySummary,
+    position: ThreadContextMenuPosition,
+  ): void => {
+    setContextMenu(undefined);
+    setDirectoryContextMenu(undefined);
+    setRenameThread(undefined);
+    setDirectoryTargetMenu({
+      requestedPosition: position,
+      directoryLabel: directory.label,
     });
   };
 
@@ -1777,6 +1863,11 @@ export function Sidebar(props: SidebarProps) {
               threads={props.threads}
               onOpenThreadContextMenu={openThreadContextMenu}
               onOpenLaunchpad={props.onOpenLaunchpad}
+              onOpenFederationTargetMenu={
+                federationThreadTargets.length > 0
+                  ? openDirectoryTargetMenu
+                  : undefined
+              }
               onPrefetchPullRequests={props.onPrefetchPullRequests}
               onPrefetchGitWorkingState={props.onPrefetchGitWorkingState}
               onRevealSelectedThreadComplete={
@@ -2345,6 +2436,33 @@ export function Sidebar(props: SidebarProps) {
             void props.onDetachPullRequest?.(pending.thread, pending.pr);
           }}
         />
+      ) : null}
+
+      {directoryTargetMenu && federationThreadTargets.length > 0 ? (
+        <div
+          ref={directoryTargetMenuRef}
+          className="new-thread-menu__card new-thread-menu__card--anchored"
+          role="menu"
+          aria-label={`New thread targets for ${directoryTargetMenu.directoryLabel}`}
+          style={{
+            left:
+              directoryTargetMenu.position?.x ??
+              directoryTargetMenu.requestedPosition.x,
+            top:
+              directoryTargetMenu.position?.y ??
+              directoryTargetMenu.requestedPosition.y,
+            visibility: directoryTargetMenu.position ? undefined : "hidden",
+          }}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <FederationTargetMenuSection
+            targets={federationThreadTargets}
+            onSelect={(instanceId) => {
+              setDirectoryTargetMenu(undefined);
+              void props.onCreateThreadOnFederationTarget?.(instanceId);
+            }}
+          />
+        </div>
       ) : null}
 
       {directoryContextMenu ? (

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -5910,14 +5910,21 @@ describe("Sidebar directory pinning", () => {
     expect(onOpenLaunchpad).toHaveBeenCalledTimes(1);
     expect(onCreateThreadOnFederationTarget).not.toHaveBeenCalled();
 
-    await clickElement(
-      screen.getByRole("button", {
-        name: "Choose a machine for a new thread in ProjectA",
-      }),
+    const chevron = screen.getByRole("button", {
+      name: "Start a new thread on another machine (from ProjectA)",
+    });
+    // The group hover treatment is gated on this modifier, so that it never
+    // applies to a lone launchpad button.
+    expect(chevron.parentElement).toHaveClass(
+      "directory-row__launchpad-cluster--split",
     );
+    expect(chevron).toHaveAttribute("aria-expanded", "false");
+    await clickElement(chevron);
+    expect(chevron).toHaveAttribute("aria-expanded", "true");
     await clickElement(
       await screen.findByRole("menuitem", { name: "Studio Mac / work" }),
     );
+    expect(chevron).toHaveAttribute("aria-expanded", "false");
 
     expect(onCreateThreadOnFederationTarget).toHaveBeenCalledWith("studio-work");
     // Opening a remote launchpad is not also a local launchpad open.
@@ -5950,7 +5957,7 @@ describe("Sidebar directory pinning", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", {
-        name: "Choose a machine for a new thread in ProjectA",
+        name: "Start a new thread on another machine (from ProjectA)",
       }),
     ).not.toBeInTheDocument();
   });
@@ -5958,16 +5965,20 @@ describe("Sidebar directory pinning", () => {
   it("omits the chevron entirely when the federation offers no machines", () => {
     renderSidebar([projectADirectory], { newThreadFederationTargets: [] });
 
-    expect(
-      screen.getByRole("button", {
-        name: "Open new thread launchpad for ProjectA",
-      }),
-    ).toBeInTheDocument();
+    const launchpad = screen.getByRole("button", {
+      name: "Open new thread launchpad for ProjectA",
+    });
+    expect(launchpad).toBeInTheDocument();
     expect(
       screen.queryByRole("button", {
-        name: "Choose a machine for a new thread in ProjectA",
+        name: "Start a new thread on another machine (from ProjectA)",
       }),
     ).not.toBeInTheDocument();
+    // Without a second half there is no group to express, and the group tint
+    // would only composite under the button's own hover pill and darken it.
+    expect(launchpad.parentElement).not.toHaveClass(
+      "directory-row__launchpad-cluster--split",
+    );
   });
 
   it("opens a context menu offering Pin Directory on an unpinned row", async () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -14,6 +14,7 @@ import type {
   NavigationDirectorySummary,
   NavigationThreadSummary,
 } from "@pwragent/shared";
+import type { FederationThreadTarget } from "../../chrome/federation-thread-targets";
 import { Sidebar } from "../Sidebar";
 
 /**
@@ -5607,6 +5608,13 @@ describe("Sidebar directory pinning", () => {
       ) => Promise<void>;
       onReorderDirectoryPins?: (directoryKeys: string[]) => Promise<void>;
       onRemoveDirectory?: (directory: NavigationDirectorySummary) => void;
+      onOpenLaunchpad?: (
+        directory: NavigationDirectorySummary,
+      ) => Promise<void>;
+      onCreateThreadOnFederationTarget?: (
+        instanceId: string,
+      ) => Promise<void>;
+      newThreadFederationTargets?: readonly FederationThreadTarget[];
     } = {},
   ): void {
     render(
@@ -5621,9 +5629,13 @@ describe("Sidebar directory pinning", () => {
         creatingThread={undefined}
         selectedItemKey={undefined}
         threads={[]}
+        newThreadFederationTargets={overrides.newThreadFederationTargets}
         onBrowseModeChange={() => undefined}
         onCreateThread={async () => undefined}
-        onOpenLaunchpad={async () => undefined}
+        onCreateThreadOnFederationTarget={
+          overrides.onCreateThreadOnFederationTarget
+        }
+        onOpenLaunchpad={overrides.onOpenLaunchpad ?? (async () => undefined)}
         onSelectThread={() => undefined}
         onSetDirectoryPin={overrides.onSetDirectoryPin}
         onReorderDirectoryPins={overrides.onReorderDirectoryPins}
@@ -5871,6 +5883,60 @@ describe("Sidebar directory pinning", () => {
       pinnedB.key,
       pinnedA.key,
     ]);
+  });
+
+  it("keeps the directory launchpad button a single click and puts machines behind the chevron", async () => {
+    const onOpenLaunchpad = vi.fn(async () => undefined);
+    const onCreateThreadOnFederationTarget = vi.fn(async () => undefined);
+
+    renderSidebar([projectADirectory], {
+      onOpenLaunchpad,
+      onCreateThreadOnFederationTarget,
+      newThreadFederationTargets: [
+        {
+          availability: "available",
+          instanceId: "studio-work",
+          label: "Studio Mac / work",
+        },
+      ],
+    });
+
+    // The icon itself keeps its existing one-click meaning.
+    await clickElement(
+      screen.getByRole("button", {
+        name: "Open new thread launchpad for ProjectA",
+      }),
+    );
+    expect(onOpenLaunchpad).toHaveBeenCalledTimes(1);
+    expect(onCreateThreadOnFederationTarget).not.toHaveBeenCalled();
+
+    await clickElement(
+      screen.getByRole("button", {
+        name: "Choose a machine for a new thread in ProjectA",
+      }),
+    );
+    await clickElement(
+      await screen.findByRole("menuitem", { name: "Studio Mac / work" }),
+    );
+
+    expect(onCreateThreadOnFederationTarget).toHaveBeenCalledWith("studio-work");
+    // Opening a remote launchpad is not also a local launchpad open.
+    expect(onOpenLaunchpad).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the chevron entirely when the federation offers no machines", () => {
+    renderSidebar([projectADirectory], { newThreadFederationTargets: [] });
+
+    expect(
+      screen.getByRole("button", {
+        name: "Open new thread launchpad for ProjectA",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Choose a machine for a new thread in ProjectA",
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it("opens a context menu offering Pin Directory on an unpinned row", async () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -5924,6 +5924,37 @@ describe("Sidebar directory pinning", () => {
     expect(onOpenLaunchpad).toHaveBeenCalledTimes(1);
   });
 
+  it("hides the whole launchpad cluster on a directory this instance cannot host", () => {
+    // The unconfigured guard wraps icon AND chevron. Offering "new chat on
+    // <machine>" from a row with no local launchpad would reintroduce the
+    // affordance that guard exists to remove, and it is not directory-scoped
+    // anyway — it opens the peer's own launchpad.
+    renderSidebar(
+      [{ ...projectADirectory, localAvailability: "unconfigured" }],
+      {
+        newThreadFederationTargets: [
+          {
+            availability: "available",
+            instanceId: "studio-work",
+            label: "Studio Mac / work",
+          },
+        ],
+        onCreateThreadOnFederationTarget: async () => undefined,
+      },
+    );
+
+    expect(
+      screen.queryByRole("button", {
+        name: "Open new thread launchpad for ProjectA",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Choose a machine for a new thread in ProjectA",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
   it("omits the chevron entirely when the federation offers no machines", () => {
     renderSidebar([projectADirectory], { newThreadFederationTargets: [] });
 

--- a/apps/desktop/src/renderer/src/icons/ChevronDownIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/ChevronDownIcon.tsx
@@ -1,0 +1,9 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+export function ChevronDownIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -10,6 +10,7 @@ export { CelestialSunIcon } from "./celestial/CelestialSunIcon";
 export { CelestialTiltedRingedPlanetIcon } from "./celestial/CelestialTiltedRingedPlanetIcon";
 export { CalendarPlusIcon } from "./CalendarPlusIcon";
 export { CheckIcon } from "./CheckIcon";
+export { ChevronDownIcon } from "./ChevronDownIcon";
 export { ChevronLeftIcon } from "./ChevronLeftIcon";
 export { ChevronRightIcon } from "./ChevronRightIcon";
 export { ChevronUpIcon } from "./ChevronUpIcon";

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5415,6 +5415,20 @@ textarea,
 .directory-row__launchpad-cluster {
   display: inline-flex;
   align-items: center;
+  border-radius: 6px;
+}
+
+/* Hovering either half tints the whole cluster and warms both glyphs, so the
+   pair reads as one control with two actions rather than two unrelated icons.
+   Deliberately weaker than the per-half hover below — the group tint says
+   "these belong together", the strong pill says "this is the one that fires". */
+.directory-row__launchpad-cluster:hover {
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+}
+
+.directory-row__launchpad-cluster:hover .directory-row__launchpad-button,
+.directory-row__launchpad-cluster:hover .directory-row__launchpad-targets-button {
+  color: var(--accent);
 }
 
 .directory-row__launchpad-targets-button {
@@ -5433,13 +5447,22 @@ textarea,
   line-height: 1;
 }
 
-.directory-row__launchpad-button:hover,
-.directory-row__launchpad-button:focus-visible,
-.directory-row__launchpad-targets-button:hover,
-.directory-row__launchpad-targets-button:focus-visible {
+/* The half actually under the pointer (or focused) takes the full accent-soft
+   pill. Cluster-scoped so it matches the group rule above at equal
+   specificity and wins the tie by coming later. */
+.directory-row__launchpad-cluster .directory-row__launchpad-button:hover,
+.directory-row__launchpad-cluster .directory-row__launchpad-button:focus-visible,
+.directory-row__launchpad-cluster .directory-row__launchpad-targets-button:hover,
+.directory-row__launchpad-cluster .directory-row__launchpad-targets-button:focus-visible {
   background: var(--accent-soft);
   color: var(--accent-bright);
   outline: none;
+}
+
+/* An unsent draft outranks the group tint: hovering the chevron must not dim
+   the "you have a draft here" cue on its sibling. */
+.directory-row__launchpad-cluster:hover .directory-row__launchpad-button.has-draft {
+  color: var(--accent-bright);
 }
 
 .directory-row__launchpad-button.has-draft {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -652,6 +652,11 @@ textarea,
 .new-thread-menu__card {
   min-width: 220px;
   max-width: min(320px, calc(100vw - 32px));
+  /* The federation section grows one row per enrolled machine, and the card
+     is anchored below the trigger with no flip, so an unbounded height runs
+     off the bottom of the window on a large federation. */
+  max-height: min(420px, calc(100vh - 96px));
+  overflow-y: auto;
   padding: 6px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
@@ -698,11 +703,64 @@ textarea,
   background: var(--border-subtle);
 }
 
+/* Matches `.project-picker__section` / `.branch-picker__eyebrow`, the app's
+   other in-popover group labels. Sentence case at --text-muted reads as a
+   disabled menu item rather than a heading. */
 .new-thread-menu__section-label {
-  padding: 4px 10px 2px;
+  padding: 6px 10px 4px;
   color: var(--text-muted);
   font-size: 11px;
   font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* The directory-row split button opens this same card, but anchored to the
+   chevron rather than nested under the masthead trigger — the row lives
+   inside the scrolling thread list, which would clip an absolute child. */
+.new-thread-menu__card--anchored {
+  position: fixed;
+  z-index: 50;
+}
+
+.new-thread-menu__item--target {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.new-thread-menu__target-dot {
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--status-ok);
+}
+
+/* Reachable-but-not-now and cannot-ever read differently: a filled grey dot
+   for a peer that will come back, a hollow one for a build that can't host
+   a thread until it is upgraded. */
+.new-thread-menu__target-dot[data-availability="offline"] {
+  background: var(--status-suspended);
+}
+
+.new-thread-menu__target-dot[data-availability="unsupported"] {
+  background: transparent;
+  box-shadow: inset 0 0 0 1px var(--status-suspended);
+}
+
+.new-thread-menu__target-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.new-thread-menu__target-state {
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding-left: 8px;
+  color: var(--text-muted);
+  font-size: 11px;
 }
 
 /* macOS floats the traffic lights over the cluster's left. Match the sidebar
@@ -5352,8 +5410,33 @@ textarea,
      additional margin needed here. */
 }
 
+/* Split button: the icon keeps its one-click "new thread here" meaning and the
+   chevron adds the machine choice, so the common case stays a single click. */
+.directory-row__launchpad-cluster {
+  display: inline-flex;
+  align-items: center;
+}
+
+.directory-row__launchpad-targets-button {
+  display: inline-flex;
+  width: 16px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  appearance: none;
+  cursor: pointer;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  line-height: 1;
+}
+
 .directory-row__launchpad-button:hover,
-.directory-row__launchpad-button:focus-visible {
+.directory-row__launchpad-button:focus-visible,
+.directory-row__launchpad-targets-button:hover,
+.directory-row__launchpad-targets-button:focus-visible {
   background: var(--accent-soft);
   color: var(--accent-bright);
   outline: none;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -692,9 +692,24 @@ textarea,
   outline: none;
 }
 
-.new-thread-menu__item:disabled {
+.new-thread-menu__item:disabled,
+.new-thread-menu__item[aria-disabled="true"] {
   color: var(--text-muted);
   cursor: default;
+}
+
+/* `aria-disabled` keeps the row focusable, so it still matches the accent
+   hover/focus rule above. Restate the muted treatment at higher specificity
+   so an unreachable machine never looks actionable — but keep a surface for
+   focus, or a keyboard user loses their place in the list. */
+.new-thread-menu__item[aria-disabled="true"]:hover {
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.new-thread-menu__item[aria-disabled="true"]:focus-visible {
+  background: var(--surface-overlay-soft);
+  color: var(--text-muted);
 }
 
 .new-thread-menu__separator {
@@ -5421,13 +5436,19 @@ textarea,
 /* Hovering either half tints the whole cluster and warms both glyphs, so the
    pair reads as one control with two actions rather than two unrelated icons.
    Deliberately weaker than the per-half hover below — the group tint says
-   "these belong together", the strong pill says "this is the one that fires". */
-.directory-row__launchpad-cluster:hover {
+   "these belong together", the strong pill says "this is the one that fires".
+
+   Gated on the `--split` modifier, not on :has(): the cluster also wraps a
+   lone launchpad button on an install with no federation peers, where the
+   tint would just composite under the per-half pill and darken it for no
+   reason. A :has() prefix would also outrank the per-half rule below and
+   invert which half looks active. */
+.directory-row__launchpad-cluster--split:hover {
   background: color-mix(in srgb, var(--accent) 6%, transparent);
 }
 
-.directory-row__launchpad-cluster:hover .directory-row__launchpad-button,
-.directory-row__launchpad-cluster:hover .directory-row__launchpad-targets-button {
+.directory-row__launchpad-cluster--split:hover .directory-row__launchpad-button,
+.directory-row__launchpad-cluster--split:hover .directory-row__launchpad-targets-button {
   color: var(--accent);
 }
 
@@ -5461,7 +5482,7 @@ textarea,
 
 /* An unsent draft outranks the group tint: hovering the chevron must not dim
    the "you have a draft here" cue on its sibling. */
-.directory-row__launchpad-cluster:hover .directory-row__launchpad-button.has-draft {
+.directory-row__launchpad-cluster--split:hover .directory-row__launchpad-button.has-draft {
   color: var(--accent-bright);
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5204,10 +5204,13 @@ textarea,
   top: 0;
   z-index: 5;
   /* Gap between summary button and launchpad icon button. Tightened
-     from 8 → 4 — the icon button itself lost its border (no longer
-     reads as a separate "card" the way the framed 34px button did). */
+     8 → 4 when the icon button lost its border (no longer reads as a
+     separate "card" the way the framed 34px button did), then 4 → 2:
+     the count and the launchpad icon read as one cluster, and the real
+     distance between them is this plus the summary's right padding
+     plus the icon button's own 4px inset. */
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 4px;
+  gap: 2px;
   align-items: center;
   background: var(--bg-sidebar);
 }
@@ -5307,9 +5310,11 @@ textarea,
      than the comfortable touch target instead of 54px. */
   min-height: 32px;
   /* Lateral inset: 4px on the left sits before the disclosure chevron
-     and folder icon; 10px on the right gives the meta block (attention
-     count pill) breathing room from the selected-row border. */
-  padding: 4px 10px 4px 4px;
+     and folder icon; 6px on the right still clears the selected-row
+     border for the meta block (attention count pill) without stranding
+     the count away from the launchpad icon beside it. Was 10px, the
+     largest share of an 18px count-to-icon gap. */
+  padding: 4px 6px 4px 4px;
 }
 
 .directory-row__summary:focus,


### PR DESCRIPTION
## Summary

Stacked on #1522 — **base is `agent/federation-launchpad-targets`, not `main`.** Review #1522 first; this diff is only what sits on top of it.

- put the New Thread flyout's federation targets on each directory row's launchpad button, as a split button
- move the verb into the group label so rows carry only the machine name
- make the group a real `role="group"`, and the label follow the app's popover-label convention
- list unreachable peers disabled with a reason instead of filtering them out
- sort targets by label, and give the card a scroll ceiling

## Why

#1522 put the launch-target choice in one place: the masthead New Thread flyout. The per-directory launchpad button is the other place an operator starts a thread, and it offered no such choice — so "new thread in this project, on that machine" meant going somewhere else first.

The rest is a design review of #1522's own group, applied to both surfaces at once so they can't drift.

## Implementation

`FederationTargetMenuSection` renders the group for both surfaces over `buildFederationThreadTargets`, a pure model that turns federation health into sorted, availability-tagged rows.

The directory row becomes a split button: the icon keeps its existing one-click "new thread here" behavior, and a chevron beside it opens the machine list. The chevron does not render at all when the federation has no peers, so a single-instance install is unchanged. The row lives inside the scrolling thread list, so the card is anchored from the sidebar root like the two existing context menus — nested in the row, the scroll container clips it. Placement reuses `placeThreadContextMenu`, right-aligned to the chevron once the card has been measured (its width is a 220–320px range, so subtracting a guess would misplace it).

Three changes to how the group reads:

- **The verb moved to the label.** Rows are `nowrap`/`ellipsis` inside a card capped at 320px, and repeating `New chat on ` per row spent about a quarter of that budget pushing the machine label — including the ` / <profile>` suffix that exists precisely to tell two entries apart — toward the clip.
- **`role="group"` + `aria-labelledby`** replaces a `role="presentation"` div. As a presentational div the label was removed from the accessibility tree, so a screen reader heard one undifferentiated run of menu items and never learned that these ones start work on another machine.
- **The label picks up the house convention** (uppercase, `0.06em`) from `.project-picker__section` / `.branch-picker__eyebrow`. Sentence case at `--text-muted` read as a disabled menu item rather than a heading.

## Behavior change worth flagging

#1522 filtered out peers that were disconnected or missing a capability. They are now **listed and disabled**, with a status word and a dot. This matches Settings → Federation, which already lists a peer with a disabled "Browse remote threads" — a machine vanishing from the list is indistinguishable from a bug, and it is what makes the online dot carry information. `app-shell.test.tsx`'s assertion that a read-only peer is absent was rewritten to assert it is present and disabled, rather than dropped.

Targets also sort by display label. Health re-reads on every peer transition and on window focus, and a hover-opened list that reorders under the pointer turns a misclick into a thread created on the wrong machine.

## Not included

Cross-machine sub-threads from the thread kebab menu. The machinery exists (`parentThreadInstanceId` is plumbed through sqlite, `backend-registry`, and the renderer's `thread/parent/set`; `federation-agent-tools-service` runs the full flow including `mountRemoteChildAtGroupingRoot`), but it is reachable only as the `create_instance_thread` agent tool — there is no IPC a human click can call, and the human flow needs a pending-parent handshake across `openFederationWindow` → remote materialize → mount that the agent flow does not. Deliberately left for its own PR.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/chrome/__tests__/ apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- `pnpm test apps/desktop/src/renderer` — 163 files pass; the 7 failures (star-map, `useThreadSessionState`) fail identically on the base branch
- `pnpm typecheck` — clean apart from 3 pre-existing `createCommandInvocation` errors present on the base branch
- `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries`, `pnpm lint:colors`
- `git diff --check`

New coverage: 5 cases in `federation-thread-targets.test.ts` (sort order, offline vs unsupported, revoked peers dropped, profile-suffix disambiguation), 2 in `NewThreadButton.test.tsx` (group labelling, disabled unreachable rows), 2 in `sidebar.test.tsx` (icon stays one click / chevron opens the list, chevron absent with no peers).

Headed Electron E2E was not run — repository guidance requires an operator-provided off-desktop lab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)