### PR TITLE
fix(desktop): backport Grok ACP working updates

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1058,6 +1058,10 @@ describe("AcpBackendAdapter", () => {
       status: "completed",
     });
     transport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_message_chunk",
+      content: { type: "text", text: "\n" },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
       session_update: "agent_thought_chunk",
       content: { type: "text", text: "Now I will run the build." },
     });

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -3694,6 +3694,67 @@ describe("AcpAgentClient", () => {
     },
   );
 
+  it("does not allocate a live assistant item for whitespace after a tool", async () => {
+    const assistantMessageItemIds: Array<string | undefined> = [];
+    const transport = new FakeAcpAgentTransport();
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      store,
+      transport,
+      now: () => 1000,
+      onSessionUpdate: ({ assistantMessageItemId, update }) => {
+        if (update.sessionUpdate === "agent_message_chunk") {
+          assistantMessageItemIds.push(assistantMessageItemId);
+        }
+      },
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Inspect this",
+      turnId: "turn-1",
+    });
+
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "Before the tool." },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "tool_call",
+      toolCallId: "read-1",
+      kind: "read",
+      title: "Read `README.md`",
+      status: "completed",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "\n" },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "After the tool." },
+    });
+
+    expect(assistantMessageItemIds).toEqual([
+      "assistant:turn-1:0",
+      undefined,
+      "assistant:turn-1:1",
+    ]);
+    expect(
+      client
+        .readReplay(session.sessionId)
+        .messages.filter((message) => message.role === "assistant"),
+    ).toEqual([
+      expect.objectContaining({ role: "assistant", text: "Before the tool." }),
+      expect.objectContaining({ role: "assistant", text: "After the tool." }),
+    ]);
+  });
+
   it("strips legacy transcript updates when upserting stored sessions", () => {
     store.upsertSession({
       backendId: "acp:kimi",

--- a/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
@@ -315,6 +315,84 @@ describe("acpToolUpdateNotifications", () => {
     ]);
   });
 
+  it("maps Grok open-page output to a concrete web fetch", () => {
+    const notifications = acpToolUpdateNotifications({
+      threadId: "session-1",
+      turnId: "turn-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "ws_grok-open-1",
+        status: "completed",
+        title: "Web search:",
+        rawOutput: {
+          id: "ws_grok-open-1",
+          action: {
+            type: "open_page",
+            url: "https://api.slack.com/methods/chat.update",
+          },
+        },
+      },
+    });
+
+    expect(notifications).toEqual([
+      expect.objectContaining({
+        method: "item/completed",
+        params: expect.objectContaining({
+          item: expect.objectContaining({
+            id: "ws_grok-open-1",
+            type: "commandExecution",
+            toolName: "web_fetch",
+            command:
+              'web_fetch(url="https://api.slack.com/methods/chat.update")',
+            commandActions: [
+              {
+                type: "read",
+                name: "Fetched https://api.slack.com/methods/chat.update",
+              },
+            ],
+          }),
+        }),
+      }),
+    ]);
+  });
+
+  it("maps Grok find-in-page output to its pattern and page", () => {
+    const notifications = acpToolUpdateNotifications({
+      threadId: "session-1",
+      turnId: "turn-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "ws_grok-find-1",
+        status: "completed",
+        title: "Web search:",
+        rawOutput: {
+          id: "ws_grok-find-1",
+          action: {
+            type: "find_in_page",
+            url: "https://api.slack.com/methods/chat.update",
+            pattern: "blocks",
+          },
+        },
+      },
+    });
+
+    expect(notifications).toEqual([
+      expect.objectContaining({
+        method: "item/completed",
+        params: expect.objectContaining({
+          item: {
+            id: "ws_grok-find-1",
+            type: "webSearch",
+            toolName: "search_web",
+            status: "completed",
+            arguments: { query: "blocks" },
+            sources: [{ url: "https://api.slack.com/methods/chat.update" }],
+          },
+        }),
+      }),
+    ]);
+  });
+
   it("does not classify a generic ACP search action as Grok web search", () => {
     const notifications = acpToolUpdateNotifications({
       threadId: "session-1",

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -74,6 +74,34 @@ describe("AcpSessionReplayNormalizer", () => {
     expect(normalizer.replay().lastAssistantMessage).toBe("Hello world");
   });
 
+  it("preserves an assistant message across a skipped whitespace thought", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { kind: "agent_message_chunk", content: "Before " },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: { kind: "agent_thought_chunk", content: "\n" },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1002,
+      update: { kind: "agent_message_chunk", content: "after." },
+    });
+
+    expect(replay.messages).toEqual([
+      expect.objectContaining({
+        id: "assistant:session-1:0",
+        role: "assistant",
+        text: "Before after.",
+      }),
+    ]);
+  });
+
   it("prefers a provider timestamp extension over local receipt time", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -25,6 +25,55 @@ describe("AcpSessionReplayNormalizer", () => {
     expect(replay.lastAssistantMessage).toBe("Hello world");
   });
 
+  it("drops a whitespace-only assistant chunk after a tool boundary", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { kind: "agent_message_chunk", content: "Before the tool." },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "read-1",
+        kind: "read",
+        title: "Read `README.md`",
+        status: "completed",
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1002,
+      update: { kind: "agent_message_chunk", content: "\n" },
+    });
+
+    expect(replay.messages).toEqual([
+      expect.objectContaining({ role: "assistant", text: "Before the tool." }),
+    ]);
+    expect(replay.lastAssistantMessage).toBe("Before the tool.");
+  });
+
+  it("preserves whitespace chunks inside an active assistant message", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    for (const [receivedAt, content] of [
+      [1000, "Hello"],
+      [1001, " "],
+      [1002, "world"],
+    ] as const) {
+      normalizer.apply({
+        sessionId: "session-1",
+        receivedAt,
+        update: { kind: "agent_message_chunk", content },
+      });
+    }
+
+    expect(normalizer.replay().lastAssistantMessage).toBe("Hello world");
+  });
+
   it("prefers a provider timestamp extension over local receipt time", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 
@@ -656,6 +705,50 @@ describe("AcpSessionReplayNormalizer", () => {
     ]);
   });
 
