### PR TITLE
fix(tests): wait for the dev-profile app to exit instead of sleeping 5s

### DIFF
--- a/.agents/skills/pwragent-dev-profile/SKILL.md
+++ b/.agents/skills/pwragent-dev-profile/SKILL.md
@@ -57,9 +57,12 @@ Verify that a previously started instance is still up:
 
 ## Closing the app
 
-`close` sends SIGTERM and then **waits for the process to actually exit**,
-polling until it is gone or 30 seconds pass. Do not replace this with a fixed
-sleep, and do not `kill` the Electron PID yourself.
+`close` signals the app's own process, **waits for it to actually exit**
+(polling until gone or 30 seconds pass), and only then cleans up the `pnpm dev`
+supervisor chain. Do not replace the wait with a fixed sleep, do not `kill` the
+Electron PID yourself, and do not collapse the two phases back into one signal
+to every matched pid — SIGTERMing the supervisor or a renderer alongside the
+main process cuts short the very drain the wait exists to protect.
 
 A SIGTERM'd app does not exit promptly. Note what SIGTERM does **not** do:
 `installProcessShutdownHandlers` in `index.ts` calls `allowImmediateQuit()`, so

--- a/.agents/skills/pwragent-dev-profile/SKILL.md
+++ b/.agents/skills/pwragent-dev-profile/SKILL.md
@@ -51,8 +51,36 @@ Verify that a previously started instance is still up:
    `Electron` display name, shared `com.github.Electron` bundle id, or installed
    `com.pwrdrvr.pwragent` app: those can select a sibling project, another
    checkout, or a packaged build that does not contain the code under test.
-4. Run `close` when the user only wants the dev-profile app stopped.
+4. Run `close` when the user only wants the dev-profile app stopped. Never
+   `kill` the Electron PID by hand — see "Closing the app" below.
 5. Relay the script output and the log path to the user. The default log is `.local/pwragent-dev-profile.log`.
+
+## Closing the app
+
+`close` sends SIGTERM and then **waits for the process to actually exit**,
+polling until it is gone or 30 seconds pass. Do not replace this with a fixed
+sleep, and do not `kill` the Electron PID yourself.
+
+A SIGTERM'd app does not exit promptly. Note what SIGTERM does **not** do:
+`installProcessShutdownHandlers` in `index.ts` calls `allowImmediateQuit()`, so
+the signal path deliberately skips the quit-confirmation dialog and its
+10-second countdown. That countdown belongs to Cmd-Q and window close, not to
+this script.
+
+What the wait is for is the phased drain that follows.
+`disposeMainProcessResources` runs the before-quit phases under a 12-second
+global budget (`MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS`), and the app-server phase
+alone may take 7.5s, with messaging and federation at 4s each and renderer
+teardown adding 2s. **The messaging and federation runtimes are stopped in
+those phases**, so a SIGKILL landing mid-drain strands the profile's leases:
+the next instance boots with federation off, names the dead PID as the lease
+holder in Settings → Federation, and shows zero peers until the dead-owner
+grace expires. Any federation-dependent UI then renders its empty state and
+looks broken when it is not — observed on 2026-08-12 after a hand-rolled
+`kill` that did not wait.
+
+If the 30-second budget is exhausted, `close` escalates to SIGKILL but says
+loudly that it did, and warns that the next launch may report federation off.
 
 ## Script Notes
 

--- a/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
+++ b/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
@@ -423,8 +423,44 @@ stop_matches() {
   done
 }
 
