### PR TITLE
fix(desktop): backport searchable handoff branch picker

### DIFF
--- a/apps/desktop/e2e/workspace-handoff-dialog.inspect.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-dialog.inspect.spec.ts
@@ -31,7 +31,11 @@ test("opens the local-to-worktree handoff dialog until Electron is closed manual
     await expect(dialog).toContainText("Handoff to Detached HEAD");
     await expect(dialog).toContainText("main");
     await dialog.getByRole("radio", { name: /Handoff Current Branch/ }).click();
-    await expect(dialog.getByLabel("Leave current checkout on")).toHaveValue("HEAD");
+    // `exact` matters: the branch picker's listbox is labelled
+    // "Leave current checkout on options", and getByLabel matches substrings.
+    await expect(
+      dialog.getByLabel("Leave current checkout on", { exact: true }),
+    ).toHaveAttribute("data-value", "HEAD");
     await expect(dialog).toContainText("Ignored files are not moved by handoff.");
 
     console.log(

--- a/apps/desktop/e2e/workspace-handoff-dialog.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-dialog.spec.ts
@@ -43,7 +43,11 @@ test("centers the local-to-worktree handoff dialog in the window", async () => {
     await expect(dialog).toContainText("main");
 
     await dialog.getByRole("radio", { name: /Handoff Current Branch/ }).click();
-    await expect(dialog.getByLabel("Leave current checkout on")).toHaveValue("HEAD");
+    // `exact` matters: the branch picker's listbox is labelled
+    // "Leave current checkout on options", and getByLabel matches substrings.
+    await expect(
+      dialog.getByLabel("Leave current checkout on", { exact: true }),
+    ).toHaveAttribute("data-value", "HEAD");
 
     await dialog.getByRole("radio", { name: /Handoff to New Branch/ }).click();
     await expect(dialog.getByLabel("New branch name")).toHaveValue(

--- a/apps/desktop/e2e/workspace-handoff-flows.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-flows.spec.ts
@@ -213,6 +213,23 @@ async function openLocalHandoffDialog(page: Page, title: string) {
   return dialog;
 }
 
+/**
+ * Picks a row in the handoff dialog's "leave current checkout on" branch
+ * picker. `optionLabel` is the row's visible text, so the detached-HEAD
+ * sentinel is "Detached HEAD" rather than the "HEAD" value it submits.
+ */
+async function chooseLeaveLocalBranch(page: Page, optionLabel: string) {
+  const dialog = page.getByRole("dialog", { name: "Handoff to New Worktree" });
+  // `exact` matters: the picker's listbox is labelled "<name> options" and
+  // getByLabel matches substrings, so a bare name resolves to two elements
+  // once the popover opens.
+  await dialog.getByLabel("Leave current checkout on", { exact: true }).click();
+  await dialog
+    .getByRole("listbox", { name: "Leave current checkout on options" })
+    .getByRole("option", { name: optionLabel, exact: true })
+    .click();
+}
+
 async function handoffBackToLocal(page: Page) {
   await page.getByLabel("Workspace mode").click();
   await page.getByRole("menuitem", { name: "Handoff to Local" }).click();
@@ -256,7 +273,7 @@ test.describe("workspace handoff git flows", () => {
       configure: async (page: Page) => {
         const dialog = page.getByRole("dialog", { name: "Handoff to New Worktree" });
         await dialog.getByRole("radio", { name: /Handoff Current Branch/ }).click();
-        await dialog.getByLabel("Leave current checkout on").selectOption("main");
+        await chooseLeaveLocalBranch(page, "main");
       },
       expectedLocalBranchAfterLocalHandoff: "main",
       expectedLocalBranchAfterReturn: "feature/handoff",
@@ -267,7 +284,7 @@ test.describe("workspace handoff git flows", () => {
       configure: async (page: Page) => {
         const dialog = page.getByRole("dialog", { name: "Handoff to New Worktree" });
         await dialog.getByRole("radio", { name: /Handoff Current Branch/ }).click();
-        await dialog.getByLabel("Leave current checkout on").selectOption("HEAD");
+        await chooseLeaveLocalBranch(page, "Detached HEAD");
       },
       expectedLocalBranchAfterLocalHandoff: "",
       expectedLocalBranchAfterReturn: "feature/handoff",

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1618,6 +1618,17 @@ type LaunchpadBranchOption = {
   current?: boolean;
   /** The repository's default branch (origin/HEAD, or main/master/...). */
   isDefault?: boolean;
+  /**
+   * Display text for rows whose `name` is a sentinel rather than a branch
+   * (the handoff dialog's `"HEAD"` → "Detached HEAD"). Falls back to `name`.
+   */
+  label?: string;
+  /**
+   * Hold the row above the recency-ordered list no matter what is selected.
+   * A sentinel row has no commit date, so recency ordering would drop it in
+   * an arbitrary spot once the operator picks a real branch.
+   */
+  pinned?: boolean;
 };
 
 /**
@@ -1645,15 +1656,17 @@ function BranchPicker(props: {
   const [activeIndex, setActiveIndex] = useState(0);
   const [menuShift, setMenuShift] = useState(0);
   const listboxId = useId();
+  const selectedLabelId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const ref = useDismissableMenu<HTMLDivElement>(open, () => setOpen(false));
 
   const normalizedQuery = query.trim().toLowerCase();
-  // Pin the anchor branches — the one you'll branch off (selected), the repo
-  // default, and the checked-out branch — to the top, deduped in that
-  // priority order. Everything else follows in recency order. When the three
-  // anchors are the same branch (the common case) this is a single pinned row.
+  // Pin the anchor branches — caller-pinned sentinels, the one you'll branch
+  // off (selected), the repo default, and the checked-out branch — to the top,
+  // deduped in that priority order. Everything else follows in recency order.
+  // When the three anchors are the same branch (the common case) this is a
+  // single pinned row.
   const { pinnedOptions, restOptions } = useMemo(() => {
     const byName = new Map(props.options.map((option) => [option.name, option]));
     const pinnedNames = new Set<string>();
@@ -1664,6 +1677,11 @@ function BranchPicker(props: {
         pinned.push(option);
       }
     };
+    for (const option of props.options) {
+      if (option.pinned) {
+        addPin(option);
+      }
+    }
     addPin(byName.get(props.value));
     addPin(props.options.find((option) => option.isDefault));
     addPin(props.options.find((option) => option.current));
@@ -1672,7 +1690,9 @@ function BranchPicker(props: {
   }, [props.options, props.value]);
 
   const matchesQuery = (option: LaunchpadBranchOption): boolean =>
-    !normalizedQuery || option.name.toLowerCase().includes(normalizedQuery);
+    !normalizedQuery
+    || option.name.toLowerCase().includes(normalizedQuery)
+    || Boolean(option.label?.toLowerCase().includes(normalizedQuery));
   const visiblePinned = pinnedOptions.filter(matchesQuery);
   const visibleRest = restOptions.filter(matchesQuery);
   const flatVisible = [...visiblePinned, ...visibleRest];
@@ -1763,7 +1783,7 @@ function BranchPicker(props: {
     const relativeTime = formatBranchRelativeTime(option.lastCommitAt, nowMs);
     return (
       <button
-        aria-label={option.name}
+        aria-label={option.label ?? option.name}
         aria-selected={isSelected}
         className={[
           "branch-picker__option",
@@ -1784,7 +1804,9 @@ function BranchPicker(props: {
         <span aria-hidden="true" className="branch-picker__option-icon">
           <BranchIcon size={12} />
         </span>
-        <span className="branch-picker__option-name">{option.name}</span>
+        <span className="branch-picker__option-name">
+          {option.label ?? option.name}
+        </span>
         {option.current ? (
           <span
             aria-hidden="true"
@@ -1831,6 +1853,11 @@ function BranchPicker(props: {
     >
       <button
         aria-controls={open ? listboxId : undefined}
+        // `aria-label` is the field name and overrides the button's content in
+        // the accessible-name computation, so without this the selected branch
+        // is never announced — the native <select> this replaced did announce
+        // its value. Describes rather than renames so by-name queries hold.
+        aria-describedby={selectedLabelId}
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-label={props.ariaLabel}
@@ -1845,8 +1872,8 @@ function BranchPicker(props: {
         <span aria-hidden="true" className="composer-dropdown__icon">
           <BranchIcon size={13} />
         </span>
-        <span className="composer-dropdown__label">
-          {selectedOption?.name ?? props.value}
+        <span className="composer-dropdown__label" id={selectedLabelId}>
+          {selectedOption?.label ?? selectedOption?.name ?? props.value}
         </span>
         <span aria-hidden="true" className="composer-dropdown__chevron">
           ⌄
@@ -1884,7 +1911,10 @@ function BranchPicker(props: {
             </div>
           ) : null}
           <div
-            aria-label={props.ariaLabel}
+            // Not bare `ariaLabel` — that name belongs to the trigger, and
+            // duplicating it makes every by-name query ambiguous while the
+            // menu is open. Mirrors ReviewBranchPicker.
+            aria-label={`${props.ariaLabel} options`}
             className="branch-picker__list"
             id={listboxId}
             role="listbox"
@@ -6673,10 +6703,15 @@ export function Composer(props: ComposerProps) {
       : props.directory?.gitStatus?.currentBranch ??
         props.thread?.observedGitBranch ??
         props.thread?.gitBranch;
-  const branchOptions = getLeaveLocalBranchOptions({
-    currentBranch: sourceBranch,
-    directory: props.directory,
-  });
+  const leaveLocalBranchOptions = useMemo(
+    () =>
+      buildLeaveLocalBranchPickerOptions({
+        currentBranch: sourceBranch,
+        directory: props.directory,
+      }),
+    [sourceBranch, props.directory],
+  );
+  const branchOptions = leaveLocalBranchOptions.map((option) => option.name);
   const canHandoffThreadWorkspace = Boolean(
     props.thread &&
       threadWorkspace &&
@@ -7301,22 +7336,17 @@ export function Composer(props: ComposerProps) {
                     </button>
                   </div>
                   {localHandoffStrategy === "move-branch" ? (
-                    <label className="workspace-handoff-dialog__field">
-                      Leave current checkout on
-                      <select
-                        aria-label="Leave current checkout on"
-                        className="composer__select"
-                        disabled={handoffSubmitting || branchOptions.length === 0}
+                    <div className="workspace-handoff-dialog__field">
+                      <span aria-hidden="true">Leave current checkout on</span>
+                      <BranchPicker
+                        ariaLabel="Leave current checkout on"
+                        className="branch-picker--dialog"
+                        disabled={handoffSubmitting}
+                        options={leaveLocalBranchOptions}
                         value={leaveLocalBranch}
-                        onChange={(event) => setLeaveLocalBranch(event.target.value)}
-                      >
-                        {branchOptions.map((branch) => (
-                          <option key={branch} value={branch}>
-                            {formatLeaveLocalBranchOption(branch)}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
+                        onChange={setLeaveLocalBranch}
+                      />
+                    </div>
                   ) : null}
                   {localHandoffStrategy === "new-branch" ? (
                     <label className="workspace-handoff-dialog__field">
@@ -9699,6 +9729,36 @@ function getLeaveLocalBranchOptions(params: {
   return ["HEAD", ...new Set(ordered)];
 }
 
-function formatLeaveLocalBranchOption(branch: string): string {
-  return branch === "HEAD" ? "Detached HEAD" : branch;
+/**
+ * Options for the handoff dialog's "leave current checkout on" picker.
+ *
+ * `getLeaveLocalBranchOptions` decides *which* refs are offered — it already
+ * drops the branch being moved and (via `handoffBranches`) anything another
+ * worktree holds. This only enriches those names with the recency and
+ * default-branch metadata the picker renders, so the two stay in sync.
+ *
+ * The leading `"HEAD"` sentinel is a checkout state rather than a branch, so
+ * it carries a display label and stays pinned above the recency list.
+ */
+function buildLeaveLocalBranchPickerOptions(params: {
+  currentBranch?: string;
+  directory?: NavigationDirectorySummary;
+}): LaunchpadBranchOption[] {
+  const details = params.directory?.gitStatus?.branchDetails ?? [];
+  const detailByName = new Map(details.map((detail) => [detail.name, detail]));
+  const defaultBranch = params.directory?.gitStatus?.defaultBranch;
+  return getLeaveLocalBranchOptions(params).map((name) => {
+    if (name === "HEAD") {
+      return { name, label: "Detached HEAD", pinned: true };
+    }
+    const detail = detailByName.get(name);
+    return {
+      name,
+      lastCommitAt: detail?.lastCommitAt,
+      // Only reachable on the `branches` fallback path — `handoffBranches`
+      // has already filtered in-use branches out.
+      inUse: detail?.inUse,
+      isDefault: defaultBranch ? name === defaultBranch : false,
+    };
+  });
 }

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9035,7 +9035,12 @@ describe("Composer", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: "Handoff to New Worktree" }));
     fireEvent.click(screen.getByRole("radio", { name: /Handoff Current Branch/ }));
 
-    expect(screen.getByLabelText("Leave current checkout on")).toHaveValue("HEAD");
+    const leaveOn = screen.getByLabelText("Leave current checkout on");
+    expect(leaveOn).toHaveAttribute("data-value", "HEAD");
+    expect(leaveOn).toHaveTextContent("Detached HEAD");
+    // The aria-label names the field and suppresses the button's content, so
+    // the selection has to reach assistive tech as a description instead.
+    expect(leaveOn).toHaveAccessibleDescription("Detached HEAD");
     fireEvent.click(screen.getByRole("button", { name: "Handoff" }));
 
     await waitFor(() => {
@@ -9046,6 +9051,103 @@ describe("Composer", () => {
         sourcePath: "/repo",
         sourceBranch: "feature/handoff",
         leaveLocalBranch: "HEAD",
+      });
+    });
+  });
+
+  it("filters the handoff leave-branch picker and shows branch metadata", async () => {
+    const onHandoffThreadWorkspace = vi.fn(async () => undefined);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        disabled={false}
+        directory={{
+          key: "directory:/repo",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/repo",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "feature/handoff",
+            defaultBranch: "main",
+            branches: ["feature/handoff", "main", "release"],
+            branchDetails: [
+              { name: "release", lastCommitAt: nowSeconds - 3600 },
+              { name: "main", lastCommitAt: nowSeconds - 172800 },
+            ],
+            handoffBranches: ["main", "release"],
+            syncState: "untracked",
+          },
+        }}
+        onHandoffThreadWorkspace={onHandoffThreadWorkspace}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          gitBranch: "feature/handoff",
+          linkedDirectories: [
+            { id: "dir-1", label: "PwrAgent", path: "/repo", kind: "local" },
+          ],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Workspace mode"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Handoff to New Worktree" }));
+    fireEvent.click(screen.getByRole("radio", { name: /Handoff Current Branch/ }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Leave current checkout on" })
+    );
+
+    const listbox = screen.getByRole("listbox", {
+      name: "Leave current checkout on options",
+    });
+    // Pinned rows lead: the sentinel (it has no commit date to sort by), then
+    // the default branch. Everything else follows in handoffBranches order.
+    expect(
+      within(listbox)
+        .getAllByRole("option")
+        .map((option) => option.getAttribute("aria-label"))
+    ).toEqual(["Detached HEAD", "main", "release"]);
+    expect(within(listbox).getByRole("option", { name: "main" })).toHaveTextContent(
+      "Default"
+    );
+    expect(
+      within(listbox).getByRole("option", { name: "release" })
+    ).toHaveTextContent("1h ago");
+
+    fireEvent.change(screen.getByLabelText("Find a branch"), {
+      target: { value: "rel" },
+    });
+    expect(
+      within(listbox)
+        .getAllByRole("option")
+        .map((option) => option.getAttribute("aria-label"))
+    ).toEqual(["release"]);
+
+    fireEvent.click(within(listbox).getByRole("option", { name: "release" }));
+    expect(screen.getByLabelText("Leave current checkout on")).toHaveAttribute(
+      "data-value",
+      "release"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Handoff" }));
+
+    await waitFor(() => {
+      expect(onHandoffThreadWorkspace).toHaveBeenCalledWith({
+        direction: "local-to-worktree",
+        strategy: "move-branch",
+        repositoryPath: "/repo",
+        sourcePath: "/repo",
+        sourceBranch: "feature/handoff",
+        leaveLocalBranch: "release",
       });
     });
   });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15509,25 +15509,36 @@ a.transcript-message__messaging-origin:focus-visible {
   max-height: min(440px, calc(100dvh - 128px));
 }
 
-.branch-picker--review {
-  width: min(100%, 640px);
+/* Dialog variant: the picker stands in for a form field (the handoff dialog's
+   "leave current checkout on"), so it fills the field row and squares off to
+   match the sibling text input instead of hugging a toolbar as a pill. */
+.branch-picker--dialog {
+  width: 100%;
   max-width: 100%;
 }
 
-.branch-picker--review .composer-dropdown__button {
+.branch-picker--dialog .composer-dropdown__button {
   min-height: 34px;
-  justify-content: flex-start;
   border-radius: 6px;
-  font-weight: 700;
+  font-weight: 500;
 }
 
-.branch-picker--review .branch-picker__menu {
+.branch-picker--dialog .composer-dropdown__label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Anchor to the field's left edge and match its width — the trigger spans the
+   dialog rather than sitting near the right gutter. */
+.branch-picker--dialog .branch-picker__menu {
   right: auto;
   left: 0;
-  z-index: 45;
-  min-width: min(100%, 420px);
-  width: min(640px, calc(100vw - 32px));
-  max-width: calc(100vw - 32px);
+  min-width: 100%;
+  max-width: 100%;
 }
 
 .review-branch-picker {


### PR DESCRIPTION
## Summary

- Backports the searchable `BranchPicker` for the **Leave current checkout on** field in the *Handoff to New Worktree* dialog.
- Preserves the release branch’s handoff selection rules: the existing helper remains the source of legal checkout targets; the picker only enriches them with labels, pinning, recency, default-branch, and in-use metadata.
- Includes the focused unit and E2E updates for branch selection, including the Detached HEAD sentinel and accessible listbox naming.

## Source and adaptation

- Source PR: https://github.com/pwrdrvr/PwrAgent/pull/1546
- Source squash: `1729e8e348a8b99263957d66dae90861d291f7a8`
- Applied the source squash cleanly to the latest `releases/1.0` tip (`3927a2043b631260eaad6b8c30d90afbaaebd33b`) with no manual adaptation and no added prerequisites.
- Excludes unrelated composer, Federation, Automations, and other 1.1 work.

## Migration audit

No database, SQLite schema, SQL, or migration files are changed. No `user_version` changes or migration collision risk.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` — 208 passed
- `pnpm test:desktop-e2e e2e/workspace-handoff-dialog.spec.ts e2e/workspace-handoff-flows.spec.ts` — 7 passed (includes desktop production build)
- `pnpm exec eslint <six changed files>` — 0 errors; 10 pre-existing `Composer.tsx` hook-dependency warnings
- `pnpm lint:colors` — passed
- `pnpm --filter @pwragent/desktop typecheck` — passed