+  it("lets a refined file-tool label replace Grok's raw tool name", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "read-file-1",
+        kind: "other",
+        title: "read_file",
+        status: "pending",
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "read-file-1",
+        kind: "read",
+        title: "Read `docs/messaging-adapter-contract.md`",
+        status: "completed",
+        locations: [{ path: "docs/messaging-adapter-contract.md" }],
+      },
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        id: "read-file-1",
+        summary: "Read `docs/messaging-adapter-contract.md`",
+        status: "completed",
+        details: [
+          expect.objectContaining({
+            kind: "read",
+            label: "Read `docs/messaging-adapter-contract.md`",
+            path: "docs/messaging-adapter-contract.md",
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("merges ACP tool call updates into the original activity", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 
@@ -839,6 +932,53 @@ describe("AcpSessionReplayNormalizer", () => {
             label: "Models",
             url: "https://docs.x.ai/developers/models",
           },
+        ],
+      }),
+    ]);
+  });
+
+  it("upgrades a historical Grok open-page search to a web fetch", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+    const url = "https://api.slack.com/methods/chat.update";
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "ws_grok-open-1",
+        title: "Web search:",
+        kind: "search",
+        status: "in_progress",
+        rawInput: { variant: "WebSearch", backend: true },
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "ws_grok-open-1",
+        title: "Web search:",
+        status: "completed",
+        rawOutput: {
+          id: "ws_grok-open-1",
+          action: { type: "open_page", url },
+        },
+      },
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        id: "ws_grok-open-1",
+        summary: `Fetched ${url}`,
+        status: "completed",
+        details: [
+          expect.objectContaining({
+            kind: "read",
+            label: `Fetched ${url}`,
+          }),
         ],
       }),
     ]);

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -1024,12 +1024,20 @@ export class AcpAgentClient {
       && toolCallId !== undefined
       && activeTurn?.knownToolCallIds.has(toolCallId) === true;
     let assistantMessageItemId: string | undefined;
-    if (shouldTrackAssistantTextUpdate && activeTurn && text) {
-      const phase: AppServerTranscriptPhase =
-        updateKind === "agent_thought_chunk" ? "commentary" : "final";
+    const assistantTextPhase: AppServerTranscriptPhase =
+      updateKind === "agent_thought_chunk" ? "commentary" : "final";
+    const continuesActiveAssistantMessage =
+      activeTurn?.activeAssistantMessageItemId !== undefined
+      && activeTurn.activeAssistantMessagePhase === assistantTextPhase;
+    if (
+      shouldTrackAssistantTextUpdate
+      && activeTurn
+      && text
+      && (text.trim() || continuesActiveAssistantMessage)
+    ) {
       assistantMessageItemId = assistantMessageItemIdForUpdate({
         activeTurn,
-        phase,
+        phase: assistantTextPhase,
         update,
       });
       if (updateKind === "agent_message_chunk") {

--- a/apps/desktop/src/main/acp/acp-command-extraction.ts
+++ b/apps/desktop/src/main/acp/acp-command-extraction.ts
@@ -74,8 +74,9 @@ export function readAcpWebSearch(
     readString(record, "toolCallId") ??
     readString(record, "tool_call_id");
   const outputId = readString(rawOutput ?? {}, "id");
+  const actionType = readString(action ?? {}, "type");
   const isGrokWebSearchOutput =
-    readString(action ?? {}, "type") === "search"
+    (actionType === "search" || actionType === "find_in_page")
     && [toolCallId, outputId].some((id) => id?.startsWith("ws_"));
   const isWebSearch =
     variant === "WebSearch"
@@ -88,8 +89,15 @@ export function readAcpWebSearch(
 
   const query =
     readString(action ?? {}, "query") ??
+    readString(action ?? {}, "pattern") ??
     readString(rawInput ?? {}, "query");
-  const rawSources = Array.isArray(action?.sources) ? action.sources : [];
+  const actionUrl = readString(action ?? {}, "url");
+  const rawSources = [
+    ...(Array.isArray(action?.sources) ? action.sources : []),
+    ...(actionType === "find_in_page" && actionUrl
+      ? [{ url: actionUrl }]
+      : []),
+  ];
   const sources = rawSources.flatMap((value): AcpWebSearch["sources"] => {
     const source = asRecord(value);
     if (!source) {
@@ -116,25 +124,36 @@ export function readAcpWebFetchUrl(
   record: Record<string, unknown>,
 ): string | undefined {
   const rawInput = asRecord(record.rawInput);
+  const rawOutput = asRecord(record.rawOutput);
+  const action = asRecord(rawOutput?.action);
   const metadata = readAcpToolMetadata(record);
   const variant = readString(rawInput ?? {}, "variant");
   const metadataName = readString(metadata ?? {}, "name");
   const metadataKind = readString(metadata ?? {}, "kind");
   const kind = readString(record, "kind");
   const title = readString(record, "title");
+  const toolCallId =
+    readString(record, "toolCallId") ??
+    readString(record, "tool_call_id");
+  const outputId = readString(rawOutput ?? {}, "id");
+  const isGrokOpenPage =
+    readString(action ?? {}, "type") === "open_page"
+    && [toolCallId, outputId].some((id) => id?.startsWith("ws_"));
   const isWebFetch =
     variant?.toLowerCase() === "webfetch"
     || metadataName === "web_fetch"
     || metadataKind === "web_fetch"
     || kind === "fetch"
     || /^web_fetch$/i.test(title ?? "")
-    || /^fetch:\s+/i.test(title ?? "");
+    || /^fetch:\s+/i.test(title ?? "")
+    || isGrokOpenPage;
   if (!isWebFetch) {
     return undefined;
   }
 
   return (
     readString(rawInput ?? {}, "url") ??
+    readString(action ?? {}, "url") ??
     readString(asRecord(metadata?.input) ?? {}, "url") ??
     /^fetch:\s+(.+)$/i.exec(title ?? "")?.[1]?.trim()
   );

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -190,14 +190,22 @@ export class AcpSessionReplayNormalizer {
         readContentText(update.update, "content") ??
         readString(update.update, "text") ??
         "";
+      const phase: AppServerTranscriptPhase =
+        kind === "agent_message_chunk" ? "final" : "commentary";
+      // A whitespace-only chunk at a phase boundary is a provider artifact,
+      // not a new assistant message. Ignore it before switching phase so a
+      // later chunk can keep the existing live assistant item identity.
+      if (!text.trim() && this.activeAssistantMessagePhase !== phase) {
+        return this.replay();
+      }
       if (text.trim() && !isModeUpdateMarker(text) && this.currentTurnId) {
         this.removeAgentWaitingActivity(this.currentTurnId);
       }
       if (kind === "agent_message_chunk") {
-        this.resetAssistantMessageIfPhaseChanged("final");
+        this.resetAssistantMessageIfPhaseChanged(phase);
         this.applyAgentMessageChunk(update, createdAt);
       } else {
-        this.resetAssistantMessageIfPhaseChanged("commentary");
+        this.resetAssistantMessageIfPhaseChanged(phase);
         this.applyAgentThoughtChunk(update, createdAt);
       }
     } else if (kind === "user_message_chunk") {

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -190,7 +190,7 @@ export class AcpSessionReplayNormalizer {
         readContentText(update.update, "content") ??
         readString(update.update, "text") ??
         "";
-      if (text && !isModeUpdateMarker(text) && this.currentTurnId) {
+      if (text.trim() && !isModeUpdateMarker(text) && this.currentTurnId) {
         this.removeAgentWaitingActivity(this.currentTurnId);
       }
       if (kind === "agent_message_chunk") {
@@ -317,7 +317,11 @@ export class AcpSessionReplayNormalizer {
       readContentText(update.update, "content") ??
       readString(update.update, "text") ??
       "";
-    if (!text || isModeUpdateMarker(text)) {
+    if (
+      !text
+      || isModeUpdateMarker(text)
+      || (!this.activeAssistantMessageId && !text.trim())
+    ) {
       return;
     }
     const id = this.assistantMessageIdForChunk(update);
@@ -369,7 +373,7 @@ export class AcpSessionReplayNormalizer {
       readContentText(update.update, "content") ??
       readString(update.update, "text") ??
       "";
-    if (!text) {
+    if (!text || (!this.activeAssistantMessageId && !text.trim())) {
       return;
     }
     const id = this.assistantMessageIdForChunk(update);
@@ -1137,9 +1141,13 @@ function isGenericActivityLabel(value: string): boolean {
     "zsh",
     "execute",
     "read",
+    "read_file",
     "write",
     "search",
+    "web_search",
+    "x_search",
     "list",
+    "list_dir",
     "tool call",
     "tool_call",
     "tool call update",

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -2022,7 +2022,13 @@ export class AcpBackendAdapter {
               shouldSurfaceAcpThoughtsAsMessages(agent.backendId)))
         ) {
           const delta = readAcpUpdateText(update);
-          if (delta) {
+          // The client deliberately leaves the item ID unset when a provider
+          // sends a whitespace-only chunk after a tool boundary. Do not revive
+          // that skipped chunk under the legacy fallback ID: doing so creates
+          // a blank live assistant card even though replay normalization drops
+          // the same artifact. Preserve whitespace only when it continues an
+          // already-active assistant item.
+          if (delta && (assistantMessageItemId || delta.trim())) {
             const phase =
               updateKind === "agent_thought_chunk" ? "commentary" : "final";
             await this.emit({


### PR DESCRIPTION
## Summary

Backports Grok ACP working-update correctness from [#1525](https://github.com/pwrdrvr/PwrAgent/pull/1525) to `releases/1.0`.

Source squash commit: `3ab0a6d91ae432bb5809e248e64798376ae9ad7f`

- Suppress standalone whitespace-only assistant chunks at tool boundaries while preserving whitespace inside an active stream.
- Decode Grok hosted-search `open_page` as a concrete web fetch and `find_in_page` as a search with its pattern and page source.
- Allow refined file-tool labels to replace raw generic tool names during live rendering and replay.

## Release adaptation and dependencies

The source squash does not apply cleanly because `releases/1.0` contains subsequent ACP replay and launch-selection backports. This manually applies the same eight-file logical unit to the current release architecture, preserving those release-only changes, including the #1402-equivalent unknown-update behavior.

No unrelated prerequisite or mainline refactor is included. Slack live working cards (#1519), Automations, Federation, and Star Map are excluded.

## Migration audit

No state DB migration, DDL, schema, or `user_version` change. The diff only updates ACP client/normalizer/extraction/adapter code and focused tests.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-live-notifications.test.ts apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts` — 4 files, 177 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; existing warning baseline only
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:sql`
- `git diff --check`
