### PR TITLE
ci: complete Electron cache backport to 1.0

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -21,6 +21,7 @@ jobs:
         uses: pwrdrvr/configure-nodejs@v1
         with:
           node-version: 24.x
+          cache-electron: "true"
 
       - name: Compute preview version
         id: version


### PR DESCRIPTION
## Summary

- Complete the Electron lifecycle-download cache backport by opting the macOS preview DMG workflow into `cache-electron: "true"`.
- Preserve the preview workflow’s existing published `pwrdrvr/configure-nodejs@v1` reference.

## Source and adaptation

- Source PR: #1551
- Source squash commit: `60a13c9d76c8cb891b70d0ef79d7f3cd5c3e9c1e`

The source squash does not apply cleanly to current `releases/1.0`: #1550 already added the cache to both POSIX release-preparation invocations, while #1552 moved the label-gated Windows installer to the intentional Windows-local setup action. Therefore this backport includes only the remaining `configure-nodejs` install site that packages Electron: `preview-build.yml`.

The label-gated Windows installer was audited but is not changed: it no longer invokes `configure-nodejs`, and adding a separate cache implementation to its local setup action would be outside #1551’s logical unit. No release/signing behavior or release-sensitive action pins were changed.

`pwrdrvr/configure-nodejs@v1` and published `v1.4.0` both resolve to `e1bd1cc1494a20f0ee91dae622b0d2523b6fb53c`, whose action contract declares the `cache-electron` input.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color` over CI, preview, and release workflows, with the repository’s known custom `pwrdrvr-macos` runner-label warning ignored.
- Structural workflow assertion: all 15 `configure-nodejs` calls opt into `cache-electron`; preview retains `@v1`; the label-gated Windows installer retains the local Windows setup action.
- `git diff --check`

## Migration audit

No application code, SQLite files, database migrations, SQL schema, or schema-version changes are included.