### PR TITLE
feat(desktop): backport PR hover-card head branch

### DIFF
--- a/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
@@ -19,6 +19,7 @@ function node(overrides: Partial<GraphqlPrNode> = {}): GraphqlPrNode {
     state: "OPEN",
     isDraft: false,
     mergeable: "MERGEABLE",
+    headRefName: "agent/pr-status-card-branch",
     headRepository: { name: "PwrAgent" },
     headRepositoryOwner: { login: "pwrdrvr" },
     commits: {
@@ -158,6 +159,7 @@ describe("buildBatchedPrQuery", () => {
       "createdAt",
       "mergedAt",
       "closedAt",
+      "headRefName",
     ]) {
       expect(query).toContain(field);
     }
@@ -263,6 +265,7 @@ describe("mapGraphqlPrNode", () => {
       org: "pwrdrvr",
       repo: "PwrAgent",
       title: "Add polling",
+      headRefName: "agent/pr-status-card-branch",
       state: "passing",
       checkState: "passing",
       lifecycleState: "open",

--- a/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
@@ -53,6 +53,7 @@ describe("parseGhPrPayload", () => {
       org: "pwrdrvr",
       repo: "PwrAgent",
       title: "Retain thread pull request history",
+      headRefName: "feat/desktop-thread-reactions-and-pr-chips",
       state: "passing",
       checkState: "passing",
       lifecycleState: "merged",
@@ -591,6 +592,7 @@ describe("GithubPrFetcher", () => {
           org: "pwrdrvr",
           repo: "PwrAgent",
           title: "Retain thread pull request history",
+          headRefName: "feat/desktop-thread-reactions-and-pr-chips",
           state: "passing",
           checkState: "passing",
           lifecycleState: "merged",
@@ -629,6 +631,7 @@ describe("GithubPrFetcher", () => {
         "mergedAt",
         "closedAt",
         "commits",
+        "headRefName",
       ]) {
         expect(fields?.split(",")).toContain(field);
       }
@@ -659,6 +662,7 @@ describe("GithubPrFetcher", () => {
         org: "pwrdrvr",
         repo: "PwrAgent",
         title: "Retain thread pull request history",
+        headRefName: "feat/desktop-thread-reactions-and-pr-chips",
         state: "passing",
         checkState: "passing",
         lifecycleState: "merged",

--- a/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
@@ -285,12 +285,13 @@ describe("SqliteOverlayStore — thread PRs", () => {
   });
 
   it("persists canonical PR status cache rows across reopen", async () => {
+    const cachedPr = { ...prPassing, headRefName: "fix/pr-status-card-branch" };
     await store.writePrStatusCacheEntries([
       {
         provider: "github.com",
         prKey: "github.com/pwrdrvr/pwragent#179",
         fetchedAt: 1234,
-        pr: prPassing,
+        pr: cachedPr,
       },
     ]);
 
@@ -304,7 +305,7 @@ describe("SqliteOverlayStore — thread PRs", () => {
         provider: "github.com",
         prKey: "github.com/pwrdrvr/pwragent#179",
         fetchedAt: 1234,
-        pr: prPassing,
+        pr: cachedPr,
       },
     });
     reopened.close();

--- a/apps/desktop/src/main/__tests__/pr-summaries-equal.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-summaries-equal.test.ts
@@ -37,6 +37,7 @@ describe("prSummariesEqual", () => {
     ["createdAt", { createdAt: 1_700_000_999_000 }],
     ["mergedAt", { mergedAt: 1_800_000_000_000 }],
     ["closedAt", { closedAt: 1_800_000_000_000 }],
+    ["headRefName", { headRefName: "fix/pr-status-card-branch" }],
   ])("detects a change to %s alone", (_field, overrides) => {
     expect(
       prSummariesEqual([basePr()], [basePr(overrides as Partial<PrSummary>)]),

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -598,6 +598,7 @@ function normalizePrSummary(pr: PrSummary): PrSummary {
     reviewState: pr.reviewState ?? legacyPrReviewState(pr.state),
     mergeState: pr.mergeState ?? "unknown",
     commitShas: normalizeCommitShas(pr.commitShas),
+    ...(pr.headRefName?.trim() ? { headRefName: pr.headRefName.trim() } : {}),
   };
 }
 
@@ -718,6 +719,7 @@ export function prSummariesEqual(left: PrSummary[], right: PrSummary[]): boolean
       candidate.org === pr.org &&
       candidate.repo === pr.repo &&
       candidate.title === pr.title &&
+      candidate.headRefName === pr.headRefName &&
       candidate.state === pr.state &&
       candidate.checkState === pr.checkState &&
       candidate.lifecycleState === pr.lifecycleState &&

--- a/apps/desktop/src/main/pr-status/github-graphql-client.ts
+++ b/apps/desktop/src/main/pr-status/github-graphql-client.ts
@@ -144,6 +144,7 @@ fragment PrStatus on PullRequest {
   state
   isDraft
   mergeable
+  headRefName
   additions
   deletions
   changedFiles
@@ -170,6 +171,7 @@ export type GraphqlPrNode = {
   state: string;
   isDraft: boolean;
   mergeable?: string | null;
+  headRefName?: string | null;
   additions?: number | null;
   deletions?: number | null;
   changedFiles?: number | null;
@@ -329,6 +331,7 @@ export function mapGraphqlPrNode(node: GraphqlPrNode): PrSummary {
     org: node.headRepositoryOwner?.login ?? "",
     repo: node.headRepository?.name ?? "",
     ...(node.title?.trim() ? { title: node.title.trim() } : {}),
+    ...(node.headRefName?.trim() ? { headRefName: node.headRefName.trim() } : {}),
     state: checkState,
     checkState,
     lifecycleState: deriveLifecycleState(shaped),

--- a/apps/desktop/src/main/pr-status/pr-derivations.ts
+++ b/apps/desktop/src/main/pr-status/pr-derivations.ts
@@ -65,6 +65,7 @@ export function parseGhPrPayload(row: GhPrPayload): PrSummary {
     org: row.headRepositoryOwner?.login ?? "",
     repo: row.headRepository?.name ?? "",
     ...(row.title?.trim() ? { title: row.title.trim() } : {}),
+    ...(row.headRefName?.trim() ? { headRefName: row.headRefName.trim() } : {}),
     state: checkState,
     checkState,
     lifecycleState: deriveLifecycleState(row),

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -98,6 +98,7 @@ function normalizePrSummary(pr: PrSummary): PrSummary {
     reviewState: pr.reviewState ?? legacyPrReviewState(pr.state),
     mergeState: pr.mergeState ?? "unknown",
     commitShas: normalizeCommitShas(pr.commitShas),
+    ...(pr.headRefName?.trim() ? { headRefName: pr.headRefName.trim() } : {}),
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -48,6 +48,7 @@ export function PrChip(props: PrChipProps) {
     pr.repo,
     pr.number,
     pr.title,
+    pr.headRefName,
     status,
     chipState,
     props.withStatusPills,

--- a/apps/desktop/src/renderer/src/features/pr-status/PrStatusCard.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrStatusCard.tsx
@@ -1,4 +1,5 @@
 import type { PrSummary } from "@pwragent/shared";
+import { BranchIcon } from "../../icons";
 import { DiffStat } from "../../lib/DiffStat";
 import { formatRunningDurationMs } from "../../lib/format-duration";
 import {
@@ -20,6 +21,7 @@ export function PrStatusCard(props: {
   const dotState = resolveDotState(pr, props.withStatusPills === true);
   const changes = readPrChanges(pr);
   const timeline = readPrTimeline(pr, now);
+  const branch = readPrBranch(pr);
 
   return (
     <>
@@ -31,6 +33,25 @@ export function PrStatusCard(props: {
       <div className="pr-status-card__identity">
         {`${pr.org}/${pr.repo}#${pr.number}`}
       </div>
+      {branch ? (
+        <div className="pr-status-card__branch">
+          <BranchIcon
+            aria-hidden="true"
+            className="pr-status-card__branch-icon"
+            size={11}
+          />
+          {/* The split is a truncation mechanism, not two facts — but flex
+              items are blockified, so assistive tech reports the halves as two
+              separate nodes and reads them as two branch names ("…backport-pr-stat",
+              "us-hover-1.0"). Hide the visual split and carry the name once,
+              whole, for anything that listens rather than looks. */}
+          <span aria-hidden="true" className="pr-status-card__branch-name">
+            <span className="pr-status-card__branch-head">{branch.head}</span>
+            <span className="pr-status-card__branch-tail">{branch.tail}</span>
+          </span>
+          <span className="pr-status-card__branch-full">{branch.full}</span>
+        </div>
+      ) : null}
       <div className="pr-status-card__status">
         <span
           aria-hidden="true"
@@ -92,6 +113,70 @@ function resolveDotState(pr: PrSummary, withStatusPills: boolean): string {
     return "conflicting";
   }
   return chipState;
+}
+
+/**
+ * How many trailing characters the branch row keeps when the name is too long
+ * for one line. Twelve is enough to carry a trailing `-1.0` / short-sha style
+ * discriminator plus the word before it, and — at the card's 11px mono — short
+ * enough that the fixed tail can never outgrow the 244px content column.
+ */
+const BRANCH_TAIL_CHARS = 12;
+
+/** `full` is the name as one string; `head`/`tail` are the visual split only. */
+type PrBranch = { full: string; head: string; tail: string };
+
+/**
+ * Split the head branch for the CSS middle-truncation trick: only the `head`
+ * span flexes, so the browser drops its ellipsis where the two halves meet
+ * instead of at one end.
+ *
+ * Middle rather than either end is the whole point. Branch names on a thread
+ * share BOTH a prefix (`claude/`, `agent/`) and, often, a suffix convention —
+ * so start- or end-truncation can render two different branches identically,
+ * which is exactly the confusion this row exists to remove.
+ */
+function readPrBranch(pr: PrSummary): PrBranch | undefined {
+  const branch = pr.headRefName?.trim();
+  if (!branch) {
+    return undefined;
+  }
+  const clusters = splitGraphemes(branch);
+  // The tail never truncates, so never hand it more than half the name — on a
+  // short branch a fixed 12 would swallow the whole string.
+  const tailLength = Math.min(BRANCH_TAIL_CHARS, Math.floor(clusters.length / 2));
+  if (tailLength <= 0) {
+    return { full: branch, head: branch, tail: "" };
+  }
+  return {
+    full: branch,
+    head: clusters.slice(0, clusters.length - tailLength).join(""),
+    tail: clusters.slice(clusters.length - tailLength).join(""),
+  };
+}
+
+/**
+ * Split into grapheme clusters — what a reader calls a character — rather than
+ * code points.
+ *
+ * Code points are not a safe cut: macOS normalizes filenames to NFD and a loose
+ * git ref IS a file, so `chore/déjà-vu-dedupe` really does reach us with `a`
+ * followed by a separate U+0300. Cutting between them drops the accent from the
+ * head (`déja`) and starts the tail with a bare combining mark, which renders as
+ * a dotted circle or lands on the ellipsis. ZWJ emoji tear the same way.
+ *
+ * Clusters also bound the tail's WIDTH, which the fixed `flex: 0 0 auto` tail
+ * depends on: an arbitrarily long ZWJ sequence is still one glyph, so 12
+ * clusters can never exceed roughly 12em.
+ */
+function splitGraphemes(value: string): string[] {
+  if (typeof Intl.Segmenter !== "function") {
+    return [...value];
+  }
+  // Fixed locale: cluster boundaries are effectively locale-invariant, and
+  // pinning it keeps the split identical on every operator's machine.
+  const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
+  return [...segmenter.segment(value)].map((segment) => segment.segment);
 }
 
 type PrChanges = {

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
@@ -114,6 +114,32 @@ describe("PrChip", () => {
     expect(chip).not.toHaveAttribute("aria-describedby");
   });
 
+  it("refreshes an open card when its head branch changes", () => {
+    const onOpen = vi.fn();
+    const { container, rerender } = render(
+      <PrChip
+        pr={basePr({ headRefName: "agent/backport-pr-status-card" })}
+        showRepoPrefix={false}
+        onOpen={onOpen}
+      />,
+    );
+    const chip = container.querySelector(".pr-chip") as HTMLElement;
+    fireEvent.mouseEnter(chip);
+    expect(document.querySelector(".pr-status-card__branch-full"))
+      .toHaveTextContent("agent/backport-pr-status-card");
+
+    rerender(
+      <PrChip
+        pr={basePr({ headRefName: "agent/backport-pr-status-card-v2" })}
+        showRepoPrefix={false}
+        onOpen={onOpen}
+      />,
+    );
+
+    expect(document.querySelector(".pr-status-card__branch-full"))
+      .toHaveTextContent("agent/backport-pr-status-card-v2");
+  });
+
   it("defers draft + conflict to sibling pills when withStatusPills is set", () => {
     // In the Pull Requests card the chip sits next to explicit pills, so the
     // dot must stay the check-state color (agreeing with the "Checks …" pill)

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrStatusCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrStatusCard.test.tsx
@@ -35,6 +35,10 @@ function renderCard(pr: PrSummary, withStatusPills = false) {
   return container;
 }
 
+function text(container: HTMLElement, selector: string): string | undefined {
+  return container.querySelector(selector)?.textContent ?? undefined;
+}
+
 describe("PrStatusCard", () => {
   it("renders changes, commits, and opened age", () => {
     const container = renderCard(basePr({
@@ -106,5 +110,81 @@ describe("PrStatusCard", () => {
     cleanup();
     const withPills = renderCard(basePr({ mergeState: "conflicting" }), true);
     expect(withPills.querySelector(".pr-status-card__dot--pending")).not.toBeNull();
+  });
+});
+
+describe("PrStatusCard branch", () => {
+  it("exposes the branch to assistive tech as one unbroken string", () => {
+    // Flex items are blockified, so the two visual halves surface as SEPARATE
+    // accessibility nodes and get announced as two branch names. Asserting
+    // `textContent` on the row would not catch that — it concatenates whatever
+    // spans exist regardless of box structure. What has to hold is that the
+    // split is hidden and exactly one node carries the whole name.
+    const container = renderCard(basePr({
+      headRefName: "claude/agent/backport-pr-status-hover-1.0",
+    }));
+
+    expect(container.querySelector(".pr-status-card__branch-name"))
+      .toHaveAttribute("aria-hidden", "true");
+    expect(text(container, ".pr-status-card__branch-full"))
+      .toBe("claude/agent/backport-pr-status-hover-1.0");
+  });
+
+  it("splits so the ellipsis falls in the middle, not at either end", () => {
+    // Branches on one thread share a prefix and often a suffix convention, so
+    // the discriminating characters live at both ends. The head span is the
+    // only one CSS lets shrink, which is what puts the ellipsis between them.
+    const container = renderCard(basePr({
+      headRefName: "claude/agent/backport-pr-status-hover-1.0",
+    }));
+
+    expect(text(container, ".pr-status-card__branch-head"))
+      .toBe("claude/agent/backport-pr-stat");
+    expect(text(container, ".pr-status-card__branch-tail")).toBe("us-hover-1.0");
+  });
+
+  it("never hands the non-truncating tail more than half a short name", () => {
+    // The tail is `flex: 0 0 auto` — it cannot shrink, so a fixed 12 characters
+    // on a short branch would leave nothing for the head to give up.
+    const container = renderCard(basePr({ headRefName: "main" }));
+
+    expect(text(container, ".pr-status-card__branch-head")).toBe("ma");
+    expect(text(container, ".pr-status-card__branch-tail")).toBe("in");
+  });
+
+  it("splits on grapheme clusters, not code points", () => {
+    // macOS normalizes filenames to NFD and a loose git ref IS a file, so this
+    // name really does arrive with `a` + a separate U+0300. A code-point split
+    // lands between them: the head loses the accent (`déja`) and the tail opens
+    // with a bare combining mark that renders on the ellipsis.
+    const container = renderCard(basePr({
+      headRefName: "chore/déjà-vu-dedupe".normalize("NFD"),
+    }));
+
+    expect(text(container, ".pr-status-card__branch-head"))
+      .toBe("chore/déjà".normalize("NFD"));
+    expect(text(container, ".pr-status-card__branch-tail")).toBe("-vu-dedupe");
+
+    cleanup();
+
+    // Same tear, ZWJ flavor: a code-point split leaves the tail leading with a
+    // zero-width joiner and the head holding a lone body part.
+    const zwj = renderCard(basePr({ headRefName: "fix/family-👨‍👩‍👧-avatar" }));
+
+    expect(text(zwj, ".pr-status-card__branch-head")).toBe("fix/family");
+    expect(text(zwj, ".pr-status-card__branch-tail")).toBe("-👨‍👩‍👧-avatar");
+  });
+
+  it("omits the row when no provider reported a head branch", () => {
+    // Same rule as every other section: absent is "not known", and the card has
+    // to look finished without it.
+    const container = renderCard(basePr({ headRefName: "   " }));
+    expect(container.querySelector(".pr-status-card__branch")).toBeNull();
+
+    cleanup();
+
+    expect(
+      renderCard(basePr()).querySelector(".pr-status-card__branch"),
+    ).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4093,6 +4093,64 @@ textarea,
   font-size: 11px;
 }
 
+/* The PR's head branch, one line, never wrapping and never widening the card.
+   This is what tells two PRs on the same thread apart when only one of their
+   branches is checked out. */
+.pr-status-card__branch {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.pr-status-card__branch-icon {
+  flex: 0 0 auto;
+}
+
+/* Middle truncation without measuring anything: the name is rendered as two
+   spans, and only the head is allowed to shrink. The browser puts its ellipsis
+   at the end of the shrinking span — which is the middle of the name, because
+   the fixed tail is still to the right of it. `direction: rtl` (used by the
+   jump palette) would instead sacrifice the prefix, and branches on one thread
+   usually share a prefix and differ later. */
+.pr-status-card__branch-name {
+  display: flex;
+  min-width: 0;
+}
+
+.pr-status-card__branch-head {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pr-status-card__branch-tail {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+/* The whole branch name, for assistive tech only. The visual halves above are
+   `aria-hidden` because flex blockifies them into two separate a11y nodes, so
+   the name would otherwise be announced split mid-word. Absolute positioning
+   keeps this out of the flex flow entirely. */
+.pr-status-card__branch-full {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
 .pr-status-card__status {
   display: flex;
   align-items: baseline;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -250,6 +250,8 @@ export type PrSummary = {
   repo: string;
   /** Last observed pull request title, when the provider returns one. */
   title?: string;
+  /** Branch containing the PR changes, when the provider returns one. */
+  headRefName?: string;
   /**
    * Deprecated compatibility alias for `checkState`. New writers keep this
    * check-only so review/lifecycle/mergeability never collide with checks.


### PR DESCRIPTION
## Summary

Backports the PR-head branch row from #1547 to the structured PR status hover card on `releases/1.0`.

The card now shows the head branch below `org/repo#number`, with grapheme-safe middle truncation that preserves both branch-name ends. The visual split is hidden from assistive technology; one visually hidden string exposes the complete branch name. An open hover card also refreshes when the branch value changes.

## Source

- Source PR: https://github.com/pwrdrvr/PwrAgent/pull/1547
- Source squash commit: `6272d38c647991f4708b92707b620e37f77c2ff9`

## Adaptation and dependency note

`releases/1.0` already requested `headRefName` from `gh`, but it did not carry the value into `PrSummary`, the GraphQL fragment, cache normalization, or change detection. This backport includes only that minimum in-memory/cache-payload bridge so the renderer row can receive and refresh the value. It deliberately excludes #1148's base-branch and stacked-review behavior, plus all Automations, Federation, and Star Map work.

## Migration audit

No SQLite schema or migration changes. The existing `pr_status_cache` and `pr_lookup_cache` tables persist complete `PrSummary` JSON payloads, so the optional field round-trips without DDL or a `user_version` change.

## Validation

- Focused Vitest: 6 files, 127 tests
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:colors`
- `pnpm --filter @pwragent/desktop build`
