### PR TITLE
fix(desktop): backport thread creation time to info panel

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -249,6 +249,41 @@ describe("ThreadContextPanel", () => {
     expect(panel).toHaveAttribute("aria-labelledby", activeTab.id);
   });
 
+  it("shows the thread creation and update timestamps in Thread info", () => {
+    const createdAt = new Date(2026, 6, 8, 9, 15).getTime();
+    const updatedAt = new Date(2026, 6, 9, 10, 41).getTime();
+    renderPanel({
+      pinned: true,
+      thread: {
+        ...baseThread,
+        createdAt,
+        updatedAt,
+      },
+    });
+
+    const executionContext = screen
+      .getByRole("heading", { level: 3, name: "Execution context" })
+      .closest("section");
+    expect(executionContext).not.toBeNull();
+    const context = within(executionContext!);
+    expect(context.getByText("Created").nextElementSibling).toHaveTextContent(
+      new Intl.DateTimeFormat(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      }).format(createdAt),
+    );
+    expect(context.getByText("Updated").nextElementSibling).toHaveTextContent(
+      new Intl.DateTimeFormat(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      }).format(updatedAt),
+    );
+  });
+
   it("renders persisted sub-agent cards with monitor usage", () => {
     renderPanel({
       activeTab: "subagents",

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ThreadInfoPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ThreadInfoPanel.tsx
@@ -142,6 +142,12 @@ export function ThreadInfoPanel(props: ThreadInfoPanelProps) {
             </dd>
           </div>
           <div>
+            <dt>Created</dt>
+            <dd>
+              {props.thread.createdAt ? formatTimestamp(props.thread.createdAt) : "Unknown"}
+            </dd>
+          </div>
+          <div>
             <dt>Updated</dt>
             <dd>
               {props.thread.updatedAt ? formatTimestamp(props.thread.updatedAt) : "Unknown"}


### PR DESCRIPTION
## Summary

- Backports the Thread info-panel creation timestamp from source PR #1411.
- Shows **Created** next to the existing **Updated** timestamp, retaining the existing `Unknown` fallback.
- Adds the focused renderer assertion for both timestamp values.

## Source

- Source PR: https://github.com/pwrdrvr/PwrAgent/pull/1411
- Source squash commit: `26f0b6becbd96e16f08204554d50894669119e13`

## Release adaptation and dependencies

The source renderer change and focused test applied unchanged to `releases/1.0`; `NavigationThreadSummary.createdAt` is already available there, so no prerequisite or mainline refactor was included.

The source's `todo-thread-shell` visual golden was intentionally omitted: that snapshot no longer exists on `releases/1.0`, and this backport should not restore unrelated visual-snapshot churn. No Automations, Federation, or Star Map work is included.

## Migration audit

No database, SQLite schema, or migration files changed. `user_version` is unchanged.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx` (53 passed)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; 136 pre-existing warnings)
- `pnpm lint:boundaries`
- `git diff --check`