+# A SIGTERM'd app does not exit promptly. `installProcessShutdownHandlers`
+# (index.ts) calls allowImmediateQuit(), so SIGTERM deliberately SKIPS the quit
+# confirmation dialog and its countdown — that path is for Cmd-Q and window
+# close, not for us. What we wait on instead is the phased drain that follows:
+# disposeMainProcessResources runs before-quit phases bounded by
+# MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS (12s global; app-server alone may take 7.5s,
+# messaging and federation 4s each), plus renderer-window teardown at 2s. The
+# messaging and federation runtimes are stopped in those phases, so a SIGKILL
+# landing mid-drain strands the profile's leases and the next instance boots
+# with federation off, naming the dead PID as the holder.
+#
+# 30s covers the ~14s worst case with headroom. The former fixed `sleep 5`
+# could expire while the app-server phase was still draining and then SIGKILL a
+# healthy app that was shutting down correctly.
+readonly GRACEFUL_EXIT_TIMEOUT_SECONDS=30
+readonly GRACEFUL_EXIT_POLL_SECONDS=0.5
+
+# wait_for_exit <timeout-seconds> <lister-command...>
+#
+# Polls until the lister prints nothing (every process gone) or the deadline
+# passes. Returns 0 when they exited, 1 on timeout. Polling rather than
+# sleeping the full budget means the common case — an idle app with nothing in
+# flight — returns in well under a second instead of always costing the worst
+# case.
+wait_for_exit() {
+  local timeout="$1"
+  shift
+  local deadline=$(( $(date +%s) + timeout ))
+
+  while true; do
+    [[ -z "$("$@")" ]] && return 0
+    (( $(date +%s) >= deadline )) && return 1
+    sleep "$GRACEFUL_EXIT_POLL_SECONDS"
+  done
+}
+
 close_app() {
-  local remaining removed_job=0
+  local removed_job=0
 
   mkdir -p "${log_path:h}" || die "failed to create log directory: ${log_path:h}"
   log_line "close root=$root profile=$profile rootHash=$root_hash_value" >> "$log_path"
@@ -440,15 +476,25 @@ close_app() {
   fi
 
   stop_matches TERM >> "$log_path"
-  sleep 5
 
-  remaining="$(matching_dev_pids)"
-  if [[ -n "$remaining" ]]; then
-    stop_matches KILL >> "$log_path"
+  if wait_for_exit "$GRACEFUL_EXIT_TIMEOUT_SECONDS" matching_dev_pids; then
+    rm -f "$pid_file"
+    say "closed $profile profile app for $root"
+    return 0
   fi
 
+  # Escalating here is a real cost, not a tidy-up: SIGKILL skips the
+  # before-quit phases, so the profile's messaging and federation leases are
+  # never released and the next instance boots with federation off until the
+  # dead-owner grace expires. Say so rather than reporting a clean close.
+  log_line "graceful exit timed out after ${GRACEFUL_EXIT_TIMEOUT_SECONDS}s; escalating to KILL" >> "$log_path"
+  say "warning: $profile profile app did not exit within ${GRACEFUL_EXIT_TIMEOUT_SECONDS}s of SIGTERM"
+  say "warning: that is well past the 12s shutdown budget, so a before-quit phase is likely wedged — check $log_path for the last 'shutdown phase completed' line"
+  say "warning: escalating to SIGKILL, which skips lease release; the next instance may report federation off until the lease is reclaimed"
+  stop_matches KILL >> "$log_path"
+
   rm -f "$pid_file"
-  say "closed $profile profile app for $root"
+  say "force-closed $profile profile app for $root"
 }
 
 tail_log() {
@@ -564,6 +610,16 @@ run_self_test() {
   assert_failure "missing Electron main target is ambiguous" single_electron_window_target
   assert_failure "multiple Electron main targets are ambiguous" single_electron_window_target $'101\t/Users/example/Electron.app' $'202\t/Users/example/Electron.app'
   [[ "$root_hash_value" == "c976f17804e892f9" ]] || die "self-test failed: unexpected root hash $root_hash_value"
+
+  assert_success "wait_for_exit returns once nothing is left" \
+    wait_for_exit 5 print -r -- ""
+  assert_failure "wait_for_exit gives up on a process that never exits" \
+    wait_for_exit 1 print -r -- "424242"
+  # The budget has to outlast the app's own worst-case drain, or the wait
+  # expires mid-shutdown and SIGKILL strands the profile's leases.
+  # MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS is 12s and renderer teardown adds 2s.
+  (( GRACEFUL_EXIT_TIMEOUT_SECONDS >= 14 )) \
+    || die "self-test failed: graceful exit budget ${GRACEFUL_EXIT_TIMEOUT_SECONDS}s is under the 12s main-process shutdown drain plus 2s renderer teardown"
 
   say "self-test passed"
 }

--- a/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
+++ b/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
@@ -423,6 +423,34 @@ stop_matches() {
   done
 }
 
+stop_pid_list() {
+  local signal="$1"
+  shift
+  local pid
+
+  for pid in "$@"; do
+    log_line "$signal pid=$pid"
+    kill "-$signal" "$pid" 2>/dev/null || true
+  done
+}
+
+# Lease-backed Electron main processes only.
+#
+# `matching_dev_pids` deliberately also returns Electron's helper children and
+# its `pnpm dev` / electron-vite parent chain. That set is right for the final
+# sweep and wrong for the graceful signal: SIGTERMing the supervisor or the
+# renderer alongside the main process can tear the app down before its
+# before-quit phases run, which is the exact drain this close is waiting for.
+# Signal the app itself, let it exit on its own terms, then clean up the rest.
+managed_electron_main_pids() {
+  local instance_id pid cwd_hint heartbeat desired effective disabled
+
+  query_root_instances 2>/dev/null | while IFS=$'\t' read -r instance_id pid cwd_hint heartbeat desired effective disabled; do
+    [[ -n "$pid" ]] || continue
+    is_live_pid "$pid" && print -r -- "$pid"
+  done
+}
+
 # A SIGTERM'd app does not exit promptly. `installProcessShutdownHandlers`
 # (index.ts) calls allowImmediateQuit(), so SIGTERM deliberately SKIPS the quit
 # confirmation dialog and its countdown — that path is for Cmd-Q and window
@@ -439,6 +467,10 @@ stop_matches() {
 # healthy app that was shutting down correctly.
 readonly GRACEFUL_EXIT_TIMEOUT_SECONDS=30
 readonly GRACEFUL_EXIT_POLL_SECONDS=0.5
+# The supervisor chain has no drain of its own to protect; the daemon helper
+# already stops `pnpm dev` once the Electron instance it started exits, so this
+# is a short backstop for stragglers rather than a real wait.
+readonly SUPERVISOR_EXIT_TIMEOUT_SECONDS=10
 
 # wait_for_exit <timeout-seconds> <lister-command...>
 #
@@ -460,7 +492,8 @@ wait_for_exit() {
 }
 
 close_app() {
-  local removed_job=0
+  local removed_job=0 graceful=1 main_pid
+  local -a main_pids
 
   mkdir -p "${log_path:h}" || die "failed to create log directory: ${log_path:h}"
   log_line "close root=$root profile=$profile rootHash=$root_hash_value" >> "$log_path"
@@ -475,26 +508,47 @@ close_app() {
     return 0
   fi
 
-  stop_matches TERM >> "$log_path"
+  # Phase 1: signal the app itself and let it drain. Nothing else is signalled
+  # yet — killing the supervisor or a renderer here would cut the drain short.
+  main_pids=()
+  while IFS= read -r main_pid; do
+    [[ -n "$main_pid" ]] && main_pids+=("$main_pid")
+  done < <(managed_electron_main_pids)
 
-  if wait_for_exit "$GRACEFUL_EXIT_TIMEOUT_SECONDS" matching_dev_pids; then
-    rm -f "$pid_file"
+  if (( ${#main_pids} )); then
+    stop_pid_list TERM "${main_pids[@]}" >> "$log_path"
+    if ! wait_for_exit "$GRACEFUL_EXIT_TIMEOUT_SECONDS" managed_electron_main_pids; then
+      graceful=0
+      # Escalating is a real cost, not a tidy-up: SIGKILL skips the before-quit
+      # phases, so the profile's messaging and federation leases are never
+      # released and the next instance boots with federation off until the
+      # dead-owner grace expires. Say so rather than reporting a clean close.
+      log_line "graceful exit timed out after ${GRACEFUL_EXIT_TIMEOUT_SECONDS}s" >> "$log_path"
+      say "warning: $profile profile app did not exit within ${GRACEFUL_EXIT_TIMEOUT_SECONDS}s of SIGTERM"
+      say "warning: that is well past the 12s shutdown budget, so a before-quit phase is likely wedged — check $log_path for the last 'shutdown phase completed' line"
+      say "warning: escalating to SIGKILL, which skips lease release; the next instance may report federation off until the lease is reclaimed"
+    fi
+  fi
+
+  # Phase 2: the supervisor chain and any stragglers. Usually already gone —
+  # the daemon helper stops `pnpm dev` when its Electron instance exits.
+  if [[ -n "$(matching_dev_pids)" ]]; then
+    stop_matches TERM >> "$log_path"
+    if ! wait_for_exit "$SUPERVISOR_EXIT_TIMEOUT_SECONDS" matching_dev_pids; then
+      graceful=0
+      log_line "supervisor chain still alive after ${SUPERVISOR_EXIT_TIMEOUT_SECONDS}s; escalating to KILL" >> "$log_path"
+      say "warning: dev supervisor processes did not exit within ${SUPERVISOR_EXIT_TIMEOUT_SECONDS}s of SIGTERM"
+      stop_matches KILL >> "$log_path"
+    fi
+  fi
+
+  rm -f "$pid_file"
+  if (( graceful )); then
     say "closed $profile profile app for $root"
     return 0
   fi
-
-  # Escalating here is a real cost, not a tidy-up: SIGKILL skips the
-  # before-quit phases, so the profile's messaging and federation leases are
-  # never released and the next instance boots with federation off until the
-  # dead-owner grace expires. Say so rather than reporting a clean close.
-  log_line "graceful exit timed out after ${GRACEFUL_EXIT_TIMEOUT_SECONDS}s; escalating to KILL" >> "$log_path"
-  say "warning: $profile profile app did not exit within ${GRACEFUL_EXIT_TIMEOUT_SECONDS}s of SIGTERM"
-  say "warning: that is well past the 12s shutdown budget, so a before-quit phase is likely wedged — check $log_path for the last 'shutdown phase completed' line"
-  say "warning: escalating to SIGKILL, which skips lease release; the next instance may report federation off until the lease is reclaimed"
-  stop_matches KILL >> "$log_path"
-
-  rm -f "$pid_file"
   say "force-closed $profile profile app for $root"
+  return 1
 }
 
 tail_log() {
@@ -620,6 +674,16 @@ run_self_test() {
   # MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS is 12s and renderer teardown adds 2s.
   (( GRACEFUL_EXIT_TIMEOUT_SECONDS >= 14 )) \
     || die "self-test failed: graceful exit budget ${GRACEFUL_EXIT_TIMEOUT_SECONDS}s is under the 12s main-process shutdown drain plus 2s renderer teardown"
+  (( SUPERVISOR_EXIT_TIMEOUT_SECONDS > 0 )) \
+    || die "self-test failed: supervisor exit budget must be positive"
+  # The graceful signal must reach the app alone. If this ever starts emitting
+  # the parent chain or helper children the way matching_dev_pids does, the
+  # 30s wait would be waiting on a drain the same signal just cut short.
+  root="/nonexistent-root-for-self-test"
+  root_hash_value="$(compute_root_hash "$root")"
+  state_db="/nonexistent-state-db-for-self-test"
+  [[ -z "$(managed_electron_main_pids)" ]] \
+    || die "self-test failed: managed_electron_main_pids returned pids for an unknown checkout"
 
   say "self-test passed"
 }


### PR DESCRIPTION
## Summary

Isolated on purpose — based on `main`, touches only the `pwragent-dev-profile` skill, and is independent of #1522 / #1562.

- `close` signals the app's own process and **waits for it to actually exit**, instead of sleeping a fixed 5s
- it signals the `pnpm dev` supervisor chain **after** that, not alongside it
- SIGKILL stays as a backstop but announces itself and says what the next launch will look like

## Why

`close_app` sent SIGTERM to every matched pid, slept **5 seconds**, then SIGKILLed anything still alive. Two separate problems, and the second one is the interesting one.

**The wait was too short.** SIGTERM does not tear the app down directly — `installProcessShutdownHandlers` allows the quit and then runs `disposeMainProcessResources`, whose before-quit phases are bounded by `MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS` at **12s globally**, with the app-server phase alone allowed 7.5s, messaging and federation 4s each, and renderer teardown adding 2s.

**And the signal was too wide.** `matching_dev_pids` deliberately returns the Electron main, its helper children, *and* its `pnpm dev` / electron-vite parent chain. Signalling all of them at the same instant tears the app down before the drain finishes — so a longer wait alone would have been guarding a shutdown that had already been interrupted.

This matters because **the messaging and federation runtimes are stopped in those phases**, and the federation phase is where `releaseFederationLeaseSync()` runs. Miss it and the profile's leases are stranded: the next launch comes up with federation off, names the dead pid as the lease holder in Settings → Federation, and shows zero peers until the dead-owner grace expires. Every federation-dependent surface then renders its empty state, which reads as a broken feature rather than a stranded lease.

## Evidence

Same machine, same checkout, before and after the two-phase change:

| | before | after |
|---|---|---|
| `shutdown phase completed` lines | none — only `pnpm dev exited signal=SIGTERM` | all four, incl. `federation durationMs=11` |
| instance in `leases` | `stale` | `exited` |
| next `restart` | federation off, dead pid named as holder | `federation client connected` |

That last table row is the whole point of the change.

This also resolves what an earlier revision of this PR listed as an unrelated open question — gracefully-closed instances showing `stale` rather than `exited` was not a separate mystery about who writes that column, it was this.

## A correction worth recording

The intuitive explanation for "SIGTERM doesn't exit promptly" is the quit-confirmation countdown — the 10s auto-quit you get when threads, terminals, or automation runs are active. **That is not what happens here.** SIGTERM calls `allowImmediateQuit()`, so the signal path deliberately skips the dialog entirely; the countdown belongs to Cmd-Q and window close.

The wait is for the *drain*, not the countdown. The comments and SKILL.md say so explicitly, because the wrong explanation is the one a reader will reach for — and it would justify the wrong budget.

## Also faster

Polling makes the common case cheaper, not more expensive. An idle app is gone in about a second; the old code always paid the full five. Measured locally: `close` on an idle instance went from a fixed ~5s to ~1.1s.

## Validation

- `pwragent-dev-profile.zsh self-test` — passes; new cases cover `wait_for_exit` returning promptly when the lister drains, giving up on a process that never exits, the budget being at least the app's own worst-case drain, and the graceful signal targeting the app alone
- mutation-checked the budget assertion: setting `GRACEFUL_EXIT_TIMEOUT_SECONDS=5` fails self-test with `graceful exit budget 5s is under the 12s main-process shutdown drain plus 2s renderer teardown`
- `zsh -n` syntax check
- end-to-end against a real dev instance: `restart` → `close` → `restart`, confirming a clean ~1.1s graceful exit, all four shutdown phases, an `exited` lease record, and federation connected on the next boot

`wait_for_exit` takes its process lister as an argument specifically so self-test can drive it without spawning real processes. `close` now returns non-zero when either phase had to escalate; `start_app` calls it unguarded under `set -u` with no `set -e`, so the new status is safe there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)