### PR TITLE
feat(desktop): tighten left-sidebar density, typography, and disclosure chrome

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -1078,9 +1078,16 @@ test("directory launchpad keeps new worktree as the sticky default after startin
       .first();
     // Renamed in the chip-flow refactor: meta + PR + binding + reactions
     // chips all share a single `.thread-row__chips` flex-wrap container.
+    // The location chip is icon-only since the 2026-08 density pass, so the
+    // worktree/local kind lives in the copyable chip's aria-label rather
+    // than as visible chip text.
     const startedThreadChips = startedThreadRow.locator(".thread-row__chips");
-    await expect(startedThreadChips.getByText("worktree", { exact: true })).toBeVisible();
-    await expect(startedThreadChips.getByText("local", { exact: true })).toHaveCount(0);
+    await expect(
+      startedThreadChips.getByLabel(/^Copy path for worktree /),
+    ).toBeVisible();
+    await expect(
+      startedThreadChips.getByLabel(/^Copy local path for /),
+    ).toHaveCount(0);
 
     const contextRail = app.window.getByRole("complementary", {
       name: "Thread context",

--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -1233,9 +1233,12 @@ test.describe("federation remote window", () => {
         timeout: 90_000,
       });
 
+      // Anchored regex, not `exact: true`: this test pins the parent, and
+      // a pinned row's accessible name is "<title>, pinned" — while the
+      // anchor still excludes the row's kebab/sub-thread labels that
+      // merely contain the title.
       const remoteParentButton = viewer.window.getByRole("button", {
-        name: "Remote Kimi parent",
-        exact: true,
+        name: /^Remote Kimi parent(, pinned)?$/,
       });
       await remoteParentButton.click({ button: "right" });
       await expect(

--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.png
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2618e70e464adc7fc82dc0485787008c9ac0dca1afa48f21203ff1c620cb4ced
-size 148993
+oid sha256:9e9e3bc858fa00a610802fffb2238539def7ee200675849567a03d7d262fb28e
+size 144067

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -720,15 +720,17 @@ describe("DesktopSettingsService", () => {
     expect(readBootstrapAppearance(configPath)).toEqual({
       theme: "system",
       density: "mission-control",
+      sidebarTextSize: "md",
     });
 
     // Write non-default values. The byte-preserving patch path should
-    // create `[general.appearance]` with both keys.
+    // create `[general.appearance]` with all three keys.
     await service.writeConfigPatch({
       general: {
         appearance: {
           theme: "light",
           density: "compact",
+          sidebarTextSize: "lg",
         },
       },
     });
@@ -737,6 +739,7 @@ describe("DesktopSettingsService", () => {
     expect(writtenFile).toContain("[general.appearance]");
     expect(writtenFile).toContain('theme = "light"');
     expect(writtenFile).toContain('density = "compact"');
+    expect(writtenFile).toContain('sidebar_text_size = "lg"');
 
     const afterWrite = await service.readSettings();
     expect(afterWrite.general.appearance.theme).toEqual({
@@ -747,18 +750,24 @@ describe("DesktopSettingsService", () => {
       value: "compact",
       source: "config",
     });
+    expect(afterWrite.general.appearance.sidebarTextSize).toEqual({
+      value: "lg",
+      source: "config",
+    });
     expect(readBootstrapAppearance(configPath)).toEqual({
       theme: "light",
       density: "compact",
+      sidebarTextSize: "lg",
     });
 
-    // Restore to defaults: the patch path should DELETE both keys
+    // Restore to defaults: the patch path should DELETE the keys
     // (defaults aren't written to disk) so the file stays minimal.
     await service.writeConfigPatch({
       general: {
         appearance: {
           theme: "system",
           density: "mission-control",
+          sidebarTextSize: "md",
         },
       },
     });
@@ -766,13 +775,18 @@ describe("DesktopSettingsService", () => {
     const restoredFile = fs.readFileSync(configPath, "utf8");
     expect(restoredFile).not.toContain('theme = "');
     expect(restoredFile).not.toContain('density = "');
+    expect(restoredFile).not.toContain('sidebar_text_size = "');
 
     const afterRestore = await service.readSettings();
     expect(afterRestore.general.appearance.theme.source).toBe("default");
     expect(afterRestore.general.appearance.density.source).toBe("default");
+    expect(afterRestore.general.appearance.sidebarTextSize.source).toBe(
+      "default",
+    );
     expect(readBootstrapAppearance(configPath)).toEqual({
       theme: "system",
       density: "mission-control",
+      sidebarTextSize: "md",
     });
   });
 
@@ -809,6 +823,7 @@ describe("DesktopSettingsService", () => {
     expect(onAppearanceChange).toHaveBeenLastCalledWith({
       theme: "light",
       density: "compact",
+      sidebarTextSize: "md",
     });
 
     // Patch that restores defaults still fires (the renderer needs to
@@ -828,6 +843,7 @@ describe("DesktopSettingsService", () => {
     expect(onAppearanceChange).toHaveBeenLastCalledWith({
       theme: "system",
       density: "mission-control",
+      sidebarTextSize: "md",
     });
 
     // Patch with `general` but only developerMode (not appearance) must
@@ -850,6 +866,7 @@ describe("DesktopSettingsService", () => {
     expect(onAppearanceChange).toHaveBeenLastCalledWith({
       theme: "dark",
       density: "mission-control",
+      sidebarTextSize: "md",
     });
   });
 

--- a/apps/desktop/src/main/settings/appearance-bootstrap.ts
+++ b/apps/desktop/src/main/settings/appearance-bootstrap.ts
@@ -16,10 +16,13 @@
 import type {
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
+  DesktopSidebarTextSize,
 } from "@pwragent/shared";
 import {
   DESKTOP_APPEARANCE_DENSITY_DEFAULT,
   DESKTOP_APPEARANCE_THEME_DEFAULT,
+  DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
+  isDesktopSidebarTextSize,
 } from "@pwragent/shared";
 import {
   readDesktopSettingsConfig,
@@ -29,6 +32,7 @@ import {
 export type BootstrapAppearance = {
   theme: DesktopAppearanceTheme;
   density: DesktopAppearanceDensity;
+  sidebarTextSize: DesktopSidebarTextSize;
 };
 
 export const BOOTSTRAP_APPEARANCE_ARG_PREFIX = "--pwragent-appearance=";
@@ -116,6 +120,9 @@ export function readBootstrapAppearance(
       density:
         config.general?.appearance?.density
         ?? DESKTOP_APPEARANCE_DENSITY_DEFAULT,
+      sidebarTextSize:
+        config.general?.appearance?.sidebarTextSize
+        ?? DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
     };
   } catch {
     // Config missing / unreadable / malformed → fall back to defaults.
@@ -124,6 +131,7 @@ export function readBootstrapAppearance(
     return {
       theme: DESKTOP_APPEARANCE_THEME_DEFAULT,
       density: DESKTOP_APPEARANCE_DENSITY_DEFAULT,
+      sidebarTextSize: DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
     };
   }
 }
@@ -151,7 +159,12 @@ export function parseBootstrapAppearanceArg(
           && (raw.density === "mission-control" || raw.density === "compact")
           ? (raw.density as DesktopAppearanceDensity)
           : DESKTOP_APPEARANCE_DENSITY_DEFAULT;
-      return { theme, density };
+      const sidebarTextSize =
+        raw && typeof raw.sidebarTextSize === "string"
+          && isDesktopSidebarTextSize(raw.sidebarTextSize)
+          ? raw.sidebarTextSize
+          : DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT;
+      return { theme, density, sidebarTextSize };
     } catch {
       return undefined;
     }

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -24,6 +24,7 @@ import type {
   DesktopProviderModelDefaults,
   DesktopProviderThreadModelMigration,
   DesktopSettingsConfigPatch,
+  DesktopSidebarTextSize,
   DesktopUpdateChannel,
   DesktopWorktreeStorageLocation,
   MessagingToolUpdateMode,
@@ -31,12 +32,14 @@ import type {
 import {
   DESKTOP_APPEARANCE_DENSITY_DEFAULT,
   DESKTOP_APPEARANCE_THEME_DEFAULT,
+  DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
   DESKTOP_CODEX_PROFILE_MODEL_DEFAULT,
   DESKTOP_FEDERATION_MODE_DEFAULT,
   DESKTOP_INTEGRATED_TERMINAL_WINDOWS_SHELL_DEFAULT,
   DESKTOP_UPDATE_CHANNEL_DEFAULT,
   isDesktopAppearanceDensity,
   isDesktopAppearanceTheme,
+  isDesktopSidebarTextSize,
   isDesktopCodexProfileModel,
   isDesktopFederationMode,
   isFederationGatewayEndpointUrl,
@@ -98,6 +101,7 @@ export type DesktopSettingsConfig = {
     appearance?: {
       theme?: DesktopAppearanceTheme;
       density?: DesktopAppearanceDensity;
+      sidebarTextSize?: DesktopSidebarTextSize;
     };
     codexProfileModel?: DesktopCodexProfileModel;
     messagingAcknowledgment?: DesktopMessagingAcknowledgment | null;
@@ -724,6 +728,23 @@ export function desktopSettingsPatchToEdits(
       set(
         ["general", "appearance", "density"],
         patch.general.appearance.density,
+      );
+    }
+  }
+
+  if (patch.general?.appearance?.sidebarTextSize !== undefined) {
+    if (
+      patch.general.appearance.sidebarTextSize
+        === DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT
+    ) {
+      edits.push({
+        op: "delete",
+        path: ["general", "appearance", "sidebar_text_size"],
+      });
+    } else {
+      set(
+        ["general", "appearance", "sidebar_text_size"],
+        patch.general.appearance.sidebarTextSize,
       );
     }
   }
@@ -1560,6 +1581,9 @@ function normalizeDesktopConfig(
       appearance: {
         theme: readAppearanceTheme(generalAppearance?.theme),
         density: readAppearanceDensity(generalAppearance?.density),
+        sidebarTextSize: readSidebarTextSize(
+          generalAppearance?.sidebar_text_size,
+        ),
       },
       codexProfileModel: readCodexProfileModel(general?.codex_profile_model),
       messagingAcknowledgment: readMessagingAcknowledgment(
@@ -2201,6 +2225,14 @@ function readAppearanceDensity(
   value: TomlScalar | undefined,
 ): DesktopAppearanceDensity | undefined {
   return typeof value === "string" && isDesktopAppearanceDensity(value)
+    ? value
+    : undefined;
+}
+
+function readSidebarTextSize(
+  value: TomlScalar | undefined,
+): DesktopSidebarTextSize | undefined {
+  return typeof value === "string" && isDesktopSidebarTextSize(value)
     ? value
     : undefined;
 }

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -1,6 +1,7 @@
 import type {
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
+  DesktopSidebarTextSize,
   DesktopApplicationsSnapshot,
   DesktopChatReplyComposer,
   DesktopAuthorizedContact,
@@ -39,6 +40,7 @@ import {
   DEFAULT_PAUSE_PR_AUTO_DISPATCH_WHEN_BUDGET_EMPTY,
   DESKTOP_APPEARANCE_DENSITY_DEFAULT,
   DESKTOP_APPEARANCE_THEME_DEFAULT,
+  DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
   DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT,
   DESKTOP_CODEX_PROFILE_MODEL_DEFAULT,
   DESKTOP_FEDERATION_MODE_DEFAULT,
@@ -240,6 +242,7 @@ type DesktopSettingsServiceOptions = {
   onAppearanceChange?: (appearance: {
     theme: DesktopAppearanceTheme;
     density: DesktopAppearanceDensity;
+    sidebarTextSize: DesktopSidebarTextSize;
   }) => void;
 };
 
@@ -642,6 +645,9 @@ export class DesktopSettingsService {
           ),
           density: this.resolveAppearanceDensity(
             config.general?.appearance?.density,
+          ),
+          sidebarTextSize: this.resolveSidebarTextSize(
+            config.general?.appearance?.sidebarTextSize,
           ),
         },
         codexProfileModel: this.resolveCodexProfileModel(
@@ -1343,12 +1349,15 @@ export class DesktopSettingsService {
     if (
       appearancePatch
       && (appearancePatch.theme !== undefined
-        || appearancePatch.density !== undefined)
+        || appearancePatch.density !== undefined
+        || appearancePatch.sidebarTextSize !== undefined)
     ) {
       const next = this.readConfig().config.general?.appearance;
       this.options.onAppearanceChange?.({
         theme: next?.theme ?? DESKTOP_APPEARANCE_THEME_DEFAULT,
         density: next?.density ?? DESKTOP_APPEARANCE_DENSITY_DEFAULT,
+        sidebarTextSize:
+          next?.sidebarTextSize ?? DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
       });
     }
     // Any successful write notifies generic listeners so main-process services
@@ -1951,6 +1960,15 @@ export class DesktopSettingsService {
   ): DesktopSettingsValue<DesktopAppearanceDensity> {
     return {
       value: configValue ?? DESKTOP_APPEARANCE_DENSITY_DEFAULT,
+      source: configValue === undefined ? "default" : "config",
+    };
+  }
+
+  private resolveSidebarTextSize(
+    configValue: DesktopSidebarTextSize | undefined,
+  ): DesktopSettingsValue<DesktopSidebarTextSize> {
+    return {
+      value: configValue ?? DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
       source: configValue === undefined ? "default" : "config",
     };
   }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,8 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
 import {
   DEFAULT_NAVIGATION_BROWSE_MODE,
+  DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
+  isDesktopSidebarTextSize,
   normalizeNavigationBrowseMode,
 } from "@pwragent/shared";
 import {
@@ -21,6 +23,7 @@ import type {
   CreateScheduledThreadActionRequest,
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
+  DesktopSidebarTextSize,
   CancelThreadExecutionModeQueueRequest,
   CancelThreadExecutionModeQueueResponse,
   EnsureDirectoryLaunchpadRequest,
@@ -1961,6 +1964,7 @@ const desktopApi = Object.freeze({
     callback: (appearance: {
       theme: DesktopAppearanceTheme;
       density: DesktopAppearanceDensity;
+      sidebarTextSize: DesktopSidebarTextSize;
     }) => void,
   ): (() => void) => {
     const listener = (
@@ -1968,6 +1972,7 @@ const desktopApi = Object.freeze({
       payload: {
         theme: DesktopAppearanceTheme;
         density: DesktopAppearanceDensity;
+        sidebarTextSize: DesktopSidebarTextSize;
       },
     ) => callback(payload);
     ipcRenderer.on(APPEARANCE_CHANGED_EVENT_CHANNEL, listener);
@@ -2162,6 +2167,7 @@ const APPEARANCE_ARG_PREFIX = "--pwragent-appearance=";
 function readBootstrapAppearance(): {
   theme: "system" | "dark" | "light";
   density: "mission-control" | "compact";
+  sidebarTextSize: DesktopSidebarTextSize;
 } {
   for (const arg of process.argv) {
     if (!arg.startsWith(APPEARANCE_ARG_PREFIX)) continue;
@@ -2175,12 +2181,24 @@ function readBootstrapAppearance(): {
         raw && (raw.density === "mission-control" || raw.density === "compact")
           ? raw.density
           : "mission-control";
-      return { theme, density };
+      // Shared guard, not a hand-copied literal list: a notch added to
+      // DESKTOP_SIDEBAR_TEXT_SIZES must not silently coerce to "md" on
+      // first paint only (the flash this bootstrap exists to prevent).
+      const sidebarTextSize =
+        raw && typeof raw.sidebarTextSize === "string"
+          && isDesktopSidebarTextSize(raw.sidebarTextSize)
+          ? raw.sidebarTextSize
+          : DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT;
+      return { theme, density, sidebarTextSize };
     } catch {
       break;
     }
   }
-  return { theme: "system", density: "mission-control" };
+  return {
+    theme: "system",
+    density: "mission-control",
+    sidebarTextSize: DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
+  };
 }
 const bootstrapAppearance = readBootstrapAppearance();
 

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -69,6 +69,22 @@
           if (density === "compact") {
             document.documentElement.setAttribute("data-density", "compact");
           }
+          // Sidebar text size: "md" is the default the bare :root carries;
+          // any other bridged value sets the attribute. No notch allowlist
+          // here on purpose — this inline script cannot import the shared
+          // enum, an unknown value is inert in CSS (no notch selector
+          // matches, the :root default holds), and a stale hand-copied
+          // list would downgrade future notches to md at first paint.
+          var sidebarTextSize = bridged.sidebarTextSize;
+          if (
+            typeof sidebarTextSize === "string"
+            && sidebarTextSize !== "md"
+          ) {
+            document.documentElement.setAttribute(
+              "data-sidebar-text",
+              sidebarTextSize
+            );
+          }
         } catch (_) {
           // Bridge unavailable or shape wrong — fall back to dark + mission-
           // control defaults. The useAppearance hook will resync once the

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -165,6 +165,8 @@ export function App() {
       ? {
         theme: settings.snapshot.general.appearance.theme.value,
         density: settings.snapshot.general.appearance.density.value,
+        sidebarTextSize:
+          settings.snapshot.general.appearance.sidebarTextSize.value,
       }
       : undefined,
     writeConfig: settings.writeConfig,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -959,6 +959,7 @@ describe("App", () => {
         appearance: {
           theme: { value: "system", source: "default" },
           density: { value: "mission-control", source: "default" },
+          sidebarTextSize: { value: "md", source: "default" },
         },
         codexProfileModel: { value: "shared", source: "default" },
         messagingAcknowledgment: { value: null, source: "default" },
@@ -1261,6 +1262,7 @@ describe("App", () => {
             appearance: {
               theme: { value: "system", source: "default" },
               density: { value: "mission-control", source: "default" },
+              sidebarTextSize: { value: "md", source: "default" },
             },
           },
           onboarding: {
@@ -2243,6 +2245,7 @@ describe("App", () => {
               appearance: {
                 theme: { value: "system", source: "default" },
                 density: { value: "mission-control", source: "default" },
+                sidebarTextSize: { value: "md", source: "default" },
               },
             },
             onboarding: {

--- a/apps/desktop/src/renderer/src/features/navigation/AgentThreadChip.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/AgentThreadChip.tsx
@@ -12,7 +12,7 @@ export function AgentThreadChip(props: { threadRow?: boolean }) {
         aria-label="Agent thread"
         className={
           props.threadRow
-            ? "thread-row__chip thread-row__chip--agent"
+            ? "thread-row__chip thread-row__chip--agent thread-row__chip--persistent"
             : "chip chip--agent"
         }
         onMouseEnter={(event) =>

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -30,7 +30,6 @@ import {
 } from "@pwragent/shared";
 import {
   ChevronDownIcon,
-  FolderIcon,
   NewThreadIcon,
   UnlinkedDotIcon,
   WorkspaceIcon,
@@ -1457,7 +1456,24 @@ export function DirectoriesList(props: DirectoriesListProps) {
         }
       >
         <div
-          className="directory-row__header"
+          // The modifier classes mirror booleans this render already
+          // computes, so the CSS that swaps the count block for the
+          // launchpad cluster can match plain classes instead of
+          // re-running :has() subtree scans on every header hover —
+          // and `--with-launchpad` scopes the hover fade so an
+          // unconfigured directory (which renders no cluster) never
+          // blanks its counts with nothing in their place.
+          className={`directory-row__header${
+            directoryUnconfigured ? "" : " directory-row__header--with-launchpad"
+          }${
+            props.onOpenFederationTargetMenu
+              ? " directory-row__header--split"
+              : ""
+          }${
+            !directoryUnconfigured && hasPendingLaunchpadState(directory)
+              ? " directory-row__header--has-draft"
+              : ""
+          }`}
           draggable={directoryDraggable}
           onDragStart={
             directoryDraggable
@@ -1588,17 +1604,24 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 aria-hidden="true"
                 className={`directory-row__chevron${expanded ? " is-open" : ""}`}
               />
-              <span aria-hidden="true" className="directory-row__icon">
-                {directory.kind === "workspace" ? (
-                  <WorkspaceIcon size={14} />
-                ) : directory.kind === "unlinked" ? (
-                  <UnlinkedDotIcon size={14} />
-                ) : (
-                  <FolderIcon size={14} />
-                )}
-              </span>
+              {/* Icon only where it distinguishes: a folder on EVERY plain
+                  directory row carried no information (2026-08 density
+                  pass), so ordinary directories lead with the chevron +
+                  label alone; workspace and unlinked rows keep their marks
+                  because those are the exceptions worth flagging. */}
+              {directory.kind === "workspace" || directory.kind === "unlinked" ? (
+                <span aria-hidden="true" className="directory-row__icon">
+                  {directory.kind === "workspace" ? (
+                    <WorkspaceIcon size={14} />
+                  ) : (
+                    <UnlinkedDotIcon size={14} />
+                  )}
+                </span>
+              ) : null}
               <span className="directory-row__title-wrap">
-                <span className="thread-row__title">{directory.label}</span>
+                <span className="thread-row__title directory-row__title">
+                  {directory.label}
+                </span>
               </span>
             </span>
 

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -5,7 +5,6 @@ import {
   BranchIcon,
   DraftIcon,
   FolderIcon,
-  PinIcon,
   TerminalIcon,
   WorktreeIcon,
 } from "../../icons";
@@ -29,8 +28,6 @@ type ThreadMetaChipsProps = {
   /** A shell is alive for this thread — the row is how you find it again. */
   hasIntegratedTerminal?: boolean;
   hasInputRequest?: boolean;
-  /** Removes this top-level thread from the pinned section. */
-  onUnpin?: () => void;
   /**
    * When set, renders the "Scheduled" (future send time) or "Queued"
    * (waiting on the active turn) chip. Resolved upstream so a thread with
@@ -59,11 +56,15 @@ type ThreadMetaChipsProps = {
    */
   hideInstanceChip?: boolean;
   /**
-   * Suppresses the pinned marker. The Star Map is not the pinned section,
-   * so a pin chip there costs prime card space to say something the
-   * surface never acts on.
+   * PR chips, slotted into the flow right after the linked-directory
+   * chips and BEFORE the branch chip. The owner (ThreadRow) still
+   * renders them — this slot only fixes their position: provider +
+   * location are short fixed-width chips, PR chips are the actionable
+   * work product, and the branch is the longest, least-scanned string,
+   * so packing PRs before it keeps them on the first chip line instead
+   * of trailing the row.
    */
-  hidePinChip?: boolean;
+  prChips?: ReactNode;
   thread: NavigationThreadSummary;
 };
 
@@ -72,24 +73,17 @@ export function ThreadMetaChips({
   hasUnsentDraft = false,
   hasIntegratedTerminal = false,
   hasInputRequest = false,
-  onUnpin,
   queuedMessageState,
   includeLinkedDirectories = false,
   linkedDirectoryMode = "label",
   hideInstanceChip = false,
-  hidePinChip = false,
+  prChips,
   chipVisibility,
   thread,
 }: ThreadMetaChipsProps) {
   const showProvider = chipVisibility?.provider ?? true;
   const showBranch = chipVisibility?.branch ?? true;
   const maxLinkedDirectories = chipVisibility?.maxLinkedDirectories;
-  // Hover tooltip for the icon-only pin marker — sighted users get the
-  // "Pinned" label without the old text pill; screen readers get it from
-  // the marker's role="img" + aria-label. Uses the shared viewport
-  // tooltip (not a native `title`) so it escapes the sidebar's clipped
-  // scroll region, matching the copyable branch/path chips.
-  const pinTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const gitStateTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   // Sidebar rows are a clipped scroll region, so a native `title` gets
   // edge-clipped — the viewport tooltip is what the neighbouring chips use.
@@ -98,8 +92,6 @@ export function ThreadMetaChips({
   // the Star Map layer would paint over one anyway.
   const draftTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const branchDrifted = isBranchDrifted(thread.gitBranch, thread.observedGitBranch);
-  const pinIsActionable = Boolean(onUnpin);
-  const pinTooltipText = pinIsActionable ? "Click to unpin" : "Pinned";
   const branchChip = thread.gitBranch ?? thread.observedGitBranch;
   const gitWorking = thread.gitWorkingState;
   const branchTooltip = useMemo(
@@ -163,6 +155,10 @@ export function ThreadMetaChips({
             ...new Map(
               thread.linkedDirectories.map((directory) => [
                 directory.kind,
+                // Icon-only: the worktree/local distinction is a glyph, not
+                // a word (2026-08 density pass — the literal "worktree"
+                // pill was the widest fixed chip on every row). The
+                // aria-label + copy tooltip still spell it out.
                 (
                   <CopyableThreadChip
                     aria-label={
@@ -171,14 +167,20 @@ export function ThreadMetaChips({
                         : `Copy local path for ${directory.label}`
                     }
                     key={`${thread.id}:${directory.kind}:location-kind`}
-                    className="thread-row__chip path-copy-target tooltip-target thread-row__chip--mono"
+                    className="thread-row__chip thread-row__chip--location path-copy-target tooltip-target"
                     value={
                       directory.kind === "worktree"
                         ? directory.worktreePath ?? directory.path
                         : directory.path
                     }
                   >
-                    {directory.kind}
+                    <span aria-hidden="true" className="thread-row__chip-icon">
+                      {directory.kind === "worktree" ? (
+                        <WorktreeIcon size={12} />
+                      ) : (
+                        <FolderIcon size={12} />
+                      )}
+                    </span>
                   </CopyableThreadChip>
                 ),
               ]),
@@ -251,7 +253,7 @@ export function ThreadMetaChips({
         <span
           aria-label="A message is scheduled to send"
           role="img"
-          className="thread-row__chip thread-row__chip--scheduled"
+          className="thread-row__chip thread-row__chip--scheduled thread-row__chip--persistent"
           title="A message is scheduled to send"
         >
           Scheduled
@@ -260,7 +262,7 @@ export function ThreadMetaChips({
         <span
           aria-label="A message is queued to send"
           role="img"
-          className="thread-row__chip thread-row__chip--queued"
+          className="thread-row__chip thread-row__chip--queued thread-row__chip--persistent"
           title="A message is queued to send"
         >
           Queued
@@ -282,7 +284,7 @@ export function ThreadMetaChips({
           // never be heard. Same reason the pin and terminal markers below
           // carry one.
           role="img"
-          className="thread-row__chip thread-row__chip--draft"
+          className="thread-row__chip thread-row__chip--draft thread-row__chip--persistent"
           data-thread-draft="unsent"
           onMouseEnter={(event) =>
             draftTooltip.show(
@@ -340,56 +342,7 @@ export function ThreadMetaChips({
         ? linkedDirectoryChips
         : linkedDirectoryChips.slice(0, maxLinkedDirectories)}
 
-      {thread.pinnedRank && !thread.parentThreadId && !hidePinChip ? (
-        <span
-          aria-label={pinIsActionable ? "Unpin thread" : "Pinned"}
-          role={pinIsActionable ? "button" : "img"}
-          tabIndex={pinIsActionable ? 0 : undefined}
-          className="thread-row__chip thread-row__chip--pin"
-          // Deliberately use click, rather than pointer-down: the browser only
-          // dispatches click here when the pointer is released over the pin.
-          // Moving off the marker before release therefore leaves it pinned.
-          onClick={
-            pinIsActionable
-              ? (event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  pinTooltip.hide();
-                  onUnpin?.();
-                }
-              : undefined
-          }
-          onKeyDown={
-            pinIsActionable
-              ? (event) => {
-                  if (event.key !== "Enter" && event.key !== " ") {
-                    return;
-                  }
-
-                  event.preventDefault();
-                  event.stopPropagation();
-                  pinTooltip.hide();
-                  onUnpin?.();
-                }
-              : undefined
-          }
-          onMouseEnter={(event) =>
-            pinTooltip.show(event.currentTarget, pinTooltipText)
-          }
-          onMouseLeave={pinTooltip.hide}
-          onFocus={
-            pinIsActionable
-              ? (event) => pinTooltip.show(event.currentTarget, pinTooltipText)
-              : undefined
-          }
-          onBlur={pinIsActionable ? pinTooltip.hide : undefined}
-        >
-          <span aria-hidden="true" className="thread-row__chip-icon">
-            <PinIcon size={12} />
-          </span>
-        </span>
-      ) : null}
-      {pinTooltip.tooltipNode}
+      {prChips}
 
       {branchChip && showBranch ? (
         <CopyableThreadChip
@@ -455,7 +408,7 @@ export function ThreadMetaChips({
         <span
           aria-label={detachedUnpublishedTooltip}
           role="img"
-          className="thread-row__chip thread-row__chip--unpublished"
+          className="thread-row__chip thread-row__chip--unpublished thread-row__chip--persistent"
           onMouseEnter={(event) =>
             gitStateTooltip.show(event.currentTarget, detachedUnpublishedTooltip)
           }

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -13,7 +13,7 @@ import type {
   PrSummary,
 } from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
-import { SmileyIcon } from "../../icons";
+import { PinIcon, SmileyIcon } from "../../icons";
 import {
   formatMessagingPlatformName,
   MESSAGING_PLATFORM_ICONS,
@@ -297,7 +297,18 @@ export function ThreadRow(props: ThreadRowProps) {
             as `nested-interactive`. `.star-map-card-shell` uses the same
             shape for its kebab. */}
         <button
-          aria-label={props.thread.title}
+          // ", pinned" keeps the pinned state in the row's accessible
+          // name now that the old role="img" pin chip is gone — the
+          // in-title marker is aria-hidden (it sits inside this button,
+          // where an interactive replacement would be invalid), and the
+          // hover cluster's toggle only exists when a pin handler is
+          // wired. Screen readers hear the state wherever the row
+          // renders.
+          aria-label={
+            props.thread.pinnedRank && !props.thread.parentThreadId
+              ? `${props.thread.title}, pinned`
+              : props.thread.title
+          }
           aria-pressed={selected}
           className="thread-row__header thread-row__open"
           type="button"
@@ -329,20 +340,32 @@ export function ThreadRow(props: ThreadRowProps) {
           <span className="thread-row__heading">
             <ThreadRowStatus status={status} />
             <span className="thread-row__title">{props.thread.title}</span>
+            {/* Passive pinned-state marker on the title line (both
+                densities — the pin no longer spends a chip). Inside the
+                open-thread button, so no role/tabindex — a nested
+                interactive control would be invalid; the ACTIONABLE pin
+                toggle is the hover-revealed button in the actions
+                cluster, alongside the reaction + overflow buttons. */}
+            {props.thread.pinnedRank && !props.thread.parentThreadId ? (
+              <span aria-hidden="true" className="thread-row__heading-pin">
+                <PinIcon size={11} />
+              </span>
+            ) : null}
           </span>
           <span className="thread-row__time">
             {formatRelativeTime(props.thread.updatedAt)}
           </span>
         </button>
 
-        {/* Single ordered chip flow: meta (provider / location / pinned /
-            branch / drift) → messaging binding chips → PR chips →
-            reactions. Pinned rides with the meta chips so it never lands
-            alone on a wrapped row; PR chips + reactions stay last so the
-            fixed-width metadata packs first and single-chip orphan rows
-            are minimized. flex-wrap handles overflow naturally; the
-            hover-only add-reaction affordance is positioned outside the
-            flow so it cannot reserve a phantom wrapped row while hidden.
+        {/* Single ordered chip flow: meta (provider / location → PR chips
+            → branch / drift / git state) → messaging binding chips →
+            reactions. PR chips slot into the middle of the meta flow (see
+            ThreadMetaChips.prChips) so they pack right after the short
+            fixed-width chips instead of trailing the branch — the longest,
+            least-scanned string on the row. flex-wrap handles overflow
+            naturally; the hover-only add-reaction affordance is positioned
+            outside the flow so it cannot reserve a phantom wrapped row
+            while hidden.
 
             The container is `pointer-events: none` (see app.css) so the
             gaps between chips fall through to the open-thread overlay, so
@@ -367,17 +390,34 @@ export function ThreadRow(props: ThreadRowProps) {
             hasApprovalRequest={props.approvalRequestThreadKeys?.[threadKey] === true}
             hasIntegratedTerminal={props.terminalThreadKeys?.[threadKey] === true}
             hasInputRequest={props.inputRequestThreadKeys?.[threadKey] === true}
-            onUnpin={
-              onSetThreadPin
-                ? () => {
-                    void onSetThreadPin(props.thread, false);
-                  }
-                : undefined
-            }
             queuedMessageState={props.queuedMessageThreadKeys?.[threadKey]}
             hasUnsentDraft={props.draftThreadKeys?.[threadKey] === true}
             includeLinkedDirectories={props.includeLinkedDirectories}
             linkedDirectoryMode={props.linkedDirectoryMode}
+            prChips={prs.map((pr) => (
+              <PrChip
+                key={pr.url}
+                pr={pr}
+                showRepoPrefix={needsRepoPrefix(props.thread, pr, prs)}
+                onOpen={openPr}
+                onOpenContextMenu={
+                  props.onOpenPullRequestContextMenu
+                    ? (targetPr, position) =>
+                        props.onOpenPullRequestContextMenu!(
+                          props.thread,
+                          targetPr,
+                          position,
+                        )
+                    : undefined
+                }
+                onDetach={
+                  props.onDetachPullRequest
+                    ? (targetPr) =>
+                        props.onDetachPullRequest!(props.thread, targetPr)
+                    : undefined
+                }
+              />
+            ))}
             thread={props.thread}
           />
 
@@ -389,30 +429,6 @@ export function ThreadRow(props: ThreadRowProps) {
                 props.onUnbindMessagingBinding
                   ? (target) =>
                       void props.onUnbindMessagingBinding!(props.thread, target)
-                  : undefined
-              }
-            />
-          ))}
-
-          {prs.map((pr) => (
-            <PrChip
-              key={pr.url}
-              pr={pr}
-              showRepoPrefix={needsRepoPrefix(props.thread, pr, prs)}
-              onOpen={openPr}
-              onOpenContextMenu={
-                props.onOpenPullRequestContextMenu
-                  ? (targetPr, position) =>
-                      props.onOpenPullRequestContextMenu!(
-                        props.thread,
-                        targetPr,
-                        position,
-                      )
-                  : undefined
-              }
-              onDetach={
-                props.onDetachPullRequest
-                  ? (targetPr) => props.onDetachPullRequest!(props.thread, targetPr)
                   : undefined
               }
             />
@@ -430,6 +446,31 @@ export function ThreadRow(props: ThreadRowProps) {
       </div>
 
       <div className="thread-row__actions">
+        {/* Hover-revealed pin toggle: pin an unpinned thread, unpin a
+            pinned one. Lives with the other row actions instead of in
+            the chip flow, so the pinned STATE costs no chip space (the
+            in-title marker carries it) and pinning gains a one-click
+            affordance it never had. Sub-threads cannot be pinned. */}
+        {onSetThreadPin && !props.thread.parentThreadId ? (
+          <button
+            aria-label={
+              props.thread.pinnedRank ? "Unpin thread" : "Pin thread"
+            }
+            aria-pressed={Boolean(props.thread.pinnedRank)}
+            className={`thread-row__pin-button${
+              props.thread.pinnedRank ? " is-pinned" : ""
+            }`}
+            title={props.thread.pinnedRank ? "Unpin thread" : "Pin thread"}
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              void onSetThreadPin(props.thread, !props.thread.pinnedRank);
+            }}
+          >
+            <PinIcon size={12} aria-hidden="true" />
+          </button>
+        ) : null}
+
         {canReact ? (
           <AddReactionChip
             anchorRef={addReactionRef}
@@ -488,7 +529,7 @@ function ReactionChip(props: { emoji: string; onToggle: () => void }) {
       role="button"
       tabIndex={0}
       aria-label={`Remove reaction ${emoji} from thread`}
-      className="thread-row__chip thread-row__chip--reaction"
+      className="thread-row__chip thread-row__chip--reaction thread-row__chip--persistent"
       onClick={handleActivate}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -313,7 +313,7 @@ describe("Sidebar", () => {
     );
 
     expect(
-      threadCard(screen.getByRole("button", { name: "Cross-project cleanup" })),
+      threadCard(screen.getByRole("button", { name: /^Cross-project cleanup/ })),
     ).toHaveClass("is-remote-offline");
     expect(
       screen.queryByText("Error invoking remote method: peer is not connected"),
@@ -978,7 +978,7 @@ describe("Sidebar", () => {
     );
 
     expect(container.querySelector(".subthread-list")).not.toBeNull();
-    expect(screen.getByRole("button", { name: "Cross-project cleanup" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Cross-project cleanup/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Adversarial review" })).toBeInTheDocument();
 
     fireEvent.click(
@@ -1264,7 +1264,7 @@ describe("Sidebar", () => {
       />,
     );
 
-    fireEvent.contextMenu(screen.getByRole("button", { name: "Cross-project cleanup" }));
+    fireEvent.contextMenu(screen.getByRole("button", { name: /^Cross-project cleanup/ }));
     expect(screen.queryByRole("menuitem", { name: "Sub-thread in Local" })).toBeNull();
     fireEvent.click(screen.getByRole("menuitem", { name: "Sub-thread in Same Worktree" }));
 
@@ -1480,7 +1480,7 @@ describe("Sidebar", () => {
       />,
     );
 
-    fireEvent.contextMenu(screen.getByRole("button", { name: "Cross-project cleanup" }));
+    fireEvent.contextMenu(screen.getByRole("button", { name: /^Cross-project cleanup/ }));
     expect(screen.getByRole("menu")).toBeInTheDocument();
 
     fireEvent.contextMenu(document.body);
@@ -1542,7 +1542,7 @@ describe("Sidebar", () => {
       />,
     );
 
-    fireEvent.contextMenu(screen.getByRole("button", { name: "Cross-project cleanup" }));
+    fireEvent.contextMenu(screen.getByRole("button", { name: /^Cross-project cleanup/ }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Fork into New Worktree" }));
 
     expect(onForkThread).toHaveBeenCalledWith(sharedThread, "new-worktree");
@@ -1603,7 +1603,7 @@ describe("Sidebar", () => {
       />,
     );
 
-    fireEvent.contextMenu(screen.getByRole("button", { name: "Cross-project cleanup" }));
+    fireEvent.contextMenu(screen.getByRole("button", { name: /^Cross-project cleanup/ }));
 
     expect(screen.queryByRole("menuitem", { name: "Fork into Same Worktree" })).toBeNull();
     expect(screen.queryByRole("menuitem", { name: "Fork into New Worktree" })).toBeNull();
@@ -1921,9 +1921,18 @@ describe("Sidebar", () => {
       }),
     );
 
-    expect(within(worktreeThreadRow).getByText("worktree")).toBeInTheDocument();
+    // Kind chips are icon-only since the 2026-08 density pass — the
+    // worktree/local word lives in the copyable chip's aria-label, not
+    // as visible chip text.
+    expect(
+      within(worktreeThreadRow).getByLabelText("Copy path for worktree PwrAgent"),
+    ).toBeInTheDocument();
+    expect(within(worktreeThreadRow).queryByText("worktree")).not.toBeInTheDocument();
     expect(within(worktreeThreadRow).queryByText("PwrAgent")).not.toBeInTheDocument();
-    expect(within(localThreadRow).getByText("local")).toBeInTheDocument();
+    expect(
+      within(localThreadRow).getByLabelText("Copy local path for PwrAgent"),
+    ).toBeInTheDocument();
+    expect(within(localThreadRow).queryByText("local")).not.toBeInTheDocument();
   });
 
   it("names every linked project in multi-directory rows", () => {
@@ -3256,7 +3265,7 @@ describe("Sidebar", () => {
     );
 
     const pinnedButton = screen.getByRole("button", {
-      name: "Pinned batch thread",
+      name: /^Pinned batch thread/,
     });
     const childButton = screen.getByRole("button", {
       name: "Child batch thread",
@@ -3509,7 +3518,7 @@ describe("Sidebar", () => {
     );
 
     fireEvent.contextMenu(
-      screen.getByRole("button", { name: "Cross-project cleanup" }),
+      screen.getByRole("button", { name: /^Cross-project cleanup/ }),
       { clientX: 48, clientY: 64 },
     );
 
@@ -3667,7 +3676,9 @@ describe("Sidebar", () => {
       expect.stringContaining("Updated thread"),
     ]);
     expect(
-      within(threadCard(rows[1]!)).getByRole("button", { name: "Unpin thread" }),
+      within(
+        rows[1]!.closest(".thread-row-shell") as HTMLElement,
+      ).getByRole("button", { name: "Unpin thread" }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("separator", { name: "Unpinned threads" }),
@@ -3846,10 +3857,15 @@ describe("Sidebar", () => {
       name: /Cross-project cleanup|Updated thread/i,
     });
     expect(rows[0]).toHaveTextContent("Updated thread");
+    // Pinned state is the aria-hidden in-title marker since the 2026-08
+    // density pass (the old role="img" pin chip left the chip flow).
     expect(
-      within(threadCard(rows[0]!)).getByRole("img", { name: "Pinned" }),
-    ).toBeInTheDocument();
+      threadCard(rows[0]!).querySelector(".thread-row__heading-pin"),
+    ).not.toBeNull();
     expect(rows[1]).toHaveTextContent("Cross-project cleanup");
+    expect(
+      threadCard(rows[1]!).querySelector(".thread-row__heading-pin"),
+    ).toBeNull();
   });
 
   it("minimizes only unpinned directory threads and restores the sticky state", async () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -244,7 +244,7 @@ describe("ThreadRow chip flow", () => {
     expect(onUnbindMessagingBinding).not.toHaveBeenCalled();
   });
 
-  it("unpins only when the pin click finishes on the marker", () => {
+  it("toggles the pin from the hover actions button without selecting the row", () => {
     const onSetThreadPin = vi.fn(async () => undefined);
     const { onSelectThread } = renderRow({
       thread: {
@@ -255,17 +255,26 @@ describe("ThreadRow chip flow", () => {
       onSetThreadPin,
     });
 
+    // The pin left the chip flow in the 2026-08 density pass: pinned
+    // STATE is the aria-hidden in-title marker, and the toggle is a
+    // real button in the hover actions cluster beside the reaction +
+    // overflow buttons.
     const pin = screen.getByRole("button", { name: "Unpin thread" });
-    const rowButton = screen.getByRole("button", { name: /Chip flow thread/i });
-    expect(pin.tagName).toBe("SPAN");
-    expect(pin).toHaveClass("thread-row__chip--pin");
-
-    // The marker mutates on click, not press: releasing on the surrounding
-    // row after leaving the pin must leave the thread pinned.
-    fireEvent.mouseDown(pin);
-    fireEvent.mouseLeave(pin);
-    fireEvent.mouseUp(rowButton);
-    expect(onSetThreadPin).not.toHaveBeenCalled();
+    expect(pin.tagName).toBe("BUTTON");
+    expect(pin).toHaveClass("thread-row__pin-button");
+    expect(pin).toHaveAttribute("aria-pressed", "true");
+    // The pinned STATE stays in the row's accessible name (the in-title
+    // marker is aria-hidden and this toggle only exists when a pin
+    // handler is wired), so screen readers hear it wherever rows render.
+    expect(
+      screen.getByRole("button", { name: "Chip flow thread, pinned" }),
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector(".thread-row__heading-pin"),
+    ).not.toBeNull();
+    expect(
+      document.querySelector(".thread-row__chip--pin"),
+    ).toBeNull();
 
     fireEvent.click(pin);
     expect(onSetThreadPin).toHaveBeenCalledWith(
@@ -273,6 +282,29 @@ describe("ThreadRow chip flow", () => {
       false,
     );
     expect(onSelectThread).not.toHaveBeenCalled();
+  });
+
+  it("pins an unpinned thread from the same actions button", () => {
+    const onSetThreadPin = vi.fn(async () => undefined);
+    renderRow({
+      thread: {
+        ...baseThread,
+        pinnedRank: undefined,
+        reactions: [],
+      },
+      onSetThreadPin,
+    });
+
+    const pin = screen.getByRole("button", { name: "Pin thread" });
+    expect(pin).toHaveAttribute("aria-pressed", "false");
+    // No pinned-state marker on an unpinned row.
+    expect(document.querySelector(".thread-row__heading-pin")).toBeNull();
+
+    fireEvent.click(pin);
+    expect(onSetThreadPin).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "thread-chips" }),
+      true,
+    );
   });
 
   it("does not invoke onSelectThread when the add-reaction smiley is clicked", () => {
@@ -594,14 +626,19 @@ describe("ThreadRow chip flow", () => {
     // ThreadMetaChips internals.
     const indexOf = (selector: string): number =>
       chipNodes.findIndex((el) => el.matches(selector) || el.querySelector(selector) !== null);
-    const prIdx = indexOf(".thread-row__chip--pr, [data-pr-chip]");
+    const prIdx = indexOf(".pr-chip");
+    const branchIdx = indexOf(".thread-row__chip--mono");
     const bindingIdx = indexOf(".thread-row__chip--binding, .thread-row__chip-wrap");
     const reactionIdx = indexOf(".thread-row__chip--reaction");
-    // Each chip type that's present comes after the previous one. Messaging
-    // bindings sit before PR chips so fixed-width metadata packs first and
-    // the variable-count PR + reaction chips trail at the end.
-    if (bindingIdx >= 0 && prIdx >= 0) expect(bindingIdx).toBeLessThan(prIdx);
-    if (prIdx >= 0 && reactionIdx >= 0) expect(prIdx).toBeLessThan(reactionIdx);
+    // PR chips slot into the meta flow BEFORE the branch chip (2026-08
+    // density pass — the branch is the longest, least-scanned string, so
+    // the actionable PRs pack ahead of it); bindings and reactions still
+    // trail the meta flow.
+    if (prIdx >= 0 && branchIdx >= 0) expect(prIdx).toBeLessThan(branchIdx);
+    if (branchIdx >= 0 && bindingIdx >= 0) expect(branchIdx).toBeLessThan(bindingIdx);
+    if (bindingIdx >= 0 && reactionIdx >= 0) {
+      expect(bindingIdx).toBeLessThan(reactionIdx);
+    }
   });
 
   it("shows the PR title and status in the shared hover card", () => {

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -44,6 +44,7 @@ import {
   FeishuIcon,
   LineIcon,
   MattermostIcon,
+  PinIcon,
   SlackIcon,
   TelegramIcon,
 } from "../../icons";
@@ -2840,14 +2841,16 @@ function ChoiceCard(props: {
    ---------------------------------------------------------------- */
 
 /* Mini ThreadRow chips — composed to mirror the live ThreadRow primitive:
-   - .mini-chip-pin renders the "Pinned" pill (accent-bordered, accent text)
+   - .mini-pin renders the in-title pin marker (the live sidebar stopped
+     spending a chip on pinned state in the 2026-08 density pass)
    - .mini-chip-pr renders the "#123" PR pill (dot + number)
    - .mini-chip-meta renders the gray-fill chips (OpenAI / PwrAgnt / branch)
-   Compact mode keeps Pin + PR + emoji; Mission Control adds the meta row. */
+   Compact mode keeps the pin marker + PR + emoji; Mission Control adds
+   the meta row. */
 function MiniPinChip() {
   return (
-    <span className="onboarding-wizard__mini-chip onboarding-wizard__mini-chip--pin">
-      Pinned
+    <span aria-hidden="true" className="onboarding-wizard__mini-pin">
+      <PinIcon size={9} />
     </span>
   );
 }
@@ -2935,32 +2938,32 @@ function DensityMissionControlPreview() {
     <div className="onboarding-wizard__mini">
       <div className="onboarding-wizard__mini-row onboarding-wizard__mini-row--mc is-active">
         <span className="onboarding-wizard__mini-title">PwrAgent - Release</span>
+        <MiniPinChip />
         <span className="onboarding-wizard__mini-time">2h</span>
         <div className="onboarding-wizard__mini-meta">
           <MiniMetaChip>OpenAI</MiniMetaChip>
           <MiniMetaChip>📁 PwrAgnt</MiniMetaChip>
           <MiniMetaChip>⌥ main</MiniMetaChip>
-          <MiniPinChip />
         </div>
       </div>
       <div className="onboarding-wizard__mini-row onboarding-wizard__mini-row--mc">
         <span className="onboarding-wizard__mini-title">PwrSnap - Release</span>
+        <MiniPinChip />
         <span className="onboarding-wizard__mini-time">May 7</span>
         <div className="onboarding-wizard__mini-meta">
           <MiniMetaChip>OpenAI</MiniMetaChip>
           <MiniMetaChip>📁 PwrSnap</MiniMetaChip>
           <MiniMetaChip>⌥ main</MiniMetaChip>
-          <MiniPinChip />
         </div>
       </div>
       <div className="onboarding-wizard__mini-row onboarding-wizard__mini-row--mc">
         <span className="onboarding-wizard__mini-title">Text Mode for Button Platforms</span>
+        <MiniPinChip />
         <span className="onboarding-wizard__mini-time">2d</span>
         <div className="onboarding-wizard__mini-meta">
           <MiniMetaChip>OpenAI</MiniMetaChip>
           <MiniMetaChip>⌥ PwrAgnt</MiniMetaChip>
           <MiniMetaChip>⌥ feat/messaging-text-mode</MiniMetaChip>
-          <MiniPinChip />
           <MiniPrChip num="352" status="ok" />
           <span className="onboarding-wizard__mini-emoji">👀</span>
         </div>
@@ -2968,12 +2971,12 @@ function DensityMissionControlPreview() {
       <div className="onboarding-wizard__mini-row onboarding-wizard__mini-row--mc">
         <span className="onboarding-wizard__mini-cookie" />
         <span className="onboarding-wizard__mini-title">Automation scheduling system</span>
+        <MiniPinChip />
         <span className="onboarding-wizard__mini-time">2d</span>
         <div className="onboarding-wizard__mini-meta">
           <MiniMetaChip>OpenAI</MiniMetaChip>
           <MiniMetaChip>⌥ PwrAgnt</MiniMetaChip>
           <MiniMetaChip>⌥ feat/automation</MiniMetaChip>
-          <MiniPinChip />
           <MiniPrChip num="376" status="ok" />
           <span className="onboarding-wizard__mini-emoji">🏃</span>
         </div>

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -13,6 +13,7 @@ import type { DesktopApi } from "../../lib/desktop-api";
 import type {
   AppearanceController,
   DensityPreference,
+  SidebarTextSizePreference,
   ThemePreference,
 } from "../../lib/useAppearance";
 import {
@@ -44,7 +45,18 @@ const DENSITY_OPTIONS: Array<{
     meta: "Full thread chips",
     value: "mission-control",
   },
-  { label: "Compact", meta: "Chips hidden", value: "compact" },
+  { label: "Compact", meta: "Metadata chips hidden", value: "compact" },
+];
+
+const SIDEBAR_TEXT_SIZE_OPTIONS: Array<{
+  label: string;
+  value: SidebarTextSizePreference;
+}> = [
+  { label: "XS", value: "xs" },
+  { label: "S", value: "sm" },
+  { label: "M", value: "md" },
+  { label: "L", value: "lg" },
+  { label: "XL", value: "xl" },
 ];
 
 const PASTED_IMAGE_PATCH_OPTIONS: Array<{
@@ -279,13 +291,13 @@ export function GeneralSettings(props: {
               }
             />
             <SettingsField
-              label="Density"
-              sub="Compact hides the directory and PR chips in thread rows so more threads fit on screen. Reaction and pin markers stay visible."
+              label="Info density"
+              sub="Compact hides the provider, directory, and branch chips in thread rows so more threads fit on screen. PR chips, reactions, and pin markers stay visible."
               control={
                 <div
                   className="settings-segmented"
                   role="radiogroup"
-                  aria-label="Density"
+                  aria-label="Info density"
                 >
                   {DENSITY_OPTIONS.map((option) => (
                     <button
@@ -304,6 +316,40 @@ export function GeneralSettings(props: {
                       <span className="settings-segmented__meta">
                         {option.meta}
                       </span>
+                    </button>
+                  ))}
+                </div>
+              }
+            />
+            <SettingsField
+              label="Sidebar text size"
+              sub="Scales the thread and directory titles in the left sidebar. M is the tuned default; each notch moves the titles one pixel."
+              control={
+                <div
+                  className="settings-segmented"
+                  role="radiogroup"
+                  aria-label="Sidebar text size"
+                >
+                  {SIDEBAR_TEXT_SIZE_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      aria-checked={
+                        appearance.sidebarTextSize === option.value
+                      }
+                      className={`settings-segmented__button${
+                        appearance.sidebarTextSize === option.value
+                          ? " is-active"
+                          : ""
+                      }`}
+                      role="radio"
+                      type="button"
+                      onClick={() => {
+                        props.appearanceController?.setSidebarTextSize(
+                          option.value,
+                        );
+                      }}
+                    >
+                      {option.label}
                     </button>
                   ))}
                 </div>

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -132,6 +132,7 @@ function createSnapshot(
       appearance: {
         theme: { value: "system", source: "default" },
         density: { value: "mission-control", source: "default" },
+        sidebarTextSize: { value: "md", source: "default" },
       },
       codexProfileModel: { value: "shared", source: "default" },
       messagingAcknowledgment: { value: null, source: "default" },

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapThreadCard.tsx
@@ -214,7 +214,6 @@ export function StarMapThreadCard(props: {
             // In the instance lenses the lane and the watermark already say
             // which machine this is; under the projects lens they do not.
             hideInstanceChip={!props.showInstanceChip}
-            hidePinChip
             chipVisibility={{
               provider: props.cardFields.provider,
               branch: props.cardFields.branch,

--- a/apps/desktop/src/renderer/src/lib/appearance.ts
+++ b/apps/desktop/src/renderer/src/lib/appearance.ts
@@ -22,24 +22,30 @@
 import type {
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
+  DesktopSidebarTextSize,
 } from "@pwragent/shared";
 import {
   DESKTOP_APPEARANCE_DENSITY_DEFAULT,
   DESKTOP_APPEARANCE_THEME_DEFAULT,
+  DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
+  isDesktopSidebarTextSize,
 } from "@pwragent/shared";
 
 export type ThemePreference = DesktopAppearanceTheme;
 export type DensityPreference = DesktopAppearanceDensity;
+export type SidebarTextSizePreference = DesktopSidebarTextSize;
 export type ResolvedTheme = "dark" | "light";
 
 export type AppearancePreference = {
   theme: ThemePreference;
   density: DensityPreference;
+  sidebarTextSize: SidebarTextSizePreference;
 };
 
 export const DEFAULT_APPEARANCE: AppearancePreference = {
   theme: DESKTOP_APPEARANCE_THEME_DEFAULT,
   density: DESKTOP_APPEARANCE_DENSITY_DEFAULT,
+  sidebarTextSize: DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT,
 };
 
 /** Resolve `"system"` to either `"dark"` or `"light"` by querying the
@@ -64,6 +70,7 @@ export function resolveTheme(preference: ThemePreference): ResolvedTheme {
 export function applyAppearanceAttributes(
   resolvedTheme: ResolvedTheme,
   density: DensityPreference,
+  sidebarTextSize: SidebarTextSizePreference,
 ): void {
   if (typeof document === "undefined") return;
   const root = document.documentElement;
@@ -76,6 +83,11 @@ export function applyAppearanceAttributes(
     root.setAttribute("data-density", "compact");
   } else {
     root.removeAttribute("data-density");
+  }
+  if (sidebarTextSize !== DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT) {
+    root.setAttribute("data-sidebar-text", sidebarTextSize);
+  } else {
+    root.removeAttribute("data-sidebar-text");
   }
 }
 
@@ -94,6 +106,7 @@ export function readBridgedAppearance(): AppearancePreference {
   return {
     theme: normalizeTheme(bridged?.theme),
     density: normalizeDensity(bridged?.density),
+    sidebarTextSize: normalizeSidebarTextSize(bridged?.sidebarTextSize),
   };
 }
 
@@ -107,4 +120,10 @@ function normalizeDensity(value: unknown): DensityPreference {
   return value === "compact" || value === "mission-control"
     ? value
     : DEFAULT_APPEARANCE.density;
+}
+
+function normalizeSidebarTextSize(value: unknown): SidebarTextSizePreference {
+  return typeof value === "string" && isDesktopSidebarTextSize(value)
+    ? value
+    : DEFAULT_APPEARANCE.sidebarTextSize;
 }

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -338,6 +338,7 @@ import type {
   DeleteDesktopPwrAgentProfileResponse,
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
+  DesktopSidebarTextSize,
   DesktopMessagingContactLookupRequest,
   DesktopMessagingContactLookupResponse,
   DesktopSettingsWriteResponse,
@@ -1091,6 +1092,7 @@ export type DesktopApi = {
     callback: (appearance: {
       theme: DesktopAppearanceTheme;
       density: DesktopAppearanceDensity;
+      sidebarTextSize: DesktopSidebarTextSize;
     }) => void,
   ) => () => void;
   onCodexEnvironmentSetupProgress?: (

--- a/apps/desktop/src/renderer/src/lib/useAppearance.ts
+++ b/apps/desktop/src/renderer/src/lib/useAppearance.ts
@@ -9,6 +9,7 @@ import {
   type AppearancePreference,
   type DensityPreference,
   type ResolvedTheme,
+  type SidebarTextSizePreference,
   type ThemePreference,
 } from "./appearance";
 
@@ -21,6 +22,7 @@ export type AppearanceController = {
   appearance: AppearanceState;
   setTheme(theme: ThemePreference): void;
   setDensity(density: DensityPreference): void;
+  setSidebarTextSize(sidebarTextSize: SidebarTextSizePreference): void;
   setAppearance(preference: AppearancePreference): void;
 };
 
@@ -55,6 +57,7 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
   const { snapshotPreference, writeConfig } = input;
   const snapshotDensity = snapshotPreference?.density;
   const snapshotTheme = snapshotPreference?.theme;
+  const snapshotSidebarTextSize = snapshotPreference?.sidebarTextSize;
 
   const [appearance, setAppearanceState] = useState<AppearanceState>(() => {
     const initial = snapshotPreference ?? readBridgedAppearance();
@@ -69,28 +72,34 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
   // We compare by value to avoid stomping local in-flight writes that
   // haven't been re-read yet.
   useEffect(() => {
-    if (!snapshotDensity || !snapshotTheme) return;
+    if (!snapshotDensity || !snapshotTheme || !snapshotSidebarTextSize) return;
     setAppearanceState((current) => {
       if (
         current.theme === snapshotTheme
         && current.density === snapshotDensity
+        && current.sidebarTextSize === snapshotSidebarTextSize
       ) {
         return current;
       }
       return {
         density: snapshotDensity,
         resolvedTheme: resolveTheme(snapshotTheme),
+        sidebarTextSize: snapshotSidebarTextSize,
         theme: snapshotTheme,
       };
     });
-  }, [snapshotDensity, snapshotTheme]);
+  }, [snapshotDensity, snapshotTheme, snapshotSidebarTextSize]);
 
   // Apply DOM attributes whenever the resolved appearance changes. No
   // localStorage cache to maintain — the source of truth is TOML, the
   // synchronous first-paint hint is the preload-bridged value.
   useEffect(() => {
-    applyAppearanceAttributes(appearance.resolvedTheme, appearance.density);
-  }, [appearance.resolvedTheme, appearance.density]);
+    applyAppearanceAttributes(
+      appearance.resolvedTheme,
+      appearance.density,
+      appearance.sidebarTextSize,
+    );
+  }, [appearance.resolvedTheme, appearance.density, appearance.sidebarTextSize]);
 
   // Subscribe to prefers-color-scheme changes so `theme: "system"` flips
   // live when the OS theme changes. Unsubscribe on unmount.
@@ -127,9 +136,13 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
   }, [writeConfig]);
 
   const persist = useCallback(
-    (theme: ThemePreference, density: DensityPreference) => {
+    (
+      theme: ThemePreference,
+      density: DensityPreference,
+      sidebarTextSize: SidebarTextSizePreference,
+    ) => {
       void writeConfigRef.current({
-        general: { appearance: { theme, density } },
+        general: { appearance: { theme, density, sidebarTextSize } },
       });
     },
     [],
@@ -139,7 +152,7 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
     (theme: ThemePreference) => {
       setAppearanceState((current) => {
         if (current.theme === theme) return current;
-        persist(theme, current.density);
+        persist(theme, current.density, current.sidebarTextSize);
         return {
           ...current,
           theme,
@@ -154,10 +167,24 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
     (density: DensityPreference) => {
       setAppearanceState((current) => {
         if (current.density === density) return current;
-        persist(current.theme, density);
+        persist(current.theme, density, current.sidebarTextSize);
         return {
           ...current,
           density,
+        };
+      });
+    },
+    [persist],
+  );
+
+  const setSidebarTextSize = useCallback(
+    (sidebarTextSize: SidebarTextSizePreference) => {
+      setAppearanceState((current) => {
+        if (current.sidebarTextSize === sidebarTextSize) return current;
+        persist(current.theme, current.density, sidebarTextSize);
+        return {
+          ...current,
+          sidebarTextSize,
         };
       });
     },
@@ -170,10 +197,15 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
         if (
           current.theme === preference.theme
           && current.density === preference.density
+          && current.sidebarTextSize === preference.sidebarTextSize
         ) {
           return current;
         }
-        persist(preference.theme, preference.density);
+        persist(
+          preference.theme,
+          preference.density,
+          preference.sidebarTextSize,
+        );
         return {
           ...preference,
           resolvedTheme: resolveTheme(preference.theme),
@@ -187,9 +219,15 @@ export function useAppearance(input: UseAppearanceInput): AppearanceController {
     appearance,
     setTheme,
     setDensity,
+    setSidebarTextSize,
     setAppearance,
   };
 }
 
 export { DEFAULT_APPEARANCE };
-export type { ThemePreference, DensityPreference, ResolvedTheme };
+export type {
+  ThemePreference,
+  DensityPreference,
+  ResolvedTheme,
+  SidebarTextSizePreference,
+};

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import type {
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
+  DesktopSidebarTextSize,
 } from "@pwragent/shared";
 import { App } from "./App";
 import { RendererErrorBoundary } from "./features/diagnostics/RendererErrorBoundary";
@@ -35,6 +36,7 @@ const desktopApi = (
         callback: (appearance: {
           theme: DesktopAppearanceTheme;
           density: DesktopAppearanceDensity;
+          sidebarTextSize: DesktopSidebarTextSize;
         }) => void,
       ) => () => void;
       onWindowFullscreen?: (
@@ -59,6 +61,7 @@ const unsubscribeAppearance = desktopApi?.onAppearanceChanged?.(
     applyAppearanceAttributes(
       resolveTheme(appearance.theme),
       appearance.density,
+      appearance.sidebarTextSize,
     );
   },
 );

--- a/apps/desktop/src/renderer/src/styles/__tests__/chevron-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/chevron-contract.test.ts
@@ -8,8 +8,15 @@ import { describe, expect, it } from "vitest";
  * expand/collapse chevron must point RIGHT when collapsed (`rotate(-45deg)`)
  * and rotate 90deg to point DOWN when expanded (`rotate(45deg)`). The
  * direction lives entirely in CSS, so it can only be asserted here, not in
- * a render test. The sidebar thread-tree triangle is a deliberate FILLED
- * exception and is asserted separately.
+ * a render test.
+ *
+ * The SIDEBAR is a deliberate FILLED-triangle family, asserted separately:
+ * the thread-tree toggle, the directory header, and the directory-threads
+ * divider all draw the same solid caret (2026-08 density pass — the
+ * directory rows used to carry the unfilled language, which left the one
+ * navigation surface speaking two disclosure vocabularies). Filled =
+ * sidebar navigation tree, unfilled = inline content disclosure
+ * (transcript, settings, live-work rail).
  */
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const css = readFileSync(path.resolve(testDir, "../app.css"), "utf8");
@@ -50,11 +57,6 @@ const INLINE_CHEVRONS: Array<{ name: string; collapsed: string; expanded: string
       '.transcript-work-phase-group__toggle[aria-expanded="true"] .transcript-work-phase-group__chevron',
   },
   {
-    name: "sidebar directory header",
-    collapsed: ".directory-row__chevron",
-    expanded: ".directory-row__chevron.is-open",
-  },
-  {
     name: "settings section header",
     collapsed: ".settings-panel--is-collapsed .settings-section__chevron::before",
     expanded: ".settings-section__chevron::before",
@@ -83,11 +85,12 @@ const NON_ARIA_STATE_CHEVRONS = INLINE_CHEVRONS.filter(
 );
 
 // The base element rule that paints each unfilled chevron's "V" shape.
+// (`.directory-row__chevron` left this list in the 2026-08 density pass —
+// it now belongs to the sidebar's filled-triangle family below.)
 const UNFILLED_BASE_RULES = [
   ".transcript-activity__chevron",
   ".transcript-work-phase-group__chevron",
   ".transcript-monitor-result__chevron",
-  ".directory-row__chevron",
   ".settings-section__chevron::before",
   ".live-work-rail__chevron",
 ];
@@ -267,11 +270,24 @@ describe("chevron disclosure direction contract", () => {
     expect(ruleBody(selector)).toMatch(/flex:\s*0 0 auto/);
   });
 
-  it("keeps the sidebar thread-tree as a deliberate FILLED-triangle exception", () => {
-    // Intentionally NOT the unfilled -45/45 language: filled = navigation
-    // tree, unfilled = inline content disclosure. A solid triangle via
-    // border-left that swings 0 -> 90deg.
-    expect(ruleBody(".thread-row__subthread-toggle::before")).toContain("border-left");
-    expect(ruleBody(".thread-row__subthread-toggle.is-open::before")).toContain("rotate(90deg)");
+  it("keeps the sidebar as one deliberate FILLED-triangle family", () => {
+    // Intentionally NOT the unfilled -45/45 language: filled = sidebar
+    // navigation tree, unfilled = inline content disclosure. A solid
+    // triangle via border-left that swings 0 -> 90deg — on the
+    // thread-tree toggle, the directory header, and the
+    // directory-threads divider alike, so the sidebar speaks a single
+    // disclosure vocabulary.
+    for (const [base, open] of [
+      [".thread-row__subthread-toggle::before", ".thread-row__subthread-toggle.is-open::before"],
+      [".directory-row__chevron", ".directory-row__chevron.is-open"],
+      [
+        ".directory-row__thread-divider-chevron",
+        ".directory-row__thread-divider-chevron.is-open",
+      ],
+    ] as const) {
+      expect(ruleBody(base), `${base} filled caret`).toContain("border-left");
+      expect(ruleBody(base), `${base} filled caret`).not.toContain("border-right");
+      expect(ruleBody(open), `${open} swing`).toContain("rotate(90deg)");
+    }
   });
 });

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1281,24 +1281,15 @@ describe("Tangerine Terminal theme contract", () => {
   });
 
   it("keeps the directory pin boundary neutral in both densities", () => {
+    // Both densities share one 2px list gap since the 2026-08 inter-card
+    // spacing pass, so a single boundary compensation pairs with it — the
+    // boundary stays layout-neutral as long as these two values match.
     expect(
       extractRuleBody(css, ".sidebar-list,\n.directory-groups"),
-    ).toContain("gap: 4px;");
+    ).toContain("gap: 2px;");
     expect(
       extractRuleBody(css, ".directory-row__pin-drop-boundary"),
-    ).toContain("margin-block: -4px;");
-    expect(
-      extractRuleBody(
-        css,
-        ':root[data-density="compact"] .directory-row__pin-drop-boundary',
-      ),
     ).toContain("margin-block: -2px;");
-    expect(
-      extractRuleBody(
-        css,
-        ':root[data-density="compact"] .sidebar-list,\n:root[data-density="compact"] .directory-groups',
-      ),
-    ).toContain("gap: 2px;");
   });
 
   it("aligns the sidebar masthead and lanes to one shared inset system", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -195,6 +195,14 @@
      that defeat scanning. Themes / future surfaces can override
      this single token to retune both surfaces in lockstep. */
   --chat-column-max: 940px;
+
+  /* Sidebar title size — the user-adjustable text-size axis
+     (Settings → General → Appearance → Sidebar text size). 13px is the
+     "md" default; `:root[data-sidebar-text]` notches override it ±2px
+     (see the SIDEBAR TEXT SIZE section). Thread titles read it
+     directly; directory labels derive from it (−1px) so the hierarchy
+     holds at every notch. */
+  --sidebar-title-size: 13px;
 }
 
 /* ===========================================================================
@@ -419,76 +427,93 @@
    The default :root values target Mission Control behavior; the explicit
    data-density attribute selector only carries overrides.
    =========================================================================== */
-/* Suppress directory / PR / binding chips in the list. Reaction, Agent,
-   and pin markers stay visible — reactions because they're user-curated,
-   Agent because it changes how messaging can route to the thread, and pin
-   because the pin marker on its own is information-dense.
+/* Suppress directory / binding / provider chips in the list. Reaction and
+   Agent markers stay visible — reactions because they're user-curated,
+   Agent because it changes how messaging can route to the thread. PR chips
+   (`.pr-chip`, deliberately not a `.thread-row__chip`) also survive: they
+   are the row's actionable work product, not describable metadata.
    The "Scheduled"/"Queued" pending-send and detached-work "Unpublished"
    chips also stay visible: these time-sensitive commitments need to remain
-   visible at a glance, so they survive the density strip like the pin marker.
+   visible at a glance, so they survive the density strip.
    "Draft" survives for the same reason from the other direction: it is the
    one pending state nothing but the operator will ever resolve, so hiding it
    in the denser view is exactly where it would be lost.
+   (The pin is absent from this list because it is no longer a chip in ANY
+   density: pinned state rides the title line as
+   `.thread-row__heading-pin`, and the toggle lives in the hover actions
+   cluster as `.thread-row__pin-button` — a lone pin pill used to keep a
+   whole second chip row alive.)
+
+   Surviving chips carry the `thread-row__chip--persistent` marker class
+   in TSX — ONE source of truth shared with the gap-zeroing rule below,
+   instead of the two hand-synced class enumerations that used to drift.
 
    Scope the rule to `.thread-row__chips` so non-list surfaces that
    carry a `.thread-row__chip--*` variant (e.g. the questionnaire's mode
    chip in the transcript) don't get collapsed when compact density is
    on. The skill chip in the composer and the standalone SkillChip use
    `.chip` directly and aren't affected by this rule. */
-:root[data-density="compact"] .thread-row__chips .thread-row__chip:not(.thread-row__chip--reaction):not(.thread-row__chip--agent):not(.thread-row__chip--pin):not(.thread-row__chip--scheduled):not(.thread-row__chip--queued):not(.thread-row__chip--draft):not(.thread-row__chip--unpublished) {
+:root[data-density="compact"] .thread-row__chips .thread-row__chip:not(.thread-row__chip--persistent) {
   display: none;
 }
 
 :root[data-density="compact"] .thread-row__chips {
-  /* Tighter inter-chip gap when only reactions + pin remain visible. */
+  /* Tighter inter-chip gap when only reactions + PRs remain visible. */
   gap: 4px;
-}
-
-/* Shrink the icon-only pin marker a touch in Compact so it tracks the
-   denser rows (the marker itself already replaced the old "Pinned"
-   pill — see `.thread-row__chip--pin`). */
-:root[data-density="compact"] .thread-row__chip--pin {
-  height: 18px;
-  min-width: 18px;
-  padding: 0 4px;
 }
 
 /* Tighten thread-row vertical real estate. The row keeps its column
-   layout (title row → chips row when chips remain), but every vertical
-   measurement shrinks. The hidden-chips selector zeroes the column gap
-   for rows where every chip is suppressed — :has() lets us detect
-   "container has at least one visible chip" without JS. */
+   layout (title row → chips row when chips remain), but the title→chips
+   gap shrinks. Block padding matches the 4px Mission Control base, so
+   `.thread-row__actions` / `.thread-row__subthread-toggle` need no
+   compact offset overrides and only padding-left differs here. The
+   hidden-chips selector zeroes the column gap for rows where every chip
+   is suppressed — the `--persistent` marker (same source of truth as
+   the suppression rule above) plus `.pr-chip` are the only things that
+   survive, so two :has() checks decide it without JS. */
 :root[data-density="compact"] .thread-row {
   gap: 4px;
-  padding: 6px 10px 6px 12px;
+  padding-left: 12px;
 }
 
-/* Pull the overflow + add-reaction buttons up by the same amount the row
-   shrank its top padding, so they keep aligning with the title line
-   instead of sinking toward the row's geometric center on short
-   single-line rows. .thread-row__actions is a SIBLING of .thread-row
-   under .thread-row-shell, so the override targets it directly. */
-:root[data-density="compact"] .thread-row__actions {
-  top: 3px;
-}
-
-/* Mirror the .thread-row__actions compact shift for the sub-thread toggle:
-   compact rows pad 6px (vs 8px), so the title line — and the toggle that
-   centers on it — moves up 2px (9px -> 7px). */
-:root[data-density="compact"] .thread-row__subthread-toggle {
-  top: 7px;
-}
-
-:root[data-density="compact"] .thread-row:not(:has(.thread-row__chip--reaction)):not(:has(.thread-row__chip--agent)):not(:has(.thread-row__chip--pin)):not(:has(.thread-row__chip--unpublished)) {
+:root[data-density="compact"] .thread-row:not(:has(.thread-row__chip--persistent)):not(:has(.pr-chip)) {
   gap: 0;
 }
 
-/* Pull the inter-row gap in tight so the list reads as a scannable
-   index, not a card stack. The section divider (.recents-pinned-divider)
-   keeps its own vertical breathing room. */
-:root[data-density="compact"] .sidebar-list,
-:root[data-density="compact"] .directory-groups {
-  gap: 2px;
+/* (No compact-specific list gap anymore: the base `.sidebar-list` /
+   `.directory-groups` gap tightened to Compact's 2px for both
+   densities in the inter-card spacing pass — the densities now differ
+   only in which chips render.) */
+
+/* ===========================================================================
+   SIDEBAR TEXT SIZE — user-adjustable title scale
+
+   A third appearance axis (theme, density, text size), persisted as
+   `[general.appearance] sidebar_text_size` and applied as
+   `<html data-sidebar-text>` through the same bootstrap path as theme
+   and density. Only the sidebar's title typography scales — chips,
+   timestamps, and metadata hold still so a notch reads as "bigger
+   titles", not a page zoom. "md" (13px) is the tuned default and, like
+   the other axes, carries no attribute; each notch moves titles 1px.
+   The directory label derives from the same token (see
+   `.directory-row__title`), so the header/row hierarchy is preserved at
+   every notch. The "md" default value lives with the other tokens in
+   the top-of-file `:root` block; only the notch overrides live here.
+   =========================================================================== */
+:root[data-sidebar-text="xs"] {
+  --sidebar-title-size: 11px;
+}
+
+:root[data-sidebar-text="sm"] {
+  --sidebar-title-size: 12px;
+}
+
+:root[data-sidebar-text="lg"] {
+  --sidebar-title-size: 14px;
+}
+
+:root[data-sidebar-text="xl"] {
+  --sidebar-title-size: 15px;
 }
 
 /* Thin, themed scrollbars on every scroll container — sidebar,
@@ -3481,11 +3506,13 @@ textarea,
 .directory-groups {
   display: flex;
   flex-direction: column;
-  /* Tightened from 8px in the Mission Control density pass. Rows are
-     borderless here, so the gap is pure separation — 4px reads as a
-     scannable index without the cards merging. Compact density drops
-     this further (see the density block). */
-  gap: 4px;
+  /* Tightened 8px → 4px → 2px across the density passes. Rows are
+     borderless here, so the gap is pure separation, and the row's own
+     4px block padding carries the rest of the rhythm (10px
+     text-to-text). Both densities share this value now; a focused
+     card's ring paints over the 2px seam by design (it holds
+     z-index 2 — see `.thread-row:has(.thread-row__open:focus)`). */
+  gap: 2px;
   padding: 12px 0 16px;
 }
 
@@ -3570,7 +3597,9 @@ textarea,
   width: 100%;
   min-width: 0;
   align-items: center;
-  gap: 6px;
+  /* 4px (was 6): match the tightened caret→content rhythm of the
+     directory headers and sub-thread toggles. */
+  gap: 4px;
   padding: 5px 6px;
   border: 1px solid transparent;
   border-radius: 6px;
@@ -3718,18 +3747,27 @@ textarea,
    subthread-list connector). Previously the whole card was padded 30px,
    which made parents look nested. */
 .thread-row-shell.has-subthreads .thread-row__heading {
-  padding-left: 20px;
+  /* 14px (was 20): the toggle's 18px hit box ends 16px into the row,
+     but its GLYPH is a 5px triangle centered in that box — clearing the
+     whole box pushed the title (and the unread cookie's lane) 10-13px
+     visual pixels away from the glyph, the widest seam in the sidebar.
+     14px lets the box's empty right edge overlap the heading by 2px
+     (the pill on the toggle's own hover barely grazes the text) and
+     lands the glyph→content distance at the same ~5px the cookie→title
+     pair reads. */
+  padding-left: 14px;
 }
 
 .thread-row__subthread-toggle {
   position: absolute;
   /* Center the toggle on the title's FIRST line, not the row's geometric
-     center — same anchoring as .thread-row__actions, whose 26px button is
-     topped at 5px so its midpoint lands on the ~18px title-line midpoint
-     (8px row padding-top + ~9px into the 15px/1.25 line box). The toggle is
-     18px tall, so top = 18 - 9 = 9. Compact density shifts this up 2px (see
-     the density-compact block) to track its 6px top padding. */
-  top: 9px;
+     center — same anchoring (and the same token-derived math) as
+     .thread-row__actions: title-line midpoint = 4px padding +
+     (size × 1.25 line + 2px descender pad) / 2, minus half the toggle's
+     18px height, rounded to a whole pixel (same golden-stability
+     rationale as the actions rule). Resolves to 4px at the md notch and
+     tracks every user-selected notch of `--sidebar-title-size`. */
+  top: round(calc(4px + (var(--sidebar-title-size) * 1.25 + 2px) / 2 - 9px), 1px);
   left: 8px;
   z-index: 4;
   display: grid;
@@ -3840,14 +3878,16 @@ textarea,
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   width: 100%;
-  /* Tightened from `12px 12px 12px 14px` in the Mission Control density
-     pass. With the lane's 8px inline padding this leaves ~18px of text
-     inset on each side; 8px block padding + the 4px row gap give ~20px
-     text-to-text between rows. (`.thread-row__actions` top is kept in
+  /* Tightened again in the 2026-08 sidebar density passes (12px → 8px →
+     6px → 4px block): 4px block padding + the 2px row gap give ~10px
+     text-to-text between rows — the inter-card air was the loosest
+     measurement left on the surface once the type and chips shrank.
+     Both densities share this padding; they differ in what they SHOW,
+     not how the card breathes. (`.thread-row__actions` top is kept in
      step with the block padding — see that rule.) */
-  padding: 8px 10px;
+  padding: 4px 10px;
   border: 1px solid transparent;
   border-radius: 8px;
   background: transparent;
@@ -3954,16 +3994,18 @@ textarea,
 
 .thread-row__actions {
   position: absolute;
-  /* Align the overflow button + add-reaction chip with the title line,
-     not the row's geometric center. The 26-px-tall button sits a few
-     pixels into the row's top padding so its vertical midpoint matches
-     the title's line midpoint. When the row is multi-line (chips
-     present) the title is still the FIRST line, so the same offset
-     keeps the button anchored to it. Offset tracks the row's top padding
-     (`top ≈ padding-top − 3`): Mission Control rows pad 8px → 5px here;
-     the Compact density variant overrides this `top` to 3px (see the
-     density-compact block at the top of the file) for its 6px padding. */
-  top: 5px;
+  /* Align the pin/overflow buttons + add-reaction chip with the title
+     line, not the row's geometric center. The 26-px-tall cluster sits so
+     its vertical midpoint matches the title's line midpoint. When the
+     row is multi-line (chips present) the title is still the FIRST
+     line, so the same offset keeps the cluster anchored to it. Derived
+     from the user-adjustable title token so every notch stays aligned:
+     title-line midpoint = 4px padding + (size × 1.25 line + 2px
+     descender pad) / 2; subtract half the 26px cluster height, rounded
+     to a whole pixel so the cluster never sits on a fractional
+     boundary (which would antialias-shift the visual goldens). At the
+     md notch (13px) this resolves to 0. */
+  top: round(calc(4px + (var(--sidebar-title-size) * 1.25 + 2px) / 2 - 13px), 1px);
   right: 9px;
   z-index: 3;
   display: flex;
@@ -3972,10 +4014,14 @@ textarea,
   pointer-events: none;
 }
 
+/* One base chrome + reveal mechanic for both hover-revealed row action
+   buttons (pin toggle + overflow kebab) — shared selectors, so a reveal
+   or chrome tweak cannot drift between them. Only the width and the
+   pin's `.is-pinned` accent live in per-button rules below. */
+.thread-row__pin-button,
 .thread-row__overflow-button {
   position: static;
   display: grid;
-  width: 30px;
   height: 26px;
   place-items: center;
   padding: 0;
@@ -3983,8 +4029,6 @@ textarea,
   border-radius: 6px;
   background: var(--bg-panel-elevated);
   color: var(--text-secondary);
-  font-size: 15px;
-  font-weight: 700;
   line-height: 1;
   opacity: 0;
   pointer-events: none;
@@ -3995,6 +4039,13 @@ textarea,
     opacity 120ms ease;
 }
 
+.thread-row__overflow-button {
+  width: 30px;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.thread-row-shell:has(.thread-row__pin-button:focus-visible) .thread-row__time,
 .thread-row-shell:hover .thread-row__time,
 .thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row__time,
 .thread-row-shell:has(.thread-row__chip--add-reaction:focus-visible) .thread-row__time,
@@ -4002,12 +4053,16 @@ textarea,
   opacity: 0;
 }
 
+.thread-row-shell:hover .thread-row__pin-button,
+.thread-row__pin-button:focus-visible,
 .thread-row-shell:hover .thread-row__overflow-button,
 .thread-row__overflow-button:focus-visible {
   opacity: 1;
   pointer-events: auto;
 }
 
+.thread-row__pin-button:hover,
+.thread-row__pin-button:focus-visible,
 .thread-row__overflow-button:hover,
 .thread-row__overflow-button:focus-visible {
   border-color: var(--accent-border);
@@ -4298,14 +4353,41 @@ textarea,
 .thread-row:has(.thread-row__open:focus) {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
+  /* The ring paints 4px outside the card (2px width @ 2px offset), into
+     the inter-row gap. `.is-selected` lifts itself to z-index 1 so its
+     border survives neighbouring hover fills — which also buried THIS
+     ring's edge whenever the previously selected card sat directly
+     below the focused one. The focused card is the one being acted on,
+     so it wins the stack. */
+  z-index: 2;
 }
 
 .thread-row__heading {
   display: flex;
   min-width: 0;
   align-items: center;
-  gap: 8px;
+  /* 2px, from 8: the 16px status-indicator lane already carries ~3px of
+     slack around the 10px cookie, so the visible cookie→title distance
+     is gap + slack. At 8px the mark floated twice as far from its title
+     as the identical cookie sits from the directory-header counts; 2px
+     brings the two surfaces to parity. */
+  gap: 2px;
   flex: 1 1 auto;
+}
+
+/* Passive pinned-state signal riding the title line (both densities —
+   the pin no longer spends a chip anywhere). Lives INSIDE the
+   open-thread button, so it is deliberately non-interactive (a button
+   inside a button is `nested-interactive`); the actionable pin toggle
+   is `.thread-row__pin-button` in the hover actions cluster. */
+.thread-row__heading-pin {
+  display: inline-flex;
+  flex: 0 0 auto;
+  /* The heading gap is tuned for the status-indicator lane's slack;
+     this marker has none, so give it back a little air after the
+     title. */
+  margin-left: 2px;
+  color: var(--accent-bright);
 }
 
 .thread-row__title,
@@ -4319,19 +4401,17 @@ textarea,
 
 .thread-row__title {
   padding-bottom: 2px;
-  /* Sidebar readability tune (issue #240 follow-up). The default
-     sidebar is 408px wide and resizes up to 560px in this app;
-     internal feedback noted that the previous 14/600 felt thin and
-     hard to read against the near-black panel at those widths. The
-     v2 design preview uses 13/600, but its sidebar is only 320px
-     wide — narrower than ours and built for a denser layout. We
-     err toward our wider canvas: 15/650 reads as a clear
-     scannable list-row title without going full Bold (700) which
-     would pull focus from the active thread's accent treatment.
-     Titles average 5-6 words so the extra px doesn't push them to
-     wrap. */
-  font-size: 15px;
-  font-weight: 650;
+  /* Sidebar density pass (2026-08). The previous 15/650 (an issue #240
+     "reads thin" follow-up) made every row shout — directory headers
+     and thread titles shared one heavy style, so the list had bulk but
+     no hierarchy. Back to the v2 design's 13/600 as the default, with
+     the size behind the `--sidebar-title-size` token so the operator
+     can move it ±2px from Settings → General → Appearance (the old
+     15px lives at the "XL" notch). Weight stays 600 at every notch:
+     scaling weight with size made the large notches read as bold-on-
+     bold again. */
+  font-size: var(--sidebar-title-size);
+  font-weight: 600;
   line-height: 1.25;
 }
 
@@ -4362,12 +4442,21 @@ textarea,
   align-items: center;
   justify-content: center;
   flex: 0 0 16px;
+  /* The title carries 2px of descender padding, so its glyphs sit ~1px
+     above the heading's flex center; nudge the mark up to align with
+     the TEXT rather than the padded box. */
+  transform: translateY(-1px);
 }
 
 .thread-row__status-cookie {
   display: block;
-  width: 12px;
-  height: 12px;
+  /* 10px, down from 12 in the 2026-08 density pass: next to the 13px
+     titles the old cookie read as the heaviest mark on the row, and it
+     visibly outweighed the same cookie beside the directory-header
+     counts. One size everywhere now — the header count's former 9px
+     override is gone so both surfaces draw the identical mark. */
+  width: 10px;
+  height: 10px;
   border: 1px solid var(--accent-border);
   border-radius: 999px;
   background:
@@ -4437,6 +4526,34 @@ textarea,
   white-space: nowrap;
 }
 
+/* Sidebar-list chips run one step smaller than the shared pill primitive:
+   24px pills under the tightened 13px titles read as the bulkiest thing
+   on the card. Scoped to the row's `.thread-row__chips` flow so the
+   thread-header eyebrow, transcript chips, and the hover-only
+   add-reaction control (which lives in `.thread-row__actions`, beside
+   the 26px overflow button) keep the full-size primitive. Declared
+   BEFORE the variant rules below so equal-specificity variants (e.g.
+   the reaction chip's 16px emoji, pinned by theme-contract) still win
+   their own properties. */
+.thread-row__chips .thread-row__chip {
+  height: 20px;
+  gap: 5px;
+  font-size: 11px;
+}
+
+.thread-row__chips .pr-chip {
+  height: 20px;
+}
+
+/* Icon-only worktree/local location chip — square-ish so it reads as a
+   marker, not a truncated word. The kind lives in the aria-label and
+   the copy tooltip. */
+.thread-row__chip--location {
+  min-width: 20px;
+  justify-content: center;
+  padding: 0 5px;
+}
+
 .thread-row__chip.thread-row__chip--reaction {
   min-width: 24px;
   justify-content: center;
@@ -4492,28 +4609,21 @@ textarea,
   font-weight: 600;
 }
 
-/* Pin marker — an icon-only orange pill. The pushpin glyph + the accent
-   tint carry the "pinned" signal without spending a word of row width.
-   When it has an unpin callback, it becomes an explicit click target;
-   its hover label explains the action. Square-ish (min-width == height)
-   so it reads as a marker, not a text chip. */
-.thread-row__chip--pin {
-  min-width: 24px;
-  justify-content: center;
-  padding: 0 6px;
-  border: 1px solid var(--accent-border);
-  background: var(--accent-soft);
+/* Pin toggle — hover-revealed row action beside the reaction + overflow
+   buttons (the pin stopped being a chip in the 2026-08 density pass:
+   passive pinned STATE is the in-title `.thread-row__heading-pin`
+   marker; this button is the one-click pin/unpin). Base chrome, reveal,
+   and hover-accent rules are SHARED with `.thread-row__overflow-button`
+   (see that block) — only the width and pinned accent live here. */
+.thread-row__pin-button {
+  width: 26px;
+}
+
+/* Pinned state reads accent even before its own hover, so the revealed
+   cluster says "this one is pinned" at a glance. */
+.thread-row__pin-button.is-pinned {
+  border-color: var(--accent-border);
   color: var(--accent-bright);
-}
-
-.thread-row__chip--pin[role="button"] {
-  cursor: pointer;
-}
-
-.thread-row__chip--pin[role="button"]:hover,
-.thread-row__chip--pin[role="button"]:focus-visible {
-  border-color: var(--accent-strong);
-  background: var(--bg-row-active);
 }
 
 .thread-row__chip--approval,
@@ -5183,19 +5293,23 @@ textarea,
   /* Sidebar-tightening pass: the previous 10px top padding + 44px
      summary min-height + 34px launchpad button meant each
      directory header took ~54px. Recovered ~20px per row by halving
-     the top padding and tightening the summary geometry below. */
+     the top padding and tightening the summary geometry below.
+     2026-08 density pass: the inter-row `border-top` hairline is gone —
+     each header already separates itself with its disclosure caret,
+     label, and (when non-zero) count block, so the rule was
+     double-encoding the boundary and made the lens read as a stack of
+     framed cards. */
   /* `position: relative` is the containing block for the directory
      drop-indicator pseudo-elements (`.directory-row.is-drop-target-*
      ::before/::after`) so they can stretch across the full expanded
      section instead of only the sticky header. Plan 2026-05-09-002
      Unit K follow-up. */
   position: relative;
-  padding: 4px 0 0;
-  border-top: 1px solid var(--border-subtle);
-}
-
-.directory-row:first-child {
-  border-top: 0;
+  /* 2px top (was 4): with the hairline gone and the summary's own
+     min-height slack, 4px pushed collapsed directories ~20px of blank
+     label-to-label; 2px + the 2px list gap + the summary slack lands
+     at ~10px. */
+  padding: 2px 0 0;
 }
 
 .directory-row__header {
@@ -5203,14 +5317,12 @@ textarea,
   position: sticky;
   top: 0;
   z-index: 5;
-  /* Gap between summary button and launchpad icon button. Tightened
-     8 → 4 when the icon button lost its border (no longer reads as a
-     separate "card" the way the framed 34px button did), then 4 → 2:
-     the count and the launchpad icon read as one cluster, and the real
-     distance between them is this plus the summary's right padding
-     plus the icon button's own 4px inset. */
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 2px;
+  /* One column: the launchpad cluster no longer owns a lane outside the
+     summary's hover border — it overlays the summary's right edge
+     (absolute, see `.directory-row__launchpad-cluster`) and swaps with
+     the count block on hover, the same trade the thread rows make
+     between the timestamp and the overflow kebab. */
+  grid-template-columns: minmax(0, 1fr);
   align-items: center;
   background: var(--bg-sidebar);
 }
@@ -5303,12 +5415,14 @@ textarea,
      12 → 8 since the meta block now sits tighter against the
      scrollbar gutter. */
   gap: 8px;
-  /* Row height tightened 44 → 32. Was set to match the masthead's
-     44px button height, but rows are list entries and don't need
-     that same hit-target generosity. Combined with the row top
-     padding drop, each directory header now reads ~22px taller
-     than the comfortable touch target instead of 54px. */
-  min-height: 32px;
+  /* Row height tightened 44 → 32 → 24 across the density passes. 44
+     matched the masthead's button height, but rows are list entries
+     and don't need that hit-target generosity; at 32 the leftover
+     slack was still the largest blank band in the collapsed
+     Directories lens. 24 fits the 16px title line + block padding
+     with ~3px of slack, and the 24px launchpad cluster still fills
+     the row exactly on hover. */
+  min-height: 24px;
   /* Lateral inset: 4px on the left sits before the disclosure chevron
      and folder icon; 6px on the right still clears the selected-row
      border for the meta block (attention count pill) without stranding
@@ -5340,13 +5454,19 @@ textarea,
 }
 
 .directory-row__summary-main {
-  gap: 8px;
+  /* 5px (was 8): the disclosure caret is a 5px glyph with no box slack,
+     so the raw flex gap IS the visual gap — 8px read wider than the
+     cookie→title distance on the thread rows below. */
+  gap: 5px;
 }
 
 .directory-row__summary-meta {
   flex: 0 0 auto;
   gap: 10px;
   justify-content: flex-end;
+  /* Fades under the hover-revealed launchpad cluster — see the
+     `.directory-row__header--with-launchpad` rules by the cluster. */
+  transition: opacity 120ms ease;
 }
 
 .directory-row__icon {
@@ -5359,6 +5479,19 @@ textarea,
 .directory-row__title-wrap {
   flex: 1 1 auto;
   min-width: 0;
+}
+
+/* Directory labels are section headers, not content rows: one pixel
+   smaller than the thread title (tracking the same user-adjustable
+   token so every notch keeps the hierarchy) and a step quieter in
+   color. Before the 2026-08 density pass both used the identical
+   15/650 style, which left the tree with bulk but no hierarchy. The
+   folder glyph, counts, and selection accent carry the rest of the
+   header's identity; `--unconfigured` rows still override to muted
+   via their higher-specificity rule. */
+.directory-row__title {
+  color: var(--text-secondary);
+  font-size: calc(var(--sidebar-title-size) - 1px);
 }
 
 .directory-row__active-count,
@@ -5381,36 +5514,70 @@ textarea,
   color: var(--text-secondary);
 }
 
-.directory-row__review-count .thread-row__status-cookie {
-  width: 9px;
-  height: 9px;
-}
+/* The header count cookie inherits the base 10px size — it used to be a
+   9px one-off, which made the thread rows' (then-12px) cookie read as a
+   different, chunkier mark for the same state. */
 
 .directory-row__chevron {
-  /* Standard inline disclosure chevron (see .live-work-rail__chevron):
-     points right when collapsed, rotates 90deg to point down when
-     expanded. Sits at the left of the row, before the folder icon. */
+  /* Filled disclosure caret — the same triangle the sub-thread toggle
+     (`.thread-row__subthread-toggle::before`) and the sub-agents
+     disclosure draw, so the sidebar carries ONE disclosure vocabulary.
+     This replaced the border-stroke chevron, which read chunky at
+     header size and existed nowhere else in the sidebar. Points right
+     when collapsed, rotates to point down when expanded. */
   display: inline-flex;
+  width: 0;
+  height: 0;
   flex: 0 0 auto;
-  width: 9px;
-  height: 9px;
-  border-right: 1.75px solid var(--text-muted);
-  border-bottom: 1.75px solid var(--text-muted);
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid var(--text-muted);
   opacity: 0.82;
   transition: transform 120ms ease;
-  transform: rotate(-45deg);
 }
 
 .directory-row__chevron.is-open {
-  transform: rotate(45deg);
+  transform: rotate(90deg);
+}
+
+/* Split launchpad cluster: the icon keeps its one-click "new thread
+   here" meaning and the chevron adds the machine choice, so the common
+   case stays a single click.
+
+   The CLUSTER is also the hover-revealed overlay on the summary's right
+   edge, where the count block sits — the counts fade as it appears, the
+   same swap the thread rows make between the timestamp and the overflow
+   kebab. Absolute inside the sticky header (a positioned ancestor), so
+   it sits INSIDE the summary's hover/selection border instead of owning
+   chrome beside it.
+
+   `pointer-events` stays AUTO at rest, unlike the kebab: a mouse user
+   cannot reach this spot without hovering the header first (at which
+   point the cluster is visible), and driving it from a test runner's
+   pre-move hit-target check must not require a synthetic hover. The
+   kebab keeps its gate because it overlays content that must stay
+   clickable when its cluster is hidden; here the space under the
+   cluster is the non-interactive count block. */
+.directory-row__launchpad-cluster {
+  display: inline-flex;
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  z-index: 2;
+  align-items: center;
+  border-radius: 6px;
+  opacity: 0;
+  transform: translateY(-50%);
+  transition: opacity 120ms ease;
+}
+
+.directory-row__header:hover .directory-row__launchpad-cluster,
+.directory-row__launchpad-cluster:has(:focus-visible),
+.directory-row__header--has-draft .directory-row__launchpad-cluster {
+  opacity: 1;
 }
 
 .directory-row__launchpad-button {
-  /* Sidebar-tightening pass: stripped the 34px framed-button
-     treatment (border + bg-panel + 8px radius) — at directory-row
-     density it read as "another card" inside the row instead of an
-     inline icon affordance. Now a flat 24px icon button that picks
-     up an accent-soft hover state. */
   display: inline-flex;
   width: 24px;
   height: 24px;
@@ -5425,17 +5592,6 @@ textarea,
   color: var(--text-muted);
   font-size: 16px;
   line-height: 1;
-  /* The list wrapper carries `padding-right: 4px` so the icon
-     glyph already sits clear of the scrollbar gutter — no
-     additional margin needed here. */
-}
-
-/* Split button: the icon keeps its one-click "new thread here" meaning and the
-   chevron adds the machine choice, so the common case stays a single click. */
-.directory-row__launchpad-cluster {
-  display: inline-flex;
-  align-items: center;
-  border-radius: 6px;
 }
 
 /* Hovering either half tints the whole cluster and warms both glyphs, so the
@@ -5499,11 +5655,59 @@ textarea,
   color: var(--accent-bright);
 }
 
+/* The count block yields to the revealed cluster: fade it on header
+   hover (or keyboard focus inside the cluster), exactly like the
+   thread-row timestamp yields to the kebab. Scoped to
+   `--with-launchpad` headers (set in TSX for configured directories):
+   an unconfigured directory renders NO cluster, and fading its counts
+   would leave the header's right edge simply blank while hovered.
+   The TSX-computed modifier classes (`--with-launchpad`, `--split`,
+   `--has-draft`) replace per-hover :has() subtree scans with plain
+   class matches — DirectoriesList already knows all three booleans. */
+.directory-row__header--with-launchpad:hover .directory-row__summary-meta,
+.directory-row__header--with-launchpad:has(.directory-row__launchpad-cluster :focus-visible) .directory-row__summary-meta {
+  opacity: 0;
+}
+
+/* A directory holding an unsent launchpad draft shows the tinted "+"
+   permanently, so its counts shift left to sit beside the cluster
+   rather than under it — further when the split chevron widens it.
+   The margins reserve the cluster's rendered width + its 6px inset
+   (24px button / 24+16px split — see the cluster rules above). */
+.directory-row__header--has-draft:not(:hover) .directory-row__summary-meta {
+  margin-right: 28px;
+}
+
+.directory-row__header--has-draft.directory-row__header--split:not(:hover) .directory-row__summary-meta {
+  margin-right: 44px;
+}
+
+/* Hover-less input (touch, pen): there is no hover to reveal the
+   cluster, and an invisible-but-tappable control overlaying the counts
+   would misfire. Keep the cluster always visible there, with the
+   counts shifted beside it exactly like the has-draft state. */
+@media (hover: none) {
+  .directory-row__header--with-launchpad .directory-row__launchpad-cluster {
+    opacity: 1;
+  }
+
+  .directory-row__header--with-launchpad .directory-row__summary-meta {
+    margin-right: 28px;
+  }
+
+  .directory-row__header--with-launchpad.directory-row__header--split .directory-row__summary-meta {
+    margin-right: 44px;
+  }
+}
+
 .directory-row__details {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 8px 0 14px 0;
+  /* Bottom tightened 14 → 10 with the inter-card spacing pass so the
+     seam between an expanded directory's last thread and the next
+     directory header tracks the tighter row rhythm. */
+  padding: 8px 0 10px 0;
 }
 
 .directory-row__threads {
@@ -5523,15 +5727,10 @@ textarea,
   z-index: 7;
   height: 0;
   flex: 0 0 auto;
-  /* The list contributes a 4px gap on both sides of this flex item. Cancel
+  /* The list contributes a 2px gap on both sides of this flex item. Cancel
      those gaps so this permanently mounted zero-height target is layout-neutral
-     and starting a drag never moves the source row under the held card. */
-  margin-block: -4px;
-}
-
-:root[data-density="compact"] .directory-row__pin-drop-boundary {
-  /* Compact density reduces `.sidebar-list` to a 2px gap. Keep the boundary's
-     compensation paired with that value so it remains layout-neutral. */
+     and starting a drag never moves the source row under the held card.
+     (Keep paired with the `.sidebar-list` gap — both densities share 2px.) */
   margin-block: -2px;
 }
 
@@ -5615,17 +5814,19 @@ textarea,
 }
 
 .directory-row__thread-divider-chevron {
-  width: 6px;
-  height: 6px;
-  border-right: 1.5px solid currentColor;
-  border-bottom: 1.5px solid currentColor;
+  /* Same filled-caret vocabulary as `.directory-row__chevron`, one size
+     down for the divider's 11px label. */
+  width: 0;
+  height: 0;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  border-left: 4px solid currentColor;
   opacity: 0.82;
   transition: transform 120ms ease;
-  transform: rotate(-45deg);
 }
 
 .directory-row__thread-divider-chevron.is-open {
-  transform: rotate(45deg);
+  transform: rotate(90deg);
 }
 
 .directory-row__threads .thread-row--compact {
@@ -25188,13 +25389,14 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 /* Real-app-mimic chips used in the preview cards. The visual contract
-   mirrors the live ThreadRow primitive — Pin chip uses --accent, PR
-   chip uses a small status dot + #number, Meta chips are gray-on-near-
-   black for OpenAI / directory / branch slots. */
-.onboarding-wizard__mini-chip--pin {
-  color: var(--accent);
-  border-color: var(--accent-border);
-  background: transparent;
+   mirrors the live ThreadRow primitive — the pin is the in-title accent
+   marker (`.thread-row__heading-pin` in the live sidebar), PR chip uses
+   a small status dot + #number, Meta chips are gray-on-near-black for
+   OpenAI / directory / branch slots. */
+.onboarding-wizard__mini-pin {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--accent-bright);
 }
 .onboarding-wizard__mini-chip--pr {
   display: inline-flex;

--- a/docs/design/desktop-style-guide.md
+++ b/docs/design/desktop-style-guide.md
@@ -79,7 +79,7 @@ Use a restrained desktop scale:
 
 - App title / page title: `40px / 700`
 - Section title: `24px / 650`
-- Thread row primary text: `14px / 600`
+- Thread row primary text: `13px / 600` (user-adjustable ±2px via Settings → General → Appearance → Sidebar text size; directory labels ride 1px below the thread title)
 - Body text: `14px / 400`
 - Secondary metadata: `12px / 500`
 - Labels / caps / tiny status: `11px / 600`

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -66,6 +66,7 @@ describe("desktop settings contracts", () => {
         appearance: {
           theme: { value: "system", source: "default" },
           density: { value: "mission-control", source: "default" },
+          sidebarTextSize: { value: "md", source: "default" },
         },
         codexProfileModel: { value: "shared", source: "default" },
         messagingAcknowledgment: { value: null, source: "default" },

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -67,6 +67,24 @@ export type DesktopAppearanceDensity =
 export const DESKTOP_APPEARANCE_DENSITY_DEFAULT: DesktopAppearanceDensity =
   "mission-control";
 
+/**
+ * Sidebar text-size notches. "md" is the default 13px thread-row title;
+ * each notch moves the title (and the directory label derived from it)
+ * by 1px in either direction. Deliberately a discrete scale rather than
+ * a free pixel value so every notch is a size the sidebar was actually
+ * designed and reviewed at.
+ */
+export const DESKTOP_SIDEBAR_TEXT_SIZES = [
+  "xs",
+  "sm",
+  "md",
+  "lg",
+  "xl",
+] as const;
+export type DesktopSidebarTextSize =
+  (typeof DESKTOP_SIDEBAR_TEXT_SIZES)[number];
+export const DESKTOP_SIDEBAR_TEXT_SIZE_DEFAULT: DesktopSidebarTextSize = "md";
+
 export const DESKTOP_INTEGRATED_TERMINAL_WINDOWS_SHELLS = [
   "auto",
   "pwsh",
@@ -363,6 +381,7 @@ export type DesktopIntegratedTerminalSettingsSnapshot = {
 export type DesktopAppearanceSnapshot = {
   theme: DesktopSettingsValue<DesktopAppearanceTheme>;
   density: DesktopSettingsValue<DesktopAppearanceDensity>;
+  sidebarTextSize: DesktopSettingsValue<DesktopSidebarTextSize>;
 };
 
 export type DesktopGeneralSettingsSnapshot = {
@@ -903,6 +922,7 @@ export type DesktopSettingsConfigPatch = {
     appearance?: {
       theme?: DesktopAppearanceTheme;
       density?: DesktopAppearanceDensity;
+      sidebarTextSize?: DesktopSidebarTextSize;
     };
     codexProfileModel?: DesktopCodexProfileModel;
     /** `null` clears the persisted acknowledgement. */
@@ -1524,6 +1544,14 @@ export function isDesktopAppearanceDensity(
 ): value is DesktopAppearanceDensity {
   return DESKTOP_APPEARANCE_DENSITIES.includes(
     value as DesktopAppearanceDensity,
+  );
+}
+
+export function isDesktopSidebarTextSize(
+  value: string,
+): value is DesktopSidebarTextSize {
+  return DESKTOP_SIDEBAR_TEXT_SIZES.includes(
+    value as DesktopSidebarTextSize,
   );
 }
 


### PR DESCRIPTION
## Summary

Design-review pass over the thread-list sidebar, from the "left bar is too chunky" feedback. Reviewed live against the dev app with a structured critique (hierarchy / consistency / usability), then implemented the tightening.

### Design review findings → fixes

| Finding | Fix |
|---|---|
| Directory headers and thread titles shared one heavy style (15px/650) — container and content had identical weight, so the tree read flat and loud. (The style guide itself specifies smaller/lighter row text; 15/650 was an issue #240-era deviation.) | Thread titles **13px/600** by default; directory labels ride **1px smaller in `--text-secondary`**. New **Sidebar text size** setting (XS–XL) moves titles ±2px — the old 15px is the XL notch. |
| Two disclosure vocabularies: border-stroke chevron (directory rows, "Directory threads" divider) vs. filled triangle (sub-thread toggle, sub-agents). | One vocabulary: the **filled caret** everywhere in the sidebar. |
| `border-top` hairline between every directory row double-encoded a boundary the 32px headers already carry. | Hairlines removed. |
| Folder icon on every plain directory row carried zero information. | Icon only where it distinguishes: workspace + unlinked keep their marks. |
| Launchpad `+` always visible on every header while the row kebab is hover-only. | `+` is **hover/focus-revealed**, and stays pinned while it carries a draft (there the icon *is* the signal). |
| 24px chip pills under the titles were the bulkiest thing on the card (~120px for a pinned worktree thread). | Sidebar-scoped shrink to **20px/11px** — the shared `.chip` primitive, thread-header eyebrow chips, and transcript chips are untouched. Row padding 8→6px. |
| Unread cookie was 12px in rows vs 9px beside directory counts, sat ~1px below the text's optical center, and the title gap was too wide. | One **10px** cookie everywhere, nudged onto the title line, heading gap 8→6px. |
| **Bug:** pressing a card buried its focus ring's edge under the previously selected card below (`.is-selected` z-index 1 vs. unlifted focused row). | Focused card lifts to **z-index 2**. |
| **Bug:** in Compact, a pinned thread's pin chip kept a whole second chip row alive — exactly the space Compact exists to reclaim. | Compact suppresses the pin chip and renders an **in-title pin marker** instead (non-interactive by necessity — it lives inside the open-thread button; unpin stays on the context menu). |
| Settings copy claimed Compact hides PR chips; it never did (`.pr-chip` isn't matched by the density strip). | "Density" → **"Info density"**, copy now matches actual behavior. |

### New setting plumbing

`[general.appearance] sidebar_text_size = "xs" | "sm" | "md" | "lg" | "xl"` (default `md`, defaults not written to disk), flowing through the existing no-flash appearance path: shared contract → desktop-config TOML read/write → settings service (+ `onAppearanceChange` broadcast to aux windows) → bootstrap args → preload → `index.html` inline script → `useAppearance` → `<html data-sidebar-text>`. Additive config change only.

## Testing

- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors`, `pnpm lint:boundaries` — all pass
- Targeted vitest: shared settings contract, desktop-settings-service (round-trip extended to the new key), screenshot-appearance, profiles-ipc, settings-screen, app-shell, theme-contract, navigation suites — all pass
- Verified live in the dev app (both densities, all five text-size notches, hover reveals, pressed-ring overlap repro before/after, compact pin marker)

## Follow-ups (deliberately out of scope)

- **Info-density presets as per-field defaults** (Mission Control / Balanced / Compact / Custom picking provider, location indicator, directory count caps, branch chips, PRs, emojis, pin placement per-field)
- **Balanced preset** (branch chips off, pin on title row)
- **PR chip placement option** (bin-pack after provider/location instead of always-last)
- Pin placement as an explicit setting (Hide / Title bar / Chip bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)